### PR TITLE
feat(permission): per-session bypass + configurable always-ask rules

### DIFF
--- a/crates/app/bamboo-server-tools/src/memory/tests.rs
+++ b/crates/app/bamboo-server-tools/src/memory/tests.rs
@@ -37,6 +37,7 @@ fn test_context<'a>(session_id: &'a str) -> ToolExecutionContext<'a> {
         tool_call_id: "tool-call-1",
         event_tx: None,
         available_tool_schemas: None,
+        bypass_permissions: false,
     }
 }
 

--- a/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
@@ -123,6 +123,7 @@ Use this demo skill."#,
         tool_call_id: "tool-call-1",
         event_tx: None,
         available_tool_schemas: None,
+        bypass_permissions: false,
     };
 
     let error = tool
@@ -185,6 +186,7 @@ Use this demo skill."#,
         tool_call_id: "tool-call-2",
         event_tx: None,
         available_tool_schemas: None,
+        bypass_permissions: false,
     };
 
     let _ = tool
@@ -253,12 +255,14 @@ Use this demo skill."#,
         tool_call_id: "tool-call-load",
         event_tx: None,
         available_tool_schemas: None,
+        bypass_permissions: false,
     };
     let read_ctx = ToolExecutionContext {
         session_id: Some(session_id),
         tool_call_id: "tool-call-read",
         event_tx: None,
         available_tool_schemas: None,
+        bypass_permissions: false,
     };
 
     let _ = load_tool

--- a/crates/app/bamboo-server-tools/tests/ask_agent_tool.rs
+++ b/crates/app/bamboo-server-tools/tests/ask_agent_tool.rs
@@ -45,6 +45,7 @@ async fn ask_agent_tool_queries_a_broker_agent() {
         tool_call_id: "tc1",
         event_tx: None,
         available_tool_schemas: None,
+        bypass_permissions: false,
     };
     let result = tool
         .execute_with_context(
@@ -73,6 +74,7 @@ async fn ask_agent_tool_rejects_unknown_mode() {
         tool_call_id: "tc2",
         event_tx: None,
         available_tool_schemas: None,
+        bypass_permissions: false,
     };
     let err = tool
         .execute_with_context(

--- a/crates/app/bamboo-server/src/app_state/resume_adapter.rs
+++ b/crates/app/bamboo-server/src/app_state/resume_adapter.rs
@@ -212,6 +212,7 @@ impl ResumeExecutionPort for AppStateResumeRef {
                         tool_call_id: reexecute_tool_call_id.as_str(),
                         event_tx: Some(&mpsc_tx),
                         available_tool_schemas: None,
+                        bypass_permissions: false,
                     };
                     executor.execute_with_context(&tool_call, ctx).await
                 };

--- a/crates/app/bamboo-server/src/app_state/tests.rs
+++ b/crates/app/bamboo-server/src/app_state/tests.rs
@@ -264,6 +264,7 @@ async fn memory_tool_merge_action_updates_existing_project_memory() {
                 tool_call_id: "tool-call-write-target",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -291,6 +292,7 @@ async fn memory_tool_merge_action_updates_existing_project_memory() {
                 tool_call_id: "tool-call-write-source",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -317,6 +319,7 @@ async fn memory_tool_merge_action_updates_existing_project_memory() {
                 tool_call_id: "tool-call-merge",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -363,6 +366,7 @@ async fn memory_tool_write_merges_heuristically_similar_memory_when_enabled() {
                 tool_call_id: "tool-call-write-heuristic-original",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -390,6 +394,7 @@ async fn memory_tool_write_merges_heuristically_similar_memory_when_enabled() {
                 tool_call_id: "tool-call-write-heuristic-merge",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -413,6 +418,7 @@ async fn memory_tool_write_merges_heuristically_similar_memory_when_enabled() {
                 tool_call_id: "tool-call-inspect-heuristic-merge",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -452,6 +458,7 @@ async fn memory_tool_merge_mode_contradict_marks_memory_contradicted() {
                 tool_call_id: "tool-call-write-contradict-target",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -477,6 +484,7 @@ async fn memory_tool_merge_mode_contradict_marks_memory_contradicted() {
                 tool_call_id: "tool-call-write-contradict-source",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -503,6 +511,7 @@ async fn memory_tool_merge_mode_contradict_marks_memory_contradicted() {
                 tool_call_id: "tool-call-contradict",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -549,6 +558,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 tool_call_id: "tool-call-write-stale",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -573,6 +583,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 tool_call_id: "tool-call-mark-stale",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -596,6 +607,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 tool_call_id: "tool-call-write-active",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -622,6 +634,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 tool_call_id: "tool-call-batch-purge",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -662,6 +675,7 @@ async fn memory_tool_inspect_and_rebuild_expose_observability_fields() {
                 tool_call_id: "tool-call-write-inspect",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -682,6 +696,7 @@ async fn memory_tool_inspect_and_rebuild_expose_observability_fields() {
                 tool_call_id: "tool-call-inspect",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -709,6 +724,7 @@ async fn memory_tool_inspect_and_rebuild_expose_observability_fields() {
                 tool_call_id: "tool-call-rebuild",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
@@ -148,7 +148,8 @@ pub async fn patch_session(
         || req.provider.is_some()
         || req.model.is_some()
         || req.reasoning_effort.is_some()
-        || req.clear_reasoning_effort.unwrap_or(false);
+        || req.clear_reasoning_effort.unwrap_or(false)
+        || req.bypass_permissions.is_some();
 
     if touches_non_metadata {
         let request_model_ref = derive_model_ref(
@@ -188,6 +189,16 @@ pub async fn patch_session(
                     session.reasoning_effort = None;
                 } else if let Some(reasoning_effort) = req.reasoning_effort {
                     session.reasoning_effort = Some(reasoning_effort);
+                }
+
+                // Per-session "bypass permissions" toggle. Stored on the session's
+                // runtime state (runtime.json), creating it on demand so the flag
+                // can be set before the session's first run.
+                if let Some(bypass) = req.bypass_permissions {
+                    session
+                        .agent_runtime_state
+                        .get_or_insert_with(bamboo_domain::AgentRuntimeState::default)
+                        .bypass_permissions = bypass;
                 }
 
                 model_changed

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/tests.rs
@@ -9,6 +9,7 @@ use chrono::Utc;
 fn session_summary_from_entry_includes_last_run_fields() {
     let entry = SessionIndexEntry {
         id: "child-1".to_string(),
+        bypass_permissions: false,
         kind: SessionKind::Child,
         rel_path: "sessions/root/children/child-1".to_string(),
         title: "Child Session".to_string(),
@@ -52,6 +53,7 @@ fn session_summary_from_entry_includes_last_run_fields() {
 fn session_summary_from_entry_propagates_subagent_type() {
     let entry = SessionIndexEntry {
         id: "child-2".to_string(),
+        bypass_permissions: false,
         kind: SessionKind::Child,
         rel_path: "sessions/root/children/child-2".to_string(),
         title: "Plan Child".to_string(),

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/types.rs
@@ -69,6 +69,11 @@ pub struct SessionSummary {
     pub running_child_count: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gold_config: Option<GoldConfig>,
+    /// Per-session "bypass permissions" toggle, read from the session's runtime
+    /// state. Only populated by the detail endpoint (which loads the full
+    /// session); list endpoints leave it `false`.
+    #[serde(default)]
+    pub bypass_permissions: bool,
 }
 
 impl SessionSummary {
@@ -104,6 +109,7 @@ impl SessionSummary {
             plan_mode: entry.plan_mode,
             running_child_count: 0,
             gold_config: parse_session_gold_config(entry.gold_config_json.as_deref()),
+            bypass_permissions: entry.bypass_permissions,
         }
     }
 }
@@ -221,6 +227,10 @@ pub struct PatchSessionRequest {
     pub clear_reasoning_effort: Option<bool>,
     #[serde(default)]
     pub gold_config: Option<serde_json::Value>,
+    /// Toggle the per-session "bypass permissions" mode. When `true`, tool
+    /// permission checks are skipped for this session only.
+    #[serde(default)]
+    pub bypass_permissions: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -352,6 +362,7 @@ mod tests {
     fn test_create_session_response_serialization() {
         let summary = SessionSummary {
             id: "test-id".to_string(),
+            bypass_permissions: false,
             kind: bamboo_agent_core::SessionKind::Root,
             title: "Test".to_string(),
             title_version: 0,
@@ -394,6 +405,7 @@ mod tests {
     fn test_get_session_response_serialization() {
         let summary = SessionSummary {
             id: "session-123".to_string(),
+            bypass_permissions: false,
             kind: bamboo_agent_core::SessionKind::Child,
             title: "My Session".to_string(),
             title_version: 0,
@@ -523,6 +535,7 @@ mod tests {
     fn test_session_summary_debug() {
         let summary = SessionSummary {
             id: "test".to_string(),
+            bypass_permissions: false,
             kind: bamboo_agent_core::SessionKind::Root,
             title: "Test".to_string(),
             title_version: 0,

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/model_limit_defaults.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/model_limit_defaults.rs
@@ -23,7 +23,7 @@ struct ModelLimitDefaultsResponse {
 }
 
 /// Returns the single global model-limit default from the backend
-/// source-of-truth (`1M` context / `64K` output).
+/// source-of-truth (`1M` context / `128K` output).
 pub async fn get_model_limit_defaults() -> Result<HttpResponse, AppError> {
     let limit = default_model_limit();
     let default = ModelLimitDefault {
@@ -67,7 +67,7 @@ mod tests {
         let default = &payload.model_limits[0];
         assert_eq!(default.model_pattern, "default");
         assert_eq!(default.max_context_tokens, 1_000_000);
-        assert_eq!(default.max_output_tokens, 64_000);
+        assert_eq!(default.max_output_tokens, 128_000);
         // Safety margin scales with context window: max(1_000_000 / 100, 1_000).
         assert_eq!(default.safety_margin, 10_000);
     }

--- a/crates/app/bamboo-server/src/handlers/settings/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/mod.rs
@@ -7,6 +7,7 @@ mod access_control;
 mod bamboo_config;
 mod env_vars;
 mod keyword_masking;
+mod permission;
 mod provider;
 mod provider_instances;
 mod redaction;
@@ -26,6 +27,7 @@ pub use env_vars::{delete_env_var, list_env_vars, replace_env_vars, upsert_env_v
 pub use keyword_masking::{
     get_keyword_masking_config, update_keyword_masking_config, validate_keyword_entries,
 };
+pub use permission::{get_permission_ask_rules, update_permission_ask_rules};
 pub use provider::{
     fetch_catalog_models, fetch_provider_models, get_provider_catalog, get_provider_config,
     reload_provider_config, update_provider_config, UpdateProviderRequest,

--- a/crates/app/bamboo-server/src/handlers/settings/permission.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/permission.rs
@@ -1,0 +1,69 @@
+//! Permission rule settings: the "always ask" rules that force a user
+//! confirmation for matching tool calls even under bypass / permissive modes.
+//!
+//! Rules use the same pattern syntax as the rest of the permission system,
+//! e.g. `Bash(rm -rf *)`, `Bash(git push *)`, `Write(/etc/**)`. Built-in
+//! dangerous-command detection is layered on top and is not configurable here.
+
+use actix_web::{web, HttpResponse};
+use serde::{Deserialize, Serialize};
+
+use crate::{app_state::AppState, error::AppError};
+
+#[derive(Debug, Serialize)]
+pub struct AskRulesResponse {
+    pub rules: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateAskRulesRequest {
+    #[serde(default)]
+    pub rules: Vec<String>,
+}
+
+/// Returns the configured "always ask" rule patterns.
+pub async fn get_permission_ask_rules(
+    app_state: web::Data<AppState>,
+) -> Result<HttpResponse, AppError> {
+    let rules = app_state
+        .permission_checker
+        .permission_config()
+        .map(|config| config.ask_rule_patterns())
+        .unwrap_or_default();
+    Ok(HttpResponse::Ok().json(AskRulesResponse { rules }))
+}
+
+/// Replaces the "always ask" rule patterns and persists them to disk.
+pub async fn update_permission_ask_rules(
+    app_state: web::Data<AppState>,
+    payload: web::Json<UpdateAskRulesRequest>,
+) -> Result<HttpResponse, AppError> {
+    let req = payload.into_inner();
+    // Normalize: trim and drop blank entries so the UI can send a raw list.
+    let rules: Vec<String> = req
+        .rules
+        .into_iter()
+        .map(|r| r.trim().to_string())
+        .filter(|r| !r.is_empty())
+        .collect();
+
+    let Some(config) = app_state.permission_checker.permission_config() else {
+        return Err(AppError::InternalError(anyhow::anyhow!(
+            "Permission checker does not support configurable rules"
+        )));
+    };
+
+    // Apply in-memory (takes effect immediately for subsequent tool calls)...
+    config.set_ask_rules(rules.clone());
+
+    // ...then persist to the same store `load_permission_checker` reads at boot.
+    let storage =
+        bamboo_tools::permission::PermissionStorage::new(app_state.app_data_dir.clone());
+    storage.save(config.as_ref()).await.map_err(|error| {
+        AppError::InternalError(anyhow::anyhow!(
+            "Failed to persist permission rules: {error}"
+        ))
+    })?;
+
+    Ok(HttpResponse::Ok().json(AskRulesResponse { rules }))
+}

--- a/crates/app/bamboo-server/src/handlers/tools/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/tools/mod.rs
@@ -121,6 +121,7 @@ pub async fn execute_tool(
                 tool_call_id: &call.id,
                 event_tx: None,
                 available_tool_schemas: Some(available_tool_schemas.as_slice()),
+                bypass_permissions: false,
             },
         )
         .await

--- a/crates/app/bamboo-server/src/routes/bamboo_v1.rs
+++ b/crates/app/bamboo-server/src/routes/bamboo_v1.rs
@@ -86,6 +86,14 @@ fn bamboo_v1_scope() -> impl HttpServiceFactory {
             web::post().to(settings::validate_keyword_entries),
         )
         .route(
+            "/bamboo/permission/ask-rules",
+            web::get().to(settings::get_permission_ask_rules),
+        )
+        .route(
+            "/bamboo/permission/ask-rules",
+            web::put().to(settings::update_permission_ask_rules),
+        )
+        .route(
             "/bamboo/settings/provider",
             web::get().to(settings::get_provider_config),
         )

--- a/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
+++ b/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
@@ -291,6 +291,7 @@ fn ctx_for<'a>(session_id: &'a str, tool_call_id: &'static str) -> ToolExecution
         tool_call_id,
         event_tx: None,
         available_tool_schemas: None,
+        bypass_permissions: false,
     }
 }
 
@@ -489,6 +490,7 @@ async fn create_emits_sub_agent_started_event_after_queueing() {
                 tool_call_id: "tool_call_1",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -555,6 +557,7 @@ async fn create_uses_async_subagent_model_resolver() {
                 tool_call_id: "tool_call_async_resolver",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -595,6 +598,7 @@ async fn resident_create_reuses_same_child_session() {
         tool_call_id: tcid,
         event_tx: None,
         available_tool_schemas: None,
+        bypass_permissions: false,
     };
     let create = |name_task: &'static str, prompt: &'static str| {
         json!({
@@ -716,6 +720,7 @@ async fn backward_compat_legacy_subagent_call_without_action_defaults_to_create(
                 tool_call_id: "tool_call_legacy",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -748,6 +753,7 @@ async fn send_message_appends_follow_up_without_replacing_history() {
                 tool_call_id: "tool_call_send_message",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -799,6 +805,7 @@ async fn send_message_queues_on_running_child_without_interrupt() {
                 tool_call_id: "tool_call_running",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -865,6 +872,7 @@ async fn send_message_can_interrupt_running_child() {
                 tool_call_id: "tool_call_interrupt_running",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -914,6 +922,7 @@ async fn send_message_can_queue_child_immediately() {
                 tool_call_id: "tool_call_queue",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -997,6 +1006,7 @@ async fn cancel_stops_running_child() {
                 tool_call_id: "tool_call_cancel",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -1023,6 +1033,7 @@ async fn list_returns_children() {
                 tool_call_id: "tool_call_list",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -1065,6 +1076,7 @@ async fn get_returns_runner_diagnostics() {
                 tool_call_id: "tool_call_get_diagnostics",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -1101,6 +1113,7 @@ async fn create_returns_duration_hint() {
                 tool_call_id: "tool_call_create_hint",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -1149,6 +1162,7 @@ async fn create_persists_explicit_reasoning_effort_to_child_session() {
                 tool_call_id: "tool_call_create_with_effort",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -1200,6 +1214,7 @@ async fn create_without_reasoning_effort_leaves_child_at_provider_default() {
                 tool_call_id: "tool_call_create_default_effort",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -1256,6 +1271,7 @@ async fn update_can_change_reasoning_effort_on_existing_child() {
                 tool_call_id: "tool_call_update_effort",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -1290,6 +1306,7 @@ async fn delete_removes_child() {
                 tool_call_id: "tool_call_delete",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -1326,6 +1343,7 @@ async fn create_requires_workspace() {
                 tool_call_id: "tool_call_no_workspace",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -1363,6 +1381,7 @@ async fn create_sets_child_workspace() {
                 tool_call_id: "tool_call_workspace",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await

--- a/crates/core/bamboo-agent-core/src/tools/context.rs
+++ b/crates/core/bamboo-agent-core/src/tools/context.rs
@@ -8,11 +8,46 @@
 use tokio::sync::mpsc;
 
 use crate::tools::ToolSchema;
-use crate::AgentEvent;
+use crate::{AgentEvent, Session};
+
+/// Per-session flags that flow into every tool call's [`ToolExecutionContext`].
+///
+/// These are derived ONCE from the executing [`Session`] (via
+/// [`ToolExecutionSessionFlags::from_session`]) and copied into the context. To
+/// add a new per-session execution flag, add a field here, derive it in
+/// `from_session`, and map it in [`ToolExecutionContext::for_dispatch`]. Because
+/// both agent loops build their context through `for_dispatch`, a new flag
+/// reaches every dispatch path automatically — it can't be wired into one loop
+/// and silently skipped in the other.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ToolExecutionSessionFlags {
+    /// When `true`, the session is in "bypass permissions" mode and tool
+    /// permission checks are skipped. Sourced from the session's runtime state.
+    pub bypass_permissions: bool,
+}
+
+impl ToolExecutionSessionFlags {
+    /// Derive the per-session tool-execution flags from a session's runtime
+    /// state. This is the single source of truth for both agent loops.
+    pub fn from_session(session: &Session) -> Self {
+        Self {
+            bypass_permissions: session
+                .agent_runtime_state
+                .as_ref()
+                .is_some_and(|state| state.bypass_permissions),
+        }
+    }
+}
 
 /// Context passed to tools during execution.
 ///
 /// All fields are optional and should be treated as best-effort hints.
+///
+/// ⚠️ Real tool dispatch must build this via [`ToolExecutionContext::for_dispatch`]
+/// (both agent loops do), NOT a struct literal — that routes every per-session
+/// flag through [`ToolExecutionSessionFlags`] so a new flag can't be wired into
+/// one loop and silently skipped in the other. Struct literals are for tests
+/// and tools that synthesize a child context.
 #[derive(Clone, Copy, Debug)]
 pub struct ToolExecutionContext<'a> {
     /// Bamboo session id that is executing the tool.
@@ -23,6 +58,10 @@ pub struct ToolExecutionContext<'a> {
     pub event_tx: Option<&'a mpsc::Sender<AgentEvent>>,
     /// Snapshot of tools currently available to the executing session.
     pub available_tool_schemas: Option<&'a [ToolSchema]>,
+    /// When `true`, the executing session is in "bypass permissions" mode, so
+    /// tool permission checks are skipped. Sourced per-session from the
+    /// session's runtime state (`runtime.json`), not the global checker.
+    pub bypass_permissions: bool,
 }
 
 impl<'a> ToolExecutionContext<'a> {
@@ -32,6 +71,28 @@ impl<'a> ToolExecutionContext<'a> {
             tool_call_id,
             event_tx: None,
             available_tool_schemas: None,
+            bypass_permissions: false,
+        }
+    }
+
+    /// Build a context for a real tool dispatch, applying every per-session flag
+    /// from [`ToolExecutionSessionFlags`]. This is the SINGLE place that maps
+    /// session flags onto the context, and the only constructor the agent loops
+    /// use — keep both loops (`per_call.rs`, `result_handler.rs`) on it so a new
+    /// per-session field reaches all dispatch paths without per-site edits.
+    pub fn for_dispatch(
+        session_id: &'a str,
+        tool_call_id: &'a str,
+        event_tx: &'a mpsc::Sender<AgentEvent>,
+        available_tool_schemas: &'a [ToolSchema],
+        flags: ToolExecutionSessionFlags,
+    ) -> Self {
+        Self {
+            session_id: Some(session_id),
+            tool_call_id,
+            event_tx: Some(event_tx),
+            available_tool_schemas: Some(available_tool_schemas),
+            bypass_permissions: flags.bypass_permissions,
         }
     }
 
@@ -68,6 +129,44 @@ impl<'a> ToolExecutionContext<'a> {
 }
 
 #[cfg(test)]
+mod session_flags_tests {
+    use super::*;
+    use bamboo_domain::AgentRuntimeState;
+
+    #[test]
+    fn from_session_defaults_false_without_runtime_state() {
+        let session = Session::new("s-none", "test-model");
+        assert_eq!(
+            ToolExecutionSessionFlags::from_session(&session),
+            ToolExecutionSessionFlags { bypass_permissions: false }
+        );
+    }
+
+    #[test]
+    fn from_session_reads_bypass_from_runtime_state() {
+        let mut session = Session::new("s-bypass", "test-model");
+        let mut runtime = AgentRuntimeState::new("run-1");
+        runtime.bypass_permissions = true;
+        session.agent_runtime_state = Some(runtime);
+        assert!(ToolExecutionSessionFlags::from_session(&session).bypass_permissions);
+    }
+
+    #[test]
+    fn for_dispatch_maps_flags_onto_context() {
+        let (tx, _rx) = mpsc::channel(1);
+        let ctx = ToolExecutionContext::for_dispatch(
+            "s1",
+            "call-1",
+            &tx,
+            &[],
+            ToolExecutionSessionFlags { bypass_permissions: true },
+        );
+        assert_eq!(ctx.session_id, Some("s1"));
+        assert!(ctx.bypass_permissions);
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -84,6 +183,7 @@ mod tests {
             tool_call_id: "call_1",
             event_tx: Some(&tx),
             available_tool_schemas: None,
+            bypass_permissions: false,
         };
 
         tokio::time::timeout(
@@ -110,6 +210,7 @@ mod tests {
             tool_call_id: "call_123",
             event_tx: Some(&tx),
             available_tool_schemas: None,
+            bypass_permissions: false,
         };
 
         ctx.emit(AgentEvent::Token {
@@ -138,6 +239,7 @@ mod tests {
             tool_call_id: "call_456",
             event_tx: Some(&tx),
             available_tool_schemas: None,
+            bypass_permissions: false,
         };
 
         // Test with various non-Token events
@@ -177,6 +279,7 @@ mod tests {
             tool_call_id: "call_abc",
             event_tx: Some(&tx),
             available_tool_schemas: None,
+            bypass_permissions: false,
         };
 
         ctx.emit_tool_token("convenient output").await;
@@ -227,6 +330,7 @@ mod tests {
             tool_call_id: "call_clone",
             event_tx: Some(&tx),
             available_tool_schemas: None,
+            bypass_permissions: false,
         };
 
         let cloned = ctx.cloned_sender();
@@ -250,6 +354,7 @@ mod tests {
             tool_call_id: "call_multi",
             event_tx: Some(&tx),
             available_tool_schemas: None,
+            bypass_permissions: false,
         };
 
         for i in 0..5 {
@@ -278,6 +383,7 @@ mod tests {
             tool_call_id: "call_copy",
             event_tx: Some(&tx),
             available_tool_schemas: None,
+            bypass_permissions: false,
         };
 
         // Can clone (Copy implies Clone)
@@ -305,6 +411,7 @@ mod tests {
             tool_call_id: "",
             event_tx: Some(&tx),
             available_tool_schemas: None,
+            bypass_permissions: false,
         };
 
         ctx.emit(AgentEvent::Token {
@@ -329,6 +436,7 @@ mod tests {
             tool_call_id: "调用_123",
             event_tx: Some(&tx),
             available_tool_schemas: None,
+            bypass_permissions: false,
         };
 
         ctx.emit(AgentEvent::Token {
@@ -357,6 +465,7 @@ mod tests {
             tool_call_id: "call-with_special.chars:123",
             event_tx: Some(&tx),
             available_tool_schemas: None,
+            bypass_permissions: false,
         };
 
         ctx.emit(AgentEvent::Token {
@@ -381,6 +490,7 @@ mod tests {
             tool_call_id: "call_string",
             event_tx: Some(&tx),
             available_tool_schemas: None,
+            bypass_permissions: false,
         };
 
         let content = String::from("owned string");
@@ -403,6 +513,7 @@ mod tests {
             tool_call_id: "call_str",
             event_tx: Some(&tx),
             available_tool_schemas: None,
+            bypass_permissions: false,
         };
 
         ctx.emit_tool_token("string slice").await;

--- a/crates/core/bamboo-agent-core/src/tools/mod.rs
+++ b/crates/core/bamboo-agent-core/src/tools/mod.rs
@@ -106,7 +106,7 @@ pub use agentic::{
     convert_from_standard_result, convert_to_standard_result, AgenticContext, AgenticTool,
     AgenticToolExecutor, AgenticToolResult, Interaction, InteractionRole, ToolGoal,
 };
-pub use context::ToolExecutionContext;
+pub use context::{ToolExecutionContext, ToolExecutionSessionFlags};
 pub use executor::{execute_tool_call, execute_tool_call_with_context, ToolError, ToolExecutor};
 pub use registry::{
     global_registry, normalize_tool_name, RegistryError, SharedTool, Tool, ToolRegistry,

--- a/crates/core/bamboo-agent-core/src/tools/result_handler.rs
+++ b/crates/core/bamboo-agent-core/src/tools/result_handler.rs
@@ -7,7 +7,7 @@ use crate::composition::CompositionExecutor;
 use crate::tools::executor::execute_tool_call_with_context;
 use crate::tools::{
     convert_from_standard_result, AgenticToolResult, ToolCall, ToolError, ToolExecutionContext,
-    ToolExecutor, ToolResult,
+    ToolExecutionSessionFlags, ToolExecutor, ToolResult,
 };
 use crate::{AgentEvent, Message, PendingQuestionSource, Session};
 
@@ -370,12 +370,16 @@ pub async fn execute_sub_actions(
             })
             .await;
 
-        let tool_ctx = ToolExecutionContext {
-            session_id: Some(&session.id),
-            tool_call_id: &action.id,
-            event_tx: Some(event_tx),
-            available_tool_schemas: Some(available_tools.as_slice()),
-        };
+        // NOTE: this is bamboo-agent-core's own loop; the bamboo SERVER runs the
+        // bamboo-engine runtime (`tool_execution/per_call.rs`). Both build the
+        // context via `for_dispatch` so per-session flags stay in sync.
+        let tool_ctx = ToolExecutionContext::for_dispatch(
+            &session.id,
+            &action.id,
+            event_tx,
+            available_tools.as_slice(),
+            ToolExecutionSessionFlags::from_session(session),
+        );
 
         match execute_tool_call_with_context(&action, tools, composition_executor.clone(), tool_ctx)
             .await

--- a/crates/core/bamboo-domain/src/session/persistence.rs
+++ b/crates/core/bamboo-domain/src/session/persistence.rs
@@ -19,11 +19,7 @@ pub trait RuntimeSessionPersistence: Send + Sync {
     /// a no-op so non-file-backed persisters are unaffected.
     ///
     /// [`Storage::append_token_usage_record`]: crate::storage::Storage::append_token_usage_record
-    async fn append_token_usage_record(
-        &self,
-        session_id: &str,
-        json_line: &str,
-    ) -> io::Result<()> {
+    async fn append_token_usage_record(&self, session_id: &str, json_line: &str) -> io::Result<()> {
         let _ = (session_id, json_line);
         Ok(())
     }
@@ -35,11 +31,7 @@ impl<T: RuntimeSessionPersistence + ?Sized> RuntimeSessionPersistence for Arc<T>
         (**self).save_runtime_session(session).await
     }
 
-    async fn append_token_usage_record(
-        &self,
-        session_id: &str,
-        json_line: &str,
-    ) -> io::Result<()> {
+    async fn append_token_usage_record(&self, session_id: &str, json_line: &str) -> io::Result<()> {
         (**self)
             .append_token_usage_record(session_id, json_line)
             .await

--- a/crates/core/bamboo-domain/src/session/runtime_state.rs
+++ b/crates/core/bamboo-domain/src/session/runtime_state.rs
@@ -248,6 +248,11 @@ pub struct AgentRuntimeState {
     pub checkpoints: Vec<HookCheckpoint>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plan_mode: Option<PlanModeState>,
+    /// When `true`, this session skips all tool permission checks (the
+    /// "bypass permissions" mode). Scoped to a single session so concurrent
+    /// sessions are unaffected; persisted in `runtime.json`.
+    #[serde(default)]
+    pub bypass_permissions: bool,
 }
 
 impl AgentRuntimeState {
@@ -266,6 +271,7 @@ impl AgentRuntimeState {
             waiting_for_children: None,
             checkpoints: Vec::new(),
             plan_mode: None,
+            bypass_permissions: false,
         }
     }
 }
@@ -286,6 +292,7 @@ impl Default for AgentRuntimeState {
             waiting_for_children: None,
             checkpoints: Vec::new(),
             plan_mode: None,
+            bypass_permissions: false,
         }
     }
 }

--- a/crates/core/bamboo-domain/src/session/types.rs
+++ b/crates/core/bamboo-domain/src/session/types.rs
@@ -614,7 +614,14 @@ impl Session {
         title: impl Into<String>,
     ) -> Self {
         let root_session_id = root_session_id.into();
-        Self::new_child_inner(id, root_session_id.clone(), root_session_id, 1, model, title)
+        Self::new_child_inner(
+            id,
+            root_session_id.clone(),
+            root_session_id,
+            1,
+            model,
+            title,
+        )
     }
 
     /// Create a child session whose parent is `parent`, supporting arbitrary

--- a/crates/engine/bamboo-engine/src/model_config_helper.rs
+++ b/crates/engine/bamboo-engine/src/model_config_helper.rs
@@ -991,5 +991,4 @@ mod tests {
         assert_eq!(infer_provider("  "), None);
         assert_eq!(infer_provider(""), None);
     }
-
 }

--- a/crates/engine/bamboo-engine/src/runtime/goal_state.rs
+++ b/crates/engine/bamboo-engine/src/runtime/goal_state.rs
@@ -256,7 +256,10 @@ mod tests {
         assert_eq!(loaded.declared_at_round, Some(4));
         assert_eq!(loaded.continuation_count, 2);
         assert_eq!(loaded.eval_history.len(), 1);
-        assert_eq!(loaded.eval_history[0].next_action.as_deref(), Some("write the e2e test"));
+        assert_eq!(
+            loaded.eval_history[0].next_action.as_deref(),
+            Some("write the e2e test")
+        );
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/gold.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/gold.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 
 use crate::runtime::config::AgentLoopConfig;
-use crate::runtime::gold_evaluation::{
-    apply_gold_evaluation_result, build_async_gold_evaluation_request, evaluate_gold,
-    execute_async_gold_evaluation, AsyncGoldEvaluationRequest, GoldEvaluationResult,
-};
 use crate::runtime::goal_state::{
     ensure_goal_state, write_goal_state, GoalDeclaredStatus, GoalEvalRecord, GoalRuntimeStatus,
     GoalState,
+};
+use crate::runtime::gold_evaluation::{
+    apply_gold_evaluation_result, build_async_gold_evaluation_request, evaluate_gold,
+    execute_async_gold_evaluation, AsyncGoldEvaluationRequest, GoldEvaluationResult,
 };
 use crate::runtime::runner::loop_execution::startup::{InFlightGoldEvaluation, LoopRunState};
 use crate::runtime::task_context::TaskLoopContext;
@@ -648,7 +648,10 @@ mod tests {
             &verdict(GoldDecision::Continue, GoldConfidence::Low),
             GoldConfidence::Medium,
         );
-        assert_eq!(action, GoalTerminalAction::Stop(GoalRuntimeStatus::Complete));
+        assert_eq!(
+            action,
+            GoalTerminalAction::Stop(GoalRuntimeStatus::Complete)
+        );
     }
 
     #[test]
@@ -658,7 +661,10 @@ mod tests {
             &verdict(GoldDecision::Achieved, GoldConfidence::High),
             GoldConfidence::Medium,
         );
-        assert_eq!(action, GoalTerminalAction::Stop(GoalRuntimeStatus::Complete));
+        assert_eq!(
+            action,
+            GoalTerminalAction::Stop(GoalRuntimeStatus::Complete)
+        );
     }
 
     #[test]
@@ -680,7 +686,10 @@ mod tests {
             &verdict(GoldDecision::Achieved, GoldConfidence::High),
             GoldConfidence::Medium,
         );
-        assert_eq!(action, GoalTerminalAction::Stop(GoalRuntimeStatus::Complete));
+        assert_eq!(
+            action,
+            GoalTerminalAction::Stop(GoalRuntimeStatus::Complete)
+        );
     }
 
     #[test]
@@ -813,7 +822,10 @@ mod tests {
 
         // A hidden continuation message was injected, carrying the untrusted
         // objective and the update_goal instruction.
-        let last = session.messages.last().expect("continuation message appended");
+        let last = session
+            .messages
+            .last()
+            .expect("continuation message appended");
         assert!(matches!(last.role, Role::User));
         assert!(last.never_compress);
         let metadata = last.metadata.as_ref().expect("runtime metadata");
@@ -874,7 +886,10 @@ mod tests {
         assert!(matches!(decision, GoldTerminalDecision::Stop));
         let state = read_goal_state(&session).expect("goal state persisted");
         assert_eq!(state.status, GoalRuntimeStatus::Complete);
-        assert_eq!(state.declared_status, None, "declaration cleared after acting");
+        assert_eq!(
+            state.declared_status, None,
+            "declaration cleared after acting"
+        );
     }
 
     #[tokio::test]
@@ -906,7 +921,10 @@ mod tests {
         ));
         let state = read_goal_state(&session).expect("goal state persisted");
         assert_eq!(state.status, GoalRuntimeStatus::Active);
-        assert_eq!(state.declared_status, None, "stale declaration cleared on veto");
+        assert_eq!(
+            state.declared_status, None,
+            "stale declaration cleared on veto"
+        );
     }
 
     #[tokio::test]
@@ -947,7 +965,10 @@ mod tests {
                 saw_goal_event = true;
             }
         }
-        assert!(saw_goal_event, "expected a GoalStatusChanged event on continue");
+        assert!(
+            saw_goal_event,
+            "expected a GoalStatusChanged event on continue"
+        );
     }
 
     /// Provider whose evaluator call always errors, to exercise the

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/startup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/startup.rs
@@ -132,6 +132,13 @@ pub(super) async fn initialize_loop_state(
     let auxiliary_models = resolve_auxiliary_models(config);
 
     let mut runtime_state = AgentRuntimeState::new(&session_id);
+    // "Bypass permissions" is a per-session sticky toggle (set via PATCH /sessions
+    // and persisted in runtime.json). Each run rebuilds a fresh runtime state, so
+    // carry the flag forward from the prior state instead of resetting it.
+    runtime_state.bypass_permissions = session
+        .agent_runtime_state
+        .as_ref()
+        .is_some_and(|prev| prev.bypass_permissions);
     runtime_state.llm.model_name = Some(model_name.clone());
     runtime_state.llm.provider_name = config.provider_name.clone();
     runtime_state.llm.fast_model_name = auxiliary_models.fast_model_name.clone();

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
@@ -187,6 +187,8 @@ async fn execute_and_apply_single_tool_call(
                     round,
                     tools,
                     config,
+                    session_flags:
+                        bamboo_agent_core::tools::ToolExecutionSessionFlags::from_session(session),
                 })
                 .await
             }
@@ -475,6 +477,11 @@ pub(crate) async fn execute_round_tool_calls(
             let parallel_start = std::time::Instant::now();
             let per_tool_timeout = std::time::Duration::from_secs(config.per_tool_timeout_secs);
             let batch_timeout = std::time::Duration::from_secs(config.parallel_batch_timeout_secs);
+            // Derive once before the parallel borrow; the Copy flags struct is
+            // captured by each concurrent task (we can't borrow `&mut session`
+            // inside them).
+            let session_flags =
+                bamboo_agent_core::tools::ToolExecutionSessionFlags::from_session(session);
             let outcomes = tokio::time::timeout(
                 batch_timeout,
                 join_all(batch.iter().map(|tool_call| {
@@ -491,6 +498,7 @@ pub(crate) async fn execute_round_tool_calls(
                                 round,
                                 tools,
                                 config,
+                                session_flags,
                             }),
                         )
                         .await

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/execution_paths/success_path.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/execution_paths/success_path.rs
@@ -30,7 +30,13 @@ pub(super) async fn handle_successful_tool_result(ctx: SuccessPathContext<'_>) -
 
     workspace::maybe_apply_workspace_update(ctx.session, ctx.tool_call, ctx.result, ctx.session_id);
 
-    goal::maybe_apply_goal_update(ctx.session, ctx.tool_call, ctx.result, ctx.config, ctx.round);
+    goal::maybe_apply_goal_update(
+        ctx.session,
+        ctx.tool_call,
+        ctx.result,
+        ctx.config,
+        ctx.round,
+    );
 
     if clarification::maybe_handle_user_question_tool(
         ctx.tool_call,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
@@ -5,7 +5,8 @@ use tokio::sync::mpsc;
 use crate::runtime::config::AgentLoopConfig;
 use crate::runtime::task_context::TaskLoopContext;
 use bamboo_agent_core::tools::{
-    parse_tool_args_best_effort, ToolCall, ToolExecutionContext, ToolExecutor, ToolResult,
+    parse_tool_args_best_effort, ToolCall, ToolExecutionContext, ToolExecutionSessionFlags,
+    ToolExecutor, ToolResult,
 };
 use bamboo_agent_core::{AgentEvent, Session};
 use bamboo_metrics::MetricsCollector;
@@ -38,6 +39,11 @@ pub(super) struct ToolExecutionOnlyContext<'a> {
     pub round: usize,
     pub tools: &'a Arc<dyn ToolExecutor>,
     pub config: &'a AgentLoopConfig,
+    /// Per-session execution flags (e.g. bypass permissions), derived from the
+    /// session via `ToolExecutionSessionFlags::from_session` at the call site
+    /// and threaded through so this (parallel-safe) path can apply them without
+    /// borrowing the session.
+    pub session_flags: ToolExecutionSessionFlags,
 }
 
 pub(super) struct ToolExecutionApplyContext<'a> {
@@ -133,12 +139,16 @@ pub(super) async fn execute_tool_call_only(
 
     let tool_timer = std::time::Instant::now();
     let available_tool_schemas = ctx.tools.list_tools();
-    let tool_ctx = ToolExecutionContext {
-        session_id: Some(ctx.session_id),
-        tool_call_id: &ctx.tool_call.id,
-        event_tx: Some(ctx.event_tx),
-        available_tool_schemas: Some(available_tool_schemas.as_slice()),
-    };
+    // THIS is the live server tool-dispatch path (engine runtime). Build via
+    // `for_dispatch` so per-session flags stay in sync with the other loop
+    // (bamboo-agent-core's `result_handler.rs`).
+    let tool_ctx = ToolExecutionContext::for_dispatch(
+        ctx.session_id,
+        &ctx.tool_call.id,
+        ctx.event_tx,
+        available_tool_schemas.as_slice(),
+        ctx.session_flags,
+    );
 
     let result = bamboo_agent_core::tools::executor::execute_tool_call_with_context(
         ctx.tool_call,

--- a/crates/engine/bamboo-engine/src/session_app/child_session/actions.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_session/actions.rs
@@ -56,6 +56,22 @@ pub async fn create_child_action(
         child.reasoning_effort = Some(effort);
     }
 
+    // Children inherit the parent's "bypass permissions" mode: a bypassed
+    // parent shouldn't be re-gated the moment it delegates work to a sub-agent.
+    // Seed the child's runtime state so the flag is live from its first run
+    // (startup carries it forward thereafter) and mirrored into the index.
+    if input
+        .parent_session
+        .agent_runtime_state
+        .as_ref()
+        .is_some_and(|state| state.bypass_permissions)
+    {
+        child
+            .agent_runtime_state
+            .get_or_insert_with(bamboo_domain::AgentRuntimeState::default)
+            .bypass_permissions = true;
+    }
+
     child.workspace = Some(input.workspace.clone());
     bamboo_agent_core::workspace_state::set_workspace(
         &child.id,

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -279,9 +279,25 @@ impl ToolExecutor for BuiltinToolExecutor {
             if let Some(contexts) =
                 check_permissions(&tool_name, &args).map_err(permission_error_to_tool_error)?
             {
+                // "Always ask" rules (configured patterns + built-in dangerous
+                // commands) force a confirmation even under bypass. Everything
+                // else is skipped when this session is in "bypass permissions"
+                // mode (scoped per-session via its runtime state).
+                let force_ask =
+                    permission_checker.requires_forced_confirmation(&tool_name, &args);
                 for context in contexts {
+                    if ctx.bypass_permissions && !force_ask {
+                        continue;
+                    }
                     let resource = context.resource.clone();
-                    match permission_checker.check_or_request(context).await {
+                    // Forced confirmations route through `check_or_request_forced`
+                    // so the active mode/bypass cannot suppress the prompt.
+                    let decision = if force_ask {
+                        permission_checker.check_or_request_forced(context).await
+                    } else {
+                        permission_checker.check_or_request(context).await
+                    };
+                    match decision {
                         Ok(true) => {}
                         Ok(false) => {
                             return Err(ToolError::Execution(format!(
@@ -882,6 +898,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_bypass_permissions_skips_checker() {
+        // Even with a deny-all checker, a context flagged `bypass_permissions`
+        // must skip the permission check entirely and let the write through.
+        let checker = Arc::new(crate::permission::DenyDangerousPermissionChecker);
+        let executor = make_executor(Some(checker));
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bypass_allows_write.txt");
+        let path_str = path.to_str().unwrap();
+
+        let call = make_tool_call("Write", json!({"file_path": path_str, "content": "ok"}));
+        let ctx = ToolExecutionContext {
+            session_id: Some("s-bypass"),
+            tool_call_id: &call.id,
+            event_tx: None,
+            available_tool_schemas: None,
+            bypass_permissions: true,
+        };
+        let result = executor.execute_with_context(&call, ctx).await;
+
+        assert!(result.is_ok(), "bypass should allow the write: {result:?}");
+        assert_eq!(fs::read_to_string(&path).await.unwrap(), "ok");
+    }
+
+    #[tokio::test]
+    async fn test_forced_ask_rule_overrides_bypass() {
+        // A configured "always ask" rule must force a confirmation even when the
+        // session is in bypass mode. With no event sink the executor fails closed
+        // (approval required) rather than silently writing.
+        let config = Arc::new(crate::permission::PermissionConfig::new());
+        config.set_ask_rules(["Write(/etc/**)".to_string()]);
+        let checker = Arc::new(crate::permission::ConfigPermissionChecker::new(config));
+        let executor = make_executor(Some(checker));
+
+        let call = make_tool_call("Write", json!({"file_path": "/etc/forced.conf", "content": "x"}));
+        let ctx = ToolExecutionContext {
+            session_id: Some("s-forced"),
+            tool_call_id: &call.id,
+            event_tx: None,
+            available_tool_schemas: None,
+            bypass_permissions: true,
+        };
+        let result = executor.execute_with_context(&call, ctx).await;
+
+        assert!(
+            matches!(result, Err(ToolError::Execution(ref m)) if m.contains("approval required")),
+            "forced ask rule should block under bypass: {result:?}"
+        );
+        assert!(fs::metadata("/etc/forced.conf").await.is_err());
+    }
+
+    #[tokio::test]
     async fn tool_can_stream_events_via_execute_with_context() {
         struct StreamingTool;
 
@@ -937,6 +1004,7 @@ mod tests {
                     tool_call_id: &call.id,
                     event_tx: Some(&tx),
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/bash.rs
+++ b/crates/engine/bamboo-tools/src/tools/bash.rs
@@ -515,6 +515,7 @@ mod tests {
                     tool_call_id: "call_1",
                     event_tx: Some(&tx),
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await
@@ -680,6 +681,7 @@ mod tests {
                     tool_call_id: "call_1",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/edit.rs
+++ b/crates/engine/bamboo-tools/src/tools/edit.rs
@@ -834,6 +834,7 @@ mod tests {
                     tool_call_id: call_id,
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await;
@@ -847,6 +848,7 @@ mod tests {
                     tool_call_id: call_id,
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await
@@ -864,6 +866,7 @@ mod tests {
                     tool_call_id: call_id,
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await
@@ -1216,6 +1219,7 @@ mod tests {
                     tool_call_id: "call_1",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await
@@ -1234,6 +1238,7 @@ mod tests {
                     tool_call_id: "call_2",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/memory_note.rs
+++ b/crates/engine/bamboo-tools/src/tools/memory_note.rs
@@ -189,6 +189,7 @@ mod tests {
                     tool_call_id: "tool_call_unknown",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await;
@@ -205,6 +206,7 @@ mod tests {
                     tool_call_id: "tool_call_replace",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await;
@@ -227,6 +229,7 @@ mod tests {
                     tool_call_id: "tool_call_append",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await
@@ -243,6 +246,7 @@ mod tests {
                     tool_call_id: "tool_call_read",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await
@@ -261,6 +265,7 @@ mod tests {
                     tool_call_id: "tool_call_list",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await
@@ -277,6 +282,7 @@ mod tests {
                     tool_call_id: "tool_call_clear",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await
@@ -299,6 +305,7 @@ mod tests {
                 tool_call_id: "tool_call_replace_long",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -312,6 +319,7 @@ mod tests {
                     tool_call_id: "tool_call_read_long",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await
@@ -327,6 +335,7 @@ mod tests {
                 tool_call_id: "tool_call_replace_limit",
                 event_tx: None,
                 available_tool_schemas: None,
+                bypass_permissions: false,
             },
         )
         .await
@@ -340,6 +349,7 @@ mod tests {
                     tool_call_id: "tool_call_append_limit",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/read.rs
+++ b/crates/engine/bamboo-tools/src/tools/read.rs
@@ -287,6 +287,7 @@ mod tests {
             tool_call_id: "call_1",
             event_tx: None,
             available_tool_schemas: None,
+            bypass_permissions: false,
         };
 
         let read_tool = ReadTool::new();

--- a/crates/engine/bamboo-tools/src/tools/slash_command_tool.rs
+++ b/crates/engine/bamboo-tools/src/tools/slash_command_tool.rs
@@ -146,6 +146,7 @@ mod tests {
                     tool_call_id: "call_1",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/workspace.rs
+++ b/crates/engine/bamboo-tools/src/tools/workspace.rs
@@ -198,6 +198,7 @@ mod tests {
                     tool_call_id: "call_1",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await
@@ -225,6 +226,7 @@ mod tests {
                     tool_call_id: "call_1",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await
@@ -240,6 +242,7 @@ mod tests {
                     tool_call_id: "call_2",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await
@@ -263,6 +266,7 @@ mod tests {
                     tool_call_id: "call_1",
                     event_tx: None,
                     available_tool_schemas: None,
+                    bypass_permissions: false,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/write.rs
+++ b/crates/engine/bamboo-tools/src/tools/write.rs
@@ -134,6 +134,7 @@ mod tests {
             tool_call_id: "call_1",
             event_tx: None,
             available_tool_schemas: None,
+            bypass_permissions: false,
         }
     }
 

--- a/crates/infra/bamboo-compression/src/limits.rs
+++ b/crates/infra/bamboo-compression/src/limits.rs
@@ -23,13 +23,13 @@ pub const DEFAULT_MODEL_PATTERN: &str = "default";
 pub const DEFAULT_MAX_CONTEXT_TOKENS: u32 = 1_000_000;
 
 /// Global default maximum output tokens.
-pub const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 64_000;
+pub const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 128_000;
 
 /// Default safety margin for token counting errors (floor; scales with context
 /// window via [`ModelLimit::get_safety_margin`]).
 pub const DEFAULT_SAFETY_MARGIN: u32 = 1000;
 
-/// Build the single global default limit (`1M` context / `64K` output).
+/// Build the single global default limit (`1M` context / `128K` output).
 pub fn default_model_limit() -> ModelLimit {
     builtin_limit(
         DEFAULT_MODEL_PATTERN,
@@ -289,11 +289,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_limit_is_1m_64k() {
+    fn default_limit_is_1m_128k() {
         let limit = default_model_limit();
         assert_eq!(limit.model_pattern, DEFAULT_MODEL_PATTERN);
         assert_eq!(limit.max_context_tokens, 1_000_000);
-        assert_eq!(limit.get_max_output_tokens(), 64_000);
+        assert_eq!(limit.get_max_output_tokens(), 128_000);
     }
 
     #[test]
@@ -332,7 +332,7 @@ mod tests {
         let limit = registry.get_or_default("unknown-model-xyz");
         assert_eq!(limit.model_pattern, DEFAULT_MODEL_PATTERN);
         assert_eq!(limit.max_context_tokens, 1_000_000);
-        assert_eq!(limit.get_max_output_tokens(), 64_000);
+        assert_eq!(limit.get_max_output_tokens(), 128_000);
     }
 
     #[test]
@@ -458,13 +458,13 @@ mod tests {
         let unknown = registry.get_or_default("brand-new-frontier-model");
         assert_eq!(unknown.model_pattern, DEFAULT_MODEL_PATTERN);
         assert_eq!(unknown.max_context_tokens, 1_000_000);
-        assert_eq!(unknown.get_max_output_tokens(), 64_000);
+        assert_eq!(unknown.get_max_output_tokens(), 128_000);
     }
 
     #[test]
     fn create_budget_for_model_uses_global_default_for_any_model() {
         let budget = create_budget_for_model("anything-at-all", crate::BudgetStrategy::default());
         assert_eq!(budget.max_context_tokens, 1_000_000);
-        assert_eq!(budget.max_output_tokens, 64_000);
+        assert_eq!(budget.max_output_tokens, 128_000);
     }
 }

--- a/crates/infra/bamboo-permission/src/bash_security.rs
+++ b/crates/infra/bamboo-permission/src/bash_security.rs
@@ -50,6 +50,12 @@ const PRIVILEGE_ESCALATION_COMMANDS: &[&str] = &["sudo", "su", "doas", "run0", "
 const PERMISSION_MODIFICATION_COMMANDS: &[&str] = &["chmod", "chown", "chgrp", "chattr"];
 
 /// Sensitive paths that should not be redirected to.
+///
+/// NOTE: deliberately excludes the benign pseudo-devices `/dev/null`,
+/// `/dev/zero`, `/dev/random`, `/dev/urandom` — redirecting to them is a
+/// ubiquitous, harmless idiom (`2>/dev/null`). Flagging them produced a `Deny`
+/// verdict that forced approval on ordinary commands even under bypass. Only
+/// block devices and system files that can brick/compromise the host belong here.
 const SENSITIVE_REDIRECT_PATHS: &[&str] = &[
     "/etc/passwd",
     "/etc/shadow",
@@ -59,10 +65,6 @@ const SENSITIVE_REDIRECT_PATHS: &[&str] = &[
     "/dev/hd",
     "/dev/nvme",
     "/dev/mmcblk",
-    "/dev/null",
-    "/dev/zero",
-    "/dev/random",
-    "/dev/urandom",
     "/dev/mem",
     "/dev/kmem",
     "/dev/port",
@@ -1043,6 +1045,40 @@ fn check_heredoc_expansions_node(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- Redirect-to-/dev/null is benign, not a sensitive-path Deny ----
+
+    #[test]
+    fn redirect_to_dev_null_is_not_denied() {
+        for cmd in [
+            "git stash 2>/dev/null",
+            "rm -f foo.tmp 2>/dev/null",
+            "ls >/dev/null 2>&1",
+            "grep -c foo bar 2>/dev/null; echo done",
+        ] {
+            let a = analyze_command(cmd);
+            assert_ne!(
+                a.verdict,
+                BashVerdict::Deny,
+                "`{cmd}` should not be Deny (redirect to /dev/null is benign)"
+            );
+            assert!(
+                !a.warnings
+                    .iter()
+                    .any(|w| w.kind == BashWarningKind::RedirectToSensitivePath),
+                "`{cmd}` should not flag RedirectToSensitivePath"
+            );
+        }
+    }
+
+    #[test]
+    fn redirect_to_block_device_still_denied() {
+        // Overwriting a real block device / system file must remain a hard Deny.
+        let a = analyze_command("echo x > /dev/sda");
+        assert_eq!(a.verdict, BashVerdict::Deny);
+        let a = analyze_command("echo x > /etc/passwd");
+        assert_eq!(a.verdict, BashVerdict::Deny);
+    }
 
     // ---- Safe commands ----
 

--- a/crates/infra/bamboo-permission/src/checker.rs
+++ b/crates/infra/bamboo-permission/src/checker.rs
@@ -141,6 +141,35 @@ pub trait PermissionChecker: Send + Sync {
     /// apply it to their shared config so it takes effect for subsequent checks.
     fn set_permission_mode(&self, _mode: PermissionMode) {}
 
+    /// Access the underlying mutable [`PermissionConfig`] when the implementation
+    /// is config-backed. Used by settings/admin endpoints to read and update
+    /// persisted rules (e.g. the "always ask" patterns). The default returns
+    /// `None`; config-backed implementations return their shared config.
+    fn permission_config(&self) -> Option<Arc<PermissionConfig>> {
+        None
+    }
+
+    /// Whether this tool call matches an "always ask" rule (configured pattern
+    /// or built-in dangerous-command detection) and must therefore force a user
+    /// confirmation REGARDLESS of the active permission mode — including
+    /// `BypassPermissions`. The default returns `false`; config-backed
+    /// implementations consult their [`PermissionConfig`].
+    fn requires_forced_confirmation(&self, _tool_name: &str, _args: &serde_json::Value) -> bool {
+        false
+    }
+
+    /// Like [`check_or_request`](Self::check_or_request) but IGNORES the active
+    /// permission mode/bypass. Used to enforce "always ask" rules even under
+    /// bypass. The default delegates to `check_or_request`, which is correct for
+    /// mode-unaware implementations; mode-aware wrappers override this to route
+    /// through their inner (mode-unaware) checker.
+    async fn check_or_request_forced(
+        &self,
+        ctx: PermissionContext,
+    ) -> Result<bool, PermissionError> {
+        self.check_or_request(ctx).await
+    }
+
     /// Check permission and either grant or request confirmation
     ///
     /// This is a convenience method that:
@@ -197,6 +226,14 @@ impl PermissionChecker for ConfigPermissionChecker {
     fn grant_session_permission(&self, perm_type: PermissionType, resource: String) {
         self.config.grant_session_permission(perm_type, resource);
     }
+
+    fn requires_forced_confirmation(&self, tool_name: &str, args: &serde_json::Value) -> bool {
+        self.config.requires_forced_confirmation(tool_name, args)
+    }
+
+    fn permission_config(&self) -> Option<Arc<PermissionConfig>> {
+        Some(self.config.clone())
+    }
 }
 
 /// A permission checker that wraps another checker and logs all permission checks
@@ -243,6 +280,21 @@ impl<T: PermissionChecker> PermissionChecker for LoggingPermissionChecker<T> {
             resource
         );
         self.inner.grant_session_permission(perm_type, resource);
+    }
+
+    fn requires_forced_confirmation(&self, tool_name: &str, args: &serde_json::Value) -> bool {
+        self.inner.requires_forced_confirmation(tool_name, args)
+    }
+
+    async fn check_or_request_forced(
+        &self,
+        ctx: PermissionContext,
+    ) -> Result<bool, PermissionError> {
+        self.inner.check_or_request_forced(ctx).await
+    }
+
+    fn permission_config(&self) -> Option<Arc<PermissionConfig>> {
+        self.inner.permission_config()
     }
 }
 
@@ -472,6 +524,25 @@ impl PermissionChecker for ModeAwarePermissionChecker {
         // Shared `Arc<PermissionConfig>` with `inner`, and `mode()` is read per
         // check, so this takes effect immediately for subsequent gating.
         self.config.set_mode(mode);
+    }
+
+    fn requires_forced_confirmation(&self, tool_name: &str, args: &serde_json::Value) -> bool {
+        self.config.requires_forced_confirmation(tool_name, args)
+    }
+
+    async fn check_or_request_forced(
+        &self,
+        ctx: PermissionContext,
+    ) -> Result<bool, PermissionError> {
+        // Route through the inner (mode-unaware) checker so the active mode —
+        // including BypassPermissions — does NOT suppress the forced prompt.
+        // Session grants still short-circuit, so a re-attempt after approval
+        // passes.
+        self.inner.check_or_request(ctx).await
+    }
+
+    fn permission_config(&self) -> Option<Arc<PermissionConfig>> {
+        Some(self.config.clone())
     }
 }
 

--- a/crates/infra/bamboo-permission/src/config.rs
+++ b/crates/infra/bamboo-permission/src/config.rs
@@ -16,6 +16,8 @@ use serde::{Deserialize, Serialize};
 // Re-export PermissionMode from the shared location in bamboo-infrastructure
 pub use bamboo_config::settings::PermissionMode;
 
+use crate::rule_parser::ParsedRule;
+
 /// Types of permissions that can be granted
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -599,6 +601,12 @@ pub struct PermissionConfig {
     /// Defaults to `Low` (confirm everything) to preserve legacy behavior; the
     /// server sets it to `High` for the "ask on high-risk" posture.
     confirm_threshold: RwLock<RiskLevel>,
+    /// "Always ask" rules: tool-call patterns (e.g. `Bash(rm -rf *)`,
+    /// `Bash(git push *)`) that force a user confirmation EVEN under bypass or
+    /// other permissive modes. Built-in dangerous-command detection
+    /// (`bash_security` Deny verdict) is layered on top of these. See
+    /// [`PermissionConfig::requires_forced_confirmation`].
+    ask_rules: RwLock<Vec<ParsedRule>>,
 }
 
 impl Default for PermissionConfig {
@@ -617,6 +625,7 @@ impl PermissionConfig {
             enabled: AtomicBool::new(true),
             mode: RwLock::new(PermissionMode::Default),
             confirm_threshold: RwLock::new(RiskLevel::Low),
+            ask_rules: RwLock::new(Vec::new()),
         }
     }
 
@@ -629,6 +638,7 @@ impl PermissionConfig {
             enabled: AtomicBool::new(enabled),
             mode: RwLock::new(PermissionMode::Default),
             confirm_threshold: RwLock::new(RiskLevel::Low),
+            ask_rules: RwLock::new(Vec::new()),
         }
     }
 
@@ -670,6 +680,60 @@ impl PermissionConfig {
             .confirm_threshold
             .write()
             .expect("confirm_threshold lock poisoned") = threshold;
+    }
+
+    /// Replace the "always ask" rules from a list of pattern strings (e.g.
+    /// `["Bash(rm -rf *)", "Bash(git push *)"]`). Unparseable entries degrade to
+    /// a bare tool-name match per [`ParsedRule::parse`].
+    pub fn set_ask_rules(&self, patterns: impl IntoIterator<Item = String>) {
+        let parsed = patterns
+            .into_iter()
+            .map(|p| ParsedRule::parse(&p))
+            .collect();
+        *self.ask_rules.write().expect("ask_rules lock poisoned") = parsed;
+    }
+
+    /// The configured "always ask" rules rendered back to pattern strings, for
+    /// persistence (round-trips `Tool` and `Tool(pattern)` forms).
+    pub fn ask_rule_patterns(&self) -> Vec<String> {
+        self.ask_rules
+            .read()
+            .expect("ask_rules lock poisoned")
+            .iter()
+            .map(|rule| match &rule.pattern {
+                Some(pattern) => format!("{}({})", rule.tool_name, pattern),
+                None => rule.tool_name.clone(),
+            })
+            .collect()
+    }
+
+    /// Whether this tool call must force a user confirmation regardless of the
+    /// active permission mode (including `BypassPermissions`). True when:
+    /// - the command is a built-in hard-dangerous shell command (a
+    ///   `bash_security` `Deny` verdict), or
+    /// - it matches a configured "always ask" rule.
+    pub fn requires_forced_confirmation(
+        &self,
+        tool_name: &str,
+        args: &serde_json::Value,
+    ) -> bool {
+        // Built-in backstop: hard-dangerous shell commands always ask.
+        if tool_name.eq_ignore_ascii_case("Bash") {
+            if let Some(command) = args.get("command").and_then(|v| v.as_str()) {
+                if crate::bash_security::analyze_command(command).verdict
+                    == crate::bash_security::BashVerdict::Deny
+                {
+                    return true;
+                }
+            }
+        }
+
+        // Configured "always ask" rules.
+        self.ask_rules
+            .read()
+            .expect("ask_rules lock poisoned")
+            .iter()
+            .any(|rule| rule.matches_tool_call(tool_name, args))
     }
 
     /// Get the session grant duration
@@ -805,6 +869,7 @@ impl PermissionConfig {
             session_grant_duration_secs: self.session_grant_duration.as_secs(),
             mode: Some(self.mode()),
             confirm_threshold: Some(self.confirm_threshold()),
+            ask_rules: self.ask_rule_patterns(),
         }
     }
 
@@ -818,6 +883,11 @@ impl PermissionConfig {
 
         let mode = config.mode.unwrap_or_default();
         let confirm_threshold = config.confirm_threshold.unwrap_or(RiskLevel::Low);
+        let ask_rules = config
+            .ask_rules
+            .iter()
+            .map(|p| ParsedRule::parse(p))
+            .collect();
 
         Self {
             whitelist,
@@ -826,6 +896,7 @@ impl PermissionConfig {
             enabled: AtomicBool::new(config.enabled),
             mode: RwLock::new(mode),
             confirm_threshold: RwLock::new(confirm_threshold),
+            ask_rules: RwLock::new(ask_rules),
         }
     }
 
@@ -865,6 +936,22 @@ impl PermissionConfig {
         // Enabled flag from other takes precedence
         merged.set_enabled(other.is_enabled());
 
+        // "Always ask" rules: union of both, other's appended after self's.
+        let mut ask_rules = self
+            .ask_rules
+            .read()
+            .expect("ask_rules lock poisoned")
+            .clone();
+        ask_rules.extend(
+            other
+                .ask_rules
+                .read()
+                .expect("ask_rules lock poisoned")
+                .iter()
+                .cloned(),
+        );
+        *merged.ask_rules.write().expect("ask_rules lock poisoned") = ask_rules;
+
         merged
     }
 }
@@ -877,6 +964,10 @@ pub struct SerializablePermissionConfig {
     pub mode: Option<PermissionMode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub confirm_threshold: Option<RiskLevel>,
+    /// "Always ask" rule patterns (e.g. `Bash(rm -rf *)`) that force a prompt
+    /// even under bypass. See [`PermissionConfig::requires_forced_confirmation`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ask_rules: Vec<String>,
 }
 
 impl Default for SerializablePermissionConfig {
@@ -887,6 +978,7 @@ impl Default for SerializablePermissionConfig {
             session_grant_duration_secs: 30 * 60, // 30 minutes
             mode: None,
             confirm_threshold: None,
+            ask_rules: Vec::new(),
         }
     }
 }
@@ -1571,5 +1663,53 @@ mod integration_tests {
         let json = r#"{"whitelist":[],"enabled":true,"session_grant_duration_secs":1800}"#;
         let restored = PermissionConfig::from_serializable(serde_json::from_str(json).unwrap());
         assert_eq!(restored.confirm_threshold(), RiskLevel::Low);
+    }
+
+    #[test]
+    fn forced_confirmation_builtin_dangerous_command() {
+        let config = PermissionConfig::new();
+        // Built-in detection: a hard-dangerous (Deny) shell command forces a
+        // prompt even with no configured ask rules.
+        assert!(config.requires_forced_confirmation(
+            "Bash",
+            &serde_json::json!({ "command": "eval 'cat /etc/passwd'" }),
+        ));
+        // A benign command is not forced.
+        assert!(!config.requires_forced_confirmation(
+            "Bash",
+            &serde_json::json!({ "command": "ls -la" }),
+        ));
+    }
+
+    #[test]
+    fn forced_confirmation_configured_ask_rule() {
+        let config = PermissionConfig::new();
+        config.set_ask_rules(["Bash(rm -rf *)".to_string(), "Write(/etc/**)".to_string()]);
+
+        assert!(config.requires_forced_confirmation(
+            "Bash",
+            &serde_json::json!({ "command": "rm -rf /tmp/data" }),
+        ));
+        assert!(config.requires_forced_confirmation(
+            "Write",
+            &serde_json::json!({ "file_path": "/etc/hosts" }),
+        ));
+        // Non-matching call is not forced.
+        assert!(!config.requires_forced_confirmation(
+            "Bash",
+            &serde_json::json!({ "command": "git status" }),
+        ));
+    }
+
+    #[test]
+    fn ask_rules_round_trip_through_serialization() {
+        let config = PermissionConfig::new();
+        config.set_ask_rules(["Bash(rm -rf *)".to_string(), "Read".to_string()]);
+        let json = serde_json::to_string(&config.to_serializable()).unwrap();
+        let restored = PermissionConfig::from_serializable(serde_json::from_str(&json).unwrap());
+        assert_eq!(
+            restored.ask_rule_patterns(),
+            vec!["Bash(rm -rf *)".to_string(), "Read".to_string()]
+        );
     }
 }

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -125,6 +125,11 @@ pub struct SessionIndexEntry {
     /// APIs can surface plan mode without loading every session.json.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plan_mode: Option<bamboo_domain::PlanModeState>,
+    /// Per-session "bypass permissions" toggle mirrored into the index from
+    /// `session.agent_runtime_state.bypass_permissions`, so the session-list API
+    /// can surface it without loading every session.json.
+    #[serde(default)]
+    pub bypass_permissions: bool,
     /// Last known run status for this session
     /// ("pending" | "running" | "completed" | "error" | "cancelled" | "skipped").
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -525,6 +530,10 @@ impl SessionStoreV2 {
             .agent_runtime_state
             .as_ref()
             .and_then(|state| state.plan_mode.clone());
+        let bypass_permissions = session
+            .agent_runtime_state
+            .as_ref()
+            .is_some_and(|state| state.bypass_permissions);
         self.update_index(|index| {
             index.sessions.insert(
                 session.id.clone(),
@@ -551,6 +560,7 @@ impl SessionStoreV2 {
                     has_attachments,
                     has_pending_question: session.has_pending_question(),
                     plan_mode,
+                    bypass_permissions,
                     last_run_status,
                     last_run_error,
                     token_usage: session.token_usage.clone(),

--- a/tests/deploy_agent_tool_e2e.rs
+++ b/tests/deploy_agent_tool_e2e.rs
@@ -23,6 +23,7 @@ fn ctx() -> ToolExecutionContext<'static> {
         tool_call_id: "tc",
         event_tx: None,
         available_tool_schemas: None,
+        bypass_permissions: false,
     }
 }
 

--- a/tests/schedule_tasks_tool.rs
+++ b/tests/schedule_tasks_tool.rs
@@ -95,6 +95,7 @@ fn ctx_for_session<'a>(session_id: &'a str) -> ToolExecutionContext<'a> {
         tool_call_id: "tool_call",
         event_tx: None,
         available_tool_schemas: None,
+        bypass_permissions: false,
     }
 }
 

--- a/tests/session_inspector_tool.rs
+++ b/tests/session_inspector_tool.rs
@@ -18,6 +18,7 @@ fn ctx_for_session<'a>(session_id: &'a str) -> ToolExecutionContext<'a> {
         tool_call_id: "tool_call",
         event_tx: None,
         available_tool_schemas: None,
+        bypass_permissions: false,
     }
 }
 


### PR DESCRIPTION
Closes #65

Backend for the per-session permission controls. Frontend counterpart: bigduu/Lotus#20.

## Changes
**Permission feature** (`feat(permission)`)
- Per-session `bypass_permissions` toggle, persisted in `runtime.json` and mirrored into the session index
- Threaded through both agent loops via `ToolExecutionSessionFlags` / `for_dispatch`; carried forward across runs and inherited by child sessions
- API: `PATCH /sessions` toggle; `GET`/`PUT /bamboo/permission/ask-rules`; new `settings/permission` handler
- Configurable always-ask rules + a built-in dangerous-command backstop (`check_or_request_forced`) that force a prompt even under bypass
- Stop Denying benign redirects to `/dev/null`

**Other commits**
- `feat(config)`: raise `DEFAULT_MAX_OUTPUT_TOKENS` 64K → 128K (+ endpoint doc/test)
- `style`: rustfmt only (import order + line wrapping, no behavior change)

## Verification
- `cargo check --workspace --tests` clean (exit 0)