### PR TITLE
feat(subagent): Guardian review + direct nested execution (depth cap, child approval review)

### DIFF
--- a/crates/app/bamboo-server-tools/src/lib.rs
+++ b/crates/app/bamboo-server-tools/src/lib.rs
@@ -23,5 +23,5 @@ pub use memory::MemoryTool;
 pub use overlay_executor::OverlayToolExecutor;
 pub use session_inspector::SessionInspectorTool;
 pub use skill_runtime::{LoadSkillTool, ReadSkillResourceTool};
-pub use sub_agent::SubAgentTool;
+pub use sub_agent::{SubAgentProxyTool, SubAgentTool, DEFAULT_MAX_SPAWN_DEPTH};
 pub use surface::{ToolSurface, ToolSurfaceFactory};

--- a/crates/app/bamboo-server-tools/src/sub_agent.rs
+++ b/crates/app/bamboo-server-tools/src/sub_agent.rs
@@ -1022,7 +1022,10 @@ mod tests {
         async fn spawn(&self, args: serde_json::Value) -> Result<serde_json::Value, String> {
             // Echo the action back so the test can assert the args were forwarded.
             let mut reply = self.0.clone();
-            reply["action_seen"] = args.get("action").cloned().unwrap_or(serde_json::Value::Null);
+            reply["action_seen"] = args
+                .get("action")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null);
             Ok(reply)
         }
     }
@@ -1060,7 +1063,9 @@ mod tests {
         let r = SubAgentProxyTool
             .execute(serde_json::json!({"action": "create"}))
             .await;
-        assert!(matches!(r, Err(ToolError::Execution(ref m)) if m.contains("not running in a nested-worker")));
+        assert!(
+            matches!(r, Err(ToolError::Execution(ref m)) if m.contains("not running in a nested-worker"))
+        );
     }
 
     #[test]

--- a/crates/app/bamboo-server-tools/src/sub_agent.rs
+++ b/crates/app/bamboo-server-tools/src/sub_agent.rs
@@ -80,6 +80,11 @@ enum SubAgentArgs {
         /// create; honored on reuse.
         #[serde(default)]
         context: Option<String>,
+        /// Phase 3 model-controllable context fork: when `> 0`, carry the last N
+        /// of the parent's messages into the child's task brief. `None`/0 (the
+        /// default) gives the child a clean, freshly-seeded context.
+        #[serde(default)]
+        fork_last_messages: Option<usize>,
     },
     /// Suspend the parent run until its background child sessions finish.
     ///
@@ -302,12 +307,201 @@ fn parse_model_spec(
     Ok(bamboo_domain::ProviderModelRef::new(provider, spec))
 }
 
+/// Default max nesting depth for sub-agent spawning (Phase 6: direct nested
+/// execution). An agent at `spawn_depth >= this` may not create more children,
+/// bounding worker→worker→… recursion. Root orchestrator = depth 0, so this
+/// allows 4 levels of sub-agents below the root.
+pub const DEFAULT_MAX_SPAWN_DEPTH: u32 = 4;
+
 /// The `SubAgent` tool description. Exposed standalone so a nested worker's
 /// SubAgent proxy can advertise the identical tool to its own LLM (no drift).
 pub fn subagent_tool_description() -> &'static str {
     "Create, inspect, and manage child sessions for explicitly requested delegated, parallel, or sub-agent work. A child session is a full agent that runs independently under the current root session with its own conversation context and the full toolset, streams progress back to the parent via sub_agent_* events, and can be reopened from the Sub-agents panel. \
 PARALLEL FAN-OUT (important): action=create now runs the child in the BACKGROUND and returns immediately WITHOUT suspending the parent. To launch several agents in parallel, call create once per child (ideally several creates in a single turn), then call action=wait ONCE to suspend until they finish. Do NOT pass wait=true on each create for parallel work — that would serialize them (suspend after the first). action=wait defaults to waiting on every active child; if you forget to call it, the runtime auto-waits at the end of the turn so results are never lost. \
 Use list/get to inspect existing children; use update/run/send_message/cancel/delete to manage existing children. Use only when the user explicitly asks for delegation/parallelism or when a side task would otherwise flood the main context. Do not use for simple one-step tasks. IMPORTANT: When a child fails or needs redirection, prefer send_message over creating a duplicate child. Use list before create to avoid spawning redundant children."
+}
+
+/// The `SubAgent` parameters schema. Exposed standalone (mirroring
+/// [`subagent_tool_description`]) so a nested worker's SubAgent proxy advertises
+/// the IDENTICAL schema to its own LLM — no drift between the real tool and the
+/// proxy.
+pub fn subagent_parameters_schema() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["create", "wait", "list", "get", "update", "run", "send_message", "cancel", "delete", "list_models"],
+                "description": "Sub-agent lifecycle operation. To run work in parallel: call create once per child (this no longer suspends the parent — children run in the background), then call wait ONCE to suspend until they all finish. Use list/get to inspect; update/run/send_message/cancel/delete to manage existing children; list_models to enumerate the models you can pin a child to via create.model. \
+        A create call requires: title, responsibility, and prompt (workspace is optional and defaults to the parent's workspace). EXAMPLE create: {\"action\":\"create\",\"title\":\"Analyze auth module\",\"responsibility\":\"Map the auth flow and list its public API\",\"prompt\":\"Read crates/auth/src/lib.rs, summarize the login flow, and list every pub fn.\",\"workspace\":\"/abs/path/to/repo\"}. Then EXAMPLE wait: {\"action\":\"wait\"}."
+            },
+            "child_session_id": {
+                "type": "string",
+                "description": "Existing child session id. Required for get/update/run/send_message/cancel/delete."
+            },
+            "child_session_ids": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "For wait: optional explicit subset of child sessions to wait on. Omit to wait on every currently-active child."
+            },
+            "wait_for": {
+                "type": "string",
+                "enum": ["all", "any", "first_error"],
+                "description": "For wait: resume policy. all (default) resumes when every tracked child is done; any resumes on the first; first_error resumes early on any error/timeout/cancel."
+            },
+            "wait": {
+                "type": "boolean",
+                "description": "For create: if true, suspend immediately and wait for just THIS child (legacy one-shot behavior). Defaults to false — create returns immediately and the child runs in the background; suspend later with action=wait."
+            },
+            "title": {
+                "type": "string",
+                "description": "Short title for a new or updated child session. Required for create. Displayed in the Sub-agents panel."
+            },
+            "description": {
+                "type": "string",
+                "description": "Legacy alias of title; prefer title."
+            },
+            "responsibility": {
+                "type": "string",
+                "description": "Single explicit responsibility for the child session. Required for create. Keep this narrow and non-overlapping with other child sessions."
+            },
+            "prompt": {
+                "type": "string",
+                "description": "Detailed task instructions, context, constraints, and expected output for the child session. Required for create; optional for update."
+            },
+            "subagent_type": {
+                "type": "string",
+                "description": "For create: an optional free-text label for this child (e.g. \"researcher\", \"impl\"), used only for display and as the warm-worker reuse key. Cosmetic — it does NOT change the child's tools or system prompt; every sub-agent is a full agent. Optional; omit it if you have no useful label."
+            },
+            "workspace": {
+                "type": "string",
+                "description": "For create: absolute path to the child session's working directory for file operations. Optional — defaults to the parent session's workspace when omitted."
+            },
+            "auto_run": {
+                "type": "boolean",
+                "description": "For create/send_message/update: whether to enqueue the child session immediately. Defaults to true for create/send_message and false for update."
+            },
+            "fork_last_messages": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "For create: model-controllable context fork. When > 0, the last N messages of YOUR (the parent's) conversation are carried into the child's task brief as a 'Forked context from parent' block, so the child starts with the recent context it needs. Omit/0 (default) gives the child a clean, freshly-seeded context. Use a small N (e.g. 2-6) to share just the immediately relevant turns; omit it when the task brief is already self-contained."
+            },
+            "reset_after_update": {
+                "type": "boolean",
+                "description": "For update: whether to truncate messages after refreshed assignment. Defaults to true."
+            },
+            "reset_to_last_user": {
+                "type": "boolean",
+                "description": "For run: whether to truncate messages after the last user message before rerun. Defaults to true."
+            },
+            "message": {
+                "type": "string",
+                "description": "Follow-up instruction to append as a new user message for send_message. Required for send_message."
+            },
+            "interrupt_running": {
+                "type": "boolean",
+                "description": "For send_message/cancel: if true, cancel a currently running child session before appending or returning. Defaults to false for send_message. When false on a running child, the message is queued and will be picked up at the next turn boundary without canceling progress."
+            },
+            "reasoning_effort": {
+                "type": "string",
+                "enum": ["low", "medium", "high", "xhigh", "max"],
+                "description": "For create/update: reasoning effort level applied to the child session's own LLM calls. Use \"low\" for trivial fan-outs (e.g. simple lookups), \"medium\"/\"high\" for normal coding/analysis, \"xhigh\"/\"max\" for deep reasoning tasks. Omit to leave at provider default; the child does NOT inherit the parent's reasoning_effort."
+            },
+            "model": {
+                "type": "string",
+                "description": "For create: explicit model for the child as 'provider:model' (e.g. 'anthropic:claude-sonnet-4-6'), or a bare model id to use the parent's provider. Takes precedence over per-subagent_type model routing. Pick a cheaper/faster model for simple fan-outs and a stronger model for hard reasoning. Call list_models first to see what is available; omit to use the configured default for the given subagent_type label."
+            },
+            "lifecycle": {
+                "type": "string",
+                "enum": ["oneshot", "resident"],
+                "description": "For create: 'oneshot' (default) spins up a fresh throwaway child for this task. 'resident' reuses ONE long-lived agent (identified by 'name', scoped to this conversation) across many tasks — the first resident create spins it up, later creates with the same name route the new task to that same agent instead of spawning another. Use resident for recurring task types (e.g. an 'essayist' that writes many essays — one agent, one panel entry, not N); use oneshot for independent throwaway work."
+            },
+            "name": {
+                "type": "string",
+                "description": "For create with lifecycle=resident: the resident agent's stable reuse key, e.g. 'essayist'. Required to reuse a resident; defaults to subagent_type when omitted. Reusing the same name routes the new task to the existing resident agent."
+            },
+            "context": {
+                "type": "string",
+                "enum": ["reset", "accumulate"],
+                "description": "For create with lifecycle=resident: how the resident treats prior tasks. 'reset' (default) makes each task independent (clears prior context). 'accumulate' makes the agent remember earlier tasks (useful for a researcher building up knowledge). Set on first create; honored on reuse."
+            }
+        },
+        "required": ["action"],
+        "additionalProperties": false
+    })
+}
+
+/// Worker-side stand-in for [`SubAgentTool`] (Phase 6: nested execution).
+///
+/// A subagent worker runs out-of-process and cannot spawn its own children
+/// directly. This tool advertises the IDENTICAL `SubAgent` tool (same name,
+/// description, and schema) to the worker's LLM, but its execution forwards the
+/// call to the host over the actor protocol via the task-local
+/// [`bamboo_tools::NestedSpawnProxy`]. The host runs the real [`SubAgentTool`]
+/// (parenting a grandchild under this worker's child session) and returns the
+/// result. Outside a nested-worker run (no proxy installed) the tool errors.
+pub struct SubAgentProxyTool;
+
+/// Map a host `SubagentReply` body (`{success, result, display_preference}`)
+/// back into a `ToolResult` for the worker's engine. Tolerant of shape: a
+/// non-string `result` is stringified; missing `success` defaults to true.
+fn reply_to_tool_result(reply: serde_json::Value) -> ToolResult {
+    let success = reply
+        .get("success")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    let result = match reply.get("result") {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(other) => other.to_string(),
+        None => reply.to_string(),
+    };
+    let display_preference = reply
+        .get("display_preference")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    ToolResult {
+        success,
+        result,
+        display_preference,
+        images: Vec::new(),
+    }
+}
+
+#[async_trait]
+impl Tool for SubAgentProxyTool {
+    fn name(&self) -> &str {
+        "SubAgent"
+    }
+
+    fn description(&self) -> &str {
+        subagent_tool_description()
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        subagent_parameters_schema()
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> Result<ToolResult, ToolError> {
+        self.execute_with_context(args, ToolExecutionContext::none("tool_call"))
+            .await
+    }
+
+    async fn execute_with_context(
+        &self,
+        args: serde_json::Value,
+        _ctx: ToolExecutionContext<'_>,
+    ) -> Result<ToolResult, ToolError> {
+        let Some(proxy) = bamboo_tools::current_nested_spawn_proxy() else {
+            return Err(ToolError::Execution(
+                "SubAgent is unavailable: not running in a nested-worker context".to_string(),
+            ));
+        };
+        let reply = proxy
+            .spawn(args)
+            .await
+            .map_err(|e| ToolError::Execution(format!("nested SubAgent spawn failed: {e}")))?;
+        Ok(reply_to_tool_result(reply))
+    }
 }
 
 #[async_trait]
@@ -321,104 +515,7 @@ impl Tool for SubAgentTool {
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "action": {
-                    "type": "string",
-                    "enum": ["create", "wait", "list", "get", "update", "run", "send_message", "cancel", "delete", "list_models"],
-                    "description": "Sub-agent lifecycle operation. To run work in parallel: call create once per child (this no longer suspends the parent — children run in the background), then call wait ONCE to suspend until they all finish. Use list/get to inspect; update/run/send_message/cancel/delete to manage existing children; list_models to enumerate the models you can pin a child to via create.model. \
-        A create call requires: title, responsibility, and prompt (workspace is optional and defaults to the parent's workspace). EXAMPLE create: {\"action\":\"create\",\"title\":\"Analyze auth module\",\"responsibility\":\"Map the auth flow and list its public API\",\"prompt\":\"Read crates/auth/src/lib.rs, summarize the login flow, and list every pub fn.\",\"workspace\":\"/abs/path/to/repo\"}. Then EXAMPLE wait: {\"action\":\"wait\"}."
-                },
-                "child_session_id": {
-                    "type": "string",
-                    "description": "Existing child session id. Required for get/update/run/send_message/cancel/delete."
-                },
-                "child_session_ids": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "For wait: optional explicit subset of child sessions to wait on. Omit to wait on every currently-active child."
-                },
-                "wait_for": {
-                    "type": "string",
-                    "enum": ["all", "any", "first_error"],
-                    "description": "For wait: resume policy. all (default) resumes when every tracked child is done; any resumes on the first; first_error resumes early on any error/timeout/cancel."
-                },
-                "wait": {
-                    "type": "boolean",
-                    "description": "For create: if true, suspend immediately and wait for just THIS child (legacy one-shot behavior). Defaults to false — create returns immediately and the child runs in the background; suspend later with action=wait."
-                },
-                "title": {
-                    "type": "string",
-                    "description": "Short title for a new or updated child session. Required for create. Displayed in the Sub-agents panel."
-                },
-                "description": {
-                    "type": "string",
-                    "description": "Legacy alias of title; prefer title."
-                },
-                "responsibility": {
-                    "type": "string",
-                    "description": "Single explicit responsibility for the child session. Required for create. Keep this narrow and non-overlapping with other child sessions."
-                },
-                "prompt": {
-                    "type": "string",
-                    "description": "Detailed task instructions, context, constraints, and expected output for the child session. Required for create; optional for update."
-                },
-                "subagent_type": {
-                    "type": "string",
-                    "description": "For create: an optional free-text label for this child (e.g. \"researcher\", \"impl\"), used only for display and as the warm-worker reuse key. Cosmetic — it does NOT change the child's tools or system prompt; every sub-agent is a full agent. Optional; omit it if you have no useful label."
-                },
-                "workspace": {
-                    "type": "string",
-                    "description": "For create: absolute path to the child session's working directory for file operations. Optional — defaults to the parent session's workspace when omitted."
-                },
-                "auto_run": {
-                    "type": "boolean",
-                    "description": "For create/send_message/update: whether to enqueue the child session immediately. Defaults to true for create/send_message and false for update."
-                },
-                "reset_after_update": {
-                    "type": "boolean",
-                    "description": "For update: whether to truncate messages after refreshed assignment. Defaults to true."
-                },
-                "reset_to_last_user": {
-                    "type": "boolean",
-                    "description": "For run: whether to truncate messages after the last user message before rerun. Defaults to true."
-                },
-                "message": {
-                    "type": "string",
-                    "description": "Follow-up instruction to append as a new user message for send_message. Required for send_message."
-                },
-                "interrupt_running": {
-                    "type": "boolean",
-                    "description": "For send_message/cancel: if true, cancel a currently running child session before appending or returning. Defaults to false for send_message. When false on a running child, the message is queued and will be picked up at the next turn boundary without canceling progress."
-                },
-                "reasoning_effort": {
-                    "type": "string",
-                    "enum": ["low", "medium", "high", "xhigh", "max"],
-                    "description": "For create/update: reasoning effort level applied to the child session's own LLM calls. Use \"low\" for trivial fan-outs (e.g. simple lookups), \"medium\"/\"high\" for normal coding/analysis, \"xhigh\"/\"max\" for deep reasoning tasks. Omit to leave at provider default; the child does NOT inherit the parent's reasoning_effort."
-                },
-                "model": {
-                    "type": "string",
-                    "description": "For create: explicit model for the child as 'provider:model' (e.g. 'anthropic:claude-sonnet-4-6'), or a bare model id to use the parent's provider. Takes precedence over per-subagent_type model routing. Pick a cheaper/faster model for simple fan-outs and a stronger model for hard reasoning. Call list_models first to see what is available; omit to use the configured default for the given subagent_type label."
-                },
-                "lifecycle": {
-                    "type": "string",
-                    "enum": ["oneshot", "resident"],
-                    "description": "For create: 'oneshot' (default) spins up a fresh throwaway child for this task. 'resident' reuses ONE long-lived agent (identified by 'name', scoped to this conversation) across many tasks — the first resident create spins it up, later creates with the same name route the new task to that same agent instead of spawning another. Use resident for recurring task types (e.g. an 'essayist' that writes many essays — one agent, one panel entry, not N); use oneshot for independent throwaway work."
-                },
-                "name": {
-                    "type": "string",
-                    "description": "For create with lifecycle=resident: the resident agent's stable reuse key, e.g. 'essayist'. Required to reuse a resident; defaults to subagent_type when omitted. Reusing the same name routes the new task to the existing resident agent."
-                },
-                "context": {
-                    "type": "string",
-                    "enum": ["reset", "accumulate"],
-                    "description": "For create with lifecycle=resident: how the resident treats prior tasks. 'reset' (default) makes each task independent (clears prior context). 'accumulate' makes the agent remember earlier tasks (useful for a researcher building up knowledge). Set on first create; honored on reuse."
-                }
-            },
-            "required": ["action"],
-            "additionalProperties": false
-        })
+        subagent_parameters_schema()
     }
 
     async fn execute(&self, args: serde_json::Value) -> Result<ToolResult, ToolError> {
@@ -484,7 +581,19 @@ impl Tool for SubAgentTool {
                 lifecycle,
                 name,
                 context,
+                fork_last_messages,
             } => {
+                // Phase 6: enforce the max nesting-depth cap. `parent` is this
+                // agent's run session; its `spawn_depth` is the current nesting
+                // level (workers stamp it from the actor spec, so it accumulates
+                // across the actor boundary). Refuse to spawn beyond the cap so
+                // worker→worker→… recursion is bounded.
+                if parent.spawn_depth >= DEFAULT_MAX_SPAWN_DEPTH {
+                    return Err(ToolError::InvalidArguments(format!(
+                        "spawn depth limit ({}) reached: this agent is at depth {} and cannot create more sub-agents. Finish the work here, or delegate to a sibling.",
+                        DEFAULT_MAX_SPAWN_DEPTH, parent.spawn_depth
+                    )));
+                }
                 let title = normalize_title(title, description)?;
                 let responsibility = normalize_required_text(responsibility, "responsibility")?;
                 let prompt = normalize_required_text(Some(prompt), "prompt")?;
@@ -644,6 +753,10 @@ impl Tool for SubAgentTool {
                                 resident_context: resident_name
                                     .as_ref()
                                     .map(|_| resident_context.clone()),
+                                disabled_tools: None,
+                                // Phase 3: model-controllable context fork — carry
+                                // the last N parent messages into the child's brief.
+                                context_fork: fork_last_messages.filter(|n| *n > 0),
                             },
                         )
                         .await
@@ -901,6 +1014,68 @@ impl Tool for SubAgentTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct StubNestedSpawn(serde_json::Value);
+
+    #[async_trait]
+    impl bamboo_tools::NestedSpawnProxy for StubNestedSpawn {
+        async fn spawn(&self, args: serde_json::Value) -> Result<serde_json::Value, String> {
+            // Echo the action back so the test can assert the args were forwarded.
+            let mut reply = self.0.clone();
+            reply["action_seen"] = args.get("action").cloned().unwrap_or(serde_json::Value::Null);
+            Ok(reply)
+        }
+    }
+
+    #[test]
+    fn proxy_tool_advertises_identical_name_and_schema() {
+        // Same name the real SubAgentTool exposes, and schema/description from the
+        // shared standalone fns (no drift between the real tool and the proxy).
+        assert_eq!(SubAgentProxyTool.name(), "SubAgent");
+        assert_eq!(
+            SubAgentProxyTool.parameters_schema(),
+            subagent_parameters_schema()
+        );
+        assert_eq!(SubAgentProxyTool.description(), subagent_tool_description());
+    }
+
+    #[tokio::test]
+    async fn proxy_tool_forwards_to_nested_spawn_proxy() {
+        let proxy: Arc<dyn bamboo_tools::NestedSpawnProxy> = Arc::new(StubNestedSpawn(
+            serde_json::json!({"success": true, "result": "grandchild-1", "display_preference": null}),
+        ));
+        let out = bamboo_tools::with_nested_spawn_proxy(Some(proxy), async {
+            SubAgentProxyTool
+                .execute(serde_json::json!({"action": "create", "title": "t"}))
+                .await
+        })
+        .await
+        .expect("proxy tool execute");
+        assert!(out.success);
+        assert_eq!(out.result, "grandchild-1");
+    }
+
+    #[tokio::test]
+    async fn proxy_tool_errors_without_a_proxy_installed() {
+        let r = SubAgentProxyTool
+            .execute(serde_json::json!({"action": "create"}))
+            .await;
+        assert!(matches!(r, Err(ToolError::Execution(ref m)) if m.contains("not running in a nested-worker")));
+    }
+
+    #[test]
+    fn reply_to_tool_result_maps_fields_and_stringifies_nonstring() {
+        let r = reply_to_tool_result(
+            serde_json::json!({"success": false, "result": "boom", "display_preference": "Collapsible"}),
+        );
+        assert!(!r.success);
+        assert_eq!(r.result, "boom");
+        assert_eq!(r.display_preference.as_deref(), Some("Collapsible"));
+        // Non-string result is stringified; missing success defaults true.
+        let r2 = reply_to_tool_result(serde_json::json!({"result": {"child_session_id": "c1"}}));
+        assert!(r2.success);
+        assert!(r2.result.contains("child_session_id"));
+    }
 
     #[test]
     fn normalize_title_accepts_legacy_description() {

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -385,6 +385,36 @@ impl AppState {
             persistence.clone(),
         );
 
+        // Dedicated child-session adapter backing the guardian review spawner.
+        // The guardian path passes an explicit model (no subagent_type routing)
+        // and registers its parent wait at the terminal gate (not via the
+        // adapter's coalescing slots), so a lightweight adapter with no resolver
+        // and a fresh wait-slot map suffices. `Arc<ChildSessionAdapter>` doubles
+        // as `Arc<dyn GuardianSpawner>`.
+        let child_adapter = Arc::new(crate::tools::ChildSessionAdapter {
+            session_store: session_store.clone(),
+            storage: storage.clone(),
+            persistence: persistence.clone(),
+            scheduler: spawn_scheduler.clone(),
+            sessions_cache: sessions.clone(),
+            agent_runners: agent_runners.clone(),
+            session_event_senders: session_event_senders.clone(),
+            subagent_model_resolver: None,
+            config: config.clone(),
+            parent_wait_slots: Arc::new(dashmap::DashMap::new()),
+        });
+        let guardian_spawner: Arc<dyn bamboo_engine::GuardianSpawner> = child_adapter.clone();
+        // Phase 6: install the process-global nested-spawn handler (the same
+        // adapter, as a NestedSpawnHandler) now that it exists — resolving the
+        // runner→scheduler→adapter construction-order cycle. The actor host's
+        // `drive()` reads it to fulfil a worker's nested `SubAgent` create.
+        bamboo_engine::external_agents::set_nested_spawn_handler(child_adapter.clone());
+        // Wire the spawner into the completion coordinator too, so a resumed run
+        // can re-spawn a guardian to re-review a fix after a reject verdict.
+        child_completion_coordinator
+            .set_guardian_spawner(guardian_spawner.clone())
+            .await;
+
         Ok(Self {
             app_data_dir: bamboo_home_dir,
             config,
@@ -397,6 +427,7 @@ impl AppState {
             persistence,
             spawn_scheduler,
             child_completion_coordinator,
+            guardian_spawner,
             schedule_store,
             schedule_manager,
             tool_factory,

--- a/crates/app/bamboo-server/src/app_state/mod.rs
+++ b/crates/app/bamboo-server/src/app_state/mod.rs
@@ -211,6 +211,12 @@ pub struct AppState {
     /// Coordinates child completion notifications into parent resume.
     pub child_completion_coordinator: Arc<bamboo_engine::ChildCompletionCoordinator>,
 
+    /// Spawner for the guardian adversarial-review child, injected into each run
+    /// so the terminal gate can create a read-only reviewer (the engine runner
+    /// cannot construct a child directly — see [`bamboo_engine::GuardianSpawner`]).
+    /// Backed by a dedicated [`crate::tools::ChildSessionAdapter`].
+    pub guardian_spawner: Arc<dyn bamboo_engine::GuardianSpawner>,
+
     /// Schedule store (timed tasks).
     pub schedule_store: Arc<ScheduleStore>,
 

--- a/crates/app/bamboo-server/src/app_state/resume_adapter.rs
+++ b/crates/app/bamboo-server/src/app_state/resume_adapter.rs
@@ -236,8 +236,7 @@ impl ResumeExecutionPort for AppStateResumeRef {
                         (tool_result.result, tool_result.success)
                     }
                     Err(error) => {
-                        let message =
-                            format!("Tool re-execution after approval failed: {error}");
+                        let message = format!("Tool re-execution after approval failed: {error}");
                         let _ = mpsc_tx
                             .send(emitter.error(message.clone()).clone().into_agent_event())
                             .await;

--- a/crates/app/bamboo-server/src/handlers/agent/child_approval.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/child_approval.rs
@@ -1,0 +1,78 @@
+//! Phase 2: route a human's approval decision to a child sub-agent's blocked
+//! gated tool.
+//!
+//! When an out-of-process child worker hits a gated tool, the host surfaces an
+//! `AgentEvent::ChildApprovalRequested { child_session_id, request_id, .. }` on
+//! the agent stream. The frontend posts the human's choice here, and we deliver
+//! it over the child's live actor connection — the worker's gated tool is
+//! parked on the matching `host.approval_call`, so approve lets it proceed and
+//! deny fails it closed. See `bamboo_engine::external_agents::live`.
+
+use actix_web::{web, HttpResponse, Responder};
+use serde::{Deserialize, Serialize};
+
+/// Body for `POST /api/v1/child-approval/{child_session_id}`.
+#[derive(Debug, Deserialize)]
+pub struct ChildApprovalDecision {
+    /// The `request_id` carried by the surfaced `ChildApprovalRequested` event.
+    pub request_id: String,
+    /// Whether the human approved (`true`) or denied (`false`) the gated action.
+    pub approved: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ChildApprovalResponse {
+    delivered: bool,
+}
+
+/// Deliver a human approval decision to a live child sub-agent (Phase 2).
+///
+/// `POST /api/v1/child-approval/{child_session_id}`
+pub async fn handler(
+    path: web::Path<String>,
+    body: web::Json<ChildApprovalDecision>,
+) -> impl Responder {
+    let child_session_id = path.into_inner();
+    let ChildApprovalDecision {
+        request_id,
+        approved,
+    } = body.into_inner();
+
+    let delivered = bamboo_engine::external_agents::live::deliver_approval(
+        &child_session_id,
+        &request_id,
+        approved,
+    );
+
+    if delivered {
+        tracing::info!(
+            "[{}] child approval delivered (request_id={}, approved={})",
+            child_session_id,
+            request_id,
+            approved
+        );
+        HttpResponse::Ok().json(ChildApprovalResponse { delivered: true })
+    } else {
+        // The child isn't live (finished, timed out, or already answered) — there
+        // is no connection to carry the decision.
+        tracing::warn!(
+            "[{}] child approval not delivered (request_id={}): child not live",
+            child_session_id,
+            request_id
+        );
+        HttpResponse::NotFound().json(ChildApprovalResponse { delivered: false })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decision_body_deserializes() {
+        let v: ChildApprovalDecision =
+            serde_json::from_str(r#"{"request_id":"r1","approved":true}"#).unwrap();
+        assert_eq!(v.request_id, "r1");
+        assert!(v.approved);
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
@@ -142,8 +142,7 @@ pub(super) async fn has_running_child(state: &web::Data<AppState>, session_id: &
         runners
             .iter()
             .filter_map(|(running_id, runner)| {
-                (matches!(runner.status, AgentStatus::Running)
-                    && running_id.as_str() != session_id)
+                (matches!(runner.status, AgentStatus::Running) && running_id.as_str() != session_id)
                     .then(|| running_id.clone())
             })
             .collect()

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
@@ -169,6 +169,11 @@ pub(crate) fn spawn_agent_execution(args: SpawnAgentExecution) {
         mpsc_tx: args.mpsc_tx,
         image_fallback: args.image_fallback,
         gold_config: args.gold_config,
+        // The guardian reviewer spawner is always available; the terminal gate
+        // stays inert until `guardian_config` is enabled. (TODO: surface a
+        // guardian config on the request, mirroring `gold_config`.)
+        guardian_config: None,
+        guardian_spawner: Some(args.state.guardian_spawner.clone()),
         app_data_dir: args.app_data_dir,
         runners: args.state.agent_runners.clone(),
         sessions_cache: args.state.sessions.clone(),

--- a/crates/app/bamboo-server/src/handlers/agent/history.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/history.rs
@@ -302,7 +302,10 @@ mod tests {
         // The runtime goal state is surfaced so the frontend can show live progress.
         assert_eq!(resp["goal_state"]["status"], "complete");
         assert_eq!(resp["goal_state"]["continuation_count"], 1);
-        assert_eq!(resp["goal_state"]["eval_history"][0]["decision"], "achieved");
+        assert_eq!(
+            resp["goal_state"]["eval_history"][0]["decision"],
+            "achieved"
+        );
         assert_eq!(
             resp["goal_state"]["eval_history"][0]["checkpoint"],
             "terminal"

--- a/crates/app/bamboo-server/src/handlers/agent/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/mod.rs
@@ -4,6 +4,7 @@
 //! chat, execution, event streaming, session management, and MCP.
 
 pub mod chat;
+pub mod child_approval;
 pub mod delete;
 pub mod dev;
 pub mod events;

--- a/crates/app/bamboo-server/src/handlers/settings/permission.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/permission.rs
@@ -57,8 +57,7 @@ pub async fn update_permission_ask_rules(
     config.set_ask_rules(rules.clone());
 
     // ...then persist to the same store `load_permission_checker` reads at boot.
-    let storage =
-        bamboo_tools::permission::PermissionStorage::new(app_state.app_data_dir.clone());
+    let storage = bamboo_tools::permission::PermissionStorage::new(app_state.app_data_dir.clone());
     storage.save(config.as_ref()).await.map_err(|error| {
         AppError::InternalError(anyhow::anyhow!(
             "Failed to persist permission rules: {error}"

--- a/crates/app/bamboo-server/src/routes/agent.rs
+++ b/crates/app/bamboo-server/src/routes/agent.rs
@@ -168,6 +168,12 @@ pub fn agent_routes(cfg: &mut web::ServiceConfig) {
             // sessions (multi-client sync, replaces session-index polling).
             .route("/stream", web::get().to(agent::stream::handler))
             .route("/stop/{session_id}", web::post().to(agent::stop::handler))
+            // Phase 2: deliver a human approval decision to a child sub-agent's
+            // blocked gated tool (surfaced via AgentEvent::ChildApprovalRequested).
+            .route(
+                "/child-approval/{child_session_id}",
+                web::post().to(agent::child_approval::handler),
+            )
             .route(
                 "/history/{session_id}",
                 web::get().to(agent::history::handler),

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -420,6 +420,9 @@ async fn run_schedule_job(
         mpsc_tx,
         image_fallback: None,
         gold_config: resolved.gold_config.clone(),
+        // Guardian review is not wired into the schedule path for now.
+        guardian_config: None,
+        guardian_spawner: None,
         app_data_dir: ctx.app_data_dir.clone(),
         runners: ctx.agent_runners.clone(),
         sessions_cache: ctx.sessions_cache.clone(),

--- a/crates/app/bamboo-server/src/tools/child_session_adapter.rs
+++ b/crates/app/bamboo-server/src/tools/child_session_adapter.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use chrono::{Duration as ChronoDuration, Utc};
+use chrono::Utc;
 use tokio::sync::{broadcast, RwLock};
 use tokio::time::{sleep, Duration, Instant};
 
@@ -97,6 +97,38 @@ fn write_runtime_state(session: &mut Session, runtime_state: &AgentRuntimeState)
 }
 
 impl ChildSessionAdapter {
+    /// Construct an adapter. Public so a self-orchestrating WORKER (Phase 6:
+    /// direct nested execution) can build its OWN child-session machinery
+    /// against its own store/scheduler — the struct fields are `pub(crate)`, so
+    /// out-of-crate callers (the worker binary) go through this constructor.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        session_store: Arc<SessionStoreV2>,
+        storage: Arc<dyn Storage>,
+        persistence: Arc<LockedSessionStore>,
+        scheduler: Arc<SpawnScheduler>,
+        sessions_cache: bamboo_engine::SessionCache,
+        agent_runners: Arc<RwLock<HashMap<String, AgentRunner>>>,
+        session_event_senders: Arc<RwLock<HashMap<String, broadcast::Sender<AgentEvent>>>>,
+        subagent_model_resolver: crate::tools::OptionalSubagentModelResolver,
+        config: Arc<RwLock<Config>>,
+    ) -> Self {
+        Self {
+            session_store,
+            storage,
+            persistence,
+            scheduler,
+            sessions_cache,
+            agent_runners,
+            session_event_senders,
+            subagent_model_resolver,
+            config,
+            // Fresh per-adapter wait-coalescing map (the type is private to this
+            // crate, so out-of-crate callers can't supply it).
+            parent_wait_slots: Arc::new(dashmap::DashMap::new()),
+        }
+    }
+
     /// Resolve the provider+model ref for a given subagent_type using the configured resolver.
     pub async fn resolve_subagent_model(
         &self,
@@ -241,13 +273,7 @@ impl ChildSessionAdapter {
         let mut wait = runtime_state
             .waiting_for_children
             .take()
-            .unwrap_or_else(|| WaitingForChildrenState {
-                child_session_ids: Vec::new(),
-                wait_for: policy,
-                registered_at: now,
-                timeout_at: Some(now + ChronoDuration::hours(6)),
-                registered_by_tool_call_id: None,
-            });
+            .unwrap_or_else(|| WaitingForChildrenState::for_children(Vec::new(), policy, now));
         // An explicit wait re-asserts the policy on any pre-existing wait state.
         wait.wait_for = policy;
         for (child_session_id, tool_call_id) in batch {
@@ -318,6 +344,222 @@ impl SubagentResolutionPort for ChildSessionAdapter {
         subagent_type: &str,
     ) -> std::collections::HashMap<String, String> {
         ChildSessionAdapter::resolve_runtime_metadata(self, subagent_type).await
+    }
+}
+
+/// Lets a [`ChildSessionAdapter`] act as the engine's guardian-review spawner.
+///
+/// `Arc<ChildSessionAdapter>` therefore doubles as `Arc<dyn GuardianSpawner>`
+/// (wired onto `AppState`), so the terminal gate spawns the read-only reviewer
+/// through the same child-session machinery the `SubAgent` tool uses — no second
+/// spawn path. The reviewer is a real sub-agent: it fetches the diff and runs
+/// tests itself via its (read-only) toolset.
+#[async_trait]
+impl bamboo_engine::GuardianSpawner for ChildSessionAdapter {
+    async fn spawn_guardian_review(
+        &self,
+        parent_session: &Session,
+        review_prompt: String,
+        model: String,
+        disabled_tools: Option<std::collections::BTreeSet<String>>,
+    ) -> Result<String, String> {
+        let input = bamboo_engine::session_app::child_session::CreateChildInput {
+            parent_session: parent_session.clone(),
+            child_id: format!("guardian-{}", uuid::Uuid::new_v4()),
+            title: "Guardian review".to_string(),
+            responsibility: "Adversarially verify the parent agent's completed work."
+                .to_string(),
+            assignment_prompt: review_prompt,
+            // The coordinator branches on this subagent_type to recognize a
+            // guardian completion and parse its verdict.
+            subagent_type: "guardian".to_string(),
+            workspace: parent_session.workspace_path_meta().unwrap_or_default(),
+            model_override: Some(model),
+            model_ref_override: None,
+            runtime_metadata: HashMap::new(),
+            auto_run: true,
+            reasoning_effort: None,
+            lifecycle: None,
+            resident_name: None,
+            resident_context: None,
+            disabled_tools,
+            context_fork: None,
+        };
+        bamboo_engine::session_app::child_session::create_child_action(self, input)
+            .await
+            .map(|result| result.child_session_id)
+            .map_err(|error| error.to_string())
+    }
+}
+
+impl ChildSessionAdapter {
+    /// Host-side nested `wait` (Phase 6: nested execution). The worker's
+    /// `SubAgent`-proxy forwards `wait` to the host (it does NOT suspend its own
+    /// engine), so this polls the requesting child's grandchildren to terminal
+    /// (bounded by a timeout), then returns their final results. The worker's
+    /// `wait` tool call blocks on the WS round-trip while this runs — no
+    /// worker-side suspend / multi-level resume needed. The grandchildren run on
+    /// independent scheduler tasks, so they progress while we poll.
+    async fn nested_wait(
+        &self,
+        child_session_id: &str,
+        request: &serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        // Optional explicit subset; empty ⇒ wait on every active grandchild.
+        let explicit: Vec<String> = request
+            .get("child_session_ids")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|x| x.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let started = std::time::Instant::now();
+        let timeout = std::time::Duration::from_secs(600);
+        loop {
+            let active = self.active_child_ids(child_session_id).await;
+            let still_active: Vec<String> = if explicit.is_empty() {
+                active
+            } else {
+                active.into_iter().filter(|id| explicit.contains(id)).collect()
+            };
+            if still_active.is_empty() {
+                break;
+            }
+            if started.elapsed() >= timeout {
+                return Ok(serde_json::json!({
+                    "success": false,
+                    "result": format!("nested wait timed out; still active: {still_active:?}"),
+                    "display_preference": null,
+                }));
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+
+        // Collect final results from the (now-terminal) grandchildren.
+        let statuses = self
+            .storage
+            .list_child_run_statuses(child_session_id)
+            .await
+            .unwrap_or_default();
+        let mut children = Vec::new();
+        for (id, status) in statuses {
+            if !explicit.is_empty() && !explicit.contains(&id) {
+                continue;
+            }
+            let result = match self.storage.load_session(&id).await {
+                Ok(Some(session)) => session
+                    .messages
+                    .iter()
+                    .rev()
+                    .find(|m| matches!(m.role, bamboo_agent_core::Role::Assistant))
+                    .map(|m| m.content.clone())
+                    .unwrap_or_default(),
+                _ => String::new(),
+            };
+            children.push(serde_json::json!({
+                "child_session_id": id,
+                "status": status,
+                "result": result,
+            }));
+        }
+
+        Ok(serde_json::json!({
+            "success": true,
+            "result": { "children": children },
+            "display_preference": "Collapsible",
+        }))
+    }
+}
+
+/// Lets a [`ChildSessionAdapter`] fulfil a nested worker's `SubAgent` spawn
+/// request on the host (Phase 6: nested execution). A worker can't spawn
+/// directly (separate process); its `SubAgent`-proxy tool forwards the call over
+/// the actor protocol, the host `drive()` routes it here, and we run the real
+/// spawn through the SAME child-session machinery — parenting a grandchild under
+/// the requesting child. `create` is fire-and-forget (auto_run enqueues it in
+/// the background); `wait` polls those grandchildren to completion (see
+/// [`ChildSessionAdapter::nested_wait`]).
+#[async_trait]
+impl bamboo_engine::external_agents::NestedSpawnHandler for ChildSessionAdapter {
+    async fn spawn_nested(
+        &self,
+        child_session_id: &str,
+        request: serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        let action = request.get("action").and_then(|v| v.as_str()).unwrap_or("");
+        if action == "wait" {
+            return self.nested_wait(child_session_id, &request).await;
+        }
+        if action != "create" {
+            return Ok(serde_json::json!({
+                "success": false,
+                "result": format!(
+                    "nested SubAgent action '{action}' is not supported yet (create/wait)"
+                ),
+                "display_preference": null,
+            }));
+        }
+
+        // The requesting child is the grandchild's parent.
+        let parent = self
+            .storage
+            .load_session(child_session_id)
+            .await
+            .map_err(|e| format!("load requesting child {child_session_id}: {e}"))?
+            .ok_or_else(|| format!("requesting child {child_session_id} not found"))?;
+
+        let str_field =
+            |k: &str| request.get(k).and_then(|v| v.as_str()).map(|s| s.to_string());
+        let prompt = str_field("prompt").unwrap_or_default();
+        if prompt.trim().is_empty() {
+            return Err("nested SubAgent create requires a 'prompt'".to_string());
+        }
+        let workspace = str_field("workspace")
+            .or_else(|| parent.workspace_path_meta())
+            .unwrap_or_default();
+
+        let input = bamboo_engine::session_app::child_session::CreateChildInput {
+            parent_session: parent,
+            child_id: format!("nested-{}", uuid::Uuid::new_v4()),
+            title: str_field("title")
+                .or_else(|| str_field("description"))
+                .unwrap_or_else(|| "Sub-agent".to_string()),
+            responsibility: str_field("responsibility").unwrap_or_default(),
+            assignment_prompt: prompt,
+            subagent_type: str_field("subagent_type").unwrap_or_else(|| "worker".to_string()),
+            workspace,
+            model_override: str_field("model"),
+            model_ref_override: None,
+            runtime_metadata: HashMap::new(),
+            auto_run: true,
+            reasoning_effort: None,
+            lifecycle: None,
+            resident_name: None,
+            resident_context: None,
+            disabled_tools: None,
+            context_fork: request
+                .get("fork_last_messages")
+                .and_then(|v| v.as_u64())
+                .map(|n| n as usize)
+                .filter(|n| *n > 0),
+        };
+
+        let result = bamboo_engine::session_app::child_session::create_child_action(self, input)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok(serde_json::json!({
+            "success": true,
+            "result": {
+                "child_session_id": result.child_session_id,
+                "status": "created",
+                "message": "Grandchild created and enqueued; it runs in the background. Use action=wait to await it once nested wait is supported."
+            },
+            "display_preference": "Collapsible",
+        }))
     }
 }
 
@@ -459,10 +701,17 @@ impl ChildSessionPort for ChildSessionAdapter {
             ));
         }
 
-        // Sub-agents are full agents with the full toolset: no per-role tool
-        // trimming. (The unrelated global `config.disabled_tools` path feeds
-        // `SpawnJob.disabled_tools` elsewhere; it is never computed here.)
-        let disabled_tools = None;
+        // Per-child tool denylist: persisted onto the child session by
+        // `create_child_action` (JSON in metadata). Most sub-agents are full
+        // agents and carry none; a read-only Guardian reviewer carries a
+        // denylist here so the worker trims its toolset. `SpawnJob` wants a
+        // `Vec<String>`, so collect the set.
+        let disabled_tools = child
+            .metadata
+            .get("disabled_tools")
+            .and_then(|raw| serde_json::from_str::<std::collections::BTreeSet<String>>(raw).ok())
+            .filter(|set| !set.is_empty())
+            .map(|set| set.into_iter().collect::<Vec<String>>());
 
         // NOTE: enqueue only *runs* the child in the background. Registering the
         // parent's wait (which suspends the parent) is now an explicit, separate

--- a/crates/app/bamboo-server/src/tools/child_session_adapter.rs
+++ b/crates/app/bamboo-server/src/tools/child_session_adapter.rs
@@ -367,8 +367,7 @@ impl bamboo_engine::GuardianSpawner for ChildSessionAdapter {
             parent_session: parent_session.clone(),
             child_id: format!("guardian-{}", uuid::Uuid::new_v4()),
             title: "Guardian review".to_string(),
-            responsibility: "Adversarially verify the parent agent's completed work."
-                .to_string(),
+            responsibility: "Adversarially verify the parent agent's completed work.".to_string(),
             assignment_prompt: review_prompt,
             // The coordinator branches on this subagent_type to recognize a
             // guardian completion and parse its verdict.
@@ -423,7 +422,10 @@ impl ChildSessionAdapter {
             let still_active: Vec<String> = if explicit.is_empty() {
                 active
             } else {
-                active.into_iter().filter(|id| explicit.contains(id)).collect()
+                active
+                    .into_iter()
+                    .filter(|id| explicit.contains(id))
+                    .collect()
             };
             if still_active.is_empty() {
                 break;
@@ -511,8 +513,12 @@ impl bamboo_engine::external_agents::NestedSpawnHandler for ChildSessionAdapter 
             .map_err(|e| format!("load requesting child {child_session_id}: {e}"))?
             .ok_or_else(|| format!("requesting child {child_session_id} not found"))?;
 
-        let str_field =
-            |k: &str| request.get(k).and_then(|v| v.as_str()).map(|s| s.to_string());
+        let str_field = |k: &str| {
+            request
+                .get(k)
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        };
         let prompt = str_field("prompt").unwrap_or_default();
         if prompt.trim().is_empty() {
             return Err("nested SubAgent create requires a 'prompt'".to_string());

--- a/crates/app/bamboo-server/src/tools/mod.rs
+++ b/crates/app/bamboo-server/src/tools/mod.rs
@@ -11,8 +11,8 @@
 // Re-export framework-agnostic tools from the bamboo-server-tools crate.
 pub use bamboo_server_tools::{
     AskAgentTool, CompactContextTool, DeployAgentTool, DeployedRegistry, LoadSkillTool, MemoryTool,
-    OverlayToolExecutor, ReadSkillResourceTool, SessionInspectorTool, SubAgentTool, ToolSurface,
-    ToolSurfaceFactory,
+    OverlayToolExecutor, ReadSkillResourceTool, SessionInspectorTool, SubAgentProxyTool,
+    SubAgentTool, ToolSurface, ToolSurfaceFactory,
 };
 
 pub mod child_session_adapter;

--- a/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
+++ b/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
@@ -319,6 +319,60 @@ async fn create_without_subagent_type_defaults_to_worker_label() {
 }
 
 #[tokio::test]
+async fn create_refused_at_max_spawn_depth() {
+    // Phase 6: an agent at the depth cap cannot create more sub-agents (bounds
+    // worker→worker→… recursion). Put the parent run session at the cap.
+    let harness = build_test_harness().await;
+    let mut parent = harness
+        .storage
+        .load_session(&harness.parent_session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    parent.spawn_depth = bamboo_server_tools::DEFAULT_MAX_SPAWN_DEPTH;
+    harness.storage.save_session(&parent).await.unwrap();
+
+    let err = harness
+        .tool
+        .execute_with_context(
+            json!({"action":"create","title":"X","responsibility":"Y","prompt":"Z","workspace":"/tmp/ws"}),
+            ctx_for(&harness.parent_session_id, "tc_depth_cap"),
+        )
+        .await
+        .expect_err("create at the depth cap must be refused");
+    assert!(
+        matches!(err, bamboo_agent_core::tools::ToolError::InvalidArguments(ref m) if m.contains("depth limit")),
+        "expected a depth-limit InvalidArguments, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn create_allowed_just_below_max_spawn_depth() {
+    // One level below the cap, create proceeds (depth gate does not fire).
+    let harness = build_test_harness().await;
+    let mut parent = harness
+        .storage
+        .load_session(&harness.parent_session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    parent.spawn_depth = bamboo_server_tools::DEFAULT_MAX_SPAWN_DEPTH - 1;
+    harness.storage.save_session(&parent).await.unwrap();
+
+    let result = harness
+        .tool
+        .execute_with_context(
+            json!({"action":"create","title":"X","responsibility":"Y","prompt":"Z","workspace":"/tmp/ws"}),
+            ctx_for(&harness.parent_session_id, "tc_depth_ok"),
+        )
+        .await;
+    assert!(
+        result.is_ok(),
+        "create just below the cap should proceed, got {result:?}"
+    );
+}
+
+#[tokio::test]
 async fn create_with_wait_true_suspends_and_registers_wait() {
     let harness = build_test_harness().await;
     let result = harness

--- a/crates/core/bamboo-agent-core/src/agent/events.rs
+++ b/crates/core/bamboo-agent-core/src/agent/events.rs
@@ -499,6 +499,24 @@ pub enum AgentEvent {
         parameters: serde_json::Value,
     },
 
+    /// A child sub-agent (out-of-process worker) hit a gated tool and proxied
+    /// the approval decision to this parent over the actor protocol (Phase 2).
+    /// The parent surfaces it to the human; the decision is routed back to the
+    /// waiting child via
+    /// `external_agents::live::deliver_approval(child_session_id, request_id, approved)`.
+    ChildApprovalRequested {
+        /// The child session whose gated tool is blocked awaiting approval.
+        child_session_id: String,
+        /// Correlates the eventual approve/deny reply back to the blocked tool.
+        request_id: String,
+        /// Name of the gated tool the child wants to run.
+        tool_name: String,
+        /// Human-readable description of the permission requested.
+        permission: String,
+        /// The concrete resource the action targets.
+        resource: String,
+    },
+
     /// Agent execution completed successfully.
     Complete {
         /// Final token usage statistics

--- a/crates/core/bamboo-agent-core/src/tools/context.rs
+++ b/crates/core/bamboo-agent-core/src/tools/context.rs
@@ -138,7 +138,9 @@ mod session_flags_tests {
         let session = Session::new("s-none", "test-model");
         assert_eq!(
             ToolExecutionSessionFlags::from_session(&session),
-            ToolExecutionSessionFlags { bypass_permissions: false }
+            ToolExecutionSessionFlags {
+                bypass_permissions: false
+            }
         );
     }
 
@@ -159,7 +161,9 @@ mod session_flags_tests {
             "call-1",
             &tx,
             &[],
-            ToolExecutionSessionFlags { bypass_permissions: true },
+            ToolExecutionSessionFlags {
+                bypass_permissions: true,
+            },
         );
         assert_eq!(ctx.session_id, Some("s1"));
         assert!(ctx.bypass_permissions);

--- a/crates/core/bamboo-domain/src/session/runtime_state.rs
+++ b/crates/core/bamboo-domain/src/session/runtime_state.rs
@@ -159,6 +159,30 @@ pub struct WaitingForChildrenState {
     pub registered_by_tool_call_id: Option<String>,
 }
 
+impl WaitingForChildrenState {
+    /// Construct a parent wait over `child_session_ids` with the default
+    /// 6-hour wait lease (`timeout_at = now + 6h`) and no registering tool
+    /// call. Callers needing a specific lease or originating tool-call id set
+    /// those fields on the returned value afterward.
+    ///
+    /// Centralizes the wait-record defaults so every runner-initiated suspend
+    /// (the orphaned-children safety net, the guardian review gate, ...) and the
+    /// adapter's merge default-branch build the record identically.
+    pub fn for_children(
+        child_session_ids: Vec<String>,
+        wait_for: ChildWaitPolicy,
+        now: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            child_session_ids,
+            wait_for,
+            registered_at: now,
+            timeout_at: Some(now + chrono::Duration::hours(6)),
+            registered_by_tool_call_id: None,
+        }
+    }
+}
+
 /// Suspension reason and context for resumable runs.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SuspensionState {

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -238,8 +238,8 @@ pub fn child_approval_reviewer() -> Option<Arc<dyn ChildApprovalReviewer>> {
 /// reply back down. The top server never installs one ⇒ its drive() falls to the
 /// human-loop. Set per-run (a worker serves runs sequentially, so one active
 /// bridge); a stale bridge from a finished run errors on call ⇒ fail-closed.
-fn escalation_bridge_slot() -> &'static std::sync::Mutex<Option<bamboo_subagent::executor::HostBridge>>
-{
+fn escalation_bridge_slot(
+) -> &'static std::sync::Mutex<Option<bamboo_subagent::executor::HostBridge>> {
     static SLOT: std::sync::Mutex<Option<bamboo_subagent::executor::HostBridge>> =
         std::sync::Mutex::new(None);
     &SLOT
@@ -907,15 +907,27 @@ mod tests {
 
         let mut depth = spec_with("explorer", "p", "m", Some("/ws"), None);
         depth.identity.depth = 2;
-        assert_ne!(base_fp, ActorChildRunner::fingerprint(&depth), "depth must split");
+        assert_ne!(
+            base_fp,
+            ActorChildRunner::fingerprint(&depth),
+            "depth must split"
+        );
 
         let mut nested = spec_with("explorer", "p", "m", Some("/ws"), None);
         nested.capabilities.nested_spawn = true;
-        assert_ne!(base_fp, ActorChildRunner::fingerprint(&nested), "nested_spawn must split");
+        assert_ne!(
+            base_fp,
+            ActorChildRunner::fingerprint(&nested),
+            "nested_spawn must split"
+        );
 
         let mut bypass = spec_with("explorer", "p", "m", Some("/ws"), None);
         bypass.capabilities.bypass = true;
-        assert_ne!(base_fp, ActorChildRunner::fingerprint(&bypass), "bypass must split");
+        assert_ne!(
+            base_fp,
+            ActorChildRunner::fingerprint(&bypass),
+            "bypass must split"
+        );
 
         let mut enforce = spec_with("explorer", "p", "m", Some("/ws"), None);
         enforce.capabilities.enforce_permissions = true;
@@ -927,7 +939,11 @@ mod tests {
 
         let mut cap = spec_with("explorer", "p", "m", Some("/ws"), None);
         cap.capabilities.max_spawn_depth = Some(8);
-        assert_ne!(base_fp, ActorChildRunner::fingerprint(&cap), "max_spawn_depth must split");
+        assert_ne!(
+            base_fp,
+            ActorChildRunner::fingerprint(&cap),
+            "max_spawn_depth must split"
+        );
     }
 
     struct StaticDecider(bool);
@@ -942,8 +958,7 @@ mod tests {
     #[tokio::test]
     async fn child_approval_fails_closed_without_decider() {
         // No decider wired ⇒ the host denies (safe default), unchanged behavior.
-        let body =
-            serde_json::json!({"tool_name":"Bash","permission":"run","resource":"rm -rf /"});
+        let body = serde_json::json!({"tool_name":"Bash","permission":"run","resource":"rm -rf /"});
         assert!(!decide_child_approval(None, "child-1", &body).await);
     }
 
@@ -974,16 +989,14 @@ mod tests {
     async fn nested_spawn_unavailable_without_handler() {
         let reply = fulfil_nested_spawn(None, "child-1", serde_json::json!({})).await;
         assert_eq!(reply["success"], serde_json::json!(false));
-        assert!(reply["result"]
-            .as_str()
-            .unwrap()
-            .contains("not available"));
+        assert!(reply["result"].as_str().unwrap().contains("not available"));
     }
 
     #[tokio::test]
     async fn nested_spawn_returns_handler_result_or_error_body() {
-        let ok: Arc<dyn NestedSpawnHandler> =
-            Arc::new(StaticSpawn(Ok(serde_json::json!({"success": true, "result": "spawned"}))));
+        let ok: Arc<dyn NestedSpawnHandler> = Arc::new(StaticSpawn(Ok(
+            serde_json::json!({"success": true, "result": "spawned"}),
+        )));
         let reply = fulfil_nested_spawn(Some(&ok), "child-1", serde_json::json!({})).await;
         assert_eq!(reply["result"], serde_json::json!("spawned"));
 
@@ -995,8 +1008,7 @@ mod tests {
 
     #[test]
     fn approval_request_fields_extracts_and_defaults() {
-        let full =
-            serde_json::json!({"tool_name":"Bash","permission":"run","resource":"ls"});
+        let full = serde_json::json!({"tool_name":"Bash","permission":"run","resource":"ls"});
         assert_eq!(
             approval_request_fields(&full),
             ("Bash".to_string(), "run".to_string(), "ls".to_string())

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -33,6 +33,13 @@ use crate::runtime::execution::{ExternalChildRunner, SpawnJob};
 /// Default cap on simultaneously running actor processes.
 pub const DEFAULT_MAX_CONCURRENT_ACTORS: usize = 8;
 
+/// Max nesting depth for direct nested execution (Phase 6). A worker whose
+/// session `spawn_depth` is below this gets its own spawn stack + the real
+/// SubAgent tool; at/over it, neither (and the tool itself refuses). Mirrors
+/// `bamboo_server_tools::DEFAULT_MAX_SPAWN_DEPTH` (kept in sync; engine can't
+/// depend on server-tools). Root orchestrator = 0 ⇒ 4 levels of sub-agents.
+pub const MAX_SPAWN_DEPTH: u32 = 4;
+
 /// Default cap on idle pooled (warm, reusable) workers kept per fingerprint.
 const DEFAULT_MAX_IDLE_PER_KEY: usize = 4;
 
@@ -71,6 +78,180 @@ pub struct ActorChildRunner {
     /// fresh process — collapsing N sibling sub-agents onto a few processes.
     pool: Arc<Mutex<HashMap<String, Vec<PooledActor>>>>,
     max_idle_per_key: usize,
+    /// Host-side decision for a child's gated-tool approval request (Phase 2).
+    /// `None` ⇒ fail-closed DENY (the safe default). A wired decider (policy or
+    /// human-routing bridge) returns approve/deny over the actor WS.
+    approval_decider: Option<Arc<dyn ChildApprovalDecider>>,
+    /// Host-side fulfilment of a child's nested SubAgent spawn request (Phase 6).
+    /// `None` ⇒ graceful "not available" error (the safe default).
+    nested_spawn_handler: Option<Arc<dyn NestedSpawnHandler>>,
+}
+
+/// Decides how the host answers a child worker's gated-tool approval request
+/// (Phase 2: child → parent approval delegation). Async so an implementation
+/// can consult a policy or defer to a human. With no decider wired the host
+/// replies with a fail-closed DENY.
+///
+/// NOTE: `decide` is awaited inside the per-child frame pump, so an
+/// implementation must resolve promptly (e.g. a policy lookup). A human-in-the-
+/// loop decision that may block indefinitely should instead be delivered
+/// out-of-band as a `ParentFrame::ApprovalReply` via the live steering channel
+/// (`super::live`), which `drive()` already forwards to the worker without
+/// stalling the pump.
+#[async_trait]
+pub trait ChildApprovalDecider: Send + Sync {
+    /// Decide whether `child_session_id` may perform the gated action described
+    /// by `request` (`{tool_name, permission, resource}`).
+    async fn decide(&self, child_session_id: &str, request: &serde_json::Value) -> bool;
+}
+
+/// Resolve a child approval request to approve/deny. Fail-closed (DENY) when no
+/// decider is wired — the single, testable seam for the host-side decision.
+async fn decide_child_approval(
+    decider: Option<&Arc<dyn ChildApprovalDecider>>,
+    child_session_id: &str,
+    request: &serde_json::Value,
+) -> bool {
+    match decider {
+        Some(decider) => decider.decide(child_session_id, request).await,
+        None => false,
+    }
+}
+
+/// How long the host waits for a human approval decision before failing the
+/// child's gated tool closed (DENY). Bounds an unanswered request so it can't
+/// hang the worker indefinitely.
+const CHILD_APPROVAL_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Extract `(tool_name, permission, resource)` from a worker's approval request
+/// body (`{tool_name, permission, resource}`); missing fields default to empty.
+fn approval_request_fields(body: &serde_json::Value) -> (String, String, String) {
+    let field = |k: &str| {
+        body.get(k)
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
+    (field("tool_name"), field("permission"), field("resource"))
+}
+
+/// Fulfils a child worker's nested SubAgent spawn request on the host (Phase 6:
+/// nested execution). When a child wants a grandchild, its `host.subagent_call`
+/// arrives as a `ChildFrame::SubagentRequest`; an implementation runs the real
+/// spawn (parenting the grandchild under the requesting child) and returns the
+/// SubAgent tool's result JSON. With no handler wired the host replies with a
+/// graceful error so the child's tool fails cleanly instead of hanging.
+#[async_trait]
+pub trait NestedSpawnHandler: Send + Sync {
+    /// Run a nested SubAgent spawn requested by `child_session_id`; `request` is
+    /// the SubAgent tool-call body. Returns the tool-result JSON, or an error
+    /// string (surfaced to the child as a failed tool result).
+    async fn spawn_nested(
+        &self,
+        child_session_id: &str,
+        request: serde_json::Value,
+    ) -> Result<serde_json::Value, String>;
+}
+
+/// The graceful "not available" reply body for an unfulfilled nested spawn.
+fn nested_spawn_unavailable(reason: &str) -> serde_json::Value {
+    serde_json::json!({
+        "success": false,
+        "result": reason,
+        "display_preference": null,
+    })
+}
+
+/// Resolve a nested-spawn request to a `SubagentReply` body. With no handler
+/// wired, returns the graceful "not available" error body (unchanged default).
+async fn fulfil_nested_spawn(
+    handler: Option<&Arc<dyn NestedSpawnHandler>>,
+    child_session_id: &str,
+    request: serde_json::Value,
+) -> serde_json::Value {
+    match handler {
+        Some(handler) => match handler.spawn_nested(child_session_id, request).await {
+            Ok(result) => result,
+            Err(e) => nested_spawn_unavailable(&format!("nested sub-agent spawn failed: {e}")),
+        },
+        None => nested_spawn_unavailable("nested sub-agent spawn is not available in this build"),
+    }
+}
+
+/// Process-global slot for the singleton host-side nested-spawn handler.
+///
+/// Set once at server startup — AFTER the `ChildSessionAdapter` exists, which is
+/// how we resolve the runner→scheduler→adapter construction-order cycle (the
+/// runner is built before the adapter that would be its handler, and it's then
+/// dyn-erased into the composite runner so it can't be reached for a setter).
+/// Read by `drive()` for every child run. Mirrors the `super::live` registry.
+fn nested_spawn_handler_slot() -> &'static std::sync::OnceLock<Arc<dyn NestedSpawnHandler>> {
+    static SLOT: std::sync::OnceLock<Arc<dyn NestedSpawnHandler>> = std::sync::OnceLock::new();
+    &SLOT
+}
+
+/// Install the process-global nested-spawn handler (idempotent; first wins).
+pub fn set_nested_spawn_handler(handler: Arc<dyn NestedSpawnHandler>) {
+    let _ = nested_spawn_handler_slot().set(handler);
+}
+
+/// The process-global nested-spawn handler, if installed.
+pub fn nested_spawn_handler() -> Option<Arc<dyn NestedSpawnHandler>> {
+    nested_spawn_handler_slot().get().cloned()
+}
+
+/// Off-loop reviewer for a child's gated-tool approval request (Phase 6, Part B).
+///
+/// Installed (process-global) by a BYPASSED self-orchestrating worker so its
+/// children's forced-ask (dangerous) gated actions — which still raise
+/// `ConfirmationRequired` even under bypass — get an LLM reasonableness check
+/// rather than a blind pass. `review` is an LLM call: `drive()` invokes it in a
+/// SPAWNED task (NEVER in the frame pump) and delivers the verdict async via the
+/// live channel, so the agent loop is never blocked.
+#[async_trait]
+pub trait ChildApprovalReviewer: Send + Sync {
+    /// Judge whether the gated action `request` (`{tool_name, permission,
+    /// resource}`) is reasonable for `child_session_id`'s task. `true` = approve.
+    async fn review(&self, child_session_id: &str, request: &serde_json::Value) -> bool;
+}
+
+fn child_approval_reviewer_slot() -> &'static std::sync::OnceLock<Arc<dyn ChildApprovalReviewer>> {
+    static SLOT: std::sync::OnceLock<Arc<dyn ChildApprovalReviewer>> = std::sync::OnceLock::new();
+    &SLOT
+}
+
+/// Install the process-global child-approval reviewer (idempotent; first wins).
+pub fn set_child_approval_reviewer(reviewer: Arc<dyn ChildApprovalReviewer>) {
+    let _ = child_approval_reviewer_slot().set(reviewer);
+}
+
+/// The process-global child-approval reviewer, if installed.
+pub fn child_approval_reviewer() -> Option<Arc<dyn ChildApprovalReviewer>> {
+    child_approval_reviewer_slot().get().cloned()
+}
+
+/// Per-run escalation bridge for non-bypass child-approval routing (Phase 6,
+/// Part B). A WORKER's `run()` installs its OWN host bridge here; its `drive()`
+/// (driving grandchildren) uses it to RE-PROXY a child's approval request UP to
+/// its own parent — chaining the request up every level until a bypass level
+/// (model-review) or the top orchestrator (human) decides, then relaying the
+/// reply back down. The top server never installs one ⇒ its drive() falls to the
+/// human-loop. Set per-run (a worker serves runs sequentially, so one active
+/// bridge); a stale bridge from a finished run errors on call ⇒ fail-closed.
+fn escalation_bridge_slot() -> &'static std::sync::Mutex<Option<bamboo_subagent::executor::HostBridge>>
+{
+    static SLOT: std::sync::Mutex<Option<bamboo_subagent::executor::HostBridge>> =
+        std::sync::Mutex::new(None);
+    &SLOT
+}
+
+/// Install (or clear with `None`) the process escalation host bridge.
+pub fn set_escalation_host_bridge(bridge: Option<bamboo_subagent::executor::HostBridge>) {
+    *escalation_bridge_slot().lock().unwrap() = bridge;
+}
+
+fn escalation_host_bridge() -> Option<bamboo_subagent::executor::HostBridge> {
+    escalation_bridge_slot().lock().unwrap().clone()
 }
 
 impl ActorChildRunner {
@@ -97,7 +278,23 @@ impl ActorChildRunner {
             spawn_timeout: Duration::from_secs(30),
             pool: Arc::new(Mutex::new(HashMap::new())),
             max_idle_per_key: DEFAULT_MAX_IDLE_PER_KEY,
+            approval_decider: None,
+            nested_spawn_handler: None,
         }
+    }
+
+    /// Wire the host-side decider for child gated-tool approval requests
+    /// (Phase 2). Without this the host fail-closed DENYs every request.
+    pub fn with_approval_decider(mut self, decider: Arc<dyn ChildApprovalDecider>) -> Self {
+        self.approval_decider = Some(decider);
+        self
+    }
+
+    /// Wire the host-side nested SubAgent spawn handler (Phase 6). Without it, a
+    /// child's nested spawn request fails gracefully ("not available").
+    pub fn with_nested_spawn_handler(mut self, handler: Arc<dyn NestedSpawnHandler>) -> Self {
+        self.nested_spawn_handler = Some(handler);
+        self
     }
 
     /// Reuse fingerprint: two children are interchangeable on one warm worker iff
@@ -195,6 +392,11 @@ impl ActorChildRunner {
                     .get("subagent_type")
                     .cloned()
                     .unwrap_or_else(|| "worker".to_string()),
+                // The child session already carries the correct depth
+                // (create_child_action's new_child_of did parent.spawn_depth+1);
+                // stamp it so the worker can re-establish it on its run session
+                // and enforce the max-depth cap across the actor boundary.
+                depth: session.spawn_depth,
             },
             self.executor.clone(),
             self.fabric_dir.to_string_lossy().into_owned(),
@@ -233,6 +435,22 @@ impl ActorChildRunner {
                 provider
             );
         }
+        // Phase 6 (direct nested execution): a worker BELOW the depth cap may
+        // orchestrate its OWN children — on startup it builds its own spawn
+        // stack and runs the real SubAgent tool (no host proxy). The cap (the
+        // SubAgent tool refuses to spawn at/over `max_spawn_depth`) bounds the
+        // recursion. Driven purely by the child's depth, so it auto-propagates
+        // down the tree without any extra config threading.
+        spec.capabilities.nested_spawn = session.spawn_depth < MAX_SPAWN_DEPTH;
+        spec.capabilities.max_spawn_depth = Some(MAX_SPAWN_DEPTH);
+        // Propagate "bypass permissions" so a self-orchestrating worker knows it
+        // is a bypassed parent and installs the off-loop model-reviewer for its
+        // children's forced-ask actions (Phase 6, Part B). The child session
+        // already carries the inherited flag (create_child_action seeds it).
+        spec.capabilities.bypass = session
+            .agent_runtime_state
+            .as_ref()
+            .is_some_and(|s| s.bypass_permissions);
         spec
     }
 }
@@ -330,7 +548,23 @@ impl ExternalChildRunner for ActorChildRunner {
         let (live_tx, mut live_rx) = mpsc::unbounded_channel::<ParentFrame>();
         let live_guard = super::live::register(&job.child_session_id, live_tx);
 
-        let result = drive(&mut client, &event_tx, &cancel_token, &mut live_rx).await;
+        // The nested-spawn handler is normally the process-global installed at
+        // startup (see `set_nested_spawn_handler`); an explicit per-runner field
+        // overrides it (used in tests).
+        let nested_handler = self
+            .nested_spawn_handler
+            .clone()
+            .or_else(nested_spawn_handler);
+        let result = drive(
+            &mut client,
+            &job.child_session_id,
+            self.approval_decider.as_ref(),
+            nested_handler.as_ref(),
+            &event_tx,
+            &cancel_token,
+            &mut live_rx,
+        )
+        .await;
         // Unregister IMMEDIATELY: after drive returns nobody consumes live_rx,
         // so a send_message landing in the close/park window below must see
         // "not live" and take the durable-queue fallback instead of vanishing.
@@ -366,8 +600,12 @@ impl ExternalChildRunner for ActorChildRunner {
 /// Pump child frames -> parent events until a terminal frame (or cancellation).
 /// On success, yields the actor's final result text (for session write-back).
 /// `live_rx` carries in-band frames (steering messages) from the live registry.
+#[allow(clippy::too_many_arguments)]
 async fn drive(
     client: &mut ChildClient,
+    child_session_id: &str,
+    approval_decider: Option<&Arc<dyn ChildApprovalDecider>>,
+    nested_spawn_handler: Option<&Arc<dyn NestedSpawnHandler>>,
     event_tx: &mpsc::Sender<AgentEvent>,
     cancel_token: &CancellationToken,
     live_rx: &mut mpsc::UnboundedReceiver<ParentFrame>,
@@ -392,23 +630,116 @@ async fn drive(
                             let _ = event_tx.send(ev).await;
                         }
                     }
-                    Ok(Some(ChildFrame::SubagentRequest { id, .. })) => {
-                        // A nested worker child proxied a SubAgent tool call back
-                        // to the host. The host-side handler that runs the real
-                        // SubAgent tool (parenting grandchildren under this child)
-                        // is not wired here yet — answer with a graceful error so
-                        // the worker's tool call fails cleanly instead of hanging.
-                        let body = serde_json::json!({
-                            "success": false,
-                            "result": "nested sub-agent spawn is not available in this build",
-                            "display_preference": null,
-                        });
+                    Ok(Some(ChildFrame::SubagentRequest { id, body })) => {
+                        // Phase 6: a nested worker child proxied a SubAgent tool
+                        // call back to the host. A wired `NestedSpawnHandler` runs
+                        // the real spawn (parenting a grandchild under this child)
+                        // and returns the tool result; with none wired we reply
+                        // with a graceful "not available" error so the worker's
+                        // tool call fails cleanly instead of hanging.
+                        let reply =
+                            fulfil_nested_spawn(nested_spawn_handler, child_session_id, body).await;
                         if client
-                            .send(ParentFrame::SubagentReply { id, body })
+                            .send(ParentFrame::SubagentReply { id, body: reply })
                             .await
                             .is_err()
                         {
                             tracing::warn!("failed to answer subagent_request; connection failing");
+                        }
+                    }
+                    Ok(Some(ChildFrame::ApprovalRequest { id, body })) => {
+                        // Phase 2: a worker proxied a gated-tool approval back to
+                        // the host. The WORKER side is live — its executor installs
+                        // a per-run task-local `ApprovalProxy` (subagent_worker.rs)
+                        // that calls `host.approval_call`, so this frame arrives
+                        // when a child hits `ConfirmationRequired`.
+                        if let Some(reviewer) = child_approval_reviewer() {
+                            // Phase 6, Part B: a BYPASSED parent worker
+                            // model-reviews its children's forced-ask (dangerous)
+                            // actions. The review is an LLM call, so run it OFF
+                            // the frame pump in a spawned task and deliver the
+                            // verdict async via the live channel — the pump keeps
+                            // forwarding events and the agent loop never blocks. A
+                            // timeout denies a hung review so the child can't hang.
+                            let child = child_session_id.to_string();
+                            let req_id = id.clone();
+                            let body = body.clone();
+                            tokio::spawn(async move {
+                                let approved = tokio::time::timeout(
+                                    CHILD_APPROVAL_TIMEOUT,
+                                    reviewer.review(&child, &body),
+                                )
+                                .await
+                                .unwrap_or(false);
+                                super::live::deliver_approval(&child, &req_id, approved);
+                            });
+                        } else if approval_decider.is_some() {
+                            // A decider is wired (policy / auto): decide promptly
+                            // and reply inline. (Must not block the pump — see the
+                            // `ChildApprovalDecider` doc.)
+                            let approved =
+                                decide_child_approval(approval_decider, child_session_id, &body)
+                                    .await;
+                            if client
+                                .send(ParentFrame::ApprovalReply { id, approved })
+                                .await
+                                .is_err()
+                            {
+                                tracing::warn!(
+                                    "failed to answer approval_request; connection failing"
+                                );
+                            }
+                        } else if let Some(host) = escalation_host_bridge() {
+                            // Non-bypass WORKER: ESCALATE up our own actor link
+                            // (re-proxy) so the request chains to our parent — and
+                            // up every level until a bypass level (model-review) or
+                            // the top orchestrator (human) decides. Off-loop so the
+                            // pump never blocks; relay the reply down to the child.
+                            let child = child_session_id.to_string();
+                            let req_id = id.clone();
+                            let body = body.clone();
+                            tokio::spawn(async move {
+                                let approved = match tokio::time::timeout(
+                                    CHILD_APPROVAL_TIMEOUT,
+                                    host.approval_call(body),
+                                )
+                                .await
+                                {
+                                    Ok(Ok(reply)) => reply
+                                        .get("approved")
+                                        .and_then(|v| v.as_bool())
+                                        .unwrap_or(false),
+                                    // Transport error or timeout ⇒ fail closed.
+                                    _ => false,
+                                };
+                                super::live::deliver_approval(&child, &req_id, approved);
+                            });
+                        } else {
+                            // Top orchestrator (no escalation bridge): human-in-the-
+                            // loop. Surface the request on the parent's event stream
+                            // and DEFER — the decision arrives out-of-band via
+                            // `live::deliver_approval(child, request_id, approved)`
+                            // (→ this child's `live_rx` → forwarded to the worker
+                            // above). A timeout denies a never-answered request so
+                            // it can't hang the child forever.
+                            let (tool_name, permission, resource) =
+                                approval_request_fields(&body);
+                            let _ = event_tx
+                                .send(AgentEvent::ChildApprovalRequested {
+                                    child_session_id: child_session_id.to_string(),
+                                    request_id: id.clone(),
+                                    tool_name,
+                                    permission,
+                                    resource,
+                                })
+                                .await;
+                            let child = child_session_id.to_string();
+                            tokio::spawn(async move {
+                                tokio::time::sleep(CHILD_APPROVAL_TIMEOUT).await;
+                                // No-op if already answered (worker ignores an
+                                // unknown/duplicate id) or the child is gone.
+                                super::live::deliver_approval(&child, &id, false);
+                            });
                         }
                     }
                     Ok(Some(ChildFrame::Terminal { status, result, error, .. })) => {
@@ -480,6 +811,7 @@ mod tests {
                 parent_id: None,
                 project_key: None,
                 role: role.into(),
+                depth: 0,
             },
             ExecutorSpec::Echo,
             "/tmp/fab".into(),
@@ -548,6 +880,85 @@ mod tests {
                 Some("/ws"),
                 Some(vec!["Bash"])
             ))
+        );
+    }
+
+    struct StaticDecider(bool);
+
+    #[async_trait]
+    impl ChildApprovalDecider for StaticDecider {
+        async fn decide(&self, _child: &str, _req: &serde_json::Value) -> bool {
+            self.0
+        }
+    }
+
+    #[tokio::test]
+    async fn child_approval_fails_closed_without_decider() {
+        // No decider wired ⇒ the host denies (safe default), unchanged behavior.
+        let body =
+            serde_json::json!({"tool_name":"Bash","permission":"run","resource":"rm -rf /"});
+        assert!(!decide_child_approval(None, "child-1", &body).await);
+    }
+
+    #[tokio::test]
+    async fn child_approval_honors_wired_decider() {
+        let body =
+            serde_json::json!({"tool_name":"Write","permission":"write","resource":"/tmp/x"});
+        let approve: Arc<dyn ChildApprovalDecider> = Arc::new(StaticDecider(true));
+        let deny: Arc<dyn ChildApprovalDecider> = Arc::new(StaticDecider(false));
+        assert!(decide_child_approval(Some(&approve), "child-1", &body).await);
+        assert!(!decide_child_approval(Some(&deny), "child-1", &body).await);
+    }
+
+    struct StaticSpawn(Result<serde_json::Value, String>);
+
+    #[async_trait]
+    impl NestedSpawnHandler for StaticSpawn {
+        async fn spawn_nested(
+            &self,
+            _child: &str,
+            _req: serde_json::Value,
+        ) -> Result<serde_json::Value, String> {
+            self.0.clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn nested_spawn_unavailable_without_handler() {
+        let reply = fulfil_nested_spawn(None, "child-1", serde_json::json!({})).await;
+        assert_eq!(reply["success"], serde_json::json!(false));
+        assert!(reply["result"]
+            .as_str()
+            .unwrap()
+            .contains("not available"));
+    }
+
+    #[tokio::test]
+    async fn nested_spawn_returns_handler_result_or_error_body() {
+        let ok: Arc<dyn NestedSpawnHandler> =
+            Arc::new(StaticSpawn(Ok(serde_json::json!({"success": true, "result": "spawned"}))));
+        let reply = fulfil_nested_spawn(Some(&ok), "child-1", serde_json::json!({})).await;
+        assert_eq!(reply["result"], serde_json::json!("spawned"));
+
+        let err: Arc<dyn NestedSpawnHandler> = Arc::new(StaticSpawn(Err("boom".to_string())));
+        let reply = fulfil_nested_spawn(Some(&err), "child-1", serde_json::json!({})).await;
+        assert_eq!(reply["success"], serde_json::json!(false));
+        assert!(reply["result"].as_str().unwrap().contains("boom"));
+    }
+
+    #[test]
+    fn approval_request_fields_extracts_and_defaults() {
+        let full =
+            serde_json::json!({"tool_name":"Bash","permission":"run","resource":"ls"});
+        assert_eq!(
+            approval_request_fields(&full),
+            ("Bash".to_string(), "run".to_string(), "ls".to_string())
+        );
+        // Missing fields default to empty strings.
+        let partial = serde_json::json!({"tool_name":"Write"});
+        assert_eq!(
+            approval_request_fields(&partial),
+            ("Write".to_string(), String::new(), String::new())
         );
     }
 }

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -298,9 +298,16 @@ impl ActorChildRunner {
     }
 
     /// Reuse fingerprint: two children are interchangeable on one warm worker iff
-    /// they share role, provider, model, workspace, and disabled-tool set (those
-    /// are baked into the worker at provision time; everything else — assignment,
-    /// history — is shipped per-run in the `RunSpec`).
+    /// they share role, provider, model, workspace, disabled-tool set, AND every
+    /// capability the worker BAKES at provision time (`BambooRuntimeExecutor`
+    /// stamps these once and reuses them across runs): nesting depth, nested-spawn
+    /// stack, bypass mode, permission enforcement, and the depth cap. Omitting any
+    /// of these lets the pool hand a run a worker baked for a DIFFERENT posture —
+    /// e.g. a depth-1 worker (with its own spawn stack) reused for a depth-4
+    /// child would re-stamp `spawn_depth=1` and pass the depth-cap check, breaking
+    /// the recursion bound; or a bypass worker reused for a non-bypass child. So
+    /// these MUST split the pool bucket. Everything else (assignment, history) is
+    /// shipped per-run in the `RunSpec` and does not affect the fingerprint.
     fn fingerprint(spec: &ProvisionSpec) -> String {
         let role = spec.identity.role.as_str();
         let (provider, model) = spec
@@ -311,9 +318,15 @@ impl ActorChildRunner {
         let workspace = spec.workspace.as_deref().unwrap_or("");
         let mut tools = spec.disabled_tools.clone().unwrap_or_default();
         tools.sort();
+        let caps = &spec.capabilities;
         format!(
-            "{role}\u{1}{provider}\u{1}{model}\u{1}{workspace}\u{1}{}",
-            tools.join(",")
+            "{role}\u{1}{provider}\u{1}{model}\u{1}{workspace}\u{1}{}\u{1}d={}\u{1}ns={}\u{1}by={}\u{1}ep={}\u{1}md={}",
+            tools.join(","),
+            spec.identity.depth,
+            caps.nested_spawn,
+            caps.bypass,
+            caps.enforce_permissions,
+            caps.max_spawn_depth.unwrap_or(0),
         )
     }
 
@@ -881,6 +894,40 @@ mod tests {
                 Some(vec!["Bash"])
             ))
         );
+    }
+
+    #[test]
+    fn fingerprint_splits_on_baked_capabilities() {
+        // Every capability baked once at provision time must split the pool
+        // bucket, else a worker baked for one posture gets reused for another
+        // (e.g. a depth-1 worker re-stamping spawn_depth onto a depth-4 child,
+        // breaking the depth cap; or a bypass worker reused for a non-bypass one).
+        let base_fp =
+            ActorChildRunner::fingerprint(&spec_with("explorer", "p", "m", Some("/ws"), None));
+
+        let mut depth = spec_with("explorer", "p", "m", Some("/ws"), None);
+        depth.identity.depth = 2;
+        assert_ne!(base_fp, ActorChildRunner::fingerprint(&depth), "depth must split");
+
+        let mut nested = spec_with("explorer", "p", "m", Some("/ws"), None);
+        nested.capabilities.nested_spawn = true;
+        assert_ne!(base_fp, ActorChildRunner::fingerprint(&nested), "nested_spawn must split");
+
+        let mut bypass = spec_with("explorer", "p", "m", Some("/ws"), None);
+        bypass.capabilities.bypass = true;
+        assert_ne!(base_fp, ActorChildRunner::fingerprint(&bypass), "bypass must split");
+
+        let mut enforce = spec_with("explorer", "p", "m", Some("/ws"), None);
+        enforce.capabilities.enforce_permissions = true;
+        assert_ne!(
+            base_fp,
+            ActorChildRunner::fingerprint(&enforce),
+            "enforce_permissions must split"
+        );
+
+        let mut cap = spec_with("explorer", "p", "m", Some("/ws"), None);
+        cap.capabilities.max_spawn_depth = Some(8);
+        assert_ne!(base_fp, ActorChildRunner::fingerprint(&cap), "max_spawn_depth must split");
     }
 
     struct StaticDecider(bool);

--- a/crates/engine/bamboo-engine/src/external_agents/live.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/live.rs
@@ -54,6 +54,29 @@ pub fn deliver_message(child_id: &str, text: &str) -> bool {
     }
 }
 
+/// Deliver a host/human approval decision to a live child's pending gated-tool
+/// request (Phase 2: child → parent approval delegation). Sends
+/// `ParentFrame::ApprovalReply{id, approved}` over the child's live WS
+/// connection; `drive()` forwards it to the worker, whose pending map resolves
+/// the `host.approval_call` the child's gated tool is blocked on (approve ⇒ the
+/// tool proceeds, deny ⇒ it fails closed). This is the decision-DOWN half of the
+/// human-in-the-loop route: a parent-side responder (e.g. a `/respond`-style
+/// handler) calls this with the `request_id` it surfaced to the human. Returns
+/// `false` when the child is not live (no connection to answer on — the caller
+/// should treat that as a denied/expired request).
+pub fn deliver_approval(child_id: &str, request_id: &str, approved: bool) -> bool {
+    let guard = map().lock().unwrap();
+    match guard.get(child_id) {
+        Some(tx) => tx
+            .send(ParentFrame::ApprovalReply {
+                id: request_id.to_string(),
+                approved,
+            })
+            .is_ok(),
+        None => false,
+    }
+}
+
 /// Whether a child currently has a live actor connection.
 pub fn is_live(child_id: &str) -> bool {
     map().lock().unwrap().contains_key(child_id)
@@ -85,5 +108,22 @@ mod tests {
         let _guard = register("c-dead", tx);
         drop(rx);
         assert!(!deliver_message("c-dead", "hi"));
+    }
+
+    #[test]
+    fn deliver_approval_routes_reply_frame() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let guard = register("c-appr", tx);
+        assert!(deliver_approval("c-appr", "req-7", true));
+        match rx.try_recv() {
+            Ok(ParentFrame::ApprovalReply { id, approved }) => {
+                assert_eq!(id, "req-7");
+                assert!(approved);
+            }
+            other => panic!("expected approval reply, got {other:?}"),
+        }
+        drop(guard);
+        // Not-live child ⇒ false (no connection to answer on).
+        assert!(!deliver_approval("c-appr", "req-8", false));
     }
 }

--- a/crates/engine/bamboo-engine/src/external_agents/mod.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/mod.rs
@@ -6,7 +6,10 @@ pub mod mapping;
 pub mod runtime;
 
 pub use a2a_adapter::A2AExternalChildRunner;
-pub use actor_adapter::ActorChildRunner;
+pub use actor_adapter::{
+    child_approval_reviewer, set_child_approval_reviewer, set_escalation_host_bridge,
+    set_nested_spawn_handler, ActorChildRunner, ChildApprovalReviewer, NestedSpawnHandler,
+};
 pub use config::{
     parse_external_agents, parse_subagent_routing, resolve_runtime_metadata, ExternalAgentProfile,
     ExternalAgentProtocol, SubagentRouting,

--- a/crates/engine/bamboo-engine/src/lib.rs
+++ b/crates/engine/bamboo-engine/src/lib.rs
@@ -37,7 +37,10 @@ pub use runtime::agent::AgentBuilder;
 // `AgentLoopConfig` is intentionally NOT re-exported: its fields are `pub(crate)`,
 // so it cannot be constructed outside the engine. Execution funnels solely through
 // `AgentRuntime::execute`.
-pub use runtime::config::{AuxiliaryModelConfig, ImageFallbackConfig, ImageFallbackMode};
+pub use runtime::config::{
+    ApprovalDelegate, AuxiliaryModelConfig, ChildApprovalOutcome, ChildApprovalRequest,
+    GuardianConfig, GuardianSpawner, ImageFallbackConfig, ImageFallbackMode,
+};
 pub use runtime::execution::runner_state::{AgentRunner, AgentStatus};
 pub use runtime::hooks::HookRunner;
 pub use runtime::managers::{

--- a/crates/engine/bamboo-engine/src/runtime/approval_delegation_state.rs
+++ b/crates/engine/bamboo-engine/src/runtime/approval_delegation_state.rs
@@ -190,12 +190,16 @@ mod tests {
         let mut state = ApprovalDelegationState::default();
         state.upsert(req("child-1", "q-1"));
         write_approval_delegation_state(&mut parent, state);
-        assert!(parent.metadata.contains_key(APPROVAL_DELEGATION_METADATA_KEY));
+        assert!(parent
+            .metadata
+            .contains_key(APPROVAL_DELEGATION_METADATA_KEY));
 
         // Resolving the only pending → empty → key removed.
         let mut state = ensure_approval_delegation_state(&parent);
         state.take_by_question("q-1");
         write_approval_delegation_state(&mut parent, state);
-        assert!(!parent.metadata.contains_key(APPROVAL_DELEGATION_METADATA_KEY));
+        assert!(!parent
+            .metadata
+            .contains_key(APPROVAL_DELEGATION_METADATA_KEY));
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/approval_delegation_state.rs
+++ b/crates/engine/bamboo-engine/src/runtime/approval_delegation_state.rs
@@ -1,0 +1,201 @@
+//! Durable parent-side record of child sub-agent approval requests delegated up.
+//!
+//! Phase 2 of the sub-agent roadmap (child→parent approval delegation): a
+//! non-bypassed child that hits a gated tool cannot answer its own permission
+//! prompt (no human is attached to a child session). Instead the request is
+//! delegated UP to the parent — which surfaces it to the human via the parent's
+//! existing pending-question / notification / `/respond` machinery — and the
+//! decision is routed back DOWN to resume the waiting child.
+//!
+//! This module owns the durable mapping the parent needs to route an answer back
+//! to the right child + tool call. Like [`crate::runtime::guardian_state`] it
+//! lives in `session.metadata` under [`APPROVAL_DELEGATION_METADATA_KEY`] as a
+//! single JSON blob, so it round-trips through the normal session save/load path
+//! with no new storage entity. It is stored on the PARENT session.
+
+use bamboo_agent_core::Session;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+/// Parent-session metadata key holding the serialized [`ApprovalDelegationState`].
+pub const APPROVAL_DELEGATION_METADATA_KEY: &str = "approval.delegation.state";
+
+/// Upper bound on retained pending approvals, so a runaway fan-out of children
+/// cannot grow the persisted blob without limit. Oldest entries are dropped.
+const MAX_PENDING: usize = 64;
+
+/// One child approval request awaiting the parent's (human's) decision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingChildApproval {
+    /// The child session that is suspended waiting for this decision.
+    pub child_session_id: String,
+    /// The gated tool call on the child to re-execute once approved.
+    pub child_tool_call_id: String,
+    /// The gated tool name (for the surfaced question + diagnostics).
+    pub tool_name: String,
+    /// Permission type as a string (e.g. "WriteFile", "ExecuteCommand").
+    pub permission_type: String,
+    /// The concrete resource the permission applies to (path, command, …).
+    pub resource: String,
+    /// The synthetic pending-question id surfaced on the PARENT for this request
+    /// — the key the parent's `/respond` answer is correlated back through.
+    pub parent_pending_question_id: String,
+    pub registered_at: String,
+}
+
+/// Durable parent-side set of in-flight child approval delegations.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ApprovalDelegationState {
+    #[serde(default)]
+    pub pending: Vec<PendingChildApproval>,
+}
+
+impl ApprovalDelegationState {
+    /// Record a new pending approval (deduped on `parent_pending_question_id`),
+    /// trimming the oldest if the cap is exceeded.
+    pub fn upsert(&mut self, request: PendingChildApproval) {
+        self.pending
+            .retain(|p| p.parent_pending_question_id != request.parent_pending_question_id);
+        self.pending.push(request);
+        if self.pending.len() > MAX_PENDING {
+            let overflow = self.pending.len() - MAX_PENDING;
+            self.pending.drain(0..overflow);
+        }
+    }
+
+    /// Remove and return the pending approval surfaced under `question_id`.
+    pub fn take_by_question(&mut self, question_id: &str) -> Option<PendingChildApproval> {
+        let idx = self
+            .pending
+            .iter()
+            .position(|p| p.parent_pending_question_id == question_id)?;
+        Some(self.pending.remove(idx))
+    }
+
+    /// Remove and return the pending approval for `child_session_id`, if any.
+    pub fn take_by_child(&mut self, child_session_id: &str) -> Option<PendingChildApproval> {
+        let idx = self
+            .pending
+            .iter()
+            .position(|p| p.child_session_id == child_session_id)?;
+        Some(self.pending.remove(idx))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.pending.is_empty()
+    }
+}
+
+/// Read the persisted parent-side delegation state, if present and parseable.
+pub fn read_approval_delegation_state(session: &Session) -> Option<ApprovalDelegationState> {
+    let raw = session.metadata.get(APPROVAL_DELEGATION_METADATA_KEY)?;
+    serde_json::from_str::<ApprovalDelegationState>(raw).ok()
+}
+
+/// Read the existing delegation state, or a fresh empty one.
+pub fn ensure_approval_delegation_state(session: &Session) -> ApprovalDelegationState {
+    read_approval_delegation_state(session).unwrap_or_default()
+}
+
+/// Persist the delegation state into the parent `session.metadata`. An empty
+/// state is removed (keeps metadata clean once all approvals resolve).
+pub fn write_approval_delegation_state(session: &mut Session, state: ApprovalDelegationState) {
+    if state.is_empty() {
+        session.metadata.remove(APPROVAL_DELEGATION_METADATA_KEY);
+        return;
+    }
+    match serde_json::to_string(&state) {
+        Ok(json) => {
+            session
+                .metadata
+                .insert(APPROVAL_DELEGATION_METADATA_KEY.to_string(), json);
+        }
+        Err(error) => {
+            tracing::warn!(
+                "failed to serialize approval delegation state for session {}: {error}",
+                session.id
+            );
+        }
+    }
+}
+
+/// Build a [`PendingChildApproval`] stamped with the current time.
+pub fn new_pending_child_approval(
+    child_session_id: impl Into<String>,
+    child_tool_call_id: impl Into<String>,
+    tool_name: impl Into<String>,
+    permission_type: impl Into<String>,
+    resource: impl Into<String>,
+    parent_pending_question_id: impl Into<String>,
+) -> PendingChildApproval {
+    PendingChildApproval {
+        child_session_id: child_session_id.into(),
+        child_tool_call_id: child_tool_call_id.into(),
+        tool_name: tool_name.into(),
+        permission_type: permission_type.into(),
+        resource: resource.into(),
+        parent_pending_question_id: parent_pending_question_id.into(),
+        registered_at: Utc::now().to_rfc3339(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_agent_core::Session;
+
+    fn req(child: &str, question: &str) -> PendingChildApproval {
+        new_pending_child_approval(child, "tc-1", "Write", "WriteFile", "/tmp/x", question)
+    }
+
+    #[test]
+    fn round_trips_through_parent_metadata() {
+        let mut parent = Session::new("parent", "model");
+        let mut state = ApprovalDelegationState::default();
+        state.upsert(req("child-1", "q-1"));
+        state.upsert(req("child-2", "q-2"));
+        write_approval_delegation_state(&mut parent, state);
+
+        let loaded = read_approval_delegation_state(&parent).expect("persists");
+        assert_eq!(loaded.pending.len(), 2);
+        assert_eq!(loaded.pending[0].child_session_id, "child-1");
+        assert_eq!(loaded.pending[1].parent_pending_question_id, "q-2");
+    }
+
+    #[test]
+    fn upsert_dedupes_on_question_id() {
+        let mut state = ApprovalDelegationState::default();
+        state.upsert(req("child-1", "q-1"));
+        state.upsert(req("child-1b", "q-1")); // same question id → replaces
+        assert_eq!(state.pending.len(), 1);
+        assert_eq!(state.pending[0].child_session_id, "child-1b");
+    }
+
+    #[test]
+    fn take_by_question_and_child() {
+        let mut state = ApprovalDelegationState::default();
+        state.upsert(req("child-1", "q-1"));
+        state.upsert(req("child-2", "q-2"));
+        let taken = state.take_by_question("q-1").expect("found by question");
+        assert_eq!(taken.child_session_id, "child-1");
+        assert_eq!(state.pending.len(), 1);
+        let taken2 = state.take_by_child("child-2").expect("found by child");
+        assert_eq!(taken2.parent_pending_question_id, "q-2");
+        assert!(state.pending.is_empty());
+    }
+
+    #[test]
+    fn empty_state_is_removed_from_metadata() {
+        let mut parent = Session::new("parent", "model");
+        let mut state = ApprovalDelegationState::default();
+        state.upsert(req("child-1", "q-1"));
+        write_approval_delegation_state(&mut parent, state);
+        assert!(parent.metadata.contains_key(APPROVAL_DELEGATION_METADATA_KEY));
+
+        // Resolving the only pending → empty → key removed.
+        let mut state = ensure_approval_delegation_state(&parent);
+        state.take_by_question("q-1");
+        write_approval_delegation_state(&mut parent, state);
+        assert!(!parent.metadata.contains_key(APPROVAL_DELEGATION_METADATA_KEY));
+    }
+}

--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -508,10 +508,7 @@ impl AgentLoopConfig {
     /// config is present and enabled.
     pub fn guardian_active(&self) -> bool {
         self.guardian_spawner.is_some()
-            && self
-                .guardian_config
-                .as_ref()
-                .is_some_and(|cfg| cfg.enabled)
+            && self.guardian_config.as_ref().is_some_and(|cfg| cfg.enabled)
     }
 
     /// Maximum guardian review passes for this run (the budget). `0` when no

--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -120,6 +120,111 @@ impl GoldConfig {
     }
 }
 
+fn default_guardian_max_reviews() -> u32 {
+    2
+}
+
+/// Configuration for the guardian adversarial-review terminal gate.
+///
+/// Mirrors [`GoldConfig`]: a plain, serde-defaulting struct surfaced per run.
+/// When `enabled` is false (the default) the guardian gate is inactive and the
+/// terminal completion path is unchanged.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct GuardianConfig {
+    /// Master switch for the guardian review gate.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Optional dedicated reviewer model. Falls back to the run's main model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
+    /// Maximum guardian review passes per run (budget; mirrors
+    /// [`GoldConfig::max_auto_continuations`]).
+    #[serde(default = "default_guardian_max_reviews")]
+    pub max_reviews: u32,
+}
+
+impl Default for GuardianConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            model_name: None,
+            max_reviews: default_guardian_max_reviews(),
+        }
+    }
+}
+
+/// Late-bound spawner for the guardian reviewer child.
+///
+/// The runner cannot construct a child directly: the `SpawnScheduler` is built
+/// *after* the `Agent` that drives the runner (a construction-order cycle), so
+/// the terminal gate spawns the reviewer through this trait object, injected
+/// per-request on [`AgentLoopConfig`] exactly like `auxiliary_model_resolver`.
+/// The implementation lives in the server (it captures the already-built
+/// scheduler + child-session adapter); the engine holds only the trait, keeping
+/// the engine free of any dependency on server/AppState types.
+#[async_trait::async_trait]
+pub trait GuardianSpawner: Send + Sync {
+    /// Create a read-only reviewer child for `parent_session_id`, seeded with
+    /// `review_prompt`, enqueue it to run, and return its session id so the
+    /// caller can register a wait on it.
+    async fn spawn_guardian_review(
+        &self,
+        parent_session: &bamboo_agent_core::Session,
+        review_prompt: String,
+        model: String,
+        disabled_tools: Option<BTreeSet<String>>,
+    ) -> Result<String, String>;
+}
+
+/// A child sub-agent's request to have a gated tool approved by its parent.
+///
+/// A non-bypassed child cannot answer its own permission prompt (no human is
+/// attached to a child session), so the request is delegated up to the parent.
+#[derive(Debug, Clone)]
+pub struct ChildApprovalRequest {
+    pub child_session_id: String,
+    pub parent_session_id: String,
+    /// The gated tool call on the child to re-execute once approved.
+    pub child_tool_call_id: String,
+    pub tool_name: String,
+    /// Permission type as a string (e.g. "WriteFile", "ExecuteCommand").
+    pub permission_type: String,
+    /// The concrete resource the permission applies to (path, command, …).
+    pub resource: String,
+    /// Human-facing approval question to surface on the parent.
+    pub question: String,
+    /// The raw `awaiting_permission_approval` payload the child's executor built,
+    /// so the parent can reuse the existing grant-extraction path verbatim.
+    pub approval_payload: serde_json::Value,
+}
+
+/// What the executor should do after delegating a child's approval upward.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChildApprovalOutcome {
+    /// Registered on the parent; the child must SUSPEND and await the decision.
+    Delegated,
+    /// Parent policy auto-approved (bypass / existing grant); proceed to execute.
+    AutoApproved,
+    /// Parent policy auto-denied; the executor must deny the tool.
+    AutoDenied,
+}
+
+/// Late-bound delegate that routes a child's approval request up to its parent.
+///
+/// Injected per-request on [`AgentLoopConfig`] exactly like [`GuardianSpawner`];
+/// the trait lives in the engine, the implementation in the server (it owns the
+/// parent session store + pending-question + notification machinery).
+#[async_trait::async_trait]
+pub trait ApprovalDelegate: Send + Sync {
+    /// Register `request` on its parent (or auto-resolve by policy) and report
+    /// what the child's executor should do next.
+    async fn delegate_child_approval(
+        &self,
+        request: ChildApprovalRequest,
+    ) -> Result<ChildApprovalOutcome, String>;
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ImageFallbackMode {
     Placeholder,
@@ -280,6 +385,17 @@ pub struct AgentLoopConfig {
     /// When `None` or `enabled == false`, Gold evaluation is disabled and the
     /// existing execute/respond/resume loop remains unchanged.
     pub(crate) gold_config: Option<GoldConfig>,
+    /// Optional guardian adversarial-review gate configuration. When `None` or
+    /// `enabled == false`, the guardian terminal gate is inactive.
+    pub(crate) guardian_config: Option<GuardianConfig>,
+    /// Late-bound spawner for the guardian reviewer child. `None` (the default)
+    /// leaves the guardian gate inert even when `guardian_config.enabled` is set,
+    /// since the runner cannot create a child without it. Wired by the server.
+    pub(crate) guardian_spawner: Option<Arc<dyn GuardianSpawner>>,
+    /// Late-bound delegate that routes a child's gated-tool approval request up
+    /// to its parent (Phase 2). `None` (the default) leaves child gating on its
+    /// legacy path. Wired by the server.
+    pub(crate) approval_delegate: Option<Arc<dyn ApprovalDelegate>>,
     /// Enable dynamic per-round model routing based on task complexity.
     /// When true, the pipeline classifies complexity at each round end and
     /// stores the result in session metadata.
@@ -353,6 +469,9 @@ impl Default for AgentLoopConfig {
             parallel_batch_timeout_secs: 300,
             permission_mode: None,
             gold_config: None,
+            guardian_config: None,
+            guardian_spawner: None,
+            approval_delegate: None,
             features_dynamic_model_routing: false,
             auxiliary_model_resolver: None,
             mcp_tool_guidance: None,
@@ -382,6 +501,37 @@ impl AgentLoopConfig {
         self.gold_config.as_ref().is_some_and(|cfg| {
             cfg.enabled && cfg.auto_continue_enabled && cfg.effective_goal().is_some()
         })
+    }
+
+    /// Whether the guardian review gate is active for this run: a spawner is
+    /// wired (so the runner can actually create the reviewer child) AND the
+    /// config is present and enabled.
+    pub fn guardian_active(&self) -> bool {
+        self.guardian_spawner.is_some()
+            && self
+                .guardian_config
+                .as_ref()
+                .is_some_and(|cfg| cfg.enabled)
+    }
+
+    /// Maximum guardian review passes for this run (the budget). `0` when no
+    /// guardian config is set.
+    pub fn guardian_max_reviews(&self) -> u32 {
+        self.guardian_config
+            .as_ref()
+            .map_or(0, |cfg| cfg.max_reviews)
+    }
+
+    /// The reviewer model override, if a guardian config sets one.
+    pub fn guardian_model(&self) -> Option<&str> {
+        self.guardian_config
+            .as_ref()
+            .and_then(|cfg| cfg.model_name.as_deref())
+    }
+
+    /// Whether child→parent approval delegation is wired for this run.
+    pub fn delegation_active(&self) -> bool {
+        self.approval_delegate.is_some()
     }
 }
 

--- a/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
@@ -17,7 +17,9 @@ use bamboo_agent_core::{AgentError, AgentEvent, Session};
 use bamboo_domain::ReasoningEffort;
 use bamboo_llm::LLMProvider;
 
-use crate::runtime::config::{AuxiliaryModelConfig, GoldConfig, ImageFallbackConfig};
+use crate::runtime::config::{
+    AuxiliaryModelConfig, GoldConfig, GuardianConfig, GuardianSpawner, ImageFallbackConfig,
+};
 use crate::runtime::execution::runner_lifecycle::finalize_runner;
 use crate::runtime::execution::runner_state::AgentRunner;
 use crate::runtime::model_roster::ModelRoster;
@@ -133,6 +135,11 @@ pub struct SessionExecutionArgs {
     pub mpsc_tx: mpsc::Sender<AgentEvent>,
     pub image_fallback: Option<ImageFallbackConfig>,
     pub gold_config: Option<GoldConfig>,
+    /// Optional guardian adversarial-review gate configuration.
+    pub guardian_config: Option<GuardianConfig>,
+    /// Late-bound guardian reviewer spawner (server-provided; the runner cannot
+    /// construct a child directly).
+    pub guardian_spawner: Option<Arc<dyn GuardianSpawner>>,
     pub app_data_dir: Option<std::path::PathBuf>,
 
     // Post-execution resources.
@@ -165,6 +172,8 @@ struct ExecuteRequestParams {
     selected_skill_mode: Option<String>,
     image_fallback: Option<ImageFallbackConfig>,
     gold_config: Option<GoldConfig>,
+    guardian_config: Option<GuardianConfig>,
+    guardian_spawner: Option<Arc<dyn GuardianSpawner>>,
     app_data_dir: Option<std::path::PathBuf>,
 }
 
@@ -192,12 +201,16 @@ fn build_execute_request(
         selected_skill_mode,
         image_fallback,
         gold_config,
+        guardian_config,
+        guardian_spawner,
         app_data_dir,
     } = params;
 
     let mut builder = ExecuteRequestBuilder::new(initial_message, event_tx, cancel_token)
         .model_roster(model_roster)
-        .gold_config(gold_config);
+        .gold_config(gold_config)
+        .guardian_config(guardian_config)
+        .guardian_spawner(guardian_spawner);
 
     if let Some(tools) = tools {
         builder = builder.tools(tools);
@@ -265,6 +278,8 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
                 mpsc_tx,
                 image_fallback,
                 gold_config,
+                guardian_config,
+                guardian_spawner,
                 app_data_dir,
                 runners,
                 sessions_cache,
@@ -325,6 +340,8 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
                     selected_skill_mode,
                     image_fallback,
                     gold_config,
+                    guardian_config,
+                    guardian_spawner,
                     app_data_dir,
                 },
             );

--- a/crates/engine/bamboo-engine/src/runtime/guardian_state.rs
+++ b/crates/engine/bamboo-engine/src/runtime/guardian_state.rs
@@ -425,8 +425,7 @@ mod tests {
         let mut state = GuardianState::new();
         state.record_spawn("guardian-child-1");
         state.record_verdict(
-            GuardianVerdict::rejected(vec!["missing test".to_string()])
-                .with_summary("one bug"),
+            GuardianVerdict::rejected(vec!["missing test".to_string()]).with_summary("one bug"),
             7,
         );
 
@@ -434,7 +433,10 @@ mod tests {
         let loaded = read_guardian_state(&session).expect("state persists");
 
         assert_eq!(loaded.phase, GuardianPhase::Reviewed);
-        assert_eq!(loaded.guardian_child_id.as_deref(), Some("guardian-child-1"));
+        assert_eq!(
+            loaded.guardian_child_id.as_deref(),
+            Some("guardian-child-1")
+        );
         assert_eq!(loaded.review_count, 1);
         assert_eq!(loaded.last_reviewed_at_round, 7);
         let verdict = loaded.last_verdict.expect("verdict persisted");
@@ -500,8 +502,9 @@ mod tests {
 
     #[test]
     fn parse_verdict_bare_object() {
-        let v = parse_guardian_verdict(r#"{"approve": false, "summary": "bug", "findings": ["x"]}"#)
-            .expect("parses");
+        let v =
+            parse_guardian_verdict(r#"{"approve": false, "summary": "bug", "findings": ["x"]}"#)
+                .expect("parses");
         assert!(!v.approve);
         assert_eq!(v.summary.as_deref(), Some("bug"));
         assert_eq!(v.findings, vec!["x".to_string()]);
@@ -515,7 +518,8 @@ mod tests {
                 .expect("fenced parses")
                 .approve
         );
-        let embedded = "Here is my verdict:\n{\"approve\": false, \"findings\": [\"nope\"]}\nThanks.";
+        let embedded =
+            "Here is my verdict:\n{\"approve\": false, \"findings\": [\"nope\"]}\nThanks.";
         let v = parse_guardian_verdict(embedded).expect("embedded parses");
         assert!(!v.approve);
         assert_eq!(v.findings, vec!["nope".to_string()]);

--- a/crates/engine/bamboo-engine/src/runtime/guardian_state.rs
+++ b/crates/engine/bamboo-engine/src/runtime/guardian_state.rs
@@ -1,0 +1,561 @@
+//! Durable per-session guardian-review state for the adversarial completion gate.
+//!
+//! The guardian feature is a sibling of the goal loop ([`crate::runtime::goal_state`]):
+//! when the main agent would otherwise complete the run, the runtime can spawn a
+//! read-only **guardian child** to adversarially review the final diff against
+//! the active task's completion criteria before the run is allowed to stop. This
+//! module owns the durable record that ties a single review pass together.
+//!
+//! Like `goal_state`, it lives in `session.metadata` under
+//! [`GUARDIAN_STATE_METADATA_KEY`] as a single JSON value (the established
+//! Bamboo pattern for structured, session-scoped state), so it round-trips
+//! through the normal session save/load path with no new storage entity.
+//!
+//! The review budget mirrors the goal loop's `continuation_count`: a count-based
+//! cap ([`GuardianState::review_count`] checked against a configured max via
+//! [`GuardianState::budget_exhausted`]) so a pathological review → fix → review
+//! cycle cannot run unbounded. The cap value itself lives with the caller (the
+//! terminal gate), mirroring how `continuation_count` is enforced in `gold.rs`
+//! rather than in `goal_state.rs`.
+
+use std::collections::BTreeSet;
+
+use bamboo_agent_core::Session;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+/// Session metadata key holding the serialized [`GuardianState`] JSON blob.
+pub const GUARDIAN_STATE_METADATA_KEY: &str = "guardian.state";
+
+/// Upper bound on retained findings on a single verdict, so a runaway reviewer
+/// cannot grow the persisted blob without limit. The newest findings are kept.
+const MAX_FINDINGS: usize = 50;
+
+/// Lifecycle phase of the current guardian review pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GuardianPhase {
+    /// No review is outstanding for the current terminal point.
+    None,
+    /// A guardian child has been spawned and a verdict is awaited.
+    Pending,
+    /// A verdict has been recorded for the current terminal point.
+    Reviewed,
+}
+
+impl GuardianPhase {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Pending => "pending",
+            Self::Reviewed => "reviewed",
+        }
+    }
+
+    /// Whether a guardian child is currently in flight.
+    pub fn is_pending(self) -> bool {
+        matches!(self, Self::Pending)
+    }
+
+    /// Whether a verdict has already been recorded for this pass.
+    pub fn is_reviewed(self) -> bool {
+        matches!(self, Self::Reviewed)
+    }
+}
+
+/// A single guardian review verdict, parsed from the reviewer child's final
+/// message (see the G5 verdict parser). The JSON shape the reviewer is asked to
+/// emit matches this struct's serde representation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GuardianVerdict {
+    /// Whether the guardian approves stopping the run.
+    pub approve: bool,
+    /// The reviewer's short rationale, if provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    /// Concrete findings the guardian wants addressed before approval.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub findings: Vec<String>,
+}
+
+impl GuardianVerdict {
+    /// Build an approving verdict with no findings.
+    pub fn approved() -> Self {
+        Self {
+            approve: true,
+            summary: None,
+            findings: Vec::new(),
+        }
+    }
+
+    /// Build a rejecting verdict carrying the given findings, trimmed to the
+    /// newest [`MAX_FINDINGS`].
+    pub fn rejected(findings: Vec<String>) -> Self {
+        Self {
+            approve: false,
+            summary: None,
+            findings: trim_findings(findings),
+        }
+    }
+
+    /// Attach a reviewer summary (builder style).
+    pub fn with_summary(mut self, summary: impl Into<String>) -> Self {
+        self.summary = Some(summary.into());
+        self
+    }
+
+    /// Normalize a freshly-parsed verdict: clamp findings to [`MAX_FINDINGS`].
+    pub fn normalized(mut self) -> Self {
+        self.findings = trim_findings(std::mem::take(&mut self.findings));
+        self
+    }
+}
+
+/// Keep only the newest [`MAX_FINDINGS`] findings.
+fn trim_findings(mut findings: Vec<String>) -> Vec<String> {
+    if findings.len() > MAX_FINDINGS {
+        let overflow = findings.len() - MAX_FINDINGS;
+        findings.drain(0..overflow);
+    }
+    findings
+}
+
+/// Durable guardian record persisted in `session.metadata`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GuardianState {
+    /// Lifecycle phase of the current review pass.
+    pub phase: GuardianPhase,
+    /// The session id of the in-flight (or most recent) guardian child, if any.
+    /// Used by the completion coordinator to correlate a completing child with
+    /// the review this parent actually dispatched.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guardian_child_id: Option<String>,
+    /// The most recent guardian verdict, if a review has completed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_verdict: Option<GuardianVerdict>,
+    /// The round at which the last verdict was recorded. Observability/diagnostics
+    /// only — NOT currently read by the gate.
+    ///
+    /// KNOWN v1 SCOPE: the gate does not yet re-review work produced *after* an
+    /// approval (e.g. during a Gold goal-continuation) or across top-level user
+    /// turns, and the review budget is session-cumulative. A robust staleness
+    /// re-review needs a cross-turn-monotonic "new work" signal (the per-run
+    /// round counter resets each turn) plus a per-turn budget reset; deferred
+    /// until the feature is enabled in production.
+    #[serde(default)]
+    pub last_reviewed_at_round: u32,
+    /// How many guardian review passes have fired this session (the budget).
+    #[serde(default)]
+    pub review_count: u32,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl GuardianState {
+    fn new() -> Self {
+        let now = Utc::now().to_rfc3339();
+        Self {
+            phase: GuardianPhase::None,
+            guardian_child_id: None,
+            last_verdict: None,
+            last_reviewed_at_round: 0,
+            review_count: 0,
+            created_at: now.clone(),
+            updated_at: now,
+        }
+    }
+
+    /// Record that a guardian child has been spawned (move to `Pending`), and
+    /// charge the review budget.
+    pub fn record_spawn(&mut self, child_id: impl Into<String>) {
+        self.guardian_child_id = Some(child_id.into());
+        self.phase = GuardianPhase::Pending;
+        self.review_count = self.review_count.saturating_add(1);
+    }
+
+    /// Record a completed guardian verdict (move to `Reviewed`).
+    pub fn record_verdict(&mut self, verdict: GuardianVerdict, round: u32) {
+        self.last_verdict = Some(verdict.normalized());
+        self.last_reviewed_at_round = round;
+        self.phase = GuardianPhase::Reviewed;
+    }
+
+    /// Clear the in-flight review pass (after it has been acted upon), keeping
+    /// the budget count and the last verdict as the durable record.
+    pub fn clear(&mut self) {
+        self.phase = GuardianPhase::None;
+        self.guardian_child_id = None;
+    }
+
+    /// Whether the review budget is spent, mirroring the goal loop's
+    /// `continuation_count >= max_auto_continuations` gate.
+    pub fn budget_exhausted(&self, max_reviews: u32) -> bool {
+        self.review_count >= max_reviews
+    }
+
+    /// Whether the most recent verdict approved stopping the run.
+    pub fn last_approved(&self) -> bool {
+        self.last_verdict
+            .as_ref()
+            .is_some_and(|verdict| verdict.approve)
+    }
+}
+
+/// Read the persisted guardian state, if present and parseable.
+pub fn read_guardian_state(session: &Session) -> Option<GuardianState> {
+    let raw = session.metadata.get(GUARDIAN_STATE_METADATA_KEY)?;
+    serde_json::from_str::<GuardianState>(raw).ok()
+}
+
+/// Persist the guardian state into `session.metadata` (touching `updated_at`).
+pub fn write_guardian_state(session: &mut Session, mut state: GuardianState) {
+    state.updated_at = Utc::now().to_rfc3339();
+    match serde_json::to_string(&state) {
+        Ok(json) => {
+            session
+                .metadata
+                .insert(GUARDIAN_STATE_METADATA_KEY.to_string(), json);
+        }
+        Err(error) => {
+            // Serializing a plain data struct effectively never fails, but if it
+            // ever does, the on-disk guardian state would silently go stale —
+            // log loudly rather than swallow it (mirrors write_goal_state).
+            tracing::warn!(
+                "failed to serialize guardian state for session {}: {error}",
+                session.id
+            );
+        }
+    }
+}
+
+/// Read the existing guardian state, or create a fresh one.
+pub fn ensure_guardian_state(session: &Session) -> GuardianState {
+    read_guardian_state(session).unwrap_or_else(GuardianState::new)
+}
+
+/// Session metadata key holding the run's serialized [`GuardianConfig`].
+///
+/// The terminal gate persists the config here at first spawn so the resumed run
+/// — driven by the completion coordinator, which has no original request — can
+/// re-inject the guardian config and keep the review → fix → re-review loop
+/// active across the suspend/resume boundary.
+pub const GUARDIAN_CONFIG_METADATA_KEY: &str = "guardian.config";
+
+/// Persist the run's [`crate::runtime::config::GuardianConfig`] into the session.
+pub fn write_guardian_config(
+    session: &mut Session,
+    config: &crate::runtime::config::GuardianConfig,
+) {
+    if let Ok(json) = serde_json::to_string(config) {
+        session
+            .metadata
+            .insert(GUARDIAN_CONFIG_METADATA_KEY.to_string(), json);
+    }
+}
+
+/// Read the run's persisted [`crate::runtime::config::GuardianConfig`], if any.
+pub fn read_guardian_config(session: &Session) -> Option<crate::runtime::config::GuardianConfig> {
+    let raw = session.metadata.get(GUARDIAN_CONFIG_METADATA_KEY)?;
+    serde_json::from_str(raw).ok()
+}
+
+/// The adversarial-review rubric handed to the guardian child as its task brief.
+///
+/// The terminal gate appends the run's concrete completion criteria and goal
+/// after this template (see the guardian gate in the runner). The reviewer runs
+/// as a real read-only sub-agent: it fetches the diff and runs tests *itself*
+/// via its Bash/Read/Grep tools (so the engine never needs an in-process git),
+/// and emits a single JSON verdict as its final message.
+pub const GUARDIAN_REVIEW_RUBRIC: &str = r#"You are an adversarial code reviewer (Guardian). Another agent claims its task is complete. Independently VERIFY the work and decide whether the run may stop.
+
+Verify, do not trust:
+- Run `git diff` and `git status` in the workspace to see exactly what changed.
+- Read the changed files and the surrounding code to judge correctness.
+- If the task implies behavior, run the relevant tests or build (e.g. `cargo test`, `npm test`) and confirm they pass.
+- Check every completion criterion below against real evidence, not the agent's claims.
+
+Be skeptical. Flag real bugs, missed requirements, broken or skipped tests, and unmet criteria. You are READ-ONLY: do not modify files.
+
+Emit your verdict as your FINAL message and ONLY as a single JSON object (no prose around it):
+{"approve": <true|false>, "summary": "<one-line rationale>", "findings": ["<concrete issue>", "..."]}
+Set approve=true ONLY if the work is correct and every criterion is met; otherwise approve=false with concrete, actionable findings."#;
+
+/// The denylist of tool names disabled for a read-only guardian reviewer.
+///
+/// A DENYLIST matched by EXACT `ToolSchema.function.name` (see the worker's
+/// `tool_schemas` retain). The reviewer keeps read/search/shell tools (Read,
+/// Grep, Glob, GetFileInfo, Bash + its companions) so it can fetch the diff and
+/// run tests, but loses every file-mutating, escalation, web, and interaction
+/// tool. Names not registered in a given build are simply never matched, so the
+/// list is safe to keep conservative and forward-looking.
+pub fn guardian_read_only_disabled_tools() -> BTreeSet<String> {
+    [
+        // File mutation.
+        "Edit",
+        "Write",
+        "NotebookEdit",
+        "apply_patch",
+        "MultiEdit",
+        // Escalation / spawning / persistent side effects.
+        "Task",
+        "SubAgent",
+        "DeployAgent",
+        "AskAgent",
+        "scheduler",
+        "sub_session_manager",
+        "session_note",
+        "memory_note",
+        // Plan-mode / interaction / permissions.
+        "EnterPlanMode",
+        "ExitPlanMode",
+        "request_permissions",
+        "conclusion_with_options",
+        // Arbitrary execution surfaces beyond Bash, and web.
+        "SlashCommand",
+        "js_repl",
+        "Workspace",
+        "WebFetch",
+        "WebSearch",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+}
+
+/// Parse a [`GuardianVerdict`] from the reviewer child's final message.
+///
+/// No schema is enforced on the child's output, so the reviewer is asked (by the
+/// rubric) to emit a single JSON object. This is tolerant: it accepts a bare
+/// object, a ```json fenced block, or an object embedded in surrounding prose
+/// (first `{` … last `}`). Returns the normalized verdict, or an error string
+/// when no parseable JSON object is found.
+pub fn parse_guardian_verdict(text: &str) -> Result<GuardianVerdict, String> {
+    let trimmed = text.trim();
+    if let Ok(verdict) = serde_json::from_str::<GuardianVerdict>(trimmed) {
+        return Ok(verdict.normalized());
+    }
+    let unfenced = strip_code_fence(trimmed);
+    if let Ok(verdict) = serde_json::from_str::<GuardianVerdict>(unfenced.trim()) {
+        return Ok(verdict.normalized());
+    }
+    // Try each balanced top-level `{...}` object, preferring the LAST one (the
+    // verdict normally follows any prose / examples / config snippets the
+    // reviewer printed). A string-aware, brace-balanced scan avoids the
+    // first-`{`-to-last-`}` over-capture that turned an embedded valid verdict
+    // into a parse error (and thus a wrongful synthetic reject).
+    for candidate in balanced_json_objects(unfenced).into_iter().rev() {
+        if let Ok(verdict) = serde_json::from_str::<GuardianVerdict>(candidate) {
+            return Ok(verdict.normalized());
+        }
+    }
+    Err(format!(
+        "no parseable guardian verdict JSON in reviewer output ({} chars)",
+        trimmed.len()
+    ))
+}
+
+/// Strip a single leading ```/```json fence and its trailing ``` if present.
+fn strip_code_fence(text: &str) -> &str {
+    let trimmed = text.trim();
+    let Some(rest) = trimmed.strip_prefix("```") else {
+        return trimmed;
+    };
+    // Drop the rest of the fence line (e.g. ```json) up to the first newline.
+    let after_lang = rest.find('\n').map_or("", |idx| &rest[idx + 1..]);
+    after_lang
+        .trim_end()
+        .strip_suffix("```")
+        .unwrap_or(after_lang)
+}
+
+/// All top-level brace-balanced `{...}` spans in `text`, in source order.
+///
+/// String-aware (braces inside JSON string literals don't affect depth) and
+/// nesting-aware, so a reviewer message like `config {a:1}; verdict {"approve":
+/// true}` yields TWO candidates rather than the single over-wide first-`{`..
+/// last-`}` slice that fails to parse.
+fn balanced_json_objects(text: &str) -> Vec<&str> {
+    let bytes = text.as_bytes();
+    let mut objects = Vec::new();
+    let mut depth = 0usize;
+    let mut start: Option<usize> = None;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (i, &b) in bytes.iter().enumerate() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match b {
+            b'"' => in_string = true,
+            b'{' => {
+                if depth == 0 {
+                    start = Some(i);
+                }
+                depth += 1;
+            }
+            b'}' if depth > 0 => {
+                depth -= 1;
+                if depth == 0 {
+                    if let Some(s) = start.take() {
+                        objects.push(&text[s..=i]);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    objects
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_agent_core::Session;
+
+    #[test]
+    fn round_trips_through_metadata() {
+        let mut session = Session::new("s1", "model");
+        let mut state = GuardianState::new();
+        state.record_spawn("guardian-child-1");
+        state.record_verdict(
+            GuardianVerdict::rejected(vec!["missing test".to_string()])
+                .with_summary("one bug"),
+            7,
+        );
+
+        write_guardian_state(&mut session, state);
+        let loaded = read_guardian_state(&session).expect("state persists");
+
+        assert_eq!(loaded.phase, GuardianPhase::Reviewed);
+        assert_eq!(loaded.guardian_child_id.as_deref(), Some("guardian-child-1"));
+        assert_eq!(loaded.review_count, 1);
+        assert_eq!(loaded.last_reviewed_at_round, 7);
+        let verdict = loaded.last_verdict.expect("verdict persisted");
+        assert!(!verdict.approve);
+        assert_eq!(verdict.summary.as_deref(), Some("one bug"));
+        assert_eq!(verdict.findings, vec!["missing test".to_string()]);
+    }
+
+    #[test]
+    fn ensure_creates_fresh_when_absent() {
+        let session = Session::new("s1", "model");
+        let state = ensure_guardian_state(&session);
+        assert_eq!(state.phase, GuardianPhase::None);
+        assert_eq!(state.review_count, 0);
+        assert!(state.guardian_child_id.is_none());
+    }
+
+    #[test]
+    fn budget_gate_mirrors_continuation_count() {
+        let mut state = GuardianState::new();
+        assert!(!state.budget_exhausted(2));
+        state.record_spawn("c1"); // review_count = 1
+        assert!(!state.budget_exhausted(2));
+        state.clear();
+        state.record_spawn("c2"); // review_count = 2
+        assert!(state.budget_exhausted(2));
+    }
+
+    #[test]
+    fn clear_keeps_budget_and_verdict() {
+        let mut state = GuardianState::new();
+        state.record_spawn("c1");
+        state.record_verdict(GuardianVerdict::approved(), 3);
+        state.clear();
+        assert_eq!(state.phase, GuardianPhase::None);
+        assert!(state.guardian_child_id.is_none());
+        // Budget + last verdict survive the clear (they are the record).
+        assert_eq!(state.review_count, 1);
+        assert!(state.last_approved());
+    }
+
+    #[test]
+    fn rejected_trims_findings_to_newest() {
+        let findings: Vec<String> = (0..(MAX_FINDINGS + 10)).map(|i| format!("f{i}")).collect();
+        let verdict = GuardianVerdict::rejected(findings);
+        assert_eq!(verdict.findings.len(), MAX_FINDINGS);
+        // Oldest dropped; newest kept.
+        assert_eq!(
+            verdict.findings.last().unwrap(),
+            &format!("f{}", MAX_FINDINGS + 9)
+        );
+    }
+
+    #[test]
+    fn missing_optional_fields_parse() {
+        // The reviewer may emit a minimal verdict; summary/findings default.
+        let verdict: GuardianVerdict =
+            serde_json::from_str(r#"{"approve": true}"#).expect("minimal verdict parses");
+        assert!(verdict.approve);
+        assert!(verdict.summary.is_none());
+        assert!(verdict.findings.is_empty());
+    }
+
+    #[test]
+    fn parse_verdict_bare_object() {
+        let v = parse_guardian_verdict(r#"{"approve": false, "summary": "bug", "findings": ["x"]}"#)
+            .expect("parses");
+        assert!(!v.approve);
+        assert_eq!(v.summary.as_deref(), Some("bug"));
+        assert_eq!(v.findings, vec!["x".to_string()]);
+    }
+
+    #[test]
+    fn parse_verdict_fenced_and_embedded() {
+        let fenced = "```json\n{\"approve\": true}\n```";
+        assert!(
+            parse_guardian_verdict(fenced)
+                .expect("fenced parses")
+                .approve
+        );
+        let embedded = "Here is my verdict:\n{\"approve\": false, \"findings\": [\"nope\"]}\nThanks.";
+        let v = parse_guardian_verdict(embedded).expect("embedded parses");
+        assert!(!v.approve);
+        assert_eq!(v.findings, vec!["nope".to_string()]);
+    }
+
+    #[test]
+    fn parse_verdict_rejects_garbage() {
+        assert!(parse_guardian_verdict("no json here at all").is_err());
+    }
+
+    #[test]
+    fn parse_verdict_picks_trailing_object_after_prose_braces() {
+        // A reviewer that prints a config/example object before the real verdict
+        // must not be mis-parsed into a synthetic reject (the old first-{..last-}
+        // slice failed here).
+        let text = "I inspected config {timeout: 30} then ran the suite.\n\
+                    Verdict: {\"approve\": true, \"summary\": \"ok\"}";
+        let v = parse_guardian_verdict(text).expect("parses the trailing verdict");
+        assert!(v.approve);
+        assert_eq!(v.summary.as_deref(), Some("ok"));
+    }
+
+    #[test]
+    fn parse_verdict_is_string_aware_for_braces_in_findings() {
+        // Braces inside a JSON string must not break brace-balancing, and the
+        // object must still be found when embedded in prose.
+        let text = "note: {\"approve\": false, \"findings\": [\"foo() { x }\"]}";
+        let v = parse_guardian_verdict(text).expect("parses despite braces in the string");
+        assert!(!v.approve);
+        assert_eq!(v.findings, vec!["foo() { x }".to_string()]);
+    }
+
+    #[test]
+    fn read_only_denylist_blocks_mutation_keeps_read() {
+        let denied = guardian_read_only_disabled_tools();
+        for tool in ["Edit", "Write", "SubAgent", "WebFetch", "Task", "js_repl"] {
+            assert!(denied.contains(tool), "{tool} should be denied");
+        }
+        for tool in ["Read", "Grep", "Bash", "Glob", "GetFileInfo"] {
+            assert!(!denied.contains(tool), "{tool} should remain allowed");
+        }
+    }
+}

--- a/crates/engine/bamboo-engine/src/runtime/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/mod.rs
@@ -1,12 +1,14 @@
 //! Agent execution runtime: loop, stream handling, task evaluation.
 
 pub mod agent;
+pub mod approval_delegation_state;
 pub mod complexity_classifier;
 pub mod config;
 pub mod context;
 pub mod execution;
 pub mod goal_state;
 pub mod gold_evaluation;
+pub mod guardian_state;
 pub mod hooks;
 pub mod managers;
 pub mod model_roster;
@@ -20,7 +22,10 @@ pub mod task_evaluation;
 pub use agent::{Agent, AgentBuilder};
 pub use bamboo_domain::RuntimeSessionPersistence;
 pub use complexity_classifier::{ComplexityClassifier, TaskComplexity};
-pub use config::{GoldConfig, ImageFallbackConfig, ImageFallbackMode};
+pub use config::{
+    ApprovalDelegate, ChildApprovalOutcome, ChildApprovalRequest, GoldConfig, GuardianConfig,
+    GuardianSpawner, ImageFallbackConfig, ImageFallbackMode,
+};
 // `AgentLoopConfig` is intentionally NOT re-exported: its fields are `pub(crate)`,
 // so it is unconstructible outside the engine. Internal call sites reach it via
 // `crate::runtime::config::AgentLoopConfig`. External code drives the loop only

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -19,6 +19,10 @@ use crate::runtime::runner::loop_execution::startup::{
 use crate::runtime::runner::prompt_context::PromptMemoryRuntimeContext;
 use crate::runtime::runner::session_setup::tool_schemas::resolve_available_tool_schemas_for_session;
 use crate::runtime::stream::handler::StreamHandlingOutput;
+use crate::runtime::guardian_state::{
+    ensure_guardian_state, guardian_read_only_disabled_tools, write_guardian_config,
+    write_guardian_state, GuardianPhase, GUARDIAN_REVIEW_RUBRIC,
+};
 use crate::runtime::task_context::TaskLoopContext;
 use bamboo_agent_core::tools::ToolExecutor;
 use bamboo_agent_core::{AgentError, AgentEvent, Message, Session};
@@ -87,6 +91,59 @@ fn is_terminal_child_status(status: &str) -> bool {
     )
 }
 
+/// Runner primitive: durably suspend `session` to wait on a known set of child
+/// sessions, returning the canonical "stop the turn, do not send complete"
+/// outcome.
+///
+/// Centralizes the suspend transaction so every runner-initiated terminal gate
+/// (the orphaned-children safety net, the guardian review gate, ...) registers
+/// the wait identically: build the durable [`WaitingForChildrenState`], mirror
+/// it into the session via [`state_bridge::write_runtime_state`], stamp the
+/// `runtime.suspend_reason` metadata — always `"waiting_for_children"`, the
+/// discriminant the suspend-finalization keys on — bump `updated_at`, and
+/// persist so the completion coordinator can resume this parent and the suspend
+/// finalization merges (rather than clobbers) the durable wait.
+///
+/// The caller owns child *discovery*; `child_session_ids` is assumed already
+/// sorted/deduped where order matters.
+async fn suspend_to_wait_for_children(
+    session: &mut Session,
+    runtime_state: &mut AgentRuntimeState,
+    persistence: Option<&Arc<dyn bamboo_domain::RuntimeSessionPersistence>>,
+    child_session_ids: Vec<String>,
+    wait_for: ChildWaitPolicy,
+) -> TurnOutcome {
+    let now = Utc::now();
+    let count = child_session_ids.len();
+    runtime_state.waiting_for_children = Some(WaitingForChildrenState::for_children(
+        child_session_ids,
+        wait_for,
+        now,
+    ));
+    state_bridge::write_runtime_state(session, runtime_state);
+    session.metadata.insert(
+        "runtime.suspend_reason".to_string(),
+        "waiting_for_children".to_string(),
+    );
+    session.updated_at = now;
+
+    if let Some(persistence) = persistence {
+        if let Err(error) = persistence.save_runtime_session(session).await {
+            tracing::warn!(
+                "[{}] suspend-to-wait failed to persist parent wait on {} child(ren): {}",
+                session.id,
+                count,
+                error
+            );
+        }
+    }
+
+    TurnOutcome {
+        should_break: true,
+        sent_complete: false,
+    }
+}
+
 /// End-of-turn safety net for the spawn/wait model.
 ///
 /// `SubAgent.create` runs children in the background without suspending, and the
@@ -123,42 +180,180 @@ async fn maybe_suspend_for_orphaned_children(
     active.sort();
     active.dedup();
 
-    let now = Utc::now();
-    let count = active.len();
-    runtime_state.waiting_for_children = Some(WaitingForChildrenState {
-        child_session_ids: active,
-        wait_for: ChildWaitPolicy::All,
-        registered_at: now,
-        timeout_at: Some(now + chrono::Duration::hours(6)),
-        registered_by_tool_call_id: None,
-    });
-    state_bridge::write_runtime_state(session, runtime_state);
-    session.metadata.insert(
-        "runtime.suspend_reason".to_string(),
-        "waiting_for_children".to_string(),
-    );
-    session.updated_at = now;
-
-    // Persist so the completion coordinator can resume this parent, and so the
-    // suspend finalization merges (rather than clobbers) the durable wait.
-    if let Some(persistence) = config.persistence.as_ref() {
-        if let Err(error) = persistence.save_runtime_session(session).await {
-            tracing::warn!(
-                "[{}] safety-net auto-wait failed to persist parent wait: {}",
-                session.id,
-                error
-            );
-        }
-    }
     tracing::info!(
         "[{}] end-of-turn safety net: suspending to wait for {} orphaned child session(s) the model did not explicitly wait on",
         session.id,
-        count,
+        active.len(),
     );
-    Some(TurnOutcome {
-        should_break: true,
-        sent_complete: false,
-    })
+    Some(
+        suspend_to_wait_for_children(
+            session,
+            runtime_state,
+            config.persistence.as_ref(),
+            active,
+            ChildWaitPolicy::All,
+        )
+        .await,
+    )
+}
+
+/// Build the guardian reviewer's task brief: the static rubric plus the active
+/// task's completion criteria and the session goal, when present.
+fn build_guardian_review_prompt(
+    task_context: &Option<TaskLoopContext>,
+    config: &AgentLoopConfig,
+) -> String {
+    let mut prompt = String::from(GUARDIAN_REVIEW_RUBRIC);
+
+    let criteria: Vec<String> = task_context
+        .as_ref()
+        .and_then(|ctx| {
+            ctx.items
+                .iter()
+                .find(|item| Some(&item.id) == ctx.active_item_id.as_ref())
+        })
+        .map(|item| item.completion_criteria.clone())
+        .unwrap_or_default();
+    if !criteria.is_empty() {
+        prompt.push_str("\n\n## Completion criteria (verify EACH against real evidence)\n");
+        for (idx, criterion) in criteria.iter().enumerate() {
+            prompt.push_str(&format!("{}. {}\n", idx + 1, criterion));
+        }
+    }
+
+    let goal = config.active_goal();
+    if let Some(goal) = goal {
+        prompt.push_str("\n\n## Session goal\n");
+        prompt.push_str(goal);
+        prompt.push('\n');
+    }
+
+    if criteria.is_empty() && goal.is_none() {
+        prompt.push_str(
+            "\n\n(No explicit completion criteria or goal were provided; review the diff for correctness, completeness, and obvious bugs.)\n",
+        );
+    }
+    prompt
+}
+
+/// Terminal gate (peer to [`maybe_suspend_for_orphaned_children`]): before a run
+/// completes, spawn a read-only adversarial reviewer child and suspend on its
+/// verdict. Returns `Some` suspend outcome when it engages a review, or `None`
+/// to let the run complete — guardian inactive, the verdict already accepted the
+/// work, the review budget is spent, or a spawn failure that must not strand the
+/// run.
+///
+/// Driven by [`GuardianState`]: `None` → spawn the first review; `Pending` →
+/// never double-spawn (a review is in flight, the resume path re-enters with a
+/// verdict); `Reviewed` + approve → complete; `Reviewed` + reject → re-review the
+/// fix until [`GuardianState::budget_exhausted`]. The budget is the hard bound on
+/// the review→fix→review loop, so it always terminates.
+async fn maybe_spawn_guardian_review(
+    session: &mut Session,
+    config: &AgentLoopConfig,
+    task_context: &Option<TaskLoopContext>,
+    runtime_state: &mut AgentRuntimeState,
+    iteration: u32,
+) -> Option<TurnOutcome> {
+    // Already suspended waiting on a child (orphan gate / explicit wait won).
+    if runtime_state.waiting_for_children.is_some() {
+        return None;
+    }
+    if !config.guardian_active() {
+        return None;
+    }
+    let spawner = config.guardian_spawner.as_ref()?;
+    let max_reviews = config.guardian_max_reviews();
+
+    let mut guardian_state = ensure_guardian_state(session);
+    match guardian_state.phase {
+        // A review is in flight (we suspended for it); never double-spawn.
+        GuardianPhase::Pending => return None,
+        GuardianPhase::Reviewed => {
+            if guardian_state.last_approved() {
+                // Work accepted — allow completion.
+                return None;
+            }
+            if guardian_state.budget_exhausted(max_reviews) {
+                tracing::warn!(
+                    "[{}] guardian: review budget ({}) exhausted with unresolved findings; allowing completion",
+                    session.id,
+                    max_reviews
+                );
+                return None;
+            }
+            // Rejected and budget remains → re-review the fix below.
+        }
+        GuardianPhase::None => {
+            if guardian_state.budget_exhausted(max_reviews) {
+                return None;
+            }
+            // First review → spawn below.
+        }
+    }
+
+    // Persist the guardian config so the resumed run (driven by the completion
+    // coordinator, which has no original request) re-injects it and keeps the
+    // review → fix → re-review loop active across the suspend/resume boundary.
+    if let Some(guardian_config) = config.guardian_config.as_ref() {
+        write_guardian_config(session, guardian_config);
+    }
+
+    let review_prompt = build_guardian_review_prompt(task_context, config);
+    let Some(model) = config
+        .guardian_model()
+        .map(str::to_string)
+        .or_else(|| config.model_name.clone())
+        .map(|model| model.trim().to_string())
+        .filter(|model| !model.is_empty())
+    else {
+        // No reviewer model resolves — skip the review rather than spawning a
+        // child with an empty model id, which would error out and burn the
+        // review budget on a reviewer that never actually runs.
+        tracing::warn!(
+            "[{}] guardian: no reviewer model resolved; skipping review at this terminal",
+            session.id
+        );
+        return None;
+    };
+    let disabled_tools = Some(guardian_read_only_disabled_tools());
+
+    match spawner
+        .spawn_guardian_review(session, review_prompt, model, disabled_tools)
+        .await
+    {
+        Ok(child_id) => {
+            guardian_state.record_spawn(&child_id);
+            guardian_state.last_reviewed_at_round = iteration;
+            let pass = guardian_state.review_count;
+            write_guardian_state(session, guardian_state);
+            tracing::info!(
+                "[{}] guardian: spawned read-only review child {} (pass {}/{}); suspending until verdict",
+                session.id,
+                child_id,
+                pass,
+                max_reviews
+            );
+            Some(
+                suspend_to_wait_for_children(
+                    session,
+                    runtime_state,
+                    config.persistence.as_ref(),
+                    vec![child_id],
+                    ChildWaitPolicy::All,
+                )
+                .await,
+            )
+        }
+        Err(error) => {
+            tracing::warn!(
+                "[{}] guardian: failed to spawn review child: {}; allowing completion",
+                session.id,
+                error
+            );
+            None
+        }
+    }
 }
 
 // ---- Metrics helpers (from round_error.rs) ----
@@ -946,6 +1141,22 @@ pub(super) async fn run_pipeline(
                     turn_outcome = Some(suspend);
                     break;
                 }
+                // Adversarial guardian review: before completing, spawn a
+                // read-only reviewer child to verify the work and suspend until
+                // its verdict returns. Inert unless a guardian config + spawner
+                // are wired (`config.guardian_active()`).
+                if let Some(review) = maybe_spawn_guardian_review(
+                    session,
+                    config,
+                    &state.task_context,
+                    &mut state.runtime_state,
+                    turn_counter + 1,
+                )
+                .await
+                {
+                    turn_outcome = Some(review);
+                    break;
+                }
                 let reasoning = (!stream_output.reasoning_content.trim().is_empty())
                     .then_some(stream_output.reasoning_content);
                 let eval_model = state
@@ -1085,6 +1296,19 @@ pub(super) async fn run_pipeline(
                     hook_point: Some("AfterToolExecution".to_string()),
                 });
             }
+            Some("awaiting_parent_approval") => {
+                // Phase 2: a CHILD suspended while its gated tool awaits the
+                // PARENT's approval. Resumable — the parent's decision sets the
+                // re-execute marker and resumes this child via the same path as
+                // `awaiting_clarification`.
+                state.runtime_state.status = AgentStatusState::Suspended;
+                state.runtime_state.suspension = Some(SuspensionState {
+                    reason: "awaiting_parent_approval".to_string(),
+                    suspended_at: Utc::now(),
+                    resumable: true,
+                    hook_point: Some("AfterToolExecution".to_string()),
+                });
+            }
             Some("waiting_for_children") => {
                 state.runtime_state.status = AgentStatusState::Suspended;
                 state.runtime_state.suspension = Some(SuspensionState {
@@ -1121,7 +1345,18 @@ pub(super) async fn run_pipeline(
                                 .as_ref()
                                 .and_then(|metadata| metadata.get("runtime_kind"))
                                 .and_then(|value| value.as_str())
-                                .is_some_and(|kind| kind == "child_completion_resume");
+                                // Preserve BOTH the generic child-completion resume
+                                // and the guardian review resume: a fast guardian
+                                // child can append its verdict message before this
+                                // suspended runner's final (message-overwriting)
+                                // save lands, and the verdict/findings must not be
+                                // dropped.
+                                .is_some_and(|kind| {
+                                    matches!(
+                                        kind,
+                                        "child_completion_resume" | "guardian_review_resume"
+                                    )
+                                });
                             if hidden_runtime_resume && !existing_ids.contains(message.id.as_str())
                             {
                                 session.messages.push(message);
@@ -1253,11 +1488,15 @@ mod tests {
     use super::super::startup::OverflowRecoveryState;
     use super::{
         is_overflow_recoverable, is_terminal_child_status, map_turn_error_status,
-        maybe_suspend_for_orphaned_children, should_retry_turn_error,
+        maybe_spawn_guardian_review, maybe_suspend_for_orphaned_children, should_retry_turn_error,
     };
-    use crate::runtime::config::AgentLoopConfig;
+    use crate::runtime::config::{AgentLoopConfig, GuardianConfig, GuardianSpawner};
     use crate::runtime::goal_state::{
         ensure_goal_state, read_goal_state, write_goal_state, GoalDeclaredStatus, GoalRuntimeStatus,
+    };
+    use crate::runtime::guardian_state::{
+        ensure_guardian_state, read_guardian_state, write_guardian_state, GuardianPhase,
+        GuardianVerdict,
     };
     use crate::runtime::runner::state_bridge;
     use bamboo_agent_core::storage::Storage;
@@ -1272,6 +1511,159 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::RwLock;
+
+    /// A guardian spawner stub that returns a canned child id without touching
+    /// any real spawn machinery — lets the gate's state machine be unit-tested.
+    struct MockGuardianSpawner {
+        child_id: String,
+    }
+    #[async_trait::async_trait]
+    impl GuardianSpawner for MockGuardianSpawner {
+        async fn spawn_guardian_review(
+            &self,
+            _parent_session: &Session,
+            _review_prompt: String,
+            _model: String,
+            _disabled_tools: Option<std::collections::BTreeSet<String>>,
+        ) -> Result<String, String> {
+            Ok(self.child_id.clone())
+        }
+    }
+
+    /// An `AgentLoopConfig` with the guardian gate enabled and a mock spawner.
+    fn guardian_enabled_config(max_reviews: u32) -> AgentLoopConfig {
+        let spawner: Arc<dyn GuardianSpawner> = Arc::new(MockGuardianSpawner {
+            child_id: "guardian-child".to_string(),
+        });
+        AgentLoopConfig {
+            guardian_config: Some(GuardianConfig {
+                enabled: true,
+                model_name: Some("guardian-test-model".to_string()),
+                max_reviews,
+            }),
+            guardian_spawner: Some(spawner),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn guardian_gate_spawns_and_suspends_on_first_terminal() {
+        let mut session = Session::new("s1", "model");
+        let config = guardian_enabled_config(2);
+        let mut runtime_state = AgentRuntimeState::new("s1".to_string());
+
+        let outcome =
+            maybe_spawn_guardian_review(&mut session, &config, &None, &mut runtime_state, 1)
+                .await
+                .expect("guardian should engage a review and suspend");
+
+        assert!(outcome.should_break && !outcome.sent_complete);
+        assert!(runtime_state.waiting_for_children.is_some());
+        let guardian_state = read_guardian_state(&session).expect("guardian state persisted");
+        assert_eq!(guardian_state.phase, GuardianPhase::Pending);
+        assert_eq!(
+            guardian_state.guardian_child_id.as_deref(),
+            Some("guardian-child")
+        );
+        assert_eq!(guardian_state.review_count, 1);
+    }
+
+    #[tokio::test]
+    async fn guardian_gate_inert_without_config() {
+        let mut session = Session::new("s1", "model");
+        let config = AgentLoopConfig::default(); // no guardian config / spawner
+        let mut runtime_state = AgentRuntimeState::new("s1".to_string());
+        assert!(
+            maybe_spawn_guardian_review(&mut session, &config, &None, &mut runtime_state, 1)
+                .await
+                .is_none()
+        );
+        assert!(runtime_state.waiting_for_children.is_none());
+    }
+
+    #[tokio::test]
+    async fn guardian_gate_skips_when_no_model_resolves() {
+        // Guardian enabled + spawner wired, but no reviewer model anywhere
+        // (guardian_config.model_name None AND AgentLoopConfig.model_name None).
+        let spawner: Arc<dyn GuardianSpawner> = Arc::new(MockGuardianSpawner {
+            child_id: "guardian-child".to_string(),
+        });
+        let config = AgentLoopConfig {
+            guardian_config: Some(GuardianConfig {
+                enabled: true,
+                model_name: None,
+                max_reviews: 2,
+            }),
+            guardian_spawner: Some(spawner),
+            ..Default::default()
+        };
+        let mut session = Session::new("s1", "model");
+        let mut runtime_state = AgentRuntimeState::new("s1".to_string());
+        // Skip the review (no spawn, no suspend) rather than spawning a reviewer
+        // with an empty model id; the budget is NOT charged.
+        assert!(
+            maybe_spawn_guardian_review(&mut session, &config, &None, &mut runtime_state, 1)
+                .await
+                .is_none()
+        );
+        assert!(runtime_state.waiting_for_children.is_none());
+        assert!(
+            read_guardian_state(&session).is_none(),
+            "no guardian review budget should be charged when skipped"
+        );
+    }
+
+    #[tokio::test]
+    async fn guardian_gate_completes_after_approval() {
+        let mut session = Session::new("s1", "model");
+        let mut guardian_state = ensure_guardian_state(&session);
+        guardian_state.record_spawn("guardian-child");
+        guardian_state.record_verdict(GuardianVerdict::approved(), 1);
+        write_guardian_state(&mut session, guardian_state);
+
+        let config = guardian_enabled_config(2);
+        let mut runtime_state = AgentRuntimeState::new("s1".to_string());
+        // Reviewed + approved → allow completion (no suspend, no re-spawn).
+        assert!(
+            maybe_spawn_guardian_review(&mut session, &config, &None, &mut runtime_state, 2)
+                .await
+                .is_none()
+        );
+        assert!(runtime_state.waiting_for_children.is_none());
+    }
+
+    #[tokio::test]
+    async fn guardian_gate_re_reviews_after_reject_then_completes_on_budget() {
+        let mut session = Session::new("s1", "model");
+        // One review already done and rejected; budget 2 → a re-review is allowed.
+        let mut guardian_state = ensure_guardian_state(&session);
+        guardian_state.record_spawn("guardian-child");
+        guardian_state.record_verdict(GuardianVerdict::rejected(vec!["bug".to_string()]), 1);
+        write_guardian_state(&mut session, guardian_state);
+
+        let config = guardian_enabled_config(2);
+        let mut runtime_state = AgentRuntimeState::new("s1".to_string());
+        let outcome =
+            maybe_spawn_guardian_review(&mut session, &config, &None, &mut runtime_state, 2)
+                .await
+                .expect("rejected within budget → re-review (suspend)");
+        assert!(outcome.should_break && !outcome.sent_complete);
+        let after = read_guardian_state(&session).expect("state persisted");
+        assert_eq!(after.review_count, 2, "second review spawned");
+        assert_eq!(after.phase, GuardianPhase::Pending);
+
+        // The second review also rejects, exhausting the budget → completion.
+        let mut exhausted = ensure_guardian_state(&session);
+        exhausted.record_verdict(GuardianVerdict::rejected(vec!["still".to_string()]), 3);
+        write_guardian_state(&mut session, exhausted);
+        let mut runtime_state2 = AgentRuntimeState::new("s1".to_string());
+        assert!(
+            maybe_spawn_guardian_review(&mut session, &config, &None, &mut runtime_state2, 4)
+                .await
+                .is_none(),
+            "budget exhausted → allow completion despite unresolved findings"
+        );
+    }
 
     /// Minimal provider for terminal-gate tests. Never actually invoked when Gold
     /// is disabled (the gate short-circuits before any LLM call).

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -13,16 +13,16 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::runtime::config::AgentLoopConfig;
+use crate::runtime::guardian_state::{
+    ensure_guardian_state, guardian_read_only_disabled_tools, write_guardian_config,
+    write_guardian_state, GuardianPhase, GUARDIAN_REVIEW_RUBRIC,
+};
 use crate::runtime::runner::loop_execution::startup::{
     resolve_auxiliary_models, InFlightTaskEvaluation, LoopRunState,
 };
 use crate::runtime::runner::prompt_context::PromptMemoryRuntimeContext;
 use crate::runtime::runner::session_setup::tool_schemas::resolve_available_tool_schemas_for_session;
 use crate::runtime::stream::handler::StreamHandlingOutput;
-use crate::runtime::guardian_state::{
-    ensure_guardian_state, guardian_read_only_disabled_tools, write_guardian_config,
-    write_guardian_state, GuardianPhase, GUARDIAN_REVIEW_RUBRIC,
-};
 use crate::runtime::task_context::TaskLoopContext;
 use bamboo_agent_core::tools::ToolExecutor;
 use bamboo_agent_core::{AgentError, AgentEvent, Message, Session};

--- a/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/tests.rs
@@ -101,8 +101,7 @@ fn strip_existing_tool_guide_context_does_not_remove_user_heading_without_marker
 }
 
 #[tokio::test]
-async fn external_memory_includes_global_dream_fallback_and_session_note_when_project_unknown(
-) {
+async fn external_memory_includes_global_dream_fallback_and_session_note_when_project_unknown() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
     store
@@ -546,8 +545,7 @@ async fn external_memory_limits_relevant_memories_to_top_k() {
 }
 
 #[tokio::test]
-async fn external_memory_uses_global_relevant_memory_fallback_only_when_project_has_no_hits()
-{
+async fn external_memory_uses_global_relevant_memory_fallback_only_when_project_has_no_hits() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
     let workspace = temp_dir.path().join("workspace-recall-fallback");
@@ -653,8 +651,7 @@ async fn external_memory_prefers_project_dream_over_global_fallback() {
 }
 
 #[tokio::test]
-async fn external_memory_uses_global_dream_fallback_when_project_dream_and_index_are_missing(
-) {
+async fn external_memory_uses_global_dream_fallback_when_project_dream_and_index_are_missing() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
     let workspace = temp_dir.path().join("workspace-global-dream-fallback");
@@ -755,8 +752,7 @@ async fn external_memory_omits_project_index_when_project_prompt_injection_disab
 }
 
 #[tokio::test]
-async fn external_memory_omits_relevant_recall_and_uses_global_dream_when_project_first_disabled(
-) {
+async fn external_memory_omits_relevant_recall_and_uses_global_dream_when_project_first_disabled() {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let store = bamboo_memory::memory_store::MemoryStore::new(temp_dir.path());
     let workspace = temp_dir.path().join("workspace-global-dream-mode");

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
@@ -28,6 +28,24 @@ fn build_context_pressure(session: &Session) -> Option<output_compressor::Contex
     })
 }
 
+/// Build the task-aware compression hint from the ACTIVE task item's completion
+/// criteria (+ description), so a truncated tool output preferentially preserves
+/// lines relevant to what the task is verifying (Phase 4). `None` when there is
+/// no active task or it yields no significant terms.
+fn build_task_compression_hint(
+    task_context: &Option<TaskLoopContext>,
+) -> Option<output_compressor::TaskCompressionHint> {
+    let ctx = task_context.as_ref()?;
+    let item = ctx
+        .items
+        .iter()
+        .find(|item| Some(&item.id) == ctx.active_item_id.as_ref())?;
+    let mut phrases = item.completion_criteria.clone();
+    phrases.push(item.description.clone());
+    let hint = output_compressor::TaskCompressionHint::from_phrases(phrases);
+    (!hint.is_empty()).then_some(hint)
+}
+
 /// Tools exempt from plan-mode blocking (UI pause/clarification tools).
 const PLAN_MODE_EXEMPT_TOOLS: &[&str] = &[
     "EnterPlanMode",
@@ -124,6 +142,7 @@ async fn execute_and_apply_single_tool_call(
                 tool_duration: std::time::Duration::ZERO,
             };
             policy_guard.observe_outcome(tool_call, &outcome.result);
+            let task_hint = build_task_compression_hint(task_context);
             let outcome = output_compressor::maybe_compress(
                 &tool_call.function.name,
                 &tool_call.function.arguments,
@@ -135,6 +154,7 @@ async fn execute_and_apply_single_tool_call(
                     .map(|b| b.max_tool_output_tokens)
                     .unwrap_or(0),
                 build_context_pressure(session),
+                task_hint.as_ref(),
             )
             .await;
             let should_break = per_call::apply_tool_execution_outcome(
@@ -214,6 +234,7 @@ async fn execute_and_apply_single_tool_call(
     policy_guard.observe_outcome(tool_call, &outcome.result);
 
     // Compress tool output before applying
+    let task_hint = build_task_compression_hint(task_context);
     let outcome = output_compressor::maybe_compress(
         &tool_call.function.name,
         &tool_call.function.arguments,
@@ -225,6 +246,7 @@ async fn execute_and_apply_single_tool_call(
             .map(|b| b.max_tool_output_tokens)
             .unwrap_or(0),
         build_context_pressure(session),
+        task_hint.as_ref(),
     )
     .await;
 
@@ -564,6 +586,7 @@ pub(crate) async fn execute_round_tool_calls(
                 .map(|b| b.max_tool_output_tokens)
                 .unwrap_or(0);
             let pressure = build_context_pressure(session);
+            let task_hint = build_task_compression_hint(task_context);
             let compressed: Vec<_> =
                 join_all(batch.iter().zip(outcomes).map(|(batch_call, outcome)| {
                     let tool_name = batch_call.function.name.clone();
@@ -575,6 +598,7 @@ pub(crate) async fn execute_round_tool_calls(
                             usage_percent: p.usage_percent,
                             remaining_tokens: p.remaining_tokens,
                         });
+                    let task_hint = task_hint.clone();
                     async move {
                         output_compressor::maybe_compress(
                             &tool_name,
@@ -583,6 +607,7 @@ pub(crate) async fn execute_round_tool_calls(
                             outcome,
                             max_tool_tokens,
                             pressure,
+                            task_hint.as_ref(),
                         )
                         .await
                     }

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification.rs
@@ -289,6 +289,34 @@ pub(super) async fn maybe_handle_user_question_tool(
             .await;
     }
 
+    // Child→parent approval delegation (Phase 2): a non-bypassed CHILD cannot
+    // answer its own permission prompt (no human is attached to a child session).
+    // When a delegate is wired and this is a permission approval, route the
+    // request UP to the parent (which surfaces it to the human + persists the
+    // mapping) and suspend the child distinctly — do NOT set a human-answerable
+    // pending question on the child, which would strand it.
+    if try_delegate_child_approval(session, tool_call, &result.result, config)
+        .await
+        .is_some()
+    {
+        // ANY delegated outcome routes the decision to the parent and suspends
+        // the child here — never a child-side pending question (which a child has
+        // no human to answer, so it would strand). Auto-approve/auto-deny
+        // fast-paths are resolved on the resume side, not by falling through to
+        // the legacy clarification pause.
+        tracing::info!(
+            "[{}] child gated tool `{}` delegated to parent for approval; suspending child",
+            session_id,
+            tool_call.function.name
+        );
+        session.metadata.insert(
+            "runtime.suspend_reason".to_string(),
+            "awaiting_parent_approval".to_string(),
+        );
+        persist_session_after_question(config, session, session_id).await;
+        return true;
+    }
+
     emit_need_clarification_event(
         event_tx,
         &question_payload,
@@ -313,6 +341,71 @@ pub(super) async fn maybe_handle_user_question_tool(
     persist_session_after_question(config, session, session_id).await;
 
     true
+}
+
+/// If a paused tool call is a permission approval AND the executing session is a
+/// CHILD with an approval delegate wired, route the request up to the parent.
+/// Returns the delegate outcome when delegation was attempted, or `None` to let
+/// the caller fall back to the legacy on-session pending-question pause (the
+/// session is not a child, no delegate is wired, this is not a permission
+/// approval, or the delegate failed).
+async fn try_delegate_child_approval(
+    session: &Session,
+    tool_call: &ToolCall,
+    raw_result: &str,
+    config: &AgentLoopConfig,
+) -> Option<crate::runtime::config::ChildApprovalOutcome> {
+    let delegate = config.approval_delegate.as_ref()?;
+    let parent_session_id = session.parent_session_id.clone()?;
+
+    let payload: serde_json::Value = serde_json::from_str(raw_result).ok()?;
+    if payload.get("status").and_then(|v| v.as_str()) != Some("awaiting_permission_approval") {
+        // A non-permission user question (e.g. ExitPlanMode / conclusion) — not
+        // an approval to delegate.
+        return None;
+    }
+    let permission_type = payload
+        .get("permission_type")
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_string)
+                .unwrap_or_else(|| value.to_string())
+        })
+        .unwrap_or_default();
+    let resource = payload
+        .get("resource")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let question = payload
+        .get("question")
+        .and_then(|value| value.as_str())
+        .unwrap_or("Permission required")
+        .to_string();
+
+    let request = crate::runtime::config::ChildApprovalRequest {
+        child_session_id: session.id.clone(),
+        parent_session_id,
+        child_tool_call_id: tool_call.id.clone(),
+        tool_name: tool_call.function.name.clone(),
+        permission_type,
+        resource,
+        question,
+        approval_payload: payload,
+    };
+
+    match delegate.delegate_child_approval(request).await {
+        Ok(outcome) => Some(outcome),
+        Err(error) => {
+            tracing::warn!(
+                "[{}] child approval delegation failed: {}; falling back to local pause",
+                session.id,
+                error
+            );
+            None
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/output_compressor/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/output_compressor/mod.rs
@@ -529,11 +529,9 @@ fn truncate_to_token_budget(
 ) -> String {
     use bamboo_compression::TokenCounter;
 
-    let preserved = task_hint
-        .filter(|hint| !hint.is_empty())
-        .and_then(|hint| {
-            collect_task_relevant_lines(text, hint, (max_tokens as f64 * 0.15) as u32, counter)
-        });
+    let preserved = task_hint.filter(|hint| !hint.is_empty()).and_then(|hint| {
+        collect_task_relevant_lines(text, hint, (max_tokens as f64 * 0.15) as u32, counter)
+    });
 
     if let Some(lines) = preserved {
         // Reserve ~15% of the budget for task-relevant lines and shrink head/tail
@@ -1093,10 +1091,16 @@ mod tests {
         let mut lines: Vec<String> = (0..400)
             .map(|i| format!("filler line number {i} with some padding words"))
             .collect();
-        lines.insert(200, "CRITICAL zephyrqux module test FAILED here".to_string());
+        lines.insert(
+            200,
+            "CRITICAL zephyrqux module test FAILED here".to_string(),
+        );
         let text = lines.join("\n");
         let max_tokens = 80;
-        assert!(counter.count_text(&text) > max_tokens, "text must exceed budget");
+        assert!(
+            counter.count_text(&text) > max_tokens,
+            "text must exceed budget"
+        );
 
         let hint = TaskCompressionHint::from_phrases(vec!["zephyrqux module passes".to_string()]);
         let out = truncate_to_token_budget(&text, max_tokens, &counter, Some(&hint));

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/output_compressor/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/output_compressor/mod.rs
@@ -373,6 +373,7 @@ pub(super) async fn maybe_compress(
     mut outcome: ToolExecutionOutcome,
     max_tool_output_tokens: u32,
     context_pressure: Option<ContextPressure>,
+    task_hint: Option<&TaskCompressionHint>,
 ) -> ToolExecutionOutcome {
     let result = match outcome.result {
         Ok(ref mut result) => result,
@@ -416,8 +417,12 @@ pub(super) async fn maybe_compress(
         let counter = bamboo_compression::TiktokenTokenCounter::default();
         let tokens = counter.count_text(&result.result);
         if tokens > max_tool_output_tokens {
-            let truncated =
-                truncate_to_token_budget(&result.result, max_tool_output_tokens, &counter);
+            let truncated = truncate_to_token_budget(
+                &result.result,
+                max_tool_output_tokens,
+                &counter,
+                task_hint,
+            );
             tracing::info!(
                 "[{}] Tool output truncated: {} tokens > {} limit, {} chars → {} chars",
                 session_id,
@@ -433,13 +438,123 @@ pub(super) async fn maybe_compress(
     outcome
 }
 
+/// Task-aware compression hint: significant terms from the ACTIVE task's
+/// completion criteria (+ description). When a tool output must be truncated to
+/// fit the token budget, lines matching any term are preferentially preserved so
+/// task-relevant evidence (e.g. the criterion the agent is verifying) survives
+/// the cut. Built once per round from the `TaskLoopContext`
+/// (see `build_task_compression_hint`). This is the Phase-4 "task-aware" masking:
+/// truncation is biased toward what the active task needs, not just head/tail.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TaskCompressionHint {
+    keywords: Vec<String>,
+}
+
+impl TaskCompressionHint {
+    /// Build from raw phrases (criteria / description): split into lowercased
+    /// significant terms (≥4 chars), deduped, capped.
+    pub(crate) fn from_phrases<I: IntoIterator<Item = String>>(phrases: I) -> Self {
+        let mut keywords: Vec<String> = Vec::new();
+        'outer: for phrase in phrases {
+            for term in phrase.split(|c: char| !c.is_alphanumeric()) {
+                let term = term.trim().to_lowercase();
+                if term.len() >= 4 && !keywords.contains(&term) {
+                    keywords.push(term);
+                }
+                if keywords.len() >= 32 {
+                    break 'outer;
+                }
+            }
+        }
+        Self { keywords }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.keywords.is_empty()
+    }
+
+    fn matches(&self, line: &str) -> bool {
+        let lower = line.to_lowercase();
+        self.keywords.iter().any(|k| lower.contains(k.as_str()))
+    }
+}
+
+/// Collect up to `max_tokens` worth of lines from `text` that match the task
+/// hint, for preservation when the output is otherwise truncated. Returns `None`
+/// when no lines match (or the hint is empty).
+fn collect_task_relevant_lines(
+    text: &str,
+    hint: &TaskCompressionHint,
+    max_tokens: u32,
+    counter: &bamboo_compression::TiktokenTokenCounter,
+) -> Option<String> {
+    use bamboo_compression::TokenCounter;
+    if hint.is_empty() || max_tokens == 0 {
+        return None;
+    }
+    let mut kept: Vec<&str> = Vec::new();
+    let mut used = 0u32;
+    for line in text.lines() {
+        if !hint.matches(line) {
+            continue;
+        }
+        let cost = counter.count_text(line).saturating_add(1);
+        if used.saturating_add(cost) > max_tokens {
+            break;
+        }
+        used += cost;
+        kept.push(line);
+        if kept.len() >= 50 {
+            break;
+        }
+    }
+    if kept.is_empty() {
+        None
+    } else {
+        Some(kept.join("\n"))
+    }
+}
+
 /// Truncate text to fit within a token budget by keeping head + tail portions.
+///
+/// When a [`TaskCompressionHint`] is present AND some lines in the dropped middle
+/// match it, a slice of the budget is reserved to preserve those task-relevant
+/// lines (Phase-4 task-aware masking). With no hint (or no match) the behaviour
+/// is the original 70/30 head/tail split, byte-for-byte.
 fn truncate_to_token_budget(
     text: &str,
     max_tokens: u32,
     counter: &bamboo_compression::TiktokenTokenCounter,
+    task_hint: Option<&TaskCompressionHint>,
 ) -> String {
     use bamboo_compression::TokenCounter;
+
+    let preserved = task_hint
+        .filter(|hint| !hint.is_empty())
+        .and_then(|hint| {
+            collect_task_relevant_lines(text, hint, (max_tokens as f64 * 0.15) as u32, counter)
+        });
+
+    if let Some(lines) = preserved {
+        // Reserve ~15% of the budget for task-relevant lines and shrink head/tail
+        // to 0.5/0.2, leaving ~15% headroom for the truncation marker + role/
+        // newline boilerplate so the assembled output stays within `max_tokens`
+        // (head + tail are sliced from the full text, so their sum must stay
+        // comfortably under budget rather than at it).
+        let head_tokens = (max_tokens as f64 * 0.5) as u32;
+        let tail_tokens = (max_tokens as f64 * 0.2) as u32;
+        let head = find_prefix_within_tokens(text, head_tokens, counter);
+        let tail = find_suffix_within_tokens(text, tail_tokens, counter);
+        return format!(
+            "{}\n\n[... tool output truncated: {} tokens → {} token budget; task-relevant lines preserved ...]\n{}\n\n{}",
+            head,
+            counter.count_text(text),
+            max_tokens,
+            lines,
+            tail,
+        );
+    }
+
     let head_tokens = (max_tokens as f64 * 0.7) as u32;
     let tail_tokens = max_tokens.saturating_sub(head_tokens);
 
@@ -967,5 +1082,52 @@ mod tests {
     fn detect_command_with_env_prefix() {
         let args = r#"{"command": "CI=true cargo test"}"#;
         assert_eq!(detect_scenario("Bash", args), OutputScenario::BashTest);
+    }
+
+    // ── Task-aware truncation (Phase 4) ──
+
+    #[test]
+    fn truncate_preserves_task_relevant_middle_lines() {
+        use bamboo_compression::TokenCounter;
+        let counter = bamboo_compression::TiktokenTokenCounter::default();
+        let mut lines: Vec<String> = (0..400)
+            .map(|i| format!("filler line number {i} with some padding words"))
+            .collect();
+        lines.insert(200, "CRITICAL zephyrqux module test FAILED here".to_string());
+        let text = lines.join("\n");
+        let max_tokens = 80;
+        assert!(counter.count_text(&text) > max_tokens, "text must exceed budget");
+
+        let hint = TaskCompressionHint::from_phrases(vec!["zephyrqux module passes".to_string()]);
+        let out = truncate_to_token_budget(&text, max_tokens, &counter, Some(&hint));
+        assert!(
+            out.contains("task-relevant lines preserved"),
+            "preserved-section marker present"
+        );
+        assert!(
+            out.contains("zephyrqux"),
+            "the matching middle line must survive truncation"
+        );
+    }
+
+    #[test]
+    fn truncate_without_hint_keeps_original_format() {
+        let counter = bamboo_compression::TiktokenTokenCounter::default();
+        let text = (0..400)
+            .map(|i| format!("line {i} content"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let out = truncate_to_token_budget(&text, 50, &counter, None);
+        assert!(out.contains("[... tool output truncated:"));
+        assert!(!out.contains("task-relevant lines preserved"));
+    }
+
+    #[test]
+    fn task_hint_extracts_significant_terms_and_matches() {
+        let hint =
+            TaskCompressionHint::from_phrases(vec!["All tests pass for module X".to_string()]);
+        assert!(!hint.is_empty());
+        assert!(hint.matches("re-running the module checks"));
+        assert!(!hint.matches("xyz qrs unrelated"));
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -23,7 +23,8 @@ use bamboo_metrics::MetricsCollector;
 use bamboo_skills::SkillManager;
 
 use crate::runtime::config::{
-    AgentLoopConfig, AuxiliaryModelConfig, GoldConfig, ImageFallbackConfig, PromptMemoryFlags,
+    AgentLoopConfig, AuxiliaryModelConfig, GoldConfig, GuardianConfig, GuardianSpawner,
+    ImageFallbackConfig, PromptMemoryFlags,
 };
 use crate::runtime::hooks::HookRunner;
 use crate::runtime::managers::{
@@ -288,6 +289,11 @@ pub struct ExecuteRequest {
     pub selected_skill_mode: Option<String>,
     pub image_fallback: Option<ImageFallbackConfig>,
     pub gold_config: Option<GoldConfig>,
+    /// Optional guardian adversarial-review gate configuration.
+    pub guardian_config: Option<GuardianConfig>,
+    /// Late-bound spawner for the guardian reviewer child (wired by the server;
+    /// the runner cannot construct a child directly).
+    pub guardian_spawner: Option<Arc<dyn GuardianSpawner>>,
     /// Bamboo application data directory (typically `~/.bamboo`).
     pub app_data_dir: Option<std::path::PathBuf>,
 }
@@ -334,6 +340,8 @@ pub struct ExecuteRequestBuilder {
     selected_skill_mode: Option<String>,
     image_fallback: Option<ImageFallbackConfig>,
     gold_config: Option<GoldConfig>,
+    guardian_config: Option<GuardianConfig>,
+    guardian_spawner: Option<Arc<dyn GuardianSpawner>>,
     app_data_dir: Option<std::path::PathBuf>,
 }
 
@@ -368,6 +376,8 @@ impl ExecuteRequestBuilder {
             selected_skill_mode: None,
             image_fallback: None,
             gold_config: None,
+            guardian_config: None,
+            guardian_spawner: None,
             app_data_dir: None,
         }
     }
@@ -512,6 +522,20 @@ impl ExecuteRequestBuilder {
         self
     }
 
+    /// Set the internal `guardian_config` feature flag (crate-visible, like
+    /// [`Self::gold_config`]). Public SDK callers leave it `None`.
+    pub(crate) fn guardian_config(mut self, v: Option<GuardianConfig>) -> Self {
+        self.guardian_config = v;
+        self
+    }
+
+    /// Set the late-bound guardian reviewer spawner (crate-visible; wired by the
+    /// server's spawn path so the runner can create the reviewer child).
+    pub(crate) fn guardian_spawner(mut self, v: Option<Arc<dyn GuardianSpawner>>) -> Self {
+        self.guardian_spawner = v;
+        self
+    }
+
     /// Set the Bamboo application data directory.
     pub fn app_data_dir(mut self, v: std::path::PathBuf) -> Self {
         self.app_data_dir = Some(v);
@@ -552,6 +576,8 @@ impl ExecuteRequestBuilder {
             selected_skill_mode: self.selected_skill_mode,
             image_fallback: self.image_fallback,
             gold_config: self.gold_config,
+            guardian_config: self.guardian_config,
+            guardian_spawner: self.guardian_spawner,
             app_data_dir: self.app_data_dir,
         }
     }
@@ -601,6 +627,8 @@ impl AgentRuntime {
             selected_skill_mode,
             image_fallback,
             gold_config,
+            guardian_config,
+            guardian_spawner,
             app_data_dir,
         } = req;
         let tools = tools.unwrap_or_else(|| self.default_tools.clone());
@@ -680,6 +708,8 @@ impl AgentRuntime {
                 .and_then(|state| state.plan_mode.as_ref())
                 .map(|_| PermissionMode::Plan),
             gold_config,
+            guardian_config,
+            guardian_spawner,
             // Capture the tool executor's server-level guidance (connected MCP
             // servers' `instructions`) once, so it lands in the system prompt only
             // while those servers are loaded for this run.

--- a/crates/engine/bamboo-engine/src/sdk/spawn.rs
+++ b/crates/engine/bamboo-engine/src/sdk/spawn.rs
@@ -268,8 +268,20 @@ pub async fn run_child_spawn(ctx: SpawnContext, job: SpawnJob) -> Result<(), Str
             };
 
         let timeout_error = timeout_reason.read().await.clone();
+        // Phase 2: a child that suspended awaiting the PARENT's approval of a
+        // gated tool is NOT done — publish a NON-terminal "suspended" status so
+        // the parent's completion coordinator does not resume the parent
+        // prematurely. The child is resumed once the human decides, then runs to
+        // a real terminal completion that re-enters this path.
+        let suspended_for_parent_approval = session
+            .metadata
+            .get("runtime.suspend_reason")
+            .map(|reason| reason == "awaiting_parent_approval")
+            .unwrap_or(false);
         let (status, error) = if let Some(reason) = timeout_error {
             ("timeout".to_string(), Some(reason))
+        } else if suspended_for_parent_approval && result.is_ok() {
+            ("suspended".to_string(), None)
         } else {
             match &result {
                 Ok(_) => ("completed".to_string(), None),

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -253,7 +253,9 @@ fn guardian_resume_message(completion: &ChildCompletion, verdict: &GuardianVerdi
             body.push_str(&format!("\n{}. {}", idx + 1, finding));
         }
     }
-    body.push_str("\n\nIf you need the full guardian transcript, call SubAgent.get(child_session_id).");
+    body.push_str(
+        "\n\nIf you need the full guardian transcript, call SubAgent.get(child_session_id).",
+    );
 
     let mut message = Message::user(body);
     message.metadata = Some(serde_json::json!({

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -12,6 +12,11 @@ use crate::execution::{
     create_event_forwarder, spawn_session_execution, try_reserve_runner, AgentRunner,
     ChildCompletion, ChildCompletionHandler, RunnerReservation, SessionExecutionArgs,
 };
+use crate::runtime::config::GuardianSpawner;
+use crate::runtime::guardian_state::{
+    parse_guardian_verdict, read_guardian_config, read_guardian_state, write_guardian_state,
+    GuardianVerdict,
+};
 use crate::Agent;
 use async_trait::async_trait;
 use bamboo_agent_core::storage::Storage;
@@ -224,6 +229,45 @@ fn runtime_resume_message(
     message
 }
 
+/// The hidden resume message for a completed **guardian** review: a directive,
+/// verdict-tailored note that carries the reviewer's findings straight into the
+/// parent (so it can act without a `SubAgent.get`), mirroring
+/// [`runtime_resume_message`]'s hidden/compressible shape.
+fn guardian_resume_message(completion: &ChildCompletion, verdict: &GuardianVerdict) -> Message {
+    let mut body = if verdict.approve {
+        String::from(
+            "Guardian review APPROVED: an independent reviewer verified the work and found no blocking issues. You may finalize the task.",
+        )
+    } else {
+        String::from(
+            "Guardian review REJECTED: an independent reviewer found issues. Address every finding below before completing — do NOT declare the task complete until they are resolved.",
+        )
+    };
+    if let Some(summary) = verdict.summary.as_deref().filter(|s| !s.trim().is_empty()) {
+        body.push_str("\n\nReviewer summary: ");
+        body.push_str(summary);
+    }
+    if !verdict.findings.is_empty() {
+        body.push_str("\n\nFindings:");
+        for (idx, finding) in verdict.findings.iter().enumerate() {
+            body.push_str(&format!("\n{}. {}", idx + 1, finding));
+        }
+    }
+    body.push_str("\n\nIf you need the full guardian transcript, call SubAgent.get(child_session_id).");
+
+    let mut message = Message::user(body);
+    message.metadata = Some(serde_json::json!({
+        RUNTIME_RESUME_MESSAGE_HIDDEN_KEY: true,
+        RUNTIME_RESUME_MESSAGE_KIND_KEY: "guardian_review_resume",
+        "child_session_id": completion.child_session_id,
+        "child_status": completion.status,
+        "guardian_approved": verdict.approve,
+        "completed_at": completion.completed_at,
+    }));
+    message.never_compress = false;
+    message
+}
+
 #[derive(Clone)]
 pub struct ChildCompletionCoordinator {
     storage: Arc<dyn Storage>,
@@ -238,6 +282,10 @@ pub struct ChildCompletionCoordinator {
     app_data_dir: std::path::PathBuf,
     account_feed_inbox: Option<crate::execution::AccountFeedInbox>,
     root_tools: Arc<RwLock<Option<Arc<dyn ToolExecutor>>>>,
+    /// Late-bound guardian reviewer spawner, set post-construction by the server
+    /// (mirrors `root_tools`). Re-injected into resumed runs so a guardian's
+    /// reject→fix verdict can be re-reviewed across the suspend/resume boundary.
+    guardian_spawner: Arc<RwLock<Option<Arc<dyn GuardianSpawner>>>>,
 }
 
 impl ChildCompletionCoordinator {
@@ -268,11 +316,18 @@ impl ChildCompletionCoordinator {
             app_data_dir,
             account_feed_inbox,
             root_tools: Arc::new(RwLock::new(None)),
+            guardian_spawner: Arc::new(RwLock::new(None)),
         }
     }
 
     pub async fn set_root_tools(&self, tools: Arc<dyn ToolExecutor>) {
         *self.root_tools.write().await = Some(tools);
+    }
+
+    /// Wire the guardian reviewer spawner (server-provided), so resumed runs can
+    /// re-spawn a guardian to re-review a fix after a reject verdict.
+    pub async fn set_guardian_spawner(&self, spawner: Arc<dyn GuardianSpawner>) {
+        *self.guardian_spawner.write().await = Some(spawner);
     }
 
     fn build_resume_config(
@@ -388,18 +443,16 @@ impl ChildCompletionHandler for ChildCompletionCoordinator {
 
         if should_resume {
             parent.metadata.remove("runtime.suspend_reason");
-            // Best-effort: load the child session so we can include its final
-            // assistant content in the hidden resume message. This avoids the
-            // root LLM having to make an extra `SubAgent.get` call after
-            // resume just to read what the child concluded — which would cost
-            // an additional LLM round trip.
-            let child_final_response = match self
+            // Load the completed child once. The guardian branch inspects its
+            // subagent_type + final verdict; the generic path folds its final
+            // assistant content into the hidden resume message (avoiding an extra
+            // `SubAgent.get` round trip after resume).
+            let loaded_child = match self
                 .storage
                 .load_session(&completion.child_session_id)
                 .await
             {
-                Ok(Some(child)) => child_final_assistant_text(&child),
-                Ok(None) => None,
+                Ok(child) => child,
                 Err(error) => {
                     tracing::warn!(
                         child_session_id = %completion.child_session_id,
@@ -409,11 +462,82 @@ impl ChildCompletionHandler for ChildCompletionCoordinator {
                     None
                 }
             };
-            parent.add_message(runtime_resume_message(
-                &completion,
-                remaining_children,
-                child_final_response.as_deref(),
-            ));
+
+            // Guardian branch: a completing guardian reviewer that matches the
+            // parent's recorded review advances GuardianState (phase → Reviewed)
+            // and resumes with a verdict-tailored, findings-carrying message. Any
+            // id mismatch or unparseable verdict falls through to the generic
+            // resume, so the parent is never stranded.
+            let reviewed_round = runtime_state.round.current_round;
+            let guardian_resume = loaded_child.as_ref().and_then(|child| {
+                if child.subagent_type().as_deref() != Some("guardian") {
+                    return None;
+                }
+                let mut guardian_state = read_guardian_state(&parent)?;
+                if guardian_state.guardian_child_id.as_deref()
+                    != Some(completion.child_session_id.as_str())
+                {
+                    // A *different* guardian is legitimately still in flight —
+                    // leave its Pending state intact and use the generic resume.
+                    tracing::warn!(
+                        parent_session_id = %completion.parent_session_id,
+                        child_session_id = %completion.child_session_id,
+                        expected = ?guardian_state.guardian_child_id,
+                        "guardian completion does not match recorded guardian_child_id; using generic resume"
+                    );
+                    return None;
+                }
+                // This IS the guardian we dispatched, so we MUST advance the
+                // phase out of `Pending` — otherwise the next terminal gate's
+                // `Pending => return None` would let the run complete unreviewed.
+                // A reviewer that errored or produced unparseable output is
+                // treated as a SYNTHETIC REJECT (never a silent pass), so the
+                // budgeted re-review loop governs the outcome: fail-closed, but
+                // still bounded by `max_reviews`.
+                let verdict = child_final_assistant_text(child)
+                    .and_then(|text| match parse_guardian_verdict(&text) {
+                        Ok(verdict) => Some(verdict),
+                        Err(error) => {
+                            tracing::warn!(
+                                child_session_id = %completion.child_session_id,
+                                %error,
+                                "guardian verdict unparseable; recording a synthetic reject"
+                            );
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| {
+                        GuardianVerdict::rejected(vec![
+                            "The guardian reviewer did not return a usable verdict (it errored or \
+                             emitted unparseable output); the work has NOT been independently \
+                             verified."
+                                .to_string(),
+                        ])
+                    });
+                let approved = verdict.approve;
+                let message = guardian_resume_message(&completion, &verdict);
+                guardian_state.record_verdict(verdict, reviewed_round);
+                write_guardian_state(&mut parent, guardian_state);
+                tracing::info!(
+                    parent_session_id = %completion.parent_session_id,
+                    child_session_id = %completion.child_session_id,
+                    approved,
+                    "guardian verdict recorded; resuming parent"
+                );
+                Some(message)
+            });
+
+            let resume_message = guardian_resume.unwrap_or_else(|| {
+                runtime_resume_message(
+                    &completion,
+                    remaining_children,
+                    loaded_child
+                        .as_ref()
+                        .and_then(child_final_assistant_text)
+                        .as_deref(),
+                )
+            });
+            parent.add_message(resume_message);
         } else if runtime_state.waiting_for_children.is_some() {
             runtime_state.status = AgentStatusState::Suspended;
             runtime_state.suspension = Some(SuspensionState {
@@ -588,6 +712,14 @@ impl ResumeExecutionPort for ChildCompletionCoordinator {
                 config.summarization_model_provider,
             ),
         };
+
+        // Re-inject guardian state on resume so a reject→fix verdict can be
+        // re-reviewed: config from the session (persisted at first spawn),
+        // spawner from the coordinator-held handle. Absent guardian config this
+        // stays `None`, and the approve→complete path is unchanged.
+        let guardian_config = read_guardian_config(&session);
+        let guardian_spawner = self.guardian_spawner.read().await.clone();
+
         spawn_session_execution(SessionExecutionArgs {
             agent: self.agent.clone(),
             session_id,
@@ -606,6 +738,8 @@ impl ResumeExecutionPort for ChildCompletionCoordinator {
             mpsc_tx,
             image_fallback: config.image_fallback,
             gold_config,
+            guardian_config,
+            guardian_spawner,
             app_data_dir: Some(self.app_data_dir.clone()),
             runners: self.agent_runners.clone(),
             sessions_cache: self.sessions.clone(),

--- a/crates/engine/bamboo-engine/src/session_app/child_session/actions.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_session/actions.rs
@@ -267,7 +267,15 @@ pub fn assemble_session_tree(
         }
     }
     let mut visited = std::collections::HashSet::new();
-    build(root_id, root_title, None, 0, max_depth, adjacency, &mut visited)
+    build(
+        root_id,
+        root_title,
+        None,
+        0,
+        max_depth,
+        adjacency,
+        &mut visited,
+    )
 }
 
 /// Materialize the full transitive parent→child session graph rooted at

--- a/crates/engine/bamboo-engine/src/session_app/child_session/actions.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_session/actions.rs
@@ -6,12 +6,13 @@ use serde_json::json;
 
 use super::helpers::{
     compute_status_guidance, format_child_assignment, map_child_entry, metadata_text,
-    normalize_non_empty_optional, normalize_required_text, replace_or_append_last_user_message,
-    truncate_after_index, truncate_after_last_user,
+    normalize_non_empty_optional, normalize_required_text, render_forked_parent_context,
+    replace_or_append_last_user_message, truncate_after_index, truncate_after_last_user,
 };
 use super::DELEGATION_NOTE;
 use super::{
-    ChildSessionError, ChildSessionPort, CreateChildInput, CreateChildResult, QueuedInjectedMessage,
+    ChildSessionEntry, ChildSessionError, ChildSessionPort, CreateChildInput, CreateChildResult,
+    QueuedInjectedMessage,
 };
 
 pub async fn create_child_action(
@@ -156,10 +157,32 @@ pub async fn create_child_action(
         &input.subagent_type,
         &input.assignment_prompt,
     );
+    // Phase 3: optionally fork a slice of the parent's recent context into the
+    // child's task brief (model-controllable via the SubAgent tool's
+    // `fork_last_messages`). `None`/0 keeps the child on a clean fresh context.
+    let assignment = match input
+        .context_fork
+        .and_then(|n| render_forked_parent_context(&input.parent_session, n))
+    {
+        Some(forked) => format!("{forked}\n\n{assignment}"),
+        None => assignment,
+    };
     child.add_message(Message::user(assignment));
 
     if let Some(parent_task_list) = input.parent_session.task_list.clone() {
         child.set_task_list(parent_task_list);
+    }
+
+    // Persist any per-child tool denylist so the spawn path (enqueue_child_run
+    // → SpawnJob.disabled_tools) can trim the child's toolset (e.g. a read-only
+    // Guardian reviewer). Most children carry none and keep the full toolset.
+    if let Some(ref disabled) = input.disabled_tools {
+        if !disabled.is_empty() {
+            child.metadata.insert(
+                "disabled_tools".to_string(),
+                serde_json::to_string(disabled).unwrap_or_default(),
+            );
+        }
     }
 
     let model = child.model.clone();
@@ -185,6 +208,104 @@ pub async fn list_children_action(
         "children": children.iter().map(map_child_entry).collect::<Vec<_>>(),
         "count": children.len(),
     })
+}
+
+/// A node in the materialized parent→child session graph (Phase 6: persistent
+/// multi-level nesting graph). `children` are the transitive descendants.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct SessionTreeNode {
+    pub session_id: String,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_run_status: Option<String>,
+    pub depth: u32,
+    pub children: Vec<SessionTreeNode>,
+}
+
+/// Assemble the transitive parent→child tree rooted at `root_id` from a
+/// pre-fetched adjacency map (pure — unit-testable without a port). Bounded by
+/// `max_depth`; a first-visit guard breaks cycles (a re-encountered session
+/// becomes a leaf rather than recursing forever).
+pub fn assemble_session_tree(
+    root_id: &str,
+    root_title: &str,
+    adjacency: &std::collections::HashMap<String, Vec<ChildSessionEntry>>,
+    max_depth: u32,
+) -> SessionTreeNode {
+    fn build(
+        id: &str,
+        title: &str,
+        status: Option<String>,
+        depth: u32,
+        max_depth: u32,
+        adjacency: &std::collections::HashMap<String, Vec<ChildSessionEntry>>,
+        visited: &mut std::collections::HashSet<String>,
+    ) -> SessionTreeNode {
+        let first_visit = visited.insert(id.to_string());
+        let mut children = Vec::new();
+        if first_visit && depth < max_depth {
+            if let Some(kids) = adjacency.get(id) {
+                for kid in kids {
+                    children.push(build(
+                        &kid.child_session_id,
+                        &kid.title,
+                        kid.last_run_status.clone(),
+                        depth + 1,
+                        max_depth,
+                        adjacency,
+                        visited,
+                    ));
+                }
+            }
+        }
+        SessionTreeNode {
+            session_id: id.to_string(),
+            title: title.to_string(),
+            last_run_status: status,
+            depth,
+            children,
+        }
+    }
+    let mut visited = std::collections::HashSet::new();
+    build(root_id, root_title, None, 0, max_depth, adjacency, &mut visited)
+}
+
+/// Materialize the full transitive parent→child session graph rooted at
+/// `root_id` from the persisted session index (Phase 6). BFS-fetches each
+/// level's children via [`ChildSessionPort::list_children`] (a first-visit guard
+/// + a hard node cap protect against cycles / runaway trees), then assembles the
+/// tree. The graph is derived from durable index state, so it survives restarts.
+pub async fn build_session_tree_action(
+    port: &dyn ChildSessionPort,
+    root_id: &str,
+    max_depth: u32,
+) -> SessionTreeNode {
+    use std::collections::{HashMap, HashSet, VecDeque};
+    const NODE_CAP: usize = 5000;
+
+    let root_title = port
+        .load_root_session(root_id)
+        .await
+        .map(|s| s.title)
+        .unwrap_or_default();
+
+    let mut adjacency: HashMap<String, Vec<ChildSessionEntry>> = HashMap::new();
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue: VecDeque<(String, u32)> = VecDeque::new();
+    queue.push_back((root_id.to_string(), 0));
+
+    while let Some((id, depth)) = queue.pop_front() {
+        if depth >= max_depth || adjacency.len() >= NODE_CAP || !visited.insert(id.clone()) {
+            continue;
+        }
+        let kids = port.list_children(&id).await;
+        for kid in &kids {
+            queue.push_back((kid.child_session_id.clone(), depth + 1));
+        }
+        adjacency.insert(id, kids);
+    }
+
+    assemble_session_tree(root_id, &root_title, &adjacency, max_depth)
 }
 
 pub async fn get_child_action(
@@ -529,4 +650,73 @@ pub async fn delete_child_action(
         "deleted": true,
         "cancelled_running_child": result.cancelled_running_child,
     }))
+}
+
+#[cfg(test)]
+mod tree_tests {
+    use super::super::ChildSessionEntry;
+    use super::assemble_session_tree;
+    use std::collections::HashMap;
+
+    fn entry(id: &str, title: &str) -> ChildSessionEntry {
+        ChildSessionEntry {
+            child_session_id: id.to_string(),
+            title: title.to_string(),
+            pinned: false,
+            message_count: 0,
+            updated_at: String::new(),
+            last_run_status: Some("completed".to_string()),
+            last_run_error: None,
+        }
+    }
+
+    #[test]
+    fn assembles_multi_level_tree() {
+        let mut adj: HashMap<String, Vec<ChildSessionEntry>> = HashMap::new();
+        adj.insert(
+            "root".into(),
+            vec![entry("c1", "child 1"), entry("c2", "child 2")],
+        );
+        adj.insert("c1".into(), vec![entry("g1", "grandchild")]);
+
+        let tree = assemble_session_tree("root", "Root", &adj, 8);
+        assert_eq!(tree.session_id, "root");
+        assert_eq!(tree.depth, 0);
+        assert_eq!(tree.children.len(), 2);
+        let c1 = tree.children.iter().find(|n| n.session_id == "c1").unwrap();
+        assert_eq!(c1.depth, 1);
+        assert_eq!(c1.children.len(), 1);
+        assert_eq!(c1.children[0].session_id, "g1");
+        assert_eq!(c1.children[0].depth, 2);
+        let c2 = tree.children.iter().find(|n| n.session_id == "c2").unwrap();
+        assert!(c2.children.is_empty());
+    }
+
+    #[test]
+    fn depth_cap_stops_descent() {
+        let mut adj: HashMap<String, Vec<ChildSessionEntry>> = HashMap::new();
+        adj.insert("root".into(), vec![entry("c1", "c1")]);
+        adj.insert("c1".into(), vec![entry("g1", "g1")]);
+        let tree = assemble_session_tree("root", "Root", &adj, 1);
+        assert_eq!(tree.children.len(), 1);
+        assert!(
+            tree.children[0].children.is_empty(),
+            "depth cap stops expansion at depth 1"
+        );
+    }
+
+    #[test]
+    fn cycle_is_broken_by_first_visit_guard() {
+        let mut adj: HashMap<String, Vec<ChildSessionEntry>> = HashMap::new();
+        adj.insert("a".into(), vec![entry("b", "b")]);
+        adj.insert("b".into(), vec![entry("a", "a")]); // cycle a → b → a
+        let tree = assemble_session_tree("a", "A", &adj, 100);
+        assert_eq!(tree.children.len(), 1);
+        let b = &tree.children[0];
+        assert_eq!(b.session_id, "b");
+        assert_eq!(b.children.len(), 1);
+        let a2 = &b.children[0];
+        assert_eq!(a2.session_id, "a");
+        assert!(a2.children.is_empty(), "cycle must terminate as a leaf");
+    }
 }

--- a/crates/engine/bamboo-engine/src/session_app/child_session/helpers.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_session/helpers.rs
@@ -60,6 +60,92 @@ pub fn format_child_assignment(
     )
 }
 
+/// Render the last `n` non-system messages of `parent` into a compact
+/// "forked context" block for seeding a child sub-session (Phase 3
+/// model-controllable context fork). Returns `None` when `n == 0` or there is no
+/// non-system content. Rendered as `role: content` lines (content trimmed to a
+/// sane length) — a single text block, NOT spliced raw messages, so it can be
+/// safely prepended to the child's task brief without breaking role structure.
+pub fn render_forked_parent_context(parent: &Session, n: usize) -> Option<String> {
+    use bamboo_agent_core::Role;
+    if n == 0 {
+        return None;
+    }
+    let mut recent: Vec<&bamboo_agent_core::Message> = parent
+        .messages
+        .iter()
+        .filter(|m| !matches!(m.role, Role::System))
+        .rev()
+        .take(n)
+        .collect();
+    recent.reverse();
+
+    let rendered: Vec<String> = recent
+        .into_iter()
+        .filter_map(|m| {
+            let content = m.content.trim();
+            if content.is_empty() {
+                return None;
+            }
+            let role = match m.role {
+                Role::User => "user",
+                Role::Assistant => "assistant",
+                _ => "context",
+            };
+            let snippet = if content.chars().count() > 2000 {
+                let truncated: String = content.chars().take(2000).collect();
+                format!("{truncated}…")
+            } else {
+                content.to_string()
+            };
+            Some(format!("{role}: {snippet}"))
+        })
+        .collect();
+
+    if rendered.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "## Forked context from parent (last {} message(s))\n{}",
+            rendered.len(),
+            rendered.join("\n")
+        ))
+    }
+}
+
+#[cfg(test)]
+mod fork_context_tests {
+    use super::render_forked_parent_context;
+    use bamboo_agent_core::{Message, Session};
+
+    #[test]
+    fn renders_recent_non_system_messages() {
+        let mut parent = Session::new("p", "model");
+        parent.add_message(Message::system("you are root"));
+        parent.add_message(Message::user("first user msg"));
+        parent.add_message(Message::assistant("assistant reply", None));
+        parent.add_message(Message::user("latest ask"));
+
+        let forked = render_forked_parent_context(&parent, 2).expect("renders");
+        assert!(forked.contains("Forked context from parent"));
+        // Last 2 non-system messages, oldest-first.
+        assert!(forked.contains("assistant: assistant reply"));
+        assert!(forked.contains("user: latest ask"));
+        // The older user msg + the system msg are excluded by n=2 / system filter.
+        assert!(!forked.contains("first user msg"));
+        assert!(!forked.contains("you are root"));
+    }
+
+    #[test]
+    fn none_when_zero_or_empty() {
+        let mut parent = Session::new("p", "model");
+        parent.add_message(Message::user("hi"));
+        assert!(render_forked_parent_context(&parent, 0).is_none());
+        let empty = Session::new("p2", "model");
+        assert!(render_forked_parent_context(&empty, 5).is_none());
+    }
+}
+
 pub fn replace_or_append_last_user_message(session: &mut Session, content: String) -> usize {
     use bamboo_agent_core::Role;
 

--- a/crates/engine/bamboo-engine/src/session_app/child_session/mod.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_session/mod.rs
@@ -16,8 +16,9 @@ mod helpers;
 mod tests;
 
 pub use actions::{
-    cancel_child_action, create_child_action, delete_child_action, get_child_action,
-    list_children_action, run_child_action, send_message_to_child_action, update_child_action,
+    assemble_session_tree, build_session_tree_action, cancel_child_action, create_child_action,
+    delete_child_action, get_child_action, list_children_action, run_child_action,
+    send_message_to_child_action, update_child_action, SessionTreeNode,
 };
 pub use helpers::{
     compute_status_guidance, format_child_assignment, map_child_entry, metadata_text,
@@ -125,6 +126,17 @@ pub struct CreateChildInput {
     /// For a resident agent, how successive tasks treat prior context:
     /// `"reset"` (default — independent tasks) or `"accumulate"` (remember).
     pub resident_context: Option<String>,
+    /// Tool names to disable for this child (denylist; matched by EXACT
+    /// `ToolSchema.function.name`). `None` (the default) = full toolset. A
+    /// read-only Guardian reviewer sets e.g. {"Edit","Write","SubAgent",...}.
+    /// Carried to the child's `SpawnJob.disabled_tools` via the child session
+    /// metadata (see `create_child_action`) so the worker trims its toolset.
+    pub disabled_tools: Option<std::collections::BTreeSet<String>>,
+    /// Model-controllable context fork (Phase 3): when `Some(n)` with `n > 0`,
+    /// the last `n` non-system parent messages are rendered into a "Forked
+    /// context from parent" block prepended to the child's task brief. `None`
+    /// (the default) keeps the child on a clean, freshly-seeded context.
+    pub context_fork: Option<usize>,
 }
 
 /// Result of creating a child session.

--- a/crates/engine/bamboo-tools/src/approval.rs
+++ b/crates/engine/bamboo-tools/src/approval.rs
@@ -1,0 +1,128 @@
+//! Cross-process approval proxy (Phase 2: child → parent approval delegation).
+//!
+//! When a tool's permission check returns [`ConfirmationRequired`], the executor
+//! normally either pauses an interactive session (synthesizing an
+//! `awaiting_permission_approval` result that the engine turns into a
+//! clarification) or — with no event sink — fails closed.
+//!
+//! A **subagent worker** runs out-of-process and cannot surface a prompt to the
+//! human itself. Instead it installs an [`ApprovalProxy`] for the duration of a
+//! child run (task-local, so concurrent runs on a shared worker can't see each
+//! other's proxy). When a gated tool hits `ConfirmationRequired`, the executor
+//! forwards the decision to the worker's parent ("host") over the
+//! `bamboo-subagent` WebSocket protocol and blocks *inline* for the reply —
+//! approve lets the tool proceed, deny fails it closed. No suspend/resume is
+//! involved: the tool's future simply parks on the host round-trip.
+//!
+//! The proxy is **unset on every non-worker path**, so default behavior
+//! (interactive pause / fail-closed) is byte-for-byte unchanged.
+//!
+//! [`ConfirmationRequired`]: crate::permission::PermissionError::ConfirmationRequired
+
+use std::future::Future;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+/// A pending gated-tool approval to forward to the host.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApprovalAsk {
+    /// The tool requesting the gated action (e.g. `Write`, `Bash`).
+    pub tool_name: String,
+    /// Human-readable description of the permission being requested.
+    pub permission: String,
+    /// The concrete resource the action targets (path, command, …).
+    pub resource: String,
+}
+
+/// Forwards a gated-tool approval decision to an out-of-process host (parent).
+///
+/// Implementations live in the worker and bridge to the host over the subagent
+/// protocol. A transport failure MUST resolve to `false` (fail closed) rather
+/// than letting an unapproved action proceed.
+#[async_trait]
+pub trait ApprovalProxy: Send + Sync {
+    /// Ask the host to approve `ask`. Return `true` to proceed, `false` to deny.
+    async fn request_approval(&self, ask: ApprovalAsk) -> bool;
+}
+
+tokio::task_local! {
+    static APPROVAL_PROXY: Option<Arc<dyn ApprovalProxy>>;
+}
+
+/// Run `fut` with `proxy` installed as the ambient approval proxy for the
+/// duration of the future (and everything it awaits). The worker scopes this
+/// around a single child run so the proxy is bound per-run, not per-process.
+pub async fn with_approval_proxy<F, T>(proxy: Option<Arc<dyn ApprovalProxy>>, fut: F) -> T
+where
+    F: Future<Output = T>,
+{
+    APPROVAL_PROXY.scope(proxy, fut).await
+}
+
+/// The ambient approval proxy for the current task, if one is installed.
+///
+/// Returns `None` outside any [`with_approval_proxy`] scope (i.e. on every
+/// non-worker path), which makes the executor fall back to its existing
+/// interactive-pause / fail-closed behavior.
+pub fn current_approval_proxy() -> Option<Arc<dyn ApprovalProxy>> {
+    APPROVAL_PROXY.try_with(|p| p.clone()).ok().flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct Recorder {
+        approve: bool,
+        seen: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ApprovalProxy for Recorder {
+        async fn request_approval(&self, _ask: ApprovalAsk) -> bool {
+            self.seen.fetch_add(1, Ordering::SeqCst);
+            self.approve
+        }
+    }
+
+    #[tokio::test]
+    async fn current_proxy_is_none_outside_scope() {
+        assert!(current_approval_proxy().is_none());
+    }
+
+    #[tokio::test]
+    async fn scope_installs_and_clears_proxy() {
+        let seen = Arc::new(AtomicUsize::new(0));
+        let proxy: Arc<dyn ApprovalProxy> = Arc::new(Recorder {
+            approve: true,
+            seen: seen.clone(),
+        });
+
+        with_approval_proxy(Some(proxy), async {
+            let got = current_approval_proxy().expect("proxy installed in scope");
+            assert!(
+                got.request_approval(ApprovalAsk {
+                    tool_name: "Write".into(),
+                    permission: "write".into(),
+                    resource: "/tmp/x".into(),
+                })
+                .await
+            );
+        })
+        .await;
+
+        assert_eq!(seen.load(Ordering::SeqCst), 1);
+        // Proxy is cleared once the scope ends.
+        assert!(current_approval_proxy().is_none());
+    }
+
+    #[tokio::test]
+    async fn none_scope_keeps_proxy_unset() {
+        with_approval_proxy(None, async {
+            assert!(current_approval_proxy().is_none());
+        })
+        .await;
+    }
+}

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -309,6 +309,35 @@ impl ToolExecutor for BuiltinToolExecutor {
                             permission_type,
                             resource: _,
                         }) => {
+                            // Phase 2 (cross-process): a subagent worker installs a
+                            // task-local `ApprovalProxy` for the duration of its run.
+                            // When present, forward the decision to the worker's host
+                            // (parent) and block this tool inline for the reply —
+                            // approve proceeds (treated like a granted context), deny
+                            // fails closed. Checked BEFORE the interactive sink below
+                            // so a worker (which also has an `event_tx`) proxies to its
+                            // parent instead of trying to prompt a human itself. The
+                            // proxy is unset on every non-worker path, so the behavior
+                            // there is unchanged.
+                            if let Some(proxy) = crate::approval::current_approval_proxy() {
+                                let approved = proxy
+                                    .request_approval(crate::approval::ApprovalAsk {
+                                        tool_name: tool_name.clone(),
+                                        permission: permission_type.description().to_string(),
+                                        resource: resource.clone(),
+                                    })
+                                    .await;
+                                if approved {
+                                    // Treat as a granted context: check any remaining
+                                    // contexts, then fall through to execution.
+                                    continue;
+                                }
+                                return Err(ToolError::Execution(format!(
+                                    "Permission denied by host for: {}",
+                                    resource
+                                )));
+                            }
+
                             // Interactive sessions pause for approval by reusing the
                             // same pending-question pipeline as `request_permissions`:
                             // synthesize an "awaiting_permission_approval" result that
@@ -946,6 +975,88 @@ mod tests {
             "forced ask rule should block under bypass: {result:?}"
         );
         assert!(fs::metadata("/etc/forced.conf").await.is_err());
+    }
+
+    // ---- Phase 2: cross-process approval proxy ----------------------------
+
+    struct HostStub {
+        approve: bool,
+    }
+
+    #[async_trait]
+    impl crate::approval::ApprovalProxy for HostStub {
+        async fn request_approval(&self, _ask: crate::approval::ApprovalAsk) -> bool {
+            self.approve
+        }
+    }
+
+    #[tokio::test]
+    async fn approval_proxy_grant_lets_gated_tool_proceed() {
+        // A subagent worker installs an ApprovalProxy for its run. A forced-ask
+        // rule with NO event sink would otherwise fail closed; with the host
+        // proxy granting, the executor treats the context as approved and the
+        // tool proceeds inline (no suspend, no synthetic pause).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("approved.txt");
+        let path_str = path.to_str().unwrap().to_string();
+        let config = Arc::new(crate::permission::PermissionConfig::new());
+        config.set_ask_rules([format!("Write({}/**)", dir.path().to_str().unwrap())]);
+        let checker = Arc::new(crate::permission::ConfigPermissionChecker::new(config));
+        let executor = make_executor(Some(checker));
+
+        let call = make_tool_call("Write", json!({"file_path": path_str, "content": "ok"}));
+        let ctx = ToolExecutionContext {
+            session_id: Some("s-worker"),
+            tool_call_id: &call.id,
+            event_tx: None,
+            available_tool_schemas: None,
+            bypass_permissions: false,
+        };
+
+        let proxy: Arc<dyn crate::approval::ApprovalProxy> = Arc::new(HostStub { approve: true });
+        let result = crate::approval::with_approval_proxy(
+            Some(proxy),
+            executor.execute_with_context(&call, ctx),
+        )
+        .await;
+
+        assert!(result.is_ok(), "host grant should let the write through: {result:?}");
+        assert_eq!(fs::read_to_string(&path).await.unwrap(), "ok");
+    }
+
+    #[tokio::test]
+    async fn approval_proxy_deny_fails_gated_tool_closed() {
+        // With the host proxy denying, the gated tool fails closed and the side
+        // effect never happens.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("denied.txt");
+        let path_str = path.to_str().unwrap().to_string();
+        let config = Arc::new(crate::permission::PermissionConfig::new());
+        config.set_ask_rules([format!("Write({}/**)", dir.path().to_str().unwrap())]);
+        let checker = Arc::new(crate::permission::ConfigPermissionChecker::new(config));
+        let executor = make_executor(Some(checker));
+
+        let call = make_tool_call("Write", json!({"file_path": path_str, "content": "nope"}));
+        let ctx = ToolExecutionContext {
+            session_id: Some("s-worker"),
+            tool_call_id: &call.id,
+            event_tx: None,
+            available_tool_schemas: None,
+            bypass_permissions: false,
+        };
+
+        let proxy: Arc<dyn crate::approval::ApprovalProxy> = Arc::new(HostStub { approve: false });
+        let result = crate::approval::with_approval_proxy(
+            Some(proxy),
+            executor.execute_with_context(&call, ctx),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(ToolError::Execution(ref m)) if m.contains("denied by host")),
+            "host deny should fail the tool closed: {result:?}"
+        );
+        assert!(fs::metadata(&path).await.is_err());
     }
 
     #[tokio::test]

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -283,8 +283,7 @@ impl ToolExecutor for BuiltinToolExecutor {
                 // commands) force a confirmation even under bypass. Everything
                 // else is skipped when this session is in "bypass permissions"
                 // mode (scoped per-session via its runtime state).
-                let force_ask =
-                    permission_checker.requires_forced_confirmation(&tool_name, &args);
+                let force_ask = permission_checker.requires_forced_confirmation(&tool_name, &args);
                 for context in contexts {
                     if ctx.bypass_permissions && !force_ask {
                         continue;
@@ -960,7 +959,10 @@ mod tests {
         let checker = Arc::new(crate::permission::ConfigPermissionChecker::new(config));
         let executor = make_executor(Some(checker));
 
-        let call = make_tool_call("Write", json!({"file_path": "/etc/forced.conf", "content": "x"}));
+        let call = make_tool_call(
+            "Write",
+            json!({"file_path": "/etc/forced.conf", "content": "x"}),
+        );
         let ctx = ToolExecutionContext {
             session_id: Some("s-forced"),
             tool_call_id: &call.id,
@@ -1020,7 +1022,10 @@ mod tests {
         )
         .await;
 
-        assert!(result.is_ok(), "host grant should let the write through: {result:?}");
+        assert!(
+            result.is_ok(),
+            "host grant should let the write through: {result:?}"
+        );
         assert_eq!(fs::read_to_string(&path).await.unwrap(), "ok");
     }
 

--- a/crates/engine/bamboo-tools/src/lib.rs
+++ b/crates/engine/bamboo-tools/src/lib.rs
@@ -3,7 +3,9 @@
 //! This crate provides a plugin-based tool system using the ToolRegistry pattern.
 //! All tools implement the `Tool` trait and can be dynamically registered.
 
+pub mod approval;
 pub mod events;
+pub mod nested_spawn;
 pub mod executor;
 pub mod exposure;
 pub mod guide;
@@ -17,6 +19,14 @@ pub mod tools;
 
 // Re-export executor types
 pub use executor::{BuiltinToolExecutor, BuiltinToolExecutorBuilder};
+
+// Re-export cross-process approval proxy (Phase 2: child → parent delegation)
+pub use approval::{current_approval_proxy, with_approval_proxy, ApprovalAsk, ApprovalProxy};
+
+// Re-export nested-spawn proxy (Phase 6: nested execution)
+pub use nested_spawn::{
+    current_nested_spawn_proxy, with_nested_spawn_proxy, NestedSpawnProxy,
+};
 
 // Re-export tool name utilities
 pub use bamboo_domain::tool_names::{

--- a/crates/engine/bamboo-tools/src/lib.rs
+++ b/crates/engine/bamboo-tools/src/lib.rs
@@ -5,10 +5,10 @@
 
 pub mod approval;
 pub mod events;
-pub mod nested_spawn;
 pub mod executor;
 pub mod exposure;
 pub mod guide;
+pub mod nested_spawn;
 pub mod orchestrator;
 pub mod output_manager;
 pub mod parallel;
@@ -24,9 +24,7 @@ pub use executor::{BuiltinToolExecutor, BuiltinToolExecutorBuilder};
 pub use approval::{current_approval_proxy, with_approval_proxy, ApprovalAsk, ApprovalProxy};
 
 // Re-export nested-spawn proxy (Phase 6: nested execution)
-pub use nested_spawn::{
-    current_nested_spawn_proxy, with_nested_spawn_proxy, NestedSpawnProxy,
-};
+pub use nested_spawn::{current_nested_spawn_proxy, with_nested_spawn_proxy, NestedSpawnProxy};
 
 // Re-export tool name utilities
 pub use bamboo_domain::tool_names::{

--- a/crates/engine/bamboo-tools/src/nested_spawn.rs
+++ b/crates/engine/bamboo-tools/src/nested_spawn.rs
@@ -32,10 +32,7 @@ tokio::task_local! {
 
 /// Run `fut` with `proxy` installed as the ambient nested-spawn proxy for the
 /// duration of the future. The worker scopes this around a single child run.
-pub async fn with_nested_spawn_proxy<F, T>(
-    proxy: Option<Arc<dyn NestedSpawnProxy>>,
-    fut: F,
-) -> T
+pub async fn with_nested_spawn_proxy<F, T>(proxy: Option<Arc<dyn NestedSpawnProxy>>, fut: F) -> T
 where
     F: Future<Output = T>,
 {
@@ -71,7 +68,10 @@ mod tests {
         let proxy: Arc<dyn NestedSpawnProxy> = Arc::new(EchoProxy);
         with_nested_spawn_proxy(Some(proxy), async {
             let got = current_nested_spawn_proxy().expect("proxy installed in scope");
-            let out = got.spawn(serde_json::json!({"action": "create"})).await.unwrap();
+            let out = got
+                .spawn(serde_json::json!({"action": "create"}))
+                .await
+                .unwrap();
             assert_eq!(out["echoed"]["action"], serde_json::json!("create"));
         })
         .await;

--- a/crates/engine/bamboo-tools/src/nested_spawn.rs
+++ b/crates/engine/bamboo-tools/src/nested_spawn.rs
@@ -1,0 +1,80 @@
+//! Per-run nested-spawn proxy (Phase 6: nested execution).
+//!
+//! A subagent worker runs out-of-process and cannot spawn its own sub-agents
+//! directly. When the worker's `SubAgent`-proxy tool runs, it forwards the call
+//! to the host (parent orchestrator) over the actor protocol, which performs the
+//! real spawn (parenting a grandchild under the requesting child) and returns
+//! the tool result.
+//!
+//! This module is the task-local seam — symmetric to [`crate::approval`]: the
+//! worker installs a [`NestedSpawnProxy`] for the duration of a run (task-local,
+//! so concurrent runs on a shared worker can't see each other's proxy); the
+//! `SubAgent`-proxy tool reads it via [`current_nested_spawn_proxy`]. Unset on
+//! every non-worker path (the in-process orchestrator runs the real `SubAgent`
+//! tool, not the proxy), so default behavior is unchanged.
+
+use std::future::Future;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+/// Forwards a `SubAgent` tool call from an out-of-process worker to its host.
+#[async_trait]
+pub trait NestedSpawnProxy: Send + Sync {
+    /// Forward the `SubAgent` tool-call arguments to the host and return the
+    /// tool-result JSON. A transport failure should surface as `Err`.
+    async fn spawn(&self, args: serde_json::Value) -> Result<serde_json::Value, String>;
+}
+
+tokio::task_local! {
+    static NESTED_SPAWN_PROXY: Option<Arc<dyn NestedSpawnProxy>>;
+}
+
+/// Run `fut` with `proxy` installed as the ambient nested-spawn proxy for the
+/// duration of the future. The worker scopes this around a single child run.
+pub async fn with_nested_spawn_proxy<F, T>(
+    proxy: Option<Arc<dyn NestedSpawnProxy>>,
+    fut: F,
+) -> T
+where
+    F: Future<Output = T>,
+{
+    NESTED_SPAWN_PROXY.scope(proxy, fut).await
+}
+
+/// The ambient nested-spawn proxy for the current task, if one is installed.
+/// `None` outside any [`with_nested_spawn_proxy`] scope (every non-worker path).
+pub fn current_nested_spawn_proxy() -> Option<Arc<dyn NestedSpawnProxy>> {
+    NESTED_SPAWN_PROXY.try_with(|p| p.clone()).ok().flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct EchoProxy;
+
+    #[async_trait]
+    impl NestedSpawnProxy for EchoProxy {
+        async fn spawn(&self, args: serde_json::Value) -> Result<serde_json::Value, String> {
+            Ok(serde_json::json!({ "echoed": args }))
+        }
+    }
+
+    #[tokio::test]
+    async fn current_proxy_is_none_outside_scope() {
+        assert!(current_nested_spawn_proxy().is_none());
+    }
+
+    #[tokio::test]
+    async fn scope_installs_and_clears_proxy() {
+        let proxy: Arc<dyn NestedSpawnProxy> = Arc::new(EchoProxy);
+        with_nested_spawn_proxy(Some(proxy), async {
+            let got = current_nested_spawn_proxy().expect("proxy installed in scope");
+            let out = got.spawn(serde_json::json!({"action": "create"})).await.unwrap();
+            assert_eq!(out["echoed"]["action"], serde_json::json!("create"));
+        })
+        .await;
+        assert!(current_nested_spawn_proxy().is_none());
+    }
+}

--- a/crates/infra/bamboo-notification/src/policy.rs
+++ b/crates/infra/bamboo-notification/src/policy.rs
@@ -132,7 +132,10 @@ pub fn classify(
                 if !prefs.on_clarification {
                     return None;
                 }
-                (NotificationCategory::NeedsClarification, "Your input needed")
+                (
+                    NotificationCategory::NeedsClarification,
+                    "Your input needed",
+                )
             };
             Some(ClassifiedNotification {
                 category,

--- a/crates/infra/bamboo-permission/src/config.rs
+++ b/crates/infra/bamboo-permission/src/config.rs
@@ -712,11 +712,7 @@ impl PermissionConfig {
     /// - the command is a built-in hard-dangerous shell command (a
     ///   `bash_security` `Deny` verdict), or
     /// - it matches a configured "always ask" rule.
-    pub fn requires_forced_confirmation(
-        &self,
-        tool_name: &str,
-        args: &serde_json::Value,
-    ) -> bool {
+    pub fn requires_forced_confirmation(&self, tool_name: &str, args: &serde_json::Value) -> bool {
         // Built-in backstop: hard-dangerous shell commands always ask.
         if tool_name.eq_ignore_ascii_case("Bash") {
             if let Some(command) = args.get("command").and_then(|v| v.as_str()) {
@@ -1675,10 +1671,8 @@ mod integration_tests {
             &serde_json::json!({ "command": "eval 'cat /etc/passwd'" }),
         ));
         // A benign command is not forced.
-        assert!(!config.requires_forced_confirmation(
-            "Bash",
-            &serde_json::json!({ "command": "ls -la" }),
-        ));
+        assert!(!config
+            .requires_forced_confirmation("Bash", &serde_json::json!({ "command": "ls -la" }),));
     }
 
     #[test]
@@ -1695,10 +1689,12 @@ mod integration_tests {
             &serde_json::json!({ "file_path": "/etc/hosts" }),
         ));
         // Non-matching call is not forced.
-        assert!(!config.requires_forced_confirmation(
-            "Bash",
-            &serde_json::json!({ "command": "git status" }),
-        ));
+        assert!(
+            !config.requires_forced_confirmation(
+                "Bash",
+                &serde_json::json!({ "command": "git status" }),
+            )
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -1041,11 +1041,7 @@ impl Storage for SessionStoreV2 {
             .collect())
     }
 
-    async fn append_token_usage_record(
-        &self,
-        session_id: &str,
-        json_line: &str,
-    ) -> io::Result<()> {
+    async fn append_token_usage_record(&self, session_id: &str, json_line: &str) -> io::Result<()> {
         use tokio::io::AsyncWriteExt;
 
         validate_session_id(session_id)?;
@@ -1156,7 +1152,10 @@ mod tests {
 
         let rel = storage.resolve_rel_path("tu-1").await.unwrap();
         let path = storage.abs_path_from_rel(&rel).join(TOKEN_USAGE_FILE);
-        assert!(path.exists(), "token-usage.jsonl should sit in the session dir");
+        assert!(
+            path.exists(),
+            "token-usage.jsonl should sit in the session dir"
+        );
 
         let contents = tokio::fs::read_to_string(&path).await?;
         let lines: Vec<&str> = contents.lines().collect();

--- a/crates/infra/bamboo-subagent/src/executor.rs
+++ b/crates/infra/bamboo-subagent/src/executor.rs
@@ -10,9 +10,20 @@ use tokio_util::sync::CancellationToken;
 
 use crate::proto::{RunSpec, TerminalStatus};
 
+/// Which kind of host callback a [`HostRequest`] is — selects the wire frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostRequestKind {
+    /// Proxy a `SubAgent` tool call to the host (→ `ChildFrame::SubagentRequest`).
+    Subagent,
+    /// Proxy a gated-tool approval to the host (→ `ChildFrame::ApprovalRequest`).
+    Approval,
+}
+
 /// A single host-callback request: an executor proxies a `SubAgent` tool call
-/// back to the host over the run's WS and awaits the reply.
+/// (or a gated-tool approval) back to the host over the run's WS and awaits the
+/// reply.
 pub struct HostRequest {
+    pub kind: HostRequestKind,
     pub body: serde_json::Value,
     pub reply: oneshot::Sender<serde_json::Value>,
 }
@@ -36,9 +47,27 @@ impl HostBridge {
         &self,
         body: serde_json::Value,
     ) -> Result<serde_json::Value, String> {
+        self.call(HostRequestKind::Subagent, body).await
+    }
+
+    /// Proxy one gated-tool approval to the host and await the decision JSON
+    /// (`{"approved": bool}`). The worker's permission flow blocks on this so the
+    /// human decides on the parent; mirrors [`Self::subagent_call`] (Phase 2).
+    pub async fn approval_call(
+        &self,
+        body: serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        self.call(HostRequestKind::Approval, body).await
+    }
+
+    async fn call(
+        &self,
+        kind: HostRequestKind,
+        body: serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
         let (reply, rx) = oneshot::channel();
         self.req_tx
-            .send(HostRequest { body, reply })
+            .send(HostRequest { kind, body, reply })
             .map_err(|_| "host bridge closed".to_string())?;
         rx.await.map_err(|_| "host bridge dropped reply".to_string())
     }
@@ -259,5 +288,32 @@ mod tests {
             )
             .await;
         assert_eq!(outcome.status, TerminalStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn approval_call_sends_approval_kind_and_round_trips_reply() {
+        let (bridge, mut req_rx) = HostBridge::channel();
+        let caller = tokio::spawn(async move {
+            bridge
+                .approval_call(serde_json::json!({"resource": "/tmp/x"}))
+                .await
+        });
+        let req = req_rx.recv().await.expect("a host request");
+        assert_eq!(req.kind, HostRequestKind::Approval);
+        assert_eq!(req.body["resource"], "/tmp/x");
+        let _ = req.reply.send(serde_json::json!({"approved": true}));
+        let reply = caller.await.unwrap().expect("decision");
+        assert_eq!(reply["approved"], true);
+    }
+
+    #[tokio::test]
+    async fn subagent_call_sends_subagent_kind() {
+        let (bridge, mut req_rx) = HostBridge::channel();
+        let caller =
+            tokio::spawn(async move { bridge.subagent_call(serde_json::json!({"a": 1})).await });
+        let req = req_rx.recv().await.expect("a host request");
+        assert_eq!(req.kind, HostRequestKind::Subagent);
+        let _ = req.reply.send(serde_json::json!({"ok": true}));
+        let _ = caller.await.unwrap();
     }
 }

--- a/crates/infra/bamboo-subagent/src/executor.rs
+++ b/crates/infra/bamboo-subagent/src/executor.rs
@@ -69,7 +69,8 @@ impl HostBridge {
         self.req_tx
             .send(HostRequest { kind, body, reply })
             .map_err(|_| "host bridge closed".to_string())?;
-        rx.await.map_err(|_| "host bridge dropped reply".to_string())
+        rx.await
+            .map_err(|_| "host bridge dropped reply".to_string())
     }
 }
 

--- a/crates/infra/bamboo-subagent/src/proto.rs
+++ b/crates/infra/bamboo-subagent/src/proto.rs
@@ -44,7 +44,9 @@ pub struct RunSpec {
 pub enum ParentFrame {
     Run(RunSpec),
     Cancel,
-    Message { text: String },
+    Message {
+        text: String,
+    },
     /// Reply to a [`ChildFrame::SubagentRequest`] — the host's result for a
     /// SubAgent tool call the worker proxied back over this same WS. `id`
     /// correlates to the request; `body` is the proxied tool result JSON.
@@ -73,20 +75,14 @@ pub enum ChildFrame {
     /// nested sub-agent's grandchildren are created in the host store (parented
     /// to this worker's host session). The host answers with
     /// [`ParentFrame::SubagentReply`] carrying the same `id`.
-    SubagentRequest {
-        id: String,
-        body: serde_json::Value,
-    },
+    SubagentRequest { id: String, body: serde_json::Value },
     /// The worker hit a tool needing human approval (Phase 2 child→parent
     /// approval delegation). Proxied to the host — which surfaces it to the
     /// human via the parent session's pending-question / notification path —
     /// mirroring [`ChildFrame::SubagentRequest`]. The host answers with
     /// [`ParentFrame::ApprovalReply`] carrying the same `id`. `body` carries
     /// `{tool_name, permission_type, resource, question}`.
-    ApprovalRequest {
-        id: String,
-        body: serde_json::Value,
-    },
+    ApprovalRequest { id: String, body: serde_json::Value },
     Terminal {
         status: TerminalStatus,
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/infra/bamboo-subagent/src/proto.rs
+++ b/crates/infra/bamboo-subagent/src/proto.rs
@@ -52,6 +52,15 @@ pub enum ParentFrame {
         id: String,
         body: serde_json::Value,
     },
+    /// Reply to a [`ChildFrame::ApprovalRequest`] — the host's human/policy
+    /// decision on a gated tool the worker proxied back (Phase 2 child→parent
+    /// approval delegation). `id` correlates to the request. When
+    /// `approved == true` the worker records the grant locally and proceeds;
+    /// `false` denies the tool. Mirrors the `SubagentReply` proxy pattern.
+    ApprovalReply {
+        id: String,
+        approved: bool,
+    },
 }
 
 /// Child → parent event/terminal frames.
@@ -65,6 +74,16 @@ pub enum ChildFrame {
     /// to this worker's host session). The host answers with
     /// [`ParentFrame::SubagentReply`] carrying the same `id`.
     SubagentRequest {
+        id: String,
+        body: serde_json::Value,
+    },
+    /// The worker hit a tool needing human approval (Phase 2 child→parent
+    /// approval delegation). Proxied to the host — which surfaces it to the
+    /// human via the parent session's pending-question / notification path —
+    /// mirroring [`ChildFrame::SubagentRequest`]. The host answers with
+    /// [`ParentFrame::ApprovalReply`] carrying the same `id`. `body` carries
+    /// `{tool_name, permission_type, resource, question}`.
+    ApprovalRequest {
         id: String,
         body: serde_json::Value,
     },
@@ -165,6 +184,23 @@ mod tests {
             body: serde_json::json!({"success":true}),
         };
         assert_eq!(ParentFrame::from_text(&reply.to_text()).unwrap(), reply);
+
+        // Phase 2 approval request/reply round-trip over the per-child WS.
+        let areq = ChildFrame::ApprovalRequest {
+            id: "a1".into(),
+            body: serde_json::json!({
+                "tool_name": "Write",
+                "permission_type": "WriteFile",
+                "resource": "/tmp/x",
+                "question": "approve?",
+            }),
+        };
+        assert_eq!(ChildFrame::from_text(&areq.to_text()).unwrap(), areq);
+        let areply = ParentFrame::ApprovalReply {
+            id: "a1".into(),
+            approved: true,
+        };
+        assert_eq!(ParentFrame::from_text(&areply.to_text()).unwrap(), areply);
     }
 
     #[test]

--- a/crates/infra/bamboo-subagent/src/provision.rs
+++ b/crates/infra/bamboo-subagent/src/provision.rs
@@ -88,6 +88,35 @@ pub struct Capabilities {
     /// exclusive with `mcp` direct-sync — proxy covers all MCP.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp_proxy: Option<McpProxyConfig>,
+    /// When `true`, the worker builds its tool executor WITH a permission
+    /// checker, so gated tools hit `ConfirmationRequired` and delegate the
+    /// decision to the host via the per-run `ApprovalProxy` (Phase 2:
+    /// child → parent approval). Default `false` preserves the legacy behavior
+    /// (the worker runs all tools unchecked). Only meaningful when the run has a
+    /// host bridge to proxy to — real actor runs always do.
+    #[serde(default)]
+    pub enforce_permissions: bool,
+    /// When `true`, the worker advertises the `SubAgent` tool (a proxy) to its
+    /// LLM and forwards its calls to the host over the actor protocol, so a
+    /// nested worker can spawn grandchildren (Phase 6: nested execution).
+    /// Default `false` — the worker has no `SubAgent` tool (legacy behavior).
+    /// Only meaningful when the host wires a `NestedSpawnHandler` to fulfil the
+    /// request (real actor runs do).
+    #[serde(default)]
+    pub nested_spawn: bool,
+    /// Max nesting depth a self-orchestrating worker may spawn to (Phase 6:
+    /// direct nested execution). A worker (or the root) refuses to spawn a child
+    /// when its own `spawn_depth >= max_spawn_depth`. `None` ⇒ the default cap
+    /// (4) applies. Carried down so every level enforces the same bound.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_spawn_depth: Option<u32>,
+    /// Whether this actor runs in "bypass permissions" mode (propagated from the
+    /// parent at spawn). Phase 6: when true, a self-orchestrating worker installs
+    /// an OFF-LOOP model-reviewer so its CHILDREN's forced-ask (dangerous) gated
+    /// actions — which still fire `ConfirmationRequired` even under bypass — get
+    /// an LLM reasonableness check instead of a blind pass.
+    #[serde(default)]
+    pub bypass: bool,
 }
 
 /// How a worker reaches the orchestrator's MCP proxy over the broker.
@@ -127,6 +156,13 @@ pub struct ChildIdentity {
     /// Role/profile id, e.g. "researcher". Also published in the discovery record.
     #[serde(default)]
     pub role: String,
+    /// Nesting depth of THIS actor in the spawn tree (root orchestrator = 0, its
+    /// direct worker = 1, …). The worker stamps this onto its run session's
+    /// `spawn_depth` so in-process children accumulate depth correctly ACROSS the
+    /// actor process boundary (each worker otherwise starts at a fresh root).
+    /// Used to enforce the max-depth cap (Phase 6: direct nested execution).
+    #[serde(default)]
+    pub depth: u32,
 }
 
 /// Which engine runs the task. The worker's factory maps each variant to a `ChildExecutor`;
@@ -240,6 +276,7 @@ mod tests {
                 parent_id: Some("p1".into()),
                 project_key: Some("proj".into()),
                 role: "researcher".into(),
+                depth: 0,
             },
             ExecutorSpec::Echo,
             "/tmp/fabric".into(),
@@ -324,6 +361,10 @@ mod tests {
             mcp: Some(serde_json::json!({ "version": 1, "servers": [] })),
             skills_dir: Some("/home/u/.bamboo/skills".into()),
             mcp_proxy: None,
+            enforce_permissions: false,
+            nested_spawn: false,
+            max_spawn_depth: None,
+            bypass: false,
         };
         let parsed = ProvisionSpec::from_json(&s.to_json().unwrap()).unwrap();
         assert_eq!(
@@ -341,6 +382,17 @@ mod tests {
         });
         let parsed = ProvisionSpec::from_json(&minimal.to_string()).unwrap();
         assert_eq!(parsed.capabilities, Capabilities::default());
+    }
+
+    #[test]
+    fn enforce_permissions_defaults_false_and_round_trips() {
+        // Absent in JSON ⇒ false (backward compatible with older orchestrators).
+        assert!(!Capabilities::default().enforce_permissions);
+        // Round-trips when opted in.
+        let mut s = spec();
+        s.capabilities.enforce_permissions = true;
+        let parsed = ProvisionSpec::from_json(&s.to_json().unwrap()).unwrap();
+        assert!(parsed.capabilities.enforce_permissions);
     }
 
     #[test]

--- a/crates/infra/bamboo-subagent/src/transport.rs
+++ b/crates/infra/bamboo-subagent/src/transport.rs
@@ -18,7 +18,7 @@ use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{accept_async, connect_async, MaybeTlsStream, WebSocketStream};
 use tokio_util::sync::CancellationToken;
 
-use crate::executor::{ChildExecutor, EventSink, HostBridge, SteerInbox};
+use crate::executor::{ChildExecutor, EventSink, HostBridge, HostRequestKind, SteerInbox};
 use crate::proto::{ChildFrame, ParentFrame, RunSpec};
 
 /// Pending host-callback replies, keyed by request id, shared between the
@@ -162,6 +162,15 @@ async fn handle_conn<E: ChildExecutor + ?Sized>(
                         let _ = reply.send(body);
                     }
                 }
+                // Phase 2: the host's decision on a proxied gated-tool approval.
+                // Routed through the same `pending` correlation map as
+                // `SubagentReply` (body = {"approved": bool}); a worker that
+                // proxied an `ApprovalRequest` awaits its oneshot here.
+                Ok(ParentFrame::ApprovalReply { id, approved }) => {
+                    if let Some(reply) = pending.lock().expect("pending lock").remove(&id) {
+                        let _ = reply.send(serde_json::json!({ "approved": approved }));
+                    }
+                }
                 Ok(ParentFrame::Run(spec)) => {
                     // A new run supersedes any active run: cancel the previous
                     // task *before* starting the new one so the old run stops
@@ -261,10 +270,11 @@ fn start_run<E: ChildExecutor + ?Sized>(
                 .lock()
                 .expect("pending lock")
                 .insert(id.clone(), req.reply);
-            if out_req
-                .send(ChildFrame::SubagentRequest { id, body: req.body })
-                .is_err()
-            {
+            let frame = match req.kind {
+                HostRequestKind::Subagent => ChildFrame::SubagentRequest { id, body: req.body },
+                HostRequestKind::Approval => ChildFrame::ApprovalRequest { id, body: req.body },
+            };
+            if out_req.send(frame).is_err() {
                 break;
             }
         }
@@ -352,6 +362,7 @@ mod tests {
             match frame {
                 ChildFrame::Event { event } => events.push(event),
                 ChildFrame::SubagentRequest { .. } => {}
+                ChildFrame::ApprovalRequest { .. } => {}
                 ChildFrame::Terminal { status, result, .. } => {
                     terminal = Some((status, result));
                     break;
@@ -481,6 +492,86 @@ mod tests {
         let _ = srv.await;
     }
 
+    /// Phase 2: a worker that hits a gated tool proxies an approval to the host
+    /// over the per-child WS and blocks for the decision — the FULL cross-process
+    /// round-trip (worker `approval_call` → `ChildFrame::ApprovalRequest` →
+    /// host `ParentFrame::ApprovalReply` → the awaiting call resolves).
+    #[tokio::test]
+    async fn approval_request_round_trips_to_host_and_back() {
+        use crate::executor::{ChildExecutor, ChildOutcome, SteerInbox};
+
+        /// Proxies one approval to the host and reports the decision.
+        struct ApprovalProber;
+        #[async_trait::async_trait]
+        impl ChildExecutor for ApprovalProber {
+            async fn run(
+                &self,
+                _spec: RunSpec,
+                events: EventSink,
+                _steer: SteerInbox,
+                _cancel: CancellationToken,
+            ) -> ChildOutcome {
+                let Some(host) = events.host() else {
+                    return ChildOutcome::error("no host bridge wired");
+                };
+                match host
+                    .approval_call(serde_json::json!({
+                        "tool_name": "Write",
+                        "permission_type": "WriteFile",
+                        "resource": "/tmp/x",
+                        "question": "approve?",
+                    }))
+                    .await
+                {
+                    Ok(decision) => ChildOutcome::completed(format!(
+                        "approved: {}",
+                        decision["approved"].as_bool().unwrap_or(false)
+                    )),
+                    Err(e) => ChildOutcome::error(format!("bridge: {e}")),
+                }
+            }
+        }
+
+        let server = WsServer::bind_loopback().await.unwrap();
+        let endpoint = server.ws_endpoint();
+        let srv = tokio::spawn(async move { server.serve_one(Arc::new(ApprovalProber)).await });
+
+        let mut client = ChildClient::connect(&endpoint).await.unwrap();
+        client
+            .send(ParentFrame::Run(RunSpec {
+                assignment: "go".into(),
+                reasoning_effort: None,
+                messages: Vec::new(),
+            }))
+            .await
+            .unwrap();
+
+        let mut terminal = None;
+        while let Some(frame) = client.next_frame().await.unwrap() {
+            match frame {
+                ChildFrame::ApprovalRequest { id, body } => {
+                    assert_eq!(body["resource"], "/tmp/x");
+                    assert_eq!(body["tool_name"], "Write");
+                    client
+                        .send(ParentFrame::ApprovalReply { id, approved: true })
+                        .await
+                        .unwrap();
+                }
+                ChildFrame::Terminal { status, result, .. } => {
+                    terminal = Some((status, result));
+                    break;
+                }
+                _ => {}
+            }
+        }
+        let (status, result) = terminal.expect("terminal");
+        assert_eq!(status, TerminalStatus::Completed);
+        assert_eq!(result.as_deref(), Some("approved: true"));
+
+        let _ = client.close().await;
+        let _ = srv.await;
+    }
+
     /// Service-agent mode: two concurrent connections to one `serve()` must be
     /// fully isolated — each client sees only its own run's events/terminal,
     /// and per-connection cancel state (the round-2 fix) must not cross talk.
@@ -553,6 +644,7 @@ mod tests {
                     }
                 }
                 ChildFrame::SubagentRequest { .. } => {}
+                ChildFrame::ApprovalRequest { .. } => {}
                 ChildFrame::Terminal {
                     status, result: r, ..
                 } => {

--- a/crates/infra/bamboo-subagent/tests/e2e_subprocess.rs
+++ b/crates/infra/bamboo-subagent/tests/e2e_subprocess.rs
@@ -24,6 +24,7 @@ async fn spawn_discover_run_stream_terminal() {
             parent_id: Some("p1".into()),
             project_key: None,
             role: "demo".into(),
+            depth: 0,
         },
         ExecutorSpec::Echo,
         fabric.to_string_lossy().into_owned(),
@@ -55,6 +56,7 @@ async fn spawn_discover_run_stream_terminal() {
         match frame {
             ChildFrame::Event { event } => events.push(event),
             ChildFrame::SubagentRequest { .. } => {}
+            ChildFrame::ApprovalRequest { .. } => {}
             ChildFrame::Terminal { status, result, .. } => {
                 terminal = Some((status, result));
                 break;
@@ -90,6 +92,7 @@ async fn reusable_worker_serves_two_sequential_assignments_same_process() {
             parent_id: Some("p1".into()),
             project_key: None,
             role: "demo".into(),
+            depth: 0,
         },
         ExecutorSpec::Echo,
         fabric.to_string_lossy().into_owned(),

--- a/src/actor_cli.rs
+++ b/src/actor_cli.rs
@@ -279,6 +279,10 @@ async fn connect_and_stream(endpoint: &str, prompt: &str, raw: bool) -> Result<(
                     Ok(Some(ChildFrame::SubagentRequest { .. })) => {
                         // This CLI does not host nested spawning; ignore.
                     }
+                    Ok(Some(ChildFrame::ApprovalRequest { .. })) => {
+                        // This CLI does not route gated-tool approvals; ignore.
+                        // (The production host in actor_adapter answers these.)
+                    }
                     Ok(Some(ChildFrame::Terminal { status, result, error, .. })) => {
                         println!();
                         match status {
@@ -346,6 +350,7 @@ fn prepare_spec(
             parent_id: None,
             project_key: None,
             role: role.to_string(),
+            depth: 0,
         },
         if echo {
             ExecutorSpec::Echo

--- a/src/admin_cli.rs
+++ b/src/admin_cli.rs
@@ -88,7 +88,12 @@ pub async fn status(conn: ConnArgs) -> anyhow::Result<()> {
     match health {
         Ok(r) if r.status().is_success() => println!("{:<10}{}", "health:".bold(), "ok".green()),
         Ok(r) => {
-            println!("{:<10}{} (HTTP {})", "health:".bold(), "down".red(), r.status());
+            println!(
+                "{:<10}{} (HTTP {})",
+                "health:".bold(),
+                "down".red(),
+                r.status()
+            );
             return Ok(());
         }
         Err(e) => {
@@ -200,7 +205,11 @@ pub async fn stop(conn: ConnArgs, session_id: &str) -> anyhow::Result<()> {
         .unwrap_or("")
         .to_string();
     if status.is_success() {
-        let msg = if message.is_empty() { "stopped" } else { &message };
+        let msg = if message.is_empty() {
+            "stopped"
+        } else {
+            &message
+        };
         println!("{} {msg}", "✓".green());
         Ok(())
     } else if status.as_u16() == 404 {

--- a/src/broker_agent.rs
+++ b/src/broker_agent.rs
@@ -82,6 +82,7 @@ fn build_spec(args: &BrokerAgentArgs) -> Result<ProvisionSpec, String> {
                 .role
                 .clone()
                 .unwrap_or_else(|| "general-purpose".into()),
+            depth: 0,
         },
         ExecutorSpec::BambooRuntime,
         std::env::temp_dir()

--- a/src/broker_agent.rs
+++ b/src/broker_agent.rs
@@ -94,22 +94,18 @@ fn build_spec(args: &BrokerAgentArgs) -> Result<ProvisionSpec, String> {
     // Model precedence: explicit --model > config defaults.sub_agent > defaults.chat.
     // A deployed worker given no --model must still inherit the configured default,
     // otherwise its AgentLoopConfig has no model_name and every LLM call fails.
-    spec.model = args
-        .model
-        .as_deref()
-        .and_then(parse_model)
-        .or_else(|| {
-            config.defaults.as_ref().and_then(|defaults| {
-                defaults
-                    .sub_agent
-                    .as_ref()
-                    .or(Some(&defaults.chat))
-                    .map(|r| ModelRefSpec {
-                        provider: r.provider.clone(),
-                        model: r.model.clone(),
-                    })
-            })
-        });
+    spec.model = args.model.as_deref().and_then(parse_model).or_else(|| {
+        config.defaults.as_ref().and_then(|defaults| {
+            defaults
+                .sub_agent
+                .as_ref()
+                .or(Some(&defaults.chat))
+                .map(|r| ModelRefSpec {
+                    provider: r.provider.clone(),
+                    model: r.model.clone(),
+                })
+        })
+    });
     spec.workspace = args.workspace.clone();
     spec.secrets.provider_credentials = credentials;
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -39,9 +39,7 @@ fn parse_permission_mode(s: &str) -> Result<PermissionMode, String> {
 fn pick_option(options: &[String], needle: &str) -> String {
     options
         .iter()
-        .find(|opt| {
-            opt.eq_ignore_ascii_case(needle) || opt.to_ascii_lowercase().contains(needle)
-        })
+        .find(|opt| opt.eq_ignore_ascii_case(needle) || opt.to_ascii_lowercase().contains(needle))
         .cloned()
         .unwrap_or_else(|| needle.to_string())
 }

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -23,7 +23,6 @@ use tokio_util::sync::CancellationToken;
 
 use bamboo_agent_core::{AgentError, AgentEvent, Message, Role, Session};
 use bamboo_llm::{create_provider_by_name, Config, LLMChunk, LLMProvider};
-use futures::StreamExt;
 use bamboo_metrics::{MetricsCollector, SqliteMetricsStorage};
 use bamboo_skills::{SkillManager, SkillStoreConfig};
 use bamboo_storage::{LockedSessionStore, SessionStoreV2};
@@ -34,6 +33,7 @@ use bamboo_subagent::executor::{
 use bamboo_subagent::proto::{AgentRecord, RunSpec};
 use bamboo_subagent::provision::{ExecutorSpec, ProvisionSpec};
 use bamboo_subagent::transport::WsServer;
+use futures::StreamExt;
 
 /// How long a finished actor's isolated storage is retained for debugging
 /// before background GC removes it.
@@ -418,7 +418,8 @@ impl BambooRuntimeExecutor {
                 Some(Arc::new(bamboo_server::tools::OverlayToolExecutor::new(
                     default_tools,
                     sub_agent,
-                )) as Arc<dyn bamboo_agent_core::tools::ToolExecutor>)
+                ))
+                    as Arc<dyn bamboo_agent_core::tools::ToolExecutor>)
             } else {
                 None
             };
@@ -432,7 +433,11 @@ impl BambooRuntimeExecutor {
             bamboo_engine::external_agents::set_child_approval_reviewer(Arc::new(
                 ModelApprovalReviewer {
                     provider: provider_for_review,
-                    model: spec.model.as_ref().map(|m| m.model.clone()).unwrap_or_default(),
+                    model: spec
+                        .model
+                        .as_ref()
+                        .map(|m| m.model.clone())
+                        .unwrap_or_default(),
                 },
             ));
         }

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -22,12 +22,15 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use bamboo_agent_core::{AgentError, AgentEvent, Message, Role, Session};
-use bamboo_llm::{create_provider_by_name, Config};
+use bamboo_llm::{create_provider_by_name, Config, LLMChunk, LLMProvider};
+use futures::StreamExt;
 use bamboo_metrics::{MetricsCollector, SqliteMetricsStorage};
 use bamboo_skills::{SkillManager, SkillStoreConfig};
 use bamboo_storage::{LockedSessionStore, SessionStoreV2};
 use bamboo_subagent::discovery::Fabric;
-use bamboo_subagent::executor::{ChildExecutor, ChildOutcome, EchoExecutor, EventSink, SteerInbox};
+use bamboo_subagent::executor::{
+    ChildExecutor, ChildOutcome, EchoExecutor, EventSink, HostBridge, SteerInbox,
+};
 use bamboo_subagent::proto::{AgentRecord, RunSpec};
 use bamboo_subagent::provision::{ExecutorSpec, ProvisionSpec};
 use bamboo_subagent::transport::WsServer;
@@ -121,7 +124,7 @@ pub async fn run() -> std::result::Result<(), String> {
 
 /// `ChildExecutor` backed by the real bamboo agent loop, assembled from a `ProvisionSpec`.
 pub struct BambooRuntimeExecutor {
-    agent: bamboo_engine::Agent,
+    agent: Arc<bamboo_engine::Agent>,
     /// Same store the agent persists to, kept as the concrete type so steering
     /// can do a LOCKED read-modify-write (`update_runtime_config`) instead of
     /// an unlocked load+save that could revert a concurrent loop save.
@@ -130,6 +133,19 @@ pub struct BambooRuntimeExecutor {
     workspace: Option<String>,
     disabled_tools: Option<BTreeSet<String>>,
     child_id: String,
+    /// Per-run tool executor that ADDS the real `SubAgent` tool (Phase 6: direct
+    /// nested execution). `Some` only for a sub-cap worker with `nested_spawn`;
+    /// supplied to each run via `ExecuteRequestBuilder.tools()` to break the
+    /// agent→tools→adapter→scheduler→agent construction cycle.
+    run_tools: Option<Arc<dyn bamboo_agent_core::tools::ToolExecutor>>,
+    /// This worker's nesting depth (from the actor spec). Stamped onto each run
+    /// session's `spawn_depth` so the depth cap accumulates across the boundary.
+    spawn_depth: u32,
+    /// Whether this worker runs in "bypass permissions" mode (from the actor
+    /// spec). Stamped onto each run session so the worker's own tools honor it
+    /// AND it propagates to grandchildren (whose forced-ask actions then get the
+    /// installed model-reviewer). Phase 6, Part B.
+    bypass: bool,
 }
 
 impl BambooRuntimeExecutor {
@@ -218,9 +234,28 @@ impl BambooRuntimeExecutor {
         let metrics_collector = MetricsCollector::spawn(metrics_storage, 90);
 
         let config = Arc::new(tokio::sync::RwLock::new(config));
-        let builtin: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(
-            bamboo_tools::BuiltinToolExecutor::new_with_config(config.clone()),
-        );
+        let builtin: Arc<dyn bamboo_agent_core::tools::ToolExecutor> =
+            if spec.capabilities.enforce_permissions {
+                // Phase 2: enforce permissions so gated tools hit
+                // ConfirmationRequired and the per-run ApprovalProxy delegates the
+                // decision to the host. A default `PermissionConfig` confirms at
+                // the Low threshold (gates mutating ops); session grants flow back
+                // via the host's approval reply.
+                let checker: Arc<dyn bamboo_tools::permission::PermissionChecker> =
+                    Arc::new(bamboo_tools::permission::ConfigPermissionChecker::new(
+                        Arc::new(bamboo_tools::permission::PermissionConfig::new()),
+                    ));
+                Arc::new(
+                    bamboo_tools::BuiltinToolExecutor::new_with_config_and_permissions(
+                        config.clone(),
+                        checker,
+                    ),
+                )
+            } else {
+                Arc::new(bamboo_tools::BuiltinToolExecutor::new_with_config(
+                    config.clone(),
+                ))
+            };
         // MCP composition (absent for actor children → builtin-only, unchanged):
         //   1. mcp_proxy set → proxy ALL MCP to the orchestrator over the broker
         //      (it runs the host-bound servers like nova; P2).
@@ -309,17 +344,98 @@ impl BambooRuntimeExecutor {
             ))
         };
 
-        let agent = bamboo_engine::Agent::builder()
-            .storage(store.clone())
-            .persistence(persistence)
-            .attachment_reader(store)
-            .skill_manager(skill_manager)
-            .metrics_collector(metrics_collector)
-            .config(config)
-            .provider(provider)
-            .default_tools(default_tools)
-            .build()
-            .map_err(|e| format!("build agent runtime: {e}"))?;
+        // Capture clones for the worker's OWN spawn stack (Phase 6: direct nested
+        // execution) before the agent builder consumes the originals. `persistence`
+        // is moved into the builder, but `locked_store` is already a clone of it.
+        let store_for_stack = store.clone();
+        let config_for_stack = config.clone();
+        let provider_for_review = provider.clone();
+
+        let agent = Arc::new(
+            bamboo_engine::Agent::builder()
+                .storage(store.clone())
+                .persistence(persistence)
+                .attachment_reader(store)
+                .skill_manager(skill_manager)
+                .metrics_collector(metrics_collector)
+                .config(config)
+                .provider(provider)
+                // Base tools only; the real SubAgent tool is added per-run via
+                // `ExecuteRequestBuilder.tools()` (see `run_tools` below) to break
+                // the agent→tools→adapter→scheduler→agent construction cycle.
+                .default_tools(default_tools.clone())
+                .build()
+                .map_err(|e| format!("build agent runtime: {e}"))?,
+        );
+
+        // A worker BELOW the depth cap orchestrates its OWN children directly: it
+        // builds its own external-child runner + scheduler + adapter and runs the
+        // REAL SubAgent tool against them (no host proxy). `nested_spawn` is set
+        // by the host's build_spec purely from depth (< MAX_SPAWN_DEPTH), so it
+        // auto-propagates down the tree and bottoms out at the cap.
+        let run_tools: Option<Arc<dyn bamboo_agent_core::tools::ToolExecutor>> =
+            if spec.capabilities.nested_spawn {
+                // Point the worker's own actor runner at the shared fabric so
+                // grandchildren are discoverable; the worker binary itself is
+                // found via `current_exe()` inside build_local_actor_runner.
+                {
+                    let mut cfg = config_for_stack.write().await;
+                    if cfg.subagents.fabric_dir.is_none() {
+                        cfg.subagents.fabric_dir = Some(spec.fabric_dir.clone());
+                    }
+                }
+                let external_runner = {
+                    let cfg = config_for_stack.read().await;
+                    bamboo_engine::external_agents::runtime::build_external_child_runner(&cfg)
+                };
+                let scheduler = bamboo_server::app_state::init::build_spawn_scheduler(
+                    agent.clone(),
+                    default_tools.clone(),
+                    Arc::new(dashmap::DashMap::new()),
+                    Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
+                    Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
+                    external_runner,
+                    None,
+                    None,
+                    Some(storage_dir.clone()),
+                    None,
+                );
+                let adapter = Arc::new(bamboo_server::tools::ChildSessionAdapter::new(
+                    store_for_stack.clone(),
+                    store_for_stack.clone(),
+                    locked_store.clone(),
+                    scheduler,
+                    Arc::new(dashmap::DashMap::new()),
+                    Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
+                    Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
+                    None,
+                    config_for_stack.clone(),
+                ));
+                let sub_agent = Arc::new(bamboo_server::tools::SubAgentTool::new(
+                    adapter.clone(),
+                    adapter,
+                ));
+                Some(Arc::new(bamboo_server::tools::OverlayToolExecutor::new(
+                    default_tools,
+                    sub_agent,
+                )) as Arc<dyn bamboo_agent_core::tools::ToolExecutor>)
+            } else {
+                None
+            };
+
+        // Phase 6, Part B: a BYPASSED self-orchestrating worker installs an
+        // off-loop model-reviewer so its children's forced-ask (dangerous)
+        // actions — which still fire even under bypass — get an LLM
+        // reasonableness check instead of a blind pass. Process-global, read by
+        // this worker's `drive()` when a child sends an ApprovalRequest.
+        if spec.capabilities.bypass && spec.capabilities.nested_spawn {
+            bamboo_engine::external_agents::set_child_approval_reviewer(Arc::new(
+                ModelApprovalReviewer {
+                    provider: provider_for_review,
+                    model: spec.model.as_ref().map(|m| m.model.clone()).unwrap_or_default(),
+                },
+            ));
+        }
 
         Ok(Self {
             agent,
@@ -331,7 +447,115 @@ impl BambooRuntimeExecutor {
                 .as_ref()
                 .map(|v| v.iter().cloned().collect()),
             child_id: spec.identity.child_id.clone(),
+            run_tools,
+            spawn_depth: spec.identity.depth,
+            bypass: spec.capabilities.bypass,
         })
+    }
+}
+
+/// Bridges the engine's task-local [`bamboo_tools::ApprovalProxy`] to the host
+/// over the subagent protocol (Phase 2). When a gated tool in this worker hits
+/// a `ConfirmationRequired`, the executor calls this; we forward the ask to the
+/// parent via [`HostBridge::approval_call`] and block inline for the decision.
+/// Any transport failure resolves to `false` (fail closed).
+struct HostApprovalProxy {
+    host: HostBridge,
+}
+
+#[async_trait]
+impl bamboo_tools::ApprovalProxy for HostApprovalProxy {
+    async fn request_approval(&self, ask: bamboo_tools::ApprovalAsk) -> bool {
+        let body = serde_json::json!({
+            "tool_name": ask.tool_name,
+            "permission": ask.permission,
+            "resource": ask.resource,
+        });
+        match self.host.approval_call(body).await {
+            Ok(reply) => reply
+                .get("approved")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+            Err(e) => {
+                tracing::warn!("approval proxy: host call failed ({e}); denying (fail closed)");
+                false
+            }
+        }
+    }
+}
+
+/// Parse an LLM review verdict: approve ONLY on a clear APPROVE with no DENY
+/// (fail closed on anything ambiguous/empty). Phase 6, Part B.
+fn parse_review_verdict(content: &str) -> bool {
+    let upper = content.to_uppercase();
+    upper.contains("APPROVE") && !upper.contains("DENY")
+}
+
+/// LLM-judge reviewer for a BYPASSED parent worker's children (Phase 6, Part B).
+/// When a child's forced-ask (dangerous) action raises `ConfirmationRequired`
+/// even under bypass, the worker's `drive()` calls this OFF-LOOP (in a spawned
+/// task) to decide whether the action is reasonable, instead of a blind pass.
+/// Fails CLOSED (deny) on any LLM/transport error or an unparseable verdict.
+struct ModelApprovalReviewer {
+    provider: Arc<dyn LLMProvider>,
+    model: String,
+}
+
+#[async_trait]
+impl bamboo_engine::external_agents::ChildApprovalReviewer for ModelApprovalReviewer {
+    async fn review(&self, _child_session_id: &str, request: &serde_json::Value) -> bool {
+        if self.model.trim().is_empty() {
+            return false;
+        }
+        let field = |k: &str| {
+            request
+                .get(k)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string()
+        };
+        let prompt = format!(
+            "A sub-agent you supervise wants to run a GATED action that requires confirmation \
+             even in bypass mode (i.e. it is potentially dangerous or irreversible):\n\
+             - tool: {}\n- permission: {}\n- target/command: {}\n\n\
+             Decide whether this action is reasonable and safe to allow for ordinary task work. \
+             If it is clearly destructive, out of scope, or risky, DENY it.\n\
+             Reply with EXACTLY one word: APPROVE or DENY.",
+            field("tool_name"),
+            field("permission"),
+            field("resource"),
+        );
+        let messages = vec![Message::user(prompt)];
+        let mut stream = match self
+            .provider
+            .chat_stream(&messages, &[], Some(16), &self.model)
+            .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("model approval review: LLM call failed ({e}); denying");
+                return false;
+            }
+        };
+        let mut content = String::new();
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                Ok(LLMChunk::Token(t)) => content.push_str(&t),
+                Ok(LLMChunk::Done) => break,
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!("model approval review: stream error ({e}); denying");
+                    return false;
+                }
+            }
+        }
+        let approved = parse_review_verdict(&content);
+        tracing::info!(
+            "model approval review verdict={} (raw={:?})",
+            if approved { "APPROVE" } else { "DENY" },
+            content.trim()
+        );
+        approved
     }
 }
 
@@ -355,6 +579,19 @@ impl ChildExecutor for BambooRuntimeExecutor {
             self.model.clone().unwrap_or_default(),
         );
         session.workspace = self.workspace.clone();
+        // Phase 6: re-establish this worker's nesting depth on its fresh run
+        // session (Session::new starts at 0), so the depth cap accumulates across
+        // the actor boundary and in-process children get spawn_depth = this + 1.
+        session.spawn_depth = self.spawn_depth;
+        // Phase 6, Part B: re-establish bypass on the fresh run session so the
+        // worker's own tools honor it AND create_child_action propagates it to
+        // grandchildren (whose forced-ask actions then reach the model-reviewer).
+        if self.bypass {
+            session
+                .agent_runtime_state
+                .get_or_insert_with(bamboo_domain::AgentRuntimeState::default)
+                .bypass_permissions = true;
+        }
         let rehydrated: Vec<Message> = run
             .messages
             .iter()
@@ -422,6 +659,19 @@ impl ChildExecutor for BambooRuntimeExecutor {
             }
         });
 
+        // Phase 2: if the host wired an approval bridge, install a per-run
+        // ApprovalProxy so this run's gated tools delegate the decision to the
+        // parent over the WS protocol instead of failing closed in this headless
+        // worker. Captured here BEFORE `events` moves into the forward task.
+        let approval_proxy: Option<Arc<dyn bamboo_tools::ApprovalProxy>> =
+            events.host().cloned().map(|host| {
+                Arc::new(HostApprovalProxy { host }) as Arc<dyn bamboo_tools::ApprovalProxy>
+            });
+        // Phase 6, Part B: install our host bridge as the process escalation
+        // bridge so this worker's `drive()` can re-proxy a (non-bypass) child's
+        // approval request UP to our own parent — chaining it to the top human.
+        bamboo_engine::external_agents::set_escalation_host_bridge(events.host().cloned());
+
         // AgentEvents stream to the parent verbatim (zero mapping).
         let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(256);
         let forward = tokio::spawn(async move {
@@ -443,8 +693,21 @@ impl ChildExecutor for BambooRuntimeExecutor {
         if let Some(disabled) = self.disabled_tools.clone() {
             builder = builder.disabled_tools(disabled);
         }
+        // Phase 6: when this worker self-orchestrates, run with the tool executor
+        // that includes the REAL SubAgent tool (bound to the worker's own spawn
+        // stack), so its LLM can create+wait on grandchildren directly.
+        if let Some(tools) = self.run_tools.clone() {
+            builder = builder.tools(tools);
+        }
 
-        let result = self.agent.execute(&mut session, builder.build()).await;
+        // Scope the approval proxy to exactly this run (task-local), so gated
+        // tools route ConfirmationRequired to the host. Unset => unchanged
+        // (fail-closed) behavior.
+        let result = bamboo_tools::with_approval_proxy(
+            approval_proxy,
+            self.agent.execute(&mut session, builder.build()),
+        )
+        .await;
         steer_task.abort();
         let _ = forward.await; // flush remaining events before the terminal frame
 
@@ -538,6 +801,21 @@ mod tests {
     use super::*;
     use bamboo_subagent::provision::{ChildIdentity, ModelRefSpec, ScopedCredential};
 
+    #[test]
+    fn review_verdict_approves_only_on_clear_approve() {
+        // Phase 6, Part B: the model-reviewer fails CLOSED on anything ambiguous.
+        assert!(parse_review_verdict("APPROVE"));
+        assert!(parse_review_verdict("approve"));
+        assert!(parse_review_verdict("APPROVE — looks fine for the task"));
+        assert!(!parse_review_verdict("DENY"));
+        assert!(!parse_review_verdict("deny, this is destructive"));
+        // Mentions both ⇒ deny (fail closed).
+        assert!(!parse_review_verdict("I would APPROVE but actually DENY"));
+        // Anything unrecognized ⇒ deny.
+        assert!(!parse_review_verdict("maybe"));
+        assert!(!parse_review_verdict(""));
+    }
+
     fn spec_with(provider: &str, key: &str, model: Option<(&str, &str)>) -> ProvisionSpec {
         let mut s = ProvisionSpec::new(
             ChildIdentity {
@@ -545,6 +823,7 @@ mod tests {
                 parent_id: None,
                 project_key: None,
                 role: "worker".into(),
+                depth: 0,
             },
             ExecutorSpec::BambooRuntime,
             "/tmp/fabric".into(),

--- a/tests/subagent_worker_e2e.rs
+++ b/tests/subagent_worker_e2e.rs
@@ -27,6 +27,7 @@ async fn real_bamboo_binary_serves_a_subagent_run() {
             parent_id: Some("p1".into()),
             project_key: None,
             role: "smoke".into(),
+            depth: 0,
         },
         ExecutorSpec::Echo,
         fabric.to_string_lossy().into_owned(),
@@ -66,6 +67,7 @@ async fn real_bamboo_binary_serves_a_subagent_run() {
                 }
             }
             ChildFrame::SubagentRequest { .. } => {}
+            ChildFrame::ApprovalRequest { .. } => {}
             ChildFrame::Terminal { status, result, .. } => {
                 terminal = Some((status, result));
                 break;


### PR DESCRIPTION
## Summary

Multi-phase sub-agent roadmap (the branch grew well beyond the original Guardian feature). All workspace tests are green; the broker e2e includes a **real Docker container** run.

### Phases

- **Phase 1 — Guardian**: adversarial reviewer spawned when the agent declares complete, via the durable suspend/resume path; verdict parsing; read-only reviewer toolset.
- **Phase 2 — child→parent approval (cross-process)**: worker `ApprovalProxy` → `host.approval_call` → `drive()` surfaces `AgentEvent::ChildApprovalRequested` + `POST /api/v1/child-approval/{id}` → `live::deliver_approval`; worker permission-enforcement opt-in. (Frontend lands in the `lotus` repo.)
- **Phase 3 — model-controllable context fork** (`fork_last_messages`).
- **Phase 4 — task-aware tool-output trimming** (preserve task-relevant lines under the token cap).
- **Phase 6 — persistent child graph + DIRECT nested execution**: a worker self-orchestrates — builds its own spawn stack and runs the **real** `SubAgent` tool (no host proxy). The `agent→tools→adapter→scheduler→agent` construction cycle is broken via `ExecuteRequestBuilder.tools()`. **Max nesting depth cap (default 4)** propagated across the actor boundary (`spawn_depth`) and enforced in `SubAgent` create.
- **Child approval review**: a **bypass** parent model-reviews its children's forced-ask (dangerous) actions **off-loop** (spawned LLM-judge task → async `deliver_approval`); a **non-bypass** parent **re-proxies** the request up the actor chain to the top human, and the reply relays back down. Non-blocking throughout (no path awaits a decision inside the frame pump / agent loop).

### Tests

- bamboo: agent-core 106 · tools 287 · server-tools 30 · subagent 46 (+2 e2e) · engine 841 · server 850 · root 38 — all green.
- `broker_deploy_e2e` 3/3, including a real Docker container (`bamboo broker-agent` inside `bamboo-e2e:latest` joining the broker over WS).
- `cargo check --workspace` clean.

### Known follow-up

The non-bypass escalation host bridge is a **per-run process-global** (workers serve runs sequentially). Correct for the common `wait` case, but a fire-and-forget grandchild outliving its parent run could see a stale/overwritten bridge → its re-proxy fails closed (safe deny, not misrouted). Binding the bridge per-run through the scheduler task boundary is filed as a follow-up issue.
