### PR TITLE
refactor(subagent): bind child-approval escalation bridge per-run (#68)

### DIFF
--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -82,6 +82,17 @@ pub struct ActorChildRunner {
     /// `None` ⇒ fail-closed DENY (the safe default). A wired decider (policy or
     /// human-routing bridge) returns approve/deny over the actor WS.
     approval_decider: Option<Arc<dyn ChildApprovalDecider>>,
+    /// Per-run escalation host bridge for non-bypass child-approval routing (#68;
+    /// Phase 6, Part B). The owning worker's `run()` installs its OWN host bridge
+    /// here via `set_escalation_bridge`; `execute_external_child` CAPTURES it at
+    /// grandchild-spawn time and hands the owned value to `drive()`, which uses it
+    /// to RE-PROXY a child's approval request UP to the parent run — chaining up
+    /// every level until a bypass level (model-review) or the top orchestrator
+    /// (human) decides, then relaying the reply back down. Was a process-global
+    /// slot; now per-runner so a fire-and-forget grandchild that OUTLIVES the run
+    /// that spawned it keeps that run's bridge for its whole lifetime instead of
+    /// reading a stale/overwritten global at approval time (→ fail-closed deny).
+    escalation_bridge: Arc<std::sync::Mutex<Option<bamboo_subagent::executor::HostBridge>>>,
 }
 
 /// Decides how the host answers a child worker's gated-tool approval request
@@ -162,30 +173,6 @@ pub fn child_approval_reviewer() -> Option<Arc<dyn ChildApprovalReviewer>> {
     child_approval_reviewer_slot().get().cloned()
 }
 
-/// Per-run escalation bridge for non-bypass child-approval routing (Phase 6,
-/// Part B). A WORKER's `run()` installs its OWN host bridge here; its `drive()`
-/// (driving grandchildren) uses it to RE-PROXY a child's approval request UP to
-/// its own parent — chaining the request up every level until a bypass level
-/// (model-review) or the top orchestrator (human) decides, then relaying the
-/// reply back down. The top server never installs one ⇒ its drive() falls to the
-/// human-loop. Set per-run (a worker serves runs sequentially, so one active
-/// bridge); a stale bridge from a finished run errors on call ⇒ fail-closed.
-fn escalation_bridge_slot(
-) -> &'static std::sync::Mutex<Option<bamboo_subagent::executor::HostBridge>> {
-    static SLOT: std::sync::Mutex<Option<bamboo_subagent::executor::HostBridge>> =
-        std::sync::Mutex::new(None);
-    &SLOT
-}
-
-/// Install (or clear with `None`) the process escalation host bridge.
-pub fn set_escalation_host_bridge(bridge: Option<bamboo_subagent::executor::HostBridge>) {
-    *escalation_bridge_slot().lock().unwrap() = bridge;
-}
-
-fn escalation_host_bridge() -> Option<bamboo_subagent::executor::HostBridge> {
-    escalation_bridge_slot().lock().unwrap().clone()
-}
-
 impl ActorChildRunner {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -211,6 +198,7 @@ impl ActorChildRunner {
             pool: Arc::new(Mutex::new(HashMap::new())),
             max_idle_per_key: DEFAULT_MAX_IDLE_PER_KEY,
             approval_decider: None,
+            escalation_bridge: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -436,6 +424,10 @@ impl ExternalChildRunner for ActorChildRunner {
             && session.metadata.get("external.agent_id") == Some(&self.agent_id)
     }
 
+    fn set_escalation_bridge(&self, bridge: Option<bamboo_subagent::executor::HostBridge>) {
+        *self.escalation_bridge.lock().unwrap() = bridge;
+    }
+
     async fn execute_external_child(
         &self,
         session: &mut Session,
@@ -443,6 +435,15 @@ impl ExternalChildRunner for ActorChildRunner {
         event_tx: mpsc::Sender<AgentEvent>,
         cancel_token: CancellationToken,
     ) -> crate::runtime::runner::Result<()> {
+        // #68 CORRECTNESS CRUX: capture the per-run escalation bridge HERE, at the
+        // moment this grandchild is spawned — while the parent run's bridge is
+        // still in our slot — into an owned local handed to `drive()` for this
+        // grandchild's whole lifetime. A fire-and-forget grandchild that OUTLIVES
+        // the run that spawned it must NOT re-read `self.escalation_bridge` at
+        // approval time: by then `run()` may have cleared/overwritten it (a worker
+        // serves runs sequentially), and re-proxying through a closed bridge
+        // fail-closed denies. Capturing at spawn pins the right bridge per run.
+        let escalation = self.escalation_bridge.lock().unwrap().clone();
         let assignment = extract_assignment(session);
         let mut spec = self.build_spec(session, job);
         // Make every actor a warm, reusable worker so the pool can recycle it for
@@ -525,6 +526,7 @@ impl ExternalChildRunner for ActorChildRunner {
             &mut client,
             &job.child_session_id,
             self.approval_decider.as_ref(),
+            escalation,
             &event_tx,
             &cancel_token,
             &mut live_rx,
@@ -565,10 +567,18 @@ impl ExternalChildRunner for ActorChildRunner {
 /// Pump child frames -> parent events until a terminal frame (or cancellation).
 /// On success, yields the actor's final result text (for session write-back).
 /// `live_rx` carries in-band frames (steering messages) from the live registry.
+///
+/// `escalation_bridge` (#68) is the per-run escalation host bridge CAPTURED BY
+/// VALUE at spawn time in `execute_external_child` (NOT read live here): when a
+/// non-bypass child re-proxies an approval request, this owned bridge routes it
+/// UP to the parent run. Owning it for the call's lifetime is what lets a
+/// fire-and-forget grandchild that outlives its spawning run still escalate to
+/// the correct (then-current) parent bridge rather than a stale/overwritten one.
 async fn drive(
     client: &mut ChildClient,
     child_session_id: &str,
     approval_decider: Option<&Arc<dyn ChildApprovalDecider>>,
+    escalation_bridge: Option<bamboo_subagent::executor::HostBridge>,
     event_tx: &mpsc::Sender<AgentEvent>,
     cancel_token: &CancellationToken,
     live_rx: &mut mpsc::UnboundedReceiver<ParentFrame>,
@@ -635,7 +645,7 @@ async fn drive(
                                     "failed to answer approval_request; connection failing"
                                 );
                             }
-                        } else if let Some(host) = escalation_host_bridge() {
+                        } else if let Some(host) = escalation_bridge.clone() {
                             // Non-bypass WORKER: ESCALATE up our own actor link
                             // (re-proxy) so the request chains to our parent — and
                             // up every level until a bypass level (model-review) or

--- a/crates/engine/bamboo-engine/src/external_agents/mod.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/mod.rs
@@ -7,8 +7,7 @@ pub mod runtime;
 
 pub use a2a_adapter::A2AExternalChildRunner;
 pub use actor_adapter::{
-    child_approval_reviewer, set_child_approval_reviewer, set_escalation_host_bridge,
-    ActorChildRunner, ChildApprovalReviewer,
+    child_approval_reviewer, set_child_approval_reviewer, ActorChildRunner, ChildApprovalReviewer,
 };
 pub use config::{
     parse_external_agents, parse_subagent_routing, resolve_runtime_metadata, ExternalAgentProfile,

--- a/crates/engine/bamboo-engine/src/external_agents/runtime.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/runtime.rs
@@ -52,6 +52,16 @@ impl ExternalChildRunner for CompositeExternalChildRunner {
             "No matching external child runner found for session metadata".to_string(),
         ))
     }
+
+    /// #68: fan the per-run escalation bridge out to every inner runner. The
+    /// composite is what `build_external_child_runner` returns and what the
+    /// worker retains, so without this forward the bind would hit the trait's
+    /// no-op default and the wrapped `ActorChildRunner`s would never see it.
+    fn set_escalation_bridge(&self, bridge: Option<bamboo_subagent::executor::HostBridge>) {
+        for runner in &self.runners {
+            runner.set_escalation_bridge(bridge.clone());
+        }
+    }
 }
 
 /// Build the child runner from the application config.

--- a/crates/engine/bamboo-engine/src/runtime/execution/spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/spawn.rs
@@ -48,6 +48,14 @@ pub trait ExternalChildRunner: Send + Sync {
         event_tx: tokio::sync::mpsc::Sender<AgentEvent>,
         cancel_token: CancellationToken,
     ) -> crate::runtime::runner::Result<()>;
+
+    /// Bind this runner's per-run escalation host bridge (#68). A nested worker's
+    /// `run()` installs its OWN host bridge here so the runner can hand it to each
+    /// grandchild's `drive()` AT SPAWN time (captured into the drive task, not read
+    /// later), letting the grandchild re-proxy a non-bypass approval request UP to
+    /// its parent run for its whole lifetime — even when it outlives the run that
+    /// spawned it. Default no-op for runners that don't escalate (e.g. A2A).
+    fn set_escalation_bridge(&self, _bridge: Option<bamboo_subagent::executor::HostBridge>) {}
 }
 
 #[derive(Clone)]

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -152,6 +152,12 @@ pub struct BambooRuntimeExecutor {
     /// instead of forwarding the approval to a host whose human-loop would
     /// 300s-deny it. `None` (interactive) ⇒ forward to the host as usual.
     no_human_review: Option<Arc<dyn bamboo_engine::external_agents::ChildApprovalReviewer>>,
+    /// #68: this worker's own external-child runner (the spawn stack that drives
+    /// grandchildren), retained so each `run()` can bind its host bridge onto it
+    /// as the PER-RUN escalation bridge — replacing the old process-global slot.
+    /// `Some` only for a sub-cap worker with `nested_spawn` (the only one that
+    /// drives grandchildren); `None` otherwise (a leaf worker never escalates).
+    child_runner: Option<Arc<dyn bamboo_engine::runtime::execution::ExternalChildRunner>>,
 }
 
 impl BambooRuntimeExecutor {
@@ -398,7 +404,9 @@ impl BambooRuntimeExecutor {
         // REAL SubAgent tool against them (no host proxy). `nested_spawn` is set
         // by the host's build_spec purely from depth (< MAX_SPAWN_DEPTH), so it
         // auto-propagates down the tree and bottoms out at the cap.
-        let run_tools: Option<Arc<dyn bamboo_agent_core::tools::ToolExecutor>> =
+        type RunTools = Arc<dyn bamboo_agent_core::tools::ToolExecutor>;
+        type ChildRunner = Arc<dyn bamboo_engine::runtime::execution::ExternalChildRunner>;
+        let (run_tools, child_runner): (Option<RunTools>, Option<ChildRunner>) =
             if spec.capabilities.nested_spawn {
                 // Point the worker's own actor runner at the shared fabric so
                 // grandchildren are discoverable; the worker binary itself is
@@ -413,6 +421,10 @@ impl BambooRuntimeExecutor {
                     let cfg = config_for_stack.read().await;
                     bamboo_engine::external_agents::runtime::build_external_child_runner(&cfg)
                 };
+                // #68: retain this exact runner so `run()` can bind its host
+                // bridge onto it per-run (the runner the scheduler drives is the
+                // one whose `ActorChildRunner`s capture the bridge at spawn).
+                let child_runner = external_runner.clone();
                 let scheduler = bamboo_server::app_state::init::build_spawn_scheduler(
                     agent.clone(),
                     default_tools.clone(),
@@ -440,13 +452,13 @@ impl BambooRuntimeExecutor {
                     adapter.clone(),
                     adapter,
                 ));
-                Some(Arc::new(bamboo_server::tools::OverlayToolExecutor::new(
+                let run_tools = Arc::new(bamboo_server::tools::OverlayToolExecutor::new(
                     default_tools,
                     sub_agent,
-                ))
-                    as Arc<dyn bamboo_agent_core::tools::ToolExecutor>)
+                )) as RunTools;
+                (Some(run_tools), Some(child_runner))
             } else {
-                None
+                (None, None)
             };
 
         // The off-loop model-reviewer (provider + model). Built once and shared:
@@ -494,6 +506,7 @@ impl BambooRuntimeExecutor {
             spawn_depth: spec.identity.depth,
             bypass: spec.capabilities.bypass,
             no_human_review,
+            child_runner,
         })
     }
 }
@@ -790,10 +803,17 @@ impl ChildExecutor for BambooRuntimeExecutor {
             } else {
                 None
             };
-        // Phase 6, Part B: install our host bridge as the process escalation
-        // bridge so this worker's `drive()` can re-proxy a (non-bypass) child's
-        // approval request UP to our own parent — chaining it to the top human.
-        bamboo_engine::external_agents::set_escalation_host_bridge(events.host().cloned());
+        // Phase 6, Part B (#68): bind our host bridge onto THIS worker's own child
+        // runner as the per-run escalation bridge, so when it drives a grandchild
+        // that grandchild captures the bridge at spawn and its `drive()` can
+        // re-proxy a (non-bypass) child's approval request UP to our own parent —
+        // chaining it to the top human. Per-runner (was a process-global slot), so
+        // a fire-and-forget grandchild outliving this run still escalates through
+        // the run's own bridge rather than a stale/overwritten global. `None` for
+        // a leaf worker (no spawn stack), which never drives grandchildren.
+        if let Some(runner) = &self.child_runner {
+            runner.set_escalation_bridge(events.host().cloned());
+        }
 
         // AgentEvents stream to the parent verbatim (zero mapping).
         let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(256);


### PR DESCRIPTION
Closes #68.

## Problem
The non-bypass approval **escalation** `HostBridge` lived in a process-global slot (set per-run by the worker's `run()`, read by `drive()` at approval time). A worker serves runs serially, so usually fine — but a **fire-and-forget grandchild that outlives its parent run** read a stale/overwritten bridge → re-proxy through a closed bridge → fail-closed deny instead of escalation.

## Fix — per-runner slot + capture-at-spawn
- New `ExternalChildRunner::set_escalation_bridge` trait method (default no-op); `ActorChildRunner` stores it in a per-runner slot; `CompositeExternalChildRunner` fans it to inner runners; the worker's `run()` binds `events.host()` through a retained `child_runner` handle.
- **`execute_external_child` CAPTURES the bridge at grandchild-spawn** into an owned local and passes it into `drive()`. So each grandchild holds *its* parent run's bridge for its whole lifetime — `drive()` never re-reads the slot at approval time, fixing the fire-and-forget staleness.
- Removed the process globals (`set_escalation_host_bridge`/`escalation_host_bridge`/`escalation_bridge_slot`).

## Verify
`cargo check --workspace` + all test targets compile; engine 836, root 40, e2e (subagent_worker_e2e, broker_deploy_e2e) green. Verified the capture is at spawn (actor_adapter.rs:446), not at approval time.