### PR TITLE
fix(subagent): no_human_approver per user-execute + resident re-seed (#74)

### DIFF
--- a/crates/app/bamboo-server-tools/src/sub_agent.rs
+++ b/crates/app/bamboo-server-tools/src/sub_agent.rs
@@ -596,6 +596,35 @@ impl Tool for SubAgentTool {
                                 .await
                                 .map_err(tool_error_from_child_session)?;
                         }
+                        // #74: re-seed the reused resident's posture from the LIVE
+                        // parent. The resident-reuse path bypasses
+                        // `create_child_action` (which seeds `bypass_permissions` /
+                        // `no_human_approver` on the child's first run), so without
+                        // this a resident created under one posture keeps a stale
+                        // flag when reused under another (e.g. parent flipped from
+                        // headless to interactive, or toggled bypass). Mirror BOTH
+                        // flags so the reused resident matches the current parent.
+                        {
+                            let mut child = self
+                                .sessions
+                                .load_child_for_parent(&parent.id, &existing_id)
+                                .await
+                                .map_err(tool_error_from_child_session)?;
+                            let (parent_bypass, parent_no_human) = parent
+                                .agent_runtime_state
+                                .as_ref()
+                                .map(|s| (s.bypass_permissions, s.no_human_approver))
+                                .unwrap_or((false, false));
+                            let rs = child
+                                .agent_runtime_state
+                                .get_or_insert_with(bamboo_domain::AgentRuntimeState::default);
+                            rs.bypass_permissions = parent_bypass;
+                            rs.no_human_approver = parent_no_human;
+                            self.sessions
+                                .save_child_session(&mut child)
+                                .await
+                                .map_err(tool_error_from_child_session)?;
+                        }
                         // Reuse: reset => update (truncate + new task) then rerun;
                         // accumulate => send the task as a new message (auto-runs).
                         if resident_context == "accumulate" {

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
@@ -161,6 +161,7 @@ pub async fn handler(
                     model_source,
                     reasoning_source,
                     is_child_session,
+                    no_human_approver: req.no_human_approver,
                 },
                 &config,
                 &config_snapshot,

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
@@ -34,6 +34,9 @@ pub(super) struct ReadyExecution {
     pub model_source: &'static str,
     pub reasoning_source: &'static str,
     pub is_child_session: bool,
+    /// The `no_human_approver` posture from THIS execute request. #74: re-derived
+    /// per user-initiated execute and written over the session's persisted flag.
+    pub no_human_approver: bool,
 }
 
 /// Reserve the runner, persist, and spawn the agent loop for a ready session.
@@ -48,6 +51,13 @@ pub(super) async fn handle_execute_ready(
     disabled_skill_ids_vec: Vec<String>,
 ) -> HttpResponse {
     let mut session = ready.session;
+
+    // #74: re-derive the "no interactive human approver" posture per
+    // user-initiated execute, OVERWRITING the session's persisted flag (see
+    // `apply_no_human_approver`). Done before the `merge_save_runtime` persist
+    // below so the corrected posture is what's stored and handed to the spawn.
+    apply_no_human_approver(&mut session, ready.no_human_approver);
+
     // ---- Reserve runner ----
     let session_tx = state.get_session_event_sender(session_id).await;
     let (cancel_token, run_id) =
@@ -174,4 +184,101 @@ pub(super) async fn handle_execute_ready(
     });
 
     started_response(session_id, sync_info, run_id)
+}
+
+/// #74: re-derive the "no interactive human approver" posture for a
+/// user-initiated execute, OVERWRITING the session's persisted flag with
+/// `no_human_approver` from THIS request.
+///
+/// Why an overwrite (not a sticky carry-forward): a session first run
+/// headlessly/scheduled persists `true`; if it is later reopened INTERACTIVELY,
+/// the UI omits the field (→ `false`), so this resets the session to the
+/// human-present posture. Otherwise its sub-agents (which inherit the flag)
+/// would silently model-review approvals that a now-present human should answer.
+///
+/// Safe w.r.t. suspend/resume: a within-run resume (answering a pending
+/// question, the waiting_for_children resume, gold auto-answer) does NOT
+/// re-enter the execute handler — it goes through `resume_session_execution`,
+/// which reloads the persisted `runtime_state` and never touches an
+/// `ExecuteRequest`. So this overwrite only fires on a fresh user execute; the
+/// startup carry-forward then preserves the posture across the run's segments.
+fn apply_no_human_approver(session: &mut bamboo_agent_core::Session, no_human_approver: bool) {
+    session
+        .agent_runtime_state
+        .get_or_insert_with(bamboo_domain::AgentRuntimeState::default)
+        .no_human_approver = no_human_approver;
+}
+
+#[cfg(test)]
+mod ready_tests {
+    use super::apply_no_human_approver;
+    use bamboo_agent_core::Session;
+    use bamboo_domain::AgentRuntimeState;
+
+    #[test]
+    fn interactive_execute_resets_persisted_no_human_approver_to_false() {
+        // Cross-mode resume (#74): a session first run headlessly persists
+        // `no_human_approver = true`. Reopening it INTERACTIVELY (the UI omits
+        // the field, so the request carries `false`) must OVERWRITE the stale
+        // `true` back to `false` so approvals reach the now-present human.
+        let mut session = Session::new("sess-cross-mode", "test-model");
+        let mut prev = AgentRuntimeState::new("run-prev");
+        prev.no_human_approver = true;
+        session.agent_runtime_state = Some(prev);
+
+        apply_no_human_approver(&mut session, false);
+
+        assert!(
+            !session
+                .agent_runtime_state
+                .as_ref()
+                .unwrap()
+                .no_human_approver,
+            "interactive execute (false) must reset a persisted true"
+        );
+    }
+
+    #[test]
+    fn headless_execute_yields_no_human_approver_true() {
+        // Headless `-p` sends `no_human_approver = true` on the request; the
+        // overwrite must set it on a session with no prior runtime state.
+        let mut session = Session::new("sess-headless", "test-model");
+        assert!(session.agent_runtime_state.is_none());
+
+        apply_no_human_approver(&mut session, true);
+
+        assert!(
+            session
+                .agent_runtime_state
+                .as_ref()
+                .unwrap()
+                .no_human_approver,
+            "headless execute (true) must set the posture"
+        );
+    }
+
+    #[test]
+    fn execute_overwrites_regardless_of_prior_value() {
+        // The overwrite is unconditional (not OR-sticky): an interactive run
+        // (false) over a persisted false stays false, and a true-over-true stays
+        // true — the request value is authoritative each execute.
+        for (prev_flag, req_flag) in [(false, false), (true, true), (false, true), (true, false)] {
+            let mut session = Session::new("sess", "test-model");
+            let mut prev = AgentRuntimeState::new("run-prev");
+            prev.no_human_approver = prev_flag;
+            session.agent_runtime_state = Some(prev);
+
+            apply_no_human_approver(&mut session, req_flag);
+
+            assert_eq!(
+                session
+                    .agent_runtime_state
+                    .as_ref()
+                    .unwrap()
+                    .no_human_approver,
+                req_flag,
+                "request value must be authoritative (prev={prev_flag}, req={req_flag})"
+            );
+        }
+    }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/execute/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/tests.rs
@@ -75,6 +75,7 @@ fn execute_request_empty_model_normalizes_to_compat_absent() {
         skill_mode: None,
         reasoning_effort: None,
         client_sync: None,
+        no_human_approver: false,
     };
 
     let model = request.model.as_deref().unwrap_or("").trim();

--- a/crates/app/bamboo-server/src/handlers/agent/execute/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/types.rs
@@ -129,6 +129,15 @@ pub struct ExecuteRequest {
     /// Optional server-confirmed client cursor used for pre-execution sync checks.
     #[serde(default)]
     pub client_sync: Option<ExecuteClientSync>,
+    /// Whether this run has NO interactive human approver (headless `-p`, a
+    /// scheduled job, a deployed broker). #74: this is re-derived per
+    /// user-initiated execute and OVERWRITES the session's persisted
+    /// `no_human_approver`, so a session first run headlessly and later reopened
+    /// interactively (UI omits this → `false`) correctly resets to the
+    /// human-present posture. Suspend/resume does NOT go through this handler,
+    /// so a within-run resume keeps the persisted posture.
+    #[serde(default)]
+    pub no_human_approver: bool,
 }
 
 #[cfg(test)]

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -171,6 +171,12 @@ pub async fn run(args: HeadlessArgs) -> Result<(), String> {
 
     // Append the prompt as the driving user message (execute runs the session's
     // last user turn — same contract as the HTTP API).
+    //
+    // #74: the `no_human_approver` posture is no longer set here. It rides on the
+    // `ExecuteRequest` below (`no_human_approver: true`) and is re-derived +
+    // OVERWRITTEN per execute by the handler, so a session first run headlessly
+    // and later reopened interactively correctly resets to the human-present
+    // posture instead of staying sticky-true.
     {
         let mut session = state
             .storage
@@ -179,15 +185,6 @@ pub async fn run(args: HeadlessArgs) -> Result<(), String> {
             .map_err(|e| format!("load session: {e}"))?
             .ok_or_else(|| "session vanished".to_string())?;
         session.add_message(Message::user(args.prompt.clone()));
-        // #73: a headless `-p` run has no interactive approver. Mark the root
-        // session so its sub-agents (which inherit the flag) decide gated actions
-        // with the off-loop model-reviewer locally instead of escalating to an
-        // absent human — which would otherwise 300s-deny. Sticky; carried forward
-        // each run by startup.
-        session
-            .agent_runtime_state
-            .get_or_insert_with(bamboo_domain::AgentRuntimeState::default)
-            .no_human_approver = true;
         state
             .storage
             .save_session(&session)
@@ -225,6 +222,11 @@ pub async fn run(args: HeadlessArgs) -> Result<(), String> {
             skill_mode: None,
             reasoning_effort: None,
             client_sync: None,
+            // #74: a headless `-p` run has no interactive approver. The handler
+            // re-derives + persists this onto the root session each execute, so
+            // its sub-agents (which inherit it) route gated actions to the
+            // off-loop model-reviewer instead of escalating to an absent human.
+            no_human_approver: true,
         }),
     )
     .await;


### PR DESCRIPTION
Closes #74.

## Problem
`no_human_approver` was persisted + carried forward, so a session first run headless/scheduled and later reopened **interactively** kept the no-human posture → its sub-agents silently model-reviewed instead of asking the now-present human (the worse direction). The resident-child reuse path also left the flag sticky-stale.

## Fix
- **Per-execute re-derive**: `ExecuteRequest` gains `no_human_approver`; the execute handler OVERWRITES the session's flag from it (`apply_no_human_approver`) before persisting. Headless sends `true`; the interactive UI omits → `false`, resetting a stale `true`.
- **Suspend/resume preserved** (verified): the waiting-for-children / pending-question / gold resume paths go through `resume_session_execution`, NOT the execute handler — so a within-run resume keeps the posture (the flag stays persisted + carried-forward for exactly that). Only a fresh user-initiated execute re-derives it.
- **Resident reuse** re-seeds `bypass_permissions` + `no_human_approver` from the LIVE parent (the reuse branch bypasses `create_child_action`'s inheritance).

## Verify
`cargo check --workspace` + all test targets compile; engine 836 / server 853 / root 40, incl. suspend/resume + guardian tests + 3 new `apply_no_human_approver` tests (interactive resets stale true; headless yields true; overwrite authoritative).