### PR TITLE
feat(child-approval): server-side request_id correlation + unpredictable ids (#7)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/child_approval.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/child_approval.rs
@@ -38,7 +38,7 @@ pub async fn handler(
         approved,
     } = body.into_inner();
 
-    let delivered = bamboo_engine::external_agents::live::deliver_approval(
+    let delivered = bamboo_engine::external_agents::live::deliver_approval_checked(
         &child_session_id,
         &request_id,
         approved,
@@ -53,10 +53,12 @@ pub async fn handler(
         );
         HttpResponse::Ok().json(ChildApprovalResponse { delivered: true })
     } else {
-        // The child isn't live (finished, timed out, or already answered) — there
-        // is no connection to carry the decision.
+        // Not delivered: the request_id isn't a currently-pending human-loop
+        // approval — unknown/guessed, already answered, timed out, or the child
+        // isn't live (finished/disconnected). The checked entry consumes pending
+        // ids one-shot, so a replay also lands here.
         tracing::warn!(
-            "[{}] child approval not delivered (request_id={}): child not live",
+            "[{}] child approval not delivered (request_id={}): not a pending request",
             child_session_id,
             request_id
         );

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -680,6 +680,11 @@ async fn drive(
                             // it can't hang the child forever.
                             let (tool_name, permission, resource) =
                                 approval_request_fields(&body);
+                            // Register the pending request BEFORE surfacing it so
+                            // the external handler's `deliver_approval_checked` can
+                            // correlate an out-of-band POST against a genuine
+                            // human-loop request (and consume it one-shot).
+                            super::live::register_pending_approval(child_session_id, &id);
                             let _ = event_tx
                                 .send(AgentEvent::ChildApprovalRequested {
                                     child_session_id: child_session_id.to_string(),
@@ -692,9 +697,13 @@ async fn drive(
                             let child = child_session_id.to_string();
                             tokio::spawn(async move {
                                 tokio::time::sleep(CHILD_APPROVAL_TIMEOUT).await;
-                                // No-op if already answered (worker ignores an
-                                // unknown/duplicate id) or the child is gone.
-                                super::live::deliver_approval(&child, &id, false);
+                                // Deny only if still pending: a one-shot consume so
+                                // we don't double-deliver if the human already
+                                // answered (the POST took it), and so a late POST
+                                // after this fires finds nothing pending.
+                                if super::live::take_pending_approval(&child, &id) {
+                                    super::live::deliver_approval(&child, &id, false);
+                                }
                             });
                         }
                     }

--- a/crates/engine/bamboo-engine/src/external_agents/live.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/live.rs
@@ -8,7 +8,7 @@
 //! children use, extended across the process boundary. When the child is not
 //! live, callers fall back to the durable `pending_injected_messages` queue.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, OnceLock};
 
 use bamboo_subagent::proto::ParentFrame;
@@ -20,6 +20,64 @@ fn map() -> &'static Mutex<HashMap<String, mpsc::UnboundedSender<ParentFrame>>> 
     MAP.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Process-global registry of pending human-loop approval requests, keyed by
+/// `child_id` → set of `request_id`s currently awaiting a decision. Only the
+/// human-in-the-loop path (top orchestrator) registers here; trusted internal
+/// paths (model-review, escalation-bridge) do NOT — so the external handler's
+/// [`deliver_approval_checked`] correctly rejects any stray external POST aimed
+/// at a request that isn't a genuinely-pending human-loop one.
+fn pending() -> &'static Mutex<HashMap<String, HashSet<String>>> {
+    static PENDING: OnceLock<Mutex<HashMap<String, HashSet<String>>>> = OnceLock::new();
+    PENDING.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Record a `(child_id, request_id)` as a pending human-loop approval. Called
+/// just before surfacing `ChildApprovalRequested` so an external POST can be
+/// correlated against a genuinely-pending request.
+pub fn register_pending_approval(child_id: &str, request_id: &str) {
+    pending()
+        .lock()
+        .unwrap()
+        .entry(child_id.to_string())
+        .or_default()
+        .insert(request_id.to_string());
+}
+
+/// One-shot consume of a `(child_id, request_id)` pending pair: remove it and
+/// return whether it WAS present. A second call for the same pair returns
+/// `false`, so a request can't be answered (or replayed) twice.
+pub fn take_pending_approval(child_id: &str, request_id: &str) -> bool {
+    let mut guard = pending().lock().unwrap();
+    let Some(set) = guard.get_mut(child_id) else {
+        return false;
+    };
+    let took = set.remove(request_id);
+    if set.is_empty() {
+        guard.remove(child_id);
+    }
+    took
+}
+
+/// Drop all pending approvals for a child (e.g. when its live connection ends).
+pub fn clear_pending_approvals_for(child_id: &str) {
+    pending().lock().unwrap().remove(child_id);
+}
+
+/// Validated external entry point: deliver an approval decision ONLY if the
+/// `(child_id, request_id)` pair is currently pending. Consumes the pending
+/// entry (one-shot) before delivering, so the same request can't be replayed,
+/// and rejects (returns `false`) any `request_id` that isn't currently pending
+/// — unknown, already-answered/timed-out, or a non-human-loop path
+/// (model-review / escalation) that never registered. This is the entry the
+/// external HTTP handler must use.
+pub fn deliver_approval_checked(child_id: &str, request_id: &str, approved: bool) -> bool {
+    if take_pending_approval(child_id, request_id) {
+        deliver_approval(child_id, request_id, approved)
+    } else {
+        false
+    }
+}
+
 /// Unregisters the child on drop, so a panicking/returning runner can't leak
 /// a stale sender.
 pub struct LiveActorGuard {
@@ -29,6 +87,9 @@ pub struct LiveActorGuard {
 impl Drop for LiveActorGuard {
     fn drop(&mut self) {
         map().lock().unwrap().remove(&self.child_id);
+        // A disconnecting child can't answer any still-pending approval — drop
+        // them so a late external POST finds nothing pending and is rejected.
+        clear_pending_approvals_for(&self.child_id);
     }
 }
 
@@ -125,5 +186,57 @@ mod tests {
         drop(guard);
         // Not-live child ⇒ false (no connection to answer on).
         assert!(!deliver_approval("c-appr", "req-8", false));
+    }
+
+    #[test]
+    fn pending_approval_is_one_shot() {
+        register_pending_approval("c-pend", "req-1");
+        // First take consumes it; the second finds nothing.
+        assert!(take_pending_approval("c-pend", "req-1"));
+        assert!(!take_pending_approval("c-pend", "req-1"));
+    }
+
+    #[test]
+    fn take_of_unregistered_pair_is_false() {
+        // Unknown child entirely.
+        assert!(!take_pending_approval("c-unknown", "req-x"));
+        // Known child, but an unregistered request_id.
+        register_pending_approval("c-known", "req-real");
+        assert!(!take_pending_approval("c-known", "req-bogus"));
+        // The real one is still pending (a bogus take didn't disturb it).
+        assert!(take_pending_approval("c-known", "req-real"));
+    }
+
+    #[test]
+    fn deliver_approval_checked_only_delivers_for_registered_pair() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let _guard = register("c-checked", tx);
+
+        // Not registered ⇒ rejected, nothing on the wire.
+        assert!(!deliver_approval_checked("c-checked", "req-stray", true));
+        assert!(rx.try_recv().is_err());
+
+        // Registered ⇒ delivered, frame rides the wire, and consumed.
+        register_pending_approval("c-checked", "req-ok");
+        assert!(deliver_approval_checked("c-checked", "req-ok", true));
+        match rx.try_recv() {
+            Ok(ParentFrame::ApprovalReply { id, approved }) => {
+                assert_eq!(id, "req-ok");
+                assert!(approved);
+            }
+            other => panic!("expected approval reply, got {other:?}"),
+        }
+        // One-shot: a replay is rejected (and nothing further on the wire).
+        assert!(!deliver_approval_checked("c-checked", "req-ok", true));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn clear_pending_approvals_for_drops_them() {
+        register_pending_approval("c-clear", "req-a");
+        register_pending_approval("c-clear", "req-b");
+        clear_pending_approvals_for("c-clear");
+        assert!(!take_pending_approval("c-clear", "req-a"));
+        assert!(!take_pending_approval("c-clear", "req-b"));
     }
 }

--- a/crates/infra/bamboo-subagent/src/transport.rs
+++ b/crates/infra/bamboo-subagent/src/transport.rs
@@ -7,7 +7,6 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use futures_util::stream::{SplitSink, SplitStream};
@@ -17,6 +16,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{accept_async, connect_async, MaybeTlsStream, WebSocketStream};
 use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
 
 use crate::executor::{ChildExecutor, EventSink, HostBridge, HostRequestKind, SteerInbox};
 use crate::proto::{ChildFrame, ParentFrame, RunSpec};
@@ -258,10 +258,13 @@ fn start_run<E: ChildExecutor + ?Sized>(
     let sink = sink.with_host_bridge(bridge);
     let out_req = out_tx.clone();
     let pending_for_pump = pending.clone();
-    let ids = AtomicU64::new(0);
     let pump = tokio::spawn(async move {
         while let Some(req) = req_rx.recv().await {
-            let id = format!("sa-{}", ids.fetch_add(1, Ordering::Relaxed));
+            // Random + unguessable: the worker's pending map and the host-side
+            // pending-approval registry both key on this exact string, so a
+            // sequential `sa-{n}` would let an external POST guess a live
+            // request_id. A v4 uuid removes that. Keep the `sa-` prefix.
+            let id = format!("sa-{}", Uuid::new_v4());
             pending_for_pump
                 .lock()
                 .expect("pending lock")


### PR DESCRIPTION
Closes #7 (the server-side correlation part of #69's deferred hardening).

## Problem
`POST /api/v1/child-approval/{child}` delivered on a **caller-supplied request_id** with no server-side correlation to a pending request, and ids were sequential/predictable (`sa-{n}`). The worker-side pending map was the only backstop.

## Fix
- **Pending-approval registry** (live.rs): `register_pending_approval` / `take_pending_approval` (one-shot) / `clear_pending_approvals_for`; **`deliver_approval_checked`** validates + consumes the `(child_id, request_id)` pair before delivering — rejecting unknown / already-answered / replayed ids and any non-human-loop path (model-review/escalation never register). `LiveActorGuard::drop` clears a child's pending on disconnect.
- **Human-loop wiring** (drive()): registers the id *before* emitting `ChildApprovalRequested`; the 300s timeout **one-shot-consumes** (take-then-deny) so it can't double-deliver after a human answer, and a late POST is rejected. Internal model-review/escalation arms untouched (so a stray external POST aimed at them is rejected).
- The handler uses `deliver_approval_checked`.
- **Unpredictable ids** (transport.rs): host-request id is now `sa-{uuidv4}` instead of a sequential counter.

## Verify
`cargo check --workspace` + all test targets compile; engine 840 / server 853 / subagent 45 (incl. 4 new live.rs registry tests). The endpoint stays behind the access-password middleware.