### PR TITLE
fix(bamboo-tools): cap Read tool at 10MB to prevent OOM (#33)

### DIFF
--- a/crates/engine/bamboo-tools/src/tools/read.rs
+++ b/crates/engine/bamboo-tools/src/tools/read.rs
@@ -21,6 +21,8 @@ const BLOCKED_DEVICE_PATHS: &[&str] = &[
     "/dev/fd/2",
 ];
 
+const MAX_READ_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
+
 #[derive(Debug, Deserialize)]
 struct ReadArgs {
     file_path: String,
@@ -237,6 +239,16 @@ impl Tool for ReadTool {
                 display_preference: Some("Collapsible".to_string()),
                 images: Vec::new(),
             });
+        }
+
+        if metadata.len() > MAX_READ_SIZE {
+            return Err(ToolError::Execution(format!(
+                "File is {} bytes, which exceeds the maximum readable size of {} bytes ({} MB). \
+                 Use Grep to search within this file instead.",
+                metadata.len(),
+                MAX_READ_SIZE,
+                MAX_READ_SIZE / 1024 / 1024
+            )));
         }
 
         let bytes = tokio::fs::read(path)


### PR DESCRIPTION
## What
Adds a `MAX_READ_SIZE` (10MB) guard to the Read tool, after the `metadata` stat and after the directory branch, so an LLM-controlled Read on a multi-GB or maliciously huge file returns a clear error pointing to Grep instead of reading the whole file into memory. Mirrors Grep's 2MB skip and Bash's 512KB output cap.

## Verification
`cargo check -p bamboo-tools` ✅. Guard placement confirmed (directories unaffected, `metadata.len()` in scope).

## Provenance
Implemented by the bamboo headless agent; reviewed + compiled by hand.

Closes #33

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp