### PR TITLE
fix(broker,subagent): non-panicking to_text()/ReplyBody serialization (#57)

### DIFF
--- a/crates/app/bamboo-broker/src/proto.rs
+++ b/crates/app/bamboo-broker/src/proto.rs
@@ -41,7 +41,7 @@ pub enum BrokerFrame {
 
 impl ClientFrame {
     pub fn to_text(&self) -> String {
-        serde_json::to_string(self).expect("ClientFrame serializes")
+        serde_json::to_string(self).unwrap_or_else(|_| "{}".to_string())
     }
     pub fn from_text(s: &str) -> serde_json::Result<Self> {
         serde_json::from_str(s)
@@ -50,7 +50,7 @@ impl ClientFrame {
 
 impl BrokerFrame {
     pub fn to_text(&self) -> String {
-        serde_json::to_string(self).expect("BrokerFrame serializes")
+        serde_json::to_string(self).unwrap_or_else(|_| "{}".to_string())
     }
     pub fn from_text(s: &str) -> serde_json::Result<Self> {
         serde_json::from_str(s)

--- a/crates/app/bamboo-broker/src/serve.rs
+++ b/crates/app/bamboo-broker/src/serve.rs
@@ -66,7 +66,8 @@ where
                     id: MsgId::new(),
                     from: me.clone(),
                     kind: InboxKind::Reply,
-                    body: serde_json::to_value(ReplyBody { answer }).expect("ReplyBody serializes"),
+                    body: serde_json::to_value(ReplyBody { answer })
+                        .unwrap_or_else(|_| serde_json::json!({})),
                     created_at: Utc::now(),
                     correlation_id: Some(id.clone()),
                 };

--- a/crates/infra/bamboo-subagent/src/proto.rs
+++ b/crates/infra/bamboo-subagent/src/proto.rs
@@ -98,7 +98,7 @@ pub enum TerminalStatus {
 
 impl ParentFrame {
     pub fn to_text(&self) -> String {
-        serde_json::to_string(self).expect("ParentFrame serializes")
+        serde_json::to_string(self).unwrap_or_else(|_| "{}".to_string())
     }
     pub fn from_text(s: &str) -> serde_json::Result<Self> {
         serde_json::from_str(s)
@@ -107,7 +107,7 @@ impl ParentFrame {
 
 impl ChildFrame {
     pub fn to_text(&self) -> String {
-        serde_json::to_string(self).expect("ChildFrame serializes")
+        serde_json::to_string(self).unwrap_or_else(|_| "{}".to_string())
     }
     pub fn from_text(s: &str) -> serde_json::Result<Self> {
         serde_json::from_str(s)


### PR DESCRIPTION
## What
Replaces 5 `serde_json…expect()` calls with `unwrap_or_else` fallbacks across the frame/reply helpers (`ParentFrame`/`ChildFrame`/`ClientFrame`/`BrokerFrame` `to_text` + `serve.rs` `ReplyBody`). A future field that breaks serde now degrades to a recoverable deserialize error on the peer instead of panicking the worker/broker process mid-agent-loop.

## Verification
`cargo check -p bamboo-subagent -p bamboo-broker` ✅. No targeted serde `expect()` remaining.

## Scope
Left untouched (out of scope): unrelated non-serde `expect()`s in `serve.rs`, and adding a `BrokerError::Serde` variant for true `?` propagation.

## Provenance
Implemented by the bamboo headless agent (bypass mode); reviewed + compiled by hand.

Closes #57

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp