### PR TITLE
feat(bamboo-tools): session-keyed background shell registry (#84 phase 2a)

### DIFF
--- a/crates/engine/bamboo-tools/src/tools/bash.rs
+++ b/crates/engine/bamboo-tools/src/tools/bash.rs
@@ -398,9 +398,14 @@ impl Tool for BashTool {
         let session_workspace = workspace_state::workspace_or_process_cwd(ctx.session_id);
         let cwd = Self::resolve_cwd(&session_workspace, parsed.workdir.as_deref())?;
         if parsed.run_in_background.unwrap_or(false) {
-            let shell = bash_runtime::spawn_background(command, Some(&cwd), ctx.cloned_sender())
-                .await
-                .map_err(ToolError::Execution)?;
+            let shell = bash_runtime::spawn_background(
+                command,
+                Some(&cwd),
+                ctx.cloned_sender(),
+                ctx.session_id.map(str::to_string),
+            )
+            .await
+            .map_err(ToolError::Execution)?;
 
             if let Some(requested_timeout) = parsed.timeout {
                 let kill_after_ms = Self::effective_timeout_ms(Some(requested_timeout));
@@ -666,7 +671,7 @@ mod tests {
     async fn bash_background_emits_completion_event_with_exit_code() {
         prime_test_command_environment();
         let (tx, mut rx) = mpsc::channel(8);
-        let shell = super::bash_runtime::spawn_background("true", None, Some(tx))
+        let shell = super::bash_runtime::spawn_background("true", None, Some(tx), None)
             .await
             .expect("background shell should spawn");
         let expected_id = shell.id.clone();
@@ -699,7 +704,7 @@ mod tests {
     async fn bash_background_emits_completion_event_for_failing_command() {
         prime_test_command_environment();
         let (tx, mut rx) = mpsc::channel(8);
-        let shell = super::bash_runtime::spawn_background("false", None, Some(tx))
+        let shell = super::bash_runtime::spawn_background("false", None, Some(tx), None)
             .await
             .expect("background shell should spawn");
         let expected_id = shell.id.clone();
@@ -731,7 +736,7 @@ mod tests {
     async fn bash_background_emits_killed_when_shell_is_killed() {
         prime_test_command_environment();
         let (tx, mut rx) = mpsc::channel(8);
-        let shell = super::bash_runtime::spawn_background("sleep 30", None, Some(tx))
+        let shell = super::bash_runtime::spawn_background("sleep 30", None, Some(tx), None)
             .await
             .expect("background shell should spawn");
         let expected_id = shell.id.clone();
@@ -764,7 +769,7 @@ mod tests {
     #[tokio::test]
     async fn bash_background_without_sender_still_completes() {
         prime_test_command_environment();
-        let shell = super::bash_runtime::spawn_background("true", None, None)
+        let shell = super::bash_runtime::spawn_background("true", None, None, None)
             .await
             .expect("background shell should spawn");
 
@@ -796,7 +801,7 @@ mod tests {
         })
         .expect("prefill channel slot");
 
-        let shell = super::bash_runtime::spawn_background("true", None, Some(tx))
+        let shell = super::bash_runtime::spawn_background("true", None, Some(tx), None)
             .await
             .expect("background shell should spawn");
 
@@ -926,5 +931,80 @@ mod tests {
         assert!(
             matches!(result, Err(ToolError::InvalidArguments(msg)) if msg.contains("directory"))
         );
+    }
+
+    /// `running_shells_for_session` reports only the running shells tagged with the
+    /// requested session, excluding completed shells and shells owned by another
+    /// session (or none). (issue #84, phase 2a.)
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn running_shells_for_session_filters_by_session_and_status() {
+        prime_test_command_environment();
+
+        // Two long-running shells owned by sess-A.
+        let a1 = super::bash_runtime::spawn_background(
+            "sleep 30",
+            None,
+            None,
+            Some("sess-A".to_string()),
+        )
+        .await
+        .expect("spawn a1");
+        let a2 = super::bash_runtime::spawn_background(
+            "sleep 30",
+            None,
+            None,
+            Some("sess-A".to_string()),
+        )
+        .await
+        .expect("spawn a2");
+        // One long-running shell owned by sess-B.
+        let b = super::bash_runtime::spawn_background(
+            "sleep 30",
+            None,
+            None,
+            Some("sess-B".to_string()),
+        )
+        .await
+        .expect("spawn b");
+        // An untagged (None) long-running shell.
+        let untagged = super::bash_runtime::spawn_background("sleep 30", None, None, None)
+            .await
+            .expect("spawn untagged");
+        // A sess-A shell that completes immediately — must be excluded once done.
+        let done =
+            super::bash_runtime::spawn_background("true", None, None, Some("sess-A".to_string()))
+                .await
+                .expect("spawn done");
+
+        // Wait for the fast shell to reach "completed" so we exercise the status filter.
+        let started = Instant::now();
+        loop {
+            if done.status() == "completed" {
+                break;
+            }
+            if started.elapsed() > Duration::from_secs(3) {
+                panic!("sess-A fast shell never completed");
+            }
+            sleep(Duration::from_millis(25)).await;
+        }
+
+        // sess-A should report exactly the two long-running shells, order-independent.
+        let mut running = super::bash_runtime::running_shells_for_session("sess-A");
+        running.sort();
+        let mut expected = vec![a1.id.clone(), a2.id.clone()];
+        expected.sort();
+        assert_eq!(running, expected);
+
+        // sess-B should report exactly its own single running shell.
+        assert_eq!(
+            super::bash_runtime::running_shells_for_session("sess-B"),
+            vec![b.id.clone()]
+        );
+
+        // Cleanup: kill the still-running shells so the GC isn't left holding them.
+        for shell in [a1, a2, b, untagged] {
+            let _ = shell.kill().await;
+        }
     }
 }

--- a/crates/engine/bamboo-tools/src/tools/bash.rs
+++ b/crates/engine/bamboo-tools/src/tools/bash.rs
@@ -1002,9 +1002,11 @@ mod tests {
             vec![b.id.clone()]
         );
 
-        // Cleanup: kill the still-running shells so the GC isn't left holding them.
+        // Cleanup: kill the still-running shells so the GC isn't left holding them,
+        // and drop the already-completed `done` shell from the process-global registry.
         for shell in [a1, a2, b, untagged] {
             let _ = shell.kill().await;
         }
+        let _ = super::bash_runtime::remove_shell(&done.id);
     }
 }

--- a/crates/engine/bamboo-tools/src/tools/bash_runtime.rs
+++ b/crates/engine/bamboo-tools/src/tools/bash_runtime.rs
@@ -294,6 +294,10 @@ pub fn remove_shell(id: &str) -> Option<Arc<ShellSession>> {
 /// stored `session_id` equals `Some(session_id)` and `status()` is `"running"`,
 /// so completed shells and shells belonging to another session (or none) are
 /// excluded.
+///
+/// The result is a point-in-time snapshot: a returned shell may finish between
+/// this call and the caller acting on its id, so callers must re-check liveness
+/// (e.g. via `get_shell(id).status()`) before treating an id as still running.
 pub fn running_shells_for_session(session_id: &str) -> Vec<String> {
     sessions()
         .iter()

--- a/crates/engine/bamboo-tools/src/tools/bash_runtime.rs
+++ b/crates/engine/bamboo-tools/src/tools/bash_runtime.rs
@@ -23,6 +23,10 @@ const COMPLETED_SESSION_TTL_SECS: u64 = 300;
 pub struct ShellSession {
     pub id: String,
     pub command: String,
+    /// Bamboo session id that owns this background shell, if any. Set from the
+    /// dispatch context (issue #84, phase 2a) so the registry can be queried
+    /// per-session. `None` means the shell is untagged (e.g. spawned from tests).
+    pub session_id: Option<String>,
     pub environment: CommandEnvironmentDiagnostics,
     child: Arc<Mutex<Child>>,
     output: Arc<Mutex<Vec<String>>>,
@@ -128,6 +132,7 @@ pub async fn spawn_background(
     command: &str,
     cwd: Option<&Path>,
     event_tx: Option<mpsc::Sender<AgentEvent>>,
+    session_id: Option<String>,
 ) -> Result<Arc<ShellSession>, String> {
     let shell = preferred_bash_shell();
     trace_windows_command(
@@ -163,15 +168,16 @@ pub async fn spawn_background(
         .take()
         .ok_or_else(|| "Failed to capture shell stderr".to_string())?;
 
-    let session_id = uuid::Uuid::new_v4().to_string();
+    let shell_id = uuid::Uuid::new_v4().to_string();
     let output = Arc::new(Mutex::new(Vec::new()));
     let base_index = Arc::new(Mutex::new(0usize));
     let running = Arc::new(AtomicBool::new(true));
     let exit_code = Arc::new(Mutex::new(None));
 
     let session = Arc::new(ShellSession {
-        id: session_id.clone(),
+        id: shell_id.clone(),
         command: command.to_string(),
+        session_id,
         environment: prepared_env.diagnostics.clone(),
         child: Arc::new(Mutex::new(child)),
         output: output.clone(),
@@ -198,9 +204,9 @@ pub async fn spawn_background(
 
     {
         let child = session.child.clone();
-        let session_id_for_gc = session_id.clone();
+        let session_id_for_gc = shell_id.clone();
         // Owned copies for the completion signal (issue #84, phase 1).
-        let bash_id_for_event = session_id.clone();
+        let bash_id_for_event = shell_id.clone();
         let command_for_event = command.to_string();
         tokio::spawn(async move {
             // Determine the terminal status/exit_code, then break out to emit
@@ -269,7 +275,7 @@ pub async fn spawn_background(
         });
     }
 
-    sessions().insert(session_id, session.clone());
+    sessions().insert(shell_id, session.clone());
     Ok(session)
 }
 
@@ -279,4 +285,25 @@ pub fn get_shell(id: &str) -> Option<Arc<ShellSession>> {
 
 pub fn remove_shell(id: &str) -> Option<Arc<ShellSession>> {
     sessions().remove(id).map(|(_, value)| value)
+}
+
+/// Returns the ids of background shells owned by `session_id` that are still
+/// running (issue #84, phase 2a). Mirrors the sync `get_shell`/`remove_shell`
+/// helpers over the global registry — not async because the registry is a sync
+/// `DashMap` and `status()` is a sync read. A shell is included only when its
+/// stored `session_id` equals `Some(session_id)` and `status()` is `"running"`,
+/// so completed shells and shells belonging to another session (or none) are
+/// excluded.
+pub fn running_shells_for_session(session_id: &str) -> Vec<String> {
+    sessions()
+        .iter()
+        .filter(|entry| {
+            entry
+                .session_id
+                .as_deref()
+                .is_some_and(|sid| sid == session_id)
+                && entry.status() == "running"
+        })
+        .map(|entry| entry.id.clone())
+        .collect()
 }


### PR DESCRIPTION
## Phase 2a of #84 — session-keyed shell registry

Pure plumbing, **zero behavior change**. Establishes the bash<->session association that the loop wait/resume work (phases 2b/2c) needs.

### Changes
- `ShellSession.session_id: Option<String>` (owning Bamboo session).
- `spawn_background` takes `session_id`; `BashTool` passes `ctx.session_id`.
- New `running_shells_for_session(session_id) -> Vec<String>`.
- Renamed the shell-uuid local `session_id` -> `shell_id` (clarity).

### Verification
`cargo check --workspace` ✅ · `cargo test -p bamboo-tools` ✅ (292, incl. new `running_shells_for_session_filters_by_session_and_status`) · fmt + clippy clean on the touched crate.

### Roadmap (designed, risk-ordered)
- **2b**: `WaitingForBashState` + `\"waiting_for_bash\"` suspend reason.
- **2c**: resume coordinator (event-forwarder post-stop path; output injected as hidden user message).
- **2d**: the flip via auto-sync promotion (preserve sync semantics for fast commands).

### Provenance
Implemented by the bamboo headless agent; reviewed + built/tested by hand.

Refs #84

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp