### PR TITLE
feat(bamboo-tools): Bash async-by-default via auto-sync promotion (#84 phase 2d)

### DIFF
--- a/crates/app/bamboo-server-tools/src/memory/tests.rs
+++ b/crates/app/bamboo-server-tools/src/memory/tests.rs
@@ -38,6 +38,7 @@ fn test_context<'a>(session_id: &'a str) -> ToolExecutionContext<'a> {
         event_tx: None,
         available_tool_schemas: None,
         bypass_permissions: false,
+        can_async_resume: false,
     }
 }
 

--- a/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
@@ -124,6 +124,7 @@ Use this demo skill."#,
         event_tx: None,
         available_tool_schemas: None,
         bypass_permissions: false,
+        can_async_resume: false,
     };
 
     let error = tool
@@ -187,6 +188,7 @@ Use this demo skill."#,
         event_tx: None,
         available_tool_schemas: None,
         bypass_permissions: false,
+        can_async_resume: false,
     };
 
     let _ = tool
@@ -256,6 +258,7 @@ Use this demo skill."#,
         event_tx: None,
         available_tool_schemas: None,
         bypass_permissions: false,
+        can_async_resume: false,
     };
     let read_ctx = ToolExecutionContext {
         session_id: Some(session_id),
@@ -263,6 +266,7 @@ Use this demo skill."#,
         event_tx: None,
         available_tool_schemas: None,
         bypass_permissions: false,
+        can_async_resume: false,
     };
 
     let _ = load_tool

--- a/crates/app/bamboo-server-tools/tests/ask_agent_tool.rs
+++ b/crates/app/bamboo-server-tools/tests/ask_agent_tool.rs
@@ -46,6 +46,7 @@ async fn ask_agent_tool_queries_a_broker_agent() {
         event_tx: None,
         available_tool_schemas: None,
         bypass_permissions: false,
+        can_async_resume: false,
     };
     let result = tool
         .execute_with_context(
@@ -75,6 +76,7 @@ async fn ask_agent_tool_rejects_unknown_mode() {
         event_tx: None,
         available_tool_schemas: None,
         bypass_permissions: false,
+        can_async_resume: false,
     };
     let err = tool
         .execute_with_context(

--- a/crates/app/bamboo-server/src/app_state/resume_adapter.rs
+++ b/crates/app/bamboo-server/src/app_state/resume_adapter.rs
@@ -213,6 +213,7 @@ impl ResumeExecutionPort for AppStateResumeRef {
                         event_tx: Some(&mpsc_tx),
                         available_tool_schemas: None,
                         bypass_permissions: false,
+                        can_async_resume: false,
                     };
                     executor.execute_with_context(&tool_call, ctx).await
                 };

--- a/crates/app/bamboo-server/src/app_state/tests.rs
+++ b/crates/app/bamboo-server/src/app_state/tests.rs
@@ -265,6 +265,7 @@ async fn memory_tool_merge_action_updates_existing_project_memory() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -293,6 +294,7 @@ async fn memory_tool_merge_action_updates_existing_project_memory() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -320,6 +322,7 @@ async fn memory_tool_merge_action_updates_existing_project_memory() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -367,6 +370,7 @@ async fn memory_tool_write_merges_heuristically_similar_memory_when_enabled() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -395,6 +399,7 @@ async fn memory_tool_write_merges_heuristically_similar_memory_when_enabled() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -419,6 +424,7 @@ async fn memory_tool_write_merges_heuristically_similar_memory_when_enabled() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -459,6 +465,7 @@ async fn memory_tool_merge_mode_contradict_marks_memory_contradicted() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -485,6 +492,7 @@ async fn memory_tool_merge_mode_contradict_marks_memory_contradicted() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -512,6 +520,7 @@ async fn memory_tool_merge_mode_contradict_marks_memory_contradicted() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -559,6 +568,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -584,6 +594,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -608,6 +619,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -635,6 +647,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -676,6 +689,7 @@ async fn memory_tool_inspect_and_rebuild_expose_observability_fields() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -697,6 +711,7 @@ async fn memory_tool_inspect_and_rebuild_expose_observability_fields() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -725,6 +740,7 @@ async fn memory_tool_inspect_and_rebuild_expose_observability_fields() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await

--- a/crates/app/bamboo-server/src/handlers/tools/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/tools/mod.rs
@@ -122,6 +122,7 @@ pub async fn execute_tool(
                 event_tx: None,
                 available_tool_schemas: Some(available_tool_schemas.as_slice()),
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -433,11 +433,16 @@ async fn run_schedule_job(
         guardian_config: None,
         guardian_spawner: None,
         // No bash self-resume hook on the schedule path: the end-of-turn bash
-        // suspend gate is therefore inert here (it requires a wired hook). This
-        // is graceful degradation — a scheduled run that leaves a
-        // `run_in_background` shell running simply completes; the shell keeps
-        // running detached and stays readable via BashOutput. No strand can
-        // occur because the gate refuses to suspend without the hook.
+        // suspend gate is therefore inert here (it requires a wired hook).
+        // Because the loop can't resume a backgrounded shell, the Bash tool's
+        // auto path detects this (can_async_resume == false, derived from
+        // hook+persistence) and stays purely synchronous — a long command on
+        // the default path blocks to its timeout rather than promoting to an
+        // orphaned background shell whose output this loop could never await
+        // (issue #84, phase 2d). An explicitly backgrounded shell
+        // (`run_in_background: true`) still runs detached and stays readable via
+        // BashOutput; no strand can occur because the gate refuses to suspend
+        // without the hook.
         bash_resume_hook: None,
         app_data_dir: ctx.app_data_dir.clone(),
         runners: ctx.agent_runners.clone(),

--- a/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
+++ b/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
@@ -292,6 +292,7 @@ fn ctx_for<'a>(session_id: &'a str, tool_call_id: &'static str) -> ToolExecution
         event_tx: None,
         available_tool_schemas: None,
         bypass_permissions: false,
+        can_async_resume: false,
     }
 }
 
@@ -545,6 +546,7 @@ async fn create_emits_sub_agent_started_event_after_queueing() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -612,6 +614,7 @@ async fn create_uses_async_subagent_model_resolver() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -653,6 +656,7 @@ async fn resident_create_reuses_same_child_session() {
         event_tx: None,
         available_tool_schemas: None,
         bypass_permissions: false,
+        can_async_resume: false,
     };
     let create = |name_task: &'static str, prompt: &'static str| {
         json!({
@@ -775,6 +779,7 @@ async fn backward_compat_legacy_subagent_call_without_action_defaults_to_create(
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -808,6 +813,7 @@ async fn send_message_appends_follow_up_without_replacing_history() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -860,6 +866,7 @@ async fn send_message_queues_on_running_child_without_interrupt() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -927,6 +934,7 @@ async fn send_message_can_interrupt_running_child() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -977,6 +985,7 @@ async fn send_message_can_queue_child_immediately() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -1061,6 +1070,7 @@ async fn cancel_stops_running_child() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -1088,6 +1098,7 @@ async fn list_returns_children() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -1131,6 +1142,7 @@ async fn get_returns_runner_diagnostics() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -1168,6 +1180,7 @@ async fn create_returns_duration_hint() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -1217,6 +1230,7 @@ async fn create_persists_explicit_reasoning_effort_to_child_session() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -1269,6 +1283,7 @@ async fn create_without_reasoning_effort_leaves_child_at_provider_default() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -1326,6 +1341,7 @@ async fn update_can_change_reasoning_effort_on_existing_child() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -1361,6 +1377,7 @@ async fn delete_removes_child() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -1398,6 +1415,7 @@ async fn create_requires_workspace() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -1436,6 +1454,7 @@ async fn create_sets_child_workspace() {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await

--- a/crates/core/bamboo-agent-core/src/tools/context.rs
+++ b/crates/core/bamboo-agent-core/src/tools/context.rs
@@ -62,6 +62,16 @@ pub struct ToolExecutionContext<'a> {
     /// tool permission checks are skipped. Sourced per-session from the
     /// session's runtime state (`runtime.json`), not the global checker.
     pub bypass_permissions: bool,
+    /// When `true`, the executing agent loop can suspend the current turn for a
+    /// backgrounded shell and self-resume once it finishes (i.e. a
+    /// `bash_resume_hook` AND persistence are wired). The Bash tool uses this to
+    /// decide whether its auto path (`run_in_background` omitted) may promote a
+    /// long command to background: when `false`, the auto path stays purely
+    /// synchronous so the command's output is never orphaned on a loop that
+    /// can't resume it (issue #84, phase 2d). Derived from the loop config at
+    /// the dispatch site — NOT session-derived — so it is a direct
+    /// `for_dispatch` parameter rather than a `ToolExecutionSessionFlags` field.
+    pub can_async_resume: bool,
 }
 
 impl<'a> ToolExecutionContext<'a> {
@@ -72,6 +82,7 @@ impl<'a> ToolExecutionContext<'a> {
             event_tx: None,
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         }
     }
 
@@ -86,6 +97,11 @@ impl<'a> ToolExecutionContext<'a> {
         event_tx: &'a mpsc::Sender<AgentEvent>,
         available_tool_schemas: &'a [ToolSchema],
         flags: ToolExecutionSessionFlags,
+        // Whether the executing loop can suspend for and self-resume a
+        // backgrounded bash shell (`bash_resume_hook` + persistence wired).
+        // When `false`, the Bash auto path stays synchronous (issue #84,
+        // phase 2d). NOT session-derived — set by the dispatch site.
+        can_async_resume: bool,
     ) -> Self {
         Self {
             session_id: Some(session_id),
@@ -93,6 +109,7 @@ impl<'a> ToolExecutionContext<'a> {
             event_tx: Some(event_tx),
             available_tool_schemas: Some(available_tool_schemas),
             bypass_permissions: flags.bypass_permissions,
+            can_async_resume,
         }
     }
 
@@ -164,9 +181,11 @@ mod session_flags_tests {
             ToolExecutionSessionFlags {
                 bypass_permissions: true,
             },
+            true,
         );
         assert_eq!(ctx.session_id, Some("s1"));
         assert!(ctx.bypass_permissions);
+        assert!(ctx.can_async_resume);
     }
 }
 
@@ -188,6 +207,7 @@ mod tests {
             event_tx: Some(&tx),
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         tokio::time::timeout(
@@ -215,6 +235,7 @@ mod tests {
             event_tx: Some(&tx),
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         ctx.emit(AgentEvent::Token {
@@ -244,6 +265,7 @@ mod tests {
             event_tx: Some(&tx),
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         // Test with various non-Token events
@@ -284,6 +306,7 @@ mod tests {
             event_tx: Some(&tx),
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         ctx.emit_tool_token("convenient output").await;
@@ -335,6 +358,7 @@ mod tests {
             event_tx: Some(&tx),
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         let cloned = ctx.cloned_sender();
@@ -359,6 +383,7 @@ mod tests {
             event_tx: Some(&tx),
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         for i in 0..5 {
@@ -388,6 +413,7 @@ mod tests {
             event_tx: Some(&tx),
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         // Can clone (Copy implies Clone)
@@ -416,6 +442,7 @@ mod tests {
             event_tx: Some(&tx),
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         ctx.emit(AgentEvent::Token {
@@ -441,6 +468,7 @@ mod tests {
             event_tx: Some(&tx),
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         ctx.emit(AgentEvent::Token {
@@ -470,6 +498,7 @@ mod tests {
             event_tx: Some(&tx),
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         ctx.emit(AgentEvent::Token {
@@ -495,6 +524,7 @@ mod tests {
             event_tx: Some(&tx),
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         let content = String::from("owned string");
@@ -518,6 +548,7 @@ mod tests {
             event_tx: Some(&tx),
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         ctx.emit_tool_token("string slice").await;

--- a/crates/core/bamboo-agent-core/src/tools/result_handler.rs
+++ b/crates/core/bamboo-agent-core/src/tools/result_handler.rs
@@ -379,6 +379,11 @@ pub async fn execute_sub_actions(
             event_tx,
             available_tools.as_slice(),
             ToolExecutionSessionFlags::from_session(session),
+            // bamboo-agent-core's own loop has no engine suspend/resume
+            // machinery (that lives in bamboo-engine's pipeline), so it can
+            // never safely auto-promote a Bash command — keep it synchronous
+            // (issue #84, phase 2d).
+            false,
         );
 
         match execute_tool_call_with_context(&action, tools, composition_executor.clone(), tool_ctx)

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
@@ -148,6 +148,12 @@ pub(super) async fn execute_tool_call_only(
         ctx.event_tx,
         available_tool_schemas.as_slice(),
         ctx.session_flags,
+        // Only let the Bash auto path promote to background when this loop can
+        // actually suspend for and self-resume the shell — i.e. a
+        // `bash_resume_hook` AND persistence are both wired (issue #84, phase
+        // 2d). On hook-less paths (e.g. the schedule loop) this is false, so the
+        // auto path stays synchronous and never orphans a promoted shell.
+        ctx.config.bash_resume_hook.is_some() && ctx.config.persistence.is_some(),
     );
 
     let result = bamboo_agent_core::tools::executor::execute_tool_call_with_context(

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -942,6 +942,7 @@ mod tests {
             event_tx: None,
             available_tool_schemas: None,
             bypass_permissions: true,
+            can_async_resume: false,
         };
         let result = executor.execute_with_context(&call, ctx).await;
 
@@ -969,6 +970,7 @@ mod tests {
             event_tx: None,
             available_tool_schemas: None,
             bypass_permissions: true,
+            can_async_resume: false,
         };
         let result = executor.execute_with_context(&call, ctx).await;
 
@@ -1013,6 +1015,7 @@ mod tests {
             event_tx: None,
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         let proxy: Arc<dyn crate::approval::ApprovalProxy> = Arc::new(HostStub { approve: true });
@@ -1048,6 +1051,7 @@ mod tests {
             event_tx: None,
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         let proxy: Arc<dyn crate::approval::ApprovalProxy> = Arc::new(HostStub { approve: false });
@@ -1121,6 +1125,7 @@ mod tests {
                     event_tx: Some(&tx),
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/bash.rs
+++ b/crates/engine/bamboo-tools/src/tools/bash.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::time::{Duration, Instant};
@@ -18,6 +19,27 @@ use super::{bash_runtime, workspace_state};
 const DEFAULT_TIMEOUT_MS: u64 = 120_000;
 const MAX_TIMEOUT_MS: u64 = 600_000;
 const MAX_CAPTURE_BYTES: usize = 512 * 1024;
+
+/// Auto-sync promotion threshold (issue #84, phase 2d). Commands started via the
+/// auto path (`run_in_background` omitted) that are still running after this many
+/// milliseconds are promoted to background instead of continuing to block.
+/// Deliberately generous so virtually all interactive commands stay synchronous.
+const PROMOTE_TO_BACKGROUND_AFTER_MS: u64 = 10_000;
+
+/// Test override for the promotion threshold (issue #84, phase 2d). When > 0,
+/// tests use this value instead of `PROMOTE_TO_BACKGROUND_AFTER_MS` so promotion
+/// can be exercised without waiting 10 seconds. Always 0 in production builds.
+static PROMOTE_AFTER_MS_OVERRIDE: AtomicU64 = AtomicU64::new(0);
+
+/// The effective auto-sync promotion threshold, honoring the test override.
+fn promote_to_background_after_ms() -> u64 {
+    let val = PROMOTE_AFTER_MS_OVERRIDE.load(Ordering::Relaxed);
+    if val > 0 {
+        val
+    } else {
+        PROMOTE_TO_BACKGROUND_AFTER_MS
+    }
+}
 
 #[derive(Debug, Deserialize)]
 struct BashArgs {
@@ -189,10 +211,23 @@ impl BashTool {
         build_command_environment(&overrides).await
     }
 
-    async fn run_foreground(
+    /// Run a command with streaming output (issue #84, phase 2d).
+    ///
+    /// When `promote_after_ms` is `None`, this is pure synchronous foreground:
+    /// blocks until the command completes or the timeout fires — byte-identical
+    /// to the pre-2d `run_foreground` (same streaming, capture, exit code, result).
+    ///
+    /// When `promote_after_ms` is `Some(ms)`, the command starts foreground but
+    /// is auto-promoted to background if still running after `ms` milliseconds.
+    /// Fast commands that finish before the promotion deadline never reach the
+    /// promotion branch, so their behavior is unchanged. Only the promotion
+    /// deadline (not the timeout) triggers the hand-off: a timeout with
+    /// `ms >= timeout_ms` kills the child exactly as before.
+    async fn run_streaming_command(
         &self,
         command: &str,
         timeout_ms: u64,
+        promote_after_ms: Option<u64>,
         cwd: &Path,
         ctx: ToolExecutionContext<'_>,
     ) -> Result<ToolResult, ToolError> {
@@ -241,20 +276,32 @@ impl BashTool {
 
         let mut stdout_buf = String::new();
         let mut stderr_buf = String::new();
+        // Individual decoded lines collected for promotion seeding. Only
+        // populated when promotion is enabled — a cheap Vec::push per line that
+        // is never touched on the pure-foreground path.
+        let mut stdout_lines: Vec<String> = Vec::new();
+        let mut stderr_lines: Vec<String> = Vec::new();
         let mut stdout_truncated = false;
         let mut stderr_truncated = false;
         let mut stdout_done = false;
         let mut stderr_done = false;
-        let deadline = Instant::now() + Duration::from_millis(timeout_ms);
-        let mut timed_out = false;
+
+        // Effective deadline: when promotion is enabled, the earlier of the
+        // promotion threshold and the timeout; otherwise just the timeout.
+        let timeout_deadline = Instant::now() + Duration::from_millis(timeout_ms);
+        let effective_deadline = match promote_after_ms {
+            Some(promote_ms) => {
+                (Instant::now() + Duration::from_millis(promote_ms)).min(timeout_deadline)
+            }
+            None => timeout_deadline,
+        };
 
         while !(stdout_done && stderr_done) {
-            if Instant::now() >= deadline {
-                timed_out = true;
+            if Instant::now() >= effective_deadline {
                 break;
             }
 
-            let remaining = deadline.saturating_duration_since(Instant::now());
+            let remaining = effective_deadline.saturating_duration_since(Instant::now());
             tokio::select! {
                 line = stdout_reader.read_until(b'\n', &mut stdout_line_bytes), if !stdout_done => {
                     match line {
@@ -262,6 +309,9 @@ impl BashTool {
                         Ok(_) => {
                             let line = decode_process_line_lossy(&mut stdout_line_bytes);
                             Self::append_capped(&mut stdout_buf, &line, &mut stdout_truncated);
+                            if promote_after_ms.is_some() {
+                                stdout_lines.push(line.clone());
+                            }
                             ctx.emit_tool_token(format!("{}\n", line)).await;
                         }
                         Err(e) => {
@@ -275,6 +325,9 @@ impl BashTool {
                         Ok(_) => {
                             let line = decode_process_line_lossy(&mut stderr_line_bytes);
                             Self::append_capped(&mut stderr_buf, &line, &mut stderr_truncated);
+                            if promote_after_ms.is_some() {
+                                stderr_lines.push(line.clone());
+                            }
                             ctx.emit_tool_token(format!("{}\n", line)).await;
                         }
                         Err(e) => {
@@ -283,39 +336,114 @@ impl BashTool {
                     }
                 }
                 _ = tokio::time::sleep(remaining) => {
-                    timed_out = true;
                     break;
                 }
             }
         }
 
-        let status = if timed_out {
-            let _ = child.kill().await;
-            None
-        } else {
-            Some(
-                child
-                    .wait()
-                    .await
-                    .map_err(|e| ToolError::Execution(format!("Failed waiting command: {}", e)))?,
+        let streams_closed = stdout_done && stderr_done;
+
+        // A promotion fires only when promotion is enabled AND the promotion
+        // threshold is strictly less than the timeout. When promotion is
+        // disabled or timeout <= promote, the deadline firing is a timeout.
+        let promotion_fired =
+            !streams_closed && promote_after_ms.is_some() && promote_after_ms.unwrap() < timeout_ms;
+
+        if streams_closed {
+            // Command completed normally — identical to the pre-2d foreground path.
+            let status = child
+                .wait()
+                .await
+                .map_err(|e| ToolError::Execution(format!("Failed waiting command: {}", e)))?;
+            let exit_code = status.code();
+            let success = exit_code.unwrap_or(-1) == 0;
+            let cwd_display = bamboo_config::paths::path_to_display_string(cwd);
+            let environment = Self::environment_json(&prepared_env.diagnostics, !success);
+
+            return Ok(ToolResult {
+                success,
+                result: json!({
+                    "command": command,
+                    "cwd": cwd_display,
+                    "stdout": stdout_buf,
+                    "stderr": stderr_buf,
+                    "exit_code": exit_code,
+                    "timed_out": false,
+                    "stdout_truncated": stdout_truncated,
+                    "stderr_truncated": stderr_truncated,
+                    "environment": environment,
+                })
+                .to_string(),
+                display_preference: Some("Collapsible".to_string()),
+                images: Vec::new(),
+            });
+        }
+
+        if promotion_fired {
+            // Promotion deadline fired while the child is still running —
+            // hand off the live child to the background registry. Do NOT kill:
+            // pump tasks continue draining and the completion poll emits
+            // BashCompleted when the child exits (issue #84, phase 2d).
+            //
+            // Flush any partial line bytes left by a cancelled `read_until` —
+            // they represent real bytes consumed from the pipe that must not be
+            // lost across the hand-off.
+            if !stdout_line_bytes.is_empty() {
+                let partial = decode_process_line_lossy(&mut stdout_line_bytes);
+                if !partial.is_empty() {
+                    stdout_lines.push(partial);
+                }
+            }
+            if !stderr_line_bytes.is_empty() {
+                let partial = decode_process_line_lossy(&mut stderr_line_bytes);
+                if !partial.is_empty() {
+                    stderr_lines.push(partial);
+                }
+            }
+
+            let session = bash_runtime::adopt_running_child(
+                child,
+                stdout_reader,
+                stderr_reader,
+                stdout_lines,
+                stderr_lines,
+                command,
+                ctx.session_id.map(str::to_string),
+                prepared_env.diagnostics.clone(),
+                ctx.cloned_sender(),
             )
-        };
+            .await
+            .map_err(ToolError::Execution)?;
 
-        let exit_code = status.and_then(|s| s.code());
-        let success = !timed_out && exit_code.unwrap_or(-1) == 0;
+            return Ok(ToolResult {
+                success: true,
+                result: json!({
+                    "bash_id": session.id,
+                    "command": session.command,
+                    "status": "running",
+                    "cwd": bamboo_config::paths::path_to_display_string(cwd),
+                    "environment": Self::environment_json(&session.environment, false),
+                })
+                .to_string(),
+                display_preference: Some("Collapsible".to_string()),
+                images: Vec::new(),
+            });
+        }
+
+        // Timeout fired (promotion disabled or timeout <= promote threshold).
+        let _ = child.kill().await;
         let cwd_display = bamboo_config::paths::path_to_display_string(cwd);
-
-        let environment = Self::environment_json(&prepared_env.diagnostics, !success);
+        let environment = Self::environment_json(&prepared_env.diagnostics, true);
 
         Ok(ToolResult {
-            success,
+            success: false,
             result: json!({
                 "command": command,
                 "cwd": cwd_display,
                 "stdout": stdout_buf,
                 "stderr": stderr_buf,
-                "exit_code": exit_code,
-                "timed_out": timed_out,
+                "exit_code": serde_json::Value::Null,
+                "timed_out": true,
                 "stdout_truncated": stdout_truncated,
                 "stderr_truncated": stderr_truncated,
                 "environment": environment,
@@ -340,7 +468,14 @@ impl Tool for BashTool {
     }
 
     fn description(&self) -> &str {
-        "Execute shell commands with streaming output (supports background mode). Default timeout is 120000ms (max 600000ms); captured stdout/stderr are each capped at 512KB."
+        "Execute shell commands with streaming output (supports background mode). \
+         By default (run_in_background omitted), commands run synchronously but are \
+         auto-promoted to background if they run longer than ~10s — fast commands \
+         behave exactly as foreground. Set run_in_background to false to force \
+         synchronous (block until timeout), or true to force immediate background. \
+         Backgrounded commands are observed via BashOutput and the loop waits for \
+         them at turn end. Default timeout is 120000ms (max 600000ms); captured \
+         stdout/stderr are each capped at 512KB."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -361,7 +496,7 @@ impl Tool for BashTool {
                 },
                 "run_in_background": {
                     "type": "boolean",
-                    "description": "Set to true to run this command in the background"
+                    "description": "Controls execution mode. Omit (default) for auto: runs synchronously but auto-backgrounds if the command runs longer than ~10s. Set to false to force synchronous (block until timeout). Set to true to force immediate background (observe via BashOutput; the loop waits at turn end)."
                 },
                 "workdir": {
                     "type": "string",
@@ -397,43 +532,64 @@ impl Tool for BashTool {
         let timeout_ms = Self::effective_timeout_ms(parsed.timeout);
         let session_workspace = workspace_state::workspace_or_process_cwd(ctx.session_id);
         let cwd = Self::resolve_cwd(&session_workspace, parsed.workdir.as_deref())?;
-        if parsed.run_in_background.unwrap_or(false) {
-            let shell = bash_runtime::spawn_background(
-                command,
-                Some(&cwd),
-                ctx.cloned_sender(),
-                ctx.session_id.map(str::to_string),
-            )
-            .await
-            .map_err(ToolError::Execution)?;
+        match parsed.run_in_background {
+            Some(true) => {
+                // Force background — spawn immediately (issue #84, phase 1).
+                let shell = bash_runtime::spawn_background(
+                    command,
+                    Some(&cwd),
+                    ctx.cloned_sender(),
+                    ctx.session_id.map(str::to_string),
+                )
+                .await
+                .map_err(ToolError::Execution)?;
 
-            if let Some(requested_timeout) = parsed.timeout {
-                let kill_after_ms = Self::effective_timeout_ms(Some(requested_timeout));
-                let shell_clone = shell.clone();
-                tokio::spawn(async move {
-                    tokio::time::sleep(Duration::from_millis(kill_after_ms)).await;
-                    if shell_clone.status() == "running" {
-                        let _ = shell_clone.kill().await;
-                    }
-                });
-            }
+                if let Some(requested_timeout) = parsed.timeout {
+                    let kill_after_ms = Self::effective_timeout_ms(Some(requested_timeout));
+                    let shell_clone = shell.clone();
+                    tokio::spawn(async move {
+                        tokio::time::sleep(Duration::from_millis(kill_after_ms)).await;
+                        if shell_clone.status() == "running" {
+                            let _ = shell_clone.kill().await;
+                        }
+                    });
+                }
 
-            return Ok(ToolResult {
-                success: true,
-                result: json!({
-                    "bash_id": shell.id,
-                    "command": shell.command,
-                    "status": "running",
-                    "cwd": bamboo_config::paths::path_to_display_string(&cwd),
-                    "environment": Self::environment_json(&shell.environment, false),
+                Ok(ToolResult {
+                    success: true,
+                    result: json!({
+                        "bash_id": shell.id,
+                        "command": shell.command,
+                        "status": "running",
+                        "cwd": bamboo_config::paths::path_to_display_string(&cwd),
+                        "environment": Self::environment_json(&shell.environment, false),
+                    })
+                    .to_string(),
+                    display_preference: Some("Collapsible".to_string()),
+                    images: Vec::new(),
                 })
-                .to_string(),
-                display_preference: Some("Collapsible".to_string()),
-                images: Vec::new(),
-            });
+            }
+            Some(false) => {
+                // Force synchronous — pure foreground, no promotion (issue #84,
+                // phase 2d). Blocks until the command completes or times out,
+                // exactly like the pre-2d behavior.
+                self.run_streaming_command(command, timeout_ms, None, &cwd, ctx)
+                    .await
+            }
+            None => {
+                // Auto-sync promotion (issue #84, phase 2d). Runs foreground but
+                // promotes to background if still running after the promotion
+                // threshold (~10s). Fast commands finish synchronously.
+                self.run_streaming_command(
+                    command,
+                    timeout_ms,
+                    Some(promote_to_background_after_ms()),
+                    &cwd,
+                    ctx,
+                )
+                .await
+            }
         }
-
-        self.run_foreground(command, timeout_ms, &cwd, ctx).await
     }
 }
 
@@ -1008,5 +1164,182 @@ mod tests {
             let _ = shell.kill().await;
         }
         let _ = super::bash_runtime::remove_shell(&done.id);
+    }
+
+    // ── Auto-sync promotion tests (issue #84, phase 2d) ──────────────────
+
+    // (a) A fast command via the auto (None) path returns a synchronous result
+    // with stdout + exit_code and no bash_id — identical to the old foreground.
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn auto_path_fast_command_returns_synchronous_result() {
+        prime_test_command_environment();
+        let tool = BashTool::new();
+        let (tx, _rx) = mpsc::channel(32);
+        let ctx = ToolExecutionContext {
+            session_id: Some("session_auto_fast"),
+            tool_call_id: "call_auto_fast",
+            event_tx: Some(&tx),
+            available_tool_schemas: None,
+            bypass_permissions: false,
+        };
+
+        let result = tool
+            .execute_with_context(json!({ "command": "echo auto-fast-output" }), ctx)
+            .await
+            .expect("auto fast command should succeed");
+
+        let payload: Value = serde_json::from_str(&result.result).unwrap();
+        assert!(
+            payload.get("bash_id").is_none(),
+            "fast auto command must not return a bash_id"
+        );
+        assert_eq!(payload["exit_code"], 0);
+        assert_eq!(payload["timed_out"], false);
+        assert!(payload["stdout"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("auto-fast-output"));
+    }
+
+    // (b) Promotion: with a low test threshold, a long command (sleep) on the
+    // auto path returns a background {bash_id, running} result, the adopted
+    // shell appears in running_shells_for_session, and later emits
+    // BashCompleted with the right id.
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn auto_path_promotes_long_command_to_background() {
+        prime_test_command_environment();
+        let tool = BashTool::new();
+        let session_id = "session_auto_promote";
+        let (tx, mut rx) = mpsc::channel(8);
+        let ctx = ToolExecutionContext::for_dispatch(
+            session_id,
+            "call_auto_promote",
+            &tx,
+            &[],
+            ToolExecutionSessionFlags::default(),
+        );
+        let cwd = super::workspace_state::workspace_or_process_cwd(Some(session_id));
+
+        // Call run_streaming_command directly with a 200ms promotion threshold
+        // so we don't touch the process-global PROMOTE_AFTER_MS_OVERRIDE (which
+        // would race with other auto-path tests running in parallel).
+        let result = tool
+            .run_streaming_command("sleep 10", 60000, Some(200), &cwd, ctx)
+            .await
+            .expect("auto promote should succeed");
+
+        assert!(result.success);
+        let payload: Value = serde_json::from_str(&result.result).unwrap();
+        let bash_id = payload["bash_id"]
+            .as_str()
+            .expect("promoted result must have bash_id")
+            .to_string();
+        assert_eq!(payload["status"], "running");
+
+        let running = super::bash_runtime::running_shells_for_session(session_id);
+        assert!(
+            running.contains(&bash_id),
+            "adopted shell {bash_id} must appear in running_shells, got {running:?}"
+        );
+
+        let event = tokio::time::timeout(Duration::from_secs(15), rx.recv())
+            .await
+            .expect("timed out waiting for BashCompleted")
+            .expect("event channel closed before BashCompleted");
+        match event {
+            AgentEvent::BashCompleted {
+                bash_id: id,
+                exit_code,
+                status,
+                ..
+            } => {
+                assert_eq!(id, bash_id);
+                assert_eq!(exit_code, Some(0));
+                assert_eq!(status, "completed");
+            }
+            other => panic!("expected BashCompleted, got {other:?}"),
+        }
+
+        if let Some(shell) = super::bash_runtime::get_shell(&bash_id) {
+            let _ = shell.kill().await;
+        }
+    }
+
+    // (c) run_in_background:Some(false) does NOT promote — blocks/times out
+    // like the pre-2d foreground path.
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn force_sync_does_not_promote_and_times_out() {
+        prime_test_command_environment();
+        let tool = BashTool::new();
+
+        let result = tool
+            .execute(json!({
+                "command": "sleep 10",
+                "run_in_background": false,
+                "timeout": 50
+            }))
+            .await
+            .expect("force-sync should produce a timed-out result");
+
+        let payload: Value = serde_json::from_str(&result.result).unwrap();
+        assert!(
+            payload.get("bash_id").is_none(),
+            "force-sync must never promote"
+        );
+        assert_eq!(payload["timed_out"], true);
+        assert!(!result.success, "timed-out result must not be successful");
+    }
+
+    // (d) adopt_running_child preserves already-captured output: seed lines
+    // appear in subsequent read_output_since calls.
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn adopt_running_child_preserves_seeded_output() {
+        prime_test_command_environment();
+        let shell = bamboo_infrastructure::process::preferred_bash_shell();
+        let mut cmd = tokio::process::Command::new(&shell.program);
+        bamboo_infrastructure::process::hide_window_for_tokio_command(&mut cmd);
+        cmd.arg(shell.arg)
+            .arg("echo seeded-line-1; echo seeded-line-2; sleep 5")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+        let mut child = cmd.spawn().expect("spawn child");
+        let stdout_reader = tokio::io::BufReader::new(child.stdout.take().unwrap());
+        let stderr_reader = tokio::io::BufReader::new(child.stderr.take().unwrap());
+
+        // Let the echo output land in the pipe buffer before adoption.
+        sleep(Duration::from_millis(200)).await;
+
+        let session = super::bash_runtime::adopt_running_child(
+            child,
+            stdout_reader,
+            stderr_reader,
+            vec!["seeded-line-1".to_string(), "seeded-line-2".to_string()],
+            vec![],
+            "echo seeded-line-1; echo seeded-line-2; sleep 5",
+            Some("session_seed_test".to_string()),
+            test_environment_diagnostics(),
+            None,
+        )
+        .await
+        .expect("adopt should succeed");
+
+        let (lines, _cursor, _dropped) = session.read_output_since(0, None).await;
+        assert!(
+            lines.iter().any(|l| l.contains("seeded-line-1")),
+            "seeded line 1 must be present, got {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("seeded-line-2")),
+            "seeded line 2 must be present, got {lines:?}"
+        );
+
+        let _ = session.kill().await;
+        let _ = super::bash_runtime::remove_shell(&session.id);
     }
 }

--- a/crates/engine/bamboo-tools/src/tools/bash.rs
+++ b/crates/engine/bamboo-tools/src/tools/bash.rs
@@ -9,7 +9,6 @@ use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::time::{Duration, Instant};
@@ -25,21 +24,6 @@ const MAX_CAPTURE_BYTES: usize = 512 * 1024;
 /// milliseconds are promoted to background instead of continuing to block.
 /// Deliberately generous so virtually all interactive commands stay synchronous.
 const PROMOTE_TO_BACKGROUND_AFTER_MS: u64 = 10_000;
-
-/// Test override for the promotion threshold (issue #84, phase 2d). When > 0,
-/// tests use this value instead of `PROMOTE_TO_BACKGROUND_AFTER_MS` so promotion
-/// can be exercised without waiting 10 seconds. Always 0 in production builds.
-static PROMOTE_AFTER_MS_OVERRIDE: AtomicU64 = AtomicU64::new(0);
-
-/// The effective auto-sync promotion threshold, honoring the test override.
-fn promote_to_background_after_ms() -> u64 {
-    let val = PROMOTE_AFTER_MS_OVERRIDE.load(Ordering::Relaxed);
-    if val > 0 {
-        val
-    } else {
-        PROMOTE_TO_BACKGROUND_AFTER_MS
-    }
-}
 
 #[derive(Debug, Deserialize)]
 struct BashArgs {
@@ -92,6 +76,22 @@ impl BashTool {
             }
         }
         *truncated = true;
+    }
+
+    /// Append a line to a promotion-seed buffer, draining the oldest entries
+    /// when over the same budget the background registry enforces
+    /// (`bash_runtime::MAX_OUTPUT_LINES`). Keeps a chatty command from ballooning
+    /// memory during the ~10s promotion window (issue #84, phase 2d) — the
+    /// `stdout_buf`/`stderr_buf` capture is byte-capped, but the seed Vecs feed
+    /// the background buffer and must not grow unbounded. Mirrors `push_line`'s
+    /// drain-oldest semantics.
+    fn push_capped_seed_line(buf: &mut Vec<String>, line: String) {
+        buf.push(line);
+        let cap = bash_runtime::MAX_OUTPUT_LINES;
+        if buf.len() > cap {
+            let overflow = buf.len() - cap;
+            buf.drain(0..overflow);
+        }
     }
 
     fn python_diagnostics_json(
@@ -310,7 +310,7 @@ impl BashTool {
                             let line = decode_process_line_lossy(&mut stdout_line_bytes);
                             Self::append_capped(&mut stdout_buf, &line, &mut stdout_truncated);
                             if promote_after_ms.is_some() {
-                                stdout_lines.push(line.clone());
+                                Self::push_capped_seed_line(&mut stdout_lines, line.clone());
                             }
                             ctx.emit_tool_token(format!("{}\n", line)).await;
                         }
@@ -326,7 +326,7 @@ impl BashTool {
                             let line = decode_process_line_lossy(&mut stderr_line_bytes);
                             Self::append_capped(&mut stderr_buf, &line, &mut stderr_truncated);
                             if promote_after_ms.is_some() {
-                                stderr_lines.push(line.clone());
+                                Self::push_capped_seed_line(&mut stderr_lines, line.clone());
                             }
                             ctx.emit_tool_token(format!("{}\n", line)).await;
                         }
@@ -391,13 +391,13 @@ impl BashTool {
             if !stdout_line_bytes.is_empty() {
                 let partial = decode_process_line_lossy(&mut stdout_line_bytes);
                 if !partial.is_empty() {
-                    stdout_lines.push(partial);
+                    Self::push_capped_seed_line(&mut stdout_lines, partial);
                 }
             }
             if !stderr_line_bytes.is_empty() {
                 let partial = decode_process_line_lossy(&mut stderr_line_bytes);
                 if !partial.is_empty() {
-                    stderr_lines.push(partial);
+                    Self::push_capped_seed_line(&mut stderr_lines, partial);
                 }
             }
 
@@ -579,15 +579,18 @@ impl Tool for BashTool {
             None => {
                 // Auto-sync promotion (issue #84, phase 2d). Runs foreground but
                 // promotes to background if still running after the promotion
-                // threshold (~10s). Fast commands finish synchronously.
-                self.run_streaming_command(
-                    command,
-                    timeout_ms,
-                    Some(promote_to_background_after_ms()),
-                    &cwd,
-                    ctx,
-                )
-                .await
+                // threshold (~10s). Fast commands finish synchronously. Promotion
+                // is ONLY enabled when the executing loop can actually suspend
+                // for and self-resume a backgrounded shell (`can_async_resume`):
+                // on hook-less paths (schedule / external-child loops) it stays
+                // purely synchronous so a long command's output is never orphaned.
+                let promote_after_ms = if ctx.can_async_resume {
+                    Some(PROMOTE_TO_BACKGROUND_AFTER_MS)
+                } else {
+                    None
+                };
+                self.run_streaming_command(command, timeout_ms, promote_after_ms, &cwd, ctx)
+                    .await
             }
         }
     }
@@ -678,6 +681,7 @@ mod tests {
                     event_tx: Some(&tx),
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await
@@ -1004,6 +1008,7 @@ mod tests {
             &tx,
             &[],
             ToolExecutionSessionFlags::default(),
+            true,
         );
 
         let result = tool
@@ -1060,6 +1065,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await
@@ -1182,6 +1188,7 @@ mod tests {
             event_tx: Some(&tx),
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         let result = tool
@@ -1219,12 +1226,16 @@ mod tests {
             &tx,
             &[],
             ToolExecutionSessionFlags::default(),
+            // `can_async_resume` is irrelevant here — this test drives
+            // promotion directly via run_streaming_command(Some(200)).
+            true,
         );
         let cwd = super::workspace_state::workspace_or_process_cwd(Some(session_id));
 
         // Call run_streaming_command directly with a 200ms promotion threshold
-        // so we don't touch the process-global PROMOTE_AFTER_MS_OVERRIDE (which
-        // would race with other auto-path tests running in parallel).
+        // so this test exercises promotion deterministically without depending
+        // on the production 10s default or the None dispatch arm's
+        // `can_async_resume` gating.
         let result = tool
             .run_streaming_command("sleep 10", 60000, Some(200), &cwd, ctx)
             .await
@@ -1291,6 +1302,39 @@ mod tests {
         );
         assert_eq!(payload["timed_out"], true);
         assert!(!result.success, "timed-out result must not be successful");
+    }
+
+    // (e) Auto path (run_in_background OMITTED) with can_async_resume == false
+    // also does NOT promote — it runs purely synchronously, exactly like (c),
+    // even though promotion is now the default. This is the hook-less-path guard
+    // (issue #84, phase 2d): a loop that can't suspend+resume a background shell
+    // (schedule path, agent-core loop) must never orphan one via auto-promotion.
+    // `execute()` builds `ToolExecutionContext::none`, whose can_async_resume is
+    // false, so the None dispatch arm passes promote_after_ms = None.
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn auto_path_does_not_promote_when_not_resume_capable() {
+        prime_test_command_environment();
+        let tool = BashTool::new();
+
+        let result = tool
+            .execute(json!({
+                "command": "sleep 10",
+                "timeout": 50
+            }))
+            .await
+            .expect("non-resume-capable auto path should produce a result");
+
+        let payload: Value = serde_json::from_str(&result.result).unwrap();
+        assert!(
+            payload.get("bash_id").is_none(),
+            "auto path must not promote when can_async_resume is false"
+        );
+        assert_eq!(payload["timed_out"], true);
+        assert!(
+            !result.success,
+            "a timed-out command must not report success"
+        );
     }
 
     // (d) adopt_running_child preserves already-captured output: seed lines

--- a/crates/engine/bamboo-tools/src/tools/bash_runtime.rs
+++ b/crates/engine/bamboo-tools/src/tools/bash_runtime.rs
@@ -17,7 +17,10 @@ use tokio::sync::Mutex;
 use tokio::time::{sleep, timeout, Duration};
 use tracing::warn;
 
-const MAX_OUTPUT_LINES: usize = 20_000;
+/// Per-stream line cap for a background shell's captured output, AND for the
+/// foreground promotion-seed buffers (`bash.rs`). Shared so a chatty command
+/// can't balloon memory before it promotes (issue #84, phase 2d).
+pub(crate) const MAX_OUTPUT_LINES: usize = 20_000;
 const COMPLETED_SESSION_TTL_SECS: u64 = 300;
 
 #[derive(Debug)]

--- a/crates/engine/bamboo-tools/src/tools/bash_runtime.rs
+++ b/crates/engine/bamboo-tools/src/tools/bash_runtime.rs
@@ -9,7 +9,8 @@ use std::path::Path;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::AsyncBufReadExt;
+use tokio::io::BufReader;
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
@@ -202,78 +203,170 @@ pub async fn spawn_background(
         });
     }
 
-    {
-        let child = session.child.clone();
-        let session_id_for_gc = shell_id.clone();
-        // Owned copies for the completion signal (issue #84, phase 1).
-        let bash_id_for_event = shell_id.clone();
-        let command_for_event = command.to_string();
-        tokio::spawn(async move {
-            // Determine the terminal status/exit_code, then break out to emit
-            // the completion signal below.
-            let (status_str, exit_code_value) = loop {
-                let poll = {
-                    let mut guard = child.lock().await;
-                    guard.try_wait()
-                };
-                match poll {
-                    Ok(Some(status)) => {
-                        let code = status.code();
-                        *exit_code.lock().await = code;
-                        running.store(false, Ordering::Relaxed);
-                        // A signal/kill/timeout termination yields no numeric
-                        // exit code on Unix — surface that as "killed" rather
-                        // than masking it behind "completed" (issue #84).
-                        break (
-                            if code.is_none() {
-                                "killed"
-                            } else {
-                                "completed"
-                            },
-                            code,
-                        );
-                    }
-                    Ok(None) => {
-                        sleep(Duration::from_millis(100)).await;
-                    }
-                    Err(_) => {
-                        running.store(false, Ordering::Relaxed);
-                        break ("error", None);
-                    }
-                }
-            };
+    spawn_completion_poll(
+        session.child.clone(),
+        shell_id.clone(),
+        command.to_string(),
+        running,
+        exit_code,
+        event_tx,
+    );
 
-            // Phase 1 (issue #84): emit a completion signal so clients can react
-            // to a long-running background command finishing. This is the ONLY
-            // chance to deliver the signal — the poll task emits exactly once,
-            // then sleeps the GC TTL and removes the shell. A non-blocking
-            // `try_send` would silently drop it under a saturated event channel,
-            // so we bound the await instead: wait up to 500ms for room (the emit
-            // runs before the GC sleep, so a short wait never stalls collection),
-            // and fall back to a visible `warn!` if the channel stays full or is
-            // closed. A dropped signal is therefore rare AND observable.
-            if let Some(tx) = &event_tx {
-                let event = AgentEvent::BashCompleted {
-                    bash_id: bash_id_for_event,
-                    command: command_for_event,
-                    exit_code: exit_code_value,
-                    status: status_str.to_string(),
-                };
-                if timeout(Duration::from_millis(500), tx.send(event))
-                    .await
-                    .is_err()
-                {
-                    warn!(
-                        bash_id = %session_id_for_gc,
-                        "BashCompleted signal dropped (event channel saturated or closed after 500ms)"
+    sessions().insert(shell_id, session.clone());
+    Ok(session)
+}
+
+/// Shared completion-poll task. Polls the child until it exits, then sets the
+/// exit code/running flags, emits a `BashCompleted` event (when a sender is
+/// wired), and GCs the shell from the registry after the TTL. Used by both
+/// [`spawn_background`] and [`adopt_running_child`] so the poll/emit logic is
+/// never duplicated (issue #84, phase 2d).
+fn spawn_completion_poll(
+    child: Arc<Mutex<Child>>,
+    shell_id: String,
+    command: String,
+    running: Arc<AtomicBool>,
+    exit_code: Arc<Mutex<Option<i32>>>,
+    event_tx: Option<mpsc::Sender<AgentEvent>>,
+) {
+    let session_id_for_gc = shell_id.clone();
+    let bash_id_for_event = shell_id;
+    let command_for_event = command;
+    tokio::spawn(async move {
+        let (status_str, exit_code_value) = loop {
+            let poll = {
+                let mut guard = child.lock().await;
+                guard.try_wait()
+            };
+            match poll {
+                Ok(Some(status)) => {
+                    let code = status.code();
+                    *exit_code.lock().await = code;
+                    running.store(false, Ordering::Relaxed);
+                    break (
+                        if code.is_none() {
+                            "killed"
+                        } else {
+                            "completed"
+                        },
+                        code,
                     );
                 }
+                Ok(None) => {
+                    sleep(Duration::from_millis(100)).await;
+                }
+                Err(_) => {
+                    running.store(false, Ordering::Relaxed);
+                    break ("error", None);
+                }
             }
+        };
 
-            sleep(Duration::from_secs(COMPLETED_SESSION_TTL_SECS)).await;
-            let _ = remove_shell(&session_id_for_gc);
+        // Phase 1 (issue #84): emit a completion signal so clients can react
+        // to a long-running background command finishing. This is the ONLY
+        // chance to deliver the signal — the poll task emits exactly once,
+        // then sleeps the GC TTL and removes the shell. A non-blocking
+        // `try_send` would silently drop it under a saturated event channel,
+        // so we bound the await instead (500ms) and fall back to a visible
+        // `warn!` if the channel stays full or closed.
+        if let Some(tx) = &event_tx {
+            let event = AgentEvent::BashCompleted {
+                bash_id: bash_id_for_event,
+                command: command_for_event,
+                exit_code: exit_code_value,
+                status: status_str.to_string(),
+            };
+            if timeout(Duration::from_millis(500), tx.send(event))
+                .await
+                .is_err()
+            {
+                warn!(
+                    bash_id = %session_id_for_gc,
+                    "BashCompleted signal dropped (event channel saturated or closed after 500ms)"
+                );
+            }
+        }
+
+        sleep(Duration::from_secs(COMPLETED_SESSION_TTL_SECS)).await;
+        let _ = remove_shell(&session_id_for_gc);
+    });
+}
+
+/// Adopt a child process that was spawned and partially drained by the
+/// foreground streaming loop (auto-sync promotion, issue #84 phase 2d).
+///
+/// Builds a [`ShellSession`] seeded with the already-captured output lines so
+/// they survive the hand-off and appear in subsequent `read_output_since`
+/// calls, then spawns the same pump + completion-poll tasks as
+/// [`spawn_background`] to keep draining the handed-over readers and eventually
+/// emit `BashCompleted`. The poll/emit logic is shared via
+/// [`spawn_completion_poll`] — it is never duplicated between the two entry
+/// points.
+#[allow(clippy::too_many_arguments)]
+pub async fn adopt_running_child(
+    child: Child,
+    stdout_reader: impl tokio::io::AsyncRead + Unpin + Send + 'static,
+    stderr_reader: impl tokio::io::AsyncRead + Unpin + Send + 'static,
+    seeded_stdout_lines: Vec<String>,
+    seeded_stderr_lines: Vec<String>,
+    command: &str,
+    session_id: Option<String>,
+    environment: CommandEnvironmentDiagnostics,
+    event_tx: Option<mpsc::Sender<AgentEvent>>,
+) -> Result<Arc<ShellSession>, String> {
+    let shell_id = uuid::Uuid::new_v4().to_string();
+    let output = Arc::new(Mutex::new(Vec::new()));
+    let base_index = Arc::new(Mutex::new(0usize));
+    let running = Arc::new(AtomicBool::new(true));
+    let exit_code = Arc::new(Mutex::new(None));
+
+    // Seed the output buffer with already-captured lines so they are not lost
+    // across the foreground→background hand-off. Lines captured by the
+    // foreground phase are pushed here; the pump tasks below will append any
+    // subsequent output produced after promotion.
+    for line in seeded_stdout_lines.iter().chain(seeded_stderr_lines.iter()) {
+        push_line(&output, &base_index, line.clone()).await;
+    }
+
+    let session = Arc::new(ShellSession {
+        id: shell_id.clone(),
+        command: command.to_string(),
+        session_id,
+        environment,
+        child: Arc::new(Mutex::new(child)),
+        output: output.clone(),
+        base_index: base_index.clone(),
+        running: running.clone(),
+        exit_code: exit_code.clone(),
+    });
+
+    // Spawn pump tasks to continue draining the handed-over readers. The
+    // readers may still hold buffered data from the foreground phase — wrapping
+    // them in a new BufReader (as pump_stream_lines does) reads through that
+    // buffer first, so no data is lost or double-counted.
+    {
+        let output = output.clone();
+        let base_index = base_index.clone();
+        tokio::spawn(async move {
+            pump_stream_lines("stdout", stdout_reader, output, base_index).await;
         });
     }
+    {
+        let output = output.clone();
+        let base_index = base_index.clone();
+        tokio::spawn(async move {
+            pump_stream_lines("stderr", stderr_reader, output, base_index).await;
+        });
+    }
+
+    spawn_completion_poll(
+        session.child.clone(),
+        shell_id.clone(),
+        command.to_string(),
+        running,
+        exit_code,
+        event_tx,
+    );
 
     sessions().insert(shell_id, session.clone());
     Ok(session)

--- a/crates/engine/bamboo-tools/src/tools/edit.rs
+++ b/crates/engine/bamboo-tools/src/tools/edit.rs
@@ -835,6 +835,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await;
@@ -849,6 +850,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await
@@ -867,6 +869,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await
@@ -1220,6 +1223,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await
@@ -1239,6 +1243,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/memory_note.rs
+++ b/crates/engine/bamboo-tools/src/tools/memory_note.rs
@@ -190,6 +190,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await;
@@ -207,6 +208,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await;
@@ -230,6 +232,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await
@@ -247,6 +250,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await
@@ -266,6 +270,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await
@@ -283,6 +288,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await
@@ -306,6 +312,7 @@ mod tests {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -320,6 +327,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await
@@ -336,6 +344,7 @@ mod tests {
                 event_tx: None,
                 available_tool_schemas: None,
                 bypass_permissions: false,
+                can_async_resume: false,
             },
         )
         .await
@@ -350,6 +359,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/read.rs
+++ b/crates/engine/bamboo-tools/src/tools/read.rs
@@ -300,6 +300,7 @@ mod tests {
             event_tx: None,
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         };
 
         let read_tool = ReadTool::new();

--- a/crates/engine/bamboo-tools/src/tools/slash_command_tool.rs
+++ b/crates/engine/bamboo-tools/src/tools/slash_command_tool.rs
@@ -147,6 +147,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/workspace.rs
+++ b/crates/engine/bamboo-tools/src/tools/workspace.rs
@@ -199,6 +199,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await
@@ -227,6 +228,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await
@@ -243,6 +245,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await
@@ -267,6 +270,7 @@ mod tests {
                     event_tx: None,
                     available_tool_schemas: None,
                     bypass_permissions: false,
+                    can_async_resume: false,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/write.rs
+++ b/crates/engine/bamboo-tools/src/tools/write.rs
@@ -135,6 +135,7 @@ mod tests {
             event_tx: None,
             available_tool_schemas: None,
             bypass_permissions: false,
+            can_async_resume: false,
         }
     }
 

--- a/tests/deploy_agent_tool_e2e.rs
+++ b/tests/deploy_agent_tool_e2e.rs
@@ -24,6 +24,7 @@ fn ctx() -> ToolExecutionContext<'static> {
         event_tx: None,
         available_tool_schemas: None,
         bypass_permissions: false,
+        can_async_resume: false,
     }
 }
 

--- a/tests/schedule_tasks_tool.rs
+++ b/tests/schedule_tasks_tool.rs
@@ -96,6 +96,7 @@ fn ctx_for_session<'a>(session_id: &'a str) -> ToolExecutionContext<'a> {
         event_tx: None,
         available_tool_schemas: None,
         bypass_permissions: false,
+        can_async_resume: false,
     }
 }
 

--- a/tests/session_inspector_tool.rs
+++ b/tests/session_inspector_tool.rs
@@ -19,6 +19,7 @@ fn ctx_for_session<'a>(session_id: &'a str) -> ToolExecutionContext<'a> {
         event_tx: None,
         available_tool_schemas: None,
         bypass_permissions: false,
+        can_async_resume: false,
     }
 }
 


### PR DESCRIPTION
## Phase 2d of #84 — async-by-default Bash (the flip)

Completes #84. Bash now runs **synchronously by default but auto-promotes to background** if a command is still running after ~10s — fast commands behave exactly as before (zero regression), only genuinely long commands go async and engage the Phase 2b suspend/resume.

### Contract (`run_in_background`)
| value | behavior |
|---|---|
| `Some(true)` | immediate background (unchanged) |
| `Some(false)` | pure synchronous, no promotion (explicit override) |
| `None` (new default) | auto-sync: foreground, promote to background after ~10s **only if the loop can suspend+resume** |

### How it works
- `run_foreground` -> `run_streaming_command(promote_after_ms)`. `effective_deadline = min(promote, timeout)`. Three post-loop branches: completed -> identical sync result; promotion fired -> flush partial bytes + `adopt_running_child` (hand the live child + readers + seeded output to the registry, continue pumping, return `{bash_id, running}`); else timeout-kill.
- Shared `spawn_completion_poll` (used by `spawn_background` + `adopt_running_child`).
- **Resume-capability gate**: `ToolExecutionContext.can_async_resume` (= `bash_resume_hook` + persistence wired). Hook-less paths (schedule/external-child) stay **purely synchronous** — never orphan a promoted shell.
- Seed buffers capped at `MAX_OUTPUT_LINES`.

### Reviewed (adversarial, by bamboo)
Review confirmed the fast path is **byte-identical** and the handoff has **no loss/dup** even at the straddling-line boundary, child ownership is safe, and `spawn_completion_poll` is behaviorally identical (2a/2b intact). It caught a real regression — the async flip would orphan 10-120s commands on the `bash_resume_hook=None` schedule path — now closed via `can_async_resume` (new test proves it).

### Verification
`cargo check --workspace --tests` ✅ · bamboo-tools 297, engine 848, server 853 (0 failures, --lib) ✅ · fmt + clippy clean. 18 pre-existing bash tests unchanged + 5 new.

### Provenance
Implemented + adversarially reviewed by the bamboo headless agent; verified + built/tested by hand.

Closes #84

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp