### PR TITLE
fix(bamboo-server): block path traversal in command handler workflow id (#34)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/command/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/command/handlers.rs
@@ -2,6 +2,7 @@ use actix_web::{web, HttpResponse};
 
 use crate::app_state::AppState;
 use crate::error::AppError;
+use crate::handlers::settings::is_safe_workflow_name;
 
 use super::sources::{list_mcp_tools_as_commands, list_workflows_as_commands, skill_to_command};
 use super::types::CommandListResponse;
@@ -48,6 +49,10 @@ pub async fn get_command(
 
     match command_type.as_str() {
         "workflow" => {
+            if !is_safe_workflow_name(&id) {
+                return Err(AppError::BadRequest("Invalid workflow name".to_string()));
+            }
+
             let workflows_dir = app_state.app_data_dir.join("workflows");
             let filename = format!("{id}.md");
             let filepath = workflows_dir.join(&filename);

--- a/crates/app/bamboo-server/src/handlers/command/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/command/tests.rs
@@ -1,3 +1,4 @@
+use actix_web::{http::StatusCode, web};
 use bamboo_skills::types::SkillDefinition;
 
 use super::sources::skill_to_command;
@@ -12,4 +13,35 @@ fn skill_to_command_maps_core_fields() {
     assert_eq!(command.name, "sample");
     assert_eq!(command.display_name, "Sample");
     assert_eq!(command.command_type, "skill");
+}
+
+#[actix_web::test]
+async fn get_command_rejects_path_traversal_in_workflow_id() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    std::fs::create_dir_all(temp.path().join("workflows")).expect("create workflows dir");
+    // Secret file one level above the workflows dir. Without name validation,
+    // `GET /commands/workflow/..%2Fsecret` resolves to this file and leaks it.
+    std::fs::write(temp.path().join("secret.md"), "TOPSECRET")
+        .expect("write secret file outside workflows dir");
+
+    let app_state = web::Data::new(
+        crate::app_state::AppState::new(temp.path().to_path_buf())
+            .await
+            .expect("app state should initialize"),
+    );
+    let app = actix_web::test::init_service(
+        actix_web::App::new()
+            .app_data(app_state)
+            .configure(super::config),
+    )
+    .await;
+
+    // Percent-encoded `..` keeps the payload within a single path segment so it
+    // binds to the `{id}` route param instead of adding extra segments.
+    let req = actix_web::test::TestRequest::get()
+        .uri("/commands/workflow/..%2Fsecret")
+        .to_request();
+    let resp = actix_web::test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }

--- a/crates/app/bamboo-server/src/handlers/settings/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/mod.rs
@@ -38,6 +38,7 @@ pub use provider_instances::{
 };
 pub use redaction::{redact_config_for_api, redact_providers_for_api};
 pub use setup::{get_setup_status, mark_setup_complete, mark_setup_incomplete};
+pub(crate) use workflows::is_safe_workflow_name;
 pub use workflows::{
     delete_workflow, get_workflow, list_workflows, save_workflow, SaveWorkflowRequest,
 };

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/mod.rs
@@ -6,3 +6,5 @@ mod validation;
 
 pub use handlers::{delete_workflow, get_workflow, list_workflows, save_workflow};
 pub use types::SaveWorkflowRequest;
+
+pub(crate) use validation::is_safe_workflow_name;

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/validation.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/validation.rs
@@ -1,5 +1,5 @@
 /// Validates workflow names for security (prevents path traversal, etc.).
-pub(super) fn is_safe_workflow_name(name: &str) -> bool {
+pub(crate) fn is_safe_workflow_name(name: &str) -> bool {
     // Check basic constraints.
     if name.is_empty() || name.len() > 255 {
         return false;


### PR DESCRIPTION
Closes #34 — GET /v1/commands/workflow/{id} joined the URL `id` to the workflows dir with no sanitization, so `..%2F..%2Fconfig` could read arbitrary .md files outside it. Every other workflow handler already validates first; this one did not.

- Apply the existing `is_safe_workflow_name(&id)` before path construction → 400 on reject.
- Widened the helper `pub(super)`→`pub(crate)` + re-exported through settings/workflows (no duplication).
- HTTP regression test: `GET /commands/workflow/..%2Fsecret` → 400 (200/leak without the fix).

Reviewed by bamboo (security-focused). Verified: cargo test -p bamboo-server --lib command (12) green; fmt + clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp