### PR TITLE
fix(bamboo-llm): surface mid-stream SSE error events for OpenAI/Copilot/Bodhi (#26)

### DIFF
--- a/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 use super::tool_schema::sanitize_openai_function_parameters_schema;
-use crate::provider::Result;
+use crate::provider::{LLMError, Result};
 use crate::types::LLMChunk;
 use bamboo_domain::ReasoningEffort;
 
@@ -219,30 +219,76 @@ pub fn parse_openai_compat_chunk(chunk: OpenAICompatStreamChunk) -> LLMChunk {
     LLMChunk::Token(String::new())
 }
 
+/// Surface a mid-stream OpenAI-compatible `"error"` event as an [`LLMError::Api`].
+///
+/// OpenAI-compatible providers (OpenAI, GitHub Copilot, Bodhi) deliver
+/// rate-limit / server / content-filter errors as ordinary SSE `data:` JSON
+/// carrying a top-level `"error"` field, e.g.
+/// `{"error":{"message":"rate limit exceeded","type":"rate_limit_error"}}`.
+/// If the error object has a human-readable `"message"` string we surface it
+/// directly; otherwise we fall back to the JSON form of the whole error
+/// object so no detail is lost. Mirrors the error-event handling already used
+/// by the Gemini (`gemini/stream.rs`) and Anthropic (`anthropic/mod.rs`)
+/// parsers.
+fn openai_compat_error_to_llm_error(error: &Value) -> LLMError {
+    let message = error
+        .get("message")
+        .and_then(|m| m.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| error.to_string());
+    LLMError::Api(message)
+}
+
 /// Parse an SSE `data:` payload in strict mode (OpenAI behavior).
 ///
 /// - `"[DONE]"` -> `LLMChunk::Done`
+/// - A JSON object with a top-level `"error"` field -> `Err(LLMError::Api(..))`
+///   (rate limits, server errors, content-filter triggers, etc. — these arrive
+///   as regular `data:` JSON and would otherwise be swallowed as an empty
+///   token). See issue #26.
 /// - Invalid JSON -> error
 pub fn parse_openai_compat_sse_data_strict(data: &str) -> Result<LLMChunk> {
     if data.trim() == "[DONE]" {
         return Ok(LLMChunk::Done);
     }
 
-    let chunk: OpenAICompatStreamChunk = serde_json::from_str(data)?;
+    // Parse into a generic JSON value first so we can detect mid-stream error
+    // events (which otherwise deserialize as a chunk with empty `choices` and
+    // silently swallow the provider's error) before deserializing the stream
+    // chunk type. See issue #26.
+    let value: Value = serde_json::from_str(data)?;
+    if let Some(error) = value.get("error") {
+        return Err(openai_compat_error_to_llm_error(error));
+    }
+    let chunk: OpenAICompatStreamChunk = serde_json::from_value(value)?;
     Ok(parse_openai_compat_chunk(chunk))
 }
 
 /// Parse an SSE `data:` payload in lenient mode (Copilot behavior).
 ///
 /// - `"[DONE]"` -> `LLMChunk::Done`
-/// - Invalid JSON -> `LLMChunk::Token(\"\")`
+/// - A JSON object with a top-level `"error"` field -> `Err(LLMError::Api(..))`
+///   (surfaced even in lenient mode so provider errors are never silently
+///   swallowed as empty tokens). See issue #26.
+/// - Invalid JSON -> `LLMChunk::Token("")`
 pub fn parse_openai_compat_sse_data_lenient(data: &str) -> Result<LLMChunk> {
     if data.trim() == "[DONE]" {
         return Ok(LLMChunk::Done);
     }
 
-    match serde_json::from_str::<OpenAICompatStreamChunk>(data) {
-        Ok(chunk) => Ok(parse_openai_compat_chunk(chunk)),
+    match serde_json::from_str::<Value>(data) {
+        Ok(value) => {
+            // Surface mid-stream API errors even in lenient mode; only
+            // structurally-unexpected (or unparseable) payloads degrade to an
+            // empty token.
+            if let Some(error) = value.get("error") {
+                return Err(openai_compat_error_to_llm_error(error));
+            }
+            match serde_json::from_value::<OpenAICompatStreamChunk>(value) {
+                Ok(chunk) => Ok(parse_openai_compat_chunk(chunk)),
+                Err(_) => Ok(LLMChunk::Token(String::new())),
+            }
+        }
         Err(_) => Ok(LLMChunk::Token(String::new())),
     }
 }
@@ -548,6 +594,91 @@ mod tests {
     fn parse_openai_compat_sse_data_lenient_valid_json_works() {
         let data = r#"{"id":"chatcmpl_1","choices":[{"delta":{"content":"Hello"}}]}"#;
         let chunk = super::parse_openai_compat_sse_data_lenient(data).unwrap();
+        match chunk {
+            LLMChunk::Token(token) => assert_eq!(token, "Hello"),
+            other => panic!("expected LLMChunk::Token, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_openai_compat_sse_data_strict_error_event_yields_api_error() {
+        // Issue #26: a mid-stream error event arrives as ordinary `data:` JSON
+        // with a top-level "error" field and must NOT be swallowed as an empty
+        // token.
+        let data = r#"{"error":{"message":"rate limit exceeded","type":"rate_limit_error"}}"#;
+
+        let result = super::parse_openai_compat_sse_data_strict(data);
+        assert!(result.is_err(), "expected an error for an error event");
+        match result.unwrap_err() {
+            crate::provider::LLMError::Api(msg) => {
+                assert!(
+                    msg.contains("rate limit exceeded"),
+                    "error message should surface the provider message, got: {msg}"
+                );
+            }
+            other => panic!("expected LLMError::Api, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_openai_compat_sse_data_lenient_error_event_yields_api_error() {
+        // Even lenient mode (Copilot) must surface mid-stream API errors
+        // instead of silently swallowing them as empty tokens. See issue #26.
+        let data = r#"{"error":{"message":"rate limit exceeded","type":"rate_limit_error"}}"#;
+
+        let result = super::parse_openai_compat_sse_data_lenient(data);
+        assert!(result.is_err(), "expected an error for an error event");
+        match result.unwrap_err() {
+            crate::provider::LLMError::Api(msg) => {
+                assert!(
+                    msg.contains("rate limit exceeded"),
+                    "error message should surface the provider message, got: {msg}"
+                );
+            }
+            other => panic!("expected LLMError::Api, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_openai_compat_sse_data_strict_error_event_without_message_falls_back_to_object() {
+        // No "message" field -> fall back to stringifying the whole error object.
+        let data = r#"{"error":{"type":"server_error","code":503}}"#;
+
+        let result = super::parse_openai_compat_sse_data_strict(data);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            crate::provider::LLMError::Api(msg) => {
+                assert!(
+                    msg.contains("server_error"),
+                    "fallback should carry the error object, got: {msg}"
+                );
+            }
+            other => panic!("expected LLMError::Api, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_openai_compat_sse_data_strict_string_error_surfaces_value() {
+        // Some providers send "error" as a plain string rather than an object.
+        let data = r#"{"error":"quota exceeded"}"#;
+
+        let result = super::parse_openai_compat_sse_data_strict(data);
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            crate::provider::LLMError::Api(msg) => {
+                assert!(msg.contains("quota exceeded"), "got: {msg}");
+            }
+            other => panic!("expected LLMError::Api, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_openai_compat_sse_data_strict_normal_chunk_unchanged_after_error_check() {
+        // Happy path regression: a normal content delta still yields a Token,
+        // unaffected by the new error-field check.
+        let data = r#"{"id":"chatcmpl_1","choices":[{"delta":{"content":"Hello"}}]}"#;
+
+        let chunk = super::parse_openai_compat_sse_data_strict(data).unwrap();
         match chunk {
             LLMChunk::Token(token) => assert_eq!(token, "Hello"),
             other => panic!("expected LLMChunk::Token, got {other:?}"),

--- a/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
@@ -239,6 +239,23 @@ fn openai_compat_error_to_llm_error(error: &Value) -> LLMError {
     LLMError::Api(message)
 }
 
+/// Whether a top-level SSE `"error"` field actually represents an error.
+///
+/// Several OpenAI-compatible gateways (LiteLLM, OneAPI/New-API, some Azure
+/// proxies) emit `{"error": null}` (or `""`/`{}`) as a *no-error* marker on an
+/// otherwise-normal chunk. `serde_json`'s `get("error")` returns `Some(Null)`
+/// for an explicit null, so without this guard such a benign marker would abort
+/// a valid stream (issue #26). Only a non-null, non-empty value is a real error.
+fn sse_error_is_present(error: &Value) -> bool {
+    match error {
+        Value::Null => false,
+        Value::String(s) => !s.trim().is_empty(),
+        Value::Object(map) => !map.is_empty(),
+        Value::Array(items) => !items.is_empty(),
+        _ => true,
+    }
+}
+
 /// Parse an SSE `data:` payload in strict mode (OpenAI behavior).
 ///
 /// - `"[DONE]"` -> `LLMChunk::Done`
@@ -257,7 +274,7 @@ pub fn parse_openai_compat_sse_data_strict(data: &str) -> Result<LLMChunk> {
     // silently swallow the provider's error) before deserializing the stream
     // chunk type. See issue #26.
     let value: Value = serde_json::from_str(data)?;
-    if let Some(error) = value.get("error") {
+    if let Some(error) = value.get("error").filter(|e| sse_error_is_present(e)) {
         return Err(openai_compat_error_to_llm_error(error));
     }
     let chunk: OpenAICompatStreamChunk = serde_json::from_value(value)?;
@@ -281,7 +298,7 @@ pub fn parse_openai_compat_sse_data_lenient(data: &str) -> Result<LLMChunk> {
             // Surface mid-stream API errors even in lenient mode; only
             // structurally-unexpected (or unparseable) payloads degrade to an
             // empty token.
-            if let Some(error) = value.get("error") {
+            if let Some(error) = value.get("error").filter(|e| sse_error_is_present(e)) {
                 return Err(openai_compat_error_to_llm_error(error));
             }
             match serde_json::from_value::<OpenAICompatStreamChunk>(value) {
@@ -682,6 +699,43 @@ mod tests {
         match chunk {
             LLMChunk::Token(token) => assert_eq!(token, "Hello"),
             other => panic!("expected LLMChunk::Token, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn null_or_empty_error_field_does_not_abort() {
+        // Several OpenAI-compatible gateways emit `{"error": null}` (or empty
+        // string/object/array) as a *no-error* marker. `serde_json::get` returns
+        // Some(Null) for an explicit null, so these must NOT be treated as errors
+        // (issue #26): they must continue the stream, not abort it.
+        for data in [
+            r#"{"error":null}"#,
+            r#"{"error":""}"#,
+            r#"{"error":{}}"#,
+            r#"{"error":[]}"#,
+            r#"{"error":null,"choices":[{"delta":{"content":"Hi"}}]}"#,
+        ] {
+            // strict: must not return Err(LLMError::Api)
+            let strict = super::parse_openai_compat_sse_data_strict(data);
+            assert!(
+                !matches!(strict, Err(crate::provider::LLMError::Api(_))),
+                "strict wrongly aborted on benign error marker: {data} -> {strict:?}"
+            );
+            // lenient: contract is "never abort"
+            let lenient = super::parse_openai_compat_sse_data_lenient(data);
+            assert!(
+                !matches!(lenient, Err(crate::provider::LLMError::Api(_))),
+                "lenient wrongly aborted on benign error marker: {data} -> {lenient:?}"
+            );
+        }
+        // And the content alongside a null error still surfaces.
+        match super::parse_openai_compat_sse_data_strict(
+            r#"{"error":null,"choices":[{"delta":{"content":"Hi"}}]}"#,
+        )
+        .unwrap()
+        {
+            LLMChunk::Token(token) => assert_eq!(token, "Hi"),
+            other => panic!("expected Token(\"Hi\"), got {other:?}"),
         }
     }
 


### PR DESCRIPTION
Closes #26 — the OpenAI-compat SSE parsers deserialized an error event as a stream chunk, so a mid-stream `{\"error\":...}` from OpenAI/Copilot/Bodhi became an empty chunk and the provider error (rate limit / server error / content filter) was silently swallowed.

- strict + lenient parsers now check a top-level `\"error\"` field before chunk deserialization → `Err(LLMError::Api)` (prefers error.message, else stringifies; handles bare-string error). Happy path unchanged. Shared parser → covers all 3 providers.
- 5 new tests incl. happy-path regression.

Verified: cargo test -p bamboo-llm (419) green; fmt + clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp