### PR TITLE
fix(bamboo-engine,bamboo-llm): inter-chunk idle timeout for stalled LLM streams (#28)

### DIFF
--- a/crates/core/bamboo-agent-core/src/agent/error.rs
+++ b/crates/core/bamboo-agent-core/src/agent/error.rs
@@ -20,6 +20,14 @@ pub enum AgentError {
     #[error("LLM overflow: {0}")]
     LLMOverflow(String),
 
+    /// The provider's stream stalled mid-response: no chunk was received within
+    /// the inter-chunk idle deadline (issue #28). This indicates a hung
+    /// connection rather than a slow-but-healthy stream — the consume loop
+    /// resets the deadline on every received chunk, so a legitimately long
+    /// stream that keeps producing data never trips it.
+    #[error("Stream timed out: {0}")]
+    StreamTimeout(String),
+
     /// Error during tool execution
     #[error("Tool error: {0}")]
     Tool(String),

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -8,6 +10,22 @@ use bamboo_llm::LLMStream;
 mod chunk_handling;
 mod consume;
 mod stream_state;
+
+/// Default *inter-chunk* idle timeout for LLM streams (issue #28).
+///
+/// A provider connection that stops sending chunks for longer than this is
+/// treated as a hung stream. Because the deadline resets on every received
+/// chunk (see [`consume::consume_llm_stream_internal`]), a legitimately long
+/// stream that keeps producing data — e.g. a thinking model that streams for
+/// minutes — is never affected; only a true stall (no chunk at all) trips it.
+///
+/// This is a well-named const default rather than a threaded config field: the
+/// consume function is shared across the main stream path and several
+/// auxiliary (silent) callers, and wiring a new field through `AgentLoopConfig`
+/// plus every call site is invasive for a streaming hot path. The internal
+/// function still accepts an `idle_timeout` override so it remains configurable
+/// and testable; full config wiring is deferred.
+const DEFAULT_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
 
 pub struct StreamHandlingOutput {
     pub response_id: Option<String>,
@@ -28,7 +46,14 @@ pub async fn consume_llm_stream(
     cancel_token: &CancellationToken,
     session_id: &str,
 ) -> Result<StreamHandlingOutput, AgentError> {
-    consume::consume_llm_stream_internal(stream, Some(event_tx), cancel_token, session_id).await
+    consume::consume_llm_stream_internal(
+        stream,
+        Some(event_tx),
+        cancel_token,
+        session_id,
+        DEFAULT_STREAM_IDLE_TIMEOUT,
+    )
+    .await
 }
 
 pub async fn consume_llm_stream_silent(
@@ -36,7 +61,14 @@ pub async fn consume_llm_stream_silent(
     cancel_token: &CancellationToken,
     session_id: &str,
 ) -> Result<StreamHandlingOutput, AgentError> {
-    consume::consume_llm_stream_internal(stream, None, cancel_token, session_id).await
+    consume::consume_llm_stream_internal(
+        stream,
+        None,
+        cancel_token,
+        session_id,
+        DEFAULT_STREAM_IDLE_TIMEOUT,
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/consume.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/consume.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use futures::StreamExt;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -29,16 +31,30 @@ pub(super) async fn consume_llm_stream_internal(
     event_tx: Option<&mpsc::Sender<AgentEvent>>,
     cancel_token: &CancellationToken,
     session_id: &str,
+    // Inter-chunk idle deadline: the maximum gap allowed between two
+    // consecutive stream chunks. The sleep is created fresh every loop
+    // iteration, so this is a true *inter-chunk* deadline that resets on
+    // every received chunk — NOT an overall stream cap. A legitimately long
+    // stream that keeps producing chunks is never killed; only a stall with
+    // no chunk for `idle_timeout` trips it (issue #28).
+    idle_timeout: Duration,
 ) -> Result<StreamHandlingOutput, AgentError> {
     let mut state = StreamAccumulationState::new();
 
     loop {
-        // Select on cancellation *and* the next chunk so a stalled or
-        // non-terminating provider stream is interruptible the instant the
-        // token is cancelled — `stream.next().await` alone blocks forever and
-        // the previous between-chunks `is_cancelled()` poll never ran. `biased`
-        // checks cancellation first so a ready-but-cancelled chunk is dropped,
-        // preserving the prior "return Cancelled without handling" semantics.
+        // Select on cancellation, the next chunk, *and* an inter-chunk idle
+        // deadline so a stalled provider connection is bounded.
+        //
+        // `biased` checks branches top-to-bottom: cancellation first (so a
+        // ready-but-cancelled chunk is dropped), then the pending chunk, then
+        // the idle timer. The idle `sleep` is created fresh every iteration, so
+        // it is a true *inter-chunk* deadline that resets on every received
+        // chunk — NOT an overall stream cap. A legitimately long stream that
+        // keeps producing chunks is never killed; only a stall with no chunk
+        // for `idle_timeout` trips it. Without this branch,
+        // `stream.next().await` blocks forever when the provider's connection
+        // hangs mid-stream (issue #28). Listing `stream.next()` ahead of the
+        // timer means a ready chunk always wins over the timer.
         let chunk_result = tokio::select! {
             biased;
             _ = cancel_token.cancelled() => return Err(AgentError::Cancelled),
@@ -46,6 +62,17 @@ pub(super) async fn consume_llm_stream_internal(
                 Some(chunk_result) => chunk_result,
                 None => break,
             },
+            _ = tokio::time::sleep(idle_timeout) => {
+                tracing::warn!(
+                    "[{}] LLM stream timed out: no chunk received within {:?}; \
+                     aborting stalled stream",
+                    session_id,
+                    idle_timeout,
+                );
+                return Err(AgentError::StreamTimeout(format!(
+                    "the model stopped responding (no data received for over {idle_timeout:?})"
+                )));
+            }
         };
 
         handle_chunk_result(chunk_result, &mut state, event_tx, session_id).await?;

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
@@ -1,4 +1,6 @@
-use futures::stream;
+use std::time::Duration;
+
+use futures::{stream, StreamExt};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio_util::sync::CancellationToken;
@@ -8,6 +10,7 @@ use bamboo_agent_core::{AgentError, AgentEvent};
 use bamboo_llm::provider::LLMError;
 use bamboo_llm::{LLMChunk, LLMStream};
 
+use super::consume::consume_llm_stream_internal;
 use super::{consume_llm_stream, consume_llm_stream_silent};
 
 fn build_stream(items: Vec<bamboo_llm::provider::Result<LLMChunk>>) -> LLMStream {
@@ -143,4 +146,95 @@ async fn consume_llm_stream_interrupts_blocked_next_on_mid_stream_cancel() {
     .expect("must not hang: mid-stream cancellation should interrupt the blocked next()");
 
     assert!(matches!(result, Err(AgentError::Cancelled)));
+}
+
+#[tokio::test]
+async fn consume_llm_stream_times_out_when_stream_stalls_after_first_chunk() {
+    // Issue #28: a stream that yields one chunk, then never yields again and
+    // never closes, models a provider connection that stalls mid-stream. The
+    // inter-chunk idle deadline must trip and return a StreamTimeout error
+    // instead of hanging forever.
+    let stream: LLMStream = Box::pin(
+        stream::once(async { Ok::<_, LLMError>(LLMChunk::Token("first".to_string())) })
+            .chain(stream::pending()),
+    );
+
+    let idle_timeout = Duration::from_millis(80);
+    let started = std::time::Instant::now();
+
+    let result = tokio::time::timeout(
+        // Generous outer bound; the idle timeout must trip well before this.
+        Duration::from_secs(2),
+        consume_llm_stream_internal(
+            stream,
+            None,
+            &CancellationToken::new(),
+            "session-timeout",
+            idle_timeout,
+        ),
+    )
+    .await
+    .expect("idle timeout must interrupt the stalled stream, not hang");
+
+    let elapsed = started.elapsed();
+    match result {
+        Err(AgentError::StreamTimeout(_)) => {}
+        Err(other) => panic!("expected AgentError::StreamTimeout, got Err({other:?})"),
+        Ok(_) => panic!("expected AgentError::StreamTimeout, got Ok(_)"),
+    }
+
+    // The first chunk arrives immediately, so the idle timer effectively starts
+    // after it. The timeout should fire ~80ms later. A mild lower bound guards
+    // against an "instant timeout" regression; the upper bound guards against
+    // the timeout being ignored.
+    assert!(
+        elapsed >= Duration::from_millis(50),
+        "timeout fired too early ({elapsed:?}): the first chunk should reset the idle timer"
+    );
+    assert!(
+        elapsed < Duration::from_millis(800),
+        "timeout fired too late ({elapsed:?}): the stalled stream was not interrupted in time"
+    );
+}
+
+#[tokio::test]
+async fn consume_llm_stream_idle_timeout_does_not_affect_healthy_stream() {
+    // Issue #28: each chunk arrives well within the idle window (25ms << 80ms),
+    // but the *total* stream duration (~150ms) far exceeds the idle timeout.
+    // Because the deadline resets on every received chunk, a legitimately long
+    // stream that keeps producing data must complete normally — the idle
+    // timeout only fires on a true stall (no chunk at all).
+    let idle_timeout = Duration::from_millis(80);
+    let per_chunk_delay = Duration::from_millis(25);
+    let chunk_count: u32 = 6;
+
+    let stream: LLMStream = Box::pin(stream::unfold(0u32, move |i| async move {
+        if i >= chunk_count {
+            return None;
+        }
+        tokio::time::sleep(per_chunk_delay).await;
+        Some((
+            Ok::<_, LLMError>(LLMChunk::Token(format!("chunk-{i}"))),
+            i + 1,
+        ))
+    }));
+
+    let output = tokio::time::timeout(
+        Duration::from_secs(3),
+        consume_llm_stream_internal(
+            stream,
+            None,
+            &CancellationToken::new(),
+            "session-healthy",
+            idle_timeout,
+        ),
+    )
+    .await
+    .expect("healthy stream must complete without timing out")
+    .expect("stream should succeed");
+
+    assert_eq!(output.content, "chunk-0chunk-1chunk-2chunk-3chunk-4chunk-5");
+    // `token_count` is the total character count of the stream, not the chunk
+    // count: 6 chunks × 7 chars ("chunk-N") = 42.
+    assert_eq!(output.token_count, output.content.chars().count());
 }

--- a/crates/infra/bamboo-llm/src/http_client.rs
+++ b/crates/infra/bamboo-llm/src/http_client.rs
@@ -3,6 +3,8 @@
 //! We centralize proxy handling here so all code paths (server handlers,
 //! provider factory, auth flows) consistently respect `Config` proxy settings.
 
+use std::time::Duration;
+
 use crate::provider::LLMError;
 use bamboo_config::Config;
 use reqwest::{Client, NoProxy, Proxy};
@@ -34,7 +36,15 @@ pub fn build_proxy(config: &Config) -> Result<Option<Proxy>, LLMError> {
 }
 
 pub fn build_http_client(config: &Config) -> Result<Client, LLMError> {
-    let mut builder = Client::builder();
+    // `connect_timeout` bounds only TCP/TLS connection establishment. That is
+    // safe for streaming: it never kills an in-flight streaming response. We
+    // deliberately do NOT set an overall `.timeout()` here — this client is
+    // shared between streaming and non-streaming calls, and an overall timeout
+    // would abort legitimately long streaming responses (thinking models can
+    // stream for minutes). Mid-stream stalls — where the connection stays open
+    // but no chunks arrive — are instead bounded by the inter-chunk idle
+    // timeout in `consume_llm_stream_internal` (issue #28).
+    let mut builder = Client::builder().connect_timeout(Duration::from_secs(30));
     if let Some(proxy) = build_proxy(config)? {
         builder = builder.proxy(proxy);
     }


### PR DESCRIPTION
Closes #28 — a mid-stream provider stall made stream.next() block forever, hanging the agent loop.

- consume loop selects (biased) on cancel / next-chunk / a fresh per-iteration idle sleep → a true INTER-CHUNK deadline (resets on each chunk; long healthy streams unaffected). Timeout → terminal AgentError::StreamTimeout + error event (not retried). Default 120s const; internal override keeps it configurable/testable without touching the ~50-field config.
- http_client: connect_timeout(30s) ONLY — deliberately no overall reqwest .timeout() (would kill long streaming responses on the shared client); the idle timeout handles stalls.
- Tests: stall→timeout within bound; healthy 6-chunk stream unaffected.

bamboo-reviewed. Verified: check --workspace; bamboo-engine (851) + bamboo-llm (420) green; fmt + clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp