### PR TITLE
perf(bamboo-engine,bamboo-tools): cache tool schemas + dedupe parallel-classification arg parse (#17)

### DIFF
--- a/crates/core/bamboo-agent-core/src/tools/executor.rs
+++ b/crates/core/bamboo-agent-core/src/tools/executor.rs
@@ -129,6 +129,26 @@ pub trait ToolExecutor: Send + Sync {
     fn call_concurrency_safe(&self, call: &ToolCall) -> bool {
         self.tool_concurrency_safe(call.function.name.trim())
     }
+
+    /// Classify a tool call's mutability AND concurrency-safety together,
+    /// returning `(mutability, concurrency_safe)`.
+    ///
+    /// The default delegates to [`call_mutability`](Self::call_mutability) and
+    /// [`call_concurrency_safe`](Self::call_concurrency_safe) — i.e. the exact
+    /// prior behavior, so every executor that doesn't override this is
+    /// unchanged. Concrete executors that parse the call's arguments inside BOTH
+    /// of those methods (e.g. `BuiltinToolExecutor`) override this to parse the
+    /// arguments a single time while returning the identical pair. The combined
+    /// result lets callers that need both (parallel scheduling) avoid a
+    /// redundant argument parse per tool call.
+    fn call_parallel_classification(
+        &self,
+        call: &ToolCall,
+    ) -> (crate::tools::ToolMutability, bool) {
+        let mutability = self.call_mutability(call);
+        let concurrency_safe = self.call_concurrency_safe(call);
+        (mutability, concurrency_safe)
+    }
 }
 
 /// Executes a tool call with composition support

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
@@ -118,6 +118,9 @@ async fn execute_and_apply_single_tool_call(
     session: &mut Session,
     tools: &Arc<dyn ToolExecutor>,
     config: &AgentLoopConfig,
+    // Pre-built per-round snapshot of the executor's full tool-schema list —
+    // avoids re-cloning every schema on each tool call.
+    available_tool_schemas: &[ToolSchema],
     task_context: &mut Option<TaskLoopContext>,
     state: &mut RoundExecutionState,
     policy_guard: &mut policy::ToolPolicyGuard,
@@ -209,6 +212,7 @@ async fn execute_and_apply_single_tool_call(
                     config,
                     session_flags:
                         bamboo_agent_core::tools::ToolExecutionSessionFlags::from_session(session),
+                    available_tool_schemas,
                 })
                 .await
             }
@@ -381,6 +385,20 @@ pub(crate) async fn execute_round_tool_calls(
     let config = frame.config;
     let llm = frame.llm;
 
+    // Build the executor's full tool-schema list ONCE for this round instead of
+    // on every individual tool call (the per-call path previously called
+    // `tools.list_tools()`, which clones all ~25 schemas — each carrying a JSON
+    // parameters block — per invocation). The slice is threaded into the dispatch
+    // context via `ToolExecutionOnlyContext::available_tool_schemas`. It is a
+    // local, so it is scoped to this round/session and can never leak one
+    // session's tool set into another. NOTE: this is the executor's full set and
+    // is DISTINCT from the `tool_schemas` parameter (the per-session *filtered*
+    // prompt set) — they must not be conflated. The agent loop never
+    // registers/unregisters tools mid-round, so the snapshot stays valid for the
+    // whole round.
+    let available_tool_schemas: Vec<ToolSchema> = tools.list_tools();
+    let available_tool_schemas = available_tool_schemas.as_slice();
+
     let mut state = RoundExecutionState::default();
     let mut policy_guard = policy::ToolPolicyGuard::new(
         config.max_tool_calls_per_round,
@@ -424,6 +442,7 @@ pub(crate) async fn execute_round_tool_calls(
                         session,
                         tools,
                         config,
+                        available_tool_schemas,
                         task_context,
                         &mut state,
                         &mut policy_guard,
@@ -462,6 +481,7 @@ pub(crate) async fn execute_round_tool_calls(
                     session,
                     tools,
                     config,
+                    available_tool_schemas,
                     task_context,
                     &mut state,
                     &mut policy_guard,
@@ -521,6 +541,7 @@ pub(crate) async fn execute_round_tool_calls(
                                 tools,
                                 config,
                                 session_flags,
+                                available_tool_schemas,
                             }),
                         )
                         .await
@@ -665,6 +686,7 @@ pub(crate) async fn execute_round_tool_calls(
             session,
             tools,
             config,
+            available_tool_schemas,
             task_context,
             &mut state,
             &mut policy_guard,
@@ -964,6 +986,7 @@ mod tests {
             &mut session,
             &tools,
             &config,
+            tools.list_tools().as_slice(),
             &mut None,
             &mut state,
             &mut policy_guard,
@@ -1020,6 +1043,7 @@ mod tests {
             &mut session,
             &tools,
             &config,
+            tools.list_tools().as_slice(),
             &mut None,
             &mut state,
             &mut policy_guard,
@@ -1070,6 +1094,7 @@ mod tests {
             &mut session,
             &tools,
             &config,
+            tools.list_tools().as_slice(),
             &mut None,
             &mut state,
             &mut policy_guard,
@@ -1121,6 +1146,7 @@ mod tests {
             &mut session,
             &tools,
             &config,
+            tools.list_tools().as_slice(),
             &mut None,
             &mut state,
             &mut policy_guard,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
@@ -6,7 +6,7 @@ use crate::runtime::config::AgentLoopConfig;
 use crate::runtime::task_context::TaskLoopContext;
 use bamboo_agent_core::tools::{
     parse_tool_args_best_effort, ToolCall, ToolExecutionContext, ToolExecutionSessionFlags,
-    ToolExecutor, ToolResult,
+    ToolExecutor, ToolResult, ToolSchema,
 };
 use bamboo_agent_core::{AgentEvent, Session};
 use bamboo_metrics::MetricsCollector;
@@ -44,6 +44,16 @@ pub(super) struct ToolExecutionOnlyContext<'a> {
     /// and threaded through so this (parallel-safe) path can apply them without
     /// borrowing the session.
     pub session_flags: ToolExecutionSessionFlags,
+    /// Snapshot of every tool schema the executor exposes for THIS round, built
+    /// once per round (in `execute_round_tool_calls`) rather than re-cloned on
+    /// every single tool call. Passed straight into the dispatch context's
+    /// `available_tool_schemas`. Scoped to the round — never global/static — so
+    /// one session's tool set can't leak into another. ASSUMPTION: the
+    /// executor's tool set is stable for the duration of a round; the agent
+    /// loop never registers/unregisters tools mid-round, and this field
+    /// currently has no readers, so a per-round snapshot can't diverge
+    /// observably from the prior per-call `list_tools()`.
+    pub available_tool_schemas: &'a [ToolSchema],
 }
 
 pub(super) struct ToolExecutionApplyContext<'a> {
@@ -138,15 +148,16 @@ pub(super) async fn execute_tool_call_only(
     }
 
     let tool_timer = std::time::Instant::now();
-    let available_tool_schemas = ctx.tools.list_tools();
     // THIS is the live server tool-dispatch path (engine runtime). Build via
     // `for_dispatch` so per-session flags stay in sync with the other loop
-    // (bamboo-agent-core's `result_handler.rs`).
+    // (bamboo-agent-core's `result_handler.rs`). The schema slice is the
+    // per-round snapshot threaded in via `ctx.available_tool_schemas` (built
+    // once in `execute_round_tool_calls`) instead of re-cloning every call.
     let tool_ctx = ToolExecutionContext::for_dispatch(
         ctx.session_id,
         &ctx.tool_call.id,
         ctx.event_tx,
-        available_tool_schemas.as_slice(),
+        ctx.available_tool_schemas,
         ctx.session_flags,
         // Only let the Bash auto path promote to background when this loop can
         // actually suspend for and self-resume the shell — i.e. a

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
@@ -49,10 +49,12 @@ pub(super) struct ToolExecutionOnlyContext<'a> {
     /// every single tool call. Passed straight into the dispatch context's
     /// `available_tool_schemas`. Scoped to the round — never global/static — so
     /// one session's tool set can't leak into another. ASSUMPTION: the
-    /// executor's tool set is stable for the duration of a round; the agent
-    /// loop never registers/unregisters tools mid-round, and this field
-    /// currently has no readers, so a per-round snapshot can't diverge
-    /// observably from the prior per-call `list_tools()`.
+    /// executor's tool set is stable for the duration of a round (the agent loop
+    /// only registers hooks mid-round, never tools), so the snapshot equals what
+    /// a fresh `list_tools()` would return on every call. It is consumed only by
+    /// `for_dispatch`, which threads it into the dispatch context's
+    /// `available_tool_schemas` — a metadata field no builtin tool currently
+    /// inspects — so even a hypothetical divergence would be unobservable today.
     pub available_tool_schemas: &'a [ToolSchema],
 }
 

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -430,6 +430,26 @@ impl ToolExecutor for BuiltinToolExecutor {
             .map(|tool| tool.call_concurrency_safe(&args))
             .unwrap_or_else(|| self.tool_concurrency_safe(&canonical))
     }
+
+    fn call_parallel_classification(&self, call: &ToolCall) -> (crate::ToolMutability, bool) {
+        // `call_mutability` and `call_concurrency_safe` each independently resolve
+        // the canonical tool name and parse the call's arguments. Computing both
+        // together here lets us do that work a single time, while returning the
+        // exact same `(mutability, concurrency_safe)` pair the two methods
+        // produce. Equivalent to calling both, but with one (not two) arg parses.
+        let canonical = resolve_registered_tool_name(&self.registry, call.function.name.trim());
+        let args = bamboo_agent_core::parse_tool_args_best_effort(&call.function.arguments).0;
+        match self.registry.get(&canonical) {
+            Some(tool) => (
+                tool.call_mutability(&args),
+                tool.call_concurrency_safe(&args),
+            ),
+            None => (
+                self.tool_mutability(&canonical),
+                self.tool_concurrency_safe(&canonical),
+            ),
+        }
+    }
 }
 
 /// Builder for constructing a BuiltinToolExecutor with custom tool configurations
@@ -731,6 +751,68 @@ mod tests {
             crate::ToolMutability::Mutating
         );
         assert!(!executor.call_concurrency_safe(&set_call));
+    }
+
+    #[test]
+    fn call_parallel_classification_matches_individual_methods() {
+        // Regression guard for the issue #17 perf refactor: the combined
+        // `call_parallel_classification` (which parses args once) must return the
+        // exact same (mutability, concurrency_safe) pair as calling
+        // `call_mutability` and `call_concurrency_safe` separately (which each
+        // parse args). Covers a read-only tool, mutating tools, and an
+        // args-aware tool (Workspace get vs set) so every branch of the
+        // single-parse override is exercised.
+        let executor = BuiltinToolExecutor::new();
+        let cases: &[(&str, serde_json::Value)] = &[
+            ("Read", json!({})),
+            ("Grep", json!({"pattern": "x"})),
+            (
+                "Write",
+                json!({"file_path": "/tmp/par_cls.txt", "content": "y"}),
+            ),
+            ("Bash", json!({"command": "echo hi"})),
+            ("Workspace", json!({})),
+            ("Workspace", json!({"path": "/tmp"})),
+        ];
+
+        for (name, args) in cases {
+            let call = make_tool_call(name, args.clone());
+            let expected_mutability = executor.call_mutability(&call);
+            let expected_concurrency = executor.call_concurrency_safe(&call);
+            let (mutability, concurrency) = executor.call_parallel_classification(&call);
+            assert_eq!(
+                mutability, expected_mutability,
+                "mutability mismatch for {name} ({args})"
+            );
+            assert_eq!(
+                concurrency, expected_concurrency,
+                "concurrency mismatch for {name} ({args})"
+            );
+        }
+    }
+
+    #[test]
+    fn list_tools_snapshot_is_stable_across_calls() {
+        // The per-round schema cache (issue #17 Part A) assumes the executor's
+        // `list_tools()` is stable within a round: a snapshot taken once must
+        // equal a fresh call. Guards that invariant so caching the set for the
+        // duration of a round can't serve a stale or filtered view.
+        let executor = BuiltinToolExecutor::new();
+        let first: Vec<String> = executor
+            .list_tools()
+            .into_iter()
+            .map(|s| s.function.name)
+            .collect();
+        let second: Vec<String> = executor
+            .list_tools()
+            .into_iter()
+            .map(|s| s.function.name)
+            .collect();
+        assert!(!first.is_empty(), "builtin executor should expose tools");
+        assert_eq!(
+            first, second,
+            "list_tools() must be deterministic per round"
+        );
     }
 
     #[tokio::test]

--- a/crates/engine/bamboo-tools/src/parallel.rs
+++ b/crates/engine/bamboo-tools/src/parallel.rs
@@ -53,8 +53,10 @@ impl ToolCallRuntime {
 
     /// Determine if a tool supports parallel execution.
     pub fn supports_parallel(executor: &Arc<dyn ToolExecutor>, call: &ToolCall) -> bool {
-        executor.call_mutability(call) == ToolMutability::ReadOnly
-            && executor.call_concurrency_safe(call)
+        // Compute mutability + concurrency-safety together so the executor parses
+        // the call's arguments once instead of once per classification (issue #17).
+        let (mutability, concurrency_safe) = executor.call_parallel_classification(call);
+        mutability == ToolMutability::ReadOnly && concurrency_safe
     }
 
     /// Execute a single tool call with appropriate concurrency control.


### PR DESCRIPTION
Refs #17 (pure perf, zero behavior change).

- **Part A**: stop cloning all ~20+ tool schemas into a fresh Vec on every tool call — cache the list once per round (snapshot stable across calls), scoped to the run (no cross-session leak).
- **Part B2**: supports_parallel parsed args twice (call_mutability + call_concurrency_safe). New ToolExecutor::call_parallel_classification (default delegates → zero blast radius; BuiltinToolExecutor parses once). All 4 parse sites verified to share one parser, so unifying is behavior-safe.
- **Deferred (B1)**: the execute_with_context double-parse straddles the trait boundary — tracked as a follow-up.

Tests: classification combined==separate; schema-cache stability. Verified: check --workspace; bamboo-engine (853) + bamboo-tools (311) green; fmt + clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp