### PR TITLE
fix(bamboo-llm): emit token UsageSummary from Gemini streams (#27)

### DIFF
--- a/crates/infra/bamboo-llm/src/providers/bodhi/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/bodhi/mod.rs
@@ -352,9 +352,13 @@ impl BodhiProvider {
         }
 
         let mut state = GeminiStreamState::default();
-        let stream = llm_stream_from_sse(response, move |event, data| {
-            parse_gemini_sse_event(&mut state, event, data)
-        });
+        // Multi-chunk adapter: a final Gemini `usageMetadata` carries both a
+        // cache hit and output/thinking usage in one event, and the stream sends
+        // no [DONE], so both must be emitted from that single event (issue #27).
+        let stream = crate::providers::common::sse::llm_stream_from_sse_multi(
+            response,
+            move |event, data| parse_gemini_sse_event(&mut state, event, data),
+        );
 
         Ok(stream)
     }

--- a/crates/infra/bamboo-llm/src/providers/common/sse.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/sse.rs
@@ -1,6 +1,7 @@
 //! Shared SSE -> [`LLMStream`] adapter.
 
 use eventsource_stream::Eventsource;
+use futures::stream;
 use futures::StreamExt;
 use reqwest::Response;
 
@@ -20,9 +21,34 @@ fn to_stream_error(err: LLMError) -> LLMError {
 /// - return `Ok(Some(chunk))` to emit a chunk
 /// - return `Ok(None)` to skip an event
 /// - return `Err(_)` to emit a stream error (mapped to `LLMError::Stream`)
+///
+/// This is the common case where each SSE event yields at most one chunk.
+/// Providers whose events can carry several chunks (e.g. Gemini's final
+/// `usageMetadata` folds a cache hit and output/thinking usage into one event)
+/// should use [`llm_stream_from_sse_multi`] instead.
 pub fn llm_stream_from_sse<H>(response: Response, mut handler: H) -> LLMStream
 where
     H: FnMut(&str, &str) -> Result<Option<LLMChunk>> + Send + 'static,
+{
+    llm_stream_from_sse_multi(response, move |event, data| {
+        Ok(handler(event, data)?.into_iter().collect())
+    })
+}
+
+/// Like [`llm_stream_from_sse`], but the handler may emit **zero or more**
+/// chunks per SSE event; they are flattened into the stream in order.
+///
+/// This is required for providers where a single SSE event must surface
+/// multiple logical chunks. The motivating case is Gemini: a final
+/// `usageMetadata` event carries both a prompt-cache hit AND output/thinking
+/// token usage, and `streamGenerateContent?alt=sse` sends no `[DONE]`
+/// sentinel — so a chunk deferred to "the next event" would be silently lost
+/// when the connection closes. Returning every chunk from the one event (via
+/// `Vec`) and flattening here delivers both with no buffering and no reliance
+/// on a trailing event (issue #27).
+pub fn llm_stream_from_sse_multi<H>(response: Response, mut handler: H) -> LLMStream
+where
+    H: FnMut(&str, &str) -> Result<Vec<LLMChunk>> + Send + 'static,
 {
     let stream = response
         .bytes_stream()
@@ -31,12 +57,11 @@ where
             let event = event.map_err(|e| LLMError::Stream(e.to_string()))?;
             handler(event.event.as_str(), event.data.as_str()).map_err(to_stream_error)
         })
-        .filter_map(|result| async move {
-            match result {
-                Ok(Some(chunk)) => Some(Ok(chunk)),
-                Ok(None) => None,
-                Err(err) => Some(Err(err)),
-            }
+        .flat_map(|result| {
+            stream::iter(match result {
+                Ok(chunks) => chunks.into_iter().map(Ok).collect::<Vec<_>>(),
+                Err(err) => vec![Err(err)],
+            })
         });
 
     Box::pin(stream)

--- a/crates/infra/bamboo-llm/src/providers/gemini/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/gemini/mod.rs
@@ -346,20 +346,26 @@ impl LLMProvider for GeminiProvider {
         tracing::debug!("Gemini stream started successfully");
 
         // Parse SSE stream with Gemini-specific parser
+        // Parse SSE stream with Gemini-specific parser. Uses the multi-chunk
+        // adapter: a single Gemini event can yield several chunks (a final
+        // `usageMetadata` carries both a cache hit and output/thinking usage),
+        // and `streamGenerateContent?alt=sse` sends no [DONE], so emitting all
+        // chunks from the one event — rather than deferring — guarantees usage
+        // is delivered even when the connection closes immediately afterwards.
         let mut state = GeminiStreamState::default();
         let model_for_log = model.to_string();
         let requested_reasoning_for_log = applied_reasoning_effort;
         let request_thinking_budget_for_log = applied_thinking_budget;
         let mut logged_summary = false;
 
-        let stream = crate::providers::common::sse::llm_stream_from_sse(
+        let stream = crate::providers::common::sse::llm_stream_from_sse_multi(
             response,
             move |event, data| {
-                let chunk = parse_gemini_sse_event(&mut state, event, data)?;
+                let chunks = parse_gemini_sse_event(&mut state, event, data)?;
 
-                if matches!(chunk, Some(LLMChunk::Done))
-                    && !logged_summary
+                if !logged_summary
                     && (requested_reasoning_for_log.is_some() || state.observed_thinking_signal)
+                    && chunks.iter().any(|c| matches!(c, LLMChunk::Done))
                 {
                     tracing::info!(
                         "Gemini reasoning summary: model='{}' requested_effort={} request_thinking_budget={} observed_thinking_signal={} thinking_parts_count={} thinking_text_chars={}",
@@ -377,7 +383,7 @@ impl LLMProvider for GeminiProvider {
                     logged_summary = true;
                 }
 
-                Ok(chunk)
+                Ok(chunks)
             },
         );
 

--- a/crates/infra/bamboo-llm/src/providers/gemini/stream.rs
+++ b/crates/infra/bamboo-llm/src/providers/gemini/stream.rs
@@ -8,6 +8,14 @@
 //!
 //! data: [DONE]
 //! ```
+//!
+//! Gemini's `streamGenerateContent?alt=sse` sends **no** `[DONE]` sentinel — the
+//! connection simply closes after the final chunk. A single Gemini event can
+//! carry several logical outputs (the final `usageMetadata` folds a
+//! prompt-cache hit AND output/thinking token usage into one JSON object), so
+//! [`parse_gemini_sse_event`] returns a [`Vec<LLMChunk>`]: it emits every chunk
+//! an event carries in order, and the caller flattens them. Nothing is deferred
+//! to a later parse call — there is no later call (issue #27).
 
 use crate::provider::{LLMError, Result};
 use crate::types::LLMChunk;
@@ -34,12 +42,6 @@ pub struct GeminiStreamState {
     /// Whether an [`LLMChunk::UsageSummary`] has already been emitted for this
     /// stream. Like cache usage, emitted once from the final `usageMetadata`.
     usage_summary_emitted: bool,
-    /// A usage chunk (e.g. [`LLMChunk::UsageSummary`]) deferred from an earlier
-    /// content-free chunk, awaiting the next parse call. Gemini folds cache and
-    /// output/thinking usage into a single final `usageMetadata`, but a parse
-    /// call yields at most one [`LLMChunk`]; the secondary chunk is buffered
-    /// here and drained at the top of the next call.
-    pending_usage: Option<LLMChunk>,
 }
 
 impl GeminiStreamState {
@@ -92,35 +94,40 @@ fn take_gemini_usage_summary(state: &mut GeminiStreamState, value: &Value) -> Op
     })
 }
 
-/// Emit the final usage from a content-free Gemini chunk's `usageMetadata`:
-/// the existing [`LLMChunk::CacheUsage`] (cache hit) plus the new
-/// [`LLMChunk::UsageSummary`] (output/thinking). Gemini folds both into a
-/// single final `usageMetadata`, but a parse call returns at most one chunk, so
-/// when both are present the cache chunk is emitted first (unchanged path) and
-/// the usage summary is buffered in [`GeminiStreamState::pending_usage`] for
-/// the next parse call. Either may be `None`; returns `None` only when neither
-/// is reported.
-fn take_gemini_final_usage(state: &mut GeminiStreamState, value: &Value) -> Option<LLMChunk> {
+/// Emit the final usage carried by a content-free Gemini chunk's
+/// `usageMetadata` as an *ordered* sequence of chunks: the existing
+/// [`LLMChunk::CacheUsage`] (cache hit) first, then the new
+/// [`LLMChunk::UsageSummary`] (output/thinking).
+///
+/// Gemini folds both pieces into a single final `usageMetadata`, but
+/// `streamGenerateContent?alt=sse` sends no `[DONE]` sentinel — the connection
+/// closes right after that final event. Returning both chunks from this one
+/// call (rather than deferring the second to a later parse call that never
+/// comes) guarantees usage is delivered for cached requests too. Either piece
+/// may be absent (or already emitted); only the pieces present are included.
+fn take_gemini_final_usage(state: &mut GeminiStreamState, value: &Value) -> Vec<LLMChunk> {
     let cache = take_gemini_cache_usage(state, value);
     let summary = take_gemini_usage_summary(state, value);
-    match (cache, summary) {
-        (Some(cache), Some(summary)) => {
-            state.pending_usage = Some(summary);
-            Some(cache)
-        }
-        (Some(chunk), None) | (None, Some(chunk)) => Some(chunk),
-        (None, None) => None,
+    let mut out = Vec::with_capacity(2);
+    if let Some(cache) = cache {
+        out.push(cache);
     }
+    if let Some(summary) = summary {
+        out.push(summary);
+    }
+    out
 }
 
-/// Parse a single Gemini SSE event into an optional [`LLMChunk`].
+/// Parse a single Gemini SSE event into zero or more [`LLMChunk`]s.
 ///
 /// Gemini sends JSON objects as data, not named events. The `event_type` parameter
 /// is typically empty or "message" for Gemini streams.
 ///
 /// Returns:
-/// - `Ok(Some(chunk))` for content-bearing events (text, tool calls)
-/// - `Ok(None)` for non-content events (empty data, metadata)
+/// - `Ok(vec![chunk, ..])` for content-bearing events (text, tool calls) and
+///   usage events (a final `usageMetadata` may yield both a `CacheUsage` and a
+///   `UsageSummary`, in that order)
+/// - `Ok(vec![])` for non-content events (empty data, metadata already emitted)
 /// - `Err(_)` for malformed JSON or unexpected shapes
 ///
 /// # Example
@@ -131,31 +138,23 @@ fn take_gemini_final_usage(state: &mut GeminiStreamState, value: &Value) -> Opti
 /// let mut state = GeminiStreamState::default();
 /// let data = r#"{"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"}}]}"#;
 ///
-/// let chunk = parse_gemini_sse_event(&mut state, "", data).unwrap();
+/// let chunks = parse_gemini_sse_event(&mut state, "", data).unwrap();
 /// ```
 pub fn parse_gemini_sse_event(
     state: &mut GeminiStreamState,
     _event_type: &str,
     data: &str,
-) -> Result<Option<LLMChunk>> {
-    // Drain any usage chunk deferred from a previous content-free chunk (see
-    // `take_gemini_final_usage`) before handling the current event, so a final
-    // `usageMetadata` that carries both cache and output/thinking usage still
-    // surfaces both chunks.
-    if let Some(pending) = state.pending_usage.take() {
-        return Ok(Some(pending));
-    }
-
+) -> Result<Vec<LLMChunk>> {
     // Trim whitespace
     let data = data.trim();
 
     // Empty data or [DONE] signal
     if data.is_empty() {
-        return Ok(None);
+        return Ok(Vec::new());
     }
 
     if data == "[DONE]" {
-        return Ok(Some(LLMChunk::Done));
+        return Ok(vec![LLMChunk::Done]);
     }
 
     // Parse the JSON response
@@ -203,7 +202,7 @@ pub fn parse_gemini_sse_event(
     // Extract parts array
     let parts = match content.get("parts").and_then(|p| p.as_array()) {
         Some(p) => p,
-        None => return Ok(None),
+        None => return Ok(Vec::new()),
     };
 
     if parts.is_empty() {
@@ -236,11 +235,11 @@ pub fn parse_gemini_sse_event(
     if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
         if !text.is_empty() {
             if is_thinking_part {
-                return Ok(Some(LLMChunk::ReasoningToken(text.to_string())));
+                return Ok(vec![LLMChunk::ReasoningToken(text.to_string())]);
             }
-            return Ok(Some(LLMChunk::Token(text.to_string())));
+            return Ok(vec![LLMChunk::Token(text.to_string())]);
         }
-        return Ok(None);
+        return Ok(Vec::new());
     }
 
     // Check for function call (tool call)
@@ -265,18 +264,18 @@ pub fn parse_gemini_sse_event(
 
         let tool_id = state.generate_tool_id();
 
-        return Ok(Some(LLMChunk::ToolCalls(vec![ToolCall {
+        return Ok(vec![LLMChunk::ToolCalls(vec![ToolCall {
             id: tool_id,
             tool_type: "function".to_string(),
             function: FunctionCall {
                 name: name.to_string(),
                 arguments: args_str,
             },
-        }])));
+        }])]);
     }
 
     // Unknown part type, skip it
-    Ok(None)
+    Ok(Vec::new())
 }
 
 #[cfg(test)]
@@ -288,11 +287,10 @@ mod tests {
         let mut state = GeminiStreamState::default();
         let data = r#"{"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"}}]}"#;
 
-        let chunk = parse_gemini_sse_event(&mut state, "", data)
-            .unwrap()
-            .expect("chunk");
+        let chunks = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert_eq!(chunks.len(), 1);
 
-        match chunk {
+        match &chunks[0] {
             LLMChunk::Token(text) => assert_eq!(text, "Hello"),
             other => panic!("expected LLMChunk::Token, got {:?}", other),
         }
@@ -303,11 +301,10 @@ mod tests {
         let mut state = GeminiStreamState::default();
         let data = r#"{"candidates":[{"content":{"parts":[{"thought":true,"text":"Thinking..."}],"role":"model"}}]}"#;
 
-        let chunk = parse_gemini_sse_event(&mut state, "", data)
-            .unwrap()
-            .expect("chunk");
+        let chunks = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert_eq!(chunks.len(), 1);
 
-        match chunk {
+        match &chunks[0] {
             LLMChunk::ReasoningToken(text) => assert_eq!(text, "Thinking..."),
             other => panic!("expected LLMChunk::ReasoningToken, got {:?}", other),
         }
@@ -321,17 +318,16 @@ mod tests {
         let mut state = GeminiStreamState::default();
         let data = r#"{"candidates":[],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":42,"thoughtsTokenCount":7,"totalTokenCount":59}}"#;
 
-        let chunk = parse_gemini_sse_event(&mut state, "", data)
-            .unwrap()
-            .expect("chunk");
+        let chunks = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert_eq!(chunks.len(), 1);
 
-        match chunk {
+        match &chunks[0] {
             LLMChunk::UsageSummary {
                 output_tokens,
                 thinking_tokens,
             } => {
-                assert_eq!(output_tokens, 42);
-                assert_eq!(thinking_tokens, 7);
+                assert_eq!(*output_tokens, 42);
+                assert_eq!(*thinking_tokens, 7);
             }
             other => panic!("expected LLMChunk::UsageSummary, got {:?}", other),
         }
@@ -343,17 +339,16 @@ mod tests {
         let mut state = GeminiStreamState::default();
         let data = r#"{"candidates":[],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":42,"totalTokenCount":52}}"#;
 
-        let chunk = parse_gemini_sse_event(&mut state, "", data)
-            .unwrap()
-            .expect("chunk");
+        let chunks = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert_eq!(chunks.len(), 1);
 
-        match chunk {
+        match &chunks[0] {
             LLMChunk::UsageSummary {
                 output_tokens,
                 thinking_tokens,
             } => {
-                assert_eq!(output_tokens, 42);
-                assert_eq!(thinking_tokens, 0);
+                assert_eq!(*output_tokens, 42);
+                assert_eq!(*thinking_tokens, 0);
             }
             other => panic!("expected LLMChunk::UsageSummary, got {:?}", other),
         }
@@ -368,8 +363,9 @@ mod tests {
         let data = r#"{"candidates":[],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":42,"thoughtsTokenCount":7,"totalTokenCount":59}}"#;
 
         let first = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert_eq!(first.len(), 1);
         assert!(
-            matches!(first, Some(LLMChunk::UsageSummary { .. })),
+            matches!(first[0], LLMChunk::UsageSummary { .. }),
             "expected UsageSummary on first usageMetadata chunk, got {:?}",
             first
         );
@@ -377,7 +373,7 @@ mod tests {
         // A second, identical cumulative usageMetadata chunk must not re-emit.
         let second = parse_gemini_sse_event(&mut state, "", data).unwrap();
         assert!(
-            second.is_none(),
+            second.is_empty(),
             "UsageSummary must be emitted only once; got {:?}",
             second
         );
@@ -386,55 +382,165 @@ mod tests {
     #[test]
     fn parse_usage_metadata_preserves_cache_usage() {
         // A final chunk can carry BOTH a prompt-cache hit and output/thinking
-        // usage. Cache reporting (issue #12) must survive the new usage
-        // emission: CacheUsage is emitted first, the UsageSummary is buffered
-        // and drained on the next parse call.
+        // usage. Gemini folds them into one `usageMetadata`, so BOTH must be
+        // delivered from this single parse call — Gemini's stream sends no
+        // [DONE], so there is no later call on which a deferred chunk could
+        // surface (issue #27). CacheUsage comes first, UsageSummary second.
         let mut state = GeminiStreamState::default();
         let data = r#"{"candidates":[],"usageMetadata":{"promptTokenCount":1000,"candidatesTokenCount":42,"thoughtsTokenCount":7,"cachedContentTokenCount":555,"totalTokenCount":1042}}"#;
 
-        let cache = parse_gemini_sse_event(&mut state, "", data)
-            .unwrap()
-            .expect("cache chunk");
-        match cache {
+        let chunks = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert_eq!(
+            chunks.len(),
+            2,
+            "expected cache + usage chunks, got {:?}",
+            chunks
+        );
+
+        match &chunks[0] {
             LLMChunk::CacheUsage {
                 cache_read_input_tokens,
                 ..
-            } => assert_eq!(cache_read_input_tokens, 555),
+            } => assert_eq!(*cache_read_input_tokens, 555),
             other => panic!("expected LLMChunk::CacheUsage first, got {:?}", other),
         }
-
-        // The UsageSummary was buffered; it surfaces on the next parse call
-        // (here, the trailing [DONE] event).
-        let summary = parse_gemini_sse_event(&mut state, "", "[DONE]")
-            .unwrap()
-            .expect("buffered usage summary");
-        match summary {
+        match &chunks[1] {
             LLMChunk::UsageSummary {
                 output_tokens,
                 thinking_tokens,
             } => {
-                assert_eq!(output_tokens, 42);
-                assert_eq!(thinking_tokens, 7);
+                assert_eq!(*output_tokens, 42);
+                assert_eq!(*thinking_tokens, 7);
             }
-            other => panic!("expected buffered LLMChunk::UsageSummary, got {:?}", other),
+            other => panic!("expected LLMChunk::UsageSummary second, got {:?}", other),
+        }
+
+        // A second identical chunk must not re-emit either piece.
+        let second = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert!(
+            second.is_empty(),
+            "cache + usage must each be emitted only once; got {:?}",
+            second
+        );
+    }
+
+    /// Real-world Gemini termination: the final chunk carries BOTH a
+    /// prompt-cache hit and output/thinking usage, then the connection CLOSES
+    /// — `streamGenerateContent?alt=sse` sends no `[DONE]` sentinel and no
+    /// further event. This drives the SSE stream the way `consume.rs` does
+    /// (pull every chunk until the stream is exhausted, with NO synthetic
+    /// trailing event) and asserts that BOTH cache reporting AND the usage
+    /// summary actually reach the consumer (issue #27 regression guard).
+    #[tokio::test]
+    async fn final_cache_usage_delivered_when_stream_ends_without_done() {
+        use crate::providers::common::sse::llm_stream_from_sse_multi;
+        use futures::StreamExt;
+
+        let payload = r#"{"candidates":[],"usageMetadata":{"promptTokenCount":1000,"candidatesTokenCount":42,"thoughtsTokenCount":7,"cachedContentTokenCount":555,"totalTokenCount":1042}}"#;
+        // One final event, then the body ends — exactly how Gemini closes the
+        // connection, with no trailing `data: [DONE]`.
+        let sse_body = format!("data: {payload}\n\n");
+
+        let response = reqwest::Response::from(
+            http::Response::builder()
+                .status(200)
+                .header("content-type", "text/event-stream")
+                .body(sse_body)
+                .expect("http response"),
+        );
+
+        let mut state = GeminiStreamState::default();
+        let mut stream = llm_stream_from_sse_multi(response, move |event, data| {
+            parse_gemini_sse_event(&mut state, event, data)
+        });
+
+        // Pull until exhausted — no extra trailing event injected.
+        let mut chunks = Vec::new();
+        while let Some(item) = stream.next().await {
+            chunks.push(item.expect("chunk"));
+        }
+
+        assert_eq!(
+            chunks.len(),
+            2,
+            "cache + usage must both be delivered on stream close; got {:?}",
+            chunks
+        );
+        match &chunks[0] {
+            LLMChunk::CacheUsage {
+                cache_read_input_tokens,
+                ..
+            } => assert_eq!(*cache_read_input_tokens, 555),
+            other => panic!("expected CacheUsage first, got {:?}", other),
+        }
+        match &chunks[1] {
+            LLMChunk::UsageSummary {
+                output_tokens,
+                thinking_tokens,
+            } => {
+                assert_eq!(*output_tokens, 42);
+                assert_eq!(*thinking_tokens, 7);
+            }
+            other => panic!("expected UsageSummary second, got {:?}", other),
+        }
+    }
+
+    /// Non-cached Gemini termination: the final chunk carries only output/
+    /// thinking usage (no `cachedContentTokenCount`), then the connection
+    /// closes. A single UsageSummary must still be delivered (issue #27).
+    #[tokio::test]
+    async fn final_usage_delivered_when_stream_ends_without_cache() {
+        use crate::providers::common::sse::llm_stream_from_sse_multi;
+        use futures::StreamExt;
+
+        let payload = r#"{"candidates":[],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":42,"thoughtsTokenCount":7,"totalTokenCount":59}}"#;
+        let sse_body = format!("data: {payload}\n\n");
+
+        let response = reqwest::Response::from(
+            http::Response::builder()
+                .status(200)
+                .header("content-type", "text/event-stream")
+                .body(sse_body)
+                .expect("http response"),
+        );
+
+        let mut state = GeminiStreamState::default();
+        let mut stream = llm_stream_from_sse_multi(response, move |event, data| {
+            parse_gemini_sse_event(&mut state, event, data)
+        });
+
+        let mut chunks = Vec::new();
+        while let Some(item) = stream.next().await {
+            chunks.push(item.expect("chunk"));
+        }
+
+        assert_eq!(chunks.len(), 1, "got {:?}", chunks);
+        match &chunks[0] {
+            LLMChunk::UsageSummary {
+                output_tokens,
+                thinking_tokens,
+            } => {
+                assert_eq!(*output_tokens, 42);
+                assert_eq!(*thinking_tokens, 7);
+            }
+            other => panic!("expected UsageSummary, got {:?}", other),
         }
     }
 
     #[test]
     fn parse_empty_data_returns_none() {
         let mut state = GeminiStreamState::default();
-        let chunk = parse_gemini_sse_event(&mut state, "", "").unwrap();
-        assert!(chunk.is_none());
+        let chunks = parse_gemini_sse_event(&mut state, "", "").unwrap();
+        assert!(chunks.is_empty());
     }
 
     #[test]
     fn parse_done_signal() {
         let mut state = GeminiStreamState::default();
-        let chunk = parse_gemini_sse_event(&mut state, "", "[DONE]")
-            .unwrap()
-            .expect("chunk");
+        let chunks = parse_gemini_sse_event(&mut state, "", "[DONE]").unwrap();
+        assert_eq!(chunks.len(), 1);
 
-        match chunk {
+        match &chunks[0] {
             LLMChunk::Done => {}
             other => panic!("expected LLMChunk::Done, got {:?}", other),
         }
@@ -445,11 +551,10 @@ mod tests {
         let mut state = GeminiStreamState::default();
         let data = r#"{"candidates":[{"content":{"parts":[{"functionCall":{"name":"search","args":{"q":"test"}}}],"role":"model"}}]}"#;
 
-        let chunk = parse_gemini_sse_event(&mut state, "", data)
-            .unwrap()
-            .expect("chunk");
+        let chunks = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert_eq!(chunks.len(), 1);
 
-        match chunk {
+        match &chunks[0] {
             LLMChunk::ToolCalls(calls) => {
                 assert_eq!(calls.len(), 1);
                 assert_eq!(calls[0].function.name, "search");
@@ -465,8 +570,8 @@ mod tests {
         let mut state = GeminiStreamState::default();
         let data = r#"{"candidates":[]}"#;
 
-        let chunk = parse_gemini_sse_event(&mut state, "", data).unwrap();
-        assert!(chunk.is_none());
+        let chunks = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert!(chunks.is_empty());
     }
 
     #[test]
@@ -474,8 +579,8 @@ mod tests {
         let mut state = GeminiStreamState::default();
         let data = r#"{"candidates":[{"finishReason":"STOP"}]}"#;
 
-        let chunk = parse_gemini_sse_event(&mut state, "", data).unwrap();
-        assert!(chunk.is_none());
+        let chunks = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert!(chunks.is_empty());
     }
 
     #[test]
@@ -504,22 +609,18 @@ mod tests {
 
         // First chunk
         let data1 = r#"{"candidates":[{"content":{"parts":[{"text":"Hello "}],"role":"model"}}]}"#;
-        let chunk1 = parse_gemini_sse_event(&mut state, "", data1)
-            .unwrap()
-            .expect("chunk1");
-
-        match chunk1 {
+        let chunks1 = parse_gemini_sse_event(&mut state, "", data1).unwrap();
+        assert_eq!(chunks1.len(), 1);
+        match &chunks1[0] {
             LLMChunk::Token(text) => assert_eq!(text, "Hello "),
             other => panic!("expected LLMChunk::Token, got {:?}", other),
         }
 
         // Second chunk
         let data2 = r#"{"candidates":[{"content":{"parts":[{"text":"world!"}],"role":"model"}}]}"#;
-        let chunk2 = parse_gemini_sse_event(&mut state, "", data2)
-            .unwrap()
-            .expect("chunk2");
-
-        match chunk2 {
+        let chunks2 = parse_gemini_sse_event(&mut state, "", data2).unwrap();
+        assert_eq!(chunks2.len(), 1);
+        match &chunks2[0] {
             LLMChunk::Token(text) => assert_eq!(text, "world!"),
             other => panic!("expected LLMChunk::Token, got {:?}", other),
         }
@@ -530,11 +631,9 @@ mod tests {
         let mut state = GeminiStreamState::default();
         let data = r#"{"candidates":[{"content":{"parts":[{"functionCall":{"name":"get_time","args":{}}}],"role":"model"}}]}"#;
 
-        let chunk = parse_gemini_sse_event(&mut state, "", data)
-            .unwrap()
-            .expect("chunk");
-
-        match chunk {
+        let chunks = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert_eq!(chunks.len(), 1);
+        match &chunks[0] {
             LLMChunk::ToolCalls(calls) => {
                 assert_eq!(calls.len(), 1);
                 assert_eq!(calls[0].function.name, "get_time");
@@ -549,11 +648,10 @@ mod tests {
         let mut state = GeminiStreamState::default();
         let data = "   [DONE]   ";
 
-        let chunk = parse_gemini_sse_event(&mut state, "", data)
-            .unwrap()
-            .expect("chunk");
+        let chunks = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert_eq!(chunks.len(), 1);
 
-        match chunk {
+        match &chunks[0] {
             LLMChunk::Done => {}
             other => panic!("expected LLMChunk::Done, got {:?}", other),
         }
@@ -579,21 +677,19 @@ mod tests {
         let mut state = GeminiStreamState::default();
 
         let data1 = r#"{"candidates":[{"content":{"parts":[{"functionCall":{"name":"search","args":{}}}],"role":"model"}}]}"#;
-        let chunk1 = parse_gemini_sse_event(&mut state, "", data1)
-            .unwrap()
-            .expect("chunk1");
+        let chunks1 = parse_gemini_sse_event(&mut state, "", data1).unwrap();
+        assert_eq!(chunks1.len(), 1);
 
         let data2 = r#"{"candidates":[{"content":{"parts":[{"functionCall":{"name":"read","args":{}}}],"role":"model"}}]}"#;
-        let chunk2 = parse_gemini_sse_event(&mut state, "", data2)
-            .unwrap()
-            .expect("chunk2");
+        let chunks2 = parse_gemini_sse_event(&mut state, "", data2).unwrap();
+        assert_eq!(chunks2.len(), 1);
 
-        let id1 = match chunk1 {
+        let id1 = match &chunks1[0] {
             LLMChunk::ToolCalls(calls) => calls[0].id.clone(),
             other => panic!("expected LLMChunk::ToolCalls, got {:?}", other),
         };
 
-        let id2 = match chunk2 {
+        let id2 = match &chunks2[0] {
             LLMChunk::ToolCalls(calls) => calls[0].id.clone(),
             other => panic!("expected LLMChunk::ToolCalls, got {:?}", other),
         };

--- a/crates/infra/bamboo-llm/src/providers/gemini/stream.rs
+++ b/crates/infra/bamboo-llm/src/providers/gemini/stream.rs
@@ -31,6 +31,15 @@ pub struct GeminiStreamState {
     /// Gemini reports `usageMetadata` cumulatively; emitting once (on the final,
     /// content-free chunk) keeps the downstream accumulator from over-counting.
     cache_usage_emitted: bool,
+    /// Whether an [`LLMChunk::UsageSummary`] has already been emitted for this
+    /// stream. Like cache usage, emitted once from the final `usageMetadata`.
+    usage_summary_emitted: bool,
+    /// A usage chunk (e.g. [`LLMChunk::UsageSummary`]) deferred from an earlier
+    /// content-free chunk, awaiting the next parse call. Gemini folds cache and
+    /// output/thinking usage into a single final `usageMetadata`, but a parse
+    /// call yields at most one [`LLMChunk`]; the secondary chunk is buffered
+    /// here and drained at the top of the next call.
+    pending_usage: Option<LLMChunk>,
 }
 
 impl GeminiStreamState {
@@ -54,6 +63,54 @@ fn take_gemini_cache_usage(state: &mut GeminiStreamState, value: &Value) -> Opti
         .and_then(crate::cache::cache_usage_from_gemini_usage)?;
     state.cache_usage_emitted = true;
     Some(chunk)
+}
+
+/// Emit an [`LLMChunk::UsageSummary`] once, from a Gemini chunk's
+/// `usageMetadata`: `candidatesTokenCount` maps to `output_tokens` and
+/// `thoughtsTokenCount` maps to `thinking_tokens`. `thoughtsTokenCount` is
+/// absent for non-thinking models (or when no thinking occurred), so it
+/// defaults to `0`. Returns `None` when no output token count is reported.
+///
+/// This is the Gemini analogue of the usage emission Anthropic
+/// (`message_delta` `usage`) and OpenAI Responses (`response.completed`
+/// `usage`) already perform, so downstream cost accounting / budget
+/// enforcement works for Gemini too (issue #27).
+fn take_gemini_usage_summary(state: &mut GeminiStreamState, value: &Value) -> Option<LLMChunk> {
+    if state.usage_summary_emitted {
+        return None;
+    }
+    let usage = value.get("usageMetadata")?;
+    let output_tokens = usage.get("candidatesTokenCount").and_then(Value::as_u64)?;
+    let thinking_tokens = usage
+        .get("thoughtsTokenCount")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    state.usage_summary_emitted = true;
+    Some(LLMChunk::UsageSummary {
+        output_tokens,
+        thinking_tokens,
+    })
+}
+
+/// Emit the final usage from a content-free Gemini chunk's `usageMetadata`:
+/// the existing [`LLMChunk::CacheUsage`] (cache hit) plus the new
+/// [`LLMChunk::UsageSummary`] (output/thinking). Gemini folds both into a
+/// single final `usageMetadata`, but a parse call returns at most one chunk, so
+/// when both are present the cache chunk is emitted first (unchanged path) and
+/// the usage summary is buffered in [`GeminiStreamState::pending_usage`] for
+/// the next parse call. Either may be `None`; returns `None` only when neither
+/// is reported.
+fn take_gemini_final_usage(state: &mut GeminiStreamState, value: &Value) -> Option<LLMChunk> {
+    let cache = take_gemini_cache_usage(state, value);
+    let summary = take_gemini_usage_summary(state, value);
+    match (cache, summary) {
+        (Some(cache), Some(summary)) => {
+            state.pending_usage = Some(summary);
+            Some(cache)
+        }
+        (Some(chunk), None) | (None, Some(chunk)) => Some(chunk),
+        (None, None) => None,
+    }
 }
 
 /// Parse a single Gemini SSE event into an optional [`LLMChunk`].
@@ -81,6 +138,14 @@ pub fn parse_gemini_sse_event(
     _event_type: &str,
     data: &str,
 ) -> Result<Option<LLMChunk>> {
+    // Drain any usage chunk deferred from a previous content-free chunk (see
+    // `take_gemini_final_usage`) before handling the current event, so a final
+    // `usageMetadata` that carries both cache and output/thinking usage still
+    // surfaces both chunks.
+    if let Some(pending) = state.pending_usage.take() {
+        return Ok(Some(pending));
+    }
+
     // Trim whitespace
     let data = data.trim();
 
@@ -116,7 +181,7 @@ pub fn parse_gemini_sse_event(
         })?;
 
     if candidates.is_empty() {
-        return Ok(take_gemini_cache_usage(state, &value));
+        return Ok(take_gemini_final_usage(state, &value));
     }
 
     // Get the first candidate (Gemini typically returns one)
@@ -132,7 +197,7 @@ pub fn parse_gemini_sse_event(
     // Extract content
     let content = match candidate.get("content") {
         Some(c) => c,
-        None => return Ok(take_gemini_cache_usage(state, &value)),
+        None => return Ok(take_gemini_final_usage(state, &value)),
     };
 
     // Extract parts array
@@ -142,7 +207,7 @@ pub fn parse_gemini_sse_event(
     };
 
     if parts.is_empty() {
-        return Ok(take_gemini_cache_usage(state, &value));
+        return Ok(take_gemini_final_usage(state, &value));
     }
 
     // Process the first part (Gemini typically sends one part per chunk)
@@ -248,6 +313,111 @@ mod tests {
         }
         assert!(state.observed_thinking_signal);
         assert_eq!(state.thinking_parts_count, 1);
+    }
+
+    #[test]
+    fn parse_usage_metadata_emits_usage_summary() {
+        // Final content-free chunk: Gemini reports cumulative usage here.
+        let mut state = GeminiStreamState::default();
+        let data = r#"{"candidates":[],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":42,"thoughtsTokenCount":7,"totalTokenCount":59}}"#;
+
+        let chunk = parse_gemini_sse_event(&mut state, "", data)
+            .unwrap()
+            .expect("chunk");
+
+        match chunk {
+            LLMChunk::UsageSummary {
+                output_tokens,
+                thinking_tokens,
+            } => {
+                assert_eq!(output_tokens, 42);
+                assert_eq!(thinking_tokens, 7);
+            }
+            other => panic!("expected LLMChunk::UsageSummary, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_usage_metadata_without_thinking_defaults_to_zero() {
+        // Non-thinking models omit thoughtsTokenCount entirely.
+        let mut state = GeminiStreamState::default();
+        let data = r#"{"candidates":[],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":42,"totalTokenCount":52}}"#;
+
+        let chunk = parse_gemini_sse_event(&mut state, "", data)
+            .unwrap()
+            .expect("chunk");
+
+        match chunk {
+            LLMChunk::UsageSummary {
+                output_tokens,
+                thinking_tokens,
+            } => {
+                assert_eq!(output_tokens, 42);
+                assert_eq!(thinking_tokens, 0);
+            }
+            other => panic!("expected LLMChunk::UsageSummary, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_usage_metadata_emitted_once() {
+        // Gemini may echo usageMetadata on more than one chunk; only the first
+        // must produce a UsageSummary (the downstream accumulator would otherwise
+        // double-count output/thinking tokens).
+        let mut state = GeminiStreamState::default();
+        let data = r#"{"candidates":[],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":42,"thoughtsTokenCount":7,"totalTokenCount":59}}"#;
+
+        let first = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert!(
+            matches!(first, Some(LLMChunk::UsageSummary { .. })),
+            "expected UsageSummary on first usageMetadata chunk, got {:?}",
+            first
+        );
+
+        // A second, identical cumulative usageMetadata chunk must not re-emit.
+        let second = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert!(
+            second.is_none(),
+            "UsageSummary must be emitted only once; got {:?}",
+            second
+        );
+    }
+
+    #[test]
+    fn parse_usage_metadata_preserves_cache_usage() {
+        // A final chunk can carry BOTH a prompt-cache hit and output/thinking
+        // usage. Cache reporting (issue #12) must survive the new usage
+        // emission: CacheUsage is emitted first, the UsageSummary is buffered
+        // and drained on the next parse call.
+        let mut state = GeminiStreamState::default();
+        let data = r#"{"candidates":[],"usageMetadata":{"promptTokenCount":1000,"candidatesTokenCount":42,"thoughtsTokenCount":7,"cachedContentTokenCount":555,"totalTokenCount":1042}}"#;
+
+        let cache = parse_gemini_sse_event(&mut state, "", data)
+            .unwrap()
+            .expect("cache chunk");
+        match cache {
+            LLMChunk::CacheUsage {
+                cache_read_input_tokens,
+                ..
+            } => assert_eq!(cache_read_input_tokens, 555),
+            other => panic!("expected LLMChunk::CacheUsage first, got {:?}", other),
+        }
+
+        // The UsageSummary was buffered; it surfaces on the next parse call
+        // (here, the trailing [DONE] event).
+        let summary = parse_gemini_sse_event(&mut state, "", "[DONE]")
+            .unwrap()
+            .expect("buffered usage summary");
+        match summary {
+            LLMChunk::UsageSummary {
+                output_tokens,
+                thinking_tokens,
+            } => {
+                assert_eq!(output_tokens, 42);
+                assert_eq!(thinking_tokens, 7);
+            }
+            other => panic!("expected buffered LLMChunk::UsageSummary, got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #27 — Gemini emitted zero token usage (no cost accounting). The stream parser now emits LLMChunk::UsageSummary{output_tokens, thinking_tokens} from usageMetadata (candidatesTokenCount/thoughtsTokenCount), like Anthropic/OpenAI. Buffered via pending_usage (cache chunk first, usage drained on [DONE]) since Gemini folds both into one usageMetadata and the parser yields one chunk/call — mirrors the OpenAI Responses precedent; cache reporting preserved. No non-stream path exists (trait is stream-only; issue premise outdated).

4 tests. bamboo-reviewed. Verified: cargo test -p bamboo-llm (424) green; check --workspace; fmt + clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp