### PR TITLE
perf(bamboo-mcp): channel-based MCP client receive, no busy-wait (#14)

### DIFF
--- a/crates/infra/bamboo-mcp/src/protocol/client.rs
+++ b/crates/infra/bamboo-mcp/src/protocol/client.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, RwLock};
-use tracing::{error, trace, warn};
+use tracing::{trace, warn};
 
 use crate::error::{McpError, Result};
 use crate::protocol::models::*;
@@ -15,7 +15,28 @@ pub trait McpTransport: Send + Sync {
     async fn connect(&mut self) -> Result<()>;
     async fn disconnect(&mut self) -> Result<()>;
     async fn send(&self, message: String) -> Result<()>;
+
+    /// Returns the inbound message channel receiver for efficient, non-polling
+    /// consumption.
+    ///
+    /// The receiver yields `Some(message)` for each inbound message and `None`
+    /// when the transport disconnects or its background reader task ends (EOF /
+    /// stream error). A consumer that awaits `receiver.recv()` parks with zero
+    /// wakeups while idle — no polling, no sleep, no per-iteration lock.
+    ///
+    /// Should be called once right after [`connect`](Self::connect). Returns
+    /// `None` when the transport is not connected or the receiver was already
+    /// taken. Once taken, [`receive`](Self::receive) is no longer usable.
+    async fn take_message_receiver(&self) -> Option<mpsc::Receiver<String>>;
+
+    /// Polls for a single inbound message with a short internal timeout.
+    ///
+    /// This is the legacy receive path retained for backward compatibility and
+    /// unit tests. Production callers should prefer
+    /// [`take_message_receiver`](Self::take_message_receiver) to avoid
+    /// busy-waiting.
     async fn receive(&self) -> Result<Option<String>>;
+
     fn is_connected(&self) -> bool;
 }
 
@@ -50,15 +71,27 @@ impl McpProtocolClient {
     pub async fn connect(&mut self) -> Result<()> {
         let mut transport = self.transport.write().await;
         transport.connect().await?;
+
+        // Take the inbound message receiver once — the handler will own it and
+        // consume messages directly from the channel without touching the
+        // transport (no per-iteration RwLock, no polling, no sleep).
+        let receiver = transport.take_message_receiver().await;
         drop(transport);
 
-        // Start message handler
-        self.start_message_handler();
+        if let Some(receiver) = receiver {
+            self.start_message_handler(receiver);
+        } else {
+            warn!(
+                "Transport did not provide a message receiver; \
+                 message handler will not be started"
+            );
+        }
 
         Ok(())
     }
 
     pub async fn disconnect(&mut self) -> Result<()> {
+        // Abort the handler first so it stops consuming from the channel.
         if let Some(handler) = self.message_handler.take() {
             handler.abort();
         }
@@ -67,39 +100,31 @@ impl McpProtocolClient {
         transport.disconnect().await
     }
 
-    fn start_message_handler(&mut self) {
-        let transport = self.transport.clone();
+    /// Spawns the message handler task that consumes inbound messages directly
+    /// from the channel receiver.
+    ///
+    /// The task parks efficiently on `receiver.recv().await` — zero wakeups
+    /// while idle, no transport lock acquisition, no sleep. It exits cleanly
+    /// when the channel closes (transport disconnected / background reader
+    /// ended) or is aborted during [`disconnect`](Self::disconnect).
+    fn start_message_handler(&mut self, mut receiver: mpsc::Receiver<String>) {
         let pending_requests = self.pending_requests.clone();
         let notification_tx = self.notification_tx.clone();
 
         let handler = tokio::spawn(async move {
-            loop {
-                let transport = transport.read().await;
-                if !transport.is_connected() {
-                    break;
-                }
-
-                match transport.receive().await {
-                    Ok(Some(message)) => {
-                        // Raw inbound wire messages can be extremely noisy and may contain secrets.
-                        trace!("Received message (bytes={})", message.len());
-                        if let Err(e) =
-                            Self::handle_message(&message, &pending_requests, &notification_tx)
-                                .await
-                        {
-                            warn!("Failed to handle message: {}", e);
-                        }
-                    }
-                    Ok(None) => {
-                        // No message available, continue
-                        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-                    }
-                    Err(e) => {
-                        error!("Transport error: {}", e);
-                        break;
-                    }
+            // Await the next message from the channel. When the channel closes
+            // (all senders dropped — transport disconnected, EOF, or shutdown),
+            // `recv()` returns `None` and the loop exits gracefully.
+            while let Some(message) = receiver.recv().await {
+                // Raw inbound wire messages can be extremely noisy and may contain secrets.
+                trace!("Received message (bytes={})", message.len());
+                if let Err(e) =
+                    Self::handle_message(&message, &pending_requests, &notification_tx).await
+                {
+                    warn!("Failed to handle message: {}", e);
                 }
             }
+            trace!("MCP message handler exited (channel closed)");
         });
 
         self.message_handler = Some(handler);
@@ -296,29 +321,46 @@ impl McpProtocolClient {
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use tokio::sync::Mutex as TokioMutex;
 
-    // Mock transport for testing
+    // Mock transport for testing — backed by an mpsc channel so that
+    // `take_message_receiver` hands the client a real receiver.
     struct MockTransport {
         connected: bool,
         messages_sent: Arc<RwLock<Vec<String>>>,
-        messages_to_receive: Arc<RwLock<Vec<String>>>,
+        message_rx: TokioMutex<Option<mpsc::Receiver<String>>>,
+        // Holding the sender keeps the channel open (idle handler parks, no EOF).
+        _message_tx: Option<mpsc::Sender<String>>,
     }
 
     impl MockTransport {
         fn new() -> Self {
+            let (tx, rx) = mpsc::channel(100);
             Self {
                 connected: false,
                 messages_sent: Arc::new(RwLock::new(Vec::new())),
-                messages_to_receive: Arc::new(RwLock::new(Vec::new())),
+                message_rx: TokioMutex::new(Some(rx)),
+                _message_tx: Some(tx),
             }
         }
 
         fn with_response(message: String) -> Self {
-            let messages = Arc::new(RwLock::new(vec![message]));
+            Self::with_messages(vec![message])
+        }
+
+        /// Pre-loads `messages` into the channel then drops the sender,
+        /// simulating a server that sends N messages and closes (EOF).
+        fn with_messages(messages: Vec<String>) -> Self {
+            let (tx, rx) = mpsc::channel(100);
+            for msg in &messages {
+                let _ = tx.try_send(msg.clone());
+            }
+            drop(tx);
             Self {
                 connected: false,
                 messages_sent: Arc::new(RwLock::new(Vec::new())),
-                messages_to_receive: messages,
+                message_rx: TokioMutex::new(Some(rx)),
+                _message_tx: None,
             }
         }
     }
@@ -341,12 +383,23 @@ mod tests {
             Ok(())
         }
 
+        async fn take_message_receiver(&self) -> Option<mpsc::Receiver<String>> {
+            self.message_rx.lock().await.take()
+        }
+
         async fn receive(&self) -> Result<Option<String>> {
-            let mut messages = self.messages_to_receive.write().await;
-            if messages.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(messages.remove(0)))
+            let mut guard = self.message_rx.lock().await;
+            match guard.as_mut() {
+                None => Err(McpError::Disconnected),
+                Some(rx) => {
+                    match tokio::time::timeout(tokio::time::Duration::from_millis(100), rx.recv())
+                        .await
+                    {
+                        Ok(Some(msg)) => Ok(Some(msg)),
+                        Ok(None) => Err(McpError::Disconnected),
+                        Err(_) => Ok(None),
+                    }
+                }
             }
         }
 
@@ -462,5 +515,51 @@ mod tests {
         let result = rx2.blocking_recv().unwrap().unwrap();
         assert_eq!(result.id, 1);
         assert!(result.result.is_some());
+    }
+
+    /// Verifies that the channel-based handler delivers N messages in order
+    /// and exits cleanly when the channel closes (simulated EOF).
+    #[tokio::test]
+    async fn test_handler_delivers_messages_in_order_and_exits_on_eof() {
+        let n = 10;
+        let messages: Vec<String> = (0..n)
+            .map(|i| {
+                serde_json::to_string(&JsonRpcNotification {
+                    jsonrpc: "2.0".to_string(),
+                    method: format!("test/event/{i}"),
+                    params: None,
+                })
+                .unwrap()
+            })
+            .collect();
+
+        let transport = Box::new(MockTransport::with_messages(messages));
+        let mut client = McpProtocolClient::new(transport);
+        client.connect().await.unwrap();
+
+        // Give the handler time to process all messages.
+        tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+
+        // Drain received notifications.
+        let mut received: Vec<String> = Vec::new();
+        while let Some(notif) = client.try_receive_notification().await {
+            received.push(notif.method);
+        }
+        assert_eq!(received.len(), n, "all notifications should be delivered");
+        for (i, method) in received.iter().enumerate() {
+            assert_eq!(method, &format!("test/event/{i}"), "order preserved");
+        }
+
+        // After all messages consumed + sender dropped (EOF), the handler
+        // should have exited cleanly.
+        if let Some(handler) = &client.message_handler {
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            assert!(
+                handler.is_finished(),
+                "handler should have exited after channel closed (EOF)"
+            );
+        }
+
+        let _ = client.disconnect().await;
     }
 }

--- a/crates/infra/bamboo-mcp/src/transports/sse.rs
+++ b/crates/infra/bamboo-mcp/src/transports/sse.rs
@@ -68,8 +68,13 @@ pub struct SseTransport {
     client: Client,
     post_client: Arc<dyn PostClient>,
     connected: Arc<AtomicBool>,
-    message_tx: mpsc::Sender<String>,
-    message_rx: Mutex<mpsc::Receiver<String>>,
+    // Pre-connect keepalive sender — keeps the initial channel open so legacy
+    // `receive()` times out instead of seeing EOF before connect() runs.
+    // connect() drops this; afterwards the SSE background task is the sole
+    // sender, so when it ends (stream error / abort) the channel closes and
+    // the client message handler wakes with zero idle wakeups.
+    keepalive_tx: Option<mpsc::Sender<String>>,
+    message_rx: Mutex<Option<mpsc::Receiver<String>>>,
     sse_handle: Option<tokio::task::JoinHandle<()>>,
     endpoint_url: Arc<Mutex<Option<String>>>,
     endpoint_notify: Arc<Notify>,
@@ -81,7 +86,7 @@ impl SseTransport {
     }
 
     pub fn new_with_client(config: SseConfig, client: Client) -> Self {
-        let (message_tx, message_rx) = mpsc::channel(100);
+        let (keepalive_tx, message_rx) = mpsc::channel(100);
         let post_client: Arc<dyn PostClient> = Arc::new(ReqwestPostClient {
             client: client.clone(),
         });
@@ -90,8 +95,8 @@ impl SseTransport {
             client,
             post_client,
             connected: Arc::new(AtomicBool::new(false)),
-            message_tx,
-            message_rx: Mutex::new(message_rx),
+            keepalive_tx: Some(keepalive_tx),
+            message_rx: Mutex::new(Some(message_rx)),
             sse_handle: None,
             endpoint_url: Arc::new(Mutex::new(None)),
             endpoint_notify: Arc::new(Notify::new()),
@@ -212,8 +217,12 @@ impl McpTransport for SseTransport {
                 .and_then(|v| v.to_str().ok())
         );
 
+        // Drop the pre-connect keepalive sender — the SSE task becomes the sole
+        // sender so the channel closes when the stream ends.
+        self.keepalive_tx = None;
+
         // Start SSE event handler
-        let message_tx = self.message_tx.clone();
+        let (message_tx, message_rx) = mpsc::channel(100);
         let url = self.config.url.clone();
         let endpoint_url = self.endpoint_url.clone();
         let endpoint_notify = self.endpoint_notify.clone();
@@ -267,6 +276,7 @@ impl McpTransport for SseTransport {
 
         self.sse_handle = Some(handle);
         self.connected.store(true, Ordering::SeqCst);
+        self.message_rx = Mutex::new(Some(message_rx));
 
         info!("MCP SSE transport connected");
         Ok(())
@@ -370,26 +380,31 @@ impl McpTransport for SseTransport {
         Ok(())
     }
 
+    async fn take_message_receiver(&self) -> Option<mpsc::Receiver<String>> {
+        self.message_rx.lock().await.take()
+    }
+
     async fn receive(&self) -> Result<Option<String>> {
         if !self.is_connected() {
             return Err(McpError::Disconnected);
         }
 
-        let mut rx = self.message_rx.lock().await;
-        match tokio::time::timeout(tokio::time::Duration::from_millis(100), rx.recv()).await {
-            Ok(Some(message)) => {
-                // Don't log raw message bodies at debug/info: they may contain tool args/secrets.
-                trace!("Received SSE message (bytes={})", message.len());
-                Ok(Some(message))
-            }
-            Ok(None) => {
-                // Channel closed
-                warn!("SSE message channel closed");
-                Err(McpError::Disconnected)
-            }
-            Err(_) => {
-                // Timeout, no message available
-                Ok(None)
+        let mut guard = self.message_rx.lock().await;
+        match guard.as_mut() {
+            None => Err(McpError::Disconnected),
+            Some(rx) => {
+                match tokio::time::timeout(tokio::time::Duration::from_millis(100), rx.recv()).await
+                {
+                    Ok(Some(message)) => {
+                        trace!("Received SSE message (bytes={})", message.len());
+                        Ok(Some(message))
+                    }
+                    Ok(None) => {
+                        warn!("SSE message channel closed");
+                        Err(McpError::Disconnected)
+                    }
+                    Err(_) => Ok(None),
+                }
             }
         }
     }

--- a/crates/infra/bamboo-mcp/src/transports/stdio.rs
+++ b/crates/infra/bamboo-mcp/src/transports/stdio.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, ChildStdin, ChildStdout, Command};
-use tokio::sync::Mutex;
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::{mpsc, Mutex};
 use tracing::{error, info, trace, warn};
 
 use crate::config::StdioConfig;
@@ -10,14 +10,20 @@ use crate::error::{McpError, Result};
 use crate::protocol::client::McpTransport;
 use bamboo_infrastructure::process::{hide_window_for_tokio_command, trace_windows_command};
 
+use std::sync::Arc;
+
 pub struct StdioTransport {
     config: StdioConfig,
     child: Option<Child>,
     stdin: Option<Arc<Mutex<ChildStdin>>>,
-    stdout: Option<Arc<Mutex<BufReader<ChildStdout>>>>,
+    // Inbound messages are delivered through this channel by a dedicated
+    // reader task (spawned in connect). The reader task owns the child's
+    // stdout and is the sole sender — when stdout reaches EOF or an error,
+    // the sender is dropped and the channel closes, which wakes the client
+    // handler with zero idle wakeups.
+    message_rx: Mutex<Option<mpsc::Receiver<String>>>,
+    reader_handle: Option<tokio::task::JoinHandle<()>>,
 }
-
-use std::sync::Arc;
 
 impl StdioTransport {
     pub fn new(config: StdioConfig) -> Self {
@@ -25,7 +31,8 @@ impl StdioTransport {
             config,
             child: None,
             stdin: None,
-            stdout: None,
+            message_rx: Mutex::new(None),
+            reader_handle: None,
         }
     }
 }
@@ -85,9 +92,45 @@ impl McpTransport for StdioTransport {
             });
         }
 
+        // Spawn a dedicated reader task that owns stdout and pushes each
+        // non-empty line into the message channel. This replaces the old
+        // per-call `receive()` that polled stdout with a 100ms timeout.
+        let (message_tx, message_rx) = mpsc::channel(100);
+        let reader_handle = tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => {
+                        let line = line.trim();
+                        if line.is_empty() {
+                            continue;
+                        }
+                        // Raw wire logs can be extremely noisy (e.g., keepalive pings).
+                        trace!("Received: {}", line);
+                        if message_tx.send(line.to_string()).await.is_err() {
+                            // Receiver dropped — client handler is gone.
+                            break;
+                        }
+                    }
+                    Ok(None) => {
+                        // EOF — child exited.
+                        warn!("MCP server stdout closed (EOF)");
+                        break;
+                    }
+                    Err(e) => {
+                        warn!("MCP server stdout read error: {}", e);
+                        break;
+                    }
+                }
+            }
+            // message_tx is dropped here → channel closes → handler exits.
+        });
+
         self.child = Some(child);
         self.stdin = Some(Arc::new(Mutex::new(stdin)));
-        self.stdout = Some(Arc::new(Mutex::new(BufReader::new(stdout))));
+        self.message_rx = Mutex::new(Some(message_rx));
+        self.reader_handle = Some(reader_handle);
 
         info!("MCP server process started successfully");
         Ok(())
@@ -96,9 +139,14 @@ impl McpTransport for StdioTransport {
     async fn disconnect(&mut self) -> Result<()> {
         info!("Disconnecting MCP server process");
 
-        // Close stdin to signal EOF
+        // Close stdin to signal EOF to the child process.
         self.stdin = None;
-        self.stdout = None;
+
+        // Abort the reader task (belt-and-suspenders: it should end on its own
+        // when stdout closes after the child is killed).
+        if let Some(handle) = self.reader_handle.take() {
+            handle.abort();
+        }
 
         if let Some(mut child) = self.child.take() {
             // Try graceful shutdown
@@ -111,6 +159,13 @@ impl McpTransport for StdioTransport {
                     let _ = child.kill().await;
                 }
             }
+        }
+
+        // Drop the message receiver so any lingering take_message_receiver
+        // consumer sees a clean close.
+        {
+            let mut guard = self.message_rx.lock().await;
+            *guard = None;
         }
 
         Ok(())
@@ -135,37 +190,28 @@ impl McpTransport for StdioTransport {
         Ok(())
     }
 
+    async fn take_message_receiver(&self) -> Option<mpsc::Receiver<String>> {
+        self.message_rx.lock().await.take()
+    }
+
     async fn receive(&self) -> Result<Option<String>> {
-        let stdout = self.stdout.as_ref().ok_or_else(|| McpError::Disconnected)?;
-
-        let mut stdout = stdout.lock().await;
-        let mut line = String::new();
-
-        match tokio::time::timeout(
-            tokio::time::Duration::from_millis(100),
-            stdout.read_line(&mut line),
-        )
-        .await
-        {
-            Ok(Ok(0)) => {
-                // EOF
-                warn!("MCP server stdout closed (EOF)");
-                Err(McpError::Disconnected)
-            }
-            Ok(Ok(_)) => {
-                let line = line.trim();
-                if line.is_empty() {
-                    Ok(None)
-                } else {
-                    // Raw wire logs can be extremely noisy (e.g., keepalive pings).
-                    trace!("Received: {}", line);
-                    Ok(Some(line.to_string()))
+        let mut guard = self.message_rx.lock().await;
+        match guard.as_mut() {
+            None => Err(McpError::Disconnected),
+            Some(rx) => {
+                match tokio::time::timeout(tokio::time::Duration::from_millis(100), rx.recv()).await
+                {
+                    Ok(Some(message)) => Ok(Some(message)),
+                    Ok(None) => {
+                        // Channel closed (reader task ended / EOF).
+                        warn!("MCP server stdout channel closed");
+                        Err(McpError::Disconnected)
+                    }
+                    Err(_) => {
+                        // Timeout, no data available.
+                        Ok(None)
+                    }
                 }
-            }
-            Ok(Err(e)) => Err(McpError::Transport(format!("Failed to read: {}", e))),
-            Err(_) => {
-                // Timeout, no data available
-                Ok(None)
             }
         }
     }
@@ -173,7 +219,8 @@ impl McpTransport for StdioTransport {
     fn is_connected(&self) -> bool {
         // Note: is_connected is called on &self, but try_wait needs &mut self
         // We use a simple check - if we have a child handle, assume connected
-        // Actual process exit will be detected during receive()
+        // Actual process exit will be detected when the reader task ends and
+        // the channel closes.
         self.child.is_some()
     }
 }
@@ -200,7 +247,7 @@ mod tests {
         let transport = StdioTransport::new(config);
         assert!(transport.child.is_none());
         assert!(transport.stdin.is_none());
-        assert!(transport.stdout.is_none());
+        assert!(transport.reader_handle.is_none());
     }
 
     #[tokio::test]
@@ -212,7 +259,7 @@ mod tests {
         assert!(result.is_ok());
         assert!(transport.child.is_some());
         assert!(transport.stdin.is_some());
-        assert!(transport.stdout.is_some());
+        assert!(transport.reader_handle.is_some());
         assert!(transport.is_connected());
 
         // Clean up
@@ -231,7 +278,7 @@ mod tests {
         assert!(result.is_ok());
         assert!(transport.child.is_none());
         assert!(transport.stdin.is_none());
-        assert!(transport.stdout.is_none());
+        assert!(transport.reader_handle.is_none());
         assert!(!transport.is_connected());
     }
 
@@ -345,13 +392,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_stdio_receive_timeout() {
-        let config = create_test_config();
+        // Use `sleep` so the process stays alive without producing output,
+        // keeping the channel open and letting receive() time out properly.
+        let config = StdioConfig {
+            command: "sleep".to_string(),
+            args: vec!["10".to_string()],
+            cwd: None,
+            env: HashMap::new(),
+            env_encrypted: HashMap::new(),
+            startup_timeout_ms: 5000,
+        };
         let mut transport = StdioTransport::new(config);
         transport.connect().await.unwrap();
 
-        // Echo doesn't output anything without input, so receive should timeout
         let result = transport.receive().await;
-        // Should be Ok(None) on timeout
+        // Should be Ok(None) on timeout (no data, channel still open).
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
 
@@ -370,5 +425,35 @@ mod tests {
 
         transport.disconnect().await.unwrap();
         assert!(!transport.is_connected());
+    }
+
+    /// Verifies that the reader task delivers multiple messages in order and
+    /// that the channel closes (clean shutdown) when stdout reaches EOF.
+    #[tokio::test]
+    async fn test_stdio_reader_delivers_messages_then_eof() {
+        // `printf` outputs three lines then exits → reader task delivers them
+        // and then gets EOF, closing the channel.
+        let config = StdioConfig {
+            command: "printf".to_string(),
+            args: vec!["line-a\\nline-b\\nline-c\\n".to_string()],
+            cwd: None,
+            env: HashMap::new(),
+            env_encrypted: HashMap::new(),
+            startup_timeout_ms: 5000,
+        };
+        let mut transport = StdioTransport::new(config);
+        transport.connect().await.unwrap();
+
+        // Collect messages via take_message_receiver.
+        let mut rx = transport.take_message_receiver().await.expect("receiver");
+
+        let mut received = Vec::new();
+        while let Some(msg) = rx.recv().await {
+            received.push(msg);
+        }
+        // All three lines delivered in order.
+        assert_eq!(received, vec!["line-a", "line-b", "line-c"]);
+
+        let _ = transport.disconnect().await;
     }
 }

--- a/crates/infra/bamboo-mcp/src/transports/streamable_http.rs
+++ b/crates/infra/bamboo-mcp/src/transports/streamable_http.rs
@@ -26,8 +26,10 @@ pub struct StreamableHttpTransport {
     client: Client,
     session_id: Arc<Mutex<Option<String>>>,
     connected: Arc<AtomicBool>,
-    message_tx: mpsc::Sender<String>,
-    message_rx: Mutex<mpsc::Receiver<String>>,
+    // Dropped in disconnect() so the channel closes and the client handler
+    // wakes without polling.
+    message_tx: Option<mpsc::Sender<String>>,
+    message_rx: Mutex<Option<mpsc::Receiver<String>>>,
     get_sse_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
@@ -43,8 +45,8 @@ impl StreamableHttpTransport {
             client,
             session_id: Arc::new(Mutex::new(None)),
             connected: Arc::new(AtomicBool::new(false)),
-            message_tx,
-            message_rx: Mutex::new(message_rx),
+            message_tx: Some(message_tx),
+            message_rx: Mutex::new(Some(message_rx)),
             get_sse_handle: Mutex::new(None),
         }
     }
@@ -154,7 +156,9 @@ impl StreamableHttpTransport {
         if content_type.contains("text/event-stream") {
             // SSE response — parse events and forward each to channel.
             trace!("MCP StreamableHTTP POST response is SSE stream");
-            let tx = self.message_tx.clone();
+            let Some(tx) = self.message_tx.clone() else {
+                return Ok(()); // disconnected
+            };
             let url = self.config.url.clone();
             let connected = self.connected.clone();
 
@@ -193,8 +197,10 @@ impl StreamableHttpTransport {
                     "MCP StreamableHTTP POST response is JSON (bytes={})",
                     body.len()
                 );
-                if self.message_tx.send(body).await.is_err() {
-                    warn!("MCP StreamableHTTP: message channel closed");
+                if let Some(tx) = self.message_tx.as_ref() {
+                    if tx.send(body).await.is_err() {
+                        warn!("MCP StreamableHTTP: message channel closed");
+                    }
                 }
             }
         }
@@ -263,7 +269,9 @@ impl StreamableHttpTransport {
 
         debug!("MCP StreamableHTTP GET SSE stream opened");
 
-        let tx = self.message_tx.clone();
+        let Some(tx) = self.message_tx.clone() else {
+            return; // disconnected
+        };
         let connected = self.connected.clone();
 
         let handle = tokio::spawn(async move {
@@ -318,6 +326,10 @@ impl McpTransport for StreamableHttpTransport {
         debug!("Disconnecting MCP StreamableHTTP transport");
 
         self.connected.store(false, Ordering::SeqCst);
+
+        // Drop the struct's message sender so the channel closes, waking the
+        // client handler (if any) without polling.
+        self.message_tx = None;
 
         // Cancel the GET SSE stream background task.
         {
@@ -382,25 +394,35 @@ impl McpTransport for StreamableHttpTransport {
         Ok(())
     }
 
+    async fn take_message_receiver(&self) -> Option<mpsc::Receiver<String>> {
+        self.message_rx.lock().await.take()
+    }
+
     async fn receive(&self) -> Result<Option<String>> {
         if !self.is_connected() {
             return Err(McpError::Disconnected);
         }
 
-        let mut rx = self.message_rx.lock().await;
-        match tokio::time::timeout(tokio::time::Duration::from_millis(100), rx.recv()).await {
-            Ok(Some(message)) => {
-                trace!(
-                    "MCP StreamableHTTP received message (bytes={})",
-                    message.len()
-                );
-                Ok(Some(message))
+        let mut guard = self.message_rx.lock().await;
+        match guard.as_mut() {
+            None => Err(McpError::Disconnected),
+            Some(rx) => {
+                match tokio::time::timeout(tokio::time::Duration::from_millis(100), rx.recv()).await
+                {
+                    Ok(Some(message)) => {
+                        trace!(
+                            "MCP StreamableHTTP received message (bytes={})",
+                            message.len()
+                        );
+                        Ok(Some(message))
+                    }
+                    Ok(None) => {
+                        warn!("MCP StreamableHTTP message channel closed");
+                        Err(McpError::Disconnected)
+                    }
+                    Err(_) => Ok(None),
+                }
             }
-            Ok(None) => {
-                warn!("MCP StreamableHTTP message channel closed");
-                Err(McpError::Disconnected)
-            }
-            Err(_) => Ok(None), // Timeout, no message available
         }
     }
 


### PR DESCRIPTION
Closes #14 — the MCP client handler busy-waited (~100 wakeups/sec/server idle + RwLock contention). Now each transport hands out an mpsc Receiver (SSE/StreamableHTTP expose their existing internal channel; stdio gets an AsyncBufReadExt reader task), and the client handler awaits it — zero idle wakeups, no per-iteration lock. message_tx is Option; disconnect closes the channel; shutdown is clean on all paths.

152 tests pass + 2 new (in-order+EOF, stdio reader). bamboo-reviewed. Verified: check --workspace; bamboo-mcp (152) green; fmt + clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp