### PR TITLE
fix(bamboo-broker): timeout on deliver() receipt wait (#51)

### DIFF
--- a/crates/app/bamboo-broker/src/client.rs
+++ b/crates/app/bamboo-broker/src/client.rs
@@ -3,6 +3,8 @@
 //! `delivered` receipt stream — so one connection can both deliver and
 //! subscribe (the parent does both: deliver an Ask, subscribe for the Reply).
 
+use std::time::Duration;
+
 use bamboo_subagent::{AgentRef, InboxMessage, MsgId};
 use futures_util::stream::SplitSink;
 use futures_util::{SinkExt, StreamExt};
@@ -15,6 +17,13 @@ use crate::error::{BrokerError, BrokerResult};
 use crate::proto::{BrokerFrame, ClientFrame};
 
 type WsSink = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
+
+/// Upper bound on how long [`BrokerClient::deliver`] waits for the broker's
+/// `Delivered` receipt before giving up. The receipt only means the broker
+/// durably accepted the `Deliver` (not that the worker replied), so it should
+/// arrive promptly; 30s is a generous cap that still guarantees a caller can
+/// never hang indefinitely if the broker dies after receiving `Deliver`.
+const DELIVER_RECEIPT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A connected broker client bound to one session mailbox.
 pub struct BrokerClient {
@@ -88,15 +97,38 @@ impl BrokerClient {
 
     /// Durably enqueue `message` into session `to`'s mailbox; returns the stored
     /// id once the broker confirms (`Delivered`).
+    ///
+    /// Bounded by [`DELIVER_RECEIPT_TIMEOUT`]: if the broker accepts the
+    /// `Deliver` frame but crashes (or stalls) before sending `Delivered`, the
+    /// receipt wait fails instead of hanging the caller forever.
     pub async fn deliver(&mut self, to: &str, message: InboxMessage) -> BrokerResult<MsgId> {
+        self.deliver_with_receipt_timeout(to, message, DELIVER_RECEIPT_TIMEOUT)
+            .await
+    }
+
+    /// [`deliver`](Self::deliver) with an explicit receipt-wait bound. Private
+    /// so tests can drive the timeout with a tiny value instead of waiting out
+    /// the real [`DELIVER_RECEIPT_TIMEOUT`].
+    async fn deliver_with_receipt_timeout(
+        &mut self,
+        to: &str,
+        message: InboxMessage,
+        receipt_timeout: Duration,
+    ) -> BrokerResult<MsgId> {
         self.send(ClientFrame::Deliver {
             to: to.into(),
             message,
         })
         .await?;
-        self.delivered.recv().await.ok_or_else(|| {
-            BrokerError::Transport("connection closed before delivery receipt".into())
-        })
+        match tokio::time::timeout(receipt_timeout, self.delivered.recv()).await {
+            Ok(Some(id)) => Ok(id),
+            Ok(None) => Err(BrokerError::Transport(
+                "connection closed before delivery receipt".into(),
+            )),
+            Err(_) => Err(BrokerError::Transport(
+                "timed out waiting for delivery receipt from broker".into(),
+            )),
+        }
     }
 
     /// Start receiving this client's own mailbox. Pushed messages arrive via
@@ -120,5 +152,98 @@ impl BrokerClient {
             .send(Message::Text(frame.to_text()))
             .await
             .map_err(|e| BrokerError::Transport(format!("ws send: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_subagent::{AskBody, AskMode, InboxKind};
+    use chrono::Utc;
+    use tokio_tungstenite::accept_async;
+
+    fn test_agent(id: &str) -> AgentRef {
+        AgentRef {
+            session_id: id.into(),
+            role: None,
+        }
+    }
+
+    fn test_ask(from: &str) -> InboxMessage {
+        InboxMessage {
+            id: MsgId::new(),
+            from: test_agent(from),
+            kind: InboxKind::Ask,
+            body: serde_json::to_value(AskBody {
+                question: "ping".into(),
+                mode: AskMode::Query,
+            })
+            .unwrap(),
+            created_at: Utc::now(),
+            correlation_id: None,
+        }
+    }
+
+    /// Spawn a raw WS server that completes the client's `Hello`→`Welcome`
+    /// handshake, then silently drains every later frame without EVER sending a
+    /// `Delivered` receipt — so a client `deliver()` can only time out. The
+    /// connection is held open (not closed) so the client's receipt channel is
+    /// never closed: the wait must hit the timeout, not a `recv() -> None`.
+    async fn broker_that_never_acks() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let ws = accept_async(stream).await.expect("ws upgrade");
+            let (mut sink, mut source) = ws.split();
+            // First text frame is the client's `Hello`; answer with `Welcome`.
+            if let Some(Ok(Message::Text(_))) = source.next().await {
+                let _ = sink
+                    .send(Message::Text(BrokerFrame::Welcome.to_text()))
+                    .await;
+            }
+            // Drain the `Deliver` (and anything else) but never reply with
+            // `Delivered`.
+            while let Some(Ok(_)) = source.next().await {}
+        });
+        format!("ws://{addr}")
+    }
+
+    /// Regression test for issue #51: when the broker never sends `Delivered`,
+    /// `deliver()` must return a clear timeout error promptly instead of
+    /// hanging the caller forever.
+    #[tokio::test]
+    async fn deliver_times_out_when_broker_never_sends_receipt() {
+        let endpoint = broker_that_never_acks().await;
+        let mut client = BrokerClient::connect(&endpoint, test_agent("parent"), "ignored")
+            .await
+            .expect("handshake completes");
+
+        // Inject a tiny receipt bound via the private entry point so the test
+        // is fast; the outer timeout guards against a regression to an
+        // unbounded recv hanging the whole suite.
+        let started = std::time::Instant::now();
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(2),
+            client.deliver_with_receipt_timeout(
+                "child",
+                test_ask("parent"),
+                Duration::from_millis(50),
+            ),
+        )
+        .await;
+
+        let result = outcome.expect("deliver() resolved instead of hanging");
+        assert!(
+            matches!(result, Err(BrokerError::Transport(ref m)) if m.contains("timed out")),
+            "expected a timeout transport error, got {result:?}",
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "deliver() should fail fast, but took {:?}",
+            started.elapsed(),
+        );
     }
 }


### PR DESCRIPTION
Closes #51 — BrokerClient::deliver() awaited the Delivered receipt with no timeout, so a broker crash mid-deliver hung the orchestrator forever. Wrap the recv in tokio::time::timeout(30s); success path byte-identical (private deliver_with_receipt_timeout lets tests inject a small bound); timeout/channel-close both map to BrokerError::Transport (no Timeout variant exists). Test holds the connection open to hit the timeout path.

bamboo-reviewed. Verified: check --workspace; bamboo-broker (18+3) green; fmt + clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp