### PR TITLE
fix(bamboo-broker): supervised reconnect for MCP proxy, both sides (#47)

### DIFF
--- a/crates/app/bamboo-broker/src/lib.rs
+++ b/crates/app/bamboo-broker/src/lib.rs
@@ -38,7 +38,10 @@ pub use crate::deploy::{
     AgentDeployment, DeployedAgent, Deployer, DockerDeployer, LocalProcessDeployer, SshDeployer,
 };
 pub use crate::error::{BrokerError, BrokerResult};
-pub use crate::mcp::{serve_mcp_proxy, McpProxyExecutor, McpReply, McpRequest, ProxiedResult};
+pub use crate::mcp::{
+    serve_mcp_proxy, serve_mcp_proxy_supervised, McpProxyExecutor, McpReply, McpRequest,
+    ProxiedResult,
+};
 pub use crate::proto::{BrokerFrame, ClientFrame};
 pub use crate::serve::{serve_executor, serve_loop, serve_mailbox, serve_with, Handled};
 pub use crate::server::BrokerServer;

--- a/crates/app/bamboo-broker/src/mcp.rs
+++ b/crates/app/bamboo-broker/src/mcp.rs
@@ -9,7 +9,8 @@
 //! - Orchestrator side: [`serve_mcp_proxy`] answers `McpRequest`s from a backend
 //!   [`ToolExecutor`] (the real `McpServerManager`).
 
-use std::sync::Arc;
+use std::future::Future;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -20,10 +21,31 @@ use bamboo_subagent::{AgentRef, InboxKind, InboxMessage, MsgId};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 
 use crate::ask::request_over;
 use crate::client::BrokerClient;
 use crate::error::{BrokerError, BrokerResult};
+
+// --- supervised-reconnect tuning (issue #47) ----------------------------------
+
+/// Initial backoff for the orchestrator-side MCP proxy supervisor. The proxy
+/// connection is long-lived, so this only gates *restarts* after a drop.
+const PROXY_RECONNECT_INITIAL_BACKOFF: Duration = Duration::from_millis(500);
+/// Cap for the orchestrator proxy reconnect backoff.
+const PROXY_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(30);
+/// A serve run that lasts at least this long counts as "healthy": the next
+/// restart resets the backoff to the floor instead of continuing to grow it,
+/// so a single blip doesn't leave a large lingering backoff.
+const PROXY_BACKOFF_RESET_AFTER: Duration = Duration::from_secs(10);
+
+/// Initial backoff for the worker-side lazy reconnect.
+const WORKER_RECONNECT_INITIAL_BACKOFF: Duration = Duration::from_millis(200);
+/// Cap for the worker-side lazy reconnect backoff.
+const WORKER_RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(2);
+/// Maximum reconnect attempts per call before surfacing a transient error. A
+/// later call can try again; the executor is never permanently disabled.
+const WORKER_RECONNECT_MAX_ATTEMPTS: u32 = 5;
 
 /// Body of an `McpRequest` (worker → orchestrator).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -91,6 +113,96 @@ pub async fn serve_mcp_proxy(
     Ok(())
 }
 
+/// Supervised orchestrator-side MCP proxy (issue #47): run [`serve_mcp_proxy`]
+/// in a loop, restarting it with bounded exponential backoff whenever the broker
+/// connection drops, and stop cleanly when `shutdown` is cancelled.
+///
+/// A healthy, long-lived connection behaves identically to the bare
+/// [`serve_mcp_proxy`] — this only adds resilience to transient WebSocket drops.
+///
+/// - **Backoff**: starts at [`PROXY_RECONNECT_INITIAL_BACKOFF`], doubles on each
+///   quick restart, and is capped at [`PROXY_RECONNECT_MAX_BACKOFF`]. Reset to
+///   the floor after a run that lasted ≥ [`PROXY_BACKOFF_RESET_AFTER`] (a healthy
+///   connection), so a brief blip doesn't leave a large backoff lingering.
+/// - **Shutdown**: the in-flight serve is raced against `shutdown.cancelled()` so
+///   an intended stop interrupts it promptly; the backoff sleep between restarts
+///   is also raced against shutdown. The loop never restarts once shutdown is
+///   requested, so there is no leaked task / infinite restart after a stop.
+pub async fn serve_mcp_proxy_supervised(
+    endpoint: &str,
+    me: AgentRef,
+    token: &str,
+    backend: Arc<dyn ToolExecutor>,
+    shutdown: CancellationToken,
+) {
+    supervise_reconnect(
+        || serve_mcp_proxy(endpoint, me.clone(), token, backend.clone()),
+        shutdown,
+        PROXY_RECONNECT_INITIAL_BACKOFF,
+        PROXY_RECONNECT_MAX_BACKOFF,
+        PROXY_BACKOFF_RESET_AFTER,
+    )
+    .await
+}
+
+/// Generic reconnect supervisor: call `serve_once` repeatedly, restarting on
+/// return/error with bounded exponential backoff, until `shutdown` cancels.
+/// Factored out so the backoff/restart/shutdown behavior is unit-testable with a
+/// stub `serve_once` and tiny backoff constants (no real broker needed).
+async fn supervise_reconnect<F, Fut>(
+    mut serve_once: F,
+    shutdown: CancellationToken,
+    initial_backoff: Duration,
+    max_backoff: Duration,
+    reset_after: Duration,
+) where
+    F: FnMut() -> Fut + Send,
+    Fut: Future<Output = BrokerResult<()>> + Send,
+{
+    let mut backoff = initial_backoff;
+    loop {
+        // Race the in-flight serve against an intended shutdown so an otherwise
+        // indefinitely-blocked healthy connection still stops promptly.
+        let started = std::time::Instant::now();
+        let outcome = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => {
+                tracing::info!("MCP proxy supervisor: shutdown requested, stopping");
+                return;
+            }
+            r = serve_once() => r,
+        };
+
+        // A run that outlasted `reset_after` was healthy → reset backoff.
+        if started.elapsed() >= reset_after {
+            backoff = initial_backoff;
+        }
+
+        match outcome {
+            Ok(()) => tracing::warn!(
+                "MCP proxy connection ended; restarting (backoff {:?})",
+                backoff
+            ),
+            Err(e) => tracing::warn!(
+                "MCP proxy service errored: {e}; restarting (backoff {:?})",
+                backoff
+            ),
+        }
+
+        // Backoff sleep, abortable by shutdown so we don't linger after a stop.
+        let slept = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => false,
+            _ = tokio::time::sleep(backoff) => true,
+        };
+        if !slept {
+            tracing::info!("MCP proxy supervisor: shutdown during backoff, stopping");
+            return;
+        }
+        backoff = std::cmp::min(backoff * 2, max_backoff);
+    }
+}
+
 async fn handle_mcp_request(backend: &dyn ToolExecutor, msg: InboxMessage) -> McpReply {
     match serde_json::from_value::<McpRequest>(msg.body) {
         Ok(McpRequest::Manifest) => McpReply {
@@ -133,9 +245,19 @@ async fn handle_mcp_request(backend: &dyn ToolExecutor, msg: InboxMessage) -> Mc
 /// tools and forwards calls to them over the broker.
 pub struct McpProxyExecutor {
     client: Mutex<BrokerClient>,
+    /// Serializes reconnect attempts so concurrent callers don't each rebuild
+    /// the client. Held only across the (bounded) reconnect — the `client`
+    /// mutex above is never held across a backoff sleep, so a reconnect can't
+    /// deadlock or stall an unrelated caller's lock acquisition.
+    reconnect_lock: Mutex<()>,
     me: AgentRef,
+    endpoint: String,
+    token: String,
     orchestrator: String,
-    manifest: Vec<ToolSchema>,
+    /// Proxiable tool surface, refreshed on each (re)connect. Behind a sync
+    /// `RwLock` because `list_tools` is a sync trait method; reads/writes are
+    /// instantaneous (clone/swap a `Vec`), never held across an `.await`.
+    manifest: RwLock<Vec<ToolSchema>>,
     timeout: Duration,
 }
 
@@ -173,46 +295,163 @@ impl McpProxyExecutor {
 
         Ok(Self {
             client: Mutex::new(client),
+            reconnect_lock: Mutex::new(()),
             me,
+            endpoint: endpoint.to_string(),
+            token: token.to_string(),
             orchestrator,
-            manifest,
+            manifest: RwLock::new(manifest),
             timeout,
         })
     }
 
     /// Number of proxiable tools advertised.
     pub fn tool_count(&self) -> usize {
-        self.manifest.len()
+        self.manifest.read().map(|m| m.len()).unwrap_or(0)
+    }
+
+    /// One request/reply over the current client (under its lock). Does NOT
+    /// reconnect — callers decide that from the error + connection state.
+    async fn request_once(&self, body: serde_json::Value) -> BrokerResult<serde_json::Value> {
+        let mut client = self.client.lock().await;
+        request_over(
+            &mut client,
+            &self.me,
+            &self.orchestrator,
+            InboxKind::McpRequest,
+            body,
+            self.timeout,
+        )
+        .await
+    }
+
+    /// Forward one MCP call, lazily reconnecting a single time if the broker
+    /// connection is *actually* broken (reader exited). A transient timeout or
+    /// an unrelated error is returned as-is — only a dead connection triggers
+    /// the reconnect+retry. On reconnect exhaustion a transient error is
+    /// returned (a later call may succeed), never a permanent one.
+    async fn request_with_reconnect(
+        &self,
+        body: serde_json::Value,
+    ) -> Result<serde_json::Value, ToolError> {
+        match self.request_once(body.clone()).await {
+            Ok(v) => Ok(v),
+            Err(first) => {
+                // Only worth a reconnect if the connection itself is gone; a
+                // plain timeout (reader still alive) surfaces directly.
+                if !self.connection_broken().await {
+                    return Err(ToolError::Execution(format!("mcp proxy: {first}")));
+                }
+                tracing::warn!("mcp proxy connection dropped; reconnecting: {first}");
+                self.reconnect_if_needed()
+                    .await
+                    .map_err(|re| ToolError::Execution(format!("mcp proxy (reconnect): {re}")))?;
+                // Retry exactly once over the freshly established client.
+                self.request_once(body)
+                    .await
+                    .map_err(|re| ToolError::Execution(format!("mcp proxy: {re}")))
+            }
+        }
+    }
+
+    /// `true` when the broker connection is known to be dead (the background
+    /// reader has exited). Used to decide whether a failed request is worth a
+    /// reconnect+retry rather than a plain error.
+    async fn connection_broken(&self) -> bool {
+        let client = self.client.lock().await;
+        !client.reader_alive()
+    }
+
+    /// Lazily re-establish the broker sub-connection: re-Hello/Subscribe and
+    /// re-fetch the manifest, then swap in the fresh client. Serialized by
+    /// [`reconnect_lock`](Self.reconnect_lock); a concurrent caller that already
+    /// reconnected is a no-op. Bounded exponential backoff so a dead broker
+    /// can't hot-loop. Returns a *transient* error (not a permanent one) on
+    /// exhaustion, so a later call can try again — the executor is never
+    /// permanently disabled by a transient drop (issue #47).
+    async fn reconnect_if_needed(&self) -> BrokerResult<()> {
+        let _guard = self.reconnect_lock.lock().await;
+        // While we waited for the guard, another caller may already have
+        // rebuilt the client; if so, there is nothing to do.
+        if !self.connection_broken().await {
+            return Ok(());
+        }
+        let mut backoff = WORKER_RECONNECT_INITIAL_BACKOFF;
+        for _ in 0..WORKER_RECONNECT_MAX_ATTEMPTS {
+            match self.reconnect_once().await {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    tracing::warn!("mcp proxy reconnect failed (backoff {:?}): {e}", backoff);
+                }
+            }
+            // Backoff WITHOUT holding the client mutex — only the reconnect
+            // serialization guard, which is the intended behavior (concurrent
+            // callers await the same single reconnect instead of racing).
+            tokio::time::sleep(backoff).await;
+            backoff = std::cmp::min(backoff * 2, WORKER_RECONNECT_MAX_BACKOFF);
+        }
+        Err(BrokerError::Transport(
+            "mcp proxy reconnect attempts exhausted".into(),
+        ))
+    }
+
+    /// One reconnect attempt: connect, subscribe, re-fetch the manifest, and
+    /// swap the new client + manifest into place. No backoff here — the caller
+    /// (`reconnect_if_needed`) owns the bounded retry/backoff loop.
+    async fn reconnect_once(&self) -> BrokerResult<()> {
+        let mut client =
+            BrokerClient::connect(&self.endpoint, self.me.clone(), &self.token).await?;
+        client.subscribe().await?;
+        // Re-fetch the manifest so any tool-surface change during the outage is
+        // reflected (the only state the proxy keeps beyond the live connection).
+        let reply = request_over(
+            &mut client,
+            &self.me,
+            &self.orchestrator,
+            InboxKind::McpRequest,
+            serde_json::to_value(McpRequest::Manifest).expect("McpRequest serializes"),
+            self.timeout,
+        )
+        .await?;
+        let reply: McpReply = serde_json::from_value(reply)
+            .map_err(|e| BrokerError::Protocol(format!("bad manifest reply: {e}")))?;
+        let manifest = reply.manifest.unwrap_or_default();
+        {
+            let mut slot = self.client.lock().await;
+            *slot = client;
+        }
+        if let Ok(mut m) = self.manifest.write() {
+            *m = manifest;
+        }
+        Ok(())
     }
 }
 
 #[async_trait]
 impl ToolExecutor for McpProxyExecutor {
     async fn execute(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
-        if !self
-            .manifest
-            .iter()
-            .any(|s| s.function.name == call.function.name)
         {
-            return Err(ToolError::NotFound(call.function.name.clone()));
+            let manifest = self
+                .manifest
+                .read()
+                .map_err(|_| ToolError::Execution("mcp proxy manifest lock poisoned".into()))?;
+            if !manifest
+                .iter()
+                .any(|s| s.function.name == call.function.name)
+            {
+                return Err(ToolError::NotFound(call.function.name.clone()));
+            }
         }
-        let req = McpRequest::Call {
+        let body = serde_json::to_value(McpRequest::Call {
             tool: call.function.name.clone(),
             arguments: call.function.arguments.clone(),
-        };
-        let reply = {
-            let mut client = self.client.lock().await;
-            request_over(
-                &mut client,
-                &self.me,
-                &self.orchestrator,
-                InboxKind::McpRequest,
-                serde_json::to_value(req).expect("McpRequest serializes"),
-                self.timeout,
-            )
-            .await
-        }
-        .map_err(|e| ToolError::Execution(format!("mcp proxy: {e}")))?;
+        })
+        .expect("McpRequest serializes");
+
+        // Forward the call, lazily reconnecting once if the broker connection
+        // is actually broken (reader exited). A healthy connection takes the
+        // fast path below — identical bytes to the pre-reconnect behavior.
+        let reply = self.request_with_reconnect(body).await?;
 
         let reply: McpReply = serde_json::from_value(reply)
             .map_err(|e| ToolError::Execution(format!("bad mcp reply: {e}")))?;
@@ -239,7 +478,7 @@ impl ToolExecutor for McpProxyExecutor {
     }
 
     fn list_tools(&self) -> Vec<ToolSchema> {
-        self.manifest.clone()
+        self.manifest.read().map(|m| m.clone()).unwrap_or_default()
     }
 }
 
@@ -250,6 +489,7 @@ mod tests {
     use crate::server::BrokerServer;
     use bamboo_agent_core::tools::FunctionSchema;
     use serde_json::json;
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
     use tokio::net::TcpListener;
 
     const TOKEN: &str = "t";
@@ -356,5 +596,244 @@ mod tests {
             proxy.execute(&miss).await,
             Err(ToolError::NotFound(_))
         ));
+    }
+
+    // --- issue #47: supervised reconnect on both sides ------------------------
+
+    /// Orchestrator supervisor: it restarts `serve_once` after each return with
+    /// bounded backoff, and stops cleanly on shutdown. Driven with a stub
+    /// `serve_once` (no real broker) and tiny backoff constants so it is fast
+    /// and deterministic.
+    #[tokio::test]
+    async fn supervisor_restarts_on_drop_and_stops_on_shutdown() {
+        let shutdown = CancellationToken::new();
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_for_serve = calls.clone();
+        // serve_once: succeed quickly 3 times (quick restarts), then block
+        // forever — a "healthy", long-lived connection that only ends on cancel.
+        let serve = move || {
+            let c = calls_for_serve.clone();
+            async move {
+                let n = c.fetch_add(1, Ordering::SeqCst);
+                if n < 3 {
+                    Ok(())
+                } else {
+                    std::future::pending::<BrokerResult<()>>().await
+                }
+            }
+        };
+
+        let started = std::time::Instant::now();
+        let task = tokio::spawn(supervise_reconnect(
+            serve,
+            shutdown.clone(),
+            Duration::from_millis(2),
+            Duration::from_millis(8),
+            Duration::from_secs(60), // runs are instant → never "healthy", backoff grows
+        ));
+
+        // 4 serve calls = 3 quick restarts + 1 blocking run, all within the
+        // bounded backoff window (not e.g. 30s — proves the backoff is bounded).
+        tokio::time::timeout(Duration::from_secs(3), async {
+            while calls.load(Ordering::SeqCst) < 4 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("supervisor restarted within bounded backoff");
+        assert!(calls.load(Ordering::SeqCst) >= 4);
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "restarts were bounded-fast, took {:?}",
+            started.elapsed()
+        );
+
+        // Shutdown interrupts the blocking serve (+ any backoff) and ends the loop.
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(3), task)
+            .await
+            .expect("supervisor stops promptly on shutdown")
+            .expect("supervisor task did not panic");
+    }
+
+    /// Build the correlated `McpReply` for one worker `McpRequest` (used by the
+    /// stand-in broker below).
+    fn answer_mcp_request(req_msg: InboxMessage, orch: &AgentRef) -> InboxMessage {
+        let reply_body = match serde_json::from_value::<McpRequest>(req_msg.body) {
+            Ok(McpRequest::Manifest) => McpReply {
+                manifest: Some(vec![ToolSchema {
+                    schema_type: "function".into(),
+                    function: FunctionSchema {
+                        name: "nova_click".into(),
+                        description: "click a mark".into(),
+                        parameters: json!({ "type": "object" }),
+                    },
+                }]),
+                ..Default::default()
+            },
+            Ok(McpRequest::Call { tool, arguments }) => McpReply {
+                result: Some(ProxiedResult {
+                    success: true,
+                    result: format!("ran {tool} args={arguments}"),
+                }),
+                ..Default::default()
+            },
+            Err(_) => McpReply {
+                error: Some("bad mcp request".into()),
+                ..Default::default()
+            },
+        };
+        InboxMessage {
+            id: MsgId::new(),
+            from: orch.clone(),
+            kind: InboxKind::McpReply,
+            body: serde_json::to_value(reply_body).unwrap_or_default(),
+            created_at: Utc::now(),
+            correlation_id: Some(req_msg.id),
+        }
+    }
+
+    /// A stand-in broker that ALSO answers `McpRequest`s as the orchestrator
+    /// would (the worker can't tell the difference — it just needs correlated
+    /// replies). The FIRST accepted connection serves the connect `Manifest` +
+    /// one `Call`, then closes the socket — simulating a transient WebSocket
+    /// drop. Subsequent connections (reconnects) stay open and keep answering.
+    /// Returns (endpoint, connections-accepted-counter).
+    async fn flaky_mcp_broker() -> (String, Arc<AtomicU32>) {
+        use futures_util::{SinkExt, StreamExt};
+        use tokio_tungstenite::accept_async;
+        use tokio_tungstenite::tungstenite::Message;
+
+        use crate::proto::{BrokerFrame, ClientFrame};
+
+        let orch = AgentRef {
+            session_id: "orchestrator".into(),
+            role: None,
+        };
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let first_taken = Arc::new(AtomicBool::new(false));
+        let conns = Arc::new(AtomicU32::new(0));
+        let conns_for_loop = conns.clone();
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(s) => s,
+                    Err(_) => break,
+                };
+                let is_first = !first_taken.swap(true, Ordering::SeqCst);
+                conns_for_loop.fetch_add(1, Ordering::SeqCst);
+                let orch = orch.clone();
+                tokio::spawn(async move {
+                    let ws = match accept_async(stream).await {
+                        Ok(ws) => ws,
+                        Err(_) => return,
+                    };
+                    let (mut sink, mut source) = ws.split();
+
+                    // 1. Hello → Welcome.
+                    while let Some(Ok(msg)) = source.next().await {
+                        if let Message::Text(t) = msg {
+                            if ClientFrame::from_text(&t).is_ok() {
+                                let _ = sink
+                                    .send(Message::Text(BrokerFrame::Welcome.to_text()))
+                                    .await;
+                                break;
+                            }
+                        }
+                    }
+
+                    // 2. Serve Deliver frames. The first connection closes right
+                    //    after it has answered the connect Manifest + one Call
+                    //    (the simulated blip). Reconnects stay open.
+                    let mut delivered = 0u32;
+                    while let Some(Ok(msg)) = source.next().await {
+                        let message = match msg {
+                            Message::Text(t) => match ClientFrame::from_text(&t) {
+                                Ok(ClientFrame::Deliver { message, .. }) => message,
+                                _ => continue,
+                            },
+                            _ => continue,
+                        };
+                        let _ = sink
+                            .send(Message::Text(
+                                BrokerFrame::Delivered {
+                                    id: message.id.clone(),
+                                }
+                                .to_text(),
+                            ))
+                            .await;
+                        let reply = answer_mcp_request(message, &orch);
+                        let _ = sink
+                            .send(Message::Text(
+                                BrokerFrame::Message { message: reply }.to_text(),
+                            ))
+                            .await;
+                        if is_first {
+                            delivered += 1;
+                            if delivered == 2 {
+                                // manifest + call served → drop the connection
+                                let _ = sink.send(Message::Close(None)).await;
+                                break;
+                            }
+                        }
+                    }
+                });
+            }
+        });
+        (format!("ws://{addr}"), conns)
+    }
+
+    /// Worker reconnect (issue #47): after the broker connection drops mid-run,
+    /// a later call transparently reconnects and succeeds instead of surfacing a
+    /// permanent transport error.
+    #[tokio::test]
+    async fn proxy_executor_reconnects_after_transient_drop() {
+        let (endpoint, conns) = flaky_mcp_broker().await;
+
+        let proxy = McpProxyExecutor::connect(
+            &endpoint,
+            "worker#mcp",
+            TOKEN,
+            "orchestrator",
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("proxy connects + fetches manifest");
+        assert_eq!(proxy.list_tools().len(), 1);
+
+        let call = |n: usize| ToolCall {
+            id: format!("c{n}"),
+            tool_type: "function".into(),
+            function: FunctionCall {
+                name: "nova_click".into(),
+                arguments: "{}".into(),
+            },
+        };
+
+        // conn1: the first call succeeds before the (simulated) drop.
+        let r1 = proxy.execute(&call(1)).await.expect("call1 on conn1");
+        assert!(r1.success);
+
+        // conn1 is now closed. This call must lazily reconnect (conn2) and retry
+        // — NOT return a permanent "connection closed before reply" error.
+        let r2 = tokio::time::timeout(Duration::from_secs(15), proxy.execute(&call(2)))
+            .await
+            .expect("call2 did not hang")
+            .expect("call2 succeeds after reconnect (not a permanent error)");
+        assert!(r2.success);
+        assert_eq!(r2.result, "ran nova_click args={}");
+
+        // The reconnect opened a second broker connection.
+        assert!(
+            conns.load(Ordering::SeqCst) >= 2,
+            "worker reconnected (>=2 connections accepted), got {}",
+            conns.load(Ordering::SeqCst)
+        );
+
+        // A third call on the (now healthy) reconnected connection succeeds too,
+        // proving the executor is not permanently disabled by the drop.
+        let r3 = proxy.execute(&call(3)).await.expect("call3 on conn2");
+        assert!(r3.success);
     }
 }

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -255,9 +255,13 @@ impl AppState {
         // Initialize sub-session spawn scheduler (async background jobs).
         let config_snapshot = config.read().await.clone();
 
-        // When a broker is configured, run the MCP proxy service: deployed
-        // workers forward their (host-bound) MCP tool calls here, and we execute
-        // them against this orchestrator's real MCP servers (single MCP host).
+        // When a broker is configured, run the MCP proxy service under a
+        // supervisor (issue #47): deployed workers forward their (host-bound)
+        // MCP tool calls here, and we execute them against this orchestrator's
+        // real MCP servers (single MCP host). The supervisor restarts the proxy
+        // with bounded backoff after a transient WebSocket drop instead of
+        // permanently disabling proxied tools for the worker's lifetime.
+        let mcp_proxy_shutdown = tokio_util::sync::CancellationToken::new();
         if let Some(broker) = config_snapshot.subagents.broker.clone() {
             if !broker.endpoint.trim().is_empty() {
                 let backend: std::sync::Arc<dyn bamboo_agent_core::tools::ToolExecutor> =
@@ -265,17 +269,20 @@ impl AppState {
                         mcp_manager.clone(),
                         mcp_manager.tool_index(),
                     ));
+                let shutdown = mcp_proxy_shutdown.clone();
                 tokio::spawn(async move {
                     let me = bamboo_broker::AgentRef {
                         session_id: bamboo_broker::ORCHESTRATOR_ID.to_string(),
                         role: Some("orchestrator".into()),
                     };
-                    if let Err(e) =
-                        bamboo_broker::serve_mcp_proxy(&broker.endpoint, me, &broker.token, backend)
-                            .await
-                    {
-                        tracing::warn!("MCP proxy service ended: {e}");
-                    }
+                    bamboo_broker::serve_mcp_proxy_supervised(
+                        &broker.endpoint,
+                        me,
+                        &broker.token,
+                        backend,
+                        shutdown,
+                    )
+                    .await;
                 });
             }
         }
@@ -436,6 +443,7 @@ impl AppState {
             permission_checker,
             notification_service,
             cancel_tokens: Arc::new(RwLock::new(HashMap::new())),
+            mcp_proxy_shutdown,
             skill_manager,
             mcp_manager,
             metrics_service,

--- a/crates/app/bamboo-server/src/app_state/mod.rs
+++ b/crates/app/bamboo-server/src/app_state/mod.rs
@@ -251,6 +251,11 @@ pub struct AppState {
     /// allowing graceful shutdown of long-running operations.
     pub cancel_tokens: Arc<RwLock<HashMap<String, CancellationToken>>>,
 
+    /// Cancels the supervised MCP proxy service (issue #47) on shutdown so the
+    /// reconnect/backoff supervisor stops cleanly instead of looping forever
+    /// after an intended stop. Unused when no broker is configured.
+    pub mcp_proxy_shutdown: CancellationToken,
+
     /// Skill manager for prompt-based skill execution
     ///
     /// Manages the skill registry and handles skill lookup,

--- a/crates/app/bamboo-server/src/app_state/provider_api.rs
+++ b/crates/app/bamboo-server/src/app_state/provider_api.rs
@@ -82,6 +82,9 @@ impl AppState {
     #[allow(dead_code)]
     pub async fn shutdown(&self) {
         tracing::info!("Shutting down MCP servers...");
+        // Stop the supervised MCP proxy service (issue #47) so its reconnect
+        // supervisor exits cleanly instead of looping after an intended stop.
+        self.mcp_proxy_shutdown.cancel();
         self.mcp_manager.shutdown_all().await;
         tracing::info!("MCP servers shut down complete");
     }


### PR DESCRIPTION
Closes #47 — a transient WS drop permanently disabled proxied host MCP tools for a workers life. Orchestrator: serve_mcp_proxy wrapped in a supervisor restart loop with bounded backoff (500ms->30s, reset after healthy) + CancellationToken shutdown (biased select, no leaked task). Worker: McpProxyExecutor lazily reconnects only when the connection is actually broken (reader_alive==false, from #52), retries once, bounded (5x, 200ms->2s), transient error on exhaustion; Mutex<BrokerClient> never held across backoff. Healthy path + serve_mcp_proxy byte-identical.

bamboo-reviewed. Verified: check --workspace; bamboo-broker (21) + bamboo-server (854) green; fmt + clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp