### PR TITLE
test(bamboo-server-tools): DeployedRegistry deploy/stop/list lifecycle (#60)

### DIFF
--- a/crates/app/bamboo-broker/src/deploy.rs
+++ b/crates/app/bamboo-broker/src/deploy.rs
@@ -49,6 +49,22 @@ pub struct DeployedAgent {
 }
 
 impl DeployedAgent {
+    /// Build from an already-spawned child process and an optional cleanup
+    /// command. Used by the deployers below; also lets integration tests
+    /// exercise the registry/shutdown lifecycle with a trivial child instead of
+    /// a real docker/ssh deployment.
+    pub fn from_parts(
+        id: impl Into<String>,
+        child: tokio::process::Child,
+        cleanup: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            child,
+            cleanup,
+        }
+    }
+
     pub fn pid(&self) -> Option<u32> {
         self.child.id()
     }
@@ -122,11 +138,7 @@ impl Deployer for LocalProcessDeployer {
             .env("BAMBOO_BROKER_TOKEN", &d.token)
             .kill_on_drop(true);
         let child = cmd.spawn().map_err(spawn_err)?;
-        Ok(DeployedAgent {
-            id: d.id.clone(),
-            child,
-            cleanup: None,
-        })
+        Ok(DeployedAgent::from_parts(d.id.clone(), child, None))
     }
 }
 
@@ -243,16 +255,16 @@ impl Deployer for DockerDeployer {
         let mut cmd = Command::new(&self.docker_bin);
         cmd.args(self.argv(d, &container)).kill_on_drop(true);
         let child = cmd.spawn().map_err(spawn_err)?;
-        Ok(DeployedAgent {
-            id: d.id.clone(),
+        Ok(DeployedAgent::from_parts(
+            d.id.clone(),
             child,
-            cleanup: Some(vec![
+            Some(vec![
                 self.docker_bin.clone(),
                 "rm".into(),
                 "-f".into(),
                 container,
             ]),
-        })
+        ))
     }
 }
 
@@ -330,11 +342,7 @@ impl Deployer for SshDeployer {
         let mut cmd = Command::new(&self.ssh_bin);
         cmd.args(self.argv(d)).kill_on_drop(true);
         let child = cmd.spawn().map_err(spawn_err)?;
-        Ok(DeployedAgent {
-            id: d.id.clone(),
-            child,
-            cleanup: None,
-        })
+        Ok(DeployedAgent::from_parts(d.id.clone(), child, None))
     }
 }
 

--- a/crates/app/bamboo-server-tools/src/deploy_agent.rs
+++ b/crates/app/bamboo-server-tools/src/deploy_agent.rs
@@ -287,3 +287,121 @@ impl Tool for DeployAgentTool {
         }
     }
 }
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    fn empty_registry() -> DeployedRegistry {
+        std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()))
+    }
+
+    fn tool_with(registry: DeployedRegistry) -> DeployAgentTool {
+        // bamboo_bin is never spawned in these tests (we don't drive deploy()).
+        DeployAgentTool::new("ws://localhost:0", "test-token", "/bin/true", registry)
+    }
+
+    /// A trivial long-running child so the kill/wait path is genuinely exercised.
+    fn spawn_sleeper(id: &str, cleanup: Option<Vec<String>>) -> DeployedAgent {
+        let child = tokio::process::Command::new("sleep")
+            .arg("60")
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn sleep");
+        DeployedAgent::from_parts(id, child, cleanup)
+    }
+
+    /// True while `pid` is a live process (POSIX `kill -0`).
+    fn pid_alive(pid: u32) -> bool {
+        std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    fn parse(result: ToolResult) -> serde_json::Value {
+        serde_json::from_str(&result.result).expect("tool result is JSON")
+    }
+
+    #[tokio::test]
+    async fn deploy_list_stop_lifecycle_kills_process() {
+        let registry = empty_registry();
+        let tool = tool_with(registry.clone());
+
+        // (1) register a worker (the registry effect of a successful deploy); list shows it.
+        let agent = spawn_sleeper("w1", None);
+        let pid = agent.pid().expect("child has a pid");
+        registry.lock().await.insert(
+            "w1".to_string(),
+            Deployed {
+                env: "local".into(),
+                handle: agent,
+            },
+        );
+        assert!(
+            pid_alive(pid),
+            "registered worker process should be running"
+        );
+
+        let listed = parse(tool.list().await.unwrap());
+        let agents = listed["agents"].as_array().unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0]["id"], "w1");
+        assert_eq!(agents[0]["env"], "local");
+
+        // (2) stop: removes the entry AND kills the process (shutdown awaits the child).
+        let stopped = parse(tool.stop("w1".to_string()).await.unwrap());
+        assert_eq!(stopped["id"], "w1");
+        assert_eq!(stopped["status"], "stopped");
+        assert!(!pid_alive(pid), "stopped worker process must be killed");
+
+        // (3) list after stop is empty.
+        let listed = parse(tool.list().await.unwrap());
+        assert!(listed["agents"].as_array().unwrap().is_empty());
+
+        // (4) double-stop (already removed) is a no-op, not a crash.
+        let again = parse(tool.stop("w1".to_string()).await.unwrap());
+        assert_eq!(again["status"], "not_found");
+    }
+
+    #[tokio::test]
+    async fn stop_unknown_id_is_not_found_not_a_crash() {
+        let tool = tool_with(empty_registry());
+        let r = parse(tool.stop("never-deployed".to_string()).await.unwrap());
+        assert_eq!(r["status"], "not_found");
+    }
+
+    #[tokio::test]
+    async fn deployed_agent_shutdown_kills_and_runs_cleanup() {
+        // A unique marker the cleanup command will `touch` — proves cleanup ran.
+        let marker = std::env::temp_dir().join(format!(
+            "bamboo_deploy_cleanup_{}_{:?}.marker",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&marker);
+
+        let agent = spawn_sleeper(
+            "cleanup-worker",
+            Some(vec![
+                "sh".into(),
+                "-c".into(),
+                format!("touch {}", marker.display()),
+            ]),
+        );
+        let pid = agent.pid().expect("child has a pid");
+
+        agent.shutdown().await;
+
+        assert!(!pid_alive(pid), "shutdown must kill the process");
+        assert!(
+            marker.exists(),
+            "shutdown must run the cleanup command (docker rm -f path)"
+        );
+        let _ = std::fs::remove_file(&marker);
+    }
+}

--- a/crates/app/bamboo-server-tools/src/deploy_agent.rs
+++ b/crates/app/bamboo-server-tools/src/deploy_agent.rs
@@ -315,6 +315,9 @@ mod tests {
     fn pid_alive(pid: u32) -> bool {
         std::process::Command::new("kill")
             .args(["-0", &pid.to_string()])
+            // `kill -0` on a reaped pid prints "No such process" to stderr; that
+            // stderr is the expected signal, not test noise — silence it.
+            .stderr(std::process::Stdio::null())
             .status()
             .map(|s| s.success())
             .unwrap_or(false)


### PR DESCRIPTION
Closes #60 — adds DeployedRegistry lifecycle coverage (deploy/list/stop/double-stop + DeployedAgent::shutdown kill+cleanup), driving a real sleep child (process death via POSIX kill -0; cleanup via a marker file). Added a small public DeployedAgent::from_parts constructor and DRY-d the 3 deployer sites onto it (genuinely used). No behavior change. Unix-gated.

Implemented by Claude Code; Bamboo-reviewed. Verified: check --workspace; bamboo-server-tools (3) + bamboo-broker (21+3) green; fmt + clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp