### PR TITLE
fix(bamboo-server): read disk inside the write lock in reload_config (#41)

### DIFF
--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -102,8 +102,15 @@ impl AppState {
     /// }
     /// ```
     pub async fn reload_config(&self) -> Config {
-        let new_config = Config::from_data_dir(Some(self.app_data_dir.clone()));
+        // Read from disk INSIDE the write lock. If the disk read happened before
+        // acquiring the lock, a concurrent update_config() could persist new
+        // state in that gap and then be clobbered here by the stale disk copy
+        // (in-memory-only mutations silently lost). Holding the lock across the
+        // read+swap serializes reload with update_config's in-memory mutation.
+        // Config::from_data_dir is a sync read (no await), so this doesn't hold
+        // the lock across an await point. #41.
         let mut config = self.config.write().await;
+        let new_config = Config::from_data_dir(Some(self.app_data_dir.clone()));
         *config = new_config.clone();
         new_config
     }


### PR DESCRIPTION
Closes #41 — reload_config() read config.json from disk BEFORE taking the config write lock, so a concurrent update_config() persisting in that gap got clobbered by stale disk data (in-memory-only mutations lost). Move the read INSIDE the lock (lock -> read -> swap). from_data_dir is sync so no await_holding_lock.

Callers: provider-reload + config-reset endpoints (both can race with set_bamboo_config). No deterministic TOCTOU test (AppState heavy to construct; race window timing-dependent — same finding as #42); inspection-verifiable lock-ordering fix.

Implemented by Claude Code; Bamboo-reviewed. Verified: check -p bamboo-server; fmt + clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp