### PR TITLE
fix(bamboo-config): Config::default() must not read disk/env (#38 part 1)

### DIFF
--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -1110,7 +1110,15 @@ fn expand_user_path(value: &str) -> PathBuf {
 
 impl Default for Config {
     fn default() -> Self {
-        Self::new()
+        // In-memory defaults ONLY. `default()` must not touch the filesystem or
+        // environment: it was delegating to `new()` → `from_data_dir(None)`,
+        // which read config.json from disk, applied BAMBOO_* env overrides, and
+        // published to the global env-var cache. That made every `..Default::
+        // default()` struct-update and every test silently disk-dependent and
+        // let non-server callers clobber the server's in-memory config cache.
+        // `create_default()` is the pure in-memory constructor; disk loading is
+        // the explicit job of `new()` / `from_data_dir()`. #38.
+        Self::create_default()
     }
 }
 
@@ -2828,13 +2836,11 @@ mod tests {
 
     #[test]
     fn default_config_has_empty_env_vars() {
-        // `Config::default()` loads from the real on-disk data dir, which makes this
-        // assertion depend on the developer's `~/.bamboo/config.json`. Isolate to an
-        // empty temp data dir (no config.json) so we exercise the in-memory default.
-        let _lock = env_lock_acquire();
-        let temp_home = TempHome::new();
-        let config = Config::from_data_dir(Some(temp_home.path.clone()));
-        assert!(config.env_vars.is_empty());
+        // `Config::default()` is a pure in-memory constructor (no disk read, no
+        // env overrides), so this is independent of the developer's
+        // `~/.bamboo/config.json` — no temp-dir isolation needed. Directly
+        // asserts the #38 invariant that default() does not touch the filesystem.
+        assert!(Config::default().env_vars.is_empty());
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/provider_instance.rs
+++ b/crates/infra/bamboo-config/src/provider_instance.rs
@@ -166,8 +166,9 @@ mod tests {
     use super::*;
     use crate::config::Config;
 
-    /// Build a clean test config that doesn't load from the user's filesystem.
-    /// This avoids env-var and file-system bleed that pollutes `Config::default()`.
+    /// Build a test config with explicit empty providers/instances. (Since #38,
+    /// `Config::default()` is in-memory only — no filesystem/env bleed — so the
+    /// remaining fields come from clean defaults.)
     fn clean_test_config() -> Config {
         Config {
             providers: crate::config::ProviderConfigs::default(),


### PR DESCRIPTION
Part 1 of #38 (Config singleton). impl Default delegated to new() -> from_data_dir(None) — so default() read config.json, applied BAMBOO_* env overrides, and published to the global env-var cache. Every ..Default::default() + every test was silently disk/env-dependent, and non-server default() callers could clobber the server in-memory cache. Point Default at create_default() (pure in-memory); disk loading stays explicit (new()/from_data_dir()).

Audited all callers: non-test ones want in-memory or are struct-updates; none rely on default() reading disk. Satisfies #38 acceptance #1; the true shared-instance refactor is the larger follow-on.

Implemented by Claude Code; Bamboo-reviewed. Verified: bamboo-config(112)/llm(426)/engine(856)/server(855)/bin(2) green; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp