### PR TITLE
fix(bamboo-engine): token_budget reads live config, not a fresh Config::new() (#38)

### DIFF
--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -387,6 +387,12 @@ pub struct AgentLoopConfig {
     pub(crate) disabled_tools: BTreeSet<String>,
     /// Token budget for context management (optional, defaults to model's limits)
     pub(crate) token_budget: Option<TokenBudget>,
+    /// Legacy `config.json` `model_limits` value, snapshotted from the live
+    /// in-memory Config when this loop config is built. Consulted only by
+    /// `resolve_token_budget` as a last-resort fallback when `model_limits.json`
+    /// fails to load — so the engine never does a fresh disk-reading
+    /// `Config::new()` (which would also clobber the global env-var cache). #38.
+    pub(crate) legacy_model_limits: Option<serde_json::Value>,
     /// Optional image fallback behavior applied to *LLM requests only* (never persisted).
     ///
     /// This is intended for text-only provider paths where image parts must be degraded
@@ -480,6 +486,7 @@ impl Default for AgentLoopConfig {
             app_data_dir: None,
             disabled_tools: BTreeSet::new(),
             token_budget: None,
+            legacy_model_limits: None,
             image_fallback: None,
             prompt_memory_flags: PromptMemoryFlags::default(),
             max_tool_calls_per_round: 80,

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/token_budget.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/token_budget.rs
@@ -47,34 +47,12 @@ pub(super) async fn resolve_token_budget(
     };
 
     if !loaded_from_file {
-        let unified_model_limits = match tokio::task::spawn_blocking(|| {
-            let config = bamboo_llm::Config::new();
-            load_model_limits_from_unified_config(config.extra.get("model_limits"))
-        })
-        .await
-        {
-            Ok(Ok(limits)) => limits,
-            Ok(Err(error)) => {
-                tracing::warn!(
-                    "Failed to parse legacy model limits from config.json key 'model_limits': {}.",
-                    error
-                );
-                None
-            }
-            Err(error) => {
-                tracing::warn!(
-                    "Failed to load legacy model limits from config.json: {}.",
-                    error
-                );
-                None
-            }
-        };
-
-        if let Some(limits) = unified_model_limits {
-            for limit in limits {
-                registry.add_limit(limit);
-            }
-        }
+        // Legacy fallback: parse the config.json `model_limits` key. The value is
+        // snapshotted from the live in-memory config at loop-config build time
+        // (config.legacy_model_limits) — NOT re-read from disk via Config::new(),
+        // which would diverge from the server's live config and clobber the global
+        // env-var cache (#38). Pure JSON parse, so no spawn_blocking needed.
+        apply_legacy_model_limits(&mut registry, config.legacy_model_limits.as_ref());
     }
 
     let matched_limit = registry.get(model_name);
@@ -106,6 +84,29 @@ pub(super) async fn resolve_token_budget(
         bamboo_compression::BudgetStrategy::default(),
         model_limit.get_safety_margin(),
     )
+}
+
+/// Apply the legacy `config.json` `model_limits` value (snapshotted from the
+/// live in-memory config) to `registry`. Pure: parses the JSON and adds each
+/// limit; a parse error is logged and ignored (the registry keeps its defaults).
+fn apply_legacy_model_limits(
+    registry: &mut ModelLimitsRegistry,
+    legacy_model_limits: Option<&serde_json::Value>,
+) {
+    match load_model_limits_from_unified_config(legacy_model_limits) {
+        Ok(Some(limits)) => {
+            for limit in limits {
+                registry.add_limit(limit);
+            }
+        }
+        Ok(None) => {}
+        Err(error) => {
+            tracing::warn!(
+                "Failed to parse legacy model limits from config.json key 'model_limits': {}.",
+                error
+            );
+        }
+    }
 }
 
 async fn resolve_provider_runtime_limit(
@@ -157,6 +158,33 @@ mod tests {
     use bamboo_agent_core::{tools::ToolSchema, Message};
     use bamboo_llm::provider::{LLMError, ProviderModelInfo, Result};
     use bamboo_llm::types::LLMChunk;
+
+    #[test]
+    fn apply_legacy_model_limits_adds_parsed_limits_to_registry() {
+        // A legacy config.json `model_limits` value, as snapshotted into
+        // AgentLoopConfig.legacy_model_limits from the live in-memory config.
+        let legacy = serde_json::json!([
+            { "model_pattern": "legacy-model", "max_context_tokens": 12345 }
+        ]);
+        let mut registry = ModelLimitsRegistry::new();
+        apply_legacy_model_limits(&mut registry, Some(&legacy));
+        let got = registry
+            .get("legacy-model")
+            .expect("legacy model limit was applied to the registry");
+        assert_eq!(got.max_context_tokens, 12345);
+    }
+
+    #[test]
+    fn apply_legacy_model_limits_is_noop_for_none_or_malformed() {
+        let mut registry = ModelLimitsRegistry::new();
+        // No legacy value -> nothing added.
+        apply_legacy_model_limits(&mut registry, None);
+        assert!(registry.get("legacy-model").is_none());
+        // Malformed value -> logged + ignored, not a panic, nothing added.
+        let bad = serde_json::json!({ "not": "an array" });
+        apply_legacy_model_limits(&mut registry, Some(&bad));
+        assert!(registry.get("legacy-model").is_none());
+    }
 
     #[derive(Default)]
     struct MetadataProvider {

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -668,6 +668,9 @@ impl AgentRuntime {
         let loop_config = AgentLoopConfig {
             max_rounds: 200,
             system_prompt,
+            // Snapshot the legacy model_limits from the live in-memory config so
+            // resolve_token_budget never falls back to a disk-reading Config::new(). #38.
+            legacy_model_limits: config.extra.get("model_limits").cloned(),
             disabled_skill_ids: disabled_skill_ids.unwrap_or_else(|| config.disabled_skill_ids()),
             selected_skill_ids,
             selected_skill_mode,


### PR DESCRIPTION
Part 2 of #38 (PR 1 of 3) — eliminate in-process divergent Config instances. resolve_token_budget legacy fallback called bamboo_llm::Config::new() inside the server agent loop: a divergent disk read that also published stale env vars to the global cache (clobber). Thread the value via a pub(crate) AgentLoopConfig.legacy_model_limits snapshotted from the live in-memory config; the fallback now does a pure parse (spawn_blocking + Config::new() gone). Extracted apply_legacy_model_limits() + unit-tested it (the fallback trigger depends on the global ~/.bamboo path, not isolable; the helper is).

Next: default-workspace resolver (builder.rs) + chat.rs workspace fallback.

Implemented by Claude Code; Bamboo-reviewed. Verified: bamboo-engine lib (858, +2) green; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp