### PR TITLE
fix(bamboo-server): default-workspace resolver reads live config, not disk (#38)

### DIFF
--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -107,13 +107,6 @@ impl AppState {
         provider: Arc<dyn LLMProvider>,
     ) -> Result<Self, AppError> {
         // Wire the configured-default-workspace resolver into agent-core. This keeps
-        // the dependency arrow pointing down (agent-core no longer imports the
-        // infrastructure config crate); the server owns config and provides it here.
-        bamboo_agent_core::workspace_state::set_default_workspace_provider(|| {
-            bamboo_llm::Config::from_data_dir(Some(bamboo_config::paths::bamboo_dir()))
-                .get_default_work_area_path()
-        });
-
         let data_dir = bamboo_home_dir.clone();
         let (session_store, storage) = init_storage(&data_dir).await?;
         let persistence = Arc::new(LockedSessionStore::new(storage.clone()));
@@ -122,6 +115,32 @@ impl AppState {
         let sessions: bamboo_engine::SessionCache = Arc::new(dashmap::DashMap::new());
 
         let config = Arc::new(RwLock::new(config));
+
+        // Wire the configured-default-workspace resolver into agent-core. This keeps
+        // the dependency arrow pointing down (agent-core owns only the slot; the
+        // server fills it). The closure reads the server's LIVE in-memory config —
+        // not a fresh disk-reading Config::new(), which would diverge from the live
+        // config and clobber the global env-var cache (#38). `try_read` never blocks
+        // (the resolver is called from sync code, so a blocking read could deadlock);
+        // on the rare write-lock contention it returns the last successfully-resolved
+        // path so a session never transiently falls back to the process cwd.
+        {
+            let config_for_workspace = config.clone();
+            let last_known: Arc<std::sync::Mutex<Option<PathBuf>>> =
+                Arc::new(std::sync::Mutex::new(None));
+            bamboo_agent_core::workspace_state::set_default_workspace_provider(Box::new(
+                move || match config_for_workspace.try_read() {
+                    Ok(cfg) => {
+                        let path = cfg.get_default_work_area_path();
+                        if let Ok(mut cache) = last_known.lock() {
+                            *cache = path.clone();
+                        }
+                        path
+                    }
+                    Err(_) => last_known.lock().ok().and_then(|c| c.clone()),
+                },
+            ));
+        }
 
         let permission_checker = load_permission_checker(&bamboo_home_dir).await;
         let notification_service = Arc::new(bamboo_notification::NotificationService::new(

--- a/crates/core/bamboo-agent-core/src/workspace_state.rs
+++ b/crates/core/bamboo-agent-core/src/workspace_state.rs
@@ -40,7 +40,10 @@ pub fn get_workspace(session_id: &str) -> Option<PathBuf> {
 /// config crate. Instead, the composition root (the server bootstrap) registers
 /// a provider here via [`set_default_workspace_provider`]; until then this
 /// resolves to `None` and callers fall back to the process working directory.
-type DefaultWorkspaceProvider = fn() -> Option<PathBuf>;
+/// A boxed closure (not a bare `fn`) so the composition root can capture state —
+/// e.g. a handle to the server's live in-memory config — instead of being forced
+/// to re-read config from disk on every call. #38.
+type DefaultWorkspaceProvider = Box<dyn Fn() -> Option<PathBuf> + Send + Sync>;
 static DEFAULT_WORKSPACE_PROVIDER: OnceLock<DefaultWorkspaceProvider> = OnceLock::new();
 
 /// Register the provider that resolves the configured default workspace.


### PR DESCRIPTION
Part 2 of #38 (PR 2 of 3). The default-workspace resolver closure called Config::from_data_dir() on every resolution — a divergent disk read + env-cache clobber inside the server runtime. Change the agent-core provider from a bare fn() to a boxed closure so the server can capture a handle to its LIVE Arc<RwLock<Config>>; the closure try_reads it (never blocks -> no deadlock vs config writes) with a last-known-good cache for the rare contention. Registration moved after the Arc<RwLock> is built. The only remaining from_data_dir in builder.rs is the legitimate bootstrap seed.

Implemented by Claude Code; Bamboo-reviewed. Verified: bamboo-agent-core(106), bamboo-server lib(855) green; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp