### PR TITLE
fix(bamboo-engine): chat workspace fallback prefers live config over disk (#38)

### DIFF
--- a/crates/engine/bamboo-engine/src/session_app/chat.rs
+++ b/crates/engine/bamboo-engine/src/session_app/chat.rs
@@ -202,8 +202,17 @@ pub fn resolve_workspace_path(
         .map(ToString::to_string)
         .or_else(|| session.workspace_path_meta())
         .or_else(|| {
-            bamboo_llm::Config::from_data_dir(data_dir.map(Path::to_path_buf))
-                .get_default_work_area_path()
+            // Prefer the server's LIVE in-memory config via the registered
+            // workspace provider — no disk read, no global env-cache clobber
+            // (#38). Only when no provider is registered (non-server contexts:
+            // SDK / CLI / unit tests) fall back to the legacy disk read of
+            // data_dir. In the server the provider is always wired at startup,
+            // so the divergent from_data_dir read never runs there.
+            bamboo_agent_core::workspace_state::get_configured_default_workspace()
+                .or_else(|| {
+                    bamboo_llm::Config::from_data_dir(data_dir.map(Path::to_path_buf))
+                        .get_default_work_area_path()
+                })
                 .map(|path| path_to_display_string(&path))
         })
 }


### PR DESCRIPTION
Closes #38 (part 2, PR 3 of 3). resolve_workspace_path default fallback called Config::from_data_dir() every workspace-less chat turn — the third in-process divergent disk-read + env-cache clobber in the server runtime. Prefer the registered workspace provider (live config, via PR 38c); fall back to from_data_dir only when NO provider is registered (non-server: SDK/CLI/tests), preserving behavior everywhere while the server never hits the divergent read. Kept data_dir for the fallback (no caller/test churn).

Completes #38: no in-process Config::new()/from_data_dir clobbers the live env cache in the server runtime (token_budget + workspace resolver + chat fallback all fixed). CLI subcommands are separate processes (out of scope).

Implemented by Claude Code; Bamboo-reviewed. Verified: bamboo-server lib(855), bamboo-engine lib(858) green; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp