### PR TITLE
fix(bamboo-engine): gate chat workspace disk-fallback on provider registration (#131)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
@@ -169,33 +169,12 @@ fn resolve_workspace_path_uses_request_then_metadata() {
     assert_eq!(from_metadata.as_deref(), Some("/tmp/workspace"));
 }
 
-#[test]
-fn resolve_workspace_path_falls_back_to_default_work_area_config() {
-    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
-    let workspace = temp_dir.path().join("default-workspace");
-    std::fs::create_dir_all(&workspace).expect("workspace should exist");
-    let original = std::env::var_os("BAMBOO_DATA_DIR");
-    std::env::set_var("BAMBOO_DATA_DIR", temp_dir.path());
-    std::fs::write(
-        temp_dir.path().join("config.json"),
-        serde_json::json!({
-            "default_work_area": { "path": workspace.to_string_lossy() }
-        })
-        .to_string(),
-    )
-    .expect("config should be written");
-
-    let mut session = Session::new("session-1", "model");
-    let resolved = resolve_workspace_path(&mut session, None, Some(temp_dir.path()));
-    let expected = bamboo_config::paths::path_to_display_string(&workspace);
-    assert_eq!(resolved.as_deref(), Some(expected.as_str()));
-
-    if let Some(value) = original {
-        std::env::set_var("BAMBOO_DATA_DIR", value);
-    } else {
-        std::env::remove_var("BAMBOO_DATA_DIR");
-    }
-}
+// NOTE: the default-work-area disk fallback used to be tested here, but it's now
+// gated on NO workspace provider being registered (#38/#131) — and the provider
+// is a process-global first-wins OnceLock that sibling AppState tests populate,
+// so a fallback assertion can't be deterministic in the server test binary. The
+// disk fallback is unit-tested directly + deterministically in bamboo-engine's
+// session_app::chat (default_workspace_from_data_dir_reads_configured_work_area).
 
 #[test]
 fn sync_runtime_workspace_persists_workspace_for_tools() {

--- a/crates/core/bamboo-agent-core/src/workspace_state.rs
+++ b/crates/core/bamboo-agent-core/src/workspace_state.rs
@@ -61,6 +61,16 @@ pub fn get_configured_default_workspace() -> Option<PathBuf> {
         .and_then(|provider| provider())
 }
 
+/// Whether a default-workspace provider has been registered — i.e. we're running
+/// in a context (the server) that owns the live config and wired the provider at
+/// startup. When true the provider is authoritative: callers must NOT fall back
+/// to a disk read even if it resolves to `None`, since that would re-introduce a
+/// divergent disk read of config (#38 / #131). When false (SDK / CLI / unit
+/// tests) callers may use their own config source.
+pub fn has_default_workspace_provider() -> bool {
+    DEFAULT_WORKSPACE_PROVIDER.get().is_some()
+}
+
 pub fn ensure_session_workspace(session_id: &str, preferred: Option<PathBuf>) -> Option<PathBuf> {
     if let Some(workspace) = preferred {
         set_workspace(session_id, workspace.clone());

--- a/crates/engine/bamboo-engine/src/session_app/chat.rs
+++ b/crates/engine/bamboo-engine/src/session_app/chat.rs
@@ -7,7 +7,7 @@ use bamboo_config::paths::path_to_display_string;
 use bamboo_domain::Message;
 use bamboo_skills::selection::normalize_selected_skill_ids;
 use sha2::{Digest, Sha256};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::errors::ChatError;
 use super::provider_model::{derive_model_ref, persist_legacy_model_provider, persist_model_ref};
@@ -201,20 +201,32 @@ pub fn resolve_workspace_path(
     workspace_path_from_request
         .map(ToString::to_string)
         .or_else(|| session.workspace_path_meta())
-        .or_else(|| {
-            // Prefer the server's LIVE in-memory config via the registered
-            // workspace provider — no disk read, no global env-cache clobber
-            // (#38). Only when no provider is registered (non-server contexts:
-            // SDK / CLI / unit tests) fall back to the legacy disk read of
-            // data_dir. In the server the provider is always wired at startup,
-            // so the divergent from_data_dir read never runs there.
-            bamboo_agent_core::workspace_state::get_configured_default_workspace()
-                .or_else(|| {
-                    bamboo_llm::Config::from_data_dir(data_dir.map(Path::to_path_buf))
-                        .get_default_work_area_path()
-                })
-                .map(|path| path_to_display_string(&path))
-        })
+        .or_else(|| resolve_default_workspace(data_dir))
+}
+
+/// Resolve the configured default workspace (display string), preferring the
+/// server's live in-memory config.
+///
+/// If a workspace provider IS registered (the server, which owns the live
+/// `Arc<RwLock<Config>>`), it is AUTHORITATIVE: we use its result and never disk
+/// read — even when it resolves to `None` (no default work area configured).
+/// That closes the divergent disk read + global env-var-cache clobber for the
+/// whole server runtime (#38 / #131). Only when NO provider is registered
+/// (non-server contexts — SDK / CLI / unit tests) do we fall back to a direct
+/// `from_data_dir` read of `data_dir`.
+fn resolve_default_workspace(data_dir: Option<&Path>) -> Option<String> {
+    let configured = if bamboo_agent_core::workspace_state::has_default_workspace_provider() {
+        bamboo_agent_core::workspace_state::get_configured_default_workspace()
+    } else {
+        default_workspace_from_data_dir(data_dir)
+    };
+    configured.map(|path| path_to_display_string(&path))
+}
+
+/// Legacy non-server fallback: load `{data_dir}/config.json` from disk and read
+/// its default work area. Only used when no workspace provider is registered.
+fn default_workspace_from_data_dir(data_dir: Option<&Path>) -> Option<PathBuf> {
+    bamboo_llm::Config::from_data_dir(data_dir.map(Path::to_path_buf)).get_default_work_area_path()
 }
 
 pub fn resolve_selected_skill_ids(
@@ -448,4 +460,44 @@ fn build_enhanced_system_prompt_with_profile(
     };
 
     (merged_prompt, profile)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The non-server disk fallback (`default_workspace_from_data_dir`) tested
+    // directly + deterministically — no global workspace-provider involved (the
+    // server-side, provider-gated path can't be unit-tested due to the
+    // first-wins OnceLock). #38 / #131.
+
+    #[test]
+    fn default_workspace_from_data_dir_reads_configured_work_area() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let workspace = temp.path().join("default-workspace");
+        std::fs::create_dir_all(&workspace).expect("workspace dir");
+        std::fs::write(
+            temp.path().join("config.json"),
+            serde_json::json!({
+                "default_work_area": { "path": workspace.to_string_lossy() }
+            })
+            .to_string(),
+        )
+        .expect("write config.json");
+
+        let resolved = default_workspace_from_data_dir(Some(temp.path())).expect("resolves");
+        // get_default_work_area_path returns the non-canonical candidate, and temp
+        // dirs live under a symlinked prefix on macOS (/var -> /private/var), so
+        // canonicalize BOTH sides before comparing.
+        assert_eq!(
+            resolved.canonicalize().unwrap(),
+            workspace.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn default_workspace_from_data_dir_is_none_without_config() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        assert!(default_workspace_from_data_dir(Some(temp.path())).is_none());
+    }
 }


### PR DESCRIPTION
Closes #131 (completes #38). The chat default-workspace fallback gated the disk read on the provider RETURNING None, so the server with no default work area still fell through to from_data_dir() (divergent read + clobber). Gate on whether a provider is REGISTERED instead: if registered (server, owns live config) it is authoritative and we NEVER disk-read, even when it yields None. Only with no provider (SDK/CLI/tests) read data_dir. Server is now zero-divergent-read in ALL cases.

Extracted default_workspace_from_data_dir() helper. Removed the old server fallback test (non-deterministic under gate-on-registered — the provider is a first-wins global OnceLock that sibling AppState tests populate; it failed in the full suite); added 2 deterministic engine unit tests for the helper.

Implemented by Claude Code; Bamboo-reviewed. Verified: bamboo-server lib(854), bamboo-engine lib(860,+2), bamboo-agent-core(106) green; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp