### PR TITLE
fix(bamboo-config): non-publishing config load; stop permission-storage env-cache clobber (#40)

### DIFF
--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -1168,12 +1168,15 @@ impl Config {
         Self::from_data_dir(None)
     }
 
-    /// Load configuration from a specific data directory
+    /// Load configuration from a specific data directory.
     ///
-    /// # Arguments
+    /// Use [`Config::from_data_dir`] (publishes env vars to the global cache, for
+    /// the context that OWNS the cache — the server bootstrap) or
+    /// [`Config::from_data_dir_without_publish`] (for non-owning readers that must
+    /// not clobber the live cache). #40.
     ///
     /// * `data_dir` - Optional data directory path. If None, uses default (`BAMBOO_DATA_DIR` or `${HOME}/.bamboo`)
-    pub fn from_data_dir(data_dir: Option<PathBuf>) -> Self {
+    fn from_data_dir_impl(data_dir: Option<PathBuf>, publish: bool) -> Self {
         // Determine data_dir early (needed to find config file)
         let data_dir = data_dir
             .or_else(|| std::env::var("BAMBOO_DATA_DIR").ok().map(PathBuf::from))
@@ -1264,10 +1267,30 @@ impl Config {
             memory.project_first_dream = parse_bool_env(&project_first_dream);
         }
 
-        // Publish env vars to the global cache so Bash tools can inject them.
-        config.publish_env_vars();
+        // Publish env vars to the global cache so Bash tools can inject them —
+        // ONLY when the caller owns that cache. Non-owning readers pass
+        // publish=false so they don't clobber the server's live env-var cache.
+        if publish {
+            config.publish_env_vars();
+        }
 
         config
+    }
+
+    /// Load config from disk AND publish its env vars to the process-global cache
+    /// (so Bash tools inject them). For the context that OWNS that cache — the
+    /// server bootstrap. Library / secondary readers that only need to read a
+    /// value must use [`Config::from_data_dir_without_publish`] instead, or they
+    /// will clobber the server's live cache with stale disk data (#38 / #40).
+    pub fn from_data_dir(data_dir: Option<PathBuf>) -> Self {
+        Self::from_data_dir_impl(data_dir, true)
+    }
+
+    /// Load config from disk WITHOUT publishing env vars to the global cache.
+    /// For non-owning readers (e.g. permission storage) that just need a config
+    /// value and must not clobber the live env-var cache. #40.
+    pub fn from_data_dir_without_publish(data_dir: Option<PathBuf>) -> Self {
+        Self::from_data_dir_impl(data_dir, false)
     }
 
     /// Get the effective default model for the currently active provider.
@@ -2028,6 +2051,69 @@ mod tests {
                 .as_deref()
                 .is_some_and(|value| value.contains("https://internal.example"))
         }));
+    }
+
+    #[test]
+    fn from_data_dir_without_publish_does_not_clobber_global_cache() {
+        let _lock = crate::test_support::env_cache_lock_acquire();
+
+        // Seed the global cache with a marker "owned" by the live config.
+        Config {
+            env_vars: vec![EnvVarEntry {
+                name: "BAMBOO_CACHE_OWNER_40".to_string(),
+                value: "live".to_string(),
+                secret: false,
+                value_encrypted: None,
+                description: None,
+            }],
+            ..Default::default()
+        }
+        .publish_env_vars();
+        assert_eq!(
+            Config::current_env_vars()
+                .get("BAMBOO_CACHE_OWNER_40")
+                .map(String::as_str),
+            Some("live")
+        );
+
+        // A config.json on disk sets the SAME var to a different (stale) value.
+        let temp = TempHome::new();
+        temp.set_config_json(
+            &serde_json::json!({
+                "env_vars": [{ "name": "BAMBOO_CACHE_OWNER_40", "value": "stale-disk" }]
+            })
+            .to_string(),
+        );
+
+        // Non-publishing load reads the disk value into the returned Config but
+        // must NOT touch the global cache.
+        let loaded = Config::from_data_dir_without_publish(Some(temp.path.clone()));
+        assert_eq!(
+            loaded
+                .env_vars
+                .iter()
+                .find(|e| e.name == "BAMBOO_CACHE_OWNER_40")
+                .map(|e| e.value.as_str()),
+            Some("stale-disk"),
+            "the returned Config holds the disk value"
+        );
+        assert_eq!(
+            Config::current_env_vars()
+                .get("BAMBOO_CACHE_OWNER_40")
+                .map(String::as_str),
+            Some("live"),
+            "but the global cache is UNTOUCHED — no clobber (#40)"
+        );
+
+        // Contrast: the publishing variant DOES clobber the cache.
+        let _ = Config::from_data_dir(Some(temp.path.clone()));
+        assert_eq!(
+            Config::current_env_vars()
+                .get("BAMBOO_CACHE_OWNER_40")
+                .map(String::as_str),
+            Some("stale-disk"),
+            "the publishing loader clobbers the cache (contrast)"
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-permission/src/storage.rs
+++ b/crates/infra/bamboo-permission/src/storage.rs
@@ -55,8 +55,10 @@ impl PermissionStorage {
     pub async fn load(&self) -> Result<Option<PermissionConfig>, PermissionStorageError> {
         const KEY: &str = "permissions";
 
-        // Load unified config.json first.
-        let config = Config::from_data_dir(Some(self.config_dir.clone()));
+        // Load unified config.json first. Non-publishing: this is a read-only
+        // access to the `permissions` key and must not clobber the server's live
+        // env-var cache with stale disk data (#40).
+        let config = Config::from_data_dir_without_publish(Some(self.config_dir.clone()));
         if let Some(value) = config.extra.get(KEY).cloned() {
             let serializable: SerializablePermissionConfig = serde_json::from_value(value)
                 .map_err(|e| PermissionStorageError::ParseError {
@@ -148,7 +150,10 @@ impl PermissionStorage {
         }
 
         let serializable = config.to_serializable();
-        let mut root = Config::from_data_dir(Some(self.config_dir.clone()));
+        // Read-modify-write of the unified config's `permissions` key. Non-
+        // publishing: persisting permissions must not republish (clobber) the
+        // server's live env-var cache from disk (#40).
+        let mut root = Config::from_data_dir_without_publish(Some(self.config_dir.clone()));
         root.extra.insert(
             KEY.to_string(),
             serde_json::to_value(&serializable).map_err(|e| {


### PR DESCRIPTION
Closes #40. ENV_VARS_CACHE is the process-global cache the server publishes its LIVE config into. Any in-process from_data_dir() republishes ON-DISK values, clobbering it. #38 removed the hot-path clobberers (Default, token_budget, workspace resolver, chat fallback); the remaining ones were permission-storage load/save (load the full Config just to read/write the permissions extra key, on startup + every save).

- Add Config::from_data_dir_without_publish() (same load, skips publish_env_vars; both factored onto a private from_data_dir_impl(publish: bool); public from_data_dir unchanged -> no caller churn).
- bamboo-permission storage load()/save() use it -> no env-cache clobber.
- Discriminating test: non-publishing load leaves the cache untouched, publishing load clobbers (contrast).

Opt-OUT design (non-owning readers do not publish), deliberately not opt-IN, so a missed reader stays benign rather than silently losing env injection.

Implemented by Claude Code; Bamboo-reviewed. Verified: bamboo-config(113,+1), bamboo-permission(179) green; check --workspace; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp