### PR TITLE
feat(bamboo-broker): out-of-band Cancel frames (#50, PR 1/5, inert)

### DIFF
--- a/crates/app/bamboo-broker/src/proto.rs
+++ b/crates/app/bamboo-broker/src/proto.rs
@@ -22,6 +22,12 @@ pub enum ClientFrame {
     /// Acknowledge a processed message so the broker deletes it (at-least-once;
     /// an unacked message is re-pushed on the next subscribe).
     Ack { id: MsgId },
+    /// Out-of-band cancel: ask the broker to signal session `to` to abort the
+    /// in-flight run correlated to `correlation_id` (the timed-out ask's id).
+    /// Ephemeral and fire-and-forget — NOT durable, never enters a mailbox, never
+    /// acked. A control signal, deliberately off the at-least-once work path so a
+    /// cancel can never queue behind the very work it cancels. #50.
+    Cancel { to: String, correlation_id: MsgId },
 }
 
 /// Broker → client.
@@ -37,6 +43,9 @@ pub enum BrokerFrame {
     Message { message: InboxMessage },
     /// Receipt that a [`ClientFrame::Deliver`] was durably enqueued.
     Delivered { id: MsgId },
+    /// Out-of-band cancel pushed to a live subscriber: abort the in-flight run
+    /// correlated to `correlation_id`. Ephemeral — never persisted/acked (#50).
+    Cancel { correlation_id: MsgId },
 }
 
 impl ClientFrame {
@@ -97,6 +106,10 @@ mod tests {
             },
             ClientFrame::Subscribe,
             ClientFrame::Ack { id: MsgId::new() },
+            ClientFrame::Cancel {
+                to: "child".into(),
+                correlation_id: MsgId::new(),
+            },
         ];
         for f in frames {
             assert_eq!(ClientFrame::from_text(&f.to_text()).unwrap(), f);
@@ -104,6 +117,15 @@ mod tests {
         // tag stability
         let v: serde_json::Value = serde_json::from_str(&ClientFrame::Subscribe.to_text()).unwrap();
         assert_eq!(v["kind"], "subscribe");
+        let c: serde_json::Value = serde_json::from_str(
+            &ClientFrame::Cancel {
+                to: "child".into(),
+                correlation_id: MsgId::new(),
+            }
+            .to_text(),
+        )
+        .unwrap();
+        assert_eq!(c["kind"], "cancel");
     }
 
     #[test]
@@ -115,6 +137,9 @@ mod tests {
             },
             BrokerFrame::Message { message: ask_msg() },
             BrokerFrame::Delivered { id: MsgId::new() },
+            BrokerFrame::Cancel {
+                correlation_id: MsgId::new(),
+            },
         ];
         for f in frames {
             assert_eq!(BrokerFrame::from_text(&f.to_text()).unwrap(), f);

--- a/crates/app/bamboo-broker/src/server.rs
+++ b/crates/app/bamboo-broker/src/server.rs
@@ -121,6 +121,9 @@ impl BrokerServer {
                         }
                         // A second Hello is meaningless mid-session; ignore.
                         Ok(Some(ClientFrame::Hello { .. })) => {}
+                        // Out-of-band cancel: routed in a follow-up (#50 PR-2);
+                        // parsed-but-ignored here so the variant lands inertly.
+                        Ok(Some(ClientFrame::Cancel { .. })) => {}
                         Ok(None) => break Ok(()),   // client closed
                         Err(e) => break Err(e),
                     }


### PR DESCRIPTION
First inert step toward broker-bus cancellation (#50). Adds ClientFrame::Cancel{to, correlation_id} + BrokerFrame::Cancel{correlation_id} — ephemeral out-of-band control frames (NOT a durable InboxKind, per the mailbox out-of-band doc + so a cancel never queues behind the Ask it cancels). This PR is variants + round-trip tests only; server parses-but-ignores ClientFrame::Cancel (routing = PR2), client has a catch-all (lane = PR3). No behavior change. Approach sidesteps #45 (only the control signal goes concurrent).

Implemented by Claude Code; Bamboo-reviewed. Verified: bamboo-broker lib(21) green; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp