### PR TITLE
feat(bamboo-broker): route out-of-band Cancel through BrokerCore (#50, PR 2/5)

### DIFF
--- a/crates/app/bamboo-broker/src/core.rs
+++ b/crates/app/bamboo-broker/src/core.rs
@@ -21,11 +21,24 @@ use tokio::sync::{mpsc, Mutex};
 
 use crate::error::BrokerResult;
 
+/// An item pushed to a live subscriber's sink: either a durable mailbox message
+/// or an ephemeral out-of-band control signal. Both ride the same subscriber
+/// channel (so the server's single push arm handles them in arrival order), but
+/// a `Cancel` never touches the mailbox — it is not persisted, claimed, or
+/// acked. #50.
+#[derive(Debug)]
+pub enum PushItem {
+    /// A durable message claimed from the subscriber's mailbox.
+    Message(InboxMessage),
+    /// Out-of-band cancel for the in-flight run correlated to this id.
+    Cancel(MsgId),
+}
+
 /// In-process routing engine: owns the mailbox root and the live subscriber table.
 pub struct BrokerCore {
     root: PathBuf,
     /// session_id -> live subscriber sink. Present only while a client is subscribed.
-    subscribers: Mutex<HashMap<String, mpsc::UnboundedSender<InboxMessage>>>,
+    subscribers: Mutex<HashMap<String, mpsc::UnboundedSender<PushItem>>>,
 }
 
 impl BrokerCore {
@@ -55,7 +68,7 @@ impl BrokerCore {
     pub async fn subscribe(
         &self,
         session_id: &str,
-    ) -> BrokerResult<mpsc::UnboundedReceiver<InboxMessage>> {
+    ) -> BrokerResult<mpsc::UnboundedReceiver<PushItem>> {
         let (tx, rx) = mpsc::unbounded_channel();
         self.subscribers
             .lock()
@@ -66,12 +79,26 @@ impl BrokerCore {
         // Crash leftovers first (claimed-but-unacked from a previous connection),
         // then newly delivered, all in time order.
         for d in mb.recover().await? {
-            let _ = tx.send(d.msg);
+            let _ = tx.send(PushItem::Message(d.msg));
         }
         for d in mb.drain().await? {
-            let _ = tx.send(d.msg);
+            let _ = tx.send(PushItem::Message(d.msg));
         }
         Ok(rx)
+    }
+
+    /// Out-of-band cancel: if `to` is currently subscribed, push an ephemeral
+    /// [`PushItem::Cancel`] to its live sink. Does NOT touch the mailbox (not
+    /// durable, never claimed/acked/recovered), so a cancel can never queue
+    /// behind the very work it cancels. Returns true iff a live subscriber
+    /// received it (a cancel for an offline session is a meaningless no-op — the
+    /// run isn't happening). #50.
+    pub async fn cancel(&self, to: &str, correlation_id: &MsgId) -> bool {
+        let subs = self.subscribers.lock().await;
+        match subs.get(to) {
+            Some(tx) => tx.send(PushItem::Cancel(correlation_id.clone())).is_ok(),
+            None => false,
+        }
     }
 
     /// Drop the subscriber for `session_id` (connection closed). Unacked messages
@@ -105,7 +132,7 @@ impl BrokerCore {
             }
         };
         for d in self.mailbox(session_id).drain().await? {
-            let _ = tx.send(d.msg);
+            let _ = tx.send(PushItem::Message(d.msg));
         }
         Ok(())
     }
@@ -138,6 +165,13 @@ mod tests {
         (d, c)
     }
 
+    fn expect_message(item: PushItem) -> InboxMessage {
+        match item {
+            PushItem::Message(m) => m,
+            PushItem::Cancel(c) => panic!("expected a message, got Cancel({c:?})"),
+        }
+    }
+
     #[tokio::test]
     async fn deliver_then_subscribe_drains_backlog() {
         let (_d, c) = core();
@@ -147,7 +181,7 @@ mod tests {
         assert!(!c.is_subscribed("child").await);
 
         let mut rx = c.subscribe("child").await.unwrap();
-        let got = rx.try_recv().expect("backlog delivered on subscribe");
+        let got = expect_message(rx.try_recv().expect("backlog delivered on subscribe"));
         assert_eq!(got.id, m.id);
     }
 
@@ -159,7 +193,7 @@ mod tests {
 
         let m = msg(2);
         c.deliver("child", &m).await.unwrap();
-        let got = rx.recv().await.expect("live push");
+        let got = expect_message(rx.recv().await.expect("live push"));
         assert_eq!(got.id, m.id);
     }
 
@@ -169,7 +203,7 @@ mod tests {
         let m = msg(3);
         c.deliver("child", &m).await.unwrap();
         let mut rx = c.subscribe("child").await.unwrap();
-        let got = rx.recv().await.unwrap();
+        let got = expect_message(rx.recv().await.unwrap());
         assert_eq!(got.id, m.id);
 
         // ack + drop subscription, then resubscribe: nothing redelivered.
@@ -185,13 +219,13 @@ mod tests {
         let m = msg(4);
         c.deliver("child", &m).await.unwrap();
         let mut rx = c.subscribe("child").await.unwrap();
-        let got = rx.recv().await.unwrap(); // pushed, NOT acked
+        let got = expect_message(rx.recv().await.unwrap()); // pushed, NOT acked
         assert_eq!(got.id, m.id);
 
         // connection drops without ack -> message stays in cur/ -> re-pushed.
         c.unsubscribe("child").await;
         let mut rx2 = c.subscribe("child").await.unwrap();
-        let again = rx2.try_recv().expect("unacked message redelivers");
+        let again = expect_message(rx2.try_recv().expect("unacked message redelivers"));
         assert_eq!(again.id, m.id);
     }
 
@@ -204,5 +238,34 @@ mod tests {
         let mut rx_a = c.subscribe("a").await.unwrap();
         assert!(rx_a.try_recv().is_ok());
         assert!(rx_a.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn cancel_pushes_control_item_without_touching_mailbox() {
+        let (_d, c) = core();
+        let cid = MsgId::new();
+
+        // No live subscriber -> cancel is a meaningless no-op.
+        assert!(!c.cancel("worker", &cid).await);
+
+        // Subscribed -> the live subscriber receives a Cancel control item.
+        let mut rx = c.subscribe("worker").await.unwrap();
+        assert!(
+            c.cancel("worker", &cid).await,
+            "a live subscriber received the cancel"
+        );
+        match rx.try_recv().expect("cancel was pushed") {
+            PushItem::Cancel(got) => assert_eq!(got, cid),
+            PushItem::Message(_) => panic!("expected a Cancel, got a Message"),
+        }
+
+        // Out-of-band: the cancel left NO durable mailbox trace, so a fresh
+        // subscribe re-pushes nothing (no new/ or cur/ entry was created).
+        c.unsubscribe("worker").await;
+        let mut rx2 = c.subscribe("worker").await.unwrap();
+        assert!(
+            rx2.try_recv().is_err(),
+            "cancel must not persist anything to the mailbox"
+        );
     }
 }

--- a/crates/app/bamboo-broker/src/server.rs
+++ b/crates/app/bamboo-broker/src/server.rs
@@ -8,7 +8,6 @@
 
 use std::sync::Arc;
 
-use bamboo_subagent::InboxMessage;
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -16,7 +15,7 @@ use tokio::sync::mpsc;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{accept_async, WebSocketStream};
 
-use crate::core::BrokerCore;
+use crate::core::{BrokerCore, PushItem};
 use crate::error::{BrokerError, BrokerResult};
 use crate::proto::{BrokerFrame, ClientFrame};
 
@@ -90,7 +89,7 @@ impl BrokerServer {
         send(&mut sink, BrokerFrame::Welcome).await?;
 
         // 2. Serve: client frames in, subscription stream out.
-        let mut sub_rx: Option<mpsc::UnboundedReceiver<InboxMessage>> = None;
+        let mut sub_rx: Option<mpsc::UnboundedReceiver<PushItem>> = None;
         let outcome = loop {
             tokio::select! {
                 biased;
@@ -121,17 +120,25 @@ impl BrokerServer {
                         }
                         // A second Hello is meaningless mid-session; ignore.
                         Ok(Some(ClientFrame::Hello { .. })) => {}
-                        // Out-of-band cancel: routed in a follow-up (#50 PR-2);
-                        // parsed-but-ignored here so the variant lands inertly.
-                        Ok(Some(ClientFrame::Cancel { .. })) => {}
+                        // Out-of-band, fire-and-forget cancel: signal the target's
+                        // live subscriber (if any). No Delivered receipt, no mailbox
+                        // write — pure control signal. #50.
+                        Ok(Some(ClientFrame::Cancel { to, correlation_id })) => {
+                            self.core.cancel(&to, &correlation_id).await;
+                        }
                         Ok(None) => break Ok(()),   // client closed
                         Err(e) => break Err(e),
                     }
                 }
                 pushed = next_pushed(&mut sub_rx) => {
                     match pushed {
-                        Some(m) => {
+                        Some(PushItem::Message(m)) => {
                             if send(&mut sink, BrokerFrame::Message { message: m }).await.is_err() {
+                                break Ok(());
+                            }
+                        }
+                        Some(PushItem::Cancel(correlation_id)) => {
+                            if send(&mut sink, BrokerFrame::Cancel { correlation_id }).await.is_err() {
                                 break Ok(());
                             }
                         }
@@ -148,9 +155,7 @@ impl BrokerServer {
 
 /// Await the next pushed message, or never resolve when not subscribed (so the
 /// `select` arm is inert until a `Subscribe` arrives).
-async fn next_pushed(
-    rx: &mut Option<mpsc::UnboundedReceiver<InboxMessage>>,
-) -> Option<InboxMessage> {
+async fn next_pushed(rx: &mut Option<mpsc::UnboundedReceiver<PushItem>>) -> Option<PushItem> {
     match rx {
         Some(r) => r.recv().await,
         None => std::future::pending().await,


### PR DESCRIPTION
PR 2/5 of #50. The broker now ROUTES a Cancel (still behavior-inert end-to-end: no orchestrator sends one yet (PR5); the worker still ignores BrokerFrame::Cancel via its catch-all (PR3/4)).

- New PushItem { Message | Cancel }: the subscriber sink carries a durable message OR an ephemeral control signal on the same channel; the server push arm handles both in arrival order.
- BrokerCore::cancel(to, correlation_id): pushes PushItem::Cancel to a live subscriber (no-op + false if offline). Does NOT touch the mailbox -> no persist/claim/ack/recover -> a cancel can never queue behind the work it cancels.
- server.rs: ClientFrame::Cancel arm now calls core.cancel (fire-and-forget, no receipt); push arm maps Message/Cancel to the matching BrokerFrame.

Test: live subscriber gets the Cancel; offline is no-op; fresh subscribe after a cancel re-pushes NOTHING (no durable trace).

Implemented by Claude Code; Bamboo-reviewed. Verified: bamboo-broker lib(22) + ws_roundtrip(4) green; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp