### PR TITLE
feat(bamboo-broker): client out-of-band cancel lane (#50, PR 3/5)

### DIFF
--- a/crates/app/bamboo-broker/src/client.rs
+++ b/crates/app/bamboo-broker/src/client.rs
@@ -32,6 +32,10 @@ pub struct BrokerClient {
     sink: WsSink,
     messages: mpsc::UnboundedReceiver<InboxMessage>,
     delivered: mpsc::UnboundedReceiver<MsgId>,
+    /// Out-of-band cancel signals (the timed-out ask's correlation id), demuxed
+    /// by the background reader independently of `messages` — so a Cancel reaches
+    /// the worker even while its work loop is blocked on an in-flight run. #50.
+    cancels: mpsc::UnboundedReceiver<MsgId>,
     /// Cleared by [`reader_supervisor`] the instant the background reader exits
     /// (clean close / panic / cancellation), so callers can tell "no messages
     /// right now" (`next_message() -> None` but still alive) apart from "the
@@ -79,8 +83,9 @@ impl BrokerClient {
 
         let (msg_tx, messages) = mpsc::unbounded_channel();
         let (del_tx, delivered) = mpsc::unbounded_channel();
-        // The demux loop is unchanged: it pushes `Message`/`Delivered` frames
-        // into the channels and ends when the stream closes or errors.
+        let (cancel_tx, cancels) = mpsc::unbounded_channel();
+        // The demux loop pushes `Message`/`Delivered`/`Cancel` frames into their
+        // respective channels and ends when the stream closes or errors.
         let reader = tokio::spawn(async move {
             while let Some(frame) = source.next().await {
                 match frame {
@@ -90,6 +95,9 @@ impl BrokerClient {
                         }
                         Ok(BrokerFrame::Delivered { id }) => {
                             let _ = del_tx.send(id);
+                        }
+                        Ok(BrokerFrame::Cancel { correlation_id }) => {
+                            let _ = cancel_tx.send(correlation_id);
                         }
                         _ => {}
                     },
@@ -112,6 +120,7 @@ impl BrokerClient {
             sink,
             messages,
             delivered,
+            cancels,
             reader_alive,
             _supervisor: supervisor,
         })
@@ -176,6 +185,13 @@ impl BrokerClient {
         msg
     }
 
+    /// Await the next out-of-band cancel (the correlation id of the run to
+    /// abort), demuxed independently of `next_message` so it can be received
+    /// while the work loop is busy. `None` when the reader has exited. #50.
+    pub async fn next_cancel(&mut self) -> Option<MsgId> {
+        self.cancels.recv().await
+    }
+
     /// `true` while the background reader task is still running. Flips to
     /// `false` the moment the reader exits — clean close, panic, or
     /// cancellation — with the cause logged by [`reader_supervisor`]. Use this
@@ -188,6 +204,18 @@ impl BrokerClient {
     /// Acknowledge a processed message so the broker deletes it.
     pub async fn ack(&mut self, id: MsgId) -> BrokerResult<()> {
         self.send(ClientFrame::Ack { id }).await
+    }
+
+    /// Out-of-band, fire-and-forget cancel: ask the broker to signal session
+    /// `to` to abort the run correlated to `correlation_id`. Returns once the
+    /// frame is sent (no receipt — it's a control signal, deliberately off the
+    /// durable/acked path). #50.
+    pub async fn cancel(&mut self, to: &str, correlation_id: &MsgId) -> BrokerResult<()> {
+        self.send(ClientFrame::Cancel {
+            to: to.into(),
+            correlation_id: correlation_id.clone(),
+        })
+        .await
     }
 
     async fn send(&mut self, frame: ClientFrame) -> BrokerResult<()> {

--- a/crates/app/bamboo-broker/tests/ws_roundtrip.rs
+++ b/crates/app/bamboo-broker/tests/ws_roundtrip.rs
@@ -147,6 +147,43 @@ async fn bad_token_is_rejected() {
     );
 }
 
+#[tokio::test]
+async fn cancel_reaches_subscribed_worker_via_next_cancel() {
+    let (endpoint, _dir) = start_broker().await;
+
+    let mut worker = BrokerClient::connect(&endpoint, agent("worker"), TOKEN)
+        .await
+        .expect("worker connects");
+    worker.subscribe().await.expect("worker subscribes");
+
+    let mut boss = BrokerClient::connect(&endpoint, agent("boss"), TOKEN)
+        .await
+        .expect("boss connects");
+
+    // Confirm the worker's subscription is live via a normal deliver round-trip
+    // BEFORE the out-of-band cancel (which the broker drops if the target isn't
+    // subscribed) — otherwise the test could race the Subscribe registration.
+    let probe = ask("boss");
+    boss.deliver("worker", probe.clone())
+        .await
+        .expect("deliver probe");
+    assert_eq!(recv(&mut worker).await.id, probe.id);
+
+    // The cancel arrives on the worker's out-of-band lane (next_cancel), NOT the
+    // message lane.
+    let cid = MsgId::new();
+    boss.cancel("worker", &cid).await.expect("send cancel");
+
+    let cancelled = tokio::time::timeout(Duration::from_secs(5), worker.next_cancel())
+        .await
+        .expect("cancel arrives in time")
+        .expect("connection stays open");
+    assert_eq!(
+        cancelled, cid,
+        "worker received the cancel's correlation id"
+    );
+}
+
 /// Start a broker on an explicit mailbox-root (so a restart reuses the same
 /// persisted state). Returns the ws endpoint + the server task handle (abort it
 /// to simulate a crash).


### PR DESCRIPTION
PR 3/5 of #50. BrokerClient gets a third demux lane for cancels (still behavior-inert: no worker consumes next_cancel yet (PR4); ask_over does not send cancel yet (PR5)).

- The background reader routes BrokerFrame::Cancel into a new cancels mpsc (was dropped by the catch-all). It drains the socket independently of the work loop, so a Cancel reaches the worker even while its work loop is blocked on a run — the enabler for PR4.
- next_cancel(): await the next cancel correlation id (separate from next_message).
- cancel(to, correlation_id): send ClientFrame::Cancel, fire-and-forget.

Integration test (full PR1-3 path): a subscribed worker receives boss.cancel via next_cancel; a deliver round-trip first confirms the subscription is live so the test cannot race Subscribe registration. Non-flaky.

Implemented by Claude Code; Bamboo-reviewed. Verified: bamboo-broker lib(22)+ws_roundtrip(5) green; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp