### PR TITLE
feat(bamboo-engine): live-per-round disabled_tools resolver hook (#136, PR 1/2, inert)

### DIFF
--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -463,6 +463,14 @@ pub struct AgentLoopConfig {
     /// for fast/background/planning/search/summarization helpers.
     pub(crate) auxiliary_model_resolver:
         Option<Arc<dyn Fn() -> AuxiliaryModelConfig + Send + Sync>>,
+    /// Optional per-round resolver for the disabled tool/skill sets so they follow
+    /// LIVE global config instead of staying frozen for the whole run. Returns the
+    /// current `(disabled_tools, disabled_skill_ids)`. When `None`, the snapshotted
+    /// `disabled_tools` / `disabled_skill_ids` fields below are used (#44 behavior).
+    /// Re-resolved each round at the tool-schema filter, so disabling/re-enabling a
+    /// tool mid-run takes effect on the next round. #136.
+    pub(crate) disabled_filter_resolver:
+        Option<Arc<dyn Fn() -> (BTreeSet<String>, BTreeSet<String>) + Send + Sync>>,
     /// Server-level usage guidance contributed by the run's tool executor —
     /// chiefly the `instructions` connected MCP servers return from `initialize`.
     /// Captured once at config construction (from `ToolExecutor::tool_guidance`)
@@ -532,12 +540,38 @@ impl Default for AgentLoopConfig {
             approval_delegate: None,
             features_dynamic_model_routing: false,
             auxiliary_model_resolver: None,
+            disabled_filter_resolver: None,
             mcp_tool_guidance: None,
         }
     }
 }
 
 impl AgentLoopConfig {
+    /// Live `(disabled_tools, disabled_skill_ids)` for the current round: the
+    /// resolver if one is wired (#136 — follows live global config between
+    /// rounds), else the per-run snapshot (#44 frozen behavior). `Cow` avoids
+    /// cloning the snapshot in the common no-resolver path (SDK / tests).
+    pub(crate) fn resolve_disabled_filters(
+        &self,
+    ) -> (
+        std::borrow::Cow<'_, BTreeSet<String>>,
+        std::borrow::Cow<'_, BTreeSet<String>>,
+    ) {
+        match &self.disabled_filter_resolver {
+            Some(resolver) => {
+                let (tools, skills) = resolver();
+                (
+                    std::borrow::Cow::Owned(tools),
+                    std::borrow::Cow::Owned(skills),
+                )
+            }
+            None => (
+                std::borrow::Cow::Borrowed(&self.disabled_tools),
+                std::borrow::Cow::Borrowed(&self.disabled_skill_ids),
+            ),
+        }
+    }
+
     /// The active session goal to surface to the main agent, or `None` when
     /// Gold is disabled or no goal is set. Falls back to the legacy
     /// `evaluation_prompt` for back-compat via [`GoldConfig::effective_goal`].

--- a/crates/engine/bamboo-engine/src/runtime/config/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config/tests.rs
@@ -69,3 +69,48 @@ fn prompt_memory_flags_map_from_memory_config() {
     assert!(flags.relevant_recall_rerank);
     assert!(!flags.project_first_dream);
 }
+
+#[test]
+fn resolve_disabled_filters_uses_snapshot_without_resolver() {
+    // #44 frozen behavior: with no resolver, the snapshotted sets are returned.
+    let mut config = AgentLoopConfig::default();
+    config.disabled_tools = std::collections::BTreeSet::from(["frozen_tool".to_string()]);
+    config.disabled_skill_ids = std::collections::BTreeSet::from(["frozen_skill".to_string()]);
+
+    let (tools, skills) = config.resolve_disabled_filters();
+    assert!(tools.contains("frozen_tool"));
+    assert!(skills.contains("frozen_skill"));
+}
+
+#[test]
+fn resolve_disabled_filters_uses_live_resolver_and_reinvokes() {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    // #136: a wired resolver overrides the snapshot AND is re-invoked each call,
+    // so the set can change between rounds.
+    let calls = Arc::new(AtomicU32::new(0));
+    let c = calls.clone();
+    let mut config = AgentLoopConfig::default();
+    config.disabled_tools = std::collections::BTreeSet::from(["ignored_snapshot".to_string()]);
+    config.disabled_filter_resolver = Some(Arc::new(move || {
+        let n = c.fetch_add(1, Ordering::SeqCst);
+        (
+            std::collections::BTreeSet::from([format!("live-{n}")]),
+            std::collections::BTreeSet::new(),
+        )
+    }));
+
+    let (t1, _) = config.resolve_disabled_filters();
+    assert!(t1.contains("live-0"), "resolver result is used");
+    assert!(
+        !t1.contains("ignored_snapshot"),
+        "the resolver overrides the frozen snapshot"
+    );
+
+    let (t2, _) = config.resolve_disabled_filters();
+    assert!(
+        t2.contains("live-1"),
+        "the resolver is re-invoked each call (live between rounds)"
+    );
+}

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tool_schemas.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tool_schemas.rs
@@ -45,8 +45,13 @@ pub(crate) fn resolve_available_tool_schemas_for_session(
     tool_schemas.extend(config.additional_tool_schemas.clone());
     tool_schemas.sort_by(|left, right| left.function.name.cmp(&right.function.name));
     tool_schemas.dedup_by(|left, right| left.function.name == right.function.name);
-    if !config.disabled_tools.is_empty() {
-        tool_schemas.retain(|schema| !config.disabled_tools.contains(&schema.function.name));
+    // Resolve the disabled set LIVE each round (#136): when a resolver is wired
+    // (server path) a tool disabled/re-enabled mid-run takes effect on the next
+    // round, because this list is rebuilt unfiltered every round; with no resolver
+    // (SDK/tests) this is the frozen per-run snapshot (#44), unchanged.
+    let (disabled_tools, _disabled_skill_ids) = config.resolve_disabled_filters();
+    if !disabled_tools.is_empty() {
+        tool_schemas.retain(|schema| !disabled_tools.contains(&schema.function.name));
     }
 
     // The `update_goal` self-report tool is only meaningful while the autonomous

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -281,6 +281,10 @@ pub struct ExecuteRequest {
     /// Optional per-round resolver for auxiliary model settings that should be
     /// re-read from live global config between rounds.
     pub auxiliary_model_resolver: Option<Arc<dyn Fn() -> AuxiliaryModelConfig + Send + Sync>>,
+    /// Optional per-round live resolver for the disabled tool/skill sets (#136).
+    /// When `None`, the snapshotted `disabled_tools`/`disabled_skill_ids` are used.
+    pub disabled_filter_resolver:
+        Option<Arc<dyn Fn() -> (BTreeSet<String>, BTreeSet<String>) + Send + Sync>>,
     /// When `None`, falls back to `Config::disabled_tool_names()`.
     pub disabled_tools: Option<BTreeSet<String>>,
     /// When `None`, falls back to `Config::disabled_skill_ids()`.
@@ -337,6 +341,8 @@ pub struct ExecuteRequestBuilder {
     summarization_model_provider: Option<Arc<dyn LLMProvider>>,
     reasoning_effort: Option<ReasoningEffort>,
     auxiliary_model_resolver: Option<Arc<dyn Fn() -> AuxiliaryModelConfig + Send + Sync>>,
+    disabled_filter_resolver:
+        Option<Arc<dyn Fn() -> (BTreeSet<String>, BTreeSet<String>) + Send + Sync>>,
     disabled_tools: Option<BTreeSet<String>>,
     disabled_skill_ids: Option<BTreeSet<String>>,
     selected_skill_ids: Option<Vec<String>>,
@@ -374,6 +380,7 @@ impl ExecuteRequestBuilder {
             summarization_model_provider: None,
             reasoning_effort: None,
             auxiliary_model_resolver: None,
+            disabled_filter_resolver: None,
             disabled_tools: None,
             disabled_skill_ids: None,
             selected_skill_ids: None,
@@ -486,6 +493,15 @@ impl ExecuteRequestBuilder {
         self
     }
 
+    /// Set the per-round resolver for the live disabled tool/skill sets (#136).
+    pub fn disabled_filter_resolver(
+        mut self,
+        v: Arc<dyn Fn() -> (BTreeSet<String>, BTreeSet<String>) + Send + Sync>,
+    ) -> Self {
+        self.disabled_filter_resolver = Some(v);
+        self
+    }
+
     /// Set the disabled tool names (merged with config defaults at runtime).
     pub fn disabled_tools(mut self, v: BTreeSet<String>) -> Self {
         self.disabled_tools = Some(v);
@@ -582,6 +598,7 @@ impl ExecuteRequestBuilder {
             model_roster,
             reasoning_effort: self.reasoning_effort,
             auxiliary_model_resolver: self.auxiliary_model_resolver,
+            disabled_filter_resolver: self.disabled_filter_resolver,
             disabled_tools: self.disabled_tools,
             disabled_skill_ids: self.disabled_skill_ids,
             selected_skill_ids: self.selected_skill_ids,
@@ -634,6 +651,7 @@ impl AgentRuntime {
             model_roster,
             reasoning_effort,
             auxiliary_model_resolver,
+            disabled_filter_resolver,
             disabled_tools,
             disabled_skill_ids,
             selected_skill_ids,
@@ -704,6 +722,7 @@ impl AgentRuntime {
             provider_type,
             reasoning_effort,
             auxiliary_model_resolver,
+            disabled_filter_resolver,
             disabled_tools: {
                 let mut merged = config.disabled_tool_names();
                 if let Some(dt) = disabled_tools {


### PR DESCRIPTION
PR 1/2 of #136 — inert. The per-round LLM call already re-resolves the tool schema list UNFILTERED every round; only the data the disabled filter reads (frozen config.disabled_tools) is stale. So making that one filter read a LIVE set gives both disable AND re-enable for free.

- AgentLoopConfig gains disabled_filter_resolver (mirrors auxiliary_model_resolver, the existing live-per-round exception) + resolve_disabled_filters() (resolver if wired, else snapshot via Cow).
- tool_schemas.rs per-round filter reads resolve_disabled_filters() instead of config.disabled_tools.

Inert: nothing wires a resolver yet (server = PR 2) -> snapshot fallback -> #44 unchanged. Skills already live-blocked at invocation (ensure_skill_allowed).

Tests: resolver-None = snapshot; wired resolver overrides + re-invoked each call.

Implemented by Claude Code; Bamboo-reviewed. Verified: bamboo-engine lib(862,+2) green; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp