### PR TITLE
fix(bamboo-llm): Gemini SSE parser must not abort on a benign null error marker (#99)

### DIFF
--- a/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
@@ -9,6 +9,7 @@ use bamboo_domain::{Message, Role};
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use super::sse::sse_error_is_present;
 use super::tool_schema::sanitize_openai_function_parameters_schema;
 use crate::provider::{LLMError, Result};
 use crate::types::LLMChunk;
@@ -237,23 +238,6 @@ fn openai_compat_error_to_llm_error(error: &Value) -> LLMError {
         .map(str::to_string)
         .unwrap_or_else(|| error.to_string());
     LLMError::Api(message)
-}
-
-/// Whether a top-level SSE `"error"` field actually represents an error.
-///
-/// Several OpenAI-compatible gateways (LiteLLM, OneAPI/New-API, some Azure
-/// proxies) emit `{"error": null}` (or `""`/`{}`) as a *no-error* marker on an
-/// otherwise-normal chunk. `serde_json`'s `get("error")` returns `Some(Null)`
-/// for an explicit null, so without this guard such a benign marker would abort
-/// a valid stream (issue #26). Only a non-null, non-empty value is a real error.
-fn sse_error_is_present(error: &Value) -> bool {
-    match error {
-        Value::Null => false,
-        Value::String(s) => !s.trim().is_empty(),
-        Value::Object(map) => !map.is_empty(),
-        Value::Array(items) => !items.is_empty(),
-        _ => true,
-    }
 }
 
 /// Parse an SSE `data:` payload in strict mode (OpenAI behavior).

--- a/crates/infra/bamboo-llm/src/providers/common/sse.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/sse.rs
@@ -4,9 +4,28 @@ use eventsource_stream::Eventsource;
 use futures::stream;
 use futures::StreamExt;
 use reqwest::Response;
+use serde_json::Value;
 
 use crate::provider::{LLMError, LLMStream, Result};
 use crate::types::LLMChunk;
+
+/// True if a top-level SSE `"error"` field represents a REAL error.
+///
+/// Several gateways (LiteLLM, OneAPI/New-API, some Azure proxies, and some Gemini
+/// gateways) emit `{"error": null}` — or `""`/`{}` — as a *no-error* marker on an
+/// otherwise-normal chunk. `serde_json`'s `get("error")` returns `Some(Null)` for
+/// an explicit null, so without this guard such a benign marker would abort a
+/// valid stream (#26 openai-compat, #99 Gemini). Only a non-null, non-empty value
+/// is a real error. Shared by every SSE parser so the guard can't drift.
+pub(crate) fn sse_error_is_present(error: &Value) -> bool {
+    match error {
+        Value::Null => false,
+        Value::String(s) => !s.trim().is_empty(),
+        Value::Object(map) => !map.is_empty(),
+        Value::Array(items) => !items.is_empty(),
+        _ => true,
+    }
+}
 
 fn to_stream_error(err: LLMError) -> LLMError {
     match err {
@@ -71,7 +90,27 @@ where
 mod tests {
     use super::*;
     use futures::StreamExt;
+    use serde_json::json;
     // use http; // TODO: add http crate if needed
+
+    #[test]
+    fn sse_error_is_present_distinguishes_real_errors_from_benign_markers() {
+        // Benign no-error markers some gateways emit -> NOT a real error.
+        assert!(!sse_error_is_present(&Value::Null));
+        assert!(!sse_error_is_present(&json!("")));
+        assert!(!sse_error_is_present(&json!("   ")));
+        assert!(!sse_error_is_present(&json!({})));
+        assert!(!sse_error_is_present(&json!([])));
+
+        // Real errors -> present.
+        assert!(sse_error_is_present(&json!("boom")));
+        assert!(sse_error_is_present(
+            &json!({ "message": "API key invalid" })
+        ));
+        assert!(sse_error_is_present(&json!(["e"])));
+        assert!(sse_error_is_present(&json!(42)));
+        assert!(sse_error_is_present(&json!(true)));
+    }
 
     #[tokio::test]
     async fn llm_stream_from_sse_filters_none_and_passes_event_name_and_data() {

--- a/crates/infra/bamboo-llm/src/providers/gemini/stream.rs
+++ b/crates/infra/bamboo-llm/src/providers/gemini/stream.rs
@@ -18,6 +18,7 @@
 //! to a later parse call — there is no later call (issue #27).
 
 use crate::provider::{LLMError, Result};
+use crate::providers::common::sse::sse_error_is_present;
 use crate::types::LLMChunk;
 use bamboo_domain::{FunctionCall, ToolCall};
 use serde_json::Value;
@@ -162,8 +163,12 @@ pub fn parse_gemini_sse_event(
         LLMError::Stream(format!("Failed to parse Gemini SSE data: {}: {}", e, data))
     })?;
 
-    // Check for error in the response
-    if let Some(error) = value.get("error") {
+    // Check for a REAL error in the response. Guard against a benign no-error
+    // marker (`{"error": null}` / `""` / `{}`) that some Gemini gateways emit on an
+    // otherwise-normal chunk — `get("error")` returns `Some(Null)` for an explicit
+    // null, which would otherwise abort a valid stream (#99, mirroring #26).
+    let error_field = value.get("error");
+    if let Some(error) = error_field.filter(|e| sse_error_is_present(e)) {
         let error_msg = error
             .get("message")
             .and_then(|m| m.as_str())
@@ -172,12 +177,21 @@ pub fn parse_gemini_sse_event(
     }
 
     // Extract candidates array
-    let candidates = value
-        .get("candidates")
-        .and_then(|c| c.as_array())
-        .ok_or_else(|| {
-            LLMError::Stream(format!("Missing candidates in Gemini response: {}", data))
-        })?;
+    let candidates = match value.get("candidates").and_then(|c| c.as_array()) {
+        Some(candidates) => candidates,
+        // No candidates is normally malformed — EXCEPT a standalone benign no-error
+        // marker (`{"error": null}`), which carries an `error` key but no content;
+        // treat that as a no-op instead of aborting the stream (#99). Route through
+        // take_gemini_final_usage so any `usageMetadata` riding on the marker is
+        // still emitted (empty when none is present).
+        None if error_field.is_some() => return Ok(take_gemini_final_usage(state, &value)),
+        None => {
+            return Err(LLMError::Stream(format!(
+                "Missing candidates in Gemini response: {}",
+                data
+            )))
+        }
+    };
 
     if candidates.is_empty() {
         return Ok(take_gemini_final_usage(state, &value));
@@ -601,6 +615,59 @@ mod tests {
 
         let result = parse_gemini_sse_event(&mut state, "", data);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn benign_null_error_marker_does_not_abort_stream() {
+        // Some gateways emit `{"error": null}` (or ""/{}) as a NO-error marker.
+        // It must not surface as an API error or abort the stream (#99).
+        for data in [
+            r#"{"error":null}"#,
+            r#"{"error":""}"#,
+            r#"{"error":{}}"#,
+            r#"{"error":[]}"#,
+        ] {
+            let mut state = GeminiStreamState::default();
+            let result = parse_gemini_sse_event(&mut state, "", data);
+            assert!(
+                result.is_ok(),
+                "benign no-error marker {data:?} must not error, got {result:?}"
+            );
+            assert!(
+                result.unwrap().is_empty(),
+                "benign marker {data:?} yields no chunks"
+            );
+        }
+    }
+
+    #[test]
+    fn null_error_marker_alongside_content_still_parses_content() {
+        // The marker rides on an otherwise-normal chunk: the content is parsed,
+        // the null error is ignored.
+        let mut state = GeminiStreamState::default();
+        let data = r#"{"error":null,"candidates":[{"content":{"parts":[{"text":"hello"}]}}]}"#;
+
+        let chunks = parse_gemini_sse_event(&mut state, "", data).unwrap();
+        assert!(
+            chunks
+                .iter()
+                .any(|c| matches!(c, LLMChunk::Token(t) if t == "hello")),
+            "content alongside a null error marker is still parsed: {chunks:?}"
+        );
+    }
+
+    #[test]
+    fn missing_candidates_without_error_key_still_errors() {
+        // A genuinely malformed chunk (no candidates AND no error key) must still
+        // surface an error — the #99 no-op path is only for benign markers.
+        let mut state = GeminiStreamState::default();
+        let data = r#"{"usageMetadata":{"totalTokenCount":5}}"#;
+
+        let result = parse_gemini_sse_event(&mut state, "", data);
+        assert!(
+            result.is_err(),
+            "missing candidates with no error key is malformed, got {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #99 (follow-up to #26). Gemini parser treated get(\"error\")==Some(Null) (from {\"error\": null}) as an error and aborted valid streams.

- Extracted #26 sse_error_is_present into shared providers/common/sse.rs (pub(crate)); openai_compat imports it (local copy deleted) so the guard cannot drift.
- Gemini error check filtered through it; a standalone benign marker (error key, no candidates) is a no-op chunk instead of aborting on Missing candidates; malformed (no candidates AND no error) still errors.

Tests: null/empty markers -> Ok(empty); marker+content still parses content; real error still LLMError::Api; missing-candidates-without-error still errors.

Implemented by Claude Code; sub-agent reviewed. Verified: bamboo-llm lib(429,+3) green; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp