### PR TITLE
fix(security): validate JsonlStorage session ids + restrict encryption key file to 0600 (#31)

### DIFF
--- a/crates/infra/bamboo-config/src/encryption.rs
+++ b/crates/infra/bamboo-config/src/encryption.rs
@@ -151,9 +151,31 @@ fn write_key_file(key: &[u8]) -> Result<()> {
             .map_err(|e| anyhow!("Failed to create key dir {}: {e}", parent.display()))?;
     }
 
-    // Store as hex for easy inspection/backup.
-    std::fs::write(&path, hex::encode(key))
-        .map_err(|e| anyhow!("Failed to write key file {}: {e}", path.display()))?;
+    // Store as hex for easy inspection/backup. This file is the MASTER key for
+    // decrypting all API keys / proxy auth / MCP secrets, so it must NEVER be
+    // world/group readable. On Unix, create it 0600 ATOMICALLY (mode applies at
+    // creation) rather than fs::write + chmod, which would leave a brief umask-perm
+    // (0644) window an attacker could read in. #31.
+    let contents = hex::encode(key);
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| anyhow!("Failed to write key file {}: {e}", path.display()))?;
+        file.write_all(contents.as_bytes())
+            .map_err(|e| anyhow!("Failed to write key file {}: {e}", path.display()))?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&path, contents)
+            .map_err(|e| anyhow!("Failed to write key file {}: {e}", path.display()))?;
+    }
     Ok(())
 }
 
@@ -534,5 +556,33 @@ mod tests {
         // Subsequent calls must be stable and load the same key.
         let second = get_encryption_key();
         assert_eq!(first, second);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn key_file_is_written_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let _env_key = EnvVarGuard::unset(KEY_ENV_VAR);
+        let dir = TempDir::new().expect("tempdir");
+        let _data_dir = EnvPathGuard::set("BAMBOO_DATA_DIR", dir.path());
+
+        // Creating the key writes the master key file.
+        let _ = get_encryption_key();
+        let key_path = crate::paths::bamboo_dir().join(KEY_FILE_NAME);
+        assert!(key_path.exists(), "expected key file to exist");
+
+        // It must be owner-only (0600) — never world/group readable (#31).
+        let mode = std::fs::metadata(&key_path)
+            .expect("metadata")
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "key file must be 0600, got {:o}",
+            mode & 0o777
+        );
     }
 }

--- a/crates/infra/bamboo-storage/src/jsonl.rs
+++ b/crates/infra/bamboo-storage/src/jsonl.rs
@@ -74,13 +74,13 @@ impl JsonlStorage {
     }
 
     pub async fn save_session(&self, session: &Session) -> std::io::Result<()> {
-        let path = self.session_path(&session.id);
+        let path = self.session_path(&session.id)?;
         let json = serde_json::to_string(session)?;
         fs::write(path, json).await
     }
 
     pub async fn load_session(&self, session_id: &str) -> std::io::Result<Option<Session>> {
-        let path = self.session_path(session_id);
+        let path = self.session_path(session_id)?;
         if !path.exists() {
             return Ok(None);
         }
@@ -90,7 +90,7 @@ impl JsonlStorage {
     }
 
     pub async fn delete_session(&self, session_id: &str) -> std::io::Result<bool> {
-        let session_path = self.session_path(session_id);
+        let session_path = self.session_path(session_id)?;
         let mut deleted_any = false;
 
         for path in [session_path] {
@@ -106,8 +106,13 @@ impl JsonlStorage {
         Ok(deleted_any)
     }
 
-    fn session_path(&self, session_id: &str) -> PathBuf {
-        self.base_path.join(format!("{}.json", session_id))
+    /// Resolve the on-disk path for a session, REJECTING any id that could escape
+    /// `base_path` (path-separator or `..`). Without this, a `session_id` like
+    /// `"../../etc/passwd"` would read/write outside the storage directory. Shares
+    /// the same guard as `SessionStoreV2`. #31.
+    fn session_path(&self, session_id: &str) -> std::io::Result<PathBuf> {
+        crate::v2::validate_session_id(session_id)?;
+        Ok(self.base_path.join(format!("{}.json", session_id)))
     }
 }
 
@@ -137,6 +142,38 @@ mod tests {
         let storage = JsonlStorage::new(&temp_dir);
         storage.init().await?;
         Ok((storage, temp_dir))
+    }
+
+    #[tokio::test]
+    async fn rejects_path_traversal_session_ids() {
+        let (storage, _dir) = create_temp_storage().await.expect("temp storage");
+
+        // Ids that could escape base_path must be rejected on every path. #31.
+        for bad in ["../escape", "../../etc/passwd", "a/b", "a\\b", "..", ""] {
+            assert!(
+                storage.load_session(bad).await.is_err(),
+                "load_session must reject {bad:?}"
+            );
+            assert!(
+                storage.delete_session(bad).await.is_err(),
+                "delete_session must reject {bad:?}"
+            );
+        }
+
+        // save_session validates its session.id too — a crafted id can't write
+        // outside base_path.
+        let evil = Session::new("../../escape", "model");
+        assert!(
+            storage.save_session(&evil).await.is_err(),
+            "save_session must reject a traversal id"
+        );
+
+        // A valid id passes validation: it just doesn't exist yet -> Ok(None),
+        // proving the guard rejects only traversal, not legitimate ids.
+        assert!(matches!(
+            storage.load_session("valid-session-123").await,
+            Ok(None)
+        ));
     }
 
     #[tokio::test]
@@ -187,12 +224,12 @@ mod tests {
 
         storage.save_session(&session).await?;
 
-        assert!(storage.session_path(&session.id).exists());
+        assert!(storage.session_path(&session.id).unwrap().exists());
 
         let deleted = storage.delete_session(&session.id).await?;
 
         assert!(deleted);
-        assert!(!storage.session_path(&session.id).exists());
+        assert!(!storage.session_path(&session.id).unwrap().exists());
 
         fs::remove_dir_all(temp_dir).await?;
         Ok(())
@@ -216,7 +253,7 @@ mod tests {
         fs::create_dir_all(&temp_dir).await?;
         let storage = JsonlStorage::new(&temp_dir);
 
-        let session_path = storage.session_path("test-123");
+        let session_path = storage.session_path("test-123").unwrap();
 
         assert_eq!(session_path.file_name().unwrap(), "test-123.json");
 

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -29,7 +29,7 @@ use crate::search_index::{should_index_session, SessionSearchIndex};
 use bamboo_domain::AttachmentReader;
 use bamboo_domain::Storage;
 
-fn other_io_error(message: impl Into<String>) -> io::Error {
+pub(crate) fn other_io_error(message: impl Into<String>) -> io::Error {
     io::Error::other(message.into())
 }
 
@@ -70,7 +70,10 @@ fn overlay_runtime_sidecar(main: Session, sidecar: Option<Session>) -> Session {
     }
 }
 
-fn validate_session_id(session_id: &str) -> io::Result<()> {
+/// Reject a session id that could escape the storage directory (empty, or
+/// containing a path separator or `..`). Shared with [`crate::jsonl`] so every
+/// store applies the same guard. #31.
+pub(crate) fn validate_session_id(session_id: &str) -> io::Result<()> {
     if session_id.is_empty()
         || session_id.contains('/')
         || session_id.contains('\\')


### PR DESCRIPTION
Closes #31 (two local-security findings).

1. JsonlStorage PATH TRAVERSAL: session_path() interpolated session_id with no validation -> ../../etc/passwd escaped the storage dir. Shared SessionStoreV2 validate_session_id (rejects empty/separators/..) pub(crate); session_path now validates + returns io::Result; callers propagate.
2. ENCRYPTION KEY world-readable: master key (decrypts ALL secrets) written via fs::write = umask 0644. chmod 0600 (owner-only) after write, Unix.

Tests: JsonlStorage rejects traversal ids (accepts valid); key file is 0600.

Implemented by Claude Code; sub-agent reviewed. Verified: storage lib(57)+config lib(125) green; check --workspace; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp