### PR TITLE
fix(security): unify workflow-name validation + fix get_workflow 404->400 (#97)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
@@ -79,7 +79,9 @@ pub async fn get_workflow(
 ) -> Result<HttpResponse, AppError> {
     let name = workflow_name.into_inner();
     if !is_safe_workflow_name(&name) {
-        return Err(AppError::NotFound("Workflow".to_string()));
+        // An invalid (malformed) name is a 400, matching every other workflow
+        // handler — not a 404, which would imply a valid-but-absent workflow. #97.
+        return Err(AppError::BadRequest("Invalid workflow name".to_string()));
     }
 
     let dir = app_state.app_data_dir.join("workflows");

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/validation.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/validation.rs
@@ -1,38 +1,7 @@
-/// Validates workflow names for security (prevents path traversal, etc.).
-pub(crate) fn is_safe_workflow_name(name: &str) -> bool {
-    // Check basic constraints.
-    if name.is_empty() || name.len() > 255 {
-        return false;
-    }
-
-    // Trim and check for whitespace issues.
-    let trimmed = name.trim();
-    if trimmed != name || trimmed.is_empty() {
-        return false;
-    }
-
-    // Check for path separators and traversal patterns.
-    if name.contains('/') || name.contains('\\') || name.contains("..") {
-        return false;
-    }
-
-    // Check for null bytes and control characters.
-    if name.chars().any(|ch| ch.is_control() || ch == '\0') {
-        return false;
-    }
-
-    // Check for reserved Windows names.
-    let upper = name.to_uppercase();
-    let stem = upper.split('.').next().unwrap_or(&upper);
-    let reserved = [
-        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
-        "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
-    ];
-    if reserved.contains(&stem) {
-        return false;
-    }
-
-    // Only allow alphanumeric, dash, underscore, dot, and space.
-    name.chars()
-        .all(|ch| ch.is_alphanumeric() || ch == '-' || ch == '_' || ch == '.' || ch == ' ')
-}
+//! Workflow-name validation.
+//!
+//! The strict validator now lives in [`bamboo_config::paths::is_safe_workflow_name`]
+//! so the HTTP workflow handlers here and the root binary's Tauri-IPC commands
+//! share ONE implementation that can't drift (#34 / #97). Re-exported so existing
+//! `use super::validation::is_safe_workflow_name` call sites are unchanged.
+pub(crate) use bamboo_config::paths::is_safe_workflow_name;

--- a/crates/infra/bamboo-config/src/paths.rs
+++ b/crates/infra/bamboo-config/src/paths.rs
@@ -82,6 +82,50 @@ pub fn workflows_dir() -> PathBuf {
     bamboo_dir().join("workflows")
 }
 
+/// Whether `name` is a safe workflow file-name stem: rejects empty / over-long /
+/// untrimmed names, path separators and `..`, null bytes / control characters,
+/// reserved Windows device names, and anything outside the
+/// `[alphanumeric - _ . space]` allowlist. The single strict validator shared by
+/// the HTTP workflow handlers and the Tauri-IPC commands so the surfaces can't
+/// drift (#34 / #97). A workflow file is `{name}.md` under [`workflows_dir`].
+pub fn is_safe_workflow_name(name: &str) -> bool {
+    // Basic constraints.
+    if name.is_empty() || name.len() > 255 {
+        return false;
+    }
+
+    // No leading/trailing whitespace.
+    let trimmed = name.trim();
+    if trimmed != name || trimmed.is_empty() {
+        return false;
+    }
+
+    // Path separators and traversal.
+    if name.contains('/') || name.contains('\\') || name.contains("..") {
+        return false;
+    }
+
+    // Null bytes and control characters.
+    if name.chars().any(|ch| ch.is_control() || ch == '\0') {
+        return false;
+    }
+
+    // Reserved Windows device names.
+    let upper = name.to_uppercase();
+    let stem = upper.split('.').next().unwrap_or(&upper);
+    let reserved = [
+        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
+        "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    ];
+    if reserved.contains(&stem) {
+        return false;
+    }
+
+    // Allowlist: alphanumeric (incl. unicode), dash, underscore, dot, space.
+    name.chars()
+        .all(|ch| ch.is_alphanumeric() || ch == '-' || ch == '_' || ch == '.' || ch == ' ')
+}
+
 /// Get anthropic-model-mapping.json path
 pub fn anthropic_model_mapping_path() -> PathBuf {
     bamboo_dir().join("anthropic-model-mapping.json")
@@ -182,6 +226,56 @@ mod tests {
     use super::*;
     use std::sync::{Mutex, OnceLock};
     use tempfile::tempdir;
+
+    #[test]
+    fn is_safe_workflow_name_accepts_allowlisted_names() {
+        for ok in [
+            "my-workflow",
+            "workflow_123",
+            "My Workflow",
+            "test.workflow",
+            "workflow.md",
+            "v1.0",
+            "2024-01-15",
+            "a",
+            "工作流",
+            "ワークフロー",
+            "العربية",
+        ] {
+            assert!(is_safe_workflow_name(ok), "{ok:?} should be accepted");
+        }
+    }
+
+    #[test]
+    fn is_safe_workflow_name_rejects_unsafe_names() {
+        for bad in [
+            "",                // empty
+            "workflow/name",   // path separator
+            "/workflow",       // path separator
+            "workflow\\name",  // path separator
+            "..",              // traversal
+            "../workflow",     // traversal
+            "workflow..test",  // traversal substring
+            "workflow (v1)",   // not in allowlist
+            "workflow [test]", // not in allowlist
+            "workflow@2.0",    // not in allowlist
+            "workflow#1",      // not in allowlist
+            "workflow$var",    // not in allowlist
+            "workflow*",       // not in allowlist
+            "workflow+test",   // not in allowlist
+            "🚀-workflow",     // emoji is not alphanumeric
+            " workflow",       // leading whitespace
+            "workflow ",       // trailing whitespace
+            "\tworkflow",      // control char + leading whitespace
+            "work\u{0}flow",   // null byte
+            "CON",             // reserved Windows name
+            "nul.md",          // reserved Windows name (stem)
+        ] {
+            assert!(!is_safe_workflow_name(bad), "{bad:?} should be rejected");
+        }
+        // Over-length is rejected.
+        assert!(!is_safe_workflow_name(&"a".repeat(256)));
+    }
 
     #[test]
     fn test_resolve_bamboo_dir_prefers_env() {

--- a/src/commands/workflows.rs
+++ b/src/commands/workflows.rs
@@ -1,15 +1,5 @@
-use bamboo_config::paths::workflows_dir;
+use bamboo_config::paths::{is_safe_workflow_name, workflows_dir};
 use std::fs;
-
-fn is_safe_workflow_name(name: &str) -> bool {
-    if name.is_empty() {
-        return false;
-    }
-    if name.contains('/') || name.contains('\\') || name.contains("..") {
-        return false;
-    }
-    true
-}
 
 /// Save a workflow to disk
 pub async fn save_workflow(name: String, content: String) -> Result<String, String> {
@@ -46,168 +36,35 @@ pub async fn delete_workflow(name: String) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
+    // The name validator itself (`is_safe_workflow_name`) now lives in
+    // `bamboo_config::paths` and is unit-tested there (#97). These tests cover the
+    // command layer: that save/delete reject unsafe names before touching disk.
     use super::*;
 
-    #[test]
-    fn safe_workflow_name_accepts_valid_names() {
-        assert!(is_safe_workflow_name("my-workflow"));
-        assert!(is_safe_workflow_name("workflow_123"));
-        assert!(is_safe_workflow_name("My Workflow"));
-        assert!(is_safe_workflow_name("test.workflow"));
-        assert!(is_safe_workflow_name("workflow (v1)"));
-        assert!(is_safe_workflow_name("工作流"));
-        assert!(is_safe_workflow_name("a")); // Single character
-    }
-
-    #[test]
-    fn safe_workflow_name_rejects_empty_string() {
-        assert!(!is_safe_workflow_name(""));
-    }
-
-    #[test]
-    fn safe_workflow_name_rejects_forward_slash() {
-        assert!(!is_safe_workflow_name("workflow/name"));
-        assert!(!is_safe_workflow_name("/workflow"));
-        assert!(!is_safe_workflow_name("workflow/"));
-        assert!(!is_safe_workflow_name("/"));
-    }
-
-    #[test]
-    fn safe_workflow_name_rejects_backslash() {
-        assert!(!is_safe_workflow_name("workflow\\name"));
-        assert!(!is_safe_workflow_name("\\workflow"));
-        assert!(!is_safe_workflow_name("workflow\\"));
-        assert!(!is_safe_workflow_name("\\"));
-    }
-
-    #[test]
-    fn safe_workflow_name_rejects_double_dot() {
-        assert!(!is_safe_workflow_name(".."));
-        assert!(!is_safe_workflow_name("../workflow"));
-        assert!(!is_safe_workflow_name("workflow/.."));
-        assert!(!is_safe_workflow_name("workflow..test"));
-        assert!(!is_safe_workflow_name("..workflow"));
-    }
-
-    #[test]
-    fn safe_workflow_name_accepts_single_dot() {
-        // Single dots are allowed (e.g., "workflow.md" or "v1.0")
-        assert!(is_safe_workflow_name("workflow.md"));
-        assert!(is_safe_workflow_name("v1.0"));
-        assert!(is_safe_workflow_name(".workflow")); // Leading dot is allowed
-        assert!(is_safe_workflow_name("workflow.")); // Trailing dot is allowed
-    }
-
-    #[test]
-    fn safe_workflow_name_rejects_mixed_dangerous_chars() {
-        assert!(!is_safe_workflow_name("../workflow\\test"));
-        assert!(!is_safe_workflow_name("..\\workflow/test"));
-        assert!(!is_safe_workflow_name("a/b\\c..d"));
-    }
-
-    #[test]
-    fn safe_workflow_name_accepts_special_characters() {
-        // Various safe special characters
-        assert!(is_safe_workflow_name("workflow-v1"));
-        assert!(is_safe_workflow_name("workflow_v2"));
-        assert!(is_safe_workflow_name("workflow (copy)"));
-        assert!(is_safe_workflow_name("workflow [test]"));
-        assert!(is_safe_workflow_name("workflow {v1}"));
-        assert!(is_safe_workflow_name("workflow@2.0"));
-        assert!(is_safe_workflow_name("workflow#1"));
-        assert!(is_safe_workflow_name("workflow$var"));
-        assert!(is_safe_workflow_name("workflow!urgent"));
-        assert!(is_safe_workflow_name("workflow?optional"));
-        assert!(is_safe_workflow_name("workflow*"));
-        assert!(is_safe_workflow_name("workflow+test"));
-        assert!(is_safe_workflow_name("workflow=value"));
-    }
-
-    #[test]
-    fn safe_workflow_name_accepts_unicode() {
-        assert!(is_safe_workflow_name("工作流"));
-        assert!(is_safe_workflow_name("ワークフロー"));
-        assert!(is_safe_workflow_name("العربية"));
-        assert!(is_safe_workflow_name("🚀-workflow"));
-        assert!(is_safe_workflow_name("workflow-🎯"));
-    }
-
-    #[test]
-    fn safe_workflow_name_accepts_numbers() {
-        assert!(is_safe_workflow_name("123"));
-        assert!(is_safe_workflow_name("workflow-123"));
-        assert!(is_safe_workflow_name("2024-01-15"));
-    }
-
-    #[test]
-    fn safe_workflow_name_handles_whitespace() {
-        // Whitespace is technically allowed (might be trimmed elsewhere)
-        assert!(is_safe_workflow_name("workflow test"));
-        assert!(is_safe_workflow_name(" workflow"));
-        assert!(is_safe_workflow_name("workflow "));
-        assert!(is_safe_workflow_name("\tworkflow"));
-    }
-
-    #[test]
-    fn safe_workflow_name_long_names() {
-        let long_name = "a".repeat(1000);
-        assert!(is_safe_workflow_name(&long_name));
+    #[tokio::test]
+    async fn save_workflow_rejects_unsafe_names() {
+        for bad in ["test/workflow", "test\\workflow", "..workflow", "", "wf@#$"] {
+            let result = save_workflow(bad.to_string(), "content".to_string()).await;
+            assert!(
+                result
+                    .as_ref()
+                    .is_err_and(|e| e.contains("Invalid workflow name")),
+                "save_workflow must reject {bad:?}, got {result:?}"
+            );
+        }
     }
 
     #[tokio::test]
-    async fn save_workflow_rejects_unsafe_name_with_slash() {
-        let result = save_workflow("test/workflow".to_string(), "content".to_string()).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid workflow name"));
-    }
-
-    #[tokio::test]
-    async fn save_workflow_rejects_unsafe_name_with_backslash() {
-        let result = save_workflow("test\\workflow".to_string(), "content".to_string()).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid workflow name"));
-    }
-
-    #[tokio::test]
-    async fn save_workflow_rejects_unsafe_name_with_double_dot() {
-        let result = save_workflow("..workflow".to_string(), "content".to_string()).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid workflow name"));
-    }
-
-    #[tokio::test]
-    async fn save_workflow_rejects_empty_name() {
-        let result = save_workflow("".to_string(), "content".to_string()).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid workflow name"));
-    }
-
-    #[tokio::test]
-    async fn delete_workflow_rejects_unsafe_name_with_slash() {
-        let result = delete_workflow("test/workflow".to_string()).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid workflow name"));
-    }
-
-    #[tokio::test]
-    async fn delete_workflow_rejects_unsafe_name_with_backslash() {
-        let result = delete_workflow("test\\workflow".to_string()).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid workflow name"));
-    }
-
-    #[tokio::test]
-    async fn delete_workflow_rejects_unsafe_name_with_double_dot() {
-        let result = delete_workflow("..workflow".to_string()).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid workflow name"));
-    }
-
-    #[tokio::test]
-    async fn delete_workflow_rejects_empty_name() {
-        let result = delete_workflow("".to_string()).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid workflow name"));
+    async fn delete_workflow_rejects_unsafe_names() {
+        for bad in ["test/workflow", "test\\workflow", "..workflow", "", "wf@#$"] {
+            let result = delete_workflow(bad.to_string()).await;
+            assert!(
+                result
+                    .as_ref()
+                    .is_err_and(|e| e.contains("Invalid workflow name")),
+                "delete_workflow must reject {bad:?}, got {result:?}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #97 (from #34 review).

F1: the root Tauri-IPC commands had a WEAKER workflow-name validator (only empty/separators/.., no allowlist/control-char check) vs the HTTP servers strict is_safe_workflow_name. Unified: moved the strict validator to bamboo_config::paths (both crates depend on it; it owns workflows_dir), re-exported from bamboo-servers validation module (call sites unchanged), replaced the root weak check. The Tauri command now rejects @#$.+?*-style names / control chars / reserved names.

F2: get_workflow returned 404 for an invalid name while save/delete return 400; aligned to 400 (malformed input).

Tests: validator unit tests now live with it in bamboo-config; root keeps command-level reject tests.

Implemented by Claude Code; sub-agent reviewed. Verified: check --workspace; config/root/server workflow tests green; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp