### PR TITLE
fix(bamboo-server): invoke AppState::shutdown() on WebService stop/drop (#119)

### DIFF
--- a/crates/app/bamboo-server/src/app_state/provider_api.rs
+++ b/crates/app/bamboo-server/src/app_state/provider_api.rs
@@ -78,8 +78,8 @@ impl AppState {
     /// and waits for them to terminate cleanly.
     ///
     /// This should be called during application shutdown to ensure
-    /// MCP servers are not left running as orphaned processes.
-    #[allow(dead_code)]
+    /// MCP servers are not left running as orphaned processes. Invoked by
+    /// [`crate::server::web_service::WebService::stop`]. #119.
     pub async fn shutdown(&self) {
         tracing::info!("Shutting down MCP servers...");
         // Stop the supervised MCP proxy service (issue #47) so its reconnect

--- a/crates/app/bamboo-server/src/server/entrypoints.rs
+++ b/crates/app/bamboo-server/src/server/entrypoints.rs
@@ -90,6 +90,9 @@ pub async fn run(bamboo_home_dir: PathBuf, port: u16) -> Result<(), String> {
             .await
             .map_err(|e| format!("Failed to initialize app state: {e}"))?,
     );
+    // Retained for graceful shutdown after the server stops — the `move` factory
+    // below consumes `app_state`. #119.
+    let app_state_for_shutdown = app_state.clone();
     let workers = resolve_worker_count();
 
     let app_factory = move || {
@@ -152,7 +155,15 @@ pub async fn run(bamboo_home_dir: PathBuf, port: u16) -> Result<(), String> {
 
     info!("Unified server running on http://127.0.0.1:{port}");
 
-    if let Err(e) = server.await {
+    let result = server.await;
+
+    // The server has stopped (actix handles SIGINT/SIGTERM, returning here on an
+    // intended stop). Gracefully stop AppState-owned background tasks — the #47
+    // MCP-proxy reconnect supervisor + MCP servers — instead of leaking them until
+    // process exit. Runs on both the clean and error exit paths. #119.
+    app_state_for_shutdown.shutdown().await;
+
+    if let Err(e) = result {
         error!("Server error: {}", e);
         return Err(format!("Server error: {e}"));
     }
@@ -213,6 +224,9 @@ pub async fn run_with_bind_and_static(
             .await
             .map_err(|e| format!("Failed to initialize app state: {e}"))?,
     );
+    // Retained for graceful shutdown after the server stops — the `move` factory
+    // below consumes `app_state`. #119.
+    let app_state_for_shutdown = app_state.clone();
     let workers = resolve_worker_count();
 
     let bind_for_cors = bind.to_string();
@@ -281,7 +295,14 @@ pub async fn run_with_bind_and_static(
 
     info!("Unified server running on http://{}:{}", bind, port);
 
-    if let Err(e) = server.await {
+    let result = server.await;
+
+    // Gracefully stop AppState-owned background tasks (the #47 MCP-proxy reconnect
+    // supervisor + MCP servers) once the server stops, instead of leaking them
+    // until process exit. Runs on both the clean and error exit paths. #119.
+    app_state_for_shutdown.shutdown().await;
+
+    if let Err(e) = result {
         error!("Server error: {}", e);
         return Err(format!("Server error: {e}"));
     }

--- a/crates/app/bamboo-server/src/server/web_service.rs
+++ b/crates/app/bamboo-server/src/server/web_service.rs
@@ -17,6 +17,11 @@ use crate::routes::{configure_routes, configure_routes_with_rate_limiting};
 pub struct WebService {
     shutdown_tx: Option<oneshot::Sender<()>>,
     server_handle: Option<tokio::task::JoinHandle<()>>,
+    /// Handle to the running server's [`AppState`], retained so [`WebService::stop`]
+    /// /[`Drop`] can gracefully stop AppState-owned background tasks (the #47
+    /// MCP-proxy reconnect supervisor) instead of leaking them until process exit.
+    /// #119.
+    app_state: Option<web::Data<AppState>>,
     /// Bamboo home directory containing all application data (config, sessions, skills, etc.)
     bamboo_home_dir: PathBuf,
     port: u16,
@@ -31,6 +36,7 @@ impl WebService {
         Self {
             shutdown_tx: None,
             server_handle: None,
+            app_state: None,
             bamboo_home_dir,
             port: 3456, // Default port
         }
@@ -56,6 +62,8 @@ impl WebService {
                 .await
                 .map_err(|e| format!("Failed to initialize app state: {e}"))?,
         );
+        // Retain a handle so stop()/Drop can stop AppState-owned background tasks. #119
+        self.app_state = Some(app_state.clone());
         let bind_addr = bind.to_string();
         let listen_addr = format!("{bind}:{port}");
         let bind_for_log = bind_addr.clone();
@@ -125,6 +133,8 @@ impl WebService {
                 .await
                 .map_err(|e| format!("Failed to initialize app state: {e}"))?,
         );
+        // Retain a handle so stop()/Drop can stop AppState-owned background tasks. #119
+        self.app_state = Some(app_state.clone());
         let bind_addr = bind.to_string();
         let listen_addr = format!("{bind}:{port}");
         let bind_for_log = bind_addr.clone();
@@ -188,6 +198,14 @@ impl WebService {
                 }
             }
 
+            // Gracefully stop AppState-owned background tasks — the #47 MCP-proxy
+            // reconnect supervisor (via its cancellation token) and the MCP servers.
+            // Without this the token was wired but never cancelled, so the
+            // supervisor only died at process exit. #119.
+            if let Some(state) = self.app_state.take() {
+                state.shutdown().await;
+            }
+
             info!("Web service stopped successfully");
         }
 
@@ -210,5 +228,50 @@ impl Drop for WebService {
         if let Some(shutdown_tx) = self.shutdown_tx.take() {
             let _ = shutdown_tx.send(());
         }
+        // Drop can't run the async shutdown(), but cancelling the MCP-proxy
+        // supervisor's token is synchronous — so a WebService dropped without an
+        // explicit stop() still tears down the reconnect loop. (The async MCP
+        // server cleanup is left to process exit on this fallback path.) #119.
+        if let Some(state) = self.app_state.take() {
+            state.mcp_proxy_shutdown.cancel();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #119 e2e: WebService::stop() must cancel the AppState-owned MCP-proxy
+    /// reconnect supervisor's token, so it terminates on server stop rather than
+    /// leaking until process exit.
+    #[tokio::test]
+    async fn stop_cancels_mcp_proxy_supervisor_token() {
+        let home = tempfile::TempDir::new().expect("tempdir");
+        let mut service = WebService::new(home.path().to_path_buf());
+        // Port 0 -> OS-assigned ephemeral port (no conflict).
+        service
+            .start_with_bind(0, "127.0.0.1")
+            .await
+            .expect("web service starts");
+
+        // Capture the supervisor's cancellation token while the service runs.
+        let token = service
+            .app_state
+            .as_ref()
+            .expect("app_state retained after start")
+            .mcp_proxy_shutdown
+            .clone();
+        assert!(
+            !token.is_cancelled(),
+            "supervisor token is live while the service runs"
+        );
+
+        service.stop().await.expect("web service stops");
+
+        assert!(
+            token.is_cancelled(),
+            "stop() must cancel the MCP-proxy supervisor token so it terminates"
+        );
     }
 }


### PR DESCRIPTION
Closes #119 (from #47 review). AppState::shutdown() (which cancels the #47 MCP-proxy supervisor token) was #[allow(dead_code)] with ZERO callers — WebService never stored its AppState, so stop()/Drop never cancelled the token; the supervisor died only at process exit.

- WebService retains the AppState (web::Data clone), set in both start paths.
- stop() calls app_state.shutdown().await (cancels token + shuts MCP servers).
- Drop synchronously cancels mcp_proxy_shutdown (sync part) as a fallback.
- Removed #[allow(dead_code)].

Test (e2e): start on ephemeral port, capture token, stop(), assert cancelled.

Implemented by Claude Code; sub-agent reviewed. Verified: bamboo-server lib(857,+1) green; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp