### PR TITLE
fix(bamboo-storage): atomic write for JsonlStorage::save_session (#35)

### DIFF
--- a/crates/infra/bamboo-storage/src/jsonl.rs
+++ b/crates/infra/bamboo-storage/src/jsonl.rs
@@ -76,7 +76,9 @@ impl JsonlStorage {
     pub async fn save_session(&self, session: &Session) -> std::io::Result<()> {
         let path = self.session_path(&session.id)?;
         let json = serde_json::to_string(session)?;
-        fs::write(path, json).await
+        // Atomic write (temp + fsync + rename) so a crash mid-write can't leave a
+        // truncated/corrupt session file and lose conversation history. #35.
+        crate::v2::atomic_write(&path, json.as_bytes()).await
     }
 
     pub async fn load_session(&self, session_id: &str) -> std::io::Result<Option<Session>> {
@@ -142,6 +144,28 @@ mod tests {
         let storage = JsonlStorage::new(&temp_dir);
         storage.init().await?;
         Ok((storage, temp_dir))
+    }
+
+    #[tokio::test]
+    async fn save_session_round_trips_and_leaves_no_temp_file() {
+        // #35: save_session uses an atomic temp+rename write. Verify it round-trips
+        // (complete write) and cleans up its temp file.
+        let (storage, dir) = create_temp_storage().await.expect("temp storage");
+        let session = Session::new("atomic-test", "model");
+        storage.save_session(&session).await.expect("save");
+
+        let loaded = storage
+            .load_session("atomic-test")
+            .await
+            .expect("load")
+            .expect("present");
+        assert_eq!(loaded.id, "atomic-test");
+
+        let has_temp = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| e.file_name().to_string_lossy().contains(".tmp."));
+        assert!(!has_temp, "atomic write must not leave a temp file behind");
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -898,6 +898,37 @@ pub struct CleanupResult {
     pub deleted_session_ids: Vec<String>,
 }
 
+/// Atomically write `bytes` to `path`: write a uniquely-named temp file in the
+/// same directory, fsync it to durable storage, then atomically rename over the
+/// target. A crash (OOM, panic, power loss) mid-write can therefore never leave
+/// `path` truncated or half-written — a reader sees either the old content or the
+/// complete new content, never a torn write. The temp is cleaned up on a write
+/// failure. Shared by the persistence layers (vs. a plain `fs::write` overwrite).
+/// #35.
+///
+/// Residuals (tracked in #166): the rename + parent directory are not fsync'd, so
+/// after a power loss the file may revert to the OLD complete content (still never
+/// torn); a crash BETWEEN temp-create and rename leaks an orphan `*.tmp.*` (disk
+/// litter, not corruption — no sweep yet); and [`atomic_rename`] is
+/// remove-then-rename on Windows, where a crash in that window can lose the target.
+pub(crate) async fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    use tokio::io::AsyncWriteExt;
+
+    let tmp = path.with_extension(format!("tmp.{}", Uuid::new_v4()));
+    let write_result = async {
+        let mut file = fs::File::create(&tmp).await?;
+        file.write_all(bytes).await?;
+        // fsync so the bytes are durable before the rename publishes them.
+        file.sync_all().await
+    }
+    .await;
+    if let Err(e) = write_result {
+        let _ = fs::remove_file(&tmp).await;
+        return Err(e);
+    }
+    atomic_rename(&tmp, path).await
+}
+
 async fn atomic_rename(from: &Path, to: &Path) -> io::Result<()> {
     // Best-effort atomic on Unix. On Windows, rename cannot overwrite.
     match fs::rename(from, to).await {


### PR DESCRIPTION
Refs #35 (contained single-crate part). JsonlStorage::save_session used plain fs::write -> a crash mid-write could truncate/corrupt a session file and lose history.

Extracted a shared atomic_write helper (pub(crate), next to atomic_rename): temp file in same dir + fsync + atomic rename (temp cleaned up on failure). save_session uses it.

Test: round-trips + no leftover temp file.

Scope: bamboo-memory write_document (separate crate) + multi-file refresh consistency + refactoring v2 inline sites tracked in #166.

Implemented by Claude Code; sub-agent reviewed. Verified: bamboo-storage lib(58,+1) green; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp