### PR TITLE
fix(bamboo-server): apply real per-IP rate limiting on the production server (#13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-governor"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7ffa43d3e1e92518355ffbc82c146b5f0fe24fba87f19f405270da7a7b3c1e"
+dependencies = [
+ "actix-http",
+ "actix-web",
+ "futures",
+ "governor",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,7 +87,7 @@ dependencies = [
  "derive_more",
  "encoding_rs",
  "flate2",
- "foldhash",
+ "foldhash 0.1.5",
  "futures-core",
  "h2 0.3.27",
  "http 0.2.12",
@@ -190,7 +202,7 @@ dependencies = [
  "cookie",
  "derive_more",
  "encoding_rs",
- "foldhash",
+ "foldhash 0.1.5",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -1093,6 +1105,7 @@ version = "0.0.0"
 dependencies = [
  "actix-cors",
  "actix-files",
+ "actix-governor",
  "actix-rt",
  "actix-web",
  "anyhow",
@@ -2163,6 +2176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,6 +2395,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot 0.12.5",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.4",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,7 +2493,18 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -3294,6 +3347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3567,6 +3626,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3662,6 +3727,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -3841,6 +3921,15 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4537,6 +4626,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/crates/app/bamboo-server/Cargo.toml
+++ b/crates/app/bamboo-server/Cargo.toml
@@ -76,6 +76,7 @@ hex = "0.4"
 sha2 = "0.10"
 rand = "0.8"
 zip = { version = "2", default-features = false, features = ["deflate"] }
+actix-governor = "0.10.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/app/bamboo-server/src/config.rs
+++ b/crates/app/bamboo-server/src/config.rs
@@ -20,11 +20,58 @@
 //! - **Custom**: Restrictive CORS for specific addresses
 
 use actix_cors::Cors;
+use actix_governor::governor::middleware::NoOpMiddleware;
+use actix_governor::{GovernorConfig, GovernorConfigBuilder, PeerIpKeyExtractor};
 use actix_web::http::header;
 use actix_web::middleware::DefaultHeaders;
 use std::collections::HashSet;
 use tracing::info;
 use tracing::warn;
+
+/// Default sustained per-IP request rate (requests/second) for the production
+/// (network-exposed) server. Overridable via `BAMBOO_RATE_LIMIT_PER_SECOND`.
+const DEFAULT_RATE_LIMIT_PER_SECOND: u64 = 10;
+/// Default per-IP burst allowance. Overridable via `BAMBOO_RATE_LIMIT_BURST`.
+const DEFAULT_RATE_LIMIT_BURST: u32 = 20;
+
+fn rate_limiter_config(
+    per_second: u64,
+    burst: u32,
+) -> GovernorConfig<PeerIpKeyExtractor, NoOpMiddleware> {
+    // One cell replenishes every `1000 / per_second` ms (>=1), allowing `per_second`
+    // sustained req/s with a `burst` bucket. Clamp to >=1 so a bad env value can't
+    // produce a zero period/burst (which finish() would reject).
+    let ms_per_request = (1000 / per_second.max(1)).max(1);
+    GovernorConfigBuilder::default()
+        .milliseconds_per_request(ms_per_request)
+        .burst_size(burst.max(1))
+        .finish()
+        .expect("rate limiter config is valid (non-zero period and burst)")
+}
+
+/// Build the per-IP rate-limiter config applied to the PRODUCTION (network-bound)
+/// server via the `actix-governor` middleware. Throttles each client IP to
+/// `BAMBOO_RATE_LIMIT_PER_SECOND` (default 10) req/s with a `BAMBOO_RATE_LIMIT_BURST`
+/// (default 20) burst, returning 429 Too Many Requests when exceeded. Desktop
+/// (localhost) mode does not apply it. #13.
+///
+/// LIMITATION: keys on the TCP PEER IP. Behind a reverse proxy every client shares
+/// the proxy's IP, so the limit becomes effectively GLOBAL (still a real DoS
+/// backstop, but not per-client). Honoring `X-Forwarded-For` would require an
+/// opt-in trusted-proxy mode (XFF is spoofable when not behind a trusted proxy),
+/// tracked separately. The default (peer IP) is the safe, non-spoofable choice for
+/// the direct-exposure (Docker `0.0.0.0`) threat model #13 targets.
+pub fn build_rate_limiter() -> GovernorConfig<PeerIpKeyExtractor, NoOpMiddleware> {
+    let per_second = std::env::var("BAMBOO_RATE_LIMIT_PER_SECOND")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_RATE_LIMIT_PER_SECOND);
+    let burst = std::env::var("BAMBOO_RATE_LIMIT_BURST")
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .unwrap_or(DEFAULT_RATE_LIMIT_BURST);
+    rate_limiter_config(per_second, burst)
+}
 
 // Keep the default CSP reasonably strict while remaining compatible with the Lotus UI runtime.
 // Lotus + Ant Design inject runtime styles, so `style-src 'unsafe-inline'` is required for the
@@ -501,6 +548,58 @@ pub fn build_cors(bind_addr: &str, port: u16) -> Cors {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rate_limiter_config_clamps_degenerate_values() {
+        // 0 per_second / 0 burst would make finish() reject; the clamps keep it
+        // valid (no panic).
+        let _ = rate_limiter_config(0, 0);
+        let _ = rate_limiter_config(1000, 1);
+    }
+
+    #[actix_web::test]
+    async fn rate_limiter_throttles_with_429_after_burst() {
+        use actix_governor::Governor;
+        use actix_web::http::StatusCode;
+        use actix_web::{test, web, App, HttpResponse};
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        // burst=2: the first two requests from an IP pass, the rest are throttled.
+        let conf = rate_limiter_config(1, 2);
+        let app = test::init_service(
+            App::new()
+                .wrap(Governor::new(&conf))
+                .route("/", web::get().to(|| async { HttpResponse::Ok().finish() })),
+        )
+        .await;
+
+        let ip = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7)), 9999);
+        let (mut saw_ok, mut saw_429) = (false, false);
+        for _ in 0..6 {
+            let req = test::TestRequest::get().uri("/").peer_addr(ip).to_request();
+            match test::call_service(&app, req).await.status() {
+                StatusCode::OK => saw_ok = true,
+                StatusCode::TOO_MANY_REQUESTS => saw_429 = true,
+                other => panic!("unexpected status {other}"),
+            }
+        }
+        assert!(saw_ok, "requests within the burst must pass");
+        assert!(saw_429, "requests beyond the burst must be 429'd (#13)");
+
+        // A DIFFERENT client IP has its OWN bucket — proving per-IP keying (a
+        // global bucket would 429 this too); guards against a regression to a
+        // global key extractor.
+        let other_ip = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 9)), 8888);
+        let req = test::TestRequest::get()
+            .uri("/")
+            .peer_addr(other_ip)
+            .to_request();
+        assert_eq!(
+            test::call_service(&app, req).await.status(),
+            StatusCode::OK,
+            "a different IP gets its own fresh bucket (per-IP, not global)"
+        );
+    }
 
     #[test]
     fn default_csp_keeps_scripts_strict_but_allows_inline_styles() {

--- a/crates/app/bamboo-server/src/routes/mod.rs
+++ b/crates/app/bamboo-server/src/routes/mod.rs
@@ -26,8 +26,11 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
 
 /// Configure all routes for production mode.
 ///
-/// Note: OpenAI-compatible forwarding endpoints are intentionally not rate-limited in this
-/// configuration (local-first deployments).
+/// This registers the same route set as [`configure_routes`]; the actual per-IP
+/// rate limiting is applied as an `actix-governor` middleware (`.wrap(Governor)`)
+/// on the production App in `server::entrypoints` / `server::web_service`, since
+/// rate limiting is App-level middleware, not route configuration. See
+/// [`crate::config::build_rate_limiter`]. (Name kept for back-compat.) #13.
 pub fn configure_routes_with_rate_limiting(cfg: &mut web::ServiceConfig) {
     cfg.configure(agent_routes)
         .configure(bamboo_v1_routes)

--- a/crates/app/bamboo-server/src/server/entrypoints.rs
+++ b/crates/app/bamboo-server/src/server/entrypoints.rs
@@ -9,11 +9,12 @@ use tracing::{error, info};
 
 use super::listeners::{build_bind_listeners, build_desktop_listeners, resolve_worker_count};
 use crate::app_state::AppState;
-use crate::config::{build_cors, build_security_headers};
+use crate::config::{build_cors, build_rate_limiter, build_security_headers};
 use crate::routes::{configure_routes, configure_routes_with_rate_limiting};
 use crate::services::frontend_package::{
     ensure_current_frontend_dir_in, has_embedded_frontend_package, resolve_frontend_package_path,
 };
+use actix_governor::Governor;
 
 fn canonicalize_static_dir(path: &Path) -> Result<PathBuf, String> {
     let canonicalized = path
@@ -229,6 +230,10 @@ pub async fn run_with_bind_and_static(
     let app_state_for_shutdown = app_state.clone();
     let workers = resolve_worker_count();
 
+    // Per-IP rate limiter for the network-exposed production server (#13). Built
+    // once and shared (Clone) across workers; `Governor` is the outermost wrap so
+    // a throttled request is rejected with 429 before any handler work.
+    let rate_limiter = build_rate_limiter();
     let bind_for_cors = bind.to_string();
     let app_factory = move || {
         let mut app = App::new()
@@ -237,9 +242,10 @@ pub async fn run_with_bind_and_static(
             .app_data(web::JsonConfig::default().limit(25 * 1024 * 1024)) // 25MB JSON limit
             .app_data(web::PayloadConfig::new(30 * 1024 * 1024)) // 30MB payload limit
             .app_data(app_state.clone())
+            .wrap(Governor::new(&rate_limiter))
             .wrap(build_cors(&bind_for_cors, port))
             .wrap(build_security_headers())
-            .configure(configure_routes_with_rate_limiting); // Enable rate limiting
+            .configure(configure_routes_with_rate_limiting);
 
         if let Some(static_path) = &static_dir {
             let index_file = static_path.join("index.html");

--- a/crates/app/bamboo-server/src/server/web_service.rs
+++ b/crates/app/bamboo-server/src/server/web_service.rs
@@ -7,8 +7,9 @@ use tracing::{error, info};
 
 use super::listeners::DEFAULT_WORKER_COUNT;
 use crate::app_state::AppState;
-use crate::config::{build_cors, build_security_headers};
+use crate::config::{build_cors, build_rate_limiter, build_security_headers};
 use crate::routes::{configure_routes, configure_routes_with_rate_limiting};
+use actix_governor::Governor;
 
 /// Manageable web service with start/stop lifecycle
 ///
@@ -135,6 +136,8 @@ impl WebService {
         );
         // Retain a handle so stop()/Drop can stop AppState-owned background tasks. #119
         self.app_state = Some(app_state.clone());
+        // Per-IP rate limiter for this network-exposed production server. #13
+        let rate_limiter = build_rate_limiter();
         let bind_addr = bind.to_string();
         let listen_addr = format!("{bind}:{port}");
         let bind_for_log = bind_addr.clone();
@@ -144,6 +147,7 @@ impl WebService {
                 .app_data(web::JsonConfig::default().limit(25 * 1024 * 1024))
                 .app_data(web::PayloadConfig::new(30 * 1024 * 1024))
                 .app_data(app_state.clone())
+                .wrap(Governor::new(&rate_limiter))
                 .wrap(build_cors(&bind_addr, port))
                 .wrap(build_security_headers())
                 .configure(configure_routes_with_rate_limiting)


### PR DESCRIPTION
Closes #13 (SECURITY/DoS). configure_routes_with_rate_limiting was a verbatim copy of the desktop config — no actix-governor, no throttle — yet the Docker/production 0.0.0.0 entrypoint called it. Operators believed they had rate limiting on a network-exposed server; they had none.

- config::build_rate_limiter() -> PeerIpKeyExtractor GovernorConfig: BAMBOO_RATE_LIMIT_PER_SECOND (default 10) + BAMBOO_RATE_LIMIT_BURST (default 20), clamped.
- Applied as OUTERMOST .wrap(Governor) on the production App in entrypoints::run_with_bind_and_static (bamboo serve/Docker, also via run_with_bind) AND WebService::start_with_bind_and_static. 429 per client IP past the limit. Desktop/localhost unchanged.
- Corrected the misleading route-config doc.

Test: Governor-wrapped app returns 200 within burst, 429 past it (fixed peer IP); + clamp test for degenerate limits.

Implemented by Claude Code; sub-agent reviewed. Verified: server lib(859,+2) green; check --workspace; fmt+clippy clean.

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp