### PR TITLE
perf(engine,tools): parse tool args once on the execute path (#106)

### DIFF
--- a/crates/app/bamboo-server-tools/src/memory/tests.rs
+++ b/crates/app/bamboo-server-tools/src/memory/tests.rs
@@ -39,6 +39,7 @@ fn test_context<'a>(session_id: &'a str) -> ToolExecutionContext<'a> {
         available_tool_schemas: None,
         bypass_permissions: false,
         can_async_resume: false,
+        pre_parsed_args: None,
     }
 }
 

--- a/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
@@ -125,6 +125,7 @@ Use this demo skill."#,
         available_tool_schemas: None,
         bypass_permissions: false,
         can_async_resume: false,
+        pre_parsed_args: None,
     };
 
     let error = tool
@@ -189,6 +190,7 @@ Use this demo skill."#,
         available_tool_schemas: None,
         bypass_permissions: false,
         can_async_resume: false,
+        pre_parsed_args: None,
     };
 
     let _ = tool
@@ -259,6 +261,7 @@ Use this demo skill."#,
         available_tool_schemas: None,
         bypass_permissions: false,
         can_async_resume: false,
+        pre_parsed_args: None,
     };
     let read_ctx = ToolExecutionContext {
         session_id: Some(session_id),
@@ -267,6 +270,7 @@ Use this demo skill."#,
         available_tool_schemas: None,
         bypass_permissions: false,
         can_async_resume: false,
+        pre_parsed_args: None,
     };
 
     let _ = load_tool

--- a/crates/app/bamboo-server-tools/tests/ask_agent_tool.rs
+++ b/crates/app/bamboo-server-tools/tests/ask_agent_tool.rs
@@ -24,6 +24,7 @@ async fn ask_agent_tool_queries_a_broker_agent() {
         available_tool_schemas: None,
         bypass_permissions: false,
         can_async_resume: false,
+        pre_parsed_args: None,
     };
     let result = tool
         .execute_with_context(
@@ -54,6 +55,7 @@ async fn ask_agent_tool_rejects_unknown_mode() {
         available_tool_schemas: None,
         bypass_permissions: false,
         can_async_resume: false,
+        pre_parsed_args: None,
     };
     let err = tool
         .execute_with_context(
@@ -120,6 +122,7 @@ async fn concurrent_asks_to_one_worker_are_each_answered_correctly() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             };
             let result = tool
                 .execute_with_context(

--- a/crates/app/bamboo-server/src/app_state/resume_adapter.rs
+++ b/crates/app/bamboo-server/src/app_state/resume_adapter.rs
@@ -214,6 +214,7 @@ impl ResumeExecutionPort for AppStateResumeRef {
                         available_tool_schemas: None,
                         bypass_permissions: false,
                         can_async_resume: false,
+                        pre_parsed_args: None,
                     };
                     executor.execute_with_context(&tool_call, ctx).await
                 };

--- a/crates/app/bamboo-server/src/app_state/tests.rs
+++ b/crates/app/bamboo-server/src/app_state/tests.rs
@@ -266,6 +266,7 @@ async fn memory_tool_merge_action_updates_existing_project_memory() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -295,6 +296,7 @@ async fn memory_tool_merge_action_updates_existing_project_memory() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -323,6 +325,7 @@ async fn memory_tool_merge_action_updates_existing_project_memory() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -371,6 +374,7 @@ async fn memory_tool_write_merges_heuristically_similar_memory_when_enabled() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -400,6 +404,7 @@ async fn memory_tool_write_merges_heuristically_similar_memory_when_enabled() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -425,6 +430,7 @@ async fn memory_tool_write_merges_heuristically_similar_memory_when_enabled() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -466,6 +472,7 @@ async fn memory_tool_merge_mode_contradict_marks_memory_contradicted() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -493,6 +500,7 @@ async fn memory_tool_merge_mode_contradict_marks_memory_contradicted() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -521,6 +529,7 @@ async fn memory_tool_merge_mode_contradict_marks_memory_contradicted() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -569,6 +578,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -595,6 +605,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -620,6 +631,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -648,6 +660,7 @@ async fn memory_tool_batch_purge_archives_filtered_items() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -690,6 +703,7 @@ async fn memory_tool_inspect_and_rebuild_expose_observability_fields() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -712,6 +726,7 @@ async fn memory_tool_inspect_and_rebuild_expose_observability_fields() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -741,6 +756,7 @@ async fn memory_tool_inspect_and_rebuild_expose_observability_fields() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await

--- a/crates/app/bamboo-server/src/handlers/tools/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/tools/mod.rs
@@ -123,6 +123,7 @@ pub async fn execute_tool(
                 available_tool_schemas: Some(available_tool_schemas.as_slice()),
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await

--- a/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
+++ b/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
@@ -293,6 +293,7 @@ fn ctx_for<'a>(session_id: &'a str, tool_call_id: &'static str) -> ToolExecution
         available_tool_schemas: None,
         bypass_permissions: false,
         can_async_resume: false,
+        pre_parsed_args: None,
     }
 }
 
@@ -547,6 +548,7 @@ async fn create_emits_sub_agent_started_event_after_queueing() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -615,6 +617,7 @@ async fn create_uses_async_subagent_model_resolver() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -657,6 +660,7 @@ async fn resident_create_reuses_same_child_session() {
         available_tool_schemas: None,
         bypass_permissions: false,
         can_async_resume: false,
+        pre_parsed_args: None,
     };
     let create = |name_task: &'static str, prompt: &'static str| {
         json!({
@@ -780,6 +784,7 @@ async fn backward_compat_legacy_subagent_call_without_action_defaults_to_create(
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -814,6 +819,7 @@ async fn send_message_appends_follow_up_without_replacing_history() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -867,6 +873,7 @@ async fn send_message_queues_on_running_child_without_interrupt() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -935,6 +942,7 @@ async fn send_message_can_interrupt_running_child() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -986,6 +994,7 @@ async fn send_message_can_queue_child_immediately() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -1071,6 +1080,7 @@ async fn cancel_stops_running_child() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -1099,6 +1109,7 @@ async fn list_returns_children() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -1143,6 +1154,7 @@ async fn get_returns_runner_diagnostics() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -1181,6 +1193,7 @@ async fn create_returns_duration_hint() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -1231,6 +1244,7 @@ async fn create_persists_explicit_reasoning_effort_to_child_session() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -1284,6 +1298,7 @@ async fn create_without_reasoning_effort_leaves_child_at_provider_default() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -1342,6 +1357,7 @@ async fn update_can_change_reasoning_effort_on_existing_child() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -1378,6 +1394,7 @@ async fn delete_removes_child() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -1416,6 +1433,7 @@ async fn create_requires_workspace() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -1455,6 +1473,7 @@ async fn create_sets_child_workspace() {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await

--- a/crates/core/bamboo-agent-core/src/tools/context.rs
+++ b/crates/core/bamboo-agent-core/src/tools/context.rs
@@ -7,6 +7,8 @@
 
 use tokio::sync::mpsc;
 
+use serde_json::Value;
+
 use crate::tools::ToolSchema;
 use crate::{AgentEvent, Session};
 
@@ -72,6 +74,16 @@ pub struct ToolExecutionContext<'a> {
     /// the dispatch site — NOT session-derived — so it is a direct
     /// `for_dispatch` parameter rather than a `ToolExecutionSessionFlags` field.
     pub can_async_resume: bool,
+    /// The tool call's `function.arguments` JSON string, already parsed once by
+    /// the dispatching agent loop (which also parses it to populate the
+    /// `ToolStart` event). When `Some`, downstream executors should reuse this
+    /// instead of calling `parse_tool_args_best_effort` on the raw string a
+    /// second time — the value here is the *exact* output of that same parser on
+    /// the same input, so reuse is behavior-preserving (issue #106, deferred B1
+    /// from #17). When `None` (e.g. `none()` contexts, tests, or executors that
+    /// synthesize a child call), executors parse the raw string themselves,
+    /// preserving the original single-parse-per-consumer behavior.
+    pub pre_parsed_args: Option<&'a Value>,
 }
 
 impl<'a> ToolExecutionContext<'a> {
@@ -83,6 +95,7 @@ impl<'a> ToolExecutionContext<'a> {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         }
     }
 
@@ -102,6 +115,14 @@ impl<'a> ToolExecutionContext<'a> {
         // When `false`, the Bash auto path stays synchronous (issue #84,
         // phase 2d). NOT session-derived — set by the dispatch site.
         can_async_resume: bool,
+        // The call's arguments, already parsed once at the dispatch site (to
+        // populate the `ToolStart` event). Threaded down so the executor reuses
+        // it instead of re-parsing the raw JSON string (issue #106). Only pass
+        // `Some` when the value was produced by `parse_tool_args_best_effort`
+        // (the executor's own parser) so reuse is byte-for-byte equivalent; a
+        // dispatch site that parses with a different/stricter parser must pass
+        // `None` so the executor re-parses leniently and behavior is preserved.
+        pre_parsed_args: Option<&'a Value>,
     ) -> Self {
         Self {
             session_id: Some(session_id),
@@ -110,6 +131,7 @@ impl<'a> ToolExecutionContext<'a> {
             available_tool_schemas: Some(available_tool_schemas),
             bypass_permissions: flags.bypass_permissions,
             can_async_resume,
+            pre_parsed_args,
         }
     }
 
@@ -182,10 +204,28 @@ mod session_flags_tests {
                 bypass_permissions: true,
             },
             true,
+            None,
         );
         assert_eq!(ctx.session_id, Some("s1"));
         assert!(ctx.bypass_permissions);
         assert!(ctx.can_async_resume);
+        assert!(ctx.pre_parsed_args.is_none());
+    }
+
+    #[test]
+    fn for_dispatch_threads_pre_parsed_args() {
+        let (tx, _rx) = mpsc::channel(1);
+        let parsed = serde_json::json!({"v": "x"});
+        let ctx = ToolExecutionContext::for_dispatch(
+            "s1",
+            "call-1",
+            &tx,
+            &[],
+            ToolExecutionSessionFlags::default(),
+            false,
+            Some(&parsed),
+        );
+        assert_eq!(ctx.pre_parsed_args, Some(&parsed));
     }
 }
 
@@ -208,6 +248,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         tokio::time::timeout(
@@ -236,6 +277,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         ctx.emit(AgentEvent::Token {
@@ -266,6 +308,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         // Test with various non-Token events
@@ -307,6 +350,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         ctx.emit_tool_token("convenient output").await;
@@ -359,6 +403,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         let cloned = ctx.cloned_sender();
@@ -384,6 +429,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         for i in 0..5 {
@@ -414,6 +460,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         // Can clone (Copy implies Clone)
@@ -443,6 +490,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         ctx.emit(AgentEvent::Token {
@@ -469,6 +517,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         ctx.emit(AgentEvent::Token {
@@ -499,6 +548,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         ctx.emit(AgentEvent::Token {
@@ -525,6 +575,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         let content = String::from("owned string");
@@ -549,6 +600,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         ctx.emit_tool_token("string slice").await;

--- a/crates/core/bamboo-agent-core/src/tools/executor.rs
+++ b/crates/core/bamboo-agent-core/src/tools/executor.rs
@@ -205,17 +205,26 @@ pub async fn execute_tool_call_with_context(
     ctx: ToolExecutionContext<'_>,
 ) -> Result<ToolResult> {
     if let Some(executor) = composition_executor {
-        let args_raw = tool_call.function.arguments.trim();
-        let (args, parse_warning) = parse_tool_args_best_effort(&tool_call.function.arguments);
-        if let Some(warning) = parse_warning {
-            tracing::warn!(
-                "Composition executor tool args fallback applied: tool_call_id={}, tool_name={}, args_len={}, warning={}",
-                tool_call.id,
-                tool_call.function.name,
-                args_raw.len(),
-                warning
-            );
-        }
+        // Reuse the args the dispatching loop already parsed (threaded via the
+        // context) instead of re-parsing the raw string here (issue #106). When
+        // absent, parse exactly as before — including the fallback warning.
+        let args = if let Some(pre_parsed) = ctx.pre_parsed_args {
+            pre_parsed.clone()
+        } else {
+            let args_raw = tool_call.function.arguments.trim();
+            let (parsed, parse_warning) =
+                parse_tool_args_best_effort(&tool_call.function.arguments);
+            if let Some(warning) = parse_warning {
+                tracing::warn!(
+                    "Composition executor tool args fallback applied: tool_call_id={}, tool_name={}, args_len={}, warning={}",
+                    tool_call.id,
+                    tool_call.function.name,
+                    args_raw.len(),
+                    warning
+                );
+            }
+            parsed
+        };
         let expr = ToolExpr::call(tool_call.function.name.clone(), args);
         let mut exec_ctx = ExecutionContext::new();
 

--- a/crates/core/bamboo-agent-core/src/tools/result_handler.rs
+++ b/crates/core/bamboo-agent-core/src/tools/result_handler.rs
@@ -384,6 +384,12 @@ pub async fn execute_sub_actions(
             // never safely auto-promote a Bash command — keep it synchronous
             // (issue #84, phase 2d).
             false,
+            // This loop parses the `ToolStart` args with the stricter
+            // `parse_tool_args` (not `parse_tool_args_best_effort`), which
+            // differs on malformed input. Passing `None` lets the executor
+            // re-parse leniently exactly as before — behavior preserved
+            // (issue #106).
+            None,
         );
 
         match execute_tool_call_with_context(&action, tools, composition_executor.clone(), tool_ctx)

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
@@ -127,7 +127,7 @@ pub(super) async fn execute_tool_call_only(
         AgentEvent::ToolStart {
             tool_call_id: ctx.tool_call.id.clone(),
             tool_name: ctx.tool_call.function.name.clone(),
-            arguments: args,
+            arguments: args.clone(),
         },
     )
     .await;
@@ -167,6 +167,11 @@ pub(super) async fn execute_tool_call_only(
         // 2d). On hook-less paths (e.g. the schedule loop) this is false, so the
         // auto path stays synchronous and never orphans a promoted shell.
         ctx.config.bash_resume_hook.is_some() && ctx.config.persistence.is_some(),
+        // Reuse the args parsed above (for the `ToolStart` event) instead of
+        // re-parsing the raw JSON string downstream in the executor (issue #106).
+        // `args` came from `parse_tool_args_best_effort`, the same parser the
+        // executor would call, so reuse is byte-for-byte equivalent.
+        Some(&args),
     );
 
     let result = bamboo_agent_core::tools::executor::execute_tool_call_with_context(

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -249,19 +249,33 @@ impl ToolExecutor for BuiltinToolExecutor {
         call: &ToolCall,
         ctx: ToolExecutionContext<'_>,
     ) -> Result<ToolResult, ToolError> {
-        let args_raw = call.function.arguments.trim();
-        let (mut args, parse_warning) = parse_tool_args_best_effort(&call.function.arguments);
-        if let Some(warning) = parse_warning {
-            tracing::warn!(
-                "Builtin tool argument parsing fallback applied: session_id={:?}, tool_call_id={}, tool_name={}, args_len={}, args_preview=\"{}\", warning={}",
-                ctx.session_id,
-                call.id,
-                call.function.name,
-                args_raw.len(),
-                preview_for_log(args_raw, 180),
-                warning
-            );
-        }
+        // Reuse the args the dispatching agent loop already parsed (for the
+        // `ToolStart` event) when it threaded them through the context, instead
+        // of re-parsing the raw JSON string here (issue #106, deferred B1 from
+        // #17). The pre-parsed value is the exact output of
+        // `parse_tool_args_best_effort` on the same input, and that loop already
+        // logged any fallback warning at parse time, so skipping the re-parse is
+        // behavior-preserving. When absent (the `execute` entry point, tests, or
+        // a loop that parsed with a different/stricter parser), fall back to
+        // parsing here exactly as before — including the fallback-warning log.
+        let mut args = if let Some(pre_parsed) = ctx.pre_parsed_args {
+            pre_parsed.clone()
+        } else {
+            let args_raw = call.function.arguments.trim();
+            let (parsed, parse_warning) = parse_tool_args_best_effort(&call.function.arguments);
+            if let Some(warning) = parse_warning {
+                tracing::warn!(
+                    "Builtin tool argument parsing fallback applied: session_id={:?}, tool_call_id={}, tool_name={}, args_len={}, args_preview=\"{}\", warning={}",
+                    ctx.session_id,
+                    call.id,
+                    call.function.name,
+                    args_raw.len(),
+                    preview_for_log(args_raw, 180),
+                    warning
+                );
+            }
+            parsed
+        };
 
         let raw_tool_name = normalize_tool_name(&call.function.name);
         if let Some(args_obj) = args.as_object_mut() {
@@ -1026,6 +1040,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: true,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
         let result = executor.execute_with_context(&call, ctx).await;
 
@@ -1054,6 +1069,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: true,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
         let result = executor.execute_with_context(&call, ctx).await;
 
@@ -1099,6 +1115,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         let proxy: Arc<dyn crate::approval::ApprovalProxy> = Arc::new(HostStub { approve: true });
@@ -1135,6 +1152,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         let proxy: Arc<dyn crate::approval::ApprovalProxy> = Arc::new(HostStub { approve: false });
@@ -1209,6 +1227,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await
@@ -1271,5 +1290,122 @@ mod tests {
         let result = executor.execute(&call).await.expect("execute custom tool");
         assert!(result.success);
         assert_eq!(result.result, "custom-spawn-session");
+    }
+
+    // ---- issue #106: parse tool args once on the execute path -------------
+
+    /// A tool that echoes back the `v` field of the args it was invoked with, so
+    /// a test can observe *which* parsed value reached the tool.
+    struct EchoArgsTool;
+
+    #[async_trait]
+    impl Tool for EchoArgsTool {
+        fn name(&self) -> &str {
+            "echo_args"
+        }
+        fn description(&self) -> &str {
+            "echoes the `v` arg"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            json!({"type":"object","properties":{"v":{"type":"string"}}})
+        }
+        async fn execute(&self, args: serde_json::Value) -> Result<ToolResult, ToolError> {
+            let v = args
+                .get("v")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("<none>")
+                .to_string();
+            Ok(ToolResult {
+                success: true,
+                result: v,
+                display_preference: None,
+                images: Vec::new(),
+            })
+        }
+    }
+
+    fn ctx_with_pre_parsed<'a>(
+        call_id: &'a str,
+        pre_parsed: Option<&'a serde_json::Value>,
+    ) -> ToolExecutionContext<'a> {
+        ToolExecutionContext {
+            session_id: Some("s-106"),
+            tool_call_id: call_id,
+            event_tx: None,
+            available_tool_schemas: None,
+            bypass_permissions: false,
+            can_async_resume: false,
+            pre_parsed_args: pre_parsed,
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_with_context_reuses_pre_parsed_args_without_reparsing() {
+        // The raw `arguments` string and the threaded `pre_parsed_args` Value
+        // deliberately disagree. If the executor honored the contract (parse
+        // once at the dispatch site, reuse downstream), the tool sees the
+        // pre-parsed value; if it re-parsed the raw string it would see "raw".
+        // This is the load-bearing proof that the second parse was eliminated.
+        let executor = BuiltinToolExecutor::new();
+        executor.register_tool(EchoArgsTool).expect("register echo");
+
+        let call = make_tool_call("echo_args", json!({"v": "raw"}));
+        let pre_parsed = json!({"v": "preparsed"});
+        let ctx = ctx_with_pre_parsed(&call.id, Some(&pre_parsed));
+
+        let result = executor
+            .execute_with_context(&call, ctx)
+            .await
+            .expect("execute echo tool");
+        assert_eq!(
+            result.result, "preparsed",
+            "executor must reuse pre_parsed_args, not re-parse the raw string"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_with_context_parses_raw_when_no_pre_parsed_args() {
+        // Without a threaded value (the `execute` entry point / tests / a loop
+        // that parsed with a different parser), the executor falls back to
+        // parsing the raw string exactly as before — behavior preserved.
+        let executor = BuiltinToolExecutor::new();
+        executor.register_tool(EchoArgsTool).expect("register echo");
+
+        let call = make_tool_call("echo_args", json!({"v": "raw"}));
+        let ctx = ctx_with_pre_parsed(&call.id, None);
+
+        let result = executor
+            .execute_with_context(&call, ctx)
+            .await
+            .expect("execute echo tool");
+        assert_eq!(
+            result.result, "raw",
+            "without pre_parsed_args the executor parses the raw string as before"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_with_context_malformed_args_repair_unchanged_without_pre_parsed() {
+        // Malformed (truncated) JSON must still be auto-repaired by the
+        // fallback parse when no pre-parsed value is threaded — the existing
+        // error/leniency behavior is untouched by the dedup.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("recovered-no-preparsed.txt");
+        let malformed_args = format!(
+            r#"{{"file_path":"{}","content":"recovered content""#,
+            path.display()
+        );
+
+        let executor = BuiltinToolExecutor::new();
+        let call = make_tool_call_with_raw_args("Write", &malformed_args);
+        let ctx = ctx_with_pre_parsed(&call.id, None);
+
+        let result = executor
+            .execute_with_context(&call, ctx)
+            .await
+            .expect("truncated JSON should be auto-repaired");
+        assert!(result.success);
+        let written = fs::read_to_string(&path).await.expect("file written");
+        assert_eq!(written, "recovered content");
     }
 }

--- a/crates/engine/bamboo-tools/src/tools/bash.rs
+++ b/crates/engine/bamboo-tools/src/tools/bash.rs
@@ -736,6 +736,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await
@@ -1063,6 +1064,7 @@ mod tests {
             &[],
             ToolExecutionSessionFlags::default(),
             true,
+            None,
         );
 
         let result = tool
@@ -1120,6 +1122,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await
@@ -1251,6 +1254,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         let result = tool
@@ -1291,6 +1295,7 @@ mod tests {
             // `can_async_resume` is irrelevant here — this test drives
             // promotion directly via run_streaming_command(Some(200)).
             true,
+            None,
         );
         let cwd = super::workspace_state::workspace_or_process_cwd(Some(session_id));
 

--- a/crates/engine/bamboo-tools/src/tools/edit.rs
+++ b/crates/engine/bamboo-tools/src/tools/edit.rs
@@ -836,6 +836,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await;
@@ -851,6 +852,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await
@@ -870,6 +872,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await
@@ -1224,6 +1227,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await
@@ -1244,6 +1248,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/memory_note.rs
+++ b/crates/engine/bamboo-tools/src/tools/memory_note.rs
@@ -191,6 +191,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await;
@@ -209,6 +210,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await;
@@ -233,6 +235,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await
@@ -251,6 +254,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await
@@ -271,6 +275,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await
@@ -289,6 +294,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await
@@ -313,6 +319,7 @@ mod tests {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -328,6 +335,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await
@@ -345,6 +353,7 @@ mod tests {
                 available_tool_schemas: None,
                 bypass_permissions: false,
                 can_async_resume: false,
+                pre_parsed_args: None,
             },
         )
         .await
@@ -360,6 +369,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/read.rs
+++ b/crates/engine/bamboo-tools/src/tools/read.rs
@@ -301,6 +301,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         };
 
         let read_tool = ReadTool::new();

--- a/crates/engine/bamboo-tools/src/tools/slash_command_tool.rs
+++ b/crates/engine/bamboo-tools/src/tools/slash_command_tool.rs
@@ -148,6 +148,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/workspace.rs
+++ b/crates/engine/bamboo-tools/src/tools/workspace.rs
@@ -200,6 +200,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await
@@ -229,6 +230,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await
@@ -246,6 +248,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await
@@ -271,6 +274,7 @@ mod tests {
                     available_tool_schemas: None,
                     bypass_permissions: false,
                     can_async_resume: false,
+                    pre_parsed_args: None,
                 },
             )
             .await

--- a/crates/engine/bamboo-tools/src/tools/write.rs
+++ b/crates/engine/bamboo-tools/src/tools/write.rs
@@ -136,6 +136,7 @@ mod tests {
             available_tool_schemas: None,
             bypass_permissions: false,
             can_async_resume: false,
+            pre_parsed_args: None,
         }
     }
 

--- a/tests/deploy_agent_tool_e2e.rs
+++ b/tests/deploy_agent_tool_e2e.rs
@@ -25,6 +25,7 @@ fn ctx() -> ToolExecutionContext<'static> {
         available_tool_schemas: None,
         bypass_permissions: false,
         can_async_resume: false,
+        pre_parsed_args: None,
     }
 }
 

--- a/tests/schedule_tasks_tool.rs
+++ b/tests/schedule_tasks_tool.rs
@@ -97,6 +97,7 @@ fn ctx_for_session<'a>(session_id: &'a str) -> ToolExecutionContext<'a> {
         available_tool_schemas: None,
         bypass_permissions: false,
         can_async_resume: false,
+        pre_parsed_args: None,
     }
 }
 

--- a/tests/session_inspector_tool.rs
+++ b/tests/session_inspector_tool.rs
@@ -20,6 +20,7 @@ fn ctx_for_session<'a>(session_id: &'a str) -> ToolExecutionContext<'a> {
         available_tool_schemas: None,
         bypass_permissions: false,
         can_async_resume: false,
+        pre_parsed_args: None,
     }
 }
 


### PR DESCRIPTION
Deferred B1 from #17. On the engine execute path, a single tool call's `function.arguments` JSON string was parsed **multiple times**:

1. `crates/engine/bamboo-engine/.../tool_execution/per_call.rs` — parsed to populate the `ToolStart` event.
2. `crates/engine/bamboo-tools/src/executor.rs` `BuiltinToolExecutor::execute_with_context` — parsed again for permission checks + execution.
3. `crates/core/bamboo-agent-core/src/tools/executor.rs` `execute_tool_call_with_context` (composition branch) — parsed a third time when a composition executor is wired.

## Change
Parse once at the dispatch site and thread the parsed `serde_json::Value` down through a new `ToolExecutionContext::pre_parsed_args: Option<&Value>` field (set via `for_dispatch`). Downstream executors **reuse** it when present and **fall back** to parsing the raw string when absent (the `execute()` entry point, tests, or a loop that parsed with a different parser).

## Behavior preservation (the bar for this refactor)
- The reused value is the exact output of `parse_tool_args_best_effort` on the same input, so leniency / truncated-JSON auto-repair / fallback-to-`{}` are identical.
- The fallback-warning log still fires on the parsing path (it was already logged once at the dispatch site for the reused value), so no warning is lost or duplicated.
- `result_handler.rs` (bamboo-agent-core's own loop) parses its `ToolStart` event with the **stricter** `parse_tool_args` (which differs on malformed input), so it threads `None` and the executor re-parses leniently **exactly as before** — its behavior is untouched.
- `none()` contexts thread `None`, so every non-dispatch caller is unchanged.

## Tests
- `execute_with_context_reuses_pre_parsed_args_without_reparsing` — raw args and threaded value deliberately disagree; the tool must observe the **pre-parsed** value (proves the second parse is gone).
- `execute_with_context_parses_raw_when_no_pre_parsed_args` — fallback parse preserved.
- `execute_with_context_malformed_args_repair_unchanged_without_pre_parsed` — truncated-JSON auto-repair still works on the fallback path.
- `for_dispatch_threads_pre_parsed_args` — context plumbing.

`cargo test --workspace` green; `cargo fmt --check` clean; `cargo clippy -p bamboo-engine -p bamboo-tools -p bamboo-agent-core` introduces no new warnings in the changed files.

The remaining ~80 one-line diffs are mechanical `pre_parsed_args: None,` additions to existing test struct literals (the field is non-defaulted on a `Copy` struct, as the issue anticipated).

Closes #106

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp