### PR TITLE
fix(compression): resolve model limits at runtime — 4-bug budget chain (#20)

### DIFF
--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/token_budget.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/token_budget.rs
@@ -5,7 +5,7 @@ use bamboo_compression::{ModelLimitsRegistry, TokenBudget};
 use bamboo_llm::provider::LLMProvider;
 
 pub(super) async fn resolve_token_budget(
-    session: &Session,
+    session: &mut Session,
     config: &AgentLoopConfig,
     model_name: &str,
     llm: &dyn LLMProvider,
@@ -78,12 +78,23 @@ pub(super) async fn resolve_token_budget(
         );
     }
 
-    TokenBudget::with_safety_margin(
+    let resolved = TokenBudget::with_safety_margin(
         model_limit.max_context_tokens,
         model_limit.get_max_output_tokens(),
         bamboo_compression::BudgetStrategy::default(),
         model_limit.get_safety_margin(),
-    )
+    );
+
+    // Cache the resolved budget on the session so every downstream reader of
+    // `session.token_budget` sees the real, model-limit-derived budget instead
+    // of `None` (issue #20 bug 1). Previously this value was only ever returned
+    // to the immediate caller, so `build_context_pressure` (tool-output
+    // truncation), the server context bar, and `estimate_context_compression_exposure`
+    // all fell back to a default/empty-registry budget. The session-override
+    // early-return above makes this a one-time resolution per session.
+    session.token_budget = Some(resolved.clone());
+
+    resolved
 }
 
 /// Apply the legacy `config.json` `model_limits` value (snapshotted from the
@@ -184,6 +195,62 @@ mod tests {
         let bad = serde_json::json!({ "not": "an array" });
         apply_legacy_model_limits(&mut registry, Some(&bad));
         assert!(registry.get("legacy-model").is_none());
+    }
+
+    // Issue #20 bug 1: `resolve_token_budget` must cache the resolved budget on
+    // `session.token_budget`, otherwise every downstream reader
+    // (build_context_pressure, the server context bar,
+    // estimate_context_compression_exposure) sees `None` and silently falls back
+    // to a default/empty-registry budget.
+    #[tokio::test]
+    async fn resolve_token_budget_caches_resolved_budget_on_session() {
+        let mut session = bamboo_agent_core::Session::new("budget-cache", "some-model");
+        assert!(
+            session.token_budget.is_none(),
+            "precondition: a fresh session has no cached budget"
+        );
+
+        let config = AgentLoopConfig::default();
+        let provider = MetadataProvider::default();
+
+        let resolved = resolve_token_budget(&mut session, &config, "some-model", &provider).await;
+
+        // The function returns the resolved budget AND caches it on the session,
+        // so the two are identical and `session.token_budget` is no longer None.
+        let cached = session
+            .token_budget
+            .clone()
+            .expect("resolved budget must be cached on the session (#20 bug 1)");
+        assert_eq!(cached.max_context_tokens, resolved.max_context_tokens);
+        assert_eq!(cached.max_output_tokens, resolved.max_output_tokens);
+        assert_eq!(cached.safety_margin, resolved.safety_margin);
+    }
+
+    // A budget already present on the session is the highest-priority source and
+    // must be returned verbatim (never recomputed/overwritten).
+    #[tokio::test]
+    async fn resolve_token_budget_prefers_existing_session_budget() {
+        let mut session = bamboo_agent_core::Session::new("budget-existing", "some-model");
+        let preset = TokenBudget::with_safety_margin(
+            123_456,
+            7_890,
+            bamboo_compression::BudgetStrategy::default(),
+            321,
+        );
+        session.token_budget = Some(preset.clone());
+
+        let config = AgentLoopConfig::default();
+        let provider = MetadataProvider::default();
+
+        let resolved = resolve_token_budget(&mut session, &config, "some-model", &provider).await;
+        assert_eq!(resolved.max_context_tokens, 123_456);
+        assert_eq!(resolved.max_output_tokens, 7_890);
+        assert_eq!(resolved.safety_margin, preset.safety_margin);
+        // Still exactly the preset value on the session.
+        assert_eq!(
+            session.token_budget.as_ref().unwrap().max_context_tokens,
+            123_456
+        );
     }
 
     #[derive(Default)]

--- a/crates/infra/bamboo-compression/src/compression_tooling.rs
+++ b/crates/infra/bamboo-compression/src/compression_tooling.rs
@@ -1,5 +1,5 @@
 use crate::counter::{TiktokenTokenCounter, TokenCounter};
-use crate::limits::create_budget_for_model;
+use crate::limits::{create_budget_for_model, ModelLimitsRegistry};
 use crate::{BudgetStrategy, TokenBudget};
 use bamboo_domain::MessagePhase;
 use bamboo_domain::{
@@ -120,9 +120,19 @@ pub fn estimate_context_compression_exposure(
     model_name: &str,
     configured_budget: Option<&TokenBudget>,
 ) -> ContextCompressionExposure {
-    let budget = configured_budget
-        .cloned()
-        .unwrap_or_else(|| create_budget_for_model(model_name, BudgetStrategy::default()));
+    // When a budget was already resolved upstream (the production path — see
+    // `resolve_token_budget`, which now also caches it on `session.token_budget`,
+    // issue #20 bug 1), use it directly. Only when none is available do we fall
+    // back to a model-derived budget. No `model_limits.json` registry is in
+    // scope synchronously here, so this fallback resolves to the global default
+    // rather than silently fabricating an empty override registry (#20 bug 2).
+    let budget = configured_budget.cloned().unwrap_or_else(|| {
+        create_budget_for_model(
+            model_name,
+            BudgetStrategy::default(),
+            &ModelLimitsRegistry::new(),
+        )
+    });
     let counter = TiktokenTokenCounter::default();
     let active_messages = active_messages_for_budget(session);
     let active_message_tokens = counter.count_messages(&active_messages);

--- a/crates/infra/bamboo-compression/src/limits.rs
+++ b/crates/infra/bamboo-compression/src/limits.rs
@@ -57,7 +57,8 @@ pub struct ModelLimit {
     pub model_pattern: String,
     /// Maximum context window size in tokens
     pub max_context_tokens: u32,
-    /// Maximum output tokens (defaults to min(4096, max_context / 4))
+    /// Maximum output tokens (defaults to min(max_context / 4,
+    /// DEFAULT_MAX_OUTPUT_TOKENS) when unset — see [`Self::get_max_output_tokens`])
     #[serde(default)]
     pub max_output_tokens: Option<u32>,
     /// Safety margin for token counting (defaults to 1000)
@@ -77,9 +78,16 @@ impl ModelLimit {
     }
 
     /// Get max output tokens with default calculation.
+    ///
+    /// When unset, derive from the context window (`max_context_tokens / 4`)
+    /// capped at the global [`DEFAULT_MAX_OUTPUT_TOKENS`]. The cap tracks the
+    /// global default rather than a hard-coded `4096`, so a user override like
+    /// `ModelLimit::new("gpt-4o", 128_000)` (no explicit `max_output_tokens`)
+    /// resolves to `min(32_000, 128_000) = 32_000` instead of collapsing to
+    /// `4096` — see issue #20, bug 4.
     pub fn get_max_output_tokens(&self) -> u32 {
         self.max_output_tokens
-            .unwrap_or_else(|| (self.max_context_tokens / 4).min(4096))
+            .unwrap_or_else(|| (self.max_context_tokens / 4).min(DEFAULT_MAX_OUTPUT_TOKENS))
     }
 
     /// Get safety margin, scaling proportionally with context window.
@@ -163,21 +171,27 @@ impl ModelLimitsRegistry {
     /// # Matching Strategy
     /// 1. Exact match (highest priority)
     /// 2. Model contains pattern (e.g., "gpt-4o-mini" contains "gpt-4o")
-    /// 3. Pattern contains model (e.g., "gpt-4" contains "gpt")
     ///
     /// For partial matches, the longest (most specific) pattern wins.
+    ///
+    /// Only the `model.contains(pattern)` direction is correct: the configured
+    /// pattern must be a substring of the runtime model id. The reverse
+    /// (`pattern.contains(model)`) was a bug (#20, bug 3) — it let a short model
+    /// id like `"gpt-4o"` match a longer, unrelated pattern like `"gpt-4o-mini"`
+    /// and inherit the wrong limit.
     pub fn get(&self, model: &str) -> Option<ModelLimit> {
         // Exact user override match (highest priority).
         if let Some(limit) = self.user_limits.get(model) {
             return Some(limit.clone());
         }
 
-        // Best partial match among user overrides. Longer (more specific)
-        // patterns win for deterministic selection. There is no built-in table;
-        // a miss returns None and the caller falls back to the global default.
+        // Best partial match among user overrides: the pattern must be a
+        // substring of the model id. Longer (more specific) patterns win for
+        // deterministic selection. There is no built-in table; a miss returns
+        // None and the caller falls back to the global default.
         self.user_limits
             .iter()
-            .filter(|(pattern, _)| model.contains(pattern.as_str()) || pattern.contains(model))
+            .filter(|(pattern, _)| model.contains(pattern.as_str()))
             .max_by_key(|(pattern, _)| pattern.len())
             .map(|(_, limit)| limit.clone())
     }
@@ -259,11 +273,21 @@ pub fn load_model_limits_from_unified_config(
     }
 }
 
-/// Create a token budget for a specific model.
+/// Create a token budget for a specific model, resolving its limit from the
+/// supplied `registry` (with user overrides loaded) and falling back to the
+/// global default when there is no match.
 ///
-/// This is a convenience function that creates a budget with appropriate defaults.
-pub fn create_budget_for_model(model: &str, strategy: crate::BudgetStrategy) -> crate::TokenBudget {
-    let registry = ModelLimitsRegistry::default();
+/// The registry is a required parameter on purpose: a previous version built a
+/// fresh empty `ModelLimitsRegistry::default()` internally, which silently
+/// discarded every user override from `model_limits.json` and always returned
+/// the global default (#20, bug 2). Callers must pass a registry they have
+/// loaded user overrides into (or [`ModelLimitsRegistry::new`] when they
+/// genuinely want the global default).
+pub fn create_budget_for_model(
+    model: &str,
+    strategy: crate::BudgetStrategy,
+    registry: &ModelLimitsRegistry,
+) -> crate::TokenBudget {
     let limit = registry.get_or_default(model);
 
     crate::TokenBudget {
@@ -362,8 +386,41 @@ mod tests {
     #[test]
     fn model_limit_calculates_default_output_tokens() {
         let limit = ModelLimit::new("test", 100_000);
-        // Default is min(max_context / 4, 4096) = min(25000, 4096) = 4096
-        assert_eq!(limit.get_max_output_tokens(), 4096);
+        // Default is min(max_context / 4, DEFAULT_MAX_OUTPUT_TOKENS)
+        //        = min(25_000, 128_000) = 25_000 (no longer capped at 4096, #20 bug 4)
+        assert_eq!(limit.get_max_output_tokens(), 25_000);
+    }
+
+    #[test]
+    fn user_override_without_explicit_output_is_not_capped_at_4096() {
+        // Issue #20 bug 4: a user override created with `ModelLimit::new` leaves
+        // `max_output_tokens = None`. The derived default must scale with the
+        // context window (context / 4) rather than collapsing to 4096.
+        let gpt4o = ModelLimit::new("gpt-4o", 128_000);
+        assert!(gpt4o.max_output_tokens.is_none());
+        assert_eq!(gpt4o.get_max_output_tokens(), 32_000);
+
+        // Very large context windows are still capped at the global default so a
+        // single override can't request an unbounded output budget.
+        let huge = ModelLimit::new("huge", 2_000_000);
+        assert_eq!(huge.get_max_output_tokens(), DEFAULT_MAX_OUTPUT_TOKENS);
+    }
+
+    #[test]
+    fn matching_is_directional_model_contains_pattern_only() {
+        // Issue #20 bug 3: a short model id must NOT match a longer pattern.
+        let mut registry = ModelLimitsRegistry::new();
+        registry.add_limit(ModelLimit::new("gpt-4o-mini", 128_000));
+
+        // "gpt-4o" does not contain "gpt-4o-mini", so it must NOT inherit the
+        // mini override (the old `pattern.contains(model)` direction did).
+        assert!(registry.get("gpt-4o").is_none());
+
+        // The reverse still works: a model id that contains the pattern matches.
+        let mini = registry
+            .get("gpt-4o-mini-2024")
+            .expect("model id contains the pattern");
+        assert_eq!(mini.max_context_tokens, 128_000);
     }
 
     #[test]
@@ -461,10 +518,60 @@ mod tests {
         assert_eq!(unknown.get_max_output_tokens(), 128_000);
     }
 
+    #[tokio::test]
+    async fn persisted_override_drives_runtime_token_budget() {
+        // Full chain (issue #20 acceptance): set a model limit on disk →
+        // load registry → build the runtime TokenBudget → the budget reflects
+        // the user-configured context window, not a stale/default value.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("model_limits.json");
+        // Note: NO explicit max_output_tokens, exercising the bug-4 default path.
+        tokio::fs::write(
+            &path,
+            r#"[{"model_pattern":"gpt-4o","max_context_tokens":128000}]"#,
+        )
+        .await
+        .expect("seed overrides");
+
+        let mut registry = ModelLimitsRegistry::with_config_path(path);
+        registry.load_user_config().await.expect("load user config");
+
+        // The runtime budget for the configured model matches the user limit...
+        let budget = create_budget_for_model("gpt-4o", crate::BudgetStrategy::default(), &registry);
+        assert_eq!(budget.max_context_tokens, 128_000);
+        // ...and the derived output budget is context/4 (32K), not the old 4096 cap.
+        assert_eq!(budget.max_output_tokens, 32_000);
+
+        // A model that does NOT contain the pattern is unaffected (bug-3 fix):
+        // it resolves to the global default, not the gpt-4o override.
+        let other =
+            create_budget_for_model("claude-sonnet", crate::BudgetStrategy::default(), &registry);
+        assert_eq!(other.max_context_tokens, 1_000_000);
+    }
+
     #[test]
-    fn create_budget_for_model_uses_global_default_for_any_model() {
-        let budget = create_budget_for_model("anything-at-all", crate::BudgetStrategy::default());
+    fn create_budget_for_model_uses_global_default_for_unmatched_model() {
+        // An empty registry yields the global default for any model.
+        let registry = ModelLimitsRegistry::new();
+        let budget = create_budget_for_model(
+            "anything-at-all",
+            crate::BudgetStrategy::default(),
+            &registry,
+        );
         assert_eq!(budget.max_context_tokens, 1_000_000);
         assert_eq!(budget.max_output_tokens, 128_000);
+    }
+
+    #[test]
+    fn create_budget_for_model_honors_registry_user_overrides() {
+        // Issue #20 bug 2: the budget must reflect the user override carried by
+        // the registry, not silently fall back to the global default.
+        let mut registry = ModelLimitsRegistry::new();
+        registry.add_limit(ModelLimit::new("gpt-4o", 128_000));
+
+        let budget = create_budget_for_model("gpt-4o", crate::BudgetStrategy::default(), &registry);
+        assert_eq!(budget.max_context_tokens, 128_000);
+        // And the derived output budget is the un-capped context/4 (bug 4), not 4096.
+        assert_eq!(budget.max_output_tokens, 32_000);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the four interrelated bugs from #20 that prevented user-configured model limits (`model_limits.json`) from taking effect at runtime. They form a chain: the resolved budget was never cached on the session, the sync fallback ignored all overrides, matching was non-directional, and the output-token default collapsed to 4096. Fixed together so the chain resolves the correct model limit end-to-end.

## The four bugs and fixes

**Bug 1 — `session.token_budget` never persisted.** `resolve_token_budget` (`crates/engine/bamboo-engine/.../round_lifecycle/token_budget.rs`) returned the budget only to its immediate caller, so `session.token_budget` stayed `None` and every downstream reader (`build_context_pressure` tool-output truncation, the server context bar, `estimate_context_compression_exposure`) fell back to a default budget. **Fix:** cache the resolved budget on the session; the session-override early-return makes this a one-time resolution per session.

**Bug 2 — `create_budget_for_model` fabricated an empty registry.** It built `ModelLimitsRegistry::default()` internally, silently discarding all user overrides and always returning the global default. **Fix:** the function now requires a loaded `&ModelLimitsRegistry`, so an empty one can no longer be fabricated. The single synchronous runtime fallback (`estimate_context_compression_exposure`) passes an explicit empty registry (global default) — honest, since no registry is in scope there and, after Bug 1, `configured_budget` is `Some` on the production path anyway.

**Bug 3 — bidirectional `contains` matching.** `model.contains(pattern) || pattern.contains(model)` let a short id like `gpt-4o` match a longer unrelated pattern `gpt-4o-mini` and inherit the wrong limit. **Fix:** keep only `model.contains(pattern)`; longest-pattern-wins tiebreaker retained.

**Bug 4 — output tokens capped at 4096.** `get_max_output_tokens` derived `min(context/4, 4096)`, so an override like `ModelLimit::new("gpt-4o", 128000)` (no explicit output) dropped to 4096. **Fix:** cap at the global `DEFAULT_MAX_OUTPUT_TOKENS` instead, so it scales with the context window (e.g. 128K → 32K).

## Tests
- `limits.rs`: directional matching (`matching_is_directional_model_contains_pattern_only`), un-capped output default (`user_override_without_explicit_output_is_not_capped_at_4096`), registry-honoring budget (`create_budget_for_model_honors_registry_user_overrides`), full persist → load → budget chain (`persisted_override_drives_runtime_token_budget`).
- `token_budget.rs`: `resolve_token_budget_caches_resolved_budget_on_session` (Bug 1) and `resolve_token_budget_prefers_existing_session_budget`.
- `cargo test -p bamboo-compression` → 129 passed. Engine `token_budget` (8) + `context_preparation` (22) pass. `cargo fmt` + `cargo clippy` clean on touched files. `cargo check --workspace` green.

## Caveats
- The deterministic end-to-end disk-override test lives in `bamboo-compression` (hermetic temp file). The engine-level `resolve_token_budget` reads the real `bamboo_dir()/model_limits.json` and only takes the legacy-config fallback on a genuine file read/parse error (absent file is `Ok` no-op), so a disk-injecting engine test was intentionally omitted in favor of the compression-crate integration test plus the engine cache/preference tests.

Closes #20

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp
