### PR TITLE
feat(bamboo-memory): add temporal granularity dimension (day/week/month/quarter/year) to memory scope

### DIFF
--- a/crates/app/bamboo-server-tools/src/memory/args.rs
+++ b/crates/app/bamboo-server-tools/src/memory/args.rs
@@ -63,6 +63,10 @@ pub(super) enum MemoryArgs {
         tags: Vec<String>,
         #[serde(default)]
         project_key: Option<String>,
+        /// Optional temporal granularity (day/week/month/quarter/year). Orthogonal
+        /// to `scope`; omitted means the memory carries no temporal dimension.
+        #[serde(default)]
+        granularity: Option<String>,
         #[serde(default)]
         options: Option<WriteOptions>,
     },

--- a/crates/app/bamboo-server-tools/src/memory/mod.rs
+++ b/crates/app/bamboo-server-tools/src/memory/mod.rs
@@ -102,6 +102,11 @@ impl Tool for MemoryTool {
                     ]
                 },
                 "scope": {"type": "string", "enum": ["session", "project", "global"]},
+                "granularity": {
+                    "type": "string",
+                    "enum": ["day", "week", "month", "quarter", "year"],
+                    "description": "Optional temporal granularity for `write`, orthogonal to scope: day (today's working context), week (sprint), month, quarter (direction), year (long-term goals). Omit if the memory has no time horizon. Coarser granularities are prefix-cache friendly and recalled ahead of finer ones at equal relevance."
+                },
                 "project_key": {"type": "string"},
                 "topic": {"type": "string"},
                 "id": {"type": "string"},
@@ -340,6 +345,7 @@ impl Tool for MemoryTool {
                 content,
                 tags,
                 project_key,
+                granularity,
                 options,
             } => {
                 let scope = Self::parse_scope(Some(&scope))?;
@@ -349,6 +355,7 @@ impl Tool for MemoryTool {
                             .to_string(),
                     ));
                 }
+                let granularity = Self::parse_granularity(granularity.as_deref())?;
                 let project_key = self
                     .resolve_project_key(project_key.as_deref(), Some(session_id))
                     .await;
@@ -366,6 +373,7 @@ impl Tool for MemoryTool {
                         options
                             .and_then(|value| value.allow_merge_if_similar)
                             .unwrap_or(false),
+                        granularity,
                     )
                     .await
                     .map_err(|error| {

--- a/crates/app/bamboo-server-tools/src/memory/parsing.rs
+++ b/crates/app/bamboo-server-tools/src/memory/parsing.rs
@@ -3,7 +3,9 @@
 use std::collections::HashSet;
 
 use bamboo_agent_core::tools::ToolError;
-use bamboo_memory::memory_store::{DurableMemoryStatus, DurableMemoryType, MemoryScope};
+use bamboo_memory::memory_store::{
+    DurableMemoryStatus, DurableMemoryType, MemoryScope, TemporalGranularity,
+};
 
 use super::args::{FilterTypeSet, QueryFilters};
 use super::MemoryTool;
@@ -23,6 +25,22 @@ impl MemoryTool {
                 "invalid scope '{other}'; expected one of: session, project, global"
             ))),
         }
+    }
+
+    /// Parse an optional temporal granularity. `None`/empty stays `None` (the memory
+    /// simply carries no temporal dimension), preserving back-compat. An unknown
+    /// non-empty value is rejected so typos surface instead of silently dropping.
+    pub(super) fn parse_granularity(
+        granularity: Option<&str>,
+    ) -> Result<Option<TemporalGranularity>, ToolError> {
+        let Some(value) = granularity.map(str::trim).filter(|value| !value.is_empty()) else {
+            return Ok(None);
+        };
+        TemporalGranularity::parse(value).map(Some).ok_or_else(|| {
+            ToolError::InvalidArguments(format!(
+                "invalid granularity '{value}'; expected one of: day, week, month, quarter, year"
+            ))
+        })
     }
 
     pub(super) fn parse_type(value: &str) -> Result<DurableMemoryType, ToolError> {

--- a/crates/app/bamboo-server-tools/src/memory/tests.rs
+++ b/crates/app/bamboo-server-tools/src/memory/tests.rs
@@ -135,3 +135,26 @@ async fn memory_session_list_topics_includes_count() {
     assert_eq!(value["action"], "session_list_topics");
     assert_eq!(value["count"], 2);
 }
+
+#[test]
+fn parse_granularity_accepts_known_values_case_insensitively() {
+    assert_eq!(
+        MemoryTool::parse_granularity(Some("Week")).unwrap(),
+        Some(bamboo_memory::memory_store::TemporalGranularity::Week)
+    );
+    assert_eq!(
+        MemoryTool::parse_granularity(Some("  YEAR ")).unwrap(),
+        Some(bamboo_memory::memory_store::TemporalGranularity::Year)
+    );
+}
+
+#[test]
+fn parse_granularity_none_or_empty_is_none() {
+    assert_eq!(MemoryTool::parse_granularity(None).unwrap(), None);
+    assert_eq!(MemoryTool::parse_granularity(Some("   ")).unwrap(), None);
+}
+
+#[test]
+fn parse_granularity_rejects_unknown_value() {
+    assert!(MemoryTool::parse_granularity(Some("decade")).is_err());
+}

--- a/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/memory.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/memory.rs
@@ -519,6 +519,7 @@ mod tests {
                 Some("session-1"),
                 "tester",
                 false,
+                None,
             )
             .await
             .expect("write global memory");
@@ -533,6 +534,7 @@ mod tests {
                 Some("session-1"),
                 "tester",
                 false,
+                None,
             )
             .await
             .expect("write project memory");
@@ -583,6 +585,7 @@ mod tests {
                     Some("session-1"),
                     "tester",
                     false,
+                    None,
                 )
                 .await
                 .expect("write project memory");
@@ -651,6 +654,7 @@ mod tests {
                 Some("session-metrics-a"),
                 "tester",
                 false,
+                None,
             )
             .await
             .expect("write project memory");
@@ -802,6 +806,7 @@ mod tests {
                 Some("session-1"),
                 "tester",
                 false,
+                None,
             )
             .await
             .expect("write first memory");
@@ -816,6 +821,7 @@ mod tests {
                 Some("session-1"),
                 "tester",
                 false,
+                None,
             )
             .await
             .expect("write second memory");

--- a/crates/engine/bamboo-engine/src/auto_dream.rs
+++ b/crates/engine/bamboo-engine/src/auto_dream.rs
@@ -296,6 +296,7 @@ async fn extract_and_persist_durable_candidates(
                 session_id,
                 "background-fast-model",
                 false,
+                None,
             )
             .await
             .map_err(|error| {
@@ -1612,6 +1613,7 @@ mod tests {
                 Some("session-refine-recent-memory"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .expect("write recent durable memory");
@@ -1701,6 +1703,7 @@ mod tests {
                 Some("session-rebuild-mode"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .expect("write project durable memory");

--- a/crates/engine/bamboo-engine/src/gardener.rs
+++ b/crates/engine/bamboo-engine/src/gardener.rs
@@ -569,6 +569,7 @@ mod tests {
                 Some("s"),
                 "t",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -674,6 +675,7 @@ mod tests {
                     Some("s"),
                     "t",
                     false,
+                    None,
                 )
                 .await
                 .unwrap();

--- a/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/tests.rs
@@ -155,6 +155,7 @@ async fn external_memory_includes_project_memory_index_and_omits_global_dream_fa
             Some("session-project-memory"),
             "main-model",
             false,
+            None,
         )
         .await
         .expect("save project memory");
@@ -210,6 +211,7 @@ async fn external_memory_excludes_other_project_memory_index_content() {
             Some("session-project-a"),
             "main-model",
             false,
+            None,
         )
         .await
         .expect("save project A memory");
@@ -224,6 +226,7 @@ async fn external_memory_excludes_other_project_memory_index_content() {
             Some("session-project-b"),
             "main-model",
             false,
+            None,
         )
         .await
         .expect("save project B memory");
@@ -368,6 +371,7 @@ async fn external_memory_renders_relevant_memory_section_for_project_hits() {
             Some("session-recall-project"),
             "main-model",
             false,
+            None,
         )
         .await
         .expect("save relevant project memory");
@@ -418,6 +422,7 @@ async fn external_memory_adds_stale_guidance_for_old_relevant_memory_hits() {
             Some("session-recall-stale"),
             "main-model",
             false,
+            None,
         )
         .await
         .expect("save stale-eligible project memory");
@@ -515,6 +520,7 @@ async fn external_memory_limits_relevant_memories_to_top_k() {
                 Some("session-recall-topk"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .expect("save project memory");
@@ -563,6 +569,7 @@ async fn external_memory_uses_global_relevant_memory_fallback_only_when_project_
             Some("session-recall-fallback"),
             "main-model",
             false,
+            None,
         )
         .await
         .expect("save unrelated project memory");
@@ -577,6 +584,7 @@ async fn external_memory_uses_global_relevant_memory_fallback_only_when_project_
             Some("session-recall-fallback"),
             "main-model",
             false,
+            None,
         )
         .await
         .expect("save global fallback memory");
@@ -705,6 +713,7 @@ async fn external_memory_omits_project_index_when_project_prompt_injection_disab
             Some("session-no-project-index"),
             "main-model",
             false,
+            None,
         )
         .await
         .expect("save project memory");
@@ -770,6 +779,7 @@ async fn external_memory_omits_relevant_recall_and_uses_global_dream_when_projec
             Some("session-global-dream-mode"),
             "main-model",
             false,
+            None,
         )
         .await
         .expect("save relevant project memory");
@@ -848,6 +858,7 @@ async fn external_memory_uses_model_rerank_for_relevant_memories_when_enabled() 
             Some("session-rerank-recall"),
             "main-model",
             false,
+            None,
         )
         .await
         .expect("save lexical-first memory");
@@ -862,6 +873,7 @@ async fn external_memory_uses_model_rerank_for_relevant_memories_when_enabled() 
             Some("session-rerank-recall"),
             "main-model",
             false,
+            None,
         )
         .await
         .expect("save reranked-first memory");
@@ -943,6 +955,7 @@ async fn external_memory_uses_latest_background_model_on_repeated_refresh() {
             Some("session-rerank-reload"),
             "main-model",
             false,
+            None,
         )
         .await
         .expect("save lexical-first memory");
@@ -957,6 +970,7 @@ async fn external_memory_uses_latest_background_model_on_repeated_refresh() {
             Some("session-rerank-reload"),
             "main-model",
             false,
+            None,
         )
         .await
         .expect("save reranked-first memory");

--- a/crates/infra/bamboo-memory/src/memory_store/mod.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/mod.rs
@@ -28,7 +28,7 @@ pub use types::{
     DurableMemoryStatus, DurableMemoryType, MemoryConsolidateResult, MemoryContradictionResult,
     MemoryDuplicateCandidate, MemoryInspectResult, MemoryMergeResult, MemoryPurgeResult,
     MemoryQueryCursor, MemoryQueryItem, MemoryQueryOptions, MemoryQueryResult, MemoryScope,
-    MemorySplitPiece, MemorySplitResult, SessionState,
+    MemorySplitPiece, MemorySplitResult, SessionState, TemporalGranularity,
 };
 
 pub const MEMORY_SCHEMA_VERSION: u32 = 1;
@@ -410,6 +410,11 @@ pub struct LexicalIndexItem {
     pub updated_at: String,
     pub created_at: String,
     pub summary: String,
+    /// Optional temporal granularity carried from the source frontmatter so recall
+    /// can rank by cache-stability without re-reading every document. Back-compat:
+    /// older `lexical.json` index files predate this field and deserialize to `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub granularity: Option<TemporalGranularity>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -693,5 +698,103 @@ mod tests {
     fn parse_markdown_document_requires_frontmatter() {
         let result = parse_markdown_document("plain body");
         assert!(result.is_err());
+    }
+
+    /// Back-compat: a memory document written before the temporal-granularity
+    /// dimension existed (its frontmatter has no `granularity` key) must still
+    /// parse, with `granularity` defaulting to `None`.
+    #[test]
+    fn legacy_frontmatter_without_granularity_parses_to_none() {
+        let legacy = "---\n\
+id: mem-legacy\n\
+title: Legacy memory\n\
+type: project\n\
+scope: project\n\
+project_key: proj-1\n\
+status: active\n\
+created_at: 2026-01-01T00:00:00Z\n\
+updated_at: 2026-01-01T00:00:00Z\n\
+created_by:\n  kind: session\n\
+updated_by:\n  kind: memory_write\n\
+---\n\
+Legacy body content.\n";
+        let (frontmatter, body) =
+            parse_markdown_document(legacy).expect("legacy document should parse");
+        assert_eq!(frontmatter.id, "mem-legacy");
+        assert_eq!(frontmatter.granularity, None);
+        assert_eq!(body, "Legacy body content.");
+    }
+
+    /// A granularity set on the frontmatter round-trips through render + parse.
+    #[test]
+    fn granularity_round_trips_through_render_and_parse() {
+        let legacy = "---\n\
+id: mem-legacy\n\
+title: Legacy memory\n\
+type: project\n\
+scope: project\n\
+project_key: proj-1\n\
+status: active\n\
+created_at: 2026-01-01T00:00:00Z\n\
+updated_at: 2026-01-01T00:00:00Z\n\
+created_by:\n  kind: session\n\
+updated_by:\n  kind: memory_write\n\
+---\n\
+Body.\n";
+        let (mut frontmatter, body) = parse_markdown_document(legacy).unwrap();
+        frontmatter.granularity = Some(TemporalGranularity::Quarter);
+
+        let rendered = render_markdown_document(&frontmatter, &body).unwrap();
+        assert!(rendered.contains("granularity: quarter"));
+
+        let (reparsed, _) = parse_markdown_document(&rendered).unwrap();
+        assert_eq!(reparsed.granularity, Some(TemporalGranularity::Quarter));
+    }
+
+    /// `None` granularity must not emit a `granularity:` key (skip_serializing_if),
+    /// so existing documents re-rendered after a load keep their on-disk shape.
+    #[test]
+    fn none_granularity_is_omitted_on_render() {
+        let legacy = "---\n\
+id: mem-legacy\n\
+title: Legacy memory\n\
+type: project\n\
+scope: project\n\
+project_key: proj-1\n\
+status: active\n\
+created_at: 2026-01-01T00:00:00Z\n\
+updated_at: 2026-01-01T00:00:00Z\n\
+created_by:\n  kind: session\n\
+updated_by:\n  kind: memory_write\n\
+---\n\
+Body.\n";
+        let (frontmatter, body) = parse_markdown_document(legacy).unwrap();
+        let rendered = render_markdown_document(&frontmatter, &body).unwrap();
+        assert!(!rendered.contains("granularity"));
+    }
+
+    #[test]
+    fn temporal_granularity_parse_is_case_insensitive_and_rejects_unknown() {
+        assert_eq!(
+            TemporalGranularity::parse("Week"),
+            Some(TemporalGranularity::Week)
+        );
+        assert_eq!(
+            TemporalGranularity::parse("  YEAR "),
+            Some(TemporalGranularity::Year)
+        );
+        assert_eq!(TemporalGranularity::parse("decade"), None);
+    }
+
+    #[test]
+    fn cache_stability_rank_orders_coarse_before_fine_and_none_first() {
+        use TemporalGranularity::*;
+        let rank = TemporalGranularity::cache_stability_rank;
+        // None is treated as most stable, then coarsest → finest.
+        assert!(rank(None) < rank(Some(Year)));
+        assert!(rank(Some(Year)) < rank(Some(Quarter)));
+        assert!(rank(Some(Quarter)) < rank(Some(Month)));
+        assert!(rank(Some(Month)) < rank(Some(Week)));
+        assert!(rank(Some(Week)) < rank(Some(Day)));
     }
 }

--- a/crates/infra/bamboo-memory/src/memory_store/recall.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/recall.rs
@@ -12,7 +12,7 @@ use bamboo_llm::{LLMChunk, LLMProvider, LLMRequestOptions};
 
 use super::{
     extract_keywords, parse_rfc3339, DurableMemoryStatus, LexicalIndexItem, MemoryScope,
-    MemoryStore,
+    MemoryStore, TemporalGranularity,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -25,6 +25,10 @@ pub struct MemoryRecallCandidate {
     pub status: DurableMemoryStatus,
     pub updated_at: String,
     pub summary: String,
+    /// Optional temporal granularity, used as a stable tie-breaker in
+    /// [`sort_recall_candidates`]: among equally-relevant candidates, coarser
+    /// (more cache-stable) memories sort first. `None` is treated as most stable.
+    pub granularity: Option<TemporalGranularity>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -225,6 +229,7 @@ async fn shortlist_scope(
             status: item.status,
             updated_at: item.updated_at.clone(),
             summary: item.summary.clone(),
+            granularity: item.granularity,
         })
         .collect::<Vec<_>>();
 
@@ -305,6 +310,15 @@ fn sort_recall_candidates(candidates: &mut [MemoryRecallCandidate]) {
             .score
             .partial_cmp(&left.score)
             .unwrap_or(Ordering::Equal)
+            // Among equally-relevant candidates, prefer coarser (more prefix-cache
+            // friendly) granularity first so the recalled block is stable across
+            // calls and does not churn the LLM prompt prefix (issue #61). Lower
+            // cache_stability_rank = coarser = earlier.
+            .then_with(|| {
+                TemporalGranularity::cache_stability_rank(left.granularity).cmp(
+                    &TemporalGranularity::cache_stability_rank(right.granularity),
+                )
+            })
             .then_with(|| {
                 let left_dt = parse_rfc3339(&left.updated_at)
                     .unwrap_or(chrono::DateTime::<chrono::Utc>::MIN_UTC);
@@ -548,6 +562,7 @@ mod tests {
             updated_at: updated_at.to_string(),
             created_at: updated_at.to_string(),
             summary: summary.to_string(),
+            granularity: None,
         }
     }
 
@@ -584,6 +599,53 @@ mod tests {
                 Ok(LLMChunk::Done),
             ])))
         }
+    }
+
+    fn candidate(
+        id: &str,
+        score: f64,
+        granularity: Option<TemporalGranularity>,
+    ) -> MemoryRecallCandidate {
+        MemoryRecallCandidate {
+            id: id.to_string(),
+            title: id.to_string(),
+            score,
+            scope: MemoryScope::Project,
+            project_key: Some("proj-1".to_string()),
+            status: DurableMemoryStatus::Active,
+            // Same timestamp for all so granularity is the deciding tie-breaker.
+            updated_at: "2026-04-09T00:00:00Z".to_string(),
+            summary: "summary".to_string(),
+            granularity,
+        }
+    }
+
+    #[test]
+    fn equal_score_candidates_sort_coarse_granularity_first_for_cache_stability() {
+        // All same score + same timestamp → granularity decides ordering. Coarser
+        // (year) is more prefix-cache friendly and must sort ahead of finer (day).
+        let mut candidates = vec![
+            candidate("day", 5.0, Some(TemporalGranularity::Day)),
+            candidate("year", 5.0, Some(TemporalGranularity::Year)),
+            candidate("none", 5.0, None),
+            candidate("month", 5.0, Some(TemporalGranularity::Month)),
+        ];
+        sort_recall_candidates(&mut candidates);
+        let order: Vec<&str> = candidates.iter().map(|c| c.id.as_str()).collect();
+        // None is treated as most stable (rank 0), then year, month, day.
+        assert_eq!(order, vec!["none", "year", "month", "day"]);
+    }
+
+    #[test]
+    fn higher_score_still_wins_over_cache_stable_granularity() {
+        // Granularity is only a tie-breaker: a more relevant (higher score) day-level
+        // memory must still outrank a less relevant year-level one.
+        let mut candidates = vec![
+            candidate("year-low", 1.0, Some(TemporalGranularity::Year)),
+            candidate("day-high", 9.0, Some(TemporalGranularity::Day)),
+        ];
+        sort_recall_candidates(&mut candidates);
+        assert_eq!(candidates[0].id, "day-high");
     }
 
     #[test]
@@ -684,6 +746,7 @@ mod tests {
                 status: DurableMemoryStatus::Active,
                 updated_at: "2026-04-09T00:00:00Z".to_string(),
                 summary: "summary a".to_string(),
+                granularity: None,
             },
             MemoryRecallCandidate {
                 id: "mem-b".to_string(),
@@ -694,6 +757,7 @@ mod tests {
                 status: DurableMemoryStatus::Active,
                 updated_at: "2026-04-09T00:00:00Z".to_string(),
                 summary: "summary b".to_string(),
+                granularity: None,
             },
         ];
 
@@ -718,6 +782,7 @@ mod tests {
                 status: DurableMemoryStatus::Active,
                 updated_at: "2026-04-09T00:00:00Z".to_string(),
                 summary: "summary a".to_string(),
+                granularity: None,
             },
             MemoryRecallCandidate {
                 id: "mem-b".to_string(),
@@ -728,6 +793,7 @@ mod tests {
                 status: DurableMemoryStatus::Active,
                 updated_at: "2026-04-09T00:00:00Z".to_string(),
                 summary: "summary b".to_string(),
+                granularity: None,
             },
             MemoryRecallCandidate {
                 id: "mem-c".to_string(),
@@ -738,6 +804,7 @@ mod tests {
                 status: DurableMemoryStatus::Active,
                 updated_at: "2026-04-09T00:00:00Z".to_string(),
                 summary: "summary c".to_string(),
+                granularity: None,
             },
         ];
 
@@ -765,6 +832,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -779,6 +847,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -814,6 +883,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -849,6 +919,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -863,6 +934,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -916,6 +988,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -930,6 +1003,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -1013,6 +1087,7 @@ mod tests {
             status: DurableMemoryStatus::Active,
             updated_at: "2026-05-08T00:00:00Z".to_string(),
             summary: "A test durable memory entry".to_string(),
+            granularity: None,
         }];
         let context = MemoryRecallRerankContext {
             llm: provider.clone(),

--- a/crates/infra/bamboo-memory/src/memory_store/store.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/store.rs
@@ -32,7 +32,7 @@ use super::{
 use super::{
     CreatedBy, DurableMemoryDocument, DurableMemoryFrontmatter, DurableMemoryRelations,
     DurableMemoryRetrieval, DurableMemorySource, DurableMemoryStatus, DurableMemoryType,
-    MemoryScope, SessionState,
+    MemoryScope, SessionState, TemporalGranularity,
 };
 
 /// Hard structural cap on a durable memory body (characters). Appends that would
@@ -420,6 +420,7 @@ impl MemoryStore {
                 status: doc.frontmatter.status,
                 summary: derive_summary(&doc.body, per_item_max),
                 tags: doc.frontmatter.tags.clone(),
+                granularity: doc.frontmatter.granularity,
                 relevance: (*relevance * 100.0).round() / 100.0,
                 related_ids: if options.include_related {
                     Self::combined_related_ids(doc)
@@ -617,6 +618,7 @@ impl MemoryStore {
         session_id: Option<&str>,
         actor: &str,
         allow_merge_if_similar: bool,
+        granularity: Option<TemporalGranularity>,
     ) -> io::Result<DurableMemoryDocument> {
         let project_key = self.require_project_key(scope, project_key)?;
         let title = validate_memory_title(title)?;
@@ -714,6 +716,7 @@ impl MemoryStore {
             r#type,
             scope,
             project_key: project_key_owned,
+            granularity,
             status: DurableMemoryStatus::Active,
             freshness: Some("high".to_string()),
             confidence: Some("high".to_string()),
@@ -871,6 +874,7 @@ impl MemoryStore {
         let source_id = source.frontmatter.id.clone();
         let source_type = source.frontmatter.r#type;
         let source_confidence = source.frontmatter.confidence.clone();
+        let source_granularity = source.frontmatter.granularity;
         let source_sources = source.frontmatter.sources.clone();
 
         // Pieces were fully validated above; this pass only persists them.
@@ -893,6 +897,7 @@ impl MemoryStore {
                 r#type,
                 scope,
                 project_key: project_key_field,
+                granularity: source_granularity,
                 status: DurableMemoryStatus::Active,
                 freshness: Some("high".to_string()),
                 confidence: source_confidence.clone(),
@@ -1296,12 +1301,21 @@ impl MemoryStore {
                 }
             }
         }
+        // Consolidated memory inherits the coarsest (most cache-stable) granularity
+        // among its sources, so merging never makes a long-lived fact look more
+        // volatile than it was. Sources without a granularity are ignored here.
+        // (Day < Week < Month < Quarter < Year by derived Ord, so `max` is coarsest.)
+        let granularity = sources
+            .iter()
+            .filter_map(|doc| doc.frontmatter.granularity)
+            .max();
         let frontmatter = DurableMemoryFrontmatter {
             id: new_id.clone(),
             title: title.to_string(),
             r#type,
             scope,
             project_key: project_key_field,
+            granularity,
             status: DurableMemoryStatus::Active,
             freshness: Some("high".to_string()),
             confidence: sources[0].frontmatter.confidence.clone(),
@@ -1934,6 +1948,7 @@ impl MemoryStore {
                     updated_at: doc.frontmatter.updated_at.clone(),
                     created_at: doc.frontmatter.created_at.clone(),
                     summary: derive_summary(&doc.body, 240),
+                    granularity: doc.frontmatter.granularity,
                 })
                 .collect(),
         };
@@ -2422,6 +2437,7 @@ mod tests {
                 Some("s1"),
                 "test",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -2485,6 +2501,7 @@ mod tests {
                 Some("s"),
                 "t",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -2501,6 +2518,7 @@ mod tests {
                 Some("s"),
                 "t",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -2539,6 +2557,7 @@ mod tests {
                 Some("s"),
                 "t",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -2553,6 +2572,7 @@ mod tests {
                 Some("s"),
                 "t",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -2593,6 +2613,7 @@ mod tests {
                 Some("s1"),
                 "test",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -2644,6 +2665,7 @@ mod tests {
                 Some("s1"),
                 "test",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -2688,6 +2710,7 @@ mod tests {
                 Some("s1"),
                 "test",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -2705,6 +2728,7 @@ mod tests {
                 Some("s1"),
                 "test",
                 true,
+                None,
             )
             .await
             .unwrap();
@@ -2752,6 +2776,7 @@ mod tests {
                     Some("s"),
                     "t",
                     false,
+                    None,
                 )
                 .await
                 .unwrap();
@@ -2790,6 +2815,7 @@ mod tests {
                 Some("s"),
                 "t",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -2804,6 +2830,7 @@ mod tests {
                 Some("s"),
                 "t",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -2864,6 +2891,7 @@ mod tests {
                 Some("s"),
                 "t",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -2920,6 +2948,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 true,
+                None,
             )
             .await
             .unwrap();
@@ -2968,6 +2997,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -2983,6 +3013,7 @@ mod tests {
                 Some("session-2"),
                 "main-model",
                 true,
+                None,
             )
             .await
             .unwrap();
@@ -3038,6 +3069,7 @@ mod tests {
                         "main-model",
                         // No merging: each write must create its own document.
                         false,
+                        None,
                     )
                     .await
                     .expect("concurrent write succeeds")
@@ -3132,6 +3164,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -3146,6 +3179,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -3221,6 +3255,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -3235,6 +3270,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -3249,6 +3285,7 @@ mod tests {
                 Some("session-2"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -3348,6 +3385,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -3362,6 +3400,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -3429,6 +3468,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -3534,6 +3574,7 @@ mod tests {
                     Some("session-1"),
                     "main-model",
                     false,
+                    None,
                 )
                 .await
                 .unwrap();
@@ -3600,6 +3641,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -3614,6 +3656,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -3678,6 +3721,7 @@ mod tests {
                 Some("session-1"),
                 "main-model",
                 false,
+                None,
             )
             .await
             .unwrap();
@@ -3691,6 +3735,78 @@ mod tests {
         assert_eq!(lexical.items[0].id, doc.frontmatter.id);
         assert_eq!(lexical.items[0].title, "User prefers concise answers");
         assert!(lexical.items[0].keywords.iter().any(|k| k == "concise"));
+    }
+
+    #[tokio::test]
+    async fn write_memory_persists_granularity_into_document_and_lexical_index() {
+        let dir = tempdir().unwrap();
+        let store = MemoryStore::new(dir.path());
+
+        let doc = store
+            .write_memory(
+                MemoryScope::Project,
+                Some("proj-temporal"),
+                DurableMemoryType::Project,
+                "Quarterly architecture direction",
+                "This quarter we move memory recall onto a temporal granularity dimension.",
+                &["architecture".to_string()],
+                Some("session-1"),
+                "main-model",
+                false,
+                Some(TemporalGranularity::Quarter),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            doc.frontmatter.granularity,
+            Some(TemporalGranularity::Quarter)
+        );
+
+        // Re-read from disk: granularity must survive the markdown round-trip.
+        let reread = store
+            .get_memory(&doc.frontmatter.id, Some("proj-temporal"))
+            .await
+            .unwrap()
+            .expect("memory should exist on disk");
+        assert_eq!(
+            reread.frontmatter.granularity,
+            Some(TemporalGranularity::Quarter)
+        );
+
+        // And it must be carried into the lexical index used by recall.
+        let lexical = store
+            .read_lexical_index(MemoryScope::Project, Some("proj-temporal"))
+            .await
+            .unwrap()
+            .expect("lexical index should exist");
+        assert_eq!(lexical.items.len(), 1);
+        assert_eq!(
+            lexical.items[0].granularity,
+            Some(TemporalGranularity::Quarter)
+        );
+    }
+
+    #[tokio::test]
+    async fn write_memory_without_granularity_defaults_to_none() {
+        let dir = tempdir().unwrap();
+        let store = MemoryStore::new(dir.path());
+
+        let doc = store
+            .write_memory(
+                MemoryScope::Global,
+                None,
+                DurableMemoryType::Reference,
+                "Reference without temporal dimension",
+                "A plain reference note that carries no granularity.",
+                &[],
+                Some("session-1"),
+                "main-model",
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(doc.frontmatter.granularity, None);
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-memory/src/memory_store/types.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/types.rs
@@ -21,6 +21,78 @@ impl MemoryScope {
     }
 }
 
+/// Temporal granularity of a memory: an orthogonal dimension to [`MemoryScope`]
+/// that describes the *time horizon* a memory is meant to be valid over.
+///
+/// This is additive and optional — memories written before this dimension existed
+/// (and any caller that does not set it) simply carry `None`, which preserves the
+/// pre-existing behavior exactly. The dimension is intentionally NOT used as a hard
+/// recall filter that flips the recalled subset every hour/day, because the recalled
+/// memories are spliced into the LLM prompt prefix and a churning subset would shred
+/// prompt prefix-cache hit rates. Instead it is a stable *ranking / ordering* signal:
+/// coarser-grained memories (year/quarter) are low-frequency and cache-friendly and
+/// sort earlier (toward the stable prefix); finer-grained memories (day/week) change
+/// more often and sort later (toward the volatile suffix). See issue #61.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum TemporalGranularity {
+    /// Finest granularity. Highest churn, fastest to go stale (debugging notes,
+    /// today's working context). Least prefix-cache friendly → ranks last.
+    Day,
+    /// Sprint-level / weekly priorities and progress.
+    Week,
+    /// Monthly decisions and phase summaries.
+    Month,
+    /// Quarter-level direction, large refactor plans.
+    Quarter,
+    /// Coarsest granularity. Lowest churn, longest-lived (long-term goals, system
+    /// evolution). Most prefix-cache friendly → ranks first.
+    Year,
+}
+
+impl TemporalGranularity {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Day => "day",
+            Self::Week => "week",
+            Self::Month => "month",
+            Self::Quarter => "quarter",
+            Self::Year => "year",
+        }
+    }
+
+    /// Parse a case-insensitive granularity token. Returns `None` for unknown values
+    /// so callers can decide whether to error or fall back to the default.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "day" => Some(Self::Day),
+            "week" => Some(Self::Week),
+            "month" => Some(Self::Month),
+            "quarter" => Some(Self::Quarter),
+            "year" => Some(Self::Year),
+            _ => None,
+        }
+    }
+
+    /// Cache-stability rank: lower number = coarser = more prefix-cache friendly and
+    /// should be ordered earlier (toward the stable prompt prefix). Higher number =
+    /// finer = higher churn and should be ordered later (toward the volatile suffix).
+    ///
+    /// Memories with no granularity set are treated as the most stable (rank 0) so
+    /// existing/unclassified memories keep their current placement and never get
+    /// demoted below classified ones purely for lacking the new dimension.
+    pub fn cache_stability_rank(granularity: Option<Self>) -> u8 {
+        match granularity {
+            None => 0,
+            Some(Self::Year) => 1,
+            Some(Self::Quarter) => 2,
+            Some(Self::Month) => 3,
+            Some(Self::Week) => 4,
+            Some(Self::Day) => 5,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum DurableMemoryType {
@@ -111,6 +183,11 @@ pub struct DurableMemoryFrontmatter {
     pub scope: MemoryScope,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project_key: Option<String>,
+    /// Optional temporal granularity (day/week/month/quarter/year). Orthogonal to
+    /// `scope`. Defaults to `None` for back-compat: memory documents written before
+    /// this dimension existed simply omit the field and deserialize to `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub granularity: Option<TemporalGranularity>,
     pub status: DurableMemoryStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub freshness: Option<String>,
@@ -189,6 +266,8 @@ pub struct MemoryQueryItem {
     pub summary: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub granularity: Option<TemporalGranularity>,
     pub relevance: f64,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub related_ids: Vec<String>,


### PR DESCRIPTION
## Summary

Implements issue #61: an optional **temporal granularity** dimension (`day`/`week`/`month`/`quarter`/`year`) orthogonal to the existing `MemoryScope` (session/project/global).

### Interpretation (for the reviewer)
The issue left open whether granularity is a scope key, a recall filter, or a bucketing. I implemented it as an **additive metadata + stable ranking dimension**, NOT a result-flipping recall filter. Reasoning: the issue's hard *Prefix Cache Friendly* constraint says a per-hour/day-churning recalled subset would shred LLM prompt prefix-cache hit rates. So:
- Granularity is stored on the memory frontmatter (optional).
- On recall it is used only as a **tie-breaker among equally-relevant candidates**: coarser (year/quarter) = lower churn = more cache-stable → sorts toward the stable prefix; finer (day/week) → sorts toward the volatile suffix. Relevance (lexical score) still dominates, so a highly-relevant day-level memory still outranks a marginal year-level one.
- No on-disk layout change; scope keying is untouched.

### What + where
- `crates/infra/bamboo-memory/src/memory_store/types.rs` — new `TemporalGranularity` enum (`as_str`/`parse`/`cache_stability_rank`); optional `granularity` field on `DurableMemoryFrontmatter` and `MemoryQueryItem`.
- `crates/infra/bamboo-memory/src/memory_store/mod.rs` — re-export; `granularity` on `LexicalIndexItem`.
- `crates/infra/bamboo-memory/src/memory_store/store.rs` — `write_memory` takes `Option<TemporalGranularity>`; split inherits source granularity; consolidate inherits the coarsest source; index build carries it.
- `crates/infra/bamboo-memory/src/memory_store/recall.rs` — `granularity` on `MemoryRecallCandidate`; `sort_recall_candidates` tie-breaks by cache-stability rank.
- `crates/app/bamboo-server-tools/src/memory/{args,parsing,mod}.rs` — `write` action accepts optional `granularity` string; `parse_granularity` validation; JSON schema property.
- Internal `write_memory` callers (engine/server/tests) pass `None` (behavior-preserving).

### Back-compat
Every new field is `#[serde(default, skip_serializing_if)]`:
- Existing memory documents (no `granularity` key) load to `None` and re-render without emitting the key — on-disk shape preserved.
- Existing `lexical.json` indexes load unchanged.
- Default behavior with no granularity set is identical to today's recall.
Respects the #32 `scope_lock` pattern (no new mutating paths added outside existing locks).

### Recall impact
Additive only. With no granularity set, ordering is unchanged. When set, it acts purely as a low-priority, deterministic tie-breaker that keeps the recalled block prefix-cache stable.

### Tests
`cargo test -p bamboo-memory`: 96 passed (run 2x, stable). `cargo test -p bamboo-server-tools memory::`: pass. New tests: legacy-frontmatter load → None, render/parse round-trip, None omitted on render, store+index persistence, recall coarse-first tie-break, score-dominates-granularity, tool-layer parse validation. `cargo fmt` clean; `cargo clippy -p bamboo-memory -p bamboo-server-tools` no new warnings (pre-existing 8/7-arg warning on untouched `find_duplicate_candidates`).

Closes #61

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp