### PR TITLE
feat(server): v2-P1 TLS termination via rustls (manual certs) [#181]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,7 @@ dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
+ "actix-tls",
  "actix-utils",
  "base64",
  "bitflags 2.11.1",
@@ -172,6 +173,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-tls"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac453898d866cdbecdbc2334fe1738c747b4eba14a677261f2b768ba05329389"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "impl-more",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "actix-utils"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +214,7 @@ dependencies = [
  "actix-rt",
  "actix-server",
  "actix-service",
+ "actix-tls",
  "actix-utils",
  "actix-web-codegen",
  "bytes",
@@ -1145,6 +1166,8 @@ dependencies = [
  "reqwest-eventsource",
  "reqwest-middleware",
  "reqwest-retry",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/app/bamboo-server/Cargo.toml
+++ b/crates/app/bamboo-server/Cargo.toml
@@ -33,9 +33,19 @@ bamboo-storage = { path = "../../infra/bamboo-storage" }
 bamboo-domain = { path = "../../core/bamboo-domain" }
 
 # Web framework
-actix-web = "4"
+# `rustls-0_23` enables actix-web's TLS bind/listen against rustls 0.23
+# (`bind_rustls_0_23` / `listen_rustls_0_23`) for the v2 self-terminated TLS
+# face (#181). Without it the `*_rustls_0_23` methods do not exist.
+actix-web = { version = "4", features = ["rustls-0_23"] }
 actix-cors = "0.7"
 actix-files = "0.6"
+
+# v2 TLS termination (#181): load PEM cert/key and build a rustls ServerConfig.
+# Pin the `ring` crypto provider explicitly so the builder never relies on a
+# process-default provider (avoids the rustls 0.23 "no process-level
+# CryptoProvider" panic); `ring` is the provider already resolved in the lock.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+rustls-pemfile = "2"
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/crates/app/bamboo-server/src/lib.rs
+++ b/crates/app/bamboo-server/src/lib.rs
@@ -137,4 +137,7 @@ pub use routes::{
     agent_routes, anthropic_routes, bamboo_v1_routes, configure_routes,
     configure_routes_with_rate_limiting, gemini_routes, openai_prefixed_routes,
 };
-pub use server::{run, run_with_bind, run_with_bind_and_static, WebService};
+pub use server::{
+    run, run_with_bind, run_with_bind_and_static, run_with_bind_and_static_tls, run_with_bind_tls,
+    run_with_tls, WebService,
+};

--- a/crates/app/bamboo-server/src/server/entrypoints.rs
+++ b/crates/app/bamboo-server/src/server/entrypoints.rs
@@ -8,6 +8,7 @@ use actix_web::{
 use tracing::{error, info};
 
 use super::listeners::{build_bind_listeners, build_desktop_listeners, resolve_worker_count};
+use super::tls::build_rustls_config;
 use crate::app_state::AppState;
 use crate::config::{build_cors, build_rate_limiter, build_security_headers};
 use crate::routes::{configure_routes, configure_routes_with_rate_limiting};
@@ -15,6 +16,7 @@ use crate::services::frontend_package::{
     ensure_current_frontend_dir_in, has_embedded_frontend_package, resolve_frontend_package_path,
 };
 use actix_governor::Governor;
+use bamboo_config::TlsConfig;
 
 fn canonicalize_static_dir(path: &Path) -> Result<PathBuf, String> {
     let canonicalized = path
@@ -82,6 +84,17 @@ fn resolve_runtime_static_dir(
 ///   Equivalent to `${HOME}/.bamboo` in standard installations.
 /// * `port` - Port to listen on
 pub async fn run(bamboo_home_dir: PathBuf, port: u16) -> Result<(), String> {
+    run_with_tls(bamboo_home_dir, port, None).await
+}
+
+/// Like [`run`], but terminates TLS itself when `tls` is `Some` (#181).
+///
+/// Desktop loopback callers pass `None` and get the unchanged plaintext path.
+pub async fn run_with_tls(
+    bamboo_home_dir: PathBuf,
+    port: u16,
+    tls: Option<TlsConfig>,
+) -> Result<(), String> {
     info!("Starting unified server in desktop mode...");
 
     let static_dir = resolve_runtime_static_dir(&bamboo_home_dir, None)?;
@@ -143,18 +156,36 @@ pub async fn run(bamboo_home_dir: PathBuf, port: u16) -> Result<(), String> {
         app
     };
 
+    // Fail-fast: when TLS is configured, build the rustls config up front so a
+    // bad/missing cert refuses startup instead of silently falling back to
+    // plaintext. `None` → unchanged plaintext path.
+    let rustls_cfg = match &tls {
+        Some(tls) => Some(build_rustls_config(tls)?),
+        None => None,
+    };
+
     let listeners = build_desktop_listeners(port)?;
 
     let mut http = HttpServer::new(app_factory).workers(workers);
     for (idx, listener) in listeners.into_iter().enumerate() {
-        http = http
-            .listen(listener)
-            .map_err(|e| format!("Failed to attach listener #{idx}: {e}"))?;
+        http = match &rustls_cfg {
+            Some(cfg) => http
+                .listen_rustls_0_23(listener, cfg.clone())
+                .map_err(|e| format!("Failed to attach TLS listener #{idx}: {e}"))?,
+            None => http
+                .listen(listener)
+                .map_err(|e| format!("Failed to attach listener #{idx}: {e}"))?,
+        };
     }
 
     let server = http.run();
 
-    info!("Unified server running on http://127.0.0.1:{port}");
+    let scheme = if rustls_cfg.is_some() {
+        "https"
+    } else {
+        "http"
+    };
+    info!("Unified server running on {scheme}://127.0.0.1:{port}");
 
     let result = server.await;
 
@@ -189,6 +220,16 @@ pub async fn run_with_bind(bamboo_home_dir: PathBuf, port: u16, bind: &str) -> R
     run_with_bind_and_static(bamboo_home_dir, port, bind, None).await
 }
 
+/// Like [`run_with_bind`], but terminates TLS itself when `tls` is `Some` (#181).
+pub async fn run_with_bind_tls(
+    bamboo_home_dir: PathBuf,
+    port: u16,
+    bind: &str,
+    tls: Option<TlsConfig>,
+) -> Result<(), String> {
+    run_with_bind_and_static_tls(bamboo_home_dir, port, bind, None, tls).await
+}
+
 /// Run the unified server with custom bind address and static file serving
 ///
 /// Production mode with frontend serving:
@@ -215,6 +256,18 @@ pub async fn run_with_bind_and_static(
     port: u16,
     bind: &str,
     static_dir: Option<PathBuf>,
+) -> Result<(), String> {
+    run_with_bind_and_static_tls(bamboo_home_dir, port, bind, static_dir, None).await
+}
+
+/// Like [`run_with_bind_and_static`], but terminates TLS itself when `tls` is
+/// `Some` (#181). When `None`, the plaintext `.listen()` path is unchanged.
+pub async fn run_with_bind_and_static_tls(
+    bamboo_home_dir: PathBuf,
+    port: u16,
+    bind: &str,
+    static_dir: Option<PathBuf>,
+    tls: Option<TlsConfig>,
 ) -> Result<(), String> {
     info!("Starting unified server on {}:{}...", bind, port);
 
@@ -288,18 +341,36 @@ pub async fn run_with_bind_and_static(
         app
     };
 
+    // Fail-fast: build the rustls config before binding so a bad/missing cert
+    // refuses startup rather than silently downgrading to plaintext. `None` →
+    // unchanged plaintext path (desktop/loopback behavior preserved). #181.
+    let rustls_cfg = match &tls {
+        Some(tls) => Some(build_rustls_config(tls)?),
+        None => None,
+    };
+
     let listeners = build_bind_listeners(bind, port)?;
 
     let mut http = HttpServer::new(app_factory).workers(workers);
     for (idx, listener) in listeners.into_iter().enumerate() {
-        http = http
-            .listen(listener)
-            .map_err(|e| format!("Failed to attach listener #{idx}: {e}"))?;
+        http = match &rustls_cfg {
+            Some(cfg) => http
+                .listen_rustls_0_23(listener, cfg.clone())
+                .map_err(|e| format!("Failed to attach TLS listener #{idx}: {e}"))?,
+            None => http
+                .listen(listener)
+                .map_err(|e| format!("Failed to attach listener #{idx}: {e}"))?,
+        };
     }
 
     let server = http.run();
 
-    info!("Unified server running on http://{}:{}", bind, port);
+    let scheme = if rustls_cfg.is_some() {
+        "https"
+    } else {
+        "http"
+    };
+    info!("Unified server running on {scheme}://{}:{}", bind, port);
 
     let result = server.await;
 

--- a/crates/app/bamboo-server/src/server/mod.rs
+++ b/crates/app/bamboo-server/src/server/mod.rs
@@ -5,9 +5,13 @@
 
 mod entrypoints;
 mod listeners;
+mod tls;
 mod web_service;
 
-pub use entrypoints::{run, run_with_bind, run_with_bind_and_static};
+pub use entrypoints::{
+    run, run_with_bind, run_with_bind_and_static, run_with_bind_and_static_tls, run_with_bind_tls,
+    run_with_tls,
+};
 pub use web_service::WebService;
 
 #[cfg(test)]

--- a/crates/app/bamboo-server/src/server/tls.rs
+++ b/crates/app/bamboo-server/src/server/tls.rs
@@ -1,0 +1,213 @@
+//! TLS termination support for the actix-web HTTP face (v2-P1, #181).
+//!
+//! bamboo terminates TLS itself via rustls — no reverse proxy. Certificates are
+//! manual PEM files configured under `server.tls` (see
+//! `docs/api-v2-transport.md` §3). When `server.tls` is absent the server keeps
+//! its existing plaintext `.bind()` / `.listen()` path unchanged; this module is
+//! only consulted when TLS is explicitly configured.
+//!
+//! **Fail-fast invariant:** if `server.tls` is set but the cert/key files are
+//! missing or unparseable, [`build_rustls_config`] returns an `Err` and the
+//! caller must refuse to start. It never silently downgrades to plaintext.
+//!
+//! **Crypto provider:** rustls 0.23 needs an active [`CryptoProvider`]. Rather
+//! than depend on a process-default provider being installed (a common footgun
+//! that panics at handshake time), we build the config against an explicit
+//! `ring` provider via [`ServerConfig::builder_with_provider`]. `ring` is the
+//! provider already resolved in the workspace lockfile.
+
+use std::fs::File;
+use std::io::BufReader;
+use std::sync::Arc;
+
+use rustls::crypto::ring;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::ServerConfig;
+
+use bamboo_config::TlsConfig;
+
+/// Build a rustls [`ServerConfig`] from manual PEM cert/key files.
+///
+/// Returns a descriptive `Err(String)` (never panics, never falls back to
+/// plaintext) when:
+/// - the cert or key file is missing / unreadable,
+/// - the cert file contains no certificates,
+/// - the key file contains no usable private key (PKCS#8, PKCS#1/RSA, or SEC1),
+/// - rustls rejects the cert/key pair.
+pub(super) fn build_rustls_config(tls: &TlsConfig) -> Result<ServerConfig, String> {
+    let cert_path = tls.cert_file.display();
+    let key_path = tls.key_file.display();
+
+    // --- certificate chain ---
+    let cert_file = File::open(&tls.cert_file)
+        .map_err(|e| format!("TLS: failed to open cert_file '{cert_path}': {e}"))?;
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut BufReader::new(cert_file))
+        .collect::<Result<_, _>>()
+        .map_err(|e| format!("TLS: failed to parse certificates from '{cert_path}': {e}"))?;
+    if certs.is_empty() {
+        return Err(format!(
+            "TLS: no certificates found in cert_file '{cert_path}' (expected PEM CERTIFICATE blocks)"
+        ));
+    }
+
+    // --- private key (PKCS#8, then PKCS#1/RSA, then SEC1/EC) ---
+    let key = load_private_key(&tls.key_file)
+        .map_err(|e| format!("TLS: failed to load key_file '{key_path}': {e}"))?;
+
+    // Build against an explicit `ring` provider so we never rely on a process
+    // default being installed (avoids the rustls 0.23 no-provider panic).
+    let provider = Arc::new(ring::default_provider());
+    ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| format!("TLS: rustls protocol version setup failed: {e}"))?
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| {
+            format!("TLS: rustls rejected the cert/key pair (cert '{cert_path}', key '{key_path}'): {e}")
+        })
+}
+
+/// Load the first usable private key from a PEM file, trying PKCS#8, then
+/// PKCS#1/RSA, then SEC1/EC. Returns a clear error if none is present.
+fn load_private_key(path: &std::path::Path) -> Result<PrivateKeyDer<'static>, String> {
+    // rustls_pemfile::private_key understands all three PEM key kinds and
+    // returns the first one found, so a single pass covers PKCS#8 / RSA / SEC1.
+    let file = File::open(path).map_err(|e| format!("open: {e}"))?;
+    match rustls_pemfile::private_key(&mut BufReader::new(file)) {
+        Ok(Some(key)) => Ok(key),
+        Ok(None) => {
+            Err("no private key found (expected a PKCS#8, RSA, or SEC1 PEM block)".to_string())
+        }
+        Err(e) => Err(format!("parse: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    fn tmp_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "bamboo-tls-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Generate a throwaway self-signed cert + PKCS#8 key via openssl, returning
+    /// `None` (skip) if openssl is unavailable in the test environment.
+    fn gen_self_signed(dir: &Path) -> Option<(PathBuf, PathBuf)> {
+        let cert = dir.join("cert.pem");
+        let key = dir.join("key.pem");
+        let status = Command::new("openssl")
+            .args([
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:2048",
+                "-keyout",
+                key.to_str().unwrap(),
+                "-out",
+                cert.to_str().unwrap(),
+                "-days",
+                "1",
+                "-nodes",
+                "-subj",
+                "/CN=localhost",
+            ])
+            .status();
+        match status {
+            Ok(s) if s.success() => Some((cert, key)),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn build_rustls_config_errors_on_missing_cert_file() {
+        let tls = TlsConfig {
+            cert_file: PathBuf::from("/nonexistent/bamboo-tls/cert.pem"),
+            key_file: PathBuf::from("/nonexistent/bamboo-tls/key.pem"),
+        };
+        let err = build_rustls_config(&tls).expect_err("missing cert must fail");
+        assert!(
+            err.contains("cert_file"),
+            "error should name cert_file: {err}"
+        );
+        assert!(
+            err.contains("/nonexistent/bamboo-tls/cert.pem"),
+            "error should include the path: {err}"
+        );
+    }
+
+    #[test]
+    fn build_rustls_config_errors_on_empty_cert_file() {
+        let dir = tmp_dir();
+        let cert = dir.join("cert.pem");
+        let key = dir.join("key.pem");
+        std::fs::write(&cert, "not a pem certificate\n").unwrap();
+        std::fs::write(&key, "not a pem key\n").unwrap();
+        let tls = TlsConfig {
+            cert_file: cert,
+            key_file: key,
+        };
+        let err = build_rustls_config(&tls).expect_err("garbage cert must fail");
+        assert!(
+            err.contains("no certificates found"),
+            "error should explain empty cert: {err}"
+        );
+    }
+
+    #[test]
+    fn build_rustls_config_errors_on_missing_key_in_keyfile() {
+        let dir = tmp_dir();
+        // A valid-looking cert file but a key file with no key block.
+        let Some((cert, _key)) = gen_self_signed(&dir) else {
+            eprintln!("skipping: openssl unavailable");
+            return;
+        };
+        let bad_key = dir.join("bad_key.pem");
+        std::fs::write(
+            &bad_key,
+            "-----BEGIN GARBAGE-----\nzz\n-----END GARBAGE-----\n",
+        )
+        .unwrap();
+        let tls = TlsConfig {
+            cert_file: cert,
+            key_file: bad_key,
+        };
+        let err = build_rustls_config(&tls).expect_err("no key must fail");
+        assert!(
+            err.contains("key_file"),
+            "error should name key_file: {err}"
+        );
+    }
+
+    #[test]
+    fn build_rustls_config_succeeds_on_valid_self_signed_cert() {
+        // Smoke test the full success path (parse + crypto provider + accept the
+        // cert/key pair) when openssl is available to mint a throwaway cert.
+        // Skips gracefully on environments without openssl.
+        let dir = tmp_dir();
+        let Some((cert, key)) = gen_self_signed(&dir) else {
+            eprintln!("skipping build_rustls_config success test: openssl unavailable");
+            return;
+        };
+        let tls = TlsConfig {
+            cert_file: cert,
+            key_file: key,
+        };
+        let cfg = build_rustls_config(&tls).expect("valid self-signed cert should build a config");
+        // A built config implies the ring provider was usable and the pair was accepted.
+        assert!(
+            !cfg.crypto_provider().cipher_suites.is_empty(),
+            "expected a non-empty cipher suite set from the ring provider"
+        );
+    }
+}

--- a/crates/app/bamboo-server/src/server/web_service.rs
+++ b/crates/app/bamboo-server/src/server/web_service.rs
@@ -6,10 +6,12 @@ use tokio::sync::oneshot;
 use tracing::{error, info};
 
 use super::listeners::DEFAULT_WORKER_COUNT;
+use super::tls::build_rustls_config;
 use crate::app_state::AppState;
 use crate::config::{build_cors, build_rate_limiter, build_security_headers};
 use crate::routes::{configure_routes, configure_routes_with_rate_limiting};
 use actix_governor::Governor;
+use bamboo_config::TlsConfig;
 
 /// Manageable web service with start/stop lifecycle
 ///
@@ -50,6 +52,18 @@ impl WebService {
 
     /// Start the web service on the specified port and bind address.
     pub async fn start_with_bind(&mut self, port: u16, bind: &str) -> Result<(), String> {
+        self.start_with_bind_tls(port, bind, None).await
+    }
+
+    /// Start the web service, terminating TLS itself when `tls` is `Some` (#181).
+    ///
+    /// `None` keeps the plaintext `.bind()` path unchanged (desktop loopback).
+    pub async fn start_with_bind_tls(
+        &mut self,
+        port: u16,
+        bind: &str,
+        tls: Option<&TlsConfig>,
+    ) -> Result<(), String> {
         info!("Starting web service...");
         if self.server_handle.is_some() {
             return Err("Web service is already running".to_string());
@@ -75,9 +89,18 @@ impl WebService {
                 .wrap(build_cors(&bind_addr, port))
                 .configure(configure_routes) // No rate limiting for WebService
         })
-        .workers(DEFAULT_WORKER_COUNT)
-        .bind(&listen_addr)
-        .map_err(|e| format!("Failed to bind server: {e}"))?
+        .workers(DEFAULT_WORKER_COUNT);
+
+        // Fail-fast: build the rustls config before binding; `None` → unchanged
+        // plaintext `.bind()` path. #181.
+        let server = match tls {
+            Some(tls) => server
+                .bind_rustls_0_23(&listen_addr, build_rustls_config(tls)?)
+                .map_err(|e| format!("Failed to bind TLS server: {e}"))?,
+            None => server
+                .bind(&listen_addr)
+                .map_err(|e| format!("Failed to bind server: {e}"))?,
+        }
         .run();
 
         let server_handle = tokio::spawn(async move {
@@ -96,8 +119,9 @@ impl WebService {
         self.shutdown_tx = Some(shutdown_tx);
         self.server_handle = Some(server_handle);
 
+        let scheme = if tls.is_some() { "https" } else { "http" };
         info!(
-            "Web service started successfully on http://{}:{}",
+            "Web service started successfully on {scheme}://{}:{}",
             bind_for_log, port
         );
         Ok(())
@@ -110,6 +134,19 @@ impl WebService {
         port: u16,
         bind: &str,
         static_dir: PathBuf,
+    ) -> Result<(), String> {
+        self.start_with_bind_and_static_tls(port, bind, static_dir, None)
+            .await
+    }
+
+    /// Like [`WebService::start_with_bind_and_static`], terminating TLS itself
+    /// when `tls` is `Some` (#181). `None` keeps the plaintext path unchanged.
+    pub async fn start_with_bind_and_static_tls(
+        &mut self,
+        port: u16,
+        bind: &str,
+        static_dir: PathBuf,
+        tls: Option<&TlsConfig>,
     ) -> Result<(), String> {
         info!("Starting web service with static frontend...");
         if self.server_handle.is_some() {
@@ -159,9 +196,18 @@ impl WebService {
                         .disable_content_disposition(),
                 )
         })
-        .workers(DEFAULT_WORKER_COUNT)
-        .bind(&listen_addr)
-        .map_err(|e| format!("Failed to bind server: {e}"))?
+        .workers(DEFAULT_WORKER_COUNT);
+
+        // Fail-fast: build the rustls config before binding; `None` → unchanged
+        // plaintext `.bind()` path. #181.
+        let server = match tls {
+            Some(tls) => server
+                .bind_rustls_0_23(&listen_addr, build_rustls_config(tls)?)
+                .map_err(|e| format!("Failed to bind TLS server: {e}"))?,
+            None => server
+                .bind(&listen_addr)
+                .map_err(|e| format!("Failed to bind server: {e}"))?,
+        }
         .run();
 
         let server_handle = tokio::spawn(async move {
@@ -180,8 +226,9 @@ impl WebService {
         self.shutdown_tx = Some(shutdown_tx);
         self.server_handle = Some(server_handle);
 
+        let scheme = if tls.is_some() { "https" } else { "http" };
         info!(
-            "Web service with static frontend started successfully on http://{}:{}",
+            "Web service with static frontend started successfully on {scheme}://{}:{}",
             bind_for_log, port
         );
         Ok(())

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -1062,6 +1062,16 @@ pub struct ServerConfig {
     #[serde(default = "default_workers")]
     pub workers: usize,
 
+    /// v2 (API v2 transport, #181): optional TLS termination config. When both
+    /// `cert_file` and `key_file` are given, bamboo terminates TLS itself
+    /// (rustls, no reverse proxy) and serves `https://` — intended for the
+    /// public `0.0.0.0` face. When absent, the server keeps the plain `.bind()`
+    /// / `.listen()` path unchanged (desktop loopback stays plaintext). Missing
+    /// or unparseable cert/key files are fail-fast at startup, never a silent
+    /// downgrade to plaintext.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tls: Option<TlsConfig>,
+
     /// Preserve unknown keys under `server`.
     #[serde(default, flatten)]
     pub extra: BTreeMap<String, Value>,
@@ -1074,9 +1084,23 @@ impl Default for ServerConfig {
             bind: default_bind(),
             static_dir: None,
             workers: default_workers(),
+            tls: None,
             extra: BTreeMap::new(),
         }
     }
+}
+
+/// Manual TLS certificate configuration (current stage; ACME deferred).
+///
+/// Both fields point at PEM files: `cert_file` is the full certificate chain
+/// (leaf → intermediates → root), `key_file` is the matching private key
+/// (PKCS#8 or RSA). See `docs/api-v2-transport.md` §3.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TlsConfig {
+    /// PEM certificate chain (leaf → intermediates → root).
+    pub cert_file: PathBuf,
+    /// PEM private key (PKCS#8 or RSA).
+    pub key_file: PathBuf,
 }
 
 /// Proxy authentication credentials
@@ -2053,6 +2077,56 @@ mod tests {
                 None => std::env::remove_var(self.key),
             }
         }
+    }
+
+    #[test]
+    fn server_config_without_tls_field_deserializes_back_compat() {
+        // An old config.json `server` section with no `tls` key must still
+        // deserialize, leaving `tls` as None (zero behavior change on upgrade).
+        let server: ServerConfig = serde_json::from_value(serde_json::json!({
+            "port": 9562,
+            "bind": "127.0.0.1"
+        }))
+        .expect("legacy server config without tls should deserialize");
+
+        assert_eq!(server.tls, None);
+        assert_eq!(server.port, 9562);
+        assert_eq!(server.bind, "127.0.0.1");
+    }
+
+    #[test]
+    fn server_config_omits_tls_when_none() {
+        // `skip_serializing_if = "Option::is_none"` keeps the on-disk shape
+        // identical to before for the common (no-TLS) case.
+        let server = ServerConfig::default();
+        let value = serde_json::to_value(&server).expect("server config should serialize");
+        let obj = value
+            .as_object()
+            .expect("server config serializes to object");
+        assert!(
+            !obj.contains_key("tls"),
+            "tls must be omitted when None, got: {value}"
+        );
+    }
+
+    #[test]
+    fn server_config_with_tls_roundtrips() {
+        let server: ServerConfig = serde_json::from_value(serde_json::json!({
+            "port": 9562,
+            "bind": "0.0.0.0",
+            "tls": { "cert_file": "/etc/bamboo/cert.pem", "key_file": "/etc/bamboo/key.pem" }
+        }))
+        .expect("server config with tls should deserialize");
+
+        let tls = server.tls.clone().expect("tls should be Some");
+        assert_eq!(tls.cert_file, PathBuf::from("/etc/bamboo/cert.pem"));
+        assert_eq!(tls.key_file, PathBuf::from("/etc/bamboo/key.pem"));
+
+        // Round-trips: tls survives a serialize → deserialize cycle.
+        let value = serde_json::to_value(&server).expect("serialize");
+        assert!(value.as_object().unwrap().contains_key("tls"));
+        let back: ServerConfig = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(back.tls, server.tls);
     }
 
     #[test]

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -547,19 +547,24 @@ async fn main() {
 
             // Start server using the unified config
             println!("Starting Bamboo server at {}", config.server_addr());
+            // v2-P1 (#181): honor `server.tls` for in-process TLS termination
+            // (fail-fast on bad/missing certs); absent → unchanged plaintext.
+            let tls = config.server.tls.clone();
             let result = if config.server.static_dir.is_some() {
-                bamboo_agent::server::run_with_bind_and_static(
+                bamboo_agent::server::run_with_bind_and_static_tls(
                     bamboo_home_dir,
                     config.server.port,
                     &config.server.bind,
                     config.server.static_dir.clone(),
+                    tls,
                 )
                 .await
             } else {
-                bamboo_agent::server::run_with_bind(
+                bamboo_agent::server::run_with_bind_tls(
                     bamboo_home_dir,
                     config.server.port,
                     &config.server.bind,
+                    tls,
                 )
                 .await
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,21 +135,27 @@ impl BambooServer {
     pub async fn start(self) -> Result<()> {
         bamboo_config::paths::init_bamboo_dir(self.data_dir.clone());
 
+        // v2-P1 (#181): when `server.tls` is set, terminate TLS in-process
+        // (fail-fast on bad/missing certs). When absent, the plaintext paths
+        // below are unchanged.
+        let tls = self.config.server.tls.clone();
         let result = if self.config.server.static_dir.is_some() {
-            server::run_with_bind_and_static(
+            server::run_with_bind_and_static_tls(
                 self.data_dir,
                 self.config.server.port,
                 &self.config.server.bind,
                 self.config.server.static_dir.clone(),
+                tls,
             )
             .await
         } else if self.config.server.bind == "127.0.0.1" {
-            server::run(self.data_dir, self.config.server.port).await
+            server::run_with_tls(self.data_dir, self.config.server.port, tls).await
         } else {
-            server::run_with_bind(
+            server::run_with_bind_tls(
                 self.data_dir,
                 self.config.server.port,
                 &self.config.server.bind,
+                tls,
             )
             .await
         };


### PR DESCRIPTION
This is the TLS-termination slice of **v2-P1** for Epic #181 — let bamboo terminate TLS itself (rustls, no reverse proxy) for the actix-web HTTP face, with **zero behavior change when TLS is unconfigured**.

## What changed

**Config shape** (`crates/infra/bamboo-config/src/config.rs`)
- `ServerConfig.tls: Option<TlsConfig>` with `#[serde(default, skip_serializing_if = "Option::is_none")]`.
- New `TlsConfig { cert_file: PathBuf, key_file: PathBuf }` (PEM chain + private key).
- Back-compat: an old `config.json` with no `tls` key still deserializes (→ `None`); serialization omits `tls` when `None`.

```json
{ "server": { "bind": "0.0.0.0", "port": 9562,
  "tls": { "cert_file": "/etc/bamboo/cert.pem", "key_file": "/etc/bamboo/key.pem" } } }
```

**TLS builder** (`crates/app/bamboo-server/src/server/tls.rs`, new)
- `build_rustls_config(&TlsConfig) -> Result<rustls::ServerConfig, String>`: loads the PEM cert chain + private key (PKCS#8 / RSA / SEC1 via `rustls_pemfile::private_key`).
- **Fail-fast**: missing/unparseable cert or key → descriptive `Err`; callers refuse to start. **Never** silently downgrades to plaintext.

**Zero-regression-when-None wiring**
- `server.tls` `Some` → TLS bind/listen (intended for `0.0.0.0` public). `None` → existing plain `.bind()`/`.listen()` UNCHANGED (desktop loopback stays plaintext).
- `web_service.rs`: `.bind()` ↔ `.bind_rustls_0_23()` (2 sites).
- `entrypoints.rs`: prebuilt listeners use `.listen()` ↔ `.listen_rustls_0_23()` (caveat #1 — these are `.listen()`, not `.bind()`).
- `tls` flows from `BambooServer::start` (`src/lib.rs`) and `bamboo serve` (`src/bin/bamboo.rs`).

**Crypto-provider handling** (the rustls 0.23 footgun)
- The config is built against an **explicit `ring` provider** via `ServerConfig::builder_with_provider(ring::default_provider())`, so it never relies on a process-default `CryptoProvider` being installed (which would panic at handshake time). `ring` is the provider already resolved in the lock; no `aws-lc-rs` is pulled in.

**Deps** (`crates/app/bamboo-server/Cargo.toml`)
- actix-web feature `rustls-0_23` (actix-web 4.13 resolved); `rustls 0.23` (`ring, std, tls12`); `rustls-pemfile 2`. Only `actix-tls` is newly added to `Cargo.lock`.

## Tests
- Config: back-compat deserialize without `tls`, omit-when-`None`, with-`tls` roundtrip.
- Builder error paths: missing cert file, garbage cert, key file with no key block.
- Builder success path: mints a throwaway self-signed cert via `openssl` and asserts a usable `ServerConfig` is produced (skips gracefully if `openssl` is absent — this exercises the real crypto-provider + parse path).
- `cargo test -p bamboo-config` (130) + `cargo test -p bamboo-server` (863 lib) green; new code is `clippy`/`fmt` clean.

## Caveats for the reviewer
- **No live end-to-end TLS handshake test.** The success test verifies `build_rustls_config` produces a `ServerConfig` with a non-empty cipher-suite set (provider works, pair accepted), but does not stand up a server and complete a real `https://` handshake. The provider footgun is handled by construction (explicit `ring`), so a live handshake should work — but it was not exercised in CI here. Manual `curl https://...` against a real cert is recommended before the public rollout.
- Scope is **only** the actix-web HTTP face. Broker TLS, subagent `WsServer::bind_tls`, the new `/v2/stream` WSS, per-device tokens, and deflate are separate slices.

Refs #181 (v2-P1 TLS termination for HTTP face)

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp