### PR TITLE
feat(server): v2-P1 /v2/stream unified WSS multiplex (feed + agent + stop) [#181]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-ws"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12d4f2fbee3ef7a22fa6cb0e416b962237a167ed0419f22d4e451da2d7f082f8"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-web",
+ "bytestring",
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1144,7 @@ dependencies = [
  "actix-governor",
  "actix-rt",
  "actix-web",
+ "actix-ws",
  "anyhow",
  "async-stream",
  "async-trait",

--- a/crates/app/bamboo-server/Cargo.toml
+++ b/crates/app/bamboo-server/Cargo.toml
@@ -39,6 +39,11 @@ bamboo-domain = { path = "../../core/bamboo-domain" }
 actix-web = { version = "4", features = ["rustls-0_23"] }
 actix-cors = "0.7"
 actix-files = "0.6"
+# v2-P1 (#181): the `GET /v2/stream` unified WebSocket multiplex. `actix-ws`
+# gives a non-actor WS upgrade (`actix_ws::handle`) returning an owned
+# `Session` + `MessageStream` we drive from a spawned task. 0.3 targets the
+# resolved actix-web 4 / actix-http 3 line.
+actix-ws = "0.3"
 
 # v2 TLS termination (#181): load PEM cert/key and build a rustls ServerConfig.
 # Pin the `ring` crypto provider explicitly so the builder never relies on a

--- a/crates/app/bamboo-server/src/handlers/agent/events/handler.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/handler.rs
@@ -9,7 +9,7 @@ use crate::app_state::{AgentStatus, AppState};
 ///
 /// `batch_ms` is an untrusted query parameter; this caps the buffering window
 /// so a hostile/typo'd value cannot defer flushes out to the heartbeat interval.
-pub(super) const MAX_BATCH_MS: u64 = 1_000;
+pub(crate) const MAX_BATCH_MS: u64 = 1_000;
 
 /// Query parameters for the per-session events (SSE) endpoint.
 #[derive(Debug, Default, Deserialize)]

--- a/crates/app/bamboo-server/src/handlers/agent/events/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/mod.rs
@@ -12,6 +12,10 @@ pub use handler::handler;
 //   WS forwarder reuses it rather than reimplementing coalescing.
 pub(crate) use handler::MAX_BATCH_MS;
 pub(crate) use stream::Coalescer;
+// Reused by the v2 WS `agent.{sid}` forwarder to keep the channel open while
+// child sub-agents are still running (parity with the v1 SSE stream, which does
+// not close on the parent terminal while descendants survive).
+pub(crate) use terminal::has_running_child;
 
 #[cfg(test)]
 mod tests;

--- a/crates/app/bamboo-server/src/handlers/agent/events/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/mod.rs
@@ -5,6 +5,13 @@ mod stream;
 mod terminal;
 
 pub use handler::handler;
+// Reused by the v2 WS multiplex (`agent.{sid}` channel):
+// - `MAX_BATCH_MS` clamps the untrusted `?batch_ms=` query the same way the v1
+//   SSE handler does.
+// - `Coalescer` is the exact same token-merge buffer the v1 SSE path uses; the
+//   WS forwarder reuses it rather than reimplementing coalescing.
+pub(crate) use handler::MAX_BATCH_MS;
+pub(crate) use stream::Coalescer;
 
 #[cfg(test)]
 mod tests;

--- a/crates/app/bamboo-server/src/handlers/agent/events/stream.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/stream.rs
@@ -15,7 +15,7 @@ use super::terminal::has_running_child;
 /// is keyed by `tool_call_id` so that interleaved output from different tool
 /// calls never merges into the same frame.
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum CoalesceKey {
+pub(crate) enum CoalesceKey {
     Token,
     ReasoningToken,
     ToolToken(String),
@@ -24,7 +24,7 @@ enum CoalesceKey {
 /// Classifies an event as coalescible (returning its channel key) or not
 /// (`None`). Non-token events must flush any pending buffer and be emitted
 /// immediately, unchanged.
-fn coalesce_key(event: &AgentEvent) -> Option<CoalesceKey> {
+pub(crate) fn coalesce_key(event: &AgentEvent) -> Option<CoalesceKey> {
     match event {
         AgentEvent::Token { .. } => Some(CoalesceKey::Token),
         AgentEvent::ReasoningToken { .. } => Some(CoalesceKey::ReasoningToken),
@@ -43,11 +43,11 @@ fn coalesce_key(event: &AgentEvent) -> Option<CoalesceKey> {
 /// the pending event once its content exceeds the threshold, so a pathological
 /// token stream cannot amplify memory. 64 KiB is far larger than any real token
 /// burst yet small enough to bound the allocation.
-const MAX_PENDING_CONTENT_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_PENDING_CONTENT_BYTES: usize = 64 * 1024;
 
 /// Returns the byte length of a coalescible event's `content`, or 0 for
 /// non-token events (which are never buffered).
-fn pending_content_len(event: &AgentEvent) -> usize {
+pub(crate) fn pending_content_len(event: &AgentEvent) -> usize {
     match event {
         AgentEvent::Token { content }
         | AgentEvent::ReasoningToken { content }
@@ -59,7 +59,7 @@ fn pending_content_len(event: &AgentEvent) -> usize {
 /// Appends `content` from a same-key incoming token event onto the pending
 /// merged event of the same variant. Callers guarantee both events share the
 /// same [`CoalesceKey`], so the variants always match.
-fn merge_token_into(pending: &mut AgentEvent, incoming: AgentEvent) {
+pub(crate) fn merge_token_into(pending: &mut AgentEvent, incoming: AgentEvent) {
     match (pending, incoming) {
         (AgentEvent::Token { content }, AgentEvent::Token { content: more })
         | (AgentEvent::ReasoningToken { content }, AgentEvent::ReasoningToken { content: more })
@@ -82,7 +82,7 @@ fn merge_token_into(pending: &mut AgentEvent, incoming: AgentEvent) {
 /// and emits the returned events, but a `batch_ms == 0` window means the
 /// deadline fires immediately so nothing accumulates — see `live_stream_response`).
 #[derive(Default)]
-struct Coalescer {
+pub(crate) struct Coalescer {
     pending: Option<AgentEvent>,
 }
 
@@ -92,7 +92,7 @@ impl Coalescer {
     /// when the new event is non-coalescible). A coalescible event that merges
     /// into / starts the pending buffer yields an empty list — it stays buffered
     /// until a flush (different kind, deadline, terminal, heartbeat, or close).
-    fn push(&mut self, event: AgentEvent) -> Vec<AgentEvent> {
+    pub(crate) fn push(&mut self, event: AgentEvent) -> Vec<AgentEvent> {
         match coalesce_key(&event) {
             // Non-coalescible: flush pending first, then emit this event.
             None => {
@@ -138,12 +138,12 @@ impl Coalescer {
     /// Removes and returns the pending merged event, if any. Used to flush on a
     /// deadline tick, heartbeat, terminal event, or stream close so buffered
     /// content is never lost.
-    fn take_pending(&mut self) -> Option<AgentEvent> {
+    pub(crate) fn take_pending(&mut self) -> Option<AgentEvent> {
         self.pending.take()
     }
 
     /// Whether a merged event is currently buffered.
-    fn has_pending(&self) -> bool {
+    pub(crate) fn has_pending(&self) -> bool {
         self.pending.is_some()
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
@@ -128,7 +128,7 @@ pub(super) fn session_prevents_terminal_event(session: Option<&Session>) -> bool
 /// runs. For a flat tree (every child directly under the root) this is identical
 /// to the old direct-child check, because a direct child's `root_session_id`
 /// equals the root's.
-pub(super) async fn has_running_child(state: &web::Data<AppState>, session_id: &str) -> bool {
+pub(crate) async fn has_running_child(state: &web::Data<AppState>, session_id: &str) -> bool {
     // The tree root the watched session belongs to (a Root is its own root).
     let watched_root = state
         .session_store

--- a/crates/app/bamboo-server/src/handlers/agent/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/mod.rs
@@ -22,3 +22,4 @@ pub mod sessions;
 pub mod stop;
 pub mod stream;
 pub mod task;
+pub mod ws_v2;

--- a/crates/app/bamboo-server/src/handlers/agent/stop/handler.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/stop/handler.rs
@@ -10,11 +10,7 @@ pub async fn handler(state: web::Data<AppState>, path: web::Path<String>) -> imp
     let session_id = path.into_inner();
     tracing::info!("[{}] Stop request received", session_id);
 
-    let runner_cancelled = cancel_running_runner(&state, &session_id).await;
-    let legacy_cancelled = cancel_legacy_token(&state, &session_id).await;
-
-    if runner_cancelled || legacy_cancelled {
-        mark_runner_cancelled(&state, &session_id).await;
+    if cancel_session(&state, &session_id).await {
         HttpResponse::Ok().json(StopResponse {
             success: true,
             message: "Agent execution stopped".to_string(),
@@ -25,6 +21,22 @@ pub async fn handler(state: web::Data<AppState>, path: web::Path<String>) -> imp
             success: false,
             message: "No active agent execution found".to_string(),
         })
+    }
+}
+
+/// Cancel a running agent session, returning whether anything was actually
+/// cancelled. Mirrors the v1 `POST /stop/{session_id}` behavior exactly so the
+/// v2 WS `control` channel (`{"type":"stop"}`) can reuse it without duplicating
+/// the runner + legacy-token cancellation discipline.
+pub(crate) async fn cancel_session(state: &web::Data<AppState>, session_id: &str) -> bool {
+    let runner_cancelled = cancel_running_runner(state, session_id).await;
+    let legacy_cancelled = cancel_legacy_token(state, session_id).await;
+
+    if runner_cancelled || legacy_cancelled {
+        mark_runner_cancelled(state, session_id).await;
+        true
+    } else {
+        false
     }
 }
 

--- a/crates/app/bamboo-server/src/handlers/agent/stop/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/stop/mod.rs
@@ -4,6 +4,8 @@ mod handler;
 mod types;
 
 pub use handler::handler;
+// Reused by the v2 WS multiplex `control` channel (`{"type":"stop"}`).
+pub(crate) use handler::cancel_session;
 
 #[cfg(test)]
 mod tests;

--- a/crates/app/bamboo-server/src/handlers/agent/stream/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/stream/mod.rs
@@ -4,6 +4,10 @@ mod handler;
 mod response;
 
 pub use handler::handler;
+// Reused by the v2 WS multiplex (`feed` channel) so the WS path runs the exact
+// same journal-replay + cursor handoff discipline as the v1 SSE feed instead of
+// reimplementing it.
+pub(crate) use response::{plan_replay, ReplayPlan};
 
 #[cfg(test)]
 mod tests;

--- a/crates/app/bamboo-server/src/handlers/agent/stream/response.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/stream/response.rs
@@ -26,7 +26,7 @@ use bamboo_engine::events::journal;
 ///
 /// Pure and deterministic so the resume handoff can be unit-tested without an
 /// HTTP server.
-pub(super) struct ReplayPlan {
+pub(crate) struct ReplayPlan {
     /// If `Some`, the client's cursor predated the retained window; it must
     /// drop local state and full-resync. The contained value is the stale `since`.
     pub reset_from: Option<u64>,
@@ -43,7 +43,7 @@ pub(super) struct ReplayPlan {
 /// * On a cursor below the retained window: returns a reset directive and
 ///   fast-forwards `last_replayed` to `latest_at_start` (the client resyncs via
 ///   REST and the live tail serves anything newer).
-pub(super) fn plan_replay(events_dir: &Path, since: u64, latest_at_start: u64) -> ReplayPlan {
+pub(crate) fn plan_replay(events_dir: &Path, since: u64, latest_at_start: u64) -> ReplayPlan {
     if since > 0 {
         if let Ok(Some(oldest)) = journal::oldest_seq(events_dir) {
             if oldest > since + 1 {

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/envelope.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/envelope.rs
@@ -24,8 +24,17 @@ use serde_json::Value;
 pub(crate) struct ServerEnvelope {
     /// Channel id: `feed` or `agent.{session_id}`.
     pub ch: String,
-    /// Per-channel monotonic sequence number (resume cursor). For `feed` this is
-    /// `ChangeEvent.seq`; for `agent.{sid}` it is a server-maintained counter.
+    /// Per-channel monotonic sequence number.
+    ///
+    /// For `feed` this is `ChangeEvent.seq` — a durable, cross-connection cursor
+    /// the client passes back as `subscribe.since` to resume losslessly.
+    ///
+    /// For `agent.{sid}` it is a server-maintained counter that is **per
+    /// subscription**, not a durable resume cursor: it restarts at 1 on each
+    /// (re)subscribe. Agent resume is replay-cache-only (RFC §10-Q2 — a long
+    /// disconnect re-fetches session detail via REST), so `agent` `since` is not
+    /// honored as a lossless cursor and this counter is for ordering/dedup within
+    /// one subscription only.
     pub seq: u64,
     /// The carried payload: either a journaled/agent `event` or a transport
     /// `control` signal.

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/envelope.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/envelope.rs
@@ -1,0 +1,294 @@
+//! Wire types for the v2 unified WebSocket multiplex (`GET /v2/stream`).
+//!
+//! The envelope is a thin shell around the **existing** event schemas — the
+//! inner `event` is a byte-for-byte `AgentEvent` (for `agent.{sid}`) or a whole
+//! `ChangeEvent` (for `feed`). v2 only changes transport + framing, never the
+//! business event payload (see `docs/api-v2-transport.md` §5.3).
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A server→client envelope.
+///
+/// Serializes as one of two shapes sharing `{ch, seq}`:
+///
+/// ```jsonc
+/// { "ch": "agent.sess_abc", "seq": 42, "event": { "type": "token", "content": "Hi" } }
+/// { "ch": "agent.sess_abc", "seq": 43, "control": { "type": "terminal", "reason": "complete" } }
+/// ```
+///
+/// The `event` / `control` keys are mutually exclusive and flattened in, so the
+/// wire object is exactly `{ch, seq, event}` or `{ch, seq, control}` — no extra
+/// nesting.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct ServerEnvelope {
+    /// Channel id: `feed` or `agent.{session_id}`.
+    pub ch: String,
+    /// Per-channel monotonic sequence number (resume cursor). For `feed` this is
+    /// `ChangeEvent.seq`; for `agent.{sid}` it is a server-maintained counter.
+    pub seq: u64,
+    /// The carried payload: either a journaled/agent `event` or a transport
+    /// `control` signal.
+    #[serde(flatten)]
+    pub body: EnvelopeBody,
+}
+
+/// The mutually-exclusive payload of a [`ServerEnvelope`].
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(untagged)]
+pub(crate) enum EnvelopeBody {
+    /// A business event, reusing the existing `AgentEvent` / `ChangeEvent` JSON
+    /// verbatim. We carry it as an opaque [`Value`] so the envelope never
+    /// re-encodes (and so cannot drift from) the underlying schema.
+    Event {
+        /// The inner event JSON, byte-for-byte the existing schema.
+        event: Value,
+    },
+    /// A transport control / terminal marker (e.g. channel `terminal`,
+    /// `feed_reset`).
+    Control {
+        /// The control payload JSON.
+        control: Value,
+    },
+}
+
+impl ServerEnvelope {
+    /// Build an `{ch, seq, event}` envelope wrapping an already-serialized inner
+    /// event value.
+    pub(crate) fn event(ch: impl Into<String>, seq: u64, event: Value) -> Self {
+        Self {
+            ch: ch.into(),
+            seq,
+            body: EnvelopeBody::Event { event },
+        }
+    }
+
+    /// Build an `{ch, seq, control}` envelope.
+    pub(crate) fn control(ch: impl Into<String>, seq: u64, control: Value) -> Self {
+        Self {
+            ch: ch.into(),
+            seq,
+            body: EnvelopeBody::Control { control },
+        }
+    }
+
+    /// Serialize to a JSON text frame.
+    pub(crate) fn to_text(&self) -> Option<String> {
+        serde_json::to_string(self).ok()
+    }
+}
+
+/// A terminal control payload for an `agent.{sid}` channel: the agent run
+/// finished. `reason` mirrors the v1 terminal event class.
+pub(crate) fn terminal_control(reason: &str) -> Value {
+    serde_json::json!({ "type": "terminal", "reason": reason })
+}
+
+/// A feed reset control payload: the client's cursor predated the retained
+/// window, so it must drop local state and full-resync. Mirrors the v1 SSE
+/// `feed_reset` frame shape.
+pub(crate) fn feed_reset_control(from_seq: u64) -> Value {
+    serde_json::json!({ "type": "feed_reset", "from_seq": from_seq })
+}
+
+/// A client→server frame, tagged by `type`.
+///
+/// Unknown / malformed frames deserialize to [`ClientFrame::Unknown`] (via the
+/// serde `other` fallback for the tag, or a parse error the driver catches) so a
+/// bad frame logs-and-continues instead of tearing down the connection.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum ClientFrame {
+    /// First frame (auth in v2-P2). Accepted and ignored in P1 — auth is the
+    /// scope middleware only.
+    Hello {
+        #[serde(default)]
+        device_id: Option<String>,
+        #[serde(default)]
+        token: Option<String>,
+    },
+    /// Subscribe to a channel, optionally resuming from a cursor.
+    Subscribe {
+        ch: String,
+        #[serde(default)]
+        since: Option<u64>,
+    },
+    /// Unsubscribe from a channel.
+    Unsubscribe { ch: String },
+    /// Cancel a running session (the only `control` uplink in P1).
+    Stop { session_id: String },
+    /// Any frame whose `type` is not recognized. The driver logs and ignores it
+    /// rather than disconnecting.
+    #[serde(other)]
+    Unknown,
+}
+
+/// The kind of channel a `ch` string names.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum Channel {
+    /// The account-wide change feed.
+    Feed,
+    /// A per-session agent event stream.
+    Agent(String),
+}
+
+impl Channel {
+    /// Parse a `ch` wire string into a [`Channel`], or `None` if unrecognized.
+    pub(crate) fn parse(ch: &str) -> Option<Channel> {
+        if ch == "feed" {
+            Some(Channel::Feed)
+        } else if let Some(sid) = ch.strip_prefix("agent.") {
+            if sid.is_empty() {
+                None
+            } else {
+                Some(Channel::Agent(sid.to_string()))
+            }
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn server_envelope_event_shape() {
+        let env = ServerEnvelope::event(
+            "agent.sess_abc",
+            42,
+            json!({ "type": "token", "content": "Hello" }),
+        );
+        let v = serde_json::to_value(&env).unwrap();
+        assert_eq!(
+            v,
+            json!({
+                "ch": "agent.sess_abc",
+                "seq": 42,
+                "event": { "type": "token", "content": "Hello" }
+            })
+        );
+        // Exactly three keys, no nesting under a wrapper.
+        assert_eq!(v.as_object().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn server_envelope_control_shape() {
+        let env = ServerEnvelope::control("agent.sess_abc", 43, terminal_control("complete"));
+        let v = serde_json::to_value(&env).unwrap();
+        assert_eq!(
+            v,
+            json!({
+                "ch": "agent.sess_abc",
+                "seq": 43,
+                "control": { "type": "terminal", "reason": "complete" }
+            })
+        );
+    }
+
+    #[test]
+    fn feed_reset_control_shape() {
+        let env = ServerEnvelope::control("feed", 0, feed_reset_control(1006));
+        let v = serde_json::to_value(&env).unwrap();
+        assert_eq!(
+            v["control"],
+            json!({ "type": "feed_reset", "from_seq": 1006 })
+        );
+    }
+
+    #[test]
+    fn client_frame_hello_parses() {
+        let f: ClientFrame =
+            serde_json::from_str(r#"{"type":"hello","device_id":"d1","token":"bd1_x"}"#).unwrap();
+        assert_eq!(
+            f,
+            ClientFrame::Hello {
+                device_id: Some("d1".to_string()),
+                token: Some("bd1_x".to_string())
+            }
+        );
+        // Hello with no fields still parses (auth ignored in P1).
+        let f: ClientFrame = serde_json::from_str(r#"{"type":"hello"}"#).unwrap();
+        assert_eq!(
+            f,
+            ClientFrame::Hello {
+                device_id: None,
+                token: None
+            }
+        );
+    }
+
+    #[test]
+    fn client_frame_subscribe_parses_with_and_without_cursor() {
+        let f: ClientFrame =
+            serde_json::from_str(r#"{"type":"subscribe","ch":"feed","since":1006}"#).unwrap();
+        assert_eq!(
+            f,
+            ClientFrame::Subscribe {
+                ch: "feed".to_string(),
+                since: Some(1006)
+            }
+        );
+        let f: ClientFrame =
+            serde_json::from_str(r#"{"type":"subscribe","ch":"agent.s1"}"#).unwrap();
+        assert_eq!(
+            f,
+            ClientFrame::Subscribe {
+                ch: "agent.s1".to_string(),
+                since: None
+            }
+        );
+    }
+
+    #[test]
+    fn client_frame_unsubscribe_and_stop_parse() {
+        let f: ClientFrame =
+            serde_json::from_str(r#"{"type":"unsubscribe","ch":"agent.s1"}"#).unwrap();
+        assert_eq!(
+            f,
+            ClientFrame::Unsubscribe {
+                ch: "agent.s1".to_string()
+            }
+        );
+        let f: ClientFrame = serde_json::from_str(r#"{"type":"stop","session_id":"s1"}"#).unwrap();
+        assert_eq!(
+            f,
+            ClientFrame::Stop {
+                session_id: "s1".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_frame_type_maps_to_unknown_not_error() {
+        // An unrecognized `type` must NOT fail the parse — it maps to Unknown so
+        // the driver logs + continues instead of disconnecting.
+        let f: ClientFrame =
+            serde_json::from_str(r#"{"type":"execute","session_id":"s1","message":"hi"}"#).unwrap();
+        assert_eq!(f, ClientFrame::Unknown);
+    }
+
+    #[test]
+    fn malformed_json_is_a_parse_error_caught_by_driver() {
+        // Not valid JSON at all → Err. The driver treats this the same as
+        // Unknown: log + ignore, no disconnect.
+        let r: Result<ClientFrame, _> = serde_json::from_str("not json{");
+        assert!(r.is_err());
+        // A JSON object missing the `type` tag → also an error (no default tag).
+        let r: Result<ClientFrame, _> = serde_json::from_str(r#"{"ch":"feed"}"#);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn channel_parse() {
+        assert_eq!(Channel::parse("feed"), Some(Channel::Feed));
+        assert_eq!(
+            Channel::parse("agent.sess_abc"),
+            Some(Channel::Agent("sess_abc".to_string()))
+        );
+        assert_eq!(Channel::parse("agent."), None);
+        assert_eq!(Channel::parse("bogus"), None);
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
@@ -1,10 +1,18 @@
 //! Per-channel forwarder tasks for the v2 WS multiplex.
 //!
 //! Each subscribed channel runs its OWN task with its OWN broadcast receiver,
-//! pushing [`ServerEnvelope`]s onto a single shared `mpsc` that the driver
-//! drains to the WS session. This per-forwarder design gives **per-channel lag
-//! independence** (a slow/lagging channel only overruns its own broadcast ring,
-//! never blocking another channel) — the §10-Q3 backpressure requirement.
+//! pushing [`ServerEnvelope`]s onto a single shared bounded `mpsc` that the
+//! driver drains to the WS session.
+//!
+//! Backpressure (RFC §10-Q3): the per-forwarder design gives **broadcast-ring
+//! independence** — a slow/lagging channel only overruns its own broadcast ring
+//! and is never blocked at the *source* by another channel. The forwarders then
+//! merge into one bounded outbound FIFO, so a sustained burst on one channel can
+//! still queue ahead of another at the *socket* (a head-of-line window bounded
+//! by the FIFO depth); it cannot deadlock (forwarders block on `send().await`
+//! holding no shared lock, and the driver always drains). A fully per-channel
+//! outbound queue with a fair merge is a possible future refinement; the bounded
+//! shared FIFO is the pragmatic first cut.
 //!
 //! The driver keeps a `JoinHandle` per channel so `unsubscribe` (or teardown)
 //! aborts exactly that forwarder, leaving no orphaned broadcast reader.
@@ -20,8 +28,11 @@ use bamboo_agent_core::AgentEvent;
 use bamboo_engine::events::change_feed::ChangeEvent;
 use bamboo_engine::events::journal;
 
+use actix_web::web;
+
 use super::envelope::{feed_reset_control, terminal_control, ServerEnvelope};
-use crate::handlers::agent::events::Coalescer;
+use crate::app_state::AppState;
+use crate::handlers::agent::events::{has_running_child, Coalescer};
 use crate::handlers::agent::stream::{plan_replay, ReplayPlan};
 
 /// What the driver sends to the WS writer: a fully-built envelope's text frame.
@@ -143,6 +154,8 @@ impl AgentSeq {
 /// `ch` is the full channel id (`agent.{sid}`).
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn spawn_agent_forwarder(
+    state: web::Data<AppState>,
+    session_id: String,
     out: OutboundTx,
     ch: String,
     mut receiver: broadcast::Receiver<AgentEvent>,
@@ -168,15 +181,47 @@ pub(crate) fn spawn_agent_forwarder(
 
         if batch_ms == 0 {
             // Fast path: every event emitted immediately, byte-for-byte (desktop
-            // default), with no buffering. Terminal events close the channel.
+            // default), with no buffering.
+            //
+            // Terminal handling mirrors the v1 SSE stream: the parent's own turn
+            // can finish while its child sub-agents are still running. Children
+            // outlive the parent turn and forward their progress/preview onto THIS
+            // session's broadcast, so we must NOT close the channel on the parent
+            // terminal while descendants remain — doing so would silently drop
+            // every later child event. Hold the channel open and emit the
+            // `terminal` control only once no running child is left.
+            let mut awaiting_children = false;
             loop {
                 match receiver.recv().await {
                     Ok(event) => {
                         let is_terminal = is_terminal_event(&event);
+                        let is_child_completed =
+                            matches!(event, AgentEvent::SubAgentCompleted { .. });
                         if !emit_agent_event(&out, &ch, &seq, event).await {
                             return;
                         }
                         if is_terminal {
+                            if has_running_child(&state, &session_id).await {
+                                awaiting_children = true;
+                                continue;
+                            }
+                            let _ = send_env(
+                                &out,
+                                ServerEnvelope::control(
+                                    &ch,
+                                    seq.next(),
+                                    terminal_control("complete"),
+                                ),
+                            )
+                            .await;
+                            return;
+                        }
+                        // A child just finished: if it was the last running child
+                        // after the parent already terminated, close now.
+                        if awaiting_children
+                            && is_child_completed
+                            && !has_running_child(&state, &session_id).await
+                        {
                             let _ = send_env(
                                 &out,
                                 ServerEnvelope::control(
@@ -202,6 +247,9 @@ pub(crate) fn spawn_agent_forwarder(
         let mut coalescer = Coalescer::default();
         let flush_window = Duration::from_millis(batch_ms);
         let mut flush_deadline: Option<tokio::time::Instant> = None;
+        // See the fast-path comment: keep the channel open after the parent
+        // terminal while child sub-agents still run.
+        let mut awaiting_children = false;
 
         loop {
             let sleep_until = flush_deadline
@@ -220,6 +268,8 @@ pub(crate) fn spawn_agent_forwarder(
                     match recv {
                         Ok(event) => {
                             let is_terminal = is_terminal_event(&event);
+                            let is_child_completed =
+                                matches!(event, AgentEvent::SubAgentCompleted { .. });
                             // Feed through the coalescer: it returns the ordered
                             // events to emit now (a flushed pending buffer then the
                             // new event when non-coalescible). Terminal events are
@@ -238,6 +288,24 @@ pub(crate) fn spawn_agent_forwarder(
                                 flush_deadline = None;
                             }
                             if is_terminal {
+                                // Keep the channel open while children run (v1
+                                // parity); the pending buffer was already flushed
+                                // above since a terminal is non-coalescible.
+                                if has_running_child(&state, &session_id).await {
+                                    awaiting_children = true;
+                                    continue;
+                                }
+                                let _ = send_env(
+                                    &out,
+                                    ServerEnvelope::control(&ch, seq.next(), terminal_control("complete")),
+                                )
+                                .await;
+                                return;
+                            }
+                            if awaiting_children
+                                && is_child_completed
+                                && !has_running_child(&state, &session_id).await
+                            {
                                 let _ = send_env(
                                     &out,
                                     ServerEnvelope::control(&ch, seq.next(), terminal_control("complete")),

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
@@ -1,0 +1,378 @@
+//! Per-channel forwarder tasks for the v2 WS multiplex.
+//!
+//! Each subscribed channel runs its OWN task with its OWN broadcast receiver,
+//! pushing [`ServerEnvelope`]s onto a single shared `mpsc` that the driver
+//! drains to the WS session. This per-forwarder design gives **per-channel lag
+//! independence** (a slow/lagging channel only overruns its own broadcast ring,
+//! never blocking another channel) — the §10-Q3 backpressure requirement.
+//!
+//! The driver keeps a `JoinHandle` per channel so `unsubscribe` (or teardown)
+//! aborts exactly that forwarder, leaving no orphaned broadcast reader.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{broadcast, mpsc};
+
+use bamboo_agent_core::AgentEvent;
+use bamboo_engine::events::change_feed::ChangeEvent;
+use bamboo_engine::events::journal;
+
+use super::envelope::{feed_reset_control, terminal_control, ServerEnvelope};
+use crate::handlers::agent::events::Coalescer;
+use crate::handlers::agent::stream::{plan_replay, ReplayPlan};
+
+/// What the driver sends to the WS writer: a fully-built envelope's text frame.
+pub(crate) type OutboundTx = mpsc::Sender<String>;
+
+/// Push a server envelope onto the shared outbound mpsc. Returns `false` if the
+/// driver-side receiver is gone (connection closing), so the forwarder stops.
+async fn send_env(out: &OutboundTx, env: ServerEnvelope) -> bool {
+    match env.to_text() {
+        Some(text) => out.send(text).await.is_ok(),
+        // A serialization failure is per-event; skip it but keep the forwarder
+        // alive (matches the v1 SSE `serde_json::to_string(...).ok()` discipline).
+        None => true,
+    }
+}
+
+/// Spawn the `feed` forwarder.
+///
+/// Replicates the v1 SSE feed's subscribe-first → replay → live-skip → re-seek
+/// discipline **exactly** (it reuses the same [`plan_replay`] / journal reads),
+/// so a resuming client sees every event after its cursor exactly once with no
+/// duplication across the handoff. The caller MUST have already subscribed
+/// (`receiver`) before computing `latest_at_start`, so events written during
+/// replay are buffered in the ring (no gap).
+pub(crate) fn spawn_feed_forwarder(
+    out: OutboundTx,
+    mut receiver: broadcast::Receiver<Arc<ChangeEvent>>,
+    events_dir: PathBuf,
+    since: u64,
+    latest_at_start: u64,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        // Phase A: replay the durable journal from the cursor (with a feed_reset
+        // directive when the cursor predates the retained window).
+        let ReplayPlan {
+            reset_from,
+            events,
+            last_replayed,
+        } = plan_replay(&events_dir, since, latest_at_start);
+        let mut last_replayed = last_replayed;
+
+        if let Some(from) = reset_from {
+            // seq 0 on a control frame: the reset itself carries no feed seq; the
+            // client resyncs via REST and the live tail serves anything newer.
+            if !send_env(
+                &out,
+                ServerEnvelope::control("feed", 0, feed_reset_control(from)),
+            )
+            .await
+            {
+                return;
+            }
+        }
+        for ce in events {
+            if !send_env(&out, feed_envelope(&ce)).await {
+                return;
+            }
+        }
+
+        // Phase B: live tail with overlap-dedupe and lagged re-seek.
+        loop {
+            match receiver.recv().await {
+                Ok(ce) => {
+                    if ce.seq <= last_replayed {
+                        continue; // dedupe the replay/live overlap
+                    }
+                    if !send_env(&out, feed_envelope(&ce)).await {
+                        return;
+                    }
+                    last_replayed = ce.seq;
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    // Ring overran during a slow consumer; recover the gap from
+                    // the durable journal (the backstop), then continue live.
+                    if let Ok(events) = journal::read_since(&events_dir, last_replayed) {
+                        for ce in events {
+                            if ce.seq <= last_replayed {
+                                continue;
+                            }
+                            if !send_env(&out, feed_envelope(&ce)).await {
+                                return;
+                            }
+                            last_replayed = ce.seq;
+                        }
+                    }
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    })
+}
+
+/// Build a `feed` envelope: `seq` = the `ChangeEvent.seq`, and the WHOLE
+/// `ChangeEvent` is serialized as `event` to preserve its schema byte-for-byte.
+fn feed_envelope(ce: &ChangeEvent) -> ServerEnvelope {
+    let event = serde_json::to_value(ce).unwrap_or(serde_json::Value::Null);
+    ServerEnvelope::event("feed", ce.seq, event)
+}
+
+/// Per-session monotonic envelope-seq counter for an `agent.{sid}` channel.
+/// `AgentEvent` carries no seq of its own, so the forwarder mints one.
+#[derive(Default)]
+pub(crate) struct AgentSeq(AtomicU64);
+
+impl AgentSeq {
+    /// Return the next seq (1-based, strictly increasing).
+    pub(crate) fn next(&self) -> u64 {
+        self.0.fetch_add(1, Ordering::Relaxed) + 1
+    }
+}
+
+/// Spawn an `agent.{sid}` forwarder.
+///
+/// Mirrors the v1 per-session SSE path: replay cached critical state events
+/// (and the last budget event) first, then live-tail. Reuses the v1
+/// [`Coalescer`] for token batching when `batch_ms > 0` (default 0 = no
+/// coalescing). On any terminal event it emits a `terminal` control frame.
+///
+/// `ch` is the full channel id (`agent.{sid}`).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn spawn_agent_forwarder(
+    out: OutboundTx,
+    ch: String,
+    mut receiver: broadcast::Receiver<AgentEvent>,
+    budget_event_to_replay: Option<AgentEvent>,
+    critical_events_to_replay: Vec<AgentEvent>,
+    batch_ms: u64,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let seq = AgentSeq::default();
+
+        // Replay cached critical state events first (task list, sub-sessions, …),
+        // then the last budget event — mirroring the v1 SSE replay order.
+        for event in critical_events_to_replay {
+            if !emit_agent_event(&out, &ch, &seq, event).await {
+                return;
+            }
+        }
+        if let Some(event) = budget_event_to_replay {
+            if !emit_agent_event(&out, &ch, &seq, event).await {
+                return;
+            }
+        }
+
+        if batch_ms == 0 {
+            // Fast path: every event emitted immediately, byte-for-byte (desktop
+            // default), with no buffering. Terminal events close the channel.
+            loop {
+                match receiver.recv().await {
+                    Ok(event) => {
+                        let is_terminal = is_terminal_event(&event);
+                        if !emit_agent_event(&out, &ch, &seq, event).await {
+                            return;
+                        }
+                        if is_terminal {
+                            let _ = send_env(
+                                &out,
+                                ServerEnvelope::control(
+                                    &ch,
+                                    seq.next(),
+                                    terminal_control("complete"),
+                                ),
+                            )
+                            .await;
+                            return;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => return,
+                }
+            }
+        }
+
+        // Coalescing path (`batch_ms > 0`): reuse the v1 Coalescer so token-class
+        // events of the same channel merge into one frame, flushed on a different
+        // event / the deadline / a terminal / a lag gap / close. Order is
+        // preserved by the Coalescer (push returns the flushed pending FIRST).
+        let mut coalescer = Coalescer::default();
+        let flush_window = Duration::from_millis(batch_ms);
+        let mut flush_deadline: Option<tokio::time::Instant> = None;
+
+        loop {
+            let sleep_until = flush_deadline
+                .unwrap_or_else(|| tokio::time::Instant::now() + Duration::from_secs(86_400));
+
+            tokio::select! {
+                _ = tokio::time::sleep_until(sleep_until), if flush_deadline.is_some() => {
+                    if let Some(pending) = coalescer.take_pending() {
+                        if !emit_agent_event(&out, &ch, &seq, pending).await {
+                            return;
+                        }
+                    }
+                    flush_deadline = None;
+                }
+                recv = receiver.recv() => {
+                    match recv {
+                        Ok(event) => {
+                            let is_terminal = is_terminal_event(&event);
+                            // Feed through the coalescer: it returns the ordered
+                            // events to emit now (a flushed pending buffer then the
+                            // new event when non-coalescible). Terminal events are
+                            // non-coalescible, so any pending tokens flush first.
+                            for out_event in coalescer.push(event) {
+                                if !emit_agent_event(&out, &ch, &seq, out_event).await {
+                                    return;
+                                }
+                            }
+                            if coalescer.has_pending() {
+                                if flush_deadline.is_none() {
+                                    flush_deadline =
+                                        Some(tokio::time::Instant::now() + flush_window);
+                                }
+                            } else {
+                                flush_deadline = None;
+                            }
+                            if is_terminal {
+                                let _ = send_env(
+                                    &out,
+                                    ServerEnvelope::control(&ch, seq.next(), terminal_control("complete")),
+                                )
+                                .await;
+                                return;
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(_)) => {
+                            // A lag gap dropped intervening events; flush the
+                            // pending buffer so we never merge tokens across the
+                            // gap and fabricate adjacency.
+                            if let Some(pending) = coalescer.take_pending() {
+                                if !emit_agent_event(&out, &ch, &seq, pending).await {
+                                    return;
+                                }
+                                flush_deadline = None;
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            // Flush any buffered tokens before closing.
+                            if let Some(pending) = coalescer.take_pending() {
+                                let _ = emit_agent_event(&out, &ch, &seq, pending).await;
+                            }
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Serialize an `AgentEvent` into an `{ch, seq, event}` envelope and push it.
+async fn emit_agent_event(out: &OutboundTx, ch: &str, seq: &AgentSeq, event: AgentEvent) -> bool {
+    let value = match serde_json::to_value(&event) {
+        Ok(v) => v,
+        // Skip an unserializable event but keep the forwarder alive (v1 parity).
+        Err(_) => return true,
+    };
+    send_env(out, ServerEnvelope::event(ch, seq.next(), value)).await
+}
+
+/// Whether an agent event terminates the run (mirrors the v1 SSE predicate).
+fn is_terminal_event(event: &AgentEvent) -> bool {
+    matches!(
+        event,
+        AgentEvent::Complete { .. } | AgentEvent::Cancelled { .. } | AgentEvent::Error { .. }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_seq_is_monotonic_and_one_based() {
+        let seq = AgentSeq::default();
+        assert_eq!(seq.next(), 1);
+        assert_eq!(seq.next(), 2);
+        assert_eq!(seq.next(), 3);
+    }
+
+    /// The live-skip predicate used in the feed handoff drops `seq <= cursor`
+    /// and keeps `seq > cursor`, so the replay/live overlap is deduped without
+    /// dropping anything past the cursor.
+    #[test]
+    fn feed_live_skip_predicate() {
+        let last_replayed = 1006u64;
+        let skip = |seq: u64| seq <= last_replayed;
+        assert!(skip(1005));
+        assert!(skip(1006)); // boundary: already replayed → skip
+        assert!(!skip(1007)); // first new event → keep
+        assert!(!skip(2000));
+    }
+
+    /// Smoke test that the v1 `Coalescer` is reachable + behaves from the ws_v2
+    /// module (proves the `pub(crate)` widening is wired, not just compiles).
+    #[test]
+    fn coalescer_reuse_smoke() {
+        let mut c = Coalescer::default();
+        assert!(c
+            .push(AgentEvent::Token {
+                content: "Hel".into()
+            })
+            .is_empty());
+        assert!(c
+            .push(AgentEvent::Token {
+                content: "lo".into()
+            })
+            .is_empty());
+        // A non-token event flushes the merged token first, in order.
+        let out = c.push(AgentEvent::Complete {
+            usage: Default::default(),
+        });
+        assert_eq!(out.len(), 2);
+        match &out[0] {
+            AgentEvent::Token { content } => assert_eq!(content, "Hello"),
+            other => panic!("expected merged Token, got {other:?}"),
+        }
+        assert!(matches!(out[1], AgentEvent::Complete { .. }));
+    }
+
+    #[test]
+    fn terminal_event_predicate() {
+        assert!(is_terminal_event(&AgentEvent::Complete {
+            usage: Default::default()
+        }));
+        assert!(is_terminal_event(&AgentEvent::Cancelled { message: None }));
+        assert!(is_terminal_event(&AgentEvent::Error {
+            message: "x".into()
+        }));
+        assert!(!is_terminal_event(&AgentEvent::Token {
+            content: "x".into()
+        }));
+    }
+
+    #[test]
+    fn feed_envelope_uses_change_event_seq_and_full_payload() {
+        let ce = ChangeEvent {
+            seq: 99,
+            ts: chrono::Utc::now(),
+            session_id: Some("s1".into()),
+            event: AgentEvent::Token {
+                content: "hi".into(),
+            },
+        };
+        let env = feed_envelope(&ce);
+        assert_eq!(env.seq, 99);
+        let v = serde_json::to_value(&env).unwrap();
+        assert_eq!(v["ch"], "feed");
+        assert_eq!(v["seq"], 99);
+        // The whole ChangeEvent (seq, ts, session_id, event) is preserved.
+        assert_eq!(v["event"]["seq"], 99);
+        assert_eq!(v["event"]["session_id"], "s1");
+        assert_eq!(v["event"]["event"]["type"], "token");
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -104,7 +104,10 @@ async fn drive(
                     break;
                 }
             }
-            // Keepalive ping.
+            // Keepalive ping. Liveness is write-driven (a dead peer surfaces as a
+            // failed `ping`/`text` write); we do NOT track Pong arrivals or run a
+            // pong timeout — same one-directional keepalive contract as the v1 SSE
+            // stream.
             _ = ping.tick() => {
                 if session.ping(b"").await.is_err() {
                     break;
@@ -252,6 +255,8 @@ async fn subscribe(
                 .unwrap_or_default();
 
             spawn_agent_forwarder(
+                state.clone(),
+                sid.clone(),
                 out_tx.clone(),
                 ch.to_string(),
                 receiver,

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -1,0 +1,267 @@
+//! v2-P1 unified WebSocket multiplex: `GET /v2/stream`.
+//!
+//! One WebSocket replaces the two v1 SSE streams (`GET /events/{id}` +
+//! `GET /stream`) plus a minimal `stop` control uplink, so a mobile client uses
+//! ONE connection instead of two SSE + scattered POSTs. The v1 SSE/REST
+//! endpoints stay UNCHANGED (dual-track per `docs/api-v2-transport.md` §8.1).
+//!
+//! ## Channels (server→client)
+//! - `feed` — the account `ChangeEvent` stream (reuses `plan_replay` + journal).
+//! - `agent.{session_id}` — a per-session `AgentEvent` stream (reuses the v1
+//!   critical-event replay + the v1 `Coalescer` for token batching).
+//!
+//! ## Control (client→server, P1)
+//! - `stop` only — cancels a session (reuses the v1 stop discipline).
+//!
+//! ## Design
+//! Each subscribed channel runs its OWN forwarder task with its OWN broadcast
+//! receiver (per-channel lag independence; §10-Q3). Forwarders push fully-built
+//! envelope text frames onto one shared `mpsc` that the driver drains to the WS
+//! `session`. A per-channel `JoinHandle` lets `unsubscribe`/teardown abort
+//! exactly that forwarder, leaving no orphaned broadcast reader.
+//!
+//! ## DEFERRED (later slices; see PR / §5.3)
+//! - `execute` / `approve` over control (handler refactors) — clients keep REST.
+//! - per-device tokens / `hello` validation / `/v2/pair` (v2-P2) — `hello` is
+//!   accepted and ignored; auth is the scope middleware only.
+//! - msgpack subprotocol (v2-P3) — JSON text frames only.
+
+mod envelope;
+mod forwarders;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use actix_web::{web, HttpRequest, Responder};
+use actix_ws::Message;
+use futures::StreamExt;
+use tokio::sync::mpsc;
+
+use serde::Deserialize;
+
+use self::envelope::{Channel, ClientFrame};
+use self::forwarders::{spawn_agent_forwarder, spawn_feed_forwarder, OutboundTx};
+use crate::app_state::AppState;
+use crate::handlers::agent::events::MAX_BATCH_MS;
+use crate::handlers::agent::stop::cancel_session;
+
+/// Bound on the shared outbound mpsc. Caps how far ahead the (collectively)
+/// forwarders may run before the WS writer applies backpressure.
+const OUTBOUND_BUFFER: usize = 256;
+
+/// WS ping interval (~15s), mirroring the v1 SSE `[KEEPALIVE]` cadence.
+const PING_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Query parameters for the `GET /v2/stream` upgrade.
+#[derive(Debug, Default, Deserialize)]
+pub struct StreamQuery {
+    /// Token-coalescing window in milliseconds for `agent.{sid}` channels.
+    /// `0` (default) = no coalescing (desktop). Mobile passes e.g. `50`.
+    #[serde(default)]
+    pub batch_ms: u64,
+}
+
+/// `GET /v2/stream` — upgrade to the unified WS multiplex.
+///
+/// Behind the same access-password scope middleware as `/api/v1` (registered in
+/// `routes/agent.rs`); `local_bypass` keeps desktop loopback frictionless.
+pub async fn handler(
+    state: web::Data<AppState>,
+    query: web::Query<StreamQuery>,
+    req: HttpRequest,
+    body: web::Payload,
+) -> actix_web::Result<impl Responder> {
+    // Clamp the untrusted `batch_ms` the same way the v1 SSE handler does.
+    let batch_ms = query.batch_ms.min(MAX_BATCH_MS);
+
+    let (response, session, msg_stream) = actix_ws::handle(&req, body)?;
+
+    actix_web::rt::spawn(drive(state, session, msg_stream, batch_ms));
+
+    Ok(response)
+}
+
+/// The per-connection driver: owns the WS `session` (write) + `msg_stream`
+/// (read), the shared outbound mpsc, the per-channel forwarder handles, and the
+/// keepalive ping timer.
+async fn drive(
+    state: web::Data<AppState>,
+    mut session: actix_ws::Session,
+    mut msg_stream: actix_ws::MessageStream,
+    batch_ms: u64,
+) {
+    let (out_tx, mut out_rx) = mpsc::channel::<String>(OUTBOUND_BUFFER);
+    let mut forwarders: HashMap<String, tokio::task::JoinHandle<()>> = HashMap::new();
+    let mut ping = tokio::time::interval(PING_INTERVAL);
+    ping.tick().await; // skip the immediate tick
+
+    loop {
+        tokio::select! {
+            // Drain forwarder output to the WS. If the write fails the peer is
+            // gone — break and tear down.
+            Some(text) = out_rx.recv() => {
+                if session.text(text).await.is_err() {
+                    break;
+                }
+            }
+            // Keepalive ping.
+            _ = ping.tick() => {
+                if session.ping(b"").await.is_err() {
+                    break;
+                }
+            }
+            // Client frames.
+            msg = msg_stream.next() => {
+                match msg {
+                    Some(Ok(Message::Text(text))) => {
+                        handle_client_text(
+                            &state, &out_tx, &mut forwarders, &mut session, batch_ms, &text,
+                        )
+                        .await;
+                    }
+                    Some(Ok(Message::Ping(bytes))) => {
+                        if session.pong(&bytes).await.is_err() {
+                            break;
+                        }
+                    }
+                    // Pong / Binary (no msgpack in P1) / Continuation / Nop: ignore.
+                    Some(Ok(Message::Pong(_)))
+                    | Some(Ok(Message::Binary(_)))
+                    | Some(Ok(Message::Continuation(_)))
+                    | Some(Ok(Message::Nop)) => {}
+                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Err(e)) => {
+                        tracing::debug!("ws_v2: message stream error: {e}");
+                        break;
+                    }
+                }
+            }
+            else => break,
+        }
+    }
+
+    // Clean teardown: abort every forwarder so no orphaned broadcast reader
+    // survives the connection.
+    for (_ch, handle) in forwarders.drain() {
+        handle.abort();
+    }
+    let _ = session.close(None).await;
+}
+
+/// Parse + dispatch one client text frame. A malformed/unknown frame logs and is
+/// ignored — it never tears down the connection.
+async fn handle_client_text(
+    state: &web::Data<AppState>,
+    out_tx: &OutboundTx,
+    forwarders: &mut HashMap<String, tokio::task::JoinHandle<()>>,
+    _session: &mut actix_ws::Session,
+    batch_ms: u64,
+    text: &str,
+) {
+    let frame: ClientFrame = match serde_json::from_str(text) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::debug!("ws_v2: ignoring malformed client frame: {e}");
+            return;
+        }
+    };
+
+    match frame {
+        ClientFrame::Hello { .. } => {
+            // v2-P1: auth is the scope middleware only. Accept + ignore (token
+            // validation lands in v2-P2).
+            tracing::debug!("ws_v2: hello frame accepted (P1 no-op)");
+        }
+        ClientFrame::Subscribe { ch, since } => {
+            subscribe(state, out_tx, forwarders, batch_ms, &ch, since).await;
+        }
+        ClientFrame::Unsubscribe { ch } => {
+            if let Some(handle) = forwarders.remove(&ch) {
+                handle.abort();
+                tracing::debug!("ws_v2: unsubscribed {ch}");
+            }
+        }
+        ClientFrame::Stop { session_id } => {
+            let cancelled = cancel_session(state, &session_id).await;
+            tracing::debug!("ws_v2: stop {session_id} -> cancelled={cancelled}");
+        }
+        ClientFrame::Unknown => {
+            tracing::debug!("ws_v2: ignoring unknown client frame type");
+        }
+    }
+}
+
+/// Subscribe to a channel, replacing any existing forwarder for the same `ch`
+/// (a re-subscribe with a new cursor aborts the old one first, so there is never
+/// a duplicate reader on one channel).
+async fn subscribe(
+    state: &web::Data<AppState>,
+    out_tx: &OutboundTx,
+    forwarders: &mut HashMap<String, tokio::task::JoinHandle<()>>,
+    batch_ms: u64,
+    ch: &str,
+    since: Option<u64>,
+) {
+    let Some(channel) = Channel::parse(ch) else {
+        tracing::debug!("ws_v2: ignoring subscribe to unknown channel {ch}");
+        return;
+    };
+
+    // Replace any prior forwarder for this exact channel id.
+    if let Some(old) = forwarders.remove(ch) {
+        old.abort();
+    }
+
+    let handle = match channel {
+        Channel::Feed => {
+            // Subscribe FIRST so events written during journal replay are buffered
+            // in the ring and delivered in the live phase (no gap) — exactly the
+            // v1 SSE handoff discipline.
+            let receiver = state.account_sink.subscribe();
+            let latest_at_start = state.account_sink.latest_seq();
+            let events_dir = state.account_sink.events_dir().to_path_buf();
+            let since = since.unwrap_or(0);
+            spawn_feed_forwarder(out_tx.clone(), receiver, events_dir, since, latest_at_start)
+        }
+        Channel::Agent(sid) => {
+            // The session must exist; otherwise ignore (parity with the v1
+            // events handler's 404, but here we just skip the subscribe).
+            if state.session_store.get_index_entry(&sid).await.is_none() {
+                tracing::debug!("ws_v2: ignoring subscribe to unknown session {sid}");
+                return;
+            }
+
+            let sender = state.get_session_event_sender(&sid).await;
+            let receiver = sender.subscribe();
+            // Keep the notification relay running for this session (parity with
+            // the v1 events handler).
+            state.ensure_notification_relay(&sid, sender.clone());
+
+            // Snapshot the runner for critical-event + budget replay (mirrors
+            // `events/handler.rs:80-89`).
+            let runner_snapshot = {
+                let runners = state.agent_runners.read().await;
+                runners.get(&sid).cloned()
+            };
+            let budget_event_to_replay = runner_snapshot
+                .as_ref()
+                .and_then(|runner| runner.last_budget_event.clone());
+            let critical_events_to_replay: Vec<_> = runner_snapshot
+                .as_ref()
+                .map(|runner| runner.last_critical_events.clone())
+                .unwrap_or_default();
+
+            spawn_agent_forwarder(
+                out_tx.clone(),
+                ch.to_string(),
+                receiver,
+                budget_event_to_replay,
+                critical_events_to_replay,
+                batch_ms,
+            )
+        }
+    };
+
+    forwarders.insert(ch.to_string(), handle);
+    tracing::debug!("ws_v2: subscribed {ch} (since={since:?})");
+}

--- a/crates/app/bamboo-server/src/routes/agent.rs
+++ b/crates/app/bamboo-server/src/routes/agent.rs
@@ -261,6 +261,18 @@ pub fn agent_routes(cfg: &mut web::ServiceConfig) {
     }
 
     cfg.service(scope);
+
+    // v2-P1 (#181): the unified WebSocket multiplex. A single `GET /v2/stream`
+    // WS replaces the two v1 SSE streams plus a `stop` control uplink. Behind
+    // the SAME access-password middleware as `/api/v1`, so `local_bypass` keeps
+    // desktop loopback frictionless and public access still requires the
+    // password. The v1 SSE/REST endpoints above stay unchanged (dual-track).
+    let v2_scope = web::scope("/v2")
+        .wrap(actix_web::middleware::from_fn(
+            settings::enforce_access_password_middleware,
+        ))
+        .route("/stream", web::get().to(agent::ws_v2::handler));
+    cfg.service(v2_scope);
 }
 
 /// Whether the dev-only HTTP endpoints (e.g. `POST /api/v1/dev/reset`) should be

--- a/crates/app/bamboo-server/src/routes/tests.rs
+++ b/crates/app/bamboo-server/src/routes/tests.rs
@@ -263,3 +263,64 @@ async fn dev_reset_route_registered_when_dev_endpoints_enabled() {
         "dev/reset must be registered when dev endpoints are enabled"
     );
 }
+
+// --- v2-P1 (#181): `GET /v2/stream` unified WS multiplex ------------------
+
+/// The `/v2/stream` route is registered and reaches its handler. A plain GET
+/// (no WebSocket upgrade headers) is NOT a websocket request, so `actix_ws::handle`
+/// rejects it with `400 Bad Request` — which proves the route is wired through
+/// the `/v2` scope (a missing route would be `404`, a blocked one `401/426`).
+#[actix_web::test]
+async fn v2_stream_route_is_registered_and_reaches_handler() {
+    let data_dir = tempdir().unwrap();
+    let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());
+    let app = test::init_service(App::new().app_data(app_state).configure(configure_routes)).await;
+
+    // Loopback peer (default test peer is 127.0.0.1) → `local_bypass`, so the
+    // access middleware lets the request through to the handler.
+    let req = test::TestRequest::get().uri("/v2/stream").to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_ne!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "/v2/stream must be registered"
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "a non-WebSocket GET reaches the handler and is rejected by actix_ws::handle"
+    );
+}
+
+/// `/v2/stream` is behind the SAME access-password middleware as `/api/v1`: a
+/// remote (non-loopback) request with a password configured and no verified
+/// cookie is blocked with `401` BEFORE reaching the WS handler.
+#[actix_web::test]
+async fn v2_stream_is_behind_access_middleware() {
+    let data_dir = tempdir().unwrap();
+    let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());
+    {
+        let mut config = app_state.config.write().await;
+        config.access_control = Some(AccessControlConfig {
+            password_enabled: true,
+            password_hash: Some(
+                "a65192f8d645bc4d19765b8ea61bfbb896dc999cb88a4be419518c5493f92c9d".to_string(),
+            ),
+            password_salt: Some("01010101010101010101010101010101".to_string()),
+            updated_at: None,
+        });
+    }
+    let app = test::init_service(App::new().app_data(app_state).configure(configure_routes)).await;
+
+    let req = test::TestRequest::get()
+        .uri("/v2/stream")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "/v2/stream must be guarded by the access middleware for remote requests"
+    );
+}


### PR DESCRIPTION
## What

Implements the core of **v2-P1** for Epic #181: a single **GET /v2/stream** WebSocket endpoint that multiplexes the two existing SSE streams plus a minimal control channel, so a mobile client uses ONE connection instead of two SSE + scattered POSTs. Spec: docs/api-v2-transport.md sections 5 + 5.7.

The v1 SSE/REST endpoints stay **UNCHANGED** (dual-track per section 8.1). New `/v2` actix scope sits behind the **same** `enforce_access_password_middleware` as `/api/v1`, so `local_bypass` keeps desktop loopback frictionless and remote access still requires the password.

## Channels

| channel | direction | payload | replaces |
|---|---|---|---|
| `feed` | server to client | account `ChangeEvent` stream | `GET /stream` SSE |
| `agent.{session_id}` | server to client | per-session `AgentEvent` stream | `GET /events/{id}` SSE |
| control (`stop` only) | client to server | cancel a session | `POST /stop` |

Subscribe/unsubscribe is dynamic within the one connection (a re-subscribe with a new cursor aborts and replaces the prior forwarder).

## Envelope shape

A thin shell; the inner `event` is the existing `AgentEvent` / `ChangeEvent` JSON **verbatim** (carried as an opaque `serde_json::Value` so the envelope can never drift from the underlying schema):

```jsonc
{ "ch": "agent.sess_abc", "seq": 42, "event":   { "type": "token", "content": "Hi" } }
{ "ch": "agent.sess_abc", "seq": 43, "control": { "type": "terminal", "reason": "complete" } }
{ "ch": "feed",           "seq": 1007, "event": { /* whole ChangeEvent */ } }
```

`ClientFrame` is tagged by `type` (`hello` / `subscribe{ch,since}` / `unsubscribe{ch}` / `stop{session_id}`) with an `Unknown` serde fallback, so a malformed or unknown frame **logs-and-continues** instead of dropping the connection.

For `feed`, envelope `seq` = `ChangeEvent.seq` and the WHOLE `ChangeEvent` is the `event` (schema preserved byte-for-byte). For `agent.{sid}`, `AgentEvent` has no seq, so the forwarder mints a per-session monotonic counter.

## Reuse (not reimplementation)

- **Cursor resume on `feed`** reuses `plan_replay` / `ReplayPlan` and the **lagged journal re-seek** byte-for-byte: subscribe-first, replay journal from `since`, live-tail skipping `seq <= last_replayed`, and on broadcast `Lagged` re-seek `journal::read_since` from the durable watermark. A `reset_from` emits a `feed_reset` control frame. Same ordering discipline as the v1 SSE feed (no drop / no dup across the handoff).
- **Token coalescing on `agent.{sid}`** reuses the existing `Coalescer` (read `?batch_ms=`, clamped via `MAX_BATCH_MS`, default `0` = no coalescing). Flushes pending tokens before any non-token / terminal / lag-gap / close, exactly like the v1 path.
- **`stop`** reuses a factored `cancel_session` (runner `cancel_token.cancel()` + legacy `cancel_tokens` map + mark Cancelled) — v1 stop behavior unchanged.
- **agent replay** mirrors `events/handler.rs`: replay `last_critical_events` + `last_budget_event` from the runner snapshot before the live tail.

Visibility widened from private to `pub(crate)` (behavior unchanged): `Coalescer` + `MAX_BATCH_MS` (events module), `plan_replay` + `ReplayPlan` (stream module). A reviewer should confirm these are not over-exposed.

## Per-channel backpressure (section 10-Q3)

Each subscribed channel runs its OWN forwarder task with its OWN broadcast receiver, pushing fully-built envelope frames onto one shared `mpsc` the driver drains to the WS session. A slow/lagging channel only overruns its own broadcast ring, never blocking another channel. A `JoinHandle` per channel lets `unsubscribe`/teardown abort exactly that forwarder; on close/error the driver aborts ALL forwarders (no orphaned broadcast readers). WS ping keepalive ~15s.

## actix-ws

`actix-ws = "0.3"` (resolves to 0.3.1, compatible with the resolved actix-web 4.13 / actix-http 3.12). Upgrade API: `let (response, session, msg_stream) = actix_ws::handle(&req, body)?;` then `actix_web::rt::spawn` a driver task owning `session` + `msg_stream`.

## DEFERRED (later slices)

- `execute` / `approve` over the control channel (need handler refactors) — clients keep REST `POST /execute` + `POST /child-approval`.
- per-device tokens / `hello` token validation / `/v2/pair` (v2-P2) — `hello` is accepted-and-ignored; auth is the scope middleware only.
- msgpack subprotocol (v2-P3) — JSON text frames only.
- broker/subagent TLS.

## Tests

- `ServerEnvelope` JSON shapes (`{ch,seq,event}` and `{ch,seq,control}`); `feed_reset` control.
- `ClientFrame` parses each variant; unknown `type` maps to `Unknown` (no panic/disconnect); malformed JSON is an Err the driver catches.
- feed cursor-resume live-skip predicate (`seq <= last_replayed` dropped, `>` kept).
- `agent` seq counter monotonic; `feed_envelope` uses `ChangeEvent.seq` + full payload.
- `Coalescer` reuse smoke test from the ws_v2 module (proves the `pub(crate)` widening is wired).
- Two route tests: `/v2/stream` reaches its handler (non-WS GET to 400 via `actix_ws::handle`, not 404) and is guarded by the access middleware (remote to 401).

**Honest caveat:** there is **no live WS-handshake test** — no `awc`/`actix-test` dev-dep is present and `test::init_service` does not bind a real socket, so a full subscribe to event to unsubscribe round-trip is not exercised end-to-end. Forwarder send/teardown logic is covered by unit tests on the pure pieces only; the integration gap is the async driver select-loop + real WS framing.

`cargo build` / `cargo test` (889 lib + 16 new) / `cargo fmt` / `cargo clippy --all-targets` all green for this crate; zero clippy warnings in any changed file (remaining warnings are pre-existing in other crates).

Refs #181 (v2-P1 /v2/stream WSS multiplex — read channels + stop)

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp