### PR TITLE
feat(auth): v2-P2 per-device tokens — config + /v2/pair + enforcement (slice 1) [#181]

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -22,9 +22,14 @@
 //!
 //! ## DEFERRED (later slices; see PR / §5.3)
 //! - `execute` / `approve` over control (handler refactors) — clients keep REST.
-//! - per-device tokens / `hello` validation / `/v2/pair` (v2-P2) — `hello` is
-//!   accepted and ignored; auth is the scope middleware only.
 //! - msgpack subprotocol (v2-P3) — JSON text frames only.
+//!
+//! ## Auth (v2-P2, #181)
+//! The scope middleware is the PRIMARY gate (it accepts a verified password
+//! cookie or a per-device token on the upgrade request). The `hello` frame adds
+//! identity binding: if it carries `device_id` + `token`, they are verified and
+//! the connection is CLOSED on mismatch; a token-less `hello` (e.g. a local
+//! desktop the middleware already bypassed) keeps the prior accept behavior.
 
 mod envelope;
 mod forwarders;
@@ -117,10 +122,13 @@ async fn drive(
             msg = msg_stream.next() => {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
-                        handle_client_text(
+                        let keep_open = handle_client_text(
                             &state, &out_tx, &mut forwarders, &mut session, batch_ms, &text,
                         )
                         .await;
+                        if !keep_open {
+                            break;
+                        }
                     }
                     Some(Ok(Message::Ping(bytes))) => {
                         if session.pong(&bytes).await.is_err() {
@@ -153,6 +161,9 @@ async fn drive(
 
 /// Parse + dispatch one client text frame. A malformed/unknown frame logs and is
 /// ignored — it never tears down the connection.
+///
+/// Returns `false` to signal the driver to CLOSE the connection (a `hello` that
+/// presents an invalid device credential); `true` to keep it open.
 async fn handle_client_text(
     state: &web::Data<AppState>,
     out_tx: &OutboundTx,
@@ -160,20 +171,41 @@ async fn handle_client_text(
     _session: &mut actix_ws::Session,
     batch_ms: u64,
     text: &str,
-) {
+) -> bool {
     let frame: ClientFrame = match serde_json::from_str(text) {
         Ok(f) => f,
         Err(e) => {
             tracing::debug!("ws_v2: ignoring malformed client frame: {e}");
-            return;
+            return true;
         }
     };
 
     match frame {
-        ClientFrame::Hello { .. } => {
-            // v2-P1: auth is the scope middleware only. Accept + ignore (token
-            // validation lands in v2-P2).
-            tracing::debug!("ws_v2: hello frame accepted (P1 no-op)");
+        ClientFrame::Hello { device_id, token } => {
+            // Identity binding (v2-P2, #181). The scope middleware is the primary
+            // gate; here we additionally verify a presented credential and reject
+            // an unverified hello on the public WS path. A token-less hello (e.g.
+            // a local desktop the middleware already bypassed) is accepted.
+            match (device_id, token) {
+                (Some(device_id), Some(token)) => {
+                    let config = state.config.read().await.clone();
+                    if crate::handlers::settings::verify_device_token(&config, &device_id, &token) {
+                        // Bind device id onto the connection for logging. Never
+                        // log the token.
+                        tracing::debug!("ws_v2: hello verified for device {device_id}");
+                    } else {
+                        tracing::warn!(
+                            "ws_v2: hello rejected — invalid device credential for {device_id}; closing"
+                        );
+                        return false;
+                    }
+                }
+                _ => {
+                    // No credential in the hello: keep prior accept behavior
+                    // (the middleware already gated the upgrade).
+                    tracing::debug!("ws_v2: hello accepted without device token");
+                }
+            }
         }
         ClientFrame::Subscribe { ch, since } => {
             subscribe(state, out_tx, forwarders, batch_ms, &ch, since).await;
@@ -192,6 +224,7 @@ async fn handle_client_text(
             tracing::debug!("ws_v2: ignoring unknown client frame type");
         }
     }
+    true
 }
 
 /// Subscribe to a channel, replacing any existing forwarder for the same `ch`

--- a/crates/app/bamboo-server/src/handlers/settings/access_control.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/access_control.rs
@@ -17,7 +17,7 @@ use crate::{
     app_state::{AppState, ConfigUpdateEffects},
     error::AppError,
 };
-use bamboo_config::{AccessControlConfig, Config};
+use bamboo_config::{Config, DeviceCredential};
 
 #[derive(Serialize)]
 pub struct AccessStatusResponse {
@@ -192,6 +192,139 @@ fn verify_password(config: &Config, password: &str) -> bool {
         .unwrap_or(false)
 }
 
+// ── v2-P2 per-device tokens (#181) ──────────────────────────────────────────
+//
+// A device token reuses the SAME hash construction as the access password
+// (`compute_password_hash` = SHA-256(salt || secret)); no new crypto dependency.
+// Plaintext tokens are returned to the client ONCE at pairing and are NEVER
+// stored or logged — only the hash is persisted.
+
+/// Device-token prefix. `bd1_` + 32 hex chars (16 random bytes).
+const DEVICE_TOKEN_PREFIX: &str = "bd1_";
+/// Device-id prefix. `bamboo_` + 12 hex chars (6 random bytes).
+const DEVICE_ID_PREFIX: &str = "bamboo_";
+/// HTTP header carrying the device id companion for a `Authorization: Bearer`
+/// device token (the token alone can't locate its per-device salt).
+const DEVICE_ID_HEADER: &str = "x-device-id";
+
+/// Constant-time comparison over two byte slices. Returns `false` immediately on
+/// a length mismatch (lengths are not secret here — both are fixed-width hex
+/// digests), then folds every byte so the loop time does not depend on where the
+/// first differing byte is. Used for the device-token hash compare as
+/// defense-in-depth for the new credential path (the password path predates this
+/// and keeps `==`).
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Generate `len` random bytes as a lowercase hex string.
+fn random_hex(len: usize) -> String {
+    let mut bytes = vec![0_u8; len];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+/// Issue a fresh device credential for `label`.
+///
+/// Returns the [`DeviceCredential`] to persist (hash only) and the plaintext
+/// `device_token` to return to the client ONCE. A fresh 16-byte salt is generated
+/// per device; `token_hash = SHA-256(salt || token)`.
+pub(crate) fn issue_device_token(label: &str) -> (DeviceCredential, String) {
+    let device_id = format!("{DEVICE_ID_PREFIX}{}", random_hex(6));
+    let token = format!("{DEVICE_TOKEN_PREFIX}{}", random_hex(16));
+    let salt_hex = random_hex(16);
+    // compute_password_hash only returns None on a non-hex salt; ours is always
+    // valid hex, so the hash is infallible here.
+    let token_hash = compute_password_hash(&token, &salt_hex).unwrap_or_default();
+    let created_at = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+
+    let credential = DeviceCredential {
+        device_id,
+        label: label.to_string(),
+        token_hash,
+        token_salt: salt_hex,
+        created_at,
+        last_used_at: None,
+        revoked: false,
+    };
+    (credential, token)
+}
+
+/// Verify a presented `(device_id, token)` pair against the stored devices.
+///
+/// Returns `false` if access control is unset, the device is unknown or revoked,
+/// or the hash does not match. The hash comparison is constant-time.
+pub(crate) fn verify_device_token(config: &Config, device_id: &str, token: &str) -> bool {
+    let Some(access) = config.access_control.as_ref() else {
+        return false;
+    };
+    let Some(device) = access.devices.iter().find(|d| d.device_id == device_id) else {
+        return false;
+    };
+    if device.revoked {
+        return false;
+    }
+    let Some(computed) = compute_password_hash(token, &device.token_salt) else {
+        return false;
+    };
+    constant_time_eq(computed.as_bytes(), device.token_hash.as_bytes())
+}
+
+/// Whether the config has at least one non-revoked device. When true (even with
+/// no root password) the middleware must require a credential for non-local
+/// requests.
+fn has_active_devices(config: &Config) -> bool {
+    config
+        .access_control
+        .as_ref()
+        .map(|access| access.devices.iter().any(|d| !d.revoked))
+        .unwrap_or(false)
+}
+
+/// Extract a presented device token from a request.
+///
+/// Scheme (documented for clients): the token rides in
+/// `Authorization: Bearer bd1_<...>` and its companion device id in
+/// `X-Device-Id: bamboo_<...>` (the token alone cannot locate its per-device
+/// salt). Returns `(device_id, token)` when both are present and the
+/// Authorization value carries a `bd1_`-prefixed bearer token.
+fn presented_device_token(req: &HttpRequest) -> Option<(String, String)> {
+    let auth = req.headers().get(header::AUTHORIZATION)?.to_str().ok()?;
+    let token = auth
+        .strip_prefix("Bearer ")
+        .or_else(|| auth.strip_prefix("bearer "))?
+        .trim();
+    if !token.starts_with(DEVICE_TOKEN_PREFIX) {
+        return None;
+    }
+    let device_id = req
+        .headers()
+        .get(DEVICE_ID_HEADER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .to_string();
+    if device_id.is_empty() {
+        return None;
+    }
+    Some((device_id, token.to_string()))
+}
+
+/// Whether the request carries a valid device-token credential.
+fn request_has_valid_device_token(req: &HttpRequest, config: &Config) -> bool {
+    match presented_device_token(req) {
+        Some((device_id, token)) => verify_device_token(config, &device_id, &token),
+        None => false,
+    }
+}
+
 fn access_verification_cookie_value(config: &Config) -> Option<String> {
     let access = config.access_control.as_ref()?;
     if !access.password_enabled {
@@ -244,7 +377,14 @@ fn build_access_verified_cookie(config: &Config, secure: bool) -> Option<Cookie<
 fn is_public_access_route(path: &str) -> bool {
     matches!(
         path,
-        "/api/v1/health" | "/v1/bamboo/access/status" | "/v1/bamboo/access/verify"
+        "/api/v1/health"
+            | "/v1/bamboo/access/status"
+            | "/v1/bamboo/access/verify"
+            // v2-P2 (#181): a brand-new device has no credential yet, so the
+            // pairing endpoint must be reachable unauthenticated. It self-gates
+            // by requiring the owner root password in its body. `/v2/stream`
+            // stays GATED.
+            | "/v2/pair"
     )
 }
 
@@ -272,8 +412,14 @@ pub async fn enforce_access_password_middleware<B: MessageBody + 'static>(
 
     let config = app_state.config.read().await.clone();
     let access_status = build_access_status(&config, req.request());
+    // Auth is required when a credential mechanism is configured (a root password
+    // OR at least one active device) AND the request is not a local bypass. An
+    // instance with NO devices + NO password behaves EXACTLY as before — zero
+    // regression. When required, accept EITHER a verified password cookie OR a
+    // valid per-device token (#181).
     if !access_status.requires_password
         || request_has_verified_access_cookie(req.request(), &config)
+        || request_has_valid_device_token(req.request(), &config)
     {
         return next
             .call(req)
@@ -281,7 +427,7 @@ pub async fn enforce_access_password_middleware<B: MessageBody + 'static>(
             .map(ServiceResponse::map_into_left_body);
     }
 
-    let response = AppError::Unauthorized("access password verification required".to_string())
+    let response = AppError::Unauthorized("access credential verification required".to_string())
         .error_response()
         .map_into_right_body();
     Ok(req.into_response(response))
@@ -306,11 +452,15 @@ fn build_access_status(config: &Config, req: &HttpRequest) -> AccessStatusRespon
         })
         .unwrap_or(false);
     let local_bypass = is_local_request(req);
+    // v2-P2 (#181): once any device is paired, public access requires a
+    // credential even if the root password itself is unset — the device tokens
+    // become the gating mechanism. No devices + no password ⇒ unchanged behavior.
+    let credential_required = password_enabled || has_active_devices(config);
 
     AccessStatusResponse {
         password_enabled,
         local_bypass,
-        requires_password: password_enabled && !local_bypass,
+        requires_password: credential_required && !local_bypass,
     }
 }
 
@@ -390,12 +540,15 @@ pub async fn update_access_password(
     app_state
         .update_config(
             move |config| {
-                config.access_control = Some(AccessControlConfig {
-                    password_enabled: true,
-                    password_hash: Some(password_hash.clone()),
-                    password_salt: Some(salt_hex.clone()),
-                    updated_at: Some(updated_at.clone()),
-                });
+                // Mutate in place so an existing `access_control` keeps its paired
+                // `devices` across a root-password change. Replacing the whole
+                // struct with `devices: vec![]` would silently wipe every device
+                // token on every password update (#181).
+                let access = config.access_control.get_or_insert_with(Default::default);
+                access.password_enabled = true;
+                access.password_hash = Some(password_hash.clone());
+                access.password_salt = Some(salt_hex.clone());
+                access.updated_at = Some(updated_at.clone());
                 Ok(())
             },
             ConfigUpdateEffects::default(),
@@ -408,10 +561,92 @@ pub async fn update_access_password(
     }))
 }
 
+// ── v2-P2 pairing (#181) ────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct PairDeviceRequest {
+    /// Owner root password — authorizes first-device pairing.
+    #[serde(default)]
+    pub root_password: String,
+    /// Human-readable device label, e.g. "iPhone 15".
+    #[serde(default)]
+    pub label: String,
+}
+
+#[derive(Serialize)]
+pub struct PairDeviceResponse {
+    pub device_id: String,
+    /// Plaintext token — returned ONCE; the server stores only its hash.
+    pub device_token: String,
+    pub expires_hint: &'static str,
+}
+
+/// `POST /v2/pair` — first-device pairing via the owner root password.
+///
+/// Slice 1 implements ONLY the root-password path. Pairing CODES
+/// (`POST /v2/pair/code` + code-based `/v2/pair`) are deferred to slice 2.
+///
+/// The endpoint is on the public whitelist (a new device has no credential), so
+/// it self-gates: it requires the owner root password. If no root password is
+/// configured, pairing is refused with a clear instruction to set one first —
+/// the root credential is required to authorize issuing device tokens.
+pub async fn pair_device(
+    payload: web::Json<PairDeviceRequest>,
+    app_state: web::Data<AppState>,
+) -> Result<HttpResponse, AppError> {
+    let label = payload.label.trim();
+    if label.is_empty() {
+        return Err(AppError::BadRequest("label is required".to_string()));
+    }
+
+    let config = app_state.config.read().await.clone();
+
+    let password_enabled = config
+        .access_control
+        .as_ref()
+        .map(|access| access.password_enabled)
+        .unwrap_or(false);
+    if !password_enabled {
+        return Err(AppError::BadRequest(
+            "set an access password first: the owner root password is required to authorize device pairing".to_string(),
+        ));
+    }
+
+    let root_password = payload.root_password.trim();
+    if root_password.is_empty() || !verify_password(&config, root_password) {
+        return Err(AppError::Unauthorized("invalid root password".to_string()));
+    }
+
+    let (credential, token) = issue_device_token(label);
+    let device_id = credential.device_id.clone();
+
+    app_state
+        .update_config(
+            move |config| {
+                // Preserve every existing field + already-paired devices: append,
+                // never replace.
+                let access = config.access_control.get_or_insert_with(Default::default);
+                access.devices.push(credential.clone());
+                Ok(())
+            },
+            ConfigUpdateEffects::default(),
+        )
+        .await?;
+
+    // NOTE: `token` is the plaintext credential — it is returned to the client
+    // here ONCE and is never logged.
+    Ok(HttpResponse::Ok().json(PairDeviceResponse {
+        device_id,
+        device_token: token,
+        expires_hint: "rotate-on-demand",
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use actix_web::test::TestRequest;
+    use bamboo_config::AccessControlConfig;
 
     #[test]
     fn loopback_request_is_local() {
@@ -449,11 +684,163 @@ mod tests {
                 password_hash: Some(hash),
                 password_salt: Some(salt_hex),
                 updated_at: None,
+                devices: Vec::new(),
             }),
             ..Config::default()
         };
 
         assert!(verify_password(&config, "secret"));
         assert!(!verify_password(&config, "wrong"));
+    }
+
+    // ── v2-P2 device token primitives + gate (#181) ────────────────────────
+
+    fn config_with_password() -> Config {
+        let salt_hex = hex::encode([1_u8; 16]);
+        let hash = compute_password_hash("secret", &salt_hex).unwrap();
+        Config {
+            access_control: Some(AccessControlConfig {
+                password_enabled: true,
+                password_hash: Some(hash),
+                password_salt: Some(salt_hex),
+                updated_at: None,
+                devices: Vec::new(),
+            }),
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn constant_time_eq_matches_and_rejects() {
+        assert!(constant_time_eq(b"abcd", b"abcd"));
+        assert!(!constant_time_eq(b"abcd", b"abce"));
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+    }
+
+    #[test]
+    fn issued_token_has_expected_format_and_verifies() {
+        let (cred, token) = issue_device_token("iPhone 15");
+        assert!(token.starts_with("bd1_"));
+        assert_eq!(token.len(), "bd1_".len() + 32);
+        assert!(cred.device_id.starts_with("bamboo_"));
+        assert_eq!(cred.device_id.len(), "bamboo_".len() + 12);
+        assert_eq!(cred.label, "iPhone 15");
+        assert!(!cred.revoked);
+        // The plaintext token must NOT be stored anywhere on the credential.
+        assert_ne!(cred.token_hash, token);
+
+        let mut config = config_with_password();
+        config
+            .access_control
+            .as_mut()
+            .unwrap()
+            .devices
+            .push(cred.clone());
+
+        assert!(verify_device_token(&config, &cred.device_id, &token));
+        assert!(!verify_device_token(&config, &cred.device_id, "bd1_wrong"));
+        assert!(!verify_device_token(&config, "bamboo_unknown", &token));
+    }
+
+    #[test]
+    fn revoked_token_is_rejected() {
+        let (mut cred, token) = issue_device_token("iPad");
+        cred.revoked = true;
+        let mut config = config_with_password();
+        let device_id = cred.device_id.clone();
+        config.access_control.as_mut().unwrap().devices.push(cred);
+        assert!(!verify_device_token(&config, &device_id, &token));
+    }
+
+    #[test]
+    fn has_active_devices_ignores_revoked() {
+        let mut config = config_with_password();
+        assert!(!has_active_devices(&config));
+        let (mut cred, _t) = issue_device_token("d");
+        cred.revoked = true;
+        config
+            .access_control
+            .as_mut()
+            .unwrap()
+            .devices
+            .push(cred.clone());
+        assert!(!has_active_devices(&config));
+        let (cred2, _t2) = issue_device_token("d2");
+        config.access_control.as_mut().unwrap().devices.push(cred2);
+        assert!(has_active_devices(&config));
+    }
+
+    fn remote_req() -> HttpRequest {
+        TestRequest::default()
+            .insert_header((header::HOST, "bamboo.example.com"))
+            .to_http_request()
+    }
+
+    fn local_req() -> HttpRequest {
+        TestRequest::default()
+            .insert_header((header::HOST, "localhost:9562"))
+            .to_http_request()
+    }
+
+    #[test]
+    fn no_devices_no_password_does_not_require_credential() {
+        // Zero-regression baseline: an instance with neither password nor devices
+        // never requires a credential, even for a remote request.
+        let config = Config::default();
+        assert!(!build_access_status(&config, &remote_req()).requires_password);
+    }
+
+    #[test]
+    fn password_only_gate_matches_prior_behavior() {
+        let config = config_with_password();
+        assert!(build_access_status(&config, &remote_req()).requires_password);
+        assert!(!build_access_status(&config, &local_req()).requires_password);
+    }
+
+    #[test]
+    fn device_presence_requires_credential_even_without_password() {
+        // A device paired but no root password still gates remote access.
+        let (cred, _t) = issue_device_token("d");
+        let config = Config {
+            access_control: Some(AccessControlConfig {
+                password_enabled: false,
+                password_hash: None,
+                password_salt: None,
+                updated_at: None,
+                devices: vec![cred],
+            }),
+            ..Config::default()
+        };
+        assert!(build_access_status(&config, &remote_req()).requires_password);
+        // Local still bypasses.
+        assert!(!build_access_status(&config, &local_req()).requires_password);
+    }
+
+    #[test]
+    fn valid_device_token_on_request_authenticates() {
+        let (cred, token) = issue_device_token("d");
+        let device_id = cred.device_id.clone();
+        let mut config = config_with_password();
+        config.access_control.as_mut().unwrap().devices.push(cred);
+
+        let req = TestRequest::default()
+            .insert_header((header::HOST, "bamboo.example.com"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .insert_header((DEVICE_ID_HEADER, device_id))
+            .to_http_request();
+        assert!(request_has_valid_device_token(&req, &config));
+
+        // Wrong token rejected.
+        let bad = TestRequest::default()
+            .insert_header((header::AUTHORIZATION, "Bearer bd1_deadbeef"))
+            .insert_header((DEVICE_ID_HEADER, "bamboo_unknown"))
+            .to_http_request();
+        assert!(!request_has_valid_device_token(&bad, &config));
+
+        // Missing device-id header → not a credential.
+        let no_id = TestRequest::default()
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_http_request();
+        assert!(!request_has_valid_device_token(&no_id, &config));
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/access_control.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/access_control.rs
@@ -241,8 +241,10 @@ pub(crate) fn issue_device_token(label: &str) -> (DeviceCredential, String) {
     let token = format!("{DEVICE_TOKEN_PREFIX}{}", random_hex(16));
     let salt_hex = random_hex(16);
     // compute_password_hash only returns None on a non-hex salt; ours is always
-    // valid hex, so the hash is infallible here.
-    let token_hash = compute_password_hash(&token, &salt_hex).unwrap_or_default();
+    // valid hex, so the hash is infallible here. Fail loudly rather than persist
+    // an empty (dead) token_hash if that invariant is ever broken.
+    let token_hash =
+        compute_password_hash(&token, &salt_hex).expect("device salt is always valid hex");
     let created_at = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
 
     let credential = DeviceCredential {
@@ -265,6 +267,8 @@ pub(crate) fn verify_device_token(config: &Config, device_id: &str, token: &str)
     let Some(access) = config.access_control.as_ref() else {
         return false;
     };
+    // device_id is a public, non-secret companion id; a plain `==` lookup here is
+    // intentional. Only the token hash compare below must be constant-time.
     let Some(device) = access.devices.iter().find(|d| d.device_id == device_id) else {
         return false;
     };

--- a/crates/app/bamboo-server/src/handlers/settings/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/mod.rs
@@ -14,8 +14,9 @@ mod redaction;
 mod setup;
 mod workflows;
 
+pub(crate) use access_control::verify_device_token;
 pub use access_control::{
-    enforce_access_password_middleware, get_access_status, update_access_password,
+    enforce_access_password_middleware, get_access_status, pair_device, update_access_password,
     verify_access_password,
 };
 pub use bamboo_config::{

--- a/crates/app/bamboo-server/src/routes/agent.rs
+++ b/crates/app/bamboo-server/src/routes/agent.rs
@@ -267,10 +267,14 @@ pub fn agent_routes(cfg: &mut web::ServiceConfig) {
     // the SAME access-password middleware as `/api/v1`, so `local_bypass` keeps
     // desktop loopback frictionless and public access still requires the
     // password. The v1 SSE/REST endpoints above stay unchanged (dual-track).
+    // v2-P2 (#181): `/v2/pair` is on the public whitelist (a new device has no
+    // credential yet) and self-gates via the owner root password in its body.
+    // `/v2/stream` stays GATED by the same middleware.
     let v2_scope = web::scope("/v2")
         .wrap(actix_web::middleware::from_fn(
             settings::enforce_access_password_middleware,
         ))
+        .route("/pair", web::post().to(settings::pair_device))
         .route("/stream", web::get().to(agent::ws_v2::handler));
     cfg.service(v2_scope);
 }

--- a/crates/app/bamboo-server/src/routes/tests.rs
+++ b/crates/app/bamboo-server/src/routes/tests.rs
@@ -83,6 +83,7 @@ async fn remote_unverified_request_is_blocked_by_access_middleware() {
             ),
             password_salt: Some("01010101010101010101010101010101".to_string()),
             updated_at: None,
+            devices: Vec::new(),
         });
     }
     let app = test::init_service(App::new().app_data(app_state).configure(configure_routes)).await;
@@ -108,6 +109,7 @@ async fn access_bootstrap_endpoints_remain_public() {
             ),
             password_salt: Some("01010101010101010101010101010101".to_string()),
             updated_at: None,
+            devices: Vec::new(),
         });
     }
     let app = test::init_service(App::new().app_data(app_state).configure(configure_routes)).await;
@@ -140,6 +142,7 @@ async fn verified_cookie_allows_remote_request_through_middleware() {
             ),
             password_salt: Some("01010101010101010101010101010101".to_string()),
             updated_at: None,
+            devices: Vec::new(),
         });
     }
     let app = test::init_service(App::new().app_data(app_state).configure(configure_routes)).await;
@@ -234,6 +237,7 @@ async fn local_request_bypasses_access_middleware() {
             ),
             password_salt: Some("01010101010101010101010101010101".to_string()),
             updated_at: None,
+            devices: Vec::new(),
         });
     }
     let app = test::init_service(App::new().app_data(app_state).configure(configure_routes)).await;
@@ -309,6 +313,7 @@ async fn v2_stream_is_behind_access_middleware() {
             ),
             password_salt: Some("01010101010101010101010101010101".to_string()),
             updated_at: None,
+            devices: Vec::new(),
         });
     }
     let app = test::init_service(App::new().app_data(app_state).configure(configure_routes)).await;
@@ -323,4 +328,176 @@ async fn v2_stream_is_behind_access_middleware() {
         StatusCode::UNAUTHORIZED,
         "/v2/stream must be guarded by the access middleware for remote requests"
     );
+}
+
+// --- v2-P2 (#181): per-device token pairing + enforcement -----------------
+
+/// The hash of password "secret" with salt `01..01` (matches the literals above).
+const SECRET_HASH: &str = "a65192f8d645bc4d19765b8ea61bfbb896dc999cb88a4be419518c5493f92c9d";
+const SECRET_SALT: &str = "01010101010101010101010101010101";
+
+fn password_access_control() -> AccessControlConfig {
+    AccessControlConfig {
+        password_enabled: true,
+        password_hash: Some(SECRET_HASH.to_string()),
+        password_salt: Some(SECRET_SALT.to_string()),
+        updated_at: None,
+        devices: Vec::new(),
+    }
+}
+
+/// `POST /v2/pair` with the correct root password issues a device token whose
+/// hash (not the plaintext) is persisted; the token then authenticates a remote
+/// request through the access middleware.
+#[actix_web::test]
+async fn v2_pair_issues_token_that_authenticates_remote_request() {
+    let data_dir = tempdir().unwrap();
+    let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());
+    {
+        let mut config = app_state.config.write().await;
+        config.access_control = Some(password_access_control());
+    }
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .configure(configure_routes),
+    )
+    .await;
+
+    // Pair (public route; self-gates on root password).
+    let pair_req = test::TestRequest::post()
+        .uri("/v2/pair")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .set_json(serde_json::json!({ "root_password": "secret", "label": "iPhone 15" }))
+        .to_request();
+    let pair_resp = test::call_service(&app, pair_req).await;
+    assert_eq!(pair_resp.status(), StatusCode::OK);
+    let body = actix_web::body::to_bytes(pair_resp.into_body())
+        .await
+        .unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let device_id = payload["device_id"].as_str().unwrap().to_string();
+    let device_token = payload["device_token"].as_str().unwrap().to_string();
+    assert!(device_token.starts_with("bd1_"));
+    assert!(device_id.starts_with("bamboo_"));
+
+    // The plaintext token is NEVER persisted — only the hash.
+    {
+        let config = app_state.config.read().await;
+        let devices = &config.access_control.as_ref().unwrap().devices;
+        assert_eq!(devices.len(), 1);
+        assert_ne!(devices[0].token_hash, device_token);
+    }
+
+    // The token authenticates a remote request through the middleware.
+    let ok_req = test::TestRequest::get()
+        .uri("/v1/bamboo/workflows")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .insert_header((header::AUTHORIZATION, format!("Bearer {device_token}")))
+        .insert_header(("X-Device-Id", device_id))
+        .to_request();
+    let ok_resp = test::call_service(&app, ok_req).await;
+    assert_eq!(ok_resp.status(), StatusCode::OK);
+
+    // A bogus token is rejected.
+    let bad_req = test::TestRequest::get()
+        .uri("/v1/bamboo/workflows")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .insert_header((header::AUTHORIZATION, "Bearer bd1_deadbeef"))
+        .insert_header(("X-Device-Id", "bamboo_000000000000"))
+        .to_request();
+    let bad_resp = test::call_service(&app, bad_req).await;
+    assert_eq!(bad_resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// `POST /v2/pair` with a wrong root password is rejected with 401.
+#[actix_web::test]
+async fn v2_pair_rejects_wrong_root_password() {
+    let data_dir = tempdir().unwrap();
+    let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());
+    {
+        let mut config = app_state.config.write().await;
+        config.access_control = Some(password_access_control());
+    }
+    let app = test::init_service(App::new().app_data(app_state).configure(configure_routes)).await;
+
+    let req = test::TestRequest::post()
+        .uri("/v2/pair")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .set_json(serde_json::json!({ "root_password": "wrong", "label": "x" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// `POST /v2/pair` when no root password is set returns 400 with guidance.
+#[actix_web::test]
+async fn v2_pair_requires_root_password_to_be_set() {
+    let data_dir = tempdir().unwrap();
+    let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());
+    let app = test::init_service(App::new().app_data(app_state).configure(configure_routes)).await;
+
+    let req = test::TestRequest::post()
+        .uri("/v2/pair")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .set_json(serde_json::json!({ "root_password": "", "label": "x" }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+/// Changing the root password MUST preserve already-paired devices — replacing
+/// the whole `AccessControlConfig` would silently wipe every device token.
+#[actix_web::test]
+async fn password_change_preserves_paired_devices() {
+    let data_dir = tempdir().unwrap();
+    let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());
+    {
+        let mut config = app_state.config.write().await;
+        config.access_control = Some(password_access_control());
+    }
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .configure(configure_routes),
+    )
+    .await;
+
+    // Pair a device.
+    let pair_req = test::TestRequest::post()
+        .uri("/v2/pair")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .set_json(serde_json::json!({ "root_password": "secret", "label": "iPad" }))
+        .to_request();
+    let pair_resp = test::call_service(&app, pair_req).await;
+    assert_eq!(pair_resp.status(), StatusCode::OK);
+    let device_count_before = app_state
+        .config
+        .read()
+        .await
+        .access_control
+        .as_ref()
+        .unwrap()
+        .devices
+        .len();
+    assert_eq!(device_count_before, 1);
+
+    // Change the root password (local bypass → current_password not required).
+    let change_req = test::TestRequest::post()
+        .uri("/v1/bamboo/access/password")
+        .insert_header((header::HOST, "localhost:9562"))
+        .set_json(serde_json::json!({ "new_password": "newsecret" }))
+        .to_request();
+    let change_resp = test::call_service(&app, change_req).await;
+    assert_eq!(change_resp.status(), StatusCode::OK);
+
+    // The device survives the password change.
+    let config = app_state.config.read().await;
+    let access = config.access_control.as_ref().unwrap();
+    assert_eq!(
+        access.devices.len(),
+        1,
+        "password change must NOT wipe paired devices"
+    );
+    assert_eq!(access.devices[0].label, "iPad");
 }

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -109,6 +109,38 @@ pub struct AccessControlConfig {
     /// Last update timestamp for auditing / debugging.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
+    /// v2 (#181): issued per-device tokens. Empty = root-password-only mode
+    /// (back-compat with old instances). Each entry stores only the token hash;
+    /// the plaintext token is returned to the client once at pairing time.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub devices: Vec<DeviceCredential>,
+}
+
+/// A single paired device's credential (v2-P2 per-device token, #181).
+///
+/// The server stores only `token_hash` (never the plaintext token). The hash is
+/// computed with the SAME construction as the access password — `SHA-256(salt ||
+/// token)` — so no new crypto dependency is introduced (`docs/api-v2-transport.md`
+/// §4.2).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeviceCredential {
+    /// Server-generated stable id: `bamboo_<12 hex>`.
+    pub device_id: String,
+    /// Human-readable label, e.g. "iPhone 15".
+    pub label: String,
+    /// `SHA-256(hex_decode(token_salt) || token)`, hex-encoded.
+    pub token_hash: String,
+    /// Per-device salt (hex-encoded).
+    pub token_salt: String,
+    /// RFC3339 creation timestamp.
+    pub created_at: String,
+    /// RFC3339 last-used timestamp (deferred stamping; see PR).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_used_at: Option<String>,
+    /// Whether this device's token has been revoked. A revoked token is rejected
+    /// at the handshake/middleware immediately.
+    #[serde(default)]
+    pub revoked: bool,
 }
 
 /// Memory and background summarization configuration.
@@ -2127,6 +2159,64 @@ mod tests {
         assert!(value.as_object().unwrap().contains_key("tls"));
         let back: ServerConfig = serde_json::from_value(value).expect("deserialize");
         assert_eq!(back.tls, server.tls);
+    }
+
+    #[test]
+    fn access_control_without_devices_field_deserializes_back_compat() {
+        // An old config.json `access_control` with no `devices` key must still
+        // deserialize, leaving `devices` empty (root-password-only mode).
+        let access: AccessControlConfig = serde_json::from_value(serde_json::json!({
+            "password_enabled": true,
+            "password_hash": "deadbeef",
+            "password_salt": "01020304",
+        }))
+        .expect("legacy access_control without devices should deserialize");
+
+        assert!(access.devices.is_empty());
+        assert!(access.password_enabled);
+    }
+
+    #[test]
+    fn access_control_omits_devices_when_empty() {
+        // `skip_serializing_if = "Vec::is_empty"` keeps the on-disk shape
+        // identical for instances that never paired a device.
+        let access = AccessControlConfig {
+            password_enabled: true,
+            password_hash: Some("deadbeef".to_string()),
+            password_salt: Some("01020304".to_string()),
+            updated_at: None,
+            devices: Vec::new(),
+        };
+        let value = serde_json::to_value(&access).expect("serialize");
+        let obj = value.as_object().expect("object");
+        assert!(
+            !obj.contains_key("devices"),
+            "devices must be omitted when empty, got: {value}"
+        );
+    }
+
+    #[test]
+    fn access_control_with_devices_roundtrips() {
+        let device = DeviceCredential {
+            device_id: "bamboo_0123456789ab".to_string(),
+            label: "iPhone 15".to_string(),
+            token_hash: "abcd".to_string(),
+            token_salt: "ef01".to_string(),
+            created_at: "2026-06-23T00:00:00Z".to_string(),
+            last_used_at: None,
+            revoked: false,
+        };
+        let access = AccessControlConfig {
+            password_enabled: true,
+            password_hash: Some("deadbeef".to_string()),
+            password_salt: Some("01020304".to_string()),
+            updated_at: None,
+            devices: vec![device.clone()],
+        };
+        let value = serde_json::to_value(&access).expect("serialize");
+        assert!(value.as_object().unwrap().contains_key("devices"));
+        let back: AccessControlConfig = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(back.devices, vec![device]);
     }
 
     #[test]


### PR DESCRIPTION
Slice 1 of v2-P2 per-device tokens — a complete vertical slice (no dead code): config storage + token primitives + POST /v2/pair (root-password path) + additive middleware enforcement + WS hello identity binding. Spec: docs/api-v2-transport.md §4, §4.5, §11.

## Data model
AccessControlConfig gains:

    #[serde(default, skip_serializing_if = "Vec::is_empty")]
    pub devices: Vec<DeviceCredential>,

DeviceCredential { device_id, label, token_hash, token_salt, created_at, last_used_at, revoked }. Empty devices = root-password-only mode; on disk the shape is byte-identical to old configs (skip_serializing_if). Back-compat (de)serialization tests added: an old config with no devices key deserializes to an empty vec; serialization omits devices when empty; a populated config round-trips.

## Token format + presentation
- Device token: bd1_ + 32 hex (16 random bytes).
- Device id: bamboo_ + 12 hex (6 random bytes), server-generated.
- Hash: the SAME SHA-256(hex_decode(salt) || secret) construction as the access password — no new crypto dependency. A fresh 16-byte salt per device.
- Presentation scheme (documented in code): the token rides in Authorization: Bearer bd1_... and its companion device id in X-Device-Id: bamboo_... (the token alone cannot locate its per-device salt).

## POST /v2/pair (root-password path)
Body { root_password, label }. Verifies the owner root password via the existing verify_password. If no root password is set, returns 400 instructing the operator to set an access password first (the root credential authorizes pairing). Wrong password -> 401. On success issues a token, appends it to devices PRESERVING all existing fields + devices, and returns 200 { device_id, device_token, expires_hint: "rotate-on-demand" }. The plaintext token is returned ONCE; only its hash is persisted. /v2/pair is added to the public whitelist (a new device has no credential, self-gates on root_password); /v2/stream stays gated.

## Middleware enforcement (additive, zero regression)
Gate condition becomes (password_enabled OR has_active_devices) AND NOT local_bypass, where has_active_devices = any non-revoked device. An instance with NO devices + NO password behaves EXACTLY as today. When auth is required, the request passes if ANY of: a verified password cookie (existing) OR a valid device token. local_bypass (loopback/LAN) still bypasses entirely — desktop unchanged. Per-request last_used_at stamping is intentionally NOT done (would be a config write per request); deferred.

## WS hello identity binding
The scope middleware is the primary gate. The hello frame now adds identity binding: a hello carrying device_id + token is verified via verify_device_token and the connection is CLOSED on mismatch; a token-less hello (e.g. a local desktop the middleware already bypassed) keeps the prior accept behavior. The token is never logged.

## Constant-time compare
The device-token hash comparison uses a hand-rolled constant-time byte compare (defense-in-depth for the new credential path) rather than ==. Chosen over adding the subtle crate as a direct dependency — subtle is only present transitively (via aes-gcm), and the task prefers a hand-rolled compare over a new dep. The pre-existing password path keeps its == (unchanged).

## Devices-preservation-on-password-change fix
update_access_password previously rebuilt the whole AccessControlConfig struct. Adding devices: vec![] there would have silently wiped every device token on every password change. Fixed by mutating access_control in place (get_or_insert_with(Default::default) + field assignments). Every other AccessControlConfig { ... } struct literal in the workspace (5 in routes/tests.rs + 2 test literals in access_control.rs) was updated for the new field. A test proves a password change preserves a paired device.

## Tests
bamboo-config: 3 new back-compat/round-trip tests. bamboo-server: token format + roundtrip verify, revoked/unknown/wrong-token rejection, has_active_devices ignores revoked, constant-time compare, the gate (no-devices+no-password requires nothing; password-only matches prior; device presence gates even without a password; local always bypasses), a valid device token authenticating a request, and three /v2/pair end-to-end tests (issue+authenticate, wrong password -> 401, no-password -> 400) + the password-change-preserves-devices test. cargo test -p bamboo-config -p bamboo-server is green; cargo fmt + clippy clean on the new code (remaining server clippy warnings are pre-existing in terminal.rs / ready.rs and unrelated crates).

## DEFERRED to slice 2 (not in this PR)
- Pairing codes: POST /v2/pair/code + code-based /v2/pair (subsequent-device pairing without the root password).
- /v2/devices management: list / revoke / rotate.
- broker Bearer / remoting, msgpack subprotocol, per-request last_used_at stamping.

Refs #181 (v2-P2 per-device tokens — slice 1: config + pair + enforcement)

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp
