### PR TITLE
feat(subagent): remote-actor P1 — bind_tls + Bearer + ConnectLauncher [#181]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,7 +2742,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4112,7 +4112,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -5079,8 +5079,12 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -5359,6 +5363,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.6",
+ "rustls",
+ "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 1.0.69",
  "utf-8",
@@ -5684,6 +5690,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,11 +1275,14 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures-util",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-rustls",
  "tokio-tungstenite",
  "tokio-util",
  "uuid",
@@ -4313,6 +4316,7 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/crates/infra/bamboo-subagent/Cargo.toml
+++ b/crates/infra/bamboo-subagent/Cargo.toml
@@ -17,6 +17,12 @@ futures-util = "0.3"
 tokio = { version = "1", features = ["fs", "io-util", "io-std", "rt", "rt-multi-thread", "sync", "macros", "net", "time", "process"] }
 tokio-util = "0.7"
 tokio-tungstenite = "0.24"
+# TLS termination for a remotely-reachable worker (remote-actor-plan P1, #181).
+# default-features=false + ["ring","std","tls12"] matches the server's TLS face
+# (#183) so the workspace resolves a single rustls/ring provider.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
+rustls-pemfile = "2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/crates/infra/bamboo-subagent/Cargo.toml
+++ b/crates/infra/bamboo-subagent/Cargo.toml
@@ -16,7 +16,10 @@ async-trait = "0.1"
 futures-util = "0.3"
 tokio = { version = "1", features = ["fs", "io-util", "io-std", "rt", "rt-multi-thread", "sync", "macros", "net", "time", "process"] }
 tokio-util = "0.7"
-tokio-tungstenite = "0.24"
+# rustls-tls-webpki-roots gives the CLIENT (`ChildClient`) real wss:// support
+# against standard CA roots, and pulls in the `Connector` API so a parent can
+# also pin a self-signed worker cert via connect_with_auth_tls (remote-actor P1).
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 # TLS termination for a remotely-reachable worker (remote-actor-plan P1, #181).
 # default-features=false + ["ring","std","tls12"] matches the server's TLS face
 # (#183) so the workspace resolves a single rustls/ring provider.

--- a/crates/infra/bamboo-subagent/src/fleet.rs
+++ b/crates/infra/bamboo-subagent/src/fleet.rs
@@ -20,20 +20,39 @@ use crate::proto::AgentRecord;
 use crate::provision::ProvisionSpec;
 use crate::transport::{TransportError, TransportResult};
 
-/// A spawned actor subprocess plus its discovered record. Killed on drop (`kill_on_drop`).
+/// A launched actor plus its discovered record.
+///
+/// `process` is `Some` for a locally-spawned subprocess (killed on drop via
+/// `kill_on_drop`) and `None` for a remote resident worker reached over the
+/// network (remote-actor-plan P1, #181): a `ConnectLauncher` owns no OS process,
+/// so `kill()` is a no-op and `pid()` returns `None`. The parent reclaims a
+/// remote worker by closing the connection + the worker's own idle timeout, not
+/// by killing a process it does not own.
 pub struct SpawnedChild {
     pub record: AgentRecord,
-    process: Child,
+    process: Option<Child>,
 }
 
 impl SpawnedChild {
-    /// Terminate the child process.
+    /// Build a record-only handle for a worker this process does not own (a
+    /// remote resident worker connected to, not spawned). `kill()`/`pid()` are
+    /// inert.
+    pub fn remote(record: AgentRecord) -> Self {
+        Self {
+            record,
+            process: None,
+        }
+    }
+
+    /// Terminate the child process. A no-op for a remote (process-less) worker.
     pub async fn kill(mut self) {
-        let _ = self.process.kill().await;
+        if let Some(mut process) = self.process.take() {
+            let _ = process.kill().await;
+        }
     }
 
     pub fn pid(&self) -> Option<u32> {
-        self.process.id()
+        self.process.as_ref().and_then(|p| p.id())
     }
 }
 
@@ -79,7 +98,10 @@ pub async fn spawn_worker(
     let deadline = Instant::now() + wait;
     loop {
         if let Ok(Some(record)) = fab.resolve(&child_id).await {
-            return Ok(SpawnedChild { record, process });
+            return Ok(SpawnedChild {
+                record,
+                process: Some(process),
+            });
         }
         // bail early if the worker died before registering
         if let Ok(Some(status)) = process.try_wait() {

--- a/crates/infra/bamboo-subagent/src/launcher.rs
+++ b/crates/infra/bamboo-subagent/src/launcher.rs
@@ -11,10 +11,12 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use chrono::Utc;
 
 use crate::fleet::{spawn_worker, SpawnedChild};
-use crate::provision::ProvisionSpec;
-use crate::transport::TransportResult;
+use crate::proto::AgentRecord;
+use crate::provision::{Placement, ProvisionSpec};
+use crate::transport::{ChildClient, TransportError, TransportResult};
 
 /// Brings up (or connects to) one actor worker for a [`ProvisionSpec`] and waits
 /// up to `wait` for it to become reachable (self-registered in discovery).
@@ -49,9 +51,75 @@ impl WorkerLauncher for LocalSubprocessLauncher {
     }
 }
 
+/// Connect to an already-running resident worker instead of spawning one
+/// (remote-actor-plan §3.1 / P1). Owns no OS process: the returned
+/// [`SpawnedChild`] carries `process: None`, so its `kill()` is a no-op and the
+/// parent reclaims the worker by closing the connection + the worker's own idle
+/// timeout.
+///
+/// The launcher reads everything it needs from the spec:
+/// - `spec.placement` MUST be [`Placement::Remote`] — it supplies the endpoint.
+/// - `spec.secrets.worker_auth_token` supplies the bearer used for the
+///   connectivity probe (it is NEVER copied into the discovery `AgentRecord`).
+pub struct ConnectLauncher;
+
+#[async_trait]
+impl WorkerLauncher for ConnectLauncher {
+    async fn launch(&self, spec: &ProvisionSpec, wait: Duration) -> TransportResult<SpawnedChild> {
+        let endpoint = match &spec.placement {
+            Placement::Remote { endpoint } => endpoint.clone(),
+            other => {
+                return Err(TransportError::Protocol(format!(
+                    "ConnectLauncher requires Placement::Remote, got {other:?}"
+                )))
+            }
+        };
+
+        // Connectivity probe: connect (with the bearer if any) and close again,
+        // bounded by `wait`, so an unreachable / mis-authenticated worker fails
+        // fast here instead of at the first `Run`. The token authenticates the
+        // probe but never leaves this scope.
+        let token = spec.secrets.worker_auth_token.as_deref();
+        let probe = ChildClient::connect_with_auth(&endpoint, token);
+        match tokio::time::timeout(wait, probe).await {
+            Ok(Ok(client)) => {
+                let _ = client.close().await;
+            }
+            Ok(Err(e)) => {
+                return Err(TransportError::Protocol(format!(
+                    "remote worker '{}' unreachable at {endpoint}: {e}",
+                    spec.identity.child_id
+                )))
+            }
+            Err(_) => {
+                return Err(TransportError::Protocol(format!(
+                    "remote worker '{}' did not accept a connection at {endpoint} within {wait:?}",
+                    spec.identity.child_id
+                )))
+            }
+        }
+
+        // Synthesize a record from the spec's identity + the remote endpoint.
+        // No owned process (pid 0) and NO token (tokens never go in discovery
+        // records).
+        let record = AgentRecord {
+            agent_id: spec.identity.child_id.clone(),
+            role: spec.identity.role.clone(),
+            labels: Vec::new(),
+            endpoint,
+            pid: 0,
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            started_at: Utc::now(),
+            lease_expires_at: Utc::now() + chrono::Duration::seconds(60),
+        };
+        Ok(SpawnedChild::remote(record))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provision::{ChildIdentity, ExecutorSpec};
 
     /// The launcher must be object-safe so it can be stored as
     /// `Arc<dyn WorkerLauncher>` (how the fleet will hold the chosen placement).
@@ -61,5 +129,35 @@ mod tests {
         let _dyn: &dyn WorkerLauncher = &launcher;
         assert_eq!(launcher.worker_bin, PathBuf::from("/bin/true"));
         assert_eq!(launcher.worker_args, vec!["subagent-worker".to_string()]);
+    }
+
+    #[test]
+    fn connect_launcher_is_a_trait_object() {
+        let _dyn: &dyn WorkerLauncher = &ConnectLauncher;
+    }
+
+    /// A non-Remote placement is a clear error (no spawn, no connect).
+    #[tokio::test]
+    async fn connect_launcher_rejects_non_remote_placement() {
+        let spec = ProvisionSpec::new(
+            ChildIdentity {
+                child_id: "c1".into(),
+                parent_id: None,
+                project_key: None,
+                role: "demo".into(),
+                depth: 0,
+            },
+            ExecutorSpec::Echo,
+            "/tmp/fabric".into(),
+        );
+        // Default placement is Local.
+        let result = ConnectLauncher
+            .launch(&spec, Duration::from_millis(100))
+            .await;
+        match result {
+            Err(TransportError::Protocol(m)) if m.contains("Placement::Remote") => {}
+            Err(other) => panic!("expected a clear Placement::Remote error, got {other:?}"),
+            Ok(_) => panic!("Local placement must be rejected"),
+        }
     }
 }

--- a/crates/infra/bamboo-subagent/src/lib.rs
+++ b/crates/infra/bamboo-subagent/src/lib.rs
@@ -28,7 +28,7 @@ pub use discovery::{Discovery, Fabric, FileFabric};
 pub use error::{Result, StoreError};
 pub use executor::{ChildExecutor, ChildOutcome, EchoExecutor, EventSink, SteerInbox};
 pub use fleet::{spawn_worker, SpawnedChild};
-pub use launcher::{LocalSubprocessLauncher, WorkerLauncher};
+pub use launcher::{ConnectLauncher, LocalSubprocessLauncher, WorkerLauncher};
 pub use mailbox::{
     AdmittedSet, AgentRef, AskBody, AskMode, Delivered, InboxKind, InboxMessage, Mailbox, MsgId,
     ReplyBody, ADMITTED_SET_CAPACITY,

--- a/crates/infra/bamboo-subagent/src/provision.rs
+++ b/crates/infra/bamboo-subagent/src/provision.rs
@@ -223,6 +223,14 @@ pub struct Limits {
 pub struct SecretsEnvelope {
     #[serde(default)]
     pub provider_credentials: Vec<ScopedCredential>,
+    /// Bearer token a remote resident worker requires on the WS handshake
+    /// (remote-actor-plan §3.4 / P1). The parent puts the worker's expected
+    /// token here and `ConnectLauncher` reads it to authenticate the connect.
+    /// Additive + forward-compatible (older specs deserialize with `None`).
+    /// Never published in a discovery `AgentRecord` — tokens stay in the
+    /// scoped envelope, not in advertised records.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker_auth_token: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -368,6 +376,33 @@ mod tests {
             Placement::Remote {
                 endpoint: "wss://gpu-host:8443".into()
             }
+        );
+    }
+
+    #[test]
+    fn worker_auth_token_defaults_none_and_round_trips() {
+        // Absent in JSON ⇒ None (forward-compatible: older specs have no token).
+        assert!(SecretsEnvelope::default().worker_auth_token.is_none());
+        let minimal = serde_json::json!({
+            "version": 1,
+            "identity": { "child_id": "c" },
+            "executor": { "kind": "echo" },
+            "fabric_dir": "/tmp/f",
+        });
+        let parsed = ProvisionSpec::from_json(&minimal.to_string()).unwrap();
+        assert!(parsed.secrets.worker_auth_token.is_none());
+
+        // Round-trips when set, and is omitted from JSON when None.
+        let mut s = spec();
+        assert!(
+            !s.to_json().unwrap().contains("worker_auth_token"),
+            "None token must be skipped in serialization"
+        );
+        s.secrets.worker_auth_token = Some("T-secret".into());
+        let parsed = ProvisionSpec::from_json(&s.to_json().unwrap()).unwrap();
+        assert_eq!(
+            parsed.secrets.worker_auth_token.as_deref(),
+            Some("T-secret")
         );
     }
 

--- a/crates/infra/bamboo-subagent/src/transport.rs
+++ b/crates/infra/bamboo-subagent/src/transport.rs
@@ -289,12 +289,30 @@ impl Callback for BearerCallback {
     }
 }
 
-/// Constant-form check that an `Authorization` header is `Bearer <expected>`.
+/// Check that an `Authorization` header is `Bearer <expected>`, comparing the
+/// token in constant time so a network attacker cannot recover it byte-by-byte
+/// via response timing (mirrors `bamboo-server`'s `constant_time_eq` convention
+/// for credential comparison). The `Bearer ` prefix is non-secret, so the
+/// `strip_prefix` short-circuit is fine.
 fn bearer_matches(header: &str, expected: &str) -> bool {
-    header
-        .strip_prefix("Bearer ")
-        .map(|t| t == expected)
-        .unwrap_or(false)
+    match header.strip_prefix("Bearer ") {
+        Some(t) => constant_time_eq(t.as_bytes(), expected.as_bytes()),
+        None => false,
+    }
+}
+
+/// Constant-time byte comparison: returns early only on a length mismatch
+/// (length is not secret), then folds all bytes so the time does not depend on
+/// where a mismatch occurs.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 /// Build a rustls [`rustls::ServerConfig`] from PEM cert/key files against an
@@ -337,6 +355,45 @@ fn build_server_config(cert_file: &Path, key_file: &Path) -> Result<rustls::Serv
         .map_err(|e| {
             format!("rustls rejected cert/key (cert '{cert_path}', key '{key_path}'): {e}")
         })
+}
+
+/// Build a rustls [`rustls::ClientConfig`] that trusts exactly the certificate(s)
+/// in `cert_file` (PEM) as roots — for a parent connecting over `wss://` to a
+/// worker with a self-signed cert under single-direction TLS (remote-actor-plan
+/// §7 Q2: "P1 先单向"). The worker's cert must carry a SAN matching the endpoint
+/// host (e.g. `IP:127.0.0.1`) for rustls to accept it. Uses the explicit `ring`
+/// provider to match the rest of the workspace. For CA-signed worker certs use
+/// [`ChildClient::connect_with_auth`] (default webpki roots) instead.
+pub fn client_config_trusting_cert(cert_file: &Path) -> Result<rustls::ClientConfig, String> {
+    use std::fs::File;
+    use std::io::BufReader;
+
+    let cert_path = cert_file.display();
+    let cf = File::open(cert_file).map_err(|e| format!("open cert_file '{cert_path}': {e}"))?;
+    let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
+        rustls_pemfile::certs(&mut BufReader::new(cf))
+            .collect::<Result<_, _>>()
+            .map_err(|e| format!("parse cert_file '{cert_path}': {e}"))?;
+    if certs.is_empty() {
+        return Err(format!(
+            "no certificates in cert_file '{cert_path}' (expected PEM CERTIFICATE blocks)"
+        ));
+    }
+
+    let mut roots = rustls::RootCertStore::empty();
+    for cert in certs {
+        roots
+            .add(cert)
+            .map_err(|e| format!("add trust anchor from '{cert_path}': {e}"))?;
+    }
+
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let cfg = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| format!("protocol versions: {e}"))?
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    Ok(cfg)
 }
 
 /// Drive an already-upgraded WS connection (generic over the underlying stream
@@ -517,23 +574,50 @@ impl ChildClient {
     }
 
     /// Connect to a worker endpoint, optionally presenting a bearer token on the
-    /// WS upgrade (`Authorization: Bearer <token>`). A `wss://` endpoint flows
-    /// through `MaybeTlsStream` transparently. The token is never logged.
+    /// WS upgrade (`Authorization: Bearer <token>`). The token is never logged.
+    ///
+    /// A `wss://` endpoint is negotiated against the standard webpki CA roots
+    /// (the `rustls-tls-webpki-roots` feature) — i.e. a worker serving a
+    /// CA-signed cert (Let's Encrypt etc.) works with no extra configuration. To
+    /// trust a self-signed worker cert (the typical P1 single-direction-TLS
+    /// case), use [`connect_with_auth_tls`](Self::connect_with_auth_tls) with a
+    /// client config built by [`client_config_trusting_cert`].
     pub async fn connect_with_auth(endpoint: &str, token: Option<&str>) -> TransportResult<Self> {
-        let (ws, _resp) = match token {
-            None => connect_async(endpoint).await?,
-            Some(token) => {
-                use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-                let mut request = endpoint.into_client_request().map_err(TransportError::Ws)?;
-                let value = format!("Bearer {token}")
-                    .parse()
-                    .map_err(|e| TransportError::Protocol(format!("bad bearer header: {e}")))?;
-                request.headers_mut().insert(
-                    tokio_tungstenite::tungstenite::http::header::AUTHORIZATION,
-                    value,
-                );
-                connect_async(request).await?
+        Self::connect_with_auth_tls(endpoint, token, None).await
+    }
+
+    /// Like [`connect_with_auth`](Self::connect_with_auth), but for `wss://` lets
+    /// the caller supply a custom rustls [`rustls::ClientConfig`] (e.g. one that
+    /// pins/trusts a self-signed worker cert). `None` uses the default webpki-root
+    /// trust. The config is ignored for plaintext `ws://`.
+    pub async fn connect_with_auth_tls(
+        endpoint: &str,
+        token: Option<&str>,
+        tls_config: Option<rustls::ClientConfig>,
+    ) -> TransportResult<Self> {
+        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+        let mut request = endpoint.into_client_request().map_err(TransportError::Ws)?;
+        if let Some(token) = token {
+            let value = format!("Bearer {token}")
+                .parse()
+                .map_err(|e| TransportError::Protocol(format!("bad bearer header: {e}")))?;
+            request.headers_mut().insert(
+                tokio_tungstenite::tungstenite::http::header::AUTHORIZATION,
+                value,
+            );
+        }
+        let (ws, _resp) = match tls_config {
+            Some(cfg) => {
+                let connector = tokio_tungstenite::Connector::Rustls(std::sync::Arc::new(cfg));
+                tokio_tungstenite::connect_async_tls_with_config(
+                    request,
+                    None,
+                    false,
+                    Some(connector),
+                )
+                .await?
             }
+            None => connect_async(request).await?,
         };
         let (tx, rx) = ws.split();
         Ok(Self { tx, rx })

--- a/crates/infra/bamboo-subagent/src/transport.rs
+++ b/crates/infra/bamboo-subagent/src/transport.rs
@@ -7,14 +7,21 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, oneshot};
+use tokio_rustls::TlsAcceptor;
+use tokio_tungstenite::tungstenite::handshake::server::{
+    Callback, ErrorResponse, Request, Response,
+};
+use tokio_tungstenite::tungstenite::http::StatusCode;
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::{accept_async, connect_async, MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::{accept_async, accept_hdr_async, connect_async, MaybeTlsStream};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -36,30 +43,91 @@ pub enum TransportError {
     Decode(#[from] serde_json::Error),
     #[error("protocol: {0}")]
     Protocol(String),
+    /// TLS configuration / handshake failure (bad cert/key, provider, etc.).
+    #[error("tls: {0}")]
+    Tls(String),
 }
 
 pub type TransportResult<T> = Result<T, TransportError>;
 
 // ---- child side --------------------------------------------------------------
 
-/// A loopback WebSocket server an actor runs to receive work.
+/// A WebSocket server an actor runs to receive work.
+///
+/// Three knobs, all optional and independent (remote-actor-plan §3.2 / §3.4):
+/// - `listener`/`addr`: where it binds (`bind_loopback` for local default,
+///   `bind`/`bind_tls` for a remotely-reachable worker on `0.0.0.0:PORT`).
+/// - `tls`: when `Some`, every accepted connection is wrapped in TLS before the
+///   WS upgrade and the advertised endpoint is `wss://`.
+/// - `expected_token`: when `Some`, the WS upgrade is rejected (401) unless the
+///   client presents `Authorization: Bearer <token>`. None ⇒ accept any
+///   (loopback default, zero regression).
 pub struct WsServer {
     listener: TcpListener,
     addr: SocketAddr,
+    tls: Option<TlsAcceptor>,
+    expected_token: Option<String>,
 }
 
 impl WsServer {
-    /// Bind an arbitrary address. Pass `0.0.0.0:PORT` for a remotely-reachable
-    /// worker/broker; [`bind_loopback`](Self::bind_loopback) is the local default.
-    /// (TLS — `wss://` — is added with the broker in a later phase; see
-    /// `docs/remote-actor-plan.md` §3.2.)
+    /// Bind an arbitrary address with NO TLS and NO token. Pass `0.0.0.0:PORT`
+    /// for a remotely-reachable worker/broker; [`bind_loopback`](Self::bind_loopback)
+    /// is the local default. Use [`bind_with_token`](Self::bind_with_token) /
+    /// [`bind_tls`](Self::bind_tls) to require auth.
     pub async fn bind(addr: SocketAddr) -> TransportResult<Self> {
-        let listener = TcpListener::bind(addr).await?;
-        let addr = listener.local_addr()?;
-        Ok(Self { listener, addr })
+        Self::bind_with_token(addr, None).await
     }
 
-    /// Bind `127.0.0.1:0` (ephemeral port) — the local default.
+    /// Bind plaintext but optionally require a bearer token on the WS upgrade.
+    ///
+    /// A token WITHOUT TLS is insecure (the bearer crosses the wire in the
+    /// clear) — acceptable only on a trusted/loopback link (e.g. the
+    /// deterministic `remote_connect_e2e` test). For real remote exposure use
+    /// [`bind_tls`](Self::bind_tls).
+    pub async fn bind_with_token(
+        addr: SocketAddr,
+        expected_token: Option<String>,
+    ) -> TransportResult<Self> {
+        let listener = TcpListener::bind(addr).await?;
+        let addr = listener.local_addr()?;
+        Ok(Self {
+            listener,
+            addr,
+            tls: None,
+            expected_token,
+        })
+    }
+
+    /// Bind with TLS termination (`wss://`) and an optional bearer token.
+    ///
+    /// Builds a `tokio_rustls::TlsAcceptor` from `cert_file`/`key_file` (PEM)
+    /// against an explicit `ring` provider — the same approach as the server's
+    /// HTTP TLS face (`bamboo-server`'s `build_rustls_config`) so the workspace
+    /// resolves a single crypto provider and never hits the rustls 0.23
+    /// no-default-provider panic.
+    ///
+    /// **Fail-fast:** a missing/unreadable/unparseable cert or key returns
+    /// `Err` — it never silently downgrades to plaintext.
+    pub async fn bind_tls(
+        addr: SocketAddr,
+        cert_file: &Path,
+        key_file: &Path,
+        expected_token: Option<String>,
+    ) -> TransportResult<Self> {
+        let server_config =
+            build_server_config(cert_file, key_file).map_err(TransportError::Tls)?;
+        let acceptor = TlsAcceptor::from(Arc::new(server_config));
+        let listener = TcpListener::bind(addr).await?;
+        let addr = listener.local_addr()?;
+        Ok(Self {
+            listener,
+            addr,
+            tls: Some(acceptor),
+            expected_token,
+        })
+    }
+
+    /// Bind `127.0.0.1:0` (ephemeral port) — the local default (no TLS, no token).
     pub async fn bind_loopback() -> TransportResult<Self> {
         Self::bind((std::net::Ipv4Addr::LOCALHOST, 0).into()).await
     }
@@ -68,9 +136,11 @@ impl WsServer {
         self.addr
     }
 
-    /// The reachable `ws://127.0.0.1:<port>` endpoint to advertise.
+    /// The reachable endpoint to advertise: `wss://` when TLS is active,
+    /// `ws://` otherwise.
     pub fn ws_endpoint(&self) -> String {
-        format!("ws://{}", self.addr)
+        let scheme = if self.tls.is_some() { "wss" } else { "ws" };
+        format!("{scheme}://{}", self.addr)
     }
 
     /// Serve exactly one connection (owned child / demo), then return.
@@ -79,7 +149,7 @@ impl WsServer {
         executor: Arc<E>,
     ) -> TransportResult<()> {
         let (stream, _) = self.listener.accept().await?;
-        handle_conn(stream, executor).await
+        accept_and_handle(stream, &self.tls, &self.expected_token, executor).await
     }
 
     /// Serve exactly one connection, but give up if no client connects within
@@ -98,7 +168,7 @@ impl WsServer {
                     "no connection within {accept_timeout:?}; exiting"
                 ))
             })??;
-        handle_conn(stream, executor).await
+        accept_and_handle(stream, &self.tls, &self.expected_token, executor).await
     }
 
     /// Serve connection-after-connection for a **reusable** actor, one at a time.
@@ -122,7 +192,8 @@ impl WsServer {
                 Err(_) => return Ok(()), // idle: reclaim self, clean exit
             };
             // Handle this assignment to completion before accepting the next.
-            let _ = handle_conn(stream, executor.clone()).await;
+            let _ =
+                accept_and_handle(stream, &self.tls, &self.expected_token, executor.clone()).await;
         }
     }
 
@@ -131,18 +202,153 @@ impl WsServer {
         loop {
             let (stream, _) = self.listener.accept().await?;
             let exec = executor.clone();
+            // The TLS handshake + auth callback run inside the spawned task (not
+            // on the accept loop) so a slow/hostile client cannot stall the
+            // server from accepting other connections. Clones are cheap:
+            // `TlsAcceptor` is `Arc`-backed, the token is a short `String`.
+            let tls = self.tls.clone();
+            let token = self.expected_token.clone();
             tokio::spawn(async move {
-                let _ = handle_conn(stream, exec).await;
+                let _ = accept_and_handle(stream, &tls, &token, exec).await;
             });
         }
     }
 }
 
-async fn handle_conn<E: ChildExecutor + ?Sized>(
+/// Apply TLS (if configured) + the bearer-auth WS upgrade to a freshly-accepted
+/// `TcpStream`, then drive the connection. Plaintext + no-token reduces to the
+/// historical `accept_async(stream)` path (zero regression).
+async fn accept_and_handle<E: ChildExecutor + ?Sized>(
     stream: TcpStream,
+    tls: &Option<TlsAcceptor>,
+    expected_token: &Option<String>,
     executor: Arc<E>,
 ) -> TransportResult<()> {
-    let ws = accept_async(stream).await?;
+    match tls {
+        Some(acceptor) => {
+            // Terminate TLS before the WS upgrade so the bearer + frames ride an
+            // encrypted link.
+            let tls_stream = acceptor
+                .accept(stream)
+                .await
+                .map_err(|e| TransportError::Tls(format!("accept handshake: {e}")))?;
+            let ws = ws_upgrade(tls_stream, expected_token).await?;
+            handle_conn(ws, executor).await
+        }
+        None => {
+            let ws = ws_upgrade(stream, expected_token).await?;
+            handle_conn(ws, executor).await
+        }
+    }
+}
+
+/// Perform the WS upgrade over an arbitrary stream, validating the bearer token
+/// at the upgrade layer when one is expected. When `expected_token` is `None`
+/// this is exactly `accept_async` (any client accepted) — zero regression.
+async fn ws_upgrade<S>(
+    stream: S,
+    expected_token: &Option<String>,
+) -> TransportResult<tokio_tungstenite::WebSocketStream<S>>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    match expected_token {
+        None => Ok(accept_async(stream).await?),
+        Some(token) => {
+            let callback = BearerCallback {
+                expected: token.clone(),
+            };
+            Ok(accept_hdr_async(stream, callback).await?)
+        }
+    }
+}
+
+/// WS-upgrade callback that enforces `Authorization: Bearer <token>`. Rejecting
+/// here means the WebSocket never establishes — the wire protocol
+/// (`ParentFrame`/`ChildFrame`) stays byte-identical; auth lives entirely at the
+/// HTTP upgrade (remote-actor-plan §6.3). The token is never logged.
+struct BearerCallback {
+    expected: String,
+}
+
+impl Callback for BearerCallback {
+    fn on_request(self, request: &Request, response: Response) -> Result<Response, ErrorResponse> {
+        let presented = request
+            .headers()
+            .get(tokio_tungstenite::tungstenite::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok());
+        let ok = matches!(presented, Some(h) if bearer_matches(h, &self.expected));
+        if ok {
+            Ok(response)
+        } else {
+            let err = ErrorResponse::new(Some("unauthorized: bad or missing bearer token".into()));
+            let (mut parts, body) = err.into_parts();
+            parts.status = StatusCode::UNAUTHORIZED;
+            Err(ErrorResponse::from_parts(parts, body))
+        }
+    }
+}
+
+/// Constant-form check that an `Authorization` header is `Bearer <expected>`.
+fn bearer_matches(header: &str, expected: &str) -> bool {
+    header
+        .strip_prefix("Bearer ")
+        .map(|t| t == expected)
+        .unwrap_or(false)
+}
+
+/// Build a rustls [`rustls::ServerConfig`] from PEM cert/key files against an
+/// explicit `ring` provider (mirrors `bamboo-server`'s `build_rustls_config`).
+fn build_server_config(cert_file: &Path, key_file: &Path) -> Result<rustls::ServerConfig, String> {
+    use std::fs::File;
+    use std::io::BufReader;
+
+    let cert_path = cert_file.display();
+    let key_path = key_file.display();
+
+    let cf = File::open(cert_file).map_err(|e| format!("open cert_file '{cert_path}': {e}"))?;
+    let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
+        rustls_pemfile::certs(&mut BufReader::new(cf))
+            .collect::<Result<_, _>>()
+            .map_err(|e| format!("parse cert_file '{cert_path}': {e}"))?;
+    if certs.is_empty() {
+        return Err(format!(
+            "no certificates in cert_file '{cert_path}' (expected PEM CERTIFICATE blocks)"
+        ));
+    }
+
+    let kf = File::open(key_file).map_err(|e| format!("open key_file '{key_path}': {e}"))?;
+    let key = match rustls_pemfile::private_key(&mut BufReader::new(kf)) {
+        Ok(Some(k)) => k,
+        Ok(None) => {
+            return Err(format!(
+                "no private key in key_file '{key_path}' (expected PKCS#8/RSA/SEC1)"
+            ))
+        }
+        Err(e) => return Err(format!("parse key_file '{key_path}': {e}")),
+    };
+
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    rustls::ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|e| format!("protocol versions: {e}"))?
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| {
+            format!("rustls rejected cert/key (cert '{cert_path}', key '{key_path}'): {e}")
+        })
+}
+
+/// Drive an already-upgraded WS connection (generic over the underlying stream
+/// so it serves both plaintext `TcpStream` and `TlsStream<TcpStream>`).
+async fn handle_conn<S, E>(
+    ws: tokio_tungstenite::WebSocketStream<S>,
+    executor: Arc<E>,
+) -> TransportResult<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    E: ChildExecutor + ?Sized,
+{
     let (ws_tx, mut ws_rx) = ws.split();
     // One writer task owns the sink; runs push frames through this channel (decouples read/write).
     let (out_tx, out_rx) = mpsc::unbounded_channel::<ChildFrame>();
@@ -219,10 +425,12 @@ async fn handle_conn<E: ChildExecutor + ?Sized>(
     Ok(())
 }
 
-async fn writer_task(
-    mut ws_tx: SplitSink<WebSocketStream<TcpStream>, Message>,
+async fn writer_task<S>(
+    mut ws_tx: SplitSink<tokio_tungstenite::WebSocketStream<S>, Message>,
     mut out_rx: mpsc::UnboundedReceiver<ChildFrame>,
-) {
+) where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     while let Some(frame) = out_rx.recv().await {
         if ws_tx.send(Message::text(frame.to_text())).await.is_err() {
             break;
@@ -293,7 +501,7 @@ fn start_run<E: ChildExecutor + ?Sized>(
 
 // ---- parent side -------------------------------------------------------------
 
-type ClientStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+type ClientStream = tokio_tungstenite::WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 /// Parent-side connection to a child actor.
 pub struct ChildClient {
@@ -302,8 +510,31 @@ pub struct ChildClient {
 }
 
 impl ChildClient {
+    /// Connect with no bearer token (loopback / trusted-link default). Identical
+    /// to `connect_with_auth(endpoint, None)` — zero regression.
     pub async fn connect(endpoint: &str) -> TransportResult<Self> {
-        let (ws, _resp) = connect_async(endpoint).await?;
+        Self::connect_with_auth(endpoint, None).await
+    }
+
+    /// Connect to a worker endpoint, optionally presenting a bearer token on the
+    /// WS upgrade (`Authorization: Bearer <token>`). A `wss://` endpoint flows
+    /// through `MaybeTlsStream` transparently. The token is never logged.
+    pub async fn connect_with_auth(endpoint: &str, token: Option<&str>) -> TransportResult<Self> {
+        let (ws, _resp) = match token {
+            None => connect_async(endpoint).await?,
+            Some(token) => {
+                use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+                let mut request = endpoint.into_client_request().map_err(TransportError::Ws)?;
+                let value = format!("Bearer {token}")
+                    .parse()
+                    .map_err(|e| TransportError::Protocol(format!("bad bearer header: {e}")))?;
+                request.headers_mut().insert(
+                    tokio_tungstenite::tungstenite::http::header::AUTHORIZATION,
+                    value,
+                );
+                connect_async(request).await?
+            }
+        };
         let (tx, rx) = ws.split();
         Ok(Self { tx, rx })
     }
@@ -374,6 +605,74 @@ mod tests {
 
         let _ = client.close().await;
         let _ = srv.await;
+    }
+
+    /// `bind_with_token` gates the WS upgrade: the right bearer connects + runs,
+    /// a wrong / missing bearer is rejected at the upgrade (no WS, no Terminal).
+    #[tokio::test]
+    async fn bearer_token_gates_the_upgrade() {
+        let server = WsServer::bind_with_token(
+            (std::net::Ipv4Addr::LOCALHOST, 0).into(),
+            Some("T-secret".into()),
+        )
+        .await
+        .unwrap();
+        let endpoint = server.ws_endpoint();
+        // ws:// (no TLS) even though a token is set — token alone never upgrades scheme.
+        assert!(endpoint.starts_with("ws://"));
+        let srv = tokio::spawn(async move { server.serve(Arc::new(EchoExecutor)).await });
+
+        // Correct token: connects and runs to completion.
+        let mut client = ChildClient::connect_with_auth(&endpoint, Some("T-secret"))
+            .await
+            .expect("correct bearer should connect");
+        client
+            .send(ParentFrame::Run(RunSpec {
+                assignment: "go".into(),
+                reasoning_effort: None,
+                messages: Vec::new(),
+            }))
+            .await
+            .unwrap();
+        let mut terminal = None;
+        while let Some(frame) = client.next_frame().await.unwrap() {
+            if let ChildFrame::Terminal { status, .. } = frame {
+                terminal = Some(status);
+                break;
+            }
+        }
+        assert_eq!(terminal, Some(TerminalStatus::Completed));
+        let _ = client.close().await;
+
+        // Wrong token: the upgrade is rejected — connect itself errors.
+        let bad = ChildClient::connect_with_auth(&endpoint, Some("WRONG")).await;
+        assert!(bad.is_err(), "wrong bearer must be rejected at the upgrade");
+
+        // Missing token: same rejection.
+        let missing = ChildClient::connect(&endpoint).await;
+        assert!(
+            missing.is_err(),
+            "missing bearer must be rejected when a token is required"
+        );
+
+        srv.abort();
+    }
+
+    /// `bind_tls` fails fast on a missing cert/key (never falls back to plaintext).
+    #[tokio::test]
+    async fn bind_tls_fails_fast_on_missing_cert() {
+        let result = WsServer::bind_tls(
+            (std::net::Ipv4Addr::LOCALHOST, 0).into(),
+            Path::new("/nonexistent/bamboo-subagent/cert.pem"),
+            Path::new("/nonexistent/bamboo-subagent/key.pem"),
+            None,
+        )
+        .await;
+        match result {
+            Err(TransportError::Tls(m)) if m.contains("cert_file") => {}
+            Err(other) => panic!("expected a TLS error naming cert_file, got {other:?}"),
+            Ok(_) => panic!("missing cert must fail"),
+        }
     }
 
     async fn run_once(endpoint: &str, assignment: &str) -> (TerminalStatus, Option<String>) {

--- a/crates/infra/bamboo-subagent/tests/remote_connect_e2e.rs
+++ b/crates/infra/bamboo-subagent/tests/remote_connect_e2e.rs
@@ -1,0 +1,307 @@
+//! End-to-end (remote-actor-plan P1, #181): a parent reaches a *resident* worker
+//! it did not spawn, via `ConnectLauncher` + `Placement::Remote` + a bearer
+//! token — the "cross-machine connect" path, simulated deterministically on
+//! loopback.
+//!
+//! The `ConnectLauncher` path uses `WsServer::bind_with_token` (plaintext +
+//! token: the token gates the upgrade, and a loopback link keeps the launcher
+//! tests deterministic). A separate `bind_tls_real_handshake_runs_to_terminal`
+//! test mints a throwaway self-signed cert and drives a REAL `wss://` handshake
+//! through `bind_tls` (TLS terminate -> WS upgrade -> bearer gate -> Echo ->
+//! Terminal), so the TLS server path is exercised end-to-end and not just the
+//! plaintext+token path.
+
+use std::time::Duration;
+
+use bamboo_subagent::executor::EchoExecutor;
+use bamboo_subagent::launcher::{ConnectLauncher, WorkerLauncher};
+use bamboo_subagent::proto::{ChildFrame, ParentFrame, RunSpec, TerminalStatus};
+use bamboo_subagent::provision::{ChildIdentity, ExecutorSpec, Placement, ProvisionSpec};
+use bamboo_subagent::transport::{ChildClient, WsServer};
+
+const TOKEN: &str = "T-remote-secret";
+
+/// Start a resident worker on loopback that requires `TOKEN`, returning its
+/// `ws://` endpoint and the serve task handle.
+async fn start_resident_worker() -> (String, tokio::task::JoinHandle<()>) {
+    let server = WsServer::bind_with_token(
+        (std::net::Ipv4Addr::LOCALHOST, 0).into(),
+        Some(TOKEN.to_string()),
+    )
+    .await
+    .expect("bind resident worker");
+    let endpoint = server.ws_endpoint();
+    let handle = tokio::spawn(async move {
+        let _ = server.serve(std::sync::Arc::new(EchoExecutor)).await;
+    });
+    (endpoint, handle)
+}
+
+/// Build a parent-side spec whose placement points at the resident worker and
+/// whose scoped secrets envelope carries the worker's bearer token.
+fn remote_spec(endpoint: &str, token: Option<&str>) -> ProvisionSpec {
+    let mut spec = ProvisionSpec::new(
+        ChildIdentity {
+            child_id: "remote-c1".into(),
+            parent_id: Some("p1".into()),
+            project_key: None,
+            role: "remote-demo".into(),
+            depth: 0,
+        },
+        ExecutorSpec::Echo,
+        std::env::temp_dir()
+            .join("bamboo-remote-e2e-fabric")
+            .to_string_lossy()
+            .into_owned(),
+    );
+    spec.placement = Placement::Remote {
+        endpoint: endpoint.to_string(),
+    };
+    spec.secrets.worker_auth_token = token.map(|t| t.to_string());
+    spec
+}
+
+/// Happy path: ConnectLauncher connects (no spawn), then a real Run streams back
+/// a Terminal — byte-identical to the local path after the connect.
+#[tokio::test]
+async fn remote_connect_launches_runs_and_terminates() {
+    let (endpoint, srv) = start_resident_worker().await;
+
+    // Parent: ConnectLauncher with the correct token in the spec envelope.
+    let spec = remote_spec(&endpoint, Some(TOKEN));
+    let launched = ConnectLauncher
+        .launch(&spec, Duration::from_secs(5))
+        .await
+        .expect("ConnectLauncher should reach the resident worker");
+
+    // The synthesized record carries the remote endpoint + identity, NO process.
+    assert_eq!(launched.record.agent_id, "remote-c1");
+    assert_eq!(launched.record.endpoint, endpoint);
+    assert_eq!(launched.pid(), None, "a remote worker owns no local pid");
+
+    // Now drive a real run over a fresh authenticated connection.
+    let mut client = ChildClient::connect_with_auth(&launched.record.endpoint, Some(TOKEN))
+        .await
+        .expect("connect to the remote endpoint with the bearer");
+    client
+        .send(ParentFrame::Run(RunSpec {
+            assignment: "remote hello".into(),
+            reasoning_effort: None,
+            messages: Vec::new(),
+        }))
+        .await
+        .unwrap();
+
+    let mut terminal = None;
+    while let Some(frame) = client.next_frame().await.unwrap() {
+        if let ChildFrame::Terminal { status, result, .. } = frame {
+            terminal = Some((status, result));
+            break;
+        }
+    }
+    let (status, result) = terminal.expect("a Terminal must come back from the remote worker");
+    assert_eq!(status, TerminalStatus::Completed);
+    assert_eq!(result.as_deref(), Some("echo: remote hello"));
+
+    // kill() is a no-op for a remote worker; it must not panic or kill the server.
+    launched.kill().await;
+
+    let _ = client.close().await;
+    srv.abort();
+}
+
+/// Negative: a WRONG token makes the connectivity probe fail — the launcher
+/// errors and no work is dispatched (proves the bearer gate actually gates).
+#[tokio::test]
+async fn remote_connect_with_wrong_token_is_rejected() {
+    let (endpoint, srv) = start_resident_worker().await;
+
+    let spec = remote_spec(&endpoint, Some("WRONG-TOKEN"));
+    let result = ConnectLauncher.launch(&spec, Duration::from_secs(5)).await;
+    assert!(
+        result.is_err(),
+        "a wrong bearer must fail the connect, not launch"
+    );
+
+    srv.abort();
+}
+
+/// Negative: a MISSING token is likewise rejected by the gated worker.
+#[tokio::test]
+async fn remote_connect_with_missing_token_is_rejected() {
+    let (endpoint, srv) = start_resident_worker().await;
+
+    let spec = remote_spec(&endpoint, None);
+    let result = ConnectLauncher.launch(&spec, Duration::from_secs(5)).await;
+    assert!(
+        result.is_err(),
+        "a missing bearer must fail the connect against a token-gated worker"
+    );
+
+    // Direct connect attempt (bypassing the launcher) is also rejected.
+    let direct = ChildClient::connect(&endpoint).await;
+    assert!(direct.is_err(), "unauthenticated direct connect must fail");
+
+    srv.abort();
+}
+
+/// Real TLS handshake against `bind_tls`: mints a throwaway self-signed cert,
+/// serves with `WsServer::bind_tls`, then connects with a raw `tokio-rustls`
+/// client (no-verify) + the WS upgrade carrying the bearer, runs Echo, and
+/// asserts a Terminal. This exercises the actual `wss://` server path (TLS
+/// terminate -> WS upgrade -> bearer gate) — not just the plaintext+token path.
+/// Skips gracefully when openssl is unavailable.
+#[tokio::test]
+async fn bind_tls_real_handshake_runs_to_terminal() {
+    use std::sync::Arc;
+
+    let Some((cert, key, dir)) = mint_self_signed() else {
+        eprintln!("skipping bind_tls_real_handshake: openssl unavailable");
+        return;
+    };
+
+    let server = WsServer::bind_tls(
+        (std::net::Ipv4Addr::LOCALHOST, 0).into(),
+        &cert,
+        &key,
+        Some(TOKEN.to_string()),
+    )
+    .await
+    .expect("bind_tls with a valid self-signed cert");
+    let endpoint = server.ws_endpoint();
+    assert!(
+        endpoint.starts_with("wss://"),
+        "TLS endpoint must be wss://"
+    );
+    let addr = server.local_addr();
+    let srv = tokio::spawn(async move {
+        let _ = server.serve(Arc::new(EchoExecutor)).await;
+    });
+
+    // Raw tokio-rustls client that accepts the self-signed cert (test-only).
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let config = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoVerify))
+        .with_no_client_auth();
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(config));
+    let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let server_name = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+    let tls = connector
+        .connect(server_name, tcp)
+        .await
+        .expect("tls handshake");
+
+    // WS upgrade over the TLS stream, presenting the bearer in the request.
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+    let mut request = format!("ws://localhost:{}/", addr.port())
+        .into_client_request()
+        .unwrap();
+    request.headers_mut().insert(
+        tokio_tungstenite::tungstenite::http::header::AUTHORIZATION,
+        format!("Bearer {TOKEN}").parse().unwrap(),
+    );
+    let (ws, _resp) = tokio_tungstenite::client_async(request, tls)
+        .await
+        .expect("ws upgrade over tls with bearer");
+
+    use futures_util::{SinkExt, StreamExt};
+    let (mut tx, mut rx) = ws.split();
+    let run = ParentFrame::Run(RunSpec {
+        assignment: "tls hello".into(),
+        reasoning_effort: None,
+        messages: Vec::new(),
+    });
+    tx.send(tokio_tungstenite::tungstenite::Message::text(run.to_text()))
+        .await
+        .unwrap();
+
+    let mut got_terminal = false;
+    while let Some(msg) = rx.next().await {
+        if let tokio_tungstenite::tungstenite::Message::Text(t) = msg.unwrap() {
+            if let Ok(ChildFrame::Terminal { status, result, .. }) =
+                ChildFrame::from_text(t.as_str())
+            {
+                assert_eq!(status, TerminalStatus::Completed);
+                assert_eq!(result.as_deref(), Some("echo: tls hello"));
+                got_terminal = true;
+                break;
+            }
+        }
+    }
+    assert!(got_terminal, "expected a Terminal over the wss:// link");
+
+    srv.abort();
+    drop(dir); // keep the tempdir alive until here
+}
+
+/// A rustls verifier that accepts any server cert — TEST ONLY (self-signed).
+#[derive(Debug)]
+struct NoVerify;
+impl rustls::client::danger::ServerCertVerifier for NoVerify {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+/// Mint a throwaway self-signed cert + PKCS#8 key via openssl. Returns the cert
+/// path, key path, and the owning tempdir (kept alive by the caller). `None` if
+/// openssl is unavailable.
+fn mint_self_signed() -> Option<(std::path::PathBuf, std::path::PathBuf, tempfile::TempDir)> {
+    let dir = tempfile::TempDir::new().ok()?;
+    let cert = dir.path().join("cert.pem");
+    let key = dir.path().join("key.pem");
+    let status = std::process::Command::new("openssl")
+        .args([
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            key.to_str().unwrap(),
+            "-out",
+            cert.to_str().unwrap(),
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=localhost",
+        ])
+        .status()
+        .ok()?;
+    if status.success() {
+        Some((cert, key, dir))
+    } else {
+        None
+    }
+}

--- a/crates/infra/bamboo-subagent/tests/remote_connect_e2e.rs
+++ b/crates/infra/bamboo-subagent/tests/remote_connect_e2e.rs
@@ -237,6 +237,134 @@ async fn bind_tls_real_handshake_runs_to_terminal() {
     drop(dir); // keep the tempdir alive until here
 }
 
+/// The SHIPPED client over `wss://`: `ChildClient::connect_with_auth_tls` drives
+/// the full TLS terminate -> WS upgrade -> bearer -> Echo -> Terminal round-trip
+/// using a custom rustls client config (here a test no-verify one; production
+/// pins the worker cert via `client_config_trusting_cert`). This proves the
+/// actual product client can speak `wss://` — not just a raw tokio-rustls client.
+#[tokio::test]
+async fn child_client_wss_round_trip() {
+    use std::sync::Arc;
+
+    let Some((cert, key, dir)) = mint_self_signed() else {
+        eprintln!("skipping child_client_wss_round_trip: openssl unavailable");
+        return;
+    };
+
+    let server = WsServer::bind_tls(
+        (std::net::Ipv4Addr::LOCALHOST, 0).into(),
+        &cert,
+        &key,
+        Some(TOKEN.to_string()),
+    )
+    .await
+    .expect("bind_tls");
+    let endpoint = server.ws_endpoint();
+    assert!(endpoint.starts_with("wss://"));
+    let srv = tokio::spawn(async move {
+        let _ = server.serve(Arc::new(EchoExecutor)).await;
+    });
+
+    let client_cfg = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .unwrap()
+    .dangerous()
+    .with_custom_certificate_verifier(Arc::new(NoVerify))
+    .with_no_client_auth();
+
+    let mut client = ChildClient::connect_with_auth_tls(&endpoint, Some(TOKEN), Some(client_cfg))
+        .await
+        .expect("ChildClient must connect over wss:// with the bearer");
+    client
+        .send(ParentFrame::Run(RunSpec {
+            assignment: "wss hello".into(),
+            reasoning_effort: None,
+            messages: Vec::new(),
+        }))
+        .await
+        .unwrap();
+
+    let mut terminal = None;
+    while let Some(frame) = client.next_frame().await.unwrap() {
+        if let ChildFrame::Terminal { status, result, .. } = frame {
+            terminal = Some((status, result));
+            break;
+        }
+    }
+    let (status, result) = terminal.expect("Terminal over wss://");
+    assert_eq!(status, TerminalStatus::Completed);
+    assert_eq!(result.as_deref(), Some("echo: wss hello"));
+
+    let _ = client.close().await;
+    srv.abort();
+    drop(dir);
+}
+
+/// Negative: the bearer gate still applies over `wss://` — a wrong token is
+/// rejected at the upgrade even when TLS itself succeeds.
+#[tokio::test]
+async fn child_client_wss_wrong_token_is_rejected() {
+    use std::sync::Arc;
+
+    let Some((cert, key, dir)) = mint_self_signed() else {
+        eprintln!("skipping child_client_wss_wrong_token: openssl unavailable");
+        return;
+    };
+
+    let server = WsServer::bind_tls(
+        (std::net::Ipv4Addr::LOCALHOST, 0).into(),
+        &cert,
+        &key,
+        Some(TOKEN.to_string()),
+    )
+    .await
+    .expect("bind_tls");
+    let endpoint = server.ws_endpoint();
+    let srv = tokio::spawn(async move {
+        let _ = server.serve(Arc::new(EchoExecutor)).await;
+    });
+
+    let client_cfg = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .unwrap()
+    .dangerous()
+    .with_custom_certificate_verifier(Arc::new(NoVerify))
+    .with_no_client_auth();
+
+    let result =
+        ChildClient::connect_with_auth_tls(&endpoint, Some("WRONG"), Some(client_cfg)).await;
+    assert!(
+        result.is_err(),
+        "a wrong bearer must be rejected at the wss upgrade"
+    );
+
+    srv.abort();
+    drop(dir);
+}
+
+/// The production pinning helper builds a usable client config from a cert PEM.
+#[test]
+fn client_config_trusting_cert_builds_from_pem() {
+    let Some((cert, _key, dir)) = mint_self_signed() else {
+        eprintln!("skipping client_config_trusting_cert_builds_from_pem: openssl unavailable");
+        return;
+    };
+    let cfg = bamboo_subagent::transport::client_config_trusting_cert(&cert);
+    assert!(cfg.is_ok(), "should build a client config from a cert PEM");
+    // A non-existent path is a clear error, not a panic.
+    assert!(
+        bamboo_subagent::transport::client_config_trusting_cert(std::path::Path::new(
+            "/no/such/cert.pem"
+        ))
+        .is_err()
+    );
+    drop(dir);
+}
+
 /// A rustls verifier that accepts any server cert — TEST ONLY (self-signed).
 #[derive(Debug)]
 struct NoVerify;

--- a/src/actor_cli.rs
+++ b/src/actor_cli.rs
@@ -148,6 +148,16 @@ pub async fn serve(args: ActorServeArgs) -> Result<(), String> {
             .await
             .map_err(|e| format!("bind_tls: {e}"))?
     } else if let Some(bind_addr) = args.bind {
+        // A bearer token on a non-loopback PLAINTEXT bind would cross the wire in
+        // the clear, defeating its purpose. Refuse it: tokens require --tls on a
+        // public bind. (A loopback plaintext bind with a token is allowed for
+        // local/testing use.)
+        if args.token.is_some() && !bind_addr.ip().is_loopback() {
+            return Err(format!(
+                "refusing --token on a non-loopback plaintext bind ({bind_addr}): the token would \
+                 be sent in cleartext. Use --tls (with --cert-file/--key-file) for a public bind."
+            ));
+        }
         WsServer::bind_with_token(bind_addr, args.token.clone())
             .await
             .map_err(|e| format!("bind: {e}"))?

--- a/src/actor_cli.rs
+++ b/src/actor_cli.rs
@@ -7,6 +7,7 @@
 //! - `list`:  show live fabric records (who is discoverable right now).
 //! - `call`:  discover a service agent by id or role and send it a task.
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -48,6 +49,17 @@ pub struct ActorServeArgs {
     pub workspace: Option<PathBuf>,
     pub data_dir: Option<PathBuf>,
     pub echo: bool,
+    /// Address to bind. `None` ⇒ loopback ephemeral port (current behavior).
+    /// Pass `0.0.0.0:PORT` for a remotely-reachable worker
+    /// (remote-actor-plan P1, #181).
+    pub bind: Option<SocketAddr>,
+    /// Terminate TLS (`wss://`). Requires `cert_file` + `key_file`.
+    pub tls: bool,
+    pub cert_file: Option<PathBuf>,
+    pub key_file: Option<PathBuf>,
+    /// Bearer token the worker requires on the WS handshake. `None` ⇒ accept any
+    /// (loopback default).
+    pub token: Option<String>,
 }
 
 pub struct ActorCallArgs {
@@ -122,9 +134,29 @@ pub async fn serve(args: ActorServeArgs) -> Result<(), String> {
         std::sync::Arc::new(BambooRuntimeExecutor::build(&spec).await?)
     };
 
-    let server = WsServer::bind_loopback()
-        .await
-        .map_err(|e| format!("bind: {e}"))?;
+    // Bind: TLS > explicit --bind (+ optional token) > loopback default.
+    // Default (no flags) is byte-for-byte the historical loopback behavior.
+    let server = if args.tls {
+        let (cert, key) = match (&args.cert_file, &args.key_file) {
+            (Some(c), Some(k)) => (c, k),
+            _ => return Err("--tls requires both --cert-file and --key-file".to_string()),
+        };
+        let bind_addr = args
+            .bind
+            .unwrap_or_else(|| (std::net::Ipv4Addr::UNSPECIFIED, 8443).into());
+        WsServer::bind_tls(bind_addr, cert, key, args.token.clone())
+            .await
+            .map_err(|e| format!("bind_tls: {e}"))?
+    } else if let Some(bind_addr) = args.bind {
+        WsServer::bind_with_token(bind_addr, args.token.clone())
+            .await
+            .map_err(|e| format!("bind: {e}"))?
+    } else {
+        // Unchanged loopback default (no TLS, no token).
+        WsServer::bind_loopback()
+            .await
+            .map_err(|e| format!("bind: {e}"))?
+    };
     let endpoint = server.ws_endpoint();
 
     let fab = std::sync::Arc::new(Fabric::at(&spec.fabric_dir));

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -364,6 +364,29 @@ enum ActorCommands {
         /// Serve the echo executor (no LLM) — for smoke tests.
         #[arg(long)]
         echo: bool,
+
+        /// Address to bind for a remotely-reachable worker, e.g.
+        /// '0.0.0.0:8443'. Omit for the loopback ephemeral-port default
+        /// (remote-actor-plan P1, #181).
+        #[arg(long)]
+        bind: Option<std::net::SocketAddr>,
+
+        /// Terminate TLS ('wss://'). Requires --cert-file and --key-file.
+        #[arg(long)]
+        tls: bool,
+
+        /// PEM certificate chain for --tls.
+        #[arg(long)]
+        cert_file: Option<PathBuf>,
+
+        /// PEM private key for --tls.
+        #[arg(long)]
+        key_file: Option<PathBuf>,
+
+        /// Bearer token a connecting parent must present on the WS handshake.
+        /// Omit to accept any client (loopback default).
+        #[arg(long)]
+        token: Option<String>,
     },
 
     /// List actors currently discoverable in the local fabric.
@@ -611,6 +634,11 @@ async fn main() {
                     workspace,
                     data_dir,
                     echo,
+                    bind,
+                    tls,
+                    cert_file,
+                    key_file,
+                    token,
                 } => {
                     bamboo_agent::actor_cli::serve(bamboo_agent::actor_cli::ActorServeArgs {
                         role,
@@ -619,6 +647,11 @@ async fn main() {
                         workspace,
                         data_dir,
                         echo,
+                        bind,
+                        tls,
+                        cert_file,
+                        key_file,
+                        token,
                     })
                     .await
                 }


### PR DESCRIPTION
Implements **remote-actor-plan P1 (remote resident worker)** for Epic #181 at the bamboo-subagent transport + CLI layer. Makes the remote-resident-worker capability EXIST and be TESTED, demonstrated by a new two-actor remote_connect_e2e test. Builds on the already-landed P0 seams (WorkerLauncher/LocalSubprocessLauncher, Discovery/FileFabric, Placement enum, WsServer::bind, actor serve CLI).

## The four P1 gaps closed

1. **TLS bind on the worker** — WsServer::bind_tls(addr, cert, key, token) builds a tokio_rustls::TlsAcceptor from a rustls::ServerConfig via builder_with_provider(ring) (the same ring-provider approach as bamboo-server build_rustls_config, avoiding the rustls 0.23 no-default-provider panic). Fail-fast on missing/bad cert/key (never downgrades to plaintext). The accept loop wraps the TcpStream in TLS before the WS upgrade; ws_endpoint() returns wss:// under TLS. New bind_with_token allows a plaintext+token bind (insecure, loopback-only). bind_loopback/bind unchanged.

2. **Bearer auth on the handshake** — auth lives at the **WS UPGRADE layer, NOT a new ParentFrame variant**, so the wire protocol (ParentFrame/ChildFrame) stays **byte-identical**. The server validates Authorization: Bearer <token> in an accept_hdr_async callback and rejects with 401 when wrong/missing (the WS never establishes). The client gains ChildClient::connect_with_auth(endpoint, token) which sets the header on the upgrade request; connect() delegates to it with None (zero regression). The token is never logged.

3. **Token in the spec envelope** — SecretsEnvelope gains worker_auth_token: Option<String> (additive, skip_serializing_if None, forward-compatible — old specs deserialize with None). The parent puts the remote worker token here; ConnectLauncher reads it (never copies it into the discovery AgentRecord).

4. **ConnectLauncher** — impl WorkerLauncher that requires Placement::Remote { endpoint } (clear error otherwise), does NOT spawn a process, probes reachability (connect_with_auth + close, bounded by wait), and synthesizes a SpawnedChild with no process.

Plus **CLI flags** on actor serve: --bind, --tls + --cert-file/--key-file, --token, threaded into serve(). No flags = byte-for-byte the historical loopback default.

## Design choices

- **Auth at the WS upgrade, not a wire frame.** The bearer is an HTTP Authorization header validated in the upgrade callback; rejecting means no WebSocket. This keeps the ParentFrame/ChildFrame schema unchanged (remote-actor-plan steps 2-4 byte-identical promise).
- **SpawnedChild.process -> Option<Child>.** A remote worker owns no OS process: kill() becomes a no-op and pid() returns None. LocalSubprocessLauncher still returns Some(process) (its kill() still kills). Every consumer reads .process only via the kill()/pid() methods (engine actor_adapter, server-tools deploy_agent) — no direct field access elsewhere — so the ripple is contained.

## Tests

- New tests/remote_connect_e2e.rs: ConnectLauncher happy path (connect, no spawn, Run -> Terminal), wrong-token rejected, missing-token rejected, and a **real wss:// bind_tls handshake** (self-signed cert via openssl, raw tokio-rustls client, TLS terminate -> WS upgrade -> bearer gate -> Echo -> Terminal; skips if openssl absent).
- transport unit tests: bearer-gate (right token runs, wrong/missing rejected) and bind_tls fail-fast on missing cert.
- provision: worker_auth_token round-trip + None-skip + backward-compat.
- All existing subagent tests, tests/e2e_subprocess.rs, and the root tests/subagent_worker_e2e.rs (real bamboo binary) stay green.

## Zero-regression guarantees

bind_loopback / bind / connect / spawn_worker / LocalSubprocessLauncher behave identically; the engine ActorChildRunner path is untouched; ParentFrame/ChildFrame schemas are byte-identical. New code is clippy-clean (the only crate warnings are 2 pre-existing provision.rs doc-comment lints). Deps resolve ring-only (no aws-lc pulled in).

## Deferred

- Rewiring the engine **ActorChildRunner / warm-pool to ConnectLauncher** (a separate larger integration — this PR makes the capability exist + tested at the transport/CLI layer only).
- **RegistryFabric / Placement::Schedulable** (P2 control plane).
- **msgpack** wire encoding.

Refs #181

Claude-Session: https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp