### PR TITLE
feat(server): make /v2/stream hello an authoritative auth gate (browser device tokens) [#189]

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -24,12 +24,25 @@
 //! - `execute` / `approve` over control (handler refactors) — clients keep REST.
 //! - msgpack subprotocol (v2-P3) — JSON text frames only.
 //!
-//! ## Auth (v2-P2, #181)
-//! The scope middleware is the PRIMARY gate (it accepts a verified password
-//! cookie or a per-device token on the upgrade request). The `hello` frame adds
-//! identity binding: if it carries `device_id` + `token`, they are verified and
-//! the connection is CLOSED on mismatch; a token-less `hello` (e.g. a local
-//! desktop the middleware already bypassed) keeps the prior accept behavior.
+//! ## Auth (v2-P2, #181 / #189)
+//! `/v2/stream` is on the public route whitelist, so the upgrade OPENS without
+//! a middleware credential — this is the only way a browser device-token client
+//! (which cannot set `Authorization`/`X-Device-Id` headers on a WS upgrade) can
+//! present its token, via the `hello` frame. The handler is therefore the
+//! AUTHORITATIVE gate:
+//!
+//! - `pre_authorized` is computed from the SAME allow-decision the middleware
+//!   uses for every other route (`request_is_authorized`): a local bypass, a
+//!   verified password cookie (cookies ARE sent on the upgrade), or a header
+//!   device token. These connections stay frictionless — exactly as before.
+//! - While NOT authorized, the ONLY frame that does anything is `hello` carrying
+//!   a VALID `device_id` + `token`. A `subscribe`/`unsubscribe`/`stop` received
+//!   before authorization is IGNORED — no forwarder, no cancel, no channel data.
+//! - A token-less `hello` NEVER authorizes a connection that wasn't already
+//!   pre-authorized.
+//! - An unauthenticated socket that never sends a valid `hello` within
+//!   [`AUTH_DEADLINE`] is CLOSED, so it cannot linger.
+//! - The token is NEVER logged.
 
 mod envelope;
 mod forwarders;
@@ -57,6 +70,119 @@ const OUTBOUND_BUFFER: usize = 256;
 /// WS ping interval (~15s), mirroring the v1 SSE `[KEEPALIVE]` cadence.
 const PING_INTERVAL: Duration = Duration::from_secs(15);
 
+/// How long an UNAUTHORIZED connection may stay open before it must present a
+/// valid `hello` device token. A connection that opens the (now public) upgrade
+/// without a header/cookie credential and never authenticates is CLOSED when
+/// this elapses, so an unauthenticated socket can never linger (#189). Once the
+/// connection is authorized this deadline is disarmed.
+const AUTH_DEADLINE: Duration = Duration::from_secs(10);
+
+/// The verdict for one client frame while a connection is NOT yet authorized.
+///
+/// Pure decision over the parsed frame (no `AppState`), so the auth-gating
+/// contract is unit-testable without a live WS driver: while unauthorized the
+/// ONLY frame that can change anything is a `hello`, and only a `hello` carrying
+/// a credential is even a candidate to authorize.
+#[derive(Debug, PartialEq, Eq)]
+enum UnauthorizedAction {
+    /// A `hello` carrying `device_id` + `token` — verify it; valid → authorize,
+    /// invalid → close.
+    VerifyHello,
+    /// A token-less `hello` while unauthorized — a harmless no-op that does NOT
+    /// grant access (the deadline still governs).
+    TokenlessHelloNoop,
+    /// Any other frame (`subscribe`/`unsubscribe`/`stop`/unknown) while
+    /// unauthorized — IGNORE it (serve no channel data, cancel nothing).
+    Ignore,
+}
+
+impl UnauthorizedAction {
+    /// Classify a parsed frame for an unauthorized connection.
+    fn classify(frame: &ClientFrame) -> Self {
+        match frame {
+            ClientFrame::Hello {
+                device_id: Some(_),
+                token: Some(_),
+            } => UnauthorizedAction::VerifyHello,
+            ClientFrame::Hello { .. } => UnauthorizedAction::TokenlessHelloNoop,
+            _ => UnauthorizedAction::Ignore,
+        }
+    }
+}
+
+/// What the driver should do with a frame after the auth gate ran.
+#[derive(Debug, PartialEq, Eq)]
+enum GateOutcome {
+    /// The frame was fully handled by the gate (the connection is/was
+    /// unauthorized, or it just authorized): keep the socket open, do NOT fall
+    /// through to channel dispatch.
+    Handled,
+    /// An invalid credential was presented: CLOSE the connection.
+    Close,
+    /// The connection is authorized and this frame should proceed to the normal
+    /// channel dispatch (subscribe/unsubscribe/stop/hello-rebind).
+    Dispatch,
+}
+
+/// The AppState-aware auth gate, factored out of `handle_client_text` so it is
+/// unit-testable WITHOUT a live WS `Session`. It owns the entire `!authorized`
+/// decision plus the credential verification, and flips `authorized` to `true`
+/// only on a VERIFIED `hello` device token.
+///
+/// Invariants (the security review hammers these):
+/// - While `!*authorized`, a `subscribe`/`unsubscribe`/`stop` returns
+///   [`GateOutcome::Handled`] (ignored — never `Dispatch`), so no channel is
+///   served and no session cancelled before authorization.
+/// - A token-less `hello` NEVER sets `*authorized` when it was `false`.
+/// - A credentialed `hello` with a VALID token sets `*authorized = true`.
+/// - A credentialed `hello` with an INVALID token returns [`GateOutcome::Close`].
+/// - The token is NEVER logged.
+async fn apply_auth_gate(
+    state: &web::Data<AppState>,
+    frame: &ClientFrame,
+    authorized: &mut bool,
+) -> GateOutcome {
+    if *authorized {
+        return GateOutcome::Dispatch;
+    }
+
+    match UnauthorizedAction::classify(frame) {
+        UnauthorizedAction::VerifyHello => {
+            let ClientFrame::Hello {
+                device_id: Some(device_id),
+                token: Some(token),
+            } = frame
+            else {
+                unreachable!("VerifyHello implies a credentialed Hello");
+            };
+            let config = state.config.read().await.clone();
+            if crate::handlers::settings::verify_device_token(&config, device_id, token) {
+                *authorized = true;
+                // Bind device id for logging. NEVER log the token.
+                tracing::debug!("ws_v2: hello verified for device {device_id}; authorized");
+                GateOutcome::Handled
+            } else {
+                tracing::warn!(
+                    "ws_v2: hello rejected — invalid device credential for {device_id}; closing"
+                );
+                GateOutcome::Close
+            }
+        }
+        UnauthorizedAction::TokenlessHelloNoop => {
+            // A token-less hello does NOT authorize a non-pre-authorized
+            // connection. Keep the socket open; the deadline still governs.
+            tracing::debug!("ws_v2: token-less hello while unauthorized — not granting access");
+            GateOutcome::Handled
+        }
+        UnauthorizedAction::Ignore => {
+            // subscribe/unsubscribe/stop/unknown before auth: serve nothing,
+            // cancel nothing. Tolerate hello-after-subscribe ordering.
+            tracing::debug!("ws_v2: ignoring frame on unauthorized connection");
+            GateOutcome::Handled
+        }
+    }
+}
+
 /// Query parameters for the `GET /v2/stream` upgrade.
 #[derive(Debug, Default, Deserialize)]
 pub struct StreamQuery {
@@ -68,8 +194,13 @@ pub struct StreamQuery {
 
 /// `GET /v2/stream` — upgrade to the unified WS multiplex.
 ///
-/// Behind the same access-password scope middleware as `/api/v1` (registered in
-/// `routes/agent.rs`); `local_bypass` keeps desktop loopback frictionless.
+/// The upgrade itself is PUBLIC (whitelisted in `is_public_access_route`), so a
+/// browser device-token client can open the socket and authenticate via `hello`
+/// (it cannot set headers on a WS upgrade). Auth is enforced in `drive`: a
+/// connection that the middleware WOULD have allowed is `pre_authorized` here
+/// (local bypass / verified password cookie / header device token), via the same
+/// `request_is_authorized` allow-decision the middleware uses; everything else
+/// must present a verified `hello` before any channel is served, on a deadline.
 pub async fn handler(
     state: web::Data<AppState>,
     query: web::Query<StreamQuery>,
@@ -79,9 +210,19 @@ pub async fn handler(
     // Clamp the untrusted `batch_ms` the same way the v1 SSE handler does.
     let batch_ms = query.batch_ms.min(MAX_BATCH_MS);
 
+    // Pre-authorize exactly the connections the middleware would have allowed on
+    // a gated route: local bypass, a verified password cookie (sent on the
+    // upgrade), or a header device token. This preserves every existing client
+    // with ZERO change; a remote browser device-token client is NOT pre-auth and
+    // must send a valid `hello`.
+    let pre_authorized = {
+        let config = state.config.read().await.clone();
+        crate::handlers::settings::request_is_authorized(&req, &config)
+    };
+
     let (response, session, msg_stream) = actix_ws::handle(&req, body)?;
 
-    actix_web::rt::spawn(drive(state, session, msg_stream, batch_ms));
+    actix_web::rt::spawn(drive(state, session, msg_stream, batch_ms, pre_authorized));
 
     Ok(response)
 }
@@ -94,14 +235,32 @@ async fn drive(
     mut session: actix_ws::Session,
     mut msg_stream: actix_ws::MessageStream,
     batch_ms: u64,
+    pre_authorized: bool,
 ) {
     let (out_tx, mut out_rx) = mpsc::channel::<String>(OUTBOUND_BUFFER);
     let mut forwarders: HashMap<String, tokio::task::JoinHandle<()>> = HashMap::new();
     let mut ping = tokio::time::interval(PING_INTERVAL);
     ping.tick().await; // skip the immediate tick
 
+    // Authorization state (#189). Seeded from the upgrade-time decision so local
+    // / cookie / header clients are authorized immediately; everything else must
+    // present a valid `hello` before any channel is served.
+    let mut authorized = pre_authorized;
+    // The unauthorized-deadline timer. Pinned + biased to fire while `!authorized`
+    // and disarmed once the connection authorizes, so an unauthenticated socket
+    // is closed but an authorized one runs indefinitely.
+    let auth_deadline = tokio::time::sleep(AUTH_DEADLINE);
+    tokio::pin!(auth_deadline);
+
     loop {
         tokio::select! {
+            // While unauthorized, close the socket once the deadline elapses. The
+            // `!authorized` guard disarms this arm the moment the connection
+            // authorizes (a never-completing branch is simply never selected).
+            _ = &mut auth_deadline, if !authorized => {
+                tracing::debug!("ws_v2: closing unauthorized connection after auth deadline");
+                break;
+            }
             // Drain forwarder output to the WS. If the write fails the peer is
             // gone — break and tear down.
             Some(text) = out_rx.recv() => {
@@ -123,7 +282,8 @@ async fn drive(
                 match msg {
                     Some(Ok(Message::Text(text))) => {
                         let keep_open = handle_client_text(
-                            &state, &out_tx, &mut forwarders, &mut session, batch_ms, &text,
+                            &state, &out_tx, &mut forwarders, &mut session,
+                            batch_ms, &text, &mut authorized,
                         )
                         .await;
                         if !keep_open {
@@ -162,8 +322,15 @@ async fn drive(
 /// Parse + dispatch one client text frame. A malformed/unknown frame logs and is
 /// ignored — it never tears down the connection.
 ///
+/// `authorized` is the per-connection auth state (#189). While it is `false` the
+/// ONLY frame that does anything is a `hello` carrying a VALID device token (it
+/// flips `authorized` to `true`); EVERY other frame — including a
+/// `subscribe`/`unsubscribe`/`stop` — is IGNORED, so a remote unauthenticated
+/// connection gets NO channel data and cancels nothing. The driver's deadline
+/// closes a socket that never authorizes.
+///
 /// Returns `false` to signal the driver to CLOSE the connection (a `hello` that
-/// presents an invalid device credential); `true` to keep it open.
+/// presents an INVALID device credential); `true` to keep it open.
 async fn handle_client_text(
     state: &web::Data<AppState>,
     out_tx: &OutboundTx,
@@ -171,6 +338,7 @@ async fn handle_client_text(
     _session: &mut actix_ws::Session,
     batch_ms: u64,
     text: &str,
+    authorized: &mut bool,
 ) -> bool {
     let frame: ClientFrame = match serde_json::from_str(text) {
         Ok(f) => f,
@@ -180,18 +348,26 @@ async fn handle_client_text(
         }
     };
 
+    // Auth gate (#189). Until the connection is authorized, no frame may serve a
+    // channel or cancel a session — the only frame that can change anything is a
+    // `hello` that carries a verifiable device credential.
+    match apply_auth_gate(state, &frame, authorized).await {
+        GateOutcome::Handled => return true,
+        GateOutcome::Close => return false,
+        GateOutcome::Dispatch => {}
+    }
+
+    // Authorized path: full dispatch.
     match frame {
         ClientFrame::Hello { device_id, token } => {
-            // Identity binding (v2-P2, #181). The scope middleware is the primary
-            // gate; here we additionally verify a presented credential and reject
-            // an unverified hello on the public WS path. A token-less hello (e.g.
-            // a local desktop the middleware already bypassed) is accepted.
+            // Already authorized. A credentialed hello re-verifies as identity
+            // binding; an invalid one still closes. A token-less hello on an
+            // already-authorized connection is a harmless no-op.
             match (device_id, token) {
                 (Some(device_id), Some(token)) => {
                     let config = state.config.read().await.clone();
                     if crate::handlers::settings::verify_device_token(&config, &device_id, &token) {
-                        // Bind device id onto the connection for logging. Never
-                        // log the token.
+                        // NEVER log the token.
                         tracing::debug!("ws_v2: hello verified for device {device_id}");
                     } else {
                         tracing::warn!(
@@ -201,9 +377,7 @@ async fn handle_client_text(
                     }
                 }
                 _ => {
-                    // No credential in the hello: keep prior accept behavior
-                    // (the middleware already gated the upgrade).
-                    tracing::debug!("ws_v2: hello accepted without device token");
+                    tracing::debug!("ws_v2: token-less hello on authorized connection (no-op)");
                 }
             }
         }
@@ -302,4 +476,158 @@ async fn subscribe(
 
     forwarders.insert(ch.to_string(), handle);
     tracing::debug!("ws_v2: subscribed {ch} (since={since:?})");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_state::AppState;
+    use bamboo_config::{AccessControlConfig, DeviceCredential};
+    use tempfile::tempdir;
+
+    fn hello(device_id: Option<&str>, token: Option<&str>) -> ClientFrame {
+        ClientFrame::Hello {
+            device_id: device_id.map(str::to_string),
+            token: token.map(str::to_string),
+        }
+    }
+
+    // ── Pure classification (no AppState) ─────────────────────────────────────
+
+    #[test]
+    fn classify_unauthorized_frame_actions() {
+        // A credentialed hello is the only authorize candidate.
+        assert_eq!(
+            UnauthorizedAction::classify(&hello(Some("d"), Some("t"))),
+            UnauthorizedAction::VerifyHello
+        );
+        // A token-less hello (any missing field) is a no-op, never an authorizer.
+        assert_eq!(
+            UnauthorizedAction::classify(&hello(None, None)),
+            UnauthorizedAction::TokenlessHelloNoop
+        );
+        assert_eq!(
+            UnauthorizedAction::classify(&hello(Some("d"), None)),
+            UnauthorizedAction::TokenlessHelloNoop
+        );
+        assert_eq!(
+            UnauthorizedAction::classify(&hello(None, Some("t"))),
+            UnauthorizedAction::TokenlessHelloNoop
+        );
+        // Every channel-touching / control frame is IGNORED while unauthorized.
+        assert_eq!(
+            UnauthorizedAction::classify(&ClientFrame::Subscribe {
+                ch: "feed".into(),
+                since: None
+            }),
+            UnauthorizedAction::Ignore
+        );
+        assert_eq!(
+            UnauthorizedAction::classify(&ClientFrame::Unsubscribe { ch: "feed".into() }),
+            UnauthorizedAction::Ignore
+        );
+        assert_eq!(
+            UnauthorizedAction::classify(&ClientFrame::Stop {
+                session_id: "s".into()
+            }),
+            UnauthorizedAction::Ignore
+        );
+        assert_eq!(
+            UnauthorizedAction::classify(&ClientFrame::Unknown),
+            UnauthorizedAction::Ignore
+        );
+    }
+
+    // ── AppState-aware gate (no live Session) ─────────────────────────────────
+
+    async fn app_state_with_device() -> (web::Data<AppState>, DeviceCredential, String) {
+        let dir = tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let (cred, token) = crate::handlers::settings::issue_device_token("test-device");
+        {
+            let mut config = state.config.write().await;
+            config.access_control = Some(AccessControlConfig {
+                password_enabled: false,
+                password_hash: None,
+                password_salt: None,
+                updated_at: None,
+                devices: vec![cred.clone()],
+            });
+        }
+        (state, cred, token)
+    }
+
+    #[actix_web::test]
+    async fn subscribe_while_unauthorized_is_ignored_and_stays_unauthorized() {
+        let (state, _cred, _token) = app_state_with_device().await;
+        let mut authorized = false;
+        let frame = ClientFrame::Subscribe {
+            ch: "feed".into(),
+            since: None,
+        };
+        let outcome = apply_auth_gate(&state, &frame, &mut authorized).await;
+        // The driver keeps the socket open but does NOT dispatch (no forwarder).
+        assert_eq!(outcome, GateOutcome::Handled);
+        assert!(!authorized, "a subscribe must never authorize a connection");
+    }
+
+    #[actix_web::test]
+    async fn stop_while_unauthorized_is_ignored() {
+        let (state, _cred, _token) = app_state_with_device().await;
+        let mut authorized = false;
+        let frame = ClientFrame::Stop {
+            session_id: "sess".into(),
+        };
+        let outcome = apply_auth_gate(&state, &frame, &mut authorized).await;
+        assert_eq!(outcome, GateOutcome::Handled);
+        assert!(!authorized);
+    }
+
+    #[actix_web::test]
+    async fn valid_hello_authorizes() {
+        let (state, cred, token) = app_state_with_device().await;
+        let mut authorized = false;
+        let frame = hello(Some(&cred.device_id), Some(&token));
+        let outcome = apply_auth_gate(&state, &frame, &mut authorized).await;
+        assert_eq!(outcome, GateOutcome::Handled);
+        assert!(authorized, "a valid hello must authorize the connection");
+    }
+
+    #[actix_web::test]
+    async fn invalid_hello_closes_and_does_not_authorize() {
+        let (state, cred, _token) = app_state_with_device().await;
+        let mut authorized = false;
+        let frame = hello(Some(&cred.device_id), Some("bd1_wrongwrongwrong"));
+        let outcome = apply_auth_gate(&state, &frame, &mut authorized).await;
+        assert_eq!(outcome, GateOutcome::Close);
+        assert!(!authorized, "an invalid hello must never authorize");
+    }
+
+    #[actix_web::test]
+    async fn tokenless_hello_does_not_authorize_unauthorized_connection() {
+        let (state, _cred, _token) = app_state_with_device().await;
+        let mut authorized = false;
+        let frame = hello(None, None);
+        let outcome = apply_auth_gate(&state, &frame, &mut authorized).await;
+        assert_eq!(outcome, GateOutcome::Handled);
+        assert!(
+            !authorized,
+            "a token-less hello must NEVER authorize a non-pre-authorized connection"
+        );
+    }
+
+    #[actix_web::test]
+    async fn pre_authorized_connection_dispatches_subscribe() {
+        let (state, _cred, _token) = app_state_with_device().await;
+        // Pre-authorized (local / cookie / header equivalent): the gate passes
+        // every frame straight through to channel dispatch.
+        let mut authorized = true;
+        let frame = ClientFrame::Subscribe {
+            ch: "feed".into(),
+            since: None,
+        };
+        let outcome = apply_auth_gate(&state, &frame, &mut authorized).await;
+        assert_eq!(outcome, GateOutcome::Dispatch);
+        assert!(authorized);
+    }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/access_control.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/access_control.rs
@@ -388,10 +388,34 @@ fn is_public_access_route(path: &str) -> bool {
             | "/v1/bamboo/access/verify"
             // v2-P2 (#181): a brand-new device has no credential yet, so the
             // pairing endpoint must be reachable unauthenticated. It self-gates
-            // by requiring the owner root password in its body. `/v2/stream`
-            // stays GATED.
+            // by requiring the owner root password in its body.
             | "/v2/pair"
+            // v2-P2 (#189): the WS upgrade opens unauthenticated, but the ws_v2
+            // handler then ENFORCES auth before serving ANY channel — it is
+            // pre-authorized when the upgrade itself carries a credential
+            // (local bypass / verified password cookie / device-token header),
+            // OR it must present a VERIFIED `hello` device token before any
+            // subscribe/stop is honored, and an unauthenticated socket is closed
+            // on a short deadline. Browsers cannot set headers on a WS upgrade,
+            // so this open-upgrade + hello-carrier path is the ONLY way a
+            // browser device-token client can authenticate over WS.
+            // `/v2/pair/code` + `/v2/devices*` STAY gated (not listed here).
+            | "/v2/stream"
     )
+}
+
+/// The single source of truth for the access allow-decision, shared by
+/// `enforce_access_password_middleware` (every gated route) and the ws_v2
+/// handler (`/v2/stream` pre-auth). A request is authorized when no credential
+/// is required (no password + no devices, or a local bypass), OR it carries a
+/// verified password cookie, OR it carries a valid per-device token header.
+///
+/// This MUST stay a pure extraction of the middleware's prior allow expression:
+/// changing it changes the gate for every route at once.
+pub(crate) fn request_is_authorized(req: &HttpRequest, config: &Config) -> bool {
+    !build_access_status(config, req).requires_password
+        || request_has_verified_access_cookie(req, config)
+        || request_has_valid_device_token(req, config)
 }
 
 pub async fn enforce_access_password_middleware<B: MessageBody + 'static>(
@@ -417,16 +441,13 @@ pub async fn enforce_access_password_middleware<B: MessageBody + 'static>(
     };
 
     let config = app_state.config.read().await.clone();
-    let access_status = build_access_status(&config, req.request());
     // Auth is required when a credential mechanism is configured (a root password
     // OR at least one active device) AND the request is not a local bypass. An
     // instance with NO devices + NO password behaves EXACTLY as before — zero
     // regression. When required, accept EITHER a verified password cookie OR a
-    // valid per-device token (#181).
-    if !access_status.requires_password
-        || request_has_verified_access_cookie(req.request(), &config)
-        || request_has_valid_device_token(req.request(), &config)
-    {
+    // valid per-device token (#181). The allow-decision is centralized in
+    // `request_is_authorized` so the ws_v2 handler enforces the SAME rule (#189).
+    if request_is_authorized(req.request(), &config) {
         return next
             .call(req)
             .await
@@ -1218,6 +1239,87 @@ mod tests {
             .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
             .to_http_request();
         assert!(!request_has_valid_device_token(&no_id, &config));
+    }
+
+    // ── v2-P2 shared allow-decision: request_is_authorized (#189) ──────────
+    //
+    // This is the SINGLE source of truth the middleware and the ws_v2 handler
+    // both call. These tests pin its truth table so the open `/v2/stream`
+    // upgrade enforces exactly what the middleware enforces everywhere else.
+
+    #[test]
+    fn request_is_authorized_local_is_always_allowed() {
+        // A local request bypasses regardless of configured credentials.
+        let config = config_with_password();
+        assert!(request_is_authorized(&local_req(), &config));
+    }
+
+    #[test]
+    fn request_is_authorized_remote_with_devices_and_no_creds_is_denied() {
+        // Remote + a credential mechanism configured + no presented credential.
+        let (cred, _t) = issue_device_token("d");
+        let config = Config {
+            access_control: Some(AccessControlConfig {
+                password_enabled: false,
+                password_hash: None,
+                password_salt: None,
+                updated_at: None,
+                devices: vec![cred],
+            }),
+            ..Config::default()
+        };
+        assert!(!request_is_authorized(&remote_req(), &config));
+    }
+
+    #[test]
+    fn request_is_authorized_remote_with_password_and_no_creds_is_denied() {
+        let config = config_with_password();
+        assert!(!request_is_authorized(&remote_req(), &config));
+    }
+
+    #[test]
+    fn request_is_authorized_remote_with_valid_cookie_is_allowed() {
+        let config = config_with_password();
+        let cookie_value =
+            access_verification_cookie_value(&config).expect("password config yields a cookie");
+        let req = TestRequest::default()
+            .insert_header((header::HOST, "bamboo.example.com"))
+            .cookie(Cookie::new(ACCESS_VERIFIED_COOKIE_NAME, cookie_value))
+            .to_http_request();
+        assert!(request_is_authorized(&req, &config));
+    }
+
+    #[test]
+    fn request_is_authorized_remote_with_valid_device_token_header_is_allowed() {
+        let (cred, token) = issue_device_token("d");
+        let device_id = cred.device_id.clone();
+        let mut config = config_with_password();
+        config.access_control.as_mut().unwrap().devices.push(cred);
+
+        let req = TestRequest::default()
+            .insert_header((header::HOST, "bamboo.example.com"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .insert_header((DEVICE_ID_HEADER, device_id))
+            .to_http_request();
+        assert!(request_is_authorized(&req, &config));
+    }
+
+    #[test]
+    fn request_is_authorized_no_password_no_devices_is_open() {
+        // Zero-regression baseline: an instance with neither credential mechanism
+        // never requires auth, so even a remote request is authorized.
+        let config = Config::default();
+        assert!(request_is_authorized(&remote_req(), &config));
+    }
+
+    #[test]
+    fn stream_is_public_but_sibling_routes_are_not() {
+        // #189: the upgrade is whitelisted; the gated siblings are NOT.
+        assert!(is_public_access_route("/v2/stream"));
+        assert!(is_public_access_route("/v2/pair"));
+        assert!(!is_public_access_route("/v2/pair/code"));
+        assert!(!is_public_access_route("/v2/devices"));
+        assert!(!is_public_access_route("/v2/devices/bamboo_x"));
     }
 
     // ── v2-P2 pairing codes + brute-force guard (#181, slice 2) ────────────

--- a/crates/app/bamboo-server/src/handlers/settings/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/mod.rs
@@ -14,12 +14,14 @@ mod redaction;
 mod setup;
 mod workflows;
 
-pub(crate) use access_control::verify_device_token;
+#[cfg(test)]
+pub(crate) use access_control::issue_device_token;
 pub use access_control::{
     create_pairing_code, enforce_access_password_middleware, get_access_status, list_devices,
     pair_device, revoke_device, rotate_device, update_access_password, verify_access_password,
     PairingCodeEntry, PairingCodeGuard,
 };
+pub(crate) use access_control::{request_is_authorized, verify_device_token};
 pub use bamboo_config::{
     get_bamboo_config, get_bamboo_tools, get_model_limit_defaults, get_proxy_auth_status,
     reset_bamboo_config, set_bamboo_config, set_proxy_auth, validate_bamboo_config_patch,

--- a/crates/app/bamboo-server/src/routes/tests.rs
+++ b/crates/app/bamboo-server/src/routes/tests.rs
@@ -297,11 +297,18 @@ async fn v2_stream_route_is_registered_and_reaches_handler() {
     );
 }
 
-/// `/v2/stream` is behind the SAME access-password middleware as `/api/v1`: a
-/// remote (non-loopback) request with a password configured and no verified
-/// cookie is blocked with `401` BEFORE reaching the WS handler.
+/// `/v2/stream` upgrade is NOT middleware-gated (#189): browsers cannot set
+/// auth headers on a WS upgrade, so the upgrade is whitelisted and the ws_v2
+/// handler enforces auth via `hello` instead. A remote, password-protected,
+/// credential-less request therefore REACHES the handler (it is NOT the
+/// middleware's `401`); a non-WebSocket GET then gets the handler's own `400`
+/// (no upgrade headers). The handler still serves NO channel without a verified
+/// hello — that contract is covered by the ws_v2 unit tests (`apply_auth_gate`).
+///
+/// The sibling gated routes (`/v2/pair/code`, `/v2/devices`) STAY behind the
+/// middleware: a remote credential-less request is still `401`.
 #[actix_web::test]
-async fn v2_stream_is_behind_access_middleware() {
+async fn v2_stream_upgrade_is_open_but_siblings_stay_gated() {
     let data_dir = tempdir().unwrap();
     let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());
     {
@@ -318,15 +325,47 @@ async fn v2_stream_is_behind_access_middleware() {
     }
     let app = test::init_service(App::new().app_data(app_state).configure(configure_routes)).await;
 
+    // Remote, no cookie/header credential. The upgrade is whitelisted, so the
+    // middleware does NOT reject it: the request reaches the WS handler, and a
+    // non-WebSocket GET surfaces the handler's 400 (not the middleware's 401).
     let req = test::TestRequest::get()
         .uri("/v2/stream")
         .insert_header((header::HOST, "bamboo.example.com"))
         .to_request();
     let resp = test::call_service(&app, req).await;
+    assert_ne!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "/v2/stream upgrade must NOT be middleware-rejected (#189: hello carries auth)"
+    );
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "a non-WebSocket GET reaches the handler and is rejected by actix_ws::handle"
+    );
+
+    // The sibling management routes are still gated: a remote credential-less
+    // request is rejected by the middleware with 401.
+    let gated = test::TestRequest::post()
+        .uri("/v2/pair/code")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .to_request();
+    let resp = test::call_service(&app, gated).await;
     assert_eq!(
         resp.status(),
         StatusCode::UNAUTHORIZED,
-        "/v2/stream must be guarded by the access middleware for remote requests"
+        "/v2/pair/code must stay middleware-gated"
+    );
+
+    let gated = test::TestRequest::get()
+        .uri("/v2/devices")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .to_request();
+    let resp = test::call_service(&app, gated).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "/v2/devices must stay middleware-gated"
     );
 }
 
@@ -906,7 +945,7 @@ async fn v2_devices_rotate_swaps_token_and_404s_unknown() {
 }
 
 /// `POST /v2/pair/code` is GATED: a remote unauthenticated caller is 401 by the
-/// middleware (mirrors `v2_stream_is_behind_access_middleware`).
+/// middleware (unlike `/v2/stream`, which is open-upgrade + handler-enforced).
 #[actix_web::test]
 async fn v2_pair_code_requires_auth() {
     let data_dir = tempdir().unwrap();


### PR DESCRIPTION
## What

Make the `/v2/stream` WebSocket `hello` an **authoritative auth gate** so browser device-token clients can authenticate over WS. Browsers cannot set `Authorization`/`X-Device-Id` headers on a WS upgrade, so a browser holding only a device token (no password cookie) was rejected by the access middleware *before* it could send a `hello` frame. This change opens the upgrade and moves auth enforcement into the handler.

## Design: open the upgrade, enforce in the handler

- **Single source of truth.** Extracted the middleware's allow expression into `request_is_authorized(req, config)` in `access_control.rs`; both the middleware and the ws_v2 handler call it. The middleware refactor is a **pure extraction** — identical operands, identical left-to-right short-circuit order — so every other route's gate is byte-for-byte unchanged.
- **Whitelist `/v2/stream`** in `is_public_access_route`: the upgrade opens, the handler enforces. `/v2/pair` stays public; `/v2/pair/code` and `/v2/devices*` stay gated.
- **Pre-auth at connect.** The handler computes `pre_authorized = request_is_authorized(&req, &config)` from the SAME allow-decision. Local bypass, password-cookie browsers (cookies **are** sent on the upgrade), and header device-token clients stay authorized exactly as the middleware allowed them — **zero regression**.
- **Unauthorized deadline.** A connection that never authorizes is closed after `AUTH_DEADLINE = 10s` (a pinned `tokio::time::sleep` arm in the `drive` select, guarded by `if !authorized` so it disarms once authorized).
- **Enforce in `drive` + `handle_client_text`.** While not authorized, the only frame that does anything is a `hello` carrying a valid `device_id` + `token`. `subscribe`/`unsubscribe`/`stop` are ignored — no forwarder spawned, no session cancelled, no channel data. A **token-less hello never authorizes** a connection that wasn't already pre-authorized.

The token is never logged.

## Security trace

A remote, unauthenticated connection (no cookie, no header, not local): `pre_authorized = false`. Any `subscribe`/`stop` it sends is classified `Ignore` → `GateOutcome::Handled` → no dispatch, no forwarder, no cancel. A token-less hello stays unauthorized. If no valid hello arrives within 10s the deadline fires → socket closed. It receives **no channel data** and **cannot linger**. An invalid credentialed hello → `GateOutcome::Close` → immediate close.

Local/cookie/header clients: `request_is_authorized` returns true on the upgrade (local bypass / verified cookie / valid Bearer device token), so `pre_authorized = true` → every frame dispatches normally. No desktop or existing-web-UI regression.

## Tests

- `request_is_authorized` truth table: local → true; remote+devices+no-creds → false; remote+password+no-creds → false; remote+valid cookie → true; remote+valid device-token header → true; no-password+no-devices → true (open). Plus `is_public_access_route` whitelist coverage (`/v2/stream` public, `/v2/pair/code` + `/v2/devices*` gated).
- ws_v2 auth-gating via the AppState-aware `apply_auth_gate` helper (no live WS session needed): subscribe-while-unauthorized is ignored and stays unauthorized; valid hello authorizes; invalid hello closes; token-less hello does not authorize; pre-authorized dispatches. Pure frame classification covered by `UnauthorizedAction::classify`.
- Re-aimed route test: `/v2/stream` upgrade is no longer middleware-rejected (reaches the handler; non-WS GET → handler's 400), while `/v2/pair/code` and `/v2/devices` stay middleware-gated (remote → 401).

`cargo test -p bamboo-server` → 931 passed. `cargo build` (full workspace) green. New code is clippy-clean (the residual warnings are pre-existing in other crates).

### Honest caveats

There is no live WS integration harness, so the **deadline actually firing** and **subscribe-before-auth being ignored on the live driver** are not exercised end-to-end. They are covered at the decision layer (`apply_auth_gate` returns `Handled`/`Close` and never `Dispatch` while unauthorized; the deadline arm is a standard `tokio::select!` sleep guarded by `!authorized`). The live-WS test from #187 would close this gap. The middleware refactor was reviewed to be a pure extraction (same operands, same short-circuit order).

Refs #181, Closes #189

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp
