### PR TITLE
test(server): live /v2/stream WS integration harness + per-channel outbound queues [#187]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,8 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
  "impl-more",
  "pin-project-lite",
  "rustls-pki-types",
@@ -675,6 +677,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "awc"
+version = "3.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7dc0207013c5059ddce268fe12045bd12b2e919318ee660c891bfe297a54f1f"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-rt",
+ "actix-service",
+ "actix-tls",
+ "actix-utils",
+ "base64",
+ "bytes",
+ "cfg-if",
+ "cookie",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "itoa",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand 0.9.4",
+ "rustls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+]
+
+[[package]]
 name = "bamboo-a2a"
 version = "0.0.0"
 dependencies = [
@@ -1139,6 +1175,7 @@ dependencies = [
 name = "bamboo-server"
 version = "0.0.0"
 dependencies = [
+ "actix-codec",
  "actix-cors",
  "actix-files",
  "actix-governor",
@@ -1148,6 +1185,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
+ "awc",
  "bamboo-agent-core",
  "bamboo-broker",
  "bamboo-compression",

--- a/crates/app/bamboo-server/Cargo.toml
+++ b/crates/app/bamboo-server/Cargo.toml
@@ -100,6 +100,12 @@ tokio-test = "0.4"
 mockall = "0.13"
 http = "1"
 actix-rt = "2"
+# v2-P1 (#187): live WS integration harness for `GET /v2/stream`. `awc` is
+# actix's own HTTP+WS client, so it composes with the actix-web 4 server already
+# in-tree (one runtime, one ws codec) and drives a real loopback `ws://` upgrade.
+# `actix-codec` names the `Framed` half `awc::ws connect()` returns.
+awc = { version = "3", features = ["rustls-0_23"] }
+actix-codec = "0.5"
 bamboo-infrastructure = { path = "../../infra/bamboo-infrastructure", features = ["test-utils"] }
 bamboo-llm = { path = "../../infra/bamboo-llm" }
 bamboo-config = { path = "../../infra/bamboo-config", features = ["test-utils"] }

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
@@ -20,7 +20,7 @@
 //!
 //! Fairness guarantee (honest): the merge is **fair-ish, not strict
 //! round-robin**. `StreamMap` polls all ready per-channel queues starting from a
-//! rotating index, so over time no channel is systematically starved, and a
+//! randomized index each poll, so over time no channel is systematically starved, and a
 //! flooding channel cannot monopolize the socket while another has frames ready.
 //! It does NOT guarantee exact 1:1 interleaving or any latency bound; it
 //! guarantees starvation-freedom and that per-channel backpressure stays local.

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
@@ -1,21 +1,38 @@
 //! Per-channel forwarder tasks for the v2 WS multiplex.
 //!
 //! Each subscribed channel runs its OWN task with its OWN broadcast receiver,
-//! pushing [`ServerEnvelope`]s onto a single shared bounded `mpsc` that the
-//! driver drains to the WS session.
+//! pushing [`ServerEnvelope`]s onto its OWN bounded `mpsc` queue. The driver
+//! holds a `StreamMap<channel, ReceiverStream>` and drains every per-channel
+//! queue with a fair merge (see below) to the WS session.
 //!
-//! Backpressure (RFC §10-Q3): the per-forwarder design gives **broadcast-ring
-//! independence** — a slow/lagging channel only overruns its own broadcast ring
-//! and is never blocked at the *source* by another channel. The forwarders then
-//! merge into one bounded outbound FIFO, so a sustained burst on one channel can
-//! still queue ahead of another at the *socket* (a head-of-line window bounded
-//! by the FIFO depth); it cannot deadlock (forwarders block on `send().await`
-//! holding no shared lock, and the driver always drains). A fully per-channel
-//! outbound queue with a fair merge is a possible future refinement; the bounded
-//! shared FIFO is the pragmatic first cut.
+//! Backpressure (RFC §10-Q3): the design now gives **per-channel independence at
+//! BOTH ends**:
+//!   1. *Source* — each forwarder owns its own broadcast receiver, so a
+//!      slow/lagging channel only overruns its own broadcast ring and is never
+//!      blocked at the source by another channel (the lag recovery is local).
+//!   2. *Socket* — each forwarder owns its own bounded outbound queue
+//!      (`OUTBOUND_BUFFER`), and the driver merges them with `tokio_stream`'s
+//!      `StreamMap`, whose poll order ROTATES its start index every poll. So a
+//!      sustained burst on one channel fills only its OWN queue (its forwarder
+//!      then awaits on `send`, applying backpressure to THAT channel alone) and
+//!      can no longer head-of-line another channel's frames at the socket — the
+//!      shared-FIFO head-of-line point of the first cut is removed.
 //!
-//! The driver keeps a `JoinHandle` per channel so `unsubscribe` (or teardown)
-//! aborts exactly that forwarder, leaving no orphaned broadcast reader.
+//! Fairness guarantee (honest): the merge is **fair-ish, not strict
+//! round-robin**. `StreamMap` polls all ready per-channel queues starting from a
+//! rotating index, so over time no channel is systematically starved, and a
+//! flooding channel cannot monopolize the socket while another has frames ready.
+//! It does NOT guarantee exact 1:1 interleaving or any latency bound; it
+//! guarantees starvation-freedom and that per-channel backpressure stays local.
+//!
+//! Ordering WITHIN a channel is preserved end-to-end: a single forwarder pushes
+//! to a single FIFO `mpsc`, and `StreamMap` drains each inner stream in order; it
+//! only interleaves ACROSS channels.
+//!
+//! The driver keeps a `JoinHandle` per channel AND the matching queue receiver in
+//! the `StreamMap`, both keyed by the channel id, so `unsubscribe` (or teardown)
+//! aborts exactly that forwarder AND drops its queue, leaving no orphaned
+//! broadcast reader and no stale queued frame.
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -15,10 +15,13 @@
 //!
 //! ## Design
 //! Each subscribed channel runs its OWN forwarder task with its OWN broadcast
-//! receiver (per-channel lag independence; §10-Q3). Forwarders push fully-built
-//! envelope text frames onto one shared `mpsc` that the driver drains to the WS
-//! `session`. A per-channel `JoinHandle` lets `unsubscribe`/teardown abort
-//! exactly that forwarder, leaving no orphaned broadcast reader.
+//! receiver (per-channel lag independence; §10-Q3) AND its OWN bounded outbound
+//! `mpsc` queue. The driver holds a `StreamMap<channel, ReceiverStream>` and
+//! drains every per-channel queue with a fair (rotating-start) merge, so a burst
+//! on one channel can no longer head-of-line another at the socket (RFC §10-Q3 —
+//! see `forwarders.rs` for the honest fairness guarantee). A per-channel
+//! `JoinHandle` lets `unsubscribe`/teardown abort exactly that forwarder and drop
+//! its queue, leaving no orphaned broadcast reader.
 //!
 //! ## DEFERRED (later slices; see PR / §5.3)
 //! - `execute` / `approve` over control (handler refactors) — clients keep REST.
@@ -54,6 +57,8 @@ use actix_web::{web, HttpRequest, Responder};
 use actix_ws::Message;
 use futures::StreamExt;
 use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::StreamMap;
 
 use serde::Deserialize;
 
@@ -63,9 +68,12 @@ use crate::app_state::AppState;
 use crate::handlers::agent::events::MAX_BATCH_MS;
 use crate::handlers::agent::stop::cancel_session;
 
-/// Bound on the shared outbound mpsc. Caps how far ahead the (collectively)
-/// forwarders may run before the WS writer applies backpressure.
-const OUTBOUND_BUFFER: usize = 256;
+/// Bound on EACH per-channel outbound mpsc (RFC §10-Q3). Caps how far ahead one
+/// channel's forwarder may run before the WS writer applies backpressure to that
+/// channel ALONE — a slow socket no longer lets a bursting channel starve the
+/// queue of another, because each channel owns its own bounded buffer and the
+/// driver drains them with a fair merge.
+const OUTBOUND_BUFFER: usize = 64;
 
 /// WS ping interval (~15s), mirroring the v1 SSE `[KEEPALIVE]` cadence.
 const PING_INTERVAL: Duration = Duration::from_secs(15);
@@ -76,6 +84,22 @@ const PING_INTERVAL: Duration = Duration::from_secs(15);
 /// this elapses, so an unauthenticated socket can never linger (#189). Once the
 /// connection is authorized this deadline is disarmed.
 const AUTH_DEADLINE: Duration = Duration::from_secs(10);
+
+/// Env var the live integration test sets to SHORTEN the auth deadline so the
+/// "closed when no hello arrives" path is asserted in milliseconds, not 10s. It
+/// is read once per connection in [`drive`]. Production NEVER sets it, so the
+/// 10s [`AUTH_DEADLINE`] default is unchanged.
+const AUTH_DEADLINE_OVERRIDE_ENV: &str = "BAMBOO_WS_AUTH_DEADLINE_MS";
+
+/// The effective unauthorized deadline: the [`AUTH_DEADLINE`] default unless
+/// [`AUTH_DEADLINE_OVERRIDE_ENV`] is set to a valid millisecond count (test-only).
+fn auth_deadline() -> Duration {
+    std::env::var(AUTH_DEADLINE_OVERRIDE_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(AUTH_DEADLINE)
+}
 
 /// The verdict for one client frame while a connection is NOT yet authorized.
 ///
@@ -237,8 +261,14 @@ async fn drive(
     batch_ms: u64,
     pre_authorized: bool,
 ) {
-    let (out_tx, mut out_rx) = mpsc::channel::<String>(OUTBOUND_BUFFER);
+    // Per-channel outbound (RFC §10-Q3): every subscribed channel owns its OWN
+    // bounded queue. `forwarders` keeps the task handle (for unsubscribe/teardown
+    // abort) and `queues` keeps the matching receiver in a `StreamMap` the driver
+    // drains with a fair (rotating-start) merge, so a burst on one channel cannot
+    // head-of-line another at the socket. The two maps are keyed by the SAME
+    // channel id and mutated together (see [`subscribe`] / unsubscribe / teardown).
     let mut forwarders: HashMap<String, tokio::task::JoinHandle<()>> = HashMap::new();
+    let mut queues: StreamMap<String, ReceiverStream<String>> = StreamMap::new();
     let mut ping = tokio::time::interval(PING_INTERVAL);
     ping.tick().await; // skip the immediate tick
 
@@ -249,7 +279,7 @@ async fn drive(
     // The unauthorized-deadline timer. Pinned + biased to fire while `!authorized`
     // and disarmed once the connection authorizes, so an unauthenticated socket
     // is closed but an authorized one runs indefinitely.
-    let auth_deadline = tokio::time::sleep(AUTH_DEADLINE);
+    let auth_deadline = tokio::time::sleep(auth_deadline());
     tokio::pin!(auth_deadline);
 
     loop {
@@ -261,9 +291,12 @@ async fn drive(
                 tracing::debug!("ws_v2: closing unauthorized connection after auth deadline");
                 break;
             }
-            // Drain forwarder output to the WS. If the write fails the peer is
-            // gone — break and tear down.
-            Some(text) = out_rx.recv() => {
+            // Drain the per-channel queues to the WS with a fair merge. The
+            // `StreamMap` rotates its poll start each call, so no single channel's
+            // queue is favored — a bursting channel cannot starve another at the
+            // socket. `(channel, frame)` is yielded; only the frame goes on the
+            // wire. If the write fails the peer is gone — break and tear down.
+            Some((_ch, text)) = queues.next() => {
                 if session.text(text).await.is_err() {
                     break;
                 }
@@ -282,7 +315,7 @@ async fn drive(
                 match msg {
                     Some(Ok(Message::Text(text))) => {
                         let keep_open = handle_client_text(
-                            &state, &out_tx, &mut forwarders, &mut session,
+                            &state, &mut forwarders, &mut queues, &mut session,
                             batch_ms, &text, &mut authorized,
                         )
                         .await;
@@ -312,10 +345,12 @@ async fn drive(
     }
 
     // Clean teardown: abort every forwarder so no orphaned broadcast reader
-    // survives the connection.
+    // survives the connection, and drop every per-channel queue (clearing the
+    // `StreamMap` drops each receiver).
     for (_ch, handle) in forwarders.drain() {
         handle.abort();
     }
+    queues.clear();
     let _ = session.close(None).await;
 }
 
@@ -333,8 +368,8 @@ async fn drive(
 /// presents an INVALID device credential); `true` to keep it open.
 async fn handle_client_text(
     state: &web::Data<AppState>,
-    out_tx: &OutboundTx,
     forwarders: &mut HashMap<String, tokio::task::JoinHandle<()>>,
+    queues: &mut StreamMap<String, ReceiverStream<String>>,
     _session: &mut actix_ws::Session,
     batch_ms: u64,
     text: &str,
@@ -382,11 +417,15 @@ async fn handle_client_text(
             }
         }
         ClientFrame::Subscribe { ch, since } => {
-            subscribe(state, out_tx, forwarders, batch_ms, &ch, since).await;
+            subscribe(state, forwarders, queues, batch_ms, &ch, since).await;
         }
         ClientFrame::Unsubscribe { ch } => {
             if let Some(handle) = forwarders.remove(&ch) {
                 handle.abort();
+                // Drop this channel's queue too: removing it from the StreamMap
+                // drops the receiver so the (now-aborted) forwarder's sender is
+                // dead and no stale frame can leak onto the socket.
+                queues.remove(&ch);
                 tracing::debug!("ws_v2: unsubscribed {ch}");
             }
         }
@@ -406,8 +445,8 @@ async fn handle_client_text(
 /// a duplicate reader on one channel).
 async fn subscribe(
     state: &web::Data<AppState>,
-    out_tx: &OutboundTx,
     forwarders: &mut HashMap<String, tokio::task::JoinHandle<()>>,
+    queues: &mut StreamMap<String, ReceiverStream<String>>,
     batch_ms: u64,
     ch: &str,
     since: Option<u64>,
@@ -417,10 +456,17 @@ async fn subscribe(
         return;
     };
 
-    // Replace any prior forwarder for this exact channel id.
+    // Replace any prior forwarder for this exact channel id, dropping its queue
+    // (a re-subscribe with a new cursor must not leave the old queue behind).
     if let Some(old) = forwarders.remove(ch) {
         old.abort();
     }
+    queues.remove(ch);
+
+    // This channel's OWN bounded outbound queue (RFC §10-Q3). The forwarder owns
+    // the sender; the driver drains the receiver via the fair `StreamMap` merge.
+    let (out_tx, out_rx) = mpsc::channel::<String>(OUTBOUND_BUFFER);
+    let out_tx: OutboundTx = out_tx;
 
     let handle = match channel {
         Channel::Feed => {
@@ -431,7 +477,7 @@ async fn subscribe(
             let latest_at_start = state.account_sink.latest_seq();
             let events_dir = state.account_sink.events_dir().to_path_buf();
             let since = since.unwrap_or(0);
-            spawn_feed_forwarder(out_tx.clone(), receiver, events_dir, since, latest_at_start)
+            spawn_feed_forwarder(out_tx, receiver, events_dir, since, latest_at_start)
         }
         Channel::Agent(sid) => {
             // The session must exist; otherwise ignore (parity with the v1
@@ -464,7 +510,7 @@ async fn subscribe(
             spawn_agent_forwarder(
                 state.clone(),
                 sid.clone(),
-                out_tx.clone(),
+                out_tx,
                 ch.to_string(),
                 receiver,
                 budget_event_to_replay,
@@ -475,6 +521,9 @@ async fn subscribe(
     };
 
     forwarders.insert(ch.to_string(), handle);
+    // Register this channel's queue receiver into the fair-merge drain. Keyed by
+    // the SAME channel id as `forwarders`, so unsubscribe/teardown drops both.
+    queues.insert(ch.to_string(), ReceiverStream::new(out_rx));
     tracing::debug!("ws_v2: subscribed {ch} (since={since:?})");
 }
 

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -17,7 +17,7 @@
 //! Each subscribed channel runs its OWN forwarder task with its OWN broadcast
 //! receiver (per-channel lag independence; §10-Q3) AND its OWN bounded outbound
 //! `mpsc` queue. The driver holds a `StreamMap<channel, ReceiverStream>` and
-//! drains every per-channel queue with a fair (rotating-start) merge, so a burst
+//! drains every per-channel queue with a fair (randomized-start) merge, so a burst
 //! on one channel can no longer head-of-line another at the socket (RFC §10-Q3 —
 //! see `forwarders.rs` for the honest fairness guarantee). A per-channel
 //! `JoinHandle` lets `unsubscribe`/teardown abort exactly that forwarder and drop
@@ -264,7 +264,7 @@ async fn drive(
     // Per-channel outbound (RFC §10-Q3): every subscribed channel owns its OWN
     // bounded queue. `forwarders` keeps the task handle (for unsubscribe/teardown
     // abort) and `queues` keeps the matching receiver in a `StreamMap` the driver
-    // drains with a fair (rotating-start) merge, so a burst on one channel cannot
+    // drains with a fair (randomized-start) merge, so a burst on one channel cannot
     // head-of-line another at the socket. The two maps are keyed by the SAME
     // channel id and mutated together (see [`subscribe`] / unsubscribe / teardown).
     let mut forwarders: HashMap<String, tokio::task::JoinHandle<()>> = HashMap::new();
@@ -292,7 +292,7 @@ async fn drive(
                 break;
             }
             // Drain the per-channel queues to the WS with a fair merge. The
-            // `StreamMap` rotates its poll start each call, so no single channel's
+            // `StreamMap` randomizes its poll start each call, so no single channel's
             // queue is favored — a bursting channel cannot starve another at the
             // socket. `(channel, frame)` is yielded; only the frame goes on the
             // wire. If the write fails the peer is gone — break and tear down.

--- a/crates/app/bamboo-server/tests/ws_v2_live.rs
+++ b/crates/app/bamboo-server/tests/ws_v2_live.rs
@@ -1,0 +1,644 @@
+//! Live WebSocket integration harness for `GET /v2/stream` (issue #187, Epic #181).
+//!
+//! These tests stand up a REAL bound `bamboo-server` on an ephemeral loopback
+//! port and drive a REAL `awc` WebSocket client through the actual ws_v2 driver /
+//! forwarder concurrency — the path that `test::init_service` (which never binds a
+//! socket) and the in-module unit tests cannot exercise end to end. The
+//! concurrency-heavy driver, the per-channel queue fair-merge, the #186
+//! child-event hold-open, and the #195/#189 hello auth-gate all get covered over a
+//! real handshake here.
+//!
+//! Determinism: every server binds `127.0.0.1:0` (ephemeral port), every wait is a
+//! bounded `tokio::time::timeout`, and assertions are on received frames — never
+//! on fixed sleeps. The unauthorized auth-deadline is shortened (process-wide) via
+//! `BAMBOO_WS_AUTH_DEADLINE_MS` so the "closed when no hello arrives" path resolves
+//! in well under a second instead of the production 10s; it is set ONCE at the top
+//! of the binary (see [`init_short_auth_deadline`]) and is long enough that every
+//! authorized/local connection authorizes inside the window.
+
+use std::sync::Once;
+use std::time::Duration;
+
+use actix_web::{web, App, HttpServer};
+use awc::ws;
+use bamboo_agent_core::AgentEvent;
+use bamboo_config::{AccessControlConfig, DeviceCredential};
+use bamboo_domain::SessionKind;
+use bamboo_server::routes::configure_routes;
+use bamboo_server::{AgentRunner, AgentStatus, AppState};
+use futures::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+
+/// The shortened unauthorized auth deadline for the whole test binary. Long
+/// enough that an authorized/local connection always authenticates inside it, but
+/// short enough to assert the "no hello → closed" path quickly.
+const TEST_AUTH_DEADLINE_MS: u64 = 1500;
+
+/// A generous-but-bounded ceiling for any single frame wait.
+const RECV_TIMEOUT: Duration = Duration::from_secs(5);
+
+static INIT: Once = Once::new();
+
+/// Shorten the ws_v2 unauthorized auth deadline process-wide. Production never
+/// sets this env var, so the 10s default is untouched; the test binary sets it
+/// once so the deadline-close path is fast and deterministic.
+fn init_short_auth_deadline() {
+    INIT.call_once(|| {
+        std::env::set_var(
+            "BAMBOO_WS_AUTH_DEADLINE_MS",
+            TEST_AUTH_DEADLINE_MS.to_string(),
+        );
+    });
+}
+
+/// A bound test server: keeps the `AppState`, the `TempDir` (so the data dir
+/// outlives the run), the base `ws://` URL, and the running `actix_web` server
+/// handle (dropped → stopped on teardown).
+struct TestServer {
+    state: web::Data<AppState>,
+    base_ws_url: String,
+    _tmp: TempDir,
+    server_handle: actix_web::dev::ServerHandle,
+    _join: tokio::task::JoinHandle<std::io::Result<()>>,
+}
+
+impl TestServer {
+    /// Build an `AppState` (optionally pre-seeding a device + password config),
+    /// bind the full route table on an ephemeral loopback port, and spawn it.
+    async fn start(configure: impl FnOnce(&mut bamboo_config::Config)) -> Self {
+        init_short_auth_deadline();
+        let tmp = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(tmp.path().to_path_buf()).await.unwrap());
+        {
+            let mut config = state.config.write().await;
+            configure(&mut config);
+        }
+
+        // Bind first to learn the ephemeral port, then hand the listener to actix.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let std_listener = listener.into_std().unwrap();
+        std_listener.set_nonblocking(false).unwrap();
+
+        let state_for_factory = state.clone();
+        let server = HttpServer::new(move || {
+            App::new()
+                .app_data(state_for_factory.clone())
+                .configure(configure_routes)
+        })
+        .workers(1)
+        .listen(std_listener)
+        .unwrap()
+        .run();
+
+        let server_handle = server.handle();
+        let join = tokio::spawn(server);
+
+        TestServer {
+            state,
+            base_ws_url: format!("ws://127.0.0.1:{port}/v2/stream"),
+            _tmp: tmp,
+            server_handle,
+            _join: join,
+        }
+    }
+
+    async fn stop(self) {
+        self.server_handle.stop(false).await;
+    }
+}
+
+/// One live WS connection: the framed read/write half of an `awc` upgrade.
+type WsConn = actix_codec::Framed<awc::BoxedSocket, ws::Codec>;
+
+/// Open a WS connection as a LOCAL client (no Host override → `127.0.0.1` host,
+/// so `is_local_request` is true and the connection is pre-authorized).
+async fn connect_local(server: &TestServer) -> WsConn {
+    let (_resp, framed) = awc::Client::new()
+        .ws(&server.base_ws_url)
+        .connect()
+        .await
+        .expect("local ws upgrade");
+    framed
+}
+
+/// Open a WS connection as a NON-LOCAL client by overriding the `Host` header to
+/// a public name. `awc` only injects a `Host` when one is absent, so this makes
+/// `is_local_request` return false (mirrors the `access_control` unit test
+/// `remote_host_is_not_local_even_when_peer_is_loopback`). With an active device
+/// configured, such a connection is NOT pre-authorized and must `hello`.
+async fn connect_remote(server: &TestServer) -> WsConn {
+    let (_resp, framed) = awc::Client::new()
+        .ws(&server.base_ws_url)
+        .set_header(awc::http::header::HOST, "bamboo.example.com")
+        .connect()
+        .await
+        .expect("remote ws upgrade (open per #189)");
+    framed
+}
+
+/// Send a JSON client frame.
+async fn send_json(conn: &mut WsConn, value: Value) {
+    conn.send(ws::Message::Text(value.to_string().into()))
+        .await
+        .expect("send client frame");
+}
+
+/// Receive the next TEXT frame as JSON within [`RECV_TIMEOUT`], skipping
+/// transport Ping/Pong frames. Returns `None` on close/stream-end.
+async fn next_envelope(conn: &mut WsConn) -> Option<Value> {
+    let deadline = tokio::time::Instant::now() + RECV_TIMEOUT;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let frame = tokio::time::timeout(remaining, conn.next())
+            .await
+            .expect("frame did not arrive before timeout")?;
+        match frame.expect("ws protocol error") {
+            ws::Frame::Text(bytes) => {
+                return Some(serde_json::from_slice(&bytes).expect("envelope is JSON"));
+            }
+            ws::Frame::Ping(_) | ws::Frame::Pong(_) => continue,
+            ws::Frame::Close(_) => return None,
+            other => panic!("unexpected ws frame: {other:?}"),
+        }
+    }
+}
+
+/// Assert the connection is closed (or yields no more data) within [`RECV_TIMEOUT`]
+/// — i.e. a Close frame or stream end, and never another text envelope.
+async fn expect_closed(conn: &mut WsConn) {
+    let deadline = tokio::time::Instant::now() + RECV_TIMEOUT;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let next = tokio::time::timeout(remaining, conn.next())
+            .await
+            .expect("connection did not close before timeout");
+        match next {
+            None => return,
+            Some(Ok(ws::Frame::Close(_))) => return,
+            Some(Ok(ws::Frame::Ping(_))) | Some(Ok(ws::Frame::Pong(_))) => continue,
+            Some(Ok(ws::Frame::Text(bytes))) => {
+                panic!(
+                    "expected the connection to be closed, got a text frame: {}",
+                    String::from_utf8_lossy(&bytes)
+                )
+            }
+            Some(Ok(other)) => panic!("expected close, got {other:?}"),
+            Some(Err(_)) => return, // a transport error is also a closed socket
+        }
+    }
+}
+
+/// Register a session in the store so `subscribe agent.{id}` is honored and
+/// `has_running_child` can resolve its tree. Persisting via `save_session`
+/// updates the same in-memory index `get_index_entry` reads (the store and the
+/// persistence backend are the SAME `SessionStoreV2` instance).
+async fn register_session(state: &AppState, session: &mut bamboo_agent_core::Session) {
+    state.save_session(session).await;
+}
+
+/// Insert a runner for `session_id` with the given status (so `has_running_child`
+/// sees a Running child).
+async fn set_runner_status(state: &AppState, session_id: &str, status: AgentStatus) {
+    let mut runners = state.agent_runners.write().await;
+    let runner = runners
+        .entry(session_id.to_string())
+        .or_insert_with(AgentRunner::new);
+    runner.status = status;
+}
+
+/// Build a device credential with a KNOWN token, mirroring the server's
+/// `issue_device_token` hash construction (`SHA-256(hex_decode(salt) || token)`,
+/// hex-encoded). The integration test lives in a separate crate and cannot reach
+/// the `pub(crate)` `issue_device_token`, so it reproduces the (stable, documented
+/// on `DeviceCredential`) hashing here rather than widening production visibility.
+fn with_device(config: &mut bamboo_config::Config) -> (DeviceCredential, String) {
+    use sha2::{Digest, Sha256};
+
+    let device_id = "bamboo_test01device".to_string();
+    let token = "bd1_testtokentesttokentesttoken00".to_string();
+    let salt_hex = "0123456789abcdef0123456789abcdef".to_string();
+
+    let mut hasher = Sha256::new();
+    hasher.update(hex::decode(&salt_hex).unwrap());
+    hasher.update(token.as_bytes());
+    let token_hash = hex::encode(hasher.finalize());
+
+    let cred = DeviceCredential {
+        device_id,
+        label: "test-device".to_string(),
+        token_hash,
+        token_salt: salt_hex,
+        created_at: "2024-01-01T00:00:00Z".to_string(),
+        last_used_at: None,
+        revoked: false,
+    };
+    config.access_control = Some(AccessControlConfig {
+        password_enabled: false,
+        password_hash: None,
+        password_salt: None,
+        updated_at: None,
+        devices: vec![cred.clone()],
+    });
+    (cred, token)
+}
+
+// ── Scenario 1: subscribe → event → unsubscribe ─────────────────────────────
+
+/// A local client subscribes to an `agent.{sid}` channel, the server pushes an
+/// `AgentEvent` into that session's broadcast, and the client receives the
+/// `{ch,seq,event}` envelope. After unsubscribe, the forwarder stops: a further
+/// push is not delivered.
+#[actix_web::test]
+async fn subscribe_event_unsubscribe_roundtrip() {
+    let server = TestServer::start(|_| {}).await;
+    let sid = "sess_round";
+
+    let mut root = bamboo_agent_core::Session::new(sid, "test-model");
+    register_session(&server.state, &mut root).await;
+
+    let mut conn = connect_local(&server).await;
+    let ch = format!("agent.{sid}");
+    send_json(&mut conn, json!({"type": "subscribe", "ch": ch})).await;
+
+    // The forwarder subscribes to the broadcast asynchronously after our
+    // subscribe frame is processed. Push the event with a bounded retry so the
+    // test is robust to that handoff WITHOUT a fixed sleep: re-send until the
+    // first matching envelope arrives. The event payload is identical each time,
+    // so a re-send only ever produces (at most) the one envelope we assert on
+    // first.
+    let received = {
+        let mut got = None;
+        let overall = tokio::time::Instant::now() + RECV_TIMEOUT;
+        while tokio::time::Instant::now() < overall {
+            server
+                .state
+                .get_session_event_sender(sid)
+                .await
+                .send(AgentEvent::Token {
+                    content: "Hello".into(),
+                })
+                .ok();
+            if let Ok(Some(env)) =
+                tokio::time::timeout(Duration::from_millis(150), next_envelope(&mut conn)).await
+            {
+                got = Some(env);
+                break;
+            }
+        }
+        got.expect("a token envelope must arrive on the agent channel")
+    };
+
+    assert_eq!(received["ch"], ch.as_str());
+    assert!(received["seq"].as_u64().unwrap() >= 1);
+    assert_eq!(received["event"]["type"], "token");
+    assert_eq!(received["event"]["content"], "Hello");
+
+    // Unsubscribe, then confirm the forwarder stopped: drain any in-flight token
+    // re-sends, then push a DISTINCT marker and assert it never arrives.
+    send_json(&mut conn, json!({"type": "unsubscribe", "ch": ch})).await;
+    // Allow any already-queued frame to flush, then push the post-unsubscribe
+    // marker repeatedly; none of it must reach the client.
+    while let Ok(Some(_)) =
+        tokio::time::timeout(Duration::from_millis(200), next_envelope(&mut conn)).await
+    {}
+    for _ in 0..5 {
+        server
+            .state
+            .get_session_event_sender(sid)
+            .await
+            .send(AgentEvent::Token {
+                content: "AFTER_UNSUB".into(),
+            })
+            .ok();
+    }
+    let leaked = tokio::time::timeout(Duration::from_millis(400), next_envelope(&mut conn)).await;
+    match leaked {
+        Err(_) => {} // timed out: nothing arrived — the forwarder is gone.
+        Ok(None) => {}
+        Ok(Some(env)) => assert_ne!(
+            env["event"]["content"], "AFTER_UNSUB",
+            "no event must arrive after unsubscribe"
+        ),
+    }
+
+    server.stop().await;
+}
+
+// ── Scenario 2: feed cursor resume ──────────────────────────────────────────
+
+/// Publish a couple of ChangeEvents to the account feed, then connect and
+/// `subscribe {ch:"feed", since:N}`. The client must receive the backfill from
+/// the cursor plus the live tail with no dup/drop.
+#[actix_web::test]
+async fn feed_cursor_resume_backfill_and_live_tail() {
+    let server = TestServer::start(|_| {}).await;
+
+    // Two durable change events BEFORE the client connects (seq 1, 2).
+    for i in 0..2 {
+        server.state.account_sink.record(
+            None,
+            &AgentEvent::SessionDeleted {
+                session_id: format!("pre_{i}"),
+            },
+        );
+    }
+    // Wait until the writer has assigned both seqs (bounded).
+    let deadline = tokio::time::Instant::now() + RECV_TIMEOUT;
+    while server.state.account_sink.latest_seq() < 2 {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "feed writer never reached seq 2"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let mut conn = connect_local(&server).await;
+    // Resume from cursor 1 → expect backfill of seq 2 (seq 1 already seen).
+    send_json(
+        &mut conn,
+        json!({"type": "subscribe", "ch": "feed", "since": 1}),
+    )
+    .await;
+
+    let backfill = next_envelope(&mut conn)
+        .await
+        .expect("backfill envelope from cursor");
+    assert_eq!(backfill["ch"], "feed");
+    assert_eq!(
+        backfill["seq"], 2,
+        "backfill resumes strictly AFTER the cursor"
+    );
+    assert_eq!(backfill["event"]["event"]["type"], "session_deleted");
+
+    // Now a live event (seq 3) must tail in with no dup of seq 2.
+    server.state.account_sink.record(
+        None,
+        &AgentEvent::SessionDeleted {
+            session_id: "live_3".into(),
+        },
+    );
+    let live = next_envelope(&mut conn).await.expect("live tail envelope");
+    assert_eq!(live["ch"], "feed");
+    assert_eq!(
+        live["seq"], 3,
+        "live tail continues monotonically, no dup/drop"
+    );
+    assert_eq!(live["event"]["event"]["session_id"], "live_3");
+
+    server.stop().await;
+}
+
+// ── Scenario 3a: terminal with NO child closes the channel ───────────────────
+
+/// A terminal `AgentEvent` on a session with no running child closes the
+/// `agent.{sid}` channel: the client receives the terminal control frame.
+#[actix_web::test]
+async fn agent_terminal_without_child_closes_channel() {
+    let server = TestServer::start(|_| {}).await;
+    let sid = "sess_term";
+
+    let mut root = bamboo_agent_core::Session::new(sid, "test-model");
+    register_session(&server.state, &mut root).await;
+
+    let mut conn = connect_local(&server).await;
+    let ch = format!("agent.{sid}");
+    send_json(&mut conn, json!({"type": "subscribe", "ch": ch})).await;
+
+    // Push terminal events on a bounded retry until the terminal control frame
+    // arrives (robust to the subscribe→broadcast handoff with no fixed sleep).
+    let control = {
+        let mut got = None;
+        let overall = tokio::time::Instant::now() + RECV_TIMEOUT;
+        while tokio::time::Instant::now() < overall {
+            server
+                .state
+                .get_session_event_sender(sid)
+                .await
+                .send(AgentEvent::Complete {
+                    usage: Default::default(),
+                })
+                .ok();
+            // Drain until we see a control frame (the Complete event itself comes
+            // first, then the terminal control).
+            if let Ok(Some(env)) =
+                tokio::time::timeout(Duration::from_millis(200), next_envelope(&mut conn)).await
+            {
+                if env.get("control").is_some() {
+                    got = Some(env);
+                    break;
+                }
+            }
+        }
+        got.expect("a terminal control frame must arrive")
+    };
+
+    assert_eq!(control["ch"], ch.as_str());
+    assert_eq!(control["control"]["type"], "terminal");
+    assert_eq!(control["control"]["reason"], "complete");
+
+    server.stop().await;
+}
+
+// ── Scenario 3b: terminal WITH a running child holds the channel open ─────────
+
+/// #186 regression guard: an agent terminal while a child sub-agent is still
+/// "running" must NOT close the `agent.{sid}` channel; a later SubAgentCompleted
+/// (after the child stops running) closes it. This is LIVE-tested: we register a
+/// real child session in the store and a Running runner for it so
+/// `has_running_child` resolves true, then flip it before the completion.
+#[actix_web::test]
+async fn agent_terminal_with_running_child_holds_open_then_closes() {
+    let server = TestServer::start(|_| {}).await;
+    let root_id = "sess_parent";
+    let child_id = "sess_child";
+
+    let mut root = bamboo_agent_core::Session::new(root_id, "test-model");
+    register_session(&server.state, &mut root).await;
+    let mut child = bamboo_agent_core::Session::new_child(child_id, root_id, "test-model", "child");
+    assert_eq!(child.kind, SessionKind::Child);
+    register_session(&server.state, &mut child).await;
+    // The child is RUNNING → has_running_child(root) is true.
+    set_runner_status(&server.state, child_id, AgentStatus::Running).await;
+
+    let mut conn = connect_local(&server).await;
+    let ch = format!("agent.{root_id}");
+    send_json(&mut conn, json!({"type": "subscribe", "ch": ch})).await;
+
+    // Drive a terminal on the PARENT until its echoed Complete event arrives (so
+    // we know the forwarder is subscribed and processed the terminal). While the
+    // child runs, NO terminal control must follow.
+    let mut saw_complete_event = false;
+    let overall = tokio::time::Instant::now() + RECV_TIMEOUT;
+    while tokio::time::Instant::now() < overall && !saw_complete_event {
+        server
+            .state
+            .get_session_event_sender(root_id)
+            .await
+            .send(AgentEvent::Complete {
+                usage: Default::default(),
+            })
+            .ok();
+        if let Ok(Some(env)) =
+            tokio::time::timeout(Duration::from_millis(200), next_envelope(&mut conn)).await
+        {
+            // It must be the Complete EVENT, never a terminal control, while the
+            // child still runs.
+            if env.get("control").is_some() {
+                panic!("channel closed (terminal control) while a child was still running (#186)");
+            }
+            if env["event"]["type"] == "complete" {
+                saw_complete_event = true;
+            }
+        }
+    }
+    assert!(
+        saw_complete_event,
+        "the parent Complete event should be forwarded while holding the channel open"
+    );
+
+    // Assert the channel stays OPEN: no terminal control during a quiet window.
+    if let Ok(Some(env)) =
+        tokio::time::timeout(Duration::from_millis(400), next_envelope(&mut conn)).await
+    {
+        assert!(
+            env.get("control").is_none(),
+            "channel must stay open while the child runs (#186); got control {env}"
+        );
+    }
+
+    // The child stops running, then a SubAgentCompleted arrives → close now.
+    set_runner_status(&server.state, child_id, AgentStatus::Completed).await;
+    let control = {
+        let mut got = None;
+        let overall = tokio::time::Instant::now() + RECV_TIMEOUT;
+        while tokio::time::Instant::now() < overall {
+            server
+                .state
+                .get_session_event_sender(root_id)
+                .await
+                .send(AgentEvent::SubAgentCompleted {
+                    parent_session_id: root_id.into(),
+                    child_session_id: child_id.into(),
+                    status: "completed".into(),
+                    error: None,
+                })
+                .ok();
+            if let Ok(Some(env)) =
+                tokio::time::timeout(Duration::from_millis(200), next_envelope(&mut conn)).await
+            {
+                if env.get("control").is_some() {
+                    got = Some(env);
+                    break;
+                }
+            }
+        }
+        got.expect("a terminal control must arrive once the last child completes")
+    };
+    assert_eq!(control["control"]["type"], "terminal");
+    assert_eq!(control["control"]["reason"], "complete");
+
+    server.stop().await;
+}
+
+// ── Scenario 4: hello auth-gate (#189/#195) ──────────────────────────────────
+
+/// A REMOTE (non-local) connection with an active device configured is NOT
+/// pre-authorized: a subscribe WITHOUT a valid hello serves NO channel data and
+/// the socket is CLOSED by the (shortened) auth deadline.
+#[actix_web::test]
+async fn remote_without_hello_is_closed_by_deadline() {
+    let mut captured = None;
+    let server = TestServer::start(|config| {
+        captured = Some(with_device(config));
+    })
+    .await;
+    let _ = captured; // device exists so a credential is required for remotes.
+
+    let mut conn = connect_remote(&server).await;
+    // A subscribe before any hello must be ignored: no channel data.
+    send_json(&mut conn, json!({"type": "subscribe", "ch": "feed"})).await;
+    // Also push a feed event; an unauthorized connection must not receive it.
+    server.state.account_sink.record(
+        None,
+        &AgentEvent::SessionDeleted {
+            session_id: "nope".into(),
+        },
+    );
+
+    // The connection must be CLOSED by the deadline, having served nothing.
+    expect_closed(&mut conn).await;
+
+    server.stop().await;
+}
+
+/// A REMOTE connection that sends a VALID hello authorizes; a subsequent
+/// subscribe then works (feed backfill is served).
+#[actix_web::test]
+async fn remote_with_valid_hello_authorizes_then_subscribe_works() {
+    let mut captured = None;
+    let server = TestServer::start(|config| {
+        captured = Some(with_device(config));
+    })
+    .await;
+    let (cred, token) = captured.unwrap();
+
+    // A durable feed event so the subscribe has something to backfill.
+    server.state.account_sink.record(
+        None,
+        &AgentEvent::SessionDeleted {
+            session_id: "evt".into(),
+        },
+    );
+    let deadline = tokio::time::Instant::now() + RECV_TIMEOUT;
+    while server.state.account_sink.latest_seq() < 1 {
+        assert!(tokio::time::Instant::now() < deadline);
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let mut conn = connect_remote(&server).await;
+    send_json(
+        &mut conn,
+        json!({"type": "hello", "device_id": cred.device_id, "token": token}),
+    )
+    .await;
+    // After authorizing, a feed subscribe from cursor 0 backfills seq 1.
+    send_json(
+        &mut conn,
+        json!({"type": "subscribe", "ch": "feed", "since": 0}),
+    )
+    .await;
+
+    let env = next_envelope(&mut conn)
+        .await
+        .expect("an authorized remote must receive feed data");
+    assert_eq!(env["ch"], "feed");
+    assert_eq!(env["seq"], 1);
+
+    server.stop().await;
+}
+
+/// A REMOTE connection that sends an INVALID hello is closed immediately.
+#[actix_web::test]
+async fn remote_with_invalid_hello_is_closed() {
+    let mut captured = None;
+    let server = TestServer::start(|config| {
+        captured = Some(with_device(config));
+    })
+    .await;
+    let (cred, _token) = captured.unwrap();
+
+    let mut conn = connect_remote(&server).await;
+    send_json(
+        &mut conn,
+        json!({"type": "hello", "device_id": cred.device_id, "token": "bd1_wrongwrongwrong"}),
+    )
+    .await;
+
+    // An invalid credential closes the socket (well before the deadline).
+    expect_closed(&mut conn).await;
+
+    server.stop().await;
+}


### PR DESCRIPTION
Two deferred items from the v2-P1 `/v2/stream` WSS multiplex (PR #186, Epic #181).

## Part A — live WS integration harness (priority)

New `crates/app/bamboo-server/tests/ws_v2_live.rs` stands up a **real** bound `bamboo-server` on an ephemeral `127.0.0.1:0` port and drives a **real** `awc` WebSocket client through the actual ws_v2 driver/forwarder concurrency — the path `test::init_service` (no socket bind) and the in-module unit tests cannot exercise end to end. Dev-deps added: `awc` (actix's own HTTP+WS client, composes with the in-tree actix-web 4 server) + `actix-codec` (names the `Framed` half).

Scenarios — all **LIVE-tested**:
1. **subscribe → event → unsubscribe** — subscribe to `agent.{sid}`, push an `AgentEvent` into the session broadcast, assert the `{ch,seq,event}` envelope arrives; unsubscribe and assert the forwarder stops (a later distinct event never arrives).
2. **feed cursor resume** — publish ChangeEvents via `account_sink`, `subscribe {ch:"feed", since:N}`, assert backfill strictly after the cursor + monotonic live tail with no dup/drop.
3. **agent terminal + child hold-open (#186 guard)** — a terminal with a **registered Running child** holds `agent.{sid}` open (no terminal control during a quiet window), then closes on the last `SubAgentCompleted` once the child stops Running. Also the simpler terminal-with-no-child path closes immediately. The child is faithfully simulated: a real child `Session` in the store (`kind=Child`, same root) plus a `Running` `AgentRunner`, so `has_running_child` resolves true.
4. **hello auth-gate (#189/#195)** — remote without hello is closed by the auth deadline (serving no channel data); remote with a valid hello authorizes then subscribe works; remote with an invalid hello is closed immediately.

**Non-local connection**: the awc upgrade `Host` header is overridden to a public name (`awc` only injects `Host` when absent), mirroring the `access_control` unit test, plus an active device so a credential is required — so `is_local_request` is false and the connection is not pre-authorized.

**AUTH_DEADLINE timing**: the 10s production deadline is read once per connection via a new `auth_deadline()` that honors a **test-only** `BAMBOO_WS_AUTH_DEADLINE_MS` override (set once at the top of the test binary to 1500ms). Production never sets it, so the 10s default is **unchanged**.

Determinism: ephemeral port, every wait a bounded `tokio::time::timeout`, assertions on received frames, no fixed sleeps where avoidable. Ran repeatedly (multi-threaded + single-threaded) with no flakiness.

## Part B — per-channel outbound queues (RFC §10-Q3)

Replaces the single shared `mpsc(256)` FIFO with **one bounded `mpsc(64)` per channel**. The driver holds a `tokio_stream::StreamMap<channel, ReceiverStream>` and drains all per-channel queues with a **fair merge** whose poll start rotates each poll, so a sustained burst on one channel can no longer head-of-line another channel's frames at the socket.

**Honest fairness guarantee**: fair-ish (starvation-free), **not** strict round-robin — no exact 1:1 interleaving or latency bound, but no channel is systematically starved and per-channel backpressure stays local (a bursting channel fills only its own queue, applying backpressure to that channel alone). Ordering **within** a channel is preserved end to end (single forwarder → single FIFO `mpsc`, `StreamMap` drains each inner stream in order); only **across** channels is interleaved.

Preserved: the auth-gate (no forwarder spawned while unauthorized), the #186 child-hold-open, cursor-resume, coalescing, the ping keepalive, and teardown/unsubscribe (abort the forwarder **and** drop its queue, keyed by the same channel id). `forwarders.rs` docstring updated to state the new accurate guarantee.

## Production behavior

Unchanged except the intended fairness improvement. Zero v1 regression. The token is never logged.

## Tests

- `cargo test -p bamboo-server` — 931 lib + 21 ws_v2 unit + 7 live integration, all green.
- `cargo fmt`, `cargo clippy -p bamboo-server --tests` — new code clippy-clean (pre-existing clippy elsewhere untouched).
- Live tests ran repeatedly with no flakiness.

Refs #181, Closes #187

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp