### PR TITLE
feat(server): v2-P3 MessagePack subprotocol for /v2/stream [#181]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,6 +1219,7 @@ dependencies = [
  "reqwest-eventsource",
  "reqwest-middleware",
  "reqwest-retry",
+ "rmp-serde",
  "rustls",
  "rustls-pemfile",
  "serde",
@@ -4256,6 +4257,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
 ]
 
 [[package]]

--- a/crates/app/bamboo-server/Cargo.toml
+++ b/crates/app/bamboo-server/Cargo.toml
@@ -62,6 +62,10 @@ tokio-stream = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+# v2-P3 (#181): MessagePack codec for the `bamboo.v2.msgpack` subprotocol. We use
+# `to_vec_named` (structs-as-maps) so `ServerEnvelope`'s `#[serde(flatten)]` +
+# untagged body round-trip; the default array-encoding would break them.
+rmp-serde = "1"
 
 # Logging
 tracing = "0.1"

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/envelope.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/envelope.rs
@@ -8,6 +8,41 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// The wire encoding negotiated for a `/v2/stream` connection (v2-P3, §7.2).
+///
+/// Selected ONCE at the upgrade from the offered `Sec-WebSocket-Protocol`
+/// subprotocols and carried for the connection's lifetime. JSON is the default
+/// (desktop / debuggability); `bamboo.v2.msgpack` switches the SAME envelope
+/// schema to binary MessagePack. The logical schema is byte-for-byte identical —
+/// only the serialization + WS frame type (Text vs Binary) differs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Encoding {
+    /// JSON text frames (`bamboo.v2`, the default). Today's behavior, unchanged.
+    Json,
+    /// MessagePack binary frames (`bamboo.v2.msgpack`).
+    Msgpack,
+}
+
+/// The subprotocol token a `bamboo.v2.msgpack` client offers / the server echoes.
+pub(crate) const SUBPROTOCOL_MSGPACK: &str = "bamboo.v2.msgpack";
+/// The subprotocol token for the default JSON encoding.
+pub(crate) const SUBPROTOCOL_JSON: &str = "bamboo.v2";
+
+/// An already-encoded outbound frame, tagged by WS frame type.
+///
+/// The forwarders encode a [`ServerEnvelope`] per the connection's [`Encoding`]
+/// up front and push one of these onto the per-channel queue; the driver writes
+/// `Text` via `session.text` and `Binary` via `session.binary`. This keeps the
+/// final encode out of the driver's hot select loop and makes the encoding
+/// per-connection rather than per-write.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum OutFrame {
+    /// A JSON text frame (`Encoding::Json`).
+    Text(String),
+    /// A MessagePack binary frame (`Encoding::Msgpack`).
+    Binary(Vec<u8>),
+}
+
 /// A server→client envelope.
 ///
 /// Serializes as one of two shapes sharing `{ch, seq}`:
@@ -84,6 +119,40 @@ impl ServerEnvelope {
     /// Serialize to a JSON text frame.
     pub(crate) fn to_text(&self) -> Option<String> {
         serde_json::to_string(self).ok()
+    }
+
+    /// Encode to an [`OutFrame`] per the connection's [`Encoding`].
+    ///
+    /// JSON → a text frame (today's behavior, byte-for-byte). Msgpack →
+    /// `rmp_serde::to_vec_named`, which serializes structs as MAPS (named
+    /// fields). This is REQUIRED: `ServerEnvelope` uses `#[serde(flatten)]` over
+    /// an `#[serde(untagged)]` body, and rmp-serde's default `to_vec` writes
+    /// structs as positional ARRAYS, which breaks both flatten and untagged
+    /// resolution. With `to_vec_named` the logical wire schema is identical to
+    /// the JSON form (`{ch, seq, event}` / `{ch, seq, control}`), just msgpack.
+    ///
+    /// A serialization failure yields `None` — the caller skips the frame and
+    /// keeps the forwarder alive (matches the v1 SSE `to_string(...).ok()`
+    /// discipline).
+    pub(crate) fn encode(&self, encoding: Encoding) -> Option<OutFrame> {
+        match encoding {
+            Encoding::Json => self.to_text().map(OutFrame::Text),
+            Encoding::Msgpack => rmp_serde::to_vec_named(self).ok().map(OutFrame::Binary),
+        }
+    }
+}
+
+/// Decode an inbound [`ClientFrame`] per the connection's [`Encoding`].
+///
+/// JSON mode parses a Text frame's UTF-8 with serde_json (today's behavior).
+/// Msgpack mode parses a Binary frame with rmp-serde. Both honor the
+/// `#[serde(other)] Unknown` fallback, so an unrecognized `type` tag decodes to
+/// [`ClientFrame::Unknown`] rather than erroring; a truly malformed body is an
+/// `Err` the driver logs-and-ignores (it never tears down the connection).
+pub(crate) fn decode_client_frame(encoding: Encoding, bytes: &[u8]) -> Result<ClientFrame, String> {
+    match encoding {
+        Encoding::Json => serde_json::from_slice(bytes).map_err(|e| e.to_string()),
+        Encoding::Msgpack => rmp_serde::from_slice(bytes).map_err(|e| e.to_string()),
     }
 }
 
@@ -288,6 +357,153 @@ mod tests {
         // A JSON object missing the `type` tag → also an error (no default tag).
         let r: Result<ClientFrame, _> = serde_json::from_str(r#"{"ch":"feed"}"#);
         assert!(r.is_err());
+    }
+
+    // ── msgpack round-trips (v2-P3, #181) ─────────────────────────────────────
+    //
+    // The CRITICAL gotcha: `ServerEnvelope` has `#[serde(flatten)]` over an
+    // untagged body, and rmp-serde's default `to_vec` writes structs as positional
+    // ARRAYS, which breaks both. These tests pin that `to_vec_named` (structs as
+    // MAPS) round-trips the SAME logical schema as JSON. We decode back to a
+    // `serde_json::Value` (msgpack maps → JSON objects) so the assertions are on
+    // the exact field names/values the JSON form carries.
+
+    #[test]
+    fn server_envelope_event_msgpack_roundtrips_to_same_schema() {
+        let env = ServerEnvelope::event(
+            "agent.sess_abc",
+            42,
+            json!({ "type": "token", "content": "Hello" }),
+        );
+        let frame = env.encode(Encoding::Msgpack).expect("msgpack encode");
+        let OutFrame::Binary(bytes) = frame else {
+            panic!("msgpack encoding must yield a Binary frame");
+        };
+        // Decode the msgpack bytes back to a JSON Value: maps → objects, so the
+        // logical shape must equal the JSON form exactly.
+        let v: Value = rmp_serde::from_slice(&bytes).expect("msgpack decodes to Value");
+        assert_eq!(
+            v,
+            json!({
+                "ch": "agent.sess_abc",
+                "seq": 42,
+                "event": { "type": "token", "content": "Hello" }
+            }),
+            "to_vec_named must preserve flatten + untagged as a {{ch,seq,event}} map"
+        );
+        assert_eq!(v.as_object().unwrap().len(), 3, "no wrapper nesting");
+    }
+
+    #[test]
+    fn server_envelope_control_msgpack_roundtrips_to_same_schema() {
+        let env = ServerEnvelope::control("agent.sess_abc", 43, terminal_control("complete"));
+        let frame = env.encode(Encoding::Msgpack).expect("msgpack encode");
+        let OutFrame::Binary(bytes) = frame else {
+            panic!("msgpack encoding must yield a Binary frame");
+        };
+        let v: Value = rmp_serde::from_slice(&bytes).expect("msgpack decodes to Value");
+        assert_eq!(
+            v,
+            json!({
+                "ch": "agent.sess_abc",
+                "seq": 43,
+                "control": { "type": "terminal", "reason": "complete" }
+            }),
+            "the untagged Control arm must round-trip as {{ch,seq,control}}"
+        );
+    }
+
+    #[test]
+    fn server_envelope_json_encode_is_unchanged_text() {
+        // The JSON encoding path is byte-for-byte the existing `to_text`.
+        let env = ServerEnvelope::event("feed", 7, json!({ "type": "x" }));
+        let frame = env.encode(Encoding::Json).expect("json encode");
+        assert_eq!(frame, OutFrame::Text(env.to_text().unwrap()));
+    }
+
+    #[test]
+    fn client_frame_all_variants_msgpack_roundtrip() {
+        // Each variant encodes (as a tagged map) and decodes back identically.
+        for original in [
+            ClientFrame::Hello {
+                device_id: Some("d1".into()),
+                token: Some("bd1_x".into()),
+            },
+            ClientFrame::Hello {
+                device_id: None,
+                token: None,
+            },
+            ClientFrame::Subscribe {
+                ch: "feed".into(),
+                since: Some(1006),
+            },
+            ClientFrame::Subscribe {
+                ch: "agent.s1".into(),
+                since: None,
+            },
+            ClientFrame::Unsubscribe {
+                ch: "agent.s1".into(),
+            },
+            ClientFrame::Stop {
+                session_id: "s1".into(),
+            },
+        ] {
+            // ClientFrame is Deserialize-only; encode the equivalent JSON Value to
+            // msgpack (the same bytes a client would send) and decode it back.
+            let as_json = match &original {
+                ClientFrame::Hello { device_id, token } => {
+                    json!({ "type": "hello", "device_id": device_id, "token": token })
+                }
+                ClientFrame::Subscribe { ch, since } => {
+                    json!({ "type": "subscribe", "ch": ch, "since": since })
+                }
+                ClientFrame::Unsubscribe { ch } => json!({ "type": "unsubscribe", "ch": ch }),
+                ClientFrame::Stop { session_id } => {
+                    json!({ "type": "stop", "session_id": session_id })
+                }
+                ClientFrame::Unknown => unreachable!(),
+            };
+            let bytes = rmp_serde::to_vec_named(&as_json).expect("encode client frame as msgpack");
+            let decoded = decode_client_frame(Encoding::Msgpack, &bytes).expect("decode");
+            assert_eq!(decoded, original, "msgpack client frame must round-trip");
+        }
+    }
+
+    #[test]
+    fn client_frame_unknown_tag_msgpack_maps_to_unknown_not_error() {
+        // An unrecognized `type` over msgpack must map to Unknown (serde `other`),
+        // NOT an Err that would drop the connection — parity with the JSON path.
+        let bytes =
+            rmp_serde::to_vec_named(&json!({ "type": "execute", "session_id": "s1" })).unwrap();
+        let decoded =
+            decode_client_frame(Encoding::Msgpack, &bytes).expect("unknown tag is not Err");
+        assert_eq!(decoded, ClientFrame::Unknown);
+    }
+
+    #[test]
+    fn client_frame_malformed_msgpack_is_err_not_panic() {
+        // Random bytes that are not a valid msgpack map → Err, which the driver
+        // logs + ignores (no disconnect).
+        let r = decode_client_frame(Encoding::Msgpack, &[0xc1, 0x00, 0xff, 0x10]);
+        assert!(r.is_err());
+        // A valid msgpack value missing the `type` tag → also Err (no default tag),
+        // same as the JSON path.
+        let bytes = rmp_serde::to_vec_named(&json!({ "ch": "feed" })).unwrap();
+        assert!(decode_client_frame(Encoding::Msgpack, &bytes).is_err());
+    }
+
+    #[test]
+    fn decode_client_frame_json_matches_serde_json() {
+        // The JSON decode path is unchanged: same result as direct serde_json.
+        let text = r#"{"type":"subscribe","ch":"feed","since":5}"#;
+        let decoded = decode_client_frame(Encoding::Json, text.as_bytes()).unwrap();
+        assert_eq!(
+            decoded,
+            ClientFrame::Subscribe {
+                ch: "feed".into(),
+                since: Some(5)
+            }
+        );
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
@@ -47,19 +47,24 @@ use bamboo_engine::events::journal;
 
 use actix_web::web;
 
-use super::envelope::{feed_reset_control, terminal_control, ServerEnvelope};
+use super::envelope::{feed_reset_control, terminal_control, Encoding, OutFrame, ServerEnvelope};
 use crate::app_state::AppState;
 use crate::handlers::agent::events::{has_running_child, Coalescer};
 use crate::handlers::agent::stream::{plan_replay, ReplayPlan};
 
-/// What the driver sends to the WS writer: a fully-built envelope's text frame.
-pub(crate) type OutboundTx = mpsc::Sender<String>;
+/// What the driver sends to the WS writer: an already-encoded frame (a JSON text
+/// frame or a MessagePack binary frame), tagged so the driver picks
+/// `session.text` vs `session.binary` (v2-P3, #181). The forwarder encodes per
+/// the connection's [`Encoding`] up front, keeping the final encode out of the
+/// driver's hot select loop.
+pub(crate) type OutboundTx = mpsc::Sender<OutFrame>;
 
-/// Push a server envelope onto the shared outbound mpsc. Returns `false` if the
-/// driver-side receiver is gone (connection closing), so the forwarder stops.
-async fn send_env(out: &OutboundTx, env: ServerEnvelope) -> bool {
-    match env.to_text() {
-        Some(text) => out.send(text).await.is_ok(),
+/// Encode a server envelope per `encoding` and push it onto the shared outbound
+/// mpsc. Returns `false` if the driver-side receiver is gone (connection
+/// closing), so the forwarder stops.
+async fn send_env(out: &OutboundTx, encoding: Encoding, env: ServerEnvelope) -> bool {
+    match env.encode(encoding) {
+        Some(frame) => out.send(frame).await.is_ok(),
         // A serialization failure is per-event; skip it but keep the forwarder
         // alive (matches the v1 SSE `serde_json::to_string(...).ok()` discipline).
         None => true,
@@ -76,6 +81,7 @@ async fn send_env(out: &OutboundTx, env: ServerEnvelope) -> bool {
 /// replay are buffered in the ring (no gap).
 pub(crate) fn spawn_feed_forwarder(
     out: OutboundTx,
+    encoding: Encoding,
     mut receiver: broadcast::Receiver<Arc<ChangeEvent>>,
     events_dir: PathBuf,
     since: u64,
@@ -96,6 +102,7 @@ pub(crate) fn spawn_feed_forwarder(
             // client resyncs via REST and the live tail serves anything newer.
             if !send_env(
                 &out,
+                encoding,
                 ServerEnvelope::control("feed", 0, feed_reset_control(from)),
             )
             .await
@@ -104,7 +111,7 @@ pub(crate) fn spawn_feed_forwarder(
             }
         }
         for ce in events {
-            if !send_env(&out, feed_envelope(&ce)).await {
+            if !send_env(&out, encoding, feed_envelope(&ce)).await {
                 return;
             }
         }
@@ -116,7 +123,7 @@ pub(crate) fn spawn_feed_forwarder(
                     if ce.seq <= last_replayed {
                         continue; // dedupe the replay/live overlap
                     }
-                    if !send_env(&out, feed_envelope(&ce)).await {
+                    if !send_env(&out, encoding, feed_envelope(&ce)).await {
                         return;
                     }
                     last_replayed = ce.seq;
@@ -129,7 +136,7 @@ pub(crate) fn spawn_feed_forwarder(
                             if ce.seq <= last_replayed {
                                 continue;
                             }
-                            if !send_env(&out, feed_envelope(&ce)).await {
+                            if !send_env(&out, encoding, feed_envelope(&ce)).await {
                                 return;
                             }
                             last_replayed = ce.seq;
@@ -174,6 +181,7 @@ pub(crate) fn spawn_agent_forwarder(
     state: web::Data<AppState>,
     session_id: String,
     out: OutboundTx,
+    encoding: Encoding,
     ch: String,
     mut receiver: broadcast::Receiver<AgentEvent>,
     budget_event_to_replay: Option<AgentEvent>,
@@ -186,12 +194,12 @@ pub(crate) fn spawn_agent_forwarder(
         // Replay cached critical state events first (task list, sub-sessions, …),
         // then the last budget event — mirroring the v1 SSE replay order.
         for event in critical_events_to_replay {
-            if !emit_agent_event(&out, &ch, &seq, event).await {
+            if !emit_agent_event(&out, encoding, &ch, &seq, event).await {
                 return;
             }
         }
         if let Some(event) = budget_event_to_replay {
-            if !emit_agent_event(&out, &ch, &seq, event).await {
+            if !emit_agent_event(&out, encoding, &ch, &seq, event).await {
                 return;
             }
         }
@@ -214,7 +222,7 @@ pub(crate) fn spawn_agent_forwarder(
                         let is_terminal = is_terminal_event(&event);
                         let is_child_completed =
                             matches!(event, AgentEvent::SubAgentCompleted { .. });
-                        if !emit_agent_event(&out, &ch, &seq, event).await {
+                        if !emit_agent_event(&out, encoding, &ch, &seq, event).await {
                             return;
                         }
                         if is_terminal {
@@ -224,6 +232,7 @@ pub(crate) fn spawn_agent_forwarder(
                             }
                             let _ = send_env(
                                 &out,
+                                encoding,
                                 ServerEnvelope::control(
                                     &ch,
                                     seq.next(),
@@ -241,6 +250,7 @@ pub(crate) fn spawn_agent_forwarder(
                         {
                             let _ = send_env(
                                 &out,
+                                encoding,
                                 ServerEnvelope::control(
                                     &ch,
                                     seq.next(),
@@ -275,7 +285,7 @@ pub(crate) fn spawn_agent_forwarder(
             tokio::select! {
                 _ = tokio::time::sleep_until(sleep_until), if flush_deadline.is_some() => {
                     if let Some(pending) = coalescer.take_pending() {
-                        if !emit_agent_event(&out, &ch, &seq, pending).await {
+                        if !emit_agent_event(&out, encoding, &ch, &seq, pending).await {
                             return;
                         }
                     }
@@ -292,7 +302,7 @@ pub(crate) fn spawn_agent_forwarder(
                             // new event when non-coalescible). Terminal events are
                             // non-coalescible, so any pending tokens flush first.
                             for out_event in coalescer.push(event) {
-                                if !emit_agent_event(&out, &ch, &seq, out_event).await {
+                                if !emit_agent_event(&out, encoding, &ch, &seq, out_event).await {
                                     return;
                                 }
                             }
@@ -314,6 +324,7 @@ pub(crate) fn spawn_agent_forwarder(
                                 }
                                 let _ = send_env(
                                     &out,
+                                    encoding,
                                     ServerEnvelope::control(&ch, seq.next(), terminal_control("complete")),
                                 )
                                 .await;
@@ -325,6 +336,7 @@ pub(crate) fn spawn_agent_forwarder(
                             {
                                 let _ = send_env(
                                     &out,
+                                    encoding,
                                     ServerEnvelope::control(&ch, seq.next(), terminal_control("complete")),
                                 )
                                 .await;
@@ -336,7 +348,7 @@ pub(crate) fn spawn_agent_forwarder(
                             // pending buffer so we never merge tokens across the
                             // gap and fabricate adjacency.
                             if let Some(pending) = coalescer.take_pending() {
-                                if !emit_agent_event(&out, &ch, &seq, pending).await {
+                                if !emit_agent_event(&out, encoding, &ch, &seq, pending).await {
                                     return;
                                 }
                                 flush_deadline = None;
@@ -345,7 +357,7 @@ pub(crate) fn spawn_agent_forwarder(
                         Err(broadcast::error::RecvError::Closed) => {
                             // Flush any buffered tokens before closing.
                             if let Some(pending) = coalescer.take_pending() {
-                                let _ = emit_agent_event(&out, &ch, &seq, pending).await;
+                                let _ = emit_agent_event(&out, encoding, &ch, &seq, pending).await;
                             }
                             return;
                         }
@@ -356,14 +368,21 @@ pub(crate) fn spawn_agent_forwarder(
     })
 }
 
-/// Serialize an `AgentEvent` into an `{ch, seq, event}` envelope and push it.
-async fn emit_agent_event(out: &OutboundTx, ch: &str, seq: &AgentSeq, event: AgentEvent) -> bool {
+/// Serialize an `AgentEvent` into an `{ch, seq, event}` envelope and push it,
+/// encoded per `encoding`.
+async fn emit_agent_event(
+    out: &OutboundTx,
+    encoding: Encoding,
+    ch: &str,
+    seq: &AgentSeq,
+    event: AgentEvent,
+) -> bool {
     let value = match serde_json::to_value(&event) {
         Ok(v) => v,
         // Skip an unserializable event but keep the forwarder alive (v1 parity).
         Err(_) => return true,
     };
-    send_env(out, ServerEnvelope::event(ch, seq.next(), value)).await
+    send_env(out, encoding, ServerEnvelope::event(ch, seq.next(), value)).await
 }
 
 /// Whether an agent event terminates the run (mirrors the v1 SSE predicate).

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -23,9 +23,15 @@
 //! `JoinHandle` lets `unsubscribe`/teardown abort exactly that forwarder and drop
 //! its queue, leaving no orphaned broadcast reader.
 //!
+//! ## Encoding (v2-P3, #181)
+//! The wire encoding is negotiated ONCE at the upgrade from the offered
+//! `Sec-WebSocket-Protocol`: `bamboo.v2.msgpack` selects binary MessagePack,
+//! anything else (or nothing) stays JSON text (the default — desktop /
+//! debuggability). The SAME envelope schema is carried either way; only the
+//! serialization + WS frame type (Text vs Binary) differs. See `envelope::Encoding`.
+//!
 //! ## DEFERRED (later slices; see PR / §5.3)
 //! - `execute` / `approve` over control (handler refactors) — clients keep REST.
-//! - msgpack subprotocol (v2-P3) — JSON text frames only.
 //!
 //! ## Auth (v2-P2, #181 / #189)
 //! `/v2/stream` is on the public route whitelist, so the upgrade OPENS without
@@ -62,7 +68,10 @@ use tokio_stream::StreamMap;
 
 use serde::Deserialize;
 
-use self::envelope::{Channel, ClientFrame};
+use self::envelope::{
+    decode_client_frame, Channel, ClientFrame, Encoding, OutFrame, SUBPROTOCOL_JSON,
+    SUBPROTOCOL_MSGPACK,
+};
 use self::forwarders::{spawn_agent_forwarder, spawn_feed_forwarder, OutboundTx};
 use crate::app_state::AppState;
 use crate::handlers::agent::events::MAX_BATCH_MS;
@@ -148,7 +157,7 @@ enum GateOutcome {
     Dispatch,
 }
 
-/// The AppState-aware auth gate, factored out of `handle_client_text` so it is
+/// The AppState-aware auth gate, factored out of `handle_client_frame` so it is
 /// unit-testable WITHOUT a live WS `Session`. It owns the entire `!authorized`
 /// decision plus the credential verification, and flips `authorized` to `true`
 /// only on a VERIFIED `hello` device token.
@@ -216,6 +225,42 @@ pub struct StreamQuery {
     pub batch_ms: u64,
 }
 
+/// Negotiate the wire [`Encoding`] from the upgrade's `Sec-WebSocket-Protocol`
+/// header (v2-P3, §5.3 / §7.2). Returns the chosen encoding AND the subprotocol
+/// token the server must ECHO on the upgrade response (per RFC 6455 the server
+/// echoes the single selected subprotocol).
+///
+/// - Offers including `bamboo.v2.msgpack` → `(Msgpack, Some("bamboo.v2.msgpack"))`.
+/// - Offers including only `bamboo.v2` → `(Json, Some("bamboo.v2"))`.
+/// - No (recognized) subprotocol offered → `(Json, None)` — today's behavior is
+///   preserved byte-for-byte for clients that offer nothing.
+///
+/// `bamboo.v2.msgpack` wins if BOTH are offered (the client opted into binary).
+fn negotiate_encoding(req: &HttpRequest) -> (Encoding, Option<&'static str>) {
+    let offered = req
+        .headers()
+        .get(actix_web::http::header::SEC_WEBSOCKET_PROTOCOL)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    // The header is a comma-separated list of subprotocol tokens.
+    let mut has_msgpack = false;
+    let mut has_json = false;
+    for tok in offered.split(',') {
+        match tok.trim() {
+            SUBPROTOCOL_MSGPACK => has_msgpack = true,
+            SUBPROTOCOL_JSON => has_json = true,
+            _ => {}
+        }
+    }
+    if has_msgpack {
+        (Encoding::Msgpack, Some(SUBPROTOCOL_MSGPACK))
+    } else if has_json {
+        (Encoding::Json, Some(SUBPROTOCOL_JSON))
+    } else {
+        (Encoding::Json, None)
+    }
+}
+
 /// `GET /v2/stream` — upgrade to the unified WS multiplex.
 ///
 /// The upgrade itself is PUBLIC (whitelisted in `is_public_access_route`), so a
@@ -225,6 +270,10 @@ pub struct StreamQuery {
 /// (local bypass / verified password cookie / header device token), via the same
 /// `request_is_authorized` allow-decision the middleware uses; everything else
 /// must present a verified `hello` before any channel is served, on a deadline.
+///
+/// The wire [`Encoding`] is negotiated from `Sec-WebSocket-Protocol` (v2-P3):
+/// `bamboo.v2.msgpack` → binary MessagePack; otherwise JSON text (default). The
+/// selected subprotocol is ECHOED on the upgrade response per RFC 6455.
 pub async fn handler(
     state: web::Data<AppState>,
     query: web::Query<StreamQuery>,
@@ -233,6 +282,9 @@ pub async fn handler(
 ) -> actix_web::Result<impl Responder> {
     // Clamp the untrusted `batch_ms` the same way the v1 SSE handler does.
     let batch_ms = query.batch_ms.min(MAX_BATCH_MS);
+
+    // Negotiate the wire encoding from the offered subprotocols (v2-P3).
+    let (encoding, selected_subprotocol) = negotiate_encoding(&req);
 
     // Pre-authorize exactly the connections the middleware would have allowed on
     // a gated route: local bypass, a verified password cookie (sent on the
@@ -244,9 +296,26 @@ pub async fn handler(
         crate::handlers::settings::request_is_authorized(&req, &config)
     };
 
-    let (response, session, msg_stream) = actix_ws::handle(&req, body)?;
+    let (mut response, session, msg_stream) = actix_ws::handle(&req, body)?;
 
-    actix_web::rt::spawn(drive(state, session, msg_stream, batch_ms, pre_authorized));
+    // Echo the selected subprotocol on the upgrade RESPONSE (RFC 6455). A client
+    // that offered no recognized subprotocol gets none, keeping the legacy
+    // handshake byte-for-byte unchanged.
+    if let Some(proto) = selected_subprotocol {
+        response.headers_mut().insert(
+            actix_web::http::header::SEC_WEBSOCKET_PROTOCOL,
+            actix_web::http::header::HeaderValue::from_static(proto),
+        );
+    }
+
+    actix_web::rt::spawn(drive(
+        state,
+        session,
+        msg_stream,
+        batch_ms,
+        pre_authorized,
+        encoding,
+    ));
 
     Ok(response)
 }
@@ -260,6 +329,7 @@ async fn drive(
     mut msg_stream: actix_ws::MessageStream,
     batch_ms: u64,
     pre_authorized: bool,
+    encoding: Encoding,
 ) {
     // Per-channel outbound (RFC §10-Q3): every subscribed channel owns its OWN
     // bounded queue. `forwarders` keeps the task handle (for unsubscribe/teardown
@@ -268,7 +338,7 @@ async fn drive(
     // head-of-line another at the socket. The two maps are keyed by the SAME
     // channel id and mutated together (see [`subscribe`] / unsubscribe / teardown).
     let mut forwarders: HashMap<String, tokio::task::JoinHandle<()>> = HashMap::new();
-    let mut queues: StreamMap<String, ReceiverStream<String>> = StreamMap::new();
+    let mut queues: StreamMap<String, ReceiverStream<OutFrame>> = StreamMap::new();
     let mut ping = tokio::time::interval(PING_INTERVAL);
     ping.tick().await; // skip the immediate tick
 
@@ -295,9 +365,17 @@ async fn drive(
             // `StreamMap` randomizes its poll start each call, so no single channel's
             // queue is favored — a bursting channel cannot starve another at the
             // socket. `(channel, frame)` is yielded; only the frame goes on the
-            // wire. If the write fails the peer is gone — break and tear down.
-            Some((_ch, text)) = queues.next() => {
-                if session.text(text).await.is_err() {
+            // wire. The frame is ALREADY encoded per the connection's `Encoding`
+            // (the forwarder did the encode), so the driver only picks the WS frame
+            // type: `session.text` for a JSON `Text`, `session.binary` for a
+            // MessagePack `Binary`. If the write fails the peer is gone — break and
+            // tear down.
+            Some((_ch, frame)) = queues.next() => {
+                let write = match frame {
+                    OutFrame::Text(s) => session.text(s).await,
+                    OutFrame::Binary(b) => session.binary(b).await,
+                };
+                if write.is_err() {
                     break;
                 }
             }
@@ -310,13 +388,28 @@ async fn drive(
                     break;
                 }
             }
-            // Client frames.
+            // Client frames. In JSON mode the client sends TEXT frames; in msgpack
+            // mode it sends BINARY frames. A frame carrying the inbound bytes for the
+            // ACTIVE encoding is decoded + dispatched; a frame of the other kind is
+            // ignored (a Binary frame in JSON mode, a Text frame in msgpack mode),
+            // exactly as a malformed frame is — it never tears down the connection.
             msg = msg_stream.next() => {
                 match msg {
-                    Some(Ok(Message::Text(text))) => {
-                        let keep_open = handle_client_text(
-                            &state, &mut forwarders, &mut queues, &mut session,
-                            batch_ms, &text, &mut authorized,
+                    // The inbound frame type that matches the active encoding.
+                    Some(Ok(Message::Text(text))) if encoding == Encoding::Json => {
+                        let keep_open = handle_client_bytes(
+                            &state, &mut forwarders, &mut queues,
+                            batch_ms, encoding, text.as_bytes(), &mut authorized,
+                        )
+                        .await;
+                        if !keep_open {
+                            break;
+                        }
+                    }
+                    Some(Ok(Message::Binary(bytes))) if encoding == Encoding::Msgpack => {
+                        let keep_open = handle_client_bytes(
+                            &state, &mut forwarders, &mut queues,
+                            batch_ms, encoding, &bytes, &mut authorized,
                         )
                         .await;
                         if !keep_open {
@@ -328,9 +421,12 @@ async fn drive(
                             break;
                         }
                     }
-                    // Pong / Binary (no msgpack in P1) / Continuation / Nop: ignore.
-                    Some(Ok(Message::Pong(_)))
+                    // A frame of the WRONG kind for the active encoding (a Binary
+                    // frame in JSON mode / a Text frame in msgpack mode), plus Pong /
+                    // Continuation / Nop: ignore, never disconnect.
+                    Some(Ok(Message::Text(_)))
                     | Some(Ok(Message::Binary(_)))
+                    | Some(Ok(Message::Pong(_)))
                     | Some(Ok(Message::Continuation(_)))
                     | Some(Ok(Message::Nop)) => {}
                     Some(Ok(Message::Close(_))) | None => break,
@@ -354,7 +450,41 @@ async fn drive(
     let _ = session.close(None).await;
 }
 
-/// Parse + dispatch one client text frame. A malformed/unknown frame logs and is
+/// Decode one inbound frame's bytes per the connection's [`Encoding`] (serde_json
+/// for `Json`, rmp-serde for `Msgpack`) and dispatch the resulting [`ClientFrame`].
+/// A malformed body logs and is ignored — it NEVER tears down the connection, in
+/// EITHER encoding (the msgpack decode error is treated exactly like a malformed
+/// JSON text frame).
+///
+/// This is the thin decode step in front of [`handle_client_frame`]; the dispatch
+/// and auth logic is encoding-agnostic (the SAME `ClientFrame` flows through both
+/// paths), so the JSON behavior is byte-for-byte unchanged.
+///
+/// Returns `false` to signal the driver to CLOSE the connection (a `hello` that
+/// presents an INVALID device credential); `true` to keep it open.
+async fn handle_client_bytes(
+    state: &web::Data<AppState>,
+    forwarders: &mut HashMap<String, tokio::task::JoinHandle<()>>,
+    queues: &mut StreamMap<String, ReceiverStream<OutFrame>>,
+    batch_ms: u64,
+    encoding: Encoding,
+    bytes: &[u8],
+    authorized: &mut bool,
+) -> bool {
+    let frame: ClientFrame = match decode_client_frame(encoding, bytes) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::debug!("ws_v2: ignoring malformed client frame: {e}");
+            return true;
+        }
+    };
+    handle_client_frame(
+        state, forwarders, queues, batch_ms, encoding, frame, authorized,
+    )
+    .await
+}
+
+/// Dispatch one decoded client frame. A malformed/unknown frame logs and is
 /// ignored — it never tears down the connection.
 ///
 /// `authorized` is the per-connection auth state (#189). While it is `false` the
@@ -366,23 +496,15 @@ async fn drive(
 ///
 /// Returns `false` to signal the driver to CLOSE the connection (a `hello` that
 /// presents an INVALID device credential); `true` to keep it open.
-async fn handle_client_text(
+async fn handle_client_frame(
     state: &web::Data<AppState>,
     forwarders: &mut HashMap<String, tokio::task::JoinHandle<()>>,
-    queues: &mut StreamMap<String, ReceiverStream<String>>,
-    _session: &mut actix_ws::Session,
+    queues: &mut StreamMap<String, ReceiverStream<OutFrame>>,
     batch_ms: u64,
-    text: &str,
+    encoding: Encoding,
+    frame: ClientFrame,
     authorized: &mut bool,
 ) -> bool {
-    let frame: ClientFrame = match serde_json::from_str(text) {
-        Ok(f) => f,
-        Err(e) => {
-            tracing::debug!("ws_v2: ignoring malformed client frame: {e}");
-            return true;
-        }
-    };
-
     // Auth gate (#189). Until the connection is authorized, no frame may serve a
     // channel or cancel a session — the only frame that can change anything is a
     // `hello` that carries a verifiable device credential.
@@ -417,7 +539,7 @@ async fn handle_client_text(
             }
         }
         ClientFrame::Subscribe { ch, since } => {
-            subscribe(state, forwarders, queues, batch_ms, &ch, since).await;
+            subscribe(state, forwarders, queues, batch_ms, encoding, &ch, since).await;
         }
         ClientFrame::Unsubscribe { ch } => {
             if let Some(handle) = forwarders.remove(&ch) {
@@ -446,8 +568,9 @@ async fn handle_client_text(
 async fn subscribe(
     state: &web::Data<AppState>,
     forwarders: &mut HashMap<String, tokio::task::JoinHandle<()>>,
-    queues: &mut StreamMap<String, ReceiverStream<String>>,
+    queues: &mut StreamMap<String, ReceiverStream<OutFrame>>,
     batch_ms: u64,
+    encoding: Encoding,
     ch: &str,
     since: Option<u64>,
 ) {
@@ -465,7 +588,9 @@ async fn subscribe(
 
     // This channel's OWN bounded outbound queue (RFC §10-Q3). The forwarder owns
     // the sender; the driver drains the receiver via the fair `StreamMap` merge.
-    let (out_tx, out_rx) = mpsc::channel::<String>(OUTBOUND_BUFFER);
+    // Carries already-encoded [`OutFrame`]s (Text/Binary per the connection's
+    // `Encoding`).
+    let (out_tx, out_rx) = mpsc::channel::<OutFrame>(OUTBOUND_BUFFER);
     let out_tx: OutboundTx = out_tx;
 
     let handle = match channel {
@@ -477,7 +602,14 @@ async fn subscribe(
             let latest_at_start = state.account_sink.latest_seq();
             let events_dir = state.account_sink.events_dir().to_path_buf();
             let since = since.unwrap_or(0);
-            spawn_feed_forwarder(out_tx, receiver, events_dir, since, latest_at_start)
+            spawn_feed_forwarder(
+                out_tx,
+                encoding,
+                receiver,
+                events_dir,
+                since,
+                latest_at_start,
+            )
         }
         Channel::Agent(sid) => {
             // The session must exist; otherwise ignore (parity with the v1
@@ -511,6 +643,7 @@ async fn subscribe(
                 state.clone(),
                 sid.clone(),
                 out_tx,
+                encoding,
                 ch.to_string(),
                 receiver,
                 budget_event_to_replay,

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -674,6 +674,48 @@ mod tests {
         }
     }
 
+    // ── Subprotocol negotiation (v2-P3) ───────────────────────────────────────
+
+    fn negotiate_for(header: Option<&str>) -> (Encoding, Option<&'static str>) {
+        let mut req = actix_web::test::TestRequest::default();
+        if let Some(h) = header {
+            req = req.insert_header((actix_web::http::header::SEC_WEBSOCKET_PROTOCOL, h));
+        }
+        negotiate_encoding(&req.to_http_request())
+    }
+
+    #[test]
+    fn negotiate_encoding_branches() {
+        // No header / empty → JSON default, NO echo (unchanged for old clients).
+        assert_eq!(negotiate_for(None), (Encoding::Json, None));
+        assert_eq!(negotiate_for(Some("")), (Encoding::Json, None));
+        // Explicit JSON subprotocol → JSON, echo it.
+        assert_eq!(
+            negotiate_for(Some("bamboo.v2")),
+            (Encoding::Json, Some(SUBPROTOCOL_JSON))
+        );
+        // Msgpack offered → Msgpack, echo it.
+        assert_eq!(
+            negotiate_for(Some("bamboo.v2.msgpack")),
+            (Encoding::Msgpack, Some(SUBPROTOCOL_MSGPACK))
+        );
+        // Multi-offer: msgpack preferred regardless of order, and whitespace is trimmed.
+        assert_eq!(
+            negotiate_for(Some("bamboo.v2.msgpack, bamboo.v2")),
+            (Encoding::Msgpack, Some(SUBPROTOCOL_MSGPACK))
+        );
+        assert_eq!(
+            negotiate_for(Some("  bamboo.v2 ,  bamboo.v2.msgpack ")),
+            (Encoding::Msgpack, Some(SUBPROTOCOL_MSGPACK))
+        );
+        // Unknown-only offer → JSON, and NO bogus echo (echoing a non-offered
+        // subprotocol would violate RFC 6455).
+        assert_eq!(
+            negotiate_for(Some("some.other.proto")),
+            (Encoding::Json, None)
+        );
+    }
+
     // ── Pure classification (no AppState) ─────────────────────────────────────
 
     #[test]

--- a/crates/app/bamboo-server/tests/ws_v2_live.rs
+++ b/crates/app/bamboo-server/tests/ws_v2_live.rs
@@ -139,6 +139,60 @@ async fn connect_remote(server: &TestServer) -> WsConn {
     framed
 }
 
+/// Open a LOCAL WS connection negotiating the `bamboo.v2.msgpack` subprotocol
+/// (v2-P3, #181). Returns the framed socket AND the subprotocol the server ECHOED
+/// on the upgrade response (per RFC 6455 the server echoes the single selected
+/// subprotocol), so the test can assert the handshake negotiated msgpack.
+async fn connect_local_msgpack(server: &TestServer) -> (WsConn, Option<String>) {
+    let (resp, framed) = awc::Client::new()
+        .ws(&server.base_ws_url)
+        .protocols(["bamboo.v2.msgpack"])
+        .connect()
+        .await
+        .expect("local msgpack ws upgrade");
+    let echoed = resp
+        .headers()
+        .get(awc::http::header::SEC_WEBSOCKET_PROTOCOL)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    (framed, echoed)
+}
+
+/// Send a client frame as a BINARY MessagePack frame (the inbound shape a msgpack
+/// client uses): the JSON `value` is re-encoded with `to_vec_named` so the wire
+/// bytes carry the SAME logical schema the server's `decode_client_frame` expects.
+async fn send_msgpack(conn: &mut WsConn, value: Value) {
+    let bytes = rmp_serde::to_vec_named(&value).expect("encode client frame as msgpack");
+    conn.send(ws::Message::Binary(bytes.into()))
+        .await
+        .expect("send msgpack client frame");
+}
+
+/// Receive the next BINARY frame and decode the MessagePack envelope back to a
+/// JSON `Value` (msgpack maps → JSON objects), so assertions read the SAME field
+/// names/values as the JSON path. Skips Ping/Pong. Returns `None` on close.
+async fn next_msgpack_envelope(conn: &mut WsConn) -> Option<Value> {
+    let deadline = tokio::time::Instant::now() + RECV_TIMEOUT;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let frame = tokio::time::timeout(remaining, conn.next())
+            .await
+            .expect("frame did not arrive before timeout")?;
+        match frame.expect("ws protocol error") {
+            ws::Frame::Binary(bytes) => {
+                return Some(rmp_serde::from_slice(&bytes).expect("envelope is msgpack"));
+            }
+            ws::Frame::Text(bytes) => panic!(
+                "msgpack mode must yield BINARY frames, got text: {}",
+                String::from_utf8_lossy(&bytes)
+            ),
+            ws::Frame::Ping(_) | ws::Frame::Pong(_) => continue,
+            ws::Frame::Close(_) => return None,
+            other => panic!("unexpected ws frame: {other:?}"),
+        }
+    }
+}
+
 /// Send a JSON client frame.
 async fn send_json(conn: &mut WsConn, value: Value) {
     conn.send(ws::Message::Text(value.to_string().into()))
@@ -639,6 +693,107 @@ async fn remote_with_invalid_hello_is_closed() {
 
     // An invalid credential closes the socket (well before the deadline).
     expect_closed(&mut conn).await;
+
+    server.stop().await;
+}
+
+// ── Scenario 5: msgpack subprotocol (v2-P3, #181) ───────────────────────────
+
+/// A local client negotiates `bamboo.v2.msgpack`, the server ECHOES it on the
+/// handshake response, the client subscribes over a BINARY msgpack frame, the
+/// server pushes an `AgentEvent`, and the client decodes the BINARY msgpack
+/// envelope and asserts `ch`/`seq`/`event.content`. This proves the full binary
+/// path end to end (real handshake echo + real binary inbound + real binary
+/// outbound), not just the unit round-trips.
+#[actix_web::test]
+async fn msgpack_subprotocol_subscribe_event_roundtrip() {
+    let server = TestServer::start(|_| {}).await;
+    let sid = "sess_msgpack";
+
+    let mut root = bamboo_agent_core::Session::new(sid, "test-model");
+    register_session(&server.state, &mut root).await;
+
+    let (mut conn, echoed) = connect_local_msgpack(&server).await;
+    // The server MUST echo the selected subprotocol on the upgrade response.
+    assert_eq!(
+        echoed.as_deref(),
+        Some("bamboo.v2.msgpack"),
+        "server must echo the negotiated subprotocol on the handshake"
+    );
+
+    let ch = format!("agent.{sid}");
+    // Subscribe over a BINARY msgpack frame (client→server msgpack works).
+    send_msgpack(&mut conn, json!({"type": "subscribe", "ch": ch})).await;
+
+    // Same bounded-retry handoff as the JSON scenario, but decoding BINARY frames.
+    let received = {
+        let mut got = None;
+        let overall = tokio::time::Instant::now() + RECV_TIMEOUT;
+        while tokio::time::Instant::now() < overall {
+            server
+                .state
+                .get_session_event_sender(sid)
+                .await
+                .send(AgentEvent::Token {
+                    content: "Hello".into(),
+                })
+                .ok();
+            if let Ok(Some(env)) =
+                tokio::time::timeout(Duration::from_millis(150), next_msgpack_envelope(&mut conn))
+                    .await
+            {
+                got = Some(env);
+                break;
+            }
+        }
+        got.expect("a token envelope must arrive as a BINARY msgpack frame")
+    };
+
+    // The decoded msgpack envelope carries the SAME logical schema as JSON.
+    assert_eq!(received["ch"], ch.as_str());
+    assert!(received["seq"].as_u64().unwrap() >= 1);
+    assert_eq!(received["event"]["type"], "token");
+    assert_eq!(received["event"]["content"], "Hello");
+
+    server.stop().await;
+}
+
+/// A client that offers NO subprotocol still gets the JSON path with NO echoed
+/// subprotocol — the legacy handshake is byte-for-byte unchanged (zero-regression
+/// guard for v2-P3).
+#[actix_web::test]
+async fn no_subprotocol_stays_json_with_no_echo() {
+    let server = TestServer::start(|_| {}).await;
+
+    let (resp, mut conn) = awc::Client::new()
+        .ws(&server.base_ws_url)
+        .connect()
+        .await
+        .expect("local ws upgrade");
+    // No subprotocol offered → none echoed (legacy handshake unchanged).
+    assert!(
+        resp.headers()
+            .get(awc::http::header::SEC_WEBSOCKET_PROTOCOL)
+            .is_none(),
+        "a client offering no subprotocol must get no echo"
+    );
+
+    // And the wire is still JSON TEXT: a feed event arrives as a text envelope.
+    server.state.account_sink.record(
+        None,
+        &AgentEvent::SessionDeleted {
+            session_id: "j".into(),
+        },
+    );
+    send_json(
+        &mut conn,
+        json!({"type": "subscribe", "ch": "feed", "since": 0}),
+    )
+    .await;
+    let env = next_envelope(&mut conn)
+        .await
+        .expect("JSON feed envelope on the default path");
+    assert_eq!(env["ch"], "feed");
 
     server.stop().await;
 }


### PR DESCRIPTION
Implements **v2-P3 (MessagePack subprotocol)** for Epic #181 (`docs/api-v2-transport.md` §5.3 / §7.2 / §9). A `/v2/stream` client can negotiate `bamboo.v2.msgpack` to exchange the SAME envelope schema as binary MessagePack instead of JSON text. JSON stays the default (desktop / debuggability) — only the serialization + WS frame type change, never the logical schema.

## Negotiation + response echo
`handler` reads the upgrade `Sec-WebSocket-Protocol` (`negotiate_encoding`, `mod.rs`): an offer listing `bamboo.v2.msgpack` selects `Encoding::Msgpack` and the server **echoes** `bamboo.v2.msgpack` on the upgrade RESPONSE (RFC 6455 — the header is inserted on the `HttpResponse` that `actix_ws::handle` returns, before returning it). `bamboo.v2` selects JSON and echoes `bamboo.v2`; an offer of nothing recognized stays JSON with **no echo**, keeping the legacy handshake byte-for-byte unchanged. msgpack wins if both are offered. The chosen `Encoding` is passed into `drive`.

## OutFrame / Encoding plumbing
The per-channel queue item changes from `String` to `enum OutFrame { Text(String), Binary(Vec<u8>) }` (`envelope.rs`). Forwarders (`spawn_agent_forwarder`, `spawn_feed_forwarder`, `send_env`, `emit_agent_event`) take the `Encoding` and encode each `ServerEnvelope` up front; the driver drains the queue and calls `session.text` for `Text` / `session.binary` for `Binary`. The per-channel `StreamMap` structure is unchanged (only the item type).

## Inbound decoding
`handle_client_text` is refactored into a thin decode step (`handle_client_bytes`) plus the encoding-agnostic `handle_client_frame`. In JSON mode a **Text** frame is decoded with serde_json; in msgpack mode a **Binary** frame is decoded with rmp-serde (`decode_client_frame`). A malformed body in EITHER encoding logs and is ignored (never tears down the connection); a frame of the wrong kind for the active encoding (Binary in JSON mode, Text in msgpack mode) is ignored too.

## serde-msgpack flatten gotcha + round-trip proof
`ServerEnvelope` uses `#[serde(flatten)]` over an untagged body enum, and rmp-serde default `to_vec` serializes structs as positional ARRAYS, which breaks flatten/untagged resolution. The encode uses **`rmp_serde::to_vec_named`** (structs as MAPS) so the logical wire schema is identical to the JSON form (`{ch,seq,event}` / `{ch,seq,control}`). No `Value`-bridge restructure was needed — `to_vec_named` handled flatten + untagged correctly, proven by round-trip unit tests that encode an `event`/`control` envelope, decode the bytes back to a `serde_json::Value`, and assert the exact `{ch,seq,event|control}` shape; plus per-variant `ClientFrame` round-trips and an unknown-tag → `Unknown` (not an error) test.

## Zero-regression (JSON stays default)
The auth gate (#195/#189), per-channel queues (#187), coalescing, cursor resume, and child-hold-open are all encoding-agnostic and unchanged; only the final encode/decode differs. A no-subprotocol client is byte-for-byte today behavior (Text frames, serde_json, `session.text`, no echoed header). The token is never logged.

## Tests
- **Unit:** msgpack round-trips for `ServerEnvelope` (event + control) and `ClientFrame` (all variants + unknown tag + malformed). 28 ws_v2 unit tests pass.
- **Live (`tests/ws_v2_live.rs`):** `msgpack_subprotocol_subscribe_event_roundtrip` — a msgpack `awc` client subscribes to `agent.{sid}` over a real **BINARY** frame, the server pushes an `AgentEvent`, and the client decodes the **BINARY msgpack** envelope and asserts `ch`/`seq`/`event.content`; it also asserts the server **echoed** `bamboo.v2.msgpack` on the handshake response. `no_subprotocol_stays_json_with_no_echo` guards the JSON default. 9 live tests pass (ran 3x, no flakes).

`cargo test -p bamboo-server` (938 lib + 9 live), `cargo build`, `cargo fmt`, and `cargo clippy -p bamboo-server --tests` are all green on the new code.

Refs #181 (v2-P3 MessagePack subprotocol)

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp