### PR TITLE
feat(server): remote-actor P2a — /v1/agents registry + RegistryFabric [#181]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,7 @@ dependencies = [
  "bamboo-server-tools",
  "bamboo-skills",
  "bamboo-storage",
+ "bamboo-subagent",
  "bamboo-tools",
  "bytes",
  "chrono",
@@ -1314,6 +1315,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures-util",
+ "reqwest",
  "rustls",
  "rustls-pemfile",
  "serde",
@@ -1325,6 +1327,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/app/bamboo-server/Cargo.toml
+++ b/crates/app/bamboo-server/Cargo.toml
@@ -31,6 +31,11 @@ bamboo-llm = { path = "../../infra/bamboo-llm" }
 bamboo-config = { path = "../../infra/bamboo-config" }
 bamboo-storage = { path = "../../infra/bamboo-storage" }
 bamboo-domain = { path = "../../core/bamboo-domain" }
+# remote-actor P2a (#181): the server hosts the `/v1/agents` control-plane
+# registry over `bamboo_subagent::proto::AgentRecord`. The engine already pulls
+# this crate in transitively; a DIRECT dep makes the type reuse explicit (no
+# server-side DTO that could drift from the wire record).
+bamboo-subagent = { path = "../../infra/bamboo-subagent" }
 
 # Web framework
 # `rustls-0_23` enables actix-web's TLS bind/listen against rustls 0.23

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -488,6 +488,8 @@ impl AppState {
             pairing_codes: Arc::new(dashmap::DashMap::new()),
             pairing_code_guard: Arc::new(crate::handlers::settings::PairingCodeGuard::default()),
             root_password_guard: Arc::new(crate::handlers::settings::RootPasswordGuard::default()),
+            // remote-actor P2a (#181): empty in-memory agent registry.
+            agent_registry: Arc::new(crate::handlers::agent::agents::AgentRegistry::new()),
         })
     }
 }

--- a/crates/app/bamboo-server/src/app_state/mod.rs
+++ b/crates/app/bamboo-server/src/app_state/mod.rs
@@ -338,6 +338,15 @@ pub struct AppState {
     /// entries are purged opportunistically on insert/lookup.
     pub pairing_codes: Arc<dashmap::DashMap<String, crate::handlers::settings::PairingCodeEntry>>,
 
+    /// remote-actor P2a (#181): the in-memory `/v1/agents` control-plane registry.
+    /// Cross-host agent discovery — the network counterpart of the local-file
+    /// `bamboo_subagent::FileFabric`. Workers on other machines register/heartbeat
+    /// here; parents resolve/list/withdraw. PROCESS-EPHEMERAL — never persisted; a
+    /// restart drops all registrations (workers re-register on their next
+    /// heartbeat). Lease expiry is enforced lazily on read (see
+    /// [`crate::handlers::agent::agents::AgentRegistry`]).
+    pub agent_registry: Arc<crate::handlers::agent::agents::AgentRegistry>,
+
     /// v2-P2 (#181, slice 2): per-process brute-force guard for the public
     /// code-redemption path (`POST /v2/pair { code }`). A 6-digit code is only
     /// ~1M space, so a public redeem endpoint is brute-forceable without a guard.

--- a/crates/app/bamboo-server/src/handlers/agent/agents.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/agents.rs
@@ -53,7 +53,16 @@ impl AgentRegistry {
 
     /// Upsert a record by `agent_id`. The caller has already stamped
     /// `lease_expires_at`. Returns the stored record.
+    ///
+    /// Also prunes expired rows on the WRITE path so the map stays bounded to
+    /// live leases even if nothing ever calls `list` (lazy-GC-on-read alone
+    /// would let an attacker register many short-lived ids — that nobody
+    /// resolves — and grow memory; registration is the write path, so pruning
+    /// here caps growth at the rate of registrations).
     fn upsert(&self, rec: AgentRecord) -> AgentRecord {
+        let now = Utc::now();
+        self.agents
+            .retain(|id, r| id == &rec.agent_id || r.lease_expires_at > now);
         self.agents.insert(rec.agent_id.clone(), rec.clone());
         rec
     }
@@ -280,5 +289,24 @@ mod tests {
         assert!(after > before, "re-register must extend the lease");
         // still a single row (upsert, not append)
         assert_eq!(reg.list_as_of(now, None).len(), 1);
+    }
+
+    #[test]
+    fn upsert_prunes_expired_rows_on_the_write_path() {
+        let reg = AgentRegistry::new();
+        let now = Utc::now();
+        // Seed an already-expired row directly (bypass the upsert prune).
+        reg.insert_for_test(rec("ghost", "service", now - Duration::seconds(1)));
+        reg.upsert(rec("live", "service", now + Duration::seconds(30)));
+        // A registration (write) of a DIFFERENT id evicts the expired ghost even
+        // though nothing ever called list/resolve — the map stays bounded.
+        reg.upsert(rec("trigger", "service", now + Duration::seconds(30)));
+        assert!(
+            !reg.agents.contains_key("ghost"),
+            "an expired row must be pruned on the write path"
+        );
+        // Live rows (including the one that triggered the prune) are retained.
+        assert!(reg.agents.contains_key("live"));
+        assert!(reg.agents.contains_key("trigger"));
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/agents.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/agents.rs
@@ -1,0 +1,284 @@
+//! remote-actor P2a (#181): the `/v1/agents` control-plane registry.
+//!
+//! An in-memory, cross-host agent registry that lets workers on OTHER machines
+//! register (and heartbeat) and lets parents resolve/list/withdraw them over
+//! HTTP. It is the network counterpart of the local-file
+//! `bamboo_subagent::FileFabric` (`crates/infra/bamboo-subagent/src/discovery.rs`):
+//! same [`AgentRecord`] + `lease_expires_at` semantics, but reachable across the
+//! network instead of a shared filesystem. The client side is
+//! `bamboo_subagent::RegistryFabric`.
+//!
+//! AUTH: these routes are GATED by `enforce_access_password_middleware` (NOT on
+//! the public whitelist). Registration is a control-plane write — a forged
+//! record could poison routing (remote-actor-plan §5 "活性伪造:注册需持
+//! token"), so a credential (device token / verified cookie / local bypass) is
+//! required exactly like every other `/api/v1` route.
+//!
+//! GC: lazy-filter-on-read. Every GET drops records whose lease has expired
+//! (relative to `now`) before returning, and opportunistically prunes them from
+//! the map. There is NO background sweep task in P2a — a registered-but-silent
+//! worker simply ages out the moment a reader observes it past its lease. This is
+//! sufficient for P2a (documented trade-off): the map can hold expired entries
+//! between reads, but they are never SERVED, and any read prunes them.
+
+use actix_web::{web, HttpResponse};
+use bamboo_subagent::proto::AgentRecord;
+use chrono::{DateTime, Duration, Utc};
+use serde::Deserialize;
+
+use crate::error::AppError;
+use crate::AppState;
+
+/// Default lease lifetime when a registration omits `lease_ttl_secs`.
+const DEFAULT_LEASE_TTL_SECS: i64 = 30;
+/// Upper bound on a requested lease TTL — a worker cannot pin itself live for an
+/// unbounded time; it must keep heartbeating. Caps a misbehaving/forged TTL.
+const MAX_LEASE_TTL_SECS: i64 = 3600;
+
+/// In-memory control-plane registry: `agent_id -> AgentRecord`.
+///
+/// Mirrors how `pairing_codes` is held on [`AppState`] — a `DashMap` initialized
+/// in the builder. PROCESS-EPHEMERAL: never persisted; a restart drops all
+/// registrations (workers re-register on their next heartbeat, exactly like the
+/// file fabric being wiped). Lease expiry is enforced lazily on read.
+#[derive(Default)]
+pub struct AgentRegistry {
+    agents: dashmap::DashMap<String, AgentRecord>,
+}
+
+impl AgentRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Upsert a record by `agent_id`. The caller has already stamped
+    /// `lease_expires_at`. Returns the stored record.
+    fn upsert(&self, rec: AgentRecord) -> AgentRecord {
+        self.agents.insert(rec.agent_id.clone(), rec.clone());
+        rec
+    }
+
+    /// Resolve one live record as of `now`, pruning it if expired.
+    fn resolve_as_of(&self, agent_id: &str, now: DateTime<Utc>) -> Option<AgentRecord> {
+        match self.agents.get(agent_id).map(|r| r.clone()) {
+            Some(rec) if rec.lease_expires_at > now => Some(rec),
+            Some(_) => {
+                // Expired — prune lazily so the map self-cleans on read.
+                self.agents.remove(agent_id);
+                None
+            }
+            None => None,
+        }
+    }
+
+    /// All live records as of `now`, optionally filtered by `role`. Expired
+    /// records are dropped from the map as a side effect (lazy gc).
+    fn list_as_of(&self, now: DateTime<Utc>, role: Option<&str>) -> Vec<AgentRecord> {
+        // Prune expired first so the map doesn't accumulate dead rows.
+        self.agents.retain(|_id, rec| rec.lease_expires_at > now);
+        let mut out: Vec<AgentRecord> = self
+            .agents
+            .iter()
+            .filter(|r| role.is_none_or(|want| r.role == want))
+            .map(|r| r.clone())
+            .collect();
+        out.sort_by(|a, b| a.agent_id.cmp(&b.agent_id));
+        out
+    }
+
+    /// Remove a record. Idempotent (a missing id is a no-op).
+    fn remove(&self, agent_id: &str) {
+        self.agents.remove(agent_id);
+    }
+
+    /// Insert a record verbatim (lease as-is) — for tests that need to seed an
+    /// already-expired or pre-stamped record without going through the HTTP
+    /// upsert path (which always re-stamps the lease to `now + ttl`).
+    pub fn insert_for_test(&self, rec: AgentRecord) {
+        self.agents.insert(rec.agent_id.clone(), rec);
+    }
+}
+
+/// Registration / heartbeat body for `POST /v1/agents`.
+///
+/// Accepts EITHER a full record (all of `agent_id`/`pid`/`started_at`, with the
+/// client's own `lease_expires_at` IGNORED in favor of a server-stamped one) OR
+/// the lighter `{role, labels, endpoint, version, lease_ttl_secs}` shape. The
+/// server is the lease authority: it always re-derives `lease_expires_at = now +
+/// ttl` so a client cannot forge an over-long lease.
+#[derive(Debug, Deserialize)]
+pub struct RegisterAgentRequest {
+    /// Stable id; an upsert key. Defaults to a fresh UUID when omitted (a brand
+    /// new worker that lets the registry name it).
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    pub role: String,
+    #[serde(default)]
+    pub labels: Vec<String>,
+    pub endpoint: String,
+    #[serde(default)]
+    pub pid: u32,
+    #[serde(default)]
+    pub version: String,
+    /// Lease TTL in seconds; clamped to `[1, MAX_LEASE_TTL_SECS]`. Omitted →
+    /// `DEFAULT_LEASE_TTL_SECS`.
+    #[serde(default)]
+    pub lease_ttl_secs: Option<i64>,
+    /// Original creation time, preserved across heartbeats when the client sends
+    /// it; otherwise stamped to `now` on first registration.
+    #[serde(default)]
+    pub started_at: Option<DateTime<Utc>>,
+}
+
+/// Query for `GET /v1/agents`.
+#[derive(Debug, Deserialize)]
+pub struct ListAgentsQuery {
+    #[serde(default)]
+    pub role: Option<String>,
+}
+
+/// `POST /v1/agents` — register or heartbeat (GATED).
+///
+/// Upserts by `agent_id` and stamps `lease_expires_at = now + ttl`. Re-posting
+/// the same `agent_id` is the renewal mechanism (identical to the file fabric
+/// re-writing its record). Returns the stored [`AgentRecord`].
+pub async fn register_agent(
+    app_state: web::Data<AppState>,
+    body: web::Json<RegisterAgentRequest>,
+) -> Result<HttpResponse, AppError> {
+    let req = body.into_inner();
+    let now = Utc::now();
+
+    let ttl_secs = req
+        .lease_ttl_secs
+        .unwrap_or(DEFAULT_LEASE_TTL_SECS)
+        .clamp(1, MAX_LEASE_TTL_SECS);
+
+    let rec = AgentRecord {
+        agent_id: req
+            .agent_id
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+        role: req.role,
+        labels: req.labels,
+        endpoint: req.endpoint,
+        pid: req.pid,
+        version: req.version,
+        // Preserve the worker's original start time across heartbeats; default to
+        // now on first registration.
+        started_at: req.started_at.unwrap_or(now),
+        // The server is the lease authority — always re-derive it.
+        lease_expires_at: now + Duration::seconds(ttl_secs),
+    };
+
+    let stored = app_state.agent_registry.upsert(rec);
+    Ok(HttpResponse::Ok().json(stored))
+}
+
+/// `GET /v1/agents` — list live records, optionally `?role=<r>` filtered (GATED).
+/// Expired-lease records are not returned (lazy gc on read).
+pub async fn list_agents(
+    app_state: web::Data<AppState>,
+    query: web::Query<ListAgentsQuery>,
+) -> Result<HttpResponse, AppError> {
+    let recs = app_state
+        .agent_registry
+        .list_as_of(Utc::now(), query.role.as_deref());
+    Ok(HttpResponse::Ok().json(recs))
+}
+
+/// `GET /v1/agents/{agent_id}` — resolve one (GATED). 404 if absent or expired.
+pub async fn get_agent(
+    app_state: web::Data<AppState>,
+    path: web::Path<String>,
+) -> Result<HttpResponse, AppError> {
+    let agent_id = path.into_inner();
+    match app_state
+        .agent_registry
+        .resolve_as_of(&agent_id, Utc::now())
+    {
+        Some(rec) => Ok(HttpResponse::Ok().json(rec)),
+        None => Err(AppError::NotFound(format!("agent {agent_id}"))),
+    }
+}
+
+/// `DELETE /v1/agents/{agent_id}` — withdraw (GATED). Idempotent: a missing id
+/// still returns 200 (matching the file fabric's clean-shutdown semantics).
+pub async fn withdraw_agent(
+    app_state: web::Data<AppState>,
+    path: web::Path<String>,
+) -> Result<HttpResponse, AppError> {
+    let agent_id = path.into_inner();
+    app_state.agent_registry.remove(&agent_id);
+    Ok(HttpResponse::Ok().json(serde_json::json!({ "agent_id": agent_id, "withdrawn": true })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(id: &str, role: &str, expires: DateTime<Utc>) -> AgentRecord {
+        AgentRecord {
+            agent_id: id.into(),
+            role: role.into(),
+            labels: vec![],
+            endpoint: "ws://127.0.0.1:1".into(),
+            pid: 1,
+            version: "0".into(),
+            started_at: Utc::now(),
+            lease_expires_at: expires,
+        }
+    }
+
+    #[test]
+    fn upsert_resolve_list_withdraw() {
+        let reg = AgentRegistry::new();
+        let now = Utc::now();
+        reg.upsert(rec("a", "service", now + Duration::seconds(30)));
+        reg.upsert(rec("b", "gpu", now + Duration::seconds(30)));
+
+        assert!(reg.resolve_as_of("a", now).is_some());
+        assert_eq!(reg.list_as_of(now, None).len(), 2);
+        // role filter
+        let gpu = reg.list_as_of(now, Some("gpu"));
+        assert_eq!(gpu.len(), 1);
+        assert_eq!(gpu[0].agent_id, "b");
+
+        reg.remove("a");
+        assert!(reg.resolve_as_of("a", now).is_none());
+        assert_eq!(reg.list_as_of(now, None).len(), 1);
+    }
+
+    #[test]
+    fn expired_lease_is_not_returned_and_is_pruned() {
+        let reg = AgentRegistry::new();
+        let now = Utc::now();
+        reg.upsert(rec("fresh", "service", now + Duration::seconds(30)));
+        reg.upsert(rec("stale", "service", now - Duration::seconds(1)));
+
+        // resolve: stale is None, fresh is Some.
+        assert!(reg.resolve_as_of("stale", now).is_none());
+        assert!(reg.resolve_as_of("fresh", now).is_some());
+
+        // list drops the stale one (and prunes it from the map).
+        let live = reg.list_as_of(now, None);
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].agent_id, "fresh");
+        // the stale row was pruned by the list-as-of retain
+        assert!(!reg.agents.contains_key("stale"));
+    }
+
+    #[test]
+    fn reregister_refreshes_lease() {
+        let reg = AgentRegistry::new();
+        let now = Utc::now();
+        reg.upsert(rec("a", "service", now + Duration::seconds(1)));
+        let before = reg.resolve_as_of("a", now).unwrap().lease_expires_at;
+        // re-register with a later lease
+        reg.upsert(rec("a", "service", now + Duration::seconds(60)));
+        let after = reg.resolve_as_of("a", now).unwrap().lease_expires_at;
+        assert!(after > before, "re-register must extend the lease");
+        // still a single row (upsert, not append)
+        assert_eq!(reg.list_as_of(now, None).len(), 1);
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/agent/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/mod.rs
@@ -3,6 +3,7 @@
 //! These handlers provide the core agent functionality including
 //! chat, execution, event streaming, session management, and MCP.
 
+pub mod agents;
 pub mod chat;
 pub mod child_approval;
 pub mod delete;

--- a/crates/app/bamboo-server/src/routes/agent.rs
+++ b/crates/app/bamboo-server/src/routes/agent.rs
@@ -291,6 +291,27 @@ pub fn agent_routes(cfg: &mut web::ServiceConfig) {
         )
         .route("/stream", web::get().to(agent::ws_v2::handler));
     cfg.service(v2_scope);
+
+    // remote-actor P2a (#181): the `/v1/agents` control-plane registry. GATED by
+    // the SAME access-password middleware as everything else — registration is a
+    // control-plane WRITE, and a forged record could poison routing
+    // (remote-actor-plan §5 "活性伪造:注册需持 token"). It is deliberately NOT on
+    // the public whitelist (`is_public_access_route`): a remote, credential-less
+    // caller is rejected with 401, while a local-bypass desktop / valid device
+    // token / verified cookie reaches the handlers. The client side is
+    // `bamboo_subagent::RegistryFabric`.
+    let agents_scope = web::scope("/v1/agents")
+        .wrap(actix_web::middleware::from_fn(
+            settings::enforce_access_password_middleware,
+        ))
+        .route("", web::post().to(agent::agents::register_agent))
+        .route("", web::get().to(agent::agents::list_agents))
+        .route("/{agent_id}", web::get().to(agent::agents::get_agent))
+        .route(
+            "/{agent_id}",
+            web::delete().to(agent::agents::withdraw_agent),
+        );
+    cfg.service(agents_scope);
 }
 
 /// Whether the dev-only HTTP endpoints (e.g. `POST /api/v1/dev/reset`) should be

--- a/crates/app/bamboo-server/src/routes/tests.rs
+++ b/crates/app/bamboo-server/src/routes/tests.rs
@@ -1243,3 +1243,237 @@ async fn root_password_throttle_does_not_block_code_path() {
         "code path must be unaffected by the root-password throttle"
     );
 }
+
+// --- remote-actor P2a (#181): `/v1/agents` control-plane registry ------------
+
+/// Register → resolve → list (+ role filter) → withdraw over HTTP, plus
+/// re-register-refreshes-lease. A local (loopback) caller bypasses auth and
+/// reaches the gated handlers.
+#[actix_web::test]
+async fn agents_register_resolve_list_withdraw_round_trip() {
+    let data_dir = tempdir().unwrap();
+    let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .configure(configure_routes),
+    )
+    .await;
+
+    // Register a "gpu" worker (local bypass → reaches the gated handler).
+    let reg = test::TestRequest::post()
+        .uri("/v1/agents")
+        .insert_header((header::HOST, "localhost:9562"))
+        .set_json(serde_json::json!({
+            "agent_id": "w1",
+            "role": "gpu",
+            "labels": ["a100"],
+            "endpoint": "ws://10.0.0.2:8443",
+            "version": "1",
+            "lease_ttl_secs": 60
+        }))
+        .to_request();
+    let resp = test::call_service(&app, reg).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = actix_web::body::to_bytes(resp.into_body()).await.unwrap();
+    let stored: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(stored["agent_id"], "w1");
+    assert_eq!(stored["endpoint"], "ws://10.0.0.2:8443");
+    assert!(
+        stored["lease_expires_at"].is_string(),
+        "server must stamp a lease"
+    );
+
+    // Register a second worker with a different role.
+    let reg2 = test::TestRequest::post()
+        .uri("/v1/agents")
+        .insert_header((header::HOST, "localhost:9562"))
+        .set_json(serde_json::json!({
+            "agent_id": "w2",
+            "role": "cpu",
+            "endpoint": "ws://10.0.0.3:8443"
+        }))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, reg2).await.status(),
+        StatusCode::OK
+    );
+
+    // Resolve one.
+    let one = test::TestRequest::get()
+        .uri("/v1/agents/w1")
+        .insert_header((header::HOST, "localhost:9562"))
+        .to_request();
+    let resp = test::call_service(&app, one).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = actix_web::body::to_bytes(resp.into_body()).await.unwrap();
+    let got: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(got["agent_id"], "w1");
+
+    // List all → 2.
+    let list = test::TestRequest::get()
+        .uri("/v1/agents")
+        .insert_header((header::HOST, "localhost:9562"))
+        .to_request();
+    let resp = test::call_service(&app, list).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = actix_web::body::to_bytes(resp.into_body()).await.unwrap();
+    let arr: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(arr.as_array().unwrap().len(), 2);
+
+    // List filtered by role=gpu → 1.
+    let filtered = test::TestRequest::get()
+        .uri("/v1/agents?role=gpu")
+        .insert_header((header::HOST, "localhost:9562"))
+        .to_request();
+    let resp = test::call_service(&app, filtered).await;
+    let body = actix_web::body::to_bytes(resp.into_body()).await.unwrap();
+    let arr: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(arr.as_array().unwrap().len(), 1);
+    assert_eq!(arr[0]["agent_id"], "w1");
+
+    // Re-register w1 refreshes its lease (a later expiry than the first stamp).
+    let first_lease = got["lease_expires_at"].as_str().unwrap().to_string();
+    let reg_again = test::TestRequest::post()
+        .uri("/v1/agents")
+        .insert_header((header::HOST, "localhost:9562"))
+        .set_json(serde_json::json!({
+            "agent_id": "w1",
+            "role": "gpu",
+            "endpoint": "ws://10.0.0.2:8443",
+            "lease_ttl_secs": 3600
+        }))
+        .to_request();
+    let resp = test::call_service(&app, reg_again).await;
+    let body = actix_web::body::to_bytes(resp.into_body()).await.unwrap();
+    let refreshed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(
+        refreshed["lease_expires_at"].as_str().unwrap() > first_lease.as_str(),
+        "re-register must refresh (extend) the lease"
+    );
+
+    // Withdraw w1.
+    let del = test::TestRequest::delete()
+        .uri("/v1/agents/w1")
+        .insert_header((header::HOST, "localhost:9562"))
+        .to_request();
+    assert_eq!(test::call_service(&app, del).await.status(), StatusCode::OK);
+
+    // w1 is gone (404); w2 remains.
+    let gone = test::TestRequest::get()
+        .uri("/v1/agents/w1")
+        .insert_header((header::HOST, "localhost:9562"))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, gone).await.status(),
+        StatusCode::NOT_FOUND
+    );
+    let list = test::TestRequest::get()
+        .uri("/v1/agents")
+        .insert_header((header::HOST, "localhost:9562"))
+        .to_request();
+    let resp = test::call_service(&app, list).await;
+    let body = actix_web::body::to_bytes(resp.into_body()).await.unwrap();
+    let arr: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(arr.as_array().unwrap().len(), 1);
+    assert_eq!(arr[0]["agent_id"], "w2");
+}
+
+/// An expired-lease record is NOT returned by GET (lazy gc on read). Inject a
+/// 1-second TTL directly via the registry, then read past it.
+#[actix_web::test]
+async fn agents_expired_lease_is_not_returned() {
+    use bamboo_subagent::proto::AgentRecord;
+    use chrono::{Duration as ChronoDuration, Utc};
+
+    let data_dir = tempdir().unwrap();
+    let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());
+
+    // Insert an already-expired record straight into the in-memory registry.
+    let now = Utc::now();
+    app_state.agent_registry.insert_for_test(AgentRecord {
+        agent_id: "stale".into(),
+        role: "service".into(),
+        labels: vec![],
+        endpoint: "ws://127.0.0.1:1".into(),
+        pid: 1,
+        version: "0".into(),
+        started_at: now,
+        lease_expires_at: now - ChronoDuration::seconds(1),
+    });
+    app_state.agent_registry.insert_for_test(AgentRecord {
+        agent_id: "fresh".into(),
+        role: "service".into(),
+        labels: vec![],
+        endpoint: "ws://127.0.0.1:2".into(),
+        pid: 2,
+        version: "0".into(),
+        started_at: now,
+        lease_expires_at: now + ChronoDuration::seconds(60),
+    });
+
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .configure(configure_routes),
+    )
+    .await;
+
+    // GET /v1/agents/stale → 404 (expired).
+    let stale = test::TestRequest::get()
+        .uri("/v1/agents/stale")
+        .insert_header((header::HOST, "localhost:9562"))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, stale).await.status(),
+        StatusCode::NOT_FOUND
+    );
+
+    // List returns only the fresh one.
+    let list = test::TestRequest::get()
+        .uri("/v1/agents")
+        .insert_header((header::HOST, "localhost:9562"))
+        .to_request();
+    let resp = test::call_service(&app, list).await;
+    let body = actix_web::body::to_bytes(resp.into_body()).await.unwrap();
+    let arr: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(arr.as_array().unwrap().len(), 1);
+    assert_eq!(arr[0]["agent_id"], "fresh");
+}
+
+/// `/v1/agents` is GATED: a remote, password-protected, credential-less caller is
+/// rejected by the access middleware with 401 (control-plane registration must
+/// require a credential — a forged record could poison routing).
+#[actix_web::test]
+async fn agents_routes_require_auth() {
+    let data_dir = tempdir().unwrap();
+    let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());
+    {
+        let mut config = app_state.config.write().await;
+        config.access_control = Some(password_access_control());
+    }
+    let app = test::init_service(App::new().app_data(app_state).configure(configure_routes)).await;
+
+    // POST register — remote, no credential → 401.
+    let reg = test::TestRequest::post()
+        .uri("/v1/agents")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .set_json(serde_json::json!({ "role": "gpu", "endpoint": "ws://x:1" }))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, reg).await.status(),
+        StatusCode::UNAUTHORIZED,
+        "POST /v1/agents must be behind the access middleware"
+    );
+
+    // GET list — remote, no credential → 401.
+    let list = test::TestRequest::get()
+        .uri("/v1/agents")
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .to_request();
+    assert_eq!(
+        test::call_service(&app, list).await.status(),
+        StatusCode::UNAUTHORIZED,
+        "GET /v1/agents must be behind the access middleware"
+    );
+}

--- a/crates/app/bamboo-server/tests/registry_fabric_live.rs
+++ b/crates/app/bamboo-server/tests/registry_fabric_live.rs
@@ -1,0 +1,128 @@
+//! Live HTTP round-trip for the remote-actor P2a registry (#181, Epic #181).
+//!
+//! Stands up a REAL bound `bamboo-server` on an ephemeral loopback port and drives
+//! the REAL `bamboo_subagent::RegistryFabric` (an HTTP `Discovery` impl) against
+//! its `/v1/agents` control-plane routes — end to end over `reqwest` → actix,
+//! exercising the publish → resolve → discover → withdraw path the way a remote
+//! worker / parent would. `test::init_service` never binds a socket, so only a
+//! bound-port test like this proves the `reqwest` client + actix server actually
+//! talk over the network.
+//!
+//! Loopback requests bypass the access middleware (`is_local_request`), so this
+//! test reaches the gated handlers without a credential — the gated-vs-401
+//! contract is covered separately by the `routes::tests::agents_routes_require_auth`
+//! unit test, and the bearer-header wiring by the bamboo-subagent-side wiremock
+//! tests. We still construct the fabric WITH a token to confirm the token path
+//! does not break a real request.
+
+use actix_web::{web, App, HttpServer};
+use bamboo_server::routes::configure_routes;
+use bamboo_server::AppState;
+use bamboo_subagent::discovery::Discovery;
+use bamboo_subagent::proto::AgentRecord;
+use bamboo_subagent::RegistryFabric;
+use chrono::{Duration as ChronoDuration, Utc};
+use tokio::net::TcpListener;
+
+struct TestServer {
+    base_http_url: String,
+    _tmp: tempfile::TempDir,
+    server_handle: actix_web::dev::ServerHandle,
+    _join: tokio::task::JoinHandle<std::io::Result<()>>,
+}
+
+impl TestServer {
+    async fn start() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(tmp.path().to_path_buf()).await.unwrap());
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let std_listener = listener.into_std().unwrap();
+        std_listener.set_nonblocking(false).unwrap();
+
+        let state_for_factory = state.clone();
+        let server = HttpServer::new(move || {
+            App::new()
+                .app_data(state_for_factory.clone())
+                .configure(configure_routes)
+        })
+        .workers(1)
+        .listen(std_listener)
+        .unwrap()
+        .run();
+
+        let server_handle = server.handle();
+        let join = tokio::spawn(server);
+
+        TestServer {
+            base_http_url: format!("http://127.0.0.1:{port}"),
+            _tmp: tmp,
+            server_handle,
+            _join: join,
+        }
+    }
+
+    async fn stop(self) {
+        self.server_handle.stop(false).await;
+    }
+}
+
+fn rec(id: &str, role: &str) -> AgentRecord {
+    let now = Utc::now();
+    AgentRecord {
+        agent_id: id.into(),
+        role: role.into(),
+        labels: vec!["a100".into()],
+        endpoint: "ws://10.0.0.9:8443".into(),
+        pid: 99,
+        version: "1".into(),
+        started_at: now,
+        // The server is the lease authority and re-stamps this; we send a value
+        // anyway to prove it round-trips through the request body.
+        lease_expires_at: now + ChronoDuration::seconds(60),
+    }
+}
+
+#[actix_web::test]
+async fn registry_fabric_publish_resolve_discover_withdraw_over_real_http() {
+    let server = TestServer::start().await;
+
+    // A token is configured but loopback bypasses auth — this just proves the
+    // bearer-carrying client path works against a real server.
+    let fab = RegistryFabric::with_token(&server.base_http_url, "device-token-xyz").unwrap();
+
+    // publish (register/heartbeat).
+    fab.publish(&rec("live-1", "gpu")).await.unwrap();
+    fab.publish(&rec("live-2", "cpu")).await.unwrap();
+
+    // resolve one.
+    let got = fab
+        .resolve("live-1")
+        .await
+        .unwrap()
+        .expect("live-1 present");
+    assert_eq!(got.agent_id, "live-1");
+    assert_eq!(got.endpoint, "ws://10.0.0.9:8443");
+    // Server stamped a fresh lease that is still in the future.
+    assert!(got.lease_expires_at > Utc::now());
+
+    // discover lists both.
+    let all = fab.discover().await.unwrap();
+    assert_eq!(all.len(), 2);
+
+    // resolve a missing id → None.
+    assert!(fab.resolve("nope").await.unwrap().is_none());
+
+    // withdraw one; it disappears, the other stays.
+    fab.withdraw("live-1").await.unwrap();
+    assert!(fab.resolve("live-1").await.unwrap().is_none());
+    let remaining = fab.discover().await.unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].agent_id, "live-2");
+
+    // client gc is a no-op (server owns gc).
+    assert_eq!(fab.gc().await.unwrap(), 0);
+
+    server.stop().await;
+}

--- a/crates/infra/bamboo-subagent/Cargo.toml
+++ b/crates/infra/bamboo-subagent/Cargo.toml
@@ -26,7 +26,16 @@ tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
 rustls-pemfile = "2"
+# remote-actor P2a (#181): the HTTP client behind `RegistryFabric` (the network
+# `Discovery` impl that talks to the server's `/v1/agents` control plane).
+# default-features=false drops reqwest's default native-tls stack; `rustls-tls`
+# keeps this crate on the same rustls/ring posture as the rest of the workspace
+# (no system OpenSSL, no native-tls). `json` is for (de)serializing `AgentRecord`.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
 tempfile = "3"
+# remote-actor P2a (#181): mock the `/v1/agents` registry so the `RegistryFabric`
+# HTTP round-trip is exercised without standing up the full bamboo-server.
+wiremock = "0.6"

--- a/crates/infra/bamboo-subagent/src/error.rs
+++ b/crates/infra/bamboo-subagent/src/error.rs
@@ -22,6 +22,11 @@ pub enum StoreError {
     CorruptIndex { path: PathBuf },
     #[error("not found: {0}")]
     NotFound(String),
+    /// A network/transport failure from the HTTP `Discovery` backend
+    /// ([`crate::registry_fabric::RegistryFabric`]). The message is scrubbed of
+    /// any credential — never format a bearer token into this.
+    #[error("registry network error: {0}")]
+    Network(String),
 }
 
 pub type Result<T> = std::result::Result<T, StoreError>;

--- a/crates/infra/bamboo-subagent/src/lib.rs
+++ b/crates/infra/bamboo-subagent/src/lib.rs
@@ -21,6 +21,7 @@ pub mod mailbox;
 pub mod proto;
 pub mod provision;
 pub mod registry;
+pub mod registry_fabric;
 pub mod store;
 pub mod transport;
 
@@ -39,6 +40,7 @@ pub use provision::{
     ProvisionSpec, ScopedCredential, SecretsEnvelope, PROVISION_VERSION,
 };
 pub use registry::{RegisterChild, Registration, Registry};
+pub use registry_fabric::RegistryFabric;
 pub use store::{
     ChildEntry, ChildFields, ChildStatus, ChildrenIndex, MetaExtractor, ProjectIndex, ProjectKey,
     RootEntry, RootFields, SessionLoc, SubagentStore,

--- a/crates/infra/bamboo-subagent/src/registry_fabric.rs
+++ b/crates/infra/bamboo-subagent/src/registry_fabric.rs
@@ -1,0 +1,323 @@
+//! Network discovery: an HTTP-backed [`Discovery`] talking to the server's
+//! `/v1/agents` control plane (remote-actor-plan §3.3, §6 P2).
+//!
+//! Where [`crate::discovery::FileFabric`] keeps records as `*.json` files in a
+//! local directory — invisible across machines — `RegistryFabric` is its
+//! cross-host sibling: it `publish`/`resolve`/`discover`/`withdraw`s by calling
+//! a registry endpoint over HTTP(S). The same [`AgentRecord`] + `lease_expires_at`
+//! semantics carry over: a worker renews its lease by re-`publish`ing (the server
+//! refreshes `lease_expires_at = now + ttl` on each upsert), exactly as the file
+//! fabric re-writes its record.
+//!
+//! Auth: the registration face is a CREDENTIALLED control plane (a forged
+//! registration could poison routing — §5 "活性伪造:注册需持 token"). When a
+//! bearer token is configured, every request carries `Authorization: Bearer
+//! <token>`. The token is NEVER logged or formatted into an error.
+//!
+//! GC: garbage collection is the REGISTRY's responsibility (lazy filter on read,
+//! or a server sweep). The client [`Discovery::gc`] is therefore a no-op that
+//! returns `Ok(0)` — there is nothing for a client to sweep.
+
+use async_trait::async_trait;
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use reqwest::{Client, StatusCode};
+
+use crate::discovery::Discovery;
+use crate::error::{Result, StoreError};
+use crate::proto::AgentRecord;
+
+/// An HTTP-backed discovery fabric pointed at a registry's `/v1/agents` face.
+///
+/// Holds a configurable base URL (e.g. `https://control-plane:8443`) and an
+/// optional bearer token (the device/worker credential). Cheap to clone — the
+/// inner [`Client`] is an `Arc` internally.
+pub struct RegistryFabric {
+    client: Client,
+    /// Base URL WITHOUT a trailing slash, e.g. `http://127.0.0.1:8080`.
+    base: String,
+}
+
+impl RegistryFabric {
+    /// Build a fabric for `base_url` with no bearer token (e.g. a loopback/dev
+    /// registry that does not require a credential).
+    pub fn new(base_url: impl Into<String>) -> Result<Self> {
+        Self::build(base_url.into(), None)
+    }
+
+    /// Build a fabric for `base_url` that presents `token` as
+    /// `Authorization: Bearer <token>` on every request.
+    pub fn with_token(base_url: impl Into<String>, token: impl Into<String>) -> Result<Self> {
+        Self::build(base_url.into(), Some(token.into()))
+    }
+
+    fn build(base_url: String, token: Option<String>) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        if let Some(token) = token {
+            // Build the header value here so the token is captured into the
+            // reqwest default-headers and never re-stringified at call sites
+            // (and so a malformed token surfaces as a clean error, not a panic).
+            let mut value = HeaderValue::from_str(&format!("Bearer {token}"))
+                .map_err(|_| StoreError::Network("invalid bearer token".into()))?;
+            value.set_sensitive(true); // keep it out of any header Debug output
+            headers.insert(AUTHORIZATION, value);
+        }
+        let client = Client::builder()
+            .default_headers(headers)
+            .build()
+            .map_err(net_err)?;
+        Ok(Self {
+            client,
+            base: base_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    fn agents_url(&self) -> String {
+        format!("{}/v1/agents", self.base)
+    }
+
+    fn agent_url(&self, agent_id: &str) -> String {
+        format!("{}/v1/agents/{}", self.base, agent_id)
+    }
+}
+
+#[async_trait]
+impl Discovery for RegistryFabric {
+    /// `POST /v1/agents` — register or heartbeat. The server upserts by
+    /// `agent_id` and refreshes the lease. Re-publishing is the renewal path.
+    async fn publish(&self, rec: &AgentRecord) -> Result<()> {
+        let resp = self
+            .client
+            .post(self.agents_url())
+            .json(rec)
+            .send()
+            .await
+            .map_err(net_err)?;
+        ensure_ok(resp).await.map(|_| ())
+    }
+
+    /// `GET /v1/agents/{id}` — resolve one live record. A `404` (absent or
+    /// lease-expired) maps to `Ok(None)`.
+    async fn resolve(&self, agent_id: &str) -> Result<Option<AgentRecord>> {
+        let resp = self
+            .client
+            .get(self.agent_url(agent_id))
+            .send()
+            .await
+            .map_err(net_err)?;
+        if resp.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let resp = ensure_ok(resp).await?;
+        let rec = resp.json::<AgentRecord>().await.map_err(net_err)?;
+        Ok(Some(rec))
+    }
+
+    /// `GET /v1/agents` — list all live records.
+    async fn discover(&self) -> Result<Vec<AgentRecord>> {
+        let resp = self
+            .client
+            .get(self.agents_url())
+            .send()
+            .await
+            .map_err(net_err)?;
+        let resp = ensure_ok(resp).await?;
+        let recs = resp.json::<Vec<AgentRecord>>().await.map_err(net_err)?;
+        Ok(recs)
+    }
+
+    /// `DELETE /v1/agents/{id}` — withdraw a record (clean shutdown). A `404` is
+    /// treated as success (idempotent, matching the file fabric).
+    async fn withdraw(&self, agent_id: &str) -> Result<()> {
+        let resp = self
+            .client
+            .delete(self.agent_url(agent_id))
+            .send()
+            .await
+            .map_err(net_err)?;
+        if resp.status() == StatusCode::NOT_FOUND {
+            return Ok(());
+        }
+        ensure_ok(resp).await.map(|_| ())
+    }
+
+    /// GC is the REGISTRY's responsibility (server-side lazy-filter-on-read /
+    /// sweep), so the client has nothing to collect. Always `Ok(0)`.
+    async fn gc(&self) -> Result<usize> {
+        Ok(0)
+    }
+}
+
+/// Map a transport-level `reqwest::Error` into a `StoreError::Network`. Its
+/// `Display` never includes request headers, so the bearer token cannot leak.
+fn net_err(e: reqwest::Error) -> StoreError {
+    StoreError::Network(e.to_string())
+}
+
+/// Turn a non-2xx HTTP response into a `StoreError`, mapping auth failures to a
+/// distinct message. The token is never echoed (only the status is reported).
+async fn ensure_ok(resp: reqwest::Response) -> Result<reqwest::Response> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(resp);
+    }
+    if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+        return Err(StoreError::Network(format!(
+            "registry rejected the request: {status} (missing or invalid credential)"
+        )));
+    }
+    Err(StoreError::Network(format!(
+        "registry returned an error status: {status}"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+    use wiremock::matchers::{header, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn rec(id: &str) -> AgentRecord {
+        AgentRecord {
+            agent_id: id.into(),
+            role: "service".into(),
+            labels: vec!["gpu".into()],
+            endpoint: "ws://10.0.0.2:8443".into(),
+            pid: 7,
+            version: "1".into(),
+            started_at: Utc::now(),
+            lease_expires_at: Utc::now() + Duration::seconds(30),
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_resolve_discover_withdraw_round_trip_over_http() {
+        let server = MockServer::start().await;
+        let r = rec("a");
+
+        // POST /v1/agents echoes the stored record back.
+        Mock::given(method("POST"))
+            .and(path("/v1/agents"))
+            .and(header("authorization", "Bearer t-secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&r))
+            .mount(&server)
+            .await;
+        // GET /v1/agents/a resolves one.
+        Mock::given(method("GET"))
+            .and(path("/v1/agents/a"))
+            .and(header("authorization", "Bearer t-secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&r))
+            .mount(&server)
+            .await;
+        // GET /v1/agents lists.
+        Mock::given(method("GET"))
+            .and(path("/v1/agents"))
+            .and(header("authorization", "Bearer t-secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(vec![r.clone()]))
+            .mount(&server)
+            .await;
+        // DELETE /v1/agents/a withdraws.
+        Mock::given(method("DELETE"))
+            .and(path("/v1/agents/a"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let fab = RegistryFabric::with_token(server.uri(), "t-secret").unwrap();
+
+        // Drive through the trait object (object-safety + the bearer header).
+        let disc: &dyn Discovery = &fab;
+        disc.publish(&r).await.unwrap();
+        let got = disc.resolve("a").await.unwrap().unwrap();
+        assert_eq!(got.agent_id, "a");
+        assert_eq!(disc.discover().await.unwrap().len(), 1);
+        disc.withdraw("a").await.unwrap();
+        // Client GC is a no-op (server-side responsibility).
+        assert_eq!(disc.gc().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn resolve_missing_is_none_and_withdraw_missing_is_ok() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/agents/ghost"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path("/v1/agents/ghost"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let fab = RegistryFabric::new(server.uri()).unwrap();
+        assert!(fab.resolve("ghost").await.unwrap().is_none());
+        fab.withdraw("ghost").await.unwrap(); // 404 is idempotent success
+    }
+
+    #[tokio::test]
+    async fn discover_with_role_filter_query_is_sent() {
+        // `discover()` hits the bare list endpoint; this asserts the URL shape the
+        // server filters on is reachable (role filtering is a server concern, but
+        // the client must target `/v1/agents`).
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/agents"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(Vec::<AgentRecord>::new()))
+            .mount(&server)
+            .await;
+        let fab = RegistryFabric::new(server.uri()).unwrap();
+        assert!(fab.discover().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn unauthorized_maps_to_network_error_without_leaking_token() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/agents"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+        let fab = RegistryFabric::with_token(server.uri(), "super-secret-token").unwrap();
+        let err = fab.publish(&rec("x")).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("401"), "expected 401 in: {msg}");
+        assert!(
+            !msg.contains("super-secret-token"),
+            "token must never leak into the error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn trailing_slash_in_base_is_normalized() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/agents"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(Vec::<AgentRecord>::new()))
+            .mount(&server)
+            .await;
+        // Base with a trailing slash must still produce `/v1/agents`, not `//v1/agents`.
+        let fab = RegistryFabric::new(format!("{}/", server.uri())).unwrap();
+        assert!(fab.discover().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn query_param_route_is_exercisable() {
+        // Sanity that the mock server matches a role query — documents the server
+        // contract that `RegistryFabric::discover` could grow a filtered variant.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/agents"))
+            .and(query_param("role", "service"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(Vec::<AgentRecord>::new()))
+            .mount(&server)
+            .await;
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!("{}/v1/agents?role=service", server.uri()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+}


### PR DESCRIPTION
## remote-actor P2a — agent registry control plane + RegistryFabric

The foundation of remote-actor P2 (cross-machine discovery over HTTP), the network counterpart of the local-file `FileFabric`. Workers on OTHER hosts can now register/heartbeat and parents can resolve them over HTTP, reusing the same `AgentRecord` + `lease_expires_at` lease semantics. Implements `docs/remote-actor-plan.md` §3.3 / §5 / §6 (P2), scoped to **P2a only** (the scheduler is deferred to P2b).

### Server-side registry (bamboo-server)
- **`AgentRegistry`** — in-memory `DashMap<agent_id, AgentRecord>` on `AppState`, mirrored after `pairing_codes` (additive field, initialized in the builder). PROCESS-EPHEMERAL; a restart drops all registrations (workers re-register on their next heartbeat, like the file fabric being wiped).
- **Lease / GC** — the server is the lease authority: every `POST` re-derives `lease_expires_at = now + ttl` (ttl clamped to 1..3600s, default 30s) so a client cannot forge an over-long lease. GC is **lazy-filter-on-read**: every `GET` drops + prunes records past their lease. No background sweep in P2a (documented trade-off — the map can hold expired rows between reads, but they are never *served*).
- **`AgentRecord` reuse** — a new DIRECT `bamboo-subagent` dep (the engine already pulls it transitively) so the wire type is reused verbatim, no server-side DTO that could drift.

### Routes under `/v1/agents` (GATED)
Registered in `routes/agent.rs` behind `enforce_access_password_middleware`, deliberately **NOT** on the public whitelist (`is_public_access_route`). Registration is a control-plane write — a forged record could poison routing (§5 "活性伪造:注册需持 token"), so a credential is required exactly like every other `/api/v1` route.
- `POST /v1/agents` — register/heartbeat (upsert by `agent_id`, returns the stored record)
- `GET /v1/agents` — list live records, `?role=<r>` filter
- `GET /v1/agents/{agent_id}` — resolve one (404 if absent/expired)
- `DELETE /v1/agents/{agent_id}` — withdraw (idempotent)

### Auth model
`/v1/agents` is gated by the existing access middleware: a **local-bypass** desktop, a **valid per-device token** (`Authorization: Bearer <token>` + `X-Device-Id`), or a **verified password cookie** reach the handlers; a remote credential-less caller is `401`. `RegistryFabric` presents the device/worker token as `Authorization: Bearer <token>` on every request (set once as a reqwest default header, marked sensitive so it never appears in Debug output, never logged, never formatted into an error).

### RegistryFabric (bamboo-subagent)
A new `Discovery` impl alongside `Fabric`/`FileFabric` (which stays the local default — **zero regression** for single-host).
- HTTP client over a configurable base URL + optional bearer token: `publish` → `POST`, `resolve` → `GET {id}` (404 → `Ok(None)`), `discover` → `GET`, `withdraw` → `DELETE` (404 → idempotent `Ok`), `gc` → `Ok(0)` (GC is the registry's responsibility).
- `reqwest` added with `default-features=false` + `["json","rustls-tls"]` — no native-tls, matching the rustls-everywhere posture. Transport/HTTP errors map to a new `StoreError::Network`; the token never leaks.

### Tests
- **Server:** register → resolve → list (+ role filter) → withdraw round trip; expired-lease record not returned (lazy gc); re-register refreshes the lease; `/v1/agents` requires auth (remote no-cred → 401). Plus `AgentRegistry` unit tests.
- **RegistryFabric:** wiremock round trip (publish/resolve/discover/withdraw, bearer-header asserted, 401→error-without-token-leak) **and** a REAL bound-server HTTP round trip (`tests/registry_fabric_live.rs`).
- `cargo test -p bamboo-server -p bamboo-subagent` green; full workspace `cargo build` green; new code clippy-clean.

### Deferred to P2b (NOT in this PR)
- `Placement::Schedulable` routing
- the scheduler (role/capacity/health endpoint selection)
- a `RegistryLauncher`
- engine wiring to use `RegistryFabric` for placement

P2a just makes register/resolve/list/withdraw work over HTTP with auth + leases.

Refs #181 (remote-actor P2a — agent registry + RegistryFabric)

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp
