### PR TITLE
feat(engine): Schedulable connect-fail failover + RegistryFabric caching [#202]

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/agents.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/agents.rs
@@ -30,6 +30,18 @@ use crate::error::AppError;
 use crate::AppState;
 
 /// Default lease lifetime when a registration omits `lease_ttl_secs`.
+///
+/// RENEW CADENCE (worker contract, #202): a registry-published worker (a
+/// `bamboo_subagent::RegistryFabric` heartbeat loop) MUST re-`publish()` well
+/// WITHIN this TTL — each upsert refreshes `lease_expires_at = now + ttl`, and a
+/// record whose lease expires is pruned (lazily on read, eagerly on the next
+/// write) and STOPS being a scheduling candidate. Renew at roughly `TTL/2` to
+/// `TTL/3` (here ~10-15s) so a single slow/late heartbeat — or a transient
+/// network blip on the renew call — does not expire a worker that is actually
+/// alive. This mirrors the file-fabric serve loop's "renew < TTL" discipline.
+/// The Schedulable scheduler now tolerates a stale-but-leased worker by failing
+/// over to the next live candidate, but that is a SECOND line of defense; the
+/// renew cadence is the first.
 const DEFAULT_LEASE_TTL_SECS: i64 = 30;
 /// Upper bound on a requested lease TTL — a worker cannot pin itself live for an
 /// unbounded time; it must keep heartbeating. Caps a misbehaving/forged TTL.

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -151,6 +151,14 @@ pub struct ActorChildRunner {
     /// workers instead of all landing on the first candidate. Best-effort spread,
     /// not a load balancer — the registry's live set can change between picks.
     schedule_cursor: Arc<std::sync::Mutex<HashMap<String, usize>>>,
+    /// Per-`registry_url` cache of built [`RegistryFabric`]s (#202). A fabric
+    /// holds a reqwest `Client` (already connection-pooled), so under sibling
+    /// fan-out we construct ONE fabric per registry and reuse it across schedules
+    /// instead of rebuilding a fresh client every spawn. Construct-once-then-reuse;
+    /// a benign duplicate build under a startup race is harmless (last writer wins,
+    /// the loser's fabric drops). The bearer lives INSIDE the fabric's sensitive
+    /// `Authorization` header — never logged, never re-stringified here.
+    fabric_cache: Arc<std::sync::Mutex<HashMap<String, Arc<bamboo_subagent::RegistryFabric>>>>,
 }
 
 /// Decides how the host answers a child worker's gated-tool approval request
@@ -260,6 +268,7 @@ impl ActorChildRunner {
             remote_placements: HashMap::new(),
             schedulable_placements: HashMap::new(),
             schedule_cursor: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            fabric_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -529,33 +538,41 @@ impl ActorChildRunner {
         spec
     }
 
-    /// Pick a live worker for a SCHEDULABLE role from the agent registry (#181,
-    /// P2b). Builds a `RegistryFabric` at the resolved `registry_url` (Bearer if a
-    /// token is set), lists live records (the registry already excludes expired
-    /// leases — health == a live lease), filters to those whose `role` == the
-    /// configured `pool`, and picks ONE via per-pool ROUND-ROBIN so successive
-    /// sibling spawns spread across the pool. Returns the chosen [`AgentRecord`].
-    ///
-    /// No live candidate ⇒ an `AgentError` (the caller NEVER falls back to a local
-    /// subprocess; that would silently defeat the placement). A registry-query
-    /// failure is likewise a clear, terminal error — not a spawn.
-    async fn resolve_schedulable_worker(
-        &self,
-        role: &str,
-    ) -> std::result::Result<(AgentRecord, ResolvedSchedulablePlacement), AgentError> {
-        let placement = self
-            .schedulable_placements
-            .get(role)
-            .ok_or_else(|| {
-                AgentError::LLM(format!(
-                    "schedulable placement for role '{role}' vanished before scheduling"
-                ))
-            })?
-            .clone();
+    /// Max DISTINCT live candidates a single schedulable resolve will try to
+    /// connect to before giving up (#202). Bounds the connect-fail failover so a
+    /// pool full of stale-but-leased workers can't make one spawn walk the whole
+    /// fleet; the effective cap is `min(candidates.len(), MAX_SCHEDULE_CONNECT_ATTEMPTS)`.
+    const MAX_SCHEDULE_CONNECT_ATTEMPTS: usize = 3;
 
-        // Query the registry (Bearer if configured). The fabric is cheap and the
-        // resolution is per-run, so building it here keeps the bearer scoped.
-        let fabric = match placement.token.as_deref() {
+    /// Get-or-build the [`RegistryFabric`] for `placement.registry_url`, caching
+    /// it on the runner (#202). A fabric wraps a connection-pooled reqwest
+    /// `Client`; under sibling fan-out this reuses ONE client per registry instead
+    /// of constructing a fresh one every schedule. Construct-once-then-reuse: a
+    /// cache miss builds (Bearer if configured) and stores it. The bearer stays
+    /// inside the fabric's sensitive `Authorization` header — never logged here.
+    ///
+    /// Concurrency: a brief race can build two fabrics for the same url; that is
+    /// harmless (both are valid, last-insert wins, the loser drops). We never hold
+    /// the cache lock across the build, so an `await`-free critical section can't
+    /// deadlock or stall siblings.
+    fn fabric_for(
+        &self,
+        placement: &ResolvedSchedulablePlacement,
+        role: &str,
+    ) -> std::result::Result<Arc<bamboo_subagent::RegistryFabric>, AgentError> {
+        if let Some(fabric) = self
+            .fabric_cache
+            .lock()
+            .unwrap()
+            .get(&placement.registry_url)
+            .cloned()
+        {
+            return Ok(fabric);
+        }
+
+        // Cache miss: build outside the lock (construction is sync + cheap but we
+        // keep the critical section minimal and await-free regardless).
+        let built = match placement.token.as_deref() {
             Some(token) => {
                 bamboo_subagent::RegistryFabric::with_token(placement.registry_url.clone(), token)
             }
@@ -567,7 +584,54 @@ impl ActorChildRunner {
                 placement.registry_url
             ))
         })?;
+        let arc = Arc::new(built);
 
+        // Insert-or-reuse: if a concurrent caller already populated the slot, take
+        // theirs (the duplicate we built drops) so all siblings share one fabric.
+        let mut cache = self.fabric_cache.lock().unwrap();
+        Ok(cache
+            .entry(placement.registry_url.clone())
+            .or_insert(arc)
+            .clone())
+    }
+
+    /// Pick a live worker for a SCHEDULABLE role from the agent registry (#181,
+    /// P2b) and CONNECT to it, with connect-fail failover (#202).
+    ///
+    /// Uses a cached [`RegistryFabric`] (per `registry_url`) to list live records
+    /// (the registry already excludes expired leases — health == a live lease),
+    /// filters to those whose `role` == the configured `pool`, then picks a
+    /// starting candidate via per-pool ROUND-ROBIN. Because a live lease is only a
+    /// COARSE health signal (a leased worker can have a dead process / a network
+    /// blip), it does not connect blindly to that one pick: it attempts
+    /// `connect_with_auth_tls`, and on failure WALKS FORWARD to the next DISTINCT
+    /// live candidate and retries — up to `min(candidates.len(),
+    /// MAX_SCHEDULE_CONNECT_ATTEMPTS)` attempts. A single stale-but-leased worker
+    /// therefore no longer fails the whole schedule.
+    ///
+    /// Returns the connected [`ChildClient`] plus the chosen [`AgentRecord`] and
+    /// the placement. No live candidate (empty pool) ⇒ a terminal `AgentError`;
+    /// ALL attempted candidates failing to connect ⇒ a terminal `AgentError` —
+    /// the caller NEVER falls back to a local subprocess (that would silently
+    /// defeat the placement). A registry-query failure is likewise terminal. The
+    /// error logs HOW MANY candidates were tried, never the token.
+    async fn resolve_schedulable_worker(
+        &self,
+        role: &str,
+    ) -> std::result::Result<(ChildClient, AgentRecord, ResolvedSchedulablePlacement), AgentError>
+    {
+        let placement = self
+            .schedulable_placements
+            .get(role)
+            .ok_or_else(|| {
+                AgentError::LLM(format!(
+                    "schedulable placement for role '{role}' vanished before scheduling"
+                ))
+            })?
+            .clone();
+
+        // Query the registry through the cached, connection-pooled fabric (#202).
+        let fabric = self.fabric_for(&placement, role)?;
         let records = fabric.discover().await.map_err(|e| {
             AgentError::LLM(format!(
                 "schedulable role '{role}': registry '{}' query failed: {e}",
@@ -577,7 +641,7 @@ impl ActorChildRunner {
 
         // Live candidates = records published under the pool's role. The registry
         // already dropped expired leases, so presence == health.
-        let mut candidates: Vec<AgentRecord> = records
+        let candidates: Vec<AgentRecord> = records
             .into_iter()
             .filter(|r| r.role == placement.pool)
             .collect();
@@ -590,18 +654,81 @@ impl ActorChildRunner {
             )));
         }
 
-        // Round-robin: advance a per-pool cursor and index into the candidate
-        // list. Deterministic-ish spread without a real load balancer; if the live
-        // set shrank between picks the modulo still lands on a valid index.
-        let idx = {
+        // Round-robin START: advance a per-pool cursor ONCE to pick the starting
+        // index, then walk forward through the remaining candidates on connect
+        // failure. Bumping the cursor only once per resolve keeps the spread
+        // across sibling spawns (each resolve starts one slot further on); the
+        // failover walk is local to this resolve and does not perturb the cursor.
+        let start = {
             let mut cursors = self.schedule_cursor.lock().unwrap();
             let cursor = cursors.entry(placement.pool.clone()).or_insert(0);
             let i = *cursor % candidates.len();
             *cursor = cursor.wrapping_add(1);
             i
         };
-        let chosen = candidates.swap_remove(idx);
-        Ok((chosen, placement))
+
+        // Derive the TLS trust ONCE (pinned CA or default roots / plaintext ws://).
+        let trust_cfg = match placement.ca_cert_file.as_deref() {
+            Some(path) => Some(client_config_trusting_cert(path).map_err(|e| {
+                AgentError::LLM(format!(
+                    "scheduled worker CA cert '{}': {e}",
+                    path.display()
+                ))
+            })?),
+            None => None,
+        };
+
+        // Connect-fail failover: try the starting candidate, then walk forward to
+        // the NEXT DISTINCT live candidate on failure, up to the bounded cap. Each
+        // attempt hits a different candidate (modulo wrap from the start index).
+        let max_attempts = candidates.len().min(Self::MAX_SCHEDULE_CONNECT_ATTEMPTS);
+        let mut last_err: Option<String> = None;
+        for attempt in 0..max_attempts {
+            let idx = (start + attempt) % candidates.len();
+            let record = &candidates[idx];
+            let endpoint = record.endpoint.clone();
+            match ChildClient::connect_with_auth_tls(
+                &endpoint,
+                placement.token.as_deref(),
+                trust_cfg.clone(),
+            )
+            .await
+            {
+                Ok(client) => {
+                    if attempt > 0 {
+                        // We skipped one or more stale-but-leased workers — record
+                        // how many (never the endpoint contents beyond the host we
+                        // connected to, never the token).
+                        tracing::info!(
+                            "schedulable role '{role}': connected to pool '{}' worker after \
+                             {attempt} stale candidate(s) skipped",
+                            placement.pool
+                        );
+                    }
+                    return Ok((client, candidates[idx].clone(), placement));
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "schedulable role '{role}': pool '{}' candidate connect failed \
+                         (attempt {}/{max_attempts}): {e}",
+                        placement.pool,
+                        attempt + 1
+                    );
+                    last_err = Some(e.to_string());
+                }
+            }
+        }
+
+        // All attempted candidates failed to connect ⇒ terminal error. NO spawn
+        // fallback (a schedulable role has none). Log how many were tried, not the
+        // token.
+        Err(AgentError::LLM(format!(
+            "schedulable role '{role}': all {max_attempts} live candidate(s) in pool '{}' at \
+             registry '{}' failed to connect (last error: {}) — NOT spawning a local subprocess",
+            placement.pool,
+            placement.registry_url,
+            last_err.as_deref().unwrap_or("unknown")
+        )))
     }
 }
 
@@ -729,37 +856,17 @@ impl ExternalChildRunner for ActorChildRunner {
                 (actor, client)
             }
             PlacementKind::Schedulable => {
-                // SCHEDULABLE branch (#181, P2b): resolve a LIVE worker from the
-                // registry (round-robin over the pool's live records), then connect
-                // exactly like Remote. No spawn, no pool, no kill, NO local
-                // fallback — no live worker ⇒ a terminal error (raised inside
-                // resolve_schedulable_worker).
-                let (record, placement) = self
+                // SCHEDULABLE branch (#181, P2b + #202): resolve a LIVE worker from
+                // the registry (round-robin over the pool's live records) AND
+                // connect to it, with connect-fail failover — on a stale-but-leased
+                // worker, resolve walks to the next live candidate (bounded). No
+                // spawn, no pool, no kill, NO local fallback — no live worker, or
+                // ALL candidates dead ⇒ a terminal error (raised inside
+                // resolve_schedulable_worker, which owns the connect now).
+                let (client, record, _placement) = self
                     .resolve_schedulable_worker(spec.identity.role.as_str())
                     .await?;
                 let endpoint = record.endpoint.clone();
-                // Same TLS trust derivation as Remote: pinned CA or default roots.
-                let trust_cfg = match placement.ca_cert_file.as_deref() {
-                    Some(path) => Some(client_config_trusting_cert(path).map_err(|e| {
-                        AgentError::LLM(format!(
-                            "scheduled worker CA cert '{}': {e}",
-                            path.display()
-                        ))
-                    })?),
-                    None => None,
-                };
-                let client = ChildClient::connect_with_auth_tls(
-                    &endpoint,
-                    placement.token.as_deref(),
-                    trust_cfg,
-                )
-                .await
-                .map_err(|e| {
-                    AgentError::LLM(format!(
-                        "scheduled actor connect to '{endpoint}' (pool '{}') failed: {e}",
-                        placement.pool
-                    ))
-                })?;
                 // The chosen registry record IS the AgentRecord — synthesize the
                 // process-less handle straight from it (registry-managed worker).
                 let actor = PooledActor {
@@ -1555,15 +1662,36 @@ mod tests {
         assert!(spec.secrets.worker_auth_token.is_none());
     }
 
+    /// Spin up `n` loopback Echo `WsServer`s; returns their endpoints and the
+    /// JoinHandles (abort on test end). Each is a REAL connectable worker.
+    async fn spawn_echo_workers(n: usize) -> (Vec<String>, Vec<tokio::task::JoinHandle<()>>) {
+        let mut endpoints = Vec::new();
+        let mut handles = Vec::new();
+        for _ in 0..n {
+            let server = bamboo_subagent::transport::WsServer::bind_loopback()
+                .await
+                .expect("bind echo worker");
+            endpoints.push(server.ws_endpoint());
+            handles.push(tokio::spawn(async move {
+                let _ = server
+                    .serve(Arc::new(bamboo_subagent::executor::EchoExecutor))
+                    .await;
+            }));
+        }
+        (endpoints, handles)
+    }
+
     #[tokio::test]
     async fn resolve_schedulable_worker_round_robin_spreads_over_candidates() {
-        // Registry returns three live workers in the pool; successive picks must
-        // advance the per-pool cursor and cover all three (round-robin spread).
+        // Registry returns three live, CONNECTABLE workers in the pool; successive
+        // picks must advance the per-pool cursor and cover all three (round-robin
+        // spread). resolve now also connects, so the candidates are real servers.
+        let (eps, handles) = spawn_echo_workers(3).await;
         let registry = MockServer::start().await;
         let recs = vec![
-            live_record("w-0", "gpu-pool", "ws://127.0.0.1:1"),
-            live_record("w-1", "gpu-pool", "ws://127.0.0.1:2"),
-            live_record("w-2", "gpu-pool", "ws://127.0.0.1:3"),
+            live_record("w-0", "gpu-pool", &eps[0]),
+            live_record("w-1", "gpu-pool", &eps[1]),
+            live_record("w-2", "gpu-pool", &eps[2]),
             // A worker in a DIFFERENT pool must be filtered out.
             live_record("other", "cpu-pool", "ws://127.0.0.1:9"),
         ];
@@ -1583,13 +1711,15 @@ mod tests {
         // Three picks → cursor 0,1,2 → agent_ids w-0, w-1, w-2 in order.
         let mut picked = Vec::new();
         for _ in 0..3 {
-            let (rec, placement) = runner
-                .resolve_schedulable_worker("explorer")
-                .await
-                .expect("a live worker is picked");
+            let (client, rec, placement) = match runner.resolve_schedulable_worker("explorer").await
+            {
+                Ok(v) => v,
+                Err(e) => panic!("a live worker is picked: {e}"),
+            };
             assert_eq!(placement.pool, "gpu-pool");
             assert_eq!(rec.role, "gpu-pool", "only pool workers are candidates");
             picked.push(rec.agent_id);
+            let _ = client.close().await;
         }
         picked.sort();
         assert_eq!(
@@ -1597,6 +1727,149 @@ mod tests {
             vec!["w-0".to_string(), "w-1".to_string(), "w-2".to_string()],
             "round-robin covered every candidate over three picks"
         );
+        for h in handles {
+            h.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_schedulable_worker_fails_over_dead_first_candidate() {
+        // The FIRST candidate (by cursor order: cursor starts at 0) points at a
+        // DEAD endpoint (no listener on a closed port); a LATER candidate is a real
+        // Echo worker. resolve must SKIP the dead one and connect to the live one,
+        // returning the live record — connect-fail failover (#202).
+        let (eps, handles) = spawn_echo_workers(1).await;
+        // A port with no listener: bind then drop to free it (best-effort closed).
+        let dead = {
+            let l = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+                .await
+                .unwrap();
+            let port = l.local_addr().unwrap().port();
+            drop(l);
+            format!("ws://127.0.0.1:{port}")
+        };
+        let registry = MockServer::start().await;
+        let recs = vec![
+            // idx 0 = cursor start = DEAD
+            live_record("w-dead", "gpu-pool", &dead),
+            // idx 1 = LIVE echo worker
+            live_record("w-live", "gpu-pool", &eps[0]),
+        ];
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/v1/agents"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(recs))
+            .mount(&registry)
+            .await;
+
+        let mut sched = HashMap::new();
+        sched.insert(
+            "explorer".to_string(),
+            sched_placement("gpu-pool", registry.uri()),
+        );
+        let runner = bogus_sched_runner(HashMap::new(), sched);
+
+        let (client, rec, _placement) = match runner.resolve_schedulable_worker("explorer").await {
+            Ok(v) => v,
+            Err(e) => panic!("failover skips the dead candidate, connects to the live one: {e}"),
+        };
+        assert_eq!(
+            rec.agent_id, "w-live",
+            "the dead first candidate was skipped; the live one was chosen"
+        );
+        let _ = client.close().await;
+        for h in handles {
+            h.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_schedulable_worker_errors_when_all_candidates_dead() {
+        // ALL candidates point at dead endpoints: resolve must error (no panic),
+        // and CRUCIALLY no spawn (a schedulable role has no local fallback). The
+        // error names how many were tried.
+        let mut dead = Vec::new();
+        for _ in 0..2 {
+            let l = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+                .await
+                .unwrap();
+            let port = l.local_addr().unwrap().port();
+            drop(l);
+            dead.push(format!("ws://127.0.0.1:{port}"));
+        }
+        let registry = MockServer::start().await;
+        let recs = vec![
+            live_record("d-0", "gpu-pool", &dead[0]),
+            live_record("d-1", "gpu-pool", &dead[1]),
+        ];
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/v1/agents"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(recs))
+            .mount(&registry)
+            .await;
+
+        let mut sched = HashMap::new();
+        sched.insert(
+            "explorer".to_string(),
+            sched_placement("gpu-pool", registry.uri()),
+        );
+        let runner = bogus_sched_runner(HashMap::new(), sched);
+
+        let msg = match runner.resolve_schedulable_worker("explorer").await {
+            Ok(_) => panic!("all candidates dead must error, not connect"),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            msg.contains("failed to connect"),
+            "names the connect failure: {msg}"
+        );
+        assert!(msg.contains("gpu-pool"), "names the pool: {msg}");
+        assert!(
+            msg.contains("NOT spawning"),
+            "confirms no local-subprocess fallback: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fabric_cache_reuses_one_fabric_per_registry_url() {
+        // Two resolves to the SAME registry_url must REUSE one cached fabric (#202):
+        // after N calls the cache has exactly one entry for that url.
+        let (eps, handles) = spawn_echo_workers(1).await;
+        let registry = MockServer::start().await;
+        Mock::given(wm_method("GET"))
+            .and(wm_path("/v1/agents"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(vec![live_record("w-0", "gpu-pool", &eps[0])]),
+            )
+            .mount(&registry)
+            .await;
+
+        let mut sched = HashMap::new();
+        sched.insert(
+            "explorer".to_string(),
+            sched_placement("gpu-pool", registry.uri()),
+        );
+        let runner = bogus_sched_runner(HashMap::new(), sched);
+
+        for _ in 0..3 {
+            let (client, _rec, _p) = match runner.resolve_schedulable_worker("explorer").await {
+                Ok(v) => v,
+                Err(e) => panic!("resolve succeeds: {e}"),
+            };
+            let _ = client.close().await;
+        }
+
+        let cache = runner.fabric_cache.lock().unwrap();
+        assert_eq!(
+            cache.len(),
+            1,
+            "three resolves to the same registry_url reused ONE cached fabric"
+        );
+        assert!(cache.contains_key(&registry.uri()));
+        drop(cache);
+        for h in handles {
+            h.abort();
+        }
     }
 
     #[tokio::test]
@@ -1621,11 +1894,10 @@ mod tests {
         );
         let runner = bogus_sched_runner(HashMap::new(), sched);
 
-        let err = runner
-            .resolve_schedulable_worker("explorer")
-            .await
-            .expect_err("no live worker in pool must error");
-        let msg = err.to_string();
+        let msg = match runner.resolve_schedulable_worker("explorer").await {
+            Ok(_) => panic!("no live worker in pool must error, not connect"),
+            Err(e) => e.to_string(),
+        };
         assert!(msg.contains("no live worker"), "clear error: {msg}");
         assert!(msg.contains("gpu-pool"), "names the pool: {msg}");
     }

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -151,14 +151,19 @@ pub struct ActorChildRunner {
     /// workers instead of all landing on the first candidate. Best-effort spread,
     /// not a load balancer — the registry's live set can change between picks.
     schedule_cursor: Arc<std::sync::Mutex<HashMap<String, usize>>>,
-    /// Per-`registry_url` cache of built [`RegistryFabric`]s (#202). A fabric
+    /// Per-`(registry_url, token)` cache of built [`RegistryFabric`]s (#202). A fabric
     /// holds a reqwest `Client` (already connection-pooled), so under sibling
     /// fan-out we construct ONE fabric per registry and reuse it across schedules
     /// instead of rebuilding a fresh client every spawn. Construct-once-then-reuse;
     /// a benign duplicate build under a startup race is harmless (last writer wins,
     /// the loser's fabric drops). The bearer lives INSIDE the fabric's sensitive
     /// `Authorization` header — never logged, never re-stringified here.
-    fabric_cache: Arc<std::sync::Mutex<HashMap<String, Arc<bamboo_subagent::RegistryFabric>>>>,
+    // Keyed by (registry_url, token) — NOT url alone — so two placements that
+    // share a registry but present DIFFERENT bearers never reuse each other's
+    // fabric (which would issue a discover query with the wrong token). #202.
+    fabric_cache: Arc<
+        std::sync::Mutex<HashMap<(String, Option<String>), Arc<bamboo_subagent::RegistryFabric>>>,
+    >,
 }
 
 /// Decides how the host answers a child worker's gated-tool approval request
@@ -560,13 +565,10 @@ impl ActorChildRunner {
         placement: &ResolvedSchedulablePlacement,
         role: &str,
     ) -> std::result::Result<Arc<bamboo_subagent::RegistryFabric>, AgentError> {
-        if let Some(fabric) = self
-            .fabric_cache
-            .lock()
-            .unwrap()
-            .get(&placement.registry_url)
-            .cloned()
-        {
+        // (registry_url, token) identity: a wrong-token fabric must never be
+        // reused for a discover query (#202).
+        let key = (placement.registry_url.clone(), placement.token.clone());
+        if let Some(fabric) = self.fabric_cache.lock().unwrap().get(&key).cloned() {
             return Ok(fabric);
         }
 
@@ -589,10 +591,7 @@ impl ActorChildRunner {
         // Insert-or-reuse: if a concurrent caller already populated the slot, take
         // theirs (the duplicate we built drops) so all siblings share one fabric.
         let mut cache = self.fabric_cache.lock().unwrap();
-        Ok(cache
-            .entry(placement.registry_url.clone())
-            .or_insert(arc)
-            .clone())
+        Ok(cache.entry(key).or_insert(arc).clone())
     }
 
     /// Pick a live worker for a SCHEDULABLE role from the agent registry (#181,
@@ -1863,13 +1862,39 @@ mod tests {
         assert_eq!(
             cache.len(),
             1,
-            "three resolves to the same registry_url reused ONE cached fabric"
+            "three resolves to the same (registry_url, token) reused ONE cached fabric"
         );
-        assert!(cache.contains_key(&registry.uri()));
+        assert!(cache.contains_key(&(registry.uri(), None)));
         drop(cache);
         for h in handles {
             h.abort();
         }
+    }
+
+    #[test]
+    fn fabric_cache_keys_on_registry_url_and_token() {
+        // Two placements sharing a registry_url but presenting DIFFERENT tokens
+        // must NOT share a fabric — a reused wrong-bearer fabric would issue the
+        // discover query with the other role's token (#202 review F1).
+        let runner = bogus_sched_runner(HashMap::new(), HashMap::new());
+        let url = "http://127.0.0.1:9/".to_string();
+        let mut p = sched_placement("pool", url.clone());
+
+        p.token = Some("token-a".into());
+        let fa = runner.fabric_for(&p, "role-a").expect("build a");
+        p.token = Some("token-b".into());
+        let fb = runner.fabric_for(&p, "role-b").expect("build b");
+        // Same url, different token → two distinct cache entries (not aliased).
+        assert!(
+            !Arc::ptr_eq(&fa, &fb),
+            "different tokens must not share a fabric"
+        );
+        assert_eq!(runner.fabric_cache.lock().unwrap().len(), 2);
+        // Re-requesting token-a reuses the first fabric.
+        p.token = Some("token-a".into());
+        let fa2 = runner.fabric_for(&p, "role-a").expect("reuse a");
+        assert!(Arc::ptr_eq(&fa, &fa2), "same (url, token) must reuse");
+        assert_eq!(runner.fabric_cache.lock().unwrap().len(), 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Resilience follow-ups from P2b (PR #201, Epic #181) for the registry-Schedulable scheduler. The P2b scheduler lives in `crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs`.

## 1. Connect-fail failover (the main resilience win)
A live registry lease is only a COARSE health signal — a leased worker can have a dead process or hit a network blip. Previously the scheduler picked ONE candidate, connected, and a single connect failure errored the whole spawn.

`resolve_schedulable_worker` now OWNS the connect: it round-robins to a starting candidate (preserving the per-pool cursor spread, bumped once per resolve), then on a connect failure WALKS FORWARD to the next DISTINCT live candidate and retries — up to `min(candidates.len(), 3)` attempts. So one stale-but-leased worker no longer fails the schedule.

- Round-robin start preserved; the failover walk is local to the resolve and does not perturb the cursor.
- Each attempt connects to a distinct candidate (modulo wrap from the start index) — never retries the same dead endpoint.
- ALL attempted candidates failing ⇒ terminal `AgentError` with **NO spawn fallback** (a Schedulable role has no local subprocess, same as before).
- Error logs HOW MANY candidates were tried — never the token.

## 2. Per-`registry_url` RegistryFabric cache
A `RegistryFabric` (holding a connection-pooled reqwest `Client`) was rebuilt on every sibling spawn. Added `fabric_cache: Mutex<HashMap<String, Arc<RegistryFabric>>>` on `ActorChildRunner` + a `fabric_for` get-or-build helper: construct-once-then-reuse, keyed by `registry_url`. Insert-or-reuse so a benign concurrent double-build under a race is harmless (last writer wins, loser drops). The bearer stays inside the fabric's sensitive `Authorization` header — never logged, the cache never leaks it.

## 3. TTL / renew-cadence doc (doc-only)
`DEFAULT_LEASE_TTL_SECS` (registry default 30s) now documents the worker contract: a RegistryFabric worker MUST re-`publish()` well within the TTL or its record expires and it stops being scheduled — recommend renewing at ~TTL/2 to ~TTL/3, mirroring the file-fabric serve loop's renew-&lt;-TTL discipline. The failover is a second line of defense; the renew cadence is the first.

## DEFERRED (not implemented)
Item 3 of #202 — multi-tenant per-record ownership in `/v1/agents`. bamboo is single-owner (one instance = one owner, device-token model), so binding registry records to a caller identity is premature/YAGNI. The registry's any-authenticated-caller-can-upsert model is left as-is; deferred until a real multi-tenant requirement exists. `#202` stays OPEN for it.

## Zero-regression / constraints
- Local + Remote placement paths UNCHANGED — only the Schedulable resolve path changed.
- Empty candidate pool ⇒ terminal error, still no spawn. Round-robin spread preserved when connects succeed first try.
- No tokens logged; fabric cache cannot leak the token.

## Tests (all green, `cargo test -p bamboo-engine` = 879+1 pass)
- `resolve_schedulable_worker_fails_over_dead_first_candidate`: first candidate (cursor start) points at a closed port, a later one is a real Echo `WsServer` — asserts the dead one is SKIPPED and the live record returned.
- `resolve_schedulable_worker_errors_when_all_candidates_dead`: all dead ⇒ error (no panic), message confirms `NOT spawning` — no local fallback.
- `fabric_cache_reuses_one_fabric_per_registry_url`: 3 resolves to one url ⇒ cache `len == 1`.
- `resolve_schedulable_worker_round_robin_spreads_over_candidates`: extended to real Echo `WsServer`s, still spreads over all 3.
- Existing actor_adapter + full engine suite stay green; `/bin/false` worker_bin proves no-spawn. Timing-sensitive failover tests run 2x, stable. fmt + clippy clean for new code.

Refs #181, Refs #202 (scheduler connect-fail failover + RegistryFabric caching + TTL doc)

https://claude.ai/code/session_014tWsQj4bkd9HaoUbQJdTzp