### PR TITLE
fix(server): immutable long-cache for hashed /assets/* (fixes Vite preload errors behind CDN/tunnel)

### DIFF
--- a/crates/app/bamboo-server/src/config.rs
+++ b/crates/app/bamboo-server/src/config.rs
@@ -22,8 +22,10 @@
 use actix_cors::Cors;
 use actix_governor::governor::middleware::NoOpMiddleware;
 use actix_governor::{GovernorConfig, GovernorConfigBuilder, PeerIpKeyExtractor};
+use actix_web::body::MessageBody;
+use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::http::header;
-use actix_web::middleware::DefaultHeaders;
+use actix_web::middleware::{DefaultHeaders, Next};
 use std::collections::HashSet;
 use tracing::info;
 use tracing::warn;
@@ -384,6 +386,34 @@ pub fn build_security_headers() -> DefaultHeaders {
         .add((header::CONTENT_SECURITY_POLICY, csp_value))
 }
 
+/// Long-cache content-hashed frontend assets at the proxy/CDN edge.
+///
+/// Vite emits hashed filenames under `/assets/` (e.g. `main-B6snAd4S.css`), so
+/// they are inherently immutable — any content change yields a NEW filename.
+/// Tagging them `immutable, max-age=1y` lets Cloudflare and browsers cache them
+/// at the edge instead of round-tripping every chunk through the tunnel to
+/// origin. Besides being faster, this removes the transient per-asset failures
+/// (an occasional reset of one of many parallel preload requests over a
+/// cloudflared tunnel) that surface in the browser as Vite's
+/// "Unable to preload CSS for …" / "Failed to fetch dynamically imported module".
+///
+/// Only `/assets/*` is affected; `index.html` and API routes are left untouched
+/// so they always serve fresh (a new deploy must be picked up immediately).
+pub async fn add_asset_cache_headers<B: MessageBody + 'static>(
+    req: ServiceRequest,
+    next: Next<B>,
+) -> Result<ServiceResponse<B>, actix_web::Error> {
+    let is_asset = req.path().starts_with("/assets/");
+    let mut res = next.call(req).await?;
+    if is_asset {
+        res.headers_mut().insert(
+            header::CACHE_CONTROL,
+            header::HeaderValue::from_static("public, max-age=31536000, immutable"),
+        );
+    }
+    Ok(res)
+}
+
 /// Build CORS middleware based on bind address and port
 ///
 /// Automatically configures CORS policy based on deployment environment:
@@ -555,6 +585,47 @@ mod tests {
         // valid (no panic).
         let _ = rate_limiter_config(0, 0);
         let _ = rate_limiter_config(1000, 1);
+    }
+
+    #[actix_web::test]
+    async fn asset_cache_headers_only_tag_hashed_assets() {
+        use actix_web::http::header::CACHE_CONTROL;
+        use actix_web::{test, web, App, HttpResponse};
+
+        let app = test::init_service(
+            App::new()
+                .wrap(actix_web::middleware::from_fn(add_asset_cache_headers))
+                .route(
+                    "/assets/main-abc123.css",
+                    web::get().to(|| async { HttpResponse::Ok().finish() }),
+                )
+                .route(
+                    "/index.html",
+                    web::get().to(|| async { HttpResponse::Ok().finish() }),
+                ),
+        )
+        .await;
+
+        // A hashed `/assets/*` file gets the immutable long-cache header.
+        let req = test::TestRequest::get()
+            .uri("/assets/main-abc123.css")
+            .to_request();
+        let res = test::call_service(&app, req).await;
+        assert_eq!(
+            res.headers()
+                .get(CACHE_CONTROL)
+                .and_then(|v| v.to_str().ok()),
+            Some("public, max-age=31536000, immutable"),
+        );
+
+        // `index.html` (and anything outside `/assets/`) must stay fresh so a new
+        // deploy is picked up immediately — no long-cache header added.
+        let req = test::TestRequest::get().uri("/index.html").to_request();
+        let res = test::call_service(&app, req).await;
+        assert!(
+            res.headers().get(CACHE_CONTROL).is_none(),
+            "non-asset routes must not be long-cached"
+        );
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/server/entrypoints.rs
+++ b/crates/app/bamboo-server/src/server/entrypoints.rs
@@ -113,6 +113,12 @@ pub async fn run_with_tls(
         let mut app = App::new()
             .app_data(app_state.clone())
             .wrap(build_cors("127.0.0.1", port))
+            // Immutable long-cache for hashed `/assets/*` (parity with the web
+            // service path; harmless on localhost, useful when this binary is
+            // fronted by a proxy/CDN).
+            .wrap(actix_web::middleware::from_fn(
+                crate::config::add_asset_cache_headers,
+            ))
             .configure(configure_routes); // No rate limiting for desktop mode
 
         if let Some(static_path) = &static_dir {

--- a/crates/app/bamboo-server/src/server/web_service.rs
+++ b/crates/app/bamboo-server/src/server/web_service.rs
@@ -187,6 +187,12 @@ impl WebService {
                 .wrap(Governor::new(&rate_limiter))
                 .wrap(build_cors(&bind_addr, port))
                 .wrap(build_security_headers())
+                // Immutable long-cache for hashed `/assets/*` so a proxy/CDN
+                // (e.g. Cloudflare tunnel) caches chunks at the edge instead of
+                // round-tripping each one to origin (#preload-error fix).
+                .wrap(actix_web::middleware::from_fn(
+                    crate::config::add_asset_cache_headers,
+                ))
                 .configure(configure_routes_with_rate_limiting)
                 .service(
                     fs::Files::new("/", static_dir.clone())


### PR DESCRIPTION
## Problem

When bamboo serves the built frontend behind a proxy/CDN — e.g. bodhi exposed via a Cloudflare tunnel — the browser intermittently throws:

```
Unable to preload CSS for https://…/assets/index-….css
Failed to fetch dynamically imported module
```

The assets themselves are fine (200, correct `text/css`). The cause: the static responses carry **no `Cache-Control`**, so Cloudflare can't cache them (`cf-cache-status: MISS`) and **every code-split chunk round-trips through the tunnel to origin**. Under the burst of parallel preload requests on load, one of them occasionally gets reset over the tunnel → Vite surfaces it as the preload error and the lazy chunk (e.g. the heavy `mermaid` bundle) fails to render.

## Fix

A path-scoped `from_fn` middleware `add_asset_cache_headers` (in `config.rs`) tags **only `/assets/*`** with:

```
Cache-Control: public, max-age=31536000, immutable
```

Vite emits content-hashed filenames under `/assets/` (e.g. `main-B6snAd4S.css`), so they are inherently immutable — any change yields a new filename. The CDN/browser can now cache them at the edge instead of round-tripping each chunk, which removes the transient per-asset failures (and is faster).

`index.html` and API routes are untouched, so a new deploy is still picked up immediately.

Wired into **both** app factories that serve static files: `web_service.rs` (the public/TLS face that `bamboo serve --static-dir` uses for bodhi) and the desktop `entrypoints.rs`.

## Tests
- New unit test `config::tests::asset_cache_headers_only_tag_hashed_assets`: asserts `/assets/*` gets the immutable header and `/index.html` does **not**. Passes.
- `cargo check -p bamboo-server` clean.

## Deploy note
This is the server half of the fix. The client half (auto-reload on `vite:preloadError`) is a companion lotus PR. To take effect on bodhi, rebuild the bamboo binary the sidecar runs. Optionally add a Cloudflare cache rule for `/assets/*` to complement the origin header.
