### PR TITLE
feat(notification): background-task-completed notification for finished shells

### DIFF
--- a/crates/infra/bamboo-notification/src/policy.rs
+++ b/crates/infra/bamboo-notification/src/policy.rs
@@ -14,6 +14,9 @@ use crate::preferences::NotificationPreferences;
 /// Maximum body length for a clarification notification, in characters.
 const CLARIFICATION_BODY_MAX: usize = 120;
 
+/// Maximum body length for a background-task-completed notification, in characters.
+const BACKGROUND_TASK_BODY_MAX: usize = 120;
+
 /// The kind of user-facing notification a classified event maps to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NotificationCategory {
@@ -25,6 +28,8 @@ pub enum NotificationCategory {
     ContextCritical,
     /// A background sub-agent task has completed.
     SubagentCompleted,
+    /// A background shell/command (Bash `run_in_background`) has finished.
+    BackgroundTaskCompleted,
 }
 
 impl NotificationCategory {
@@ -35,6 +40,7 @@ impl NotificationCategory {
             NotificationCategory::NeedsClarification => "needs_clarification",
             NotificationCategory::ContextCritical => "context_critical",
             NotificationCategory::SubagentCompleted => "subagent_completed",
+            NotificationCategory::BackgroundTaskCompleted => "background_task_completed",
         }
     }
 }
@@ -185,6 +191,40 @@ pub fn classify(
             })
         }
 
+        AgentEvent::BashCompleted {
+            bash_id,
+            command,
+            exit_code,
+            status,
+        } => {
+            // A killed shell was terminated by the user (KillShell) — they already
+            // know; don't ping. Notify when a background command reaches a terminal
+            // state on its own ("completed" — any exit code — or an internal
+            // "error").
+            if status == "killed" {
+                return None;
+            }
+            if !prefs.on_background_task_complete {
+                return None;
+            }
+            let exit = match exit_code {
+                Some(code) => format!("exit {code}"),
+                None => "no exit code".to_string(),
+            };
+            Some(ClassifiedNotification {
+                category: NotificationCategory::BackgroundTaskCompleted,
+                priority: NotificationPriority::Normal,
+                title: "Background command finished".to_string(),
+                // Dedup by the shell id: the live `BashCompleted` fires once, but
+                // key on `bash_id` (not session) so distinct shells each notify.
+                body: truncate(
+                    &format!("{command} — {status}, {exit}"),
+                    BACKGROUND_TASK_BODY_MAX,
+                ),
+                dedup_key: format!("bash:{bash_id}"),
+            })
+        }
+
         _ => None,
     }
 }
@@ -217,6 +257,15 @@ mod tests {
             child_session_id: "child-1".to_string(),
             status: status.to_string(),
             error: None,
+        }
+    }
+
+    fn bash(bash_id: &str, status: &str, exit_code: Option<i32>) -> AgentEvent {
+        AgentEvent::BashCompleted {
+            bash_id: bash_id.to_string(),
+            command: "npm run build".to_string(),
+            exit_code,
+            status: status.to_string(),
         }
     }
 
@@ -333,6 +382,49 @@ mod tests {
     }
 
     #[test]
+    fn bash_completed_fires_and_dedups_by_bash_id() {
+        let prefs = NotificationPreferences::default();
+        let result = classify("sess", &bash("sh-9", "completed", Some(0)), &prefs).unwrap();
+        assert_eq!(
+            result.category,
+            NotificationCategory::BackgroundTaskCompleted
+        );
+        assert_eq!(result.priority, NotificationPriority::Normal);
+        assert_eq!(result.title, "Background command finished");
+        assert!(result.body.contains("npm run build"));
+        assert!(result.body.contains("exit 0"));
+        // Keyed on bash_id (not session), so distinct shells each notify.
+        assert_eq!(result.dedup_key, "bash:sh-9");
+    }
+
+    #[test]
+    fn bash_error_status_still_fires() {
+        let prefs = NotificationPreferences::default();
+        let result = classify("sess", &bash("sh-e", "error", None), &prefs).unwrap();
+        assert_eq!(
+            result.category,
+            NotificationCategory::BackgroundTaskCompleted
+        );
+        assert!(result.body.contains("no exit code"));
+    }
+
+    #[test]
+    fn bash_killed_is_none() {
+        // A user-killed shell must not ping (the user initiated the kill).
+        let prefs = NotificationPreferences::default();
+        assert!(classify("sess", &bash("sh-k", "killed", None), &prefs).is_none());
+    }
+
+    #[test]
+    fn bash_gated_by_on_background_task_complete() {
+        let prefs = NotificationPreferences {
+            on_background_task_complete: false,
+            ..NotificationPreferences::default()
+        };
+        assert!(classify("sess", &bash("sh-1", "completed", Some(0)), &prefs).is_none());
+    }
+
+    #[test]
     fn master_switch_off_yields_none() {
         let prefs = NotificationPreferences {
             enabled: false,
@@ -341,6 +433,7 @@ mod tests {
         assert!(classify("sess", &context("critical"), &prefs).is_none());
         assert!(classify("sess", &subagent("completed"), &prefs).is_none());
         assert!(classify("sess", &clarification("q", None), &prefs).is_none());
+        assert!(classify("sess", &bash("sh-1", "completed", Some(0)), &prefs).is_none());
     }
 
     #[test]

--- a/crates/infra/bamboo-notification/src/preferences.rs
+++ b/crates/infra/bamboo-notification/src/preferences.rs
@@ -37,6 +37,9 @@ pub struct NotificationPreferences {
     /// Notify when a background sub-agent task completes.
     #[serde(default = "default_true")]
     pub on_subagent_complete: bool,
+    /// Notify when a background shell/command (Bash `run_in_background`) finishes.
+    #[serde(default = "default_true")]
+    pub on_background_task_complete: bool,
 }
 
 impl Default for NotificationPreferences {
@@ -47,6 +50,7 @@ impl Default for NotificationPreferences {
             on_tool_approval: true,
             on_context_pressure: true,
             on_subagent_complete: true,
+            on_background_task_complete: true,
         }
     }
 }
@@ -115,6 +119,7 @@ mod tests {
             on_tool_approval: true,
             on_context_pressure: false,
             on_subagent_complete: true,
+            on_background_task_complete: false,
         };
         prefs.save(&path).unwrap();
         let loaded = NotificationPreferences::load(&path);

--- a/crates/infra/bamboo-notification/src/service.rs
+++ b/crates/infra/bamboo-notification/src/service.rs
@@ -212,6 +212,7 @@ mod tests {
             on_tool_approval: false,
             on_context_pressure: true,
             on_subagent_complete: false,
+            on_background_task_complete: true,
         };
         svc.set_preferences(updated.clone()).unwrap();
         assert_eq!(svc.preferences(), updated);


### PR DESCRIPTION
## What

Fast-follow to the async-bash UI (from the PR reviews of lotus #35 / lotus-next #1). Background-shell completion was pinged by the frontend directly off the raw `BashCompleted` event — a **cached CRITICAL event replayed to every (re)subscriber** — so opening a session where N shells finished while it was closed popped **N stacked toasts / OS notifications**, and the ping **bypassed the user's notification preferences**.

Route it through the existing backend notification pipeline, which is already deduped + preference-gated server-side and — crucially — **not** part of the critical-event replay.

**No new emission site.** The per-session relay (`ensure_notification_relay`) already calls `NotificationService::notify` on every live broadcast event, and the forwarder always broadcasts `BashCompleted` to that channel. So this is just a new `classify` arm:

- `NotificationCategory::BackgroundTaskCompleted` (`"background_task_completed"`) + `on_background_task_complete` preference (default true).
- `classify` arm for `AgentEvent::BashCompleted`: skip `"killed"` (user-initiated), gate on the new pref + master switch, `dedup_key = "bash:{bash_id}"` (distinct shells each notify; the 30s window coalesces a re-fire), body = command + status + exit code.

## Why it fixes the burst

`AgentEvent::Notification` is **not** in `is_critical_event`, and the replay path writes `critical_events_to_replay` directly to the connecting client's stream (not the broadcast the relay listens on). So the live `BashCompleted` yields exactly **one** `Notification`; the replayed ones never reach the relay → no burst, and the gate is enforced server-side. `BashCompleted` stays critical so the tool-card flip is unaffected.

## Testing
bamboo-notification 27/27 (new: fires on completed/error, skips killed, gated by pref + master switch, dedup by bash_id); `cargo check --workspace --all-targets` clean.

Pairs with lotus / lotus-next PRs (they drop the ad-hoc ping and surface this via `onNotification`). Merge order doesn't matter: without this, the frontends simply show no ping (card still flips).

https://claude.ai/code/session_016Ub2VDvGqQuf83uFp8Rosv
