### PR TITLE
fix(bamboo-memory): atomic writes for memory docs + staged index refresh (#166)

### DIFF
--- a/crates/infra/bamboo-memory/src/atomic_fs.rs
+++ b/crates/infra/bamboo-memory/src/atomic_fs.rs
@@ -11,26 +11,39 @@
 //! bamboo-memory does not depend on bamboo-storage (where the sibling
 //! `atomic_write` for session JSONL lives), so this is a self-contained local
 //! helper rather than a shared one — deliberately keeping the crate boundary.
+//! [`plan_store`](crate::plan_store) has a matching *synchronous* atomic writer
+//! for the plan artifacts; the two stay split because that path is sync and this
+//! one is async, but they share [`unique_temp_path`] so temp naming can't drift.
 
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
-/// A unique sibling temp path (`.<name>.<pid>.<nanos>.tmp`) so concurrent
-/// writers to the same target never collide on the temp file.
-fn unique_temp_path(path: &Path) -> PathBuf {
+/// Process-wide monotonic counter so two writers to the *same* target within a
+/// single clock tick still get distinct temp names — `nanos` alone can collide.
+static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// A unique sibling temp path (`.<name>.<pid>.<nanos>.<seq>.tmp`) so concurrent
+/// writers to the same target never collide on the temp file. Shared with
+/// [`crate::plan_store`] so both atomic writers name temps identically.
+pub(crate) fn unique_temp_path(path: &Path) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
+    let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("artifact");
-    path.with_file_name(format!(".{file_name}.{}.{nanos}.tmp", std::process::id()))
+    path.with_file_name(format!(
+        ".{file_name}.{}.{nanos}.{seq}.tmp",
+        std::process::id()
+    ))
 }
 
 /// Write `bytes` to `tmp` and fsync so the bytes are durable before any rename
@@ -90,6 +103,14 @@ pub(crate) async fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
     Ok(())
 }
 
+/// Best-effort removal of every staged temp. Temps already renamed into place
+/// are gone, so `remove_file` is a harmless no-op for those.
+async fn cleanup_temps(staged: &[(PathBuf, PathBuf)]) {
+    for (tmp, _) in staged {
+        let _ = fs::remove_file(tmp).await;
+    }
+}
+
 /// Commit multiple derived files with *staged* atomicity: every temp is written
 /// and fsync'd FIRST, and only once all have staged successfully are they
 /// renamed into place. If staging any file fails (serialization was done by the
@@ -104,28 +125,32 @@ pub(crate) async fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
 /// per-file generation manifest would give strict cross-file atomicity but is
 /// over-engineering for indexes that are always rebuildable from the documents.
 pub(crate) async fn atomic_write_batch(writes: Vec<(PathBuf, Vec<u8>)>) -> io::Result<()> {
-    // Phase 1: stage every temp. On any failure, roll back all staged temps.
     let mut staged: Vec<(PathBuf, PathBuf)> = Vec::with_capacity(writes.len());
+
+    // Phase 1: stage every temp. On ANY failure, roll back all staged temps so a
+    // failed batch leaves neither corruption nor litter.
     for (path, bytes) in &writes {
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).await?;
+            if let Err(err) = fs::create_dir_all(parent).await {
+                cleanup_temps(&staged).await;
+                return Err(err);
+            }
         }
         let tmp = unique_temp_path(path);
         if let Err(err) = write_and_sync(&tmp, bytes).await {
             let _ = fs::remove_file(&tmp).await;
-            for (staged_tmp, _) in &staged {
-                let _ = fs::remove_file(staged_tmp).await;
-            }
+            cleanup_temps(&staged).await;
             return Err(err);
         }
         staged.push((tmp, path.clone()));
     }
 
-    // Phase 2: publish. Renames of already-fsync'd temps are the only fallible
-    // step left, and each is atomic on Unix.
-    for (tmp, path) in &staged {
+    // Phase 2: publish. A rename of an already-fsync'd temp is the only fallible
+    // step left (atomic on Unix); if one fails, sweep the temps not yet renamed
+    // (already-renamed ones are gone, so cleanup skips them harmlessly).
+    for (idx, (tmp, path)) in staged.iter().enumerate() {
         if let Err(err) = atomic_rename(tmp, path).await {
-            let _ = fs::remove_file(tmp).await;
+            cleanup_temps(&staged[idx..]).await;
             return Err(err);
         }
     }
@@ -217,5 +242,26 @@ mod tests {
         assert_eq!(fs::read(&c).await.unwrap(), b"# c");
         assert!(temp_litter(a.parent().unwrap()).is_empty());
         assert!(temp_litter(c.parent().unwrap()).is_empty());
+    }
+
+    #[tokio::test]
+    async fn atomic_write_batch_failure_publishes_nothing_and_leaves_no_temp() {
+        let dir = tempdir().unwrap();
+        let first = dir.path().join("first.json");
+        // A pre-existing regular file; the second batch entry's parent IS this
+        // file, so `create_dir_all` fails mid-batch after `first` has staged.
+        let blocker = dir.path().join("blocker");
+        fs::write(&blocker, b"keep").await.unwrap();
+        let bad = blocker.join("child.json");
+
+        let result =
+            atomic_write_batch(vec![(first.clone(), b"1".to_vec()), (bad, b"2".to_vec())]).await;
+
+        assert!(result.is_err(), "staging under a file-parent must fail");
+        // Rollback: the first entry was staged but never published, and no temp
+        // is left behind; the pre-existing file is untouched.
+        assert!(!first.exists(), "a failed batch must publish nothing");
+        assert_eq!(fs::read(&blocker).await.unwrap(), b"keep");
+        assert!(temp_litter(dir.path()).is_empty());
     }
 }

--- a/crates/infra/bamboo-memory/src/atomic_fs.rs
+++ b/crates/infra/bamboo-memory/src/atomic_fs.rs
@@ -1,0 +1,221 @@
+//! Crash-safe file writes for the memory store.
+//!
+//! A plain [`tokio::fs::write`] truncates the target and then streams the new
+//! bytes, so a crash (OOM, panic, power loss) mid-write can leave a user memory
+//! document half-written or empty — the worst-impact corruption case tracked in
+//! #35. These helpers instead write to a unique sibling temp file, fsync it, and
+//! atomically rename it over the target, so a concurrent reader (or the next
+//! startup) always observes either the old content or the complete new content,
+//! never a torn write. Follow-up to #35, tracked in #166.
+//!
+//! bamboo-memory does not depend on bamboo-storage (where the sibling
+//! `atomic_write` for session JSONL lives), so this is a self-contained local
+//! helper rather than a shared one — deliberately keeping the crate boundary.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+
+/// A unique sibling temp path (`.<name>.<pid>.<nanos>.tmp`) so concurrent
+/// writers to the same target never collide on the temp file.
+fn unique_temp_path(path: &Path) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("artifact");
+    path.with_file_name(format!(".{file_name}.{}.{nanos}.tmp", std::process::id()))
+}
+
+/// Write `bytes` to `tmp` and fsync so the bytes are durable before any rename
+/// publishes them.
+async fn write_and_sync(tmp: &Path, bytes: &[u8]) -> io::Result<()> {
+    let mut file = fs::File::create(tmp).await?;
+    file.write_all(bytes).await?;
+    file.sync_all().await
+}
+
+/// Atomically rename `from` over `to`. On Unix this is a single atomic syscall
+/// even when `to` exists; on Windows rename cannot overwrite, so fall back to a
+/// remove-then-rename (which has a small non-atomic window). A genuine Unix
+/// error (e.g. cross-device) is returned as-is and never deletes `to`.
+async fn atomic_rename(from: &Path, to: &Path) -> io::Result<()> {
+    match fs::rename(from, to).await {
+        Ok(()) => Ok(()),
+        Err(_err) if cfg!(windows) && to.exists() => {
+            let _ = fs::remove_file(to).await;
+            fs::rename(from, to).await
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// fsync the parent directory so the rename entry itself is durable. Without
+/// this, a power loss just after the rename can still lose the new directory
+/// entry and revert to the old content (never torn, but stale). Best-effort:
+/// some platforms disallow opening a directory for fsync.
+async fn sync_parent_dir(path: &Path) {
+    if let Some(parent) = path.parent() {
+        if let Ok(dir) = fs::File::open(parent).await {
+            let _ = dir.sync_all().await;
+        }
+    }
+}
+
+/// Write `bytes` to `path` atomically: `create_dir_all` the parent, write+fsync
+/// a temp sibling, atomically rename it over `path`, then fsync the directory.
+/// If any step before the rename fails, the temp is removed and the existing
+/// target is left untouched — a failed write leaves neither corruption nor
+/// litter.
+pub(crate) async fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).await?;
+    }
+    let tmp = unique_temp_path(path);
+    if let Err(err) = write_and_sync(&tmp, bytes).await {
+        let _ = fs::remove_file(&tmp).await;
+        return Err(err);
+    }
+    if let Err(err) = atomic_rename(&tmp, path).await {
+        let _ = fs::remove_file(&tmp).await;
+        return Err(err);
+    }
+    sync_parent_dir(path).await;
+    Ok(())
+}
+
+/// Commit multiple derived files with *staged* atomicity: every temp is written
+/// and fsync'd FIRST, and only once all have staged successfully are they
+/// renamed into place. If staging any file fails (serialization was done by the
+/// caller, so this is an I/O failure), nothing is published and every staged
+/// temp is cleaned up — so a failure partway through a multi-file refresh never
+/// leaves a half-updated, mutually-inconsistent index set.
+///
+/// A crash *between* the renames can still leave some files from the new
+/// generation and some from the old, but every file is individually complete
+/// (never torn) and the whole set is fully derived from source, so the next
+/// refresh regenerates it — the recoverable/rebuildable state #166 asks for. A
+/// per-file generation manifest would give strict cross-file atomicity but is
+/// over-engineering for indexes that are always rebuildable from the documents.
+pub(crate) async fn atomic_write_batch(writes: Vec<(PathBuf, Vec<u8>)>) -> io::Result<()> {
+    // Phase 1: stage every temp. On any failure, roll back all staged temps.
+    let mut staged: Vec<(PathBuf, PathBuf)> = Vec::with_capacity(writes.len());
+    for (path, bytes) in &writes {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        let tmp = unique_temp_path(path);
+        if let Err(err) = write_and_sync(&tmp, bytes).await {
+            let _ = fs::remove_file(&tmp).await;
+            for (staged_tmp, _) in &staged {
+                let _ = fs::remove_file(staged_tmp).await;
+            }
+            return Err(err);
+        }
+        staged.push((tmp, path.clone()));
+    }
+
+    // Phase 2: publish. Renames of already-fsync'd temps are the only fallible
+    // step left, and each is atomic on Unix.
+    for (tmp, path) in &staged {
+        if let Err(err) = atomic_rename(tmp, path).await {
+            let _ = fs::remove_file(tmp).await;
+            return Err(err);
+        }
+    }
+
+    // Phase 3: fsync each distinct parent directory once.
+    let mut synced: Vec<PathBuf> = Vec::new();
+    for (_, path) in &staged {
+        if let Some(parent) = path.parent() {
+            if !synced.iter().any(|p| p.as_path() == parent) {
+                sync_parent_dir(path).await;
+                synced.push(parent.to_path_buf());
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Names of leftover `*.tmp` staging files in `dir` (should always be empty
+    /// after a write settles — no litter).
+    fn temp_litter(dir: &Path) -> Vec<String> {
+        std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .filter(|name| name.ends_with(".tmp"))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn atomic_write_creates_file_and_leaves_no_temp() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nested").join("doc.md");
+        atomic_write(&path, b"hello").await.unwrap();
+        assert_eq!(fs::read(&path).await.unwrap(), b"hello");
+        assert!(temp_litter(path.parent().unwrap()).is_empty());
+    }
+
+    #[tokio::test]
+    async fn atomic_write_overwrites_existing_without_temp() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("doc.md");
+        atomic_write(&path, b"v1").await.unwrap();
+        atomic_write(&path, b"v2-longer").await.unwrap();
+        assert_eq!(fs::read(&path).await.unwrap(), b"v2-longer");
+        assert!(temp_litter(dir.path()).is_empty());
+    }
+
+    #[tokio::test]
+    async fn atomic_write_failure_preserves_target_and_cleans_temp() {
+        let dir = tempdir().unwrap();
+        // Target is an existing (non-empty) directory: renaming a file over it
+        // fails, exercising the rename-error cleanup path.
+        let path = dir.path().join("busy");
+        fs::create_dir(&path).await.unwrap();
+        fs::write(path.join("child"), b"keep").await.unwrap();
+
+        let err = atomic_write(&path, b"payload").await;
+        assert!(
+            err.is_err(),
+            "writing a file over a non-empty dir must fail"
+        );
+        // The directory (and its child) survive, and no temp is left behind.
+        assert!(path.is_dir());
+        assert_eq!(fs::read(path.join("child")).await.unwrap(), b"keep");
+        assert!(temp_litter(dir.path()).is_empty());
+    }
+
+    #[tokio::test]
+    async fn atomic_write_batch_commits_all_and_leaves_no_temp() {
+        let dir = tempdir().unwrap();
+        let a = dir.path().join("idx").join("a.json");
+        let b = dir.path().join("idx").join("b.json");
+        let c = dir.path().join("views").join("c.md");
+        atomic_write_batch(vec![
+            (a.clone(), b"{\"a\":1}".to_vec()),
+            (b.clone(), b"{\"b\":2}".to_vec()),
+            (c.clone(), b"# c".to_vec()),
+        ])
+        .await
+        .unwrap();
+
+        assert_eq!(fs::read(&a).await.unwrap(), b"{\"a\":1}");
+        assert_eq!(fs::read(&b).await.unwrap(), b"{\"b\":2}");
+        assert_eq!(fs::read(&c).await.unwrap(), b"# c");
+        assert!(temp_litter(a.parent().unwrap()).is_empty());
+        assert!(temp_litter(c.parent().unwrap()).is_empty());
+    }
+}

--- a/crates/infra/bamboo-memory/src/lib.rs
+++ b/crates/infra/bamboo-memory/src/lib.rs
@@ -1,5 +1,6 @@
 //! Memory management, token budgeting, and context preparation for Bamboo agents.
 
+mod atomic_fs;
 pub mod auto_dream;
 pub mod budget;
 pub mod memory;

--- a/crates/infra/bamboo-memory/src/memory_store/store.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/store.rs
@@ -181,7 +181,7 @@ impl MemoryStore {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).await?;
         }
-        fs::write(&path, content).await?;
+        crate::atomic_fs::atomic_write(&path, content.as_bytes()).await?;
         self.persist_session_state(session_id).await?;
         Ok(path)
     }
@@ -2170,7 +2170,7 @@ impl MemoryStore {
                 }
                 if let Err(_error) = fs::rename(&legacy_single, &target).await {
                     let content = fs::read_to_string(&legacy_single).await?;
-                    fs::write(&target, content).await?;
+                    crate::atomic_fs::atomic_write(&target, content.as_bytes()).await?;
                     fs::remove_file(&legacy_single).await?;
                 }
             } else {
@@ -2188,7 +2188,7 @@ impl MemoryStore {
                         if !target.exists() {
                             if let Err(_error) = fs::rename(&path, &target).await {
                                 let content = fs::read_to_string(&path).await?;
-                                fs::write(&target, content).await?;
+                                crate::atomic_fs::atomic_write(&target, content.as_bytes()).await?;
                                 fs::remove_file(&path).await?;
                             }
                         } else {
@@ -2222,7 +2222,8 @@ impl MemoryStore {
         }
         self.ensure_scope_dirs(MemoryScope::Global, None).await?;
         let content = fs::read_to_string(&legacy).await?;
-        fs::write(&view_path, build_dream_view(Some(&content))).await?;
+        crate::atomic_fs::atomic_write(&view_path, build_dream_view(Some(&content)).as_bytes())
+            .await?;
         let _ = fs::remove_file(&legacy).await;
         Ok(())
     }
@@ -2278,7 +2279,7 @@ impl MemoryStore {
         };
         existing.push_str(&line);
         existing.push('\n');
-        fs::write(path, existing).await
+        crate::atomic_fs::atomic_write(&path, existing.as_bytes()).await
     }
 
     async fn write_json_file<T: serde::Serialize>(
@@ -2353,7 +2354,7 @@ impl MemoryStore {
             .resolver
             .views_dir(scope, project_key)
             .join(DREAM_VIEW_FILE);
-        fs::write(&path, build_dream_view(Some(content))).await?;
+        crate::atomic_fs::atomic_write(&path, build_dream_view(Some(content)).as_bytes()).await?;
         self.write_state_marker(
             scope,
             project_key,

--- a/crates/infra/bamboo-memory/src/memory_store/store.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/store.rs
@@ -48,6 +48,19 @@ const MAX_DURABLE_MEMORY_BODY_CHARS: usize = 4000;
 const MEMORY_SECTION_SEPARATOR: &str = "\n\n---\n\n";
 
 /// Projected body length (chars) after appending `content` to `body` with the
+/// Serialize `value` to pretty JSON bytes, mapping a serialization failure onto
+/// an `io::Error` so callers stay on `io::Result`. Shared by the single-file
+/// [`MemoryStore::write_json_file`] and the batched refresh so both encode
+/// artifacts identically.
+fn json_pretty_bytes<T: serde::Serialize>(value: &T) -> io::Result<Vec<u8>> {
+    serde_json::to_vec_pretty(value).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("failed to serialize json: {error}"),
+        )
+    })
+}
+
 /// section separator. Mirrors the real append, which trims trailing whitespace
 /// first, so the structural blob guard estimates exactly, not conservatively.
 fn projected_merged_body_chars(body: &str, content: &str) -> usize {
@@ -1896,7 +1909,9 @@ impl MemoryStore {
             fs::create_dir_all(parent).await?;
         }
         let rendered = render_markdown_document(&doc.frontmatter, &doc.body)?;
-        fs::write(&doc.path, rendered).await
+        // Atomic write so a crash mid-write can never truncate/corrupt a user
+        // memory document (#166, the worst-impact case from #35).
+        crate::atomic_fs::atomic_write(&doc.path, rendered.as_bytes()).await
     }
 
     async fn allocate_memory_id(
@@ -1931,6 +1946,17 @@ impl MemoryStore {
         let docs = self.list_memory_documents(scope, project_key).await?;
         let now = now_rfc3339();
 
+        let indexes_dir = self.resolver.indexes_dir(scope, project_key);
+        let views_dir = self.resolver.views_dir(scope, project_key);
+        let state_dir = self.resolver.state_dir(scope, project_key);
+
+        // Every artifact below is fully derived from `docs`. Stage them all, then
+        // commit together (all temps written+fsync'd first, then renamed) so a
+        // crash mid-refresh can't leave the index set half-updated and mutually
+        // inconsistent — each file stays individually complete and the set is
+        // regenerated on the next refresh (#166 item 2).
+        let mut artifacts: Vec<(PathBuf, Vec<u8>)> = Vec::new();
+
         let lexical = LexicalIndex {
             generated_at: now.clone(),
             items: docs
@@ -1952,13 +1978,10 @@ impl MemoryStore {
                 })
                 .collect(),
         };
-        self.write_json_file(
-            self.resolver
-                .indexes_dir(scope, project_key)
-                .join(LEXICAL_INDEX_FILE),
-            &lexical,
-        )
-        .await?;
+        artifacts.push((
+            indexes_dir.join(LEXICAL_INDEX_FILE),
+            json_pretty_bytes(&lexical)?,
+        ));
 
         let recent = RecentIndex {
             generated_at: now.clone(),
@@ -1974,13 +1997,10 @@ impl MemoryStore {
                 })
                 .collect(),
         };
-        self.write_json_file(
-            self.resolver
-                .indexes_dir(scope, project_key)
-                .join(RECENT_INDEX_FILE),
-            &recent,
-        )
-        .await?;
+        artifacts.push((
+            indexes_dir.join(RECENT_INDEX_FILE),
+            json_pretty_bytes(&recent)?,
+        ));
 
         let graph = GraphIndex {
             generated_at: now.clone(),
@@ -1994,13 +2014,10 @@ impl MemoryStore {
                 })
                 .collect(),
         };
-        self.write_json_file(
-            self.resolver
-                .indexes_dir(scope, project_key)
-                .join(GRAPH_INDEX_FILE),
-            &graph,
-        )
-        .await?;
+        artifacts.push((
+            indexes_dir.join(GRAPH_INDEX_FILE),
+            json_pretty_bytes(&graph)?,
+        ));
 
         let stale = StaleCandidatesIndex {
             generated_at: now.clone(),
@@ -2016,13 +2033,10 @@ impl MemoryStore {
                 })
                 .collect(),
         };
-        self.write_json_file(
-            self.resolver
-                .indexes_dir(scope, project_key)
-                .join(STALE_CANDIDATES_INDEX_FILE),
-            &stale,
-        )
-        .await?;
+        artifacts.push((
+            indexes_dir.join(STALE_CANDIDATES_INDEX_FILE),
+            json_pretty_bytes(&stale)?,
+        ));
 
         let mut by_type = BTreeMap::new();
         let mut by_status = BTreeMap::new();
@@ -2045,52 +2059,40 @@ impl MemoryStore {
             by_scope,
             total: docs.len(),
         };
-        self.write_json_file(
-            self.resolver
-                .indexes_dir(scope, project_key)
-                .join(TAXONOMY_INDEX_FILE),
-            &taxonomy,
-        )
-        .await?;
+        artifacts.push((
+            indexes_dir.join(TAXONOMY_INDEX_FILE),
+            json_pretty_bytes(&taxonomy)?,
+        ));
 
-        let views_dir = self.resolver.views_dir(scope, project_key);
-        fs::create_dir_all(&views_dir).await?;
-        fs::write(
+        artifacts.push((
             views_dir.join(MEMORY_VIEW_FILE),
-            build_memory_markdown_view(scope, project_key, &docs),
-        )
-        .await?;
-        fs::write(
+            build_memory_markdown_view(scope, project_key, &docs).into_bytes(),
+        ));
+        artifacts.push((
             views_dir.join(RECENT_VIEW_FILE),
-            build_recent_markdown_view(&docs),
-        )
-        .await?;
-        fs::write(
+            build_recent_markdown_view(&docs).into_bytes(),
+        ));
+        artifacts.push((
             views_dir.join(STALE_VIEW_FILE),
-            build_stale_markdown_view(&docs),
-        )
-        .await?;
+            build_stale_markdown_view(&docs).into_bytes(),
+        ));
+        // The dream view is user-authored after its first seed, so stage it only
+        // when absent — never overwrite an existing one.
         let dream_path = views_dir.join(DREAM_VIEW_FILE);
         if !dream_path.exists() {
-            fs::write(&dream_path, build_dream_view(None)).await?;
+            artifacts.push((dream_path, build_dream_view(None).into_bytes()));
         }
 
-        self.write_json_file(
-            self.resolver
-                .state_dir(scope, project_key)
-                .join("schema_version.json"),
-            &serde_json::json!({ "version": super::MEMORY_SCHEMA_VERSION }),
-        )
-        .await?;
-        self.write_json_file(
-            self.resolver
-                .state_dir(scope, project_key)
-                .join("last_reindex.json"),
-            &serde_json::json!({ "updated_at": now, "count": docs.len() }),
-        )
-        .await?;
+        artifacts.push((
+            state_dir.join("schema_version.json"),
+            json_pretty_bytes(&serde_json::json!({ "version": super::MEMORY_SCHEMA_VERSION }))?,
+        ));
+        artifacts.push((
+            state_dir.join("last_reindex.json"),
+            json_pretty_bytes(&serde_json::json!({ "updated_at": now, "count": docs.len() }))?,
+        ));
 
-        Ok(())
+        crate::atomic_fs::atomic_write_batch(artifacts).await
     }
 
     async fn ensure_scope_dirs(
@@ -2284,16 +2286,8 @@ impl MemoryStore {
         path: PathBuf,
         value: &T,
     ) -> io::Result<()> {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-        let data = serde_json::to_vec_pretty(value).map_err(|error| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("failed to serialize json: {error}"),
-            )
-        })?;
-        fs::write(path, data).await
+        let data = json_pretty_bytes(value)?;
+        crate::atomic_fs::atomic_write(&path, &data).await
     }
 
     async fn read_optional_trimmed_text_file(&self, path: PathBuf) -> io::Result<Option<String>> {

--- a/crates/infra/bamboo-memory/src/plan_store.rs
+++ b/crates/infra/bamboo-memory/src/plan_store.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::fs::{self, File, OpenOptions};
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 const PLAN_FILE_NAME: &str = "plan.md";
 const PLAN_STATE_FILE_NAME: &str = "state.json";
@@ -267,24 +266,12 @@ impl PlanStore {
         Ok(dir)
     }
 
-    fn unique_temp_path(path: &Path) -> PathBuf {
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|duration| duration.as_nanos())
-            .unwrap_or(0);
-        let file_name = path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("artifact");
-        path.with_file_name(format!(".{file_name}.{nanos}.{}.tmp", std::process::id()))
-    }
-
     fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> Result<(), PlanStoreError> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
 
-        let temp_path = Self::unique_temp_path(path);
+        let temp_path = crate::atomic_fs::unique_temp_path(path);
         let mut file = OpenOptions::new()
             .create(true)
             .truncate(true)


### PR DESCRIPTION
Closes #166 (the bamboo-memory half of #35).

## Problem
`bamboo-memory` wrote documents and indexes with plain `tokio::fs::write`, which truncates the target before streaming the new bytes. A crash (OOM, panic, power loss) mid-write could leave a **user memory document** half-written or empty — the worst-impact corruption case explicitly deferred when #35 made `JsonlStorage::save_session` atomic.

## Changes
- **New `atomic_fs` module** (self-contained; bamboo-memory doesn't depend on bamboo-storage, so this is the local-helper option (b) from the issue, not a shared crate):
  - `atomic_write` — `create_dir_all` → write+`fsync` a unique temp sibling → atomic rename → `fsync` parent dir. Temp is removed on any pre-rename failure, so a failed write leaves **neither corruption nor litter** and never touches the existing target.
  - `atomic_write_batch` — stage **all** temps first, then rename them; rolls back staged temps if any staging fails.
- **`write_document`** and every **`write_json_file`** now go through `atomic_write` → no memory doc or index is ever torn.
- **`refresh_scope_artifacts`** refactored to stage all ~11 derived artifacts (5 JSON indexes, 3–4 markdown views, 2 state files) and commit them together via `atomic_write_batch` (#166 item 2). A crash mid-refresh can no longer leave the index set half-updated; each file stays individually complete, and because the whole set is fully derived from the documents it is regenerated on the next refresh — the recoverable/rebuildable state the issue asks for. (A per-file generation manifest would give strict cross-file atomicity but is over-engineering for always-rebuildable indexes.)

## Scope
Covers items **1** (atomic `write_document` — the headline) and **2** (multi-file refresh consistency). Item **3** (optional refactor of `bamboo-storage` v2.rs inline temp+rename sites to the shared helper) is a *different crate* and left out to keep this PR focused/reviewable — happy to do it as a small follow-up.

## Testing
- New `atomic_fs` unit tests: create, overwrite-existing, failure-preserves-target-and-cleans-temp, batch-commits-all — each asserts **no `*.tmp` litter** remains.
- Existing bamboo-memory suite still green: **101 passed** (incl. `concurrent_writes_to_same_scope_persist_all_and_keep_index_consistent` and `read_lexical_index_roundtrips_generated_index`, confirming the refresh refactor preserved behavior).
- `cargo clippy -p bamboo-memory` adds no new warnings.

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u