### PR TITLE
fix(bamboo): recover from poisoned std locks instead of panicking (#92)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,6 +1131,7 @@ name = "bamboo-notification"
 version = "0.0.0"
 dependencies = [
  "bamboo-agent-core",
+ "bamboo-domain",
  "chrono",
  "dashmap",
  "serde",

--- a/crates/app/bamboo-server/src/handlers/settings/access_control.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/access_control.rs
@@ -2,6 +2,8 @@ use std::net::IpAddr;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+use bamboo_domain::poison::PoisonRecover;
+
 use actix_web::{
     body::{EitherBody, MessageBody},
     cookie::{time::Duration as CookieDuration, Cookie, SameSite},
@@ -918,7 +920,7 @@ impl PairingCodeGuard {
     /// Whether the code-redemption path is currently locked out. Clears an
     /// elapsed cooldown (and its failure count) as a side effect.
     pub fn in_cooldown(&self) -> bool {
-        let mut state = self.inner.lock().expect("pairing guard mutex poisoned");
+        let mut state = self.inner.lock().recover_poison();
         match state.cooldown_until {
             Some(until) if Instant::now() < until => true,
             Some(_) => {
@@ -934,7 +936,7 @@ impl PairingCodeGuard {
     /// Record a failed redemption. Returns `true` IFF this failure tripped the
     /// cooldown (so the caller can invalidate outstanding codes).
     pub fn record_failure(&self) -> bool {
-        let mut state = self.inner.lock().expect("pairing guard mutex poisoned");
+        let mut state = self.inner.lock().recover_poison();
         state.failures = state.failures.saturating_add(1);
         if state.failures >= PAIRING_FAILURE_THRESHOLD {
             state.cooldown_until = Some(Instant::now() + PAIRING_COOLDOWN);
@@ -946,7 +948,7 @@ impl PairingCodeGuard {
 
     /// Reset the guard after a successful redemption.
     pub fn record_success(&self) {
-        let mut state = self.inner.lock().expect("pairing guard mutex poisoned");
+        let mut state = self.inner.lock().recover_poison();
         state.failures = 0;
         state.cooldown_until = None;
     }

--- a/crates/app/bamboo-server/src/workflow/loader.rs
+++ b/crates/app/bamboo-server/src/workflow/loader.rs
@@ -1,4 +1,5 @@
 use super::{CachedWorkflow, WorkflowDefinition, WorkflowLoadError, WorkflowLoader};
+use bamboo_domain::poison::PoisonRecover;
 use serde_yaml::{Mapping, Value};
 use std::fs;
 use std::path::Path;
@@ -18,7 +19,7 @@ pub(super) fn load_from_file(
     let cache = loader
         .cache
         .read()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+        .recover_poison();
     if let Some(cached) = cache.get(path) {
         if cached.modified == modified {
             return Ok(cached.definition.clone());
@@ -37,7 +38,7 @@ pub(super) fn load_from_file(
     let mut cache = loader
         .cache
         .write()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+        .recover_poison();
     cache.insert(
         path.to_path_buf(),
         CachedWorkflow {

--- a/crates/core/bamboo-domain/src/lib.rs
+++ b/crates/core/bamboo-domain/src/lib.rs
@@ -1,6 +1,7 @@
 //! Bamboo domain types — kernel types, session, schedule, workflow, storage models.
 
 // From bamboo-shared-types
+pub mod poison;
 pub mod reasoning;
 pub mod token_usage;
 

--- a/crates/core/bamboo-domain/src/poison.rs
+++ b/crates/core/bamboo-domain/src/poison.rs
@@ -1,0 +1,86 @@
+//! Recovery for poisoned `std::sync` locks.
+//!
+//! When a thread panics while holding a `std::sync::Mutex`/`RwLock`, the lock is
+//! *poisoned*: every later `.lock()/.read()/.write()` returns `Err(PoisonError)`.
+//! Propagating that with `.unwrap()`/`.expect()` turns one thread's panic into a
+//! cascade that bricks the whole subsystem (every future caller panics too).
+//!
+//! [`PoisonRecover::recover_poison`] instead takes the still-usable guard via
+//! [`PoisonError::into_inner`] and carries on with the last-good data. Because
+//! `into_inner` does **not** clear the poison, a naive log in the recovery path
+//! would fire on *every* subsequent access and flood the hot path — so the first
+//! recovery is logged exactly once per process and the rest are silent.
+//!
+//! Follow-up to #21; see #92.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::PoisonError;
+
+/// Whether the process has already logged a poison recovery.
+static WARNED: AtomicBool = AtomicBool::new(false);
+
+fn warn_once() {
+    if !WARNED.swap(true, Ordering::Relaxed) {
+        tracing::warn!(
+            target: "bamboo::lock_poison",
+            "recovered from a poisoned std lock (a thread panicked while holding it); \
+             continuing with the last-good data. Further recoveries this process are silenced."
+        );
+    }
+}
+
+/// Extension on `std::sync` lock results that recovers from poisoning instead of
+/// panicking. Use it in place of `.unwrap()`, `.expect(..)`, or
+/// `.unwrap_or_else(|e| e.into_inner())` on a `Mutex`/`RwLock` guard.
+pub trait PoisonRecover<G> {
+    /// Return the guard, recovering (and logging once) if the lock was poisoned.
+    fn recover_poison(self) -> G;
+}
+
+impl<G> PoisonRecover<G> for Result<G, PoisonError<G>> {
+    fn recover_poison(self) -> G {
+        match self {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                warn_once();
+                poisoned.into_inner()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::sync::{Mutex, RwLock};
+
+    #[test]
+    fn recover_poison_returns_data_after_a_mutex_is_poisoned() {
+        let lock = Mutex::new(vec![1, 2, 3]);
+        // Poison the mutex by panicking while a guard is held.
+        let poisoned = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = lock.lock().unwrap();
+            panic!("intentional poison for test");
+        }));
+        assert!(poisoned.is_err(), "setup panic should have been caught");
+
+        // A subsequent lock is Err(poisoned), but recover_poison yields the data.
+        assert!(lock.lock().is_err(), "the mutex should now be poisoned");
+        assert_eq!(&*lock.lock().recover_poison(), &[1, 2, 3]);
+    }
+
+    #[test]
+    fn recover_poison_returns_data_after_an_rwlock_is_poisoned() {
+        let lock = RwLock::new(7u32);
+        let poisoned = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = lock.write().unwrap();
+            panic!("intentional poison for test");
+        }));
+        assert!(poisoned.is_err());
+
+        assert_eq!(*lock.read().recover_poison(), 7);
+        *lock.write().recover_poison() = 9;
+        assert_eq!(*lock.read().recover_poison(), 9);
+    }
+}

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use bamboo_agent_core::{AgentError, AgentEvent, Role, Session};
+use bamboo_domain::poison::PoisonRecover;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -622,7 +623,7 @@ impl ActorChildRunner {
         // needed — a listed worker is connected NOW (the bus only lists live
         // subscribers), so there is no stale-but-leased candidate to skip.
         let idx = {
-            let mut cursors = self.schedule_cursor.lock().unwrap();
+            let mut cursors = self.schedule_cursor.lock().recover_poison();
             let cursor = cursors.entry(pool.clone()).or_insert(0);
             let i = *cursor % candidates.len();
             *cursor = cursor.wrapping_add(1);
@@ -641,7 +642,7 @@ impl ExternalChildRunner for ActorChildRunner {
     }
 
     fn set_escalation_bridge(&self, bridge: Option<bamboo_subagent::executor::HostBridge>) {
-        *self.escalation_bridge.lock().unwrap() = bridge;
+        *self.escalation_bridge.lock().recover_poison() = bridge;
     }
 
     async fn execute_external_child(
@@ -659,7 +660,7 @@ impl ExternalChildRunner for ActorChildRunner {
         // approval time: by then `run()` may have cleared/overwritten it (a worker
         // serves runs sequentially), and re-proxying through a closed bridge
         // fail-closed denies. Capturing at spawn pins the right bridge per run.
-        let escalation = self.escalation_bridge.lock().unwrap().clone();
+        let escalation = self.escalation_bridge.lock().recover_poison().clone();
         let assignment = extract_assignment(session);
         let mut spec = self.build_spec(session, job);
         // Mark the worker reusable + give it an idle timeout so it self-reaps if

--- a/crates/engine/bamboo-engine/src/external_agents/live.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/live.rs
@@ -11,6 +11,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, OnceLock};
 
+use bamboo_domain::poison::PoisonRecover;
 use bamboo_subagent::proto::ParentFrame;
 use tokio::sync::mpsc;
 
@@ -37,7 +38,7 @@ fn pending() -> &'static Mutex<HashMap<String, HashSet<String>>> {
 pub fn register_pending_approval(child_id: &str, request_id: &str) {
     pending()
         .lock()
-        .unwrap()
+        .recover_poison()
         .entry(child_id.to_string())
         .or_default()
         .insert(request_id.to_string());
@@ -47,7 +48,7 @@ pub fn register_pending_approval(child_id: &str, request_id: &str) {
 /// return whether it WAS present. A second call for the same pair returns
 /// `false`, so a request can't be answered (or replayed) twice.
 pub fn take_pending_approval(child_id: &str, request_id: &str) -> bool {
-    let mut guard = pending().lock().unwrap();
+    let mut guard = pending().lock().recover_poison();
     let Some(set) = guard.get_mut(child_id) else {
         return false;
     };
@@ -60,7 +61,7 @@ pub fn take_pending_approval(child_id: &str, request_id: &str) -> bool {
 
 /// Drop all pending approvals for a child (e.g. when its live connection ends).
 pub fn clear_pending_approvals_for(child_id: &str) {
-    pending().lock().unwrap().remove(child_id);
+    pending().lock().recover_poison().remove(child_id);
 }
 
 /// Validated external entry point: deliver an approval decision ONLY if the
@@ -86,7 +87,7 @@ pub struct LiveActorGuard {
 
 impl Drop for LiveActorGuard {
     fn drop(&mut self) {
-        map().lock().unwrap().remove(&self.child_id);
+        map().lock().recover_poison().remove(&self.child_id);
         // A disconnecting child can't answer any still-pending approval — drop
         // them so a late external POST finds nothing pending and is rejected.
         clear_pending_approvals_for(&self.child_id);
@@ -95,7 +96,7 @@ impl Drop for LiveActorGuard {
 
 /// Register a live child's frame sender for the duration of its run.
 pub fn register(child_id: &str, tx: mpsc::UnboundedSender<ParentFrame>) -> LiveActorGuard {
-    map().lock().unwrap().insert(child_id.to_string(), tx);
+    map().lock().recover_poison().insert(child_id.to_string(), tx);
     LiveActorGuard {
         child_id: child_id.to_string(),
     }
@@ -104,7 +105,7 @@ pub fn register(child_id: &str, tx: mpsc::UnboundedSender<ParentFrame>) -> LiveA
 /// Deliver an in-band steering message to a live child. Returns `false` when
 /// the child is not live (caller should use the durable queue instead).
 pub fn deliver_message(child_id: &str, text: &str) -> bool {
-    let guard = map().lock().unwrap();
+    let guard = map().lock().recover_poison();
     match guard.get(child_id) {
         Some(tx) => tx
             .send(ParentFrame::Message {
@@ -126,7 +127,7 @@ pub fn deliver_message(child_id: &str, text: &str) -> bool {
 /// `false` when the child is not live (no connection to answer on — the caller
 /// should treat that as a denied/expired request).
 pub fn deliver_approval(child_id: &str, request_id: &str, approved: bool) -> bool {
-    let guard = map().lock().unwrap();
+    let guard = map().lock().recover_poison();
     match guard.get(child_id) {
         Some(tx) => tx
             .send(ParentFrame::ApprovalReply {
@@ -140,7 +141,7 @@ pub fn deliver_approval(child_id: &str, request_id: &str, approved: bool) -> boo
 
 /// Whether a child currently has a live actor connection.
 pub fn is_live(child_id: &str) -> bool {
-    map().lock().unwrap().contains_key(child_id)
+    map().lock().recover_poison().contains_key(child_id)
 }
 
 #[cfg(test)]

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -8,6 +8,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, RwLock as StdRwLock};
 use std::time::Duration;
 
+use bamboo_domain::poison::PoisonRecover;
+
 use crate::execution::{
     create_event_forwarder, spawn_session_execution, try_reserve_runner, AgentRunner,
     ChildCompletion, ChildCompletionHandler, RunnerReservation, SessionExecutionArgs,
@@ -151,7 +153,7 @@ fn parent_locks() -> &'static std::sync::Mutex<HashMap<String, Arc<tokio::sync::
 /// ([`ChildCompletionCoordinator::bash_self_resume`]) — can never double-resume.
 /// The inner sync `Mutex` guards only the brief map lookup (no await inside).
 fn session_resume_lock(session_id: &str) -> Arc<tokio::sync::Mutex<()>> {
-    let mut map = parent_locks().lock().expect("parent lock map poisoned");
+    let mut map = parent_locks().lock().recover_poison();
     map.entry(session_id.to_string())
         .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
         .clone()

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -48,6 +48,7 @@
 //! - `BAMBOO_HEADLESS`: Enable headless authentication mode
 
 use anyhow::{Context, Result};
+use bamboo_domain::poison::PoisonRecover;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -1945,13 +1946,13 @@ impl Config {
         let map = self.env_vars_as_map();
         let mut env_guard = env_vars_cache()
             .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .recover_poison();
         *env_guard = map;
 
         let prompt_safe = self.prompt_safe_env_vars();
         let mut prompt_guard = prompt_safe_env_vars_cache()
             .write()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .recover_poison();
         *prompt_guard = prompt_safe;
     }
 
@@ -1959,7 +1960,7 @@ impl Config {
     pub fn current_env_vars() -> HashMap<String, String> {
         env_vars_cache()
             .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .recover_poison()
             .clone()
     }
 
@@ -1967,7 +1968,7 @@ impl Config {
     pub fn current_prompt_safe_env_vars() -> Vec<PromptSafeEnvVarEntry> {
         prompt_safe_env_vars_cache()
             .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .recover_poison()
             .clone()
     }
 

--- a/crates/infra/bamboo-config/src/keyword_masking.rs
+++ b/crates/infra/bamboo-config/src/keyword_masking.rs
@@ -1,3 +1,4 @@
+use bamboo_domain::poison::PoisonRecover;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -131,7 +132,7 @@ impl KeywordMaskingConfig {
         // never blocks other threads.
         {
             let missing: Vec<&str> = {
-                let read = cache.read().unwrap_or_else(|e| e.into_inner());
+                let read = cache.read().recover_poison();
                 self.entries
                     .iter()
                     .filter(|entry| {
@@ -143,7 +144,7 @@ impl KeywordMaskingConfig {
                     .collect()
             };
             if !missing.is_empty() {
-                let mut write = cache.write().unwrap_or_else(|e| e.into_inner());
+                let mut write = cache.write().recover_poison();
                 for pattern in missing {
                     write
                         .entry(pattern.to_string())
@@ -155,7 +156,7 @@ impl KeywordMaskingConfig {
         // Apply masking, reusing the cached compiled regexes. Regex entries that
         // failed to compile are stored as `None` and fall through (no masking),
         // matching the previous per-call `if let Ok(regex) = ...` behavior.
-        let read = cache.read().unwrap_or_else(|e| e.into_inner());
+        let read = cache.read().recover_poison();
         for entry in &self.entries {
             if !entry.enabled {
                 continue;

--- a/crates/infra/bamboo-llm/src/provider_registry.rs
+++ b/crates/infra/bamboo-llm/src/provider_registry.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, RwLock};
 use crate::provider::{LLMError, LLMProvider};
 use crate::provider_factory::create_provider_by_name;
 use bamboo_config::Config;
+use bamboo_domain::poison::PoisonRecover;
 use bamboo_config::ProviderInstanceConfig;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -94,12 +95,12 @@ impl ProviderRegistry {
         // Recover from a poisoned lock rather than panicking the whole process: a
         // poisoned guard's inner data is still usable, and panicking here would be a
         // permanent DoS on the critical path for every LLM call.
-        *self.providers.write().unwrap_or_else(|e| e.into_inner()) = providers;
-        *self.metadata.write().unwrap_or_else(|e| e.into_inner()) = metadata;
+        *self.providers.write().recover_poison() = providers;
+        *self.metadata.write().recover_poison() = metadata;
         *self
             .default_provider
             .write()
-            .unwrap_or_else(|e| e.into_inner()) = default_provider;
+            .recover_poison() = default_provider;
         Ok(())
     }
 
@@ -279,7 +280,7 @@ impl ProviderRegistry {
     pub fn get(&self, name: &str) -> Option<Arc<dyn LLMProvider>> {
         self.providers
             .read()
-            .unwrap_or_else(|e| e.into_inner())
+            .recover_poison()
             .get(name)
             .cloned()
     }
@@ -287,7 +288,7 @@ impl ProviderRegistry {
     pub fn get_metadata(&self, name: &str) -> Option<ProviderMetadata> {
         self.metadata
             .read()
-            .unwrap_or_else(|e| e.into_inner())
+            .recover_poison()
             .get(name)
             .cloned()
     }
@@ -295,7 +296,7 @@ impl ProviderRegistry {
     pub fn provider_metadata(&self) -> Vec<ProviderMetadata> {
         self.metadata
             .read()
-            .unwrap_or_else(|e| e.into_inner())
+            .recover_poison()
             .values()
             .cloned()
             .collect()
@@ -311,7 +312,7 @@ impl ProviderRegistry {
     pub fn default_provider_name(&self) -> String {
         self.default_provider
             .read()
-            .unwrap_or_else(|e| e.into_inner())
+            .recover_poison()
             .clone()
     }
 
@@ -319,7 +320,7 @@ impl ProviderRegistry {
     pub fn provider_names(&self) -> Vec<String> {
         self.providers
             .read()
-            .unwrap_or_else(|e| e.into_inner())
+            .recover_poison()
             .keys()
             .cloned()
             .collect()
@@ -329,7 +330,7 @@ impl ProviderRegistry {
     pub fn len(&self) -> usize {
         self.providers
             .read()
-            .unwrap_or_else(|e| e.into_inner())
+            .recover_poison()
             .len()
     }
 
@@ -337,7 +338,7 @@ impl ProviderRegistry {
     pub fn is_empty(&self) -> bool {
         self.providers
             .read()
-            .unwrap_or_else(|e| e.into_inner())
+            .recover_poison()
             .is_empty()
     }
 
@@ -345,11 +346,11 @@ impl ProviderRegistry {
     pub fn insert(&self, key: String, provider: Arc<dyn LLMProvider>) {
         self.providers
             .write()
-            .unwrap_or_else(|e| e.into_inner())
+            .recover_poison()
             .insert(key.clone(), provider);
         self.metadata
             .write()
-            .unwrap_or_else(|e| e.into_inner())
+            .recover_poison()
             .insert(
                 key.clone(),
                 ProviderMetadata {
@@ -364,11 +365,11 @@ impl ProviderRegistry {
     pub fn remove(&self, key: &str) -> Option<Arc<dyn LLMProvider>> {
         self.metadata
             .write()
-            .unwrap_or_else(|e| e.into_inner())
+            .recover_poison()
             .remove(key);
         self.providers
             .write()
-            .unwrap_or_else(|e| e.into_inner())
+            .recover_poison()
             .remove(key)
     }
 
@@ -377,7 +378,7 @@ impl ProviderRegistry {
         *self
             .default_provider
             .write()
-            .unwrap_or_else(|e| e.into_inner()) = key;
+            .recover_poison() = key;
     }
 }
 

--- a/crates/infra/bamboo-notification/Cargo.toml
+++ b/crates/infra/bamboo-notification/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 
 [dependencies]
 bamboo-agent-core = { path = "../../core/bamboo-agent-core" }
+bamboo-domain = { path = "../../core/bamboo-domain" }
 serde = { workspace = true }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/infra/bamboo-notification/src/service.rs
+++ b/crates/infra/bamboo-notification/src/service.rs
@@ -19,6 +19,7 @@ use std::sync::{Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use bamboo_agent_core::AgentEvent;
+use bamboo_domain::poison::PoisonRecover;
 use dashmap::DashSet;
 
 use crate::policy;
@@ -69,12 +70,12 @@ impl NotificationService {
             let prefs = self
                 .preferences
                 .read()
-                .expect("notification preferences lock poisoned");
+                .recover_poison();
             policy::classify(session_id, event, &prefs)?
         };
 
         {
-            let mut dedup = self.dedup.lock().expect("notification dedup lock poisoned");
+            let mut dedup = self.dedup.lock().recover_poison();
             if let Some(last) = dedup.get(&classified.dedup_key) {
                 if last.elapsed() < Self::DEDUP_WINDOW {
                     return None;
@@ -102,7 +103,7 @@ impl NotificationService {
     pub fn preferences(&self) -> NotificationPreferences {
         self.preferences
             .read()
-            .expect("notification preferences lock poisoned")
+            .recover_poison()
             .clone()
     }
 
@@ -115,7 +116,7 @@ impl NotificationService {
             let mut guard = self
                 .preferences
                 .write()
-                .expect("notification preferences lock poisoned");
+                .recover_poison();
             *guard = prefs.clone();
         }
         prefs.save(&self.prefs_path)

--- a/crates/infra/bamboo-permission/src/config.rs
+++ b/crates/infra/bamboo-permission/src/config.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
+use bamboo_domain::poison::PoisonRecover;
 use tracing::warn;
 
 use dashmap::DashMap;
@@ -662,12 +663,12 @@ impl PermissionConfig {
 
     /// Get the current permission mode
     pub fn mode(&self) -> PermissionMode {
-        *self.mode.read().expect("mode lock poisoned")
+        *self.mode.read().recover_poison()
     }
 
     /// Set the permission mode
     pub fn set_mode(&self, mode: PermissionMode) {
-        *self.mode.write().expect("mode lock poisoned") = mode;
+        *self.mode.write().recover_poison() = mode;
     }
 
     /// Get the minimum risk level that requires confirmation.
@@ -675,7 +676,7 @@ impl PermissionConfig {
         *self
             .confirm_threshold
             .read()
-            .expect("confirm_threshold lock poisoned")
+            .recover_poison()
     }
 
     /// Set the minimum risk level that requires confirmation.
@@ -687,7 +688,7 @@ impl PermissionConfig {
         *self
             .confirm_threshold
             .write()
-            .expect("confirm_threshold lock poisoned") = threshold;
+            .recover_poison() = threshold;
     }
 
     /// Replace the "always ask" rules from a list of pattern strings (e.g.
@@ -698,7 +699,7 @@ impl PermissionConfig {
             .into_iter()
             .map(|p| ParsedRule::parse(&p))
             .collect();
-        *self.ask_rules.write().expect("ask_rules lock poisoned") = parsed;
+        *self.ask_rules.write().recover_poison() = parsed;
     }
 
     /// The configured "always ask" rules rendered back to pattern strings, for
@@ -706,7 +707,7 @@ impl PermissionConfig {
     pub fn ask_rule_patterns(&self) -> Vec<String> {
         self.ask_rules
             .read()
-            .expect("ask_rules lock poisoned")
+            .recover_poison()
             .iter()
             .map(|rule| match &rule.pattern {
                 Some(pattern) => format!("{}({})", rule.tool_name, pattern),
@@ -735,7 +736,7 @@ impl PermissionConfig {
         // Configured "always ask" rules.
         self.ask_rules
             .read()
-            .expect("ask_rules lock poisoned")
+            .recover_poison()
             .iter()
             .any(|rule| rule.matches_tool_call(tool_name, args))
     }
@@ -957,17 +958,17 @@ impl PermissionConfig {
         let mut ask_rules = self
             .ask_rules
             .read()
-            .expect("ask_rules lock poisoned")
+            .recover_poison()
             .clone();
         ask_rules.extend(
             other
                 .ask_rules
                 .read()
-                .expect("ask_rules lock poisoned")
+                .recover_poison()
                 .iter()
                 .cloned(),
         );
-        *merged.ask_rules.write().expect("ask_rules lock poisoned") = ask_rules;
+        *merged.ask_rules.write().recover_poison() = ask_rules;
 
         merged
     }

--- a/crates/infra/bamboo-subagent/src/lib.rs
+++ b/crates/infra/bamboo-subagent/src/lib.rs
@@ -17,6 +17,7 @@ pub mod error;
 pub mod executor;
 pub mod fleet;
 pub mod mailbox;
+pub(crate) mod poison;
 pub mod proto;
 pub mod provision;
 pub mod store;

--- a/crates/infra/bamboo-subagent/src/poison.rs
+++ b/crates/infra/bamboo-subagent/src/poison.rs
@@ -1,0 +1,72 @@
+//! Local poison-recovery for this crate's `std::sync` locks.
+//!
+//! A mirror of `bamboo_domain::poison`, kept local because `bamboo-subagent` is
+//! a deliberately dependency-light leaf crate (the sub-process worker) — it has
+//! no internal crate deps and no `tracing`. When a thread panics while holding a
+//! `std::sync` lock, the lock is poisoned and every later `.lock()` returns
+//! `Err`; propagating that with `.unwrap()`/`.expect()` would cascade one
+//! thread's panic into the worker's whole reply-routing path. Recovering via
+//! [`PoisonError::into_inner`] keeps it alive with the last-good data. The first
+//! recovery is reported once to stderr (captured by the parent) without flooding
+//! the hot path — `into_inner` never clears the poison. See #92.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::PoisonError;
+
+/// Whether the process has already reported a poison recovery.
+static WARNED: AtomicBool = AtomicBool::new(false);
+
+fn warn_once() {
+    if !WARNED.swap(true, Ordering::Relaxed) {
+        eprintln!(
+            "bamboo-subagent: recovered from a poisoned std lock (a thread panicked \
+             while holding it); continuing with the last-good data. Further recoveries \
+             this process are silenced."
+        );
+    }
+}
+
+/// Extension on `std::sync` lock results that recovers from poisoning instead of
+/// panicking. Local mirror of `bamboo_domain::poison::PoisonRecover`.
+pub(crate) trait PoisonRecover<G> {
+    /// Return the guard, recovering (and reporting once) if the lock was poisoned.
+    fn recover_poison(self) -> G;
+}
+
+impl<G> PoisonRecover<G> for Result<G, PoisonError<G>> {
+    fn recover_poison(self) -> G {
+        match self {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                warn_once();
+                poisoned.into_inner()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::sync::Mutex;
+
+    #[test]
+    fn recover_poison_returns_data_after_the_mutex_is_poisoned() {
+        // Shaped like the transport pending-replies map (a HashMap behind a std
+        // Mutex): poisoning it must not brick subsequent reply delivery.
+        let pending: Mutex<HashMap<String, u32>> =
+            Mutex::new(HashMap::from([("req-1".to_string(), 42)]));
+
+        let poisoned = catch_unwind(AssertUnwindSafe(|| {
+            let _guard = pending.lock().unwrap();
+            panic!("intentional poison for test");
+        }));
+        assert!(poisoned.is_err(), "setup panic should have been caught");
+        assert!(pending.lock().is_err(), "the mutex should now be poisoned");
+
+        // A subsequent op returns the data instead of panicking.
+        assert_eq!(pending.lock().recover_poison().remove("req-1"), Some(42));
+    }
+}

--- a/crates/infra/bamboo-subagent/src/transport.rs
+++ b/crates/infra/bamboo-subagent/src/transport.rs
@@ -25,6 +25,7 @@ use tokio_tungstenite::{accept_async, accept_hdr_async, connect_async, MaybeTlsS
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
+use crate::poison::PoisonRecover;
 use crate::executor::{ChildExecutor, EventSink, HostBridge, HostRequestKind, SteerInbox};
 use crate::proto::{ChildFrame, ParentFrame, RunSpec};
 
@@ -425,7 +426,7 @@ where
                 // {"approved": bool}); a worker that proxied an `ApprovalRequest`
                 // awaits its oneshot here.
                 Ok(ParentFrame::ApprovalReply { id, approved }) => {
-                    if let Some(reply) = pending.lock().expect("pending lock").remove(&id) {
+                    if let Some(reply) = pending.lock().recover_poison().remove(&id) {
                         let _ = reply.send(serde_json::json!({ "approved": approved }));
                     }
                 }
@@ -532,7 +533,7 @@ fn start_run<E: ChildExecutor + ?Sized>(
             let id = format!("sa-{}", Uuid::new_v4());
             pending_for_pump
                 .lock()
-                .expect("pending lock")
+                .recover_poison()
                 .insert(id.clone(), req.reply);
             let frame = match req.kind {
                 HostRequestKind::Approval => ChildFrame::ApprovalRequest { id, body: req.body },


### PR DESCRIPTION
Closes #92 (follow-up to #21). Completes the crate-wide lock-poison audit and adds observability.

## Problem
A thread that panics while holding a `std::sync::Mutex`/`RwLock` **poisons** it — every later `.lock()/.read()/.write()` then returns `Err(PoisonError)`. The codebase's pervasive `.unwrap()`/`.expect()` on those guards turned one thread's panic into a **cascade**: every subsequent caller of that lock panics too, permanently bricking the subsystem (e.g. the LLM provider registry, the per-tool permission gate, the device-pairing guard, the sub-agent reply router).

## Approach
New extension trait **`bamboo_domain::poison::PoisonRecover`**:
```rust
lock.write().recover_poison()   // instead of .unwrap() / .expect(..) / .unwrap_or_else(|e| e.into_inner())
```
It takes the still-usable guard via `into_inner()` and **logs the first recovery once per process** — `into_inner()` never clears the poison, so a naïve log would fire on *every* subsequent access and flood the hot path (the exact caution #92 called out). The extension-trait form keeps call sites readable and made the conversion a clean suffix-swap.

## What changed
- **Item 1 (observability):** `bamboo-llm/provider_registry.rs` — the ~15 previously-**silent** `.unwrap_or_else(|e| e.into_inner())` recoveries (on the critical path of every LLM call) now log once on first recovery.
- **Item 3 (crate-wide audit):** every genuine **production** bare std-lock panic converted to `.recover_poison()`:
  | crate | file | what the lock guards |
  |---|---|---|
  | bamboo-permission | `config.rs` | permission mode / ask_rules / confirm_threshold — the **per-tool-gate hot path** (10 sites) |
  | bamboo-engine | `external_agents/live.rs` | live-actor + human-approval registry |
  | bamboo-engine | `external_agents/actor_adapter.rs` | escalation bridge / schedule cursor |
  | bamboo-engine | `session_app/child_completion_coordinator.rs` | parent-lock map |
  | bamboo-server | `settings/access_control.rs` | device-pairing guard |
  | bamboo-notification | `service.rs` | preferences + dedup |
  | bamboo-subagent | `transport.rs` | pending host-callback replies |

  The inventory was redone **multi-line-aware** (a first pass missed every `.read()`↵`.expect()` chain — e.g. permission had 10 sites, not 4). Test-only mocks and `tokio::sync` locks were deliberately left as-is.
- **bamboo-subagent** is a deliberately dependency-light leaf crate (the sub-process worker, no internal deps, no `tracing`), so it gets a small **local** copy of the helper that reports once to **stderr** (captured by the parent) rather than depending on `bamboo-domain`.
- **Item 2 (tests):** poison-recovery tests in `bamboo-domain` (Mutex + RwLock) and `bamboo-subagent` (shaped like the transport pending-replies map). The existing `provider_registry::poisoned_lock_does_not_panic_subsequent_reads` still passes.

## Testing
Whole tree builds. Changed-crate lib tests green: **domain 149 / llm 441 / permission 27 / notification 183 / subagent 46 / server 962**. bamboo-engine: 892 pass, and its **one** failure — `envelope_ir_flatten_orders_runs_canonically` (a prompt-IR-ordering test) — **fails identically on clean `origin/main` (78aae7e5)**, so it is pre-existing and unrelated to this change (verified in a throwaway worktree).

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u