### PR TITLE
fix(engine): re-resolve token budget after reload / model switch (#180)

### DIFF
--- a/crates/core/bamboo-domain/src/session/types.rs
+++ b/crates/core/bamboo-domain/src/session/types.rs
@@ -528,6 +528,13 @@ pub struct Session {
     pub metadata: std::collections::HashMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_budget: Option<TokenBudget>,
+    /// Per-process cache of the model-limit-derived budget, keyed by the model it
+    /// was resolved for. Never persisted (`#[serde(skip)]`), so a reloaded session
+    /// re-resolves from the current `model_limits.json`, and a mid-session model
+    /// switch invalidates it (the key no longer matches). `token_budget` above
+    /// stays the persisted genuine/child override that takes priority. (#180)
+    #[serde(skip)]
+    pub resolved_token_budget: Option<(String, TokenBudget)>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_usage: Option<TokenBudgetUsage>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -569,6 +576,17 @@ pub enum SessionKind {
 }
 
 impl Session {
+    /// The effective token budget: a genuine/child override (`token_budget`) if
+    /// set, otherwise the per-process resolved-budget cache
+    /// (`resolved_token_budget`). Both are `None` until the first resolution.
+    /// Downstream readers should use this rather than `token_budget` directly so
+    /// they observe the engine-resolved budget without persisting it. (#180)
+    pub fn effective_token_budget(&self) -> Option<&TokenBudget> {
+        self.token_budget
+            .as_ref()
+            .or_else(|| self.resolved_token_budget.as_ref().map(|(_, budget)| budget))
+    }
+
     pub fn new(id: impl Into<String>, model: impl Into<String>) -> Self {
         let now = Utc::now();
         let id = id.into();
@@ -592,6 +610,7 @@ impl Session {
             reasoning_effort: None,
             metadata: std::collections::HashMap::new(),
             token_budget: None,
+            resolved_token_budget: None,
             token_usage: None,
             conversation_summary: None,
             prompt_snapshot: None,
@@ -674,6 +693,7 @@ impl Session {
             reasoning_effort: None,
             metadata: std::collections::HashMap::new(),
             token_budget: None,
+            resolved_token_budget: None,
             token_usage: None,
             conversation_summary: None,
             prompt_snapshot: None,

--- a/crates/core/bamboo-domain/src/session/types.rs
+++ b/crates/core/bamboo-domain/src/session/types.rs
@@ -580,7 +580,11 @@ impl Session {
     /// set, otherwise the per-process resolved-budget cache
     /// (`resolved_token_budget`). Both are `None` until the first resolution.
     /// Downstream readers should use this rather than `token_budget` directly so
-    /// they observe the engine-resolved budget without persisting it. (#180)
+    /// they observe the engine-resolved budget without persisting it. Note the
+    /// cache is returned regardless of which model it was resolved for; that is
+    /// safe because `resolve_token_budget` runs at round start (re-keying to the
+    /// current model) before any reader — don't call this expecting model-freshness
+    /// without a preceding same-round resolve. (#180)
     pub fn effective_token_budget(&self) -> Option<&TokenBudget> {
         self.token_budget
             .as_ref()

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/token_budget.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/token_budget.rs
@@ -10,7 +10,8 @@ pub(super) async fn resolve_token_budget(
     model_name: &str,
     llm: &dyn LLMProvider,
 ) -> TokenBudget {
-    // Priority: session override > config override > model defaults.
+    // Priority: session/child override > config override > per-process cache >
+    // freshly-resolved model defaults.
     if let Some(ref budget) = session.token_budget {
         tracing::debug!("Using session-specific token budget");
         return budget.clone();
@@ -19,6 +20,18 @@ pub(super) async fn resolve_token_budget(
     if let Some(ref budget) = config.token_budget {
         tracing::debug!("Using config token budget");
         return budget.clone();
+    }
+
+    // Per-process cache of a previous resolution, reused only when it was
+    // resolved for the SAME model. It is never persisted (`#[serde(skip)]`), so a
+    // reloaded session falls through and re-resolves from the current
+    // `model_limits.json`; a mid-session model switch also falls through because
+    // the cached model key no longer matches. (#180)
+    if let Some((cached_model, budget)) = session.resolved_token_budget.as_ref() {
+        if cached_model.as_str() == model_name {
+            tracing::debug!("Using cached resolved token budget for '{model_name}'");
+            return budget.clone();
+        }
     }
 
     // Default to model limits:
@@ -85,14 +98,15 @@ pub(super) async fn resolve_token_budget(
         model_limit.get_safety_margin(),
     );
 
-    // Cache the resolved budget on the session so every downstream reader of
-    // `session.token_budget` sees the real, model-limit-derived budget instead
-    // of `None` (issue #20 bug 1). Previously this value was only ever returned
-    // to the immediate caller, so `build_context_pressure` (tool-output
-    // truncation), the server context bar, and `estimate_context_compression_exposure`
-    // all fell back to a default/empty-registry budget. The session-override
-    // early-return above makes this a one-time resolution per session.
-    session.token_budget = Some(resolved.clone());
+    // Cache the resolved budget on the session (keyed by model) so every
+    // downstream reader — `build_context_pressure` (tool-output truncation), the
+    // server context bar, `estimate_context_compression_exposure` — sees the
+    // real, model-limit-derived budget via `Session::effective_token_budget`
+    // instead of `None` (issue #20 bug 1). Unlike the persisted `token_budget`
+    // override, this cache is `#[serde(skip)]`: a reloaded session re-resolves
+    // (picking up a `model_limits.json` edit) and a mid-session model switch
+    // invalidates it. (#180)
+    session.resolved_token_budget = Some((model_name.to_string(), resolved.clone()));
 
     resolved
 }
@@ -197,17 +211,18 @@ mod tests {
         assert!(registry.get("legacy-model").is_none());
     }
 
-    // Issue #20 bug 1: `resolve_token_budget` must cache the resolved budget on
-    // `session.token_budget`, otherwise every downstream reader
-    // (build_context_pressure, the server context bar,
-    // estimate_context_compression_exposure) sees `None` and silently falls back
-    // to a default/empty-registry budget.
+    // Issue #20 bug 1: `resolve_token_budget` must cache the resolved budget so
+    // every downstream reader (build_context_pressure, the server context bar,
+    // estimate_context_compression_exposure) observes it via
+    // `effective_token_budget` instead of `None`. Per #180 the cache lives in the
+    // non-persisted `resolved_token_budget` slot (keyed by model), NOT the
+    // persisted `token_budget` override slot.
     #[tokio::test]
     async fn resolve_token_budget_caches_resolved_budget_on_session() {
         let mut session = bamboo_agent_core::Session::new("budget-cache", "some-model");
         assert!(
-            session.token_budget.is_none(),
-            "precondition: a fresh session has no cached budget"
+            session.effective_token_budget().is_none(),
+            "precondition: a fresh session has no budget"
         );
 
         let config = AgentLoopConfig::default();
@@ -215,15 +230,70 @@ mod tests {
 
         let resolved = resolve_token_budget(&mut session, &config, "some-model", &provider).await;
 
-        // The function returns the resolved budget AND caches it on the session,
-        // so the two are identical and `session.token_budget` is no longer None.
-        let cached = session
-            .token_budget
+        // The persisted override slot stays empty; the cache holds the resolved
+        // budget keyed by model, and effective_token_budget surfaces it.
+        assert!(
+            session.token_budget.is_none(),
+            "the resolved cache must NOT populate the persisted override slot (#180)"
+        );
+        let (cached_model, cached) = session
+            .resolved_token_budget
             .clone()
             .expect("resolved budget must be cached on the session (#20 bug 1)");
+        assert_eq!(cached_model, "some-model");
         assert_eq!(cached.max_context_tokens, resolved.max_context_tokens);
         assert_eq!(cached.max_output_tokens, resolved.max_output_tokens);
         assert_eq!(cached.safety_margin, resolved.safety_margin);
+        assert_eq!(
+            session.effective_token_budget().unwrap().max_context_tokens,
+            resolved.max_context_tokens
+        );
+    }
+
+    // #180: the resolved cache is `#[serde(skip)]`, so it never persists. A
+    // reloaded long-lived session therefore starts with no cache and re-resolves
+    // from the current `model_limits.json` — the exact staleness #180 fixes.
+    #[tokio::test]
+    async fn resolved_token_budget_is_not_persisted() {
+        let mut session = bamboo_agent_core::Session::new("budget-persist", "some-model");
+        let config = AgentLoopConfig::default();
+        let provider = MetadataProvider::default();
+        let _ = resolve_token_budget(&mut session, &config, "some-model", &provider).await;
+        assert!(session.resolved_token_budget.is_some(), "cache populated");
+
+        let json = serde_json::to_string(&session).expect("serialize");
+        assert!(
+            !json.contains("resolved_token_budget"),
+            "the resolved cache must not be serialized (#180)"
+        );
+        let reloaded: bamboo_agent_core::Session =
+            serde_json::from_str(&json).expect("deserialize");
+        assert!(
+            reloaded.resolved_token_budget.is_none(),
+            "a reloaded session must have no cached budget, so it re-resolves (#180)"
+        );
+    }
+
+    // #180: a mid-session model switch invalidates the cache (keyed by model), so
+    // the budget is re-resolved for the new model instead of reusing the first
+    // model's cached budget.
+    #[tokio::test]
+    async fn resolve_token_budget_reresolves_on_model_switch() {
+        let mut session = bamboo_agent_core::Session::new("budget-switch", "model-a");
+        let config = AgentLoopConfig::default();
+        let provider = MetadataProvider::default();
+
+        let _ = resolve_token_budget(&mut session, &config, "model-a", &provider).await;
+        assert_eq!(session.resolved_token_budget.as_ref().unwrap().0, "model-a");
+
+        // Switch the model: the cache key no longer matches, so it re-resolves and
+        // re-keys instead of short-circuiting on "model-a".
+        let _ = resolve_token_budget(&mut session, &config, "model-b", &provider).await;
+        assert_eq!(
+            session.resolved_token_budget.as_ref().unwrap().0,
+            "model-b",
+            "a model switch must re-resolve and re-key the cache (#180)"
+        );
     }
 
     // A budget already present on the session is the highest-priority source and

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
@@ -15,7 +15,7 @@ use bamboo_metrics::{MetricsCollector, RoundStatus as MetricsRoundStatus};
 
 fn build_context_pressure(session: &Session) -> Option<output_compressor::ContextPressure> {
     let usage = session.token_usage.as_ref()?;
-    let budget = session.token_budget.as_ref()?;
+    let budget = session.effective_token_budget()?;
     let trigger = budget.compression_trigger_context_tokens();
     if trigger == 0 {
         return None;
@@ -153,8 +153,7 @@ async fn execute_and_apply_single_tool_call(
                 session_id,
                 outcome,
                 session
-                    .token_budget
-                    .as_ref()
+                    .effective_token_budget()
                     .map(|b| b.max_tool_output_tokens)
                     .unwrap_or(0),
                 build_context_pressure(session),
@@ -248,8 +247,7 @@ async fn execute_and_apply_single_tool_call(
         session_id,
         outcome,
         session
-            .token_budget
-            .as_ref()
+            .effective_token_budget()
             .map(|b| b.max_tool_output_tokens)
             .unwrap_or(0),
         build_context_pressure(session),
@@ -607,8 +605,7 @@ pub(crate) async fn execute_round_tool_calls(
 
             // Compress all outcomes in parallel before applying sequentially.
             let max_tool_tokens = session
-                .token_budget
-                .as_ref()
+                .effective_token_budget()
                 .map(|b| b.max_tool_output_tokens)
                 .unwrap_or(0);
             let pressure = build_context_pressure(session);

--- a/crates/engine/bamboo-engine/src/session_app/child_session/actions.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_session/actions.rs
@@ -159,7 +159,7 @@ pub async fn create_child_action(
     // Child sessions get more aggressive compression: trigger at 70% instead
     // of the default 85%, target 35% instead of 40%. This prevents long child
     // tasks from exhausting the context window before the parent can intervene.
-    if let Some(ref parent_budget) = input.parent_session.token_budget {
+    if let Some(parent_budget) = input.parent_session.effective_token_budget() {
         let mut child_budget = parent_budget.clone();
         child_budget.compression_trigger_percent = 70;
         child_budget.compression_target_percent = 35;

--- a/crates/infra/bamboo-compression/src/compression_tooling.rs
+++ b/crates/infra/bamboo-compression/src/compression_tooling.rs
@@ -121,7 +121,7 @@ pub fn estimate_context_compression_exposure(
     configured_budget: Option<&TokenBudget>,
 ) -> ContextCompressionExposure {
     // When a budget was already resolved upstream (the production path — see
-    // `resolve_token_budget`, which now also caches it on `session.token_budget`,
+    // `resolve_token_budget`, which caches it in `session.resolved_token_budget` (#180),
     // issue #20 bug 1), use it directly. Only when none is available do we fall
     // back to a model-derived budget. No `model_limits.json` registry is in
     // scope synchronously here, so this fallback resolves to the global default


### PR DESCRIPTION
Closes #180 (follow-up to #20 / PR #178; found by the #178 review).

## The bug
PR #178 cached the resolved token budget on `session.token_budget` so downstream readers stop seeing `None` (#20 bug 1). But that field is `#[serde(skip_serializing_if = "Option::is_none")]` — **persisted**. So the cache is durable across reload, and `resolve_token_budget`'s early-return short-circuits on it forever:
- a user edits `model_limits.json`, but an already-resolved-then-reloaded **long-lived session** keeps the stale budget;
- a **mid-session model switch** keeps the first model's budget.

## Root cause: an overloaded field
`session.token_budget` was three things at once — a genuine/child override, the engine's resolved cache, and a notional user override (**no user-override write path exists in production**; bamboo-server sets it nowhere). The child per-child budget (`child_session/actions.rs`, parent budget with 70/35 compression) legitimately needs to persist and short-circuit; the engine cache must not.

## Fix (chosen approach: separate the cache field)
- Add `Session.resolved_token_budget: Option<(String /*model*/, TokenBudget)>`, **`#[serde(skip)]`** — a per-process, model-keyed engine cache that never persists.
- `resolve_token_budget` now:
  1. returns `session.token_budget` (genuine/child override) if set — **persisted, wins first, unchanged**;
  2. returns `config.token_budget` if set;
  3. reuses `resolved_token_budget` **only if it was resolved for the current model**;
  4. otherwise resolves fresh and caches into `resolved_token_budget` keyed by model.
- New `Session::effective_token_budget()` = override-or-cache. The downstream readers that #20 fixed (`tool_execution` context-pressure + `max_tool_output_tokens`, child budget derivation) now read through it — so #20 bug 1 stays fixed **without** persisting the cache.

Result: a reload starts with no cache → re-resolves from the current `model_limits.json`; a model switch re-keys → re-resolves; a child's assigned budget still persists and short-circuits.

## Testing
- New: serde round-trip asserts `resolved_token_budget` is **absent from the JSON** and deserializes to `None` (proves the reload fix); a model-switch test asserts the cache re-keys `model-a` → `model-b` (proves re-resolution).
- Updated the #20 `caches_resolved_budget_on_session` test for the new slot; the `prefers_existing_session_budget` override test is unchanged and still passes.
- `bamboo-domain` 147 + `bamboo-engine` 894 green; `bamboo-server`/`bamboo-compression` build clean (all readers). Only 2 Session struct-literals needed the new field (38/43 use `..spread`). The lone `envelope_ir_flatten_orders_runs_canonically` failure is pre-existing on clean `origin/main`.

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u