### PR TITLE
fix(bamboo-memory): CJK-aware search + write-path keyword extraction (#242)

### DIFF
--- a/crates/infra/bamboo-memory/src/memory_store/mod.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/mod.rs
@@ -222,20 +222,15 @@ pub fn extract_keywords(title: &str, content: &str, tags: &[String]) -> Vec<Stri
         }
     }
 
+    // CJK-aware tokenization (shared with recall's `lexical_bm25::tokenize`) so a
+    // bilingual (中文 + English) library stores Chinese keywords too. The old pass
+    // keyed on `is_ascii_alphanumeric`, dropping ALL CJK — Chinese docs got no
+    // keyword-boost and (since keywords feed the recall index) full-body Chinese
+    // content was never indexed beyond the 240-char summary. English tokens keep
+    // their prior lowercased form; each Chinese run contributes char bigrams. (#242)
     let combined = format!("{}\n{}", title, content);
-    let mut current = String::new();
-    for ch in combined.chars() {
-        if ch.is_ascii_alphanumeric() {
-            current.push(ch.to_ascii_lowercase());
-            continue;
-        }
-        if current.len() >= 3 {
-            seen.insert(current.clone());
-        }
-        current.clear();
-    }
-    if current.len() >= 3 {
-        seen.insert(current);
+    for token in lexical_bm25::tokenize(&combined) {
+        seen.insert(token);
     }
 
     seen.into_iter().take(128).collect()
@@ -523,7 +518,11 @@ pub fn match_memory_query(
         return Some(1.0);
     };
 
-    let query_tokens = extract_keywords(query, "", &[]);
+    // CJK-aware tokenization (shared with recall) so a Chinese `search`/`query_scope`
+    // query matches (bigrams substring-match the Chinese-preserving title/body).
+    // The old ASCII-only pass yielded zero tokens for Chinese → matched everything
+    // unranked. (#242)
+    let query_tokens = lexical_bm25::tokenize(query);
     if query_tokens.is_empty() {
         return Some(1.0);
     }

--- a/crates/infra/bamboo-memory/src/memory_store/store.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/store.rs
@@ -3553,6 +3553,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn chinese_query_scope_matches_only_the_chinese_memory() {
+        let dir = tempdir().unwrap();
+        let store = MemoryStore::new(dir.path());
+
+        store
+            .write_memory(
+                MemoryScope::Project,
+                Some("proj-1"),
+                DurableMemoryType::Project,
+                "多租户隔离设计",
+                "外层编排每租户一实例,数据按文件夹隔离。",
+                &[],
+                Some("session-1"),
+                "main-model",
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+        store
+            .write_memory(
+                MemoryScope::Project,
+                Some("proj-1"),
+                DurableMemoryType::Project,
+                "Release freeze checklist",
+                "Generic release freeze checklist for shipping work.",
+                &[],
+                Some("session-1"),
+                "main-model",
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Before #242 a Chinese query produced zero tokens and hit the
+        // `return Some(1.0)` path → matched EVERY doc (matched_count == 2). Now it
+        // tokenizes CJK-aware and matches only the Chinese memory.
+        let result = store
+            .query_scope(
+                MemoryScope::Project,
+                Some("proj-1"),
+                Some("多租户"),
+                None,
+                None,
+                &MemoryQueryOptions {
+                    limit: Some(10),
+                    max_chars: Some(5000),
+                    cursor: None,
+                    include_related: false,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            result.matched_count, 1,
+            "a distinctly-Chinese query must match only the Chinese memory, not everything"
+        );
+    }
+
+    #[tokio::test]
     async fn query_scope_reports_cursor_and_truncation_across_multiple_matches() {
         let dir = tempdir().unwrap();
         let store = MemoryStore::new(dir.path());


### PR DESCRIPTION
Closes #242. Follow-up to #241 — closes the two remaining CJK gaps so Chinese recall is *strong*, not just working.

## 1. `search` / `query_scope` was CJK-blind
`match_memory_query` tokenized the query with the ASCII-only `extract_keywords`, so a **Chinese query produced zero tokens** and hit `return Some(1.0)` → **matched every doc, unranked**. Now it tokenizes via the shared `lexical_bm25::tokenize`; the CJK bigrams substring-match the Chinese-preserving `title`/`body`, so a Chinese search matches + ranks the right memories. (English unchanged — same tokenizer as recall.)

## 2. Write-path keyword extraction was ASCII-only
`extract_keywords` keyed on `is_ascii_alphanumeric`, so a real `lexical.json` carried **no Chinese keywords** — after #241 Chinese recall worked but rode on `title (3.0) + summary (1.0)` only (the full body was never indexed beyond the 240-char summary). It now tokenizes CJK-aware, so **new docs store Chinese keywords** and recall gains full-body Chinese coverage + the keyword(2.5) boost. Existing docs backfill on their next write (or a bulk reindex); `detect_entities` (acronym/hyphen heuristic) is intentionally left as-is since it doesn't map to Chinese.

## Testing
Store-level `query_scope` test: a distinctly-Chinese query (`多租户`) now matches **only** the Chinese memory (was: both docs, via the match-everything path). **109 lib tests green.**

Part of the memory redesign (`zenith/docs/memory-redesign.md`); next is L1 (optional local embedder / hybrid).

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u