### PR TITLE
feat(bamboo-memory): L1 semantic-retrieval seam — MemoryEmbedder + hybrid score (inert)

### DIFF
--- a/crates/infra/bamboo-memory/src/memory_store/embedding.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/embedding.rs
@@ -31,8 +31,9 @@ pub const HYBRID_COSINE_WEIGHT: f64 = 1.0;
 /// recalls on lexical BM25 alone below this; the floor only gates cosine-only hits.
 pub const SEMANTIC_FLOOR: f64 = 0.25;
 
-/// Cosine similarity in [-1, 1]. Returns 0 for empty, mismatched-length, or
-/// degenerate (zero-norm) vectors, so a missing/absent embedding is a no-op.
+/// Cosine similarity in [-1, 1]. Returns 0 for empty, mismatched-length,
+/// degenerate (zero-norm), or non-finite (NaN/inf) vectors, so a missing/absent
+/// or malformed embedding is a no-op that can never leak NaN/inf into a score.
 pub fn cosine(a: &[f32], b: &[f32]) -> f64 {
     if a.is_empty() || a.len() != b.len() {
         return 0.0;
@@ -48,9 +49,15 @@ pub fn cosine(a: &[f32], b: &[f32]) -> f64 {
     }
     let denom = na.sqrt() * nb.sqrt();
     if denom <= f64::EPSILON {
-        0.0
+        return 0.0;
+    }
+    let sim = dot / denom;
+    // Backends only SHOULD unit-normalize; a stray NaN/inf component would make
+    // `sim` non-finite. Clamp it out rather than trust the contract.
+    if sim.is_finite() {
+        sim
     } else {
-        dot / denom
+        0.0
     }
 }
 
@@ -69,5 +76,11 @@ mod tests {
         assert_eq!(cosine(&[], &[1.0]), 0.0);
         assert_eq!(cosine(&[1.0, 2.0], &[1.0]), 0.0);
         assert_eq!(cosine(&[0.0, 0.0], &[1.0, 1.0]), 0.0);
+    }
+
+    #[test]
+    fn cosine_non_finite_component_is_zero() {
+        assert_eq!(cosine(&[f32::NAN, 1.0], &[1.0, 1.0]), 0.0);
+        assert_eq!(cosine(&[f32::INFINITY, 0.0], &[1.0, 1.0]), 0.0);
     }
 }

--- a/crates/infra/bamboo-memory/src/memory_store/embedding.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/embedding.rs
@@ -1,0 +1,73 @@
+//! Optional semantic-retrieval seam for durable-memory recall ("L1" of the
+//! memory redesign): the [`MemoryEmbedder`] interface a backend implements, plus
+//! the hybrid-score building blocks ([`cosine`], [`HYBRID_COSINE_WEIGHT`],
+//! [`SEMANTIC_FLOOR`]) that `lexical_bm25` combines as `bm25 + β·cosine`.
+//!
+//! **Embedding is OPTIONAL.** With no embedder configured, recall stays pure
+//! BM25 — this seam is entirely inert (query vectors are `None`, so the cosine
+//! term drops out and scoring is byte-identical to L0). Only the interface and
+//! the hybrid-scoring path land here; the concrete backend (a local multilingual
+//! ONNX embedder, provider-independent — or an optional hosted embedding
+//! endpoint) is a deferred follow-up that just implements this trait, populates
+//! `LexicalIndexItem.embedding` at index-build time, and embeds the query at
+//! recall time. BM25 stays the PRIMARY term so the #61 cache-stable ordering and
+//! the CJK/lexical guarantees survive; the vector term only re-ranks within that
+//! and surfaces paraphrase matches lexical scoring would miss.
+
+/// A text embedder. Backends SHOULD return a unit-normalized vector; an empty
+/// vec means "no embedding available" (recall falls back to pure BM25 for that
+/// item/query). Must be cheap enough to call once per query at recall time
+/// (document vectors are precomputed at write/index time).
+pub trait MemoryEmbedder: Send + Sync {
+    /// Embed `text` into a vector. Empty return = no embedding.
+    fn embed(&self, text: &str) -> Vec<f32>;
+}
+
+/// Weight (β) on the cosine term in the hybrid score `bm25 + β·cosine`.
+pub const HYBRID_COSINE_WEIGHT: f64 = 1.0;
+
+/// Minimum cosine for a NON-lexical (pure-semantic) match to be recalled — stops
+/// the vector term from surfacing every embedded doc as a weak match. A doc still
+/// recalls on lexical BM25 alone below this; the floor only gates cosine-only hits.
+pub const SEMANTIC_FLOOR: f64 = 0.25;
+
+/// Cosine similarity in [-1, 1]. Returns 0 for empty, mismatched-length, or
+/// degenerate (zero-norm) vectors, so a missing/absent embedding is a no-op.
+pub fn cosine(a: &[f32], b: &[f32]) -> f64 {
+    if a.is_empty() || a.len() != b.len() {
+        return 0.0;
+    }
+    let mut dot = 0.0f64;
+    let mut na = 0.0f64;
+    let mut nb = 0.0f64;
+    for (x, y) in a.iter().zip(b) {
+        let (x, y) = (*x as f64, *y as f64);
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    let denom = na.sqrt() * nb.sqrt();
+    if denom <= f64::EPSILON {
+        0.0
+    } else {
+        dot / denom
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cosine_identical_is_one_orthogonal_is_zero() {
+        assert!((cosine(&[1.0, 0.0], &[2.0, 0.0]) - 1.0).abs() < 1e-9);
+        assert!(cosine(&[1.0, 0.0], &[0.0, 1.0]).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cosine_degenerate_and_mismatch_are_zero() {
+        assert_eq!(cosine(&[], &[1.0]), 0.0);
+        assert_eq!(cosine(&[1.0, 2.0], &[1.0]), 0.0);
+        assert_eq!(cosine(&[0.0, 0.0], &[1.0, 1.0]), 0.0);
+    }
+}

--- a/crates/infra/bamboo-memory/src/memory_store/lexical_bm25.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/lexical_bm25.rs
@@ -112,6 +112,8 @@ struct DocBag {
     tf: HashMap<String, f64>,
     /// Document length = sum of weighted term frequencies.
     dl: f64,
+    /// Optional dense embedding for the hybrid semantic term (L1). `None` today.
+    embedding: Option<Vec<f32>>,
 }
 
 /// BM25(F) scorer over one scope's lexical index. Corpus statistics (document
@@ -145,6 +147,7 @@ impl Bm25Corpus {
                     status: item.status,
                     tf: HashMap::new(),
                     dl: 0.0,
+                    embedding: None,
                 });
                 continue;
             }
@@ -173,6 +176,7 @@ impl Bm25Corpus {
                 status: item.status,
                 tf,
                 dl,
+                embedding: item.embedding.clone(),
             });
         }
 
@@ -180,17 +184,27 @@ impl Bm25Corpus {
         Bm25Corpus { docs, df, avgdl, n }
     }
 
-    /// BM25(F) score of `query_tokens` against the document at `index`, or `None`
-    /// if the doc is non-scorable or matches no query term. Stale docs are scaled
-    /// down so an equally-relevant Active doc ranks above them.
-    pub(super) fn score(&self, index: usize, query_tokens: &[String]) -> Option<f64> {
+    /// Hybrid score = BM25(F) `+ cosine_weight·cosine(query_vec, doc.embedding)`.
+    /// With `query_vec == None` (no embedder wired) the semantic term drops out and
+    /// this is pure BM25, byte-identical to L0 — the seam is inert. A doc recalls if
+    /// it matches lexically OR (when vectors are present) its cosine clears
+    /// [`super::embedding::SEMANTIC_FLOOR`], so paraphrase matches the lexical pass
+    /// would miss still surface. Stale docs are scaled down. `None` for a
+    /// non-scorable doc or no match.
+    pub(super) fn score_hybrid(
+        &self,
+        index: usize,
+        query_tokens: &[String],
+        query_vec: Option<&[f32]>,
+        cosine_weight: f64,
+    ) -> Option<f64> {
         let doc = self.docs.get(index)?;
         if !doc.scorable || self.n == 0 {
             return None;
         }
 
-        let mut score = 0.0;
-        let mut matched = false;
+        let mut bm25 = 0.0;
+        let mut lexical_matched = false;
         let mut seen = HashSet::new();
         for token in query_tokens {
             // A term repeated in the query must not double-count.
@@ -208,13 +222,22 @@ impl Bm25Corpus {
             // common term below zero).
             let idf = (((self.n as f64 - df as f64 + 0.5) / (df as f64 + 0.5)) + 1.0).ln();
             let denom = tf + K1 * (1.0 - B + B * (doc.dl / self.avgdl.max(f64::EPSILON)));
-            score += idf * (tf * (K1 + 1.0)) / denom.max(f64::EPSILON);
-            matched = true;
+            bm25 += idf * (tf * (K1 + 1.0)) / denom.max(f64::EPSILON);
+            lexical_matched = true;
         }
 
-        if !matched {
+        // Optional semantic term — inert when either vector is absent.
+        let cos = match (query_vec, doc.embedding.as_deref()) {
+            (Some(q), Some(d)) => super::embedding::cosine(q, d),
+            _ => 0.0,
+        };
+        let semantic_matched = cos >= super::embedding::SEMANTIC_FLOOR;
+
+        if !lexical_matched && !semantic_matched {
             return None;
         }
+
+        let mut score = bm25 + cosine_weight * cos;
         if matches!(doc.status, DurableMemoryStatus::Stale) {
             score *= STALE_MULTIPLIER;
         }
@@ -224,6 +247,12 @@ impl Bm25Corpus {
         // `sort_recall_candidates` still fires and the recalled block stays stable
         // across repeated calls (BM25's raw f64 rarely ties on its own).
         Some((score * 1000.0).round() / 1000.0)
+    }
+
+    /// Pure BM25(F) score (no semantic term) — the recall default until a
+    /// [`super::embedding::MemoryEmbedder`] backend is wired.
+    pub(super) fn score(&self, index: usize, query_tokens: &[String]) -> Option<f64> {
+        self.score_hybrid(index, query_tokens, None, 0.0)
     }
 }
 
@@ -258,6 +287,7 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".to_string(),
             summary: String::new(),
             granularity: None,
+            embedding: None,
         }
     }
 
@@ -427,5 +457,57 @@ mod tests {
             "summary-only Chinese match"
         );
         assert!(corpus.score(1, &tokenize("多租户")).is_none());
+    }
+
+    #[test]
+    fn hybrid_surfaces_a_paraphrase_via_cosine_when_lexical_misses() {
+        // Two docs with NO lexical overlap with the query; "sem" has an embedding
+        // close to the query vector, "orth" is (near-)orthogonal.
+        let mut sem = item(
+            "sem",
+            DurableMemoryStatus::Active,
+            "guardian resume design",
+            &["guardian"],
+        );
+        sem.embedding = Some(vec![1.0, 0.0, 0.0]);
+        let mut orth = item(
+            "orth",
+            DurableMemoryStatus::Active,
+            "cache prefix stability",
+            &["cache"],
+        );
+        orth.embedding = Some(vec![0.0, 1.0, 0.0]);
+        let corpus = Bm25Corpus::build(&[sem, orth]);
+
+        let q = tokenize("hibernation checkpoint"); // matches neither doc lexically
+        let qvec = [0.9_f32, 0.05, 0.0]; // ~parallel to sem, ~orthogonal to orth
+        let w = super::super::embedding::HYBRID_COSINE_WEIGHT;
+
+        // Pure BM25 (no query vector) finds nothing — the seam is inert.
+        assert!(corpus.score(0, &q).is_none());
+        // Hybrid surfaces the semantically-close doc, rejects the orthogonal one.
+        assert!(
+            corpus.score_hybrid(0, &q, Some(&qvec), w).is_some(),
+            "a cosine-close paraphrase must surface even with no lexical overlap"
+        );
+        assert!(
+            corpus.score_hybrid(1, &q, Some(&qvec), w).is_none(),
+            "an orthogonal-embedding doc stays below the semantic floor"
+        );
+    }
+
+    #[test]
+    fn hybrid_with_no_query_vector_equals_pure_bm25() {
+        let mut d = item(
+            "d",
+            DurableMemoryStatus::Active,
+            "guardian resume",
+            &["guardian"],
+        );
+        d.embedding = Some(vec![1.0, 0.0]); // present but unused without a query vector
+        let corpus = Bm25Corpus::build(&[d]);
+        let q = tokenize("guardian");
+        let w = super::super::embedding::HYBRID_COSINE_WEIGHT;
+        assert_eq!(corpus.score_hybrid(0, &q, None, w), corpus.score(0, &q));
     }
 }

--- a/crates/infra/bamboo-memory/src/memory_store/lexical_bm25.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/lexical_bm25.rs
@@ -237,7 +237,12 @@ impl Bm25Corpus {
             return None;
         }
 
-        let mut score = bm25 + cosine_weight * cos;
+        // The semantic term only ever BOOSTS: clamp cosine to >= 0 so a future
+        // backend's negative/anti-correlated vector can never demote (or, with a
+        // large weight, sink) a strong lexical match. `cosine()` already maps
+        // empty/degenerate/non-finite inputs to 0.0, so this term is always a
+        // finite, non-negative addend.
+        let mut score = bm25 + cosine_weight * cos.max(0.0);
         if matches!(doc.status, DurableMemoryStatus::Stale) {
             score *= STALE_MULTIPLIER;
         }

--- a/crates/infra/bamboo-memory/src/memory_store/mod.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/mod.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+pub mod embedding;
 pub mod freshness;
 mod lexical_bm25;
 pub mod paths;
@@ -411,6 +412,12 @@ pub struct LexicalIndexItem {
     /// older `lexical.json` index files predate this field and deserialize to `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub granularity: Option<TemporalGranularity>,
+    /// Optional dense embedding (title+keywords+summary), populated at index-build
+    /// time WHEN a [`embedding::MemoryEmbedder`] backend is configured. Reserved by
+    /// L1: absent today (recall is pure BM25) so this seam is inert; when present,
+    /// recall adds a β·cosine term. Back-compat: older index files → `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding: Option<Vec<f32>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/infra/bamboo-memory/src/memory_store/store.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/store.rs
@@ -1975,6 +1975,9 @@ impl MemoryStore {
                     created_at: doc.frontmatter.created_at.clone(),
                     summary: derive_summary(&doc.body, 240),
                     granularity: doc.frontmatter.granularity,
+                    // L1: populated at index-build time once a MemoryEmbedder backend
+                    // is wired; None today → recall stays pure BM25 (inert seam).
+                    embedding: None,
                 })
                 .collect(),
         };


### PR DESCRIPTION
Memory redesign **L1**: the interface + hybrid-scoring path for **optional** semantic recall. Per the design decision, this lands the seam; the concrete embedder backend is a deferred follow-up.

## What lands
- `memory_store::embedding`: the **`MemoryEmbedder`** trait (a backend implements `embed(&str)->Vec<f32>`), plus `cosine`, `HYBRID_COSINE_WEIGHT`, `SEMANTIC_FLOOR`.
- `LexicalIndexItem.embedding: Option<Vec<f32>>` (`#[serde(default)]`) — reserved; populated at index-build time once a backend is wired. Back-compat: old index files → `None`.
- `Bm25Corpus::score_hybrid(index, tokens, query_vec, cosine_weight)` = `BM25 + β·cosine(query_vec, doc.embedding)` when both vectors are present; a doc recalls on a **lexical match OR** `cosine ≥ SEMANTIC_FLOOR` (so paraphrases the lexical pass misses still surface). `score()` is now a thin wrapper passing `query_vec = None`.

## Inert by default (no behavior change)
No embedder is wired, so query/doc vectors are `None` → the cosine term drops out → recall is **pure BM25, byte-identical to L0** (BM25 stays the primary term; #61 cache-stable ordering preserved). This is deliberate: the seam is ready, the backend plugs in later.

## Testing
Fake-vector tests prove the hybrid path: a cosine-close paraphrase with **no lexical overlap** surfaces, an orthogonal-embedding doc stays below the floor, and `score_hybrid(query_vec=None) == score()` (pure BM25). Plus cosine edge cases (degenerate/mismatched → 0). **113 lib tests green; clippy clean.**

Backend (local ONNX multilingual embedder + write-time vector population + query embedding wired into recall) is tracked as a follow-up. Part of `zenith/docs/memory-redesign.md`.

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u