### PR TITLE
feat(bamboo-memory,engine): L3 retire lossy Dream "Refine" — notebook = grounded view of durable memory

### DIFF
--- a/crates/engine/bamboo-engine/src/auto_dream.rs
+++ b/crates/engine/bamboo-engine/src/auto_dream.rs
@@ -775,26 +775,16 @@ mod tests {
         Arc::new(ProviderRegistry::new(HashMap::new(), "test".to_string()))
     }
 
-    #[derive(Debug, Clone)]
-    enum SequenceStep {
-        Response(String),
-        Fail(String),
-    }
-
     #[derive(Clone)]
     struct SequenceProvider {
-        steps: Arc<Mutex<Vec<SequenceStep>>>,
+        responses: Arc<Mutex<Vec<String>>>,
         prompts: Arc<Mutex<Vec<String>>>,
     }
 
     impl SequenceProvider {
         fn new(responses: Vec<String>) -> Self {
-            Self::from_steps(responses.into_iter().map(SequenceStep::Response).collect())
-        }
-
-        fn from_steps(steps: Vec<SequenceStep>) -> Self {
             Self {
-                steps: Arc::new(Mutex::new(steps)),
+                responses: Arc::new(Mutex::new(responses)),
                 prompts: Arc::new(Mutex::new(Vec::new())),
             }
         }
@@ -816,14 +806,11 @@ mod tests {
             if let Some(prompt) = messages.last().map(|message| message.content.clone()) {
                 self.prompts.lock().expect("lock poisoned").push(prompt);
             }
-            let next = self.steps.lock().expect("lock poisoned").remove(0);
-            match next {
-                SequenceStep::Response(text) => Ok(Box::pin(stream::iter(vec![
-                    Ok(LLMChunk::Token(text)),
-                    Ok(LLMChunk::Done),
-                ]))),
-                SequenceStep::Fail(error) => Err(LLMError::Stream(error)),
-            }
+            let text = self.responses.lock().expect("lock poisoned").remove(0);
+            Ok(Box::pin(stream::iter(vec![
+                Ok(LLMChunk::Token(text)),
+                Ok(LLMChunk::Done),
+            ])))
         }
     }
 

--- a/crates/engine/bamboo-engine/src/auto_dream.rs
+++ b/crates/engine/bamboo-engine/src/auto_dream.rs
@@ -14,10 +14,9 @@ use bamboo_llm::{LLMChunk, LLMProvider, LLMRequestOptions};
 use bamboo_llm::{ProviderModelRouter, ProviderRegistry};
 use bamboo_memory::auto_dream::{
     build_consolidation_prompt, build_extraction_prompt, build_rebuild_consolidation_prompt,
-    build_refine_consolidation_prompt, derive_session_outline, normalize_dream_notebook_body,
-    normalize_existing_dream_for_prompt, parse_candidate_scope, parse_candidate_type,
-    parse_extraction_candidates, parse_last_consolidated_at, parse_last_full_rebuild_at,
-    should_force_full_rebuild, should_use_dream_refine_mode, truncate_chars,
+    derive_session_outline, normalize_dream_notebook_body, parse_candidate_scope,
+    parse_candidate_type, parse_extraction_candidates, parse_last_consolidated_at,
+    parse_last_full_rebuild_at, should_force_full_rebuild, truncate_chars,
     ConsolidationSessionInfo, DreamCandidateInfo, DreamGenerationMode,
 };
 use bamboo_memory::memory_store::{MemoryScope, MemoryStore};
@@ -84,7 +83,6 @@ struct CandidateSessionContext {
 #[derive(Debug, Clone)]
 struct DreamSourceWindow {
     existing_dream: Option<String>,
-    recent_durable_memory: Option<String>,
     durable_memory_index: Option<String>,
     sessions: Vec<(SessionIndexEntry, Option<String>)>,
 }
@@ -396,17 +394,6 @@ async fn read_existing_dream_for_scope(
     }
 }
 
-async fn read_recent_durable_memory_for_scope(
-    memory: &MemoryStore,
-    scope: MemoryScope,
-    project_key: Option<&str>,
-) -> Result<Option<String>, String> {
-    memory
-        .read_recent_view(scope, project_key)
-        .await
-        .map_err(|error| format!("failed to read recent durable memory view: {error}"))
-}
-
 async fn read_durable_memory_index_for_scope(
     memory: &MemoryStore,
     scope: MemoryScope,
@@ -452,83 +439,6 @@ async fn build_dream_notebook_body(
     generation_mode: DreamGenerationMode,
 ) -> Result<String, String> {
     match generation_mode {
-        DreamGenerationMode::Refine => {
-            tracing::info!(
-                target: DREAM_TRACING_TARGET,
-                event = "refine_attempt",
-                model = model,
-                session_count = source_window.sessions.len(),
-                existing_dream_present = source_window.existing_dream.is_some(),
-                recent_durable_memory_present = source_window.recent_durable_memory.is_some(),
-                "Attempting refine-mode Dream synthesis"
-            );
-
-            let existing_dream_for_prompt = normalize_existing_dream_for_prompt(
-                source_window.existing_dream.as_deref(),
-                model,
-                source_window.sessions.len(),
-                DREAM_MAX_SUMMARY_CHARS,
-            );
-            let refine_prompt = build_refine_consolidation_prompt(
-                existing_dream_for_prompt.as_deref(),
-                source_window.recent_durable_memory.as_deref(),
-                &to_consolidation_sessions(&source_window.sessions),
-            );
-            match collect_stream_text(provider.clone(), model, refine_prompt).await {
-                Ok(raw_body) => {
-                    match normalize_dream_notebook_body(&raw_body, DREAM_MAX_SUMMARY_CHARS) {
-                        Ok(body) => {
-                            tracing::info!(
-                                target: DREAM_TRACING_TARGET,
-                                event = "refine_success",
-                                model = model,
-                                session_count = source_window.sessions.len(),
-                                notebook_body_chars = body.chars().count(),
-                                existing_dream_present = source_window.existing_dream.is_some(),
-                                recent_durable_memory_present = source_window.recent_durable_memory.is_some(),
-                                "Refine-mode Dream synthesis succeeded"
-                            );
-                            Ok(body)
-                        }
-                        Err(error) => {
-                            tracing::warn!(
-                                target: DREAM_TRACING_TARGET,
-                                event = "refine_output_normalization_failed",
-                                model = model,
-                                session_count = source_window.sessions.len(),
-                                existing_dream_present = source_window.existing_dream.is_some(),
-                                recent_durable_memory_present = source_window.recent_durable_memory.is_some(),
-                                "[auto_dream] refine-mode Dream output normalization failed; falling back to incremental prompt: {}",
-                                error
-                            );
-                            let prompt = build_consolidation_prompt(&to_consolidation_sessions(
-                                &source_window.sessions,
-                            ));
-                            let raw_body =
-                                collect_stream_text(provider.clone(), model, prompt).await?;
-                            normalize_dream_notebook_body(&raw_body, DREAM_MAX_SUMMARY_CHARS)
-                        }
-                    }
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        target: DREAM_TRACING_TARGET,
-                        event = "refine_provider_failed",
-                        model = model,
-                        session_count = source_window.sessions.len(),
-                        existing_dream_present = source_window.existing_dream.is_some(),
-                        recent_durable_memory_present = source_window.recent_durable_memory.is_some(),
-                        "[auto_dream] refine-mode Dream synthesis failed; falling back to incremental prompt: {}",
-                        error
-                    );
-                    let prompt = build_consolidation_prompt(&to_consolidation_sessions(
-                        &source_window.sessions,
-                    ));
-                    let raw_body = collect_stream_text(provider.clone(), model, prompt).await?;
-                    normalize_dream_notebook_body(&raw_body, DREAM_MAX_SUMMARY_CHARS)
-                }
-            }
-        }
         DreamGenerationMode::Rebuild => {
             tracing::info!(
                 target: DREAM_TRACING_TARGET,
@@ -629,8 +539,6 @@ async fn run_auto_dream_once_for_scope(
 
     let now = Utc::now();
     let existing = read_existing_dream_for_scope(memory, scope, project_key).await?;
-    let recent_durable_memory =
-        read_recent_durable_memory_for_scope(memory, scope, project_key).await?;
     let durable_memory_index =
         read_durable_memory_index_for_scope(memory, scope, project_key).await?;
     let last_full_rebuild_at = existing.as_deref().and_then(parse_last_full_rebuild_at);
@@ -672,10 +580,14 @@ async fn run_auto_dream_once_for_scope(
         return Ok(None);
     }
 
-    let generation_mode = if force_full_rebuild {
+    // The notebook is a VIEW of durable memory (L3): rebuild it from the canonical
+    // durable memory index whenever any durable memory exists — grounded in the
+    // source of truth — and only bootstrap from recent sessions when there is no
+    // durable memory to ground on yet. `force_full_rebuild` additionally widens the
+    // session window (see `since`) on the periodic pass. The retired `Refine` mode
+    // rewrote the notebook from its own prior prose, drifting from durable truth.
+    let generation_mode = if force_full_rebuild || durable_memory_index.is_some() {
         DreamGenerationMode::Rebuild
-    } else if should_use_dream_refine_mode(&memory_cfg) && existing.is_some() {
-        DreamGenerationMode::Refine
     } else {
         DreamGenerationMode::Incremental
     };
@@ -687,11 +599,10 @@ async fn run_auto_dream_once_for_scope(
         model = model.as_str(),
         session_count = sessions.len(),
         existing_dream_present = existing.is_some(),
-        recent_durable_memory_present = recent_durable_memory.is_some(),
         durable_memory_index_present = durable_memory_index.is_some(),
+        force_full_rebuild = force_full_rebuild,
         generation_mode = match generation_mode {
             DreamGenerationMode::Incremental => "incremental",
-            DreamGenerationMode::Refine => "refine",
             DreamGenerationMode::Rebuild => "rebuild",
         },
         require_auto_dream_enabled = require_auto_dream_enabled,
@@ -700,13 +611,16 @@ async fn run_auto_dream_once_for_scope(
 
     let source_window = DreamSourceWindow {
         existing_dream: existing,
-        recent_durable_memory,
         durable_memory_index,
         sessions,
     };
     let notebook_body =
         build_dream_notebook_body(&bg_provider, &model, &source_window, generation_mode).await?;
-    let last_full_rebuild_line = if matches!(generation_mode, DreamGenerationMode::Rebuild) {
+    // Stamp the periodic-rebuild marker ONLY on a forced pass. Every non-forced
+    // pass is now a Rebuild too (the notebook is always grounded in durable
+    // memory), so keying the marker off the mode would reset the timer every tick
+    // and the wide-window periodic sweep would never fire.
+    let last_full_rebuild_line = if force_full_rebuild {
         format!("Last full rebuild at: {}\n", now.to_rfc3339())
     } else if let Some(existing_rebuild_at) = last_full_rebuild_at {
         format!(
@@ -763,11 +677,9 @@ async fn run_auto_dream_once_for_scope(
         model = model.as_str(),
         session_count = source_window.sessions.len(),
         existing_dream_present = source_window.existing_dream.is_some(),
-        recent_durable_memory_present = source_window.recent_durable_memory.is_some(),
         durable_memory_index_present = source_window.durable_memory_index.is_some(),
         generation_mode = match generation_mode {
             DreamGenerationMode::Incremental => "incremental",
-            DreamGenerationMode::Refine => "refine",
             DreamGenerationMode::Rebuild => "rebuild",
         },
         notebook_chars = notebook_chars,
@@ -1471,8 +1383,12 @@ mod tests {
         assert!(project_dream.contains("Manual project dream worked"));
     }
 
+    /// L3: even on a NON-forced pass, once durable memory exists the notebook is
+    /// (re)built grounded in the canonical durable memory index — NOT rewritten from
+    /// its own prior prose (the retired Refine mode). Also asserts a non-forced pass
+    /// does not stamp the periodic-rebuild marker, so the timer still advances.
     #[tokio::test]
-    async fn run_auto_dream_once_refine_mode_includes_existing_dream_in_prompt() {
+    async fn run_auto_dream_once_grounds_notebook_in_durable_index_not_prior_prose() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
 
@@ -1483,7 +1399,7 @@ mod tests {
         );
         let storage: Arc<dyn Storage> = session_store.clone();
         let provider = SequenceProvider::new(vec![
-            "## Current durable context\n- Refined durable theme\n\n## Cross-session patterns\n- Keep continuity\n\n## Active threads to remember\n- Update the notebook\n\n## Stable constraints and preferences\n- None\n\n## Open risks or questions\n- None".to_string(),
+            "## Current durable context\n- Grounded in durable memory\n\n## Cross-session patterns\n- Keep continuity\n\n## Active threads to remember\n- Refresh blockers\n\n## Stable constraints and preferences\n- None\n\n## Open risks or questions\n- None".to_string(),
             "{\"candidates\":[]}".to_string(),
         ]);
         let provider_handle: Arc<dyn LLMProvider> = Arc::new(provider.clone());
@@ -1491,114 +1407,36 @@ mod tests {
             memory: Some(bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 auto_dream_enabled: true,
-                dream_refine_mode: true,
                 ..bamboo_config::MemoryConfig::default()
             }),
             ..Config::default()
         }));
 
-        let workspace = temp_dir.path().join("workspace-refine-mode");
-        std::fs::create_dir_all(&workspace).expect("workspace dir");
-
-        let mut session = bamboo_agent_core::Session::new("session-refine-mode", "model");
-        session.title = "Refine mode test".to_string();
-        session.metadata.insert(
-            "workspace_path".to_string(),
-            workspace.to_string_lossy().to_string(),
-        );
-        session.conversation_summary = Some(bamboo_agent_core::ConversationSummary::new(
-            "Recent session summary for refine mode.",
-            3,
-            120,
-        ));
-        session.add_message(Message::user("Update the dream with the latest thread."));
-        storage.save_session(&session).await.expect("save session");
-
-        let memory = MemoryStore::new(temp_dir.path());
-        memory
-            .write_dream_view(
-                "# Bamboo Dream Notebook\n\nLast consolidated at: 2026-04-02T16:00:00Z\nSessions reviewed: 2\nModel: fast-model\n\n## Current durable context\n- Existing durable thread\n",
-            )
-            .await
-            .expect("write existing dream");
-        memory
-            .write_session_topic("session-refine-mode", "default", "Recent session note.")
-            .await
-            .expect("write session topic");
-
-        let context = AutoDreamContext {
-            session_store,
-            storage,
-            provider: provider_handle,
-            config,
-            provider_registry: test_registry(),
-        };
-
-        let result = run_auto_dream_once_with_store(&context, &memory)
-            .await
-            .expect("refine-mode auto dream should succeed")
-            .expect("dream output should be produced");
-        assert_eq!(result.session_count, 1);
-
-        let prompts = provider.recorded_prompts();
-        assert!(prompts.len() >= 2);
-        assert!(prompts[0].contains("## Existing Dream notebook"));
-        assert!(prompts[0].contains("Existing durable thread"));
-        assert!(prompts[0].contains("## Recent durable memory updates"));
-        assert!(prompts[0].contains("start from it and preserve still-valid durable context"));
-    }
-
-    #[tokio::test]
-    async fn run_auto_dream_once_refine_mode_includes_recent_durable_memory_in_prompt() {
-        let temp_dir = tempfile::tempdir().expect("tempdir");
-        bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
-
-        let session_store = Arc::new(
-            SessionStoreV2::new(temp_dir.path().to_path_buf())
-                .await
-                .unwrap(),
-        );
-        let storage: Arc<dyn Storage> = session_store.clone();
-        let provider = SequenceProvider::new(vec![
-            "## Current durable context\n- Refined from durable memory\n\n## Cross-session patterns\n- Keep continuity\n\n## Active threads to remember\n- Update the notebook\n\n## Stable constraints and preferences\n- None\n\n## Open risks or questions\n- None".to_string(),
-            "{\"candidates\":[]}".to_string(),
-        ]);
-        let provider_handle: Arc<dyn LLMProvider> = Arc::new(provider.clone());
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
-                background_model: Some("fast-model".to_string()),
-                auto_dream_enabled: true,
-                dream_refine_mode: true,
-                ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
-
-        let workspace = temp_dir.path().join("workspace-refine-recent-memory");
+        let workspace = temp_dir.path().join("workspace-grounded-mode");
         std::fs::create_dir_all(&workspace).expect("workspace dir");
         let project_key = bamboo_memory::memory_store::project_key_from_path(&workspace);
 
-        let mut session = bamboo_agent_core::Session::new("session-refine-recent-memory", "model");
-        session.title = "Refine recent memory test".to_string();
+        let mut session = bamboo_agent_core::Session::new("session-grounded-mode", "model");
+        session.title = "Grounded mode test".to_string();
         session.metadata.insert(
             "workspace_path".to_string(),
             workspace.to_string_lossy().to_string(),
         );
         session.conversation_summary = Some(bamboo_agent_core::ConversationSummary::new(
-            "Recent session summary for refine recent memory.",
+            "Recent session summary for grounded mode.",
             3,
             120,
         ));
-        session.add_message(Message::user(
-            "Update the dream with recent durable memory.",
-        ));
+        session.add_message(Message::user("Update the dream from durable memory."));
         storage.save_session(&session).await.expect("save session");
 
         let memory = MemoryStore::new(temp_dir.path());
+        // Existing notebook with only a "Last consolidated at" line (NO "Last full
+        // rebuild at") → force_full_rebuild is false, so this is a NON-forced pass.
         memory
             .write_project_dream_view(
                 &project_key,
-                "# Bamboo Dream Notebook\n\nProject key: project\nLast consolidated at: 2026-04-02T16:00:00Z\nSessions reviewed: 2\nModel: fast-model\n\n## Current durable context\n- Existing durable thread\n",
+                "# Bamboo Dream Notebook\n\nProject key: project\nLast consolidated at: 2026-04-02T16:00:00Z\nSessions reviewed: 2\nModel: fast-model\n\n## Current durable context\n- Stale prior notebook prose that must NOT drive the rebuild\n",
             )
             .await
             .expect("write existing project dream");
@@ -1607,16 +1445,16 @@ mod tests {
                 MemoryScope::Project,
                 Some(&project_key),
                 bamboo_memory::memory_store::DurableMemoryType::Project,
-                "Release freeze rule",
-                "The release freeze starts on Tuesday for mobile.",
-                &["release".to_string(), "freeze".to_string()],
-                Some("session-refine-recent-memory"),
+                "Canonical release decision",
+                "Release freeze starts Tuesday and all mobile changes require review.",
+                &["release".to_string(), "mobile".to_string()],
+                Some("session-grounded-mode"),
                 "main-model",
                 false,
                 None,
             )
             .await
-            .expect("write recent durable memory");
+            .expect("write project durable memory");
 
         let context = AutoDreamContext {
             session_store,
@@ -1626,16 +1464,35 @@ mod tests {
             provider_registry: test_registry(),
         };
 
-        let _ = run_project_auto_dream_once_with_store(&context, &memory, &project_key)
+        let result = run_project_auto_dream_once_with_store(&context, &memory, &project_key)
             .await
-            .expect("refine recent-memory auto dream should succeed")
+            .expect("grounded auto dream should succeed")
             .expect("dream output should be produced");
+        assert_eq!(result.session_count, 1);
 
         let prompts = provider.recorded_prompts();
         assert!(prompts.len() >= 2);
-        assert!(prompts[0].contains("## Recent durable memory updates"));
-        assert!(prompts[0].contains("Release freeze rule"));
-        assert!(prompts[0].contains("Recent Memory Updates"));
+        // Grounded in the durable memory index, not the prior notebook prose.
+        assert!(prompts[0].contains("## Durable memory index"));
+        assert!(prompts[0].contains("Canonical release decision"));
+        assert!(prompts[0].contains("canonical durable memory plus recent session activity"));
+        assert!(
+            !prompts[0].contains("## Existing Dream notebook"),
+            "notebook must not be rewritten from its own prior prose (Refine retired)"
+        );
+        assert!(!prompts[0].contains("Stale prior notebook prose"));
+
+        // A non-forced pass does not stamp the periodic-rebuild marker.
+        let dream = memory
+            .read_project_dream_view(&project_key)
+            .await
+            .expect("read project dream")
+            .expect("project dream should exist");
+        assert!(dream.contains("Grounded in durable memory"));
+        assert!(
+            !dream.contains("Last full rebuild at:"),
+            "a non-forced pass must not stamp the full-rebuild marker"
+        );
     }
 
     #[tokio::test]
@@ -1658,7 +1515,6 @@ mod tests {
             memory: Some(bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 auto_dream_enabled: true,
-                dream_refine_mode: true,
                 ..bamboo_config::MemoryConfig::default()
             }),
             ..Config::default()
@@ -1773,7 +1629,7 @@ Model: gpt-5-mini
     }
 
     #[tokio::test]
-    async fn run_auto_dream_once_refine_mode_normalizes_nested_notebook_output() {
+    async fn run_auto_dream_once_normalizes_nested_notebook_output() {
         let temp_dir = tempfile::tempdir().expect("tempdir");
         bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
 
@@ -1792,7 +1648,6 @@ Model: gpt-5-mini
             memory: Some(bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 auto_dream_enabled: true,
-                dream_refine_mode: true,
                 ..bamboo_config::MemoryConfig::default()
             }),
             ..Config::default()
@@ -1853,92 +1708,6 @@ Model: gpt-5-mini
         assert!(dream.contains("Refined durable theme"));
         assert!(!dream.contains("```md"));
         assert_eq!(dream.matches("# Bamboo Dream Notebook").count(), 1);
-    }
-
-    #[tokio::test]
-    async fn run_auto_dream_once_refine_mode_falls_back_to_legacy_prompt_on_failure() {
-        let temp_dir = tempfile::tempdir().expect("tempdir");
-        bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
-
-        let session_store = Arc::new(
-            SessionStoreV2::new(temp_dir.path().to_path_buf())
-                .await
-                .unwrap(),
-        );
-        let storage: Arc<dyn Storage> = session_store.clone();
-        let provider = SequenceProvider::from_steps(vec![
-            SequenceStep::Fail("refine prompt failed".to_string()),
-            SequenceStep::Response(
-                "## Current durable context\n- Legacy fallback result\n\n## Cross-session patterns\n- None\n\n## Active threads to remember\n- None\n\n## Stable constraints and preferences\n- None\n\n## Open risks or questions\n- None".to_string(),
-            ),
-            SequenceStep::Response("{\"candidates\":[]}".to_string()),
-        ]);
-        let provider_handle: Arc<dyn LLMProvider> = Arc::new(provider.clone());
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
-                background_model: Some("fast-model".to_string()),
-                auto_dream_enabled: true,
-                dream_refine_mode: true,
-                ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
-
-        let workspace = temp_dir.path().join("workspace-refine-fallback");
-        std::fs::create_dir_all(&workspace).expect("workspace dir");
-
-        let mut session = bamboo_agent_core::Session::new("session-refine-fallback", "model");
-        session.title = "Refine fallback test".to_string();
-        session.metadata.insert(
-            "workspace_path".to_string(),
-            workspace.to_string_lossy().to_string(),
-        );
-        session.conversation_summary = Some(bamboo_agent_core::ConversationSummary::new(
-            "Recent summary for fallback mode.",
-            3,
-            120,
-        ));
-        session.add_message(Message::user("Please update the dream safely."));
-        storage.save_session(&session).await.expect("save session");
-
-        let memory = MemoryStore::new(temp_dir.path());
-        memory
-            .write_dream_view(
-                "# Bamboo Dream Notebook\n\nLast consolidated at: 2026-04-02T16:00:00Z\nSessions reviewed: 2\nModel: fast-model\n\n## Current durable context\n- Existing durable thread\n",
-            )
-            .await
-            .expect("write existing dream");
-        memory
-            .write_session_topic("session-refine-fallback", "default", "Recent session note.")
-            .await
-            .expect("write session topic");
-
-        let context = AutoDreamContext {
-            session_store,
-            storage,
-            provider: provider_handle,
-            config,
-            provider_registry: test_registry(),
-        };
-
-        let result = run_auto_dream_once_with_store(&context, &memory)
-            .await
-            .expect("fallback auto dream should succeed")
-            .expect("dream output should be produced");
-        assert_eq!(result.session_count, 1);
-
-        let prompts = provider.recorded_prompts();
-        assert!(prompts.len() >= 3);
-        assert!(prompts[0].contains("## Existing Dream notebook"));
-        assert!(!prompts[1].contains("## Existing Dream notebook"));
-        assert!(prompts[1].contains("## Recent sessions"));
-
-        let dream = memory
-            .read_dream_view()
-            .await
-            .expect("read dream view")
-            .expect("dream should exist after fallback");
-        assert!(dream.contains("Legacy fallback result"));
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -182,9 +182,12 @@ pub struct MemoryConfig {
         alias = "memory_project_first_dream"
     )]
     pub project_first_dream: bool,
-    /// Whether Dream generation should refine from the existing notebook when present.
-    ///
-    /// This rolls out cumulative/refining Dream synthesis behind an explicit opt-in flag.
+    /// DEPRECATED (memory redesign L3): the "Refine" Dream mode — rewriting the
+    /// notebook from its own prior prose — was retired because a self-referential
+    /// narrative rewrite drifts from durable truth and silently over-merges. The
+    /// notebook is now always a grounded VIEW of the durable memory index (Rebuild)
+    /// or a session bootstrap (Incremental). This field is IGNORED; it is retained
+    /// only so existing config files that set it still deserialize.
     #[serde(default, alias = "memory_dream_refine_mode")]
     pub dream_refine_mode: bool,
     /// Whether the background "gardener" may use the LLM to split/merge "blob" memories.

--- a/crates/infra/bamboo-memory/src/auto_dream.rs
+++ b/crates/infra/bamboo-memory/src/auto_dream.rs
@@ -576,33 +576,6 @@ pub fn derive_session_outline(session: &bamboo_agent_core::Session) -> Option<St
     (!parts.is_empty()).then(|| parts.join("\n\n---\n\n"))
 }
 
-/// Normalize an existing dream notebook body for use as consolidation prompt context.
-///
-/// Returns `None` if normalization fails (logged as a warning).
-pub fn normalize_existing_dream_for_prompt(
-    existing_dream: Option<&str>,
-    model: &str,
-    session_count: usize,
-    max_summary_chars: usize,
-) -> Option<String> {
-    existing_dream.and_then(|dream| {
-        match normalize_dream_notebook_body(dream, max_summary_chars) {
-            Ok(body) => Some(body),
-            Err(error) => {
-                tracing::warn!(
-                    target: "bamboo.auto_dream",
-                    event = "existing_input_normalization_failed",
-                    model = model,
-                    session_count = session_count,
-                    "[auto_dream] failed to normalize existing Dream input; omitting prior Dream context: {}",
-                    error
-                );
-                None
-            }
-        }
-    })
-}
-
 // ---------------------------------------------------------------------------
 // Config helpers
 // ---------------------------------------------------------------------------

--- a/crates/infra/bamboo-memory/src/auto_dream.rs
+++ b/crates/infra/bamboo-memory/src/auto_dream.rs
@@ -11,10 +11,16 @@ use serde::Deserialize;
 // Extraction types
 // ---------------------------------------------------------------------------
 
+/// How the Dream Notebook VIEW is (re)synthesized. The notebook is a derived
+/// view of durable memory, never a source of truth — so it is either bootstrapped
+/// from recent sessions (`Incremental`, before any durable memory exists) or
+/// grounded in the canonical durable memory index (`Rebuild`). The old `Refine`
+/// mode — rewriting the notebook from its own prior prose — was retired in L3: a
+/// self-referential narrative rewrite drifts from durable truth and silently
+/// over-merges. See `zenith/docs/memory-redesign.md`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DreamGenerationMode {
     Incremental,
-    Refine,
     Rebuild,
 }
 
@@ -499,38 +505,6 @@ pub fn build_consolidation_prompt(sessions: &[ConsolidationSessionInfo]) -> Stri
     prompt
 }
 
-pub fn build_consolidation_prompt_with_existing_dream(
-    existing_dream: Option<&str>,
-    sessions: &[ConsolidationSessionInfo],
-) -> String {
-    build_refine_consolidation_prompt(existing_dream, None, sessions)
-}
-
-pub fn build_refine_consolidation_prompt(
-    existing_dream: Option<&str>,
-    recent_durable_memory: Option<&str>,
-    sessions: &[ConsolidationSessionInfo],
-) -> String {
-    let mut prompt = build_consolidation_prompt_prefix();
-    prompt.push_str(
-        "When an existing Dream notebook is provided, start from it and preserve still-valid durable context while updating active threads based on recent sessions and recent durable memory updates. Remove obsolete items only when the recent evidence justifies it.\n\n",
-    );
-    append_markdown_reference_section(
-        &mut prompt,
-        "## Existing Dream notebook",
-        existing_dream,
-        "_(no existing Dream notebook supplied; fall back to synthesizing from recent sessions only)_",
-    );
-    append_markdown_reference_section(
-        &mut prompt,
-        "## Recent durable memory updates",
-        recent_durable_memory,
-        "_(no recent durable memory updates supplied)_",
-    );
-    append_consolidation_recent_sessions_section(&mut prompt, sessions);
-    prompt
-}
-
 pub fn build_rebuild_consolidation_prompt(
     durable_memory_index: Option<&str>,
     sessions: &[ConsolidationSessionInfo],
@@ -632,10 +606,6 @@ pub fn normalize_existing_dream_for_prompt(
 // ---------------------------------------------------------------------------
 // Config helpers
 // ---------------------------------------------------------------------------
-
-pub fn should_use_dream_refine_mode(memory_cfg: &bamboo_config::MemoryConfig) -> bool {
-    memory_cfg.dream_refine_mode
-}
 
 pub fn should_force_full_rebuild(
     last_full_rebuild_at: Option<chrono::DateTime<chrono::Utc>>,
@@ -798,21 +768,6 @@ mod tests {
         assert!(prompt.contains("session-1"));
         assert!(prompt.contains("Important summary"));
         assert!(prompt.contains("## Current durable context"));
-    }
-
-    #[test]
-    fn refine_consolidation_prompt_includes_existing_dream() {
-        let prompt = build_refine_consolidation_prompt(
-            Some("## Current durable context\n- Existing durable thread"),
-            Some("# Recent Memory Updates\n\n- `mem-1` User prefers concise plans"),
-            &[sample_consolidation_session("session-2")],
-        );
-        assert!(prompt.contains("## Existing Dream notebook"));
-        assert!(prompt.contains("Existing durable thread"));
-        assert!(prompt.contains("## Recent durable memory updates"));
-        assert!(prompt.contains("User prefers concise plans"));
-        assert!(prompt.contains("start from it and preserve still-valid durable context"));
-        assert!(prompt.contains("session-2"));
     }
 
     #[test]


### PR DESCRIPTION
Memory redesign **L3**: retire the lossy Dream **Refine** mode; the Dream Notebook is now always a grounded VIEW of durable memory, never a self-referential prose rewrite.

## The problem
The notebook had three synthesis modes:
- **Incremental** — synthesize from recent sessions.
- **Rebuild** — synthesize from the canonical **durable memory index** (+ recent sessions).
- **Refine** — start from the notebook's **own prior prose** and rewrite it.

**Refine is a self-referential narrative rewrite.** Each pass rewrites the whole notebook from the last rewrite, so it drifts from durable truth and silently over-merges — exactly counter to the redesign principle: *durable memory is the source of truth; the notebook is only a view.*

## The change
- **Gate**: a non-forced pass with durable memory present now **Rebuilds** (grounds the notebook in the durable memory index) instead of Refine. `Incremental` is kept only to bootstrap when no durable memory exists yet.
- **Marker fix**: stamp `Last full rebuild at:` only on **forced** (periodic) passes. Every pass is a Rebuild now, so keying the marker off the *mode* would reset the periodic timer every tick and the wide-window sweep would never fire. Now the timer advances correctly.
- **Removed the dead Refine path**: `DreamGenerationMode::Refine`, `build_refine_consolidation_prompt`, `build_consolidation_prompt_with_existing_dream`, `should_use_dream_refine_mode`, `normalize_existing_dream_for_prompt`, and the now-unused `recent_durable_memory` plumbing (its read + the source-window field).
- **Config**: `dream_refine_mode` is kept but **deprecated + ignored** — existing config files that set it still deserialize; it just has no effect.

## Durable-side consolidation was already reversible
The RFC's other L3 goal — *conservative, reversible consolidation (supersede-not-rewrite)* — is already satisfied on the durable layer: the gardener consolidates via `consolidate_memories`, which creates a new memory that **supersedes** its sources and marks them `Superseded` (kept for lineage, hidden from recall). No lossy in-place rewrite exists there, so no change was needed.

## Testing
- New `run_auto_dream_once_grounds_notebook_in_durable_index_not_prior_prose`: with durable memory present but **not** a forced pass, the prompt contains `## Durable memory index` + the durable content and **not** `## Existing Dream notebook`/the stale prior prose — and the written notebook does **not** get a `Last full rebuild at:` marker (proving the marker fix).
- Deleted the two Refine-only tests (recent-durable-memory input + Refine→incremental fallback — both gone); renamed the normalization test.
- Dream tests green: **config 144, engine 892** (excl. the pre-existing `envelope_ir_flatten_orders_runs_canonically` flake, which fails on clean `origin/main`), **memory 118**. Clippy clean; `cargo check --workspace` passes.

Design: `zenith/docs/memory-redesign.md` (L3).

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u