### PR TITLE
feat(memory): L4 default-on maintenance integrators + volume-triggered gardener

### DIFF
--- a/crates/app/bamboo-server/src/app_state/tests.rs
+++ b/crates/app/bamboo-server/src/app_state/tests.rs
@@ -343,7 +343,7 @@ async fn memory_tool_merge_action_updates_existing_project_memory() {
 }
 
 #[tokio::test]
-async fn memory_tool_write_merges_heuristically_similar_memory_when_enabled() {
+async fn memory_tool_write_merges_near_identical_restatement_when_enabled() {
     let temp_dir = tempfile::tempdir().unwrap();
     bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
     let state = AppState::new(temp_dir.path().to_path_buf())
@@ -364,9 +364,9 @@ async fn memory_tool_write_merges_heuristically_similar_memory_when_enabled() {
                     "action": "write",
                     "scope": "project",
                     "type": "project",
-                    "title": "Release freeze begins next week",
-                    "content": "Merge freeze begins on Tuesday for mobile release cut.",
-                    "tags": ["release", "freeze"],
+                    "title": "Prod deploy uses blue-green with a 10 minute soak",
+                    "content": "Production deploys use a blue-green strategy with a ten minute soak window.",
+                    "tags": ["deploy"],
                     "options": { "allow_merge_if_similar": false }
                 }),
             ),
@@ -395,9 +395,9 @@ async fn memory_tool_write_merges_heuristically_similar_memory_when_enabled() {
                     "action": "write",
                     "scope": "project",
                     "type": "project",
-                    "title": "Mobile release freeze starts Tuesday",
-                    "content": "Stakeholders confirmed the mobile release freeze starts Tuesday.",
-                    "tags": ["mobile", "release"],
+                    "title": "Prod deploy uses blue-green with a 10 minute soak window",
+                    "content": "Production deploy uses blue-green with a 10 minute soak before cutover.",
+                    "tags": ["deploy"],
                     "options": { "allow_merge_if_similar": true }
                 }),
             ),

--- a/crates/engine/bamboo-engine/src/auto_dream.rs
+++ b/crates/engine/bamboo-engine/src/auto_dream.rs
@@ -491,52 +491,10 @@ async fn run_auto_dream_once_for_scope(
         return Ok(None);
     }
 
-    // Resolve background model (and provider when using ProviderModelRef).
-    let provider_ref_enabled = config_snapshot.features.provider_model_ref;
-    let model_ref = if provider_ref_enabled {
-        config_snapshot
-            .defaults
-            .as_ref()
-            .and_then(|d| d.memory_background.as_ref())
-            .or_else(|| {
-                config_snapshot
-                    .defaults
-                    .as_ref()
-                    .and_then(|d| d.fast.as_ref())
-            })
-    } else {
-        None
-    };
-
-    let (bg_provider, model): (Arc<dyn LLMProvider>, String) = if let Some(ref mr) = model_ref {
-        let router = ProviderModelRouter::new(ctx.provider_registry.clone());
-        let routed = router.route(mr).map_err(|e| {
-            format!(
-                "[auto_dream] failed to route background model ref '{}': {}",
-                mr, e
-            )
-        })?;
-        tracing::debug!(
-            target: DREAM_TRACING_TARGET,
-            model_ref = %mr,
-            "Resolved background model via ProviderModelRef"
-        );
-        (routed, mr.model.clone())
-    } else {
-        let Some(model) = config_snapshot.get_memory_background_model() else {
-            tracing::warn!(
-                target: DREAM_TRACING_TARGET,
-                event = "run_skip",
-                reason = "no_background_model",
-                scope = scope_label,
-                project_key = project_key.unwrap_or(""),
-                "[auto_dream] skipped: no memory.background_model / provider.fast_model configured"
-            );
-            return Ok(None);
-        };
-        (ctx.provider.clone(), model)
-    };
-
+    // NOTE: the background model is resolved AFTER the candidate-session check
+    // below, so an idle default-on instance with no model configured returns
+    // quietly (no candidate sessions) instead of warning every tick. Mirrors the
+    // gardener, which checks its worklist before resolving a model.
     let now = Utc::now();
     let existing = read_existing_dream_for_scope(memory, scope, project_key).await?;
     let durable_memory_index =
@@ -573,12 +531,59 @@ async fn run_auto_dream_once_for_scope(
             reason = "no_candidate_sessions",
             scope = scope_label,
             project_key = project_key.unwrap_or(""),
-            model = model.as_str(),
             existing_dream_present = existing.is_some(),
             "Skipping Dream generation because there are no candidate sessions"
         );
         return Ok(None);
     }
+
+    // There IS work — now resolve the background model (and provider when using
+    // ProviderModelRef). Doing this after the session check keeps an idle default-on
+    // instance without a model quiet; a "no model" warn here means real work exists
+    // that we can't do.
+    let provider_ref_enabled = config_snapshot.features.provider_model_ref;
+    let model_ref = if provider_ref_enabled {
+        config_snapshot
+            .defaults
+            .as_ref()
+            .and_then(|d| d.memory_background.as_ref())
+            .or_else(|| {
+                config_snapshot
+                    .defaults
+                    .as_ref()
+                    .and_then(|d| d.fast.as_ref())
+            })
+    } else {
+        None
+    };
+    let (bg_provider, model): (Arc<dyn LLMProvider>, String) = if let Some(ref mr) = model_ref {
+        let router = ProviderModelRouter::new(ctx.provider_registry.clone());
+        let routed = router.route(mr).map_err(|e| {
+            format!(
+                "[auto_dream] failed to route background model ref '{}': {}",
+                mr, e
+            )
+        })?;
+        tracing::debug!(
+            target: DREAM_TRACING_TARGET,
+            model_ref = %mr,
+            "Resolved background model via ProviderModelRef"
+        );
+        (routed, mr.model.clone())
+    } else {
+        let Some(model) = config_snapshot.get_memory_background_model() else {
+            tracing::warn!(
+                target: DREAM_TRACING_TARGET,
+                event = "run_skip",
+                reason = "no_background_model",
+                scope = scope_label,
+                project_key = project_key.unwrap_or(""),
+                "[auto_dream] skipped: no memory.background_model / provider.fast_model configured"
+            );
+            return Ok(None);
+        };
+        (ctx.provider.clone(), model)
+    };
 
     // The notebook is a VIEW of durable memory (L3): rebuild it from the canonical
     // durable memory index whenever any durable memory exists — grounded in the
@@ -1709,9 +1714,12 @@ Model: gpt-5-mini
         );
         let storage: Arc<dyn Storage> = session_store.clone();
         let provider: Arc<dyn LLMProvider> = Arc::new(SequenceProvider::new(vec![]));
+        // auto_dream is ON by default (L4), so disable it explicitly to keep
+        // covering the disabled gate (not merely "no candidate sessions").
         let config = Arc::new(RwLock::new(Config {
             memory: Some(bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
+                auto_dream_enabled: false,
                 ..bamboo_config::MemoryConfig::default()
             }),
             ..Config::default()

--- a/crates/engine/bamboo-engine/src/gardener.rs
+++ b/crates/engine/bamboo-engine/src/gardener.rs
@@ -527,8 +527,11 @@ pub fn spawn_gardener_task(ctx: AutoDreamContext) {
             force_first = false;
             run_gardener_passes(&ctx).await;
             last_run = Instant::now();
-            // Re-count after the pass so consolidations/splits are reflected in the
-            // baseline (dedup shrinks the count, split grows it).
+            // Re-baseline the count AFTER the pass so the gardener's own file writes
+            // don't re-trigger it. Superseded/archived sources are kept as tombstone
+            // files, so a split or a dedup-consolidation actually GROWS the topic-file
+            // count (a new canonical is written, sources retained); only a hard purge
+            // shrinks it. Re-baselining absorbs all of that.
             last_run_count = memory.count_all_memories().await.unwrap_or(current_count);
         }
     });

--- a/crates/engine/bamboo-engine/src/gardener.rs
+++ b/crates/engine/bamboo-engine/src/gardener.rs
@@ -11,7 +11,7 @@
 //! near-duplicates) is produced for free by `MemoryStore` scan methods.
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use futures::StreamExt;
 
@@ -431,42 +431,105 @@ async fn run_dedup_gardener_once_with_store(
     Ok(Some(result))
 }
 
-/// Spawn the recurring gardener loop. No-op cost when disabled: each tick reads
-/// config and returns immediately if neither gardener pass is enabled.
+/// How often the gardener loop polls for the volume trigger. Kept short relative
+/// to the (typically daily) time interval so library growth is caught within
+/// minutes, not a full interval. Each poll is a cheap count + a config read; the
+/// actual passes only run when the time or volume condition fires.
+const GARDENER_VOLUME_POLL_SECS: u64 = 300;
+
+/// Decide whether the gardener maintenance pass should run on this poll: on the
+/// time interval, OR early once the library has grown by `volume_trigger` memories
+/// since the last run (L4). `volume_trigger == 0` disables the volume trigger
+/// (time-only). Pure so the trigger logic is unit-testable without wall-clock.
+fn should_run_gardener_pass(
+    elapsed_secs: u64,
+    interval_secs: u64,
+    current_count: usize,
+    last_run_count: usize,
+    volume_trigger: usize,
+) -> bool {
+    if elapsed_secs >= interval_secs {
+        return true;
+    }
+    volume_trigger > 0 && current_count.saturating_sub(last_run_count) >= volume_trigger
+}
+
+/// Run both gardener passes in order. Blob remediation first, then dedup: splitting
+/// a blob can expose fresh duplicates, and superseded blob sources drop out of the
+/// dedup scan.
+async fn run_gardener_passes(ctx: &AutoDreamContext) {
+    if let Err(error) = run_gardener_once(ctx).await {
+        tracing::warn!(
+            target: GARDENER_TRACING_TARGET,
+            event = "run_failed",
+            "[gardener] run failed: {}",
+            error
+        );
+    }
+    if let Err(error) = run_dedup_gardener_once(ctx).await {
+        tracing::warn!(
+            target: GARDENER_TRACING_TARGET,
+            event = "dedup_run_failed",
+            "[dedup-gardener] run failed: {}",
+            error
+        );
+    }
+}
+
+/// Spawn the recurring gardener loop. Time- AND volume-triggered (L4): it polls on
+/// a short cadence and runs the passes when either the configured interval elapsed
+/// or enough new memories accumulated since the last run. No-op cost when disabled:
+/// each pass reads config and returns immediately if its gardener is off, and the
+/// poll itself is just a cheap topic-file count.
 pub fn spawn_gardener_task(ctx: AutoDreamContext) {
     tokio::spawn(async move {
-        let interval_secs = ctx
-            .config
-            .read()
-            .await
-            .memory
-            .as_ref()
-            .map(|memory| memory.gardener_interval_secs)
-            .filter(|secs| *secs > 0)
-            // Fall back to the config default (single source of truth for "daily")
-            // when memory config is absent or the interval was set to 0.
-            .unwrap_or_else(|| bamboo_config::MemoryConfig::default().gardener_interval_secs);
-        let mut ticker = tokio::time::interval(Duration::from_secs(interval_secs));
+        let (interval_secs, volume_trigger) = {
+            let guard = ctx.config.read().await;
+            let memory = guard.memory.as_ref();
+            let interval_secs = memory
+                .map(|memory| memory.gardener_interval_secs)
+                .filter(|secs| *secs > 0)
+                // Fall back to the config default (single source of truth for
+                // "daily") when memory config is absent or the interval was 0.
+                .unwrap_or_else(|| bamboo_config::MemoryConfig::default().gardener_interval_secs);
+            let volume_trigger = memory
+                .map(|memory| memory.gardener_volume_trigger)
+                .unwrap_or_else(|| bamboo_config::MemoryConfig::default().gardener_volume_trigger);
+            (interval_secs, volume_trigger)
+        };
+        // Poll frequently enough to catch volume growth, but never longer than the
+        // time interval itself.
+        let poll_secs = GARDENER_VOLUME_POLL_SECS.min(interval_secs.max(1));
+
+        let memory = MemoryStore::new(ctx.session_store.bamboo_home_dir());
+        let mut ticker = tokio::time::interval(Duration::from_secs(poll_secs));
+        let mut last_run = Instant::now();
+        let mut last_run_count = memory.count_all_memories().await.unwrap_or(0);
+        // Run once on startup (the first `interval` tick fired immediately before
+        // this change), then let the time/volume conditions drive it.
+        let mut force_first = true;
+
         loop {
             ticker.tick().await;
-            // Blob remediation first, then dedup: splitting a blob can expose fresh
-            // duplicates, and superseded blob sources drop out of the dedup scan.
-            if let Err(error) = run_gardener_once(&ctx).await {
-                tracing::warn!(
-                    target: GARDENER_TRACING_TARGET,
-                    event = "run_failed",
-                    "[gardener] run failed: {}",
-                    error
-                );
+            let current_count = memory.count_all_memories().await.unwrap_or(last_run_count);
+            let elapsed_secs = last_run.elapsed().as_secs();
+            if !force_first
+                && !should_run_gardener_pass(
+                    elapsed_secs,
+                    interval_secs,
+                    current_count,
+                    last_run_count,
+                    volume_trigger,
+                )
+            {
+                continue;
             }
-            if let Err(error) = run_dedup_gardener_once(&ctx).await {
-                tracing::warn!(
-                    target: GARDENER_TRACING_TARGET,
-                    event = "dedup_run_failed",
-                    "[dedup-gardener] run failed: {}",
-                    error
-                );
-            }
+            force_first = false;
+            run_gardener_passes(&ctx).await;
+            last_run = Instant::now();
+            // Re-count after the pass so consolidations/splits are reflected in the
+            // baseline (dedup shrinks the count, split grows it).
+            last_run_count = memory.count_all_memories().await.unwrap_or(current_count);
         }
     });
 }
@@ -486,6 +549,24 @@ mod tests {
     use bamboo_llm::{LLMError, LLMStream, ProviderRegistry};
     use bamboo_memory::memory_store::DurableMemoryType;
     use bamboo_storage::SessionStoreV2;
+
+    #[test]
+    fn gardener_trigger_fires_on_time_or_volume() {
+        // Time trigger: elapsed >= interval fires regardless of growth.
+        assert!(should_run_gardener_pass(86_400, 86_400, 0, 0, 25));
+        assert!(should_run_gardener_pass(90_000, 86_400, 5, 5, 25));
+        // Not yet due and not enough growth → no run.
+        assert!(!should_run_gardener_pass(60, 86_400, 30, 20, 25));
+        // Volume trigger: grew by >= threshold before the interval → early run.
+        assert!(should_run_gardener_pass(60, 86_400, 45, 20, 25));
+        assert!(should_run_gardener_pass(60, 86_400, 25, 0, 25));
+        // Growth below the threshold → no run.
+        assert!(!should_run_gardener_pass(60, 86_400, 44, 20, 25));
+        // volume_trigger == 0 disables the volume trigger (time-only).
+        assert!(!should_run_gardener_pass(60, 86_400, 10_000, 0, 0));
+        // Count shrinking (e.g. after a dedup) never underflows into a trigger.
+        assert!(!should_run_gardener_pass(60, 86_400, 5, 100, 25));
+    }
 
     #[derive(Clone)]
     struct CannedProvider {
@@ -605,7 +686,15 @@ mod tests {
         );
         let storage: Arc<dyn Storage> = session_store.clone();
         let provider: Arc<dyn LLMProvider> = Arc::new(CannedProvider::new(vec![]));
-        let config = Arc::new(RwLock::new(Config::default()));
+        // Gardener is ON by default (L4), so disable it explicitly to test the
+        // disabled path.
+        let config = Arc::new(RwLock::new(Config {
+            memory: Some(bamboo_config::MemoryConfig {
+                gardener_enabled: false,
+                ..bamboo_config::MemoryConfig::default()
+            }),
+            ..Config::default()
+        }));
         let provider_registry = Arc::new(ProviderRegistry::new(HashMap::new(), "test".to_string()));
         let ctx = AutoDreamContext {
             session_store,
@@ -707,7 +796,14 @@ mod tests {
         );
         let storage: Arc<dyn Storage> = session_store.clone();
         let provider: Arc<dyn LLMProvider> = Arc::new(CannedProvider::new(vec![]));
-        let config = Arc::new(RwLock::new(Config::default()));
+        // Dedup gardener is ON by default (L4); disable it explicitly here.
+        let config = Arc::new(RwLock::new(Config {
+            memory: Some(bamboo_config::MemoryConfig {
+                dedup_gardener_enabled: false,
+                ..bamboo_config::MemoryConfig::default()
+            }),
+            ..Config::default()
+        }));
         let provider_registry = Arc::new(ProviderRegistry::new(HashMap::new(), "test".to_string()));
         let ctx = AutoDreamContext {
             session_store,

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -152,8 +152,11 @@ pub struct MemoryConfig {
     /// Falls back to the provider fast model when unset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub background_model: Option<String>,
-    /// Whether lightweight automatic Dream-style consolidation should run in the background.
-    #[serde(default)]
+    /// Whether lightweight automatic Dream-style consolidation should run in the
+    /// background. Default ON (memory redesign L4): each tick no-ops when there is
+    /// no background model configured or no new candidate sessions, so it is free
+    /// until there is real work + a model. Set false to opt out.
+    #[serde(default = "default_true_auto_dream_enabled")]
     pub auto_dream_enabled: bool,
     /// Seconds between background auto-Dream ticks (default 30 minutes).
     /// Each tick still no-ops when there are no new candidate sessions, so raising
@@ -191,12 +194,25 @@ pub struct MemoryConfig {
     #[serde(default, alias = "memory_dream_refine_mode")]
     pub dream_refine_mode: bool,
     /// Whether the background "gardener" may use the LLM to split/merge "blob" memories.
-    /// Opt-in (default false) because it spends model tokens.
-    #[serde(default, alias = "memory_gardener_enabled")]
+    /// Default ON (memory redesign L4). The deterministic blob prefilter is cheap
+    /// and each run is bounded by `gardener_max_splits_per_run`; a run that finds
+    /// nothing, or finds work but has no background model, spends no tokens. Set
+    /// false to opt out.
+    #[serde(
+        default = "default_true_gardener_enabled",
+        alias = "memory_gardener_enabled"
+    )]
     pub gardener_enabled: bool,
-    /// Seconds between gardener runs (default daily — far slower than auto_dream).
+    /// Seconds between gardener time-triggered runs (default daily). A run may also
+    /// fire early when the library grows — see `gardener_volume_trigger`.
     #[serde(default = "default_gardener_interval_secs")]
     pub gardener_interval_secs: u64,
+    /// Run the gardener maintenance pass early (before the next time tick) once this
+    /// many new durable memories have accumulated since the last run, so pileup is
+    /// bounded by growth, not only by the clock (memory redesign L4). 0 disables the
+    /// volume trigger (time-only). Per-run caps still bound the work done.
+    #[serde(default = "default_gardener_volume_trigger")]
+    pub gardener_volume_trigger: usize,
     /// Hard cap on LLM-backed splits per gardener run (cost ceiling per run).
     #[serde(default = "default_gardener_max_splits_per_run")]
     pub gardener_max_splits_per_run: usize,
@@ -204,8 +220,13 @@ pub struct MemoryConfig {
     #[serde(default = "default_gardener_min_sections")]
     pub gardener_min_sections: usize,
     /// Whether the background dedup gardener may use the LLM to consolidate
-    /// near-duplicate memories. Opt-in (default false) because it spends tokens.
-    #[serde(default, alias = "memory_dedup_gardener_enabled")]
+    /// near-duplicate memories. Default ON (memory redesign L4); bounded by
+    /// `dedup_gardener_max_merges_per_run` and no-ops without a model. Set false to
+    /// opt out.
+    #[serde(
+        default = "default_true_dedup_gardener_enabled",
+        alias = "memory_dedup_gardener_enabled"
+    )]
     pub dedup_gardener_enabled: bool,
     /// Minimum content-keyword Jaccard (0.0–1.0) for two active memories to be
     /// flagged as dedup candidates by the deterministic prefilter.
@@ -220,22 +241,42 @@ impl Default for MemoryConfig {
     fn default() -> Self {
         Self {
             background_model: None,
-            auto_dream_enabled: false,
+            auto_dream_enabled: default_true_auto_dream_enabled(),
             auto_dream_interval_secs: default_auto_dream_interval_secs(),
             project_prompt_injection: default_true_memory_project_prompt_injection(),
             relevant_recall: default_true_memory_relevant_recall(),
             relevant_recall_rerank: false,
             project_first_dream: default_true_memory_project_first_dream(),
             dream_refine_mode: false,
-            gardener_enabled: false,
+            gardener_enabled: default_true_gardener_enabled(),
             gardener_interval_secs: default_gardener_interval_secs(),
+            gardener_volume_trigger: default_gardener_volume_trigger(),
             gardener_max_splits_per_run: default_gardener_max_splits_per_run(),
             gardener_min_sections: default_gardener_min_sections(),
-            dedup_gardener_enabled: false,
+            dedup_gardener_enabled: default_true_dedup_gardener_enabled(),
             dedup_gardener_min_score: default_dedup_gardener_min_score(),
             dedup_gardener_max_merges_per_run: default_dedup_gardener_max_merges_per_run(),
         }
     }
+}
+
+fn default_true_auto_dream_enabled() -> bool {
+    true
+}
+
+fn default_true_gardener_enabled() -> bool {
+    true
+}
+
+fn default_true_dedup_gardener_enabled() -> bool {
+    true
+}
+
+/// Fire the gardener maintenance pass early once ~this many new memories accumulate
+/// since the last run. Conservative: large enough to avoid thrashing on a few
+/// writes, small enough to bound pileup well under a full (daily) interval.
+fn default_gardener_volume_trigger() -> usize {
+    25
 }
 
 fn default_gardener_interval_secs() -> u64 {
@@ -3150,6 +3191,7 @@ mod tests {
                 dream_refine_mode: true,
                 gardener_enabled: true,
                 gardener_interval_secs: 3_600,
+                gardener_volume_trigger: 40,
                 gardener_max_splits_per_run: 4,
                 gardener_min_sections: 7,
                 dedup_gardener_enabled: true,
@@ -3171,11 +3213,41 @@ mod tests {
         assert!(memory.dream_refine_mode);
         assert!(memory.gardener_enabled);
         assert_eq!(memory.gardener_interval_secs, 3_600);
+        assert_eq!(memory.gardener_volume_trigger, 40);
         assert_eq!(memory.gardener_max_splits_per_run, 4);
         assert_eq!(memory.gardener_min_sections, 7);
         assert!(memory.dedup_gardener_enabled);
         assert_eq!(memory.dedup_gardener_min_score, 0.7);
         assert_eq!(memory.dedup_gardener_max_merges_per_run, 3);
+    }
+
+    /// L4: the maintenance integrators are ON by default — both via
+    /// `MemoryConfig::default()` AND when a config file omits the flags entirely
+    /// (serde `default = fn`, not the bare `#[serde(default)]` = `false`).
+    #[test]
+    fn memory_maintenance_integrators_default_on() {
+        let defaults = MemoryConfig::default();
+        assert!(defaults.auto_dream_enabled);
+        assert!(defaults.gardener_enabled);
+        assert!(defaults.dedup_gardener_enabled);
+        assert_eq!(defaults.gardener_volume_trigger, 25);
+
+        // A config that mentions `memory` but omits the flags must still be ON.
+        let parsed: Config = serde_json::from_str(r#"{"memory":{}}"#).expect("parse");
+        let memory = parsed.memory.expect("memory present");
+        assert!(
+            memory.auto_dream_enabled,
+            "auto_dream on when field omitted"
+        );
+        assert!(memory.gardener_enabled, "gardener on when field omitted");
+        assert!(
+            memory.dedup_gardener_enabled,
+            "dedup gardener on when field omitted"
+        );
+        // An explicit opt-out is still honored.
+        let opted_out: Config =
+            serde_json::from_str(r#"{"memory":{"gardener_enabled":false}}"#).expect("parse");
+        assert!(!opted_out.memory.unwrap().gardener_enabled);
     }
 
     #[test]

--- a/crates/infra/bamboo-memory/src/memory_store/store.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/store.rs
@@ -1849,6 +1849,42 @@ impl MemoryStore {
         Ok(docs)
     }
 
+    /// Cheap count of durable-memory topic files in one scope — a readdir with no
+    /// parse (unlike [`Self::list_memory_documents`]). Counts every `.md` topic
+    /// regardless of status; it is a growth signal, not a recall count.
+    pub async fn count_scope_memories(
+        &self,
+        scope: MemoryScope,
+        project_key: Option<&str>,
+    ) -> io::Result<usize> {
+        let project_key = self.require_project_key(scope, project_key)?;
+        let topic_dir = self.resolver.topic_dir(scope, project_key);
+        if !topic_dir.exists() {
+            return Ok(0);
+        }
+        let mut count = 0usize;
+        let mut entries = fs::read_dir(topic_dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            if entry.path().extension().is_some_and(|ext| ext == "md") {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    /// Total durable-memory count across the global scope and every project scope
+    /// (cheap; no parse). Used by the volume-triggered maintenance pass (L4) to
+    /// detect library growth between time ticks.
+    pub async fn count_all_memories(&self) -> io::Result<usize> {
+        let mut total = self.count_scope_memories(MemoryScope::Global, None).await?;
+        for key in self.list_project_keys().await.unwrap_or_default() {
+            total += self
+                .count_scope_memories(MemoryScope::Project, Some(&key))
+                .await?;
+        }
+        Ok(total)
+    }
+
     /// Classify how an incoming write relates to the scope's existing memories,
     /// using IDF-weighted cosine over field-weighted token bags (L2). Retires the
     /// old raw count-overlap gate: a common shared keyword no longer counts as much
@@ -3307,6 +3343,61 @@ mod tests {
         );
         // Idempotent: the body wasn't doubled.
         assert_eq!(docs[0].body.matches(body).count(), 1);
+    }
+
+    /// L4: `count_all_memories` sums topic files across global + project scopes
+    /// cheaply, so the volume-triggered maintenance pass can detect growth.
+    #[tokio::test]
+    async fn count_all_memories_sums_across_scopes() {
+        let dir = tempdir().unwrap();
+        let store = MemoryStore::new(dir.path());
+        assert_eq!(store.count_all_memories().await.unwrap(), 0);
+
+        let write = |scope, project_key: Option<&'static str>, title: &'static str| {
+            let store = &store;
+            async move {
+                store
+                    .write_memory(
+                        scope,
+                        project_key,
+                        if matches!(scope, MemoryScope::Global) {
+                            DurableMemoryType::Reference
+                        } else {
+                            DurableMemoryType::Project
+                        },
+                        title,
+                        "body content for the memory",
+                        &[],
+                        Some("s"),
+                        "m",
+                        false,
+                        None,
+                    )
+                    .await
+                    .unwrap();
+            }
+        };
+
+        write(MemoryScope::Global, None, "Global fact one").await;
+        write(MemoryScope::Global, None, "Global fact two").await;
+        write(MemoryScope::Project, Some("proj-a"), "Project A fact").await;
+        write(MemoryScope::Project, Some("proj-b"), "Project B fact").await;
+
+        assert_eq!(
+            store
+                .count_scope_memories(MemoryScope::Global, None)
+                .await
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            store
+                .count_scope_memories(MemoryScope::Project, Some("proj-a"))
+                .await
+                .unwrap(),
+            1
+        );
+        assert_eq!(store.count_all_memories().await.unwrap(), 4);
     }
 
     /// Many `MemoryStore` instances pointed at the SAME data dir (the real


### PR DESCRIPTION
Memory redesign **L4**: the maintenance integrators default ON, and the gardener fires on **library growth**, not just the clock. Directly addresses the durable-memory pileup (all three integrators shipped OFF → nothing ever consolidated).

## 1. Default-ON integrators
`auto_dream`, `gardener` (blob split), and `dedup_gardener` now default to **enabled**.

**Safe by construction — default-on ≠ always-spending:**
- `auto_dream` and both gardener passes **no-op without a background model** configured.
- The gardener's **deterministic prefilter is free** (readdir + structural checks) and makes **zero LLM calls** when there's no blob/dup work.
- Existing per-run caps bound cost: `gardener_max_splits_per_run`, `dedup_gardener_max_merges_per_run`, `gardener_min_sections`, `dedup_gardener_min_score`.

**Critical serde detail:** the flags now use `#[serde(default = "fn -> true")]`, not the bare `#[serde(default)]` (which is `bool::default()` = **false**). So a config file that **omits** the flag is ON too — not only `MemoryConfig::default()`. An explicit `"gardener_enabled": false` is still honored (opt-out preserved).

## 2. Volume-triggered maintenance
The gardener loop was time-only (daily interval), so a burst of writes waited for the next tick. Now it also fires **early** once the library has grown by `gardener_volume_trigger` (**default 25**) durable memories since the last run:
- Polls on a short cadence (`min(300s, interval)`), each poll a cheap count + config read.
- New `MemoryStore::count_all_memories` — a **readdir with no parse** across global + project scopes (a growth signal, not a recall count).
- Runs on `elapsed >= interval` **OR** `grown_by >= volume_trigger`, decided by a **pure, unit-tested** `should_run_gardener_pass` (0 disables the volume trigger; `saturating_sub` so a dedup that shrinks the count never underflows into a trigger).
- Startup pass preserved; the marker after each run re-baselines the count (dedup shrinks, split grows).

## Also: an L2 fallout fix
A `bamboo-server` memory-tool test (`memory_tool_write_merges_*`) still asserted the **old count-overlap MERGE** for the reworded near-dup pair that L2 now correctly **RELATES** (separate, linked memories). It was red on `main` since L2 (which only updated `bamboo-memory` tests). Retargeted to a near-identical restatement that genuinely merges, so it once again exercises the tool's merge path end-to-end.

## Testing
- **config 146**: `MemoryConfig::default()` on for all three + `gardener_volume_trigger == 25`; a `{"memory":{}}` config (flags omitted) parses to ON; explicit `false` still off.
- **memory 120**: `count_all_memories` sums across scopes.
- **engine gardener**: pure `should_run_gardener_pass` truth table (time, volume, disabled, shrink-underflow); the two `*_is_noop_when_disabled` tests now opt out explicitly (default is on).
- **server 962** green; clippy clean; `cargo build --workspace --tests` passes.

Design: `zenith/docs/memory-redesign.md` (L4).

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u