### PR TITLE
feat(memory): L5 capacity via archive-out-of-index — bound recall size, never delete

### DIFF
--- a/crates/engine/bamboo-engine/src/gardener.rs
+++ b/crates/engine/bamboo-engine/src/gardener.rs
@@ -53,6 +53,12 @@ pub struct DedupGardenerRunResult {
     pub failed: usize,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CapacityGardenerRunResult {
+    pub scopes_scanned: usize,
+    pub archived: usize,
+}
+
 async fn collect_model_json(
     provider: Arc<dyn LLMProvider>,
     model: &str,
@@ -431,6 +437,57 @@ async fn run_dedup_gardener_once_with_store(
     Ok(Some(result))
 }
 
+/// Capacity gardener (L5): bound each scope's RECALLABLE size by archiving the
+/// lowest-value overflow OUT of the recall index — never deletes (reversible), no
+/// LLM. Off unless `memory_active_capacity > 0`; `Reference`/`User`/`Feedback`
+/// memories are exempt. Runs last (after split + dedup), so it counts the
+/// post-consolidation library. `Ok(None)` when the feature is off.
+pub async fn run_capacity_gardener_once(
+    ctx: &AutoDreamContext,
+) -> Result<Option<CapacityGardenerRunResult>, String> {
+    let memory = MemoryStore::new(ctx.session_store.bamboo_home_dir());
+    run_capacity_gardener_once_with_store(ctx, &memory).await
+}
+
+async fn run_capacity_gardener_once_with_store(
+    ctx: &AutoDreamContext,
+    memory: &MemoryStore,
+) -> Result<Option<CapacityGardenerRunResult>, String> {
+    let memory_cfg = ctx.config.read().await.memory.clone().unwrap_or_default();
+    let capacity = memory_cfg.memory_active_capacity;
+    if capacity == 0 {
+        return Ok(None);
+    }
+    let max_archivals = memory_cfg.capacity_max_archivals_per_run.max(1);
+
+    let mut targets: Vec<(MemoryScope, Option<String>)> = vec![(MemoryScope::Global, None)];
+    for key in memory.list_project_keys().await.unwrap_or_default() {
+        targets.push((MemoryScope::Project, Some(key)));
+    }
+
+    let mut result = CapacityGardenerRunResult::default();
+    for (scope, project_key) in &targets {
+        let archived = memory
+            .enforce_scope_capacity(*scope, project_key.as_deref(), capacity, max_archivals)
+            .await
+            .map_err(|error| format!("capacity enforcement failed: {error}"))?;
+        result.scopes_scanned += 1;
+        result.archived += archived.len();
+    }
+    if result.archived > 0 {
+        tracing::info!(
+            target: GARDENER_TRACING_TARGET,
+            event = "capacity_run_complete",
+            scopes_scanned = result.scopes_scanned,
+            archived = result.archived,
+            capacity = capacity,
+            "[capacity-gardener] archived {} memories over capacity",
+            result.archived
+        );
+    }
+    Ok(Some(result))
+}
+
 /// How often the gardener loop polls for the volume trigger. Kept short relative
 /// to the (typically daily) time interval so library growth is caught within
 /// minutes, not a full interval. Each poll is a cheap count + a config read; the
@@ -471,6 +528,15 @@ async fn run_gardener_passes(ctx: &AutoDreamContext) {
             target: GARDENER_TRACING_TARGET,
             event = "dedup_run_failed",
             "[dedup-gardener] run failed: {}",
+            error
+        );
+    }
+    // Capacity enforcement last, so it counts the post-consolidation library.
+    if let Err(error) = run_capacity_gardener_once(ctx).await {
+        tracing::warn!(
+            target: GARDENER_TRACING_TARGET,
+            event = "capacity_run_failed",
+            "[capacity-gardener] run failed: {}",
             error
         );
     }
@@ -816,5 +882,90 @@ mod tests {
             provider_registry,
         };
         assert_eq!(run_dedup_gardener_once(&ctx).await.unwrap(), None);
+    }
+
+    /// L5: the capacity gardener is off (Ok(None)) unless `memory_active_capacity`
+    /// is set, and when set it archives the over-capacity overflow.
+    #[tokio::test]
+    async fn capacity_gardener_off_until_capacity_set_then_archives_overflow() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        bamboo_config::paths::init_bamboo_dir(temp.path().to_path_buf());
+        let session_store = Arc::new(
+            SessionStoreV2::new(temp.path().to_path_buf())
+                .await
+                .unwrap(),
+        );
+        let storage: Arc<dyn Storage> = session_store.clone();
+        let provider: Arc<dyn LLMProvider> = Arc::new(CannedProvider::new(vec![]));
+
+        let memory = MemoryStore::new(session_store.bamboo_home_dir());
+        for title in [
+            "Global fact a",
+            "Global fact b",
+            "Global fact c",
+            "Global fact d",
+        ] {
+            memory
+                .write_memory(
+                    MemoryScope::Global,
+                    None,
+                    DurableMemoryType::Project,
+                    title,
+                    "body content for the memory",
+                    &[],
+                    Some("s"),
+                    "m",
+                    false,
+                    None,
+                )
+                .await
+                .unwrap();
+        }
+
+        // Off by default (capacity == 0) → Ok(None), archives nothing.
+        let off_config = Arc::new(RwLock::new(Config::default()));
+        let provider_registry = Arc::new(ProviderRegistry::new(HashMap::new(), "test".to_string()));
+        let ctx_off = AutoDreamContext {
+            session_store: session_store.clone(),
+            storage: storage.clone(),
+            provider: provider.clone(),
+            config: off_config,
+            provider_registry: provider_registry.clone(),
+        };
+        assert_eq!(
+            run_capacity_gardener_once_with_store(&ctx_off, &memory)
+                .await
+                .unwrap(),
+            None
+        );
+
+        // Capacity 2 → archive the 2 over-capacity memories.
+        let on_config = Arc::new(RwLock::new(Config {
+            memory: Some(bamboo_config::MemoryConfig {
+                memory_active_capacity: 2,
+                ..bamboo_config::MemoryConfig::default()
+            }),
+            ..Config::default()
+        }));
+        let ctx_on = AutoDreamContext {
+            session_store,
+            storage,
+            provider,
+            config: on_config,
+            provider_registry,
+        };
+        let result = run_capacity_gardener_once_with_store(&ctx_on, &memory)
+            .await
+            .unwrap()
+            .expect("capacity pass should run when enabled");
+        assert_eq!(result.archived, 2, "archived the over-capacity overflow");
+        assert_eq!(
+            memory
+                .count_scope_memories(MemoryScope::Global, None)
+                .await
+                .unwrap(),
+            4,
+            "archived docs are kept on disk, not deleted"
+        );
     }
 }

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -239,7 +239,9 @@ pub struct MemoryConfig {
     /// archives the lowest-value overflow OUT of the recall index (memory redesign
     /// L5 — archive, never delete; reversible). 0 = unbounded (feature OFF, the
     /// default): consequential enough to be opt-in, since L4's dedup already curbs
-    /// most growth. `Reference`/`User`/`Feedback` memories are always exempt.
+    /// most growth. `Reference`/`User`/`Feedback` memories are always exempt — so
+    /// the effective floor is the count of exempt Active memories in a scope; set
+    /// this comfortably above that (a capacity below it is a no-op, not a purge).
     #[serde(default)]
     pub memory_active_capacity: usize,
     /// Hard cap on how many memories the capacity gardener archives per run, so a
@@ -3248,7 +3250,12 @@ mod tests {
         assert_eq!(MemoryConfig::default().memory_active_capacity, 0);
         assert_eq!(MemoryConfig::default().capacity_max_archivals_per_run, 50);
         let parsed: Config = serde_json::from_str(r#"{"memory":{}}"#).expect("parse");
-        assert_eq!(parsed.memory.unwrap().memory_active_capacity, 0);
+        let memory = parsed.memory.unwrap();
+        assert_eq!(memory.memory_active_capacity, 0);
+        assert_eq!(
+            memory.capacity_max_archivals_per_run, 50,
+            "omitted field takes the serde default fn"
+        );
     }
 
     /// L4: the maintenance integrators are ON by default — both via

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -235,6 +235,17 @@ pub struct MemoryConfig {
     /// Hard cap on LLM-backed consolidations per dedup gardener run (cost ceiling).
     #[serde(default = "default_dedup_gardener_max_merges_per_run")]
     pub dedup_gardener_max_merges_per_run: usize,
+    /// Max RECALLABLE (Active/Stale) memories per scope before the capacity gardener
+    /// archives the lowest-value overflow OUT of the recall index (memory redesign
+    /// L5 — archive, never delete; reversible). 0 = unbounded (feature OFF, the
+    /// default): consequential enough to be opt-in, since L4's dedup already curbs
+    /// most growth. `Reference`/`User`/`Feedback` memories are always exempt.
+    #[serde(default)]
+    pub memory_active_capacity: usize,
+    /// Hard cap on how many memories the capacity gardener archives per run, so a
+    /// large overflow drains gradually instead of in one burst.
+    #[serde(default = "default_capacity_max_archivals_per_run")]
+    pub capacity_max_archivals_per_run: usize,
 }
 
 impl Default for MemoryConfig {
@@ -256,8 +267,14 @@ impl Default for MemoryConfig {
             dedup_gardener_enabled: default_true_dedup_gardener_enabled(),
             dedup_gardener_min_score: default_dedup_gardener_min_score(),
             dedup_gardener_max_merges_per_run: default_dedup_gardener_max_merges_per_run(),
+            memory_active_capacity: 0,
+            capacity_max_archivals_per_run: default_capacity_max_archivals_per_run(),
         }
     }
+}
+
+fn default_capacity_max_archivals_per_run() -> usize {
+    50
 }
 
 fn default_true_auto_dream_enabled() -> bool {
@@ -3197,6 +3214,8 @@ mod tests {
                 dedup_gardener_enabled: true,
                 dedup_gardener_min_score: 0.7,
                 dedup_gardener_max_merges_per_run: 3,
+                memory_active_capacity: 500,
+                capacity_max_archivals_per_run: 10,
             }),
             ..Config::default()
         };
@@ -3219,6 +3238,17 @@ mod tests {
         assert!(memory.dedup_gardener_enabled);
         assert_eq!(memory.dedup_gardener_min_score, 0.7);
         assert_eq!(memory.dedup_gardener_max_merges_per_run, 3);
+        assert_eq!(memory.memory_active_capacity, 500);
+        assert_eq!(memory.capacity_max_archivals_per_run, 10);
+    }
+
+    /// L5: capacity is OFF by default (0 = unbounded) — an opt-in feature.
+    #[test]
+    fn memory_active_capacity_defaults_off() {
+        assert_eq!(MemoryConfig::default().memory_active_capacity, 0);
+        assert_eq!(MemoryConfig::default().capacity_max_archivals_per_run, 50);
+        let parsed: Config = serde_json::from_str(r#"{"memory":{}}"#).expect("parse");
+        assert_eq!(parsed.memory.unwrap().memory_active_capacity, 0);
     }
 
     /// L4: the maintenance integrators are ON by default — both via

--- a/crates/infra/bamboo-memory/src/memory_store/store.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/store.rs
@@ -1965,10 +1965,26 @@ impl MemoryStore {
                     && doc.frontmatter.r#type == DurableMemoryType::Project
             })
             .collect();
+
+        // Unachievable-bound guard: only Project docs are evictable, so the lowest
+        // recallable count we can reach is the exempt (Reference/User/Feedback)
+        // scorable count. If that alone already exceeds `capacity`, archiving every
+        // Project memory still wouldn't meet the bound — so DON'T strip them all
+        // (pointless + destructive). Skip; the capacity is set below the exempt
+        // floor and the user should raise it.
+        let exempt_scorable = scorable - evictable.len();
+        if exempt_scorable > capacity {
+            return Ok(Vec::new());
+        }
+
+        // Lowest keep-value first; within a value tie, evict the OLDEST first (keep
+        // the newer restatement). `updated_at` is UTC rfc3339 → string order is
+        // chronological.
         evictable.sort_by(|a, b| {
             memory_value(a, now)
                 .partial_cmp(&memory_value(b, now))
                 .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.frontmatter.updated_at.cmp(&b.frontmatter.updated_at))
         });
         let target = overflow.min(max_archivals).min(evictable.len());
         let archive_ids: std::collections::HashSet<String> = evictable
@@ -3638,6 +3654,59 @@ mod tests {
             assert_eq!(doc.frontmatter.r#type, DurableMemoryType::Project);
             assert_eq!(doc.frontmatter.status, DurableMemoryStatus::Archived);
         }
+    }
+
+    /// L5 guard: when exempt (Reference/User/Feedback) memories alone exceed the
+    /// capacity, the bound is unachievable by archiving only Project memories — so
+    /// the pass archives NOTHING rather than stripping every Project memory.
+    #[tokio::test]
+    async fn enforce_scope_capacity_skips_when_capacity_below_exempt_floor() {
+        let dir = tempdir().unwrap();
+        let store = MemoryStore::new(dir.path());
+        let pk = Some("proj-1");
+        let write = |title: &'static str, r#type| {
+            let store = &store;
+            async move {
+                store
+                    .write_memory(
+                        MemoryScope::Project,
+                        pk,
+                        r#type,
+                        title,
+                        "body content for the memory",
+                        &[],
+                        Some("s"),
+                        "m",
+                        false,
+                        None,
+                    )
+                    .await
+                    .unwrap();
+            }
+        };
+        // 3 exempt (Reference) + 2 evictable (Project).
+        write("Ref one", DurableMemoryType::Reference).await;
+        write("Ref two", DurableMemoryType::Reference).await;
+        write("Ref three", DurableMemoryType::Reference).await;
+        write("Proj one", DurableMemoryType::Project).await;
+        write("Proj two", DurableMemoryType::Project).await;
+
+        // capacity=2 < 3 exempt → unachievable → archive nothing (don't strip Project).
+        let archived = store
+            .enforce_scope_capacity(MemoryScope::Project, pk, 2, 100)
+            .await
+            .unwrap();
+        assert!(
+            archived.is_empty(),
+            "must not strip Project memories chasing an unreachable bound"
+        );
+        let docs = store
+            .list_memory_documents(MemoryScope::Project, pk)
+            .await
+            .unwrap();
+        assert!(docs
+            .iter()
+            .all(|d| d.frontmatter.status == DurableMemoryStatus::Active));
     }
 
     /// Many `MemoryStore` instances pointed at the SAME data dir (the real

--- a/crates/infra/bamboo-memory/src/memory_store/store.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/store.rs
@@ -76,6 +76,31 @@ enum WriteSimilarity {
     None,
 }
 
+/// Heuristic "keep value" of a memory for capacity eviction (L5), higher = more
+/// worth keeping. Recency (from `updated_at`) × confidence, with a penalty for
+/// Stale. Access frequency is NOT yet a factor: recall doesn't write back
+/// `last_accessed_at` (doing so on the read path would force an index rebuild per
+/// recall in this file-store), so it is omitted; when a cheap access signal exists
+/// it multiplies in here. Deterministic — no model, no embedding.
+fn memory_value(doc: &DurableMemoryDocument, now: chrono::DateTime<chrono::Utc>) -> f64 {
+    let confidence = match doc.frontmatter.confidence.as_deref() {
+        Some("high") => 1.0,
+        Some("low") => 0.25,
+        _ => 0.5, // "medium" or unset
+    };
+    // Unparseable timestamp → treat as very old (low recency) so it evicts first.
+    let age_days = parse_rfc3339(&doc.frontmatter.updated_at)
+        .map(|ts| (now - ts).num_days().max(0) as f64)
+        .unwrap_or(3650.0);
+    let recency = 1.0 / (1.0 + age_days / 30.0);
+    let stale_penalty = if matches!(doc.frontmatter.status, DurableMemoryStatus::Stale) {
+        0.5
+    } else {
+        1.0
+    };
+    confidence * recency * stale_penalty
+}
+
 /// Projected body length (chars) after appending `content` to `body` with the
 /// Serialize `value` to pretty JSON bytes, mapping a serialization failure onto
 /// an `io::Error` so callers stay on `io::Result`. Shared by the single-file
@@ -1885,6 +1910,118 @@ impl MemoryStore {
         Ok(total)
     }
 
+    /// Bound a scope's RECALLABLE size to `capacity` by archiving the
+    /// lowest-[`memory_value`] memories OUT OF the recall index — capacity via
+    /// archive, NEVER delete (L5). Archived docs stay on disk (reversible; a later
+    /// pass or the user can restore them) but drop out of recall/scoring.
+    ///
+    /// Precision-biased and conservative:
+    /// - Only `Active`/`Stale` docs count toward `capacity` (already-archived /
+    ///   superseded don't).
+    /// - Only `Project` memories are evictable; `Reference` (curated), `User`
+    ///   (who the user is) and `Feedback` (their preferences) are EXEMPT — they are
+    ///   high-value identity/reference facts, never auto-archived.
+    /// - At most `max_archivals` are archived per call, so a big overflow is drained
+    ///   gradually across runs rather than in one burst.
+    /// - `capacity == 0` (or `max_archivals == 0`) is a no-op (feature off).
+    ///
+    /// Returns the archived ids. One index refresh for the whole batch.
+    pub async fn enforce_scope_capacity(
+        &self,
+        scope: MemoryScope,
+        project_key: Option<&str>,
+        capacity: usize,
+        max_archivals: usize,
+    ) -> io::Result<Vec<String>> {
+        if capacity == 0 || max_archivals == 0 {
+            return Ok(Vec::new());
+        }
+        let project_key = self.require_project_key(scope, project_key)?;
+        let lock = self.scope_lock(scope, project_key);
+        let _guard = lock.lock().await;
+
+        let mut docs = self.list_memory_documents(scope, project_key).await?;
+        let is_scorable = |status: DurableMemoryStatus| {
+            matches!(
+                status,
+                DurableMemoryStatus::Active | DurableMemoryStatus::Stale
+            )
+        };
+        let scorable = docs
+            .iter()
+            .filter(|doc| is_scorable(doc.frontmatter.status))
+            .count();
+        if scorable <= capacity {
+            return Ok(Vec::new());
+        }
+        let overflow = scorable - capacity;
+        let now = chrono::Utc::now();
+
+        // Rank evictable (scorable + Project) docs by ascending keep-value.
+        let mut evictable: Vec<&DurableMemoryDocument> = docs
+            .iter()
+            .filter(|doc| {
+                is_scorable(doc.frontmatter.status)
+                    && doc.frontmatter.r#type == DurableMemoryType::Project
+            })
+            .collect();
+        evictable.sort_by(|a, b| {
+            memory_value(a, now)
+                .partial_cmp(&memory_value(b, now))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        let target = overflow.min(max_archivals).min(evictable.len());
+        let archive_ids: std::collections::HashSet<String> = evictable
+            .iter()
+            .take(target)
+            .map(|doc| doc.frontmatter.id.clone())
+            .collect();
+        if archive_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut archived = Vec::with_capacity(archive_ids.len());
+        for doc in docs
+            .iter_mut()
+            .filter(|doc| archive_ids.contains(&doc.frontmatter.id))
+        {
+            let changed = self
+                .set_memory_status(
+                    doc,
+                    DurableMemoryStatus::Archived,
+                    "capacity_eviction",
+                    "gardener",
+                )
+                .await?;
+            if changed {
+                self.append_audit(
+                    scope,
+                    project_key,
+                    PURGE_AUDIT_LOG,
+                    AuditLogEntry {
+                        timestamp: now_rfc3339(),
+                        action: DurableMemoryStatus::Archived.as_str().to_string(),
+                        scope,
+                        memory_id: Some(doc.frontmatter.id.clone()),
+                        session_id: None,
+                        topic: None,
+                        summary: "Archived out of recall to enforce scope capacity.".to_string(),
+                        metadata: Some(serde_json::json!({
+                            "reason": "capacity_eviction",
+                            "capacity": capacity,
+                        })),
+                    },
+                )
+                .await?;
+                archived.push(doc.frontmatter.id.clone());
+            }
+        }
+        if !archived.is_empty() {
+            self.refresh_scope_artifacts(scope, project_key).await?;
+        }
+        Ok(archived)
+    }
+
     /// Classify how an incoming write relates to the scope's existing memories,
     /// using IDF-weighted cosine over field-weighted token bags (L2). Retires the
     /// old raw count-overlap gate: a common shared keyword no longer counts as much
@@ -3398,6 +3535,109 @@ mod tests {
             1
         );
         assert_eq!(store.count_all_memories().await.unwrap(), 4);
+    }
+
+    /// L5: capacity eviction archives the overflow OUT of recall (never deletes),
+    /// exempts non-Project types, and respects the per-run cap.
+    #[tokio::test]
+    async fn enforce_scope_capacity_archives_overflow_exempts_and_never_deletes() {
+        let dir = tempdir().unwrap();
+        let store = MemoryStore::new(dir.path());
+        let pk = Some("proj-1");
+
+        let write = |title: &'static str, r#type| {
+            let store = &store;
+            async move {
+                store
+                    .write_memory(
+                        MemoryScope::Project,
+                        pk,
+                        r#type,
+                        title,
+                        "body content for the memory",
+                        &[],
+                        Some("s"),
+                        "m",
+                        false,
+                        None,
+                    )
+                    .await
+                    .unwrap();
+            }
+        };
+
+        for i in 0..6 {
+            write(
+                match i {
+                    0 => "Project fact zero",
+                    1 => "Project fact one",
+                    2 => "Project fact two",
+                    3 => "Project fact three",
+                    4 => "Project fact four",
+                    _ => "Project fact five",
+                },
+                DurableMemoryType::Project,
+            )
+            .await;
+        }
+        // A Reference memory in the same scope — high-value, must be EXEMPT.
+        write("Curated reference doc", DurableMemoryType::Reference).await;
+
+        let total_before = store
+            .count_scope_memories(MemoryScope::Project, pk)
+            .await
+            .unwrap();
+        assert_eq!(total_before, 7);
+
+        // capacity=0 is a no-op.
+        assert!(store
+            .enforce_scope_capacity(MemoryScope::Project, pk, 0, 100)
+            .await
+            .unwrap()
+            .is_empty());
+
+        // Per-run cap: overflow is 7-3=4, but max_archivals=2 → only 2 this run.
+        let first = store
+            .enforce_scope_capacity(MemoryScope::Project, pk, 3, 2)
+            .await
+            .unwrap();
+        assert_eq!(first.len(), 2, "per-run cap bounds archivals");
+
+        // Next run drains the rest down to capacity.
+        let second = store
+            .enforce_scope_capacity(MemoryScope::Project, pk, 3, 100)
+            .await
+            .unwrap();
+        assert_eq!(second.len(), 2, "remaining overflow archived");
+
+        let docs = store
+            .list_memory_documents(MemoryScope::Project, pk)
+            .await
+            .unwrap();
+        // Never deleted: all 7 files still present.
+        assert_eq!(docs.len(), 7, "archive must not delete");
+        let scorable = docs
+            .iter()
+            .filter(|d| {
+                matches!(
+                    d.frontmatter.status,
+                    DurableMemoryStatus::Active | DurableMemoryStatus::Stale
+                )
+            })
+            .count();
+        assert_eq!(scorable, 3, "recallable count bounded to capacity");
+        // The Reference doc is exempt: still Active.
+        let reference = docs
+            .iter()
+            .find(|d| d.frontmatter.r#type == DurableMemoryType::Reference)
+            .unwrap();
+        assert_eq!(reference.frontmatter.status, DurableMemoryStatus::Active);
+        // Everything archived is a Project memory.
+        for id in first.iter().chain(second.iter()) {
+            let doc = docs.iter().find(|d| &d.frontmatter.id == id).unwrap();
+            assert_eq!(doc.frontmatter.r#type, DurableMemoryType::Project);
+            assert_eq!(doc.frontmatter.status, DurableMemoryStatus::Archived);
+        }
     }
 
     /// Many `MemoryStore` instances pointed at the SAME data dir (the real


### PR DESCRIPTION
Memory redesign **L5** (final layer). Bounds a scope's **recallable** size by archiving the lowest-value overflow **out of the recall index** — archive, **never delete** (reversible).

## What it does
When a scope's `Active`/`Stale` (recallable) memory count exceeds `memory_active_capacity`, a **deterministic, zero-LLM** capacity gardener flips the lowest-value overflow to `Archived`. Archived docs **stay on disk** (a later pass or the user can restore them) but drop out of recall/scoring — the `Archived` status was already excluded from BM25 (`lexical_bm25.rs`), so this reuses the existing mechanism.

## Value scoring (`memory_value`, pure)
`recency(updated_at) × confidence`, with a penalty for `Stale`. Lowest value is archived first; an unparseable timestamp sorts as very old.

**Access frequency is intentionally omitted.** `last_accessed_at` is never written on recall today, and adding write-on-recall would force a full index rebuild *per recall* in this file store (recall would become a write). Filed as a follow-up: track access via a cheap append-only log, then multiply it into `memory_value`.

## Conservative + safe
- **Exemptions:** only `Project` memories are evictable. `Reference` (curated), `User` (who the user is), and `Feedback` (their preferences) are **always kept** — high-value identity/reference facts.
- **Per-run cap:** at most `capacity_max_archivals_per_run` (default **50**) archived per run, so a big overflow drains gradually across runs, not in one burst.
- **Batched:** one scope lock + one index refresh for the whole batch (set statuses, refresh once) — not N refreshes.
- **OFF by default** (`memory_active_capacity = 0` = unbounded). Eviction is consequential, and L4's default-on dedup already curbs most growth, so this is **opt-in**: set a per-scope cap to enable. (Happy to flip to a generous default cap if you'd prefer default-on capacity.)

Runs **last** in the gardener passes (after split + dedup) so it counts the post-consolidation library. New: `MemoryStore::enforce_scope_capacity` + `memory_value` (store), `run_capacity_gardener_once` (engine).

## Testing
- **memory 120**: eviction invariants — archives the overflow, **exempts** the `Reference` doc, respects the **per-run cap** (drains across runs), **never deletes** (all files remain), bounds the recallable count to capacity.
- **engine gardener 6**: capacity pass is `Ok(None)` until `memory_active_capacity` is set, then archives the overflow; archived docs kept on disk.
- **config 146**: capacity defaults off (0) via `MemoryConfig::default()` and an omitted-field parse.
- Clippy clean; `cargo build --workspace --tests` passes.

Design: `zenith/docs/memory-redesign.md` (L5). This completes the L0–L5 series.

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u