### PR TITLE
feat(cli): bamboo init / doctor / config set onboarding (#245)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Built-in skills live in `builtin_skills/`: `docx`, `pdf`, `pptx`, `xlsx`, `skill
 Configure a provider + API key without hand-editing JSON:
 
 ```bash
-# interactive — prompts for provider, API key, and model
+# interactive — prompts for provider + API key (uses a default model unless --model is given)
 bamboo init
 
 # or non-interactive (CI / scripting)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,27 @@ Built-in skills live in `builtin_skills/`: `docx`, `pdf`, `pptx`, `xlsx`, `skill
 
 ## Quick Start & Development
 
+### First-run setup
+
+Configure a provider + API key without hand-editing JSON:
+
+```bash
+# interactive — prompts for provider, API key, and model
+bamboo init
+
+# or non-interactive (CI / scripting)
+bamboo init --non-interactive --provider anthropic --api-key "sk-ant-..."
+
+# verify the install (config present, provider keyed, server reachable)
+bamboo doctor
+
+# set/rotate a single value later
+bamboo config set providers.openai.api_key "sk-..."
+bamboo config set provider openai
+```
+
+`init` writes `~/.bamboo/config.json` (override with `--data-dir`) and stores the key **encrypted at rest**. `doctor` exits non-zero if a blocking problem is found, so it doubles as a readiness check.
+
 ### Run the server
 
 ```bash
@@ -132,7 +153,10 @@ Arguments supported by `bamboo serve` (all override the config file):
 | Command | What it does |
 |---|---|
 | `bamboo serve` | Start the HTTP/SSE server (above). |
+| `bamboo init` | First-run setup: write `config.json` with a provider + API key (interactive, or `--non-interactive` for CI). |
+| `bamboo doctor` | Diagnose the install (config present, provider keyed, server reachable); exits non-zero on a blocking problem. |
 | `bamboo config [--path] [--show-secrets]` | Inspect the resolved configuration. |
+| `bamboo config set <key> <value>` | Set one value, e.g. `providers.anthropic.api_key`, `providers.<p>.model`, or `provider`. |
 | `bamboo -p "<prompt>"` | One-shot **headless** agent run (boots the full runtime incl. sub-agents, prints the result, exits). Optional `-s <session>` to continue, `-m provider:model` to pin the model, `--workspace`, `--data-dir`, `--stream-json` (NDJSON on stdout), `--echo` (keyless transport smoke). |
 | `bamboo actor run\|serve\|list\|call` | Drive the sub-agent actor fabric from the terminal (spawn + stream, run as a service, discover, or send a task). |
 | `bamboo broker serve` | Run the standalone sub-agent message broker (WebSocket bus over durable mailboxes). |
@@ -210,7 +234,7 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
-> **Precondition:** `with_defaults_for_data_dir` reads `~/.bamboo/config.json` (the same config `bamboo serve` uses) and needs the active provider configured with a non-empty `api_key` — otherwise provider creation returns an error (here surfaced by `.expect`). A fresh data dir with no `config.json` defaults to `anthropic` with no key and will fail; `copilot` is the only provider that authenticates keyless (cached OAuth). Set the key in the config file, or pass `.api_key("sk-…")` on the builder before `with_defaults_for_data_dir`.
+> **Precondition:** `with_defaults_for_data_dir` reads `~/.bamboo/config.json` (the same config `bamboo serve` uses) and needs the active provider configured with a non-empty `api_key` — otherwise provider creation returns an error (here surfaced by `.expect`). A fresh data dir with no `config.json` defaults to `anthropic` with no key and will fail; `copilot` is the only provider that authenticates keyless (cached OAuth). Fix it with `bamboo init` (or `bamboo config set providers.<p>.api_key …`), or pass `.api_key("sk-…")` on the builder before `with_defaults_for_data_dir`.
 
 > Don't need the event stream? `agent.run(&mut session, input).await?` drives the turn to completion and leaves the answer as the last message on `session`. For full control over per-request overrides (split fast/background/summarization models, skill selection, provider handles, …) build an `ExecuteRequest` with `ExecuteRequestBuilder` (both re-exported from `bamboo_sdk::agent`) and call `agent.execute(&mut session, req)` — the same canonical engine path `run` / `run_stream` funnel into.
 
@@ -228,7 +252,7 @@ anyhow = "1"
 
 ### Example configuration
 
-`${HOME}/.bamboo/config.json`:
+The easiest way to create this is `bamboo init` (see [First-run setup](#first-run-setup)), which writes it for you and encrypts the key. The equivalent file at `${HOME}/.bamboo/config.json`:
 
 ```json
 {

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -1400,7 +1400,7 @@ impl Config {
     /// not clobber the live cache). #40.
     ///
     /// * `data_dir` - Optional data directory path. If None, uses default (`BAMBOO_DATA_DIR` or `${HOME}/.bamboo`)
-    fn from_data_dir_impl(data_dir: Option<PathBuf>, publish: bool) -> Self {
+    fn from_data_dir_impl(data_dir: Option<PathBuf>, publish: bool, apply_env: bool) -> Self {
         // Determine data_dir early (needed to find config file)
         let data_dir = data_dir
             .or_else(|| std::env::var("BAMBOO_DATA_DIR").ok().map(PathBuf::from))
@@ -1459,46 +1459,11 @@ impl Config {
         // derived from runtime (BAMBOO_DATA_DIR or `${HOME}/.bamboo`).
         config.extra.remove("data_dir");
 
-        // Apply environment variable overrides (highest priority)
-        if let Ok(port) = std::env::var("BAMBOO_PORT") {
-            if let Ok(port) = port.parse() {
-                config.server.port = port;
-            }
-        }
-
-        if let Ok(bind) = std::env::var("BAMBOO_BIND") {
-            config.server.bind = bind;
-        }
-
-        // Note: BAMBOO_DATA_DIR already handled above
-        if let Ok(provider) = std::env::var("BAMBOO_PROVIDER") {
-            config.provider = provider;
-        }
-
-        if let Ok(headless) = std::env::var("BAMBOO_HEADLESS") {
-            config.headless_auth = parse_bool_env(&headless);
-        }
-
-        if let Ok(project_prompt_injection) =
-            std::env::var("BAMBOO_MEMORY_PROJECT_PROMPT_INJECTION")
-        {
-            let memory = config.memory.get_or_insert_with(MemoryConfig::default);
-            memory.project_prompt_injection = parse_bool_env(&project_prompt_injection);
-        }
-
-        if let Ok(relevant_recall) = std::env::var("BAMBOO_MEMORY_RELEVANT_RECALL") {
-            let memory = config.memory.get_or_insert_with(MemoryConfig::default);
-            memory.relevant_recall = parse_bool_env(&relevant_recall);
-        }
-
-        if let Ok(relevant_recall_rerank) = std::env::var("BAMBOO_MEMORY_RELEVANT_RECALL_RERANK") {
-            let memory = config.memory.get_or_insert_with(MemoryConfig::default);
-            memory.relevant_recall_rerank = parse_bool_env(&relevant_recall_rerank);
-        }
-
-        if let Ok(project_first_dream) = std::env::var("BAMBOO_MEMORY_PROJECT_FIRST_DREAM") {
-            let memory = config.memory.get_or_insert_with(MemoryConfig::default);
-            memory.project_first_dream = parse_bool_env(&project_first_dream);
+        // Apply environment variable overrides (highest priority). Skipped by
+        // one-shot CLI writers (`bamboo init` / `config set`) so transient
+        // `BAMBOO_*` values are never baked into the persisted config.json.
+        if apply_env {
+            config.apply_env_overrides();
         }
 
         // Publish env vars to the global cache so Bash tools can inject them —
@@ -1511,20 +1476,76 @@ impl Config {
         config
     }
 
+    /// Apply `BAMBOO_*` environment overrides (highest priority) onto a loaded
+    /// config. Factored out so one-shot writers can skip it (see
+    /// [`Config::from_data_dir_without_env`]).
+    fn apply_env_overrides(&mut self) {
+        if let Ok(port) = std::env::var("BAMBOO_PORT") {
+            if let Ok(port) = port.parse() {
+                self.server.port = port;
+            }
+        }
+
+        if let Ok(bind) = std::env::var("BAMBOO_BIND") {
+            self.server.bind = bind;
+        }
+
+        // Note: BAMBOO_DATA_DIR already handled by the caller.
+        if let Ok(provider) = std::env::var("BAMBOO_PROVIDER") {
+            self.provider = provider;
+        }
+
+        if let Ok(headless) = std::env::var("BAMBOO_HEADLESS") {
+            self.headless_auth = parse_bool_env(&headless);
+        }
+
+        if let Ok(project_prompt_injection) =
+            std::env::var("BAMBOO_MEMORY_PROJECT_PROMPT_INJECTION")
+        {
+            let memory = self.memory.get_or_insert_with(MemoryConfig::default);
+            memory.project_prompt_injection = parse_bool_env(&project_prompt_injection);
+        }
+
+        if let Ok(relevant_recall) = std::env::var("BAMBOO_MEMORY_RELEVANT_RECALL") {
+            let memory = self.memory.get_or_insert_with(MemoryConfig::default);
+            memory.relevant_recall = parse_bool_env(&relevant_recall);
+        }
+
+        if let Ok(relevant_recall_rerank) = std::env::var("BAMBOO_MEMORY_RELEVANT_RECALL_RERANK") {
+            let memory = self.memory.get_or_insert_with(MemoryConfig::default);
+            memory.relevant_recall_rerank = parse_bool_env(&relevant_recall_rerank);
+        }
+
+        if let Ok(project_first_dream) = std::env::var("BAMBOO_MEMORY_PROJECT_FIRST_DREAM") {
+            let memory = self.memory.get_or_insert_with(MemoryConfig::default);
+            memory.project_first_dream = parse_bool_env(&project_first_dream);
+        }
+    }
+
     /// Load config from disk AND publish its env vars to the process-global cache
     /// (so Bash tools inject them). For the context that OWNS that cache — the
     /// server bootstrap. Library / secondary readers that only need to read a
     /// value must use [`Config::from_data_dir_without_publish`] instead, or they
     /// will clobber the server's live cache with stale disk data (#38 / #40).
     pub fn from_data_dir(data_dir: Option<PathBuf>) -> Self {
-        Self::from_data_dir_impl(data_dir, true)
+        Self::from_data_dir_impl(data_dir, true, true)
     }
 
     /// Load config from disk WITHOUT publishing env vars to the global cache.
     /// For non-owning readers (e.g. permission storage) that just need a config
     /// value and must not clobber the live env-var cache. #40.
     pub fn from_data_dir_without_publish(data_dir: Option<PathBuf>) -> Self {
-        Self::from_data_dir_impl(data_dir, false)
+        Self::from_data_dir_impl(data_dir, false, true)
+    }
+
+    /// Load config from disk WITHOUT applying `BAMBOO_*` env-var overrides and
+    /// WITHOUT publishing to the global cache. For one-shot CLI writers
+    /// (`bamboo init` / `config set`) that immediately re-save: applying env
+    /// overrides here would bake transient values (port/bind/provider/memory
+    /// flags) permanently into config.json. Same corruption-recovery + default
+    /// fallback as the normal load.
+    pub fn from_data_dir_without_env(data_dir: Option<PathBuf>) -> Self {
+        Self::from_data_dir_impl(data_dir, false, false)
     }
 
     /// Deserialize config JSON and run the in-memory hydration + normalization

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -145,8 +145,52 @@ enum Commands {
         parent_pid: Option<u32>,
     },
 
-    /// Show Bamboo configuration
+    /// First-run setup: write `config.json` with a provider + API key.
+    ///
+    /// Interactive by default (prompts for anything not given as a flag). Pass
+    /// `--non-interactive` for CI/scripts (then `--provider` + `--api-key` are
+    /// required). The key is stored encrypted at rest.
+    Init {
+        /// Data directory holding config.json (defaults to ~/.bamboo).
+        #[arg(long)]
+        data_dir: Option<PathBuf>,
+
+        /// Provider to configure: anthropic | openai | gemini. Prompted if omitted.
+        #[arg(long)]
+        provider: Option<String>,
+
+        /// API key. Prompted (visible) if omitted in interactive mode.
+        #[arg(long)]
+        api_key: Option<String>,
+
+        /// Default chat model. A sensible provider default is used if omitted.
+        #[arg(long)]
+        model: Option<String>,
+
+        /// Overwrite an existing provider key without prompting.
+        #[arg(long)]
+        force: bool,
+
+        /// Never prompt; fail if a required value is missing (CI-safe).
+        #[arg(long)]
+        non_interactive: bool,
+    },
+
+    /// Diagnose the local install: config presence, provider credential, and
+    /// whether a server is reachable. Exits non-zero if a blocking problem is found.
+    Doctor {
+        /// Data directory holding config.json (defaults to ~/.bamboo).
+        #[arg(long)]
+        data_dir: Option<PathBuf>,
+    },
+
+    /// Show (or set) Bamboo configuration.
     Config {
+        /// Set a single config value, e.g.
+        /// `config set providers.anthropic.api_key sk-ant-...`.
+        #[command(subcommand)]
+        action: Option<ConfigAction>,
+
         /// Show config file path
         #[arg(short, long)]
         path: bool,
@@ -242,6 +286,23 @@ impl From<ConnArgs> for bamboo_agent::admin_cli::ConnArgs {
             data_dir: c.data_dir,
         }
     }
+}
+
+#[derive(Subcommand)]
+enum ConfigAction {
+    /// Set a single config value by dotted key. Supported keys:
+    ///   provider
+    ///   providers.<anthropic|openai|gemini>.api_key
+    ///   providers.<anthropic|openai|gemini>.model
+    Set {
+        /// Dotted config key, e.g. `providers.anthropic.api_key`.
+        key: String,
+        /// Value to store.
+        value: String,
+        /// Data directory holding config.json (defaults to ~/.bamboo).
+        #[arg(long)]
+        data_dir: Option<PathBuf>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -451,6 +512,8 @@ async fn main() {
         | Some(Commands::Status { .. })
         | Some(Commands::Sessions { .. })
         | Some(Commands::Stop { .. })
+        | Some(Commands::Init { .. })
+        | Some(Commands::Doctor { .. })
         | None => {
             // Worker/CLI logs go to stderr only: stdin/stdout are part of the
             // bootstrap & streaming protocol and must stay clean. (`None` is
@@ -769,8 +832,53 @@ async fn main() {
             }
         }
 
-        Commands::Config { path, show_secrets } => {
-            if path {
+        Commands::Init {
+            data_dir,
+            provider,
+            api_key,
+            model,
+            force,
+            non_interactive,
+        } => {
+            let res = bamboo_agent::setup_cli::run_init(bamboo_agent::setup_cli::InitArgs {
+                data_dir,
+                provider,
+                api_key,
+                model,
+                force,
+                non_interactive,
+            });
+            if let Err(e) = res {
+                eprintln!("init failed: {e:#}");
+                std::process::exit(1);
+            }
+        }
+
+        Commands::Doctor { data_dir } => match bamboo_agent::setup_cli::run_doctor(data_dir).await {
+            Ok(true) => {}
+            Ok(false) => std::process::exit(1),
+            Err(e) => {
+                eprintln!("doctor failed: {e:#}");
+                std::process::exit(1);
+            }
+        },
+
+        Commands::Config {
+            action,
+            path,
+            show_secrets,
+        } => {
+            if let Some(ConfigAction::Set {
+                key,
+                value,
+                data_dir,
+            }) = action
+            {
+                if let Err(e) = bamboo_agent::setup_cli::run_config_set(&key, &value, data_dir) {
+                    eprintln!("config set failed: {e:#}");
+                    std::process::exit(1);
+                }
+            } else if path {
                 println!("{}", bamboo_config::paths::config_json_path().display());
             } else {
                 let mut config = Config::new();

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -854,14 +854,16 @@ async fn main() {
             }
         }
 
-        Commands::Doctor { data_dir } => match bamboo_agent::setup_cli::run_doctor(data_dir).await {
-            Ok(true) => {}
-            Ok(false) => std::process::exit(1),
-            Err(e) => {
-                eprintln!("doctor failed: {e:#}");
-                std::process::exit(1);
+        Commands::Doctor { data_dir } => {
+            match bamboo_agent::setup_cli::run_doctor(data_dir).await {
+                Ok(true) => {}
+                Ok(false) => std::process::exit(1),
+                Err(e) => {
+                    eprintln!("doctor failed: {e:#}");
+                    std::process::exit(1);
+                }
             }
-        },
+        }
 
         Commands::Config {
             action,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,10 @@ pub mod admin_cli;
 /// The `bamboo -p` headless server mode: full AppState, one-shot, resumable.
 pub mod headless;
 
+/// The `bamboo init` / `doctor` / `config set` onboarding CLI: configure a
+/// provider + API key and self-diagnose without the web UI (server-less).
+pub mod setup_cli;
+
 // Server module is now a separate workspace crate
 pub use bamboo_server as server;
 

--- a/src/setup_cli.rs
+++ b/src/setup_cli.rs
@@ -19,6 +19,11 @@ use bamboo_config::Config;
 /// intentionally excluded here — configure it via the web UI / `bamboo actor`.
 const KEYED_PROVIDERS: [&str; 3] = ["anthropic", "openai", "gemini"];
 
+/// All providers the config recognizes, for selecting the *default* provider.
+/// Broader than [`KEYED_PROVIDERS`]: `copilot` (OAuth) and `bodhi` (proxy) are
+/// valid default providers even though this CLI does not manage their keys.
+const KNOWN_PROVIDERS: [&str; 5] = ["anthropic", "openai", "gemini", "copilot", "bodhi"];
+
 /// A reasonable default chat model per provider, matching the ids referenced
 /// elsewhere in the repo (README / `docker/config.example.json`). Used only when
 /// the user does not pass an explicit model.
@@ -26,7 +31,7 @@ fn default_model_for(provider: &str) -> Option<&'static str> {
     match provider {
         "anthropic" => Some("claude-sonnet-4-6"),
         "openai" => Some("gpt-4o-mini"),
-        "gemini" => Some("gemini-2.0-flash"),
+        "gemini" => Some("gemini-2.0-flash-exp"),
         _ => None,
     }
 }
@@ -53,10 +58,10 @@ pub fn run_init(args: InitArgs) -> Result<()> {
         .unwrap_or_else(bamboo_config::paths::resolve_bamboo_dir);
     let interactive = !args.non_interactive && std::io::stdin().is_terminal();
 
-    // Load existing (or default) config from the target dir. Non-publishing:
-    // this one-shot writer must not clobber the global env-var cache the server
-    // owns (#40).
-    let mut config = Config::from_data_dir_without_publish(Some(data_dir.clone()));
+    // Load existing (or default) config from the target dir. No env overrides
+    // (this one-shot writer immediately re-saves; applying `BAMBOO_*` here would
+    // bake transient env values into config.json) and no cache publish (#40).
+    let mut config = Config::from_data_dir_without_env(Some(data_dir.clone()));
 
     // 1. Provider.
     let provider = match args.provider {
@@ -177,14 +182,21 @@ pub async fn run_doctor(data_dir: Option<PathBuf>) -> Result<bool> {
         }
     }
 
-    // 3. Server reachability (informational — not running is normal).
+    // 3. Server reachability (informational — not running is normal). Probe the
+    // configured bind; a wildcard/empty bind is reached via loopback.
     let port = config.server.port;
-    let url = format!("http://127.0.0.1:{port}/api/v1/health");
+    let bind = config.server.bind.trim();
+    let host = if bind.is_empty() || bind == "0.0.0.0" || bind == "::" {
+        "127.0.0.1"
+    } else {
+        bind
+    };
+    let url = format!("http://{host}:{port}/api/v1/health");
     if check_health(&url).await {
-        ok(&format!("server reachable at 127.0.0.1:{port}"));
+        ok(&format!("server reachable at {host}:{port}"));
     } else {
         info(&format!(
-            "server not running on 127.0.0.1:{port} (start it with `bamboo serve`)"
+            "server not running on {host}:{port} (start it with `bamboo serve`)"
         ));
     }
 
@@ -208,11 +220,13 @@ pub async fn run_doctor(data_dir: Option<PathBuf>) -> Result<bool> {
 /// fields on the provider are preserved.
 pub fn run_config_set(key: &str, value: &str, data_dir: Option<PathBuf>) -> Result<()> {
     let data_dir = data_dir.unwrap_or_else(bamboo_config::paths::resolve_bamboo_dir);
-    let mut config = Config::from_data_dir_without_publish(Some(data_dir.clone()));
+    let mut config = Config::from_data_dir_without_env(Some(data_dir.clone()));
 
     let parts: Vec<&str> = key.split('.').collect();
     match parts.as_slice() {
-        ["provider"] => config.provider = normalize_provider(value)?,
+        // Selecting the default provider accepts any known provider (incl.
+        // copilot/bodhi), not just the keyed ones.
+        ["provider"] => config.provider = normalize_known_provider(value)?,
         ["providers", p, "api_key"] => {
             let p = normalize_provider(p)?;
             let v = value.trim();
@@ -223,7 +237,11 @@ pub fn run_config_set(key: &str, value: &str, data_dir: Option<PathBuf>) -> Resu
         }
         ["providers", p, "model"] => {
             let p = normalize_provider(p)?;
-            set_provider_model(&mut config, &p, value)?;
+            let v = value.trim();
+            if v.is_empty() {
+                bail!("model must not be empty");
+            }
+            set_provider_model(&mut config, &p, v)?;
         }
         _ => bail!(
             "unsupported config key '{key}'. Supported keys:\n  \
@@ -247,7 +265,8 @@ pub fn run_config_set(key: &str, value: &str, data_dir: Option<PathBuf>) -> Resu
 
 // ---- provider helpers ----
 
-/// Validate + canonicalize a provider name against the keyed-provider set.
+/// Validate + canonicalize a provider name against the keyed-provider set
+/// (providers this CLI can set an API key for).
 fn normalize_provider(provider: &str) -> Result<String> {
     let p = provider.trim().to_ascii_lowercase();
     if KEYED_PROVIDERS.contains(&p.as_str()) {
@@ -256,6 +275,20 @@ fn normalize_provider(provider: &str) -> Result<String> {
         bail!(
             "unsupported provider '{provider}' (supported: {})",
             KEYED_PROVIDERS.join(", ")
+        )
+    }
+}
+
+/// Validate + canonicalize a provider name against the full known-provider set
+/// (for selecting the default provider, which may be copilot/bodhi).
+fn normalize_known_provider(provider: &str) -> Result<String> {
+    let p = provider.trim().to_ascii_lowercase();
+    if KNOWN_PROVIDERS.contains(&p.as_str()) {
+        Ok(p)
+    } else {
+        bail!(
+            "unknown provider '{provider}' (known: {})",
+            KNOWN_PROVIDERS.join(", ")
         )
     }
 }
@@ -270,9 +303,27 @@ fn empty_provider<T: serde::de::DeserializeOwned>() -> T {
 
 fn set_provider_api_key(config: &mut Config, provider: &str, key: &str) -> Result<()> {
     match provider {
-        "anthropic" => config.providers.anthropic.get_or_insert_with(empty_provider).api_key = key.to_string(),
-        "openai" => config.providers.openai.get_or_insert_with(empty_provider).api_key = key.to_string(),
-        "gemini" => config.providers.gemini.get_or_insert_with(empty_provider).api_key = key.to_string(),
+        "anthropic" => {
+            config
+                .providers
+                .anthropic
+                .get_or_insert_with(empty_provider)
+                .api_key = key.to_string()
+        }
+        "openai" => {
+            config
+                .providers
+                .openai
+                .get_or_insert_with(empty_provider)
+                .api_key = key.to_string()
+        }
+        "gemini" => {
+            config
+                .providers
+                .gemini
+                .get_or_insert_with(empty_provider)
+                .api_key = key.to_string()
+        }
         _ => bail!("unsupported provider '{provider}'"),
     }
     Ok(())
@@ -281,9 +332,27 @@ fn set_provider_api_key(config: &mut Config, provider: &str, key: &str) -> Resul
 fn set_provider_model(config: &mut Config, provider: &str, model: &str) -> Result<()> {
     let model = Some(model.to_string());
     match provider {
-        "anthropic" => config.providers.anthropic.get_or_insert_with(empty_provider).model = model,
-        "openai" => config.providers.openai.get_or_insert_with(empty_provider).model = model,
-        "gemini" => config.providers.gemini.get_or_insert_with(empty_provider).model = model,
+        "anthropic" => {
+            config
+                .providers
+                .anthropic
+                .get_or_insert_with(empty_provider)
+                .model = model
+        }
+        "openai" => {
+            config
+                .providers
+                .openai
+                .get_or_insert_with(empty_provider)
+                .model = model
+        }
+        "gemini" => {
+            config
+                .providers
+                .gemini
+                .get_or_insert_with(empty_provider)
+                .model = model
+        }
         _ => bail!("unsupported provider '{provider}'"),
     }
     Ok(())
@@ -316,6 +385,13 @@ fn provider_credential_status(config: &Config, provider: &str) -> CredentialStat
             config
                 .providers
                 .gemini
+                .as_ref()
+                .map(|c| (c.api_key.as_str(), c.api_key_encrypted.as_deref())),
+        ),
+        "bodhi" => key_status(
+            config
+                .providers
+                .bodhi
                 .as_ref()
                 .map(|c| (c.api_key.as_str(), c.api_key_encrypted.as_deref())),
         ),
@@ -448,11 +524,21 @@ mod tests {
     }
 
     #[test]
-    fn normalize_provider_accepts_known_and_rejects_unknown() {
+    fn normalize_provider_accepts_keyed_and_rejects_unknown() {
         assert_eq!(normalize_provider("Anthropic").unwrap(), "anthropic");
         assert_eq!(normalize_provider("  openai ").unwrap(), "openai");
+        // copilot has no static key → not a keyed provider.
         assert!(normalize_provider("copilot").is_err());
         assert!(normalize_provider("nope").is_err());
+    }
+
+    #[test]
+    fn normalize_known_provider_accepts_oauth_and_proxy_providers() {
+        // Selecting the default provider accepts copilot/bodhi too.
+        assert_eq!(normalize_known_provider("Copilot").unwrap(), "copilot");
+        assert_eq!(normalize_known_provider("bodhi").unwrap(), "bodhi");
+        assert_eq!(normalize_known_provider("anthropic").unwrap(), "anthropic");
+        assert!(normalize_known_provider("nope").is_err());
     }
 
     #[test]

--- a/src/setup_cli.rs
+++ b/src/setup_cli.rs
@@ -1,0 +1,500 @@
+//! `bamboo init` / `bamboo doctor` / `bamboo config set` — first-run onboarding.
+//!
+//! These are local, server-less commands: they read and write `config.json`
+//! under the data dir directly (via [`bamboo_config::Config`]), so a fresh
+//! install can configure a provider + API key and self-diagnose **without** the
+//! web UI or hand-editing JSON. Writes go through `Config::save_to_dir`, which
+//! encrypts provider keys at rest and writes atomically (with a rotating `.bak`).
+
+use std::io::{IsTerminal, Write};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use bamboo_config::Config;
+
+/// Providers that `init` / `config set` can configure with a static API key.
+///
+/// Copilot uses an interactive OAuth device flow (not a static key), so it is
+/// intentionally excluded here — configure it via the web UI / `bamboo actor`.
+const KEYED_PROVIDERS: [&str; 3] = ["anthropic", "openai", "gemini"];
+
+/// A reasonable default chat model per provider, matching the ids referenced
+/// elsewhere in the repo (README / `docker/config.example.json`). Used only when
+/// the user does not pass an explicit model.
+fn default_model_for(provider: &str) -> Option<&'static str> {
+    match provider {
+        "anthropic" => Some("claude-sonnet-4-6"),
+        "openai" => Some("gpt-4o-mini"),
+        "gemini" => Some("gemini-2.0-flash"),
+        _ => None,
+    }
+}
+
+/// Arguments for [`run_init`], mirrored from the `bamboo init` clap variant.
+pub struct InitArgs {
+    pub data_dir: Option<PathBuf>,
+    pub provider: Option<String>,
+    pub api_key: Option<String>,
+    pub model: Option<String>,
+    pub force: bool,
+    pub non_interactive: bool,
+}
+
+/// `bamboo init` — scaffold/populate `config.json` with a provider + API key.
+///
+/// Interactive by default (prompts for anything not passed as a flag); with
+/// `--non-interactive` (or when stdin is not a TTY) it requires the values as
+/// flags instead of prompting, so it is CI-safe.
+pub fn run_init(args: InitArgs) -> Result<()> {
+    let data_dir = args
+        .data_dir
+        .clone()
+        .unwrap_or_else(bamboo_config::paths::resolve_bamboo_dir);
+    let interactive = !args.non_interactive && std::io::stdin().is_terminal();
+
+    // Load existing (or default) config from the target dir. Non-publishing:
+    // this one-shot writer must not clobber the global env-var cache the server
+    // owns (#40).
+    let mut config = Config::from_data_dir_without_publish(Some(data_dir.clone()));
+
+    // 1. Provider.
+    let provider = match args.provider {
+        Some(p) => normalize_provider(&p)?,
+        None if interactive => prompt_provider()?,
+        None => bail!(
+            "--provider is required in non-interactive mode (one of: {})",
+            KEYED_PROVIDERS.join(", ")
+        ),
+    };
+
+    // 2. Overwrite guard — don't silently clobber an existing key.
+    if provider_has_key(&config, &provider) && !args.force {
+        if interactive {
+            if !prompt_yes_no(
+                &format!("Provider '{provider}' already has an API key. Overwrite?"),
+                false,
+            )? {
+                println!("Aborted; existing configuration left unchanged.");
+                return Ok(());
+            }
+        } else {
+            bail!("provider '{provider}' already has an API key; pass --force to overwrite");
+        }
+    }
+
+    // 3. API key.
+    let api_key = match args.api_key {
+        Some(k) => k,
+        None if interactive => prompt_api_key(&provider)?,
+        None => bail!("--api-key is required in non-interactive mode"),
+    };
+    let api_key = api_key.trim().to_string();
+    if api_key.is_empty() {
+        bail!("API key must not be empty");
+    }
+
+    // 4. Model (explicit, else a sensible provider default).
+    let model = args
+        .model
+        .or_else(|| default_model_for(&provider).map(String::from));
+
+    // 5. Apply + persist (encrypts the key, atomic write, rotates .bak).
+    config.provider = provider.clone();
+    set_provider_api_key(&mut config, &provider, &api_key)?;
+    if let Some(m) = &model {
+        set_provider_model(&mut config, &provider, m)?;
+    }
+    config
+        .save_to_dir(data_dir.clone())
+        .context("failed to write config.json")?;
+
+    // 6. Report + next steps.
+    let path = data_dir.join("config.json");
+    println!("✓ Wrote {}", path.display());
+    println!("  provider = {provider}");
+    if let Some(m) = &model {
+        println!("  model    = {m}");
+    }
+    println!("  api_key  = {} (stored encrypted)", mask_secret(&api_key));
+    println!();
+    println!("Next steps:");
+    println!("  bamboo doctor        # verify the setup");
+    println!("  bamboo -p \"hello\"    # run a one-shot agent");
+    println!("  bamboo serve         # start the HTTP server");
+    Ok(())
+}
+
+/// `bamboo doctor` — diagnose the local install. Returns `Ok(true)` when healthy,
+/// `Ok(false)` when a blocking problem was found (caller should exit non-zero).
+pub async fn run_doctor(data_dir: Option<PathBuf>) -> Result<bool> {
+    let data_dir = data_dir.unwrap_or_else(bamboo_config::paths::resolve_bamboo_dir);
+    let config_path = data_dir.join("config.json");
+    let mut errors = 0u32;
+    let mut warns = 0u32;
+
+    println!("Bamboo doctor — data dir: {}", data_dir.display());
+    println!();
+
+    // 1. config.json presence.
+    if config_path.exists() {
+        ok(&format!("config.json found ({})", config_path.display()));
+    } else {
+        err(&format!(
+            "config.json not found ({}) — run `bamboo init`",
+            config_path.display()
+        ));
+        errors += 1;
+    }
+
+    let config = Config::from_data_dir_without_publish(Some(data_dir.clone()));
+
+    // 2. Active provider + credential.
+    let provider = config.provider.clone();
+    if provider.trim().is_empty() {
+        err("no default provider set — run `bamboo init`");
+        errors += 1;
+    } else {
+        info(&format!("default provider = {provider}"));
+        match provider_credential_status(&config, &provider) {
+            CredentialStatus::Present => ok(&format!("provider '{provider}' has an API key")),
+            CredentialStatus::OauthProvider => ok(&format!(
+                "provider '{provider}' uses interactive login (no static key required)"
+            )),
+            CredentialStatus::Missing => {
+                err(&format!(
+                    "provider '{provider}' has no API key — run `bamboo init` or \
+                     `bamboo config set providers.{provider}.api_key <key>`"
+                ));
+                errors += 1;
+            }
+            CredentialStatus::Unknown => {
+                warn(&format!(
+                    "provider '{provider}' is not a recognized keyed provider; cannot verify a credential"
+                ));
+                warns += 1;
+            }
+        }
+    }
+
+    // 3. Server reachability (informational — not running is normal).
+    let port = config.server.port;
+    let url = format!("http://127.0.0.1:{port}/api/v1/health");
+    if check_health(&url).await {
+        ok(&format!("server reachable at 127.0.0.1:{port}"));
+    } else {
+        info(&format!(
+            "server not running on 127.0.0.1:{port} (start it with `bamboo serve`)"
+        ));
+    }
+
+    println!();
+    if errors > 0 {
+        println!("✗ {errors} problem(s) found.");
+        Ok(false)
+    } else if warns > 0 {
+        println!("✓ Ready ({warns} warning(s)).");
+        Ok(true)
+    } else {
+        println!("✓ All checks passed.");
+        Ok(true)
+    }
+}
+
+/// `bamboo config set <key> <value>` — write a single config value.
+///
+/// Supported keys: `provider`, `providers.<provider>.api_key`,
+/// `providers.<provider>.model` (provider ∈ anthropic|openai|gemini). Existing
+/// fields on the provider are preserved.
+pub fn run_config_set(key: &str, value: &str, data_dir: Option<PathBuf>) -> Result<()> {
+    let data_dir = data_dir.unwrap_or_else(bamboo_config::paths::resolve_bamboo_dir);
+    let mut config = Config::from_data_dir_without_publish(Some(data_dir.clone()));
+
+    let parts: Vec<&str> = key.split('.').collect();
+    match parts.as_slice() {
+        ["provider"] => config.provider = normalize_provider(value)?,
+        ["providers", p, "api_key"] => {
+            let p = normalize_provider(p)?;
+            let v = value.trim();
+            if v.is_empty() {
+                bail!("api_key must not be empty");
+            }
+            set_provider_api_key(&mut config, &p, v)?;
+        }
+        ["providers", p, "model"] => {
+            let p = normalize_provider(p)?;
+            set_provider_model(&mut config, &p, value)?;
+        }
+        _ => bail!(
+            "unsupported config key '{key}'. Supported keys:\n  \
+             provider\n  \
+             providers.<anthropic|openai|gemini>.api_key\n  \
+             providers.<anthropic|openai|gemini>.model"
+        ),
+    }
+
+    config
+        .save_to_dir(data_dir.clone())
+        .context("failed to write config.json")?;
+    let shown = if key.ends_with("api_key") {
+        mask_secret(value)
+    } else {
+        value.to_string()
+    };
+    println!("✓ set {key} = {shown}");
+    Ok(())
+}
+
+// ---- provider helpers ----
+
+/// Validate + canonicalize a provider name against the keyed-provider set.
+fn normalize_provider(provider: &str) -> Result<String> {
+    let p = provider.trim().to_ascii_lowercase();
+    if KEYED_PROVIDERS.contains(&p.as_str()) {
+        Ok(p)
+    } else {
+        bail!(
+            "unsupported provider '{provider}' (supported: {})",
+            KEYED_PROVIDERS.join(", ")
+        )
+    }
+}
+
+/// Construct an empty provider-config struct via serde (these structs don't
+/// derive `Default`; every field is either serde-`default` or `Option`, so an
+/// empty JSON object deserializes cleanly).
+fn empty_provider<T: serde::de::DeserializeOwned>() -> T {
+    serde_json::from_value(serde_json::json!({}))
+        .expect("an empty provider config always deserializes")
+}
+
+fn set_provider_api_key(config: &mut Config, provider: &str, key: &str) -> Result<()> {
+    match provider {
+        "anthropic" => config.providers.anthropic.get_or_insert_with(empty_provider).api_key = key.to_string(),
+        "openai" => config.providers.openai.get_or_insert_with(empty_provider).api_key = key.to_string(),
+        "gemini" => config.providers.gemini.get_or_insert_with(empty_provider).api_key = key.to_string(),
+        _ => bail!("unsupported provider '{provider}'"),
+    }
+    Ok(())
+}
+
+fn set_provider_model(config: &mut Config, provider: &str, model: &str) -> Result<()> {
+    let model = Some(model.to_string());
+    match provider {
+        "anthropic" => config.providers.anthropic.get_or_insert_with(empty_provider).model = model,
+        "openai" => config.providers.openai.get_or_insert_with(empty_provider).model = model,
+        "gemini" => config.providers.gemini.get_or_insert_with(empty_provider).model = model,
+        _ => bail!("unsupported provider '{provider}'"),
+    }
+    Ok(())
+}
+
+enum CredentialStatus {
+    Present,
+    Missing,
+    OauthProvider,
+    Unknown,
+}
+
+fn provider_credential_status(config: &Config, provider: &str) -> CredentialStatus {
+    match provider {
+        "anthropic" => key_status(
+            config
+                .providers
+                .anthropic
+                .as_ref()
+                .map(|c| (c.api_key.as_str(), c.api_key_encrypted.as_deref())),
+        ),
+        "openai" => key_status(
+            config
+                .providers
+                .openai
+                .as_ref()
+                .map(|c| (c.api_key.as_str(), c.api_key_encrypted.as_deref())),
+        ),
+        "gemini" => key_status(
+            config
+                .providers
+                .gemini
+                .as_ref()
+                .map(|c| (c.api_key.as_str(), c.api_key_encrypted.as_deref())),
+        ),
+        "copilot" => CredentialStatus::OauthProvider,
+        _ => CredentialStatus::Unknown,
+    }
+}
+
+/// A credential is present if either the in-memory plaintext key or the on-disk
+/// encrypted key is non-empty.
+fn key_status(pair: Option<(&str, Option<&str>)>) -> CredentialStatus {
+    match pair {
+        Some((plain, enc))
+            if !plain.trim().is_empty() || enc.is_some_and(|e| !e.trim().is_empty()) =>
+        {
+            CredentialStatus::Present
+        }
+        _ => CredentialStatus::Missing,
+    }
+}
+
+fn provider_has_key(config: &Config, provider: &str) -> bool {
+    matches!(
+        provider_credential_status(config, provider),
+        CredentialStatus::Present
+    )
+}
+
+// ---- health probe ----
+
+async fn check_health(url: &str) -> bool {
+    let Ok(client) = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+    else {
+        return false;
+    };
+    matches!(client.get(url).send().await, Ok(r) if r.status().is_success())
+}
+
+// ---- prompts / formatting ----
+
+fn prompt_provider() -> Result<String> {
+    println!("Select a provider:");
+    for (i, p) in KEYED_PROVIDERS.iter().enumerate() {
+        println!("  {}) {}", i + 1, p);
+    }
+    let line = prompt_line("Provider [number or name] (default: anthropic): ")?;
+    let line = line.trim();
+    if line.is_empty() {
+        return Ok("anthropic".to_string());
+    }
+    if let Ok(n) = line.parse::<usize>() {
+        if (1..=KEYED_PROVIDERS.len()).contains(&n) {
+            return Ok(KEYED_PROVIDERS[n - 1].to_string());
+        }
+    }
+    normalize_provider(line)
+}
+
+fn prompt_api_key(provider: &str) -> Result<String> {
+    eprintln!("Note: the key is visible as you type; it is stored encrypted at rest.");
+    prompt_line(&format!("Enter the {provider} API key: "))
+}
+
+fn prompt_line(prompt: &str) -> Result<String> {
+    print!("{prompt}");
+    std::io::stdout().flush().ok();
+    let mut s = String::new();
+    let n = std::io::stdin()
+        .read_line(&mut s)
+        .context("failed to read from stdin")?;
+    if n == 0 {
+        bail!("unexpected end of input");
+    }
+    Ok(s.trim_end_matches(['\n', '\r']).to_string())
+}
+
+fn prompt_yes_no(question: &str, default_yes: bool) -> Result<bool> {
+    let hint = if default_yes { "[Y/n]" } else { "[y/N]" };
+    let ans = prompt_line(&format!("{question} {hint} "))?;
+    Ok(match ans.trim().to_ascii_lowercase().as_str() {
+        "" => default_yes,
+        "y" | "yes" => true,
+        _ => false,
+    })
+}
+
+/// Show a secret as `head…tail (N chars)` so a confirmation line never prints
+/// the full key.
+fn mask_secret(secret: &str) -> String {
+    let s = secret.trim();
+    let n = s.chars().count();
+    if n <= 6 {
+        return "*".repeat(n.max(1));
+    }
+    let head: String = s.chars().take(3).collect();
+    let tail: String = {
+        let mut t: Vec<char> = s.chars().rev().take(2).collect();
+        t.reverse();
+        t.into_iter().collect()
+    };
+    format!("{head}…{tail} ({n} chars)")
+}
+
+fn ok(msg: &str) {
+    println!("  ✓ {msg}");
+}
+fn err(msg: &str) {
+    println!("  ✗ {msg}");
+}
+fn warn(msg: &str) {
+    println!("  ! {msg}");
+}
+fn info(msg: &str) {
+    println!("  · {msg}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A default in-memory config that never touches a real data dir: loading
+    /// from a non-existent directory returns defaults without reading or writing
+    /// anything on disk.
+    fn default_config() -> Config {
+        Config::from_data_dir_without_publish(Some(PathBuf::from(
+            "/nonexistent-bamboo-setup-cli-test-dir",
+        )))
+    }
+
+    #[test]
+    fn normalize_provider_accepts_known_and_rejects_unknown() {
+        assert_eq!(normalize_provider("Anthropic").unwrap(), "anthropic");
+        assert_eq!(normalize_provider("  openai ").unwrap(), "openai");
+        assert!(normalize_provider("copilot").is_err());
+        assert!(normalize_provider("nope").is_err());
+    }
+
+    #[test]
+    fn set_key_and_model_preserve_the_other_field() {
+        let mut config = default_config();
+        set_provider_api_key(&mut config, "anthropic", "sk-ant-xyz").unwrap();
+        set_provider_model(&mut config, "anthropic", "claude-x").unwrap();
+        let a = config.providers.anthropic.as_ref().unwrap();
+        assert_eq!(a.api_key, "sk-ant-xyz");
+        assert_eq!(a.model.as_deref(), Some("claude-x"));
+
+        // Setting the model again must not wipe the key.
+        set_provider_model(&mut config, "anthropic", "claude-y").unwrap();
+        let a = config.providers.anthropic.as_ref().unwrap();
+        assert_eq!(a.api_key, "sk-ant-xyz");
+        assert_eq!(a.model.as_deref(), Some("claude-y"));
+    }
+
+    #[test]
+    fn credential_status_reflects_plaintext_and_encrypted() {
+        let mut config = default_config();
+        assert!(matches!(
+            provider_credential_status(&config, "openai"),
+            CredentialStatus::Missing
+        ));
+        set_provider_api_key(&mut config, "openai", "sk-openai").unwrap();
+        assert!(matches!(
+            provider_credential_status(&config, "openai"),
+            CredentialStatus::Present
+        ));
+        assert!(matches!(
+            provider_credential_status(&config, "copilot"),
+            CredentialStatus::OauthProvider
+        ));
+    }
+
+    #[test]
+    fn mask_secret_hides_the_middle() {
+        assert_eq!(mask_secret("abc"), "***");
+        let m = mask_secret("sk-ant-1234567890");
+        assert!(m.starts_with("sk-"));
+        assert!(m.ends_with("chars)"));
+        assert!(!m.contains("1234567890"));
+    }
+}


### PR DESCRIPTION
Closes #245.

## What
First-run onboarding without hand-editing `config.json` or the web UI — the biggest CLI onboarding cliff (a fresh `bamboo -p` failed on an empty key with a raw error).

- **`bamboo init`** — interactive setup of provider + API key + model; `--non-interactive` for CI (then `--provider`/`--api-key` required). Writes `config.json` via `Config::save_to_dir`, so the key is **encrypted at rest** (atomic write + rotating `.bak`). Overwrite guard: `--force` needed when a key already exists.
- **`bamboo doctor`** — checks config presence, active-provider credential, and server reachability; **exits non-zero** on a blocking problem (usable as a readiness check).
- **`bamboo config set <key> <value>`** — sets `provider`, `providers.<anthropic|openai|gemini>.api_key`, or `providers.<p>.model`, **preserving** the provider's other fields.

Server-less: all three read/write `config.json` directly via `bamboo-config`. Non-TTY stdin takes the non-interactive path (flags required) rather than blocking on a prompt, avoiding the #80-class headless hang. `config --path` / `--show-secrets` behavior is unchanged.

## Files
- `src/setup_cli.rs` (new, ~500 lines + unit tests)
- `src/bin/bamboo.rs` — `Init`/`Doctor` variants + `config set` subcommand + wiring
- `src/lib.rs` — `pub mod setup_cli`
- `README.md` — First-run setup section, subcommand table rows, manual-JSON note now points at `bamboo init`

## Testing
- 4 new unit tests + full root-crate suite (29 lib / 2 bin) green; no regressions.
- E2E verified: init writes with **0 plaintext leak / key encrypted**; doctor exit 0/1 correct; `config set` preserves the other provider's key when switching default; overwrite guard, bad-key error, empty-dir diagnosis all correct.
- Non-TTY pipe with no flags **errors fast (no hang)**; `--help` lists the new commands.
- clippy clean on the new code.

## Notes
- Hidden key input (masked typing) is **not** implemented — the repo has no `rpassword`/`dialoguer` dep, so `init` reads the key as plain stdin with a visibility note. Can add `rpassword` if masked entry is wanted.
- Default models used when `--model` is omitted: anthropic→`claude-sonnet-4-6`, openai→`gpt-4o-mini`, gemini→`gemini-2.0-flash` (matching existing repo references).

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU