### PR TITLE
fix(test): de-flake envelope_ir_flatten — fragile 'do it' marker collided with a system directive

### DIFF
--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
@@ -1135,7 +1135,10 @@ fn envelope_ir_flatten_orders_runs_canonically() {
         title: "Tasks".to_string(),
         items: vec![TaskItem {
             id: "t1".to_string(),
-            description: "do it".to_string(),
+            // A distinctive marker: a plain phrase like "do it" collides with the
+            // system directives (which contain the substring "do it"), so
+            // `pos("do it")` would match the leading System run, not this tail.
+            description: "VOLATILE_TAIL_TASK".to_string(),
             status: TaskItemStatus::InProgress,
             ..TaskItem::default()
         }],
@@ -1187,7 +1190,7 @@ fn envelope_ir_flatten_orders_runs_canonically() {
     let guide = pos("NOVA_GUIDANCE_MARKER").expect("relocated tool guide present");
     let remainder = pos("PERSISTED OPERATOR NOTE").expect("system remainder present");
     let conversation = pos("u1").expect("conversation present");
-    let volatile = pos("do it").expect("task volatile tail present");
+    let volatile = pos("VOLATILE_TAIL_TASK").expect("task volatile tail present");
     assert!(
         0 < guide && guide < remainder,
         "stable prefix (guide) before the system remainder"


### PR DESCRIPTION
Fixes the long-standing red **Test** check. Despite being called "flaky", `envelope_ir_flatten_orders_runs_canonically` failed **deterministically** — 10/10 in isolation.

## Root cause
The test locates the task **volatile tail** by substring: `pos("do it")`, where the task item's description is `"do it"`. But the assembled system prompt's **core directives** also contain the substring "do it":

> runtime/context/mod.rs:26 — *"One tool call (or one short read → grep → read sequence) gets it → **do it** directly. Don't open a Task list…"*

I instrumented the flattened output to confirm:
```
FLAT[0] System:  has_do_it=true   ← the directive (BASE_IDENTITY + core directives)
FLAT[3] User:    has_u1=true      ← conversation
FLAT[6] User:    has_do_it=true   ← the actual task volatile tail
pos("do it")=Some(0)   pos("u1")=Some(3)
```
So `volatile` resolved to **0** (the leading System run), not **6** (the task tail), and `conversation(3) < volatile(0)` was false → panic at the `"conversation before the volatile tail"` assertion.

**The flat lowering order is correct** (`system → guide → remainder → conversation → volatile tail`); only the test's marker was fragile. The directive text presumably gained the "do it" phrasing at some point, silently colliding with the fixture.

## Fix
Give the task a distinctive description — `VOLATILE_TAIL_TASK` — that can't appear in prompt directives, so `pos(...)` reliably finds the tail.

## Verification
- The test passes **10/10** in isolation (was 0/10).
- `bamboo-engine --lib`: **895 passed, 0 failed** (was 894 + this one), so the Test check goes green.
- Touched-file fmt-clean.

One-line, test-only change; no production code touched.

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u