### PR TITLE
fix(test): L4 fallout — background tickers race the mock provider in dream-endpoint tests

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/maintenance.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/maintenance.rs
@@ -258,6 +258,17 @@ mod tests {
         let config = Config {
             memory: Some(bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
+                // Disable the background maintenance tickers in tests. L4 made them
+                // default-ON, so with a background_model set the AppState builder
+                // spawns real auto_dream/gardener tasks whose first tick fires
+                // immediately and calls the mock provider — racing the endpoint's
+                // own dream call and draining the finite `SequenceProvider` queue,
+                // which flakily panics on `remove(0)`. These endpoint tests drive
+                // dream generation explicitly (the endpoint runs regardless of the
+                // flag), so the background tickers must stay quiet.
+                auto_dream_enabled: false,
+                gardener_enabled: false,
+                dedup_gardener_enabled: false,
                 ..bamboo_config::MemoryConfig::default()
             }),
             ..Config::default()


### PR DESCRIPTION
Fixes the red **Test** check. On the latest main the Test job failed on `run_project_dream_endpoint_generates_project_dream_for_session_project` (bamboo-server), panicking in the mock `SequenceProvider` at `responses.remove(0)` on an **empty** queue.

## Why it's flaky (passes locally, fails on CI)
It's a **race** introduced by **L4** (default-on integrators):
1. `build_test_app_state` sets a `background_model` and, via `..MemoryConfig::default()`, now inherits `auto_dream_enabled = gardener_enabled = dedup_gardener_enabled = true`.
2. The AppState builder (`app_state/builder.rs:357`) unconditionally spawns `spawn_auto_dream_task` + `spawn_gardener_task`. With the flags on **and a model set**, these are now *live* — and `tokio::interval`'s first tick fires **immediately**.
3. The background **global** auto_dream sees the test's freshly-saved session as a candidate, generates a dream, and calls the **shared** mock `SequenceProvider` — consuming the single canned response intended for the endpoint's own dream call.
4. The endpoint's dream call then hits the empty queue → `remove(0)` panics.

Local runs are fast enough to win the race (25/25 + full-suite green here); CI under load loses it.

## Fix
Disable the background integrators in `build_test_app_state`:
```rust
auto_dream_enabled: false,
gardener_enabled: false,
dedup_gardener_enabled: false,
```
These endpoint tests drive dream generation **explicitly** (the endpoint calls `run_project_auto_dream_once` with `require_auto_dream_enabled = false`, so it runs regardless of the flag). The background tickers just need to stay quiet so they don't race the test's mock provider. `build_test_app_state` is the **only** bamboo-server test site that sets `background_model`, so it's the sole affected spot.

## Verification
- The test: **25/25** green under a stress loop (was flaky on CI).
- `bamboo-server --lib --all-features`: **962 passed, 0 failed**.
- fmt-clean.

This is a test-only change (no production code); same class of L4-fallout as the earlier bamboo-server merge-test retarget.

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u