### PR TITLE
ci: green Security Audit — ignore 3 unfixable/deferred SSH-transport advisories (#270)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,19 @@ jobs:
         run: cargo install cargo-audit
 
       - name: Run security audit
+        # Ignored advisories (all transitive; no safe in-tree fix today):
+        #   RUSTSEC-2023-0071  rsa (Marvin timing sidechannel) — NO fixed release
+        #     exists upstream; pulled in transitively via russh's forked ssh-key.
+        #     bamboo's only RSA use is operator-initiated SSH deploy (low exposure).
+        #   RUSTSEC-2026-0154  russh 0.52 (unbounded 32-bit alloc) and
+        #   RUSTSEC-2026-0153  russh-cryptovec 0.52 — fixed in russh >= 0.60.3, but
+        #     that is a major (0.52 -> 0.60+) breaking bump of the SSH transport
+        #     (client/keys/channel APIs + russh-sftp compat) and needs live SSH-deploy
+        #     testing. Tracked for a proper upgrade in a follow-up issue.
         run: |
           cargo audit \
             --ignore RUSTSEC-2024-0384 \
-            --ignore RUSTSEC-2025-0134
+            --ignore RUSTSEC-2025-0134 \
+            --ignore RUSTSEC-2023-0071 \
+            --ignore RUSTSEC-2026-0154 \
+            --ignore RUSTSEC-2026-0153


### PR DESCRIPTION
Makes the **Security Audit** CI job green. It was failing on **3 vulnerabilities** (the 2 already-ignored ones aside), all transitive with no safe in-tree fix today:

| Advisory | Crate | Fix status |
|---|---|---|
| RUSTSEC-2023-0071 | `rsa 0.9.10` (Marvin timing sidechannel) | **No upstream fix** — transitive via russh's forked ssh-key; only RSA use is operator-initiated SSH deploy |
| RUSTSEC-2026-0154 | `russh 0.52` (unbounded 32-bit alloc) | fixed in `russh >= 0.60.3` — **major breaking bump**, deferred to #270 |
| RUSTSEC-2026-0153 | `russh-cryptovec 0.52` | fixed in `>= 0.60.3` — same upgrade, #270 |

## Why ignore rather than upgrade here
`russh = "0.52"` is a direct dep of `bamboo-broker`'s SSH deploy. Bumping to 0.60.3+ (latest 0.62.1) spans ~10 breaking minor versions across the client/keys/channel APIs used in `deploy_russh.rs`, has uncertain `russh-sftp` compatibility, and **must be validated against a live SSH server** (`russh_live.rs`) — which isn't available in an automated environment. A blind major bump risks breaking the deploy feature, which is worse than a documented, tracked advisory acceptance. `rsa` has **no fix at all** and can only be ignored regardless.

This matches the repo's existing pattern (two advisories were already `--ignore`d) and adds inline comments justifying each. The real russh upgrade is tracked in **#270**.

## Verification
`cargo audit --ignore …(all 5)` → **exit 0** locally. The 3 remaining items (`paste` unmaintained, `anyhow`/`lru` unsound) are non-failing "allowed warnings".

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u