### PR TITLE
docs: fix broken HTTP quickstart (missing execute step) + doc freshness (#250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Historical `0.x` releases followed [Semantic Versioning](https://semver.org/spec/v2.0.0.html);
+since then the project ships **date-versioned nightly releases** (see below).
+
+## [Unreleased] — nightly (date-versioned)
+
+Since `0.3.0` the project ships **date-versioned nightly releases** (e.g. `2026.7.x`)
+cut by the release train, rather than SemVer point releases. Changes between
+nightlies are tracked in the git history and merged PRs (the source of truth);
+the SemVer sections below are retained for the historical `0.x` releases.
 
 ## [0.3.0] - 2026-02-26
 

--- a/README.md
+++ b/README.md
@@ -177,25 +177,28 @@ The admin commands (`health` / `status` / `sessions` / `stop`) are thin HTTP cli
 
 ### Call the agent loop
 
-Once the server is running, the simplest way to run the **full agent loop** — the LLM plans, calls tools, and streams its work — is two HTTP calls: kick off a turn with `POST /api/v1/chat`, then watch the live events on the SSE feed `GET /api/v1/stream`.
+Once the server is running, driving the **full agent loop** — the LLM plans, calls tools, and streams its work — is three HTTP calls: create the turn with `POST /api/v1/chat`, **start the loop** with `POST /api/v1/execute/{session_id}`, then watch the SSE feed `GET /api/v1/events/{session_id}`.
 
 ```bash
-# 1. Start an agent turn. This runs the agent loop against the LLM and returns immediately.
-#    Response: { "session_id": "...", "stream_url": "...", "status": "streaming" }
-curl -s http://127.0.0.1:9562/api/v1/chat \
+# 1. Create a turn. This PERSISTS the message and returns immediately — it does
+#    NOT run the loop yet. Response includes the session id and events URL:
+#    { "session_id": "...", "stream_url": "/api/v1/events/<id>", "status": "streaming" }
+SID=$(curl -s http://127.0.0.1:9562/api/v1/chat \
   -H 'Content-Type: application/json' \
-  -d '{
-        "message": "List the files in the current directory and tell me what this project does.",
-        "model": "claude-sonnet-4-6"
-      }'
+  -d '{"message":"List the files here and tell me what this project does.","model":"claude-sonnet-4-6"}' \
+  | jq -r .session_id)
 
-# 2. Watch the agent work in real time (resumable SSE event feed).
-#    Each event is one step of the loop: assistant text, tool calls, tool results,
-#    token usage, and completion.
-curl -N http://127.0.0.1:9562/api/v1/stream
+# 2. Start the agent loop for that session. The body may be empty ({}) — every
+#    field (model/provider/skill_mode/reasoning_effort/…) is an optional override.
+curl -s -X POST "http://127.0.0.1:9562/api/v1/execute/$SID" \
+  -H 'Content-Type: application/json' -d '{}'
+
+# 3. Watch the loop in real time (SSE): assistant text, tool calls, tool results,
+#    token usage, and completion arrive as they happen.
+curl -N "http://127.0.0.1:9562/api/v1/events/$SID"
 ```
 
-`message` and `model` are the only required fields. Useful optionals: `session_id` (continue a conversation), `system_prompt`, `selected_skill_ids`, `workspace_path`, `provider`, `images`. The `chat` call returns right away and the loop runs in the background; the `stream` endpoint (SSE, resumable via `?since=<seq>` or the `Last-Event-ID` header) is where the assistant's reasoning, tool calls, and final answer arrive as they happen.
+On `POST /api/v1/chat`, `message` and `model` are the only required fields; useful optionals are `session_id` (continue a conversation), `system_prompt`, `selected_skill_ids`, `workspace_path`, `provider`, `images`. Note that `chat` only **persists** the turn — you must then `POST /api/v1/execute/{session_id}` to actually run the loop. Besides the per-session `GET /api/v1/events/{session_id}` feed, there is an account-wide, resumable change feed `GET /api/v1/stream` (SSE, resumable via `?since=<seq>` or the `Last-Event-ID` header) that streams events across **all** sessions — handy for multi-session sync.
 
 ### Use it as a Rust SDK (in-process)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -153,24 +153,27 @@ bamboo serve
 
 ### 调用 agent loop
 
-服务启动后，跑通**完整 agent loop**（LLM 规划、调用工具、流式输出全过程）最简单的方式就是两次 HTTP 调用：用 `POST /api/v1/chat` 发起一轮，再用 SSE 事件流 `GET /api/v1/stream` 实时观察。
+服务启动后，跑通**完整 agent loop**（LLM 规划、调用工具、流式输出全过程）需要三次 HTTP 调用：用 `POST /api/v1/chat` 创建一轮，用 `POST /api/v1/execute/{session_id}` **启动 loop**，再用 SSE 事件流 `GET /api/v1/events/{session_id}` 实时观察。
 
 ```bash
-# 1. 发起一轮 agent 执行。它会针对 LLM 跑起 agent loop 并立即返回。
-#    返回：{ "session_id": "...", "stream_url": "...", "status": "streaming" }
-curl -s http://127.0.0.1:9562/api/v1/chat \
+# 1. 创建一轮。它只【持久化】这条消息并立即返回，此时【还没有】跑 loop。
+#    返回含 session id 与事件 URL：
+#    { "session_id": "...", "stream_url": "/api/v1/events/<id>", "status": "streaming" }
+SID=$(curl -s http://127.0.0.1:9562/api/v1/chat \
   -H 'Content-Type: application/json' \
-  -d '{
-        "message": "列出当前目录的文件，并告诉我这个项目是做什么的。",
-        "model": "claude-sonnet-4-6"
-      }'
+  -d '{"message":"列出当前目录的文件，并告诉我这个项目是做什么的。","model":"claude-sonnet-4-6"}' \
+  | jq -r .session_id)
 
-# 2. 实时观察 agent 工作（可断点续传的 SSE 事件流）。
-#    每个事件就是 loop 的一步：助手文本、工具调用、工具结果、token 用量、完成。
-curl -N http://127.0.0.1:9562/api/v1/stream
+# 2. 为该会话启动 agent loop。body 可为空（{}）——每个字段
+#    （model/provider/skill_mode/reasoning_effort 等）都是可选覆盖项。
+curl -s -X POST "http://127.0.0.1:9562/api/v1/execute/$SID" \
+  -H 'Content-Type: application/json' -d '{}'
+
+# 3. 实时观察 loop（SSE）：助手文本、工具调用、工具结果、token 用量、完成，按发生顺序到达。
+curl -N "http://127.0.0.1:9562/api/v1/events/$SID"
 ```
 
-只有 `message` 和 `model` 是必填项。常用可选项：`session_id`（续接同一会话）、`system_prompt`、`selected_skill_ids`、`workspace_path`、`provider`、`images`。`chat` 调用会立即返回、loop 在后台运行；助手的推理、工具调用与最终答案都从 `stream` 端点（SSE，支持 `?since=<seq>` 或 `Last-Event-ID` 头续传）按发生顺序到达。
+`POST /api/v1/chat` 只有 `message` 和 `model` 是必填项；常用可选项：`session_id`（续接同一会话）、`system_prompt`、`selected_skill_ids`、`workspace_path`、`provider`、`images`。注意 `chat` 只**持久化**这一轮——必须再 `POST /api/v1/execute/{session_id}` 才会真正跑 loop。除了单会话的 `GET /api/v1/events/{session_id}` 事件流,还有一个账户级、可断点续传的变更流 `GET /api/v1/stream`（SSE，支持 `?since=<seq>` 或 `Last-Event-ID` 头续传），它汇聚**所有**会话的事件——适合多会话同步。
 
 ### 作为 Rust SDK 直接调用（进程内）
 
@@ -208,7 +211,7 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
-> 不需要事件流？`agent.run(&mut session, input).await?` 会把这一轮跑到结束，答案就是 `session` 上的最后一条消息。需要对每次请求做精细覆盖（拆分 fast/background/summarization 模型、skill 选择、provider 句柄等）时，下沉一层到 `bamboo_engine` 的 `ExecuteRequest` / `ExecuteRequestBuilder` 加 `agent.execute(&mut session, req)`——这正是门面内部调用的同一条路径。
+> 不需要事件流？`agent.run(&mut session, input).await?` 会把这一轮跑到结束，答案就是 `session` 上的最后一条消息。需要对每次请求做精细覆盖（拆分 fast/background/summarization 模型、skill 选择、provider 句柄等）时，用 `ExecuteRequestBuilder` 构造一个 `ExecuteRequest`（两者都从 `bamboo_sdk::agent` 重导出）再调用 `agent.execute(&mut session, req)`——这正是 `run` / `run_stream` 内部调用的同一条 canonical 引擎路径。
 
 把门面 crate 加为依赖（path 或 git）：
 
@@ -220,7 +223,7 @@ dirs = "5"
 anyhow = "1"
 ```
 
-> 不想自己管理这些依赖？直接 `bamboo serve` 用上面的 HTTP API —— 它驱动的是完全相同的 loop。完整类型参考见 [`docs/guides/API.md`](./docs/guides/API.md)。
+> 不想自己管理这些依赖？直接 `bamboo serve` 用上面的 HTTP API —— 它驱动的是完全相同的 loop。完整 SDK 类型参考是 [docs.rs/bamboo-agent](https://docs.rs/bamboo-agent) 上的 rustdoc（已发布 crate 把门面重导出为 `bamboo_agent::agent`）；[`docs/guides/API.md`](./docs/guides/API.md) 覆盖 HTTP/SSE 接口。
 
 ### 示例配置
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,13 @@
 
 ## Supported Versions
 
-We release patches for security vulnerabilities. Currently supported versions:
+We release patches for security vulnerabilities. The project ships
+date-versioned nightly releases; the latest nightly is the supported line:
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+| Version                     | Supported          |
+| --------------------------- | ------------------ |
+| latest nightly (`2026.x`)   | :white_check_mark: |
+| `0.x` (legacy SemVer)       | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/docs/guides/API.md
+++ b/docs/guides/API.md
@@ -30,7 +30,7 @@ Create a new chat session or add a message to an existing session.
 {
   "message": "Help me write a function",
   "session_id": "optional-session-id",
-  "model": "gpt-4o-mini",
+  "model": "claude-sonnet-4-6",
   "system_prompt": "You are a helpful assistant",
   "enhance_prompt": "Additional instructions",
   "workspace_path": "/path/to/workspace"
@@ -69,7 +69,7 @@ Start the agent execution loop for a session.
 
 ```json
 {
-  "model": "claude-3-opus"
+  "model": "claude-sonnet-4-6"
 }
 ```
 
@@ -134,6 +134,8 @@ eventSource.onmessage = (event) => {
   }
 };
 ```
+
+> **Other event transports.** Besides the per-session `GET /api/v1/events/{session_id}` feed above, there is an **account-wide, resumable** change feed `GET /api/v1/stream` (SSE) that multiplexes events across all sessions — resume with `?since=<seq>` or the `Last-Event-ID` header. There is also a **live WebSocket** transport at `/v2/stream` (per-device token auth) which is the primary transport used by the web/desktop clients; the SSE feeds remain available for simple/curl clients.
 
 ---
 
@@ -360,7 +362,7 @@ curl -X POST http://localhost:9562/api/v1/chat \
   -H "Content-Type: application/json" \
   -d '{
     "message": "Help me write a Rust function",
-    "model": "gpt-4o-mini"
+    "model": "claude-sonnet-4-6"
   }'
 ```
 
@@ -371,7 +373,7 @@ Response includes `session_id` and `stream_url`.
 ```bash
 curl -X POST http://localhost:9562/api/v1/execute/{session_id} \
   -H "Content-Type: application/json" \
-  -d '{"model": "gpt-4o-mini"}'
+  -d '{"model": "claude-sonnet-4-6"}'
 ```
 
 Response includes `events_url`.


### PR DESCRIPTION
Closes #250.

## The bug
The README HTTP quickstart (EN **and** ZH) said: `POST /api/v1/chat`, then watch `GET /api/v1/stream`. But `chat` only **persists** the turn — the agent loop never starts until you `POST /api/v1/execute/{session_id}`. Following the README verbatim produced an empty stream. It also pointed at the account-wide `/stream` feed instead of the per-session `stream_url` (`/api/v1/events/{id}`) that `chat` actually returns.

## Verified against a running server
```
chat            -> { session_id, stream_url: /api/v1/events/<id>, status: streaming }   (persist only)
execute/{id} {} -> HTTP 202                                                              (loop starts)
events/{id}     -> HTTP 200  text/event-stream
/stream         -> HTTP 200  text/event-stream
```

## Changes (docs only)
- **README EN + ZH**: rewrite the quickstart to the correct 3-call flow (`chat` → `execute/{id}` → `events/{id}`); state that `chat` only persists; note the account-wide resumable `/stream` feed.
- **EN/ZH drift**: ZH SDK escape-hatch now matches EN (`ExecuteRequestBuilder` re-exported from `bamboo_sdk::agent`, not the stale "下沉到 `bamboo_engine`"); added the missing docs.rs / `bamboo_agent::agent` paragraph to ZH.
- **docs/guides/API.md**: replaced stale model ids (`gpt-4o-mini` / `claude-3-opus` → `claude-sonnet-4-6`); added a note on the global `/stream` feed and the v2 WebSocket transport.
- **CHANGELOG.md / SECURITY.md**: reflect the date-versioned nightly scheme (were stuck at `0.3.0` / "0.1.x supported").

No code changes.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU