### PR TITLE
fix(test): de-flake mcp concurrent-proxy timing assertion (500ms → 700ms)

### DIFF
--- a/crates/app/bamboo-broker/src/mcp.rs
+++ b/crates/app/bamboo-broker/src/mcp.rs
@@ -1108,10 +1108,16 @@ mod tests {
             h.await.unwrap();
         }
         let elapsed = start.elapsed();
+        // Serial execution is unavoidably >= 4 * 200ms = 800ms, so any bound safely
+        // below 800ms proves the calls overlapped. Use 700ms (not a tight 500ms):
+        // overlapping calls take ~200ms + proxy/bus + scheduling overhead, which a
+        // loaded CI runner can push past 500ms — the gap to the 800ms serial floor
+        // is what matters, not a tight absolute time. Keeps the overlap assertion
+        // meaningful while removing the timing flake.
         assert!(
-            elapsed < Duration::from_millis(500),
+            elapsed < Duration::from_millis(700),
             "4 concurrent 200ms proxy calls must OVERLAP at the orchestrator \
-             (serial would be ~800ms); took {elapsed:?}"
+             (serial would be >= 800ms); took {elapsed:?}"
         );
     }
 


### PR DESCRIPTION
The Test check flaked on `mcp::tests::concurrent_proxy_calls_overlap_at_the_orchestrator` (bamboo-broker). **Passes 15/15 locally; failed once under CI load** — a pre-existing **timing flake**, unrelated to the two PRs on that commit (russh #272, CLI onboarding #245).

## Why it flakes
The test spawns 4 concurrent 200ms proxy calls and asserts they finish in `< 500ms` to prove they OVERLAP (serial is unavoidably `4 × 200ms = 800ms`). But overlapping calls take `~200ms + proxy/bus round-trips + task scheduling`, and a loaded CI runner can push that past the tight 500ms bound → false failure. The **gap to the 800ms serial floor** is the real signal, not a tight absolute time.

## Fix
Loosen the bound to `< 700ms` — still comfortably below the 800ms serial floor (so it still proves overlap), but tolerant of CI overhead. Added a comment explaining the reasoning.

Test-only, one-line threshold change. Passes locally; fmt-clean.

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u