### PR TITLE
ci: add dependabot.yml (cargo + github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot configuration.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # ---- Rust crates (the Cargo workspace at the repo root) ----
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+    groups:
+      # Batch routine minor/patch bumps into a single PR to cut review noise;
+      # majors still come as individual PRs so their breaking changes are visible.
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # RUSTSEC-2023-0071 (rsa, Marvin timing sidechannel): NO fix exists in ANY
+      # rsa release (incl. the 0.10-rc pulled transitively via russh's ssh-key), so
+      # a security-update attempt can only fail forever. bamboo's only RSA use is
+      # operator-initiated SSH deploy (low exposure). Kept ignored in CI audit too.
+      - dependency-name: "rsa"
+      # RUSTSEC-2026-0002 (lru, IterMut / Stacked Borrows — low-risk, TUI-only path):
+      # the fix (lru >= 0.16.3) is blocked on tui-textarea shipping ratatui 0.30.
+      # Tracked in issue #14; bump lru + ratatui together once unblocked.
+      - dependency-name: "lru"
+
+  # ---- GitHub Actions used in the workflows ----
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
GitHub's native **"Dependabot Updates"** runner was failing on every commit — the repo had **no `.github/dependabot.yml`**, so it kept trying to auto-open security-update PRs for advisories it can't resolve. This gives it an explicit config.

## What it does
- **cargo** (workspace root), **weekly**; minor/patch grouped into one PR (majors stay separate so breaking changes are visible).
- **github-actions**, weekly.
- **`ignore`** the two dependencies whose security updates can only fail:
  - **`rsa`** — RUSTSEC-2023-0071 has **no fix in any release** (transitive via russh's ssh-key); already ignored in the CI audit too.
  - **`lru`** — the RUSTSEC-2026-0002 fix (`>= 0.16.3`) is **blocked on ratatui 0.30** (tracked in #14).

The `russh` / `russh-cryptovec` advisories are already fixed by the 0.60.3 upgrade (#272), so no ignore is needed there.

Config-only; validated as well-formed YAML (`version: 2`).

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u