### PR TITLE
feat(cli): ergonomics — completions, stdin prompt, -p reasoning/skill overrides, --log-level (#246)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
+ "clap_complete",
  "colored",
  "cron",
  "dashmap",
@@ -1828,6 +1829,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,6 +196,7 @@ rand = "0.8"
 
 # CLI
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 
 # Process management
 sysinfo = "0.33"

--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ Arguments supported by `bamboo serve` (all override the config file):
 | `bamboo doctor` | Diagnose the install (config present, provider keyed, server reachable); exits non-zero on a blocking problem. |
 | `bamboo config [--path] [--show-secrets]` | Inspect the resolved configuration. |
 | `bamboo config set <key> <value>` | Set one value, e.g. `providers.anthropic.api_key`, `providers.<p>.model`, or `provider`. |
-| `bamboo -p "<prompt>"` | One-shot **headless** agent run (boots the full runtime incl. sub-agents, prints the result, exits). Optional `-s <session>` to continue, `-m provider:model` to pin the model, `--workspace`, `--data-dir`, `--stream-json` (NDJSON on stdout), `--echo` (keyless transport smoke). |
+| `bamboo -p "<prompt>"` | One-shot **headless** agent run (boots the full runtime incl. sub-agents, prints the result, exits). Use `-p -` to read the prompt from stdin. Optional `-s <session>` to continue, `-m provider:model` to pin the model, `--reasoning-effort <low\|medium\|high\|xhigh>`, `--skill-mode <mode>`, `--workspace`, `--data-dir`, `--stream-json` (NDJSON on stdout), `--echo` (keyless transport smoke). |
+| `bamboo completions <shell>` | Print a shell completion script (`bash`/`zsh`/`fish`/`powershell`/`elvish`), e.g. `bamboo completions zsh > ~/.zfunc/_bamboo`. |
 | `bamboo actor run\|serve\|list\|call` | Drive the sub-agent actor fabric from the terminal (spawn + stream, run as a service, discover, or send a task). |
 | `bamboo broker serve` | Run the standalone sub-agent message broker (WebSocket bus over durable mailboxes). |
 | `bamboo broker-agent serve` | Run a broker-connected agent (local / Docker / remote) that answers Ask/Task for its mailbox. |
@@ -167,6 +168,8 @@ Arguments supported by `bamboo serve` (all override the config file):
 | `bamboo stop <session_id>` | Stop a running session's agent loop. |
 
 The admin commands (`health` / `status` / `sessions` / `stop`) are thin HTTP clients over a running `bamboo serve`; point them at a non-default server with `--server-url` / `--port` / `--data-dir`. (`bamboo subagent-worker` also exists but is an internal worker process spawned by the server — not for interactive use.)
+
+A global `--log-level <error|warn|info|debug|trace>` sets the default log level for any command when `RUST_LOG` is unset (`RUST_LOG` still wins when present).
 
 **Defaults** (verified against code):
 

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -58,7 +58,7 @@ struct Cli {
     permission_mode: Option<String>,
 
     /// With -p: reasoning effort override for this run. One of:
-    /// low | medium | high | xhigh. Defaults to the active provider/config value.
+    /// low | medium | high | xhigh | max. Defaults to the active provider/config value.
     #[arg(long = "reasoning-effort")]
     reasoning_effort: Option<String>,
 
@@ -509,10 +509,22 @@ async fn main() {
 
     // `--log-level` seeds `RUST_LOG` (only when unset) so every logging path —
     // the fmt subscribers below AND `serve`'s file logging — honors it uniformly.
-    // An explicit `RUST_LOG` still wins.
+    // An explicit `RUST_LOG` still wins. Validated to a plain level here (use
+    // `RUST_LOG` directly for target-scoped directives).
     if let Some(level) = cli.log_level.as_deref() {
+        const LEVELS: [&str; 5] = ["error", "warn", "info", "debug", "trace"];
+        if !LEVELS.contains(&level.to_ascii_lowercase().as_str()) {
+            eprintln!(
+                "invalid --log-level '{level}' (expected: {})",
+                LEVELS.join(" | ")
+            );
+            std::process::exit(2);
+        }
         if std::env::var_os("RUST_LOG").is_none() {
-            // SAFETY: main thread, before any async runtime work or logging init.
+            // SAFETY: consistent with the other env seeding in this file. We run
+            // before any logging subscriber is installed and while the tokio
+            // worker threads (already spawned by `#[tokio::main]`) are parked and
+            // read no env, so this write races nothing in practice.
             unsafe {
                 std::env::set_var("RUST_LOG", level);
             }

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -56,6 +56,21 @@ struct Cli {
     /// stalls at the first permission-gated tool such as Bash).
     #[arg(long = "permission-mode")]
     permission_mode: Option<String>,
+
+    /// With -p: reasoning effort override for this run. One of:
+    /// low | medium | high | xhigh. Defaults to the active provider/config value.
+    #[arg(long = "reasoning-effort")]
+    reasoning_effort: Option<String>,
+
+    /// With -p: per-run skill mode (e.g. `code`, `ask`); skill discovery then
+    /// prefers `skills-<mode>` directories. Defaults to the session/config value.
+    #[arg(long = "skill-mode")]
+    skill_mode: Option<String>,
+
+    /// Default log level when `RUST_LOG` is unset: error | warn | info | debug | trace.
+    /// `RUST_LOG` still takes precedence when set.
+    #[arg(long = "log-level", global = true)]
+    log_level: Option<String>,
 }
 
 /// Spawn the sidecar orphan guard: a dedicated OS thread that exits the process
@@ -198,6 +213,14 @@ enum Commands {
         /// Show sensitive values (API keys, etc.)
         #[arg(long)]
         show_secrets: bool,
+    },
+
+    /// Generate a shell completion script. Pipe it to your shell's completion dir,
+    /// e.g. `bamboo completions zsh > ~/.zfunc/_bamboo`.
+    Completions {
+        /// Target shell.
+        #[arg(value_enum)]
+        shell: clap_complete::Shell,
     },
 
     /// Run as a sub-agent worker process (spawned by a parent bamboo server).
@@ -484,6 +507,18 @@ enum ActorCommands {
 async fn main() {
     let cli = Cli::parse();
 
+    // `--log-level` seeds `RUST_LOG` (only when unset) so every logging path —
+    // the fmt subscribers below AND `serve`'s file logging — honors it uniformly.
+    // An explicit `RUST_LOG` still wins.
+    if let Some(level) = cli.log_level.as_deref() {
+        if std::env::var_os("RUST_LOG").is_none() {
+            // SAFETY: main thread, before any async runtime work or logging init.
+            unsafe {
+                std::env::set_var("RUST_LOG", level);
+            }
+        }
+    }
+
     // Initialize logging (file + stdout, with rotation).
     // Use debug level in debug builds, info in release.
     let debug = cfg!(debug_assertions);
@@ -514,6 +549,7 @@ async fn main() {
         | Some(Commands::Stop { .. })
         | Some(Commands::Init { .. })
         | Some(Commands::Doctor { .. })
+        | Some(Commands::Completions { .. })
         | None => {
             // Worker/CLI logs go to stderr only: stdin/stdout are part of the
             // bootstrap & streaming protocol and must stay clean. (`None` is
@@ -537,6 +573,24 @@ async fn main() {
                 use clap::CommandFactory;
                 let _ = Cli::command().print_help();
                 std::process::exit(2);
+            };
+
+            // `bamboo -p -` reads the prompt from stdin (pipe-friendly).
+            let prompt = if prompt == "-" {
+                use std::io::Read as _;
+                let mut buf = String::new();
+                if std::io::stdin().read_to_string(&mut buf).is_err() {
+                    eprintln!("failed to read prompt from stdin");
+                    std::process::exit(1);
+                }
+                let trimmed = buf.trim().to_string();
+                if trimmed.is_empty() {
+                    eprintln!("empty prompt on stdin");
+                    std::process::exit(1);
+                }
+                trimmed
+            } else {
+                prompt
             };
 
             // --echo stays a bare actor-chain smoke (no server, no key).
@@ -576,6 +630,8 @@ async fn main() {
                 data_dir: bamboo_home_dir,
                 stream_json: cli.stream_json,
                 permission_mode: cli.permission_mode,
+                reasoning_effort: cli.reasoning_effort,
+                skill_mode: cli.skill_mode,
             };
             if let Err(e) = bamboo_agent::headless::run(args).await {
                 eprintln!("run failed: {e}");
@@ -672,6 +728,13 @@ async fn main() {
                 eprintln!("Failed to start server: {}", e);
                 std::process::exit(1);
             }
+        }
+
+        Commands::Completions { shell } => {
+            use clap::CommandFactory;
+            let mut cmd = Cli::command();
+            let name = cmd.get_name().to_string();
+            clap_complete::generate(shell, &mut cmd, name, &mut std::io::stdout());
         }
 
         Commands::SubagentWorker => {

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -164,6 +164,12 @@ pub struct HeadlessArgs {
     /// envelope. Nothing else is written to stdout (logs go to stderr), so
     /// the stream is pipe-safe.
     pub stream_json: bool,
+    /// Per-run reasoning effort override (`low`/`medium`/`high`/`xhigh`). `None`
+    /// keeps the active provider/config default.
+    pub reasoning_effort: Option<String>,
+    /// Per-run skill mode (e.g. `code`, `ask`). `None` keeps the session/config
+    /// default. Threads into `ExecuteRequest.skill_mode`.
+    pub skill_mode: Option<String>,
 }
 
 pub async fn run(args: HeadlessArgs) -> Result<(), String> {
@@ -254,6 +260,19 @@ pub async fn run(args: HeadlessArgs) -> Result<(), String> {
 
     let model_ref = parse_model_ref(&args.model)?;
 
+    // Parse the optional reasoning-effort override once (applies to the initial
+    // execute and to any resume after a pending question).
+    let reasoning_effort = match args.reasoning_effort.as_deref() {
+        Some(raw) => Some(
+            bamboo_domain::reasoning::ReasoningEffort::parse(raw).ok_or_else(|| {
+                format!(
+                    "invalid --reasoning-effort '{raw}' (expected: low | medium | high | xhigh)"
+                )
+            })?,
+        ),
+        None => None,
+    };
+
     if args.stream_json {
         println!(
             "{}",
@@ -274,8 +293,8 @@ pub async fn run(args: HeadlessArgs) -> Result<(), String> {
             model: None,
             provider: None,
             model_ref,
-            skill_mode: None,
-            reasoning_effort: None,
+            skill_mode: args.skill_mode.clone(),
+            reasoning_effort,
             client_sync: None,
             // #74: a headless `-p` run has no interactive approver. The handler
             // re-derives + persists this onto the root session each execute, so
@@ -387,7 +406,7 @@ pub async fn run(args: HeadlessArgs) -> Result<(), String> {
                 model: None,
                 provider: None,
                 model_ref: None,
-                reasoning_effort: None,
+                reasoning_effort,
             }),
         )
         .await;

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -164,8 +164,8 @@ pub struct HeadlessArgs {
     /// envelope. Nothing else is written to stdout (logs go to stderr), so
     /// the stream is pipe-safe.
     pub stream_json: bool,
-    /// Per-run reasoning effort override (`low`/`medium`/`high`/`xhigh`). `None`
-    /// keeps the active provider/config default.
+    /// Per-run reasoning effort override (`low`/`medium`/`high`/`xhigh`/`max`).
+    /// `None` keeps the active provider/config default.
     pub reasoning_effort: Option<String>,
     /// Per-run skill mode (e.g. `code`, `ask`). `None` keeps the session/config
     /// default. Threads into `ExecuteRequest.skill_mode`.
@@ -266,12 +266,23 @@ pub async fn run(args: HeadlessArgs) -> Result<(), String> {
         Some(raw) => Some(
             bamboo_domain::reasoning::ReasoningEffort::parse(raw).ok_or_else(|| {
                 format!(
-                    "invalid --reasoning-effort '{raw}' (expected: low | medium | high | xhigh)"
+                    "invalid --reasoning-effort '{raw}' (expected: low | medium | high | xhigh | max)"
                 )
             })?,
         ),
         None => None,
     };
+
+    // Validate the optional skill mode at the CLI boundary rather than letting the
+    // skill store silently drop a malformed value downstream.
+    if let Some(mode) = args.skill_mode.as_deref() {
+        let ok = !mode.is_empty() && mode.chars().all(|c| c.is_ascii_alphanumeric() || c == '-');
+        if !ok {
+            return Err(format!(
+                "invalid --skill-mode '{mode}' (expected non-empty [A-Za-z0-9-], e.g. `code` or `ask`)"
+            ));
+        }
+    }
 
     if args.stream_json {
         println!(


### PR DESCRIPTION
Partial fix for #246 — the highest-leverage, self-contained CLI-ergonomics items.

## What
- **`bamboo completions <shell>`** — generate a shell completion script (`bash`/`zsh`/`fish`/`powershell`/`elvish`) via `clap_complete`. First completion support in the workspace.
- **`bamboo -p -`** — read the headless prompt from **stdin** (pipe-friendly: `echo task | bamboo -p -`).
- **`-p` parity**: `--reasoning-effort <low|medium|high|xhigh>` and `--skill-mode <mode>` now thread into `ExecuteRequest` (were hardcoded to `None`), so the CLI can reach knobs the HTTP API already exposed. Invalid `--reasoning-effort` fails fast with a clear message; the value also carries into a post-question resume.
- **Global `--log-level <error|warn|info|debug|trace>`** — seeds `RUST_LOG` when unset so every path (including `serve`'s file logging) honors it uniformly; an explicit `RUST_LOG` still wins.

## Verified (built binary)
- `completions bash|zsh|fish` produce non-empty, valid scripts; an invalid shell is a clap error.
- `--help` lists the new flags/subcommand.
- `echo ping | bamboo -p - --echo` runs on the piped prompt.
- `--reasoning-effort bogus` → `invalid --reasoning-effort 'bogus' (expected: low | medium | high | xhigh)`; `high` is accepted.
- `--log-level` accepted globally; CI clippy green; root crate 30 lib + 2 bin tests pass; fmt clean.

## Deferred (bigger / separate follow-ups, still under #246)
- Full `-p` parity for `--system-prompt` / `--max-turns` / `--allowed-tools` (these are **not** carried by `ExecuteRequest` — need config/session plumbing).
- `--config <path>` (needs a config-crate file loader).
- Folding `bamboo-cli`'s `chat`/`send`/`stream`/`history` into the `bamboo` binary + unifying connection flags.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU