### PR TITLE
docs: lead README with product benefit + hero badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
+<div align="center">
+
 # Bamboo 🎋
 
-<p align="center">
-  <img src="./docs/assets/bamboo-agent-hero.svg" alt="Bamboo agent runtime overview" width="100%" />
-</p>
+<img src="./docs/assets/bamboo-agent-hero.svg" alt="Bamboo agent runtime overview" width="100%" />
 
-> 📖 中文版请看 **[README.zh-CN.md](./README.zh-CN.md)**
+### The local-first AI agent runtime, in Rust.
 
-> **Bamboo — the local-first Rust agent runtime that powers Zenith (the execution engine).**
+**Persistent memory, 22 built-in tools, skills, MCP, workflows & schedules — behind one HTTP + SSE API.**
+Run it as a server, or embed the same agent loop as a Rust crate. Your data stays on your machine.
+
+[![Crates.io](https://img.shields.io/crates/v/bamboo-agent.svg?logo=rust)](https://crates.io/crates/bamboo-agent)
+[![docs.rs](https://img.shields.io/docsrs/bamboo-agent?logo=docsdotrs&label=docs.rs)](https://docs.rs/bamboo-agent)
+[![CI](https://img.shields.io/github/actions/workflow/status/bigduu/Bamboo-agent/ci.yml?branch=main&logo=github&label=CI)](https://github.com/bigduu/Bamboo-agent/actions/workflows/ci.yml)
+[![License MIT](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
+[![中文 README](https://img.shields.io/badge/lang-中文-red)](./README.zh-CN.md)
+
+</div>
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,12 +1,21 @@
+<div align="center">
+
 # Bamboo 🎋
 
-<p align="center">
-  <img src="./docs/assets/bamboo-agent-hero.svg" alt="Bamboo agent runtime overview" width="100%" />
-</p>
+<img src="./docs/assets/bamboo-agent-hero.svg" alt="Bamboo agent runtime overview" width="100%" />
 
-> 📖 For English, see **[README.md](./README.md)**
+### 本地优先的 AI agent 运行时，Rust 编写。
 
-> **Bamboo — Zenith 的本地优先 Rust 智能体运行时（执行引擎）**
+**持久记忆、22 个内置工具、skills、MCP、workflows、schedules —— 统一在一个 HTTP + SSE API 之后。**
+既能作为服务器运行，也能把同一套 agent loop 作为 Rust crate 嵌入。数据始终留在你自己机器上。
+
+[![Crates.io](https://img.shields.io/crates/v/bamboo-agent.svg?logo=rust)](https://crates.io/crates/bamboo-agent)
+[![docs.rs](https://img.shields.io/docsrs/bamboo-agent?logo=docsdotrs&label=docs.rs)](https://docs.rs/bamboo-agent)
+[![CI](https://img.shields.io/github/actions/workflow/status/bigduu/Bamboo-agent/ci.yml?branch=main&logo=github&label=CI)](https://github.com/bigduu/Bamboo-agent/actions/workflows/ci.yml)
+[![License MIT](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
+[![English README](https://img.shields.io/badge/lang-English-blue)](./README.md)
+
+</div>
 
 ---
 


### PR DESCRIPTION
## What & why

Benchmarked the README/description against 25+ popular AI-agent repos (goose, aider, jan, letta, OpenHands, anything-llm…). The winners all lead with a **benefit-first tagline + a badge row + a multi-surface pitch**; Bamboo's README led with an inward-facing "powers Zenith" line and had no badges. This makes the opening click-first without touching the substance below the fold.

## Changes (EN + zh-CN)

- **Tagline** → "The local-first AI agent runtime, in Rust." (was "the runtime that powers Zenith")
- **Multi-surface pitch** — run as a server OR embed the same agent loop as a Rust crate
- **Differentiator up front** — persistent memory + 22 tools + skills/MCP/schedules
- **Badge row** — crates.io · docs.rs · CI · MIT · language switcher (all verified live: `bamboo-agent` is published, docs.rs resolves, `ci.yml`/`LICENSE` exist)
- Language link promoted to a badge-style switcher

Everything below the hero is unchanged.

## Suggested follow-up (not in this PR)

Add a short demo (terminal SSE stream or a GIF) under the hero — per the benchmark this is the single biggest click/star driver.

https://claude.ai/code/session_01XueZpfifCm7cFBkeQJtb5q