### PR TITLE
feat(tui): inline permission/clarification answering (#247)

### DIFF
--- a/crates/app/bamboo-tui/src/api/mod.rs
+++ b/crates/app/bamboo-tui/src/api/mod.rs
@@ -57,7 +57,10 @@ impl BambooClient {
         Ok(())
     }
 
-    pub async fn respond(&self, session_id: &str, response: &str) -> Result<()> {
+    /// Submit an answer to a pending question. Returns the server's
+    /// `auto_resume_status` (`started` / `already_running` / `completed` /
+    /// `error: …`) so the caller knows whether a run is actually resuming.
+    pub async fn respond(&self, session_id: &str, response: &str) -> Result<String> {
         let resp = self
             .client
             .post(self.url(&format!("/api/v1/respond/{}", session_id)))
@@ -69,12 +72,22 @@ impl BambooClient {
         // The respond validator rejects an answer that doesn't match an option
         // (when custom input is not allowed) with a non-2xx status. Surface that
         // so the UI can keep the question open instead of silently swallowing it.
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
             anyhow::bail!("server rejected the answer ({status}): {}", body.trim());
         }
-        Ok(())
+        // Extract auto_resume_status; the run only actually resumes for
+        // `started` / `already_running`.
+        let auto_resume = serde_json::from_str::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|v| {
+                v.get("auto_resume_status")
+                    .and_then(|s| s.as_str())
+                    .map(String::from)
+            })
+            .unwrap_or_default();
+        Ok(auto_resume)
     }
 
     pub async fn pending_question(&self, session_id: &str) -> Result<PendingQuestion> {

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -532,11 +532,19 @@ impl App {
             return Ok(());
         };
         match self.client.respond(&session_id, &answer).await {
-            Ok(()) => {
+            Ok(status) => {
                 self.pending_question = None;
-                self.status_message = format!("Answered: {answer} — resuming");
-                // The server resumes the loop; keep the spinner/streaming UI on.
-                self.chat.streaming = true;
+                // Only keep the spinner on if a run is actually running: the
+                // server returns 200 even when it did NOT resume (e.g. the
+                // session already `completed`), so a blind `streaming = true`
+                // would spin forever with no events behind it.
+                if matches!(status.as_str(), "started" | "already_running") {
+                    self.status_message = format!("Answered: {answer} — resuming");
+                    self.chat.streaming = true;
+                } else {
+                    self.status_message = format!("Answered: {answer} ({status})");
+                    self.finalize_streaming();
+                }
             }
             Err(e) => {
                 // Keep the modal open so the operator can pick a valid option.
@@ -853,6 +861,10 @@ impl App {
         self.status_message = "Ready".to_string();
         self.sse_tx = None;
         self.sse_rx = None;
+        // A run that ended (completed / cancelled / stopped) can no longer accept
+        // an answer, so drop any open question modal to avoid answering a dead
+        // session.
+        self.pending_question = None;
     }
 
     async fn stop_streaming(&mut self) -> Result<()> {
@@ -1095,5 +1107,31 @@ mod question_tests {
         let text: String = buf.content().iter().map(|c| c.symbol()).collect();
         assert!(text.contains("Run this command?"), "question text missing");
         assert!(text.contains("Approve"), "option label missing");
+    }
+
+    #[test]
+    fn many_options_window_keeps_selection_visible() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let opts: Vec<String> = (1..=30).map(|n| format!("opt{n}")).collect();
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.pending_question = Some(ActiveQuestion {
+            question: "Pick one".to_string(),
+            options: opts,
+            selected: 24, // "25. opt25", deep in the list
+            custom: None,
+        });
+
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let text: String = buf.content().iter().map(|c| c.symbol()).collect();
+
+        // The selected option is visible even though it's far down the list, and
+        // an overflow marker indicates hidden options above.
+        assert!(text.contains("opt25"), "selected option not in the window");
+        assert!(text.contains("more"), "overflow marker missing");
     }
 }

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -191,7 +191,10 @@ pub fn render_question(f: &mut Frame, app: &App) {
         return;
     };
 
-    let mut lines: Vec<Line> = vec![
+    let screen = f.area();
+    // Header: title + blank + (wrapped) question + blank. Cap the question to a
+    // few lines so a very long prompt can't push the options/footer off-screen.
+    let mut header: Vec<Line> = vec![
         Line::from(Span::styled(
             " Agent needs your input",
             Style::default()
@@ -200,27 +203,49 @@ pub fn render_question(f: &mut Frame, app: &App) {
         )),
         Line::raw(""),
     ];
-    for l in q.question.lines() {
-        lines.push(Line::raw(format!("  {l}")));
+    const MAX_QUESTION_LINES: usize = 6;
+    for l in q.question.lines().take(MAX_QUESTION_LINES) {
+        header.push(Line::raw(format!("  {l}")));
     }
-    lines.push(Line::raw(""));
+    if q.question.lines().count() > MAX_QUESTION_LINES {
+        header.push(Line::raw("  …"));
+    }
+    header.push(Line::raw(""));
 
+    let mut body: Vec<Line> = Vec::new();
     match &q.custom {
         Some(buf) => {
-            lines.push(Line::raw("  Type your answer:"));
-            lines.push(Line::from(Span::styled(
+            body.push(Line::raw("  Type your answer:"));
+            body.push(Line::from(Span::styled(
                 format!("  > {buf}\u{258f}"),
                 Style::default().fg(colors::BRAND),
             )));
-            lines.push(Line::raw(""));
-            lines.push(Line::raw(if q.options.is_empty() {
+            body.push(Line::raw(""));
+            body.push(Line::raw(if q.options.is_empty() {
                 "  Enter answer  ·  Esc dismiss"
             } else {
                 "  Enter answer  ·  Esc back to options"
             }));
         }
         None => {
-            for (i, opt) in q.options.iter().enumerate() {
+            // Window the option list around the selection so it stays visible and
+            // the modal never overflows the screen, no matter how many options.
+            let max_h = screen.height.min(22);
+            // rows available for options = modal height - borders(2) - header - footer(1)
+            let budget = (max_h as usize).saturating_sub(2 + header.len() + 1).max(1);
+            let total = q.options.len();
+            let start = if total <= budget {
+                0
+            } else {
+                q.selected
+                    .saturating_sub(budget / 2)
+                    .min(total.saturating_sub(budget))
+            };
+            let end = (start + budget).min(total);
+            if start > 0 {
+                body.push(Line::raw(format!("  \u{2191} {start} more")));
+            }
+            for i in start..end {
                 let selected = i == q.selected;
                 let marker = if selected { "\u{203a}" } else { " " };
                 let style = if selected {
@@ -230,20 +255,25 @@ pub fn render_question(f: &mut Frame, app: &App) {
                 } else {
                     Style::default()
                 };
-                lines.push(Line::from(Span::styled(
-                    format!("  {marker} {}. {opt}", i + 1),
+                body.push(Line::from(Span::styled(
+                    format!("  {marker} {}. {}", i + 1, q.options[i]),
                     style,
                 )));
             }
-            lines.push(Line::raw(""));
-            lines.push(Line::raw(
+            if end < total {
+                body.push(Line::raw(format!("  \u{2193} {} more", total - end)));
+            }
+            body.push(Line::raw(""));
+            body.push(Line::raw(
                 "  \u{2191}/\u{2193} select  ·  Enter answer  ·  1-9 quick  ·  c custom  ·  Esc dismiss",
             ));
         }
     }
 
-    let height = (lines.len() as u16 + 2).min(f.area().height);
-    let area = centered_rect(60, height, f.area());
+    let mut lines = header;
+    lines.extend(body);
+    let height = (lines.len() as u16 + 2).min(screen.height);
+    let area = centered_rect(60, height, screen);
     f.render_widget(Clear, area);
     let block = Block::default()
         .borders(Borders::ALL)


### PR DESCRIPTION
First of the #247 interactive-loop blockers — the single most important TUI gap.

## The problem
The TUI dumped an agent's `NeedClarification` question into the one-line status bar with **no way to answer it** (`app.rs:637`), so any permission-gated run hung invisibly. The `respond()` / `pending_question()` client methods existed but were **dead code** — never called from the UI.

## What
- New `ActiveQuestion` state + a **modal** (`ui/layout::render_question`) rendering the question with either a selectable option list or a free-text input.
- `NeedClarification` now opens the modal; while a question is pending it **captures all keystrokes** (Ctrl+C still stops the run).
- Answer flow wired to the existing `respond()` API: `↑/↓` + `Enter` or `1`–`9` to pick an option, `c` to switch to free-text, `Esc` to dismiss. Submitting resumes the loop.
- Hardened `respond()` to surface a **non-2xx** (rejected answer) instead of swallowing it — an invalid option keeps the modal open with an error rather than silently no-op'ing.

The `respond`/`pending` API paths + payload were verified against the actual server routes (`/api/v1/respond/{id}` + `/pending`) — they matched; the code was just never invoked.

## Tests (the crate had **zero**)
Added the first tests: the question state machine (option nav, custom-mode toggle, dismiss, no-session submit short-circuit) + a `TestBackend` render smoke test asserting the modal draws the question and options. clippy + fmt clean.

## Scope
Part of #247. The other two blockers — non-blocking event loop (API calls currently `.await` inline and freeze the UI) and SSE reconnect + double-drain — land in follow-up PRs. Manual terminal testing against a live permission-gated run is recommended before relying on it.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU