### PR TITLE
fix(server): exempt loopback from rate limiter; persist run status before finalize

### DIFF
--- a/crates/app/bamboo-server/src/config.rs
+++ b/crates/app/bamboo-server/src/config.rs
@@ -75,6 +75,16 @@ pub fn build_rate_limiter() -> GovernorConfig<PeerIpKeyExtractor, NoOpMiddleware
     rate_limiter_config(per_second, burst)
 }
 
+/// True when `bind` is a loopback/desktop address, for which the per-IP DoS
+/// rate limiter ([`build_rate_limiter`], #13) is intentionally SKIPPED. The
+/// desktop sidecar serves the local frontend, which legitimately bursts ~45
+/// hashed `/assets/*` requests on load and would otherwise trip the 429 limit
+/// (`burst` default 20). Mirrors the loopback special-casing already used for
+/// CORS; network binds (`0.0.0.0`) are still throttled.
+pub fn is_loopback_bind(bind: &str) -> bool {
+    matches!(bind, "127.0.0.1" | "localhost" | "::1")
+}
+
 // Keep the default CSP reasonably strict while remaining compatible with the Lotus UI runtime.
 // Lotus + Ant Design inject runtime styles, so `style-src 'unsafe-inline'` is required for the
 // current frontend bundle. Keep scripts strict (no `unsafe-eval`) and allow operators to override
@@ -585,6 +595,18 @@ mod tests {
         // valid (no panic).
         let _ = rate_limiter_config(0, 0);
         let _ = rate_limiter_config(1000, 1);
+    }
+
+    #[test]
+    fn loopback_binds_skip_rate_limiter() {
+        // Desktop sidecar binds must be exempt (frontend bursts asset requests);
+        // network-exposed binds must stay throttled.
+        for b in ["127.0.0.1", "localhost", "::1"] {
+            assert!(is_loopback_bind(b), "{b} should be loopback (limiter skipped)");
+        }
+        for b in ["0.0.0.0", "192.168.1.10", "::"] {
+            assert!(!is_loopback_bind(b), "{b} should be throttled");
+        }
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/server/entrypoints.rs
+++ b/crates/app/bamboo-server/src/server/entrypoints.rs
@@ -10,7 +10,7 @@ use tracing::{error, info};
 use super::listeners::{build_bind_listeners, build_desktop_listeners, resolve_worker_count};
 use super::tls::build_rustls_config;
 use crate::app_state::AppState;
-use crate::config::{build_cors, build_rate_limiter, build_security_headers};
+use crate::config::{build_cors, build_rate_limiter, build_security_headers, is_loopback_bind};
 use crate::routes::{configure_routes, configure_routes_with_rate_limiting};
 use crate::services::frontend_package::{
     ensure_current_frontend_dir_in, has_embedded_frontend_package, resolve_frontend_package_path,
@@ -293,6 +293,9 @@ pub async fn run_with_bind_and_static_tls(
     // once and shared (Clone) across workers; `Governor` is the outermost wrap so
     // a throttled request is rejected with 429 before any handler work.
     let rate_limiter = build_rate_limiter();
+    // Loopback/desktop binds skip the limiter (see is_loopback_bind): the local
+    // frontend bursts ~45 asset requests on load. Network binds stay throttled.
+    let apply_rate_limit = !is_loopback_bind(bind);
     let bind_for_cors = bind.to_string();
     let app_factory = move || {
         let mut app = App::new()
@@ -301,7 +304,10 @@ pub async fn run_with_bind_and_static_tls(
             .app_data(web::JsonConfig::default().limit(25 * 1024 * 1024)) // 25MB JSON limit
             .app_data(web::PayloadConfig::new(30 * 1024 * 1024)) // 30MB payload limit
             .app_data(app_state.clone())
-            .wrap(Governor::new(&rate_limiter))
+            .wrap(actix_web::middleware::Condition::new(
+                apply_rate_limit,
+                Governor::new(&rate_limiter),
+            ))
             .wrap(build_cors(&bind_for_cors, port))
             .wrap(build_security_headers())
             // Immutable long-cache for hashed `/assets/*` (Docker / `serve -s`

--- a/crates/app/bamboo-server/src/server/web_service.rs
+++ b/crates/app/bamboo-server/src/server/web_service.rs
@@ -8,7 +8,7 @@ use tracing::{error, info};
 use super::listeners::DEFAULT_WORKER_COUNT;
 use super::tls::build_rustls_config;
 use crate::app_state::AppState;
-use crate::config::{build_cors, build_rate_limiter, build_security_headers};
+use crate::config::{build_cors, build_rate_limiter, build_security_headers, is_loopback_bind};
 use crate::routes::{configure_routes, configure_routes_with_rate_limiting};
 use actix_governor::Governor;
 use bamboo_config::TlsConfig;
@@ -173,8 +173,12 @@ impl WebService {
         );
         // Retain a handle so stop()/Drop can stop AppState-owned background tasks. #119
         self.app_state = Some(app_state.clone());
-        // Per-IP rate limiter for this network-exposed production server. #13
+        // Per-IP rate limiter for the network-exposed production server (#13).
+        // SKIPPED for loopback/desktop binds: the local frontend legitimately
+        // bursts ~45 hashed `/assets/*` requests on load and would otherwise be
+        // throttled to a 429 (chunk import fails / "Too many requests").
         let rate_limiter = build_rate_limiter();
+        let apply_rate_limit = !is_loopback_bind(bind);
         let bind_addr = bind.to_string();
         let listen_addr = format!("{bind}:{port}");
         let bind_for_log = bind_addr.clone();
@@ -184,7 +188,10 @@ impl WebService {
                 .app_data(web::JsonConfig::default().limit(25 * 1024 * 1024))
                 .app_data(web::PayloadConfig::new(30 * 1024 * 1024))
                 .app_data(app_state.clone())
-                .wrap(Governor::new(&rate_limiter))
+                .wrap(actix_web::middleware::Condition::new(
+                    apply_rate_limit,
+                    Governor::new(&rate_limiter),
+                ))
                 .wrap(build_cors(&bind_addr, port))
                 .wrap(build_security_headers())
                 // Immutable long-cache for hashed `/assets/*` so a proxy/CDN

--- a/crates/app/bamboo-tui/src/api/mod.rs
+++ b/crates/app/bamboo-tui/src/api/mod.rs
@@ -58,13 +58,22 @@ impl BambooClient {
     }
 
     pub async fn respond(&self, session_id: &str, response: &str) -> Result<()> {
-        self.client
+        let resp = self
+            .client
             .post(self.url(&format!("/api/v1/respond/{}", session_id)))
             .json(&RespondRequest {
                 response: response.to_string(),
             })
             .send()
             .await?;
+        // The respond validator rejects an answer that doesn't match an option
+        // (when custom input is not allowed) with a non-2xx status. Surface that
+        // so the UI can keep the question open instead of silently swallowing it.
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("server rejected the answer ({status}): {}", body.trim());
+        }
         Ok(())
     }
 

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -223,6 +223,20 @@ impl ConfigState {
     }
 }
 
+// ── Interactive question (permission gate / clarification) ──
+
+/// An agent question awaiting the operator's answer, driven by the modal.
+pub struct ActiveQuestion {
+    pub question: String,
+    /// Preset choices; empty means free-text only.
+    pub options: Vec<String>,
+    /// Highlighted option index (option-select mode).
+    pub selected: usize,
+    /// `Some(buf)` = free-text entry mode (typing into `buf`); `None` =
+    /// option-select mode. Starts `Some("")` when there are no options.
+    pub custom: Option<String>,
+}
+
 // ── Main App ──
 
 pub struct App {
@@ -239,6 +253,9 @@ pub struct App {
     pub connected: bool,
     pub help_visible: bool,
     pub spinner_tick: usize,
+    /// The agent's pending question (permission gate / clarification). When
+    /// `Some`, a modal captures the answer and keystrokes route to it.
+    pub pending_question: Option<ActiveQuestion>,
     sse_tx: Option<mpsc::UnboundedSender<AgentEvent>>,
     sse_rx: Option<mpsc::UnboundedReceiver<AgentEvent>>,
 }
@@ -259,6 +276,7 @@ impl App {
             connected: false,
             help_visible: false,
             spinner_tick: 0,
+            pending_question: None,
             sse_tx: None,
             sse_rx: None,
         }
@@ -377,6 +395,12 @@ impl App {
             _ => {}
         }
 
+        // A pending agent question captures all input (Ctrl+C above still
+        // stops the run) until it is answered or dismissed.
+        if self.pending_question.is_some() {
+            return self.handle_question_key(key).await;
+        }
+
         if let KeyCode::Char(c) = key.code {
             if let Some(digit) = c.to_digit(10) {
                 if (1..=6).contains(&digit)
@@ -401,6 +425,122 @@ impl App {
             }
             _ => {
                 self.handle_tab_key(key).await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Drive the pending-question modal. Returns an answer to submit (if the
+    /// keystroke commits one) without holding a borrow across the async submit.
+    async fn handle_question_key(&mut self, key: KeyEvent) -> Result<()> {
+        enum QAction {
+            None,
+            Dismiss,
+            Submit(String),
+        }
+
+        let action = {
+            let Some(q) = self.pending_question.as_mut() else {
+                return Ok(());
+            };
+            if let Some(buf) = q.custom.as_mut() {
+                // Free-text entry mode.
+                match key.code {
+                    KeyCode::Enter => {
+                        let answer = buf.trim().to_string();
+                        if answer.is_empty() {
+                            QAction::None
+                        } else {
+                            QAction::Submit(answer)
+                        }
+                    }
+                    KeyCode::Esc => {
+                        // Back to option-select if there were options, else dismiss.
+                        if q.options.is_empty() {
+                            QAction::Dismiss
+                        } else {
+                            q.custom = None;
+                            QAction::None
+                        }
+                    }
+                    KeyCode::Backspace => {
+                        buf.pop();
+                        QAction::None
+                    }
+                    KeyCode::Char(c) => {
+                        buf.push(c);
+                        QAction::None
+                    }
+                    _ => QAction::None,
+                }
+            } else {
+                // Option-select mode.
+                match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        q.selected = q.selected.saturating_sub(1);
+                        QAction::None
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        if q.selected + 1 < q.options.len() {
+                            q.selected += 1;
+                        }
+                        QAction::None
+                    }
+                    KeyCode::Char('c') => {
+                        // Switch to free-text entry (for allow-custom questions).
+                        q.custom = Some(String::new());
+                        QAction::None
+                    }
+                    KeyCode::Enter => q
+                        .options
+                        .get(q.selected)
+                        .cloned()
+                        .map(QAction::Submit)
+                        .unwrap_or(QAction::None),
+                    KeyCode::Char(d) if ('1'..='9').contains(&d) => {
+                        let idx = d as usize - '1' as usize;
+                        q.options
+                            .get(idx)
+                            .cloned()
+                            .map(QAction::Submit)
+                            .unwrap_or(QAction::None)
+                    }
+                    KeyCode::Esc => QAction::Dismiss,
+                    _ => QAction::None,
+                }
+            }
+        };
+
+        match action {
+            QAction::Submit(answer) => self.submit_answer(answer).await?,
+            QAction::Dismiss => {
+                self.pending_question = None;
+                self.status_message =
+                    "Question dismissed (still pending on the server — Ctrl+C stops the run)"
+                        .to_string();
+            }
+            QAction::None => {}
+        }
+        Ok(())
+    }
+
+    /// Submit an answer to the agent's pending question and resume the run.
+    async fn submit_answer(&mut self, answer: String) -> Result<()> {
+        let Some(session_id) = self.chat.session_id.clone() else {
+            self.status_message = "No active chat session to answer".to_string();
+            self.pending_question = None;
+            return Ok(());
+        };
+        match self.client.respond(&session_id, &answer).await {
+            Ok(()) => {
+                self.pending_question = None;
+                self.status_message = format!("Answered: {answer} — resuming");
+                // The server resumes the loop; keep the spinner/streaming UI on.
+                self.chat.streaming = true;
+            }
+            Err(e) => {
+                // Keep the modal open so the operator can pick a valid option.
+                self.status_message = format!("Answer rejected: {e}");
             }
         }
         Ok(())
@@ -637,11 +777,20 @@ impl App {
             AgentEvent::NeedClarification {
                 question, options, ..
             } => {
-                self.status_message = format!("Question: {}", question);
-                if let Some(opts) = options {
-                    self.status_message
-                        .push_str(&format!(" [{}]", opts.join(", ")));
-                }
+                let options = options.unwrap_or_default();
+                // No preset options ⇒ open straight into free-text entry.
+                let custom = if options.is_empty() {
+                    Some(String::new())
+                } else {
+                    None
+                };
+                self.status_message = format!("Question: {} (answer in the dialog)", question);
+                self.pending_question = Some(ActiveQuestion {
+                    question,
+                    options,
+                    selected: 0,
+                    custom,
+                });
             }
             AgentEvent::Complete { usage } => {
                 self.finalize_streaming();
@@ -842,5 +991,109 @@ impl App {
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod question_tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    fn app_with_question(options: Vec<&str>) -> App {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        let options: Vec<String> = options.into_iter().map(String::from).collect();
+        let custom = if options.is_empty() {
+            Some(String::new())
+        } else {
+            None
+        };
+        app.pending_question = Some(ActiveQuestion {
+            question: "Run this command?".to_string(),
+            options,
+            selected: 0,
+            custom,
+        });
+        app
+    }
+
+    #[tokio::test]
+    async fn option_navigation_and_custom_toggle() {
+        let mut app = app_with_question(vec!["Approve", "Deny"]);
+
+        // Down moves the selection, clamped; Up moves back, clamped at 0.
+        app.handle_question_key(key(KeyCode::Down)).await.unwrap();
+        assert_eq!(app.pending_question.as_ref().unwrap().selected, 1);
+        app.handle_question_key(key(KeyCode::Down)).await.unwrap();
+        assert_eq!(app.pending_question.as_ref().unwrap().selected, 1); // clamped
+        app.handle_question_key(key(KeyCode::Up)).await.unwrap();
+        assert_eq!(app.pending_question.as_ref().unwrap().selected, 0);
+
+        // `c` switches to free-text; typing fills the buffer; Esc returns to options.
+        app.handle_question_key(key(KeyCode::Char('c')))
+            .await
+            .unwrap();
+        assert!(app.pending_question.as_ref().unwrap().custom.is_some());
+        app.handle_question_key(key(KeyCode::Char('h')))
+            .await
+            .unwrap();
+        app.handle_question_key(key(KeyCode::Char('i')))
+            .await
+            .unwrap();
+        assert_eq!(
+            app.pending_question.as_ref().unwrap().custom.as_deref(),
+            Some("hi")
+        );
+        app.handle_question_key(key(KeyCode::Backspace))
+            .await
+            .unwrap();
+        assert_eq!(
+            app.pending_question.as_ref().unwrap().custom.as_deref(),
+            Some("h")
+        );
+        app.handle_question_key(key(KeyCode::Esc)).await.unwrap();
+        assert!(app.pending_question.as_ref().unwrap().custom.is_none());
+    }
+
+    #[tokio::test]
+    async fn esc_in_option_mode_dismisses() {
+        let mut app = app_with_question(vec!["Approve", "Deny"]);
+        app.handle_question_key(key(KeyCode::Esc)).await.unwrap();
+        assert!(app.pending_question.is_none());
+    }
+
+    #[tokio::test]
+    async fn submitting_without_a_session_clears_the_question() {
+        // No chat session ⇒ submit short-circuits (no network) and clears the modal.
+        let mut app = app_with_question(vec!["Approve", "Deny"]);
+        assert!(app.chat.session_id.is_none());
+        app.handle_question_key(key(KeyCode::Enter)).await.unwrap();
+        assert!(app.pending_question.is_none());
+    }
+
+    #[tokio::test]
+    async fn no_options_opens_in_free_text_mode() {
+        let app = app_with_question(vec![]);
+        assert!(app.pending_question.as_ref().unwrap().custom.is_some());
+    }
+
+    #[test]
+    fn question_modal_renders_without_panicking() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let app = app_with_question(vec!["Approve", "Deny"]);
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| crate::ui::render(f, &app)).unwrap();
+
+        // The rendered buffer should contain the question and an option label.
+        let buf = terminal.backend().buffer().clone();
+        let text: String = buf.content().iter().map(|c| c.symbol()).collect();
+        assert!(text.contains("Run this command?"), "question text missing");
+        assert!(text.contains("Approve"), "option label missing");
     }
 }

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -1,7 +1,7 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui::Frame;
 
 use crate::app::{App, Tab};
@@ -181,6 +181,78 @@ pub fn render_help(f: &mut Frame) {
             .border_style(Style::default().fg(colors::BRAND)),
     );
     f.render_widget(help, area);
+}
+
+/// Modal for an agent question (permission gate / clarification): the operator
+/// selects an option or types a free-text answer. Rendered over everything when
+/// `app.pending_question` is set.
+pub fn render_question(f: &mut Frame, app: &App) {
+    let Some(q) = &app.pending_question else {
+        return;
+    };
+
+    let mut lines: Vec<Line> = vec![
+        Line::from(Span::styled(
+            " Agent needs your input",
+            Style::default()
+                .fg(colors::BRAND)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::raw(""),
+    ];
+    for l in q.question.lines() {
+        lines.push(Line::raw(format!("  {l}")));
+    }
+    lines.push(Line::raw(""));
+
+    match &q.custom {
+        Some(buf) => {
+            lines.push(Line::raw("  Type your answer:"));
+            lines.push(Line::from(Span::styled(
+                format!("  > {buf}\u{258f}"),
+                Style::default().fg(colors::BRAND),
+            )));
+            lines.push(Line::raw(""));
+            lines.push(Line::raw(if q.options.is_empty() {
+                "  Enter answer  ·  Esc dismiss"
+            } else {
+                "  Enter answer  ·  Esc back to options"
+            }));
+        }
+        None => {
+            for (i, opt) in q.options.iter().enumerate() {
+                let selected = i == q.selected;
+                let marker = if selected { "\u{203a}" } else { " " };
+                let style = if selected {
+                    Style::default()
+                        .fg(colors::BRAND)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                };
+                lines.push(Line::from(Span::styled(
+                    format!("  {marker} {}. {opt}", i + 1),
+                    style,
+                )));
+            }
+            lines.push(Line::raw(""));
+            lines.push(Line::raw(
+                "  \u{2191}/\u{2193} select  ·  Enter answer  ·  1-9 quick  ·  c custom  ·  Esc dismiss",
+            ));
+        }
+    }
+
+    let height = (lines.len() as u16 + 2).min(f.area().height);
+    let area = centered_rect(60, height, f.area());
+    f.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(colors::BRAND))
+        .title(" Question ");
+    let para = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    f.render_widget(para, area);
 }
 
 fn centered_rect(percent_x: u16, height: u16, r: Rect) -> Rect {

--- a/crates/app/bamboo-tui/src/ui/mod.rs
+++ b/crates/app/bamboo-tui/src/ui/mod.rs
@@ -31,4 +31,9 @@ pub fn render(f: &mut Frame, app: &App) {
     if app.help_visible {
         layout::render_help(f);
     }
+
+    // Pending-question modal takes visual priority — it's the blocking interaction.
+    if app.pending_question.is_some() {
+        layout::render_question(f, app);
+    }
 }

--- a/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
@@ -381,13 +381,32 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
                 let _ = mpsc_tx.send(error_event).await;
             }
 
-            // Update runner status.
-            finalize_runner(&runners, &session_id, &result).await;
+            // Record the terminal run status on the session BEFORE persisting so
+            // the session summary reports a real `last_run_status`. Top-level
+            // sessions otherwise never set it, so summaries show
+            // `last_run_status: null`; the frontend then cannot confirm the run
+            // finished and falls back on a ~5s optimistic-settle window, leaving
+            // a phantom "thinking" indicator after the reply is already done
+            // (notably on a session's first turn). Same Ok/cancelled/error
+            // mapping `status_from_execution_result` applies to the runner.
+            match &result {
+                Ok(()) => {
+                    session.set_last_run_status("completed");
+                    session.clear_last_run_error();
+                }
+                Err(error) if error.is_cancelled() => {
+                    session.set_last_run_status("cancelled");
+                    session.set_last_run_error(error.to_string());
+                }
+                Err(error) => {
+                    session.set_last_run_status("error");
+                    session.set_last_run_error(error.to_string());
+                }
+            }
 
             // Bespoke terminal bookkeeping (e.g. a scheduled-run status) runs
-            // here — after the runner is finalized but before persistence — so
-            // any closing message the hook appends is saved with the session
-            // below.
+            // here — before persistence — so any closing message the hook
+            // appends is saved with the session below.
             if let Some(on_complete) = on_complete {
                 on_complete(SessionExecutionOutcome::from_result(&result), &mut session).await;
             }
@@ -398,6 +417,13 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
             if let Err(error) = agent.persistence().save_runtime_session(&mut session).await {
                 tracing::warn!("[{}] Failed to save session: {}", session_id, error);
             }
+
+            // Flip the runner registry to a terminal status (which makes session
+            // summaries report `is_running: false`) ONLY AFTER the run status is
+            // persisted above, so `is_running` and `last_run_status` become
+            // visible together and the frontend settles immediately instead of
+            // lingering in its optimistic-settle window.
+            finalize_runner(&runners, &session_id, &result).await;
 
             // Update memory cache.
             sessions_cache.insert(

--- a/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
@@ -389,7 +389,24 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
             // a phantom "thinking" indicator after the reply is already done
             // (notably on a session's first turn). Same Ok/cancelled/error
             // mapping `status_from_execution_result` applies to the runner.
+            //
+            // A suspended run also returns `Ok(())` but is NOT terminal: it
+            // stamped `runtime.suspend_reason` (awaiting_clarification /
+            // waiting_for_children / waiting_for_bash / awaiting_parent_approval)
+            // and will resume later (which removes the reason — see respond.rs /
+            // child_completion_coordinator). Mark it "suspended" rather than
+            // "completed" so a session waiting on the user or on children isn't
+            // reported as finished (mirrors the child path in `sdk::spawn`).
+            let suspended_non_terminal = result.is_ok()
+                && session
+                    .metadata
+                    .get("runtime.suspend_reason")
+                    .is_some_and(|reason| !reason.trim().is_empty());
             match &result {
+                Ok(()) if suspended_non_terminal => {
+                    session.set_last_run_status("suspended");
+                    session.clear_last_run_error();
+                }
                 Ok(()) => {
                     session.set_last_run_status("completed");
                     session.clear_last_run_error();

--- a/crates/engine/bamboo-engine/src/sdk/spawn.rs
+++ b/crates/engine/bamboo-engine/src/sdk/spawn.rs
@@ -311,8 +311,6 @@ pub async fn run_child_spawn(ctx: SpawnContext, job: SpawnJob) -> Result<(), Str
             }
         };
 
-        finalize_runner(&agent_runners_for_status, &session_id_clone, &result).await;
-
         // Merge any queued injected messages that the pipeline didn't pick up
         // (e.g. if the loop exited before the next turn boundary).
         crate::runtime::runner::state_bridge::merge_pending_injected_messages(
@@ -330,6 +328,14 @@ pub async fn run_child_spawn(ctx: SpawnContext, job: SpawnJob) -> Result<(), Str
             session.clear_last_run_error();
         }
         let _ = agent.persistence().save_runtime_session(&mut session).await;
+        // Flip the runner registry to a terminal status (which makes session
+        // summaries report `is_running: false`) ONLY AFTER the final
+        // `last_run_status` is persisted above. Doing it earlier opens a window
+        // where the summary reports `{is_running: false, last_run_status: null}`,
+        // which the frontend's optimistic-race window reads as "still settling",
+        // leaving a phantom "thinking" indicator for a few seconds after the
+        // reply has already completed (notably on a session's first turn).
+        finalize_runner(&agent_runners_for_status, &session_id_clone, &result).await;
         sessions_cache.insert(
             session_id_clone.clone(),
             Arc::new(parking_lot::RwLock::new(session)),


### PR DESCRIPTION
Two backend fixes surfaced while debugging the Bodhi desktop app. Independent; reviewable separately by file.

## 1. Rate limiter wrongly throttled the localhost sidecar
The per-IP Governor limiter (10 rps / burst 20, #13) was wrapped **unconditionally** on the static-serving paths (`web_service.rs`, `entrypoints.rs`), contradicting its own doc *"desktop/localhost mode does not apply it"* (and `lib.rs` *"localhost only, No rate limiting"*). The desktop webview bursts ~45 hashed `/assets/*` requests on load → exceeds burst 20 → **429** → `import()` rejects → *"Importing a module script failed" / "Too many requests"* on startup.

**Fix:** add `config::is_loopback_bind` (matches `127.0.0.1|localhost|::1`, mirrors the existing CORS loopback casing) and gate the limiter with `actix_web::middleware::Condition`. Loopback/desktop binds skip it; network binds (`0.0.0.0` Docker) stay throttled. Unit test `loopback_binds_skip_rate_limiter`.

## 2. Phantom "Assistant is thinking…" lingering after a reply completes
`is_running` in session summaries is the live runner-registry status (`is_session_running` → `agent_runners`), flipped by `finalize_runner`. It ran **before** `last_run_status` was persisted, so summaries briefly reported `{is_running:false, last_run_status:null}` — which the frontend's optimistic-settle window reads as *"still settling"*, leaving a stray thinking indicator for a few seconds (notably a session's first turn).

- **Top-level sessions** (`agent_spawn.rs`) additionally **never set `last_run_status` at all** → summaries could never confirm completion. Now set it (`Ok→completed` / cancelled / error, mirroring `status_from_execution_result`) before persisting.
- Both top-level and **child** (`sdk/spawn.rs`) paths now call `finalize_runner` **after** `save_runtime_session`, so `is_running` and `last_run_status` become visible together.

### Safety
`finalize_runner` only mutates registry status/`completed_at` (no stream side-effects); regular sessions pass `on_complete: None` and the scheduled-run hook doesn't read runner status. `cargo check` green; spawn-ordering + guardian-suspend tests pass.

🤖 Fixes verified by rebuilding the sidecar and HTTP-probing the served frontend (all assets 200 once the limiter is bypassed).

https://claude.ai/code/session_01Uxef9zNnsJzpY7hCUdnVVp