### PR TITLE
deps: bump tokio-tungstenite 0.24 → 0.29 (#307)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "tracing",
 ]
@@ -1365,7 +1365,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "tokio-util",
  "uuid",
 ]
@@ -6541,8 +6541,20 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.24.0",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -6809,6 +6821,22 @@ dependencies = [
  "sha1 0.10.6",
  "thiserror 1.0.69",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.2",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/app/bamboo-broker/Cargo.toml
+++ b/crates/app/bamboo-broker/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1"
 futures-util = "0.3"
 tokio = { version = "1", features = ["fs", "io-util", "rt", "rt-multi-thread", "sync", "macros", "net", "time"] }
 tokio-util = "0.7"
-tokio-tungstenite = "0.24"
+tokio-tungstenite = "0.29"
 russh = { version = "0.62", default-features = false, features = ["ring", "flate2", "rsa"] }
 russh-sftp = "2.3.0"
 sha2 = "0.11"

--- a/crates/app/bamboo-broker/src/client.rs
+++ b/crates/app/bamboo-broker/src/client.rs
@@ -71,7 +71,7 @@ impl BrokerClient {
         let (mut sink, mut source) = ws.split();
 
         // Handshake: send Hello, wait for Welcome (or Error).
-        sink.send(Message::Text(
+        sink.send(Message::text(
             ClientFrame::Hello {
                 agent,
                 token: token.into(),
@@ -315,7 +315,7 @@ impl BrokerClient {
 
     async fn send(&mut self, frame: ClientFrame) -> BrokerResult<()> {
         self.sink
-            .send(Message::Text(frame.to_text()))
+            .send(Message::text(frame.to_text()))
             .await
             .map_err(|e| BrokerError::Transport(format!("ws send: {e}")))
     }
@@ -413,7 +413,7 @@ mod tests {
             // First text frame is the client's `Hello`; answer with `Welcome`.
             if let Some(Ok(Message::Text(_))) = source.next().await {
                 let _ = sink
-                    .send(Message::Text(BrokerFrame::Welcome.to_text()))
+                    .send(Message::text(BrokerFrame::Welcome.to_text()))
                     .await;
             }
             // Drain the `Deliver` (and anything else) but never reply with
@@ -473,7 +473,7 @@ mod tests {
             // First text frame is the client's `Hello`; answer with `Welcome`.
             if let Some(Ok(Message::Text(_))) = source.next().await {
                 let _ = sink
-                    .send(Message::Text(BrokerFrame::Welcome.to_text()))
+                    .send(Message::text(BrokerFrame::Welcome.to_text()))
                     .await;
             }
             // Close cleanly so the client reader's `Ok(Close)` / stream-end arm
@@ -542,7 +542,7 @@ mod tests {
             let (mut sink, mut source) = ws.split();
             if let Some(Ok(Message::Text(_))) = source.next().await {
                 let _ = sink
-                    .send(Message::Text(BrokerFrame::Welcome.to_text()))
+                    .send(Message::text(BrokerFrame::Welcome.to_text()))
                     .await;
             }
             while let Some(Ok(Message::Text(txt))) = source.next().await {
@@ -550,7 +550,7 @@ mod tests {
                     let id = message.id.clone();
                     tokio::time::sleep(Duration::from_millis(50)).await;
                     let _ = sink
-                        .send(Message::Text(BrokerFrame::Delivered { id }.to_text()))
+                        .send(Message::text(BrokerFrame::Delivered { id }.to_text()))
                         .await;
                 }
             }

--- a/crates/app/bamboo-broker/src/mcp.rs
+++ b/crates/app/bamboo-broker/src/mcp.rs
@@ -1259,7 +1259,7 @@ mod tests {
                         if let Message::Text(t) = msg {
                             if ClientFrame::from_text(&t).is_ok() {
                                 let _ = sink
-                                    .send(Message::Text(BrokerFrame::Welcome.to_text()))
+                                    .send(Message::text(BrokerFrame::Welcome.to_text()))
                                     .await;
                                 break;
                             }
@@ -1279,7 +1279,7 @@ mod tests {
                             _ => continue,
                         };
                         let _ = sink
-                            .send(Message::Text(
+                            .send(Message::text(
                                 BrokerFrame::Delivered {
                                     id: message.id.clone(),
                                 }
@@ -1288,7 +1288,7 @@ mod tests {
                             .await;
                         let reply = answer_mcp_request(message, &orch);
                         let _ = sink
-                            .send(Message::Text(
+                            .send(Message::text(
                                 BrokerFrame::Message { message: reply }.to_text(),
                             ))
                             .await;

--- a/crates/app/bamboo-broker/src/mux.rs
+++ b/crates/app/bamboo-broker/src/mux.rs
@@ -169,7 +169,7 @@ impl MultiplexedClient {
         };
         {
             let mut sink = self.sink.lock().await;
-            sink.send(Message::Text(frame.to_text()))
+            sink.send(Message::text(frame.to_text()))
                 .await
                 .map_err(|e| BrokerError::Transport(format!("ws send: {e}")))?;
         }
@@ -192,7 +192,7 @@ impl MultiplexedClient {
             correlation_id: correlation_id.clone(),
         };
         let mut sink = self.sink.lock().await;
-        sink.send(Message::Text(frame.to_text()))
+        sink.send(Message::text(frame.to_text()))
             .await
             .map_err(|e| BrokerError::Transport(format!("ws send: {e}")))
     }

--- a/crates/app/bamboo-broker/src/server.rs
+++ b/crates/app/bamboo-broker/src/server.rs
@@ -189,7 +189,7 @@ async fn read_client_frame(source: &mut SplitStream<Ws>) -> BrokerResult<Option<
 }
 
 async fn send(sink: &mut SplitSink<Ws, Message>, frame: BrokerFrame) -> BrokerResult<()> {
-    sink.send(Message::Text(frame.to_text()))
+    sink.send(Message::text(frame.to_text()))
         .await
         .map_err(|e| BrokerError::Transport(format!("ws send: {e}")))
 }


### PR DESCRIPTION
tungstenite 0.26+ changed Text/Close payloads from `String` to `Utf8Bytes`. Only breakage: the 5 `Message::Text(<String>)` **construction** sites in the broker (client/mux/server/mcp) — converted to the `Message::text(...)` constructor fn (takes `Into<Utf8Bytes>`). Pattern-match sites unchanged (`Utf8Bytes: Deref<str>`, so `from_text(&t)`/`t.as_str()` still work); subagent already used the lowercase form.

Verified: workspace builds · bamboo-broker **53/0** (bus) · bamboo-subagent **46/0** (transport) · clippy (`-D warnings`) + fmt clean · `cargo audit` EXIT=0.

Closes #307.

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u