### PR TITLE
style(server): fmt config.rs — fixes red Lint on main

### DIFF
--- a/crates/app/bamboo-server/src/config.rs
+++ b/crates/app/bamboo-server/src/config.rs
@@ -602,7 +602,10 @@ mod tests {
         // Desktop sidecar binds must be exempt (frontend bursts asset requests);
         // network-exposed binds must stay throttled.
         for b in ["127.0.0.1", "localhost", "::1"] {
-            assert!(is_loopback_bind(b), "{b} should be loopback (limiter skipped)");
+            assert!(
+                is_loopback_bind(b),
+                "{b} should be loopback (limiter skipped)"
+            );
         }
         for b in ["0.0.0.0", "192.168.1.10", "::"] {
             assert!(!is_loopback_bind(b), "{b} should be throttled");


### PR DESCRIPTION
#317 merged an unformatted `assert!` in a `config.rs` test, so `cargo fmt --check` (the Lint job) is **red on main** and on every open PR rebased onto it. `cargo fmt` wraps the one line — no behavior change. Verified: the whole workspace is fmt-clean after this.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU