### PR TITLE
feat(tui): tool-call args + expandable results, and mouse-wheel scroll (#248)

### DIFF
--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -385,6 +385,7 @@ impl App {
             AppEvent::ApiError(msg) => {
                 self.status_message = format!("Error: {}", msg);
             }
+            AppEvent::Mouse(mouse) => self.handle_mouse(mouse),
             AppEvent::SessionsLoaded(r) => {
                 self.sessions.loading = false;
                 match r {
@@ -468,6 +469,30 @@ impl App {
             _ => {}
         }
         Ok(())
+    }
+
+    /// Mouse wheel scrolls the active scrollable view (chat transcript / config).
+    fn handle_mouse(&mut self, mouse: crossterm::event::MouseEvent) {
+        use crossterm::event::MouseEventKind;
+        let delta = match mouse.kind {
+            MouseEventKind::ScrollUp => -3i32,
+            MouseEventKind::ScrollDown => 3i32,
+            _ => return,
+        };
+        match self.tab {
+            Tab::Chat => {
+                self.chat.auto_scroll = false;
+                self.chat.scroll_offset =
+                    self.chat.scroll_offset.saturating_add_signed(delta as i16);
+            }
+            Tab::Config => {
+                self.config.scroll_offset = self
+                    .config
+                    .scroll_offset
+                    .saturating_add_signed(delta as i16);
+            }
+            _ => {}
+        }
     }
 
     async fn handle_key(&mut self, key: KeyEvent) -> Result<()> {
@@ -1285,5 +1310,24 @@ mod question_tests {
             .unwrap();
         assert!(!app.sessions.loading);
         assert_eq!(app.sessions.error.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn mouse_wheel_scrolls_chat() {
+        use crossterm::event::{MouseEvent, MouseEventKind};
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.tab = Tab::Chat;
+        app.chat.scroll_offset = 10;
+        let ev = |k| MouseEvent {
+            kind: k,
+            column: 0,
+            row: 0,
+            modifiers: crossterm::event::KeyModifiers::empty(),
+        };
+        app.handle_mouse(ev(MouseEventKind::ScrollUp));
+        assert_eq!(app.chat.scroll_offset, 7);
+        assert!(!app.chat.auto_scroll);
+        app.handle_mouse(ev(MouseEventKind::ScrollDown));
+        assert_eq!(app.chat.scroll_offset, 10);
     }
 }

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -103,6 +103,9 @@ pub struct ChatState {
     pub model: String,
     pub token_usage: Option<TokenUsage>,
     pub plan_mode: bool,
+    /// When true, tool-call arguments and results render in full instead
+    /// of truncated. Toggled with `x` on the Chat tab.
+    pub expand_tools: bool,
 }
 
 impl ChatState {
@@ -123,6 +126,7 @@ impl ChatState {
             model: String::new(),
             token_usage: None,
             plan_mode: false,
+            expand_tools: false,
         }
     }
 }
@@ -708,6 +712,9 @@ impl App {
                 KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     self.stop_streaming().await?;
                 }
+                KeyCode::Char('x') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.chat.expand_tools = !self.chat.expand_tools;
+                }
                 KeyCode::Char('j') | KeyCode::Down => {
                     self.chat.auto_scroll = false;
                     self.chat.scroll_offset = self.chat.scroll_offset.saturating_add(3);
@@ -747,6 +754,9 @@ impl App {
             }
             KeyCode::Char('G') => {
                 self.chat.auto_scroll = true;
+            }
+            KeyCode::Char('x') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.chat.expand_tools = !self.chat.expand_tools;
             }
             _ => {
                 self.chat.textarea.input(key);

--- a/crates/app/bamboo-tui/src/ui/chat.rs
+++ b/crates/app/bamboo-tui/src/ui/chat.rs
@@ -4,9 +4,60 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
 use ratatui::Frame;
 
-use crate::app::{App, MessageRole};
+use crate::app::{App, MessageRole, ToolCallDisplay};
 use crate::components::markdown;
 use crate::theme::{self, colors};
+
+/// Render a tool call's arguments, result, and error under its name line.
+/// Truncated by default (args → one preview line, result → 3 lines); `expand`
+/// (Ctrl+X on the Chat tab) shows everything.
+fn push_tool_detail(lines: &mut Vec<Line<'static>>, tc: &ToolCallDisplay, expand: bool) {
+    // Arguments.
+    let args = tc.arguments.trim();
+    if !args.is_empty() && args != "null" && args != "{}" {
+        if expand {
+            for aline in args.lines() {
+                lines.push(Line::from(Span::styled(
+                    format!("   args: {aline}"),
+                    Style::default().fg(colors::SUBTLE),
+                )));
+            }
+        } else {
+            let preview: String = args.chars().take(88).collect();
+            let ellipsis = if args.chars().count() > 88 { "…" } else { "" };
+            lines.push(Line::from(Span::styled(
+                format!("   args: {preview}{ellipsis}"),
+                Style::default().fg(colors::SUBTLE),
+            )));
+        }
+    }
+
+    // Result.
+    if let Some(result) = &tc.result {
+        let max = if expand { usize::MAX } else { 3 };
+        for rline in result.lines().take(max) {
+            lines.push(Line::from(Span::styled(
+                format!("   {rline}"),
+                Style::default().fg(colors::INACTIVE),
+            )));
+        }
+        let total = result.lines().count();
+        if !expand && total > 3 {
+            lines.push(Line::from(Span::styled(
+                format!("   … ({} more — Ctrl+X to expand)", total - 3),
+                Style::default().fg(colors::SUBTLE),
+            )));
+        }
+    }
+
+    // Error.
+    if let Some(err) = &tc.error {
+        lines.push(Line::from(Span::styled(
+            format!("   Error: {err}"),
+            Style::default().fg(colors::TOOL_ERROR),
+        )));
+    }
+}
 
 pub fn render(f: &mut Frame, content: Rect, input: Rect, app: &App) {
     let lines = build_message_lines(app, content.width);
@@ -77,27 +128,7 @@ fn build_message_lines(app: &App, width: u16) -> Vec<Line<'static>> {
                         format!(" {} {}", icon, tc.tool_name),
                         style,
                     )));
-                    if let Some(result) = &tc.result {
-                        for rline in result.lines().take(3) {
-                            lines.push(Line::from(Span::styled(
-                                format!("   {}", rline),
-                                Style::default().fg(colors::INACTIVE),
-                            )));
-                        }
-                        let total = result.lines().count();
-                        if total > 3 {
-                            lines.push(Line::from(Span::styled(
-                                format!("   ... ({} more lines)", total - 3),
-                                Style::default().fg(colors::SUBTLE),
-                            )));
-                        }
-                    }
-                    if let Some(err) = &tc.error {
-                        lines.push(Line::from(Span::styled(
-                            format!("   Error: {}", err),
-                            Style::default().fg(colors::TOOL_ERROR),
-                        )));
-                    }
+                    push_tool_detail(&mut lines, tc, app.chat.expand_tools);
                 }
 
                 // Reasoning / thinking block
@@ -158,6 +189,7 @@ fn build_message_lines(app: &App, width: u16) -> Vec<Line<'static>> {
                 format!(" {} {}", icon, tc.tool_name),
                 style,
             )));
+            push_tool_detail(&mut lines, tc, app.chat.expand_tools);
         }
 
         // Streaming thinking
@@ -190,4 +222,41 @@ fn build_message_lines(app: &App, width: u16) -> Vec<Line<'static>> {
     }
 
     lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tc(args: &str, result: Option<&str>) -> ToolCallDisplay {
+        ToolCallDisplay {
+            tool_name: "Read".into(),
+            arguments: args.into(),
+            result: result.map(String::from),
+            error: None,
+            phase: "complete".into(),
+        }
+    }
+
+    #[test]
+    fn tool_detail_truncates_then_expands() {
+        let t = tc("{\"path\":\"x\"}", Some("l1\nl2\nl3\nl4\nl5"));
+
+        let mut lines: Vec<Line> = Vec::new();
+        push_tool_detail(&mut lines, &t, false);
+        // args(1) + 3 result lines + "N more" marker(1) = 5
+        assert_eq!(lines.len(), 5);
+
+        let mut lines: Vec<Line> = Vec::new();
+        push_tool_detail(&mut lines, &t, true);
+        // args(1) + all 5 result lines = 6
+        assert_eq!(lines.len(), 6);
+    }
+
+    #[test]
+    fn empty_args_and_no_result_render_nothing() {
+        let mut lines: Vec<Line> = Vec::new();
+        push_tool_detail(&mut lines, &tc("{}", None), false);
+        assert!(lines.is_empty());
+    }
 }

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -166,6 +166,7 @@ pub fn render_help(f: &mut Frame) {
         Line::raw("  Enter       Send message / Select item"),
         Line::raw("  Ctrl+C      Quit / Stop streaming"),
         Line::raw("  Ctrl+S      Stop agent execution"),
+        Line::raw("  Ctrl+X      Expand/collapse tool args & results"),
         Line::raw("  j/k         Scroll down/up"),
         Line::raw("  d           Delete (with context)"),
         Line::raw("  r           Refresh / Run schedule"),


### PR DESCRIPTION
Two #248 chat-viewing UX improvements:

**1. Tool-call arguments + expandable results.** The chat view showed a tool call's name + a 3-line result preview but **never its arguments**, and long output was unavoidably truncated. `push_tool_detail` now renders `args:` (one-line preview, or full when expanded) + result (3 lines, or full) + error, shared by the historical and live streaming paths. **`Ctrl+X`** toggles expand; truncated results show `… (N more — Ctrl+X to expand)`.

**2. Mouse-wheel scroll.** The TUI captures the mouse (disabling native scroll) but ignored the events. `handle_mouse` now routes wheel ScrollUp/ScrollDown to the chat transcript / config view (3 lines/notch, disengages chat auto-scroll).

Both added to the help overlay. Tests: truncate-vs-expand line counts, empty-args case, chat wheel-scroll. clippy + fmt clean on ratatui 0.30.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU