### PR TITLE
feat(tui): sub-agent activity view (#248)

### DIFF
--- a/crates/app/bamboo-client-core/src/lib.rs
+++ b/crates/app/bamboo-client-core/src/lib.rs
@@ -130,6 +130,25 @@ pub enum AgentEvent {
     Error {
         message: String,
     },
+
+    // ── Sub-agent lifecycle (forwarded from the parent session's stream) ──
+    // Minimal projections of the server's SubAgent* events; extra server fields
+    // (parent_session_id, timestamp, the nested `event`) are ignored on decode.
+    SubAgentStarted {
+        child_session_id: String,
+        #[serde(default)]
+        title: Option<String>,
+    },
+    SubAgentHeartbeat {
+        child_session_id: String,
+    },
+    SubAgentCompleted {
+        child_session_id: String,
+        /// "completed" | "cancelled" | "error" | "skipped"
+        status: String,
+        #[serde(default)]
+        error: Option<String>,
+    },
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -81,6 +81,14 @@ pub struct ToolCallDisplay {
 }
 
 #[derive(Debug, Clone)]
+pub struct SubAgentDisplay {
+    pub child_session_id: String,
+    pub title: Option<String>,
+    /// "running" | "completed" | "cancelled" | "error" | "skipped".
+    pub status: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct ChatMessage {
     pub role: MessageRole,
     pub content: String,
@@ -106,6 +114,8 @@ pub struct ChatState {
     /// When true, tool-call arguments and results render in full instead
     /// of truncated. Toggled with `x` on the Chat tab.
     pub expand_tools: bool,
+    /// Sub-agents spawned by the current run (child lifecycle).
+    pub sub_agents: Vec<SubAgentDisplay>,
 }
 
 impl ChatState {
@@ -127,6 +137,7 @@ impl ChatState {
             token_usage: None,
             plan_mode: false,
             expand_tools: false,
+            sub_agents: Vec::new(),
         }
     }
 }
@@ -988,6 +999,38 @@ impl App {
             AgentEvent::PlanFileUpdated { file_path, .. } => {
                 self.status_message = format!("Plan updated: {}", file_path);
             }
+            AgentEvent::SubAgentStarted {
+                child_session_id,
+                title,
+            } => {
+                if !self
+                    .chat
+                    .sub_agents
+                    .iter()
+                    .any(|s| s.child_session_id == child_session_id)
+                {
+                    self.chat.sub_agents.push(SubAgentDisplay {
+                        child_session_id,
+                        title,
+                        status: "running".to_string(),
+                    });
+                }
+            }
+            AgentEvent::SubAgentHeartbeat { .. } => {}
+            AgentEvent::SubAgentCompleted {
+                child_session_id,
+                status,
+                ..
+            } => {
+                if let Some(sa) = self
+                    .chat
+                    .sub_agents
+                    .iter_mut()
+                    .find(|s| s.child_session_id == child_session_id)
+                {
+                    sa.status = status;
+                }
+            }
         }
         Ok(())
     }
@@ -1010,6 +1053,7 @@ impl App {
         self.status_message = "Ready".to_string();
         self.sse_tx = None;
         self.sse_rx = None;
+        self.chat.sub_agents.clear();
         // A run that ended (completed / cancelled / stopped) can no longer accept
         // an answer, so drop any open question modal to avoid answering a dead
         // session.
@@ -1445,5 +1489,34 @@ mod question_tests {
         // Esc cancels.
         app.handle_schedule_form_key(k(KeyCode::Esc));
         assert!(app.schedule_form.is_none());
+    }
+
+    #[tokio::test]
+    async fn subagent_lifecycle_tracks_children() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.chat.streaming = true;
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "c1".into(),
+            title: Some("research".into()),
+        })
+        .unwrap();
+        assert_eq!(app.chat.sub_agents.len(), 1);
+        assert_eq!(app.chat.sub_agents[0].status, "running");
+
+        // Duplicate start is ignored.
+        app.handle_sse_event(AgentEvent::SubAgentStarted {
+            child_session_id: "c1".into(),
+            title: None,
+        })
+        .unwrap();
+        assert_eq!(app.chat.sub_agents.len(), 1);
+
+        app.handle_sse_event(AgentEvent::SubAgentCompleted {
+            child_session_id: "c1".into(),
+            status: "completed".into(),
+            error: None,
+        })
+        .unwrap();
+        assert_eq!(app.chat.sub_agents[0].status, "completed");
     }
 }

--- a/crates/app/bamboo-tui/src/ui/chat.rs
+++ b/crates/app/bamboo-tui/src/ui/chat.rs
@@ -192,6 +192,32 @@ fn build_message_lines(app: &App, width: u16) -> Vec<Line<'static>> {
             push_tool_detail(&mut lines, tc, app.chat.expand_tools);
         }
 
+        // Sub-agents spawned by this run.
+        if !app.chat.sub_agents.is_empty() {
+            for sa in &app.chat.sub_agents {
+                let (icon, style) = match sa.status.as_str() {
+                    "running" => {
+                        let tick = app.spinner_tick % theme::BRAILLE_SPINNER.len();
+                        (
+                            theme::BRAILLE_SPINNER[tick],
+                            Style::default().fg(colors::TOOL_RUNNING),
+                        )
+                    }
+                    "completed" => ("✓", Style::default().fg(colors::TOOL_DONE)),
+                    "error" | "cancelled" => ("✗", Style::default().fg(colors::TOOL_ERROR)),
+                    _ => ("·", Style::default().fg(colors::INACTIVE)),
+                };
+                let label = sa.title.clone().unwrap_or_else(|| {
+                    let short: String = sa.child_session_id.chars().take(8).collect();
+                    format!("sub-agent {short}")
+                });
+                lines.push(Line::from(Span::styled(
+                    format!(" {icon} ▸ {label} ({})", sa.status),
+                    style,
+                )));
+            }
+        }
+
         // Streaming thinking
         if !app.chat.current_reasoning.is_empty() {
             let sep_len: usize = 40;


### PR DESCRIPTION
Part of #248 — the last big TUI gap. The server forwards `sub_agent_started/heartbeat/completed` into the parent session's stream, but client-core's `AgentEvent` didn't model them, so the TUI **silently dropped** them and sub-agent activity was invisible.

- **client-core**: minimal `SubAgentStarted`/`SubAgentHeartbeat`/`SubAgentCompleted` variants (extra server fields ignored on decode; only bamboo-tui consumes this type).
- **TUI**: tracks children in `chat.sub_agents` (started→running, completed→final status; duplicates ignored; cleared on run end) and renders `▸ <title> (status)` per child under the streaming tool calls, spinner while running.

Test covers start → duplicate-ignore → complete. clippy + fmt clean on ratatui 0.30.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU