### PR TITLE
fix(tui): make schedule create/list match the server contract

### DIFF
--- a/crates/app/bamboo-tui/src/api/mod.rs
+++ b/crates/app/bamboo-tui/src/api/mod.rs
@@ -190,19 +190,32 @@ impl BambooClient {
             .get(self.url("/api/v1/schedules"))
             .send()
             .await?;
-        let schedules = resp.json().await?;
-        Ok(schedules)
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("list schedules failed ({status}): {body}");
+        }
+        let parsed: ListSchedulesResponse = resp.json().await?;
+        Ok(parsed
+            .schedules
+            .into_iter()
+            .map(Schedule::from_view)
+            .collect())
     }
 
-    pub async fn create_schedule(&self, req: CreateScheduleRequest) -> Result<Schedule> {
+    pub async fn create_schedule(&self, req: CreateScheduleRequest) -> Result<()> {
         let resp = self
             .client
             .post(self.url("/api/v1/schedules"))
             .json(&req)
             .send()
             .await?;
-        let schedule = resp.json().await?;
-        Ok(schedule)
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("create schedule failed ({status}): {body}");
+        }
+        Ok(())
     }
 
     pub async fn delete_schedule(&self, id: &str) -> Result<()> {

--- a/crates/app/bamboo-tui/src/api/types.rs
+++ b/crates/app/bamboo-tui/src/api/types.rs
@@ -80,34 +80,115 @@ pub struct ToolInfo {
 
 // ── Schedules ──
 
-#[derive(Deserialize, Debug, Clone)]
+/// Flat, display-oriented schedule used by the Schedules tab. Built from the
+/// server's richer `ScheduleView` via [`Schedule::from_view`] — the server has
+/// no flat `cron`/`prompt` fields, so we project its `trigger`/`state` into the
+/// handful of fields the list actually renders.
+#[derive(Debug, Clone)]
 pub struct Schedule {
     pub id: String,
-    #[serde(default)]
     pub name: Option<String>,
-    #[serde(default)]
     pub cron: Option<String>,
-    #[serde(default)]
     pub enabled: Option<bool>,
-    #[serde(default)]
     pub prompt: Option<String>,
-    #[serde(default)]
-    pub created_at: Option<DateTime<Utc>>,
-    #[serde(default)]
     pub last_run: Option<DateTime<Utc>>,
-    #[serde(default)]
     pub next_run: Option<DateTime<Utc>>,
 }
 
+impl Schedule {
+    pub fn from_view(v: ScheduleView) -> Self {
+        Self {
+            cron: Some(trigger_display(&v.trigger)),
+            name: Some(v.name),
+            enabled: Some(v.enabled),
+            prompt: v.run_config.task_message,
+            last_run: v.state.last_finished_at,
+            next_run: v.state.next_fire_at,
+            id: v.id,
+        }
+    }
+}
+
+/// Human-readable one-liner for a schedule trigger. Cron triggers show their
+/// expression; other trigger kinds show their `type` tag (e.g. `interval`).
+fn trigger_display(trigger: &serde_json::Value) -> String {
+    match trigger.get("type").and_then(|t| t.as_str()) {
+        Some("cron") => trigger
+            .get("expr")
+            .and_then(|e| e.as_str())
+            .unwrap_or("cron")
+            .to_string(),
+        Some(kind) => kind.to_string(),
+        None => "-".to_string(),
+    }
+}
+
+/// Wire shape of `GET /api/v1/schedules` — the server wraps the list in a
+/// `{ "schedules": [...] }` envelope (`ListSchedulesResponse`).
+#[derive(Deserialize, Debug, Clone)]
+pub struct ListSchedulesResponse {
+    #[serde(default)]
+    pub schedules: Vec<ScheduleView>,
+}
+
+/// Subset of the server's `ScheduleView` the TUI consumes. The full trigger
+/// enum is kept as an opaque `Value` (see [`trigger_display`]) so new trigger
+/// kinds don't break deserialization.
+#[derive(Deserialize, Debug, Clone)]
+pub struct ScheduleView {
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub trigger: serde_json::Value,
+    #[serde(default)]
+    pub state: ScheduleStateView,
+    #[serde(default)]
+    pub run_config: ScheduleRunConfigView,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct ScheduleStateView {
+    #[serde(default)]
+    pub next_fire_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub last_finished_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct ScheduleRunConfigView {
+    #[serde(default)]
+    pub task_message: Option<String>,
+}
+
+/// Body of `POST /api/v1/schedules`. Must match the server's
+/// `CreateScheduleRequest`: a tagged `trigger` and a `run_config` carrying the
+/// prompt (there is no flat `cron`/`prompt` on the server side).
 #[derive(Serialize)]
 pub struct CreateScheduleRequest {
     pub name: String,
-    pub cron: String,
-    pub prompt: String,
+    pub trigger: ScheduleTriggerReq,
+    pub enabled: bool,
+    pub run_config: ScheduleRunConfigReq,
+}
+
+/// Serialize-side mirror of the server's internally-tagged `ScheduleTrigger`.
+/// The TUI form only authors cron triggers today.
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ScheduleTriggerReq {
+    Cron { expr: String },
+}
+
+#[derive(Serialize, Default)]
+pub struct ScheduleRunConfigReq {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub workspace_path: Option<String>,
+    pub task_message: Option<String>,
+    /// Run the authored prompt when the schedule fires (only meaningful with a
+    /// `task_message`).
+    pub auto_execute: bool,
 }
 
 // ── Skills ──

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -13,7 +13,7 @@ use crate::api::BambooClient;
 use crate::event::AppEvent;
 use crate::ui;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Tab {
     Chat,
     Sessions,
@@ -551,6 +551,15 @@ impl App {
         // stops the run) until it is answered or dismissed.
         if self.pending_question.is_some() {
             return self.handle_question_key(key).await;
+        }
+
+        // The schedule-authoring modal likewise captures all input: Tab moves
+        // between fields and digits belong in cron expressions, so it must run
+        // before the global Tab/1-6 tab-switching below (which would otherwise
+        // swallow those keys and never reach the form).
+        if self.schedule_form.is_some() {
+            self.handle_schedule_form_key(key);
+            return Ok(());
         }
 
         if let KeyCode::Char(c) = key.code {
@@ -1163,10 +1172,8 @@ impl App {
     }
 
     async fn handle_schedules_key(&mut self, key: KeyEvent) -> Result<()> {
-        if self.schedule_form.is_some() {
-            self.handle_schedule_form_key(key);
-            return Ok(());
-        }
+        // Note: when `schedule_form` is open, `handle_key` routes every key
+        // straight to `handle_schedule_form_key` before reaching here.
         match key.code {
             KeyCode::Char('n') => {
                 self.schedule_form = Some(ScheduleForm::default());
@@ -1225,10 +1232,14 @@ impl App {
                 }
                 let req = CreateScheduleRequest {
                     name: form.name.trim().to_string(),
-                    cron: form.cron.trim().to_string(),
-                    prompt: form.prompt.trim().to_string(),
-                    model: None,
-                    workspace_path: None,
+                    trigger: ScheduleTriggerReq::Cron {
+                        expr: form.cron.trim().to_string(),
+                    },
+                    enabled: true,
+                    run_config: ScheduleRunConfigReq {
+                        task_message: Some(form.prompt.trim().to_string()),
+                        auto_execute: true,
+                    },
                 };
                 self.schedule_form = None;
                 if let Some(tx) = self.event_tx.clone() {
@@ -1489,6 +1500,30 @@ mod question_tests {
         // Esc cancels.
         app.handle_schedule_form_key(k(KeyCode::Esc));
         assert!(app.schedule_form.is_none());
+    }
+
+    /// Regression: while the form is open, `handle_key` must route Tab and the
+    /// 1-6 digit keys to the form instead of switching app tabs (cron
+    /// expressions are full of digits, Tab moves between fields).
+    #[tokio::test]
+    async fn schedule_form_captures_keys_through_handle_key() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let k = |c| KeyEvent::new(c, KeyModifiers::empty());
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.tab = Tab::Schedules;
+        app.handle_key(k(KeyCode::Char('n'))).await.unwrap();
+        assert!(app.schedule_form.is_some(), "`n` opens the form");
+
+        // A digit must be typed into the focused field, not switch to tab N.
+        app.handle_key(k(KeyCode::Char('1'))).await.unwrap();
+        assert_eq!(app.tab, Tab::Schedules, "digit must not switch tabs");
+        assert_eq!(app.schedule_form.as_ref().unwrap().name, "1");
+
+        // Tab must advance the form field, not switch app tab.
+        app.handle_key(k(KeyCode::Tab)).await.unwrap();
+        assert_eq!(app.tab, Tab::Schedules, "Tab must not switch tabs");
+        assert_eq!(app.schedule_form.as_ref().unwrap().field, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

The schedule-authoring modal shipped in #331 **could never create a schedule**, and the Schedules tab **could not load at all** — the sub-agent review of #331 flagged both blockers, but #331 was merged before they were addressed. This PR fixes the client↔server contract drift.

## Blockers fixed

1. **Create request shape.** `POST /api/v1/schedules` expects `{ name, trigger: ScheduleTrigger, enabled, run_config }`. The client sent flat `{ name, cron, prompt }` with no `trigger`, so Actix's JSON extractor rejected it before the handler ran. Now builds `ScheduleTrigger::Cron { expr }` + `run_config.task_message` (with `auto_execute: true` so the prompt runs when the schedule fires).

2. **List response shape.** `GET /api/v1/schedules` returns `{ schedules: [ScheduleView] }`, but the client deserialized a bare `Vec<Schedule>` → every list load errored. Now parses the envelope and projects `ScheduleView` (trigger enum + state + run_config) into the flat display `Schedule` the tab renders. The trigger is kept as an opaque `Value` so new trigger kinds don't break deserialization.

3. **Key interception.** While the form was open, `handle_key` ran the global **Tab** / **1-6** tab-switching *before* dispatching to the form, so Tab never moved between fields and typing a digit (ubiquitous in cron: `0 9 * * 1-5`) silently switched app tabs and dropped the keystroke. Now the form captures all input first, mirroring the `pending_question` modal.

## Also

- `create_schedule` / `list_schedules` now check the response status and surface the server's error body instead of a generic `error decoding response body`.
- Added a regression test that drives the form through `handle_key` (the existing test called `handle_schedule_form_key` directly, bypassing the buggy path). Added `Debug` to `Tab`.

## Verification
`cargo test -p bamboo-tui` (20 pass), `cargo clippy … -D warnings`, `cargo fmt --check` — all green locally. Cron trigger validation server-side only requires a non-empty `expr`, which the form already enforces.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU