### PR TITLE
feat(tui): edit config JSON in-place from the Config tab

### DIFF
--- a/crates/app/bamboo-tui/src/api/mod.rs
+++ b/crates/app/bamboo-tui/src/api/mod.rs
@@ -265,11 +265,17 @@ impl BambooClient {
     }
 
     pub async fn set_config(&self, config: &serde_json::Value) -> Result<()> {
-        self.client
+        let resp = self
+            .client
             .post(self.url("/v1/bamboo/config"))
             .json(config)
             .send()
             .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("set config failed ({status}): {body}");
+        }
         Ok(())
     }
 

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -272,6 +272,13 @@ impl ScheduleForm {
     }
 }
 
+/// In-place editor for the raw config JSON (opened with `e` on the Config tab).
+/// The buffer is a multi-line `TextArea`; on save it must parse as JSON before
+/// it is PATCHed to the server.
+pub struct ConfigEditor {
+    pub textarea: TextArea<'static>,
+}
+
 // ── Main App ──
 
 pub struct App {
@@ -294,6 +301,9 @@ pub struct App {
     /// In-progress new-schedule form (Schedules tab). When `Some`, a modal
     /// captures the fields.
     pub schedule_form: Option<ScheduleForm>,
+    /// In-progress raw-JSON config editor (Config tab). When `Some`, a modal
+    /// textarea captures all keystrokes.
+    pub config_editor: Option<ConfigEditor>,
     /// Sender into the main event loop, used to post results of background API
     /// calls (so those calls never block the UI thread). Set in [`run`].
     event_tx: Option<mpsc::UnboundedSender<AppEvent>>,
@@ -319,6 +329,7 @@ impl App {
             spinner_tick: 0,
             pending_question: None,
             schedule_form: None,
+            config_editor: None,
             event_tx: None,
             sse_tx: None,
             sse_rx: None,
@@ -560,6 +571,13 @@ impl App {
         if self.schedule_form.is_some() {
             self.handle_schedule_form_key(key);
             return Ok(());
+        }
+
+        // The config editor is a full multi-line text buffer, so it must claim
+        // every key (digits, Tab, Enter/newlines) before the global navigation
+        // below — same rationale as the schedule form.
+        if self.config_editor.is_some() {
+            return self.handle_config_editor_key(key);
         }
 
         if let KeyCode::Char(c) = key.code {
@@ -1292,8 +1310,69 @@ impl App {
             KeyCode::Up => {
                 self.config.scroll_offset = self.config.scroll_offset.saturating_sub(1);
             }
+            KeyCode::Char('e') => {
+                // Open the raw-JSON editor prefilled with the current config.
+                match &self.config.config {
+                    Some(val) => {
+                        let pretty =
+                            serde_json::to_string_pretty(val).unwrap_or_else(|_| val.to_string());
+                        let lines: Vec<String> = pretty.lines().map(String::from).collect();
+                        self.config_editor = Some(ConfigEditor {
+                            textarea: TextArea::new(lines),
+                        });
+                    }
+                    None => {
+                        self.status_message = "No config loaded to edit".to_string();
+                    }
+                }
+            }
             _ => {}
         }
+    }
+
+    /// Drive the raw-JSON config editor modal. `Ctrl+S` validates the buffer as
+    /// JSON and, if valid, PATCHes it to the server off the event loop; `Esc`
+    /// cancels. Every other key edits the text buffer.
+    fn handle_config_editor_key(&mut self, key: KeyEvent) -> Result<()> {
+        if key.code == KeyCode::Esc {
+            self.config_editor = None;
+            self.status_message = "Edit cancelled".to_string();
+            return Ok(());
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('s') {
+            let text = self
+                .config_editor
+                .as_ref()
+                .map(|e| e.textarea.lines().join("\n"))
+                .unwrap_or_default();
+            match serde_json::from_str::<serde_json::Value>(&text) {
+                Ok(val) => {
+                    self.config_editor = None;
+                    self.status_message = "Saving config...".to_string();
+                    if let Some(tx) = self.event_tx.clone() {
+                        let client = self.client.clone();
+                        tokio::spawn(async move {
+                            let status = match client.set_config(&val).await {
+                                Ok(()) => "Config saved".to_string(),
+                                Err(e) => format!("Save failed: {e}"),
+                            };
+                            let _ = tx.send(AppEvent::ActionDone {
+                                status,
+                                reload_tab: true,
+                            });
+                        });
+                    }
+                }
+                Err(e) => {
+                    self.status_message = format!("Invalid JSON: {e}");
+                }
+            }
+            return Ok(());
+        }
+        if let Some(editor) = self.config_editor.as_mut() {
+            editor.textarea.input(key);
+        }
+        Ok(())
     }
 }
 
@@ -1524,6 +1603,44 @@ mod question_tests {
         app.handle_key(k(KeyCode::Tab)).await.unwrap();
         assert_eq!(app.tab, Tab::Schedules, "Tab must not switch tabs");
         assert_eq!(app.schedule_form.as_ref().unwrap().field, 1);
+    }
+
+    #[tokio::test]
+    async fn config_editor_opens_validates_and_cancels() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let plain = |c| KeyEvent::new(c, KeyModifiers::empty());
+        let ctrl_s = KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL);
+
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        app.tab = Tab::Config;
+
+        // `e` with no config loaded just posts a status, opens nothing.
+        app.handle_key(plain(KeyCode::Char('e'))).await.unwrap();
+        assert!(app.config_editor.is_none());
+
+        // With a config, `e` opens the editor prefilled.
+        app.config.config = Some(serde_json::json!({ "a": 1 }));
+        app.handle_key(plain(KeyCode::Char('e'))).await.unwrap();
+        assert!(app.config_editor.is_some());
+
+        // Corrupt the buffer (prepend a stray char) → Ctrl+S must NOT close it.
+        app.handle_key(plain(KeyCode::Char('x'))).await.unwrap();
+        app.handle_key(ctrl_s).await.unwrap();
+        assert!(
+            app.config_editor.is_some(),
+            "invalid JSON must keep the editor open"
+        );
+        assert!(app.status_message.contains("Invalid JSON"));
+
+        // Esc cancels.
+        app.handle_key(plain(KeyCode::Esc)).await.unwrap();
+        assert!(app.config_editor.is_none());
+
+        // A clean open + immediate Ctrl+S (buffer is valid) closes the editor.
+        app.handle_key(plain(KeyCode::Char('e'))).await.unwrap();
+        assert!(app.config_editor.is_some());
+        app.handle_key(ctrl_s).await.unwrap();
+        assert!(app.config_editor.is_none(), "valid JSON saves and closes");
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-tui/src/ui/config.rs
+++ b/crates/app/bamboo-tui/src/ui/config.rs
@@ -87,10 +87,11 @@ pub fn render_editor(f: &mut Frame, app: &App) {
     f.render_widget(&editor.textarea, inner);
 }
 
-/// Rect covering `pw`%×`ph`% of `r`, centered.
+/// Rect covering `pw`%×`ph`% of `r`, centered. Percentage math is done in u32
+/// so a very wide terminal (width ≥ 820) can't overflow the u16 multiply.
 fn centered(r: Rect, pw: u16, ph: u16) -> Rect {
-    let w = (r.width * pw / 100).min(r.width);
-    let h = (r.height * ph / 100).min(r.height);
+    let w = ((r.width as u32 * pw as u32 / 100) as u16).min(r.width);
+    let h = ((r.height as u32 * ph as u32 / 100) as u16).min(r.height);
     let x = r.x + r.width.saturating_sub(w) / 2;
     let y = r.y + r.height.saturating_sub(h) / 2;
     Rect::new(x, y, w, h)

--- a/crates/app/bamboo-tui/src/ui/config.rs
+++ b/crates/app/bamboo-tui/src/ui/config.rs
@@ -1,7 +1,7 @@
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Paragraph, Wrap};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui::Frame;
 
 use crate::app::App;
@@ -62,9 +62,36 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
 
     let config = Paragraph::new(lines)
         .block(Block::default().title(Span::styled(
-            " Config (j/k to scroll)",
+            " Config (j/k scroll · e edit)",
             Style::default().fg(colors::BRAND),
         )))
         .wrap(Wrap { trim: false });
     f.render_widget(config, area);
+}
+
+/// Modal raw-JSON editor, rendered over everything when `app.config_editor` is
+/// set. `Ctrl+S` saves (after JSON validation), `Esc` cancels.
+pub fn render_editor(f: &mut Frame, app: &App) {
+    let Some(editor) = &app.config_editor else {
+        return;
+    };
+    let screen = f.area();
+    let area = centered(screen, 80, 80);
+    f.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(colors::BRAND))
+        .title(" Edit config · Ctrl+S save · Esc cancel ");
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    f.render_widget(&editor.textarea, inner);
+}
+
+/// Rect covering `pw`%×`ph`% of `r`, centered.
+fn centered(r: Rect, pw: u16, ph: u16) -> Rect {
+    let w = (r.width * pw / 100).min(r.width);
+    let h = (r.height * ph / 100).min(r.height);
+    let x = r.x + r.width.saturating_sub(w) / 2;
+    let y = r.y + r.height.saturating_sub(h) / 2;
+    Rect::new(x, y, w, h)
 }

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -151,7 +151,7 @@ pub fn render_tab_bar(f: &mut Frame, area: Rect, app: &App) {
 }
 
 pub fn render_help(f: &mut Frame) {
-    let area = centered_rect(50, 16, f.area());
+    let area = centered_rect(50, 18, f.area());
     let help_text = vec![
         Line::from(Span::styled(
             " Keybindings",
@@ -168,6 +168,8 @@ pub fn render_help(f: &mut Frame) {
         Line::raw("  Ctrl+S      Stop agent execution"),
         Line::raw("  Ctrl+X      Expand/collapse tool args & results"),
         Line::raw("  j/k         Scroll down/up"),
+        Line::raw("  n           New schedule (Schedules)"),
+        Line::raw("  e           Edit config (Config)"),
         Line::raw("  d           Delete (with context)"),
         Line::raw("  r           Refresh / Run schedule"),
         Line::raw("  t           Refresh MCP tools"),

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -344,7 +344,9 @@ pub fn render_schedule_form(f: &mut Frame, app: &App) {
 }
 
 fn centered_rect(percent_x: u16, height: u16, r: Rect) -> Rect {
-    let popup_width = r.width * percent_x / 100;
+    // u32 math so a very wide terminal (width ≥ 820) can't overflow the u16
+    // multiply of `r.width * percent_x`.
+    let popup_width = (r.width as u32 * percent_x as u32 / 100) as u16;
     let x = (r.width.saturating_sub(popup_width)) / 2;
     let y = (r.height.saturating_sub(height)) / 2;
     Rect::new(

--- a/crates/app/bamboo-tui/src/ui/mod.rs
+++ b/crates/app/bamboo-tui/src/ui/mod.rs
@@ -40,4 +40,8 @@ pub fn render(f: &mut Frame, app: &App) {
     if app.schedule_form.is_some() {
         layout::render_schedule_form(f, app);
     }
+
+    if app.config_editor.is_some() {
+        config::render_editor(f, app);
+    }
 }


### PR DESCRIPTION
## What

Makes the Config tab **editable**. It was read-only despite `set_config` being an implemented-but-dead client method — the last unimplemented feature item in #248.

Press **`e`** on the Config tab → a modal `TextArea` opens prefilled with the current config JSON. Edit it, **`Ctrl+S`** saves, **`Esc`** cancels.

- **JSON is validated before send.** `Ctrl+S` parses the buffer first; invalid JSON keeps the modal open with the parse error in the status line, so you can't PATCH a broken config.
- Save PATCHes `POST /v1/bamboo/config` off the event loop (via the existing `ActionDone` non-blocking pattern) and reloads the tab.
- `set_config` now checks the response status and surfaces the server's rejection body instead of silently swallowing it (same hardening as the schedule endpoints in #333).

## Why an in-TUI editor, not `$EDITOR`

Shelling out would contend for stdin with the background crossterm `EventStream` reader (it keeps reading while the editor runs). An in-TUI `TextArea` is self-contained, reuses the already-present `tui-textarea` dep, and matches the existing `pending_question` / `schedule_form` modal pattern. It's routed through the same `handle_key` early-out so digits / Tab / Enter edit the buffer instead of switching tabs.

## Tests
`config_editor_opens_validates_and_cancels` drives the full path through `handle_key`: `e` with no config is a no-op; with a config it opens prefilled; corrupt buffer + `Ctrl+S` stays open with "Invalid JSON"; `Esc` cancels; clean `Ctrl+S` saves and closes. 21 tests pass; clippy `-D warnings` and fmt clean locally.

## Note
While implementing I verified the `/v1/...` paths for skills/config are **correct**, not drift — the server mounts them under `web::scope("/v1")` (`routes/bamboo_v1.rs`), separate from agent routes under `/api/v1`. So the "API path inconsistency" cleanup item in #248 is a non-issue and I left those paths alone.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU