### PR TITLE
feat(tui): notification log so errors aren't lost off the status line

### DIFF
--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -238,6 +238,25 @@ impl ConfigState {
     }
 }
 
+// ── Notifications ──
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoticeLevel {
+    Info,
+    Warn,
+    Error,
+}
+
+/// One entry in the notification scrollback (viewed with `Ctrl+L`). Errors and
+/// warnings would otherwise be lost when the next status message overwrites the
+/// single status line.
+#[derive(Debug, Clone)]
+pub struct Notification {
+    pub level: NoticeLevel,
+    pub text: String,
+    pub at: DateTime<Utc>,
+}
+
 // ── Interactive question (permission gate / clarification) ──
 
 /// An agent question awaiting the operator's answer, driven by the modal.
@@ -304,6 +323,14 @@ pub struct App {
     /// In-progress raw-JSON config editor (Config tab). When `Some`, a modal
     /// textarea captures all keystrokes.
     pub config_editor: Option<ConfigEditor>,
+    /// Capped scrollback of past status messages so errors/warnings aren't lost
+    /// when the single status line is overwritten. Viewed with `Ctrl+L`.
+    pub notifications: Vec<Notification>,
+    /// Whether the notification-log overlay is open.
+    pub notifications_visible: bool,
+    /// Count of warn/error notifications since the log was last opened; shown as
+    /// a badge in the status bar.
+    pub unseen_alerts: usize,
     /// Sender into the main event loop, used to post results of background API
     /// calls (so those calls never block the UI thread). Set in [`run`].
     event_tx: Option<mpsc::UnboundedSender<AppEvent>>,
@@ -330,6 +357,9 @@ impl App {
             pending_question: None,
             schedule_form: None,
             config_editor: None,
+            notifications: Vec::new(),
+            notifications_visible: false,
+            unseen_alerts: 0,
             event_tx: None,
             sse_tx: None,
             sse_rx: None,
@@ -344,7 +374,7 @@ impl App {
         if self.connected {
             self.status_message = "Connected".to_string();
         } else {
-            self.status_message = "Cannot connect to server".to_string();
+            self.notify(NoticeLevel::Warn, "Cannot connect to server");
         }
 
         let (event_tx, mut event_rx) = mpsc::unbounded_channel::<AppEvent>();
@@ -394,7 +424,7 @@ impl App {
                 } => {
                     if let Some(event) = sse_event {
                         if let Err(e) = self.handle_sse_event(event) {
-                            self.status_message = format!("SSE error: {}", e);
+                            self.notify(NoticeLevel::Error, format!("SSE error: {e}"));
                         }
                     }
                 }
@@ -412,7 +442,7 @@ impl App {
         };
         for event in events {
             if let Err(e) = self.handle_sse_event(event) {
-                self.status_message = format!("SSE error: {}", e);
+                self.notify(NoticeLevel::Error, format!("SSE error: {e}"));
             }
         }
     }
@@ -425,11 +455,19 @@ impl App {
             }
         }
 
+        // The notification-log overlay is dismissed by any key.
+        if self.notifications_visible {
+            if let AppEvent::Key(_) = &event {
+                self.notifications_visible = false;
+                return Ok(());
+            }
+        }
+
         match event {
             AppEvent::Key(key) => self.handle_key(key).await?,
             AppEvent::SseEvent(agent_event) => self.handle_sse_event(agent_event)?,
             AppEvent::ApiError(msg) => {
-                self.status_message = format!("Error: {}", msg);
+                self.notify(NoticeLevel::Error, format!("Error: {msg}"));
             }
             AppEvent::Mouse(mouse) => self.handle_mouse(mouse),
             AppEvent::SessionsLoaded(r) => {
@@ -496,7 +534,16 @@ impl App {
                 }
             }
             AppEvent::ActionDone { status, reload_tab } => {
-                self.status_message = status;
+                // Background-action results carry both successes ("Config saved")
+                // and failures ("Save failed: …"); log failures as errors so they
+                // survive in the notification history.
+                let lower = status.to_lowercase();
+                let level = if lower.contains("failed") || lower.contains("error") {
+                    NoticeLevel::Error
+                } else {
+                    NoticeLevel::Info
+                };
+                self.notify(level, status);
                 if reload_tab {
                     self.load_tab_data();
                 }
@@ -509,7 +556,7 @@ impl App {
                 }
                 Err(e) => {
                     self.chat.streaming = false;
-                    self.status_message = format!("Error: {e}");
+                    self.notify(NoticeLevel::Error, format!("Error: {e}"));
                 }
             },
             _ => {}
@@ -553,6 +600,11 @@ impl App {
             }
             (KeyModifiers::CONTROL, KeyCode::Char('?')) => {
                 self.help_visible = true;
+                return Ok(());
+            }
+            (KeyModifiers::CONTROL, KeyCode::Char('l')) => {
+                self.notifications_visible = true;
+                self.unseen_alerts = 0;
                 return Ok(());
             }
             _ => {}
@@ -727,7 +779,7 @@ impl App {
             }
             Err(e) => {
                 // Keep the modal open so the operator can pick a valid option.
-                self.status_message = format!("Answer rejected: {e}");
+                self.notify(NoticeLevel::Error, format!("Answer rejected: {e}"));
             }
         }
         Ok(())
@@ -906,7 +958,7 @@ impl App {
         self.sse_rx = Some(sse_rx);
         let base_url = self.client.base_url.clone();
         if let Err(e) = SseStream::start(&base_url, &session_id, sse_tx) {
-            self.status_message = format!("SSE start failed: {e}");
+            self.notify(NoticeLevel::Error, format!("SSE start failed: {e}"));
             return;
         }
         let client = self.client.clone();
@@ -996,7 +1048,7 @@ impl App {
                 self.finalize_streaming();
             }
             AgentEvent::Error { message } => {
-                self.status_message = format!("Error: {}", message);
+                self.notify(NoticeLevel::Error, format!("Error: {message}"));
                 self.finalize_streaming();
             }
             AgentEvent::ToolToken { content, .. } => {
@@ -1302,6 +1354,27 @@ impl App {
         Ok(())
     }
 
+    /// Record a notification in the scrollback log and mirror it to the
+    /// transient status line. Warn/error entries bump the unseen-alert badge
+    /// until the log is opened. The log is capped so it can't grow unbounded.
+    fn notify(&mut self, level: NoticeLevel, text: impl Into<String>) {
+        let text = text.into();
+        if matches!(level, NoticeLevel::Warn | NoticeLevel::Error) {
+            self.unseen_alerts = self.unseen_alerts.saturating_add(1);
+        }
+        self.status_message = text.clone();
+        self.notifications.push(Notification {
+            level,
+            text,
+            at: Utc::now(),
+        });
+        const CAP: usize = 200;
+        if self.notifications.len() > CAP {
+            let excess = self.notifications.len() - CAP;
+            self.notifications.drain(0..excess);
+        }
+    }
+
     fn handle_config_key(&mut self, key: KeyEvent) {
         match key.code {
             KeyCode::Down => {
@@ -1364,7 +1437,7 @@ impl App {
                     }
                 }
                 Err(e) => {
-                    self.status_message = format!("Invalid JSON: {e}");
+                    self.notify(NoticeLevel::Error, format!("Invalid JSON: {e}"));
                 }
             }
             return Ok(());
@@ -1641,6 +1714,51 @@ mod question_tests {
         assert!(app.config_editor.is_some());
         app.handle_key(ctrl_s).await.unwrap();
         assert!(app.config_editor.is_none(), "valid JSON saves and closes");
+    }
+
+    #[tokio::test]
+    async fn notifications_log_and_badge() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+
+        // An error records to the log, mirrors to the status line, bumps badge.
+        app.notify(NoticeLevel::Error, "boom");
+        assert_eq!(app.notifications.len(), 1);
+        assert_eq!(app.status_message, "boom");
+        assert_eq!(app.unseen_alerts, 1);
+
+        // Info records but does not bump the alert badge.
+        app.notify(NoticeLevel::Info, "just fyi");
+        assert_eq!(app.unseen_alerts, 1);
+        assert_eq!(app.notifications.len(), 2);
+
+        // Ctrl+L opens the log and clears the badge.
+        app.handle_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::CONTROL))
+            .await
+            .unwrap();
+        assert!(app.notifications_visible);
+        assert_eq!(app.unseen_alerts, 0);
+
+        // Any key dismisses the overlay.
+        app.handle_event(AppEvent::Key(KeyEvent::new(
+            KeyCode::Char('q'),
+            KeyModifiers::empty(),
+        )))
+        .await
+        .unwrap();
+        assert!(!app.notifications_visible);
+    }
+
+    #[test]
+    fn notifications_log_is_capped() {
+        let mut app = App::new(BambooClient::new("http://127.0.0.1:0"));
+        for i in 0..250 {
+            app.notify(NoticeLevel::Info, format!("n{i}"));
+        }
+        assert_eq!(app.notifications.len(), 200, "log is capped at 200");
+        // Oldest entries are dropped; the newest is retained.
+        assert_eq!(app.notifications.last().unwrap().text, "n249");
+        assert_eq!(app.notifications.first().unwrap().text, "n50");
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -533,17 +533,14 @@ impl App {
                     Err(e) => self.config.error = Some(e),
                 }
             }
-            AppEvent::ActionDone { status, reload_tab } => {
-                // Background-action results carry both successes ("Config saved")
-                // and failures ("Save failed: …"); log failures as errors so they
-                // survive in the notification history.
-                let lower = status.to_lowercase();
-                let level = if lower.contains("failed") || lower.contains("error") {
-                    NoticeLevel::Error
-                } else {
-                    NoticeLevel::Info
-                };
-                self.notify(level, status);
+            AppEvent::ActionDone {
+                outcome,
+                reload_tab,
+            } => {
+                match outcome {
+                    Ok(msg) => self.notify(NoticeLevel::Info, msg),
+                    Err(msg) => self.notify(NoticeLevel::Error, msg),
+                }
                 if reload_tab {
                     self.load_tab_data();
                 }
@@ -758,7 +755,7 @@ impl App {
     /// Submit an answer to the agent's pending question and resume the run.
     async fn submit_answer(&mut self, answer: String) -> Result<()> {
         let Some(session_id) = self.chat.session_id.clone() else {
-            self.status_message = "No active chat session to answer".to_string();
+            self.notify(NoticeLevel::Warn, "No active chat session to answer");
             self.pending_question = None;
             return Ok(());
         };
@@ -1204,17 +1201,16 @@ impl App {
                         } else {
                             client.connect_mcp(&id).await
                         };
-                        let status = match res {
-                            Ok(()) => if connected {
-                                "Disconnected"
+                        let outcome = match res {
+                            Ok(()) => Ok(if connected {
+                                "Disconnected".to_string()
                             } else {
-                                "Connected"
-                            }
-                            .to_string(),
-                            Err(e) => format!("MCP action failed: {e}"),
+                                "Connected".to_string()
+                            }),
+                            Err(e) => Err(format!("MCP action failed: {e}")),
                         };
                         let _ = tx.send(AppEvent::ActionDone {
-                            status,
+                            outcome,
                             reload_tab: true,
                         });
                     });
@@ -1258,14 +1254,21 @@ impl App {
             KeyCode::Char('d') => {
                 if let Some(schedule) = self.schedules.schedules.get(self.schedules.selected) {
                     let id = schedule.id.clone();
-                    self.client.delete_schedule(&id).await?;
-                    self.load_tab_data();
+                    // Don't `?`-propagate: a failed delete must surface in the
+                    // log, not tear down the whole TUI event loop.
+                    match self.client.delete_schedule(&id).await {
+                        Ok(()) => self.load_tab_data(),
+                        Err(e) => self.notify(NoticeLevel::Error, format!("Delete failed: {e}")),
+                    }
                 }
             }
             KeyCode::Char('r') => {
                 if let Some(schedule) = self.schedules.schedules.get(self.schedules.selected) {
-                    self.client.run_schedule_now(&schedule.id).await?;
-                    self.status_message = "Schedule triggered".to_string();
+                    let id = schedule.id.clone();
+                    match self.client.run_schedule_now(&id).await {
+                        Ok(()) => self.notify(NoticeLevel::Info, "Schedule triggered"),
+                        Err(e) => self.notify(NoticeLevel::Error, format!("Run failed: {e}")),
+                    }
                 }
             }
             _ => {}
@@ -1315,12 +1318,12 @@ impl App {
                 if let Some(tx) = self.event_tx.clone() {
                     let client = self.client.clone();
                     tokio::spawn(async move {
-                        let status = match client.create_schedule(req).await {
-                            Ok(_) => "Schedule created".to_string(),
-                            Err(e) => format!("Create failed: {e}"),
+                        let outcome = match client.create_schedule(req).await {
+                            Ok(()) => Ok("Schedule created".to_string()),
+                            Err(e) => Err(format!("Create failed: {e}")),
                         };
                         let _ = tx.send(AppEvent::ActionDone {
-                            status,
+                            outcome,
                             reload_tab: true,
                         });
                     });
@@ -1395,7 +1398,7 @@ impl App {
                         });
                     }
                     None => {
-                        self.status_message = "No config loaded to edit".to_string();
+                        self.notify(NoticeLevel::Warn, "No config loaded to edit");
                     }
                 }
             }
@@ -1425,12 +1428,12 @@ impl App {
                     if let Some(tx) = self.event_tx.clone() {
                         let client = self.client.clone();
                         tokio::spawn(async move {
-                            let status = match client.set_config(&val).await {
-                                Ok(()) => "Config saved".to_string(),
-                                Err(e) => format!("Save failed: {e}"),
+                            let outcome = match client.set_config(&val).await {
+                                Ok(()) => Ok("Config saved".to_string()),
+                                Err(e) => Err(format!("Save failed: {e}")),
                             };
                             let _ = tx.send(AppEvent::ActionDone {
-                                status,
+                                outcome,
                                 reload_tab: true,
                             });
                         });

--- a/crates/app/bamboo-tui/src/event.rs
+++ b/crates/app/bamboo-tui/src/event.rs
@@ -20,10 +20,11 @@ pub enum AppEvent {
     SchedulesLoaded(Loaded<Vec<Schedule>>),
     SkillsLoaded(Loaded<Vec<Skill>>),
     ConfigLoaded(Loaded<serde_json::Value>),
-    /// A background mutation finished; carries a status line and whether the
-    /// current tab's data should be reloaded.
+    /// A background mutation finished; the outcome is `Ok(success message)` or
+    /// `Err(failure message)` so the receiver can classify it (info vs error)
+    /// without sniffing the display text. `reload_tab` reloads the current tab.
     ActionDone {
-        status: String,
+        outcome: Loaded<String>,
         reload_tab: bool,
     },
     /// A chat turn was created + started; carries the new session id.

--- a/crates/app/bamboo-tui/src/ui/layout.rs
+++ b/crates/app/bamboo-tui/src/ui/layout.rs
@@ -4,7 +4,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui::Frame;
 
-use crate::app::{App, Tab};
+use crate::app::{App, NoticeLevel, Tab};
 use crate::theme::{self, colors};
 
 pub struct AppLayout {
@@ -105,6 +105,17 @@ pub fn render_status_info(f: &mut Frame, area: Rect, app: &App) {
         spans.push(Span::styled(" · ", Style::default().fg(colors::SUBTLE)));
     }
 
+    // Unseen warning/error badge (Ctrl+L to view the log).
+    if app.unseen_alerts > 0 {
+        spans.push(Span::styled(
+            format!(" ⚠ {} ", app.unseen_alerts),
+            Style::default()
+                .fg(colors::WARNING)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::styled(" · ", Style::default().fg(colors::SUBTLE)));
+    }
+
     // Connection indicator
     if app.connected {
         spans.push(Span::styled(" ● ", Style::default().fg(colors::SUCCESS)));
@@ -151,7 +162,7 @@ pub fn render_tab_bar(f: &mut Frame, area: Rect, app: &App) {
 }
 
 pub fn render_help(f: &mut Frame) {
-    let area = centered_rect(50, 18, f.area());
+    let area = centered_rect(50, 21, f.area());
     let help_text = vec![
         Line::from(Span::styled(
             " Keybindings",
@@ -167,6 +178,7 @@ pub fn render_help(f: &mut Frame) {
         Line::raw("  Ctrl+C      Quit / Stop streaming"),
         Line::raw("  Ctrl+S      Stop agent execution"),
         Line::raw("  Ctrl+X      Expand/collapse tool args & results"),
+        Line::raw("  Ctrl+L      Notification log"),
         Line::raw("  j/k         Scroll down/up"),
         Line::raw("  n           New schedule (Schedules)"),
         Line::raw("  e           Edit config (Config)"),
@@ -184,6 +196,60 @@ pub fn render_help(f: &mut Frame) {
             .border_style(Style::default().fg(colors::BRAND)),
     );
     f.render_widget(help, area);
+}
+
+/// Notification-log overlay (`Ctrl+L`): recent status messages newest-first,
+/// colored by level, so errors/warnings aren't lost when the status line is
+/// overwritten. Dismissed by any key.
+pub fn render_notifications(f: &mut Frame, app: &App) {
+    let screen = f.area();
+    let mut lines: Vec<Line> = vec![
+        Line::from(Span::styled(
+            " Notifications",
+            Style::default()
+                .fg(colors::BRAND)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::raw(""),
+    ];
+
+    if app.notifications.is_empty() {
+        lines.push(Line::raw("  (nothing yet)"));
+    } else {
+        // Newest first; cap to what a reasonably tall modal can show.
+        let max_rows = (screen.height.saturating_sub(6)).min(30) as usize;
+        for n in app.notifications.iter().rev().take(max_rows) {
+            let (tag, color) = match n.level {
+                NoticeLevel::Info => ("info", colors::INACTIVE),
+                NoticeLevel::Warn => ("warn", colors::WARNING),
+                NoticeLevel::Error => ("err ", colors::ERROR),
+            };
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  {} ", n.at.format("%H:%M:%S")),
+                    Style::default().fg(colors::SUBTLE),
+                ),
+                Span::styled(format!("{tag}  "), Style::default().fg(color)),
+                Span::styled(n.text.clone(), Style::default().fg(color)),
+            ]));
+        }
+    }
+    lines.push(Line::raw(""));
+    lines.push(Line::raw("  Press any key to close"));
+
+    let height = (lines.len() as u16 + 2).min(screen.height);
+    let area = centered_rect(70, height, screen);
+    f.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(colors::BRAND))
+        .title(" Log ");
+    f.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false }),
+        area,
+    );
 }
 
 /// Modal for an agent question (permission gate / clarification): the operator

--- a/crates/app/bamboo-tui/src/ui/mod.rs
+++ b/crates/app/bamboo-tui/src/ui/mod.rs
@@ -32,6 +32,11 @@ pub fn render(f: &mut Frame, app: &App) {
         layout::render_help(f);
     }
 
+    // Notification-log overlay
+    if app.notifications_visible {
+        layout::render_notifications(f, app);
+    }
+
     // Pending-question modal takes visual priority — it's the blocking interaction.
     if app.pending_question.is_some() {
         layout::render_question(f, app);


### PR DESCRIPTION
## Why

The TUI had a single `status_message` line. Every SSE error, API error, and transient status ("Ready", "Streaming…") wrote to it, so a **failure was silently overwritten and lost** — you could miss that a run errored or a save failed. This was the error-surfacing feature item in #248.

## What

- **Capped notification scrollback** (200 entries). Warn/error sites now route through a single `notify(level, text)` choke point that records to the log, mirrors to the status line (behavior unchanged there), and bumps an unseen-alert counter.
- **`⚠ N` badge** in the status bar for unseen warnings/errors.
- **`Ctrl+L`** opens a log overlay — newest-first, colored by level, with timestamps — and clears the badge. Any key dismisses it.
- **`ActionDone`** background results (schedule/config saves) are classified Info vs Error by a `failed`/`error` text heuristic, so background failures land in the log rather than reading as neutral status.

Error sites converted: connect failure, both SSE-error paths, `ApiError`, chat-start error, agent `Error` event, answer-rejected, SSE-start-failed, invalid-JSON, and `ActionDone` failures.

## Tests
- `notifications_log_and_badge`: error records+mirrors+bumps badge; info doesn't bump; `Ctrl+L` opens and clears; any key dismisses.
- `notifications_log_is_capped`: 250 pushes → 200 retained, oldest dropped, newest kept.

23 tests pass; clippy `-D warnings` and fmt clean locally.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU