### PR TITLE
chore(tui): drop crate-wide dead_code allow; delete dead code

### DIFF
--- a/crates/app/bamboo-tui/src/api/mod.rs
+++ b/crates/app/bamboo-tui/src/api/mod.rs
@@ -91,16 +91,6 @@ impl BambooClient {
         Ok(auto_resume)
     }
 
-    pub async fn pending_question(&self, session_id: &str) -> Result<PendingQuestion> {
-        let resp = self
-            .client
-            .get(self.url(&format!("/api/v1/respond/{}/pending", session_id)))
-            .send()
-            .await?;
-        let pq = resp.json().await?;
-        Ok(pq)
-    }
-
     // ── Sessions ──
 
     pub async fn list_sessions(&self) -> Result<Vec<SessionSummary>> {
@@ -109,28 +99,9 @@ impl BambooClient {
         Ok(sessions)
     }
 
-    pub async fn create_session(&self, req: CreateSessionRequest) -> Result<serde_json::Value> {
-        let resp = self
-            .client
-            .post(self.url("/api/v1/sessions"))
-            .json(&req)
-            .send()
-            .await?;
-        let val = resp.json().await?;
-        Ok(val)
-    }
-
     pub async fn delete_session(&self, id: &str) -> Result<()> {
         self.client
             .delete(self.url(&format!("/api/v1/sessions/{}", id)))
-            .send()
-            .await?;
-        Ok(())
-    }
-
-    pub async fn clear_session(&self, id: &str) -> Result<()> {
-        self.client
-            .post(self.url(&format!("/api/v1/sessions/{}/clear", id)))
             .send()
             .await?;
         Ok(())
@@ -172,14 +143,6 @@ impl BambooClient {
             .await?;
         let tools = resp.json().await?;
         Ok(tools)
-    }
-
-    pub async fn delete_mcp_server(&self, id: &str) -> Result<()> {
-        self.client
-            .delete(self.url(&format!("/api/v1/mcp/servers/{}", id)))
-            .send()
-            .await?;
-        Ok(())
     }
 
     // ── Schedules ──
@@ -277,16 +240,6 @@ impl BambooClient {
             anyhow::bail!("set config failed ({status}): {body}");
         }
         Ok(())
-    }
-
-    pub async fn fetch_models(&self) -> Result<Vec<ModelInfo>> {
-        let resp = self
-            .client
-            .post(self.url("/v1/bamboo/settings/provider/models"))
-            .send()
-            .await?;
-        let models = resp.json().await?;
-        Ok(models)
     }
 
     // ── Health ──

--- a/crates/app/bamboo-tui/src/api/types.rs
+++ b/crates/app/bamboo-tui/src/api/types.rs
@@ -1,3 +1,10 @@
+//! HTTP wire types for the TUI client.
+//!
+//! These structs mirror the Bamboo server's REST responses. Some fields are
+//! deserialized for contract fidelity (and so the TUI is robust to responses
+//! that include them) but are not yet surfaced in the UI — hence the
+//! module-scoped `dead_code` allow. New *logic* dead code elsewhere in the
+//! crate still warns, since the blanket crate-level allow was removed.
 #![allow(dead_code)]
 
 use chrono::{DateTime, Utc};
@@ -27,29 +34,6 @@ pub struct SessionSummary {
     pub message_count: Option<u32>,
     #[serde(default)]
     pub status: Option<String>,
-}
-
-#[derive(Serialize, Clone)]
-pub struct CreateSessionRequest {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub workspace_path: Option<String>,
-}
-
-#[derive(Deserialize, Debug, Clone)]
-pub struct PendingQuestion {
-    pub has_pending_question: bool,
-    #[serde(default)]
-    pub question: Option<String>,
-    #[serde(default)]
-    pub options: Option<Vec<String>>,
-    #[serde(default)]
-    pub allow_custom: Option<bool>,
-    #[serde(default)]
-    pub tool_call_id: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -213,13 +197,4 @@ pub struct SkillDetail {
     pub prompt: Option<String>,
     #[serde(default)]
     pub tools: Option<Vec<String>>,
-}
-
-// ── Config ──
-
-#[derive(Deserialize, Debug, Clone)]
-pub struct ModelInfo {
-    pub id: String,
-    #[serde(default)]
-    pub name: Option<String>,
 }

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -94,7 +94,6 @@ pub struct ChatMessage {
     pub content: String,
     pub tool_calls: Vec<ToolCallDisplay>,
     pub reasoning: Option<String>,
-    pub timestamp: DateTime<Utc>,
 }
 
 pub struct ChatState {
@@ -103,7 +102,6 @@ pub struct ChatState {
     pub textarea: TextArea<'static>,
     pub scroll_offset: u16,
     pub auto_scroll: bool,
-    pub content_lines: u16,
     pub streaming: bool,
     pub current_response: String,
     pub current_tool_calls: Vec<ToolCallDisplay>,
@@ -128,7 +126,6 @@ impl ChatState {
             textarea,
             scroll_offset: 0,
             auto_scroll: true,
-            content_lines: 0,
             streaming: false,
             current_response: String::new(),
             current_tool_calls: Vec::new(),
@@ -395,7 +392,7 @@ impl App {
                     Ok(Event::Mouse(mouse)) if tx.send(AppEvent::Mouse(mouse)).is_err() => {
                         break;
                     }
-                    Ok(Event::Resize(w, h)) if tx.send(AppEvent::Resize(w, h)).is_err() => {
+                    Ok(Event::Resize(_, _)) if tx.send(AppEvent::Resize).is_err() => {
                         break;
                     }
                     _ => {}
@@ -465,10 +462,6 @@ impl App {
 
         match event {
             AppEvent::Key(key) => self.handle_key(key).await?,
-            AppEvent::SseEvent(agent_event) => self.handle_sse_event(agent_event)?,
-            AppEvent::ApiError(msg) => {
-                self.notify(NoticeLevel::Error, format!("Error: {msg}"));
-            }
             AppEvent::Mouse(mouse) => self.handle_mouse(mouse),
             AppEvent::SessionsLoaded(r) => {
                 self.sessions.loading = false;
@@ -921,7 +914,6 @@ impl App {
             content: message.clone(),
             tool_calls: Vec::new(),
             reasoning: None,
-            timestamp: Utc::now(),
         });
         self.chat.auto_scroll = true;
         self.chat.streaming = true;
@@ -1123,7 +1115,6 @@ impl App {
                 } else {
                     Some(std::mem::take(&mut self.chat.current_reasoning))
                 },
-                timestamp: Utc::now(),
             });
         }
         self.status_message = "Ready".to_string();

--- a/crates/app/bamboo-tui/src/event.rs
+++ b/crates/app/bamboo-tui/src/event.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{KeyEvent, MouseEvent};
 
-use crate::api::types::{AgentEvent, McpServer, Schedule, SessionSummary, Skill, ToolInfo};
+use crate::api::types::{McpServer, Schedule, SessionSummary, Skill, ToolInfo};
 
 /// Result of a background API call, delivered back to the event loop so the call
 /// never blocks the UI thread. `Err` carries a display string.
@@ -9,9 +9,9 @@ type Loaded<T> = Result<T, String>;
 pub enum AppEvent {
     Key(KeyEvent),
     Mouse(MouseEvent),
-    Resize(u16, u16),
-    SseEvent(AgentEvent),
-    ApiError(String),
+    /// Terminal resized; the next loop iteration redraws at the new size (the
+    /// dimensions themselves aren't needed — ratatui re-measures on draw).
+    Resize,
 
     // ── Non-blocking API results (posted by spawned tasks) ──
     SessionsLoaded(Loaded<Vec<SessionSummary>>),

--- a/crates/app/bamboo-tui/src/main.rs
+++ b/crates/app/bamboo-tui/src/main.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use anyhow::Result;
 use clap::Parser;
 use crossterm::event::{DisableMouseCapture, EnableMouseCapture};


### PR DESCRIPTION
Closes the cleanup items in #248. The front-door `#![allow(dead_code)]` (main.rs + api/types.rs) hid drift; this removes the crate-wide suppression and cleans what it masked.

## Deleted
- **Unused client methods**: `pending_question`, `create_session`, `clear_session`, `delete_mcp_server`, `fetch_models` — plus their now-orphaned types `CreateSessionRequest`, `PendingQuestion`, `ModelInfo`. None had a UI caller; re-addable in a line when one does.
- **Dead app-internal code**: the never-constructed `AppEvent::SseEvent` / `AppEvent::ApiError` variants (SSE flows through the `sse_rx` `AgentEvent` channel, not these), the unused `Resize(u16,u16)` payload (now a unit variant — the loop redraws every iteration and ratatui re-measures on draw), and the unread `ChatMessage.timestamp` / `ChatState.content_lines` fields.

## Kept (deliberately, documented)
Wire-type mirror fields the UI doesn't render yet — `SessionSummary.title/updated_at`, `McpServer.transport`, `Schedule.prompt/next_run` — stay behind a **module-scoped, documented** `#![allow(dead_code)]` in `api/types.rs`. They mirror the server contract for fidelity/robustness (and `next_run`/`prompt` are freshly-added, plausibly-surfaced-soon). The point of the change is that the *crate-wide* blanket is gone, so new **logic** dead code anywhere else now warns.

## Verification
`cargo clippy -p bamboo-tui … -D warnings` **without** `-A dead-code` is clean (matches CI Lint, which doesn't pass `-A dead-code`). 23 tests pass; fmt clean.

## Not touched
The `/v1` vs `/api/v1` "path inconsistency" from the issue — verified earlier it's **correct**, not drift (server mounts skills/config under `web::scope("/v1")`, separate from `/api/v1` agent routes).

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU