### PR TITLE
fix(anthropic): emit object tool_use.input for empty/invalid args (session-brick)

### DIFF
--- a/crates/infra/bamboo-llm/src/providers/anthropic/conversion.rs
+++ b/crates/infra/bamboo-llm/src/providers/anthropic/conversion.rs
@@ -506,16 +506,9 @@ pub fn convert_messages_response(
 
     if let Some(tool_calls) = choice.message.tool_calls {
         for tool_call in tool_calls {
-            // Anthropic requires `tool_use.input` to be a JSON object: empty
-            // arguments (a zero-argument tool call) → `{}`, and an unparseable
-            // payload → an object wrapper rather than a bare string (which the
-            // Messages API 400s on the next request).
-            let input = if tool_call.function.arguments.trim().is_empty() {
-                serde_json::json!({})
-            } else {
-                serde_json::from_str(&tool_call.function.arguments)
-                    .unwrap_or_else(|_| serde_json::json!({ "_raw": tool_call.function.arguments }))
-            };
+            // Anthropic requires `tool_use.input` to be a JSON object; delegate
+            // to the shared helper (empty → `{}`, non-object/invalid → `_raw`).
+            let input = super::tool_arguments_to_input(&tool_call.function.arguments);
             content_blocks.push(AnthropicResponseContentBlock::ToolUse {
                 id: tool_call.id,
                 name: tool_call.function.name,
@@ -668,5 +661,70 @@ pub fn format_model_display_name(model_id: &str) -> String {
             .replace("gpt-3.5", "GPT-3.5")
     } else {
         model_id.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn response_with_tool_args(arguments: &str) -> ChatCompletionResponse {
+        serde_json::from_value(serde_json::json!({
+            "id": "resp_1",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": { "name": "get_time", "arguments": arguments }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        }))
+        .expect("valid ChatCompletionResponse fixture")
+    }
+
+    fn tool_use_input(resp: &AnthropicMessagesResponse) -> serde_json::Value {
+        let json = serde_json::to_value(resp).expect("response is serializable");
+        json["content"]
+            .as_array()
+            .and_then(|blocks| blocks.iter().find(|b| b["type"] == "tool_use").cloned())
+            .map(|b| b["input"].clone())
+            .expect("response must contain a tool_use block")
+    }
+
+    #[test]
+    fn convert_messages_response_tool_use_input_is_always_object() {
+        // The response-conversion path must also produce an OBJECT `tool_use.input`
+        // for empty and non-object arguments (it delegates to the shared
+        // `tool_arguments_to_input`). A bare string/scalar input 400s Anthropic.
+        // (`AnthropicConversionError` is not `Debug`, so unwrap via `match`.)
+        let convert = |args: &str| match convert_messages_response(
+            response_with_tool_args(args),
+            "claude-test",
+        ) {
+            Ok(out) => out,
+            Err(_) => panic!("conversion should succeed for args={args:?}"),
+        };
+
+        let input = tool_use_input(&convert(""));
+        assert!(
+            input.is_object(),
+            "empty args must yield an object, got {input}"
+        );
+        assert_eq!(input.as_object().unwrap().len(), 0, "empty args -> {{}}");
+
+        for (args, raw) in [("[1,2]", "[1,2]"), ("oops", "oops")] {
+            let input = tool_use_input(&convert(args));
+            assert!(
+                input.is_object(),
+                "args={args:?} must yield an object, got {input}"
+            );
+            assert_eq!(input["_raw"], raw);
+        }
     }
 }

--- a/crates/infra/bamboo-llm/src/providers/anthropic/conversion.rs
+++ b/crates/infra/bamboo-llm/src/providers/anthropic/conversion.rs
@@ -506,8 +506,16 @@ pub fn convert_messages_response(
 
     if let Some(tool_calls) = choice.message.tool_calls {
         for tool_call in tool_calls {
-            let input = serde_json::from_str(&tool_call.function.arguments)
-                .unwrap_or(Value::String(tool_call.function.arguments));
+            // Anthropic requires `tool_use.input` to be a JSON object: empty
+            // arguments (a zero-argument tool call) → `{}`, and an unparseable
+            // payload → an object wrapper rather than a bare string (which the
+            // Messages API 400s on the next request).
+            let input = if tool_call.function.arguments.trim().is_empty() {
+                serde_json::json!({})
+            } else {
+                serde_json::from_str(&tool_call.function.arguments)
+                    .unwrap_or_else(|_| serde_json::json!({ "_raw": tool_call.function.arguments }))
+            };
             content_blocks.push(AnthropicResponseContentBlock::ToolUse {
                 id: tool_call.id,
                 name: tool_call.function.name,

--- a/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
@@ -1006,18 +1006,27 @@ fn preview_for_log(value: &str, max_chars: usize) -> String {
 
 fn tool_call_to_tool_use_block(tool_call: &bamboo_domain::ToolCall) -> Value {
     let raw_arguments = tool_call.function.arguments.trim();
-    let input: Value = match serde_json::from_str(raw_arguments) {
-        Ok(parsed) => parsed,
-        Err(error) => {
-            tracing::warn!(
-                "Anthropic tool_use conversion fallback to string input due to invalid JSON arguments: tool_call_id={}, tool_name={}, args_len={}, args_preview=\"{}\", error={}",
-                tool_call.id,
-                tool_call.function.name,
-                raw_arguments.len(),
-                preview_for_log(raw_arguments, 180),
-                error
-            );
-            Value::String(tool_call.function.arguments.clone())
+    // Anthropic requires `tool_use.input` to be a JSON object. Empty arguments
+    // are a normal, reachable state (a zero-argument tool call) and must map to
+    // `{}`; an unparseable payload falls back to an object wrapper (never a bare
+    // string, which the Messages API rejects with 400 and then poisons every
+    // subsequent request in the session).
+    let input: Value = if raw_arguments.is_empty() {
+        json!({})
+    } else {
+        match serde_json::from_str(raw_arguments) {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                tracing::warn!(
+                    "Anthropic tool_use conversion fallback to _raw object due to invalid JSON arguments: tool_call_id={}, tool_name={}, args_len={}, args_preview=\"{}\", error={}",
+                    tool_call.id,
+                    tool_call.function.name,
+                    raw_arguments.len(),
+                    preview_for_log(raw_arguments, 180),
+                    error
+                );
+                json!({ "_raw": tool_call.function.arguments.clone() })
+            }
         }
     };
 
@@ -1740,6 +1749,50 @@ mod anthropic_request_building {
             out_ids.len(),
             "out_ids must stay parallel to the messages array"
         );
+    }
+
+    #[test]
+    fn tool_use_input_is_object_for_empty_and_invalid_arguments() {
+        // Anthropic requires `tool_use.input` to be a JSON object. A zero-argument
+        // tool call (arguments == "") and an unparseable payload must NOT emit a
+        // bare string input — that is a 400 `invalid_request_error` that then
+        // poisons every subsequent request in the session. Regression for the
+        // empty-args session-brick.
+        let empty = ToolCall {
+            id: "call_empty".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: "get_time".to_string(),
+                arguments: String::new(),
+            },
+        };
+        let block = super::tool_call_to_tool_use_block(&empty);
+        assert_eq!(block["type"], "tool_use");
+        assert!(
+            block["input"].is_object(),
+            "empty arguments must produce an object input, got {}",
+            block["input"]
+        );
+        assert_eq!(
+            block["input"].as_object().unwrap().len(),
+            0,
+            "empty arguments must map to {{}}"
+        );
+
+        let invalid = ToolCall {
+            id: "call_bad".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: "search".to_string(),
+                arguments: "not json".to_string(),
+            },
+        };
+        let block = super::tool_call_to_tool_use_block(&invalid);
+        assert!(
+            block["input"].is_object(),
+            "invalid arguments must fall back to an object input, not a bare string"
+        );
+        assert_eq!(block["input"]["_raw"], "not json");
     }
 
     #[test]
@@ -2774,7 +2827,7 @@ mod anthropic_request_building_edge_cases {
     }
 
     #[test]
-    fn tool_call_with_invalid_json_arguments_falls_back_to_string() {
+    fn tool_call_with_invalid_json_arguments_falls_back_to_object() {
         use bamboo_domain::{FunctionCall, ToolCall};
         let tool_call = ToolCall {
             id: "call_1".to_string(),
@@ -2789,8 +2842,12 @@ mod anthropic_request_building_edge_cases {
         let out =
             super::build_anthropic_request(&messages, &[], "claude-test", 64, false, None, None);
 
-        // Invalid JSON should be kept as a string
-        assert_eq!(out["messages"][0]["content"][0]["input"], "not valid json");
+        // Invalid JSON must fall back to an OBJECT, not a bare string: Anthropic
+        // requires `tool_use.input` to be an object and 400s a string input,
+        // which would then poison every subsequent request in the session.
+        let input = &out["messages"][0]["content"][0]["input"];
+        assert!(input.is_object(), "input must be an object, got {input}");
+        assert_eq!(input["_raw"], "not valid json");
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
@@ -1004,37 +1004,51 @@ fn preview_for_log(value: &str, max_chars: usize) -> String {
     preview.replace('\n', "\\n").replace('\r', "\\r")
 }
 
-fn tool_call_to_tool_use_block(tool_call: &bamboo_domain::ToolCall) -> Value {
-    let raw_arguments = tool_call.function.arguments.trim();
-    // Anthropic requires `tool_use.input` to be a JSON object. Empty arguments
-    // are a normal, reachable state (a zero-argument tool call) and must map to
-    // `{}`; an unparseable payload falls back to an object wrapper (never a bare
-    // string, which the Messages API rejects with 400 and then poisons every
-    // subsequent request in the session).
-    let input: Value = if raw_arguments.is_empty() {
-        json!({})
-    } else {
-        match serde_json::from_str(raw_arguments) {
-            Ok(parsed) => parsed,
-            Err(error) => {
-                tracing::warn!(
-                    "Anthropic tool_use conversion fallback to _raw object due to invalid JSON arguments: tool_call_id={}, tool_name={}, args_len={}, args_preview=\"{}\", error={}",
-                    tool_call.id,
-                    tool_call.function.name,
-                    raw_arguments.len(),
-                    preview_for_log(raw_arguments, 180),
-                    error
-                );
-                json!({ "_raw": tool_call.function.arguments.clone() })
-            }
+/// Convert a tool-call `arguments` string into an Anthropic `tool_use.input`.
+///
+/// Anthropic requires `input` to be a JSON **object**, so anything that is not
+/// one maps to `{ "_raw": <original> }`: empty/whitespace (a zero-argument tool
+/// call → `{}`), invalid JSON, or valid-but-non-object JSON (`"5"`, `[1,2]`,
+/// `true`, `"str"`). A non-object `input` is rejected with 400
+/// `invalid_request_error` and — because the `tool_use` is persisted in
+/// conversation history — then poisons every subsequent request in the session.
+///
+/// Shared by the outbound request builder (`tool_call_to_tool_use_block`) and
+/// the response conversion (`conversion::convert_messages_response`) so the two
+/// sites cannot drift.
+pub(super) fn tool_arguments_to_input(arguments: &str) -> Value {
+    let trimmed = arguments.trim();
+    if trimmed.is_empty() {
+        return json!({});
+    }
+    match serde_json::from_str::<Value>(trimmed) {
+        Ok(value) if value.is_object() => value,
+        Ok(_) => {
+            tracing::warn!(
+                "Anthropic tool_use input fallback to _raw object: arguments are valid JSON but not an object, args_len={}, preview=\"{}\"",
+                trimmed.len(),
+                preview_for_log(trimmed, 180),
+            );
+            json!({ "_raw": arguments })
         }
-    };
+        Err(error) => {
+            tracing::warn!(
+                "Anthropic tool_use input fallback to _raw object: invalid JSON arguments, args_len={}, preview=\"{}\", error={}",
+                trimmed.len(),
+                preview_for_log(trimmed, 180),
+                error
+            );
+            json!({ "_raw": arguments })
+        }
+    }
+}
 
+fn tool_call_to_tool_use_block(tool_call: &bamboo_domain::ToolCall) -> Value {
     json!({
         "type": "tool_use",
         "id": tool_call.id,
         "name": tool_call.function.name,
-        "input": input,
+        "input": tool_arguments_to_input(&tool_call.function.arguments),
     })
 }
 
@@ -1752,47 +1766,36 @@ mod anthropic_request_building {
     }
 
     #[test]
-    fn tool_use_input_is_object_for_empty_and_invalid_arguments() {
-        // Anthropic requires `tool_use.input` to be a JSON object. A zero-argument
-        // tool call (arguments == "") and an unparseable payload must NOT emit a
-        // bare string input — that is a 400 `invalid_request_error` that then
-        // poisons every subsequent request in the session. Regression for the
-        // empty-args session-brick.
-        let empty = ToolCall {
-            id: "call_empty".to_string(),
-            tool_type: "function".to_string(),
-            function: FunctionCall {
-                name: "get_time".to_string(),
-                arguments: String::new(),
-            },
-        };
-        let block = super::tool_call_to_tool_use_block(&empty);
-        assert_eq!(block["type"], "tool_use");
-        assert!(
-            block["input"].is_object(),
-            "empty arguments must produce an object input, got {}",
-            block["input"]
-        );
+    fn tool_arguments_to_input_always_yields_an_object() {
+        use super::tool_arguments_to_input;
+        // Anthropic requires `tool_use.input` to be a JSON object; a non-object
+        // input is a 400 `invalid_request_error` that then poisons every
+        // subsequent request in the session (the reported session-brick).
+
+        // empty / whitespace-only (a zero-argument tool call) -> {}
+        assert_eq!(tool_arguments_to_input(""), serde_json::json!({}));
+        assert_eq!(tool_arguments_to_input("   "), serde_json::json!({}));
+
+        // a real object passes through unchanged
         assert_eq!(
-            block["input"].as_object().unwrap().len(),
-            0,
-            "empty arguments must map to {{}}"
+            tool_arguments_to_input(r#"{"q":"rust"}"#),
+            serde_json::json!({ "q": "rust" })
         );
 
-        let invalid = ToolCall {
-            id: "call_bad".to_string(),
-            tool_type: "function".to_string(),
-            function: FunctionCall {
-                name: "search".to_string(),
-                arguments: "not json".to_string(),
-            },
-        };
-        let block = super::tool_call_to_tool_use_block(&invalid);
-        assert!(
-            block["input"].is_object(),
-            "invalid arguments must fall back to an object input, not a bare string"
-        );
-        assert_eq!(block["input"]["_raw"], "not json");
+        // valid-but-non-object JSON must NOT pass through -> `_raw` object
+        for non_object in ["42", "true", "null", "[1,2,3]", "\"a string\""] {
+            let v = tool_arguments_to_input(non_object);
+            assert!(
+                v.is_object(),
+                "{non_object:?} must map to an object, got {v}"
+            );
+            assert_eq!(v["_raw"], non_object);
+        }
+
+        // invalid JSON -> `_raw` object
+        let v = tool_arguments_to_input("not json");
+        assert!(v.is_object());
+        assert_eq!(v["_raw"], "not json");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #351.

## Problem
Anthropic requires `tool_use.input` to be a JSON **object**. Two conversion sites produced an invalid `input`:
- `tool_call_to_tool_use_block` (`providers/anthropic/mod.rs`) — empty `arguments` (a normal zero-argument tool call) → `serde_json::from_str("")` errors → fallback `Value::String("")`; any parse error → bare string.
- `conversion.rs` (response path) — `from_str(..).unwrap_or(Value::String(..))`.

Anthropic 400s a non-object `input`, and since the bad `tool_use` is persisted in history, **every subsequent request in the session 400s too** → the agent loop dies with a non-actionable error.

## Fix
Both sites now: empty/whitespace args → `{}`, parse failure → `{ "_raw": <original> }` (object, never a bare string). No behavior change for valid object arguments.

## Tests
- Updated `tool_call_with_invalid_json_arguments_falls_back_to_string` → `..._falls_back_to_object` (it had codified the buggy string fallback).
- Added `tool_use_input_is_object_for_empty_and_invalid_arguments` asserting `input` is always an object for empty + invalid args.
- `bamboo-llm` lib: 442 passed, 0 failed; fmt + clippy (`--all-features -D warnings`) clean.

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u