### PR TITLE
fix(server): cap metrics list limit + body limits on every serve path (#252)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/filters.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/metrics/core_handlers/filters.rs
@@ -14,7 +14,7 @@ pub(super) fn build_sessions_filter(
         start_date: query.start_date,
         end_date: query.end_date,
         model: query.model.clone(),
-        limit: query.limit,
+        limit: normalize_limit(query.limit),
     }
 }
 
@@ -26,7 +26,7 @@ pub(super) fn build_forward_filter(
         end_date: query.end_date,
         endpoint: query.endpoint.clone(),
         model: query.model.clone(),
-        limit: query.limit,
+        limit: normalize_limit(query.limit),
     }
 }
 
@@ -38,7 +38,7 @@ pub(super) fn build_forward_grouped_filter(
         end_date: query.end_date,
         endpoint: None,
         model: query.model.clone(),
-        limit: query.limit,
+        limit: normalize_limit(query.limit),
     }
 }
 
@@ -46,10 +46,42 @@ pub(super) fn normalize_days(days: Option<u32>) -> u32 {
     days.unwrap_or(30).clamp(1, 365)
 }
 
+/// Default and hard cap for metrics list `limit`. A client omitting `limit`
+/// previously produced an unbounded query / full-table scan (#252); always
+/// resolve to a bounded value (mirrors [`normalize_days`]).
+const DEFAULT_METRICS_LIMIT: u32 = 100;
+const MAX_METRICS_LIMIT: u32 = 1000;
+
+pub(super) fn normalize_limit(limit: Option<u32>) -> Option<u32> {
+    Some(
+        limit
+            .unwrap_or(DEFAULT_METRICS_LIMIT)
+            .clamp(1, MAX_METRICS_LIMIT),
+    )
+}
+
 pub(super) fn resolve_timeline_granularity(value: Option<&str>) -> TimelineGranularity {
     match value.unwrap_or("daily") {
         "weekly" => TimelineGranularity::Weekly,
         "monthly" => TimelineGranularity::Monthly,
         _ => TimelineGranularity::Daily,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_limit_defaults_and_caps() {
+        // Omitted → a bounded default, not an unbounded query (#252).
+        assert_eq!(normalize_limit(None), Some(DEFAULT_METRICS_LIMIT));
+        // In-range passes through.
+        assert_eq!(normalize_limit(Some(50)), Some(50));
+        // Over the cap is clamped down; zero is clamped up to 1.
+        assert_eq!(normalize_limit(Some(1_000_000)), Some(MAX_METRICS_LIMIT));
+        assert_eq!(normalize_limit(Some(0)), Some(1));
+        // Never returns None (the unbounded case).
+        assert!(normalize_limit(None).is_some());
     }
 }

--- a/crates/app/bamboo-server/src/server/entrypoints.rs
+++ b/crates/app/bamboo-server/src/server/entrypoints.rs
@@ -111,6 +111,12 @@ pub async fn run_with_tls(
 
     let app_factory = move || {
         let mut app = App::new()
+            // Same body limits as the production/static path so a desktop chat
+            // request with an inline image isn't rejected with 413 (#252).
+            .app_data(web::JsonConfig::default().limit(super::web_service::MAX_JSON_BODY_BYTES))
+            .app_data(web::PayloadConfig::new(
+                super::web_service::MAX_PAYLOAD_BYTES,
+            ))
             .app_data(app_state.clone())
             .wrap(build_cors("127.0.0.1", port))
             // Immutable long-cache for hashed `/assets/*` (parity with the web
@@ -299,10 +305,12 @@ pub async fn run_with_bind_and_static_tls(
     let bind_for_cors = bind.to_string();
     let app_factory = move || {
         let mut app = App::new()
-            // Request size limits to prevent DoS
-            // Chat requests may include base64 images; keep limits high enough for local usage.
-            .app_data(web::JsonConfig::default().limit(25 * 1024 * 1024)) // 25MB JSON limit
-            .app_data(web::PayloadConfig::new(30 * 1024 * 1024)) // 30MB payload limit
+            // Request size limits to prevent DoS. Chat requests may include
+            // base64 images; shared with every serve path (#252).
+            .app_data(web::JsonConfig::default().limit(super::web_service::MAX_JSON_BODY_BYTES))
+            .app_data(web::PayloadConfig::new(
+                super::web_service::MAX_PAYLOAD_BYTES,
+            ))
             .app_data(app_state.clone())
             .wrap(actix_web::middleware::Condition::new(
                 apply_rate_limit,

--- a/crates/app/bamboo-server/src/server/web_service.rs
+++ b/crates/app/bamboo-server/src/server/web_service.rs
@@ -6,6 +6,13 @@ use tokio::sync::oneshot;
 use tracing::{error, info};
 
 use super::listeners::DEFAULT_WORKER_COUNT;
+
+/// Request body size limits, applied on EVERY serve path so the desktop/embedded
+/// server accepts the same payloads (e.g. an inline-image chat request) as the
+/// production server, instead of falling back to actix's ~2MB JSON / 256KB
+/// payload defaults and rejecting them with 413 (#252).
+pub(crate) const MAX_JSON_BODY_BYTES: usize = 25 * 1024 * 1024;
+pub(crate) const MAX_PAYLOAD_BYTES: usize = 30 * 1024 * 1024;
 use super::tls::build_rustls_config;
 use crate::app_state::AppState;
 use crate::config::{build_cors, build_rate_limiter, build_security_headers, is_loopback_bind};
@@ -85,6 +92,8 @@ impl WebService {
 
         let server = HttpServer::new(move || {
             App::new()
+                .app_data(web::JsonConfig::default().limit(MAX_JSON_BODY_BYTES))
+                .app_data(web::PayloadConfig::new(MAX_PAYLOAD_BYTES))
                 .app_data(app_state.clone())
                 .wrap(build_cors(&bind_addr, port))
                 .configure(configure_routes) // No rate limiting for WebService
@@ -185,8 +194,8 @@ impl WebService {
 
         let server = HttpServer::new(move || {
             App::new()
-                .app_data(web::JsonConfig::default().limit(25 * 1024 * 1024))
-                .app_data(web::PayloadConfig::new(30 * 1024 * 1024))
+                .app_data(web::JsonConfig::default().limit(MAX_JSON_BODY_BYTES))
+                .app_data(web::PayloadConfig::new(MAX_PAYLOAD_BYTES))
                 .app_data(app_state.clone())
                 .wrap(actix_web::middleware::Condition::new(
                     apply_rate_limit,


### PR DESCRIPTION
Addresses #252 (the two lowest-risk, self-contained robustness holes; broader pagination noted as follow-up).

## 1. Unbounded metrics list `limit`
`GET /api/v1/metrics/sessions` and `/metrics/forward/*` passed `query.limit` straight through with **no default and no cap** — omitting `limit` produced an unbounded query / full-table scan (while `normalize_days` right next to it correctly clamps 1..=365). Added `normalize_limit` (default **100**, hard max **1000**), applied in all three `build_*_filter` functions so the resolved limit is always bounded.

## 2. Body limits on only one serve path → 413 on desktop
The production/static path set `JsonConfig 25MB` + `PayloadConfig 30MB`, but the **desktop** entrypoint (`run`/`run_with_tls`) and `WebService::start`/`start_with_bind` set **neither**, falling back to actix's ~2MB JSON / 256KB payload defaults. So a chat request with an inline base64 image that succeeds on the Docker/production server was rejected **413** on the desktop/embedded server — same API, different limits. Hoisted the limits to shared `MAX_JSON_BODY_BYTES` / `MAX_PAYLOAD_BYTES` consts and applied them on **all four** serve paths.

## Tests
`normalize_limit_defaults_and_caps` (omitted→default, in-range passthrough, over-cap clamp, zero→1, never `None`). Server builds; clippy (full CI flag set) `-D warnings` clean.

## Follow-up (out of scope)
The broader item — `limit`/`cursor` pagination on `GET /api/v1/sessions` and a hard cap on the cold `GET /api/v1/history/{id}` fetch — is a larger, response-shape-changing API change and is left for a dedicated PR.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU