### PR TITLE
fix(openai): surface the no-reasoning retry's real error, not the stale 400 (#237 finding 3)

### DIFF
--- a/crates/infra/bamboo-llm/src/providers/openai/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/openai/mod.rs
@@ -464,6 +464,15 @@ impl LLMProvider for OpenAIProvider {
 
                     return Ok(stream);
                 }
+
+                // The no-reasoning retry itself failed — surface ITS status/body,
+                // not the stale original "reasoning unsupported" 400 (which would
+                // mask the real failure, e.g. a 500/429 on the retry). (#237)
+                let fallback_status = fallback.status();
+                let fallback_text = fallback.text().await.unwrap_or_default();
+                return Err(LLMError::Api(format!(
+                    "HTTP {fallback_status}: {fallback_text} (after retrying without reasoning_effort)"
+                )));
             }
 
             if Self::looks_like_responses_only_error(status, &text) {


### PR DESCRIPTION
Addresses **finding #3** of #237.

## Problem
`openai/mod.rs`: when `/chat/completions` rejects `reasoning_effort` with a 400 that matches `looks_like_reasoning_unsupported_error`, the provider retries the request without reasoning. But if that **fallback retry also fails**, the code fell out of the `if fallback.status().is_success()` block and continued to `return Err(HTTP {status}: {text})` using the **original** request's `status`/`text` — the fallback's response was never read. So a 400-on-reasoning whose retry 500s/429s surfaced the stale *"reasoning unsupported"* 400, masking the real failure. (The Copilot path already handles this; OpenAI didn't.)

## Fix
Immediately after the success branch, when the fallback is **not** successful, read **its** status + body and return that — annotated `(after retrying without reasoning_effort)` — instead of falling through to the original error.

## Verification
Self-contained 6-line correctness change (return the fallback's own status/body vs the stale original); 444 bamboo-llm tests pass, clippy (full CI flags) clean. A wiremock end-to-end test is feasible via `with_base_url` but would have to thread the two-request + retry-backoff interaction; happy to add it if preferred.

The other #237 sub-findings (Anthropic SSE tolerance already landed in #368; Copilot token lock, Responses arg-dup/image-drop, over-broad reasoning heuristic) remain separate.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU