### PR TITLE
fix(storage): clear stale pre-#180 Root token_budget at the load boundary (#230)

### DIFF
--- a/crates/core/bamboo-domain/src/session/types.rs
+++ b/crates/core/bamboo-domain/src/session/types.rs
@@ -576,6 +576,22 @@ pub enum SessionKind {
 }
 
 impl Session {
+    /// Load-boundary migration: a persisted `Root` session's `token_budget` can
+    /// only be a stale pre-#180 resolved-budget cache — genuine budgets flow
+    /// through `config.token_budget`, and only a `Child` persists an assigned
+    /// sub-budget. Clear it so `resolve_token_budget` re-resolves from the
+    /// current `model_limits.json` instead of short-circuiting on the stale
+    /// value forever.
+    ///
+    /// MUST be called only on freshly disk-loaded sessions — never inside
+    /// `resolve_token_budget`, which can't tell a stale disk cache from a
+    /// legitimate in-memory budget injection (tests, child sub-budgets). (#230)
+    pub fn clear_stale_root_token_budget(&mut self) {
+        if self.kind == SessionKind::Root {
+            self.token_budget = None;
+        }
+    }
+
     /// The effective token budget: a genuine/child override (`token_budget`) if
     /// set, otherwise the per-process resolved-budget cache
     /// (`resolved_token_budget`). Both are `None` until the first resolution.
@@ -1417,6 +1433,29 @@ mod tests {
         assert_eq!(child.parent_session_id.as_deref(), Some("root-1"));
         assert_eq!(child.root_session_id, "root-1");
         assert_eq!(child.spawn_depth, 1);
+    }
+
+    #[test]
+    fn clear_stale_root_token_budget_clears_root_keeps_child() {
+        // #230: a Root's persisted token_budget is a stale pre-#180 cache → clear
+        // it on load so it re-resolves. A Child's is a genuine assigned sub-budget
+        // → keep it.
+        let mut root = Session::new("root-1", "m");
+        root.token_budget = Some(crate::TokenBudget::for_model(1000));
+        root.clear_stale_root_token_budget();
+        assert!(
+            root.token_budget.is_none(),
+            "Root token_budget cleared on load"
+        );
+
+        let parent = Session::new("root-1", "m");
+        let mut child = Session::new_child_of("child-1", &parent, "m", "c");
+        child.token_budget = Some(crate::TokenBudget::for_model(500));
+        child.clear_stale_root_token_budget();
+        assert!(
+            child.token_budget.is_some(),
+            "Child assigned sub-budget preserved on load"
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-storage/src/jsonl.rs
+++ b/crates/infra/bamboo-storage/src/jsonl.rs
@@ -87,7 +87,9 @@ impl JsonlStorage {
             return Ok(None);
         }
         let content = fs::read_to_string(path).await?;
-        let session = serde_json::from_str(&content)?;
+        let mut session: Session = serde_json::from_str(&content)?;
+        // Drop a stale pre-#180 Root token_budget cache so it re-resolves (#230).
+        session.clear_stale_root_token_budget();
         Ok(Some(session))
     }
 

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -476,7 +476,12 @@ impl SessionStoreV2 {
         }
         let raw = fs::read_to_string(&path).await?;
         match serde_json::from_str::<Session>(&raw) {
-            Ok(side) => Ok(Some(side)),
+            Ok(mut side) => {
+                // The control-plane path (`load_runtime_control_plane`) returns
+                // this directly, so migrate a stale Root token_budget here too (#230).
+                side.clear_stale_root_token_budget();
+                Ok(Some(side))
+            }
             Err(error) => {
                 // A corrupt sidecar must never make a session unloadable — the
                 // authoritative copy still lives in session.json. Warn and ignore.
@@ -1056,7 +1061,10 @@ impl Storage for SessionStoreV2 {
         let session: Session = serde_json::from_str(&raw)
             .map_err(|e| other_io_error(format!("invalid session.json: {e}")))?;
         let sidecar = self.read_runtime_sidecar(session_id).await?;
-        Ok(Some(overlay_runtime_sidecar(session, sidecar)))
+        let mut session = overlay_runtime_sidecar(session, sidecar);
+        // Drop a stale pre-#180 Root token_budget cache so it re-resolves (#230).
+        session.clear_stale_root_token_budget();
+        Ok(Some(session))
     }
 
     async fn delete_session(&self, session_id: &str) -> io::Result<bool> {
@@ -1162,6 +1170,38 @@ mod tests {
         assert!(!sessions_dir.exists());
         let _storage = SessionStoreV2::new(bamboo_home).await?;
         assert!(sessions_dir.exists());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn root_token_budget_cleared_on_load_child_preserved() -> io::Result<()> {
+        // #230: a Root persisted with a token_budget (pre-#180 stale cache) loads
+        // with token_budget == None so it re-resolves; a Child's assigned
+        // sub-budget survives the reload.
+        let (storage, _dir) = create_temp_storage().await?;
+
+        let mut root = Session::new("root-1", "m");
+        root.token_budget = Some(bamboo_domain::TokenBudget::for_model(1000));
+        storage.save_session(&root).await?;
+        let loaded = storage.load_session("root-1").await?.expect("root present");
+        assert!(
+            loaded.token_budget.is_none(),
+            "stale Root token_budget must be cleared on load"
+        );
+
+        let parent = Session::new("root-1", "m");
+        let mut child = Session::new_child_of("child-1", &parent, "m", "c");
+        child.token_budget = Some(bamboo_domain::TokenBudget::for_model(500));
+        storage.save_session(&child).await?;
+        let loaded_child = storage
+            .load_session("child-1")
+            .await?
+            .expect("child present");
+        assert!(
+            loaded_child.token_budget.is_some(),
+            "Child assigned sub-budget must be preserved on load"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #230 (follow-up to #180/#229).

## Gap
#229 fixed the durable/stale token-budget cache for **new** sessions (the engine cache moved to `#[serde(skip)] resolved_token_budget`, so a reload re-resolves). But #178 previously persisted `session.token_budget = Some(resolved)` for **any** session, including `Root`. #229 keeps `token_budget` as the top-priority short-circuit (it's the genuine child/override slot), so a **`Root` session that ran ≥1 round under #178 and is later reloaded** still carries that stale budget and short-circuits forever — #180's own "reloaded session ignores a `model_limits.json` edit" scenario, still broken for pre-existing sessions.

## Fix (at the LOAD boundary, not in `resolve`)
No production path writes a genuine override into a `Root` session's `token_budget` (user/config budgets flow through `config.token_budget`; only a **child** persists an assigned sub-budget). So `Session::clear_stale_root_token_budget()` clears `token_budget` iff `kind == Root`, called on freshly disk-loaded sessions:
- `SessionStoreV2::load_session` (after the runtime-sidecar overlay) + `read_runtime_sidecar` (the control-plane path)
- `JsonlStorage::load_session`

Deliberately **not** in `resolve_token_budget` — it can't distinguish a disk-loaded stale cache from a legitimate in-memory injection (child sub-budgets, and the 9 `context_preparation` tests that set `session.token_budget = Some(..)`). #239 already deleted the dead `bamboo-infrastructure/storage` duplicate, so `bamboo-storage` is the only live load path.

## Acceptance / tests
- ✅ A `Root` persisted with `token_budget` loads with `token_budget == None` and re-resolves — covered by a **v2 integration test** (real save→load) + a domain unit test.
- ✅ `Child` sessions keep their persisted assigned sub-budget across reload — asserted in both tests.
- ✅ In-memory test/child injection is unaffected (migration is load-only, never in `resolve`).

clippy (full CI flags) clean.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU