### PR TITLE
fix(build): add missing api_key_from_env to all provider-config literals (hotfix #253)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
@@ -31,6 +31,7 @@ async fn redacted_config_json_masks_provider_api_key_and_hides_encrypted_proxy_a
     let mut config = Config::default();
     config.providers.openai = Some(OpenAIConfig {
         api_key: "sk-secret".to_string(),
+        api_key_from_env: false,
         api_key_encrypted: None,
         base_url: None,
         model: None,

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/tests.rs
@@ -26,6 +26,7 @@ fn provider_validation_issue_returns_provider_path_when_openai_key_present() {
         providers: ProviderConfigs {
             openai: Some(OpenAIConfig {
                 api_key: "sk-test".to_string(),
+                api_key_from_env: false,
                 api_key_encrypted: None,
                 base_url: None,
                 model: None,

--- a/crates/app/bamboo-server/src/handlers/settings/provider/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/tests.rs
@@ -23,6 +23,7 @@ fn build_config_with_mcp_secrets(temp_dir: &std::path::Path) -> Config {
         providers: ProviderConfigs {
             openai: Some(OpenAIConfig {
                 api_key: "sk-test".to_string(),
+                api_key_from_env: false,
                 api_key_encrypted: None,
                 base_url: None,
                 model: Some("gpt-4o".to_string()),

--- a/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
@@ -13,6 +13,7 @@ fn config_with_openai_key() -> Config {
         providers: ProviderConfigs {
             openai: Some(OpenAIConfig {
                 api_key: String::new(),
+                api_key_from_env: false,
                 api_key_encrypted: Some("enc-key".to_string()),
                 base_url: None,
                 model: None,

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -618,6 +618,7 @@ mod build_context_tests {
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
                     api_key: "test".to_string(),
+                    api_key_from_env: false,
                     api_key_encrypted: None,
                     base_url: None,
                     model: Some("gpt-4o".to_string()),

--- a/crates/engine/bamboo-engine/src/model_areas.rs
+++ b/crates/engine/bamboo-engine/src/model_areas.rs
@@ -316,6 +316,7 @@ mod tests {
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
                     api_key: "test".to_string(),
+                    api_key_from_env: false,
                     api_key_encrypted: None,
                     base_url: None,
                     model: Some("gpt-4o".to_string()),

--- a/crates/engine/bamboo-engine/src/model_config_helper.rs
+++ b/crates/engine/bamboo-engine/src/model_config_helper.rs
@@ -646,6 +646,7 @@ mod tests {
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
                     api_key: "test".to_string(),
+                    api_key_from_env: false,
                     api_key_encrypted: None,
                     base_url: None,
                     model: Some("gpt-4o".to_string()),
@@ -673,6 +674,7 @@ mod tests {
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
                     api_key: "test".to_string(),
+                    api_key_from_env: false,
                     api_key_encrypted: None,
                     base_url: None,
                     model: None, // No model configured
@@ -742,6 +744,7 @@ mod tests {
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
                     api_key: "test".to_string(),
+                    api_key_from_env: false,
                     api_key_encrypted: None,
                     base_url: None,
                     model: Some("gpt-4o".to_string()),
@@ -768,6 +771,7 @@ mod tests {
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
                     api_key: "test".to_string(),
+                    api_key_from_env: false,
                     api_key_encrypted: None,
                     base_url: None,
                     model: Some("gpt-4o".to_string()),
@@ -801,6 +805,7 @@ mod tests {
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
                     api_key: "test".to_string(),
+                    api_key_from_env: false,
                     api_key_encrypted: None,
                     base_url: None,
                     model: Some("gpt-4o".to_string()),
@@ -833,6 +838,7 @@ mod tests {
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
                     api_key: "test".to_string(),
+                    api_key_from_env: false,
                     api_key_encrypted: None,
                     base_url: None,
                     model: Some("gpt-4o".to_string()),
@@ -888,6 +894,7 @@ mod tests {
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
                     api_key: "test".to_string(),
+                    api_key_from_env: false,
                     api_key_encrypted: None,
                     base_url: None,
                     model: Some("gpt-4o".to_string()),

--- a/crates/infra/bamboo-llm/src/provider_factory.rs
+++ b/crates/infra/bamboo-llm/src/provider_factory.rs
@@ -317,6 +317,7 @@ mod tests {
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
                     api_key: "".to_string(),
+                    api_key_from_env: false,
                     api_key_encrypted: None,
                     base_url: None,
                     model: None,
@@ -349,6 +350,7 @@ mod tests {
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
                     api_key: "sk-test123".to_string(),
+                    api_key_from_env: false,
                     api_key_encrypted: None,
                     base_url: Some("https://custom.openai.com/v1".to_string()),
                     model: Some("gpt-4o".to_string()),
@@ -375,6 +377,7 @@ mod tests {
             providers: ProviderConfigs {
                 anthropic: Some(AnthropicConfig {
                     api_key: "sk-ant-test123".to_string(),
+                    api_key_from_env: false,
                     api_key_encrypted: None,
                     base_url: None,
                     model: Some("claude-3-5-sonnet-20241022".to_string()),
@@ -401,6 +404,7 @@ mod tests {
             providers: ProviderConfigs {
                 gemini: Some(GeminiConfig {
                     api_key: "AIza-test123".to_string(),
+                    api_key_from_env: false,
                     api_key_encrypted: None,
                     base_url: None,
                     model: Some("gemini-pro".to_string()),

--- a/crates/infra/bamboo-llm/src/provider_registry.rs
+++ b/crates/infra/bamboo-llm/src/provider_registry.rs
@@ -357,6 +357,9 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
         "openai" => {
             config.providers.openai = Some(bamboo_config::OpenAIConfig {
                 api_key: instance.api_key.clone(),
+                // Key comes from the provider instance, not a BAMBOO_*_API_KEY env
+                // override, so it may be persisted normally. #253.
+                api_key_from_env: false,
                 api_key_encrypted: instance.api_key_encrypted.clone(),
                 base_url: instance.base_url.clone(),
                 model: instance.model.clone(),
@@ -371,6 +374,9 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
         "anthropic" => {
             config.providers.anthropic = Some(bamboo_config::AnthropicConfig {
                 api_key: instance.api_key.clone(),
+                // Key comes from the provider instance, not a BAMBOO_*_API_KEY env
+                // override, so it may be persisted normally. #253.
+                api_key_from_env: false,
                 api_key_encrypted: instance.api_key_encrypted.clone(),
                 base_url: instance.base_url.clone(),
                 model: instance.model.clone(),
@@ -385,6 +391,9 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
         "gemini" => {
             config.providers.gemini = Some(bamboo_config::GeminiConfig {
                 api_key: instance.api_key.clone(),
+                // Key comes from the provider instance, not a BAMBOO_*_API_KEY env
+                // override, so it may be persisted normally. #253.
+                api_key_from_env: false,
                 api_key_encrypted: instance.api_key_encrypted.clone(),
                 base_url: instance.base_url.clone(),
                 model: instance.model.clone(),
@@ -481,6 +490,7 @@ mod tests {
     fn test_openai_config() -> OpenAIConfig {
         OpenAIConfig {
             api_key: "sk-test".to_string(),
+            api_key_from_env: false,
             api_key_encrypted: None,
             base_url: None,
             model: None,
@@ -515,6 +525,7 @@ mod tests {
             providers: bamboo_config::ProviderConfigs {
                 openai: Some(OpenAIConfig {
                     api_key: String::new(),
+                    api_key_from_env: false,
                     ..test_openai_config()
                 }),
                 ..bamboo_config::ProviderConfigs::default()

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -1147,6 +1147,7 @@ mod tests {
         config.providers = ProviderConfigs {
             openai: Some(OpenAIConfig {
                 api_key: "sk-cli-secret".to_string(),
+                api_key_from_env: false,
                 api_key_encrypted: None,
                 base_url: Some("https://api.openai.com/v1".to_string()),
                 model: Some("gpt-4o".to_string()),

--- a/tests/config_comprehensive.rs
+++ b/tests/config_comprehensive.rs
@@ -269,6 +269,7 @@ mod comprehensive_config_tests {
         original.provider = "anthropic".to_string();
         original.providers.anthropic = Some(bamboo_config::AnthropicConfig {
             api_key: String::new(),
+            api_key_from_env: false,
             api_key_encrypted: None,
             base_url: None,
             model: Some("claude-3".to_string()),

--- a/tests/e2e/sessions/mod.rs
+++ b/tests/e2e/sessions/mod.rs
@@ -7,6 +7,7 @@ mod patch_message_safety;
 fn openai_config_with(model: &str, reasoning_effort: Option<ReasoningEffort>) -> OpenAIConfig {
     OpenAIConfig {
         api_key: "sk-test".to_string(),
+        api_key_from_env: false,
         api_key_encrypted: None,
         base_url: None,
         model: Some(model.to_string()),


### PR DESCRIPTION
## main is broken 🔴
#253 added `#[serde(skip)] api_key_from_env: bool` to `OpenAIConfig` / `AnthropicConfig` / `GeminiConfig` and updated the literals in `config.rs` + `provider_instance.rs`, but **missed every other struct literal in the workspace**. Three are non-test (`provider_registry::apply_instance_to_config`), so `main` fails to compile — **Build, Test, Lint, and Docs are all red**, which blocks every open PR (#374, #372, …).

```
error[E0063]: missing field `api_key_from_env` in initializer of `OpenAIConfig`
  --> crates/infra/bamboo-llm/src/provider_registry.rs:358:44
```

## Fix
Add `api_key_from_env: false` to all 23 remaining literals:
- **non-test (the actual build break):** `provider_registry.rs` ×3 (`apply_instance_to_config`)
- **test / fixture code (breaks CI Test):** `provider_factory.rs`, `schedule_app/manager.rs`, engine `model_config_helper.rs` ×7 + `model_areas.rs`, server `settings/**/tests.rs` ×4, `provider_registry` tests, `src/bin/bamboo.rs`, `tests/config_comprehensive.rs`, `tests/e2e/sessions/mod.rs`

`false` is correct at every site — each builds a config from a **provider instance** or a **test fixture**, never from a `BAMBOO_*_API_KEY` env override, so the resulting key is persisted normally (the flag only exists to suppress persistence of env-injected keys).

## Verification
- ✅ `cargo build --workspace --tests` clean (was failing on `E0063`)
- ✅ `cargo test -p bamboo-llm -p bamboo-config` → 147 + 444 pass
- ✅ `cargo fmt --all` clean; no new clippy warnings (pre-existing unused-import warnings unrelated)

Pure mechanical field-completion — no behavior change. Merging this un-blocks the rest of the queue.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU