### PR TITLE
fix(config): unblock main — add missing api_key_from_env to 24 construction sites (broken by #371)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
@@ -30,6 +30,7 @@ fn model_limits_file_path_appends_model_limits_json_filename() {
 async fn redacted_config_json_masks_provider_api_key_and_hides_encrypted_proxy_auth() {
     let mut config = Config::default();
     config.providers.openai = Some(OpenAIConfig {
+        api_key_from_env: false,
         api_key: "sk-secret".to_string(),
         api_key_encrypted: None,
         base_url: None,

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/tests.rs
@@ -25,6 +25,7 @@ fn provider_validation_issue_returns_provider_path_when_openai_key_present() {
         provider: "openai".to_string(),
         providers: ProviderConfigs {
             openai: Some(OpenAIConfig {
+                api_key_from_env: false,
                 api_key: "sk-test".to_string(),
                 api_key_encrypted: None,
                 base_url: None,

--- a/crates/app/bamboo-server/src/handlers/settings/provider/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/tests.rs
@@ -22,6 +22,7 @@ fn build_config_with_mcp_secrets(temp_dir: &std::path::Path) -> Config {
         provider: "openai".to_string(),
         providers: ProviderConfigs {
             openai: Some(OpenAIConfig {
+                api_key_from_env: false,
                 api_key: "sk-test".to_string(),
                 api_key_encrypted: None,
                 base_url: None,

--- a/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
@@ -12,6 +12,7 @@ fn config_with_openai_key() -> Config {
     Config {
         providers: ProviderConfigs {
             openai: Some(OpenAIConfig {
+                api_key_from_env: false,
                 api_key: String::new(),
                 api_key_encrypted: Some("enc-key".to_string()),
                 base_url: None,

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -617,6 +617,7 @@ mod build_context_tests {
             },
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
+                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_encrypted: None,
                     base_url: None,

--- a/crates/engine/bamboo-engine/src/model_areas.rs
+++ b/crates/engine/bamboo-engine/src/model_areas.rs
@@ -315,6 +315,7 @@ mod tests {
             defaults: None,
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
+                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_encrypted: None,
                     base_url: None,

--- a/crates/engine/bamboo-engine/src/model_config_helper.rs
+++ b/crates/engine/bamboo-engine/src/model_config_helper.rs
@@ -645,6 +645,7 @@ mod tests {
             provider: "openai".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
+                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_encrypted: None,
                     base_url: None,
@@ -672,6 +673,7 @@ mod tests {
             provider: "openai".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
+                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_encrypted: None,
                     base_url: None,
@@ -741,6 +743,7 @@ mod tests {
             provider: "anthropic".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
+                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_encrypted: None,
                     base_url: None,
@@ -767,6 +770,7 @@ mod tests {
             provider: "anthropic".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
+                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_encrypted: None,
                     base_url: None,
@@ -800,6 +804,7 @@ mod tests {
             },
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
+                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_encrypted: None,
                     base_url: None,
@@ -832,6 +837,7 @@ mod tests {
             },
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
+                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_encrypted: None,
                     base_url: None,
@@ -887,6 +893,7 @@ mod tests {
             provider: "anthropic".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
+                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_encrypted: None,
                     base_url: None,

--- a/crates/infra/bamboo-llm/src/provider_factory.rs
+++ b/crates/infra/bamboo-llm/src/provider_factory.rs
@@ -316,6 +316,7 @@ mod tests {
             provider: "openai".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
+                    api_key_from_env: false,
                     api_key: "".to_string(),
                     api_key_encrypted: None,
                     base_url: None,
@@ -348,6 +349,7 @@ mod tests {
             provider: "openai".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
+                    api_key_from_env: false,
                     api_key: "sk-test123".to_string(),
                     api_key_encrypted: None,
                     base_url: Some("https://custom.openai.com/v1".to_string()),
@@ -374,6 +376,7 @@ mod tests {
             provider: "anthropic".to_string(),
             providers: ProviderConfigs {
                 anthropic: Some(AnthropicConfig {
+                    api_key_from_env: false,
                     api_key: "sk-ant-test123".to_string(),
                     api_key_encrypted: None,
                     base_url: None,
@@ -400,6 +403,7 @@ mod tests {
             provider: "gemini".to_string(),
             providers: ProviderConfigs {
                 gemini: Some(GeminiConfig {
+                    api_key_from_env: false,
                     api_key: "AIza-test123".to_string(),
                     api_key_encrypted: None,
                     base_url: None,

--- a/crates/infra/bamboo-llm/src/provider_registry.rs
+++ b/crates/infra/bamboo-llm/src/provider_registry.rs
@@ -356,6 +356,7 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
     match instance.provider_type.as_str() {
         "openai" => {
             config.providers.openai = Some(bamboo_config::OpenAIConfig {
+                api_key_from_env: false,
                 api_key: instance.api_key.clone(),
                 api_key_encrypted: instance.api_key_encrypted.clone(),
                 base_url: instance.base_url.clone(),
@@ -370,6 +371,7 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
         }
         "anthropic" => {
             config.providers.anthropic = Some(bamboo_config::AnthropicConfig {
+                api_key_from_env: false,
                 api_key: instance.api_key.clone(),
                 api_key_encrypted: instance.api_key_encrypted.clone(),
                 base_url: instance.base_url.clone(),
@@ -384,6 +386,7 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
         }
         "gemini" => {
             config.providers.gemini = Some(bamboo_config::GeminiConfig {
+                api_key_from_env: false,
                 api_key: instance.api_key.clone(),
                 api_key_encrypted: instance.api_key_encrypted.clone(),
                 base_url: instance.base_url.clone(),
@@ -480,6 +483,7 @@ mod tests {
 
     fn test_openai_config() -> OpenAIConfig {
         OpenAIConfig {
+            api_key_from_env: false,
             api_key: "sk-test".to_string(),
             api_key_encrypted: None,
             base_url: None,

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -1146,6 +1146,7 @@ mod tests {
         });
         config.providers = ProviderConfigs {
             openai: Some(OpenAIConfig {
+                api_key_from_env: false,
                 api_key: "sk-cli-secret".to_string(),
                 api_key_encrypted: None,
                 base_url: Some("https://api.openai.com/v1".to_string()),

--- a/tests/config_comprehensive.rs
+++ b/tests/config_comprehensive.rs
@@ -268,6 +268,7 @@ mod comprehensive_config_tests {
         let mut original = Config::from_data_dir(Some(temp.path.clone()));
         original.provider = "anthropic".to_string();
         original.providers.anthropic = Some(bamboo_config::AnthropicConfig {
+            api_key_from_env: false,
             api_key: String::new(),
             api_key_encrypted: None,
             base_url: None,

--- a/tests/e2e/sessions/mod.rs
+++ b/tests/e2e/sessions/mod.rs
@@ -6,6 +6,7 @@ mod patch_message_safety;
 
 fn openai_config_with(model: &str, reasoning_effort: Option<ReasoningEffort>) -> OpenAIConfig {
     OpenAIConfig {
+        api_key_from_env: false,
         api_key: "sk-test".to_string(),
         api_key_encrypted: None,
         base_url: None,


### PR DESCRIPTION
## 🔴 main is currently un-buildable — this unblocks it

**#371** (per-provider API key from env, #253) added the **required** `api_key_from_env` field to `OpenAIConfig`/`AnthropicConfig`/`GeminiConfig`, but missed **24 construction sites** across the workspace. Its own CI run (`7497eb2e`) **failed**, yet it was merged anyway — so main has been red since, and **every PR opened after it inherits the break** (`cargo test --all-features --lib --tests` fails to compile).

## Fix
Add `api_key_from_env: false` to every flagged site — the correct default (the flag is only set `true` later when a key is actually loaded from `BAMBOO_<PROVIDER>_API_KEY`; these sites project explicit config/instance/test credentials, not env). Sites were found **deterministically from the compiler's E0063 output** (only the 3 real config types, never `ProviderInstanceConfig`/`BodhiConfig` which share `api_key_encrypted` but lack this field).

Touched (24 sites / 12 files): `provider_registry.rs`, `provider_factory.rs`, `model_config_helper.rs` (×7), `model_areas.rs`, 4 `bamboo-server` settings tests, `schedule_app/manager.rs`, `tests/e2e/sessions`, `tests/config_comprehensive.rs`, `src/bin/bamboo.rs`.

## Verification
`cargo test --all-features --lib --tests --no-run` compiles clean; `cargo fmt -- --check` clean. Pure mechanical field-add (the default value), no behavior change.

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u