### PR TITLE
fix: revert #376 — it duplicated api_key_from_env (already fixed by #375), re-breaking main

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
@@ -30,7 +30,6 @@ fn model_limits_file_path_appends_model_limits_json_filename() {
 async fn redacted_config_json_masks_provider_api_key_and_hides_encrypted_proxy_auth() {
     let mut config = Config::default();
     config.providers.openai = Some(OpenAIConfig {
-        api_key_from_env: false,
         api_key: "sk-secret".to_string(),
         api_key_from_env: false,
         api_key_encrypted: None,

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/tests.rs
@@ -25,7 +25,6 @@ fn provider_validation_issue_returns_provider_path_when_openai_key_present() {
         provider: "openai".to_string(),
         providers: ProviderConfigs {
             openai: Some(OpenAIConfig {
-                api_key_from_env: false,
                 api_key: "sk-test".to_string(),
                 api_key_from_env: false,
                 api_key_encrypted: None,

--- a/crates/app/bamboo-server/src/handlers/settings/provider/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/tests.rs
@@ -22,7 +22,6 @@ fn build_config_with_mcp_secrets(temp_dir: &std::path::Path) -> Config {
         provider: "openai".to_string(),
         providers: ProviderConfigs {
             openai: Some(OpenAIConfig {
-                api_key_from_env: false,
                 api_key: "sk-test".to_string(),
                 api_key_from_env: false,
                 api_key_encrypted: None,

--- a/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
@@ -12,7 +12,6 @@ fn config_with_openai_key() -> Config {
     Config {
         providers: ProviderConfigs {
             openai: Some(OpenAIConfig {
-                api_key_from_env: false,
                 api_key: String::new(),
                 api_key_from_env: false,
                 api_key_encrypted: Some("enc-key".to_string()),

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -617,7 +617,6 @@ mod build_context_tests {
             },
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
-                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_from_env: false,
                     api_key_encrypted: None,

--- a/crates/engine/bamboo-engine/src/model_areas.rs
+++ b/crates/engine/bamboo-engine/src/model_areas.rs
@@ -315,7 +315,6 @@ mod tests {
             defaults: None,
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
-                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_from_env: false,
                     api_key_encrypted: None,

--- a/crates/engine/bamboo-engine/src/model_config_helper.rs
+++ b/crates/engine/bamboo-engine/src/model_config_helper.rs
@@ -645,7 +645,6 @@ mod tests {
             provider: "openai".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
-                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_from_env: false,
                     api_key_encrypted: None,
@@ -674,7 +673,6 @@ mod tests {
             provider: "openai".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
-                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_from_env: false,
                     api_key_encrypted: None,
@@ -745,7 +743,6 @@ mod tests {
             provider: "anthropic".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
-                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_from_env: false,
                     api_key_encrypted: None,
@@ -773,7 +770,6 @@ mod tests {
             provider: "anthropic".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
-                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_from_env: false,
                     api_key_encrypted: None,
@@ -808,7 +804,6 @@ mod tests {
             },
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
-                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_from_env: false,
                     api_key_encrypted: None,
@@ -842,7 +837,6 @@ mod tests {
             },
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
-                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_from_env: false,
                     api_key_encrypted: None,
@@ -899,7 +893,6 @@ mod tests {
             provider: "anthropic".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
-                    api_key_from_env: false,
                     api_key: "test".to_string(),
                     api_key_from_env: false,
                     api_key_encrypted: None,

--- a/crates/infra/bamboo-llm/src/provider_factory.rs
+++ b/crates/infra/bamboo-llm/src/provider_factory.rs
@@ -316,7 +316,6 @@ mod tests {
             provider: "openai".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
-                    api_key_from_env: false,
                     api_key: "".to_string(),
                     api_key_from_env: false,
                     api_key_encrypted: None,
@@ -350,7 +349,6 @@ mod tests {
             provider: "openai".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
-                    api_key_from_env: false,
                     api_key: "sk-test123".to_string(),
                     api_key_from_env: false,
                     api_key_encrypted: None,
@@ -378,7 +376,6 @@ mod tests {
             provider: "anthropic".to_string(),
             providers: ProviderConfigs {
                 anthropic: Some(AnthropicConfig {
-                    api_key_from_env: false,
                     api_key: "sk-ant-test123".to_string(),
                     api_key_from_env: false,
                     api_key_encrypted: None,
@@ -406,7 +403,6 @@ mod tests {
             provider: "gemini".to_string(),
             providers: ProviderConfigs {
                 gemini: Some(GeminiConfig {
-                    api_key_from_env: false,
                     api_key: "AIza-test123".to_string(),
                     api_key_from_env: false,
                     api_key_encrypted: None,

--- a/crates/infra/bamboo-llm/src/provider_registry.rs
+++ b/crates/infra/bamboo-llm/src/provider_registry.rs
@@ -356,7 +356,6 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
     match instance.provider_type.as_str() {
         "openai" => {
             config.providers.openai = Some(bamboo_config::OpenAIConfig {
-                api_key_from_env: false,
                 api_key: instance.api_key.clone(),
                 // Key comes from the provider instance, not a BAMBOO_*_API_KEY env
                 // override, so it may be persisted normally. #253.
@@ -374,7 +373,6 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
         }
         "anthropic" => {
             config.providers.anthropic = Some(bamboo_config::AnthropicConfig {
-                api_key_from_env: false,
                 api_key: instance.api_key.clone(),
                 // Key comes from the provider instance, not a BAMBOO_*_API_KEY env
                 // override, so it may be persisted normally. #253.
@@ -392,7 +390,6 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
         }
         "gemini" => {
             config.providers.gemini = Some(bamboo_config::GeminiConfig {
-                api_key_from_env: false,
                 api_key: instance.api_key.clone(),
                 // Key comes from the provider instance, not a BAMBOO_*_API_KEY env
                 // override, so it may be persisted normally. #253.
@@ -492,7 +489,6 @@ mod tests {
 
     fn test_openai_config() -> OpenAIConfig {
         OpenAIConfig {
-            api_key_from_env: false,
             api_key: "sk-test".to_string(),
             api_key_from_env: false,
             api_key_encrypted: None,

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -1146,7 +1146,6 @@ mod tests {
         });
         config.providers = ProviderConfigs {
             openai: Some(OpenAIConfig {
-                api_key_from_env: false,
                 api_key: "sk-cli-secret".to_string(),
                 api_key_from_env: false,
                 api_key_encrypted: None,

--- a/tests/config_comprehensive.rs
+++ b/tests/config_comprehensive.rs
@@ -268,7 +268,6 @@ mod comprehensive_config_tests {
         let mut original = Config::from_data_dir(Some(temp.path.clone()));
         original.provider = "anthropic".to_string();
         original.providers.anthropic = Some(bamboo_config::AnthropicConfig {
-            api_key_from_env: false,
             api_key: String::new(),
             api_key_from_env: false,
             api_key_encrypted: None,

--- a/tests/e2e/sessions/mod.rs
+++ b/tests/e2e/sessions/mod.rs
@@ -6,7 +6,6 @@ mod patch_message_safety;
 
 fn openai_config_with(model: &str, reasoning_effort: Option<ReasoningEffort>) -> OpenAIConfig {
     OpenAIConfig {
-        api_key_from_env: false,
         api_key: "sk-test".to_string(),
         api_key_from_env: false,
         api_key_encrypted: None,


### PR DESCRIPTION
## 🔴 Unblock main again (E0062 duplicate fields)

#371 broke main by omitting the required `api_key_from_env` field. **#375 (`997de686`) already hotfixed it** ("add missing api_key_from_env to all provider-config literals"). My **#376** was an independent hotfix for the same breakage, authored against a **pre-#375 base** — so when it squash-merged on top of the already-fixed main, GitHub applied its "add the field" diff a **second time**, producing duplicate `api_key_from_env` fields (E0062) in `provider_registry.rs` and the other literals. #376's own CI was green because it ran on the merge ref before #375's code was present; the squash commit was never re-checked.

## Fix
Straight `git revert` of #376 — removes exactly the 24 lines it added (24 deletions / 12 files), leaving #375's single, correct `api_key_from_env: false` at each site. `cargo test --all-features --lib --tests --no-run` compiles clean; `cargo fmt -- --check` clean.

(My #376 was redundant — #375 got there first. Lesson: rebase a hotfix onto latest main right before merging, since squash-merge doesn't re-run CI.)

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u