### PR TITLE
feat(server): add unversioned /healthz + /readyz JSON probes (#251 finding 6)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/health.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/health.rs
@@ -1,37 +1,67 @@
-//! Health check API handler.
+//! Health check API handlers.
 //!
-//! This module provides a simple health check endpoint for monitoring
-//! and load balancer health probes.
+//! Two flavors:
+//! - `GET /api/v1/health` — the original plain-text `"OK"` probe (kept for
+//!   back-compat).
+//! - `GET /healthz` (liveness) and `GET /readyz` (readiness) — **unversioned**,
+//!   public JSON `{status, version}` endpoints for load balancers / Kubernetes
+//!   probes, which conventionally expect a stable unversioned path and a
+//!   machine-parseable body. #251 (finding 6).
 
-use actix_web::Responder;
+use actix_web::{HttpResponse, Responder};
+use serde::Serialize;
 
-/// Health check endpoint.
+/// The server version, surfaced by the JSON health endpoints so probes and
+/// dashboards can read the running build. `0.0.0` in dev; the release train
+/// stamps the real date-version at publish.
+const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// JSON body for the `/healthz` and `/readyz` endpoints.
+#[derive(Serialize)]
+struct HealthStatus {
+    /// Always `"ok"` when the endpoint responds (a non-200 or no response is the
+    /// unhealthy signal).
+    status: &'static str,
+    /// The running server version.
+    version: &'static str,
+}
+
+impl HealthStatus {
+    fn ok() -> Self {
+        Self {
+            status: "ok",
+            version: SERVER_VERSION,
+        }
+    }
+}
+
+/// Legacy health check endpoint — `GET /api/v1/health`.
 ///
-/// Returns a simple "OK" response to indicate the server is running.
-///
-/// # HTTP Method
-///
-/// `GET /health`
-///
-/// # Response
-///
-/// - `200 OK` - Server is healthy (returns plain text "OK")
-///
-/// # Usage
-///
-/// This endpoint is commonly used by:
-/// - Load balancers for health probes
-/// - Monitoring systems for uptime checks
-/// - Kubernetes liveness/readiness probes
-///
-/// # Example
-///
-/// ```bash
-/// curl http://localhost:9562/health
-/// # Returns: OK
-/// ```
+/// Returns plain-text `"OK"`. Kept unchanged for back-compat; new probes should
+/// prefer the unversioned JSON [`healthz`] / [`readyz`].
 pub async fn handler() -> impl Responder {
     "OK"
+}
+
+/// Liveness probe — `GET /healthz` (unversioned, public).
+///
+/// Returns `200 {"status":"ok","version":"…"}` whenever the process is running
+/// and able to serve HTTP. Liveness asks only "is the process up?" — it does not
+/// check downstream dependencies, so a load balancer won't cycle the process for
+/// a transient dependency blip.
+pub async fn healthz() -> impl Responder {
+    HttpResponse::Ok().json(HealthStatus::ok())
+}
+
+/// Readiness probe — `GET /readyz` (unversioned, public).
+///
+/// Returns `200 {"status":"ok","version":"…"}` once the server is accepting
+/// requests. The route only exists after `AppState` is initialized and the
+/// listener is bound, so a successful response means the server is ready to serve
+/// traffic. Kept distinct from [`healthz`] so future readiness checks (e.g.
+/// storage reachability) can gate `/readyz` without affecting liveness.
+pub async fn readyz() -> impl Responder {
+    HttpResponse::Ok().json(HealthStatus::ok())
 }
 
 #[cfg(test)]
@@ -44,6 +74,45 @@ mod tests {
         // We'll test the actual HTTP response in other tests
         let _response = handler().await;
         // If we get here without panicking, the handler works
+    }
+
+    #[tokio::test]
+    async fn healthz_returns_json_status_and_version() {
+        use actix_web::{test, web, App};
+
+        let app = test::init_service(App::new().route("/healthz", web::get().to(healthz))).await;
+        let req = test::TestRequest::get().uri("/healthz").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), 200);
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            content_type.starts_with("application/json"),
+            "expected JSON, got {content_type}"
+        );
+
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["status"], "ok");
+        assert_eq!(body["version"], SERVER_VERSION);
+    }
+
+    #[tokio::test]
+    async fn readyz_returns_json_status_and_version() {
+        use actix_web::{test, web, App};
+
+        let app = test::init_service(App::new().route("/readyz", web::get().to(readyz))).await;
+        let req = test::TestRequest::get().uri("/readyz").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status(), 200);
+        let body: serde_json::Value = test::read_body_json(resp).await;
+        assert_eq!(body["status"], "ok");
+        assert_eq!(body["version"], SERVER_VERSION);
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/handlers/settings/access_control.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/access_control.rs
@@ -447,6 +447,10 @@ fn is_public_access_route(path: &str) -> bool {
     matches!(
         path,
         "/api/v1/health"
+            // Unversioned liveness/readiness probes for load balancers / k8s —
+            // must be reachable without a credential. #251 (finding 6).
+            | "/healthz"
+            | "/readyz"
             | "/v1/bamboo/access/status"
             | "/v1/bamboo/access/verify"
             // v2-P2 (#181): a brand-new device has no credential yet, so the
@@ -1607,6 +1611,15 @@ mod tests {
         assert!(!is_public_access_route("/v2/pair/code"));
         assert!(!is_public_access_route("/v2/devices"));
         assert!(!is_public_access_route("/v2/devices/bamboo_x"));
+    }
+
+    #[test]
+    fn health_probes_are_public() {
+        // #251 (finding 6): unversioned liveness/readiness probes must be
+        // reachable by a load balancer without a credential.
+        assert!(is_public_access_route("/healthz"));
+        assert!(is_public_access_route("/readyz"));
+        assert!(is_public_access_route("/api/v1/health"));
     }
 
     // ── v2-P2 pairing codes + brute-force guard (#181, slice 2) ────────────

--- a/crates/app/bamboo-server/src/routes/agent.rs
+++ b/crates/app/bamboo-server/src/routes/agent.rs
@@ -262,6 +262,14 @@ pub fn agent_routes(cfg: &mut web::ServiceConfig) {
 
     cfg.service(scope);
 
+    // Unversioned liveness/readiness probes (#251 finding 6). Registered at the
+    // root — OUTSIDE the `/api/v1` scope and its access-password middleware — so
+    // load balancers / Kubernetes can probe a stable, unauthenticated path. Both
+    // are on the public allow-list in `is_public_access_route`; registering them
+    // before the SPA static fallback means the fallback never shadows them.
+    cfg.route("/healthz", web::get().to(agent::health::healthz));
+    cfg.route("/readyz", web::get().to(agent::health::readyz));
+
     // v2-P1 (#181): the unified WebSocket multiplex. A single `GET /v2/stream`
     // WS replaces the two v1 SSE streams plus a `stop` control uplink. Behind
     // the SAME access-password middleware as `/api/v1`, so `local_bypass` keeps

--- a/crates/app/bamboo-server/src/routes/tests.rs
+++ b/crates/app/bamboo-server/src/routes/tests.rs
@@ -12,6 +12,9 @@ async fn configure_routes_registers_expected_api_prefixes() {
 
     let requests = vec![
         ("GET", "/api/v1/health"),
+        // Unversioned liveness/readiness probes (#251 finding 6).
+        ("GET", "/healthz"),
+        ("GET", "/readyz"),
         ("POST", "/api/v1/sessions/example/project-dream/run"),
         ("GET", "/api/v1/sessions/example/discoverable-tools"),
         ("POST", "/api/v1/sessions/example/discoverable-tools"),
@@ -44,6 +47,9 @@ async fn configure_routes_with_rate_limiting_registers_expected_api_prefixes() {
 
     let requests = vec![
         ("GET", "/api/v1/health"),
+        // Unversioned liveness/readiness probes (#251 finding 6).
+        ("GET", "/healthz"),
+        ("GET", "/readyz"),
         ("POST", "/api/v1/sessions/example/project-dream/run"),
         ("GET", "/api/v1/sessions/example/discoverable-tools"),
         ("POST", "/api/v1/sessions/example/discoverable-tools"),


### PR DESCRIPTION
Addresses **finding 6 of #251** (a contained, additive slice — the other findings remain open).

## Problem
The only health endpoint is `GET /api/v1/health` returning bare `text/plain` `"OK"` (`agent/health.rs:33`): it's **versioned** (load balancers / k8s conventionally probe a stable unversioned path) and **not machine-parseable** (no version, no JSON), with no liveness/readiness split.

## Change
Add unversioned, public JSON probes:
- `GET /healthz` (liveness) and `GET /readyz` (readiness) → `200 {"status":"ok","version":"<server version>"}`. Version from `CARGO_PKG_VERSION` (`0.0.0` in dev; the release train stamps the date-version at publish).
- Registered at the **root** — outside the `/api/v1` scope and its access-password middleware — and added to `is_public_access_route`, so an LB/k8s can probe **without a credential**. Registered before the SPA static fallback, so it never shadows them.
- The legacy `GET /api/v1/health` plain-text probe is **unchanged** (back-compat).
- Liveness and readiness are **distinct handlers** so a future readiness check (e.g. storage reachability) can gate `/readyz` without cycling the process on liveness.

## Why just finding 6
#251 bundles 7 surface-consistency findings. Finding 6 is purely **additive** (new endpoints, no behavior change to existing routes), so it's safe to land independently and doesn't block or conflict with the larger version-prefix / error-envelope normalization.

## Tests
- `healthz_returns_json_status_and_version` / `readyz_returns_json_status_and_version` — assert 200, `application/json`, and `{status:"ok", version:<CARGO_PKG_VERSION>}`.
- Route-map test (both variants) now asserts `/healthz` + `/readyz` are registered.
- `health_probes_are_public` — asserts both bypass the auth gate.

Verified: `cargo test -p bamboo-server` → 968 pass; fmt + clippy clean.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU