### PR TITLE
fix(openai): surface mid-stream errors on /v1/chat/completions instead of a clean [DONE]

### DIFF
--- a/crates/app/bamboo-server/src/handlers/openai/chat/stream/sse.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/chat/stream/sse.rs
@@ -14,6 +14,17 @@ pub(super) fn done_marker_bytes() -> Bytes {
     Bytes::from_static(b"[DONE]")
 }
 
+/// Raw payload for an OpenAI-style streaming error frame, emitted before
+/// `[DONE]` when the upstream stream errors mid-response. Without it a client
+/// sees a clean `[DONE]` and mistakes a **truncated** response for a complete
+/// one. Wrapped as `data: {…}\n\n` downstream like every other frame.
+pub(super) fn error_chunk_bytes(message: &str) -> Bytes {
+    let payload = serde_json::json!({
+        "error": { "message": message, "type": "api_error" }
+    });
+    Bytes::from(serde_json::to_string(&payload).unwrap_or_default())
+}
+
 pub(super) fn wrap_sse_data(bytes: Bytes) -> Bytes {
     let data = format!("data: {}\n\n", String::from_utf8_lossy(&bytes));
     Bytes::from(data)

--- a/crates/app/bamboo-server/src/handlers/openai/chat/stream/worker.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/chat/stream/worker.rs
@@ -6,7 +6,7 @@ use bamboo_llm::provider::LLMStream;
 use bamboo_llm::types::LLMChunk;
 use bamboo_metrics::{ForwardStatus, MetricsCollector};
 
-use super::sse::{done_marker_bytes, openai_chunk_bytes};
+use super::sse::{done_marker_bytes, error_chunk_bytes, openai_chunk_bytes};
 use crate::handlers::llm_compat::usage::{build_estimated_usage, estimate_completion_tokens};
 
 pub(super) struct StreamWorkerArgs {
@@ -25,7 +25,7 @@ pub(super) fn spawn_stream_worker(args: StreamWorkerArgs) {
 }
 
 async fn run_stream_worker(mut args: StreamWorkerArgs) {
-    let mut had_error = false;
+    let mut error_message: Option<String> = None;
     let mut saw_done = false;
     let mut streamed_text = String::new();
 
@@ -69,21 +69,28 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
             Ok(LLMChunk::CacheUsage { .. }) | Ok(LLMChunk::UsageSummary { .. }) => {}
             Err(error) => {
                 tracing::error!("Stream error: {}", error);
-                had_error = true;
+                let message = error.to_string();
                 args.metrics.forward_completed(
                     args.forward_id.clone(),
                     chrono::Utc::now(),
                     None,
                     ForwardStatus::Error,
                     None,
-                    Some(error.to_string()),
+                    Some(message.clone()),
                 );
+                error_message = Some(message);
                 break;
             }
         }
     }
 
-    if !had_error {
+    if let Some(message) = error_message {
+        // Surface the upstream error to the client instead of a clean `[DONE]`,
+        // so a truncated response isn't mistaken for a complete one. Mirrors the
+        // Anthropic streaming handler, which emits an SSE error event before end.
+        let _ = args.tx.send(Ok(error_chunk_bytes(&message))).await;
+        let _ = args.tx.send(Ok(done_marker_bytes())).await;
+    } else {
         if !saw_done {
             if let Some(done_chunk) = openai_chunk_bytes(LLMChunk::Done, &args.model) {
                 let _ = args.tx.send(Ok(done_chunk)).await;
@@ -103,7 +110,58 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
             )),
             None,
         );
-    } else {
-        let _ = args.tx.send(Ok(done_marker_bytes())).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_llm::provider::LLMError;
+    use bamboo_metrics::storage::SqliteMetricsStorage;
+    use futures::stream;
+    use std::sync::Arc;
+
+    fn test_metrics() -> (MetricsCollector, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Arc::new(SqliteMetricsStorage::new(dir.path().join("metrics.db")));
+        (MetricsCollector::spawn(storage, 7), dir)
+    }
+
+    #[tokio::test]
+    async fn stream_error_emits_error_frame_before_done() {
+        // A mid-stream upstream error must surface an error frame to the client,
+        // not just a clean `[DONE]` — otherwise a truncated response reads as
+        // complete. Some tokens have already been forwarded when the error hits.
+        let (metrics, _dir) = test_metrics();
+        let chunks: Vec<Result<LLMChunk, LLMError>> = vec![
+            Ok(LLMChunk::Token("partial".to_string())),
+            Err(LLMError::Stream("upstream boom".to_string())),
+        ];
+        let stream_result: LLMStream = Box::pin(stream::iter(chunks));
+        let (tx, mut rx) = mpsc::channel(16);
+
+        run_stream_worker(StreamWorkerArgs {
+            stream_result,
+            tx,
+            model: "gpt-x".to_string(),
+            metrics,
+            forward_id: "fid".to_string(),
+            estimated_prompt_tokens: 0,
+        })
+        .await;
+
+        let mut frames = Vec::new();
+        while let Ok(item) = rx.try_recv() {
+            frames.push(String::from_utf8_lossy(&item.unwrap()).to_string());
+        }
+
+        assert!(
+            frames
+                .iter()
+                .any(|f| f.contains("\"error\"") && f.contains("upstream boom")),
+            "expected an error frame carrying the upstream message, got: {frames:?}"
+        );
+        // The stream still terminates with the [DONE] marker.
+        assert_eq!(frames.last().map(String::as_str), Some("[DONE]"));
     }
 }


### PR DESCRIPTION
Refs #355 (chat-completions part).

## Problem
The `/v1/chat/completions` streaming worker turned a **mid-stream upstream failure into an on-the-wire success**: on `Err` it logged, recorded `ForwardStatus::Error`, then sent only `data: [DONE]`. A client (any OpenAI SDK) sees a normal stream end and treats the **truncated** output as the final answer. The Anthropic (`messages/stream.rs`) and Gemini (`gemini/stream/runtime.rs`) handlers already surface the error; only OpenAI-compat swallowed it.

## Fix
Capture the error message (previously a discarded `had_error: bool`) and emit an OpenAI-shaped error frame — `{"error":{"message":…,"type":"api_error"}}` (wrapped as `data: …\n\n` by the existing `wrap_sse_data`) — **before** `[DONE]`, so the truncation is visible.

## Test
`stream_error_emits_error_frame_before_done` feeds a stream of `[Token, Err]`, runs the worker, and asserts the frames contain the error frame (carrying the upstream message) and still terminate with `[DONE]`. `bamboo-server`: passes; fmt + clippy (`--all-features -D warnings`) clean.

## Scope
Chat completions only (the dominant endpoint). The `/v1/responses` worker has the identical swallow but needs a structured `response.failed` event (no existing helper) — **#355 stays open** for that follow-up.

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u