### PR TITLE
refactor(server): remove dead duplicate settings route map (#251 finding 5)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/mod.rs
@@ -52,83 +52,8 @@ pub use workflows::{
     delete_workflow, get_workflow, list_workflows, save_workflow, SaveWorkflowRequest,
 };
 
-use actix_web::web;
-
-/// Configures settings-related routes.
-pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.route("/bamboo/workflows", web::get().to(list_workflows))
-        .route("/bamboo/workflows/{name}", web::get().to(get_workflow))
-        .route("/bamboo/workflows", web::post().to(save_workflow))
-        .route(
-            "/bamboo/workflows/{name}",
-            web::delete().to(delete_workflow),
-        )
-        .route("/bamboo/setup/status", web::get().to(get_setup_status))
-        .route(
-            "/bamboo/setup/complete",
-            web::post().to(mark_setup_complete),
-        )
-        .route(
-            "/bamboo/setup/incomplete",
-            web::post().to(mark_setup_incomplete),
-        )
-        .route("/bamboo/config", web::get().to(get_bamboo_config))
-        .route("/bamboo/config", web::post().to(set_bamboo_config))
-        .route("/bamboo/access/status", web::get().to(get_access_status))
-        .route(
-            "/bamboo/access/verify",
-            web::post().to(verify_access_password),
-        )
-        .route(
-            "/bamboo/access/password",
-            web::post().to(update_access_password),
-        )
-        .route(
-            "/bamboo/model-limits/defaults",
-            web::get().to(get_model_limit_defaults),
-        )
-        .route(
-            "/bamboo/config/validate",
-            web::post().to(validate_bamboo_config_patch),
-        )
-        .route("/bamboo/config/reset", web::post().to(reset_bamboo_config))
-        .route("/bamboo/proxy-auth", web::post().to(set_proxy_auth))
-        .route(
-            "/bamboo/proxy-auth/status",
-            web::get().to(get_proxy_auth_status),
-        )
-        .route(
-            "/bamboo/keyword-masking",
-            web::get().to(get_keyword_masking_config),
-        )
-        .route(
-            "/bamboo/keyword-masking",
-            web::post().to(update_keyword_masking_config),
-        )
-        .route(
-            "/bamboo/keyword-masking/validate",
-            web::post().to(validate_keyword_entries),
-        )
-        .route(
-            "/bamboo/settings/provider",
-            web::get().to(get_provider_config),
-        )
-        .route(
-            "/bamboo/settings/provider",
-            web::post().to(update_provider_config),
-        )
-        .route(
-            "/bamboo/settings/provider/models",
-            web::post().to(fetch_provider_models),
-        )
-        .route(
-            "/bamboo/settings/reload",
-            web::post().to(reload_provider_config),
-        )
-        .route("/bamboo/tools", web::get().to(get_bamboo_tools))
-        // ── Env vars ──────────────────────────────────────────────
-        .route("/bamboo/env-vars", web::get().to(list_env_vars))
-        .route("/bamboo/env-vars", web::post().to(upsert_env_var))
-        .route("/bamboo/env-vars/replace", web::post().to(replace_env_vars))
-        .route("/bamboo/env-vars/{name}", web::delete().to(delete_env_var));
-}
+// NOTE: the production `/bamboo/*` route map lives in `routes::bamboo_v1_routes`
+// (`routes/bamboo_v1.rs`). A second `config()` copy used to live here, but it had
+// drifted (29 routes vs. the 70 in production) and had no callers, so it was
+// removed to eliminate the drift hazard — a stale duplicate route map that tests
+// could pass against while diverging from what actually serves. #251 (finding 5).


### PR DESCRIPTION
Addresses **finding 5 of #251** (the other findings remain open).

## Problem
`handlers/settings/mod.rs::config()` declared a **second copy** of the `/bamboo/*` route map that is also registered by the production `routes::bamboo_v1_routes` (`routes/bamboo_v1.rs`). The finding flagged this as a drift hazard: the duplicate is used (per the assessment) only by unit tests, so tests could pass against a route map that has silently diverged from production.

Confirmed the drift is **already real**: the `mod.rs` copy declares **29** routes vs. the **70** in `bamboo_v1_routes`.

## Change
Auditing usage showed `settings::config` has **no callers at all** — not production wiring (`routes/`, `server/`), not tests, not re-exported. So rather than repointing tests, this removes the dead function (and its now-unused `use actix_web::web;`) outright, eliminating the drift-prone duplicate entirely.

Production routing is untouched (`bamboo_v1_routes` is the single source of truth), and the existing route-map tests already exercise `/v1/bamboo/*` through `bamboo_v1_routes`.

## Verification
- `cargo build -p bamboo-server` + `--tests` clean (compiler confirms no caller of the removed fn).
- `cargo test -p bamboo-server` → 969 pass.
- clippy clean (no unused-import fallout from dropping `web`).

Scope: only finding 5. The remaining #251 findings (version-prefix drift, error envelopes, 200/201, REST nesting, public-route gate) are untouched.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU