### PR TITLE
fix(server): return 201 Created on POST /api/v1/sessions (#251 finding 3)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
@@ -65,7 +65,11 @@ pub async fn create_session(
     );
 
     match state.session_store.get_index_entry(&id).await {
-        Some(entry) => Ok(HttpResponse::Ok().json(CreateSessionResponse {
+        // 201 Created — a new resource was created. Aligns `POST /api/v1/sessions`
+        // with every other create endpoint (chat, mcp-add, prompt-presets,
+        // provider-instances, cluster-nodes), which already return 201. #251
+        // (finding 3).
+        Some(entry) => Ok(HttpResponse::Created().json(CreateSessionResponse {
             session: SessionSummary::from_entry(entry, false),
         })),
         None => Ok(HttpResponse::InternalServerError().json(serde_json::json!({
@@ -103,4 +107,53 @@ fn build_new_session(
     };
 
     crate_build(&input, &create_config)
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_web::{http::StatusCode, test, web, App};
+    use serde_json::Value;
+    use tempfile::tempdir;
+
+    use crate::routes::configure_routes;
+    use crate::AppState;
+
+    async fn new_state() -> web::Data<AppState> {
+        let temp_dir = tempdir().expect("tempdir");
+        bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
+        web::Data::new(
+            AppState::new(temp_dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        )
+    }
+
+    #[actix_web::test]
+    async fn create_session_returns_201_created() {
+        let state = new_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/sessions")
+                .set_json(serde_json::json!({ "title": "New session" }))
+                .to_request(),
+        )
+        .await;
+
+        // 201 Created — aligns with the other create endpoints. #251 (finding 3).
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let body: Value = test::read_body_json(resp).await;
+        assert!(
+            body["session"]["id"].as_str().is_some(),
+            "response should carry the created session summary"
+        );
+    }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/maintenance.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/maintenance.rs
@@ -374,7 +374,8 @@ mod tests {
             .set_json(serde_json::json!({ "title": "Feed test" }))
             .to_request();
         let resp = test::call_service(&app, create).await;
-        assert_eq!(resp.status(), StatusCode::OK);
+        // POST /sessions now returns 201 Created (#251 finding 3).
+        assert_eq!(resp.status(), StatusCode::CREATED);
         let body: Value = test::read_body_json(resp).await;
         let session_id = body["session"]["id"]
             .as_str()


### PR DESCRIPTION
Addresses **finding 3 of #251** (the other findings remain open).

## Problem
`POST /api/v1/sessions` returned **200** (`sessions/handlers/crud/create.rs:68`) while every other create endpoint returns **201**: chat (`chat/handler/mod.rs:137`), mcp-add (`mcp/server_handlers/crud.rs:57`), prompt-presets (`prompt_presets/handlers.rs:129`), provider-instances (`provider_instances/mod.rs:366`), cluster-nodes (`cluster_fabric/mod.rs:245`). Inconsistent status on create → clients can't rely on a uniform convention, and generating an OpenAPI spec (#226) off this would bake in the drift.

## Change
Return `201 Created` from `create_session`. Response body is unchanged (`CreateSessionResponse`); only the success status code moves 200 → 201.

## Safety
- No test or frontend asserted an **exact** 200 on create: grepped bamboo-server (only `maintenance.rs` asserted `StatusCode::OK` on create — updated to `CREATED`) and both `lotus` / `lotus-next` (no `status === 200` checks on session create; they treat any 2xx as success).
- Added a focused `create_session_returns_201_created` test — `create.rs` previously had no test module.

## Verification
`cargo test -p bamboo-server` → 970 pass; fmt + clippy clean.

Scope: only finding 3. Remaining #251 findings (version-prefix drift, error envelopes, REST nesting, public-route gate) untouched.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU