### PR TITLE
fix(config): preserve provider ciphertext when plaintext is empty (#268)

### DIFF
--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -3229,6 +3229,80 @@ mod tests {
     }
 
     #[test]
+    fn refresh_preserves_ciphertext_when_plaintext_empty() {
+        // #268: a provider whose stored ciphertext failed to decrypt at hydration
+        // has an empty in-memory api_key. An unrelated later save must NOT null its
+        // ciphertext — that would permanently drop a key the user never touched.
+        let openai = |api_key: &str, enc: Option<&str>| OpenAIConfig {
+            api_key: api_key.to_string(),
+            api_key_encrypted: enc.map(str::to_string),
+            base_url: None,
+            model: None,
+            fast_model: None,
+            vision_model: None,
+            reasoning_effort: None,
+            responses_only_models: vec![],
+            request_overrides: None,
+            extra: BTreeMap::new(),
+            api_key_from_env: false,
+        };
+
+        // Empty plaintext + existing ciphertext → ciphertext preserved (the bug).
+        let mut config = Config::default();
+        config.providers.openai = Some(openai("", Some("preexisting-ciphertext")));
+        config
+            .refresh_provider_api_keys_encrypted()
+            .expect("refresh");
+        assert_eq!(
+            config
+                .providers
+                .openai
+                .as_ref()
+                .unwrap()
+                .api_key_encrypted
+                .as_deref(),
+            Some("preexisting-ciphertext"),
+            "existing ciphertext must be preserved when plaintext is empty"
+        );
+
+        // Empty plaintext + no ciphertext → stays None (nothing to preserve).
+        let mut config = Config::default();
+        config.providers.openai = Some(openai("", None));
+        config
+            .refresh_provider_api_keys_encrypted()
+            .expect("refresh");
+        assert!(
+            config
+                .providers
+                .openai
+                .as_ref()
+                .unwrap()
+                .api_key_encrypted
+                .is_none(),
+            "no key + no ciphertext should stay None"
+        );
+
+        // Non-empty plaintext → (re)encrypted to a fresh, non-empty ciphertext.
+        let mut config = Config::default();
+        config.providers.openai = Some(openai("sk-live", Some("stale-ciphertext")));
+        config
+            .refresh_provider_api_keys_encrypted()
+            .expect("refresh");
+        let enc = config
+            .providers
+            .openai
+            .as_ref()
+            .unwrap()
+            .api_key_encrypted
+            .clone()
+            .expect("ciphertext present");
+        assert!(
+            !enc.is_empty() && enc != "stale-ciphertext",
+            "plaintext re-encrypted"
+        );
+    }
+
+    #[test]
     fn get_memory_background_model_falls_back_to_provider_fast_model() {
         let mut config = Config::default();
         config.features.provider_model_ref = false;

--- a/crates/infra/bamboo-config/src/config_crypto.rs
+++ b/crates/infra/bamboo-config/src/config_crypto.rs
@@ -146,55 +146,56 @@ impl Config {
         if let Some(openai) = self.providers.openai.as_mut() {
             if !openai.api_key_from_env {
                 let api_key = openai.api_key.trim();
-                openai.api_key_encrypted = if api_key.is_empty() {
-                    None
-                } else {
-                    Some(
+                // Only (re)encrypt when we actually hold a plaintext key. When the
+                // plaintext is empty because the stored ciphertext failed to
+                // decrypt at hydration (config.json moved across machines, a
+                // machine-id change, the ephemeral fallback key), DON'T null the
+                // ciphertext — that would permanently drop a working key the user
+                // never touched on the next unrelated save. #268.
+                if !api_key.is_empty() {
+                    openai.api_key_encrypted = Some(
                         crate::encryption::encrypt(api_key)
                             .context("Failed to encrypt OpenAI api_key")?,
-                    )
-                };
+                    );
+                }
             }
         }
 
         if let Some(anthropic) = self.providers.anthropic.as_mut() {
             if !anthropic.api_key_from_env {
                 let api_key = anthropic.api_key.trim();
-                anthropic.api_key_encrypted = if api_key.is_empty() {
-                    None
-                } else {
-                    Some(
+                // Empty plaintext → preserve existing ciphertext (see OpenAI above). #268.
+                if !api_key.is_empty() {
+                    anthropic.api_key_encrypted = Some(
                         crate::encryption::encrypt(api_key)
                             .context("Failed to encrypt Anthropic api_key")?,
-                    )
-                };
+                    );
+                }
             }
         }
 
         if let Some(gemini) = self.providers.gemini.as_mut() {
             if !gemini.api_key_from_env {
                 let api_key = gemini.api_key.trim();
-                gemini.api_key_encrypted = if api_key.is_empty() {
-                    None
-                } else {
-                    Some(
+                // Empty plaintext → preserve existing ciphertext (see OpenAI above). #268.
+                if !api_key.is_empty() {
+                    gemini.api_key_encrypted = Some(
                         crate::encryption::encrypt(api_key)
                             .context("Failed to encrypt Gemini api_key")?,
-                    )
-                };
+                    );
+                }
             }
         }
 
         if let Some(bodhi) = self.providers.bodhi.as_mut() {
             let api_key = bodhi.api_key.trim();
-            bodhi.api_key_encrypted = if api_key.is_empty() {
-                None
-            } else {
-                Some(
+            // Empty plaintext → preserve existing ciphertext (see OpenAI above). #268.
+            if !api_key.is_empty() {
+                bodhi.api_key_encrypted = Some(
                     crate::encryption::encrypt(api_key)
                         .context("Failed to encrypt Bodhi api_key")?,
-                )
-            };
+                );
+            }
         }
 
         Ok(())
@@ -224,14 +225,13 @@ impl Config {
     pub fn refresh_provider_instance_api_keys_encrypted(&mut self) -> Result<()> {
         for (id, instance) in self.provider_instances.iter_mut() {
             let api_key = instance.api_key.trim();
-            instance.api_key_encrypted = if api_key.is_empty() {
-                None
-            } else {
-                Some(crate::encryption::encrypt(api_key).context(format!(
-                    "Failed to encrypt api_key for provider instance '{}'",
-                    id
-                ))?)
-            };
+            // Empty plaintext → preserve existing ciphertext (see
+            // refresh_provider_api_keys_encrypted). #268.
+            if !api_key.is_empty() {
+                instance.api_key_encrypted = Some(crate::encryption::encrypt(api_key).context(
+                    format!("Failed to encrypt api_key for provider instance '{}'", id),
+                )?);
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
Fixes #268.

## Bug (silent key loss)
When a provider's `api_key_encrypted` fails to decrypt at hydration (`config.json` copied across machines, a `/etc/machine-id` change, or the ephemeral random fallback key), `hydrate_provider_api_keys_from_encrypted` leaves the in-memory `api_key` **empty** with only a warning. Then `refresh_provider_api_keys_encrypted` did:

```rust
api_key_encrypted = if api_key.is_empty() { None } else { Some(encrypt(...)) };
```

So the **next unrelated full-config save** — `bamboo config set providers.B.api_key ...`, `init --force`, or a settings save touching a *different* provider — nulled the undecryptable key's ciphertext, permanently dropping it. The new `bamboo init` / `config set` write paths (#245/#265) made this casually reachable.

## Fix
In `refresh_provider_api_keys_encrypted` (openai/anthropic/gemini/bodhi) and `refresh_provider_instance_api_keys_encrypted`, only overwrite `api_key_encrypted` when there is a **non-empty** plaintext. When the plaintext is empty, leave the existing ciphertext untouched rather than nulling it.

## Why this doesn't break "clear key"
Explicit clears flow through a **different, intent-gated** path: `sync_provider_api_keys_encrypted_for_patch` iterates only the providers named in the PATCH (`ProviderApiKeyIntents`) and still nulls the ciphertext for an explicitly-cleared empty key. This general refresh governs the providers the user did **not** touch — where empty plaintext means "decrypt failed, keep the stored key", never "the user cleared it". The two compose: clear-intent still clears; an untouched undecryptable key is preserved.

Deliberately **no new struct field** (a `decrypt_failed` flag would be more precise but adding a field to the provider-config structs requires a workspace-wide literal sweep — the exact failure mode that broke main via #253/#375).

## Tests
`refresh_preserves_ciphertext_when_plaintext_empty` covers: empty + existing ciphertext → **preserved**; empty + no ciphertext → stays `None`; non-empty → re-encrypted to a fresh blob. 148 `bamboo-config` + 17 server provider tests pass; fmt + clippy clean.

Severity per the issue: P3 (needs a decrypt failure to trigger), but silent and permanent when it hits.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU