### PR TITLE
fix(security): gate overlay/server tools through the permission checker (#341)

### DIFF
--- a/crates/app/bamboo-server-tools/src/overlay_executor.rs
+++ b/crates/app/bamboo-server-tools/src/overlay_executor.rs
@@ -39,6 +39,14 @@ impl ToolExecutor for OverlayToolExecutor {
                 .as_deref()
                 .is_some_and(|normalized| normalized == self.overlay.name());
         if is_overlay_call {
+            // Gate the overlay tool through the base executor's real permission
+            // check BEFORE invoking it (issue #341). The permission checker lives
+            // in the base (built-in) executor, so overlay tools (`memory`,
+            // `scheduler`, `SubAgent`, …) used to bypass it entirely. `Some`
+            // is the interactive approval pause; `Err` is deny / fail-closed.
+            if let Some(outcome) = self.base.check_permissions_for(call, &ctx).await? {
+                return Ok(outcome.into_tool_result());
+            }
             let args_raw = call.function.arguments.trim();
             let (args, parse_warning) = parse_tool_args_best_effort(&call.function.arguments);
             if let Some(warning) = parse_warning {
@@ -70,10 +78,26 @@ impl ToolExecutor for OverlayToolExecutor {
                 .as_deref()
                 .is_some_and(|normalized| normalized == self.overlay.name());
         if is_overlay_call {
+            // Same permission gate as `execute_with_context` (issue #341): the
+            // overlay tool is checked by the base executor before it runs.
+            if let Some(outcome) = self.base.check_permissions_for(call, &ctx).await? {
+                return Ok(outcome);
+            }
             let (args, _) = parse_tool_args_best_effort(&call.function.arguments);
             return self.overlay.invoke(args, ctx.to_tool_ctx()).await;
         }
         self.base.execute_with_context_outcome(call, ctx).await
+    }
+
+    /// Delegate the permission gate to the base executor so stacked overlays
+    /// chain down to the built-in executor's real check (issue #341). A wrapper
+    /// must never silently answer "allowed" — it defers to whatever it wraps.
+    async fn check_permissions_for(
+        &self,
+        call: &ToolCall,
+        ctx: &ToolExecutionContext<'_>,
+    ) -> Result<Option<ToolOutcome>, ToolError> {
+        self.base.check_permissions_for(call, ctx).await
     }
 
     fn list_tools(&self) -> Vec<ToolSchema> {
@@ -193,6 +217,199 @@ mod tests {
 
         assert!(
             matches!(err, ToolError::Execution(msg) if msg.contains("base executor called for Read"))
+        );
+    }
+
+    // ---- issue #341: overlay tools must hit the base permission gate ---------
+
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    fn make_call_with_args(name: &str, args: &str) -> ToolCall {
+        ToolCall {
+            id: "call_1".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: name.to_string(),
+                arguments: args.to_string(),
+            },
+        }
+    }
+
+    /// An overlay tool named `memory` that records whether it was actually
+    /// invoked, so a test can prove the permission gate blocked it BEFORE it ran.
+    struct RecordingMemoryOverlayTool {
+        invoked: std::sync::Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Tool for RecordingMemoryOverlayTool {
+        fn name(&self) -> &str {
+            "memory"
+        }
+
+        fn description(&self) -> &str {
+            "overlay memory tool"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            json!({"type":"object","properties":{"action":{"type":"string"}}})
+        }
+
+        async fn invoke(
+            &self,
+            _args: serde_json::Value,
+            _ctx: ToolCtx,
+        ) -> Result<ToolOutcome, ToolError> {
+            self.invoked.store(true, Ordering::SeqCst);
+            Ok(ToolOutcome::Completed(ToolResult {
+                success: true,
+                result: "purged".to_string(),
+                display_preference: None,
+                images: Vec::new(),
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn overlay_memory_purge_is_denied_by_base_permission_gate() {
+        // Full composition: an OverlayToolExecutor over a real BuiltinToolExecutor
+        // that carries a permission checker (deny-dangerous). A destructive
+        // `memory purge` overlay call must now route through the base's permission
+        // check (which classifies it as a durable WriteFile) and be DENIED instead
+        // of silently invoked — the exact hole issue #341 fixed.
+        let invoked = std::sync::Arc::new(AtomicBool::new(false));
+        let base = bamboo_tools::BuiltinToolExecutor::new_with_permissions(std::sync::Arc::new(
+            bamboo_tools::permission::DenyDangerousPermissionChecker,
+        ));
+        let overlay = OverlayToolExecutor::new(
+            std::sync::Arc::new(base),
+            std::sync::Arc::new(RecordingMemoryOverlayTool {
+                invoked: invoked.clone(),
+            }),
+        );
+
+        let call = make_call_with_args("memory", r#"{"action":"purge"}"#);
+        let result = overlay.execute(&call).await;
+
+        assert!(
+            matches!(result, Err(ToolError::Execution(_))),
+            "gated overlay call must be denied, got: {result:?}"
+        );
+        assert!(
+            !invoked.load(Ordering::SeqCst),
+            "overlay tool must NOT run when the permission gate denies it"
+        );
+    }
+
+    #[tokio::test]
+    async fn overlay_read_only_memory_action_passes_gate_and_runs() {
+        // Control: a read-only `memory query` is NOT classified as a write, so the
+        // gate is a no-op and the overlay tool still runs — proving the gate only
+        // blocks the actions it should, not every overlay call.
+        let invoked = std::sync::Arc::new(AtomicBool::new(false));
+        let base = bamboo_tools::BuiltinToolExecutor::new_with_permissions(std::sync::Arc::new(
+            bamboo_tools::permission::DenyDangerousPermissionChecker,
+        ));
+        let overlay = OverlayToolExecutor::new(
+            std::sync::Arc::new(base),
+            std::sync::Arc::new(RecordingMemoryOverlayTool {
+                invoked: invoked.clone(),
+            }),
+        );
+
+        let call = make_call_with_args("memory", r#"{"action":"query"}"#);
+        let result = overlay
+            .execute(&call)
+            .await
+            .expect("read-only overlay action should pass the gate");
+
+        assert!(result.success);
+        assert_eq!(result.result, "purged");
+        assert!(
+            invoked.load(Ordering::SeqCst),
+            "read-only overlay action must actually run"
+        );
+    }
+
+    /// A base executor whose permission gate always denies, and whose execute
+    /// paths would panic if reached — proves the overlay consults the base's
+    /// `check_permissions_for` and short-circuits on `Err` before invoking.
+    struct GateDenyingBaseExecutor;
+
+    #[async_trait]
+    impl ToolExecutor for GateDenyingBaseExecutor {
+        async fn execute(&self, _call: &ToolCall) -> Result<ToolResult, ToolError> {
+            panic!("base execute must not be reached for a denied overlay call");
+        }
+
+        async fn execute_with_context(
+            &self,
+            _call: &ToolCall,
+            _ctx: ToolExecutionContext<'_>,
+        ) -> Result<ToolResult, ToolError> {
+            panic!("base execute_with_context must not be reached for a denied overlay call");
+        }
+
+        async fn check_permissions_for(
+            &self,
+            _call: &ToolCall,
+            _ctx: &ToolExecutionContext<'_>,
+        ) -> Result<Option<ToolOutcome>, ToolError> {
+            Err(ToolError::Execution("denied-by-base-gate".to_string()))
+        }
+
+        fn list_tools(&self) -> Vec<ToolSchema> {
+            Vec::new()
+        }
+    }
+
+    #[tokio::test]
+    async fn overlay_call_short_circuits_on_base_gate_error_before_invoke() {
+        // Minimal proof of routing: the overlay call reaches the base's
+        // `check_permissions_for`, and its `Err` is returned before the overlay
+        // tool's `invoke` runs (the overlay tool records if it ran).
+        let invoked = std::sync::Arc::new(AtomicBool::new(false));
+        let overlay = OverlayToolExecutor::new(
+            std::sync::Arc::new(GateDenyingBaseExecutor),
+            std::sync::Arc::new(RecordingMemoryOverlayTool {
+                invoked: invoked.clone(),
+            }),
+        );
+
+        let call = make_call_with_args("memory", r#"{"action":"purge"}"#);
+        let err = overlay
+            .execute(&call)
+            .await
+            .expect_err("base gate error must short-circuit the overlay call");
+
+        assert!(
+            matches!(err, ToolError::Execution(msg) if msg.contains("denied-by-base-gate")),
+            "overlay must return the base gate's error verbatim"
+        );
+        assert!(
+            !invoked.load(Ordering::SeqCst),
+            "overlay tool must NOT run when the base gate errors"
+        );
+    }
+
+    #[tokio::test]
+    async fn overlay_check_permissions_for_delegates_to_base() {
+        // The overlay's own `check_permissions_for` delegates to the base, so a
+        // wrapper stacked over this overlay chains down to the real check.
+        let overlay = OverlayToolExecutor::new(
+            std::sync::Arc::new(GateDenyingBaseExecutor),
+            std::sync::Arc::new(RecordingMemoryOverlayTool {
+                invoked: std::sync::Arc::new(AtomicBool::new(false)),
+            }),
+        );
+
+        let call = make_call_with_args("memory", r#"{"action":"purge"}"#);
+        let ctx = ToolExecutionContext::none(&call.id);
+        let result = overlay.check_permissions_for(&call, &ctx).await;
+
+        assert!(
+            matches!(result, Err(ToolError::Execution(ref msg)) if msg.contains("denied-by-base-gate")),
+            "overlay check_permissions_for must return the base's decision, got: {result:?}"
         );
     }
 }

--- a/crates/core/bamboo-agent-core/src/tools/executor.rs
+++ b/crates/core/bamboo-agent-core/src/tools/executor.rs
@@ -104,6 +104,39 @@ pub trait ToolExecutor: Send + Sync {
             .map(ToolOutcome::Completed)
     }
 
+    /// Permission gate for a tool call, exposed on the executor trait so the
+    /// check is part of the executor *chain*.
+    ///
+    /// An overlay/wrapping executor runs its own tool directly (it does NOT route
+    /// that call through the inner executor's `execute` path), so before this
+    /// method existed the inner executor's permission check was silently skipped
+    /// for those tools (issue #341). By putting the check on the trait, a wrapper
+    /// can call the inner executor's real check before invoking its own tool.
+    ///
+    /// Returns:
+    /// - `Ok(None)` — the call is permitted; the caller proceeds to run the tool.
+    /// - `Ok(Some(outcome))` — the permission layer intercepts the call and THIS
+    ///   [`ToolOutcome`] is the tool call's result *without* the tool running. It
+    ///   carries the interactive "awaiting approval" pause the built-in executor
+    ///   synthesizes for a human event sink (a `Completed` result tagged
+    ///   `display_preference = "request_permissions"` that the engine turns into a
+    ///   clarification pause). Returning it here — rather than collapsing it to an
+    ///   `Err` — is what preserves the built-in path's exact pause-and-ask
+    ///   behavior when the check is routed through this method.
+    /// - `Err(_)` — the call is denied / fails closed.
+    ///
+    /// The default returns `Ok(None)` (no gate), so executors that enforce no
+    /// permissions are unaffected. The built-in executor overrides this with the
+    /// real check; overlay/wrapping executors delegate to their inner executor's
+    /// implementation so the gate can't be dropped by stacking a wrapper.
+    async fn check_permissions_for(
+        &self,
+        _call: &ToolCall,
+        _ctx: &ToolExecutionContext<'_>,
+    ) -> Result<Option<ToolOutcome>> {
+        Ok(None)
+    }
+
     /// Lists all available tools and their schemas
     ///
     /// Returns schemas for all tools that can be executed via this executor

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -300,122 +300,14 @@ impl ToolExecutor for BuiltinToolExecutor {
             .get(&tool_name)
             .ok_or_else(|| ToolError::NotFound(format!("Tool '{}' not found", tool_name)))?;
 
-        if let Some(permission_checker) = &self.permission_checker {
-            if let Some(contexts) =
-                check_permissions(&tool_name, &args).map_err(permission_error_to_tool_error)?
-            {
-                // "Always ask" rules (configured patterns + built-in dangerous
-                // commands) force a confirmation even under bypass. Everything
-                // else is skipped when this session is in "bypass permissions"
-                // mode (scoped per-session via its runtime state).
-                let force_ask = permission_checker.requires_forced_confirmation(&tool_name, &args);
-                for context in contexts {
-                    if ctx.bypass_permissions && !force_ask {
-                        continue;
-                    }
-                    let resource = context.resource.clone();
-                    // Forced confirmations route through `check_or_request_forced`
-                    // so the active mode/bypass cannot suppress the prompt.
-                    let decision = if force_ask {
-                        permission_checker.check_or_request_forced(context).await
-                    } else {
-                        permission_checker.check_or_request(context).await
-                    };
-                    match decision {
-                        Ok(true) => {}
-                        Ok(false) => {
-                            return Err(ToolError::Execution(format!(
-                                "Permission denied for: {}",
-                                resource
-                            )));
-                        }
-                        Err(PermissionError::ConfirmationRequired {
-                            permission_type,
-                            resource: _,
-                        }) => {
-                            // Phase 2 (cross-process): a subagent worker installs a
-                            // task-local `ApprovalProxy` for the duration of its run.
-                            // When present, forward the decision to the worker's host
-                            // (parent) and block this tool inline for the reply —
-                            // approve proceeds (treated like a granted context), deny
-                            // fails closed. Checked BEFORE the interactive sink below
-                            // so a worker (which also has an `event_tx`) proxies to its
-                            // parent instead of trying to prompt a human itself. The
-                            // proxy is unset on every non-worker path, so the behavior
-                            // there is unchanged.
-                            if let Some(proxy) = crate::approval::current_approval_proxy() {
-                                let approved = proxy
-                                    .request_approval(crate::approval::ApprovalAsk {
-                                        tool_name: tool_name.clone(),
-                                        permission: permission_type.description().to_string(),
-                                        resource: resource.clone(),
-                                    })
-                                    .await;
-                                if approved {
-                                    // Treat as a granted context: check any remaining
-                                    // contexts, then fall through to execution.
-                                    continue;
-                                }
-                                return Err(ToolError::Execution(format!(
-                                    "Permission denied by host for: {}",
-                                    resource
-                                )));
-                            }
-
-                            // Interactive sessions pause for approval by reusing the
-                            // same pending-question pipeline as `request_permissions`:
-                            // synthesize an "awaiting_permission_approval" result that
-                            // the engine recognizes (via display_preference) and turns
-                            // into a NeedClarification pause. On approval the respond
-                            // handler records a session grant so the re-attempt passes.
-                            if let Some(tx) = ctx.event_tx {
-                                // Keep emitting the structured approval event for observers.
-                                let _ = tx
-                                    .send(bamboo_agent_core::AgentEvent::ToolApprovalRequested {
-                                        tool_call_id: call.id.clone(),
-                                        tool_name: tool_name.clone(),
-                                        parameters: args.clone(),
-                                    })
-                                    .await;
-
-                                let question = format!(
-                                    "**Permission required**\n\nThe `{}` tool needs approval to {} on:\n\n`{}`",
-                                    tool_name,
-                                    permission_type.description(),
-                                    resource
-                                );
-                                let payload = serde_json::json!({
-                                    "status": "awaiting_permission_approval",
-                                    "question": question,
-                                    "permission_type": permission_type,
-                                    "resource": resource,
-                                    "options": ["Approve", "Deny"],
-                                    "allow_custom": false,
-                                });
-                                // Permission-gate synthesized question stays on
-                                // the Completed→sniff path for now (a later Phase B
-                                // step converts this to ToolOutcome::NeedsHuman).
-                                return Ok(ToolOutcome::Completed(ToolResult {
-                                    success: true,
-                                    result: payload.to_string(),
-                                    display_preference: Some("request_permissions".to_string()),
-                                    images: Vec::new(),
-                                }));
-                            }
-
-                            // Non-interactive (no event sink to surface the prompt):
-                            // fail closed rather than silently proceeding.
-                            return Err(ToolError::Execution(format!(
-                                "Permission approval required for: {}",
-                                resource
-                            )));
-                        }
-                        Err(other) => {
-                            return Err(permission_error_to_tool_error(other));
-                        }
-                    }
-                }
-            }
+        // Permission gate. Factored onto the `ToolExecutor` trait
+        // (`check_permissions_for`) so overlay/wrapping executors can run the
+        // exact same check before invoking their own tools (issue #341). Kept
+        // AFTER the registry lookup so a `NotFound` still takes precedence,
+        // exactly as before. `Some(outcome)` is the interactive approval pause
+        // synthesized for a human sink; `Err` is deny / fail-closed.
+        if let Some(outcome) = self.check_permissions_for(call, &ctx).await? {
+            return Ok(outcome);
         }
 
         // Rewritten dispatch: build the owned `ToolCtx` at this concrete seam and
@@ -427,6 +319,172 @@ impl ToolExecutor for BuiltinToolExecutor {
         // authoritative and removes this unwrap.
         let tool_ctx = ctx.to_tool_ctx();
         tool.invoke(args, tool_ctx).await
+    }
+
+    /// The real permission gate for built-in tools, extracted from the execute
+    /// path so it is reusable by wrapping executors (issue #341). The behavior is
+    /// byte-for-byte the same block that used to run inline in
+    /// `execute_with_context_outcome`:
+    ///
+    /// - resolves the SAME `tool_name` + `args` the execute path runs with (so
+    ///   the check sees exactly what the tool will run with);
+    /// - "always ask" rules (`requires_forced_confirmation`) force a confirmation
+    ///   even under bypass; everything else is skipped when the session is in
+    ///   bypass-permissions mode;
+    /// - forced confirmations route through `check_or_request_forced` so the
+    ///   active mode/bypass can't suppress the prompt;
+    /// - a `ConfirmationRequired` first tries the cross-process `ApprovalProxy`
+    ///   (a subagent worker forwarding to its host), then the interactive human
+    ///   sink (returning the synthesized approval pause as `Ok(Some(..))`), then
+    ///   fails closed;
+    /// - deny fails closed.
+    ///
+    /// The only mechanical difference from the old inline block: the interactive
+    /// pause is returned as `Ok(Some(outcome))` and a clean pass returns
+    /// `Ok(None)`, so the caller decides whether to run the tool. The fallback
+    /// arg-parse warning is intentionally NOT re-logged here — the execute path
+    /// already logs it once for this call.
+    async fn check_permissions_for(
+        &self,
+        call: &ToolCall,
+        ctx: &ToolExecutionContext<'_>,
+    ) -> Result<Option<ToolOutcome>, ToolError> {
+        let Some(permission_checker) = &self.permission_checker else {
+            return Ok(None);
+        };
+
+        // Mirror the head of `execute_with_context_outcome`: reuse the pre-parsed
+        // args when threaded, apply the legacy-arg normalization, then resolve the
+        // registered/alias tool name. This is what makes the gate see the exact
+        // `tool_name`/`args` the tool will actually run with.
+        let mut args = if let Some(pre_parsed) = ctx.pre_parsed_args {
+            pre_parsed.clone()
+        } else {
+            parse_tool_args_best_effort(&call.function.arguments).0
+        };
+        let raw_tool_name = normalize_tool_name(&call.function.name);
+        if let Some(args_obj) = args.as_object_mut() {
+            normalize_legacy_builtin_args(raw_tool_name, args_obj);
+        }
+        let tool_name = resolve_registered_tool_name(&self.registry, raw_tool_name);
+
+        if let Some(contexts) =
+            check_permissions(&tool_name, &args).map_err(permission_error_to_tool_error)?
+        {
+            // "Always ask" rules (configured patterns + built-in dangerous
+            // commands) force a confirmation even under bypass. Everything
+            // else is skipped when this session is in "bypass permissions"
+            // mode (scoped per-session via its runtime state).
+            let force_ask = permission_checker.requires_forced_confirmation(&tool_name, &args);
+            for context in contexts {
+                if ctx.bypass_permissions && !force_ask {
+                    continue;
+                }
+                let resource = context.resource.clone();
+                // Forced confirmations route through `check_or_request_forced`
+                // so the active mode/bypass cannot suppress the prompt.
+                let decision = if force_ask {
+                    permission_checker.check_or_request_forced(context).await
+                } else {
+                    permission_checker.check_or_request(context).await
+                };
+                match decision {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        return Err(ToolError::Execution(format!(
+                            "Permission denied for: {}",
+                            resource
+                        )));
+                    }
+                    Err(PermissionError::ConfirmationRequired {
+                        permission_type,
+                        resource: _,
+                    }) => {
+                        // Phase 2 (cross-process): a subagent worker installs a
+                        // task-local `ApprovalProxy` for the duration of its run.
+                        // When present, forward the decision to the worker's host
+                        // (parent) and block this tool inline for the reply —
+                        // approve proceeds (treated like a granted context), deny
+                        // fails closed. Checked BEFORE the interactive sink below
+                        // so a worker (which also has an `event_tx`) proxies to its
+                        // parent instead of trying to prompt a human itself. The
+                        // proxy is unset on every non-worker path, so the behavior
+                        // there is unchanged.
+                        if let Some(proxy) = crate::approval::current_approval_proxy() {
+                            let approved = proxy
+                                .request_approval(crate::approval::ApprovalAsk {
+                                    tool_name: tool_name.clone(),
+                                    permission: permission_type.description().to_string(),
+                                    resource: resource.clone(),
+                                })
+                                .await;
+                            if approved {
+                                // Treat as a granted context: check any remaining
+                                // contexts, then fall through to execution.
+                                continue;
+                            }
+                            return Err(ToolError::Execution(format!(
+                                "Permission denied by host for: {}",
+                                resource
+                            )));
+                        }
+
+                        // Interactive sessions pause for approval by reusing the
+                        // same pending-question pipeline as `request_permissions`:
+                        // synthesize an "awaiting_permission_approval" result that
+                        // the engine recognizes (via display_preference) and turns
+                        // into a NeedClarification pause. On approval the respond
+                        // handler records a session grant so the re-attempt passes.
+                        if let Some(tx) = ctx.event_tx {
+                            // Keep emitting the structured approval event for observers.
+                            let _ = tx
+                                .send(bamboo_agent_core::AgentEvent::ToolApprovalRequested {
+                                    tool_call_id: call.id.clone(),
+                                    tool_name: tool_name.clone(),
+                                    parameters: args.clone(),
+                                })
+                                .await;
+
+                            let question = format!(
+                                "**Permission required**\n\nThe `{}` tool needs approval to {} on:\n\n`{}`",
+                                tool_name,
+                                permission_type.description(),
+                                resource
+                            );
+                            let payload = serde_json::json!({
+                                "status": "awaiting_permission_approval",
+                                "question": question,
+                                "permission_type": permission_type,
+                                "resource": resource,
+                                "options": ["Approve", "Deny"],
+                                "allow_custom": false,
+                            });
+                            // Permission-gate synthesized question stays on
+                            // the Completed→sniff path for now (a later Phase B
+                            // step converts this to ToolOutcome::NeedsHuman).
+                            return Ok(Some(ToolOutcome::Completed(ToolResult {
+                                success: true,
+                                result: payload.to_string(),
+                                display_preference: Some("request_permissions".to_string()),
+                                images: Vec::new(),
+                            })));
+                        }
+
+                        // Non-interactive (no event sink to surface the prompt):
+                        // fail closed rather than silently proceeding.
+                        return Err(ToolError::Execution(format!(
+                            "Permission approval required for: {}",
+                            resource
+                        )));
+                    }
+                    Err(other) => {
+                        return Err(permission_error_to_tool_error(other));
+                    }
+                }
+            }
+        }
+
+        Ok(None)
     }
 
     fn list_tools(&self) -> Vec<ToolSchema> {
@@ -1100,6 +1158,69 @@ mod tests {
             "forced ask rule should block under bypass: {result:?}"
         );
         assert!(fs::metadata("/etc/forced.conf").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn interactive_gate_returns_synthesized_approval_pause() {
+        // With an event sink present, a forced-ask rule that yields
+        // `ConfirmationRequired` must resolve to the synthesized "awaiting
+        // approval" PAUSE result (a `Completed` result tagged
+        // `display_preference = "request_permissions"`) — NOT an error — so the
+        // engine turns it into a clarification pause. This locks in the
+        // interactive-sink path that the `check_permissions_for` extraction must
+        // preserve as `Ok(Some(outcome))` rather than collapse to an `Err`.
+        let config = Arc::new(crate::permission::PermissionConfig::new());
+        config.set_ask_rules(["Write(/etc/**)".to_string()]);
+        let checker = Arc::new(crate::permission::ConfigPermissionChecker::new(config));
+        let executor = make_executor(Some(checker));
+
+        let (tx, mut rx) = mpsc::channel(8);
+        let call = make_tool_call(
+            "Write",
+            json!({"file_path": "/etc/gated.conf", "content": "x"}),
+        );
+        let ctx = ToolExecutionContext {
+            session_id: Some("s-interactive"),
+            tool_call_id: &call.id,
+            event_tx: Some(&tx),
+            available_tool_schemas: None,
+            bypass_permissions: false,
+            can_async_resume: false,
+            bash_completion_sink: None,
+            pre_parsed_args: None,
+        };
+
+        let result = executor
+            .execute_with_context(&call, ctx)
+            .await
+            .expect("interactive gate should pause (Ok), not error");
+
+        assert_eq!(
+            result.display_preference.as_deref(),
+            Some("request_permissions"),
+            "interactive gate must return the request_permissions pause result"
+        );
+        assert!(result.result.contains("awaiting_permission_approval"));
+        assert!(fs::metadata("/etc/gated.conf").await.is_err());
+
+        let ev = rx.recv().await.expect("approval event should be emitted");
+        assert!(
+            matches!(ev, AgentEvent::ToolApprovalRequested { tool_name, .. } if tool_name == "Write")
+        );
+    }
+
+    #[tokio::test]
+    async fn check_permissions_for_returns_none_when_permitted() {
+        // A tool with no matching gate (Read, no checker rule) passes the gate:
+        // `check_permissions_for` returns `Ok(None)` so the caller runs the tool.
+        let executor = make_executor(None);
+        let call = make_tool_call("Read", json!({"file_path": "/tmp/whatever"}));
+        let ctx = ToolExecutionContext::none(&call.id);
+        let decision = executor
+            .check_permissions_for(&call, &ctx)
+            .await
+            .expect("no checker means no gate");
+        assert!(decision.is_none(), "no checker must yield Ok(None)");
     }
 
     // ---- Phase 2: cross-process approval proxy ----------------------------

--- a/crates/infra/bamboo-mcp/src/executor.rs
+++ b/crates/infra/bamboo-mcp/src/executor.rs
@@ -256,6 +256,24 @@ impl ToolExecutor for CompositeToolExecutor {
         self.mcp.execute_with_context_outcome(call, ctx).await
     }
 
+    /// Delegate the permission gate to the built-in executor, which is where the
+    /// real `PermissionChecker` lives (issue #341). This MUST be overridden (not
+    /// left to the trait default) because in the live server the overlay chain
+    /// (`memory`, `SubAgent`, `scheduler`, …) is stacked ON TOP OF this composite:
+    /// each overlay calls `base.check_permissions_for` before invoking its tool,
+    /// and that chain bottoms out here. Falling back to the default `Ok(None)`
+    /// would silently skip the gate for every overlay tool in production. MCP
+    /// tools carry no gate, and the built-in check returns `Ok(None)` for any
+    /// name it doesn't classify, so delegating solely to `builtin` is correct for
+    /// both surfaces.
+    async fn check_permissions_for(
+        &self,
+        call: &ToolCall,
+        ctx: &ToolExecutionContext<'_>,
+    ) -> std::result::Result<Option<ToolOutcome>, ToolError> {
+        self.builtin.check_permissions_for(call, ctx).await
+    }
+
     fn list_tools(&self) -> Vec<ToolSchema> {
         let mut tools = self.builtin.list_tools();
         tools.extend(self.mcp.list_tools());
@@ -392,6 +410,42 @@ mod tests {
         assert!(
             matches!(outcome, ToolOutcome::NeedsHuman { .. }),
             "composite must preserve the builtin NeedsHuman outcome, got {outcome:?}"
+        );
+    }
+
+    /// A builtin stub whose permission gate always denies, to prove the composite
+    /// delegates `check_permissions_for` to its builtin instead of the trait
+    /// default (`Ok(None)`) — the default would silently skip the gate for the
+    /// overlay chain stacked over the composite in production (issue #341).
+    struct GateDenyingBuiltin;
+
+    #[async_trait]
+    impl ToolExecutor for GateDenyingBuiltin {
+        async fn execute(&self, _call: &ToolCall) -> std::result::Result<ToolResult, ToolError> {
+            Err(ToolError::NotFound("stub".into()))
+        }
+        async fn check_permissions_for(
+            &self,
+            _call: &ToolCall,
+            _ctx: &ToolExecutionContext<'_>,
+        ) -> std::result::Result<Option<ToolOutcome>, ToolError> {
+            Err(ToolError::Execution("denied-by-builtin-gate".into()))
+        }
+        fn list_tools(&self) -> Vec<ToolSchema> {
+            Vec::new()
+        }
+    }
+
+    #[tokio::test]
+    async fn composite_delegates_permission_gate_to_builtin() {
+        let composite =
+            CompositeToolExecutor::new(Arc::new(GateDenyingBuiltin), Arc::new(GuidanceStub(None)));
+        let call = create_test_tool_call("memory", r#"{"action":"purge"}"#);
+        let ctx = ToolExecutionContext::none("test-id");
+        let result = composite.check_permissions_for(&call, &ctx).await;
+        assert!(
+            matches!(result, Err(ToolError::Execution(ref m)) if m.contains("denied-by-builtin-gate")),
+            "composite must delegate the gate to its builtin, got: {result:?}"
         );
     }
 

--- a/crates/infra/bamboo-permission/src/tool_permissions.rs
+++ b/crates/infra/bamboo-permission/src/tool_permissions.rs
@@ -98,7 +98,13 @@ pub fn check_permissions(
             );
             let write_resource = match action.as_str() {
                 "session_append" | "session_replace" | "session_clear" => Some(session_memory_dir),
-                "write" | "merge" | "purge" | "rebuild" => Some(durable_memory_dir),
+                // Keep in lockstep with `MemoryTool::classify` (bamboo-server-tools),
+                // which treats every non-read action — including `split` and
+                // `consolidate` — as mutating. Omitting those two let destructive
+                // durable-memory edits skip the WriteFile gate (issue #341).
+                "write" | "merge" | "split" | "consolidate" | "purge" | "rebuild" => {
+                    Some(durable_memory_dir)
+                }
                 _ => None,
             };
             if let Some(resource) = write_resource {
@@ -311,6 +317,49 @@ mod tests {
         assert_eq!(write.len(), 1);
         assert_eq!(write[0].permission_type, PermissionType::WriteFile);
         assert!(write[0].resource.contains("/memory/v1/scopes"));
+    }
+
+    #[test]
+    fn check_permissions_memory_mutating_actions_all_gated() {
+        // Every mutating durable-memory action must produce a WriteFile context so
+        // it hits the permission gate. `split` and `consolidate` were previously
+        // omitted (issue #341) even though `MemoryTool::classify` treats them as
+        // mutating, so a `memory(*)` ask-rule / Default-mode prompt never fired for
+        // them. Guards the full set stays in lockstep with the tool's classifier.
+        for action in ["write", "merge", "split", "consolidate", "purge", "rebuild"] {
+            let contexts = check_permissions("memory", &json!({"action": action}))
+                .unwrap_or_else(|_| panic!("memory action {action} should classify"))
+                .unwrap_or_else(|| panic!("memory action {action} must require a WriteFile gate"));
+            assert_eq!(contexts.len(), 1, "action {action}");
+            assert_eq!(
+                contexts[0].permission_type,
+                PermissionType::WriteFile,
+                "action {action} must be WriteFile"
+            );
+            assert!(
+                contexts[0].resource.contains("/memory/v1/scopes"),
+                "action {action} must scope to durable memory"
+            );
+        }
+
+        // Read-only actions stay ungated.
+        for action in [
+            "session_read",
+            "session_list_topics",
+            "query",
+            "get",
+            "find_duplicates",
+            "inspect",
+            "scan_blobs",
+            "scan_duplicates",
+        ] {
+            assert!(
+                check_permissions("memory", &json!({"action": action}))
+                    .unwrap()
+                    .is_none(),
+                "read-only memory action {action} must not be gated"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem (#341)

`OverlayToolExecutor` short-circuited every overlay-tool call straight to `overlay.invoke(...)` with **no permission check**. The gate — `check_permissions` + `requires_forced_confirmation` + `check_or_request[_forced]` + the bypass skip + the cross-process `ApprovalProxy` path — lived ONLY inside `BuiltinToolExecutor::execute_with_context_outcome`.

So server/overlay tools (`memory`, `scheduler`, `session_inspector`, `SubAgent`, `deploy_agent`, `cluster`) executed with **no permission check in any mode**: a user's `memory(*)` ask-rule never fired for them, and destructive `memory purge`/`rebuild` never prompted even in Default mode.

## Fix — make the check part of the executor *chain*

- **`ToolExecutor::check_permissions_for(call, ctx)`** (new async-trait method, default `Ok(None)` → existing executors unaffected).
- **`BuiltinToolExecutor`**: the existing permission block is extracted verbatim into `check_permissions_for`; `execute_with_context_outcome` calls it before invoking the tool (after the registry lookup, so `NotFound` still wins). Same `tool_name` resolution + args parsing as the execute path, so the gate sees exactly what the tool runs with. `force_ask`, the `bypass && !force_ask` skip, `check_or_request_forced` vs `check_or_request`, `ConfirmationRequired`→`ApprovalProxy` forwarding, the interactive sink, and deny-fail-closed are all preserved. **Zero behavior change for the built-in path.**
- **`OverlayToolExecutor`**: calls `base.check_permissions_for(...)` before `overlay.invoke(...)` in both dispatch methods, and implements `check_permissions_for` to delegate to `base` so stacked overlays chain down to the real check.
- **`CompositeToolExecutor`**: overrides `check_permissions_for` to delegate to its `builtin`. **Required** — in the live server the overlay chain is stacked over the composite, so the delegation bottoms out here; the default `Ok(None)` would otherwise leave the gate inert in production.
- **Secondary (`tool_permissions.rs`)**: the `memory` arm was missing `split` and `consolidate` (both mutating per `MemoryTool::classify`), so those durable-memory edits skipped the `WriteFile` gate. Added.

## Note on the return type (deliberate deviation from the issue sketch)

The issue proposed `check_permissions_for -> Result<(), ToolError>`. That signature **cannot preserve the built-in path's interactive-sink behavior**: when a gated tool needs human approval, the executor returns `Ok(ToolOutcome::Completed{ display_preference: "request_permissions", .. })` — a *successful pause result* the engine detects (by sniffing `display_preference`) to suspend the turn and ask the user. It is neither `()` nor `Err`. Collapsing it to `Err` would turn the interactive "pause and ask" into a hard error — a real regression the issue explicitly says to preserve.

So the method returns **`Result<Option<ToolOutcome>>`**: `Ok(None)` = proceed, `Ok(Some(outcome))` = short-circuit with this outcome (the pause), `Err` = deny/fail-closed. This keeps the built-in path byte-for-byte and gives overlay tools the *full* gate, including the interactive pause.

## Tests

- `overlay_memory_purge_is_denied_by_base_permission_gate` — real `OverlayToolExecutor` over a real `BuiltinToolExecutor` + checker; `memory purge` is denied and the overlay tool **never runs**.
- `overlay_read_only_memory_action_passes_gate_and_runs` — control: `memory query` still runs.
- `overlay_call_short_circuits_on_base_gate_error_before_invoke` + `overlay_check_permissions_for_delegates_to_base` — routing/delegation.
- `composite_delegates_permission_gate_to_builtin` — composite delegation.
- `interactive_gate_returns_synthesized_approval_pause` + `check_permissions_for_returns_none_when_permitted` — built-in extraction preserves the pause / clean-pass.
- `check_permissions_memory_mutating_actions_all_gated` — all mutating memory actions (incl. `split`/`consolidate`) classify as `WriteFile`; read-only ones stay ungated.

## Verification

- `cargo fmt -- --check` ✅
- `cargo clippy --all-features -- -D warnings` (CI flag set) ✅
- `cargo test` for `bamboo-tools` (322), `bamboo-server-tools` (54), `bamboo-permission` (199), `bamboo-agent-core` (112), `bamboo-mcp` (161) ✅

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u
