### PR TITLE
fix(permission): resolve shell quote-splicing before sensitive-path matching (#392)

### DIFF
--- a/crates/infra/bamboo-permission/src/bash_security.rs
+++ b/crates/infra/bamboo-permission/src/bash_security.rs
@@ -102,10 +102,6 @@ const SENSITIVE_HOME_PREFIXES: &[&str] = &[
 /// check. #155.
 const FILE_MUTATING_COMMANDS: &[&str] = &["cp", "mv", "tee", "dd", "install", "rsync", "ln"];
 
-/// True if `path` targets a sensitive filesystem location: an absolute system
-/// path from [`SENSITIVE_REDIRECT_PATHS`], or a sensitive dotfile/dir under the
-/// user's home (`~/…`, `$HOME/…`, `${HOME}/…`). Used for both redirect targets
-/// and destructive command arguments. #155.
 /// Best-effort static removal of shell quoting so a sensitive-path check isn't
 /// evaded by ordinary quote-splicing: `/etc/pass''wd`, `/etc/pass""wd`,
 /// `/etc/'passwd'`, `'/etc/passwd'`, `~/.ss"h"/authorized_keys` all resolve to
@@ -134,6 +130,11 @@ fn shell_unquote(s: &str) -> String {
     out
 }
 
+/// True if `path` targets a sensitive filesystem location: an absolute system
+/// path from [`SENSITIVE_REDIRECT_PATHS`], or a sensitive dotfile/dir under the
+/// user's home (`~/…`, `$HOME/…`, `${HOME}/…`). Resolves shell quote-splicing
+/// first. Used for both redirect targets and destructive command arguments.
+/// #155, #392.
 fn is_sensitive_fs_path(path: &str) -> bool {
     let unquoted = shell_unquote(path.trim());
     let trimmed = unquoted.trim();
@@ -652,6 +653,18 @@ fn walk_node_with_budget(
     let kind = node.kind();
     *node_count += 1;
 
+    // ANSI-C quoting (`$'…'`) is a security-relevant LEAF node: it's static but
+    // can encode a sensitive path via escapes (`$'/etc/pass\x77d'`) that can't be
+    // statically resolved. Flag it BEFORE the leaf-skip below, otherwise the
+    // warning is never emitted and the auto-approve gate can't fail closed. #392.
+    if kind == "ansi_c_string" {
+        warnings.push(BashWarning {
+            kind: BashWarningKind::AnsiCString,
+            detail: format!("ansi-c string: {}", truncate(&node_text(node, source), 40)),
+        });
+        return;
+    }
+
     // Skip safe leaf nodes
     if node.child_count() == 0 {
         return;
@@ -763,14 +776,6 @@ fn walk_node_with_budget(
             warnings.push(BashWarning {
                 kind: BashWarningKind::BraceExpansion,
                 detail: format!("brace expansion: {}", truncate(&text, 40)),
-            });
-        }
-
-        "ansi_c_string" => {
-            let text = node_text(node, source);
-            warnings.push(BashWarning {
-                kind: BashWarningKind::AnsiCString,
-                detail: format!("ansi-c string: {}", truncate(&text, 40)),
             });
         }
 

--- a/crates/infra/bamboo-permission/src/bash_security.rs
+++ b/crates/infra/bamboo-permission/src/bash_security.rs
@@ -106,8 +106,37 @@ const FILE_MUTATING_COMMANDS: &[&str] = &["cp", "mv", "tee", "dd", "install", "r
 /// path from [`SENSITIVE_REDIRECT_PATHS`], or a sensitive dotfile/dir under the
 /// user's home (`~/…`, `$HOME/…`, `${HOME}/…`). Used for both redirect targets
 /// and destructive command arguments. #155.
+/// Best-effort static removal of shell quoting so a sensitive-path check isn't
+/// evaded by ordinary quote-splicing: `/etc/pass''wd`, `/etc/pass""wd`,
+/// `/etc/'passwd'`, `'/etc/passwd'`, `~/.ss"h"/authorized_keys` all resolve to
+/// the same path in bash/zsh but defeat a raw `starts_with`. Drops unescaped
+/// `'`/`"` (splicing adjacent segments) and unwraps `\`-escapes.
+///
+/// This deliberately does NOT resolve variable/command/glob expansions
+/// (`/etc/$X`, `/etc/$(...)`) — those are inherently dynamic and are covered by
+/// other analyzer gates (VariableAsCommand / substitution warnings) or fall
+/// through to prompting. Over-stripping only ever makes a path MORE likely to be
+/// flagged, which is the safe direction for an auto-approve gate. #392.
+fn shell_unquote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '\'' | '"' => {}
+            '\\' => {
+                if let Some(next) = chars.next() {
+                    out.push(next);
+                }
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
 fn is_sensitive_fs_path(path: &str) -> bool {
-    let trimmed = path.trim().trim_matches(|c| c == '"' || c == '\'');
+    let unquoted = shell_unquote(path.trim());
+    let trimmed = unquoted.trim();
     let lower = trimmed.to_ascii_lowercase();
     if SENSITIVE_REDIRECT_PATHS
         .iter()
@@ -215,10 +244,8 @@ fn check_sensitive_path_arguments(command_name: &str, args: &[String]) -> Vec<Ba
 /// modification is destructive (broader than [`is_sensitive_fs_path`], which
 /// targets specific files/dirs — a recursive chmod hits the whole subtree). #155.
 fn is_system_root_path(path: &str) -> bool {
-    let p = path
-        .trim()
-        .trim_matches(|c| c == '"' || c == '\'')
-        .trim_end_matches('/');
+    let unquoted = shell_unquote(path.trim());
+    let p = unquoted.trim().trim_end_matches('/');
     // "/" trims to "" — the root itself.
     if p.is_empty() {
         return true;
@@ -1484,7 +1511,14 @@ fn check_redirects_node(node: &tree_sitter::Node, source: &str, warnings: &mut V
                 let text = node_text(&child, source);
                 if kind == "file_descriptor" || kind == "redirect_operator" {
                     redirect_op = Some(text);
-                } else if kind == "word" || kind == "string" || kind == "raw_string" {
+                } else if kind == "word"
+                    || kind == "string"
+                    || kind == "raw_string"
+                    // A quote-spliced target (`> /etc/pass''wd`) parses as a
+                    // `concatenation`; capture its full text so shell_unquote can
+                    // resolve it, otherwise the redirect check misses it. #392.
+                    || kind == "concatenation"
+                {
                     target_path = Some(text);
                 }
             }
@@ -1719,6 +1753,34 @@ fn check_heredoc_expansions_node(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn shell_unquote_resolves_spliced_paths() {
+        // #392: quote-splicing forms all resolve to the same literal.
+        assert_eq!(shell_unquote("/etc/pass''wd"), "/etc/passwd");
+        assert_eq!(shell_unquote(r#"/etc/pass""wd"#), "/etc/passwd");
+        assert_eq!(shell_unquote("/etc/'passwd'"), "/etc/passwd");
+        assert_eq!(shell_unquote("'/etc/passwd'"), "/etc/passwd");
+        assert_eq!(shell_unquote(r"/etc/pass\wd"), "/etc/passwd"); // backslash-escape unwrapped
+        assert_eq!(
+            shell_unquote("~/.ss'h'/authorized_keys"),
+            "~/.ssh/authorized_keys"
+        );
+        // Unquoted paths and dynamic ($VAR) segments are left intact.
+        assert_eq!(shell_unquote("/etc/passwd"), "/etc/passwd");
+        assert_eq!(shell_unquote("/etc/$X"), "/etc/$X");
+    }
+
+    #[test]
+    fn is_sensitive_fs_path_sees_through_quotes() {
+        // #392: the sensitive-path check must resolve quote-spliced evasions.
+        assert!(is_sensitive_fs_path("/etc/pass''wd"));
+        assert!(is_sensitive_fs_path("/etc/'sudoers.d'/zz"));
+        assert!(is_sensitive_fs_path("~/.ss'h'/authorized_keys"));
+        assert!(is_system_root_path("'/'"));
+        // A non-sensitive quoted path stays allowed.
+        assert!(!is_sensitive_fs_path("'build'/out.txt"));
+    }
 
     // ---- Redirect-to-/dev/null is benign, not a sensitive-path Deny ----
 

--- a/crates/infra/bamboo-permission/src/checker.rs
+++ b/crates/infra/bamboo-permission/src/checker.rs
@@ -561,6 +561,10 @@ fn command_can_chain_or_inject(analysis: &crate::bash_security::BashSecurityAnal
                 | VariableAsCommand
                 | RedirectToSensitivePath
                 | SensitivePathArgument
+                // ANSI-C quoting (`$'…'`) is static but can encode a sensitive
+                // path via escapes (`$'/etc/pass\x77d'`) that shell_unquote can't
+                // resolve, so fail closed rather than auto-approve it. #392.
+                | AnsiCString
                 | ParseFailed
                 | AnalysisBudgetExceeded
                 | UnknownNodeType(_)
@@ -1445,6 +1449,25 @@ mod tests {
             assert!(
                 !is_safe_edit_command(cmd),
                 "must NOT auto-approve a quote-spliced sensitive path: {cmd:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn safe_edit_rejects_ansi_c_quoted_paths() {
+        // #392: ANSI-C quoting (`$'…'`) is static but can hide a sensitive path
+        // behind escapes (`$'/etc/pass\x77d'`) that can't be statically resolved,
+        // so any ANSI-C quoting fails the gate closed (never auto-approves).
+        let evasions = [
+            r"cp evil $'/etc/passwd'",      // plain ANSI-C wrap
+            r"echo pwned > $'/etc/passwd'", // ANSI-C redirect target
+            r"cp evil $'/etc/pass\x77d'",   // hex-escaped 'w' -> /etc/passwd
+            r"chmod -R 000 $'/'",           // ANSI-C root
+        ];
+        for cmd in evasions {
+            assert!(
+                !is_safe_edit_command(cmd),
+                "must NOT auto-approve an ANSI-C quoted path: {cmd:?}"
             );
         }
     }

--- a/crates/infra/bamboo-permission/src/checker.rs
+++ b/crates/infra/bamboo-permission/src/checker.rs
@@ -1428,6 +1428,28 @@ mod tests {
     }
 
     #[test]
+    fn safe_edit_rejects_quote_spliced_sensitive_paths() {
+        // #392: ordinary shell quote-splicing resolves to the same sensitive path
+        // at runtime but defeats a raw prefix match — must still NOT auto-approve.
+        let evasions = [
+            r"cp evil /etc/pass''wd",            // empty single-quote splice
+            r#"cp evil /etc/pass""wd"#,          // empty double-quote splice
+            r"cp evil /etc/'passwd'",            // quoted segment
+            r"cp /etc/'shadow' /tmp/x",          // quoted sensitive SOURCE
+            r"cp evil ~/.ss'h'/authorized_keys", // quoted home dotfile dir
+            r"cp evil '/etc/sudoers.d/zz'",      // fully-quoted /etc subtree
+            r"echo pwned > /etc/pass''wd",       // quoted redirect target
+            r"chmod -R 000 '/'",                 // quoted root for recursive chmod
+        ];
+        for cmd in evasions {
+            assert!(
+                !is_safe_edit_command(cmd),
+                "must NOT auto-approve a quote-spliced sensitive path: {cmd:?}"
+            );
+        }
+    }
+
+    #[test]
     fn safe_edit_still_approves_plain_safe_commands() {
         // Plain single-command invocations of the safe list must STILL auto-approve.
         let safe = [


### PR DESCRIPTION
Fixes #392 (follow-up to #155, flagged in that PR's security review).

## Bug
The sensitive-path checks (`is_sensitive_fs_path` / `is_system_root_path`, and the `RedirectToSensitivePath` check that shares them) did plain `str::starts_with` on the **raw** tree-sitter node text, with no shell quote-removal. Ordinary quote-splicing resolves to the same path at runtime but defeats the prefix match, so under **AcceptEdits** these still auto-approved:

```
cp evil /etc/pass''wd             # empty single-quote splice
cp evil /etc/pass""wd
cp evil /etc/'passwd'
cp /etc/'shadow' /tmp/x           # quoted sensitive SOURCE
cp evil ~/.ss'h'/authorized_keys
echo pwned > /etc/pass''wd        # quoted redirect target
chmod -R 000 '/'
```

## Fix
- **`shell_unquote`**: best-effort static quote removal — drops unescaped `'`/`"` (splicing adjacent segments), unwraps `\`-escapes. Both `is_sensitive_fs_path` and `is_system_root_path` now resolve the path through it before matching.
- The redirect check also captures **`concatenation`** target nodes — tree-sitter parses `> /etc/pass''wd` as a `concatenation`, which the old `word|string|raw_string` filter skipped (this is why the `cp` arg forms were already caught by #155 but the redirect form wasn't).

Deliberately does **not** resolve variable/command/glob expansion (`/etc/$X`, `/etc/$(...)`) — those are inherently dynamic and already covered by other analyzer gates (`VariableAsCommand` / substitution warnings) or fall through to prompting. Over-stripping only ever makes a path **more** likely to be flagged, which is the safe direction for an auto-approve gate.

## Tests
`safe_edit_rejects_quote_spliced_sensitive_paths` (8 gate cases) + `shell_unquote_resolves_spliced_paths` + `is_sensitive_fs_path_sees_through_quotes` unit tests. A non-sensitive quoted path (`'build'/out.txt`) still auto-approves. 202 `bamboo-permission` tests pass; clippy clean; engine/server build clean.

This closes the one deferred item from the #155 review; the argument/redirect/recursive-chmod classes it hardens are now quote-resistant.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU