### PR TITLE
fix(config): preserve env-sourced provider keys across a settings PATCH (#373)

### DIFF
--- a/crates/app/bamboo-server/src/config_manager.rs
+++ b/crates/app/bamboo-server/src/config_manager.rs
@@ -140,6 +140,11 @@ pub fn build_merged_config(
     new_config.hydrate_provider_instance_api_keys_from_encrypted();
     new_config.hydrate_mcp_secrets_from_encrypted();
     new_config.hydrate_env_vars_from_encrypted();
+    // The serde round-trip above drops every provider's `#[serde(skip_serializing)]`
+    // `api_key`; hydration only restores ciphertext-backed keys, so an env-sourced
+    // key (no ciphertext, #253) would be silently blanked by any settings PATCH.
+    // Copy env-sourced keys back from the live `current` config. #373.
+    new_config.preserve_env_sourced_provider_keys(current);
     new_config.normalize_tool_settings();
     new_config.normalize_skill_settings();
 

--- a/crates/app/bamboo-server/src/config_manager.rs
+++ b/crates/app/bamboo-server/src/config_manager.rs
@@ -39,44 +39,59 @@ pub fn sync_provider_api_keys_encrypted_for_patch(
         match name.as_str() {
             "openai" => {
                 if let Some(openai) = config.providers.openai.as_mut() {
-                    let api_key = openai.api_key.trim();
-                    openai.api_key_encrypted = if api_key.is_empty() {
-                        None
-                    } else {
-                        Some(bamboo_config::encryption::encrypt(api_key).map_err(|e| {
-                            AppError::InternalError(anyhow::anyhow!(
-                                "Failed to encrypt OpenAI api_key: {e}"
-                            ))
-                        })?)
-                    };
+                    // Never encrypt/persist an env-sourced key — mirrors
+                    // refresh_provider_api_keys_encrypted's guard (#253). Without
+                    // it, an explicit `api_key: ""` clear of an env-sourced provider
+                    // (which preserve_env_sourced_provider_keys refills with the env
+                    // secret + api_key_from_env=true) would bake that plaintext
+                    // secret into config.json here. An explicit NEW key resets
+                    // api_key_from_env=false, so a real override still persists. #373.
+                    if !openai.api_key_from_env {
+                        let api_key = openai.api_key.trim();
+                        openai.api_key_encrypted = if api_key.is_empty() {
+                            None
+                        } else {
+                            Some(bamboo_config::encryption::encrypt(api_key).map_err(|e| {
+                                AppError::InternalError(anyhow::anyhow!(
+                                    "Failed to encrypt OpenAI api_key: {e}"
+                                ))
+                            })?)
+                        };
+                    }
                 }
             }
             "anthropic" => {
                 if let Some(anthropic) = config.providers.anthropic.as_mut() {
-                    let api_key = anthropic.api_key.trim();
-                    anthropic.api_key_encrypted = if api_key.is_empty() {
-                        None
-                    } else {
-                        Some(bamboo_config::encryption::encrypt(api_key).map_err(|e| {
-                            AppError::InternalError(anyhow::anyhow!(
-                                "Failed to encrypt Anthropic api_key: {e}"
-                            ))
-                        })?)
-                    };
+                    // Skip env-sourced keys (see openai above). #373.
+                    if !anthropic.api_key_from_env {
+                        let api_key = anthropic.api_key.trim();
+                        anthropic.api_key_encrypted = if api_key.is_empty() {
+                            None
+                        } else {
+                            Some(bamboo_config::encryption::encrypt(api_key).map_err(|e| {
+                                AppError::InternalError(anyhow::anyhow!(
+                                    "Failed to encrypt Anthropic api_key: {e}"
+                                ))
+                            })?)
+                        };
+                    }
                 }
             }
             "gemini" => {
                 if let Some(gemini) = config.providers.gemini.as_mut() {
-                    let api_key = gemini.api_key.trim();
-                    gemini.api_key_encrypted = if api_key.is_empty() {
-                        None
-                    } else {
-                        Some(bamboo_config::encryption::encrypt(api_key).map_err(|e| {
-                            AppError::InternalError(anyhow::anyhow!(
-                                "Failed to encrypt Gemini api_key: {e}"
-                            ))
-                        })?)
-                    };
+                    // Skip env-sourced keys (see openai above). #373.
+                    if !gemini.api_key_from_env {
+                        let api_key = gemini.api_key.trim();
+                        gemini.api_key_encrypted = if api_key.is_empty() {
+                            None
+                        } else {
+                            Some(bamboo_config::encryption::encrypt(api_key).map_err(|e| {
+                                AppError::InternalError(anyhow::anyhow!(
+                                    "Failed to encrypt Gemini api_key: {e}"
+                                ))
+                            })?)
+                        };
+                    }
                 }
             }
             "bodhi" => {
@@ -149,4 +164,92 @@ pub fn build_merged_config(
     new_config.normalize_skill_settings();
 
     Ok(new_config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_config::OpenAIConfig;
+
+    fn env_sourced_openai_config() -> Config {
+        let mut config = Config::default();
+        config.providers.openai = Some(OpenAIConfig {
+            api_key: "sk-env-secret".to_string(),
+            api_key_from_env: true,
+            ..Default::default()
+        });
+        config
+    }
+
+    // #373: an explicit `api_key: ""` clear of an env-sourced provider must NOT
+    // bake the env secret into config.json. build_merged_config restores the live
+    // env key (api_key_from_env=true), and the from_env guard in
+    // sync_provider_api_keys_encrypted_for_patch must then skip encrypting it.
+    #[test]
+    fn clearing_env_sourced_key_does_not_persist_the_secret() {
+        let current = env_sourced_openai_config();
+        let patch: Map<String, Value> =
+            serde_json::from_str(r#"{"providers":{"openai":{"api_key":""}}}"#).unwrap();
+        let intents = provider_api_key_intents(&patch);
+        assert!(
+            intents.providers.contains("openai"),
+            "empty string is a clear intent"
+        );
+
+        let mut merged = build_merged_config(&current, patch).expect("merge");
+        sync_provider_api_keys_encrypted_for_patch(&mut merged, &intents).expect("sync");
+
+        let openai = merged.providers.openai.as_ref().unwrap();
+        assert!(
+            openai.api_key_encrypted.is_none(),
+            "env secret must NOT be encrypted to disk on a clear"
+        );
+        assert!(openai.api_key_from_env, "still flagged env-sourced");
+        assert_eq!(openai.api_key, "sk-env-secret", "live env key preserved");
+    }
+
+    // A genuine NEW key for an env-sourced provider resets api_key_from_env=false
+    // and IS persisted (the explicit override wins).
+    #[test]
+    fn explicit_new_key_overrides_env_and_persists() {
+        let current = env_sourced_openai_config();
+        let patch: Map<String, Value> =
+            serde_json::from_str(r#"{"providers":{"openai":{"api_key":"sk-brand-new"}}}"#).unwrap();
+        let intents = provider_api_key_intents(&patch);
+
+        let mut merged = build_merged_config(&current, patch).expect("merge");
+        sync_provider_api_keys_encrypted_for_patch(&mut merged, &intents).expect("sync");
+
+        let openai = merged.providers.openai.as_ref().unwrap();
+        assert_eq!(openai.api_key, "sk-brand-new", "explicit override wins");
+        assert!(!openai.api_key_from_env, "override clears the env flag");
+        assert!(
+            openai.api_key_encrypted.is_some(),
+            "a real override is encrypted/persisted"
+        );
+    }
+
+    // A PATCH that doesn't touch api_key must not drop the env-sourced key.
+    #[test]
+    fn unrelated_patch_preserves_env_key() {
+        let current = env_sourced_openai_config();
+        let patch: Map<String, Value> =
+            serde_json::from_str(r#"{"providers":{"openai":{"model":"gpt-x"}}}"#).unwrap();
+        let intents = provider_api_key_intents(&patch);
+        assert!(
+            !intents.providers.contains("openai"),
+            "no api_key in patch → no intent"
+        );
+
+        let mut merged = build_merged_config(&current, patch).expect("merge");
+        sync_provider_api_keys_encrypted_for_patch(&mut merged, &intents).expect("sync");
+
+        let openai = merged.providers.openai.as_ref().unwrap();
+        assert_eq!(
+            openai.api_key, "sk-env-secret",
+            "env key preserved across unrelated patch"
+        );
+        assert!(openai.api_key_from_env);
+        assert!(openai.api_key_encrypted.is_none(), "still not persisted");
+    }
 }

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -3229,6 +3229,58 @@ mod tests {
     }
 
     #[test]
+    fn preserve_env_sourced_provider_keys_restores_only_dropped_env_keys() {
+        // #373: the settings-PATCH serde round-trip drops every provider's
+        // skip_serializing api_key; an env-sourced key (no ciphertext) can't be
+        // re-hydrated, so it must be copied back from the live `current` config —
+        // but an explicitly re-set key and non-env keys must NOT be touched.
+        let openai = |api_key: &str, from_env: bool| OpenAIConfig {
+            api_key: api_key.to_string(),
+            api_key_encrypted: None,
+            base_url: None,
+            model: None,
+            fast_model: None,
+            vision_model: None,
+            reasoning_effort: None,
+            responses_only_models: vec![],
+            request_overrides: None,
+            extra: BTreeMap::new(),
+            api_key_from_env: from_env,
+        };
+
+        // Env-sourced key dropped by the round-trip → restored.
+        let mut current = Config::default();
+        current.providers.openai = Some(openai("sk-env", true));
+        let mut merged = Config::default();
+        merged.providers.openai = Some(openai("", false)); // post-round-trip
+        merged.preserve_env_sourced_provider_keys(&current);
+        let got = merged.providers.openai.as_ref().unwrap();
+        assert_eq!(got.api_key, "sk-env", "env-sourced key restored");
+        assert!(got.api_key_from_env, "env flag restored");
+
+        // A key explicitly re-set by the patch is NOT overridden.
+        let mut merged = Config::default();
+        merged.providers.openai = Some(openai("sk-explicit", false));
+        merged.preserve_env_sourced_provider_keys(&current);
+        assert_eq!(
+            merged.providers.openai.as_ref().unwrap().api_key,
+            "sk-explicit",
+            "explicit patch key must win"
+        );
+
+        // A non-env key in current is NOT restored here (that's ciphertext hydration's job).
+        let mut current_plain = Config::default();
+        current_plain.providers.openai = Some(openai("sk-plain", false));
+        let mut merged = Config::default();
+        merged.providers.openai = Some(openai("", false));
+        merged.preserve_env_sourced_provider_keys(&current_plain);
+        assert!(
+            merged.providers.openai.as_ref().unwrap().api_key.is_empty(),
+            "non-env key must not be restored by this path"
+        );
+    }
+
+    #[test]
     fn refresh_preserves_ciphertext_when_plaintext_empty() {
         // #268: a provider whose stored ciphertext failed to decrypt at hydration
         // has an empty in-memory api_key. An unrelated later save must NOT null its

--- a/crates/infra/bamboo-config/src/config_crypto.rs
+++ b/crates/infra/bamboo-config/src/config_crypto.rs
@@ -434,4 +434,38 @@ impl Config {
             broker.token = String::new();
         }
     }
+
+    /// Restore env-sourced provider `api_key`s that a serde round-trip dropped.
+    ///
+    /// `api_key` is `#[serde(skip_serializing)]`, so serializing `previous` and
+    /// deserializing it back — as the settings-PATCH merge in
+    /// `config_manager::build_merged_config` does — loses every provider's
+    /// plaintext key. `hydrate_provider_api_keys_from_encrypted` then restores
+    /// only keys that have a persisted ciphertext, which an env-injected key
+    /// never has (that's the #253 design). Without this, a PATCH to ANY provider
+    /// setting silently blanks the live env-sourced key of every OTHER provider
+    /// until the process restarts.
+    ///
+    /// Copies the key back from `previous` for each provider still flagged
+    /// env-sourced there whose key wasn't explicitly re-set by the patch (i.e. is
+    /// empty after the round-trip), so an explicit `api_key` in the patch still
+    /// wins. #373.
+    pub fn preserve_env_sourced_provider_keys(&mut self, previous: &Config) {
+        macro_rules! restore_env_key {
+            ($field:ident) => {
+                if let (Some(current), Some(prev)) = (
+                    self.providers.$field.as_mut(),
+                    previous.providers.$field.as_ref(),
+                ) {
+                    if prev.api_key_from_env && current.api_key.trim().is_empty() {
+                        current.api_key = prev.api_key.clone();
+                        current.api_key_from_env = true;
+                    }
+                }
+            };
+        }
+        restore_env_key!(openai);
+        restore_env_key!(anthropic);
+        restore_env_key!(gemini);
+    }
 }


### PR DESCRIPTION
Fixes #373 (surfaced in the #253/#371 review).

## Bug
`config_manager::build_merged_config` (behind `PATCH /v1/bamboo/settings/provider`) does `serde_json::to_value(current)` → merge patch → deserialize back. Because provider `api_key` is `#[serde(skip_serializing)]`, that round-trip **drops the plaintext key for every provider**. `hydrate_provider_api_keys_from_encrypted` then restores only keys that have a persisted `api_key_encrypted` — which an **env-injected** key (`BAMBOO_OPENAI/ANTHROPIC/GEMINI_API_KEY`, #253) never has.

**Impact:** after #253, a PATCH to *any* provider setting silently cleared the live in-memory env-sourced key of *every other* provider until the process restarted — breaking the "set the env var and never worry" guarantee.

## Fix
Add `Config::preserve_env_sourced_provider_keys(&previous)` and call it in `build_merged_config` right after the hydrate calls. For each of openai/anthropic/gemini still flagged `api_key_from_env` in the live `current` config whose key came back **empty** from the round-trip, copy the plaintext key + `api_key_from_env` back.

- An **explicitly re-set** key (non-empty after the merge) still wins — the patch is respected.
- **Non-env** keys are untouched (those restore via ciphertext hydration, unaffected).
- Deliberately scoped to the 3 env-capable providers (the only ones with `api_key_from_env`); did not re-run the private, over-broad `apply_env_overrides` (which would also clobber port/bind/etc.).

## Tests
`preserve_env_sourced_provider_keys_restores_only_dropped_env_keys` covers all three cases (env-key restored / explicit patch wins / non-env not restored). 149 `bamboo-config` tests pass; clippy clean.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU