### PR TITLE
fix(engine): idle-evict per-session maps (agent_runners/session_event_senders/locks/parent_wait_slots) (#346)

### DIFF
--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -1,7 +1,7 @@
 use super::init::{
     build_provider_handles, build_schedule_manager, build_spawn_scheduler, init_mcp_manager,
     init_metrics_service, init_schedule_store, init_skill_manager, init_storage,
-    load_permission_checker, spawn_runner_cleanup_task,
+    load_permission_checker, spawn_session_map_cleanup_task,
 };
 use super::tools::{build_base_tools, build_root_tools};
 use super::*;
@@ -184,7 +184,9 @@ impl AppState {
 
         let agent_runners: Arc<RwLock<HashMap<String, AgentRunner>>> =
             Arc::new(RwLock::new(HashMap::new()));
-        spawn_runner_cleanup_task(agent_runners.clone(), None);
+        // NOTE: the idle-eviction sweep for `agent_runners` is spawned below,
+        // once `session_event_senders` also exists, so it can drop both maps'
+        // entries for a completed session together (issue #346).
 
         let process_registry = Arc::new(ProcessRegistry::new());
         let (provider_lock, provider_handle) = build_provider_handles(provider);
@@ -233,6 +235,11 @@ impl AppState {
         // Long-lived session event senders map (UI subscriptions + background tasks).
         let session_event_senders: Arc<RwLock<HashMap<String, broadcast::Sender<AgentEvent>>>> =
             Arc::new(RwLock::new(HashMap::new()));
+
+        // Idle-evict completed runners together with their paired session event
+        // senders (issue #346). Spawned here (not next to `agent_runners`) so it
+        // owns handles to both maps.
+        spawn_session_map_cleanup_task(agent_runners.clone(), session_event_senders.clone(), None);
 
         // Account-scoped durable change feed. Opening the journal recovers the
         // max seq so the sequence counter stays monotonic across restarts.

--- a/crates/app/bamboo-server/src/app_state/init.rs
+++ b/crates/app/bamboo-server/src/app_state/init.rs
@@ -314,9 +314,19 @@ pub fn spawn_session_map_cleanup_task(
         loop {
             tokio::time::sleep(Duration::from_secs(60)).await;
 
-            // Lock order: runners ⊃ senders. This matches `reserve_runner` (which
-            // nests senders inside the runners write lock) and is never inverted
-            // anywhere, so nesting here is deadlock-free.
+            // Lock order: runners ⊃ senders. This matches `reserve_runner_core`
+            // (which nests senders inside the runners write lock to re-assert the
+            // sender) and is never inverted anywhere, so nesting is deadlock-free.
+            //
+            // Both write locks are intentionally held across the whole O(n) pass
+            // rather than snapshot-then-remove: the atomicity is load-bearing.
+            // `reserve_runner_core` inserts a `Running` runner AND re-asserts its
+            // sender under the runners lock; holding both here means a concurrent
+            // reservation cannot interleave between our runner-eviction and our
+            // sender-removal, so we can never drop a sender that a just-reserved
+            // run re-asserted. The pass is cheap (a receiver_count atomic load +
+            // timestamp math per entry) at the 60s cadence, so the widened window
+            // is acceptable.
             let mut runners_guard = runners.write().await;
             let mut senders_guard = senders.write().await;
             let now = Utc::now();

--- a/crates/app/bamboo-server/src/app_state/init.rs
+++ b/crates/app/bamboo-server/src/app_state/init.rs
@@ -218,39 +218,121 @@ pub async fn init_metrics_service(data_dir: &Path) -> Result<Arc<MetricsService>
     Ok(Arc::new(service))
 }
 
-/// Spawn a background task that cleans up completed agent runners after 5 minutes.
-pub fn spawn_runner_cleanup_task(
+/// Idle-eviction TTL for terminal runners / session senders, in seconds.
+///
+/// A completed runner is retained for at least this long after `completed_at`
+/// so a client that subscribes shortly after the run finishes still gets the
+/// cached `last_critical_events` / `last_budget_event` replay.
+pub(crate) const SESSION_MAP_IDLE_TTL_SECS: i64 = 300;
+
+/// Single idle-eviction pass over the per-session runner + event-sender maps.
+///
+/// Drops a `(agent_runners, session_event_senders)` pair together when the
+/// runner is terminal, older than `ttl_secs`, and its broadcast channel has **no
+/// live receivers**. Returns the number of runners evicted.
+///
+/// # Why `receiver_count() == 0` is required
+///
+/// A runner's `event_sender` is a clone of the session's long-lived sender (see
+/// `reserve_runner` / `try_reserve_runner`), so `receiver_count()` reflects
+/// every SSE/WS subscriber on the session stream. Evicting while a receiver is
+/// live would (a) yank the replay cache out from under a client that just
+/// subscribed after `Complete`, and (b) silently drop a terminal parent whose
+/// still-running children forward events into this stream (that parent keeps a
+/// live subscription). So we only reclaim genuinely-idle terminal sessions —
+/// exactly the ephemeral sub-agent / guardian / scheduled runs that never had a
+/// UI subscription and whose count therefore reaches zero.
+///
+/// Removing the map's `Sender` (the last clone once the terminal runner's own
+/// clone is dropped by the `retain`) closes the channel, which also lets any
+/// per-session notification relay task exit on `RecvError::Closed`.
+///
+/// This runs synchronously under both write guards held by the caller (no
+/// `.await` between the check and the removals), so a concurrent `reserve_runner`
+/// / `get_or_create_event_sender` (which need those same locks) cannot interleave.
+pub(crate) fn evict_idle_session_entries(
+    runners: &mut HashMap<String, AgentRunner>,
+    senders: &mut HashMap<String, broadcast::Sender<AgentEvent>>,
+    ttl_secs: i64,
+    now: chrono::DateTime<Utc>,
+    log_prefix: Option<&'static str>,
+) -> usize {
+    let mut evicted: Vec<String> = Vec::new();
+
+    runners.retain(|session_id, runner| {
+        let keep = match &runner.status {
+            AgentStatus::Running => true,
+            _ => {
+                let age =
+                    now.signed_duration_since(runner.completed_at.unwrap_or(runner.started_at));
+                let expired = age.num_seconds() >= ttl_secs;
+                let has_receivers = runner.event_sender.receiver_count() > 0;
+                // Keep unless it is BOTH past the TTL AND has no live receiver.
+                !expired || has_receivers
+            }
+        };
+        if !keep {
+            evicted.push(session_id.clone());
+            if let Some(prefix) = log_prefix {
+                tracing::debug!("[{}:{}] Evicting idle terminal runner", prefix, session_id);
+            } else {
+                tracing::debug!("[{}] Evicting idle terminal runner", session_id);
+            }
+        }
+        keep
+    });
+
+    // Drop the paired long-lived sender for each evicted runner, but only if it
+    // too has no live receiver (re-checked here; it is the same channel as the
+    // runner's `event_sender`, so this is normally a formality — a session sender
+    // can, however, outlive its runner, and we must never close a channel a
+    // client is actively reading).
+    for session_id in &evicted {
+        if senders
+            .get(session_id)
+            .is_some_and(|sender| sender.receiver_count() == 0)
+        {
+            senders.remove(session_id);
+        }
+    }
+
+    evicted.len()
+}
+
+/// Spawn a background task that idle-evicts completed agent runners **and their
+/// paired session event senders** after [`SESSION_MAP_IDLE_TTL_SECS`].
+///
+/// Fire-and-forget (runs for the process lifetime), matching the other
+/// background maintenance tickers. See [`evict_idle_session_entries`] for the
+/// eviction predicate and its race-freedom argument.
+pub fn spawn_session_map_cleanup_task(
     runners: Arc<RwLock<HashMap<String, AgentRunner>>>,
+    senders: Arc<RwLock<HashMap<String, broadcast::Sender<AgentEvent>>>>,
     log_prefix: Option<&'static str>,
 ) {
     tokio::spawn(async move {
         loop {
             tokio::time::sleep(Duration::from_secs(60)).await;
 
+            // Lock order: runners ⊃ senders. This matches `reserve_runner` (which
+            // nests senders inside the runners write lock) and is never inverted
+            // anywhere, so nesting here is deadlock-free.
             let mut runners_guard = runners.write().await;
+            let mut senders_guard = senders.write().await;
             let now = Utc::now();
+            let evicted = evict_idle_session_entries(
+                &mut runners_guard,
+                &mut senders_guard,
+                SESSION_MAP_IDLE_TTL_SECS,
+                now,
+                log_prefix,
+            );
+            drop(senders_guard);
+            drop(runners_guard);
 
-            runners_guard.retain(|session_id, runner| {
-                let should_keep = match &runner.status {
-                    AgentStatus::Running => true,
-                    _ => {
-                        let age = now.signed_duration_since(
-                            runner.completed_at.unwrap_or(runner.started_at),
-                        );
-                        age.num_seconds() < 300 // 5 minute TTL
-                    }
-                };
-
-                if !should_keep {
-                    if let Some(prefix) = log_prefix {
-                        tracing::debug!("[{}:{}] Cleaning up completed runner", prefix, session_id);
-                    } else {
-                        tracing::debug!("[{}] Cleaning up completed runner", session_id);
-                    }
-                }
-
-                should_keep
-            });
+            if evicted > 0 {
+                tracing::debug!("Idle-evicted {evicted} completed session runner(s)/sender(s)");
+            }
         }
     });
 }
@@ -331,4 +413,162 @@ pub fn build_schedule_manager(
         config,
         provider_registry,
     )))
+}
+
+#[cfg(test)]
+mod eviction_tests {
+    use super::*;
+    use chrono::Duration as ChronoDuration;
+
+    const TTL: i64 = SESSION_MAP_IDLE_TTL_SECS;
+
+    /// A terminal (Completed) runner whose `event_sender` shares `tx`'s channel,
+    /// exactly as production sets it in `reserve_runner`.
+    fn terminal_runner(
+        tx: &broadcast::Sender<AgentEvent>,
+        completed_secs_ago: i64,
+        now: chrono::DateTime<Utc>,
+    ) -> AgentRunner {
+        let mut runner = AgentRunner::new();
+        runner.status = AgentStatus::Completed;
+        runner.completed_at = Some(now - ChronoDuration::seconds(completed_secs_ago));
+        runner.event_sender = tx.clone();
+        runner
+    }
+
+    fn insert_pair(
+        runners: &mut HashMap<String, AgentRunner>,
+        senders: &mut HashMap<String, broadcast::Sender<AgentEvent>>,
+        id: &str,
+        runner: AgentRunner,
+        tx: broadcast::Sender<AgentEvent>,
+    ) {
+        runners.insert(id.to_string(), runner);
+        senders.insert(id.to_string(), tx);
+    }
+
+    #[test]
+    fn evicts_idle_terminal_pair_past_ttl_with_no_receivers() {
+        let now = Utc::now();
+        let (tx, _) = broadcast::channel::<AgentEvent>(16); // receiver dropped -> count 0
+        let mut runners = HashMap::new();
+        let mut senders = HashMap::new();
+        insert_pair(
+            &mut runners,
+            &mut senders,
+            "s1",
+            terminal_runner(&tx, TTL + 100, now),
+            tx.clone(),
+        );
+
+        let evicted = evict_idle_session_entries(&mut runners, &mut senders, TTL, now, None);
+
+        assert_eq!(evicted, 1);
+        assert!(runners.is_empty(), "terminal idle runner must be dropped");
+        assert!(
+            senders.is_empty(),
+            "paired session sender must be dropped together with the runner"
+        );
+    }
+
+    #[test]
+    fn retains_terminal_runner_with_live_receiver() {
+        let now = Utc::now();
+        let (tx, _) = broadcast::channel::<AgentEvent>(16);
+        // A client subscribed just after completion — its receiver is live.
+        let _live_rx = tx.subscribe();
+        assert_eq!(tx.receiver_count(), 1);
+
+        let mut runners = HashMap::new();
+        let mut senders = HashMap::new();
+        insert_pair(
+            &mut runners,
+            &mut senders,
+            "s1",
+            terminal_runner(&tx, TTL + 100, now),
+            tx.clone(),
+        );
+
+        let evicted = evict_idle_session_entries(&mut runners, &mut senders, TTL, now, None);
+
+        assert_eq!(evicted, 0, "must not evict while a receiver is live");
+        assert!(runners.contains_key("s1"));
+        assert!(senders.contains_key("s1"));
+    }
+
+    #[test]
+    fn retains_young_terminal_runner() {
+        let now = Utc::now();
+        let (tx, _) = broadcast::channel::<AgentEvent>(16);
+        let mut runners = HashMap::new();
+        let mut senders = HashMap::new();
+        // Completed only 60s ago — inside the replay window.
+        insert_pair(
+            &mut runners,
+            &mut senders,
+            "s1",
+            terminal_runner(&tx, 60, now),
+            tx.clone(),
+        );
+
+        let evicted = evict_idle_session_entries(&mut runners, &mut senders, TTL, now, None);
+
+        assert_eq!(
+            evicted, 0,
+            "must preserve the post-completion replay window"
+        );
+        assert!(runners.contains_key("s1"));
+        assert!(senders.contains_key("s1"));
+    }
+
+    #[test]
+    fn retains_running_runner_regardless_of_age() {
+        let now = Utc::now();
+        let (tx, _) = broadcast::channel::<AgentEvent>(16);
+        let mut runner = AgentRunner::new();
+        runner.status = AgentStatus::Running;
+        runner.started_at = now - ChronoDuration::seconds(TTL + 100_000);
+        runner.completed_at = None;
+        runner.event_sender = tx.clone();
+
+        let mut runners = HashMap::new();
+        let mut senders = HashMap::new();
+        insert_pair(&mut runners, &mut senders, "s1", runner, tx.clone());
+
+        let evicted = evict_idle_session_entries(&mut runners, &mut senders, TTL, now, None);
+
+        assert_eq!(evicted, 0, "a Running runner is never evicted");
+        assert!(runners.contains_key("s1"));
+        assert!(senders.contains_key("s1"));
+    }
+
+    #[test]
+    fn keeps_sender_if_it_has_receivers_even_when_runner_evicted() {
+        // Defensive edge: the runner qualifies for eviction, but the session
+        // sender independently has a live receiver (e.g. a subscriber that
+        // reused the channel). The sender must survive so we never close a
+        // channel a client is reading.
+        let now = Utc::now();
+        let (runner_tx, _) = broadcast::channel::<AgentEvent>(16);
+        // Distinct channel for the map entry, with a live receiver.
+        let (sender_tx, _) = broadcast::channel::<AgentEvent>(16);
+        let _live = sender_tx.subscribe();
+
+        let mut runners = HashMap::new();
+        let mut senders = HashMap::new();
+        runners.insert(
+            "s1".to_string(),
+            terminal_runner(&runner_tx, TTL + 100, now),
+        );
+        senders.insert("s1".to_string(), sender_tx.clone());
+
+        let evicted = evict_idle_session_entries(&mut runners, &mut senders, TTL, now, None);
+
+        assert_eq!(evicted, 1, "runner (no receivers) is evicted");
+        assert!(runners.is_empty());
+        assert!(
+            senders.contains_key("s1"),
+            "sender with a live receiver must be retained even when the runner is dropped"
+        );
+    }
 }

--- a/crates/app/bamboo-server/src/app_state/resume_adapter.rs
+++ b/crates/app/bamboo-server/src/app_state/resume_adapter.rs
@@ -45,7 +45,13 @@ impl ResumeExecutionPort for AppStateResumeRef {
         session_id: &str,
         event_sender: &broadcast::Sender<AgentEvent>,
     ) -> Option<RunnerReservation> {
-        try_reserve_runner(&self.0.agent_runners, session_id, event_sender).await
+        try_reserve_runner(
+            &self.0.agent_runners,
+            &self.0.session_event_senders,
+            session_id,
+            event_sender,
+        )
+        .await
     }
 
     async fn get_existing_runner_run_id(&self, session_id: &str) -> Option<String> {

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/reservation.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/reservation.rs
@@ -41,5 +41,23 @@ pub(in crate::handlers::agent::execute) async fn reserve_runner(
     let run_id = runner.run_id.clone();
 
     runners.insert(session_id.to_string(), runner);
+
+    // Re-assert the session sender into the map, still holding the runners write
+    // lock. The idle-eviction sweep (issue #346) may have removed this session's
+    // sender between the caller's `get_session_event_sender` and this reservation
+    // (it evicts an idle terminal session's runner+sender together). Without this
+    // re-assert, a session re-executed after >5min idle would publish to the
+    // `session_tx` clone we hold here while a later subscriber's
+    // `get_or_create_event_sender` mints a *different* channel and sees nothing.
+    // `or_insert_with` restores the SAME channel, so it is a no-op in the common
+    // case. Lock order (runners ⊃ senders) matches the sweep, so this cannot
+    // deadlock.
+    state
+        .session_event_senders
+        .write()
+        .await
+        .entry(session_id.to_string())
+        .or_insert_with(|| session_tx.clone());
+
     RunnerReservation::Started(cancel_token, run_id)
 }

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/reservation.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/reservation.rs
@@ -1,63 +1,44 @@
 use tokio_util::sync::CancellationToken;
 
-use crate::app_state::{AgentRunner, AgentStatus, AppState};
+use crate::app_state::AppState;
 use bamboo_agent_core::AgentEvent;
+use bamboo_engine::execution::{reserve_runner_core, ReserveOutcome};
 
 pub(in crate::handlers::agent::execute) enum RunnerReservation {
     Started(CancellationToken, String),
     AlreadyRunning(String),
 }
 
+/// Reserve a runner for the fresh-execute path.
+///
+/// Delegates to the engine's [`reserve_runner_core`], which performs the
+/// check-existing → replace-stale → insert-fresh sequence AND re-asserts the
+/// session sender into `session_event_senders` under the runners write lock
+/// (closing the idle-eviction TOCTOU, #346). Sharing that core with the engine's
+/// `try_reserve_runner` (used by the resume paths) guarantees the re-assert
+/// cannot drift between the two reservation entry points.
 pub(in crate::handlers::agent::execute) async fn reserve_runner(
     state: &AppState,
     session_id: &str,
     session_tx: &tokio::sync::broadcast::Sender<AgentEvent>,
 ) -> RunnerReservation {
-    let mut runners = state.agent_runners.write().await;
-
-    // Check if there's already a running runner for this session.
-    if let Some(runner) = runners.get(session_id) {
-        if matches!(runner.status, AgentStatus::Running) {
+    match reserve_runner_core(
+        &state.agent_runners,
+        &state.session_event_senders,
+        session_id,
+        session_tx,
+    )
+    .await
+    {
+        ReserveOutcome::Reserved(reservation) => {
+            RunnerReservation::Started(reservation.cancel_token, reservation.run_id)
+        }
+        ReserveOutcome::AlreadyRunning(run_id) => {
             tracing::debug!(
                 "[{}] Runner already running, returning status: already_running",
                 session_id
             );
-            return RunnerReservation::AlreadyRunning(runner.run_id.clone());
+            RunnerReservation::AlreadyRunning(run_id)
         }
-        tracing::debug!(
-            "[{}] Existing runner with status {:?}, will restart",
-            session_id,
-            runner.status
-        );
     }
-
-    // Remove stale runner and insert new one atomically.
-    runners.remove(session_id);
-
-    let mut runner = AgentRunner::new();
-    runner.status = AgentStatus::Running;
-    runner.event_sender = session_tx.clone();
-    let cancel_token = runner.cancel_token.clone();
-    let run_id = runner.run_id.clone();
-
-    runners.insert(session_id.to_string(), runner);
-
-    // Re-assert the session sender into the map, still holding the runners write
-    // lock. The idle-eviction sweep (issue #346) may have removed this session's
-    // sender between the caller's `get_session_event_sender` and this reservation
-    // (it evicts an idle terminal session's runner+sender together). Without this
-    // re-assert, a session re-executed after >5min idle would publish to the
-    // `session_tx` clone we hold here while a later subscriber's
-    // `get_or_create_event_sender` mints a *different* channel and sees nothing.
-    // `or_insert_with` restores the SAME channel, so it is a no-op in the common
-    // case. Lock order (runners ⊃ senders) matches the sweep, so this cannot
-    // deadlock.
-    state
-        .session_event_senders
-        .write()
-        .await
-        .entry(session_id.to_string())
-        .or_insert_with(|| session_tx.clone());
-
-    RunnerReservation::Started(cancel_token, run_id)
 }

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -317,8 +317,13 @@ async fn run_schedule_job(
     let session_tx = get_or_create_event_sender(&ctx.session_event_senders, &session_id).await;
 
     // Insert runner status (for cancellation/status introspection).
-    let Some(RunnerReservation { cancel_token, .. }) =
-        try_reserve_runner(&ctx.agent_runners, &session_id, &session_tx).await
+    let Some(RunnerReservation { cancel_token, .. }) = try_reserve_runner(
+        &ctx.agent_runners,
+        &ctx.session_event_senders,
+        &session_id,
+        &session_tx,
+    )
+    .await
     else {
         return Ok(ScheduleRunLifecycleResult::Terminal(
             ScheduleRunStatus::Skipped,

--- a/crates/app/bamboo-server/src/tools/child_session_adapter.rs
+++ b/crates/app/bamboo-server/src/tools/child_session_adapter.rs
@@ -204,6 +204,23 @@ impl ChildSessionAdapter {
             }
             return Err(error);
         }
+
+        // 5. Self-clean: the slot exists only to coalesce a burst of sibling
+        //    registrations for THIS parent. Now that the batch is durably
+        //    persisted and nothing new is pending, drop the map entry so
+        //    `parent_wait_slots` does not retain one entry per parent-that-ever-
+        //    -spawned forever (issue #346). Still inside the flush barrier.
+        //
+        //    Race-freedom: `remove_if` re-checks `pending.is_empty()` under the
+        //    DashMap shard lock. A sibling that enqueued after our drain made
+        //    `pending` non-empty, so the predicate is false and we keep the slot;
+        //    that sibling (blocked on the barrier we still hold) will flush it and
+        //    run this same removal. A sibling that clones the slot Arc but has not
+        //    yet pushed keeps a live handle, so removing the map entry never loses
+        //    its child: whoever holds the barrier drains ALL pending on its Arc.
+        self.parent_wait_slots
+            .remove_if(parent_session_id, |_, slot| slot.pending.lock().is_empty());
+
         Ok(())
     }
 

--- a/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
+++ b/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
@@ -299,6 +299,52 @@ async fn repeated_registration_of_same_child_is_idempotent() {
     assert_eq!(wait.child_session_ids, vec!["dup-child".to_string()]);
 }
 
+#[tokio::test]
+async fn parent_wait_slot_is_evicted_after_flush_drains() {
+    // Issue #346: the per-parent coalescing slot must not linger in
+    // `parent_wait_slots` after its pending queue drains, otherwise the map
+    // grows by one entry per parent-that-ever-spawned and never shrinks.
+    let harness = build_test_harness().await;
+    let adapter = harness.adapter.clone();
+    let parent_id = harness.parent_session_id.clone();
+
+    adapter
+        .register_parent_wait_for_child(&parent_id, "one-child", None)
+        .await
+        .unwrap();
+
+    assert!(
+        adapter.parent_wait_slots.is_empty(),
+        "coalescing slot must be evicted once the batch is persisted and pending drains"
+    );
+}
+
+#[tokio::test]
+async fn parent_wait_slots_drain_after_concurrent_registrations() {
+    let harness = build_test_harness().await;
+    let adapter = harness.adapter.clone();
+    let parent_id = harness.parent_session_id.clone();
+
+    let mut handles = Vec::new();
+    for i in 0..6 {
+        let adapter = adapter.clone();
+        let parent_id = parent_id.clone();
+        handles.push(tokio::spawn(async move {
+            adapter
+                .register_parent_wait_for_child(&parent_id, &format!("c-{i}"), None)
+                .await
+        }));
+    }
+    for h in handles {
+        h.await.unwrap().unwrap();
+    }
+
+    assert!(
+        adapter.parent_wait_slots.is_empty(),
+        "no coalescing slot should linger once all concurrent registrations drain"
+    );
+}
+
 // -----------------------------------------------------------------------
 // Decoupled create + explicit SubAgent.wait
 // -----------------------------------------------------------------------

--- a/crates/engine/bamboo-engine/src/runtime/execution/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/mod.rs
@@ -28,7 +28,8 @@ pub use agent_spawn::{
 pub use child_completion::{ChildCompletion, ChildCompletionHandler};
 pub use event_forwarder::{create_event_forwarder, AccountFeedInbox};
 pub use runner_lifecycle::{
-    finalize_runner, status_from_execution_result, try_reserve_runner, RunnerReservation,
+    finalize_runner, reserve_runner_core, status_from_execution_result, try_reserve_runner,
+    ReserveOutcome, RunnerReservation,
 };
 pub use runner_state::{AgentRunner, AgentStatus};
 pub use session_events::{get_or_create_event_sender, SESSION_EVENT_CHANNEL_CAPACITY};

--- a/crates/engine/bamboo-engine/src/runtime/execution/runner_lifecycle.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/runner_lifecycle.rs
@@ -32,6 +32,13 @@ pub struct RunnerReservation {
 ///
 /// Otherwise removes any stale runner and inserts a fresh one, returning
 /// the associated `CancellationToken` and the new `run_id`.
+///
+/// Unlike the server's `reserve_runner`, this does NOT re-assert `event_sender`
+/// into the `session_event_senders` map after the idle-eviction sweep (#346).
+/// It is only reached for spawn / schedule sessions, which are single-shot
+/// (sub-agents, guardians) or fresh-uuid-per-fire (scheduler) and thus never
+/// re-executed under the same id, so the evict-then-re-execute race the server
+/// path guards against is unreachable here.
 pub async fn try_reserve_runner(
     runners: &Arc<RwLock<HashMap<String, AgentRunner>>>,
     session_id: &str,

--- a/crates/engine/bamboo-engine/src/runtime/execution/runner_lifecycle.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/runner_lifecycle.rs
@@ -16,39 +16,55 @@ use bamboo_agent_core::{AgentError, AgentEvent};
 
 use super::runner_state::{AgentRunner, AgentStatus};
 
-/// Reservation result from `try_reserve_runner`.
+/// Reservation result from [`reserve_runner_core`] / [`try_reserve_runner`].
 #[derive(Debug, Clone)]
 pub struct RunnerReservation {
     pub cancel_token: CancellationToken,
     pub run_id: String,
 }
 
-/// Try to reserve a runner for the given session.
+/// Outcome of the shared reservation core.
+#[derive(Debug, Clone)]
+pub enum ReserveOutcome {
+    /// A fresh runner was reserved (any stale runner was replaced).
+    Reserved(RunnerReservation),
+    /// A `Running` runner already exists for this session; carries its `run_id`
+    /// so the caller can correlate subsequent SSE/WS events.
+    AlreadyRunning(String),
+}
+
+/// Shared runner-reservation core used by BOTH the server's `reserve_runner`
+/// and the engine's [`try_reserve_runner`], so the idle-eviction sender
+/// re-assert can never drift between the two paths again (#346).
 ///
-/// If a runner with `Running` status already exists, returns `None`
-/// (caller should skip execution). The `AlreadyRunning` case is surfaced
-/// by the caller via `ExecuteResponse` with the *existing* runner's `run_id`
-/// so the frontend can correlate subsequent SSE events.
+/// While holding the `runners` write lock it:
+/// 1. short-circuits with [`ReserveOutcome::AlreadyRunning`] if a `Running`
+///    runner already exists;
+/// 2. otherwise replaces any stale runner with a fresh `Running` one whose
+///    `event_sender` is `event_sender`;
+/// 3. **re-asserts `event_sender` into `senders`** (`entry().or_insert_with`),
+///    STILL holding the `runners` write lock.
 ///
-/// Otherwise removes any stale runner and inserts a fresh one, returning
-/// the associated `CancellationToken` and the new `run_id`.
-///
-/// Unlike the server's `reserve_runner`, this does NOT re-assert `event_sender`
-/// into the `session_event_senders` map after the idle-eviction sweep (#346).
-/// It is only reached for spawn / schedule sessions, which are single-shot
-/// (sub-agents, guardians) or fresh-uuid-per-fire (scheduler) and thus never
-/// re-executed under the same id, so the evict-then-re-execute race the server
-/// path guards against is unreachable here.
-pub async fn try_reserve_runner(
+/// Step 3 closes the idle-sweep TOCTOU: a caller obtains the sender via
+/// `get_or_create_event_sender` and then reserves, but the 60s idle sweep can
+/// evict that session's sender in between (it drops a terminal runner and its
+/// sender together under the same `runners` ⊃ `senders` lock order). Without the
+/// re-assert, a resumed / re-executed run would publish to a channel no longer
+/// registered in `senders`, and a later subscriber's `get_or_create_event_sender`
+/// would mint a *different* channel and silently miss every event of that run.
+/// Because both this re-assert and the sweep acquire `runners` first, they are
+/// mutually exclusive, and a freshly-inserted `Running` runner is never swept —
+/// so the re-asserted sender is durable for the run.
+pub async fn reserve_runner_core(
     runners: &Arc<RwLock<HashMap<String, AgentRunner>>>,
+    senders: &Arc<RwLock<HashMap<String, broadcast::Sender<AgentEvent>>>>,
     session_id: &str,
     event_sender: &broadcast::Sender<AgentEvent>,
-) -> Option<RunnerReservation> {
+) -> ReserveOutcome {
     let mut guard = runners.write().await;
     if let Some(runner) = guard.get(session_id) {
         if matches!(runner.status, AgentStatus::Running) {
-            tracing::debug!("[{}] Runner already running, skipping", session_id);
-            return None;
+            return ReserveOutcome::AlreadyRunning(runner.run_id.clone());
         }
     }
 
@@ -61,9 +77,46 @@ pub async fn try_reserve_runner(
         cancel_token: runner.cancel_token.clone(),
         run_id: runner.run_id.clone(),
     };
-
     guard.insert(session_id.to_string(), runner);
-    Some(reservation)
+
+    // (3) Re-assert the session sender under the held `runners` write lock. Same
+    // channel as `event_sender`, so a no-op in the common case; restores the map
+    // entry if the idle sweep removed it. Lock order (runners ⊃ senders) matches
+    // the sweep, so this cannot deadlock.
+    senders
+        .write()
+        .await
+        .entry(session_id.to_string())
+        .or_insert_with(|| event_sender.clone());
+
+    ReserveOutcome::Reserved(reservation)
+}
+
+/// Try to reserve a runner for the given session.
+///
+/// Returns `None` if a `Running` runner already exists (the caller skips
+/// execution and surfaces the existing `run_id` separately). Otherwise reserves
+/// a fresh runner AND re-asserts the session sender into `senders` — see
+/// [`reserve_runner_core`].
+///
+/// The re-assert is **required, not optional**: this function is reached by the
+/// resume paths (`/respond`, child-completion coordinator, gold auto-answer via
+/// `resume_session_execution`), which re-execute a long-lived session under the
+/// SAME id after a wait that easily exceeds the idle TTL — exactly the
+/// evict-then-re-execute race #346's sweep newly opens.
+pub async fn try_reserve_runner(
+    runners: &Arc<RwLock<HashMap<String, AgentRunner>>>,
+    senders: &Arc<RwLock<HashMap<String, broadcast::Sender<AgentEvent>>>>,
+    session_id: &str,
+    event_sender: &broadcast::Sender<AgentEvent>,
+) -> Option<RunnerReservation> {
+    match reserve_runner_core(runners, senders, session_id, event_sender).await {
+        ReserveOutcome::Reserved(reservation) => Some(reservation),
+        ReserveOutcome::AlreadyRunning(_) => {
+            tracing::debug!("[{}] Runner already running, skipping", session_id);
+            None
+        }
+    }
 }
 
 /// Map an execution result to `AgentStatus`.
@@ -96,6 +149,10 @@ mod tests {
         Arc::new(RwLock::new(HashMap::new()))
     }
 
+    fn new_senders() -> Arc<RwLock<HashMap<String, broadcast::Sender<AgentEvent>>>> {
+        Arc::new(RwLock::new(HashMap::new()))
+    }
+
     fn new_broadcaster() -> broadcast::Sender<AgentEvent> {
         broadcast::channel(100).0
     }
@@ -103,8 +160,9 @@ mod tests {
     #[tokio::test]
     async fn try_reserve_runner_creates_runner_with_running_status() {
         let runners = new_runners();
+        let senders = new_senders();
         let tx = new_broadcaster();
-        let token = try_reserve_runner(&runners, "s1", &tx).await;
+        let token = try_reserve_runner(&runners, &senders, "s1", &tx).await;
         assert!(token.is_some());
 
         let guard = runners.read().await;
@@ -115,17 +173,19 @@ mod tests {
     #[tokio::test]
     async fn try_reserve_runner_returns_none_when_already_running() {
         let runners = new_runners();
+        let senders = new_senders();
         let tx = new_broadcaster();
-        let _ = try_reserve_runner(&runners, "s1", &tx).await;
-        let second = try_reserve_runner(&runners, "s1", &tx).await;
+        let _ = try_reserve_runner(&runners, &senders, "s1", &tx).await;
+        let second = try_reserve_runner(&runners, &senders, "s1", &tx).await;
         assert!(second.is_none());
     }
 
     #[tokio::test]
     async fn try_reserve_runner_replaces_completed_runner() {
         let runners = new_runners();
+        let senders = new_senders();
         let tx = new_broadcaster();
-        let _ = try_reserve_runner(&runners, "s1", &tx).await;
+        let _ = try_reserve_runner(&runners, &senders, "s1", &tx).await;
 
         {
             let mut guard = runners.write().await;
@@ -133,8 +193,56 @@ mod tests {
             runner.status = AgentStatus::Completed;
         }
 
-        let second = try_reserve_runner(&runners, "s1", &tx).await;
+        let second = try_reserve_runner(&runners, &senders, "s1", &tx).await;
         assert!(second.is_some());
+    }
+
+    #[tokio::test]
+    async fn try_reserve_runner_reasserts_evicted_sender_so_late_subscriber_receives() {
+        // Regression for #346: the resume path (`resume_session_execution`)
+        // obtains the session sender, then reserves — and the idle sweep can
+        // evict that sender in between. `try_reserve_runner` must re-assert it so
+        // the resumed run's channel stays registered and a late subscriber lands
+        // on the SAME channel the run publishes to.
+        use super::super::session_events::get_or_create_event_sender;
+        use bamboo_agent_core::AgentEvent;
+
+        let runners = new_runners();
+        let senders = new_senders();
+
+        // Resume ordering: obtain sender (inserts into the map) ...
+        let session_tx = get_or_create_event_sender(&senders, "s1").await;
+        // ... then the idle sweep evicts this session's sender before reservation.
+        senders.write().await.remove("s1");
+        assert!(senders.read().await.get("s1").is_none());
+
+        // Reserve with the clone obtained before the eviction.
+        let reservation = try_reserve_runner(&runners, &senders, "s1", &session_tx).await;
+        assert!(reservation.is_some(), "reservation must succeed");
+
+        // The sender MUST be re-asserted into the map. Without the fix it is
+        // absent here and the run's channel is orphaned.
+        assert!(
+            senders.read().await.get("s1").is_some(),
+            "reservation must re-assert the evicted session sender into the map"
+        );
+
+        // A late subscriber (SSE/WS handler: get_or_create then subscribe) must
+        // land on the SAME channel the run publishes to.
+        let subscriber_tx = get_or_create_event_sender(&senders, "s1").await;
+        let mut rx = subscriber_tx.subscribe();
+
+        // The resumed run publishes via its reserved channel (== session_tx).
+        let _ = session_tx.send(AgentEvent::SessionDeleted {
+            session_id: "s1".to_string(),
+        });
+
+        let received = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv()).await;
+        assert!(
+            matches!(received, Ok(Ok(_))),
+            "late subscriber must receive events from the resumed run; without the \
+             re-assert, get_or_create mints a fresh channel and the event is lost"
+        );
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/sdk/spawn.rs
+++ b/crates/engine/bamboo-engine/src/sdk/spawn.rs
@@ -147,8 +147,13 @@ pub async fn run_child_spawn(ctx: SpawnContext, job: SpawnJob) -> Result<(), Str
         .await;
 
     // Insert runner status.
-    let Some(RunnerReservation { cancel_token, .. }) =
-        try_reserve_runner(&ctx.agent_runners, &job.child_session_id, &child_tx).await
+    let Some(RunnerReservation { cancel_token, .. }) = try_reserve_runner(
+        &ctx.agent_runners,
+        &ctx.session_event_senders,
+        &job.child_session_id,
+        &child_tx,
+    )
+    .await
     else {
         return Ok(());
     };

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -619,7 +619,13 @@ impl ResumeExecutionPort for ChildCompletionCoordinator {
         session_id: &str,
         event_sender: &broadcast::Sender<AgentEvent>,
     ) -> Option<RunnerReservation> {
-        try_reserve_runner(&self.agent_runners, session_id, event_sender).await
+        try_reserve_runner(
+            &self.agent_runners,
+            &self.session_event_senders,
+            session_id,
+            event_sender,
+        )
+        .await
     }
 
     async fn get_existing_runner_run_id(&self, session_id: &str) -> Option<String> {

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -53,6 +53,45 @@ pub struct LockedSessionStore {
     locks: Arc<DashMap<String, Arc<Mutex<()>>>>,
 }
 
+/// Self-cleaning guard returned by [`LockedSessionStore::acquire_lock`].
+///
+/// Holds the `OwnedMutexGuard` for the session's serialization mutex. On drop it
+/// releases the mutex **first** (so this guard's `Arc` clone is gone before the
+/// count is read) and then removes the map entry iff `Arc::strong_count == 1` —
+/// i.e. only the map's own reference remains, no other task holds or is waiting
+/// on this session's lock.
+///
+/// ## Race freedom
+///
+/// The strong-count check and the removal execute atomically under DashMap's
+/// per-shard lock via [`DashMap::remove_if`]. A waiter that clones the `Arc`
+/// (through `acquire_lock`'s `entry()`) does so under the same shard lock, so it
+/// either:
+/// - clones **before** our `remove_if` → `strong_count >= 2` → we skip removal,
+///   the waiter keeps a live, map-resident lock; or
+/// - clones **after** our `remove_if` → the entry is gone → it inserts a fresh
+///   `Arc<Mutex<()>>`; since our guard had already been released, the two tasks
+///   never overlapped and needed no mutual exclusion.
+///
+/// There is therefore no interleaving in which a waiter observes a lock that we
+/// then delete out from under it.
+pub struct SessionLockGuard {
+    /// `Option` so `Drop` can release the mutex before evaluating strong-count.
+    guard: Option<OwnedMutexGuard<()>>,
+    locks: Arc<DashMap<String, Arc<Mutex<()>>>>,
+    session_id: String,
+}
+
+impl Drop for SessionLockGuard {
+    fn drop(&mut self) {
+        // Release the mutex (drops this guard's `Arc` clone) BEFORE reading the
+        // strong count, otherwise the count can never reach 1.
+        self.guard.take();
+        self.locks
+            .remove_if(&self.session_id, |_, arc| Arc::strong_count(arc) == 1);
+    }
+}
+
 impl LockedSessionStore {
     /// Wrap an existing storage backend.
     pub fn new(storage: Arc<dyn Storage>) -> Self {
@@ -71,13 +110,29 @@ impl LockedSessionStore {
     ///
     /// Only writes for the **same** session are serialised; writes for
     /// different sessions can proceed concurrently.
-    pub async fn acquire_lock(&self, session_id: &str) -> OwnedMutexGuard<()> {
+    ///
+    /// The returned [`SessionLockGuard`] is **self-cleaning**: when it drops it
+    /// releases the mutex and then removes the map entry iff no other holder
+    /// remains. Without this the `locks` map grew by one entry for every session
+    /// id ever written and never shrank (issue #346), so a long-lived server
+    /// leaked one `Arc<Mutex<()>>` per session-ever-persisted. See
+    /// [`SessionLockGuard`] for the race-freedom argument.
+    pub async fn acquire_lock(&self, session_id: &str) -> SessionLockGuard {
+        // `entry().or_insert_with().clone()` releases the DashMap shard lock at
+        // the end of THIS statement, before the `.await` below — never hold a
+        // shard lock across the async lock acquisition (it would deadlock the
+        // self-cleaning `remove_if` on drop, which also takes the shard lock).
         let lock = self
             .locks
             .entry(session_id.to_string())
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone();
-        lock.lock_owned().await
+        let guard = lock.lock_owned().await;
+        SessionLockGuard {
+            guard: Some(guard),
+            locks: self.locks.clone(),
+            session_id: session_id.to_string(),
+        }
     }
 
     /// Runtime-only save: persist the control-plane (`agent_runtime_state`,
@@ -674,5 +729,86 @@ mod tests {
         assert_eq!(after.title, "Committed");
         assert_eq!(after.metadata_version, 1);
         assert_eq!(after.title_version, 2);
+    }
+
+    // ── Self-cleaning per-session lock (issue #346) ─────────────────
+
+    #[tokio::test]
+    async fn acquire_lock_self_evicts_when_no_other_holder() {
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage);
+
+        {
+            let _guard = store.acquire_lock("solo").await;
+            assert_eq!(store.locks.len(), 1, "entry present while the lock is held");
+        }
+        // Dropping the guard runs the self-cleaning `remove_if`. Without the
+        // eviction logic this stays at 1 forever (the pre-#346 leak).
+        assert_eq!(
+            store.locks.len(),
+            0,
+            "lock entry must be evicted once released with no other holder"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_lock_many_distinct_ids_do_not_accumulate() {
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage);
+
+        // Serially acquire+release for 100 distinct session ids.
+        for i in 0..100 {
+            let _guard = store.acquire_lock(&format!("sess-{i}")).await;
+        }
+        assert_eq!(
+            store.locks.len(),
+            0,
+            "acquiring locks for many distinct ids must not grow the map"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_lock_concurrent_waiter_keeps_valid_lock_and_map_drains() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let (_temp, storage) = make_storage().await;
+        let store = Arc::new(LockedSessionStore::new(storage));
+
+        // Tracks concurrent holders of the SAME session lock; must never exceed 1.
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let store = store.clone();
+            let active = active.clone();
+            let max_seen = max_seen.clone();
+            handles.push(tokio::spawn(async move {
+                let _guard = store.acquire_lock("contended").await;
+                let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                max_seen.fetch_max(now, Ordering::SeqCst);
+                // Hold briefly so the other tasks actually queue on the mutex.
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                active.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        // Mutual exclusion must hold: a self-cleaning removal that raced (removed
+        // the entry a waiter had already cloned, letting a later task create and
+        // lock a *second* mutex for the same id) would show 2 concurrent holders.
+        // `remove_if`'s atomic strong-count check under the shard lock prevents it.
+        assert_eq!(
+            max_seen.load(Ordering::SeqCst),
+            1,
+            "at most one holder of a given session lock at a time"
+        );
+        assert_eq!(
+            store.locks.len(),
+            0,
+            "after all holders release, the contended entry must be fully evicted"
+        );
     }
 }


### PR DESCRIPTION
## Problem (#346)

Several per-session, process-lived in-memory maps only shrank on explicit session delete or `/sessions/cleanup` — never when a session simply finished, and never by TTL/LRU. On a long-lived server (the locked cloud-backend direction, where instances stay up and accumulate many ephemeral sub-agent/guardian/scheduled sessions) this is monotonic growth with total sessions-ever-executed. The heaviest offender retained a full `AgentRunner` (up to 32 `AgentEvent`s) **plus a 1000-slot broadcast channel** per completed session forever.

## Fix — per map

### `agent_runners` + `session_event_senders` (evicted together)
A runner reaper already existed (`spawn_runner_cleanup_task`, 300s TTL) but it (a) dropped only the `AgentRunner`, leaving the broadcast channel alive in `session_event_senders` forever, and (b) evicted terminal runners **regardless of live subscribers**.

It now sweeps **both maps** under nested `runners ⊃ senders` write locks and drops a completed runner **and its paired sender together**, but only when the runner is terminal, older than the TTL, **and `event_sender.receiver_count() == 0`**. The receiver guard:
- preserves the post-completion **replay window** — a client that subscribes right after `Complete` holds a receiver, pinning the runner until it disconnects;
- protects a terminal **parent still watching running children** (it keeps a live subscription).

`reserve_runner` re-asserts the session sender into the map under the runners lock, closing the evict-vs-re-execute race (a session re-executed after >5 min idle must not publish to a channel that a later subscriber's `get_or_create_event_sender` would replace with a fresh one). The eviction pass is factored into `evict_idle_session_entries` for direct unit testing.

### `LockedSessionStore.locks`
`acquire_lock` now returns a **self-cleaning `SessionLockGuard`**: on drop it releases the mutex, then `remove_if(Arc::strong_count == 1)`. The strong-count check and the removal are **atomic under DashMap's shard lock**, so a waiter that clones the `Arc` between our release and remove keeps a live, map-resident lock (count ≥ 2 → we skip removal) — no lost-lock race.

### `parent_wait_slots`
`register_parent_wait_for_child` does `remove_if(pending.is_empty())` inside the flush barrier after a successful persist, so the per-parent coalescing slot no longer lingers for every parent that ever spawned. `remove_if` re-checks emptiness under the shard lock, so a sibling that enqueued after the drain keeps its slot and flushes it.

## Preserved replay window & invariants
- Never evicts a runner/sender with live receivers or one that isn't terminal.
- Terminal runners live ≥ 300s after `completed_at` so late subscribers still get `last_critical_events` / `last_budget_event`.
- `finalize_runner` terminal-status/`completed_at` semantics and the guardian `waiting_for_children` discriminant are untouched.
- Explicit delete + `/sessions/cleanup` paths still work.

## Deferred (documented, not silently skipped)
Sessions with an **active notification relay** keep `receiver_count >= 1` forever (the relay is a permanent self-subscriber that only exits on channel close) and are therefore retained until explicit delete/cleanup. This is bounded by *"distinct sessions ever UI-subscribed"*, not *"total sessions executed"* — and the heavy ephemeral offenders the issue targets (sub-agents / guardians / scheduled runs, which have **no** relay, so their count reaches 0) **are** reclaimed. Making the relay non-pinning is a separate change to `notification_service` (not one of #346's listed maps).

## Regression tests
All were verified to **fail** with the eviction logic disabled.
- `init::eviction_tests`: idle terminal pair evicted together; retained with a live receiver / inside the TTL / while `Running`; a sender with a live receiver is kept even when its runner is dropped.
- `session_merge::tests`: lock entry self-evicts with no other holder; 100 distinct ids don't accumulate; concurrent waiters keep mutual exclusion (max 1 holder) and the map fully drains.
- `sub_agent_tests`: parent-wait slot evicted after single and concurrent flushes.

## Verify (exact CI commands, from worktree root)
- `cargo fmt -- --check` — clean
- `cargo clippy --all-features -- -A deprecated -A clippy::module_inception -A clippy::incompatible_msrv -A clippy::needless_borrows_for_generic_args -A clippy::too-many-arguments -A clippy::while-let-loop -A clippy::type_complexity -A dead-code -D warnings` — clean on touched crates
- `cargo test -p bamboo-engine -p bamboo-storage -p bamboo-server --all-features` — 895 / 63 / 981+9 pass
- `cargo build --workspace --tests --all-features` — Finished

Closes #346

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u