### PR TITLE
fix(server): emit response.failed on a mid-stream error in the Responses proxy (#355)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/events.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/events.rs
@@ -65,6 +65,25 @@ pub(super) fn event_to_sse_bytes<T: Serialize>(event: &ResponsesStreamEvent<T>) 
     ))
 }
 
+/// A `response.failed` SSE event carrying the upstream error.
+///
+/// Without this, a mid-stream upstream failure is reported to the client as a
+/// clean `[DONE]` (no `response.completed`, but also no failure signal), so an
+/// OpenAI-SDK client treats the TRUNCATED output as the final answer. Emitting
+/// `response.failed` before `[DONE]` lets the client distinguish a cut-off stream
+/// from a complete one — mirroring the Anthropic handler's `error` event and the
+/// chat endpoint's error chunk (#383). #355.
+pub(super) fn failed_sse_bytes(message: &str) -> Bytes {
+    let payload = serde_json::json!({
+        "type": "response.failed",
+        "response": {
+            "status": "failed",
+            "error": { "message": message, "type": "api_error" },
+        },
+    });
+    Bytes::from(format!("event: response.failed\ndata: {payload}\n\n"))
+}
+
 pub(super) fn done_sse_bytes() -> Bytes {
     Bytes::from_static(b"data: [DONE]\n\n")
 }

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/tests.rs
@@ -3,7 +3,8 @@ use serde_json::Value;
 use super::super::output::{build_completed_response, build_output_items};
 use super::errors::map_provider_error;
 use super::events::{
-    completed_event, created_event, done_sse_bytes, event_to_sse_bytes, output_text_delta_event,
+    completed_event, created_event, done_sse_bytes, event_to_sse_bytes, failed_sse_bytes,
+    output_text_delta_event,
 };
 use crate::error::AppError;
 
@@ -25,6 +26,18 @@ fn decode_sse_event(bytes: bytes::Bytes) -> (String, Value) {
     let event_name = event.to_string();
     let json = serde_json::from_str::<Value>(data).expect("data should be valid json");
     (event_name, json)
+}
+
+#[test]
+fn failed_sse_bytes_signals_failure_with_error() {
+    // #355: a mid-stream upstream error must surface as a `response.failed` event
+    // (with the error), not a clean `[DONE]` the client reads as success.
+    let (event_name, payload) = decode_sse_event(failed_sse_bytes("upstream 503"));
+    assert_eq!(event_name, "response.failed");
+    assert_eq!(payload["type"], "response.failed");
+    assert_eq!(payload["response"]["status"], "failed");
+    assert_eq!(payload["response"]["error"]["message"], "upstream 503");
+    assert_eq!(payload["response"]["error"]["type"], "api_error");
 }
 
 #[test]

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/worker.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/worker.rs
@@ -8,7 +8,8 @@ use bamboo_metrics::{ForwardStatus, MetricsCollector};
 
 use super::super::output::{build_completed_response, build_output_items};
 use super::events::{
-    completed_event, created_event, done_sse_bytes, event_to_sse_bytes, output_text_delta_event,
+    completed_event, created_event, done_sse_bytes, event_to_sse_bytes, failed_sse_bytes,
+    output_text_delta_event,
 };
 use crate::handlers::llm_compat::usage::{build_estimated_usage, estimate_completion_tokens};
 
@@ -32,6 +33,7 @@ pub(super) fn spawn_stream_worker(args: StreamWorkerArgs) {
 
 async fn run_stream_worker(mut args: StreamWorkerArgs) {
     let mut had_error = false;
+    let mut error_message: Option<String> = None;
     let mut content = String::new();
     let mut tool_calls: Vec<bamboo_agent_core::tools::ToolCall> = Vec::new();
     let mut response_id: Option<String> = None;
@@ -116,6 +118,7 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
             Ok(LLMChunk::CacheUsage { .. }) | Ok(LLMChunk::UsageSummary { .. }) => {}
             Err(error) => {
                 had_error = true;
+                error_message = Some(error.to_string());
                 tracing::error!("Stream error: {}", error);
                 args.metrics.forward_completed(
                     args.forward_id.clone(),
@@ -131,6 +134,10 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
     }
 
     if had_error {
+        // Signal the failure so the client can tell a truncated stream from a
+        // completed one, instead of a clean `[DONE]` that looks like success. #355.
+        let message = error_message.as_deref().unwrap_or("upstream stream error");
+        let _ = args.tx.send(Ok(failed_sse_bytes(message))).await;
         let _ = args.tx.send(Ok(done_sse_bytes())).await;
         return;
     }


### PR DESCRIPTION
Fixes #355 (the `/v1/responses` half; the `/v1/chat/completions` half was fixed in #383).

## Bug
The OpenAI-compat `/v1/responses` streaming worker turns a mid-stream upstream failure into an on-the-wire **success**. On `Err` it sets `had_error`, records `ForwardStatus::Error`, and `break`s — then the `had_error` tail (`responses/stream/worker.rs`) sends **only** `data: [DONE]`, with no failure event. An OpenAI-SDK client sees a clean stream end and treats the **truncated** output as the final answer, unable to distinguish a cut-off response from a complete one.

The siblings all get this right — the chat endpoint emits an error chunk (#383), Anthropic emits an SSE `error` event, Gemini fails the HTTP stream. Only the Responses path still swallowed it.

## Fix
- New `failed_sse_bytes(message)` event helper emits a `response.failed` event carrying the error: `{"type":"response.failed","response":{"status":"failed","error":{"message":…,"type":"api_error"}}}`.
- The worker captures the error string in the `Err` arm and, in the `had_error` branch, sends `response.failed` **before** `[DONE]`. So a client now receives an explicit failure signal instead of a bare `[DONE]`.

Localized change, mirrors the chat/Anthropic pattern.

## Tests
`failed_sse_bytes_signals_failure_with_error` decodes the SSE event and asserts `event: response.failed` + `response.status = "failed"` + the error message/type. 979 `bamboo-server` tests pass; clippy clean.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU