### PR TITLE
test(mcp): verify concurrent same-server call_tool correlates by JSON-RPC id (#148)

### DIFF
--- a/crates/infra/bamboo-mcp/src/protocol/client.rs
+++ b/crates/infra/bamboo-mcp/src/protocol/client.rs
@@ -459,17 +459,19 @@ mod tests {
         connected: bool,
         message_rx: TokioMutex<Option<mpsc::Receiver<String>>>,
         response_tx: mpsc::Sender<String>,
-        delay_ms: u64,
+        /// Base reply delay; the per-request delay is `base - n*5` (see `send`),
+        /// so it must exceed `max_n * 5` to stay positive.
+        base_delay_ms: u64,
     }
 
     impl EchoTransport {
-        fn new(delay_ms: u64) -> Self {
+        fn new(base_delay_ms: u64) -> Self {
             let (tx, rx) = mpsc::channel(100);
             Self {
                 connected: false,
                 message_rx: TokioMutex::new(Some(rx)),
                 response_tx: tx,
-                delay_ms,
+                base_delay_ms,
             }
         }
     }
@@ -488,9 +490,13 @@ mod tests {
             let req: serde_json::Value = serde_json::from_str(&message).expect("valid request");
             let id = req["id"].clone();
             let tx = self.response_tx.clone();
-            let delay = self.delay_ms;
-            // Reply out-of-band (spawned) and delayed so the test only passes if
-            // responses are matched by id, not by arrival order.
+            // Reply time is INVERTED vs. submission order: a higher `n` gets a
+            // shorter delay, so the LAST-issued request's response arrives FIRST.
+            // This forces a deterministically reversed arrival order, so a
+            // (hypothetical, buggy) match-by-arrival-order implementation would
+            // fail here — not just pass by coincidence of scheduling. #148.
+            let n = req["params"]["n"].as_u64().unwrap_or(0);
+            let delay = self.base_delay_ms.saturating_sub(n * 5);
             tokio::spawn(async move {
                 if delay > 0 {
                     tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
@@ -522,8 +528,9 @@ mod tests {
         // request by JSON-RPC id — even when replies arrive out of order — rather
         // than reading "the next line". A crossed id would mis-route or time out;
         // the stdin Mutex (transports/stdio.rs) also keeps concurrent writes from
-        // interleaving on the wire.
-        let mut client = McpProtocolClient::new(Box::new(EchoTransport::new(30)));
+        // interleaving on the wire. Base 100ms − n*5 keeps all 16 delays positive
+        // (100..25) while reversing arrival order (see EchoTransport::send).
+        let mut client = McpProtocolClient::new(Box::new(EchoTransport::new(100)));
         client.connect().await.expect("connect");
         let client = Arc::new(client);
 

--- a/crates/infra/bamboo-mcp/src/protocol/client.rs
+++ b/crates/infra/bamboo-mcp/src/protocol/client.rs
@@ -452,6 +452,106 @@ mod tests {
         }
     }
 
+    // Echo transport: replies to each request with a response carrying the SAME
+    // JSON-RPC id after a delay, simulating a real stdio server that multiplexes
+    // concurrent requests over one pipe and may reply out of order. #148.
+    struct EchoTransport {
+        connected: bool,
+        message_rx: TokioMutex<Option<mpsc::Receiver<String>>>,
+        response_tx: mpsc::Sender<String>,
+        delay_ms: u64,
+    }
+
+    impl EchoTransport {
+        fn new(delay_ms: u64) -> Self {
+            let (tx, rx) = mpsc::channel(100);
+            Self {
+                connected: false,
+                message_rx: TokioMutex::new(Some(rx)),
+                response_tx: tx,
+                delay_ms,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl McpTransport for EchoTransport {
+        async fn connect(&mut self) -> Result<()> {
+            self.connected = true;
+            Ok(())
+        }
+        async fn disconnect(&mut self) -> Result<()> {
+            self.connected = false;
+            Ok(())
+        }
+        async fn send(&self, message: String) -> Result<()> {
+            let req: serde_json::Value = serde_json::from_str(&message).expect("valid request");
+            let id = req["id"].clone();
+            let tx = self.response_tx.clone();
+            let delay = self.delay_ms;
+            // Reply out-of-band (spawned) and delayed so the test only passes if
+            // responses are matched by id, not by arrival order.
+            tokio::spawn(async move {
+                if delay > 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                }
+                let resp = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": { "echoed_id": id },
+                });
+                let _ = tx.send(resp.to_string()).await;
+            });
+            Ok(())
+        }
+        async fn take_message_receiver(&self) -> Option<mpsc::Receiver<String>> {
+            self.message_rx.lock().await.take()
+        }
+        async fn receive(&self) -> Result<Option<String>> {
+            Err(McpError::Disconnected)
+        }
+        fn is_connected(&self) -> bool {
+            self.connected
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_same_server_requests_correlate_by_id() {
+        // #148: serve_mcp_proxy (post-#144) issues N CONCURRENT call_tool to the
+        // SAME stdio server. Verify the client correlates each response to its own
+        // request by JSON-RPC id — even when replies arrive out of order — rather
+        // than reading "the next line". A crossed id would mis-route or time out;
+        // the stdin Mutex (transports/stdio.rs) also keeps concurrent writes from
+        // interleaving on the wire.
+        let mut client = McpProtocolClient::new(Box::new(EchoTransport::new(30)));
+        client.connect().await.expect("connect");
+        let client = Arc::new(client);
+
+        let mut handles = Vec::new();
+        for i in 0..16u64 {
+            let c = Arc::clone(&client);
+            handles.push(tokio::spawn(async move {
+                c.send_request("tools/call", Some(serde_json::json!({ "n": i })), 2000)
+                    .await
+                    .expect("concurrent request should succeed")
+            }));
+        }
+        for handle in handles {
+            let resp = handle.await.expect("task join");
+            // The echoed id in the result MUST equal this response's own request id.
+            let echoed = resp
+                .result
+                .as_ref()
+                .and_then(|r| r.get("echoed_id"))
+                .and_then(|v| v.as_u64());
+            assert_eq!(
+                echoed,
+                Some(resp.id),
+                "each concurrent response must carry its OWN request id"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_client_new() {
         let transport = Box::new(MockTransport::new());


### PR DESCRIPTION
Closes #148 (a "verify concurrency-safety" follow-up to #144).

## Verification result: already safe
#144 made `serve_mcp_proxy` process `McpRequest`s concurrently, so N proxy tasks can issue N concurrent `McpServerManager::call_tool` to the **same** stdio `server_id` (one child process, one stdin/stdout pipe). I traced both concerns raised in the issue:

1. **Response correlation** — `McpProtocolClient` registers each request in a `HashMap<u64, PendingRequest>` keyed by JSON-RPC `id` and the background handler matches responses by `response.id` (`client.rs`), **not** by reading "the next line". So concurrent, out-of-order replies route to the correct caller.
2. **Write interleaving** — the stdio transport's `send` acquires the child's `Arc<Mutex<ChildStdin>>` before `write_all` (`transports/stdio.rs:184`), so two concurrent writes serialize and can't corrupt frames on the wire.

So no code fix is needed — the design already correlates by id and serializes writes.

## What this adds
#144 introduced the concurrent path but the backend-level guarantee had no regression test (its test was at the `serve_mcp_proxy` layer). This adds one:
- An `EchoTransport` that replies to each request with a response carrying **its own id**, after a delay, **out of order** — mimicking a real multiplexing stdio server.
- `concurrent_same_server_requests_correlate_by_id`: fires **16 concurrent** `send_request`s and asserts every response's echoed id equals its own request id. A crossed id (the failure mode) would mis-route or time out.

162 `bamboo-mcp` tests pass; clippy clean.

(The issue's two LOW notes — an unbounded-spawn global `Semaphore` cap and a backend-call timeout on flapping connections — are separate robustness follow-ups, not concurrency-correctness, and are left out of scope here.)

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU