### PR TITLE
fix(llm): tighten reasoning-unsupported error heuristic (#237 finding 5)

### DIFF
--- a/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
@@ -113,20 +113,9 @@ impl AnthropicProvider {
     }
 
     fn looks_like_reasoning_unsupported_error(status: reqwest::StatusCode, body: &str) -> bool {
-        if !(status == 400 || status == 404 || status == 405 || status == 409 || status == 422) {
-            return false;
-        }
-
-        let b = body.to_ascii_lowercase();
-        let mentions_reasoning = b.contains("reasoning")
-            || b.contains("thinking")
-            || b.contains("budget_tokens")
-            || b.contains("unknown parameter");
-        let mentions_unsupported = b.contains("unsupported")
-            || b.contains("not supported")
-            || b.contains("unknown")
-            || b.contains("invalid");
-        mentions_reasoning && mentions_unsupported
+        // Shared, tightened heuristic (#237 finding 5). `budget_tokens` (Anthropic's
+        // thinking-budget param) is in the shared reasoning-token set.
+        crate::providers::common::looks_like_reasoning_unsupported_error(status, body)
     }
 }
 

--- a/crates/infra/bamboo-llm/src/providers/common/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/mod.rs
@@ -31,10 +31,10 @@ pub(crate) fn looks_like_reasoning_unsupported_error(
     // Union of every provider's reasoning/thinking parameter name. `thinking`
     // substring-covers Gemini's `thinkingBudget`/`thinkingConfig`; `budget_tokens`
     // is Anthropic's. A provider's error body won't contain another's token.
-    let mentions_reasoning = b.contains("reasoning")
-        || b.contains("reasoning_effort")
-        || b.contains("thinking")
-        || b.contains("budget_tokens");
+    // `reasoning` already substring-covers `reasoning_effort`; `thinking` covers
+    // Gemini's `thinkingBudget`/`thinkingConfig`; `budget_tokens` is Anthropic's.
+    let mentions_reasoning =
+        b.contains("reasoning") || b.contains("thinking") || b.contains("budget_tokens");
     let indicates_unsupported = b.contains("unsupported")
         || b.contains("not supported")
         || b.contains("does not support")

--- a/crates/infra/bamboo-llm/src/providers/common/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/mod.rs
@@ -8,3 +8,71 @@ pub mod responses_debug;
 pub mod sse;
 pub mod stream_tool_accumulator;
 pub mod tool_schema;
+
+/// Whether an error response means the model/endpoint doesn't support the
+/// reasoning/thinking parameter, so a retry with reasoning stripped is warranted.
+///
+/// Tightened over the original co-occurrence heuristic (#237, finding 5): it must
+/// mention an actual reasoning token (`reasoning` / `reasoning_effort` /
+/// `thinking`) AND a parameter-REJECTION phrasing. The old version counted a bare
+/// `"unknown parameter"` as a reasoning mention (it fires for ANY rejected param,
+/// e.g. `temperature`) and a bare `"invalid"` / `"unknown"` as the unsupported
+/// signal — so an unrelated validation error was misclassified and the request
+/// silently retried with reasoning stripped, yielding a lower-quality answer.
+/// Bare `"invalid"` (usually a bad-VALUE error, not "unsupported") is excluded.
+pub(crate) fn looks_like_reasoning_unsupported_error(
+    status: reqwest::StatusCode,
+    body: &str,
+) -> bool {
+    if !(status == 400 || status == 404 || status == 405 || status == 409 || status == 422) {
+        return false;
+    }
+    let b = body.to_ascii_lowercase();
+    // Union of every provider's reasoning/thinking parameter name. `thinking`
+    // substring-covers Gemini's `thinkingBudget`/`thinkingConfig`; `budget_tokens`
+    // is Anthropic's. A provider's error body won't contain another's token.
+    let mentions_reasoning = b.contains("reasoning")
+        || b.contains("reasoning_effort")
+        || b.contains("thinking")
+        || b.contains("budget_tokens");
+    let indicates_unsupported = b.contains("unsupported")
+        || b.contains("not supported")
+        || b.contains("does not support")
+        || b.contains("unknown parameter")
+        || b.contains("unexpected parameter")
+        || b.contains("unrecognized")
+        || b.contains("invalid parameter");
+    mentions_reasoning && indicates_unsupported
+}
+
+#[cfg(test)]
+mod reasoning_heuristic_tests {
+    use super::looks_like_reasoning_unsupported_error as f;
+    use reqwest::StatusCode;
+
+    #[test]
+    fn fires_only_on_reasoning_parameter_rejection() {
+        let bad = StatusCode::BAD_REQUEST;
+        // Genuine "reasoning is unsupported" → strip-and-retry is right.
+        assert!(f(bad, "reasoning_effort is not supported for this model"));
+        assert!(f(bad, "Unknown parameter: reasoning_effort"));
+        assert!(f(bad, "This model does not support reasoning"));
+        assert!(f(bad, "Unrecognized request argument: thinking"));
+
+        // Unrelated validation errors must NOT be misread as reasoning-unsupported
+        // (the #237-5 false positives that silently degraded answers).
+        assert!(!f(bad, "Unknown parameter: temperature")); // different param
+        assert!(!f(
+            bad,
+            "Invalid value for 'reasoning_effort': must be one of low, medium, high"
+        )); // bad VALUE, not unsupported
+        assert!(!f(bad, "Invalid request: missing required field 'messages'"));
+        assert!(!f(bad, "The model gpt-x is unknown or unsupported")); // model, not reasoning
+
+        // Only the listed 4xx statuses qualify.
+        assert!(!f(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "reasoning not supported"
+        ));
+    }
+}

--- a/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
@@ -488,20 +488,8 @@ impl CopilotProvider {
     }
 
     fn looks_like_reasoning_unsupported_error(status: reqwest::StatusCode, body: &str) -> bool {
-        if !(status == 400 || status == 404 || status == 405 || status == 409 || status == 422) {
-            return false;
-        }
-
-        let b = body.to_ascii_lowercase();
-        let mentions_reasoning = b.contains("reasoning")
-            || b.contains("reasoning_effort")
-            || b.contains("thinking")
-            || b.contains("unknown parameter");
-        let mentions_unsupported = b.contains("unsupported")
-            || b.contains("not supported")
-            || b.contains("unknown")
-            || b.contains("invalid");
-        mentions_reasoning && mentions_unsupported
+        // Shared, tightened heuristic (#237 finding 5).
+        crate::providers::common::looks_like_reasoning_unsupported_error(status, body)
     }
 
     fn looks_like_previous_response_id_unsupported_error(

--- a/crates/infra/bamboo-llm/src/providers/gemini/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/gemini/mod.rs
@@ -124,21 +124,9 @@ impl GeminiProvider {
     }
 
     fn looks_like_reasoning_unsupported_error(status: reqwest::StatusCode, body: &str) -> bool {
-        if !(status == 400 || status == 404 || status == 405 || status == 409 || status == 422) {
-            return false;
-        }
-
-        let b = body.to_ascii_lowercase();
-        let mentions_reasoning = b.contains("reasoning")
-            || b.contains("thinking")
-            || b.contains("thinkingbudget")
-            || b.contains("thinkingconfig")
-            || b.contains("unknown parameter");
-        let mentions_unsupported = b.contains("unsupported")
-            || b.contains("not supported")
-            || b.contains("unknown")
-            || b.contains("invalid");
-        mentions_reasoning && mentions_unsupported
+        // Shared, tightened heuristic (#237 finding 5). `thinking` substring covers
+        // Gemini's thinkingBudget/thinkingConfig.
+        crate::providers::common::looks_like_reasoning_unsupported_error(status, body)
     }
 }
 

--- a/crates/infra/bamboo-llm/src/providers/openai/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/openai/mod.rs
@@ -144,20 +144,8 @@ impl OpenAIProvider {
     }
 
     fn looks_like_reasoning_unsupported_error(status: reqwest::StatusCode, body: &str) -> bool {
-        if !(status == 400 || status == 404 || status == 405 || status == 409 || status == 422) {
-            return false;
-        }
-
-        let b = body.to_ascii_lowercase();
-        let mentions_reasoning = b.contains("reasoning")
-            || b.contains("reasoning_effort")
-            || b.contains("thinking")
-            || b.contains("unknown parameter");
-        let mentions_unsupported = b.contains("unsupported")
-            || b.contains("not supported")
-            || b.contains("unknown")
-            || b.contains("invalid");
-        mentions_reasoning && mentions_unsupported
+        // Shared, tightened heuristic (#237 finding 5).
+        crate::providers::common::looks_like_reasoning_unsupported_error(status, body)
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## What

Fixes finding 5 from the #237 review of the LLM provider layer: the per-provider `looks_like_reasoning_unsupported_error` heuristic is over-broad and misclassifies unrelated validation errors as "this model doesn't support reasoning", causing a silent retry with reasoning stripped (a degraded answer with no signal to the caller).

The old co-occurrence logic (duplicated verbatim across openai/copilot/gemini/anthropic) counted:
- a bare `"unknown parameter"` as a **reasoning** mention — but that phrase fires for ANY rejected param (e.g. `temperature`);
- a bare `"invalid"` / `"unknown"` as the **unsupported** signal — so a bad-*value* error (`Invalid value for 'reasoning_effort': must be one of ...`) was misread as unsupported.

## Change

- DRY-extract a single `pub(crate) fn looks_like_reasoning_unsupported_error` into `providers/common/mod.rs`; the four providers now delegate to it (removing ~60 lines of duplication).
- **Reasoning side** requires a genuine reasoning token: `reasoning` / `reasoning_effort` / `thinking` / `budget_tokens` (union across providers; `thinking` substring-covers Gemini's `thinkingBudget`/`thinkingConfig`, `budget_tokens` is Anthropic's). No longer counts a bare `"unknown parameter"`.
- **Unsupported side** requires parameter-rejection phrasing: `unknown parameter` / `unexpected parameter` / `unrecognized` / `not supported` / `does not support` / `invalid parameter`. No longer counts a bare `"invalid"` / `"unknown"`.

## Test

Adds `reasoning_heuristic_tests` covering the true positives *and* the previously-misclassified false positives:
- fires on: `reasoning_effort is not supported`, `Unknown parameter: reasoning_effort`, `does not support reasoning`, `Unrecognized request argument: thinking`
- does NOT fire on: `Unknown parameter: temperature`, `Invalid value for 'reasoning_effort': ...` (bad value), `missing required field 'messages'`, `model gpt-x is unknown or unsupported`, or any 5xx.

`cargo build/test/clippy -p bamboo-llm` all green (the one remaining clippy warning is a pre-existing unused import in `prompt_ir.rs`, untouched here).

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU