### PR TITLE
test(subagent): bypass permission in actor-spawn e2e (SubAgent create now gated by #402)

### DIFF
--- a/tests/subagent_actor_via_server.rs
+++ b/tests/subagent_actor_via_server.rs
@@ -81,6 +81,12 @@ async fn subagent_create_runs_actor_process_through_the_server() {
     };
     let mut ctx = ToolExecutionContext::none("t1");
     ctx.session_id = Some(parent_id);
+    // `SubAgent create` is now permission-classified (spawns a child agent
+    // process — see #395/#402), so through the real executor it requires an
+    // approval that a non-interactive test has no sink for and it fails closed.
+    // This test exercises the actor-spawn WIRING, not the permission gate, so we
+    // run it under bypass (the gate is covered by bamboo-permission's own tests).
+    ctx.bypass_permissions = true;
     let result = tools
         .execute_with_context(&call, ctx)
         .await
@@ -217,6 +223,12 @@ async fn cancel_running_actor_child_through_the_server() {
     };
     let mut ctx = ToolExecutionContext::none("t1");
     ctx.session_id = Some(parent_id);
+    // `SubAgent create` is now permission-classified (spawns a child agent
+    // process — see #395/#402), so through the real executor it requires an
+    // approval that a non-interactive test has no sink for and it fails closed.
+    // This test exercises the actor-spawn WIRING, not the permission gate, so we
+    // run it under bypass (the gate is covered by bamboo-permission's own tests).
+    ctx.bypass_permissions = true;
     let result = tools.execute_with_context(&create, ctx).await.unwrap();
     assert!(result.success, "create failed: {}", result.result);
     let child_id = serde_json::from_str::<serde_json::Value>(&result.result).unwrap()


### PR DESCRIPTION
## Problem
`#402` (implementing `#395`) permission-classifies `SubAgent create` as a compute-spinning action requiring approval. The root-package e2e `subagent_create_runs_actor_process_through_the_server` drives the tool through the **real executor** (`execute_with_context`), so after #402 the create requires an approval sink the non-interactive test doesn't have — it fails closed with `Execution("Permission approval required for: SubAgent create")`.

This turned **main's Test job red**. It first surfaced on PRs whose CI *merge-ref* included #402 (#401, #403); it does not reproduce on branches forked before #402, which is why it looked like a flake at first. Reproduced deterministically on current main and confirmed fixed by this change.

## Fix
This test verifies the actor-spawn **wiring** (spawn → fabric self-register → WS echo → write-back → persist), not the permission gate, so run it under `bypass_permissions = true`. The gate itself is covered by `bamboo-permission`'s own unit tests. Applied to the `#[ignore]`d sibling too so it won't reintroduce the break when un-ignored.

Sibling e2e `deploy_agent_tool_e2e.rs` is unaffected — it calls `tool.invoke()` directly, bypassing the executor gate.

## Verify
- Reproduced the failure on current main (`Permission approval required for: SubAgent create`).
- With the fix: `cargo test --test subagent_actor_via_server --all-features` → `1 passed; 0 failed` (full 4.1s spawn round-trip).
- `cargo fmt -- --check` clean.

Refs #395 #402