### PR TITLE
fix(llm): serialize + atomic-write copilot token cache (#237 finding 2)

### DIFF
--- a/crates/infra/bamboo-llm/src/providers/copilot/auth/handler.rs
+++ b/crates/infra/bamboo-llm/src/providers/copilot/auth/handler.rs
@@ -56,6 +56,7 @@ use anyhow::anyhow;
 use reqwest::StatusCode;
 use reqwest_middleware::ClientWithMiddleware;
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::LazyLock;
 use std::{
     fs::{read_to_string, File},
@@ -247,6 +248,75 @@ mod tests {
             anyhow::Error::msg("Copilot token request failed: HTTP 503 - service unavailable");
         assert!(!CopilotAuthHandler::should_discard_access_token(&err_503));
     }
+
+    fn count_tmp_files(dir: &std::path::Path) -> usize {
+        std::fs::read_dir(dir)
+            .expect("read_dir")
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .ends_with(".tmp")
+            })
+            .count()
+    }
+
+    /// The atomic write must leave the cache readable and drop no temp litter.
+    #[test]
+    fn atomic_write_leaves_no_temp_file() {
+        let dir = tempdir().expect("tempdir");
+        let handler = CopilotAuthHandler::new(test_http_client(), dir.path().to_path_buf(), false);
+        let token_path = dir.path().join(".copilot_token.json");
+
+        handler
+            .write_cached_copilot_config(&token_path, &sample_config(1))
+            .expect("write cache");
+
+        assert!(handler.read_cached_copilot_config(&token_path).is_some());
+        assert_eq!(count_tmp_files(dir.path()), 0, "no .tmp files should remain");
+    }
+
+    /// Concurrent writers (the #237 401-burst scenario) must never leave the
+    /// cache torn: unique temp names + atomic rename mean the final file always
+    /// parses cleanly and no temp files are orphaned.
+    #[test]
+    fn concurrent_writes_never_corrupt_cache() {
+        let dir = tempdir().expect("tempdir");
+        let handler = Arc::new(CopilotAuthHandler::new(
+            test_http_client(),
+            dir.path().to_path_buf(),
+            false,
+        ));
+        let token_path = dir.path().join(".copilot_token.json");
+
+        let handles: Vec<_> = (0..8u64)
+            .map(|i| {
+                let handler = Arc::clone(&handler);
+                let token_path = token_path.clone();
+                std::thread::spawn(move || {
+                    for _ in 0..25 {
+                        handler
+                            .write_cached_copilot_config(&token_path, &sample_config(i))
+                            .expect("write cache");
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("join");
+        }
+
+        // Final file must parse (never a partial write).
+        assert!(
+            handler.read_cached_copilot_config(&token_path).is_some(),
+            "cache must be a complete, parseable file after concurrent writes"
+        );
+        assert_eq!(
+            count_tmp_files(dir.path()),
+            0,
+            "no orphaned .tmp files after concurrent writes"
+        );
+    }
 }
 
 /// API endpoint configuration for Copilot services.
@@ -336,9 +406,18 @@ impl AccessTokenResponse {
 // across the entire application. This prevents race conditions where multiple
 // concurrent requests could trigger separate authentication flows.
 //
-// The lock is acquired in `CopilotAuthHandler::get_chat_token` before
-// attempting silent authentication or starting a new device flow.
+// The lock is acquired by every public token entry point — `get_chat_token`,
+// `try_get_chat_token_silent`, and `force_refresh_chat_token` — before touching
+// the upstream exchange or the `.copilot_token.json` cache. Without this, a 401
+// burst let N concurrent `force_refresh_chat_token` calls each run a fresh
+// GitHub token exchange (thundering herd) and each racingly rewrite the cache
+// file (#237). The internal `*_locked` helpers assume the lock is already held.
 static CHAT_TOKEN_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+// Monotonic sequence used only to give each atomic cache write a unique temp
+// filename (combined with the process id), so overlapping writers never share a
+// temp path.
+static CACHE_WRITE_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// Handler for GitHub Copilot authentication.
 ///
@@ -537,8 +616,9 @@ impl CopilotAuthHandler {
         // Acquire global lock to ensure sequential execution
         let _guard = CHAT_TOKEN_LOCK.lock().await;
 
-        // Try silent authentication first
-        if let Some(token) = self.try_get_chat_token_silent().await? {
+        // Try silent authentication first (lock already held; use the inner
+        // helper to avoid re-locking the non-reentrant mutex).
+        if let Some(token) = self.try_get_chat_token_silent_locked().await? {
             return Ok(token);
         }
 
@@ -613,8 +693,37 @@ impl CopilotAuthHandler {
         copilot_config: &CopilotConfig,
     ) -> anyhow::Result<()> {
         let serialized = serde_json::to_string(copilot_config)?;
-        let mut file = File::create(token_path)?;
-        file.write_all(serialized.as_bytes())?;
+
+        // Atomic write: serialize into a uniquely-named temp file in the same
+        // directory, flush it, then rename over the target. A concurrent reader
+        // then always observes either the old or the new COMPLETE file, never a
+        // torn/partial one. The previous `File::create` truncated-then-wrote in
+        // place, so a reader could parse a half-written file, fail, and trigger a
+        // spurious re-exchange. (#237)
+        let dir = token_path
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| PathBuf::from("."));
+        let tmp_path = dir.join(format!(
+            ".copilot_token.{}.{}.tmp",
+            std::process::id(),
+            CACHE_WRITE_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+
+        let write_tmp = || -> std::io::Result<()> {
+            let mut file = File::create(&tmp_path)?;
+            file.write_all(serialized.as_bytes())?;
+            file.sync_all()?;
+            Ok(())
+        };
+        if let Err(e) = write_tmp() {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(e.into());
+        }
+        if let Err(e) = std::fs::rename(&tmp_path, token_path) {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(e.into());
+        }
         Ok(())
     }
 
@@ -866,6 +975,15 @@ impl CopilotAuthHandler {
     /// # }
     /// ```
     pub async fn try_get_chat_token_silent(&self) -> anyhow::Result<Option<String>> {
+        // Serialize with every other token operation so a silent exchange can't
+        // race a concurrent refresh's cache write (#237).
+        let _guard = CHAT_TOKEN_LOCK.lock().await;
+        self.try_get_chat_token_silent_locked().await
+    }
+
+    /// Lock-free core of [`Self::try_get_chat_token_silent`]. The caller MUST
+    /// already hold `CHAT_TOKEN_LOCK`.
+    async fn try_get_chat_token_silent_locked(&self) -> anyhow::Result<Option<String>> {
         let copilot_token_path = self.app_data_dir.join(".copilot_token.json");
 
         // Check cached copilot token
@@ -916,6 +1034,31 @@ impl CopilotAuthHandler {
     /// - `Ok(Some(token))` if the refresh succeeded
     /// - `Ok(None)` if no cached access token exists
     pub async fn force_refresh_chat_token(&self) -> anyhow::Result<Option<String>> {
+        let copilot_token_path = self.app_data_dir.join(".copilot_token.json");
+
+        // Snapshot the cached token BEFORE contending for the lock, so that after
+        // we acquire it we can tell whether another caller already refreshed the
+        // token while we waited. On a 401 burst this collapses N upstream
+        // exchanges into one. (#237)
+        let pre_token = self
+            .read_cached_copilot_config(&copilot_token_path)
+            .map(|c| c.token);
+
+        // Serialize the exchange + cache write. Without this, concurrent callers
+        // each hit GitHub and each rewrite the cache file simultaneously.
+        let _guard = CHAT_TOKEN_LOCK.lock().await;
+
+        // Double-checked: if the cached token changed while we were blocked and
+        // is now valid, another caller already performed the refresh — reuse it
+        // instead of exchanging again. We only reuse a token that DIFFERS from
+        // the one we saw pre-lock, so we never hand back the rejected token that
+        // prompted this refresh.
+        if let Some(cached) = self.read_cached_copilot_config(&copilot_token_path) {
+            if self.is_copilot_token_valid(&cached) && Some(&cached.token) != pre_token.as_ref() {
+                return Ok(Some(cached.token));
+            }
+        }
+
         let token_path = self.app_data_dir.join(".token");
         let Some(access_token_str) = Self::read_access_token(&token_path) else {
             return Ok(None);
@@ -924,7 +1067,6 @@ impl CopilotAuthHandler {
         let access_token = AccessTokenResponse::from_token(access_token_str);
         match self.get_copilot_token(access_token).await {
             Ok(copilot_config) => {
-                let copilot_token_path = self.app_data_dir.join(".copilot_token.json");
                 self.write_cached_copilot_config(&copilot_token_path, &copilot_config)?;
                 Ok(Some(copilot_config.token))
             }

--- a/crates/infra/bamboo-llm/src/providers/copilot/auth/handler.rs
+++ b/crates/infra/bamboo-llm/src/providers/copilot/auth/handler.rs
@@ -1390,6 +1390,11 @@ mod retry_tests {
             _extensions: &mut http::Extensions,
             _next: Next<'_>,
         ) -> MiddlewareResult<reqwest::Response> {
+            // Yield once so concurrent callers (e.g. the dedup test) get a chance
+            // to interleave instead of each running to completion within a single
+            // poll. Harmless for the sequential tests.
+            tokio::task::yield_now().await;
+
             assert_eq!(
                 req.method(),
                 &self.expected_method,
@@ -1584,6 +1589,93 @@ mod retry_tests {
         let result = handler.get_copilot_token(access_token).await;
         assert!(result.is_err());
         assert_eq!(request_count.load(Ordering::SeqCst), 1);
+    }
+
+    /// A full Copilot token-exchange success reply, valid for one hour.
+    fn copilot_token_reply(token: &str) -> MockReply {
+        MockReply::json(
+            200,
+            serde_json::json!({
+                "token": token,
+                "expires_at": (SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() + 3600),
+                "annotations_enabled": true,
+                "chat_enabled": true,
+                "chat_jetbrains_enabled": false,
+                "code_quote_enabled": true,
+                "code_review_enabled": false,
+                "codesearch": false,
+                "copilotignore_enabled": true,
+                "endpoints": { "api": "https://api.githubcopilot.com" },
+                "individual": true,
+                "prompt_8k": true,
+                "public_suggestions": "disabled",
+                "refresh_in": 300,
+                "sku": "copilot_individual",
+                "snippy_load_test_enabled": false,
+                "telemetry": "disabled",
+                "tracking_id": "test-tracking-id",
+                "vsc_electron_fetcher_v2": true,
+                "xcode": false,
+                "xcode_chat": false
+            }),
+        )
+    }
+
+    /// #237 finding 2 headline: a burst of concurrent `force_refresh_chat_token`
+    /// calls (the 401-retry paths in `copilot/mod.rs`) must collapse into a
+    /// single upstream token exchange, not one per caller.
+    ///
+    /// Deterministic under the current-thread test runtime: every caller reads
+    /// the seeded pre-lock token before the first exchange's `.await` resolves,
+    /// so all but the first take the double-checked dedup fast-path.
+    #[tokio::test]
+    async fn force_refresh_collapses_concurrent_calls_to_one_exchange() {
+        use futures::future::join_all;
+
+        let request_count = Arc::new(AtomicUsize::new(0));
+        // Queue more replies than callers: if dedup regressed, the extra
+        // exchanges would be served here and the count assertion below would
+        // catch it (rather than panicking on an empty queue).
+        let mock = MockResponder::new(
+            Method::GET,
+            "/copilot_internal/v2/token",
+            request_count.clone(),
+            (0..8).map(|_| copilot_token_reply("refreshed-token")).collect(),
+        );
+        let client = create_test_client_with_retry(mock);
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let handler = CopilotAuthHandler::new(client, temp_dir.path().to_path_buf(), true)
+            .with_github_api_base_url("http://mock.local");
+
+        // A cached GitHub access token lets force_refresh perform the exchange.
+        std::fs::write(temp_dir.path().join(".token"), "gh-access-token").expect("write .token");
+        // Seed a still-unexpired-but-rejected Copilot token so every caller
+        // snapshots the same pre-lock value.
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let mut seeded = sample_config(now + 3600);
+        seeded.token = "old-rejected-token".to_string();
+        handler
+            .write_cached_copilot_config(&temp_dir.path().join(".copilot_token.json"), &seeded)
+            .expect("seed cache");
+
+        let results = join_all((0..8).map(|_| handler.force_refresh_chat_token())).await;
+
+        for r in &results {
+            let token = r
+                .as_ref()
+                .expect("force_refresh ok")
+                .as_ref()
+                .expect("some token");
+            assert_eq!(token, "refreshed-token");
+        }
+        assert_eq!(
+            request_count.load(Ordering::SeqCst),
+            1,
+            "concurrent force-refresh must collapse to a single upstream exchange"
+        );
     }
 
     /// Test device code endpoint retry.


### PR DESCRIPTION
## What

Fixes finding 2 of #237 (Med): the Copilot token silent-get / force-refresh paths bypass the token lock, so a 401 burst causes a thundering herd of GitHub token exchanges plus racing non-atomic cache writes that transiently corrupt `.copilot_token.json`.

`try_get_chat_token_silent` (`handler.rs`) and `force_refresh_chat_token` did **not** take `CHAT_TOKEN_LOCK` — only `get_chat_token` did. `force_refresh_chat_token` is called on **5** 401/403 retry paths in `copilot/mod.rs` with no lock held. On a burst, each concurrent call:
1. runs a fresh GitHub → Copilot token exchange (thundering herd), and
2. rewrites `.copilot_token.json` via `File::create` (truncate-then-write) — a racing reader can parse a half-written file, fail (swallowed to `None`), and trigger *yet another* exchange.

## Change

- **Serialize**: both public methods now acquire `CHAT_TOKEN_LOCK`. To avoid re-locking the non-reentrant tokio mutex, `get_chat_token` and the new lock-free `try_get_chat_token_silent_locked` share the inner body.
- **Dedup the herd**: `force_refresh_chat_token` snapshots the cached token *before* contending for the lock, then double-checks after acquiring it — if the token changed while blocked and is now valid, another caller already refreshed it, so we reuse it instead of exchanging again. The reuse only fires when the token **differs** from the pre-lock snapshot, so the rejected token that prompted the refresh is never handed back. A 401 burst collapses to a single exchange.
- **Atomic write**: `write_cached_copilot_config` writes to a uniquely-named temp file (pid + atomic counter) in the same dir, `sync_all`s, then `rename`s over the target. A concurrent reader always observes a complete old-or-new file, never a torn one.

## Tests

- `atomic_write_leaves_no_temp_file` — cache reads back, zero `.tmp` litter.
- `concurrent_writes_never_corrupt_cache` — 8 threads × 25 writes; the final file always parses and no temp files are orphaned.

`cargo build/test/clippy -p bamboo-llm` green (the one remaining clippy warning is a pre-existing unused import in `prompt_ir.rs`, untouched here).

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU