### PR TITLE
test(memory): verify same-doc concurrency guarantee + correct stale note (#176)

### DIFF
--- a/crates/infra/bamboo-memory/src/memory_store/store.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/store.rs
@@ -178,11 +178,12 @@ impl MemoryStore {
     /// scope are serialized — the scope index/artifacts can never be left
     /// half-written or inconsistent (the #32 corruption).
     ///
-    /// NOTE: the five resolve-then-lock methods (archive/split/consolidate/
-    /// contradict/merge) read the target document BEFORE acquiring the lock, so two
-    /// concurrent edits to the SAME memory id can still lose one update (the second
-    /// writes back its pre-lock snapshot). Index consistency is unaffected; a
-    /// re-read-under-lock would close that same-doc window — tracked as a follow-up.
+    /// The five resolve-then-lock methods (archive/split/consolidate/contradict/
+    /// merge) resolve the target document once to find its scope, then RE-READ it
+    /// under the lock before mutating (#235), so two concurrent edits to the SAME
+    /// memory id can't lose an update: the second edit sees the first's committed
+    /// state rather than a stale pre-lock snapshot. See the
+    /// `concurrent_same_memory_edits_do_not_lose_updates` regression test.
     ///
     /// The registry holds one `Arc<Mutex<()>>` per distinct scope root forever
     /// (never evicted), which is negligible: a scope root is global / sessions /
@@ -4173,6 +4174,85 @@ mod tests {
             .unwrap()
             .expect("active doc exists");
         assert_eq!(active_doc.frontmatter.status, DurableMemoryStatus::Active);
+    }
+
+    /// #176 (#32 nit): the resolve-then-lock methods re-read the target under the
+    /// scope lock (#235), so two concurrent edits to the SAME memory id both
+    /// survive. Here two `mark_memory_contradicted` calls each append a DIFFERENT
+    /// source to `relations.contradicted_by`; without the re-read the second would
+    /// write back its pre-lock snapshot (list without the first's entry) and lose
+    /// one append. With it, both entries are present.
+    #[tokio::test]
+    async fn concurrent_same_memory_edits_do_not_lose_updates() {
+        let dir = tempdir().unwrap();
+        let store = MemoryStore::new(dir.path());
+
+        // Helper to create a Project-scoped memory and return its id.
+        async fn make(store: &MemoryStore, title: &str) -> String {
+            store
+                .write_memory(
+                    MemoryScope::Project,
+                    Some("proj-1"),
+                    DurableMemoryType::Reference,
+                    title,
+                    "Body.",
+                    &[],
+                    Some("s1"),
+                    "main-model",
+                    false,
+                    None,
+                )
+                .await
+                .unwrap()
+                .frontmatter
+                .id
+        }
+
+        // Target X, and two sources A and B (mark_memory_contradicted only records
+        // sources that exist in scope).
+        let target = make(&store, "Target fact").await;
+        let source_a = make(&store, "Contradicting fact A").await;
+        let source_b = make(&store, "Contradicting fact B").await;
+
+        // Two concurrent contradictions of the SAME target with DIFFERENT sources.
+        // They serialize on the scope lock; the re-read-under-lock is what keeps
+        // the second append from clobbering the first.
+        let (r1, r2) = tokio::join!(
+            store.mark_memory_contradicted(
+                &target,
+                Some("proj-1"),
+                std::slice::from_ref(&source_a),
+                Some("conflicts A"),
+                Some("s1"),
+                "main-model",
+            ),
+            store.mark_memory_contradicted(
+                &target,
+                Some("proj-1"),
+                std::slice::from_ref(&source_b),
+                Some("conflicts B"),
+                Some("s1"),
+                "main-model",
+            ),
+        );
+        r1.unwrap().expect("first contradiction applied");
+        r2.unwrap().expect("second contradiction applied");
+
+        // BOTH appends must survive regardless of which committed first.
+        let final_doc = store
+            .get_memory(&target, Some("proj-1"))
+            .await
+            .unwrap()
+            .expect("target exists");
+        let contradicted = &final_doc.frontmatter.relations.contradicted_by;
+        assert!(
+            contradicted.contains(&source_a),
+            "source A append lost (contradicted_by = {contradicted:?})"
+        );
+        assert!(
+            contradicted.contains(&source_b),
+            "source B append lost (contradicted_by = {contradicted:?})"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Closes out the **#32 item** of #176 (review-nits bundle): a same-document TOCTOU in the five resolve-then-lock memory methods (archive/split/consolidate/contradict/merge).

The nit: those methods resolved the target document *before* acquiring the scope lock, so two concurrent edits to the same memory id could lose one update (the second writes back its pre-lock snapshot). This was actually **already fixed** by the re-read-under-lock in #235 — but the `scope_lock` doc NOTE still described it as an open follow-up, misleading future readers into thinking the data-loss window is still open.

## Change

- **Correct the stale NOTE** to document the re-read-under-lock guarantee (all five methods re-read the target under the lock before mutating).
- **Add a regression test** `concurrent_same_memory_edits_do_not_lose_updates`: two concurrent `mark_memory_contradicted` calls append *different* sources to the same memory's `relations.contradicted_by`; both entries must survive.

## Verification

I confirmed the test is a genuine guard, not a vacuous pass: with the re-read temporarily removed it fails with `source B append lost (contradicted_by = [only A])`; restored, it passes. So it would catch a regression that reintroduced the pre-lock-snapshot write.

`cargo clippy/test -p bamboo-memory` green (123 lib tests).

## Scope

The other two #176 items remain: #80 (a headless approve-first-ordering test) and #106 (threading pre-parsed args through the overlay executor to avoid a double-parse). The #106 one is a non-trivial refactor better done on its own.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU