### PR TITLE
test(storage): make token-usage flake diagnosable, keep strict count (#378)

### DIFF
--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -1482,7 +1482,18 @@ mod tests {
 
         let contents = tokio::fs::read_to_string(&path).await?;
         let lines: Vec<&str> = contents.lines().collect();
-        assert_eq!(lines.len(), 2, "one line per appended record");
+        // Storage is a unique per-test TempDir and every path resolves off the
+        // instance `bamboo_home_dir` (not a process-global), so nothing outside
+        // this test can write here — exactly two sequential appends ⇒ two lines.
+        // If CI ever trips this again (#378), dump the file so the failure is
+        // diagnosable (extra line + its source, or a lost append) instead of an
+        // opaque count mismatch. Do NOT relax this to "records present": that
+        // would mask a real double-write / lost-write regression.
+        assert_eq!(
+            lines.len(),
+            2,
+            "one line per appended record; actual token-usage.jsonl = {contents:?}"
+        );
         assert!(lines[0].contains("\"round\":1"));
         assert!(lines[1].contains("\"round\":2"));
         // Each line is valid standalone JSON.


### PR DESCRIPTION
## Investigation

Ran down #378 (`append_token_usage_record_writes_jsonl_in_session_dir` failing `left == 2` under the full concurrent suite). The issue's hypothesized mechanism — a debug-build ambient `token_usage_log` emit adding extra lines — **cannot apply to this test**:

- `create_temp_storage()` roots the store at a **unique per-test `TempDir`**.
- Every path resolves off the **instance** `self.bamboo_home_dir` (`abs_path_from_rel`), never a process-global — so no concurrent test or process (in another crate's test binary) can write to this test's `token-usage.jsonl`.
- The ambient `token_usage_log` emitter lives in `bamboo-engine`, which isn't even linked into the `bamboo-storage` test binary.
- `save_session` **awaits** `upsert_index_from_session` before returning, and `resolve_rel_path` → `get_index_entry` reads the in-memory `RwLock<SessionsIndex>` — so the just-saved `"tu-1"` is always resolvable and neither append no-ops.

Two sequential awaited appends therefore deterministically produce exactly two lines. I could **not reproduce** in 27 stress runs (the test alone and the full `bamboo-storage --lib` suite at `RUST_TEST_THREADS=32`, ×12). The single CI failure was on the #376 hotfix run (first green compile in a while, heavy backlog-clearing load), consistent with a transient infra hiccup rather than a code race.

## Change

I deliberately did **not** relax the assertion to "the two records are present" (the issue's alternative) — with a unique temp path, extra lines are impossible, so that would only mask a genuine future double-write / lost-append regression. Instead, keep the strict `== 2` and **dump the actual file contents on failure**, so if CI ever trips this again the panic shows the extra line (and its JSON source) or the lost append — turning an opaque count mismatch into an actionable report.

`cargo test/clippy -p bamboo-storage` green.

If it recurs, the new message will pinpoint the direction (>2 vs <2) and content, which would reopen a concrete investigation.

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU