### PR TITLE
chore: restore cargo fmt compliance on main (6 drifted files)

### DIFF
--- a/crates/app/bamboo-server/src/config.rs
+++ b/crates/app/bamboo-server/src/config.rs
@@ -21,7 +21,9 @@
 
 use actix_cors::Cors;
 use actix_governor::governor::middleware::NoOpMiddleware;
-use actix_governor::{GovernorConfig, GovernorConfigBuilder, KeyExtractor, SimpleKeyExtractionError};
+use actix_governor::{
+    GovernorConfig, GovernorConfigBuilder, KeyExtractor, SimpleKeyExtractionError,
+};
 use actix_web::body::MessageBody;
 use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::http::header;
@@ -973,9 +975,7 @@ mod tests {
         let v4 = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
         assert_eq!(mask_ipv6_prefix(v4), v4);
 
-        let v6 = IpAddr::V6(Ipv6Addr::new(
-            0x2001, 0xdb8, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6,
-        ));
+        let v6 = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6));
         // /56: first 7 bytes preserved, remaining 9 zeroed.
         assert_eq!(
             mask_ipv6_prefix(v6),

--- a/crates/engine/bamboo-engine/src/auto_dream.rs
+++ b/crates/engine/bamboo-engine/src/auto_dream.rs
@@ -485,7 +485,10 @@ fn full_rebuild_marker_line(
     {
         format!("Last full rebuild at: {}\n", now.to_rfc3339())
     } else if let Some(existing_rebuild_at) = last_full_rebuild_at {
-        format!("Last full rebuild at: {}\n", existing_rebuild_at.to_rfc3339())
+        format!(
+            "Last full rebuild at: {}\n",
+            existing_rebuild_at.to_rfc3339()
+        )
     } else {
         String::new()
     }
@@ -648,8 +651,12 @@ async fn run_auto_dream_once_for_scope(
     };
     let notebook_body =
         build_dream_notebook_body(&bg_provider, &model, &source_window, generation_mode).await?;
-    let last_full_rebuild_line =
-        full_rebuild_marker_line(force_full_rebuild, generation_mode, last_full_rebuild_at, now);
+    let last_full_rebuild_line = full_rebuild_marker_line(
+        force_full_rebuild,
+        generation_mode,
+        last_full_rebuild_at,
+        now,
+    );
     let final_note = match scope {
         MemoryScope::Global => format!(
             "# Bamboo Dream Notebook\n\nLast consolidated at: {}\n{}Sessions reviewed: {}\nModel: {}\n\n{}\n",
@@ -799,7 +806,10 @@ mod tests {
         // must SEED the marker with `now`, so the 30-day periodic cadence has a
         // start point instead of never firing.
         let line = full_rebuild_marker_line(false, DreamGenerationMode::Rebuild, None, now);
-        assert_eq!(line, format!("Last full rebuild at: {}\n", now.to_rfc3339()));
+        assert_eq!(
+            line,
+            format!("Last full rebuild at: {}\n", now.to_rfc3339())
+        );
     }
 
     #[test]
@@ -810,12 +820,8 @@ mod tests {
         // Once seeded, an ordinary (non-forced) pass must PRESERVE the marker, not
         // reset it to `now` — otherwise the timer would restart every tick and the
         // periodic sweep would never come due.
-        let line = full_rebuild_marker_line(
-            false,
-            DreamGenerationMode::Rebuild,
-            Some(existing),
-            now,
-        );
+        let line =
+            full_rebuild_marker_line(false, DreamGenerationMode::Rebuild, Some(existing), now);
         assert_eq!(
             line,
             format!("Last full rebuild at: {}\n", existing.to_rfc3339())
@@ -830,7 +836,10 @@ mod tests {
         // The periodic forced pass re-stamps `now`, advancing the cadence.
         let line =
             full_rebuild_marker_line(true, DreamGenerationMode::Rebuild, Some(existing), now);
-        assert_eq!(line, format!("Last full rebuild at: {}\n", now.to_rfc3339()));
+        assert_eq!(
+            line,
+            format!("Last full rebuild at: {}\n", now.to_rfc3339())
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/common/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/mod.rs
@@ -66,7 +66,10 @@ mod reasoning_heuristic_tests {
             bad,
             "Invalid value for 'reasoning_effort': must be one of low, medium, high"
         )); // bad VALUE, not unsupported
-        assert!(!f(bad, "Invalid request: missing required field 'messages'"));
+        assert!(!f(
+            bad,
+            "Invalid request: missing required field 'messages'"
+        ));
         assert!(!f(bad, "The model gpt-x is unknown or unsupported")); // model, not reasoning
 
         // Only the listed 4xx statuses qualify.

--- a/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
@@ -438,8 +438,10 @@ mod tests {
         assert_eq!(out[1]["content"], "captured");
         assert_eq!(out[2]["role"], "user");
         let content = out[2]["content"].as_array().expect("array content");
-        assert!(content.iter().any(|p| p["type"] == "image_url"
-            && p["image_url"]["url"] == "data:image/png;base64,AAAA"));
+        assert!(content
+            .iter()
+            .any(|p| p["type"] == "image_url"
+                && p["image_url"]["url"] == "data:image/png;base64,AAAA"));
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
@@ -1854,8 +1854,9 @@ mod tests {
         );
         // ...and the image is preserved as an input_image part.
         assert!(
-            arr.iter().any(|p| p["type"] == "input_image"
-                && p["image_url"] == "data:image/png;base64,AAAA"),
+            arr.iter()
+                .any(|p| p["type"] == "input_image"
+                    && p["image_url"] == "data:image/png;base64,AAAA"),
             "image part missing: {output}"
         );
     }
@@ -1890,12 +1891,11 @@ mod tests {
         let arr = out[0]["content"]
             .as_array()
             .expect("fallback content should be a typed array");
+        assert!(arr.iter().any(|p| p["type"] == "input_text"
+            && p["text"].as_str().unwrap_or("").contains("[tool_result]")));
         assert!(arr
             .iter()
-            .any(|p| p["type"] == "input_text"
-                && p["text"].as_str().unwrap_or("").contains("[tool_result]")));
-        assert!(arr.iter().any(|p| p["type"] == "input_image"
-            && p["image_url"] == "data:image/png;base64,BBBB"));
+            .any(|p| p["type"] == "input_image" && p["image_url"] == "data:image/png;base64,BBBB"));
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/copilot/auth/handler.rs
+++ b/crates/infra/bamboo-llm/src/providers/copilot/auth/handler.rs
@@ -253,11 +253,7 @@ mod tests {
         std::fs::read_dir(dir)
             .expect("read_dir")
             .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.file_name()
-                    .to_string_lossy()
-                    .ends_with(".tmp")
-            })
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
             .count()
     }
 
@@ -273,7 +269,11 @@ mod tests {
             .expect("write cache");
 
         assert!(handler.read_cached_copilot_config(&token_path).is_some());
-        assert_eq!(count_tmp_files(dir.path()), 0, "no .tmp files should remain");
+        assert_eq!(
+            count_tmp_files(dir.path()),
+            0,
+            "no .tmp files should remain"
+        );
     }
 
     /// Concurrent writers (the #237 401-burst scenario) must never leave the
@@ -1640,7 +1640,9 @@ mod retry_tests {
             Method::GET,
             "/copilot_internal/v2/token",
             request_count.clone(),
-            (0..8).map(|_| copilot_token_reply("refreshed-token")).collect(),
+            (0..8)
+                .map(|_| copilot_token_reply("refreshed-token"))
+                .collect(),
         );
         let client = create_test_client_with_retry(mock);
         let temp_dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Problem
CI's **Lint** job (`cargo fmt -- --check`) has been failing on `main` because of accumulated formatting drift in 6 files — unformatted code that merged through the chronic-red Lint gate. This makes Lint red on **every** PR (observed while merging the #341–#347 series), obscuring real lint regressions.

Clippy is clean on main; the failure is purely `cargo fmt`.

## Fix
Ran `cargo fmt` (project rustfmt config). Minimal, mechanical, behavior-preserving diffs:
- `bamboo-server/src/config.rs` — wrap a long `use` + one-line an `Ipv6Addr::new`
- `bamboo-engine/src/auto_dream.rs`
- `bamboo-llm/src/providers/common/{mod,openai_compat,openai_responses}.rs`
- `bamboo-llm/src/providers/copilot/auth/handler.rs`

`cargo fmt -- --check` is clean after this. No behavior change.