### PR TITLE
fix(server): paginate/cap list endpoints + apply body limits on every serve path (#252)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/history.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/history.rs
@@ -8,6 +8,27 @@ use serde::Deserialize;
 
 use crate::app_state::AppState;
 
+/// Hard cap on the number of UI-visible messages a cold (non-delta) history
+/// fetch returns, so a pathological long-running session can't return an
+/// unbounded array (#252). The most recent messages are kept — the tail is what
+/// a chat UI renders first — and `truncated` is surfaced so a client knows
+/// earlier messages were dropped. A delta fetch is already bounded by its cursor
+/// and is never trimmed.
+const MAX_HISTORY_MESSAGES: usize = 2000;
+
+/// Cold-fetch cap for the history response: when returning a full (non-delta)
+/// history that exceeds [`MAX_HISTORY_MESSAGES`], drop the oldest overflow so
+/// only the newest `MAX_HISTORY_MESSAGES` remain. Returns whether it trimmed.
+fn cap_cold_history<T>(messages: &mut Vec<T>, is_delta: bool) -> bool {
+    if !is_delta && messages.len() > MAX_HISTORY_MESSAGES {
+        let drop = messages.len() - MAX_HISTORY_MESSAGES;
+        messages.drain(..drop);
+        true
+    } else {
+        false
+    }
+}
+
 #[derive(Debug, Default, Deserialize)]
 pub struct HistoryQuery {
     /// When set, return only UI-visible messages appended *after* the message
@@ -136,6 +157,13 @@ pub async fn handler(
         }
     }
 
+    // Bound a cold fetch: a session that never used the delta cursor would
+    // otherwise return its entire (unbounded) message history in one response
+    // (#252). The count *before* capping is reported so a client can tell it
+    // received a truncated tail.
+    let total_message_count = messages.len();
+    let truncated = cap_cold_history(&mut messages, is_delta);
+
     // Include the session-level gold config so the frontend can update its
     // local session summary after sync-recovery without an extra round-trip.
     let gold_config = session
@@ -156,6 +184,10 @@ pub async fn handler(
         "session_id": session_id,
         "messages": messages,
         "is_delta": is_delta,
+        // Whether the cold fetch dropped older messages to stay under the cap,
+        // and the pre-cap UI-visible count so a client can detect the gap (#252).
+        "truncated": truncated,
+        "total_message_count": total_message_count,
         "compression_events": session.compression_events
     });
 
@@ -174,6 +206,36 @@ pub async fn handler(
     }
 
     HttpResponse::Ok().json(response)
+}
+
+// Pure cold-fetch-cap unit test — kept in its own module that does NOT import
+// `actix_web::test`, so the built-in `#[test]` attribute isn't shadowed by the
+// actix test-macro re-export.
+#[cfg(test)]
+mod cold_cap_tests {
+    use super::{cap_cold_history, MAX_HISTORY_MESSAGES};
+
+    #[test]
+    fn cap_cold_history_trims_cold_fetch_to_newest() {
+        // A cold fetch over the cap keeps only the newest MAX_HISTORY_MESSAGES,
+        // preserving the tail and dropping the oldest overflow (#252).
+        let mut over: Vec<u32> = (0..(MAX_HISTORY_MESSAGES as u32 + 5)).collect();
+        let newest = *over.last().unwrap();
+        assert!(cap_cold_history(&mut over, false));
+        assert_eq!(over.len(), MAX_HISTORY_MESSAGES);
+        assert_eq!(*over.last().unwrap(), newest, "keeps the newest message");
+        assert_eq!(over[0], 5, "drops the oldest overflow");
+
+        // At/under the cap the cold fetch is untouched.
+        let mut small: Vec<u32> = (0..10).collect();
+        assert!(!cap_cold_history(&mut small, false));
+        assert_eq!(small.len(), 10);
+
+        // A delta fetch is never trimmed, even when large.
+        let mut delta: Vec<u32> = (0..(MAX_HISTORY_MESSAGES as u32 + 5)).collect();
+        assert!(!cap_cold_history(&mut delta, true));
+        assert_eq!(delta.len(), MAX_HISTORY_MESSAGES + 5);
+    }
 }
 
 #[cfg(test)]

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/query.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/query.rs
@@ -4,15 +4,39 @@ use actix_web::{web, HttpResponse, Result};
 
 use crate::app_state::AppState;
 
-use super::super::super::types::{GetSessionResponse, ListSessionsResponse, SessionSummary};
+use super::super::super::types::{
+    GetSessionResponse, ListSessionsQuery, ListSessionsResponse, SessionSummary,
+};
 use super::running::{is_session_running, running_session_ids};
 
+/// Default page size for `GET /api/v1/sessions` when the client omits `limit`.
+/// Deliberately generous so a typical client sees all of its recent sessions in
+/// one page, while still bounding the response so the list can't grow without
+/// limit as session count grows forever (#252).
+const DEFAULT_SESSIONS_PAGE: usize = 200;
+/// Hard cap on the page size, so a client-supplied `limit` can't force an
+/// unbounded read (mirrors the metrics `normalize_limit` clamp). (#252)
+const MAX_SESSIONS_PAGE: usize = 1000;
+
+/// Resolve the effective page size: the default when omitted, otherwise clamped
+/// to `1..=MAX_SESSIONS_PAGE`. Never unbounded. (#252)
+fn clamp_page_size(limit: Option<usize>) -> usize {
+    limit
+        .unwrap_or(DEFAULT_SESSIONS_PAGE)
+        .clamp(1, MAX_SESSIONS_PAGE)
+}
+
 /// `GET /api/v1/sessions`
-pub async fn list_sessions(state: web::Data<AppState>) -> Result<HttpResponse> {
+pub async fn list_sessions(
+    state: web::Data<AppState>,
+    query: web::Query<ListSessionsQuery>,
+) -> Result<HttpResponse> {
     let running = running_session_ids(&state).await;
     let entries = state.session_store.list_index_entries().await;
 
-    // Compute running child counts per parent session.
+    // Compute running child counts per parent session over the FULL set: a
+    // parent's running children may land on a different page, so this count must
+    // not be paginated or it would be wrong for parents shown on this page.
     let mut running_child_counts: HashMap<String, u32> = HashMap::new();
     for entry in &entries {
         if running.contains(&entry.id) {
@@ -22,17 +46,35 @@ pub async fn list_sessions(state: web::Data<AppState>) -> Result<HttpResponse> {
         }
     }
 
+    // Server-enforced pagination bounds the response so the list stays finite as
+    // session count grows (#252). `list_index_entries` is already sorted
+    // newest-first, giving a deterministic page order.
+    let total = entries.len();
+    let limit = clamp_page_size(query.limit);
+    let offset = query.offset.unwrap_or(0).min(total);
+
+    let sessions: Vec<SessionSummary> = entries
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .map(|entry| {
+            let is_running = running.contains(&entry.id);
+            let mut summary = SessionSummary::from_entry(entry, is_running);
+            summary.running_child_count =
+                running_child_counts.get(&summary.id).copied().unwrap_or(0);
+            summary
+        })
+        .collect();
+
+    let end = offset + sessions.len();
+    let next_offset = if end < total { Some(end) } else { None };
+
     Ok(HttpResponse::Ok().json(ListSessionsResponse {
-        sessions: entries
-            .into_iter()
-            .map(|entry| {
-                let is_running = running.contains(&entry.id);
-                let mut summary = SessionSummary::from_entry(entry, is_running);
-                summary.running_child_count =
-                    running_child_counts.get(&summary.id).copied().unwrap_or(0);
-                summary
-            })
-            .collect(),
+        sessions,
+        total,
+        limit,
+        offset,
+        next_offset,
     }))
 }
 
@@ -76,5 +118,129 @@ pub async fn get_session(
             "error": "Session not found",
             "session_id": session_id
         }))),
+    }
+}
+
+// Pure clamp unit test — kept in its own module that does NOT import
+// `actix_web::test`, so the built-in `#[test]` attribute isn't shadowed by the
+// actix test-macro re-export.
+#[cfg(test)]
+mod clamp_tests {
+    use super::{clamp_page_size, DEFAULT_SESSIONS_PAGE, MAX_SESSIONS_PAGE};
+
+    #[test]
+    fn clamp_page_size_defaults_and_caps() {
+        // Omitted → the bounded default, never an unbounded read (#252).
+        assert_eq!(clamp_page_size(None), DEFAULT_SESSIONS_PAGE);
+        // In-range passes through untouched.
+        assert_eq!(clamp_page_size(Some(50)), 50);
+        // Over the hard cap is clamped down; zero is clamped up to 1.
+        assert_eq!(clamp_page_size(Some(10_000_000)), MAX_SESSIONS_PAGE);
+        assert_eq!(clamp_page_size(Some(0)), 1);
+    }
+}
+
+#[cfg(test)]
+mod pagination_http_tests {
+    use actix_web::{test, web, App};
+    use serde_json::Value;
+    use tempfile::tempdir;
+
+    use super::{DEFAULT_SESSIONS_PAGE, MAX_SESSIONS_PAGE};
+    use crate::routes::configure_routes;
+    use crate::AppState;
+    use bamboo_agent_core::Session;
+
+    async fn app_state_with_sessions(n: usize) -> web::Data<AppState> {
+        let temp_dir = tempdir().expect("tempdir");
+        bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
+        let state = web::Data::new(
+            AppState::new(temp_dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        for i in 0..n {
+            let mut session = Session::new(format!("sess-{i:03}"), "model");
+            state.save_and_cache_session(&mut session).await;
+        }
+        state
+    }
+
+    /// Omitting `limit` returns the server default page size (bounded), and a
+    /// `limit` above the hard max is clamped to the max — mirrors the metrics
+    /// `normalize_limit` clamp. Without the pagination fix the response carries
+    /// no `limit` field at all, so these assertions fail. (#252)
+    #[actix_web::test]
+    async fn list_sessions_default_and_max_are_enforced() {
+        let state = app_state_with_sessions(3).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        // No params → the effective page size is the server default, not unbounded.
+        let resp: Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/sessions")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp["limit"], DEFAULT_SESSIONS_PAGE as u64);
+        assert_eq!(resp["total"], 3);
+        assert_eq!(resp["sessions"].as_array().unwrap().len(), 3);
+        // Everything fits on the first page, so there is no next page.
+        assert!(resp.get("next_offset").is_none() || resp["next_offset"].is_null());
+
+        // A `limit` above the hard cap is clamped down to the max.
+        let capped: Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/sessions?limit=10000000")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(capped["limit"], MAX_SESSIONS_PAGE as u64);
+    }
+
+    /// `limit`/`offset` slice the newest-first list and `next_offset` walks the
+    /// pages, ending at `None` on the last page. (#252)
+    #[actix_web::test]
+    async fn list_sessions_pages_with_limit_and_offset() {
+        let state = app_state_with_sessions(3).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        // First page of 2 of 3 → a next page starts at offset 2.
+        let page1: Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/sessions?limit=2")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(page1["total"], 3);
+        assert_eq!(page1["limit"], 2);
+        assert_eq!(page1["offset"], 0);
+        assert_eq!(page1["sessions"].as_array().unwrap().len(), 2);
+        assert_eq!(page1["next_offset"], 2);
+
+        // Second page picks up the remaining 1 and reports no further page.
+        let page2: Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/sessions?limit=2&offset=2")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(page2["offset"], 2);
+        assert_eq!(page2["sessions"].as_array().unwrap().len(), 1);
+        assert!(page2.get("next_offset").is_none() || page2["next_offset"].is_null());
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/types.rs
@@ -130,9 +130,36 @@ pub(crate) fn local_placement() -> SessionPlacement {
     }
 }
 
+/// Query parameters for `GET /api/v1/sessions`.
+///
+/// Both are optional so existing clients that omit them stay working: the
+/// server applies a bounded default page instead of materializing every session
+/// (the index grows without limit as session count grows forever — #252).
+#[derive(Debug, Default, Deserialize)]
+pub struct ListSessionsQuery {
+    /// Page size. Server-clamped to `1..=MAX_SESSIONS_PAGE`; omitted → the
+    /// server default page size (never unbounded).
+    #[serde(default)]
+    pub limit: Option<usize>,
+    /// Number of (newest-first) sessions to skip before this page. Omitted → 0.
+    #[serde(default)]
+    pub offset: Option<usize>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct ListSessionsResponse {
     pub sessions: Vec<SessionSummary>,
+    /// Total sessions in the index before pagination, so a client can tell how
+    /// many pages remain. (#252)
+    pub total: usize,
+    /// The page size actually applied (the server-clamped default/max), so a
+    /// client can see the effective bound even when it sent no `limit`.
+    pub limit: usize,
+    /// The offset applied to this page.
+    pub offset: usize,
+    /// Offset to request the next page, or `None` when this is the last page.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_offset: Option<usize>,
 }
 
 /// Snapshot of an actively running session for frontend boot/reconnect replay.
@@ -368,10 +395,22 @@ mod tests {
 
     #[test]
     fn test_list_sessions_response_serialization() {
-        let response = ListSessionsResponse { sessions: vec![] };
+        let response = ListSessionsResponse {
+            sessions: vec![],
+            total: 0,
+            limit: 200,
+            offset: 0,
+            next_offset: None,
+        };
 
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("\"sessions\":[]"));
+        // Pagination metadata is present so clients can page (#252). `next_offset`
+        // is omitted when absent.
+        assert!(json.contains("\"total\":0"));
+        assert!(json.contains("\"limit\":200"));
+        assert!(json.contains("\"offset\":0"));
+        assert!(!json.contains("next_offset"));
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/server/entrypoints.rs
+++ b/crates/app/bamboo-server/src/server/entrypoints.rs
@@ -110,13 +110,11 @@ pub async fn run_with_tls(
     let workers = resolve_worker_count();
 
     let app_factory = move || {
-        let mut app = App::new()
-            // Same body limits as the production/static path so a desktop chat
-            // request with an inline image isn't rejected with 413 (#252).
-            .app_data(web::JsonConfig::default().limit(super::web_service::MAX_JSON_BODY_BYTES))
-            .app_data(web::PayloadConfig::new(
-                super::web_service::MAX_PAYLOAD_BYTES,
-            ))
+        // Body limits (and any future shared app config) come from the one shared
+        // factory used by every serve path, so a desktop chat request with an
+        // inline image isn't rejected with 413 while production accepts it — the
+        // paths can no longer drift apart (#252).
+        let mut app = super::web_service::with_body_limits(App::new())
             .app_data(app_state.clone())
             .wrap(build_cors("127.0.0.1", port))
             // Immutable long-cache for hashed `/assets/*` (parity with the web
@@ -304,13 +302,10 @@ pub async fn run_with_bind_and_static_tls(
     let apply_rate_limit = !is_loopback_bind(bind);
     let bind_for_cors = bind.to_string();
     let app_factory = move || {
-        let mut app = App::new()
-            // Request size limits to prevent DoS. Chat requests may include
-            // base64 images; shared with every serve path (#252).
-            .app_data(web::JsonConfig::default().limit(super::web_service::MAX_JSON_BODY_BYTES))
-            .app_data(web::PayloadConfig::new(
-                super::web_service::MAX_PAYLOAD_BYTES,
-            ))
+        // Request size limits (base64-image chats) come from the one shared
+        // factory used by every serve path — same limits everywhere, no drift
+        // (#252).
+        let mut app = super::web_service::with_body_limits(App::new())
             .app_data(app_state.clone())
             .wrap(actix_web::middleware::Condition::new(
                 apply_rate_limit,

--- a/crates/app/bamboo-server/src/server/web_service.rs
+++ b/crates/app/bamboo-server/src/server/web_service.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use actix_files as fs;
+use actix_web::dev::{ServiceFactory, ServiceRequest, ServiceResponse};
 use actix_web::{web, App, HttpServer};
 use tokio::sync::oneshot;
 use tracing::{error, info};
@@ -13,6 +14,30 @@ use super::listeners::DEFAULT_WORKER_COUNT;
 /// payload defaults and rejecting them with 413 (#252).
 pub(crate) const MAX_JSON_BODY_BYTES: usize = 25 * 1024 * 1024;
 pub(crate) const MAX_PAYLOAD_BYTES: usize = 30 * 1024 * 1024;
+
+/// Install the shared request body-size limits ([`MAX_JSON_BODY_BYTES`] /
+/// [`MAX_PAYLOAD_BYTES`]) onto an actix `App`.
+///
+/// EVERY serve path — desktop (`run_with_tls`), production
+/// (`run_with_bind_and_static_tls`), and `WebService::start*` — funnels its
+/// `App::new()` through this one helper, so the limits can no longer drift
+/// between paths. That drift was the #252 bug: the desktop/embedded server set
+/// neither limit and rejected an inline-image chat request with 413 while the
+/// production server (which set them) accepted it. Callers layer their own app
+/// data, middleware, routes, and static files on top of the returned `App`.
+pub(crate) fn with_body_limits<T>(app: App<T>) -> App<T>
+where
+    T: ServiceFactory<
+        ServiceRequest,
+        Config = (),
+        Response = ServiceResponse,
+        Error = actix_web::Error,
+        InitError = (),
+    >,
+{
+    app.app_data(web::JsonConfig::default().limit(MAX_JSON_BODY_BYTES))
+        .app_data(web::PayloadConfig::new(MAX_PAYLOAD_BYTES))
+}
 use super::tls::build_rustls_config;
 use crate::app_state::AppState;
 use crate::config::{build_cors, build_rate_limiter, build_security_headers, is_loopback_bind};
@@ -91,9 +116,7 @@ impl WebService {
         let bind_for_log = bind_addr.clone();
 
         let server = HttpServer::new(move || {
-            App::new()
-                .app_data(web::JsonConfig::default().limit(MAX_JSON_BODY_BYTES))
-                .app_data(web::PayloadConfig::new(MAX_PAYLOAD_BYTES))
+            with_body_limits(App::new())
                 .app_data(app_state.clone())
                 .wrap(build_cors(&bind_addr, port))
                 .configure(configure_routes) // No rate limiting for WebService
@@ -193,9 +216,7 @@ impl WebService {
         let bind_for_log = bind_addr.clone();
 
         let server = HttpServer::new(move || {
-            App::new()
-                .app_data(web::JsonConfig::default().limit(MAX_JSON_BODY_BYTES))
-                .app_data(web::PayloadConfig::new(MAX_PAYLOAD_BYTES))
+            with_body_limits(App::new())
                 .app_data(app_state.clone())
                 .wrap(actix_web::middleware::Condition::new(
                     apply_rate_limit,
@@ -314,6 +335,60 @@ impl Drop for WebService {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #252: the shared [`with_body_limits`] factory must raise actix's default
+    /// ~2MB JSON limit to 25MB on every serve path. This is the limit the
+    /// desktop/embedded serve path previously lacked (rejecting inline-image
+    /// chat requests with 413 while production accepted them). The control app
+    /// built without `with_body_limits` rejects the same body, proving the
+    /// factory — not a default — is doing the work, so this test fails without
+    /// the shared-factory change.
+    #[actix_web::test]
+    async fn shared_factory_raises_json_body_limit() {
+        use actix_web::{http::StatusCode, test, HttpResponse};
+
+        async fn echo(_body: web::Json<serde_json::Value>) -> HttpResponse {
+            HttpResponse::Ok().finish()
+        }
+
+        // ~3MB JSON body: over actix's ~2MB default, under the 25MB shared limit.
+        let big = "x".repeat(3 * 1024 * 1024);
+        let payload = serde_json::json!({ "data": big });
+
+        // Via the shared factory (what every serve path now funnels through).
+        let app =
+            test::init_service(with_body_limits(App::new()).route("/echo", web::post().to(echo)))
+                .await;
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/echo")
+                .set_json(&payload)
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "shared factory must accept a >2MB JSON body (#252)"
+        );
+
+        // Control: a plain `App` (actix's ~2MB default) rejects the same body.
+        let app_default = test::init_service(App::new().route("/echo", web::post().to(echo))).await;
+        let resp_default = test::call_service(
+            &app_default,
+            test::TestRequest::post()
+                .uri("/echo")
+                .set_json(&payload)
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            resp_default.status(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "actix's default JSON limit must reject a >2MB body"
+        );
+    }
 
     /// #119 e2e: WebService::stop() must cancel the AppState-owned MCP-proxy
     /// reconnect supervisor's token, so it terminates on server stop rather than


### PR DESCRIPTION
Fixes the two robustness issues in `bamboo-server` from #252.

## 1. Unbounded list / history reads

### `GET /api/v1/sessions` — now paginated
Previously materialized **and serialized every** index entry on every call, with no `limit`/`offset`/`cursor`; the response grew without bound as session count grows forever.

- Added `limit` + `offset` query params (both optional).
- Server-enforced **default page = 200**, **hard max = 1000** (`clamp_page_size`, mirrors the metrics `normalize_limit` clamp). Default is generous so a typical client still sees all its recent sessions, while a pathological account can't force an unbounded read.
- Response is backward-compatible — existing clients that omit params get the default page (not an error) — and now also carries `total`, `limit`, `offset`, and `next_offset` so a client can page.
- Running-child counts are still computed over the **full** set (a parent's running children may fall on another page), only the summaries are paginated.

### `GET /api/v1/history/{id}` — cold fetch capped
A session that never used the `since_message_id` delta cursor returned its **entire** message array. Cold (non-delta) fetches are now capped to the newest **2000** UI-visible messages (the tail a chat UI renders first); `truncated` + `total_message_count` are surfaced so a client can detect the gap. Delta fetches are already bounded by their cursor and are never trimmed.

### `metrics/sessions` + `metrics/forward/*`
Already capped by `normalize_limit` (default 100 / max 1000) in a prior change — left as-is. The existing `normalize_limit_defaults_and_caps` test covers them.

## 2. Body limits on every serve path (via a shared factory)

The `25MB` JSON / `30MB` payload limits were **duplicated inline** across the four serve factories — drift-prone, and drift was the original bug (the desktop/embedded path once set neither, so an inline-image chat that succeeded on the production/Docker server was rejected with **413** on desktop).

Extracted **one** helper, `with_body_limits(App) -> App`, that **every** serve path funnels its `App::new()` through, so the limits can't drift between paths again:
- desktop `run_with_tls`
- production `run_with_bind_and_static_tls`
- `WebService::start_with_bind_tls`
- `WebService::start_with_bind_and_static_tls`

## Regression tests
- `clamp_page_size_defaults_and_caps` (unit) — default when omitted; clamp to max; zero→1.
- `list_sessions_default_and_max_are_enforced` (http) — omitting `limit` yields the default page; `limit=10000000` is clamped to the max. **Confirmed this fails without the clamp** (returns `usize::MAX`).
- `list_sessions_pages_with_limit_and_offset` (http) — `limit`/`offset` slice the newest-first list; `next_offset` walks pages and ends at `None`.
- `cap_cold_history_trims_cold_fetch_to_newest` (unit) — cold fetch over cap keeps the newest tail; delta never trimmed.
- `shared_factory_raises_json_body_limit` (http) — a >2MB JSON body is **accepted** through `with_body_limits` and **rejected (413)** by a plain `App`, proving the factory (not a default) applies the limit — i.e. the test fails without the shared-factory change.

## Verify (CI's exact commands, from the worktree root)
- `cargo fmt -- --check` — clean
- `cargo clippy --all-features -- -D warnings` (CI allow-list) — clean
- `cargo test -p bamboo-server --all-features` — 998 lib + 9 integration + 9 doctest pass
- `cargo build --workspace --tests --all-features` — ok

Closes #252