### PR TITLE
fix(engine): treat mid-turn compression failure as best-effort, not a whole-turn retry (#238)

### DIFF
--- a/crates/engine/bamboo-engine/src/llm_summarizer.rs
+++ b/crates/engine/bamboo-engine/src/llm_summarizer.rs
@@ -33,7 +33,11 @@ pub enum SummaryMode {
 /// LLM-based summarizer that calls the current session's model to generate
 /// a rich summary of compressed/removed messages.
 ///
-/// Falls back to [`HeuristicSummarizer`] if the LLM call fails.
+/// Falls back to [`HeuristicSummarizer`] if the LLM call fails, UNLESS
+/// [`with_heuristic_fallback_on_error(false)`](Self::with_heuristic_fallback_on_error)
+/// is set — in which case a transient LLM *error* surfaces to the caller so a
+/// best-effort caller (mid-turn context compression) can skip and degrade
+/// gracefully instead of silently substituting a low-quality heuristic summary.
 pub struct LlmSummarizer {
     llm: Arc<dyn LLMProvider>,
     model: String,
@@ -45,6 +49,12 @@ pub struct LlmSummarizer {
     custom_instructions: Option<String>,
     /// Controls how the summarizer handles existing summaries.
     summary_mode: SummaryMode,
+    /// When true (default), a transient LLM call/stream failure is recovered by
+    /// falling back to the [`HeuristicSummarizer`]. When false, that error is
+    /// returned to the caller instead — used by best-effort callers that would
+    /// rather SKIP compression than emit a degraded heuristic summary. The
+    /// empty-response fallback is unaffected either way. (issue #238)
+    heuristic_fallback_on_error: bool,
 }
 
 impl LlmSummarizer {
@@ -76,7 +86,17 @@ impl LlmSummarizer {
             context_blocks,
             custom_instructions: None,
             summary_mode: SummaryMode::default(),
+            heuristic_fallback_on_error: true,
         }
+    }
+
+    /// Control whether a transient LLM *error* recovers via the heuristic
+    /// summarizer (default `true`) or surfaces to the caller (`false`). Set
+    /// `false` for best-effort compression (mid-turn) that should skip rather
+    /// than substitute a heuristic summary. (issue #238)
+    pub fn with_heuristic_fallback_on_error(mut self, enabled: bool) -> Self {
+        self.heuristic_fallback_on_error = enabled;
+        self
     }
 
     pub fn with_context_blocks(mut self, context_blocks: Vec<ContextBlock>) -> Self {
@@ -312,12 +332,22 @@ impl Summarizer for LlmSummarizer {
                 );
                 HeuristicSummarizer::new().summarize(messages).await
             }
-            Err(e) => {
+            Err(e) if self.heuristic_fallback_on_error => {
                 tracing::warn!(
                     "LlmSummarizer: LLM call failed ({}), falling back to heuristic",
                     e
                 );
                 HeuristicSummarizer::new().summarize(messages).await
+            }
+            // Best-effort caller opted out of the heuristic fallback: surface the
+            // transient error so the caller can skip compression entirely rather
+            // than substitute a low-quality heuristic summary. (issue #238)
+            Err(e) => {
+                tracing::warn!(
+                    "LlmSummarizer: LLM call failed ({}); surfacing error (heuristic fallback disabled)",
+                    e
+                );
+                Err(e)
             }
         }
     }
@@ -618,6 +648,60 @@ mod tests {
         assert!(
             user_content.contains("Previous summary content"),
             "IncrementalMerge user prompt should include the actual summary text"
+        );
+    }
+
+    /// Provider whose summarization stream call fails transiently (500/429/timeout).
+    struct FailingProvider;
+
+    #[async_trait]
+    impl LLMProvider for FailingProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[bamboo_domain::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<LLMStream, LLMError> {
+            Err(LLMError::Api("http 500 transient".to_string()))
+        }
+    }
+
+    fn summary_messages() -> Vec<Message> {
+        vec![
+            Message::user("do the work"),
+            Message::assistant("working on it", None),
+            Message::user("keep going"),
+        ]
+    }
+
+    #[tokio::test]
+    async fn summarize_falls_back_to_heuristic_on_llm_error_by_default() {
+        // Default: a transient LLM failure is recovered by the heuristic
+        // summarizer, so summarize() succeeds. This is what makes pre-turn /
+        // overflow compression resilient (and, historically, masked #238).
+        let summarizer =
+            LlmSummarizer::new(Arc::new(FailingProvider), "model".to_string(), None, None);
+        let out = summarizer.summarize(&summary_messages()).await;
+        assert!(
+            out.is_ok(),
+            "default heuristic fallback should recover from a transient LLM error, got {out:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn summarize_surfaces_llm_error_when_heuristic_fallback_disabled() {
+        // Best-effort caller (mid-turn compression) opts out of the heuristic
+        // fallback: the transient error must SURFACE so the caller can skip
+        // compression rather than substitute a low-quality heuristic summary.
+        // (issue #238)
+        let summarizer =
+            LlmSummarizer::new(Arc::new(FailingProvider), "model".to_string(), None, None)
+                .with_heuristic_fallback_on_error(false);
+        let out = summarizer.summarize(&summary_messages()).await;
+        assert!(
+            out.is_err(),
+            "with the heuristic fallback disabled, a transient LLM error must surface"
         );
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -3946,6 +3946,280 @@ mod tests {
         );
     }
 
+    // ── Mid-turn compression failure is best-effort, not a whole-turn retry (#238)
+    //
+    // A transient failure in the MID-TURN context-compression summarization call
+    // (host summarizer LLM) used to propagate out of `execute_round_tool_calls`
+    // via `?`, out of `handle_tool_calls_path`'s `result?`, and into the per-turn
+    // retry loop. Because the assistant message (with its `tool_calls`) is
+    // appended BEFORE tools run and tools execute one-by-one, that propagation
+    // corrupted state: it aborted the not-yet-executed tool calls and — if the
+    // error were classified retryable — re-ran the WHOLE turn, appending a SECOND
+    // assistant message and re-billing the LLM. The fix makes mid-turn
+    // compression infallible (log + degrade): the turn keeps running its
+    // remaining tools with the uncompressed context, and the failure never
+    // reaches the retry path.
+
+    /// Tool executor that records execution order and forces STRICTLY sequential
+    /// scheduling (so the mid-turn compression runs after EACH tool, never
+    /// batched — the exact one-by-one path the bug lives in). `compact_context`
+    /// is included so its post-execution tool result flips the session's manual
+    /// compression flag, deterministically triggering the mid-turn summarization
+    /// call without any token-budget arithmetic.
+    struct RecordingSequentialExecutor {
+        executed: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl ToolExecutor for RecordingSequentialExecutor {
+        async fn execute(
+            &self,
+            call: &ToolCall,
+        ) -> bamboo_agent_core::tools::executor::Result<ToolResult> {
+            self.executed
+                .lock()
+                .unwrap()
+                .push(call.function.name.clone());
+            Ok(ToolResult {
+                success: true,
+                result: format!("result-of-{}", call.function.name),
+                display_preference: None,
+                images: Vec::new(),
+            })
+        }
+
+        fn list_tools(&self) -> Vec<ToolSchema> {
+            ["compact_context", "tool_b", "tool_c"]
+                .iter()
+                .map(|name| ToolSchema {
+                    schema_type: "function".to_string(),
+                    function: FunctionSchema {
+                        name: name.to_string(),
+                        description: "test tool".to_string(),
+                        parameters: serde_json::json!({ "type": "object", "properties": {} }),
+                    },
+                })
+                .collect()
+        }
+
+        // Force Sequential scheduling for every tool: Mutating + not
+        // concurrency-safe => tools run one-by-one with a compression check
+        // interleaved after each, never in a parallel batch.
+        fn call_parallel_classification(
+            &self,
+            _call: &ToolCall,
+        ) -> (bamboo_agent_core::tools::ToolMutability, bool) {
+            (bamboo_agent_core::tools::ToolMutability::Mutating, false)
+        }
+    }
+
+    /// Provider whose only job is to FAIL the mid-turn context-compression
+    /// summarization call (identified by `request_purpose == "compression"`,
+    /// set by `LlmSummarizer`) with a transient upstream error, counting the
+    /// attempts. It is never asked to run a main-agent round here
+    /// (`handle_tool_calls_path` consumes an already-produced `StreamHandlingOutput`),
+    /// so `chat_stream` is a benign stub.
+    struct FailingCompressionProvider {
+        compression_calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl LLMProvider for FailingCompressionProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[bamboo_agent_core::tools::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<LLMStream, LLMError> {
+            Ok(Box::pin(stream::iter(vec![Ok(LLMChunk::Done)])))
+        }
+
+        async fn chat_stream_with_options(
+            &self,
+            _messages: &[Message],
+            _tools: &[bamboo_agent_core::tools::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+            options: Option<&bamboo_llm::LLMRequestOptions>,
+        ) -> Result<LLMStream, LLMError> {
+            let purpose = options
+                .and_then(|o| o.request_purpose.as_deref())
+                .unwrap_or("");
+            if purpose == "compression" {
+                self.compression_calls.fetch_add(1, Ordering::SeqCst);
+                // Transient failure: HTTP 500 / rate limit / timeout on the
+                // summarization call. This is exactly the class of error the fix
+                // downgrades to best-effort.
+                return Err(LLMError::Api(
+                    "http 500 transient upstream failure (compression summarization)".to_string(),
+                ));
+            }
+            Ok(Box::pin(stream::iter(vec![Ok(LLMChunk::Done)])))
+        }
+    }
+
+    fn tool_call(id: &str, name: &str) -> ToolCall {
+        ToolCall {
+            id: id.to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: name.to_string(),
+                arguments: "{}".to_string(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn mid_turn_compression_failure_is_best_effort_and_does_not_retry_turn() {
+        let compression_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let executed = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+
+        let llm: Arc<dyn LLMProvider> = Arc::new(FailingCompressionProvider {
+            compression_calls: compression_calls.clone(),
+        });
+        let tools: Arc<dyn ToolExecutor> = Arc::new(RecordingSequentialExecutor {
+            executed: executed.clone(),
+        });
+        let (event_tx, _event_rx) = mpsc::channel::<AgentEvent>(128);
+
+        // `background_model_name` set + no explicit summarization provider =>
+        // the summarizer runs against `frame.llm` (our failing provider).
+        let config = AgentLoopConfig {
+            model_name: Some("model".to_string()),
+            background_model_name: Some("summarizer".to_string()),
+            ..AgentLoopConfig::default()
+        };
+
+        let mut session = Session::new("s-compress-fail", "model");
+        // Seed enough non-system history that `summary_source_messages` clears the
+        // >= 3 message floor once compact_context's result is appended, so the
+        // summarization call is genuinely attempted (and fails).
+        session.add_message(Message::system("system"));
+        session.add_message(Message::user("do the work"));
+        session.add_message(Message::assistant("prior assistant turn".to_string(), None));
+        session.add_message(Message::user("keep going"));
+
+        let frame = RoundFrame {
+            session_id: "s-compress-fail",
+            round_id: "r1",
+            turn: 0,
+            debug_enabled: false,
+            event_tx: &event_tx,
+            metrics_collector: None,
+            config: &config,
+            llm: &llm,
+            tools: &tools,
+        };
+        let auxiliary_models = crate::runtime::config::AuxiliaryModelConfig::default();
+        let mut task_context: Option<TaskLoopContext> = None;
+        let cancel_token = CancellationToken::new();
+
+        // Assistant turn issues three tool calls; the FIRST is `compact_context`,
+        // whose post-execution result trips the manual-compression flag so the
+        // mid-turn summarization fires right after it — and fails transiently.
+        let stream_output = StreamHandlingOutput {
+            response_id: None,
+            content: String::new(),
+            reasoning_content: String::new(),
+            token_count: 0,
+            tool_calls: vec![
+                tool_call("call-compact", "compact_context"),
+                tool_call("call-b", "tool_b"),
+                tool_call("call-c", "tool_c"),
+            ],
+            output_tokens: 0,
+            thinking_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            input_tokens: 0,
+        };
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            handle_tool_calls_path(
+                &frame,
+                stream_output,
+                MetricsTokenUsage {
+                    prompt_tokens: 0,
+                    completion_tokens: 0,
+                    total_tokens: 0,
+                },
+                &mut session,
+                &auxiliary_models,
+                "model",
+                &mut task_context,
+                &cancel_token,
+            ),
+        )
+        .await
+        .expect("handle_tool_calls_path did not return within 10s");
+
+        // The transient compression failure must NOT surface as a turn error.
+        // Without the fix it propagates as Err out of handle_tool_calls_path,
+        // which run_pipeline's per-turn retry loop treats as a whole-turn failure
+        // (re-appending a duplicate assistant message / re-billing). The retry is
+        // gated on this Err, so proving Ok here proves the turn is not retried.
+        let _outcome = result.expect(
+            "mid-turn compression failure must be best-effort (Ok), not a whole-turn error/retry",
+        );
+
+        // The compression path was genuinely exercised and failed — else the test
+        // would prove nothing.
+        assert!(
+            compression_calls.load(Ordering::SeqCst) >= 1,
+            "mid-turn compression summarization must have been attempted (and failed)"
+        );
+
+        // (a) The turn kept running the REMAINING tools despite the failure — no
+        // orphaned tool calls. Without the fix, execution aborts right after
+        // compact_context and tool_b / tool_c never run.
+        let ran = executed.lock().unwrap().clone();
+        assert_eq!(
+            ran,
+            vec![
+                "compact_context".to_string(),
+                "tool_b".to_string(),
+                "tool_c".to_string(),
+            ],
+            "all tools must execute in order despite the mid-turn compression failure"
+        );
+
+        // (b) Exactly ONE assistant message carries this turn's tool calls — no
+        // duplicate from a whole-turn re-run.
+        let assistant_turns = session
+            .messages
+            .iter()
+            .filter(|m| {
+                m.role == bamboo_agent_core::Role::Assistant
+                    && m.tool_calls.as_ref().is_some_and(|calls| {
+                        calls.iter().any(|c| c.function.name == "compact_context")
+                    })
+            })
+            .count();
+        assert_eq!(
+            assistant_turns, 1,
+            "exactly one assistant message must exist for the turn (no duplicate)"
+        );
+
+        // (c) Each tool produced exactly one tool-result message (no re-execution
+        // / no duplicated results from a retried turn).
+        for (id, name) in [
+            ("call-compact", "compact_context"),
+            ("call-b", "tool_b"),
+            ("call-c", "tool_c"),
+        ] {
+            let count = session
+                .messages
+                .iter()
+                .filter(|m| {
+                    m.role == bamboo_agent_core::Role::Tool && m.tool_call_id.as_deref() == Some(id)
+                })
+                .count();
+            assert_eq!(count, 1, "tool {name} must have exactly one result message");
+        }
+    }
+
     // ── Async Gold/Task eval cancel + abort-on-early-exit (issue #347) ────
     //
     // The runner spawns Gold/Task evaluations as detached tokio tasks and only

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation.rs
@@ -338,12 +338,22 @@ async fn maybe_apply_host_context_compression_with_budget(
         .as_ref()
         .or(config.background_model_provider.as_ref())
         .unwrap_or(llm);
+    // Mid-turn compression is BEST-EFFORT (it runs between a turn's tool calls,
+    // after the assistant message is already committed). A transient
+    // summarization failure there must NOT be papered over with a low-quality
+    // heuristic summary that mutates in-flight context; it should SURFACE so the
+    // mid-turn call site can skip compression and continue with the uncompressed
+    // context (see `maybe_apply_mid_turn_context_compression_after_tool`). Every
+    // other phase (pre-turn, overflow-recovery) keeps the heuristic fallback so a
+    // round that genuinely needs the context reduced stays resilient. (issue #238)
+    let heuristic_fallback_on_error = phase_label != "mid-turn";
     let summarizer = LlmSummarizer::new(
         Arc::clone(summary_provider),
         summary_model.to_string(),
         existing_summary.clone(),
         None,
     )
+    .with_heuristic_fallback_on_error(heuristic_fallback_on_error)
     .with_context_blocks(compression_context_blocks)
     .with_custom_instructions(compression_instructions)
     .with_summary_mode(if existing_summary.is_some() {

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
@@ -331,6 +331,25 @@ fn detect_manual_compression_request(session: &mut Session) {
     }
 }
 
+/// Best-effort mid-turn context compression, run after a single tool result.
+///
+/// Mid-turn compression is an OPTIMIZATION, never a correctness requirement. By
+/// the time it runs the assistant turn is already mid-execution: the assistant
+/// message (carrying this round's `tool_calls`) has been appended and one or
+/// more tools have run and committed their side effects. If the host
+/// summarization LLM call fails transiently (HTTP 500 / 429 / timeout), that
+/// error MUST NOT propagate out of `execute_round_tool_calls`. Propagating it
+/// surfaces the failure to the per-turn retry loop, which would either
+///   (a) classify it as retryable and re-run the WHOLE turn — appending a
+///       SECOND assistant message, re-billing the LLM, and orphaning the
+///       not-yet-executed tool calls; or
+///   (b) fail the turn terminally and abort the remaining tools.
+/// Both corrupt session state over a discardable optimization.
+///
+/// So this function is INFALLIBLE by construction: a compression failure is
+/// logged and swallowed, and the turn keeps executing its remaining tools with
+/// the uncompressed context. Compression is retried on the next natural
+/// trigger. (issue #238)
 #[allow(clippy::too_many_arguments)]
 async fn maybe_apply_mid_turn_context_compression_after_tool(
     session: &mut Session,
@@ -341,14 +360,14 @@ async fn maybe_apply_mid_turn_context_compression_after_tool(
     model_name: Option<&str>,
     _compression_model_provider: Option<&Arc<dyn LLMProvider>>,
     tool_schemas: &[ToolSchema],
-) -> Result<(), AgentError> {
+) {
     let Some(model_name) = model_name else {
-        return Ok(());
+        return;
     };
 
     detect_manual_compression_request(session);
 
-    if super::round_lifecycle::maybe_apply_mid_turn_context_compression(
+    match super::round_lifecycle::maybe_apply_mid_turn_context_compression(
         session,
         config,
         llm,
@@ -357,14 +376,25 @@ async fn maybe_apply_mid_turn_context_compression_after_tool(
         model_name,
         tool_schemas,
     )
-    .await?
+    .await
     {
-        tracing::debug!(
-            "[{}] Applied mid-turn host context compression after single tool result",
-            session_id
-        );
+        Ok(true) => {
+            tracing::debug!(
+                "[{}] Applied mid-turn host context compression after single tool result",
+                session_id
+            );
+        }
+        Ok(false) => {}
+        // Degrade gracefully: a transient summarization failure must never abort
+        // or retry the whole turn — keep running the remaining tools uncompressed.
+        Err(error) => {
+            tracing::warn!(
+                "[{}] Mid-turn context compression failed; continuing the turn with uncompressed context (best-effort, will retry on next trigger): {}",
+                session_id,
+                error
+            );
+        }
     }
-    Ok(())
 }
 
 pub(crate) async fn execute_round_tool_calls(
@@ -461,7 +491,7 @@ pub(crate) async fn execute_round_tool_calls(
                         compression_model_provider,
                         tool_schemas,
                     )
-                    .await?;
+                    .await;
 
                     if control.should_break || control.stop_round {
                         break 'tool_calls;
@@ -500,7 +530,7 @@ pub(crate) async fn execute_round_tool_calls(
                     compression_model_provider,
                     tool_schemas,
                 )
-                .await?;
+                .await;
 
                 if control.should_break || control.stop_round {
                     break 'tool_calls;
@@ -668,7 +698,7 @@ pub(crate) async fn execute_round_tool_calls(
                     compression_model_provider,
                     tool_schemas,
                 )
-                .await?;
+                .await;
 
                 if should_break {
                     break 'tool_calls;
@@ -708,7 +738,7 @@ pub(crate) async fn execute_round_tool_calls(
             compression_model_provider,
             tool_schemas,
         )
-        .await?;
+        .await;
 
         if control.should_break || control.stop_round {
             break;


### PR DESCRIPTION
## The bug (#238)

Mid-turn context-compression is the host **summarization** run *between* a turn's tool calls (`maybe_apply_mid_turn_context_compression_after_tool`, invoked after each tool result inside `execute_round_tool_calls`). It is an **optimization, not a correctness requirement** — but its failure was wired into turn control flow.

The helper returned `Result<(), AgentError>` and was `.await?`-propagated at **4 call sites** in `execute_round_tool_calls`. Because the assistant message (with its `tool_calls`) is appended **before** tools run (`pipeline.rs` `handle_tool_calls_path`) and tools execute **one-by-one**, a compression error propagating out of the tool round corrupts turn state:

- it **aborts the not-yet-executed tool calls** (B/C never run), and
- surfaced to the per-turn retry loop (`should_retry_turn_error` + the `for attempt` loop), it could **re-run the WHOLE turn** — appending a **second** assistant message and **re-billing** a full LLM round — instead of just continuing.

Scenario: assistant issues `[A, B, C]`; A executes (side effect committed); post-A compression fails transiently → the turn is aborted/retried; B and C never ran.

### A subtlety I found while verifying the fix "fits"

`LlmSummarizer::summarize` currently **masks** a transient summarization LLM error with an **infallible heuristic-summary fallback**, so in practice the mid-turn error never even reached the seam (and when it did, it mapped to `AgentError::Budget` → terminal, not a retry). The reported "retry + duplicate" was therefore latent, guarded only by an unrelated summarizer-internal detail. The fix removes that hidden dependency and makes the turn robust regardless of the compression internals.

## The fix (two tightly-scoped parts)

1. **Swallow at the seam** (`tool_execution.rs`): `maybe_apply_mid_turn_context_compression_after_tool` is now **infallible** (`-> ()`). A compression error is logged and swallowed; the turn keeps running its remaining tools with the **uncompressed** context. A compression failure can therefore **never** reach `should_retry_turn_error`'s re-append path. All 4 call sites drop the `?`.

2. **Surface mid-turn errors so the seam is meaningful** (`llm_summarizer.rs` + `context_preparation.rs`): add `LlmSummarizer::with_heuristic_fallback_on_error` (**default `true`**, so pre-turn/overflow compression stays resilient) and disable it **only for the `"mid-turn"` phase**. A transient summarization failure then **surfaces** to the seam, which **skips** compression and continues uncompressed — realizing the intended "log + skip, continue with uncompressed context" degrade. The **empty-response** fallback is unchanged for all phases.

A real provider failure during the actual assistant LLM round (`execute_llm_round`) is untouched and **still retried as before** — only the mid-turn compression summarization failure is downgraded. Deferring mid-turn compression to the next round's pre-turn pass is safe: no LLM call happens between a turn's tools, and pre-turn compression (+ overflow recovery) runs before every LLM call.

## Regression tests

- `mid_turn_compression_failure_is_best_effort_and_does_not_retry_turn` — drives `handle_tool_calls_path` with a turn of `[compact_context, tool_b, tool_c]` (forced strictly sequential) and a mock host-summarization provider that fails the `request_purpose == "compression"` call transiently. Asserts: (a) the turn does **not** error, (b) all remaining tools run **in order** (no orphaning), (c) exactly **one** assistant message carries the turn's `tool_calls` (no duplicate), (d) each tool has exactly one result. **Verified it FAILS with only the seam fix reverted** — the `Budget("…http 500…")` error propagates out of `handle_tool_calls_path`.
- `summarize_falls_back_to_heuristic_on_llm_error_by_default` / `summarize_surfaces_llm_error_when_heuristic_fallback_disabled` — cover the new flag directly.

## Deferred (intentionally out of scope)

The two nearby resource leaks noted on #238 — `external_agents/actor_adapter.rs` pool/`schedule_cursor` pruning, and the 300s approval sleep task — are **left as a follow-up**. They overlap the just-landed #346 eviction work and deserve their own issue; this PR stays scoped to the compression-retry core bug.

## Verification (CI's exact commands, all clean)

- `cargo fmt -- --check` ✅
- `cargo clippy --all-features -- -A deprecated … -D warnings` ✅
- `cargo test -p bamboo-engine --all-features` ✅ (907 passed)
- `cargo build --workspace --tests --all-features` ✅

Closes #238

https://claude.ai/code/session_01A7asehdSsg7kQnaNZsxx3u