### PR TITLE
fix(mcp): spawn notification drain after runtime registered/client swapped (#420)

### DIFF
--- a/crates/infra/bamboo-mcp/src/manager/lifecycle.rs
+++ b/crates/infra/bamboo-mcp/src/manager/lifecycle.rs
@@ -22,7 +22,7 @@ impl McpServerManager {
         info!("Starting MCP server '{}'", server_id);
 
         let runtime_proxy_fingerprint = desired_proxy_fingerprint(self.config.as_ref()).await;
-        let (client, tools, instructions) = self
+        let (client, tools, instructions, notification_rx) = self
             .bootstrap_server_client(&server_id, &config, "start")
             .await?;
 
@@ -63,6 +63,13 @@ impl McpServerManager {
 
         // Store runtime
         self.runtimes.insert(server_id.clone(), runtime.clone());
+
+        // Spawn the notification drain only AFTER the runtime is registered, so an
+        // immediate `tools/list_changed` resolves via `refresh_tools` instead of
+        // racing `ServerNotFound`. (#420)
+        if let Some(rx) = notification_rx {
+            self.spawn_notification_drain(server_id.clone(), rx);
+        }
 
         // Emit event
         if let Some(ref tx) = self.event_tx {

--- a/crates/infra/bamboo-mcp/src/manager/reconnect.rs
+++ b/crates/infra/bamboo-mcp/src/manager/reconnect.rs
@@ -1,5 +1,7 @@
 use tokio::time::Duration;
 
+use crate::protocol::models::JsonRpcNotification;
+
 use super::*;
 
 impl McpServerManager {
@@ -148,7 +150,7 @@ impl McpServerManager {
             }
         }
 
-        let (client, tools, instructions) = self
+        let (client, tools, instructions, notification_rx) = self
             .bootstrap_server_client(&server_id, &runtime.config, "reconnect")
             .await?;
 
@@ -156,6 +158,13 @@ impl McpServerManager {
         {
             let mut client_lock = runtime.client.write().await;
             *client_lock = client;
+        }
+
+        // Spawn the notification drain only AFTER the new client is swapped in, so
+        // an immediate `tools/list_changed` refreshes against the NEW connection
+        // (not the old, disconnected one). (#420)
+        if let Some(rx) = notification_rx {
+            self.spawn_notification_drain(server_id.clone(), rx);
         }
 
         // Update tools
@@ -204,7 +213,12 @@ impl McpServerManager {
         server_id: &str,
         config: &McpServerConfig,
         phase: &'static str,
-    ) -> Result<(McpProtocolClient, Vec<McpTool>, Option<String>)> {
+    ) -> Result<(
+        McpProtocolClient,
+        Vec<McpTool>,
+        Option<String>,
+        Option<tokio::sync::mpsc::Receiver<JsonRpcNotification>>,
+    )> {
         let transport = self.build_transport(&config.transport).await?;
         let mut client = McpProtocolClient::new(transport);
 
@@ -247,18 +261,17 @@ impl McpServerManager {
             phase
         );
 
-        // Wire the server-notification consumer (#366): take this client's
-        // notification receiver and spawn a drain task that dispatches notifications
-        // (e.g. `tools/list_changed` -> refresh_tools). Runs on every (re)connect,
-        // since bootstrap is the sole client-construction path for both `start` and
-        // `reconnect`; the previous connection's drain exits when its old client is
-        // dropped (all notification senders close). Without a consumer the queue
-        // fills to capacity and silently drops every later notification.
-        if let Some(rx) = client.take_notification_receiver().await {
-            self.spawn_notification_drain(server_id.to_string(), rx);
-        }
+        // Take this client's server-notification receiver (#366) and hand it BACK
+        // to the caller rather than spawning the drain here. The drain dispatches
+        // `tools/list_changed` -> `refresh_tools`, which resolves the runtime by
+        // `server_id` and reads `runtime.client` — so it must not start until the
+        // caller has REGISTERED the runtime (`start`) / SWAPPED in the new client
+        // (`reconnect`). Spawning it inside bootstrap raced those: an immediate
+        // notification could hit `ServerNotFound` (start) or read the old,
+        // disconnected client (reconnect). (#420)
+        let notification_rx = client.take_notification_receiver().await;
 
-        Ok((client, tools, instructions))
+        Ok((client, tools, instructions, notification_rx))
     }
 
     async fn build_transport(&self, config: &TransportConfig) -> Result<Box<dyn McpTransport>> {


### PR DESCRIPTION
## What

Fixes #420 (follow-up from the #419/#366 review): `bootstrap_server_client` spawned the server-notification drain **before** the caller registered the runtime / swapped in the new client, so an immediate `tools/list_changed` could race.

- In `start_server`, the drain could dispatch before `self.runtimes.insert(...)`, so `refresh_tools` hit `ServerNotFound`.
- In `reconnect_server`, the drain could dispatch before `*client_lock = client` (there's an `.await` on the client write-lock between bootstrap returning and the swap), so `refresh_tools` read the **old, disconnected** client.

Either way `refresh_tools` just warned.

## Change

`bootstrap_server_client` now **returns** the notification receiver (4-tuple) instead of spawning the drain. Each caller spawns the drain only **after** its registration/swap point:
- `start_server` — after `runtimes.insert`
- `reconnect_server` — after the client swap

This eliminates the window entirely (the issue's preferred fix — "spawn the drain only after the runtime is registered / client swapped in").

## On testing (honest note)

The bug is **behaviorally self-healing**: the tools are already fetched fresh in the same bootstrap call, so the raced `refresh_tools` was *redundant*, not harmful — the only visible symptom was a spurious warn on an immediate post-connect notification. That makes the change behaviorally unobservable, and it isn't cleanly isolable by a new test:

- The existing `tools_list_changed_notification_triggers_refresh` and `unhandled_notification_is_drained_without_refresh` tests already exercise the drain wired **after** runtime registration (`insert_mock_runtime` → `spawn_notification_drain`) — i.e. exactly the ordering this fix now enforces in production.
- An end-to-end `start_server`/`reconnect_server` test isn't feasible without new infra: `bootstrap_server_client` builds a **real** transport from config (`build_transport` has no mock seam), so the mock harness injects clients by bypassing bootstrap. Adding transport injection for a behaviorally-invisible timing fix would be over-engineering.

I chose the structural reorder (eliminates the window) over the alternative retry-on-`ServerNotFound` band-aid. `cargo build/test/clippy/fmt -p bamboo-mcp` all green (166 tests pass).

https://claude.ai/code/session_01MHEufxse57xyD7RDntQcaU