### PR TITLE
fix: headless approve-first graceful abort + overlay parse-once (#176)

### DIFF
--- a/crates/app/bamboo-server-tools/src/overlay_executor.rs
+++ b/crates/app/bamboo-server-tools/src/overlay_executor.rs
@@ -19,6 +19,30 @@ impl OverlayToolExecutor {
     pub fn new(base: std::sync::Arc<dyn ToolExecutor>, overlay: std::sync::Arc<dyn Tool>) -> Self {
         Self { base, overlay }
     }
+
+    /// Resolve the args to hand the overlay tool, parsing the raw JSON at most
+    /// once (issue #106). When the dispatch loop already parsed them (threaded via
+    /// `ctx.pre_parsed_args`), reuse that value — the malformed-args fallback
+    /// `warn!` was already emitted (or not) at the dispatch site, so it is never
+    /// re-emitted here. Otherwise parse leniently, warning once on fallback,
+    /// preserving the original single-parse-per-consumer behavior.
+    fn resolve_args(&self, call: &ToolCall, ctx: &ToolExecutionContext<'_>) -> serde_json::Value {
+        if let Some(pre_parsed) = ctx.pre_parsed_args {
+            return pre_parsed.clone();
+        }
+        let args_raw = call.function.arguments.trim();
+        let (args, parse_warning) = parse_tool_args_best_effort(&call.function.arguments);
+        if let Some(warning) = parse_warning {
+            tracing::warn!(
+                "Overlay tool argument parsing fallback applied: tool_call_id={}, tool_name={}, args_len={}, warning={}",
+                call.id,
+                call.function.name,
+                args_raw.len(),
+                warning
+            );
+        }
+        args
+    }
 }
 
 #[async_trait]
@@ -47,17 +71,15 @@ impl ToolExecutor for OverlayToolExecutor {
             if let Some(outcome) = self.base.check_permissions_for(call, &ctx).await? {
                 return Ok(outcome.into_tool_result());
             }
-            let args_raw = call.function.arguments.trim();
-            let (args, parse_warning) = parse_tool_args_best_effort(&call.function.arguments);
-            if let Some(warning) = parse_warning {
-                tracing::warn!(
-                    "Overlay tool argument parsing fallback applied: tool_call_id={}, tool_name={}, args_len={}, warning={}",
-                    call.id,
-                    call.function.name,
-                    args_raw.len(),
-                    warning
-                );
-            }
+            // Reuse the args the dispatching loop already parsed (threaded via the
+            // context) instead of re-parsing the raw JSON string a second time here
+            // (issue #106). The threaded value is the exact output of the same
+            // parser on the same input, so reuse is behavior-preserving — and it
+            // means the malformed-args fallback `warn!` fires at most once per call
+            // (at the dispatch site), never re-emitted here. When absent (`none()`
+            // contexts, tests, synthesized child calls), parse leniently exactly as
+            // before, including the fallback warning.
+            let args = self.resolve_args(call, &ctx);
             return self
                 .overlay
                 .invoke(args, ctx.to_tool_ctx())
@@ -83,7 +105,9 @@ impl ToolExecutor for OverlayToolExecutor {
             if let Some(outcome) = self.base.check_permissions_for(call, &ctx).await? {
                 return Ok(outcome);
             }
-            let (args, _) = parse_tool_args_best_effort(&call.function.arguments);
+            // Reuse the dispatch-parsed args (parse-once) exactly as in
+            // `execute_with_context` above (issue #106).
+            let args = self.resolve_args(call, &ctx);
             return self.overlay.invoke(args, ctx.to_tool_ctx()).await;
         }
         self.base.execute_with_context_outcome(call, ctx).await
@@ -410,6 +434,150 @@ mod tests {
         assert!(
             matches!(result, Err(ToolError::Execution(ref msg)) if msg.contains("denied-by-base-gate")),
             "overlay check_permissions_for must return the base's decision, got: {result:?}"
+        );
+    }
+
+    // ---- issue #106: overlay reuses pre-parsed args (parse-once, no re-warn) ---
+
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Mutex as StdMutex;
+
+    /// An overlay tool that records the exact args `Value` it was invoked with, so
+    /// a test can prove WHICH value the overlay passed through: the threaded
+    /// pre-parsed value, or a re-parse of the raw string.
+    struct ArgsRecordingOverlayTool {
+        seen: std::sync::Arc<StdMutex<Option<serde_json::Value>>>,
+    }
+
+    #[async_trait]
+    impl Tool for ArgsRecordingOverlayTool {
+        fn name(&self) -> &str {
+            "memory"
+        }
+
+        fn description(&self) -> &str {
+            "records the args it was invoked with"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            json!({"type":"object","properties":{}})
+        }
+
+        async fn invoke(
+            &self,
+            args: serde_json::Value,
+            _ctx: ToolCtx,
+        ) -> Result<ToolOutcome, ToolError> {
+            *self.seen.lock().unwrap() = Some(args);
+            Ok(ToolOutcome::Completed(ToolResult {
+                success: true,
+                result: "ok".to_string(),
+                display_preference: None,
+                images: Vec::new(),
+            }))
+        }
+    }
+
+    /// Minimal tracing subscriber that counts WARN-level events on the current
+    /// thread — lets a test assert whether the malformed-args fallback `warn!`
+    /// fired, without pulling in `tracing-subscriber` as a dev-dependency.
+    #[derive(Clone, Default)]
+    struct WarnCounter {
+        warns: std::sync::Arc<AtomicUsize>,
+    }
+
+    impl tracing::Subscriber for WarnCounter {
+        fn enabled(&self, _m: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _a: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+        fn record(&self, _s: &tracing::span::Id, _v: &tracing::span::Record<'_>) {}
+        fn record_follows_from(&self, _s: &tracing::span::Id, _f: &tracing::span::Id) {}
+        fn event(&self, event: &tracing::Event<'_>) {
+            if *event.metadata().level() == tracing::Level::WARN {
+                self.warns.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        fn enter(&self, _s: &tracing::span::Id) {}
+        fn exit(&self, _s: &tracing::span::Id) {}
+    }
+
+    #[tokio::test]
+    async fn overlay_reuses_pre_parsed_args_and_skips_refallback_warn() {
+        // The dispatch loop already parsed the args once and threaded them via
+        // `ctx.pre_parsed_args`. The overlay must reuse that value rather than
+        // re-parse `call.function.arguments` — so even MALFORMED raw args do NOT
+        // trigger a second parse (nor its malformed-args fallback `warn!`).
+        let seen = std::sync::Arc::new(StdMutex::new(None));
+        let overlay = OverlayToolExecutor::new(
+            std::sync::Arc::new(BaseExecutor),
+            std::sync::Arc::new(ArgsRecordingOverlayTool { seen: seen.clone() }),
+        );
+
+        // Distinctive parsed value; raw args are deliberately broken so a re-parse
+        // would fall back to `{}` AND warn — neither must happen.
+        let pre_parsed = json!({"action": "query", "threaded": true});
+        let call = make_call_with_args("memory", "{ this is not valid json");
+        let mut ctx = ToolExecutionContext::none(&call.id);
+        ctx.pre_parsed_args = Some(&pre_parsed);
+
+        let counter = WarnCounter::default();
+        let warns = counter.warns.clone();
+        {
+            let _guard = tracing::subscriber::set_default(counter);
+            overlay
+                .execute_with_context(&call, ctx)
+                .await
+                .expect("overlay call should succeed");
+        }
+
+        assert_eq!(
+            seen.lock().unwrap().clone(),
+            Some(pre_parsed),
+            "overlay must invoke with the threaded pre-parsed args, not a re-parse of the raw string"
+        );
+        assert_eq!(
+            warns.load(Ordering::SeqCst),
+            0,
+            "reusing pre-parsed args must NOT re-emit the malformed-args fallback warning"
+        );
+    }
+
+    #[tokio::test]
+    async fn overlay_without_pre_parsed_reparses_and_warns_on_malformed_args() {
+        // Control proving the WarnCounter observes the fallback warn and that the
+        // reuse path above is what suppresses it: with NO pre-parsed args, the
+        // overlay re-parses the malformed raw string, falls back to `{}`, warns once.
+        let seen = std::sync::Arc::new(StdMutex::new(None));
+        let overlay = OverlayToolExecutor::new(
+            std::sync::Arc::new(BaseExecutor),
+            std::sync::Arc::new(ArgsRecordingOverlayTool { seen: seen.clone() }),
+        );
+
+        let call = make_call_with_args("memory", "{ this is not valid json");
+        let ctx = ToolExecutionContext::none(&call.id); // pre_parsed_args = None
+
+        let counter = WarnCounter::default();
+        let warns = counter.warns.clone();
+        {
+            let _guard = tracing::subscriber::set_default(counter);
+            overlay
+                .execute_with_context(&call, ctx)
+                .await
+                .expect("overlay call should succeed");
+        }
+
+        assert_eq!(
+            seen.lock().unwrap().clone(),
+            Some(json!({})),
+            "no pre-parsed args → the malformed raw string parses to the empty-object fallback"
+        );
+        assert_eq!(
+            warns.load(Ordering::SeqCst),
+            1,
+            "the malformed-args fallback must warn exactly once when it actually parses"
         );
     }
 }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -53,6 +53,14 @@ enum HeadlessPromptAction {
     /// `response` is the answer to submit (the `deny` option, fail-closed);
     /// `message` explains the auto-decision to the operator/log.
     Resolve { response: String, message: String },
+    /// stdin is NOT a terminal AND the gate has no submittable fail-closed answer
+    /// (no `deny`-labelled option and custom answers are disabled — e.g.
+    /// `exit_plan_mode`'s `["Approve …", "Stay in plan mode"]`). Routing the
+    /// literal `"deny"` fallback through `submit_response` would be guaranteed
+    /// invalid and the run would exit on a `respond rejected` error. Skip that
+    /// doomed round-trip and exit gracefully — still fail-closed (the gated tool
+    /// never runs), just cleanly (#80). `message` explains why to the operator.
+    Abort { message: String },
 }
 
 /// Decide how to handle a pending question given whether stdin is a terminal.
@@ -73,8 +81,28 @@ fn resolve_headless_permission(
     }
     // Fail closed: pick the question's own `deny` option (e.g. permission gates use
     // ["Approve", "Deny"]) so the respond validator's exact-match accepts it.
+    let deny = pick_option(&pending.options, "deny");
+    // `pick_option` falls back to the literal "deny" when no option matches. For an
+    // Approve-first gate with no deny-labelled option (e.g. `exit_plan_mode`'s
+    // `["Approve …", "Stay in plan mode"]`), that literal is NOT one of the options,
+    // so — unless the gate accepts custom answers — submitting it is guaranteed to
+    // be rejected by the respond validator. Don't route a doomed answer: abort
+    // gracefully instead (still fail-closed; the gated tool never runs) (#80).
+    let deny_is_submittable =
+        pending.allow_custom || pending.options.iter().any(|opt| opt == &deny);
+    if !deny_is_submittable {
+        return HeadlessPromptAction::Abort {
+            message: format!(
+                "cannot auto-resolve this permission gate in headless mode \
+                 (no deny option among {:?} and custom answers are disabled): \"{}\". \
+                 Pass --permission-mode bypass|accept-edits|dont-ask to run non-interactively.",
+                pending.options,
+                pending.question.trim()
+            ),
+        };
+    }
     HeadlessPromptAction::Resolve {
-        response: pick_option(&pending.options, "deny"),
+        response: deny,
         message: format!(
             "no interactive approver (stdin is not a TTY): auto-denying \"{}\". \
              Pass --permission-mode bypass|accept-edits|dont-ask to run non-interactively.",
@@ -104,6 +132,12 @@ async fn prompt_pending_response(pending: &bamboo_agent_core::PendingQuestion) -
         HeadlessPromptAction::Resolve { response, message } => {
             eprintln!("\n⏸  {message}");
             return Some(response);
+        }
+        HeadlessPromptAction::Abort { message } => {
+            // No submittable fail-closed answer: report and leave the question
+            // unanswered rather than routing a guaranteed-invalid one (#80).
+            eprintln!("\n⏸  {message}");
+            return None;
         }
         HeadlessPromptAction::Prompt => {}
     }
@@ -448,7 +482,10 @@ pub async fn run(args: HeadlessArgs) -> Result<(), String> {
         let Some(pending) = pending else { break 'run };
 
         let Some(response) = prompt_pending_response(&pending).await else {
-            eprintln!("• no input (EOF) — leaving the question unanswered");
+            // Either EOF on a TTY or a headless gate with no submittable
+            // fail-closed answer (see `HeadlessPromptAction::Abort`). Either way,
+            // leave the question unanswered and exit — the gated tool never ran.
+            eprintln!("• leaving the question unanswered (headless, fail-closed)");
             break 'run;
         };
 
@@ -724,6 +761,9 @@ mod tests {
                 assert!(message.contains("--permission-mode"));
                 assert!(message.to_ascii_lowercase().contains("deny"));
             }
+            HeadlessPromptAction::Abort { .. } => {
+                panic!("a gate with a real Deny option must resolve to it, not abort");
+            }
             HeadlessPromptAction::Prompt => {
                 panic!("non-TTY must resolve deterministically, not prompt on stdin");
             }
@@ -751,7 +791,87 @@ mod tests {
             HeadlessPromptAction::Resolve { response, .. } => {
                 assert_eq!(response, "Deny this");
             }
+            HeadlessPromptAction::Abort { .. } => {
+                panic!("a gate with a deny-containing option must resolve to it, not abort")
+            }
             HeadlessPromptAction::Prompt => panic!("expected deterministic resolve"),
+        }
+    }
+
+    /// Issue #80 (part a): an Approve-FIRST gate with NO `deny`-labelled option
+    /// (e.g. `exit_plan_mode`'s `["Approve …", "Stay in plan mode"]`) must, under a
+    /// non-TTY headless run, NEVER resolve to the Approve option — it stays fail
+    /// closed regardless of how the no-deny case is handled.
+    #[test]
+    fn non_tty_approve_first_never_auto_approves() {
+        let mut pending = permission_gate();
+        pending.options = vec![
+            "Approve (proceed with the plan)".to_string(),
+            "Stay in plan mode".to_string(),
+        ];
+        match resolve_headless_permission(false, &pending) {
+            HeadlessPromptAction::Resolve { response, .. } => assert!(
+                !response.to_ascii_lowercase().contains("approve"),
+                "fail-closed must never auto-approve; got {response:?}"
+            ),
+            // No answer is routed at all → trivially never approves.
+            HeadlessPromptAction::Abort { .. } => {}
+            HeadlessPromptAction::Prompt => {
+                panic!("non-TTY must resolve deterministically, not prompt on stdin")
+            }
+        }
+    }
+
+    /// Issue #80 (part b): the same Approve-FIRST / no-deny-label gate must not
+    /// route the guaranteed-invalid literal `"deny"` through `submit_response`
+    /// (which would exit on a `respond rejected` error). It resolves to a graceful
+    /// `Abort` that points at the escape hatch — still fail-closed, just clean.
+    #[test]
+    fn non_tty_approve_first_without_deny_label_aborts_gracefully() {
+        let mut pending = permission_gate();
+        pending.question = "Ready to code? Here is the plan…".to_string();
+        pending.options = vec![
+            "Approve (proceed with the plan)".to_string(),
+            "Keep planning".to_string(),
+            "Stay in plan mode".to_string(),
+        ];
+        pending.allow_custom = false;
+        match resolve_headless_permission(false, &pending) {
+            HeadlessPromptAction::Abort { message } => {
+                assert!(message.to_ascii_lowercase().contains("cannot auto-resolve"));
+                assert!(message.contains("--permission-mode"));
+            }
+            HeadlessPromptAction::Resolve { response, .. } => {
+                // Even without part (b) the fallback must never auto-approve, but a
+                // guaranteed-invalid literal answer is exactly what (b) removes.
+                assert!(
+                    !response.to_ascii_lowercase().contains("approve"),
+                    "must never auto-approve; got {response:?}"
+                );
+                panic!(
+                    "approve-first gate with no deny option must Abort gracefully, \
+                     not route the invalid answer {response:?} through submit_response"
+                );
+            }
+            HeadlessPromptAction::Prompt => panic!("non-TTY must resolve deterministically"),
+        }
+    }
+
+    /// A gate that accepts custom answers can still submit the literal `"deny"`
+    /// even with no deny-labelled option, so it resolves (does not abort).
+    #[test]
+    fn non_tty_no_deny_label_but_custom_allowed_resolves() {
+        let mut pending = permission_gate();
+        pending.options = vec!["Approve".to_string(), "Stay in plan mode".to_string()];
+        pending.allow_custom = true;
+        match resolve_headless_permission(false, &pending) {
+            HeadlessPromptAction::Resolve { response, .. } => {
+                assert_eq!(response, "deny");
+            }
+            HeadlessPromptAction::Abort { .. } => {
+                panic!("custom-answer gates can submit the literal deny; must not abort")
+            }
+            HeadlessPromptAction::Prompt => panic!("non-TTY must resolve deterministically"),
         }
     }
 


### PR DESCRIPTION
Closes the #80 and #106 review nits from #176. Part A (#32, memory same-doc TOCTOU) is intentionally **not** in this PR — it already landed on `main` via the re-read-under-lock in #235 and the `concurrent_same_memory_edits_do_not_lose_updates` test in #414. This PR covers only B + C.

## Part B — #80: headless approve-first, no-deny-label gate (`src/headless.rs`)
For an Approve-first gate with no `deny`-labelled option and custom answers disabled (e.g. `exit_plan_mode`'s `["Approve …", "Stay in plan mode"]`), `pick_option(&options, "deny")` falls back to the literal `"deny"`, which is not one of the options — so `submit_response` rejects it and the run exits on a `respond rejected` error (fail-closed, but ungraceful).

- **(a)** `non_tty_approve_first_never_auto_approves` — the fail-closed invariant: a non-TTY resolve of that gate never yields the Approve option.
- **(b) done** — added a graceful path: a new `HeadlessPromptAction::Abort { message }` variant. When no submittable fail-closed answer exists (no deny option **and** `!allow_custom`), the resolver skips the doomed `submit_response` round-trip and exits with a clear *"cannot auto-resolve this permission gate in headless mode …"* message pointing at `--permission-mode`. Still fail-closed (the gated tool never runs), just clean. Covered by `non_tty_approve_first_without_deny_label_aborts_gracefully` (fails without the Abort path) and `non_tty_no_deny_label_but_custom_allowed_resolves` (custom-answer gates still resolve, not abort).

## Part C — #106: overlay tools parse args once (`crates/app/bamboo-server-tools/src/overlay_executor.rs`)
`OverlayToolExecutor` re-parsed `call.function.arguments` with `parse_tool_args_best_effort` even when the dispatching loop had already parsed them and threaded the value via `ctx.pre_parsed_args` — a real double-parse for server overlay tools (`memory`, `scheduler`, `SubAgent`, …).

- Threaded the pre-parsed args through **both** overlay dispatch paths (`execute_with_context` + `execute_with_context_outcome`) via a shared `resolve_args` helper that reuses `ctx.pre_parsed_args` when present and only parses (warning once on fallback) when absent — mirroring the existing composition-executor reuse pattern in `executor.rs`. Because reuse skips the re-parse, the malformed-args fallback `warn!` is never re-emitted on the reuse path.
- `overlay_reuses_pre_parsed_args_and_skips_refallback_warn` — malformed raw args + a distinctive threaded value: the overlay must invoke with the threaded value and emit **zero** warns (fails without the fix — pre-fix it re-parses to the empty-object fallback and warns). Negative control `overlay_without_pre_parsed_reparses_and_warns_on_malformed_args` proves the warn counter actually observes the fallback that the reuse path suppresses.
- **Left as-is / deferred:** the surviving pre-dispatch classification parses in `policy.rs` and `executor.rs` (`call_mutability`/`concurrency`/`parallel`) — they run before dispatch with no context to thread through, so they're out of scope for this nit.

## Verify (CI's exact commands, from the worktree root)
- `cargo fmt -- --check` — clean
- `cargo clippy --all-features -- -A deprecated … -D warnings` — clean
- `cargo test --all-features --lib --tests` (bamboo-agent, bamboo-server-tools) — bamboo-agent lib 44 passed; bamboo-server-tools 56 + 3 passed
- `cargo build --workspace --tests --all-features` — clean

Closes #176