### PR TITLE
chore: trim dev-profile debuginfo to curb target/ disk growth

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+# Dev-profile tuning to slow down target/ disk growth (target/debug was 74G).
+# Release profile is untouched.
+
+[profile.dev]
+# Line tables keep file:line in backtraces at a fraction of full debuginfo size.
+debug = "line-tables-only"
+
+# Third-party dependencies get no debug info at all ("*" excludes workspace
+# members, so bamboo_* crates keep their line tables).
+[profile.dev.package."*"]
+debug = false


### PR DESCRIPTION
## Summary
- Add `.cargo/config.toml` setting `[profile.dev] debug = "line-tables-only"` and `[profile.dev.package."*"] debug = false`
- `target/debug` had grown to 74G locally in ~2 weeks of iteration; full debuginfo on every rlib was the dominant cost (e.g. libbamboo_server.rlib at 446M)
- Workspace crates keep file:line in backtraces via line tables; third-party deps carry no debuginfo
- Release profile untouched

## Test plan
- `cargo check -p bamboo-domain` picks up the new profile (deps recompiled under new settings, no config errors)

https://claude.ai/code/session_0138j11hELj87StgjdjRQE3Z