### PR TITLE
fix: masked api_key detection must not use substring matching

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
@@ -214,6 +214,14 @@ fn build_instance_from_create(
 
     let instance: ProviderInstanceConfig = serde_json::from_value(Value::Object(obj))
         .map_err(|e| AppError::BadRequest(format!("Invalid provider instance config: {e}")))?;
+    // On CREATE there is no existing key a placeholder could refer to — storing
+    // the literal `****...****` as the api_key would break the provider (#430).
+    if config_manager::is_masked_api_key(&instance.api_key) {
+        return Err(AppError::BadRequest(
+            "api_key looks like a masked placeholder (`****...****`); enter the real key"
+                .to_string(),
+        ));
+    }
     validate_instance_config(&instance)?;
     Ok(instance)
 }
@@ -490,4 +498,34 @@ pub async fn set_default_provider_instance(
         "success": true,
         "default_provider_instance_id": new_config.default_provider_instance,
     })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_request(api_key: &str) -> CreateInstanceRequest {
+        CreateInstanceRequest {
+            provider_type: "openai".to_string(),
+            label: None,
+            enabled: None,
+            config: serde_json::json!({ "api_key": api_key }),
+        }
+    }
+
+    #[test]
+    fn create_rejects_masked_placeholder_api_key() {
+        let err = build_instance_from_create(&create_request("****...****"))
+            .expect_err("placeholder api_key must be rejected on create");
+        assert!(matches!(err, AppError::BadRequest(_)));
+    }
+
+    #[test]
+    fn create_accepts_real_api_key_even_with_placeholder_residue() {
+        // A paste that didn't fully clear the prefilled placeholder is a real
+        // (if garbled) key — it must be stored as given, not silently dropped.
+        let instance = build_instance_from_create(&create_request("****...****sk-new"))
+            .expect("mixed value is not a placeholder");
+        assert_eq!(instance.api_key, "****...****sk-new");
+    }
 }

--- a/crates/infra/bamboo-config/src/patch.rs
+++ b/crates/infra/bamboo-config/src/patch.rs
@@ -8,10 +8,17 @@ use serde_json::{Map, Value};
 use crate::Config;
 
 /// Detect whether a string value looks like a masked/placeholder API key.
+///
+/// Only a value consisting entirely of `*`/`.` characters counts (the redaction
+/// placeholder `****...****`, or truncated/retyped variants of it). Substring
+/// matching is deliberately avoided: the UI prefills the placeholder into the
+/// editable field, so a paste that doesn't fully clear it yields values like
+/// `****...****sk-new…` — treating those as "keep existing key" silently
+/// discards the user's new token (#430).
 pub fn is_masked_api_key(value: &str) -> bool {
     let v = value.trim();
     // Empty string is treated as an explicit "clear" signal (we control all clients).
-    v.contains("***") || v.contains("...") || v == "****...****"
+    !v.is_empty() && v.chars().all(|c| c == '*' || c == '.')
 }
 
 /// Extract API-key update intents from a config patch.
@@ -409,5 +416,26 @@ mod tests {
         assert!(!intents.providers.contains("openai"));
         assert!(intents.provider_instances.contains("personal-openai"));
         assert!(!intents.provider_instances.contains("work-openai"));
+    }
+
+    #[test]
+    fn is_masked_api_key_requires_placeholder_only_values() {
+        // The redaction placeholder and all-asterisk/dot variants are masked.
+        assert!(is_masked_api_key("****...****"));
+        assert!(is_masked_api_key("********"));
+        assert!(is_masked_api_key("  ****...****  "));
+
+        // Empty is a "clear" signal, not a mask.
+        assert!(!is_masked_api_key(""));
+        assert!(!is_masked_api_key("   "));
+
+        // A placeholder with a real key pasted after it must NOT be treated as
+        // masked — that silently discards the user's new token (#430).
+        assert!(!is_masked_api_key("****...****sk-newkey123"));
+        assert!(!is_masked_api_key("sk-newkey123****...****"));
+
+        // Real keys containing dots or asterisks among other characters are keys.
+        assert!(!is_masked_api_key("id.secret...suffix"));
+        assert!(!is_masked_api_key("sk-live-abc"));
     }
 }


### PR DESCRIPTION
Fixes #430

## Summary
- `is_masked_api_key` now matches only values made entirely of `*`/`.` (the redaction placeholder and truncated variants) instead of `contains("***") || contains("...")`
- Paste-append values like `****...****sk-new…` are no longer silently treated as "keep existing key" — the user's input is stored as given, so a bad paste fails loudly at the provider instead of silently keeping the old token
- Provider-instance CREATE now rejects placeholder-looking keys with a clear 400 (previously stored the literal `****...****` as the api_key)

## Test plan
- New unit tests: `is_masked_api_key_requires_placeholder_only_values` (bamboo-config), `create_rejects_masked_placeholder_api_key` + `create_accepts_real_api_key_even_with_placeholder_residue` (bamboo-server)
- `cargo test -p bamboo-config patch` and `cargo test -p bamboo-server provider_instances` pass; `cargo fmt` clean

Frontend counterparts (Lotus/lotus-next stop prefilling the placeholder into the editable field; empty = keep) land in their own repos.

https://claude.ai/code/session_0138j11hELj87StgjdjRQE3Z