### PR TITLE
feat(release): stage lotus frontend from npm at publish time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,7 @@ target
 /examples
 **/*.log
 .DS_Store
+# Host-side npm install used only to stage frontend_package/ before the build;
+# the workspace include_bytes! embed needs the staged zip, not node_modules.
+node_modules
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,12 +13,21 @@ name: Publish Docker image (GHCR)
 # larger-runner plan, drop the arm64 matrix entry or switch to a single QEMU
 # job with docker/setup-qemu-action.)
 #
-# The lotus frontend is embedded automatically: frontend_package/ is committed
-# and crates/app/bamboo-server/frontend_package symlinks to it, so the in-image
-# `cargo build` picks it up via include_bytes! — no host-side staging needed.
+# The lotus frontend is embedded via frontend_package/ (which
+# crates/app/bamboo-server/frontend_package symlinks to, picked up by the
+# in-image `cargo build` through include_bytes!). Each build job re-stages that
+# directory from the published @bigduu/lotus npm package first, so the image
+# ships the requested (default: newest) frontend instead of whatever zip was
+# last committed — the committed copy goes stale between Lotus releases.
 
 on:
   workflow_dispatch:
+    inputs:
+      lotus_version:
+        description: "@bigduu/lotus npm version to embed as the web frontend. 'latest' resolves the newest published version."
+        required: false
+        default: "latest"
+        type: string
   push:
     tags:
       - "v*"
@@ -49,6 +58,31 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Stage frontend package from npm
+        # Overwrites the committed frontend_package/ in the build context with a
+        # bundle staged from the published npm package (tag pushes carry no
+        # inputs and stage 'latest'). LOTUS_SOURCE=package hard-fails when the
+        # package is missing — never silently falls back to the stale zip.
+        env:
+          LOTUS_VERSION: ${{ github.event.inputs.lotus_version || 'latest' }}
+        run: |
+          set -euo pipefail
+          npm install --no-save --no-package-lock "@bigduu/lotus@${LOTUS_VERSION}"
+          LOTUS_SOURCE=package node scripts/frontend-package.cjs stage
+          test -f frontend_package/lotus-frontend.zip
+          test -f frontend_package/frontend-manifest.json
+          EMBEDDED="$(node -p "require('./frontend_package/frontend-manifest.json').frontend_version")"
+          echo "Embedded lotus frontend version: ${EMBEDDED}"
+          if [ "${LOTUS_VERSION}" != "latest" ] && [ "${EMBEDDED}" != "${LOTUS_VERSION}" ]; then
+            echo "::error::Embedded lotus version ${EMBEDDED} does not match requested ${LOTUS_VERSION}"
+            exit 1
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: false
         type: boolean
+      lotus_version:
+        description: "@bigduu/lotus npm version to embed as the web frontend (for example: 2026.3.11). 'latest' resolves the newest published version."
+        required: false
+        default: "latest"
+        type: string
 
 permissions:
   contents: read
@@ -31,11 +36,26 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Stage frontend package
+      - name: Stage frontend package from npm
+        # Embed the published @bigduu/lotus package instead of the committed
+        # frontend_package/ zip — the committed copy goes stale between Lotus
+        # releases (the release train passes the exact same-day version).
+        # LOTUS_SOURCE=package hard-fails when the npm package is missing, so a
+        # fetch failure can never silently fall back to the stale zip.
+        env:
+          LOTUS_VERSION: ${{ github.event.inputs.lotus_version || 'latest' }}
         run: |
-          node scripts/frontend-package.cjs stage
+          set -euo pipefail
+          npm install --no-save --no-package-lock "@bigduu/lotus@${LOTUS_VERSION}"
+          LOTUS_SOURCE=package node scripts/frontend-package.cjs stage
           test -f frontend_package/lotus-frontend.zip
           test -f frontend_package/frontend-manifest.json
+          EMBEDDED="$(node -p "require('./frontend_package/frontend-manifest.json').frontend_version")"
+          echo "Embedded lotus frontend version: ${EMBEDDED}"
+          if [ "${LOTUS_VERSION}" != "latest" ] && [ "${EMBEDDED}" != "${LOTUS_VERSION}" ]; then
+            echo "::error::Embedded lotus version ${EMBEDDED} does not match requested ${LOTUS_VERSION}"
+            exit 1
+          fi
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Problem

`publish-crate.yml` and `docker-publish.yml` embed whatever `frontend_package/lotus-frontend.zip` was last committed. The committed zip goes stale between Lotus releases, so the GHCR image (and publish verify builds) ship an outdated frontend — the drift behind the chunk-404 class of bugs.

## Change

- Both release workflows now `npm install --no-save --no-package-lock @bigduu/lotus@<lotus_version>` and stage via `LOTUS_SOURCE=package node scripts/frontend-package.cjs stage`.
- New `lotus_version` workflow_dispatch input on both (default `latest`; the Zenith release train will pass the exact same-day version — companion Zenith PR follows).
- `LOTUS_SOURCE=package` hard-fails when the package is missing, so a fetch failure can never silently fall back to the stale committed zip; an explicit guard also asserts the staged manifest version matches the requested version.
- `node_modules` added to `.dockerignore` so the host-side install never enters the image build context.

## Notes

- The published crates are unaffected in content (root + bamboo-server both have explicit `include` whitelists; the crate never ships the zip) — this fixes the docker image and keeps verify builds honest.
- Tag-push triggered docker builds carry no inputs and stage `latest`.
- Verified locally: `npm install @bigduu/lotus@latest` + `LOTUS_SOURCE=package stage` produced a manifest at 2026.7.8 (today's Lotus) with a clean zip.
- CI jobs (ci.yml etc.) intentionally keep using the committed zip — no npm dependency added to test paths.

https://claude.ai/code/session_0138j11hELj87StgjdjRQE3Z