### PR TITLE
chore: refresh crates.io keywords and categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,10 +95,10 @@ homepage = "https://github.com/bigduu/Bamboo-agent"
 repository = "https://github.com/bigduu/Bamboo-agent"
 documentation = "https://docs.rs/bamboo-agent"
 readme = "README.md"
-keywords = ["ai", "agent", "llm", "automation", "assistant"]
+keywords = ["ai", "agent", "llm", "automation", "mcp"]
 categories = [
+    "artificial-intelligence",
     "development-tools",
-    "api-bindings",
     "web-programming",
     "asynchronous",
 ]

--- a/crates/app/bamboo-sdk/Cargo.toml
+++ b/crates/app/bamboo-sdk/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 rust-version.workspace = true
 description = "Ergonomic top-level Agent SDK facade for the Bamboo agent framework"
 license = "MIT"
+repository = "https://github.com/bigduu/Bamboo-agent"
+keywords = ["ai", "agent", "llm", "sdk", "mcp"]
+categories = ["artificial-intelligence", "development-tools", "asynchronous"]
 
 [dependencies]
 # Workspace crates (leaf-only: never depends on bamboo-server)

--- a/crates/core/bamboo-agent-core/Cargo.toml
+++ b/crates/core/bamboo-agent-core/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 rust-version.workspace = true
 description = "Core agent abstractions and execution primitives for the Bamboo agent framework"
 license = "MIT"
+repository = "https://github.com/bigduu/Bamboo-agent"
+keywords = ["ai", "agent", "llm", "automation", "mcp"]
+categories = ["artificial-intelligence", "development-tools", "asynchronous"]
 
 [dependencies]
 bamboo-domain = { path = "../../core/bamboo-domain" }


### PR DESCRIPTION
Part of the discoverability pass (repo topics/descriptions were updated separately).

- `bamboo-agent`: keywords `assistant` → `mcp`; categories: replace `api-bindings` with `artificial-intelligence`
- `bamboo-agent-core`, `bamboo-sdk`: add `repository`, `keywords`, `categories` (they had none, so they don't surface in crates.io keyword/category browsing)

Metadata-only change; takes effect on the next release-train publish. Validated with `cargo metadata`.

https://claude.ai/code/session_01SSfEv7tWa47S3xTGKWbh4F