### PR TITLE
feat(cli): respond + session lifecycle verbs; report true history total

### DIFF
--- a/src/admin_cli.rs
+++ b/src/admin_cli.rs
@@ -1,10 +1,11 @@
-//! The `bamboo health | status | sessions | stop` admin CLI.
+//! The `bamboo health | status | sessions | session | stop | respond` admin CLI.
 //!
 //! A thin HTTP client over a running `bamboo serve` instance. Each command wraps
 //! an endpoint the server already exposes — `/api/v1/health`,
-//! `/api/v1/sessions`, `/api/v1/stop/{id}` — so an operator can probe and steer
-//! the backend without hand-writing `curl`. The server is the single source of
-//! truth; this module only resolves the base URL and pretty-prints responses.
+//! `/api/v1/sessions`, `/api/v1/stop/{id}`, `/api/v1/respond/{id}` — so an
+//! operator can probe and steer the backend without hand-writing `curl`. The
+//! server is the single source of truth; this module only resolves the base URL
+//! and pretty-prints responses.
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -52,6 +53,21 @@ impl ConnArgs {
 
 fn unreachable(base: &str, e: reqwest::Error) -> anyhow::Error {
     anyhow::anyhow!("could not reach the server at {base} ({e}). Is `bamboo serve` running?")
+}
+
+/// Guard a session id used as a URL path segment: real session ids are opaque
+/// tokens (UUIDs), so reject anything that could traverse or malform the URL
+/// rather than encode it.
+fn guard_session_id(session_id: &str) -> anyhow::Result<()> {
+    if session_id.is_empty()
+        || session_id == "."
+        || session_id == ".."
+        || session_id.contains(['/', '\\', '?', '#', '%'])
+        || session_id.chars().any(char::is_whitespace)
+    {
+        anyhow::bail!("invalid session id: '{session_id}'");
+    }
+    Ok(())
 }
 
 /// `bamboo health` — liveness probe. Exits non-zero (via the returned `Err`)
@@ -179,16 +195,7 @@ pub async fn sessions_list(conn: ConnArgs) -> anyhow::Result<()> {
 
 /// `bamboo stop <id>` — cancel a running session's loop.
 pub async fn stop(conn: ConnArgs, session_id: &str) -> anyhow::Result<()> {
-    // Guard the path segment: real session ids are opaque tokens (UUIDs), so
-    // reject anything that could traverse or malform the URL rather than encode it.
-    if session_id.is_empty()
-        || session_id == "."
-        || session_id == ".."
-        || session_id.contains(['/', '\\', '?', '#', '%'])
-        || session_id.chars().any(char::is_whitespace)
-    {
-        anyhow::bail!("invalid session id: '{session_id}'");
-    }
+    guard_session_id(session_id)?;
     let base = conn.api_base();
     let url = format!("{base}/stop/{session_id}");
     let resp = reqwest::Client::new()
@@ -231,15 +238,7 @@ pub async fn stop(conn: ConnArgs, session_id: &str) -> anyhow::Result<()> {
 /// what a headless `-p` run actually did, or an interactive session's log,
 /// without the web UI. Folded in from the retired `bamboo-cli history`.
 pub async fn history(conn: ConnArgs, session_id: &str) -> anyhow::Result<()> {
-    // Same path-segment guard as `stop`: ids are opaque tokens.
-    if session_id.is_empty()
-        || session_id == "."
-        || session_id == ".."
-        || session_id.contains(['/', '\\', '?', '#', '%'])
-        || session_id.chars().any(char::is_whitespace)
-    {
-        anyhow::bail!("invalid session id: '{session_id}'");
-    }
+    guard_session_id(session_id)?;
     let base = conn.api_base();
     let url = format!("{base}/history/{session_id}");
     let resp = reqwest::Client::new()
@@ -275,8 +274,333 @@ pub async fn history(conn: ConnArgs, session_id: &str) -> anyhow::Result<()> {
         };
         println!("{label}: {content}");
     }
-    println!("\n{} message(s) in session {session_id}.", messages.len());
+    // The server caps a cold (non-delta) history fetch and reports the pre-cap
+    // count in `total_message_count` (+ `truncated`), so report the TRUE total —
+    // `messages.len()` would silently under-count a capped session (#423).
+    let total = v
+        .get("total_message_count")
+        .and_then(|x| x.as_u64())
+        .unwrap_or(messages.len() as u64);
+    let truncated = v
+        .get("truncated")
+        .and_then(|x| x.as_bool())
+        .unwrap_or(false);
+    println!(
+        "\n{}",
+        history_summary(session_id, messages.len(), total, truncated)
+    );
     Ok(())
+}
+
+/// The trailing summary line for `bamboo history`: the true total (pre-cap
+/// `total_message_count`), plus a truncation note when the server dropped
+/// older messages to stay under its cold-fetch cap (#423).
+fn history_summary(session_id: &str, shown: usize, total: u64, truncated: bool) -> String {
+    if truncated {
+        format!(
+            "{total} message(s) in session {session_id} (showing the newest {shown}; older messages omitted by the server's history cap)."
+        )
+    } else {
+        format!("{total} message(s) in session {session_id}.")
+    }
+}
+
+/// `bamboo respond <id> <answer>` — answer a session's pending question
+/// (permission gate / clarification) out-of-band via
+/// `POST /api/v1/respond/{id}`. Answering resumes the blocked run server-side.
+pub async fn respond(conn: ConnArgs, session_id: &str, answer: &str) -> anyhow::Result<()> {
+    guard_session_id(session_id)?;
+    let base = conn.api_base();
+    let url = format!("{base}/respond/{session_id}");
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .timeout(REQUEST_TIMEOUT)
+        // The same shape the frontends send; the server also accepts optional
+        // model/provider/reasoning_effort overrides which the CLI leaves unset.
+        .json(&serde_json::json!({ "response": answer }))
+        .send()
+        .await
+        .map_err(|e| unreachable(&base, e))?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+    if status.is_success() {
+        let auto_resume = body
+            .get("auto_resume_status")
+            .and_then(|s| s.as_str())
+            .unwrap_or("unknown");
+        println!(
+            "{} response recorded; the run resumes server-side (auto-resume: {auto_resume}).",
+            "✓".green()
+        );
+        if let Some(run_id) = body.get("run_id").and_then(|r| r.as_str()) {
+            println!("run id: {run_id}");
+        }
+        return Ok(());
+    }
+    if status.as_u16() == 404 {
+        anyhow::bail!("session '{session_id}' not found");
+    }
+    let error = body.get("error").and_then(|e| e.as_str()).unwrap_or("");
+    if status.as_u16() == 400 && error.contains("No pending question") {
+        anyhow::bail!(
+            "session '{session_id}' has no pending question — nothing to answer \
+             (check with: bamboo respond {session_id} --pending)"
+        );
+    }
+    let detail = body.get("message").and_then(|m| m.as_str()).unwrap_or("");
+    anyhow::bail!(
+        "respond failed: HTTP {status}{}{}",
+        if error.is_empty() {
+            String::new()
+        } else {
+            format!(" {error}")
+        },
+        if detail.is_empty() {
+            String::new()
+        } else {
+            format!(" ({detail})")
+        }
+    );
+}
+
+/// `bamboo respond <id> --pending` — show the question a session is blocked on
+/// (`GET /api/v1/respond/{id}/pending`), pretty or as raw JSON.
+pub async fn respond_pending(conn: ConnArgs, session_id: &str, json: bool) -> anyhow::Result<()> {
+    guard_session_id(session_id)?;
+    let base = conn.api_base();
+    let url = format!("{base}/respond/{session_id}/pending");
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| unreachable(&base, e))?;
+    if resp.status().as_u16() == 404 {
+        anyhow::bail!("session '{session_id}' not found");
+    }
+    if !resp.status().is_success() {
+        anyhow::bail!("GET {url} -> HTTP {}", resp.status());
+    }
+    let v: serde_json::Value = resp.json().await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&v)?);
+        return Ok(());
+    }
+    match format_pending_question(session_id, &v) {
+        Some(text) => println!("{text}"),
+        None => println!("no pending question for session '{session_id}'."),
+    }
+    Ok(())
+}
+
+/// Pretty-print the `GET /respond/{id}/pending` payload, or `None` when the
+/// session has no pending question.
+fn format_pending_question(session_id: &str, v: &serde_json::Value) -> Option<String> {
+    if !v
+        .get("has_pending_question")
+        .and_then(|b| b.as_bool())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    let question = v.get("question").and_then(|q| q.as_str()).unwrap_or("");
+    let mut out = format!("session:  {session_id}\nquestion: {question}\n");
+    if let Some(options) = v.get("options").and_then(|o| o.as_array()) {
+        if !options.is_empty() {
+            out.push_str("options:\n");
+            for (i, opt) in options.iter().enumerate() {
+                let opt = opt
+                    .as_str()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| opt.to_string());
+                out.push_str(&format!("  {}. {opt}\n", i + 1));
+            }
+        }
+    }
+    if v.get("allow_custom")
+        .and_then(|b| b.as_bool())
+        .unwrap_or(false)
+    {
+        out.push_str("(custom free-text answers are allowed)\n");
+    }
+    if let Some(tool) = v
+        .get("tool_name")
+        .and_then(|t| t.as_str())
+        .filter(|t| !t.is_empty())
+    {
+        out.push_str(&format!("tool:     {tool}\n"));
+    }
+    out.push_str(&format!(
+        "\nAnswer with: bamboo respond {session_id} \"<answer>\" — answering resumes the run server-side."
+    ));
+    Some(out)
+}
+
+/// `bamboo session show <id>` — one session's detail
+/// (`GET /api/v1/sessions/{id}`), pretty or as raw JSON.
+pub async fn session_show(conn: ConnArgs, session_id: &str, json: bool) -> anyhow::Result<()> {
+    guard_session_id(session_id)?;
+    let base = conn.api_base();
+    let url = format!("{base}/sessions/{session_id}");
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| unreachable(&base, e))?;
+    if resp.status().as_u16() == 404 {
+        anyhow::bail!("session '{session_id}' not found");
+    }
+    if !resp.status().is_success() {
+        anyhow::bail!("GET {url} -> HTTP {}", resp.status());
+    }
+    let v: serde_json::Value = resp.json().await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&v)?);
+        return Ok(());
+    }
+    let session = v.get("session").unwrap_or(&v);
+    println!("{}", format_session_detail(session));
+    Ok(())
+}
+
+/// Pretty-print the `session` object of `GET /sessions/{id}` as label/value
+/// lines (same visual style as `bamboo status`). Optional fields are only
+/// printed when present so the output stays one screen.
+fn format_session_detail(s: &serde_json::Value) -> String {
+    let str_field = |key: &str| s.get(key).and_then(|x| x.as_str()).unwrap_or("");
+    let mut lines: Vec<String> = Vec::new();
+    let mut push = |label: &str, value: String| {
+        // Pad BEFORE colorizing: ANSI escapes would otherwise count against the
+        // column width (same caveat as the `sessions` table above).
+        let label = format!("{:<16}", format!("{label}:"));
+        lines.push(format!("{}{value}", label.bold()));
+    };
+
+    push("id", str_field("id").to_string());
+    push("title", str_field("title").to_string());
+    push("kind", str_field("kind").to_string());
+    let model = str_field("model").to_string();
+    let model = match s.get("provider").and_then(|p| p.as_str()) {
+        Some(provider) if !provider.is_empty() => format!("{provider}:{model}"),
+        _ => model,
+    };
+    push("model", model);
+    let running = s
+        .get("is_running")
+        .and_then(|b| b.as_bool())
+        .unwrap_or(false);
+    push(
+        "running",
+        if running {
+            "yes".green().to_string()
+        } else {
+            "no".to_string()
+        },
+    );
+    if let Some(status) = s.get("last_run_status").and_then(|x| x.as_str()) {
+        let mut line = status.to_string();
+        if let Some(err) = s.get("last_run_error").and_then(|x| x.as_str()) {
+            line.push_str(&format!(" ({err})"));
+        }
+        push("last run", line);
+    }
+    let pending = s
+        .get("has_pending_question")
+        .and_then(|b| b.as_bool())
+        .unwrap_or(false);
+    push(
+        "pending q",
+        if pending {
+            "yes (see: bamboo respond <id> --pending)"
+                .yellow()
+                .to_string()
+        } else {
+            "no".to_string()
+        },
+    );
+    push(
+        "messages",
+        s.get("message_count")
+            .and_then(|x| x.as_u64())
+            .unwrap_or(0)
+            .to_string(),
+    );
+    if s.get("pinned").and_then(|b| b.as_bool()).unwrap_or(false) {
+        push("pinned", "yes".to_string());
+    }
+    if let Some(parent) = s.get("parent_session_id").and_then(|x| x.as_str()) {
+        push("parent", parent.to_string());
+    }
+    let child_count = s
+        .get("running_child_count")
+        .and_then(|x| x.as_u64())
+        .unwrap_or(0);
+    if child_count > 0 {
+        push("children", format!("{child_count} running"));
+    }
+    push("created", str_field("created_at").to_string());
+    push("last activity", str_field("last_activity_at").to_string());
+    if let Some(placement) = s.get("placement") {
+        let kind = placement.get("kind").and_then(|x| x.as_str()).unwrap_or("");
+        let host = placement.get("host").and_then(|x| x.as_str()).unwrap_or("");
+        if !kind.is_empty() || !host.is_empty() {
+            push("placement", format!("{kind} @ {host}"));
+        }
+    }
+    lines.join("\n")
+}
+
+/// `bamboo session delete <id>` — delete a session
+/// (`DELETE /api/v1/sessions/{id}`), cancelling any running execution.
+/// Prompts for confirmation unless `yes` is set.
+pub async fn session_delete(conn: ConnArgs, session_id: &str, yes: bool) -> anyhow::Result<()> {
+    guard_session_id(session_id)?;
+    if !yes && !confirm(&format!(
+        "Delete session '{session_id}'? This cancels any running execution and removes it permanently."
+    ))? {
+        println!("aborted (nothing deleted).");
+        return Ok(());
+    }
+    let base = conn.api_base();
+    let url = format!("{base}/sessions/{session_id}");
+    let resp = reqwest::Client::new()
+        .delete(&url)
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| unreachable(&base, e))?;
+    let status = resp.status();
+    if status.is_success() {
+        println!("{} session '{session_id}' deleted", "✓".green());
+        return Ok(());
+    }
+    if status.as_u16() == 404 {
+        anyhow::bail!("session '{session_id}' not found");
+    }
+    let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+    let error = body.get("error").and_then(|e| e.as_str()).unwrap_or("");
+    anyhow::bail!(
+        "delete failed: HTTP {status}{}",
+        if error.is_empty() {
+            String::new()
+        } else {
+            format!(" ({error})")
+        }
+    );
+}
+
+/// Ask a yes/no question on stdout and read the answer from stdin. Defaults to
+/// "no" on anything but an explicit y/yes — including EOF (non-TTY pipe), so a
+/// script that forgets `--yes` aborts instead of deleting.
+fn confirm(prompt: &str) -> anyhow::Result<bool> {
+    use std::io::Write as _;
+    print!("{prompt} [y/N] ");
+    std::io::stdout().flush()?;
+    let mut line = String::new();
+    std::io::stdin().read_line(&mut line)?;
+    let answer = line.trim().to_ascii_lowercase();
+    Ok(answer == "y" || answer == "yes")
 }
 
 /// Count array entries whose `is_running` is true.
@@ -298,5 +622,111 @@ fn truncate(s: &str, max: usize) -> String {
     } else {
         let head: String = s.chars().take(max.saturating_sub(1)).collect();
         format!("{head}…")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        format_pending_question, format_session_detail, guard_session_id, history_summary,
+    };
+
+    #[test]
+    fn guard_session_id_rejects_path_hazards() {
+        for bad in [
+            "", ".", "..", "a/b", "a\\b", "a?b", "a#b", "a%b", "a b", "a\tb",
+        ] {
+            assert!(guard_session_id(bad).is_err(), "{bad:?} must be rejected");
+        }
+        assert!(guard_session_id("0195fd1e-abc4-7def-8123-456789abcdef").is_ok());
+    }
+
+    #[test]
+    fn history_summary_reports_true_total_and_truncation() {
+        // Un-truncated: the plain total (#423 item 2 — the total, not page len).
+        assert_eq!(
+            history_summary("s1", 3, 3, false),
+            "3 message(s) in session s1."
+        );
+        // Truncated cold fetch: true total + an explicit truncation note.
+        let line = history_summary("s1", 2000, 5000, true);
+        assert!(line.starts_with("5000 message(s) in session s1"));
+        assert!(line.contains("newest 2000"));
+        assert!(line.contains("history cap"));
+    }
+
+    #[test]
+    fn format_pending_question_pretty_prints_question_and_options() {
+        colored::control::set_override(false);
+        let v = serde_json::json!({
+            "has_pending_question": true,
+            "question": "Proceed with the deploy?",
+            "options": ["Yes", "No"],
+            "allow_custom": true,
+            "tool_call_id": "tc-1",
+            "tool_name": "conclusion_with_options",
+            "source": "tool",
+        });
+        let text = format_pending_question("sess-1", &v).expect("pending question");
+        assert!(text.contains("question: Proceed with the deploy?"));
+        assert!(text.contains("1. Yes"));
+        assert!(text.contains("2. No"));
+        assert!(text.contains("custom free-text answers are allowed"));
+        assert!(text.contains("tool:     conclusion_with_options"));
+        assert!(text.contains("bamboo respond sess-1"));
+        assert!(text.contains("resumes the run server-side"));
+    }
+
+    #[test]
+    fn format_pending_question_none_when_no_question() {
+        let v = serde_json::json!({ "has_pending_question": false });
+        assert!(format_pending_question("sess-1", &v).is_none());
+        // Defensive: an empty/odd body also reads as "no pending question".
+        assert!(format_pending_question("sess-1", &serde_json::json!({})).is_none());
+    }
+
+    #[test]
+    fn format_session_detail_shows_core_and_optional_fields() {
+        colored::control::set_override(false);
+        let s = serde_json::json!({
+            "id": "sess-9",
+            "title": "Fix the bug",
+            "kind": "root",
+            "model": "claude-sonnet-5",
+            "provider": "anthropic",
+            "is_running": true,
+            "last_run_status": "failed",
+            "last_run_error": "boom",
+            "has_pending_question": true,
+            "message_count": 12,
+            "pinned": true,
+            "running_child_count": 2,
+            "created_at": "2026-07-10T00:00:00Z",
+            "last_activity_at": "2026-07-10T01:00:00Z",
+            "placement": { "kind": "local", "host": "mac.local" },
+        });
+        let text = format_session_detail(&s);
+        assert!(text.contains("sess-9"));
+        assert!(text.contains("Fix the bug"));
+        assert!(text.contains("anthropic:claude-sonnet-5"));
+        assert!(text.contains("failed (boom)"));
+        assert!(text.contains("2 running"));
+        assert!(text.contains("local @ mac.local"));
+        assert!(text.contains("bamboo respond <id> --pending"));
+
+        // Optional fields absent → their lines are omitted entirely.
+        let minimal = serde_json::json!({
+            "id": "sess-min",
+            "title": "",
+            "kind": "root",
+            "model": "m",
+            "is_running": false,
+            "message_count": 0,
+        });
+        let text = format_session_detail(&minimal);
+        assert!(!text.contains("last run"));
+        assert!(!text.contains("parent"));
+        assert!(!text.contains("children"));
+        assert!(!text.contains("placement"));
     }
 }

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -291,6 +291,44 @@ enum Commands {
         conn: ConnArgs,
     },
 
+    /// Answer a session's pending question (permission gate / clarification)
+    /// from the terminal (POST /api/v1/respond/{id}). Answering resumes the
+    /// blocked run server-side — handy for a headless/scheduled run that is
+    /// waiting on input. Use --pending to view the question first.
+    #[command(after_help = "EXAMPLES:\n  \
+        # See what a blocked session is asking\n  \
+        bamboo respond <session-id> --pending\n\n  \
+        # Answer it (the run resumes server-side)\n  \
+        bamboo respond <session-id> \"Yes\"")]
+    Respond {
+        /// Session id with the pending question.
+        session_id: String,
+
+        /// The answer — one of the offered options, or free text when the
+        /// question allows custom input. Omit it with --pending to only view
+        /// the question.
+        #[arg(required_unless_present = "pending", conflicts_with = "pending")]
+        answer: Option<String>,
+
+        /// Show the pending question (text + options) instead of answering.
+        #[arg(long)]
+        pending: bool,
+
+        /// With --pending: print the raw JSON response instead of pretty text.
+        #[arg(long, requires = "pending")]
+        json: bool,
+
+        #[command(flatten)]
+        conn: ConnArgs,
+    },
+
+    /// Per-session lifecycle verbs on a running server (list with
+    /// `bamboo sessions`).
+    Session {
+        #[command(subcommand)]
+        command: SessionCommands,
+    },
+
     /// Print a session's message transcript from a running server
     /// (GET /api/v1/history/{id}). Handy to review a headless `-p` run's log.
     History {
@@ -316,6 +354,37 @@ enum Commands {
 }
 
 #[derive(Subcommand)]
+enum SessionCommands {
+    /// Show one session's detail (GET /api/v1/sessions/{id}): title, model,
+    /// running state, pending question, message count, placement.
+    Show {
+        /// Session id to show.
+        session_id: String,
+
+        /// Print the raw JSON response instead of the pretty summary.
+        #[arg(long)]
+        json: bool,
+
+        #[command(flatten)]
+        conn: ConnArgs,
+    },
+
+    /// Delete a session permanently (DELETE /api/v1/sessions/{id}). Cancels
+    /// any running execution first. Asks for confirmation unless --yes.
+    Delete {
+        /// Session id to delete.
+        session_id: String,
+
+        /// Skip the confirmation prompt (required for scripts / non-TTY use).
+        #[arg(short = 'y', long)]
+        yes: bool,
+
+        #[command(flatten)]
+        conn: ConnArgs,
+    },
+}
+
+#[derive(Subcommand)]
 enum SkillsCommands {
     /// List discovered skills (id, name, description).
     List {
@@ -336,7 +405,8 @@ enum McpCommands {
 }
 
 /// Connection options shared by the admin subcommands (`health` / `status` /
-/// `sessions` / `stop`). Resolves which running server to talk to.
+/// `sessions` / `session` / `stop` / `respond` / `history`). Resolves which
+/// running server to talk to.
 #[derive(clap::Args, Clone)]
 struct ConnArgs {
     /// Full base URL of the server, e.g. `http://127.0.0.1:9562`.
@@ -636,6 +706,8 @@ async fn main() {
         | Some(Commands::Status { .. })
         | Some(Commands::Sessions { .. })
         | Some(Commands::Stop { .. })
+        | Some(Commands::Respond { .. })
+        | Some(Commands::Session { .. })
         | Some(Commands::History { .. })
         | Some(Commands::Skills { .. })
         | Some(Commands::Mcp { .. })
@@ -1088,6 +1160,45 @@ async fn main() {
 
         Commands::Stop { session_id, conn } => {
             if let Err(e) = bamboo_agent::admin_cli::stop(conn.into(), &session_id).await {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }
+        }
+
+        Commands::Respond {
+            session_id,
+            answer,
+            pending,
+            json,
+            conn,
+        } => {
+            let result = if pending {
+                bamboo_agent::admin_cli::respond_pending(conn.into(), &session_id, json).await
+            } else {
+                // clap enforces `answer` is present when --pending is absent.
+                let answer = answer.unwrap_or_default();
+                bamboo_agent::admin_cli::respond(conn.into(), &session_id, &answer).await
+            };
+            if let Err(e) = result {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }
+        }
+
+        Commands::Session { command } => {
+            let result = match command {
+                SessionCommands::Show {
+                    session_id,
+                    json,
+                    conn,
+                } => bamboo_agent::admin_cli::session_show(conn.into(), &session_id, json).await,
+                SessionCommands::Delete {
+                    session_id,
+                    yes,
+                    conn,
+                } => bamboo_agent::admin_cli::session_delete(conn.into(), &session_id, yes).await,
+            };
+            if let Err(e) = result {
                 eprintln!("{e}");
                 std::process::exit(1);
             }


### PR DESCRIPTION
## Summary

Adds out-of-band session interaction to the `bamboo` admin CLI — a blocked headless/scheduled run waiting on a permission gate or clarification could previously only be answered inside a live `-p` TTY. All verbs are thin HTTP wrappers in `src/admin_cli.rs` following the existing `ConnArgs` (`--server-url`/`--port`/`--data-dir`) style.

### New verbs

- **`bamboo respond <session-id> <answer>`** — `POST /api/v1/respond/{id}` with the same `{response}` body the frontends send. Prints the auto-resume status + run id; help text notes that answering resumes the run server-side. A session with no pending question gets a clean actionable error (exit 1), not a panic.
- **`bamboo respond <session-id> --pending [--json]`** — `GET /api/v1/respond/{id}/pending`; pretty-prints the question, numbered options, custom-answer allowance and originating tool (plus a ready-to-paste answer command), or `no pending question for session '<id>'.` when there is none. `--json` dumps the raw payload.
- **`bamboo session show <id> [--json]`** — `GET /api/v1/sessions/{id}` detail: title, kind, model (provider-qualified when present), running state, last run status/error, pending-question flag, message count, parent/children, timestamps, placement.
- **`bamboo session delete <id> [--yes]`** — `DELETE /api/v1/sessions/{id}` (cancels any running execution) behind a `[y/N]` confirm prompt; EOF/non-TTY input defaults to abort, so scripts must pass `--yes`.

### Naming choice

List/steer verbs stay **flat** for back-compat (`sessions`, `stop`, `history`); the new per-session lifecycle verbs live under a **`session` noun** (`session show|delete`), following the existing `skills list` / `mcp list` / `actor run|serve` noun-verb precedent. `sessions`' own hint text and the `session` help cross-reference each other.

### #423 fix (item 2)

`bamboo history <id>` printed the capped `messages.len()` as "N message(s) in session" — since the cold-history cap (#421/#422) that silently under-reports sessions over 2000 messages. It now prints the server's pre-cap `total_message_count` and an explicit note when `truncated`:

```
5000 message(s) in session s1 (showing the newest 2000; older messages omitted by the server's history cap).
```

**Item 1 verification:** the TUI `list_sessions()` envelope parse was already fixed on main by c2cca91c (`ListSessionsEnvelope {sessions,total,limit,offset,next_offset}` + tests) — both items are now addressed.

Also factors the duplicated session-id path-segment guard (`stop`/`history`) into a shared `guard_session_id`.

## Testing

- 5 new unit tests (guard, history summary line, pending-question formatting, session-detail formatting incl. optional-field omission); `cargo test -p bamboo-agent --lib --bins` green (49 + 2).
- `cargo build` + `cargo clippy` clean for the touched crate (no new warnings); `cargo fmt --check` clean.
- Smoke-tested against a throwaway `bamboo serve --port 19778`: created a session, seeded a real pending question in the `runtime.json` sidecar, then exercised `respond --pending` (pretty + `--json`), `respond "Yes"` (recorded, auto-resume `started` + run id), `respond` with no pending question (clean error), 404 paths, `session show` (pretty + after-delete 404), `session delete` (prompt-abort on `n`/EOF and `--yes` delete), and `history` (true-total line).
- clap constraints verified: `<answer>` required unless `--pending`, conflicts with `--pending`; `--json` requires `--pending`.

Fixes #423. Refs #246.

https://claude.ai/code/session_01H623Hx5w8Z887Q9jwE7C7p