### PR TITLE
feat(cli): schedules verbs — list/show/create/delete/run over the admin HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,11 @@ Arguments supported by `bamboo serve` (all override the config file):
 | `bamboo sessions` | List sessions on a running server (stop one with `bamboo stop <id>`). |
 | `bamboo stop <session_id>` | Stop a running session's agent loop. |
 | `bamboo history <session_id>` | Print a session's message transcript from a running server (review a headless `-p` run's log). |
+| `bamboo schedules list\|show\|create\|delete\|run\|runs` | Manage schedules (timed tasks) on a running server: list/inspect, create (`--cron`/`--every`/`--daily` + `--prompt`, or a raw `--json <file\|->` payload), delete (confirms unless `--yes`), trigger now, and view run history. |
 | `bamboo skills list` | List the skills the agent would load from `<data_dir>/skills` (offline; no server needed). |
 | `bamboo mcp list` | List the MCP servers configured in `config.json` (offline; live status via `bamboo status`). |
 
-The admin commands (`health` / `status` / `sessions` / `stop` / `history`) are thin HTTP clients over a running `bamboo serve`; point them at a non-default server with `--server-url` / `--port` / `--data-dir`. The read commands (`skills list` / `mcp list`) work offline against `--data-dir` (default `~/.bamboo`). (`bamboo subagent-worker` also exists but is an internal worker process spawned by the server — not for interactive use.)
+The admin commands (`health` / `status` / `sessions` / `stop` / `history` / `schedules`) are thin HTTP clients over a running `bamboo serve`; point them at a non-default server with `--server-url` / `--port` / `--data-dir`. The read commands (`skills list` / `mcp list`) work offline against `--data-dir` (default `~/.bamboo`). (`bamboo subagent-worker` also exists but is an internal worker process spawned by the server — not for interactive use.)
 
 A global `--log-level <error|warn|info|debug|trace>` sets the default log level for any command when `RUST_LOG` is unset (`RUST_LOG` still wins when present).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -150,8 +150,9 @@ bamboo serve
 | `bamboo status` | 运行中服务的一屏概览：地址、健康状态、会话数。 |
 | `bamboo sessions` | 列出运行中服务的会话（用 `bamboo stop <id>` 停止某个会话）。 |
 | `bamboo stop <session_id>` | 停止某个运行中会话的 agent loop。 |
+| `bamboo schedules list\|show\|create\|delete\|run\|runs` | 管理运行中服务上的定时任务：列出/查看、创建（`--cron`/`--every`/`--daily` + `--prompt`，或 `--json <file\|->` 原始载荷）、删除（无 `--yes` 时二次确认）、立即触发、查看运行历史。 |
 
-管理类命令（`health` / `status` / `sessions` / `stop`）是针对运行中 `bamboo serve` 的轻量 HTTP 客户端；用 `--server-url` / `--port` / `--data-dir` 指向非默认服务。（`bamboo subagent-worker` 也存在，但它是服务端派生的内部 worker 进程，不用于交互。）
+管理类命令（`health` / `status` / `sessions` / `stop` / `schedules`）是针对运行中 `bamboo serve` 的轻量 HTTP 客户端；用 `--server-url` / `--port` / `--data-dir` 指向非默认服务。（`bamboo subagent-worker` 也存在，但它是服务端派生的内部 worker 进程，不用于交互。）
 
 **默认值**（已对照代码核实）：
 

--- a/src/admin_cli.rs
+++ b/src/admin_cli.rs
@@ -1,11 +1,12 @@
-//! The `bamboo health | status | sessions | session | stop | respond` admin CLI.
+//! The `bamboo health | status | sessions | session | stop | respond |
+//! schedules` admin CLI.
 //!
 //! A thin HTTP client over a running `bamboo serve` instance. Each command wraps
 //! an endpoint the server already exposes — `/api/v1/health`,
-//! `/api/v1/sessions`, `/api/v1/stop/{id}`, `/api/v1/respond/{id}` — so an
-//! operator can probe and steer the backend without hand-writing `curl`. The
-//! server is the single source of truth; this module only resolves the base URL
-//! and pretty-prints responses.
+//! `/api/v1/sessions`, `/api/v1/stop/{id}`, `/api/v1/respond/{id}`,
+//! `/api/v1/schedules` — so an operator can probe and steer the backend without
+//! hand-writing `curl`. The server is the single source of truth; this module
+//! only resolves the base URL and pretty-prints responses.
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -55,17 +56,18 @@ fn unreachable(base: &str, e: reqwest::Error) -> anyhow::Error {
     anyhow::anyhow!("could not reach the server at {base} ({e}). Is `bamboo serve` running?")
 }
 
-/// Guard a session id used as a URL path segment: real session ids are opaque
-/// tokens (UUIDs), so reject anything that could traverse or malform the URL
-/// rather than encode it.
-fn guard_session_id(session_id: &str) -> anyhow::Result<()> {
-    if session_id.is_empty()
-        || session_id == "."
-        || session_id == ".."
-        || session_id.contains(['/', '\\', '?', '#', '%'])
-        || session_id.chars().any(char::is_whitespace)
+/// Guard an id used as a URL path segment: real ids (session ids, schedule
+/// ids) are opaque tokens (UUIDs), so reject anything that could traverse or
+/// malform the URL rather than encode it. `kind` names the id in the error,
+/// e.g. "session id".
+fn guard_id_segment(kind: &str, id: &str) -> anyhow::Result<()> {
+    if id.is_empty()
+        || id == "."
+        || id == ".."
+        || id.contains(['/', '\\', '?', '#', '%'])
+        || id.chars().any(char::is_whitespace)
     {
-        anyhow::bail!("invalid session id: '{session_id}'");
+        anyhow::bail!("invalid {kind}: '{id}'");
     }
     Ok(())
 }
@@ -195,7 +197,7 @@ pub async fn sessions_list(conn: ConnArgs) -> anyhow::Result<()> {
 
 /// `bamboo stop <id>` — cancel a running session's loop.
 pub async fn stop(conn: ConnArgs, session_id: &str) -> anyhow::Result<()> {
-    guard_session_id(session_id)?;
+    guard_id_segment("session id", session_id)?;
     let base = conn.api_base();
     let url = format!("{base}/stop/{session_id}");
     let resp = reqwest::Client::new()
@@ -238,7 +240,7 @@ pub async fn stop(conn: ConnArgs, session_id: &str) -> anyhow::Result<()> {
 /// what a headless `-p` run actually did, or an interactive session's log,
 /// without the web UI. Folded in from the retired `bamboo-cli history`.
 pub async fn history(conn: ConnArgs, session_id: &str) -> anyhow::Result<()> {
-    guard_session_id(session_id)?;
+    guard_id_segment("session id", session_id)?;
     let base = conn.api_base();
     let url = format!("{base}/history/{session_id}");
     let resp = reqwest::Client::new()
@@ -309,7 +311,7 @@ fn history_summary(session_id: &str, shown: usize, total: u64, truncated: bool) 
 /// (permission gate / clarification) out-of-band via
 /// `POST /api/v1/respond/{id}`. Answering resumes the blocked run server-side.
 pub async fn respond(conn: ConnArgs, session_id: &str, answer: &str) -> anyhow::Result<()> {
-    guard_session_id(session_id)?;
+    guard_id_segment("session id", session_id)?;
     let base = conn.api_base();
     let url = format!("{base}/respond/{session_id}");
     let resp = reqwest::Client::new()
@@ -366,7 +368,7 @@ pub async fn respond(conn: ConnArgs, session_id: &str, answer: &str) -> anyhow::
 /// `bamboo respond <id> --pending` — show the question a session is blocked on
 /// (`GET /api/v1/respond/{id}/pending`), pretty or as raw JSON.
 pub async fn respond_pending(conn: ConnArgs, session_id: &str, json: bool) -> anyhow::Result<()> {
-    guard_session_id(session_id)?;
+    guard_id_segment("session id", session_id)?;
     let base = conn.api_base();
     let url = format!("{base}/respond/{session_id}/pending");
     let resp = reqwest::Client::new()
@@ -439,7 +441,7 @@ fn format_pending_question(session_id: &str, v: &serde_json::Value) -> Option<St
 /// `bamboo session show <id>` — one session's detail
 /// (`GET /api/v1/sessions/{id}`), pretty or as raw JSON.
 pub async fn session_show(conn: ConnArgs, session_id: &str, json: bool) -> anyhow::Result<()> {
-    guard_session_id(session_id)?;
+    guard_id_segment("session id", session_id)?;
     let base = conn.api_base();
     let url = format!("{base}/sessions/{session_id}");
     let resp = reqwest::Client::new()
@@ -555,7 +557,7 @@ fn format_session_detail(s: &serde_json::Value) -> String {
 /// (`DELETE /api/v1/sessions/{id}`), cancelling any running execution.
 /// Prompts for confirmation unless `yes` is set.
 pub async fn session_delete(conn: ConnArgs, session_id: &str, yes: bool) -> anyhow::Result<()> {
-    guard_session_id(session_id)?;
+    guard_id_segment("session id", session_id)?;
     if !yes && !confirm(&format!(
         "Delete session '{session_id}'? This cancels any running execution and removes it permanently."
     ))? {
@@ -603,6 +605,533 @@ fn confirm(prompt: &str) -> anyhow::Result<bool> {
     Ok(answer == "y" || answer == "yes")
 }
 
+// ---------------------------------------------------------------------------
+// `bamboo schedules ...` — timed tasks on a running server (/api/v1/schedules).
+// The scheduler creates a fresh session per fire and (when `auto_execute` is
+// set with a task message) runs it unattended.
+// ---------------------------------------------------------------------------
+
+/// Flag-based inputs for `bamboo schedules create` (the common case). The
+/// clap layer guarantees exactly one trigger source (`cron` / `every` /
+/// `daily` / `json`) and that `name` + `prompt` accompany the flag form.
+#[derive(Debug, Clone, Default)]
+pub struct ScheduleCreateArgs {
+    /// Schedule name (required unless `json`).
+    pub name: Option<String>,
+    /// Cron trigger expression (seconds-first, as the trigger engine parses it).
+    pub cron: Option<String>,
+    /// Interval trigger: fire every N seconds.
+    pub every: Option<u64>,
+    /// Daily trigger at `HH:MM[:SS]`.
+    pub daily: Option<String>,
+    /// Task prompt: the fired session's user message, auto-executed.
+    pub prompt: Option<String>,
+    /// Model override `provider:model` for the fired session.
+    pub model: Option<String>,
+    /// Workspace directory for the fired session's file tools.
+    pub workspace: Option<String>,
+    /// IANA timezone for wall-clock triggers (daily/cron).
+    pub timezone: Option<String>,
+    /// Create the schedule disabled (it will not fire until enabled).
+    pub disabled: bool,
+    /// Raw `CreateScheduleRequest` JSON: a file path or `-` for stdin. Full
+    /// fidelity escape hatch — posted verbatim.
+    pub json: Option<String>,
+}
+
+/// `bamboo schedules list` — tabulate schedules on a running server.
+pub async fn schedules_list(conn: ConnArgs, json: bool) -> anyhow::Result<()> {
+    let base = conn.api_base();
+    let body = get_json(&base, &format!("{base}/schedules")).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&body)?);
+        return Ok(());
+    }
+    let schedules = body.get("schedules").and_then(|s| s.as_array());
+    let schedules = match schedules {
+        Some(s) if !s.is_empty() => s,
+        _ => {
+            println!("(no schedules)");
+            return Ok(());
+        }
+    };
+
+    // Plain (un-colored) cells so the column widths line up.
+    println!(
+        "{:<38} {:<4} {:<24} {:<20} {:<20} NAME",
+        "SCHEDULE ID", "ON", "TRIGGER", "NEXT RUN", "LAST RUN"
+    );
+    for s in schedules {
+        let id = s.get("id").and_then(|x| x.as_str()).unwrap_or("?");
+        let enabled = s.get("enabled").and_then(|b| b.as_bool()).unwrap_or(false);
+        let trigger = s.get("trigger").map(trigger_summary).unwrap_or_default();
+        let state = s.get("state");
+        let next = state.and_then(|st| st.get("next_fire_at"));
+        let last = state.and_then(|st| st.get("last_started_at"));
+        let name = s.get("name").and_then(|x| x.as_str()).unwrap_or("");
+        println!(
+            "{:<38} {:<4} {:<24} {:<20} {:<20} {}",
+            id,
+            if enabled { "on" } else { "off" },
+            truncate(&trigger, 24),
+            fmt_ts(next),
+            fmt_ts(last),
+            truncate(name, 40)
+        );
+    }
+    println!(
+        "\n{} schedule(s). Inspect one with: {}",
+        schedules.len(),
+        "bamboo schedules show <id>".cyan()
+    );
+    Ok(())
+}
+
+/// `bamboo schedules show <id>` — one schedule in detail. The server exposes
+/// no single-schedule GET, so this filters `GET /api/v1/schedules` by id.
+pub async fn schedules_show(conn: ConnArgs, schedule_id: &str, json: bool) -> anyhow::Result<()> {
+    guard_id_segment("schedule id", schedule_id)?;
+    let base = conn.api_base();
+    let schedule = find_schedule(&base, schedule_id).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&schedule)?);
+        return Ok(());
+    }
+
+    let str_of = |v: &serde_json::Value| v.as_str().map(str::to_string);
+    let field = |key: &str| schedule.get(key).and_then(str_of).unwrap_or_default();
+    let enabled = schedule
+        .get("enabled")
+        .and_then(|b| b.as_bool())
+        .unwrap_or(false);
+    println!("{:<16}{}", "id:".bold(), field("id"));
+    println!("{:<16}{}", "name:".bold(), field("name"));
+    println!(
+        "{:<16}{}",
+        "enabled:".bold(),
+        if enabled {
+            "true".green()
+        } else {
+            "false".red()
+        }
+    );
+    if let Some(trigger) = schedule.get("trigger") {
+        println!("{:<16}{}", "trigger:".bold(), trigger_summary(trigger));
+    }
+    for key in ["timezone", "start_at", "end_at"] {
+        if let Some(value) = schedule.get(key).and_then(|v| v.as_str()) {
+            println!("{:<16}{value}", format!("{key}:").bold());
+        }
+    }
+    for key in ["misfire_policy", "overlap_policy"] {
+        if let Some(value) = schedule.get(key) {
+            let rendered = value
+                .get("type")
+                .and_then(|t| t.as_str())
+                .map(str::to_string)
+                .or_else(|| str_of(value))
+                .unwrap_or_else(|| value.to_string());
+            println!("{:<16}{rendered}", format!("{key}:").bold());
+        }
+    }
+    if let Some(state) = schedule.get("state") {
+        println!(
+            "{:<16}{}",
+            "next fire:".bold(),
+            fmt_ts(state.get("next_fire_at"))
+        );
+        println!(
+            "{:<16}{}",
+            "last started:".bold(),
+            fmt_ts(state.get("last_started_at"))
+        );
+        println!(
+            "{:<16}{}",
+            "last success:".bold(),
+            fmt_ts(state.get("last_success_at"))
+        );
+        let count = |key: &str| state.get(key).and_then(|v| v.as_u64()).unwrap_or(0);
+        println!(
+            "{:<16}{} total, {} ok, {} failed, {} missed ({} queued, {} running now)",
+            "runs:".bold(),
+            count("total_run_count"),
+            count("total_success_count"),
+            count("total_failure_count"),
+            count("total_missed_count"),
+            count("queued_run_count"),
+            count("running_run_count"),
+        );
+    }
+    if let Some(rc) = schedule.get("run_config") {
+        let rc_str = |key: &str| rc.get(key).and_then(|v| v.as_str());
+        if let Some(task) = rc_str("task_message") {
+            println!("{:<16}{}", "prompt:".bold(), truncate(task, 120));
+        }
+        for (label, key) in [
+            ("model:", "model"),
+            ("workspace:", "workspace_path"),
+            ("reasoning:", "reasoning_effort"),
+        ] {
+            if let Some(value) = rc_str(key) {
+                println!("{:<16}{value}", label.bold());
+            }
+        }
+        let auto = rc
+            .get("auto_execute")
+            .and_then(|b| b.as_bool())
+            .unwrap_or(false);
+        println!("{:<16}{auto}", "auto-execute:".bold());
+    }
+    println!(
+        "{:<16}{}   {:<10}{}",
+        "created:".bold(),
+        fmt_ts(schedule.get("created_at")),
+        "updated:".bold(),
+        fmt_ts(schedule.get("updated_at"))
+    );
+    Ok(())
+}
+
+/// `bamboo schedules create` — POST /api/v1/schedules. Either assembles the
+/// request from the common-case flags or posts a raw JSON payload verbatim
+/// (`--json <file|->`) for full schema fidelity.
+pub async fn schedules_create(conn: ConnArgs, args: ScheduleCreateArgs) -> anyhow::Result<()> {
+    let payload = match &args.json {
+        Some(source) => read_json_payload(source)?,
+        None => build_create_payload(&args)?,
+    };
+
+    let base = conn.api_base();
+    let url = format!("{base}/schedules");
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .timeout(REQUEST_TIMEOUT)
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|e| unreachable(&base, e))?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+    if !status.is_success() {
+        anyhow::bail!(
+            "create failed: HTTP {status} {}",
+            server_error_message(&body)
+        );
+    }
+    let id = body.get("id").and_then(|x| x.as_str()).unwrap_or("?");
+    let name = body.get("name").and_then(|x| x.as_str()).unwrap_or("");
+    let enabled = body
+        .get("enabled")
+        .and_then(|b| b.as_bool())
+        .unwrap_or(false);
+    let trigger = body.get("trigger").map(trigger_summary).unwrap_or_default();
+    println!(
+        "{} created schedule {id} ('{name}', {trigger}, {})",
+        "✓".green(),
+        if enabled { "enabled" } else { "disabled" }
+    );
+    if let Some(next) = body.get("state").and_then(|st| st.get("next_fire_at")) {
+        println!("  next fire: {}", fmt_ts(Some(next)));
+    }
+    Ok(())
+}
+
+/// `bamboo schedules delete <id>` — DELETE /api/v1/schedules/{id}. Confirms
+/// interactively (after resolving the schedule's name) unless `yes` is set.
+pub async fn schedules_delete(conn: ConnArgs, schedule_id: &str, yes: bool) -> anyhow::Result<()> {
+    guard_id_segment("schedule id", schedule_id)?;
+    let base = conn.api_base();
+    if !yes {
+        // Resolve the name first so the operator confirms the right thing
+        // (this also fails fast on an unknown id before prompting).
+        let schedule = find_schedule(&base, schedule_id).await?;
+        let name = schedule.get("name").and_then(|x| x.as_str()).unwrap_or("?");
+        if !confirm(&format!("Delete schedule '{name}' ({schedule_id})?"))? {
+            println!("aborted (nothing deleted).");
+            return Ok(());
+        }
+    }
+    let url = format!("{base}/schedules/{schedule_id}");
+    let resp = reqwest::Client::new()
+        .delete(&url)
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| unreachable(&base, e))?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+    if status.as_u16() == 404 {
+        anyhow::bail!("schedule '{schedule_id}' not found");
+    }
+    if !status.is_success() {
+        anyhow::bail!(
+            "delete failed: HTTP {status} {}",
+            server_error_message(&body)
+        );
+    }
+    println!("{} deleted schedule {schedule_id}", "✓".green());
+    Ok(())
+}
+
+/// `bamboo schedules run <id>` — POST /api/v1/schedules/{id}/run (trigger now).
+pub async fn schedules_run(conn: ConnArgs, schedule_id: &str) -> anyhow::Result<()> {
+    guard_id_segment("schedule id", schedule_id)?;
+    let base = conn.api_base();
+    let url = format!("{base}/schedules/{schedule_id}/run");
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| unreachable(&base, e))?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+    if status.as_u16() == 404 {
+        anyhow::bail!("schedule '{schedule_id}' not found");
+    }
+    if !status.is_success() {
+        anyhow::bail!("run failed: HTTP {status} {}", server_error_message(&body));
+    }
+    let run_id = body.get("run_id").and_then(|x| x.as_str()).unwrap_or("?");
+    println!(
+        "{} run {run_id} enqueued (watch it with: {})",
+        "✓".green(),
+        format!("bamboo schedules runs {schedule_id}").cyan()
+    );
+    Ok(())
+}
+
+/// `bamboo schedules runs <id>` — run history (GET /api/v1/schedules/{id}/runs).
+pub async fn schedules_runs(conn: ConnArgs, schedule_id: &str, json: bool) -> anyhow::Result<()> {
+    guard_id_segment("schedule id", schedule_id)?;
+    let base = conn.api_base();
+    let body = get_json(&base, &format!("{base}/schedules/{schedule_id}/runs")).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&body)?);
+        return Ok(());
+    }
+    let runs = body.get("runs").and_then(|r| r.as_array());
+    let runs = match runs {
+        Some(r) if !r.is_empty() => r,
+        _ => {
+            println!("(no runs)");
+            return Ok(());
+        }
+    };
+    println!(
+        "{:<38} {:<9} {:<20} {:<20} {:>9}  SESSION",
+        "RUN ID", "STATUS", "SCHEDULED FOR", "STARTED", "DURATION"
+    );
+    for r in runs {
+        let run_id = r.get("run_id").and_then(|x| x.as_str()).unwrap_or("?");
+        let run_status = r.get("status").and_then(|x| x.as_str()).unwrap_or("?");
+        let duration = r
+            .get("execution_duration_ms")
+            .and_then(|x| x.as_u64())
+            .map(|ms| format!("{ms}ms"))
+            .unwrap_or_else(|| "-".to_string());
+        let session = r.get("session_id").and_then(|x| x.as_str()).unwrap_or("-");
+        println!(
+            "{:<38} {:<9} {:<20} {:<20} {:>9}  {}",
+            run_id,
+            run_status,
+            fmt_ts(r.get("scheduled_for")),
+            fmt_ts(r.get("started_at")),
+            duration,
+            session
+        );
+    }
+    println!("\n{} run(s) for schedule {schedule_id}.", runs.len());
+    Ok(())
+}
+
+/// GET `url` and parse the JSON body, with the shared unreachable/HTTP-status
+/// error surface.
+async fn get_json(base: &str, url: &str) -> anyhow::Result<serde_json::Value> {
+    let resp = reqwest::Client::new()
+        .get(url)
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| unreachable(base, e))?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+    if !status.is_success() {
+        anyhow::bail!("GET {url} -> HTTP {status} {}", server_error_message(&body));
+    }
+    Ok(body)
+}
+
+/// Resolve one schedule by exact id from the list endpoint (the server has no
+/// single-schedule GET).
+async fn find_schedule(base: &str, schedule_id: &str) -> anyhow::Result<serde_json::Value> {
+    let body = get_json(base, &format!("{base}/schedules")).await?;
+    body.get("schedules")
+        .and_then(|s| s.as_array())
+        .and_then(|schedules| {
+            schedules
+                .iter()
+                .find(|s| s.get("id").and_then(|x| x.as_str()) == Some(schedule_id))
+        })
+        .cloned()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "schedule '{schedule_id}' not found (list them with: bamboo schedules list)"
+            )
+        })
+}
+
+/// Assemble a `CreateScheduleRequest` body from the flag-based inputs.
+fn build_create_payload(args: &ScheduleCreateArgs) -> anyhow::Result<serde_json::Value> {
+    let name = args
+        .name
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("--name is required (or pass --json)"))?;
+    let prompt = args
+        .prompt
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("--prompt is required (or pass --json)"))?;
+
+    let trigger = if let Some(expr) = &args.cron {
+        serde_json::json!({ "type": "cron", "expr": expr })
+    } else if let Some(every_seconds) = args.every {
+        serde_json::json!({ "type": "interval", "every_seconds": every_seconds })
+    } else if let Some(hms) = &args.daily {
+        let (hour, minute, second) = parse_daily_time(hms)?;
+        serde_json::json!({ "type": "daily", "hour": hour, "minute": minute, "second": second })
+    } else {
+        anyhow::bail!("a trigger is required: --cron <expr>, --every <seconds>, or --daily <HH:MM[:SS]> (or pass --json)");
+    };
+
+    // The fired session's task message auto-executes: a schedule created from
+    // the CLI's flag form exists to run an agent, not just to park a session.
+    let mut run_config = serde_json::json!({
+        "task_message": prompt,
+        "auto_execute": true,
+    });
+    if let Some(model) = &args.model {
+        run_config["model"] = serde_json::json!(model);
+    }
+    if let Some(workspace) = &args.workspace {
+        run_config["workspace_path"] = serde_json::json!(workspace);
+    }
+
+    let mut payload = serde_json::json!({
+        "name": name,
+        "trigger": trigger,
+        "enabled": !args.disabled,
+        "run_config": run_config,
+    });
+    if let Some(timezone) = &args.timezone {
+        payload["timezone"] = serde_json::json!(timezone);
+    }
+    Ok(payload)
+}
+
+/// Parse `HH:MM` / `HH:MM:SS` for the `--daily` trigger.
+fn parse_daily_time(value: &str) -> anyhow::Result<(u8, u8, u8)> {
+    let bad = || anyhow::anyhow!("invalid --daily time '{value}' (expected HH:MM or HH:MM:SS)");
+    let parts: Vec<&str> = value.split(':').collect();
+    if parts.len() != 2 && parts.len() != 3 {
+        return Err(bad());
+    }
+    let hour: u8 = parts[0].parse().map_err(|_| bad())?;
+    let minute: u8 = parts[1].parse().map_err(|_| bad())?;
+    let second: u8 = if parts.len() == 3 {
+        parts[2].parse().map_err(|_| bad())?
+    } else {
+        0
+    };
+    if hour > 23 || minute > 59 || second > 59 {
+        return Err(bad());
+    }
+    Ok((hour, minute, second))
+}
+
+/// Read a raw JSON payload from a file path or stdin (`-`).
+fn read_json_payload(source: &str) -> anyhow::Result<serde_json::Value> {
+    let text = if source == "-" {
+        use std::io::Read as _;
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf)?;
+        buf
+    } else {
+        std::fs::read_to_string(source)
+            .map_err(|e| anyhow::anyhow!("failed to read '{source}': {e}"))?
+    };
+    serde_json::from_str(text.trim()).map_err(|e| anyhow::anyhow!("payload is not valid JSON: {e}"))
+}
+
+/// Pull the server's `{"error": "..."}` detail out of an error body, if any.
+fn server_error_message(body: &serde_json::Value) -> String {
+    body.get("error")
+        .and_then(|e| e.as_str())
+        .map(|e| format!("({e})"))
+        .unwrap_or_default()
+}
+
+/// One-line human summary of a `ScheduleTrigger` JSON value.
+fn trigger_summary(trigger: &serde_json::Value) -> String {
+    let joined = |key: &str| {
+        trigger
+            .get(key)
+            .and_then(|v| v.as_array())
+            .map(|items| {
+                items
+                    .iter()
+                    .map(|d| match d {
+                        serde_json::Value::String(s) => s.clone(),
+                        other => other.to_string(),
+                    })
+                    .collect::<Vec<_>>()
+                    .join(",")
+            })
+            .unwrap_or_default()
+    };
+    let hm = || {
+        format!(
+            "{:02}:{:02}",
+            trigger.get("hour").and_then(|v| v.as_u64()).unwrap_or(0),
+            trigger.get("minute").and_then(|v| v.as_u64()).unwrap_or(0)
+        )
+    };
+    match trigger.get("type").and_then(|t| t.as_str()) {
+        Some("interval") => format!(
+            "every {}s",
+            trigger
+                .get("every_seconds")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0)
+        ),
+        Some("daily") => format!(
+            "daily {}:{:02}",
+            hm(),
+            trigger.get("second").and_then(|v| v.as_u64()).unwrap_or(0)
+        ),
+        Some("weekly") => format!("weekly {} {}", joined("weekdays"), hm()),
+        Some("monthly") => format!("monthly {} {}", joined("days"), hm()),
+        Some("cron") => format!(
+            "cron '{}'",
+            trigger.get("expr").and_then(|v| v.as_str()).unwrap_or("?")
+        ),
+        _ => trigger.to_string(),
+    }
+}
+
+/// Render an RFC3339 timestamp value as `YYYY-MM-DD HH:MM:SS` (UTC); `-` when
+/// absent. Keeps table columns narrow without a chrono dependency here.
+fn fmt_ts(value: Option<&serde_json::Value>) -> String {
+    let Some(s) = value.and_then(|v| v.as_str()) else {
+        return "-".to_string();
+    };
+    // "2026-07-10T12:34:56.789Z" -> "2026-07-10 12:34:56"
+    if s.len() >= 19 && s.is_char_boundary(19) && s.as_bytes().get(10) == Some(&b'T') {
+        format!("{} {}", &s[..10], &s[11..19])
+    } else {
+        s.to_string()
+    }
+}
+
 /// Count array entries whose `is_running` is true.
 fn count_running(sessions: &[serde_json::Value]) -> usize {
     sessions
@@ -628,17 +1157,25 @@ fn truncate(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        format_pending_question, format_session_detail, guard_session_id, history_summary,
+        build_create_payload, fmt_ts, format_pending_question, format_session_detail,
+        guard_id_segment, history_summary, parse_daily_time, server_error_message, trigger_summary,
+        ScheduleCreateArgs,
     };
 
     #[test]
-    fn guard_session_id_rejects_path_hazards() {
+    fn guard_id_segment_rejects_path_hazards() {
         for bad in [
             "", ".", "..", "a/b", "a\\b", "a?b", "a#b", "a%b", "a b", "a\tb",
         ] {
-            assert!(guard_session_id(bad).is_err(), "{bad:?} must be rejected");
+            assert!(
+                guard_id_segment("session id", bad).is_err(),
+                "{bad:?} must be rejected"
+            );
         }
-        assert!(guard_session_id("0195fd1e-abc4-7def-8123-456789abcdef").is_ok());
+        assert!(guard_id_segment("session id", "0195fd1e-abc4-7def-8123-456789abcdef").is_ok());
+        // The error names the id kind so schedule/session messages stay distinct.
+        let err = guard_id_segment("schedule id", "a/b").unwrap_err();
+        assert!(err.to_string().contains("invalid schedule id"));
     }
 
     #[test]
@@ -728,5 +1265,129 @@ mod tests {
         assert!(!text.contains("parent"));
         assert!(!text.contains("children"));
         assert!(!text.contains("placement"));
+    }
+    #[test]
+    fn parse_daily_time_accepts_hm_and_hms() {
+        assert_eq!(parse_daily_time("09:30").unwrap(), (9, 30, 0));
+        assert_eq!(parse_daily_time("23:59:59").unwrap(), (23, 59, 59));
+    }
+
+    #[test]
+    fn parse_daily_time_rejects_malformed_and_out_of_range() {
+        for bad in ["", "9", "24:00", "09:60", "09:30:60", "a:b", "09:30:15:00"] {
+            assert!(parse_daily_time(bad).is_err(), "{bad:?}");
+        }
+    }
+
+    #[test]
+    fn build_create_payload_maps_flags_to_request_shape() {
+        let payload = build_create_payload(&ScheduleCreateArgs {
+            name: Some("nightly".to_string()),
+            cron: Some("0 0 2 * * *".to_string()),
+            prompt: Some("run the suite".to_string()),
+            model: Some("anthropic:claude-sonnet-4".to_string()),
+            workspace: Some("/tmp/repo".to_string()),
+            timezone: Some("Asia/Shanghai".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_eq!(payload["name"], "nightly");
+        assert_eq!(payload["enabled"], true);
+        assert_eq!(payload["trigger"]["type"], "cron");
+        assert_eq!(payload["trigger"]["expr"], "0 0 2 * * *");
+        assert_eq!(payload["timezone"], "Asia/Shanghai");
+        assert_eq!(payload["run_config"]["task_message"], "run the suite");
+        assert_eq!(payload["run_config"]["auto_execute"], true);
+        assert_eq!(payload["run_config"]["model"], "anthropic:claude-sonnet-4");
+        assert_eq!(payload["run_config"]["workspace_path"], "/tmp/repo");
+    }
+
+    #[test]
+    fn build_create_payload_daily_and_disabled() {
+        let payload = build_create_payload(&ScheduleCreateArgs {
+            name: Some("standup".to_string()),
+            daily: Some("09:30".to_string()),
+            prompt: Some("summarize".to_string()),
+            disabled: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_eq!(payload["enabled"], false);
+        assert_eq!(payload["trigger"]["type"], "daily");
+        assert_eq!(payload["trigger"]["hour"], 9);
+        assert_eq!(payload["trigger"]["minute"], 30);
+        assert_eq!(payload["trigger"]["second"], 0);
+        // Optional fields stay absent so server defaults apply.
+        assert!(payload.get("timezone").is_none());
+        assert!(payload["run_config"].get("model").is_none());
+    }
+
+    #[test]
+    fn build_create_payload_interval_trigger() {
+        let payload = build_create_payload(&ScheduleCreateArgs {
+            name: Some("tick".to_string()),
+            every: Some(3600),
+            prompt: Some("check".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(payload["trigger"]["type"], "interval");
+        assert_eq!(payload["trigger"]["every_seconds"], 3600);
+    }
+
+    #[test]
+    fn build_create_payload_requires_name_prompt_and_trigger() {
+        assert!(build_create_payload(&ScheduleCreateArgs::default()).is_err());
+        assert!(build_create_payload(&ScheduleCreateArgs {
+            name: Some("x".to_string()),
+            prompt: Some("y".to_string()),
+            ..Default::default()
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn trigger_summary_renders_each_kind() {
+        let case = |json: serde_json::Value| trigger_summary(&json);
+        assert_eq!(
+            case(serde_json::json!({"type":"interval","every_seconds":60})),
+            "every 60s"
+        );
+        assert_eq!(
+            case(serde_json::json!({"type":"daily","hour":9,"minute":30,"second":0})),
+            "daily 09:30:00"
+        );
+        assert_eq!(
+            case(serde_json::json!({"type":"weekly","weekdays":["mon","fri"],"hour":9,"minute":0})),
+            "weekly mon,fri 09:00"
+        );
+        assert_eq!(
+            case(serde_json::json!({"type":"monthly","days":[1,15],"hour":8,"minute":5})),
+            "monthly 1,15 08:05"
+        );
+        assert_eq!(
+            case(serde_json::json!({"type":"cron","expr":"0 0 2 * * *"})),
+            "cron '0 0 2 * * *'"
+        );
+    }
+
+    #[test]
+    fn fmt_ts_shortens_rfc3339_and_defaults_to_dash() {
+        let value = serde_json::json!("2026-07-10T12:34:56.789012Z");
+        assert_eq!(fmt_ts(Some(&value)), "2026-07-10 12:34:56");
+        assert_eq!(fmt_ts(None), "-");
+        let null = serde_json::Value::Null;
+        assert_eq!(fmt_ts(Some(&null)), "-");
+    }
+
+    #[test]
+    fn server_error_message_extracts_error_field() {
+        assert_eq!(
+            server_error_message(&serde_json::json!({"error":"name is required"})),
+            "(name is required)"
+        );
+        assert_eq!(server_error_message(&serde_json::Value::Null), "");
     }
 }

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -338,6 +338,14 @@ enum Commands {
         conn: ConnArgs,
     },
 
+    /// Manage schedules (timed tasks) on a running server (/api/v1/schedules).
+    /// The scheduler creates a fresh session per fire and auto-executes its
+    /// task prompt.
+    Schedules {
+        #[command(subcommand)]
+        command: SchedulesCommands,
+    },
+
     /// Inspect the skill surface the agent would load (offline read of
     /// `<data_dir>/skills`; no running server required).
     Skills {
@@ -401,6 +409,140 @@ enum McpCommands {
         /// Data directory holding config.json (defaults to ~/.bamboo).
         #[arg(long)]
         data_dir: Option<PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
+enum SchedulesCommands {
+    /// List schedules (id, name, trigger, enabled, next/last run).
+    List {
+        /// Print the raw server response as pretty JSON instead of a table.
+        #[arg(long)]
+        json: bool,
+
+        #[command(flatten)]
+        conn: ConnArgs,
+    },
+
+    /// Show one schedule in detail (definition, state counters, run config).
+    Show {
+        /// Schedule id to show.
+        schedule_id: String,
+
+        /// Print the schedule as pretty JSON instead of the detail view.
+        #[arg(long)]
+        json: bool,
+
+        #[command(flatten)]
+        conn: ConnArgs,
+    },
+
+    /// Create a schedule. Give exactly one trigger: --cron, --every, --daily —
+    /// or --json for a raw create payload (full schema: weekly/monthly
+    /// triggers, misfire/overlap policies, start/end window, ...).
+    #[command(group(
+        clap::ArgGroup::new("trigger")
+            .required(true)
+            .args(["cron", "every", "daily", "json"])
+    ))]
+    #[command(after_help = "EXAMPLES:\n  \
+        # Every day at 09:00 (server timezone unless --timezone)\n  \
+        bamboo schedules create --name standup --daily 09:00 \\\n    \
+        --prompt \"summarize yesterday's commits\" --timezone Asia/Shanghai\n\n  \
+        # Cron trigger (seconds-first expression), pinned model + workspace\n  \
+        bamboo schedules create --name nightly --cron '0 0 2 * * *' \\\n    \
+        --prompt \"run the test suite and report\" \\\n    \
+        --model anthropic:claude-sonnet-4 --workspace /path/to/repo\n\n  \
+        # Full-fidelity raw payload (POST /api/v1/schedules body)\n  \
+        bamboo schedules create --json schedule.json\n  \
+        cat schedule.json | bamboo schedules create --json -")]
+    Create {
+        /// Schedule name.
+        #[arg(long, required_unless_present = "json")]
+        name: Option<String>,
+
+        /// Cron trigger: a seconds-first cron expression,
+        /// e.g. '0 30 9 * * *' = every day at 09:30:00.
+        #[arg(long, value_name = "EXPR")]
+        cron: Option<String>,
+
+        /// Interval trigger: fire every N seconds.
+        #[arg(long, value_name = "SECONDS")]
+        every: Option<u64>,
+
+        /// Daily trigger at a wall-clock time, e.g. '09:30' or '09:30:15'.
+        #[arg(long, value_name = "HH:MM[:SS]")]
+        daily: Option<String>,
+
+        /// Task prompt: each fire creates a fresh session with this user
+        /// message and auto-executes it.
+        #[arg(long, required_unless_present = "json")]
+        prompt: Option<String>,
+
+        /// Model as 'provider:model' for the fired sessions (defaults to the
+        /// server's configured schedule model).
+        #[arg(long)]
+        model: Option<String>,
+
+        /// Working directory for the fired sessions' file tools.
+        #[arg(long)]
+        workspace: Option<String>,
+
+        /// IANA timezone for wall-clock triggers, e.g. 'Asia/Shanghai'
+        /// (defaults to the server's timezone handling).
+        #[arg(long)]
+        timezone: Option<String>,
+
+        /// Create the schedule disabled (it won't fire until enabled).
+        #[arg(long)]
+        disabled: bool,
+
+        /// Raw CreateScheduleRequest JSON: a FILE path or '-' for stdin,
+        /// POSTed verbatim. Conflicts with the flag-based fields.
+        #[arg(
+            long,
+            value_name = "FILE|-",
+            conflicts_with_all = ["name", "prompt", "model", "workspace", "timezone", "disabled"]
+        )]
+        json: Option<String>,
+
+        #[command(flatten)]
+        conn: ConnArgs,
+    },
+
+    /// Delete a schedule (asks for confirmation unless --yes).
+    Delete {
+        /// Schedule id to delete.
+        schedule_id: String,
+
+        /// Skip the confirmation prompt.
+        #[arg(long, short = 'y')]
+        yes: bool,
+
+        #[command(flatten)]
+        conn: ConnArgs,
+    },
+
+    /// Trigger a schedule to run now (POST /api/v1/schedules/{id}/run).
+    Run {
+        /// Schedule id to run.
+        schedule_id: String,
+
+        #[command(flatten)]
+        conn: ConnArgs,
+    },
+
+    /// Show a schedule's run history (status, timings, session ids).
+    Runs {
+        /// Schedule id whose runs to list.
+        schedule_id: String,
+
+        /// Print the raw server response as pretty JSON instead of a table.
+        #[arg(long)]
+        json: bool,
+
+        #[command(flatten)]
+        conn: ConnArgs,
     },
 }
 
@@ -709,6 +851,7 @@ async fn main() {
         | Some(Commands::Respond { .. })
         | Some(Commands::Session { .. })
         | Some(Commands::History { .. })
+        | Some(Commands::Schedules { .. })
         | Some(Commands::Skills { .. })
         | Some(Commands::Mcp { .. })
         | Some(Commands::Init { .. })
@@ -1206,6 +1349,67 @@ async fn main() {
 
         Commands::History { session_id, conn } => {
             if let Err(e) = bamboo_agent::admin_cli::history(conn.into(), &session_id).await {
+                eprintln!("{e}");
+                std::process::exit(1);
+            }
+        }
+
+        Commands::Schedules { command } => {
+            use bamboo_agent::admin_cli;
+            let result = match command {
+                SchedulesCommands::List { json, conn } => {
+                    admin_cli::schedules_list(conn.into(), json).await
+                }
+                SchedulesCommands::Show {
+                    schedule_id,
+                    json,
+                    conn,
+                } => admin_cli::schedules_show(conn.into(), &schedule_id, json).await,
+                SchedulesCommands::Create {
+                    name,
+                    cron,
+                    every,
+                    daily,
+                    prompt,
+                    model,
+                    workspace,
+                    timezone,
+                    disabled,
+                    json,
+                    conn,
+                } => {
+                    admin_cli::schedules_create(
+                        conn.into(),
+                        admin_cli::ScheduleCreateArgs {
+                            name,
+                            cron,
+                            every,
+                            daily,
+                            prompt,
+                            model,
+                            workspace,
+                            timezone,
+                            disabled,
+                            json,
+                        },
+                    )
+                    .await
+                }
+                SchedulesCommands::Delete {
+                    schedule_id,
+                    yes,
+                    conn,
+                } => admin_cli::schedules_delete(conn.into(), &schedule_id, yes).await,
+                SchedulesCommands::Run { schedule_id, conn } => {
+                    admin_cli::schedules_run(conn.into(), &schedule_id).await
+                }
+                SchedulesCommands::Runs {
+                    schedule_id,
+                    json,
+                    conn,
+                } => admin_cli::schedules_runs(conn.into(), &schedule_id, json).await,
+            };
+            if let Err(e) = result {
                 eprintln!("{e}");
                 std::process::exit(1);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,9 @@ pub mod broker_agent;
 /// The `bamboo actor run` CLI: drive an actor from the terminal.
 pub mod actor_cli;
 
-/// The `bamboo health|status|sessions|stop` admin CLI: a thin HTTP client over a
-/// running `bamboo serve` for operators (health probe, session list/stop).
+/// The `bamboo health|status|sessions|session|stop|respond|schedules` admin
+/// CLI: a thin HTTP client over a running `bamboo serve` for operators (health
+/// probe, session list/inspect/stop/respond, schedule management).
 pub mod admin_cli;
 
 /// The `bamboo -p` headless server mode: full AppState, one-shot, resumable.


### PR DESCRIPTION
## What

Adds a `bamboo schedules` verb family to the CLI — the single biggest CLI-coverage gap: the server has had full `/api/v1/schedules` routes (schedule_app: 15s ticker, new-session-per-fire) for a while, but the CLI had no way to reach them short of hand-written `curl`. This follows the existing admin-CLI pattern exactly: thin HTTP client in `src/admin_cli.rs`, shared `ConnArgs` (`--server-url` / `--port` / `--data-dir`), clap derive with `after_help` examples, pretty tables + `--json` for scripting.

Refs #246 (CLI ergonomics & client coherence — `-p` parity with the HTTP API).

## Command tree

```
bamboo schedules list   [--json]                 GET    /api/v1/schedules (table: id, on, trigger, next/last run, name)
bamboo schedules show   <id> [--json]            GET    /api/v1/schedules, filtered client-side (no single-GET on the server)
bamboo schedules create ...                      POST   /api/v1/schedules
bamboo schedules delete <id> [--yes]             DELETE /api/v1/schedules/{id} (interactive confirm w/ name resolution unless --yes)
bamboo schedules run    <id>                     POST   /api/v1/schedules/{id}/run (trigger now)
bamboo schedules runs   <id> [--json]            GET    /api/v1/schedules/{id}/runs (run history)
```

`create` covers the common case with flags and keeps full schema fidelity via a raw-payload escape hatch:

- exactly one trigger (clap ArgGroup): `--cron <expr>` (seconds-first, same `cron::Schedule` grammar the trigger engine parses), `--every <seconds>`, `--daily <HH:MM[:SS]>` — or `--json <file|->`, which POSTs a raw `CreateScheduleRequest` verbatim (weekly/monthly triggers, misfire/overlap policies, start/end windows, ...) and conflicts with the flag fields
- `--prompt` maps to `run_config.task_message` with `auto_execute: true` (a CLI-created schedule exists to run an agent), `--model` / `--workspace` / `--timezone` / `--disabled` map to their schema fields; unset optionals stay absent so server defaults apply
- flag-form schedules are created **enabled** (the API's bare default is disabled; explicit `--disabled` opts out)

Shell completions pick the new verbs up for free (`bamboo completions` generates from the clap tree — verified `zsh`/`bash` output includes `schedules`).

Also folded in (reconciled with #436 after rebasing onto it): #436's `guard_session_id` is generalized into a single shared `guard_id_segment(kind, id)` helper — same checks and messages, `kind` names the id in the error — used by all six session verbs (stop/history/respond/respond --pending/session show/session delete) and the schedule-id routes; `schedules delete` reuses #436's `confirm()` prompt (defaults to "no" on EOF, so a non-TTY pipe without `--yes` aborts instead of deleting).

## Examples

```bash
bamboo schedules create --name nightly --cron '0 0 2 * * *' \
  --prompt "run the test suite and report" \
  --model anthropic:claude-sonnet-4 --workspace /path/to/repo

bamboo schedules create --name standup --daily 09:00 \
  --prompt "summarize yesterday's commits" --timezone Asia/Shanghai

cat schedule.json | bamboo schedules create --json -

bamboo schedules list
bamboo schedules show <id> --json
bamboo schedules run <id> && bamboo schedules runs <id>
bamboo schedules delete <id> --yes
```

## Smoke evidence

Against a throwaway `bamboo serve --port 19777 --data-dir <tmp>`:

```
=== create (flags, cron) ===
✓ created schedule bee206a1-... ('nightly-suite', cron '0 0 2 * * *', enabled)
  next fire: 2026-07-10 18:00:00
=== create (raw --json file: weekly + catch_up_window + skip) ===
✓ created schedule c3319106-... ('weekly-digest (raw json)', weekly mon,fri 08:30, enabled)
=== create (raw --json stdin) ===
✓ created schedule f3bfa332-... ('tick', every 86400s, enabled)

=== list ===
SCHEDULE ID                            ON   TRIGGER                  NEXT RUN             LAST RUN             NAME
f3bfa332-...                           on   every 86400s             2026-07-11 11:14:29  2026-07-10 11:14:42  tick
bee206a1-...                           on   cron '0 0 2 * * *'       2026-07-10 18:00:00  -                    nightly-suite

=== run (trigger now) ===
✓ run 4426f44c-... enqueued (watch it with: bamboo schedules runs f3bfa332-...)
=== runs ===
RUN ID                                 STATUS    SCHEDULED FOR        STARTED               DURATION  SESSION
4426f44c-...                           failed    2026-07-10 11:14:42  2026-07-10 11:14:42      434ms  880c3fa6-...

=== delete (confirm resolves the name first) ===
Delete schedule 'standup' (79d9e9da-...)? [y/N] ✓ deleted schedule 79d9e9da-...
```

(The triggered run itself fails on the throwaway server — no API key configured — which exercises the failed-status rendering in `runs`.)

Error paths verified: unknown id (`show`/`delete` → exit 1 with hint), malformed `--daily` (local validation), invalid cron (server 400 surfaced with the server's `error` detail), `--json` vs flag conflicts and required-trigger enforcement via clap.

## Verification

- `cargo build -p bamboo-agent --bin bamboo` — clean
- `cargo test -p bamboo-agent` — passes (adds unit tests for `guard_id_segment`, `parse_daily_time`, `build_create_payload` shape mapping, `trigger_summary`, `fmt_ts`, `server_error_message`)
- `cargo clippy -p bamboo-agent --bin bamboo --lib` — no new warnings (remaining warnings are pre-existing in other workspace crates)
- `rustfmt --check` clean on the three touched files

Refs #246

https://claude.ai/code/session_01H623Hx5w8Z887Q9jwE7C7p
