### PR TITLE
feat(cli): server-backed MCP verbs + generic validated config set

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Arguments supported by `bamboo serve` (all override the config file):
 | `bamboo init` | First-run setup: write `config.json` with a provider + API key (interactive, or `--non-interactive` for CI). |
 | `bamboo doctor` | Diagnose the install (config present, provider keyed, server reachable); exits non-zero on a blocking problem. |
 | `bamboo config [--path] [--show-secrets]` | Inspect the resolved configuration. |
-| `bamboo config set <key> <value>` | Set one value, e.g. `providers.anthropic.api_key`, `providers.<p>.model`, or `provider`. |
+| `bamboo config set <key> <value>` | Set one value by dotted key. Secret-aware keys (`providers.<p>.api_key`, `provider_instances.<id>.api_key`, `notifications.ntfy.token`, `notifications.bark.device_key`) are stored encrypted at rest; every other key is a generic validated dot-path (e.g. `server.port 9563`, `tools.disabled '["Bash"]'`) — JSON values are parsed as JSON, unknown keys / type mismatches are rejected before writing. `--dry-run` previews the diff. |
 | `bamboo -p "<prompt>"` | One-shot **headless** agent run (boots the full runtime incl. sub-agents, prints the result, exits). Use `-p -` to read the prompt from stdin. Optional `-s <session>` to continue, `-m provider:model` **or** a bare `-m <model>` (bound to `--provider`, else the configured default provider) to pin the model, `--provider <name>` to select a provider, `--reasoning-effort <low\|medium\|high\|xhigh>`, `--skill-mode <mode>`, `--workspace`, `--data-dir`, `--stream-json` (NDJSON on stdout), `--echo` (keyless transport smoke). |
 | `bamboo completions <shell>` | Print a shell completion script (`bash`/`zsh`/`fish`/`powershell`/`elvish`), e.g. `bamboo completions zsh > ~/.zfunc/_bamboo`. |
 | `bamboo actor run\|serve\|list\|call` | Drive the sub-agent actor fabric from the terminal (spawn + stream, run as a service, discover, or send a task). |
@@ -178,9 +178,10 @@ Arguments supported by `bamboo serve` (all override the config file):
 | `bamboo history <session_id>` | Print a session's message transcript from a running server (review a headless `-p` run's log). |
 | `bamboo schedules list\|show\|create\|delete\|run\|runs` | Manage schedules (timed tasks) on a running server: list/inspect, create (`--cron`/`--every`/`--daily` + `--prompt`, or a raw `--json <file\|->` payload), delete (confirms unless `--yes`), trigger now, and view run history. |
 | `bamboo skills list` | List the skills the agent would load from `<data_dir>/skills` (offline; no server needed). |
-| `bamboo mcp list` | List the MCP servers configured in `config.json` (offline; live status via `bamboo status`). |
+| `bamboo mcp list` | List the MCP servers configured in `config.json` (offline; no server needed). |
+| `bamboo mcp status\|connect\|disconnect\|refresh\|tools\|add\|remove` | Manage MCP servers on a running instance over `/api/v1/mcp`: live connection state + tool counts (`status [--json]`), enable/connect + disable/disconnect a server, re-list tools (`refresh [<id>]`), inspect tools (`tools [<id>] [--json]`), add from a raw JSON payload (`add --json <file\|->`), and delete (`remove <id>`, confirms unless `--yes`; a removed server can be re-added with `add`). |
 
-The admin commands (`health` / `status` / `sessions` / `stop` / `history` / `schedules`) are thin HTTP clients over a running `bamboo serve`; point them at a non-default server with `--server-url` / `--port` / `--data-dir`. The read commands (`skills list` / `mcp list`) work offline against `--data-dir` (default `~/.bamboo`). (`bamboo subagent-worker` also exists but is an internal worker process spawned by the server — not for interactive use.)
+The admin commands (`health` / `status` / `sessions` / `stop` / `history` / `schedules`) are thin HTTP clients over a running `bamboo serve`; point them at a non-default server with `--server-url` / `--port` / `--data-dir`. The read commands (`skills list` / `mcp list`) work offline against `--data-dir` (default `~/.bamboo`); the other `mcp` verbs are server-backed and take the same connection flags. (`bamboo subagent-worker` also exists but is an internal worker process spawned by the server — not for interactive use.)
 
 A global `--log-level <error|warn|info|debug|trace>` sets the default log level for any command when `RUST_LOG` is unset (`RUST_LOG` still wins when present).
 

--- a/crates/infra/bamboo-config/src/dot_path.rs
+++ b/crates/infra/bamboo-config/src/dot_path.rs
@@ -1,0 +1,699 @@
+//! Generic, validated dot-path `config set` support (offline writer).
+//!
+//! Backs `bamboo config set <key> <value>` for keys beyond the historical
+//! hardcoded trio (`provider`, `providers.<p>.api_key`, `providers.<p>.model`).
+//! The flow is deliberately conservative — it never writes a config file it
+//! cannot fully re-read:
+//!
+//! 1. Serialize the current (hydrated, in-memory) [`Config`] to JSON.
+//! 2. Apply the dot-path assignment onto that JSON tree.
+//! 3. Deserialize the patched JSON back into the typed [`Config`] — a type
+//!    mismatch fails here with the offending key in the error.
+//! 4. Reject typos: a key that serde silently *dropped* (strict struct) or
+//!    that landed in one of the forward-compat `extra` flatten maps is
+//!    reported as an unknown key instead of being written.
+//! 5. Hand the validated [`Config`] back to the caller, which persists it via
+//!    [`Config::save_to_dir`] — the single writer that re-encrypts secrets and
+//!    writes atomically (with `.bak` rotation).
+//!
+//! # Secrets
+//!
+//! Plaintext secret fields (`providers.<p>.api_key`,
+//! `provider_instances.<id>.api_key`, `notifications.ntfy.token`,
+//! `notifications.bark.device_key`, broker/proxy credentials) are
+//! `#[serde(skip_serializing)]` — they cannot round-trip through JSON, so this
+//! generic setter REFUSES them with [`DotPathError::SecretPath`] /
+//! [`DotPathError::Unsupported`]; the CLI routes them through the dedicated
+//! typed setters instead. `*_encrypted` fields are derived state and are
+//! always refused (writing ciphertext directly is how cipher divergence — and
+//! real data loss — happens).
+//!
+//! `proxy_auth` needs one extra guard: unlike every other refresh,
+//! [`Config::refresh_proxy_auth_encrypted`] CLEARS the at-rest ciphertext when
+//! the in-memory plaintext is `None`. Since the JSON round-trip drops the
+//! (skip-serializing) plaintext, [`apply_dot_path_set`] carries `proxy_auth`
+//! over from the current config so an unrelated `config set` can never wipe
+//! stored proxy credentials.
+
+use std::collections::BTreeSet;
+
+use serde_json::{Map, Value};
+
+use crate::Config;
+
+/// Errors surfaced by [`apply_dot_path_set`]. Messages are user-facing (the
+/// CLI prints them verbatim), so each names the failing key.
+#[derive(Debug, thiserror::Error)]
+pub enum DotPathError {
+    /// The key does not correspond to a recognized config field.
+    #[error("unknown config key '{key}'{hint}")]
+    UnknownKey { key: String, hint: String },
+
+    /// The value cannot be stored at this key (type mismatch, bad shape, …).
+    #[error("invalid value for '{key}': {message}")]
+    InvalidValue { key: String, message: String },
+
+    /// The key holds a secret that must go through the dedicated
+    /// encrypt-at-rest writer, not the generic JSON patch.
+    #[error("'{key}' is a secret: {guidance}")]
+    SecretPath { key: String, guidance: String },
+
+    /// The key exists but cannot be written by this setter.
+    #[error("cannot set '{key}': {reason}")]
+    Unsupported { key: String, reason: String },
+}
+
+/// Result of a validated dot-path assignment (not yet persisted).
+#[derive(Debug)]
+pub struct DotPathSetOutcome {
+    /// The updated, fully validated config — ready for `save_to_dir`.
+    pub config: Config,
+    /// The previous JSON value at the key (None when the key was absent).
+    pub old_value: Option<Value>,
+    /// The JSON value that was applied.
+    pub new_value: Value,
+}
+
+/// Parse a CLI value: anything that parses as JSON is taken as JSON
+/// (numbers, bools, null, arrays, objects); everything else is a string.
+/// Pass a quoted value (`'"true"'`) to force a literal string.
+pub fn parse_cli_value(raw: &str) -> Value {
+    serde_json::from_str(raw).unwrap_or_else(|_| Value::String(raw.to_string()))
+}
+
+/// Apply `key = value` onto `current` with full validation (see module docs).
+/// Returns the new [`Config`] to persist; never touches the disk itself.
+pub fn apply_dot_path_set(
+    current: &Config,
+    key: &str,
+    value: Value,
+) -> Result<DotPathSetOutcome, DotPathError> {
+    let segments: Vec<&str> = key.split('.').collect();
+    if key.trim().is_empty() || segments.iter().any(|s| s.is_empty()) {
+        return Err(DotPathError::InvalidValue {
+            key: key.to_string(),
+            message: "empty path segment (keys are dot-separated, e.g. `server.port`)".to_string(),
+        });
+    }
+    guard_reserved_paths(&segments, key)?;
+
+    let before = serde_json::to_value(current).map_err(|e| DotPathError::InvalidValue {
+        key: key.to_string(),
+        message: format!("failed to serialize current config: {e}"),
+    })?;
+    let old_value = resolve_path(&before, &segments).cloned();
+
+    let mut patched = before;
+    apply_path(&mut patched, &segments, key, value.clone())?;
+
+    let mut config: Config =
+        serde_json::from_value(patched).map_err(|e| DotPathError::InvalidValue {
+            key: key.to_string(),
+            message: e.to_string(),
+        })?;
+
+    // Typo guard 1: a key the typed config only "kept" by capturing it into a
+    // forward-compat `extra` flatten map is not a real field — refuse it
+    // rather than persist a key every reader will ignore.
+    if let Some(extra_key) = first_new_extra_key(current, &config) {
+        return Err(DotPathError::UnknownKey {
+            key: extra_key,
+            hint: " (not a recognized config field)".to_string(),
+        });
+    }
+
+    // Typo guard 2: strict structs silently DROP unknown fields on
+    // deserialize — detect that by checking the key survived a round-trip.
+    // The `mcpServers` subtree is exempt: its custom (de)serializer converts
+    // between the internal shape and the mainstream on-disk shape, so paths
+    // legitimately move (`enabled` ⇄ `disabled`, transport flattening).
+    let mcp_subtree = matches!(segments[0], "mcpServers" | "mcp");
+    if !mcp_subtree {
+        let after = serde_json::to_value(&config).map_err(|e| DotPathError::InvalidValue {
+            key: key.to_string(),
+            message: format!("failed to serialize updated config: {e}"),
+        })?;
+        match resolve_path(&after, &segments) {
+            Some(round_tripped) if values_equivalent(round_tripped, &value) => {}
+            Some(round_tripped) => {
+                return Err(DotPathError::InvalidValue {
+                    key: key.to_string(),
+                    message: format!(
+                        "value did not survive a config round-trip (stored form would be \
+                         {round_tripped}); refusing to write"
+                    ),
+                });
+            }
+            // Setting a field to an empty/default value can legitimately make
+            // it disappear from the serialized form (skip_serializing_if).
+            None if is_vanishing_default(&value) => {}
+            None => {
+                return Err(DotPathError::UnknownKey {
+                    key: key.to_string(),
+                    hint: " (the config schema has no such field; nothing would be stored)"
+                        .to_string(),
+                });
+            }
+        }
+    }
+
+    // Round-trip restore: `proxy_auth` is in-memory-only and its refresh
+    // CLEARS the ciphertext when None (see module docs). Reserved-path guards
+    // above ensure the patch never targets it, so carrying it over is safe.
+    config.proxy_auth = current.proxy_auth.clone();
+
+    Ok(DotPathSetOutcome {
+        config,
+        old_value,
+        new_value: value,
+    })
+}
+
+/// Compute the changed leaf paths between two JSON trees, as
+/// `(dotted_path, old, new)` tuples (`None` = absent on that side).
+/// Used for `config set --dry-run` previews.
+pub fn diff_json(before: &Value, after: &Value) -> Vec<(String, Option<Value>, Option<Value>)> {
+    let mut out = Vec::new();
+    diff_json_inner(before, after, String::new(), &mut out);
+    out
+}
+
+fn diff_json_inner(
+    before: &Value,
+    after: &Value,
+    path: String,
+    out: &mut Vec<(String, Option<Value>, Option<Value>)>,
+) {
+    if before == after {
+        return;
+    }
+    match (before, after) {
+        (Value::Object(b), Value::Object(a)) => {
+            let keys: BTreeSet<&String> = b.keys().chain(a.keys()).collect();
+            for k in keys {
+                let child = if path.is_empty() {
+                    k.to_string()
+                } else {
+                    format!("{path}.{k}")
+                };
+                match (b.get(k), a.get(k)) {
+                    (Some(bv), Some(av)) => diff_json_inner(bv, av, child, out),
+                    (Some(bv), None) => out.push((child, Some(bv.clone()), None)),
+                    (None, Some(av)) => out.push((child, None, Some(av.clone()))),
+                    (None, None) => unreachable!("key came from the union of both maps"),
+                }
+            }
+        }
+        (Value::Array(b), Value::Array(a)) if b.len() == a.len() => {
+            for (i, (bv, av)) in b.iter().zip(a.iter()).enumerate() {
+                diff_json_inner(bv, av, format!("{path}.{i}"), out);
+            }
+        }
+        _ => out.push((path, Some(before.clone()), Some(after.clone()))),
+    }
+}
+
+/// Refuse secret-bearing and derived paths (see module docs).
+fn guard_reserved_paths(segments: &[&str], key: &str) -> Result<(), DotPathError> {
+    if segments.iter().any(|s| s.ends_with("_encrypted")) {
+        return Err(DotPathError::Unsupported {
+            key: key.to_string(),
+            reason: "encrypted fields are derived automatically from their plaintext \
+                     counterpart on save; set the plaintext key instead"
+                .to_string(),
+        });
+    }
+
+    match segments {
+        ["proxy_auth", ..] => Err(DotPathError::Unsupported {
+            key: key.to_string(),
+            reason: "proxy credentials are managed via the web UI settings (stored \
+                     encrypted as `proxy_auth_encrypted`)"
+                .to_string(),
+        }),
+        ["providers", p, "api_key"] => Err(DotPathError::SecretPath {
+            key: key.to_string(),
+            guidance: format!(
+                "API keys are encrypted at rest; use the dedicated setter \
+                 (`bamboo config set providers.{p}.api_key <key>` routes there automatically)"
+            ),
+        }),
+        ["provider_instances", id, "api_key"] => Err(DotPathError::SecretPath {
+            key: key.to_string(),
+            guidance: format!(
+                "instance API keys are encrypted at rest; use the dedicated setter \
+                 (`bamboo config set provider_instances.{id}.api_key <key>` routes there \
+                 automatically)"
+            ),
+        }),
+        ["notifications", "ntfy", "token"] | ["notifications", "bark", "device_key"] => {
+            Err(DotPathError::SecretPath {
+                key: key.to_string(),
+                guidance: "notification-channel secrets are encrypted at rest; the CLI \
+                           routes this key through the dedicated setter automatically"
+                    .to_string(),
+            })
+        }
+        ["subagents", "broker", ..] => Err(DotPathError::Unsupported {
+            key: key.to_string(),
+            reason: "the broker client config is runtime-only and not persisted in \
+                     config.json"
+                .to_string(),
+        }),
+        _ => Ok(()),
+    }
+}
+
+/// Resolve a dot-path inside a JSON tree (numeric segments index arrays).
+fn resolve_path<'a>(root: &'a Value, segments: &[&str]) -> Option<&'a Value> {
+    let mut node = root;
+    for seg in segments {
+        node = match node {
+            Value::Object(map) => map.get(*seg)?,
+            Value::Array(items) => items.get(seg.parse::<usize>().ok()?)?,
+            _ => return None,
+        };
+    }
+    Some(node)
+}
+
+/// Apply `value` at the dot-path, creating intermediate objects as needed.
+/// Numeric segments index arrays (final segment may append at `len`).
+fn apply_path(
+    root: &mut Value,
+    segments: &[&str],
+    key: &str,
+    value: Value,
+) -> Result<(), DotPathError> {
+    let mut node = root;
+    for (i, seg) in segments.iter().enumerate() {
+        let last = i + 1 == segments.len();
+        match node {
+            Value::Object(map) => {
+                if last {
+                    map.insert(seg.to_string(), value);
+                    return Ok(());
+                }
+                node = map
+                    .entry(seg.to_string())
+                    .or_insert_with(|| Value::Object(Map::new()));
+            }
+            Value::Array(items) => {
+                let idx = seg
+                    .parse::<usize>()
+                    .map_err(|_| DotPathError::InvalidValue {
+                        key: key.to_string(),
+                        message: format!(
+                            "'{}' is an array; segment '{seg}' must be a numeric index",
+                            segments[..i].join(".")
+                        ),
+                    })?;
+                if last {
+                    if idx < items.len() {
+                        items[idx] = value;
+                    } else if idx == items.len() {
+                        items.push(value);
+                    } else {
+                        return Err(DotPathError::InvalidValue {
+                            key: key.to_string(),
+                            message: format!(
+                                "array index {idx} out of range for '{}' (length {})",
+                                segments[..i].join("."),
+                                items.len()
+                            ),
+                        });
+                    }
+                    return Ok(());
+                }
+                node = items
+                    .get_mut(idx)
+                    .ok_or_else(|| DotPathError::InvalidValue {
+                        key: key.to_string(),
+                        message: format!(
+                            "array index {idx} out of range for '{}'",
+                            segments[..i].join(".")
+                        ),
+                    })?;
+            }
+            other => {
+                return Err(DotPathError::InvalidValue {
+                    key: key.to_string(),
+                    message: format!(
+                        "cannot descend into '{}': it holds {} — not an object/array",
+                        segments[..i].join("."),
+                        json_type_name(other)
+                    ),
+                });
+            }
+        }
+    }
+    unreachable!("segments is non-empty; the loop always returns on the last segment");
+}
+
+fn json_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "a boolean",
+        Value::Number(_) => "a number",
+        Value::String(_) => "a string",
+        Value::Array(_) => "an array",
+        Value::Object(_) => "an object",
+    }
+}
+
+/// Values whose disappearance from the serialized form is expected
+/// (`skip_serializing_if` on empty/None fields).
+fn is_vanishing_default(value: &Value) -> bool {
+    match value {
+        Value::Null => true,
+        Value::String(s) => s.is_empty(),
+        Value::Array(a) => a.is_empty(),
+        Value::Object(o) => o.is_empty(),
+        _ => false,
+    }
+}
+
+/// Loose equality: exact match, or numerically-equal numbers (so an f64
+/// round-trip through a float field doesn't false-negative).
+fn values_equivalent(a: &Value, b: &Value) -> bool {
+    if a == b {
+        return true;
+    }
+    match (a.as_f64(), b.as_f64()) {
+        (Some(x), Some(y)) => (x - y).abs() <= f64::EPSILON * x.abs().max(y.abs()).max(1.0) * 4.0,
+        _ => false,
+    }
+}
+
+/// Dotted paths of every key currently held by a forward-compat `extra`
+/// flatten map. Keep in sync with the `#[serde(flatten)] extra` fields on
+/// [`Config`] and its sub-structs (root, `server`, `providers` container,
+/// the per-provider configs, `provider_instances.<id>`).
+fn extra_key_paths(config: &Config) -> BTreeSet<String> {
+    let mut keys: BTreeSet<String> = config.extra.keys().cloned().collect();
+    keys.extend(config.server.extra.keys().map(|k| format!("server.{k}")));
+    keys.extend(
+        config
+            .providers
+            .extra
+            .keys()
+            .map(|k| format!("providers.{k}")),
+    );
+
+    macro_rules! provider_extra {
+        ($field:ident) => {
+            if let Some(p) = &config.providers.$field {
+                keys.extend(
+                    p.extra
+                        .keys()
+                        .map(|k| format!("providers.{}.{k}", stringify!($field))),
+                );
+            }
+        };
+    }
+    provider_extra!(openai);
+    provider_extra!(anthropic);
+    provider_extra!(gemini);
+    provider_extra!(copilot);
+    provider_extra!(bodhi);
+
+    for (id, instance) in &config.provider_instances {
+        keys.extend(
+            instance
+                .extra
+                .keys()
+                .map(|k| format!("provider_instances.{id}.{k}")),
+        );
+    }
+    keys
+}
+
+/// First `extra`-captured key present in `candidate` but not in `current`
+/// (i.e. introduced by the patch → an unknown field).
+fn first_new_extra_key(current: &Config, candidate: &Config) -> Option<String> {
+    let before = extra_key_paths(current);
+    extra_key_paths(candidate)
+        .into_iter()
+        .find(|k| !before.contains(k))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ProxyAuth;
+    use serde_json::json;
+    use std::path::PathBuf;
+
+    /// A default in-memory config that never touches a real data dir and —
+    /// unlike `from_data_dir_without_publish` — applies NO `BAMBOO_*` env
+    /// overrides, so parallel tests that mutate the env can't leak in.
+    fn default_config() -> Config {
+        Config::from_data_dir_without_env(Some(PathBuf::from(
+            "/nonexistent-bamboo-dot-path-test-dir",
+        )))
+    }
+
+    #[test]
+    fn parse_cli_value_json_first_then_string() {
+        assert_eq!(parse_cli_value("9999"), json!(9999));
+        assert_eq!(parse_cli_value("true"), json!(true));
+        assert_eq!(parse_cli_value("null"), Value::Null);
+        assert_eq!(parse_cli_value(r#"{"a":1}"#), json!({"a":1}));
+        assert_eq!(parse_cli_value("[1,2]"), json!([1, 2]));
+        assert_eq!(parse_cli_value("anthropic"), json!("anthropic"));
+        // Quoting forces a literal string.
+        assert_eq!(parse_cli_value(r#""true""#), json!("true"));
+    }
+
+    #[test]
+    fn valid_set_updates_typed_field() {
+        let config = default_config();
+        let outcome = apply_dot_path_set(&config, "server.port", json!(19999)).unwrap();
+        assert_eq!(outcome.config.server.port, 19999);
+        assert_eq!(outcome.old_value, Some(json!(9562)));
+        assert_eq!(outcome.new_value, json!(19999));
+    }
+
+    #[test]
+    fn valid_set_creates_missing_intermediate_objects() {
+        let config = default_config();
+        assert!(config.providers.anthropic.is_none());
+        let outcome =
+            apply_dot_path_set(&config, "providers.anthropic.model", json!("claude-x")).unwrap();
+        assert_eq!(
+            outcome
+                .config
+                .providers
+                .anthropic
+                .as_ref()
+                .unwrap()
+                .model
+                .as_deref(),
+            Some("claude-x")
+        );
+    }
+
+    #[test]
+    fn type_mismatch_is_rejected_with_key_in_error() {
+        let config = default_config();
+        let err = apply_dot_path_set(&config, "server.port", json!("not-a-port")).unwrap_err();
+        match err {
+            DotPathError::InvalidValue { key, .. } => assert_eq!(key, "server.port"),
+            other => panic!("expected InvalidValue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_root_key_is_rejected_not_written_to_extra() {
+        let config = default_config();
+        let err = apply_dot_path_set(&config, "serverr", json!({"port": 1})).unwrap_err();
+        assert!(matches!(err, DotPathError::UnknownKey { ref key, .. } if key == "serverr"));
+    }
+
+    #[test]
+    fn unknown_nested_key_captured_by_extra_is_rejected() {
+        let config = default_config();
+        // `server` has a forward-compat extra map — a typo lands there.
+        let err = apply_dot_path_set(&config, "server.prot", json!(8080)).unwrap_err();
+        assert!(matches!(err, DotPathError::UnknownKey { ref key, .. } if key == "server.prot"));
+
+        // Unknown provider names are captured by the providers container map.
+        let err = apply_dot_path_set(&config, "providers.grok.model", json!("g1")).unwrap_err();
+        assert!(matches!(err, DotPathError::UnknownKey { ref key, .. } if key == "providers.grok"));
+    }
+
+    #[test]
+    fn unknown_key_dropped_by_strict_struct_is_rejected() {
+        let config = default_config();
+        // KeywordMaskingConfig has no extra map: serde drops unknown fields.
+        let err = apply_dot_path_set(&config, "keyword_masking.nope", json!(true)).unwrap_err();
+        assert!(
+            matches!(err, DotPathError::UnknownKey { ref key, .. } if key == "keyword_masking.nope")
+        );
+    }
+
+    #[test]
+    fn existing_extension_keys_remain_editable() {
+        let mut config = default_config();
+        config
+            .extra
+            .insert("setup".to_string(), json!({"completed": false}));
+        let outcome = apply_dot_path_set(&config, "setup.completed", json!(true)).unwrap();
+        assert_eq!(outcome.config.extra["setup"], json!({"completed": true}));
+    }
+
+    #[test]
+    fn secret_paths_are_refused_by_the_generic_setter() {
+        let config = default_config();
+        for key in [
+            "providers.anthropic.api_key",
+            "providers.bodhi.api_key",
+            "provider_instances.work.api_key",
+            "notifications.ntfy.token",
+            "notifications.bark.device_key",
+        ] {
+            let err = apply_dot_path_set(&config, key, json!("sk-secret")).unwrap_err();
+            assert!(
+                matches!(err, DotPathError::SecretPath { .. }),
+                "expected SecretPath for {key}, got {err:?}"
+            );
+        }
+        for key in [
+            "proxy_auth.username",
+            "providers.anthropic.api_key_encrypted",
+            "proxy_auth_encrypted",
+            "subagents.broker.token",
+        ] {
+            let err = apply_dot_path_set(&config, key, json!("x")).unwrap_err();
+            assert!(
+                matches!(err, DotPathError::Unsupported { .. }),
+                "expected Unsupported for {key}, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn vanishing_default_values_are_accepted() {
+        let config = default_config();
+        // `server.tls = null` disappears from the serialized form
+        // (skip_serializing_if) — that must not be treated as unknown.
+        let outcome = apply_dot_path_set(&config, "server.tls", Value::Null).unwrap();
+        assert!(outcome.config.server.tls.is_none());
+    }
+
+    #[test]
+    fn mcp_subtree_is_type_checked_but_shape_exempt() {
+        let config = default_config();
+        let outcome = apply_dot_path_set(
+            &config,
+            "mcpServers.everything",
+            json!({"command": "npx", "args": ["mcp-everything"]}),
+        )
+        .unwrap();
+        let server = outcome
+            .config
+            .mcp
+            .servers
+            .iter()
+            .find(|s| s.id == "everything")
+            .expect("server added");
+        assert!(server.enabled);
+
+        // Garbage transport combos still fail typed validation.
+        let err = apply_dot_path_set(
+            &config,
+            "mcpServers.bad",
+            json!({"command": "npx", "url": "http://x"}),
+        )
+        .unwrap_err();
+        assert!(matches!(err, DotPathError::InvalidValue { .. }));
+    }
+
+    #[test]
+    fn proxy_auth_survives_an_unrelated_generic_set() {
+        let mut config = default_config();
+        config.proxy_auth = Some(ProxyAuth {
+            username: "alice".to_string(),
+            password: "hunter2".to_string(),
+        });
+        let outcome =
+            apply_dot_path_set(&config, "http_proxy", json!("http://proxy:8080")).unwrap();
+        // Without the carry-over, save_to_dir would CLEAR proxy_auth_encrypted
+        // (refresh_proxy_auth_encrypted nulls it when proxy_auth is None).
+        assert_eq!(
+            outcome
+                .config
+                .proxy_auth
+                .as_ref()
+                .map(|a| a.username.as_str()),
+            Some("alice")
+        );
+        assert_eq!(outcome.config.http_proxy, "http://proxy:8080");
+    }
+
+    #[test]
+    fn generic_set_preserves_api_key_encrypted_at_rest() {
+        let _guard = crate::test_support::env_cache_lock_acquire();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = dir.path().to_path_buf();
+
+        // Seed a config with an encrypted-at-rest anthropic key (the dedicated
+        // CLI writer path: plaintext in memory, save encrypts).
+        let mut config = Config::from_data_dir_without_env(Some(data_dir.clone()));
+        config.providers.anthropic =
+            Some(serde_json::from_value(json!({"api_key": "sk-ant-super-secret"})).unwrap());
+        config.save_to_dir(data_dir.clone()).expect("seed save");
+
+        let on_disk = std::fs::read_to_string(data_dir.join("config.json")).unwrap();
+        assert!(
+            !on_disk.contains("sk-ant-super-secret"),
+            "plaintext key must never be written to disk"
+        );
+        let cipher_before = serde_json::from_str::<Value>(&on_disk).unwrap()["providers"]
+            ["anthropic"]["api_key_encrypted"]
+            .as_str()
+            .expect("encrypted key present")
+            .to_string();
+
+        // Now perform an UNRELATED generic set and save again.
+        let loaded = Config::from_data_dir_without_env(Some(data_dir.clone()));
+        assert_eq!(
+            loaded.providers.anthropic.as_ref().unwrap().api_key,
+            "sk-ant-super-secret",
+            "hydration sanity check"
+        );
+        let outcome =
+            apply_dot_path_set(&loaded, "providers.anthropic.model", json!("claude-x")).unwrap();
+        outcome.config.save_to_dir(data_dir.clone()).expect("save");
+
+        let on_disk = std::fs::read_to_string(data_dir.join("config.json")).unwrap();
+        assert!(!on_disk.contains("sk-ant-super-secret"));
+        let root: Value = serde_json::from_str(&on_disk).unwrap();
+        assert_eq!(root["providers"]["anthropic"]["model"], json!("claude-x"));
+        assert_eq!(
+            root["providers"]["anthropic"]["api_key_encrypted"]
+                .as_str()
+                .expect("encrypted key still present"),
+            cipher_before,
+            "an unrelated generic set must not churn or drop the stored ciphertext"
+        );
+
+        // And the key still decrypts after the round-trip.
+        let reloaded = Config::from_data_dir_without_env(Some(data_dir));
+        assert_eq!(
+            reloaded.providers.anthropic.as_ref().unwrap().api_key,
+            "sk-ant-super-secret"
+        );
+    }
+
+    #[test]
+    fn diff_json_reports_changed_paths() {
+        let before = json!({"a": {"b": 1, "keep": true}, "gone": 1});
+        let after = json!({"a": {"b": 2, "keep": true}, "new": [1]});
+        let diff = diff_json(&before, &after);
+        assert!(diff.contains(&("a.b".to_string(), Some(json!(1)), Some(json!(2)))));
+        assert!(diff.contains(&("gone".to_string(), Some(json!(1)), None)));
+        assert!(diff.contains(&("new".to_string(), None, Some(json!([1])))));
+        assert_eq!(diff.len(), 3);
+    }
+}

--- a/crates/infra/bamboo-config/src/lib.rs
+++ b/crates/infra/bamboo-config/src/lib.rs
@@ -14,6 +14,7 @@ pub mod cluster_fabric;
 #[allow(clippy::module_inception)]
 pub mod config;
 pub mod config_crypto;
+pub mod dot_path;
 pub mod encryption;
 pub mod keyword_masking;
 pub mod model_mapping;

--- a/src/admin_cli.rs
+++ b/src/admin_cli.rs
@@ -1132,6 +1132,335 @@ fn fmt_ts(value: Option<&serde_json::Value>) -> String {
     }
 }
 
+// ---------------------------------------------------------------------------
+// `bamboo mcp status|connect|disconnect|refresh|tools|add|remove` — MCP server
+// management on a running instance (/api/v1/mcp). The offline config view
+// stays `bamboo mcp list` (read_cli).
+// ---------------------------------------------------------------------------
+
+/// Startup/refresh of an MCP server can take a while (stdio child spawn +
+/// initialize handshake, default startup timeout 20s), so the mutating MCP
+/// verbs get a more generous budget than the plain reads.
+const MCP_MUTATE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// `bamboo mcp status` — live view over `GET /api/v1/mcp/servers`: connection
+/// state + tool counts per configured server. `--json` prints the raw response.
+pub async fn mcp_status(conn: ConnArgs, json: bool) -> anyhow::Result<()> {
+    let base = conn.api_base();
+    let url = format!("{base}/mcp/servers");
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| unreachable(&base, e))?;
+    if !resp.status().is_success() {
+        anyhow::bail!("GET {url} -> HTTP {}", resp.status());
+    }
+    let v: serde_json::Value = resp.json().await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&v)?);
+        return Ok(());
+    }
+
+    let servers = v.get("servers").and_then(|s| s.as_array());
+    let servers = match servers {
+        Some(s) if !s.is_empty() => s,
+        _ => {
+            println!("(no MCP servers configured)");
+            return Ok(());
+        }
+    };
+
+    // Plain (un-colored) cells so the column widths line up.
+    println!(
+        "{:<24} {:<8} {:<14} {:>5}  NAME",
+        "ID", "ENABLED", "STATUS", "TOOLS"
+    );
+    for s in servers {
+        let id = s.get("id").and_then(|x| x.as_str()).unwrap_or("?");
+        let enabled = s.get("enabled").and_then(|b| b.as_bool()).unwrap_or(false);
+        let status = s.get("status").and_then(|x| x.as_str()).unwrap_or("?");
+        let tools = s.get("tool_count").and_then(|x| x.as_u64()).unwrap_or(0);
+        let name = s.get("name").and_then(|x| x.as_str()).unwrap_or("");
+        println!(
+            "{:<24} {:<8} {:<14} {:>5}  {}",
+            truncate(id, 24),
+            if enabled { "yes" } else { "no" },
+            truncate(status, 14),
+            tools,
+            truncate(name, 40)
+        );
+    }
+    for s in servers {
+        if let Some(err) = s.get("last_error").and_then(|e| e.as_str()) {
+            if !err.trim().is_empty() {
+                let id = s.get("id").and_then(|x| x.as_str()).unwrap_or("?");
+                println!("{} {id}: {}", "!".yellow(), truncate(err, 100));
+            }
+        }
+    }
+    let connected = servers
+        .iter()
+        .filter(|s| s.get("status").and_then(|x| x.as_str()) == Some("connected"))
+        .count();
+    println!("\n{connected} connected of {}.", servers.len());
+    Ok(())
+}
+
+/// `bamboo mcp connect <id>` — enable + (re)connect a configured server
+/// (`POST /api/v1/mcp/servers/{id}/connect`).
+pub async fn mcp_connect(conn: ConnArgs, server_id: &str) -> anyhow::Result<()> {
+    guard_id_segment("MCP server id", server_id)?;
+    let base = conn.api_base();
+    let url = format!("{base}/mcp/servers/{server_id}/connect");
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .timeout(MCP_MUTATE_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| unreachable(&base, e))?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+    if status.is_success() {
+        println!("{} server '{server_id}' connected", "✓".green());
+        Ok(())
+    } else if status.as_u16() == 404 {
+        anyhow::bail!("MCP server '{server_id}' not found (check `bamboo mcp status`)");
+    } else {
+        anyhow::bail!(
+            "connect failed: HTTP {status} {}",
+            server_error_message(&body)
+        );
+    }
+}
+
+/// `bamboo mcp disconnect <id>` — disable + disconnect a server
+/// (`POST /api/v1/mcp/servers/{id}/disconnect`).
+pub async fn mcp_disconnect(conn: ConnArgs, server_id: &str) -> anyhow::Result<()> {
+    guard_id_segment("MCP server id", server_id)?;
+    let base = conn.api_base();
+    let url = format!("{base}/mcp/servers/{server_id}/disconnect");
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .timeout(MCP_MUTATE_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| unreachable(&base, e))?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+    if status.is_success() {
+        println!("{} server '{server_id}' disconnected", "✓".green());
+        Ok(())
+    } else if status.as_u16() == 404 {
+        anyhow::bail!("MCP server '{server_id}' not found (check `bamboo mcp status`)");
+    } else {
+        anyhow::bail!(
+            "disconnect failed: HTTP {status} {}",
+            server_error_message(&body)
+        );
+    }
+}
+
+/// `bamboo mcp refresh [<id>]` — re-list tools from one server, or from every
+/// enabled server when no id is given (`POST /api/v1/mcp/servers/{id}/refresh`).
+pub async fn mcp_refresh(conn: ConnArgs, server_id: Option<&str>) -> anyhow::Result<()> {
+    let base = conn.api_base();
+    let client = reqwest::Client::new();
+
+    let targets: Vec<String> = match server_id {
+        Some(id) => {
+            guard_id_segment("MCP server id", id)?;
+            vec![id.to_string()]
+        }
+        None => {
+            // Refresh every ENABLED server (a disabled one has nothing to list).
+            let url = format!("{base}/mcp/servers");
+            let resp = client
+                .get(&url)
+                .timeout(REQUEST_TIMEOUT)
+                .send()
+                .await
+                .map_err(|e| unreachable(&base, e))?;
+            if !resp.status().is_success() {
+                anyhow::bail!("GET {url} -> HTTP {}", resp.status());
+            }
+            let v: serde_json::Value = resp.json().await?;
+            let ids: Vec<String> = v
+                .get("servers")
+                .and_then(|s| s.as_array())
+                .map(|servers| {
+                    servers
+                        .iter()
+                        .filter(|s| s.get("enabled").and_then(|b| b.as_bool()).unwrap_or(false))
+                        .filter_map(|s| s.get("id").and_then(|x| x.as_str()))
+                        .map(String::from)
+                        .collect()
+                })
+                .unwrap_or_default();
+            if ids.is_empty() {
+                println!("(no enabled MCP servers to refresh)");
+                return Ok(());
+            }
+            ids
+        }
+    };
+
+    let mut failures = 0usize;
+    for id in &targets {
+        let url = format!("{base}/mcp/servers/{id}/refresh");
+        let result = client.post(&url).timeout(MCP_MUTATE_TIMEOUT).send().await;
+        match result {
+            Ok(resp) if resp.status().is_success() => {
+                let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+                let tools = body.get("tool_count").and_then(|t| t.as_u64()).unwrap_or(0);
+                println!("{} {id}: {tools} tool(s)", "✓".green());
+            }
+            Ok(resp) => {
+                let status = resp.status();
+                let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+                println!(
+                    "{} {id}: HTTP {status} {}",
+                    "✗".red(),
+                    server_error_message(&body)
+                );
+                failures += 1;
+            }
+            Err(e) => {
+                println!("{} {id}: {e}", "✗".red());
+                failures += 1;
+            }
+        }
+    }
+    if failures > 0 {
+        anyhow::bail!("{failures} of {} refresh(es) failed", targets.len());
+    }
+    Ok(())
+}
+
+/// `bamboo mcp tools [<id>]` — list the tools one server exposes
+/// (`GET /api/v1/mcp/servers/{id}/tools`), or every server's tools
+/// (`GET /api/v1/mcp/tools`) when no id is given. `--json` prints raw JSON.
+pub async fn mcp_tools(conn: ConnArgs, server_id: Option<&str>, json: bool) -> anyhow::Result<()> {
+    let base = conn.api_base();
+    let url = match server_id {
+        Some(id) => {
+            guard_id_segment("MCP server id", id)?;
+            format!("{base}/mcp/servers/{id}/tools")
+        }
+        None => format!("{base}/mcp/tools"),
+    };
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .timeout(REQUEST_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| unreachable(&base, e))?;
+    if resp.status().as_u16() == 404 {
+        anyhow::bail!(
+            "MCP server '{}' not found (check `bamboo mcp status`)",
+            server_id.unwrap_or("?")
+        );
+    }
+    if !resp.status().is_success() {
+        anyhow::bail!("GET {url} -> HTTP {}", resp.status());
+    }
+    let v: serde_json::Value = resp.json().await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&v)?);
+        return Ok(());
+    }
+
+    let tools = v.get("tools").and_then(|t| t.as_array());
+    let tools = match tools {
+        Some(t) if !t.is_empty() => t,
+        _ => {
+            println!("(no tools)");
+            return Ok(());
+        }
+    };
+    println!("{:<32} {:<20} DESCRIPTION", "ALIAS", "SERVER");
+    for t in tools {
+        let alias = t.get("alias").and_then(|x| x.as_str()).unwrap_or("?");
+        let server = t.get("server_id").and_then(|x| x.as_str()).unwrap_or("");
+        let desc = t.get("description").and_then(|x| x.as_str()).unwrap_or("");
+        println!(
+            "{:<32} {:<20} {}",
+            truncate(alias, 32),
+            truncate(server, 20),
+            truncate(desc, 70)
+        );
+    }
+    println!("\n{} tool(s).", tools.len());
+    Ok(())
+}
+
+/// `bamboo mcp add --json <file|->` — add (or overwrite) a server from a raw
+/// JSON payload passed through to `POST /api/v1/mcp/servers`. The payload may
+/// be the internal shape or the mainstream flat shape (`command`/`url`), same
+/// as the HTTP API.
+pub async fn mcp_add(conn: ConnArgs, payload_source: &str) -> anyhow::Result<()> {
+    // Fail fast on malformed JSON instead of bouncing off the server.
+    let payload = read_json_payload(payload_source)?;
+
+    let base = conn.api_base();
+    let url = format!("{base}/mcp/servers");
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .timeout(MCP_MUTATE_TIMEOUT)
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|e| unreachable(&base, e))?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+    if status.is_success() {
+        let id = body
+            .get("server_id")
+            .and_then(|s| s.as_str())
+            .unwrap_or("?");
+        println!("{} server '{id}' saved", "✓".green());
+        Ok(())
+    } else {
+        anyhow::bail!("add failed: HTTP {status} {}", server_error_message(&body));
+    }
+}
+
+/// `bamboo mcp remove <id>` — stop + delete a server
+/// (`DELETE /api/v1/mcp/servers/{id}`). Destructive (the stored config is
+/// gone), though a removed server can be re-added with `bamboo mcp add` — so
+/// it confirms like `sessions delete` / `schedules delete` unless `--yes`.
+pub async fn mcp_remove(conn: ConnArgs, server_id: &str, yes: bool) -> anyhow::Result<()> {
+    guard_id_segment("MCP server id", server_id)?;
+    if !yes
+        && !confirm(&format!(
+            "Remove MCP server '{server_id}'? This stops it and deletes its stored config."
+        ))?
+    {
+        println!("aborted (nothing removed).");
+        return Ok(());
+    }
+    let base = conn.api_base();
+    let url = format!("{base}/mcp/servers/{server_id}");
+    let resp = reqwest::Client::new()
+        .delete(&url)
+        .timeout(MCP_MUTATE_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| unreachable(&base, e))?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+    if status.is_success() {
+        println!("{} server '{server_id}' removed", "✓".green());
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "remove failed: HTTP {status} {}",
+            server_error_message(&body)
+        );
+    }
+}
+
 /// Count array entries whose `is_running` is true.
 fn count_running(sessions: &[serde_json::Value]) -> usize {
     sessions

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -353,8 +353,9 @@ enum Commands {
         command: SkillsCommands,
     },
 
-    /// Inspect the MCP servers configured in `config.json` (offline read; live
-    /// connection status needs a running server via `bamboo status`).
+    /// Manage MCP servers: `list` is an offline read of `config.json`; the
+    /// other verbs (`status`/`connect`/`disconnect`/`refresh`/`tools`/`add`/
+    /// `remove`) talk to a running `bamboo serve` instance.
     Mcp {
         #[command(subcommand)]
         command: McpCommands,
@@ -404,11 +405,90 @@ enum SkillsCommands {
 
 #[derive(Subcommand)]
 enum McpCommands {
-    /// List configured MCP servers (id, enabled, transport, name).
+    /// List configured MCP servers (id, enabled, transport, name) — offline
+    /// read of `config.json`; no running server required.
     List {
         /// Data directory holding config.json (defaults to ~/.bamboo).
         #[arg(long)]
         data_dir: Option<PathBuf>,
+    },
+
+    /// Live status from a running server: connection state, tool counts and
+    /// last errors per server (GET /api/v1/mcp/servers).
+    Status {
+        #[command(flatten)]
+        conn: ConnArgs,
+
+        /// Print the raw JSON response instead of a table.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Enable and (re)connect a configured server on a running instance
+    /// (POST /api/v1/mcp/servers/{id}/connect).
+    Connect {
+        /// Server id (see `bamboo mcp status`).
+        name: String,
+        #[command(flatten)]
+        conn: ConnArgs,
+    },
+
+    /// Disable and disconnect a server on a running instance
+    /// (POST /api/v1/mcp/servers/{id}/disconnect).
+    Disconnect {
+        /// Server id (see `bamboo mcp status`).
+        name: String,
+        #[command(flatten)]
+        conn: ConnArgs,
+    },
+
+    /// Re-list tools from one server, or from every enabled server when no id
+    /// is given (POST /api/v1/mcp/servers/{id}/refresh).
+    Refresh {
+        /// Server id; omit to refresh every enabled server.
+        name: Option<String>,
+        #[command(flatten)]
+        conn: ConnArgs,
+    },
+
+    /// List the tools a server exposes, or every server's tools when no id is
+    /// given (GET /api/v1/mcp/servers/{id}/tools, GET /api/v1/mcp/tools).
+    Tools {
+        /// Server id; omit for all servers.
+        name: Option<String>,
+        #[command(flatten)]
+        conn: ConnArgs,
+
+        /// Print the raw JSON response instead of a table.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Add (or overwrite) a server from a raw JSON payload passed through to
+    /// POST /api/v1/mcp/servers. Accepts the mainstream flat shape
+    /// (`{"id": "...", "command": "..."}` / `{"id": "...", "url": "..."}`)
+    /// or Bamboo's internal shape, exactly like the HTTP API.
+    Add {
+        /// Path to a JSON file with the server config, or `-` to read stdin.
+        #[arg(long = "json", value_name = "FILE|-")]
+        json: String,
+        #[command(flatten)]
+        conn: ConnArgs,
+    },
+
+    /// Stop and delete a server (DELETE /api/v1/mcp/servers/{id}). Asks for
+    /// confirmation unless --yes (a removed server can be re-added with
+    /// `bamboo mcp add`).
+    Remove {
+        /// Server id (see `bamboo mcp status`).
+        name: String,
+
+        /// Skip the confirmation prompt.
+        #[arg(long, short = 'y')]
+        yes: bool,
+
+        #[command(flatten)]
+        conn: ConnArgs,
     },
 }
 
@@ -577,18 +657,32 @@ impl From<ConnArgs> for bamboo_agent::admin_cli::ConnArgs {
 
 #[derive(Subcommand)]
 enum ConfigAction {
-    /// Set a single config value by dotted key. Supported keys:
+    /// Set a single config value by dotted key.
+    ///
+    /// Secret-aware keys (stored encrypted at rest):
     ///   provider
-    ///   providers.<anthropic|openai|gemini>.api_key
+    ///   providers.<anthropic|openai|gemini|bodhi>.api_key
     ///   providers.<anthropic|openai|gemini>.model
+    ///   provider_instances.<id>.api_key
+    ///   notifications.ntfy.token / notifications.bark.device_key
+    ///
+    /// Any other key is a generic validated dot-path into config.json
+    /// (e.g. `server.port 9563`, `features.provider_model_ref true`,
+    /// `tools.disabled '["Bash"]'`). The value is parsed as JSON when it
+    /// parses, else taken as a string; unknown keys and type mismatches are
+    /// rejected before anything is written. `proxy_auth.*` and `*_encrypted`
+    /// keys cannot be set here.
     Set {
         /// Dotted config key, e.g. `providers.anthropic.api_key`.
         key: String,
-        /// Value to store.
+        /// Value to store (JSON or plain string).
         value: String,
         /// Data directory holding config.json (defaults to ~/.bamboo).
         #[arg(long)]
         data_dir: Option<PathBuf>,
+        /// Validate and preview the resulting change without writing.
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -1251,9 +1345,12 @@ async fn main() {
                 key,
                 value,
                 data_dir,
+                dry_run,
             }) = action
             {
-                if let Err(e) = bamboo_agent::setup_cli::run_config_set(&key, &value, data_dir) {
+                if let Err(e) =
+                    bamboo_agent::setup_cli::run_config_set(&key, &value, data_dir, dry_run)
+                {
                     eprintln!("config set failed: {e:#}");
                     std::process::exit(1);
                 }
@@ -1424,8 +1521,33 @@ async fn main() {
         }
 
         Commands::Mcp { command } => {
-            let McpCommands::List { data_dir } = command;
-            if let Err(e) = bamboo_agent::read_cli::mcp_list(data_dir).await {
+            let result = match command {
+                // Offline read (no server) — unchanged.
+                McpCommands::List { data_dir } => bamboo_agent::read_cli::mcp_list(data_dir).await,
+                // Server-backed verbs over the /api/v1/mcp routes.
+                McpCommands::Status { conn, json } => {
+                    bamboo_agent::admin_cli::mcp_status(conn.into(), json).await
+                }
+                McpCommands::Connect { name, conn } => {
+                    bamboo_agent::admin_cli::mcp_connect(conn.into(), &name).await
+                }
+                McpCommands::Disconnect { name, conn } => {
+                    bamboo_agent::admin_cli::mcp_disconnect(conn.into(), &name).await
+                }
+                McpCommands::Refresh { name, conn } => {
+                    bamboo_agent::admin_cli::mcp_refresh(conn.into(), name.as_deref()).await
+                }
+                McpCommands::Tools { name, conn, json } => {
+                    bamboo_agent::admin_cli::mcp_tools(conn.into(), name.as_deref(), json).await
+                }
+                McpCommands::Add { json, conn } => {
+                    bamboo_agent::admin_cli::mcp_add(conn.into(), &json).await
+                }
+                McpCommands::Remove { name, yes, conn } => {
+                    bamboo_agent::admin_cli::mcp_remove(conn.into(), &name, yes).await
+                }
+            };
+            if let Err(e) = result {
                 eprintln!("{e}");
                 std::process::exit(1);
             }

--- a/src/setup_cli.rs
+++ b/src/setup_cli.rs
@@ -215,18 +215,59 @@ pub async fn run_doctor(data_dir: Option<PathBuf>) -> Result<bool> {
 
 /// `bamboo config set <key> <value>` — write a single config value.
 ///
-/// Supported keys: `provider`, `providers.<provider>.api_key`,
-/// `providers.<provider>.model` (provider ∈ anthropic|openai|gemini). Existing
-/// fields on the provider are preserved.
-pub fn run_config_set(key: &str, value: &str, data_dir: Option<PathBuf>) -> Result<()> {
+/// Two classes of keys:
+///
+/// **Secret-aware keys** (encrypted at rest; the value is set on the typed
+/// config and `Config::save_to_dir` writes the `*_encrypted` form):
+///   - `provider` (default provider selection; not a secret, kept for
+///     backward compatibility)
+///   - `providers.<anthropic|openai|gemini>.api_key` (unchanged legacy path)
+///   - `providers.bodhi.api_key`
+///   - `provider_instances.<id>.api_key` (the instance must already exist)
+///   - `notifications.ntfy.token`, `notifications.bark.device_key`
+///   - `providers.<anthropic|openai|gemini>.model` (legacy path, not a secret)
+///
+/// **Everything else** goes through the generic validated dot-path setter
+/// ([`bamboo_config::dot_path::apply_dot_path_set`]): the value is parsed as
+/// JSON when it parses (numbers/bools/arrays/objects), else taken as a
+/// string; the result must deserialize back into the typed `Config` (type
+/// mismatches and unknown fields are rejected before anything is written).
+/// `proxy_auth.*`, `subagents.broker.*` and all `*_encrypted` keys are
+/// refused. With `dry_run` the resulting diff is printed and nothing is
+/// saved.
+pub fn run_config_set(
+    key: &str,
+    value: &str,
+    data_dir: Option<PathBuf>,
+    dry_run: bool,
+) -> Result<()> {
     let data_dir = data_dir.unwrap_or_else(bamboo_config::paths::resolve_bamboo_dir);
     let mut config = Config::from_data_dir_without_env(Some(data_dir.clone()));
 
     let parts: Vec<&str> = key.split('.').collect();
-    match parts.as_slice() {
+    // `Some(outcome)` = generic dot-path set (validated new config inside);
+    // `None` = a dedicated arm mutated `config` in place.
+    let outcome = match parts.as_slice() {
         // Selecting the default provider accepts any known provider (incl.
         // copilot/bodhi), not just the keyed ones.
-        ["provider"] => config.provider = normalize_known_provider(value)?,
+        ["provider"] => {
+            config.provider = normalize_known_provider(value)?;
+            None
+        }
+        // Bodhi's static key is secret-aware too, but is not a keyed provider
+        // for `init` — handled before the legacy keyed-provider arm.
+        ["providers", "bodhi", "api_key"] => {
+            let v = value.trim();
+            if v.is_empty() {
+                bail!("api_key must not be empty");
+            }
+            config
+                .providers
+                .bodhi
+                .get_or_insert_with(empty_provider)
+                .api_key = v.to_string();
+            None
+        }
         ["providers", p, "api_key"] => {
             let p = normalize_provider(p)?;
             let v = value.trim();
@@ -234,6 +275,7 @@ pub fn run_config_set(key: &str, value: &str, data_dir: Option<PathBuf>) -> Resu
                 bail!("api_key must not be empty");
             }
             set_provider_api_key(&mut config, &p, v)?;
+            None
         }
         ["providers", p, "model"] => {
             let p = normalize_provider(p)?;
@@ -242,25 +284,114 @@ pub fn run_config_set(key: &str, value: &str, data_dir: Option<PathBuf>) -> Resu
                 bail!("model must not be empty");
             }
             set_provider_model(&mut config, &p, v)?;
+            None
         }
-        _ => bail!(
-            "unsupported config key '{key}'. Supported keys:\n  \
-             provider\n  \
-             providers.<anthropic|openai|gemini>.api_key\n  \
-             providers.<anthropic|openai|gemini>.model"
-        ),
-    }
+        ["provider_instances", id, "api_key"] => {
+            let v = value.trim();
+            if v.is_empty() {
+                bail!("api_key must not be empty");
+            }
+            let Some(instance) = config.provider_instances.get_mut(*id) else {
+                bail!(
+                    "provider instance '{id}' not found; create the instance first \
+                     (its api_key is then stored encrypted at rest)"
+                );
+            };
+            instance.api_key = v.to_string();
+            None
+        }
+        ["notifications", "ntfy", "token"] => {
+            let v = value.trim();
+            if v.is_empty() {
+                bail!("token must not be empty");
+            }
+            config.notifications.ntfy.token = Some(v.to_string());
+            None
+        }
+        ["notifications", "bark", "device_key"] => {
+            let v = value.trim();
+            if v.is_empty() {
+                bail!("device_key must not be empty");
+            }
+            config.notifications.bark.device_key = Some(v.to_string());
+            None
+        }
+        // Generic, validated dot-path set for every other key. Secret paths
+        // not routed above are refused inside (defense in depth), so a
+        // plaintext secret can never be silently dropped or mis-stored.
+        _ => {
+            let parsed = bamboo_config::dot_path::parse_cli_value(value);
+            Some(bamboo_config::dot_path::apply_dot_path_set(
+                &config, key, parsed,
+            )?)
+        }
+    };
 
-    config
-        .save_to_dir(data_dir.clone())
-        .context("failed to write config.json")?;
-    let shown = if key.ends_with("api_key") {
+    let is_secret_key =
+        key.ends_with("api_key") || key.ends_with(".token") || key.ends_with(".device_key");
+    let shown = if is_secret_key {
         mask_secret(value)
     } else {
         value.to_string()
     };
+
+    if dry_run {
+        match &outcome {
+            Some(out) => print_dry_run_diff(&config, &out.config),
+            None => println!(
+                "--dry-run: would set {key} = {shown} via the dedicated setter \
+                 (secrets are stored encrypted at rest). No changes written."
+            ),
+        }
+        return Ok(());
+    }
+
+    let to_save = match outcome {
+        Some(out) => out.config,
+        None => config,
+    };
+    to_save
+        .save_to_dir(data_dir.clone())
+        .context("failed to write config.json")?;
     println!("✓ set {key} = {shown}");
     Ok(())
+}
+
+/// Print the prospective `config set` change as a path-level diff.
+/// Both sides are serialized with plaintext secrets sanitized (the same
+/// clearing `save_to_dir` performs), so the preview never leaks a secret.
+fn print_dry_run_diff(current: &Config, updated: &Config) {
+    let before = sanitized_config_value(current);
+    let after = sanitized_config_value(updated);
+    let diff = bamboo_config::dot_path::diff_json(&before, &after);
+    if diff.is_empty() {
+        println!("--dry-run: no effective change. Nothing would be written.");
+        return;
+    }
+    println!(
+        "--dry-run: would apply {} change(s) (secrets omitted):",
+        diff.len()
+    );
+    for (path, old, new) in diff {
+        let old = old
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "(absent)".to_string());
+        let new = new
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "(absent)".to_string());
+        println!("  {path}: {old} -> {new}");
+    }
+    println!("No changes written.");
+}
+
+/// In-memory serialization with the same plaintext-secret clearing that
+/// `save_to_dir` applies before writing (env vars, cluster-fabric SSH
+/// secrets; `api_key`/token plaintexts are `skip_serializing` already).
+fn sanitized_config_value(config: &Config) -> serde_json::Value {
+    let mut c = config.clone();
+    c.sanitize_env_vars_for_disk();
+    c.sanitize_cluster_fabric_for_disk();
+    serde_json::to_value(&c).unwrap_or(serde_json::Value::Null)
 }
 
 // ---- provider helpers ----
@@ -582,5 +713,102 @@ mod tests {
         assert!(m.starts_with("sk-"));
         assert!(m.ends_with("chars)"));
         assert!(!m.contains("1234567890"));
+    }
+
+    #[test]
+    fn config_set_generic_key_round_trips_to_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = dir.path().to_path_buf();
+
+        run_config_set("server.port", "19999", Some(data_dir.clone()), false).unwrap();
+        let raw = std::fs::read_to_string(data_dir.join("config.json")).unwrap();
+        let root: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(root["server"]["port"], serde_json::json!(19999));
+
+        // Unknown / mistyped keys are rejected without writing.
+        assert!(run_config_set("server.prot", "1", Some(data_dir.clone()), false).is_err());
+        assert!(
+            run_config_set("server.port", "not-a-port", Some(data_dir.clone()), false).is_err()
+        );
+        let raw_after = std::fs::read_to_string(data_dir.join("config.json")).unwrap();
+        let root: serde_json::Value = serde_json::from_str(&raw_after).unwrap();
+        assert_eq!(root["server"]["port"], serde_json::json!(19999));
+    }
+
+    #[test]
+    fn config_set_dry_run_writes_nothing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = dir.path().to_path_buf();
+
+        run_config_set("server.port", "12001", Some(data_dir.clone()), true).unwrap();
+        assert!(
+            !data_dir.join("config.json").exists(),
+            "--dry-run must not create/modify config.json"
+        );
+    }
+
+    #[test]
+    fn config_set_api_key_still_encrypted_at_rest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = dir.path().to_path_buf();
+
+        // Legacy secret-aware arm (unchanged behavior).
+        run_config_set(
+            "providers.anthropic.api_key",
+            "sk-ant-setupcli-secret",
+            Some(data_dir.clone()),
+            false,
+        )
+        .unwrap();
+
+        let raw = std::fs::read_to_string(data_dir.join("config.json")).unwrap();
+        assert!(
+            !raw.contains("sk-ant-setupcli-secret"),
+            "plaintext api_key must never reach disk"
+        );
+        let root: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert!(root["providers"]["anthropic"]["api_key_encrypted"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()));
+
+        // A follow-up generic set must keep the stored ciphertext intact.
+        run_config_set(
+            "providers.anthropic.model",
+            "claude-x",
+            Some(data_dir.clone()),
+            false,
+        )
+        .unwrap();
+        let raw = std::fs::read_to_string(data_dir.join("config.json")).unwrap();
+        assert!(!raw.contains("sk-ant-setupcli-secret"));
+        let root: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(root["providers"]["anthropic"]["model"], "claude-x");
+        assert!(root["providers"]["anthropic"]["api_key_encrypted"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()));
+
+        let reloaded = Config::from_data_dir_without_env(Some(data_dir));
+        assert_eq!(
+            reloaded.providers.anthropic.as_ref().unwrap().api_key,
+            "sk-ant-setupcli-secret",
+            "the stored key must still decrypt after a generic set"
+        );
+    }
+
+    #[test]
+    fn config_set_rejects_secret_paths_it_cannot_protect() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = dir.path().to_path_buf();
+        for (key, value) in [
+            ("proxy_auth.username", "alice"),
+            ("providers.anthropic.api_key_encrypted", "cipher"),
+            ("provider_instances.nope.api_key", "sk-x"),
+        ] {
+            assert!(
+                run_config_set(key, value, Some(data_dir.clone()), false).is_err(),
+                "{key} must be refused"
+            );
+        }
+        assert!(!data_dir.join("config.json").exists());
     }
 }


### PR DESCRIPTION
Refs #246 (do not close — this covers the CLI slice of the surface-coverage backlog).

## What

### 1. Server-backed MCP management verbs

`bamboo mcp list` stays the offline read of `config.json`. New verbs are thin HTTP clients over the existing `/api/v1/mcp` routes, sharing the same `ConnArgs` (`--server-url` / `--port` / `--data-dir`) as `health`/`status`/`sessions`/`stop`:

| Verb | Route |
|---|---|
| `bamboo mcp status [--json]` | `GET /mcp/servers` — table of connection state, tool counts, last errors |
| `bamboo mcp connect <id>` | `POST /mcp/servers/{id}/connect` (enables + (re)starts) |
| `bamboo mcp disconnect <id>` | `POST /mcp/servers/{id}/disconnect` (disables + stops) |
| `bamboo mcp refresh [<id>]` | `POST /mcp/servers/{id}/refresh`; without an id, refreshes every enabled server |
| `bamboo mcp tools [<id>] [--json]` | `GET /mcp/servers/{id}/tools`, or `GET /mcp/tools` for all |
| `bamboo mcp add --json <file\|->` | raw payload passthrough to `POST /mcp/servers` (internal or mainstream flat shape) |
| `bamboo mcp remove <id>` | `DELETE /mcp/servers/{id}` |

Server ids are validated as URL path segments (same guard as `stop`/`history`); mutating verbs get a 60s budget (stdio startup handshake).

### 2. `config set`: 3 hardcoded keys → generic validated dot-path setter

New `bamboo_config::dot_path` module; `bamboo config set <key> <value> [--dry-run]`.

**Backward compatible:** `provider`, `providers.<anthropic|openai|gemini>.api_key`, `providers.<p>.model` behave exactly as before (same dedicated arms, same validation and messages).

**Secret-aware paths** (routed through the typed setters; `Config::save_to_dir` — the safe offline writer — encrypts at rest): `providers.<anthropic|openai|gemini|bodhi>.api_key`, `provider_instances.<id>.api_key` (instance must exist), `notifications.ntfy.token`, `notifications.bark.device_key`.

**Everything else** is a generic dot-path set with hard validation before any write:
- value parsed as JSON when it parses (numbers/bools/arrays/objects), else string; quote (`'"true"'`) to force a string
- the patched JSON must deserialize back into the typed `Config` → type mismatches error with the failing key
- unknown keys are rejected whether serde silently drops them (strict structs) or a forward-compat `#[serde(flatten)] extra` map captures them (root, `server`, `providers` container, per-provider configs, provider instances); pre-existing extension keys (e.g. `setup.*`) stay editable
- the `mcpServers` subtree is type-checked but exempt from the round-trip shape check (its custom serializer converts internal ⇄ mainstream shapes)
- refused outright: any `*_encrypted` leaf (derived state — writing ciphertext directly is how cipher divergence happens), `proxy_auth.*`, `subagents.broker.*`

**Data-loss guard:** `refresh_proxy_auth_encrypted` clears the at-rest ciphertext when the in-memory plaintext is `None`, and `proxy_auth` is `#[serde(skip_serializing)]` — so a naive JSON round-trip + save would wipe stored proxy credentials on ANY unrelated `config set`. The setter carries `proxy_auth` across the round-trip; a regression test covers it. All other secret refreshes preserve ciphertext when plaintext is empty (#268), verified by a test asserting the stored `api_key_encrypted` is byte-identical after an unrelated generic set.

`--dry-run` prints the resulting path-level diff (both sides serialized with the same plaintext-secret sanitization `save_to_dir` applies) and writes nothing.

## Verification

- `cargo build` (bamboo-agent + bamboo-config): clean
- `cargo test -p bamboo-config`: 172 passed (14 new dot_path tests: valid set, unknown root/nested/dropped key rejected, type mismatch rejected, secret paths refused, proxy_auth carry-over, api_key still encrypted at rest + ciphertext untouched by unrelated set, mcp subtree, dry-run diff)
- `cargo test -p bamboo-agent --lib setup_cli` / `--bin bamboo`: 9 + 2 passed (4 new: generic round-trip to disk, dry-run writes nothing, api_key encrypted at rest through the CLI arm, secret-path rejections)
- `cargo clippy`: 0 warnings in bamboo-config; all 14 bamboo-agent warnings pre-exist on origin/main in other crates (engine/memory/server) — none in touched files
- `cargo fmt --check`: touched files clean (config.rs untouched)
- Smoke: `config set` matrix against a throwaway `--data-dir` (legacy keys, generic typed/JSON values, dry-run, unknown/type/encrypted rejections, no plaintext secret on disk); all 8 MCP verbs exercised against a throwaway `bamboo serve` on port 19779 (add via stdin + file, status table + `--json`, tools, 404 paths, connect/disconnect error surfaces, refresh-all, remove, offline `mcp list` unchanged)

https://claude.ai/code/session_01H623Hx5w8Z887Q9jwE7C7p