### PR TITLE
feat(cli): fold the TUI into the main binary as `bamboo tui`

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -215,17 +215,10 @@ jobs:
           - workspace dependency resolution
           - workspace buildability
 
-          Real publish order:
-          1. bamboo-domain
-          2. bamboo-infrastructure
-          3. bamboo-agent-core
-          4. bamboo-compression
-          5. bamboo-memory
-          6. bamboo-tools
-          7. bamboo-engine
-          8. bamboo-server
-          9. bamboo-agent
+          Real publish order (computed from the dependency graph, exactly as
+          the publish step below computes it):
           EOF
+          python3 scripts/compute-publish-order.py
 
       - name: Publish to crates.io
         if: github.event.inputs.dry_run != 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,6 +909,7 @@ dependencies = [
  "bamboo-storage",
  "bamboo-subagent",
  "bamboo-tools",
+ "bamboo-tui",
  "base64",
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ bamboo-broker = { path = "crates/app/bamboo-broker" }
 bamboo-mcp = { path = "crates/infra/bamboo-mcp" }
 bamboo-skills = { path = "crates/infra/bamboo-skills" }
 bamboo-metrics = { path = "crates/infra/bamboo-metrics" }
+bamboo-tui = { path = "crates/app/bamboo-tui" }
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Arguments supported by `bamboo serve` (all override the config file):
 | Command | What it does |
 |---|---|
 | `bamboo serve` | Start the HTTP/SSE server (above). |
+| `bamboo tui` | Full-screen terminal client (chat, sessions, MCP, schedules, skills, config) over a running server; offers to auto-start a local one when unreachable (`--auto-serve`/`--no-auto-serve`). |
 | `bamboo init` | First-run setup: write `config.json` with a provider + API key (interactive, or `--non-interactive` for CI). |
 | `bamboo doctor` | Diagnose the install (config present, provider keyed, server reachable); exits non-zero on a blocking problem. |
 | `bamboo config [--path] [--show-secrets]` | Inspect the resolved configuration. |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -141,6 +141,7 @@ bamboo serve
 | 命令 | 作用 |
 |---|---|
 | `bamboo serve` | 启动 HTTP/SSE 服务（见上）。 |
+| `bamboo tui` | 全屏终端客户端（聊天、会话、MCP、定时任务、技能、配置），连接运行中的服务；本地服务不可达时会提示自动拉起（`--auto-serve`/`--no-auto-serve`）。 |
 | `bamboo init` | 首次安装引导：写入含 provider + API key 的 `config.json`（交互式，CI 用 `--non-interactive`）。 |
 | `bamboo doctor` | 诊断安装状态（配置存在、provider 已配 key、服务可达）；有阻塞问题时以非零退出。 |
 | `bamboo config [--path] [--show-secrets]` | 查看解析后的配置。 |

--- a/crates/app/bamboo-tui/src/lib.rs
+++ b/crates/app/bamboo-tui/src/lib.rs
@@ -1,0 +1,104 @@
+//! Bamboo TUI — a full-screen terminal client for a running Bamboo server
+//! (chat, sessions, MCP, schedules, skills, config).
+//!
+//! This crate is both a standalone binary (`bamboo-tui`) and a library: the
+//! main `bamboo` binary embeds it as the `bamboo tui` subcommand, so one
+//! binary on PATH exposes serve + CLI + TUI. The entry point is [`run`] — a
+//! plain `async fn` (no runtime of its own) so it composes with the caller's
+//! existing tokio runtime; both binaries provide one via `#[tokio::main]`.
+
+use anyhow::Result;
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::execute;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
+use std::io::{self, IsTerminal};
+
+mod api;
+mod app;
+mod components;
+mod event;
+mod history;
+mod theme;
+mod ui;
+
+pub use app::AutoServeMode;
+
+/// Default `--server-url`: the concrete loopback IPv4 (not `localhost`, which
+/// resolves to `::1` first on dual-stack hosts while the server default-binds
+/// `127.0.0.1` only → ECONNREFUSED).
+pub const DEFAULT_SERVER_URL: &str = "http://127.0.0.1:9562";
+
+/// Options for [`run`] — the library-level mirror of the CLI flags shared by
+/// the standalone `bamboo-tui` binary and the `bamboo tui` subcommand.
+pub struct TuiOptions {
+    /// Base URL of the Bamboo server to talk to (see [`DEFAULT_SERVER_URL`]).
+    pub server_url: String,
+    /// Session ID to resume on startup (optional).
+    pub session_id: Option<String>,
+    /// Model override for the chat (optional).
+    pub model: Option<String>,
+    /// How an unreachable loopback `server_url` is handled at startup:
+    /// spawn a local `bamboo serve` automatically, offer y/n, or never.
+    pub auto_serve: AutoServeMode,
+}
+
+impl Default for TuiOptions {
+    fn default() -> Self {
+        Self {
+            server_url: DEFAULT_SERVER_URL.to_string(),
+            session_id: None,
+            model: None,
+            auto_serve: AutoServeMode::Prompt,
+        }
+    }
+}
+
+/// Run the full-screen TUI until the user quits.
+///
+/// Requires an interactive terminal: on a non-TTY stdin/stdout this fails
+/// closed with a clear error *before* touching terminal state — entering raw
+/// mode + the alternate screen on a pipe would only garble the caller's
+/// output. On a TTY it sets the terminal up, drives the app, and restores the
+/// terminal (raw mode off, main screen back) before returning.
+pub async fn run(opts: TuiOptions) -> Result<()> {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        anyhow::bail!("bamboo tui requires an interactive terminal (stdin/stdout is not a TTY)");
+    }
+
+    // Setup terminal.
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    // Create client and app.
+    let client = api::BambooClient::new(&opts.server_url);
+    let mut app = app::App::new(client);
+
+    // Apply options.
+    if let Some(session_id) = opts.session_id {
+        app.chat.session_id = Some(session_id);
+    }
+    if let Some(model) = opts.model {
+        app.chat.model = model;
+    }
+
+    // Run app.
+    let result = app.run(&mut terminal, opts.auto_serve).await;
+
+    // Restore terminal.
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    terminal.show_cursor()?;
+
+    result
+}

--- a/crates/app/bamboo-tui/src/main.rs
+++ b/crates/app/bamboo-tui/src/main.rs
@@ -1,21 +1,10 @@
-use anyhow::Result;
-use clap::Parser;
-use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
-use crossterm::execute;
-use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
-};
-use ratatui::backend::CrosstermBackend;
-use ratatui::Terminal;
-use std::io;
+//! Standalone `bamboo-tui` binary — a thin clap wrapper over the `bamboo_tui`
+//! library. The same TUI ships inside the main `bamboo` binary as the
+//! `bamboo tui` subcommand; keep the flag surfaces in lock-step.
 
-mod api;
-mod app;
-mod components;
-mod event;
-mod history;
-mod theme;
-mod ui;
+use anyhow::Result;
+use bamboo_tui::{AutoServeMode, TuiOptions};
+use clap::Parser;
 
 #[derive(Parser)]
 #[command(name = "bamboo-tui")]
@@ -26,7 +15,7 @@ struct Cli {
     /// Bamboo server URL. Defaults to the concrete loopback IPv4 (not
     /// `localhost`, which resolves to `::1` first on dual-stack hosts while the
     /// server default-binds `127.0.0.1` only → ECONNREFUSED).
-    #[arg(long, default_value = "http://127.0.0.1:9562")]
+    #[arg(long, default_value = bamboo_tui::DEFAULT_SERVER_URL)]
     server_url: String,
 
     /// Session ID to resume (optional)
@@ -53,43 +42,19 @@ struct Cli {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    // Setup terminal.
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
-
-    // Create client and app.
-    let client = api::BambooClient::new(&cli.server_url);
-    let mut app = app::App::new(client);
-
-    // Apply CLI args.
-    if let Some(session_id) = cli.session_id {
-        app.chat.session_id = Some(session_id);
-    }
-    if let Some(model) = cli.model {
-        app.chat.model = model;
-    }
-    let auto_serve_mode = if cli.auto_serve {
-        app::AutoServeMode::Auto
+    let auto_serve = if cli.auto_serve {
+        AutoServeMode::Auto
     } else if cli.no_auto_serve {
-        app::AutoServeMode::Off
+        AutoServeMode::Off
     } else {
-        app::AutoServeMode::Prompt
+        AutoServeMode::Prompt
     };
 
-    // Run app.
-    let result = app.run(&mut terminal, auto_serve_mode).await;
-
-    // Restore terminal.
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
-    result
+    bamboo_tui::run(TuiOptions {
+        server_url: cli.server_url,
+        session_id: cli.session_id,
+        model: cli.model,
+        auto_serve,
+    })
+    .await
 }

--- a/scripts/compute-publish-order.py
+++ b/scripts/compute-publish-order.py
@@ -8,9 +8,10 @@ release: a dependency was published before the crates it needs existed on the
 index. Computing the order here keeps it in lock-step with the workspace.
 
 Scope: ``bamboo-agent``'s transitive workspace-dependency closure (the published
-library and everything it pulls in), dependencies first. Standalone binaries
-outside that closure (bamboo-tui, bamboo-client-core) are not part
-of the published library and are intentionally excluded.
+library and everything it pulls in), dependencies first. Since the TUI folded
+into the main binary as ``bamboo tui``, that closure includes bamboo-tui and
+bamboo-client-core automatically — no list to maintain. Workspace members
+outside the closure are intentionally excluded.
 
 Run from the workspace root (where the top-level Cargo.toml lives).
 """

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -169,6 +169,44 @@ enum Commands {
         parent_pid: Option<u32>,
     },
 
+    /// Full-screen terminal client (TUI) over a running server: chat,
+    /// sessions, MCP, schedules, skills and config in one keyboard-driven
+    /// interface. If a loopback --server-url is unreachable it offers to
+    /// start a local `bamboo serve` (y/n) — see --auto-serve/--no-auto-serve.
+    #[command(after_help = "EXAMPLES:\n  \
+        # Connect to the default local server (offers to start one if absent)\n  \
+        bamboo tui\n\n  \
+        # Resume a session, headless-server URL pinned\n  \
+        bamboo tui --server-url http://127.0.0.1:9562 --session-id <id>\n\n  \
+        # Never offer/auto-start a local server (just warn when unreachable)\n  \
+        bamboo tui --no-auto-serve")]
+    Tui {
+        /// Bamboo server URL. Defaults to the concrete loopback IPv4 (not
+        /// `localhost`, which resolves to `::1` first on dual-stack hosts
+        /// while the server default-binds `127.0.0.1` only → ECONNREFUSED).
+        #[arg(long, default_value = bamboo_tui::DEFAULT_SERVER_URL)]
+        server_url: String,
+
+        /// Session ID to resume (optional)
+        #[arg(long)]
+        session_id: Option<String>,
+
+        /// Model to use
+        #[arg(short, long)]
+        model: Option<String>,
+
+        /// If `--server-url` is unreachable and loopback, start a local
+        /// `bamboo serve` automatically instead of asking (y/n). No effect for
+        /// a remote (non-loopback) `--server-url` — that always just warns.
+        #[arg(long, conflicts_with = "no_auto_serve")]
+        auto_serve: bool,
+
+        /// Never offer/auto-start a local server, even for an unreachable
+        /// loopback `--server-url` — just warn, like a remote URL always does.
+        #[arg(long, conflicts_with = "auto_serve")]
+        no_auto_serve: bool,
+    },
+
     /// First-run setup: write `config.json` with a provider + API key.
     ///
     /// Interactive by default (prompts for anything not given as a flag). Pass
@@ -934,6 +972,12 @@ async fn main() {
                 )
                 .init();
         }
+        Some(Commands::Tui { .. }) => {
+            // No logging subscriber: the TUI owns the terminal (raw mode +
+            // alternate screen), so a stdout/stderr fmt layer would garble the
+            // display. Matches the standalone `bamboo-tui` binary, which
+            // installs none.
+        }
         Some(Commands::SubagentWorker)
         | Some(Commands::Actor { .. })
         | Some(Commands::Broker { .. })
@@ -1134,6 +1178,36 @@ async fn main() {
 
             if let Err(e) = result {
                 eprintln!("Failed to start server: {}", e);
+                std::process::exit(1);
+            }
+        }
+
+        Commands::Tui {
+            server_url,
+            session_id,
+            model,
+            auto_serve,
+            no_auto_serve,
+        } => {
+            let auto_serve = if auto_serve {
+                bamboo_tui::AutoServeMode::Auto
+            } else if no_auto_serve {
+                bamboo_tui::AutoServeMode::Off
+            } else {
+                bamboo_tui::AutoServeMode::Prompt
+            };
+            // `bamboo_tui::run` fails closed on a non-TTY stdin/stdout before
+            // touching terminal state (raw mode / alternate screen), so a
+            // scripted `bamboo tui` errors cleanly instead of garbling output.
+            let result = bamboo_tui::run(bamboo_tui::TuiOptions {
+                server_url,
+                session_id,
+                model,
+                auto_serve,
+            })
+            .await;
+            if let Err(e) = result {
+                eprintln!("{e}");
                 std::process::exit(1);
             }
         }
@@ -1656,5 +1730,64 @@ mod tests {
             "super-secret"
         );
         assert_eq!(value["tools"]["disabled"], json!(["Bash", "Read"]));
+    }
+
+    #[test]
+    fn cli_tree_includes_tui_subcommand_with_standalone_flag_surface() {
+        use clap::CommandFactory;
+
+        let cmd = super::Cli::command();
+        // Full-tree consistency check (what `--help` generation relies on).
+        cmd.clone().debug_assert();
+
+        let tui = cmd
+            .find_subcommand("tui")
+            .expect("`tui` must be in the subcommand tree");
+        let args: Vec<&str> = tui.get_arguments().map(|a| a.get_id().as_str()).collect();
+        // Same flag surface as the standalone `bamboo-tui` binary.
+        for expected in [
+            "server_url",
+            "session_id",
+            "model",
+            "auto_serve",
+            "no_auto_serve",
+        ] {
+            assert!(args.contains(&expected), "missing --{expected} on `tui`");
+        }
+    }
+
+    #[test]
+    fn tui_help_parses_and_auto_serve_flags_conflict() {
+        use clap::Parser;
+
+        // `bamboo tui --help` parses down the tree (clap reports help as an
+        // "error" of kind DisplayHelp).
+        let Err(help) = super::Cli::try_parse_from(["bamboo", "tui", "--help"]) else {
+            panic!("--help must surface as a DisplayHelp error");
+        };
+        assert_eq!(help.kind(), clap::error::ErrorKind::DisplayHelp);
+
+        // The flags parse.
+        assert!(super::Cli::try_parse_from(["bamboo", "tui", "--auto-serve"]).is_ok());
+        assert!(super::Cli::try_parse_from([
+            "bamboo",
+            "tui",
+            "--server-url",
+            "http://127.0.0.1:9999",
+            "--session-id",
+            "abc",
+            "-m",
+            "anthropic:claude-sonnet-4",
+            "--no-auto-serve",
+        ])
+        .is_ok());
+
+        // --auto-serve and --no-auto-serve are mutually exclusive.
+        let Err(conflict) =
+            super::Cli::try_parse_from(["bamboo", "tui", "--auto-serve", "--no-auto-serve"])
+        else {
+            panic!("conflicting flags must be rejected");
+        };
+        assert_eq!(conflict.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 }


### PR DESCRIPTION
## Motivation

Bodhi desktop bundles the `bamboo` sidecar binary but not `bamboo-tui` — so the TUI simply isn't there on machines that only have the sidecar. Folding it in means **one binary on PATH exposes everything** (serve + CLI + TUI), and `cargo install bamboo-agent` users get the TUI for free.

## Design

**Runtime / entry point.** `bamboo-tui` gains a `src/lib.rs` exposing `TuiOptions` (mirror of the standalone CLI flags) and `pub async fn run(TuiOptions) -> anyhow::Result<()>`. It is a plain `async fn` with **no runtime of its own**, so it composes with the root binary's existing `#[tokio::main]` — no nested-runtime hazard. The standalone `bamboo-tui` binary keeps working as a thin clap wrapper over the lib (its own `#[tokio::main]` + `bamboo_tui::run(...)`), with the flag surfaces kept in lock-step.

**Subcommand.** `bamboo tui` carries the exact standalone flag surface: `--server-url` (default `http://127.0.0.1:9562` via the shared `bamboo_tui::DEFAULT_SERVER_URL` const), `--session-id`, `-m/--model`, and the mutually-exclusive `--auto-serve` / `--no-auto-serve`, with an `after_help` EXAMPLES block matching the existing clap style. The logging-init match gets a dedicated arm that installs **no subscriber** for `tui` — the TUI owns the terminal (raw mode + alternate screen), and a stdout/stderr fmt layer would garble it; this matches the standalone binary, which installs none.

**TTY guard (new).** The TUI previously had no non-TTY handling — it would enter raw mode + the alternate screen on a pipe and garble output. `bamboo_tui::run` now fails closed *before touching terminal state* when stdin or stdout is not a TTY:

```
$ bamboo tui < /dev/null | cat
bamboo tui requires an interactive terminal (stdin/stdout is not a TTY)   # exit 1
```

Living in the lib entry, the guard covers both the subcommand and the standalone binary.

## Publish-chain findings

- The publish order is **topological and automatic**: `.github/workflows/publish-crate.yml` derives it from the real dependency graph via `scripts/compute-publish-order.py` (`cargo metadata`, transitive closure of `bamboo-agent`). With the new root dependency, `bamboo-client-core` and `bamboo-tui` enter that closure automatically — verified locally, the computed order now ends `... bamboo-server, bamboo-client-core, bamboo-tui, bamboo-agent` (24 crates). **No hardcoded list to extend.**
- Neither crate has `publish = false`, and both already carry the crates.io-required metadata (`description`, `license = "MIT"`, workspace version placeholder); the manifest-rewrite step's `crates/*/*/Cargo.toml` glob already covers them, so their path deps get versioned at publish time.
- Cleaned up two stale artifacts of the old world: the script docstring that declared bamboo-tui/bamboo-client-core "intentionally excluded", and the dry-run step's drifted hand-written 9-crate "Real publish order" (the workspace closure is 24) — the dry run now prints the actually-computed order.

## Verification

- `cargo build -p bamboo-agent --bin bamboo` — green
- `cargo test -p bamboo-tui` — **102 passed** (now in the lib target), 0 failed
- `cargo test -p bamboo-agent --lib --bins` — 62 + 4 passed (incl. new clap-level tests: `tui` in the subcommand tree with the full standalone flag surface; `--help` parses; `--auto-serve`+`--no-auto-serve` → `ArgumentConflict`)
- `cargo clippy -p bamboo-tui --all-targets` / `-p bamboo-agent --lib --bins` — no warnings in touched code (remaining ones are pre-existing in bamboo-engine/bamboo-server/etc.)
- `rustfmt --check` clean on the three touched Rust files
- Smoke: `target/debug/bamboo tui --help` renders; non-TTY invocation of both `bamboo tui` and standalone `bamboo-tui` prints the clean error above and exits 1 (interactive TUI intentionally not exercised)

## Docs

`bamboo tui` row added to the CLI tables in README.md and README.zh-CN.md.