### PR TITLE
feat(subagent): Claude Code external agent executor

### DIFF
--- a/crates/engine/bamboo-engine/src/external_agents/runtime.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/runtime.rs
@@ -105,6 +105,16 @@ pub fn build_external_child_runner(config: &Config) -> Arc<dyn ExternalChildRunn
                 Some("bamboo_runtime") | None => {
                     bamboo_subagent::provision::ExecutorSpec::BambooRuntime
                 }
+                // The profile schema has no dedicated model/permission-mode
+                // fields yet for a non-bamboo_runtime executor (#441 follow-up);
+                // this kind runs with the CLI's own defaults (binary `claude`
+                // on PATH, default permission mode) until that's plumbed
+                // through.
+                Some("claude_code") => bamboo_subagent::provision::ExecutorSpec::ClaudeCode {
+                    binary: None,
+                    model: None,
+                    permission_mode: None,
+                },
                 Some(other) => {
                     tracing::error!(
                         "Actor agent profile {} has unknown executor '{}'; skipping",
@@ -214,6 +224,14 @@ fn build_local_actor_runner(config: &Config) -> Result<Arc<dyn ExternalChildRunn
     let executor = match sub.executor.as_deref() {
         Some("echo") => bamboo_subagent::provision::ExecutorSpec::Echo,
         Some("bamboo_runtime") | None => bamboo_subagent::provision::ExecutorSpec::BambooRuntime,
+        // See the matching arm in `build_external_child_runner` above: no
+        // config field carries model/permission-mode for this kind yet, so it
+        // runs with the CLI's own defaults (#441 follow-up).
+        Some("claude_code") => bamboo_subagent::provision::ExecutorSpec::ClaudeCode {
+            binary: None,
+            model: None,
+            permission_mode: None,
+        },
         Some(other) => return Err(format!("unknown subagents.executor '{other}'")),
     };
 

--- a/crates/infra/bamboo-subagent/src/provision.rs
+++ b/crates/infra/bamboo-subagent/src/provision.rs
@@ -219,6 +219,20 @@ pub enum ExecutorSpec {
     BambooRuntime,
     /// Wrap an external CLI agent as the engine.
     CliAdapter { command: String, args: Vec<String> },
+    /// Drive the official Claude Code CLI (`claude`) as the engine over its
+    /// stream-json wire protocol (see `docs/claude-code-executor.md`). `binary`
+    /// overrides the executable (tests point it at a stub script); `None` runs
+    /// `claude` from `PATH`. `model`/`permission_mode` map to the CLI's
+    /// `--model` / `--permission-mode` flags; `None` omits the flag (CLI
+    /// default).
+    ClaudeCode {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        binary: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        permission_mode: Option<String>,
+    },
 }
 
 /// Provider+model pair, parent-resolved. (Local mirror of `ProviderModelRef`;
@@ -530,5 +544,25 @@ mod tests {
             serde_json::to_value(ExecutorSpec::BambooRuntime).unwrap()["kind"],
             "bamboo_runtime"
         );
+        let claude_code = ExecutorSpec::ClaudeCode {
+            binary: Some("/usr/local/bin/claude".into()),
+            model: Some("claude-sonnet-4-6".into()),
+            permission_mode: Some("bypassPermissions".into()),
+        };
+        let vcc = serde_json::to_value(&claude_code).unwrap();
+        assert_eq!(vcc["kind"], "claude_code");
+        assert_eq!(vcc["binary"], "/usr/local/bin/claude");
+        // Round-trips.
+        assert_eq!(
+            serde_json::from_value::<ExecutorSpec>(vcc).unwrap(),
+            claude_code
+        );
+        let minimal = ExecutorSpec::ClaudeCode {
+            binary: None,
+            model: None,
+            permission_mode: None,
+        };
+        let vmin = serde_json::to_value(&minimal).unwrap();
+        assert_eq!(vmin, serde_json::json!({"kind": "claude_code"}));
     }
 }

--- a/docs/claude-code-executor.md
+++ b/docs/claude-code-executor.md
@@ -1,0 +1,183 @@
+# Driving Claude Code as an external agent — protocol reference
+
+Status: reference knowledge for a future `ClaudeCodeExecutor` (`ChildExecutor` impl).
+Source: distilled from `chenhg5/cc-connect` `agent/claudecode/` (Go, battle-tested against
+Claude Code 2.x in production), verified against the repo at commit `main@2026-07-11`.
+File references below are to that repo.
+
+## Where this plugs into bamboo
+
+`bamboo-subagent::provision::ExecutorSpec` already reserves the slot
+(`provision.rs:221`):
+
+```rust
+/// Wrap an external CLI agent as the engine.
+CliAdapter { command: String, args: Vec<String> },
+```
+
+No executor implements it yet. The work is:
+
+1. `ClaudeCodeExecutor: ChildExecutor` (`executor.rs:169`) — owns the child process,
+   translates `RunSpec` → stream-json stdin, stream-json stdout → `EventSink`,
+   `SteerInbox` → mid-turn user injection / permission responses,
+   `CancellationToken` → graceful shutdown (see §7).
+2. Worker executor factory: map `ExecutorSpec::CliAdapter`(or a dedicated
+   `ClaudeCode` variant carrying model/permission-mode/resume-id) to it.
+3. `bamboo-engine/src/external_agents/runtime.rs:104,215` — accept executor kind
+   `"claude_code"` alongside `"echo"` / `"bamboo_runtime"`.
+
+## 1. Spawn
+
+One **long-lived process per session** (NOT per message). Repeated turns are
+repeated stdin writes to the same process; `--resume` is only for reattaching
+after the process died.
+
+```
+claude \
+  --output-format stream-json \
+  --input-format  stream-json \
+  --permission-prompt-tool stdio \
+  --replay-user-messages \
+  --verbose \
+  [--permission-mode <acceptEdits|plan|bypassPermissions>]   # omit for "default"
+  [--resume <session_id>]                                    # omit for a fresh session
+  [--model <model>]
+  [--allowedTools a,b] [--disallowedTools a,b]
+  [--system-prompt <s>] [--append-system-prompt-file <path>]
+```
+
+(cc-connect: `agent/claudecode/session.go:234-322`)
+
+Environment:
+- **Strip `CLAUDECODE`** from the child env — otherwise Claude Code detects a
+  nested session and misbehaves (`session.go:372`).
+- Put the child in its own **process group** so shutdown can kill the whole tree
+  (claude → its MCP servers) (`session.go:369`).
+- Inject whatever env the executor wants the agent's shell tools to see
+  (cc-connect injects `CC_PROJECT` / `CC_SESSION_KEY` for its send-back IPC).
+
+Gotchas:
+- Drop `--verbose` when routing through claude-code-router — router output
+  corrupts the JSON stream (`claudecode.go:524-526`).
+- `bypassPermissions` under euid 0 is rejected by the CLI; downgrade and surface
+  a warning (`session.go:225-229`).
+
+## 2. Wire protocol
+
+Newline-delimited JSON both ways. **Reader must allow 10 MB lines**
+(`session.go:472` uses a 10 MB scanner buffer; tool results can be huge).
+
+### stdin → claude (user turn)
+
+```json
+{"type":"user","message":{"role":"user","content":"fix the failing test"}}
+```
+
+Multimodal content uses parts:
+
+```json
+{"type":"user","message":{"role":"user","content":[
+  {"type":"text","text":"what is in this screenshot?"},
+  {"type":"image","source":{"type":"base64","media_type":"image/png","data":"..."}}
+]}}
+```
+
+Non-image files are NOT inlined: write them to a scratch dir and reference the
+absolute paths in the prompt text ("Files saved locally, please read them: …") —
+the agent opens them with its own Read tool (`core/message.go:103-141`).
+
+### stdout → executor, dispatched on top-level `type`
+
+| type | meaning | what to extract |
+|---|---|---|
+| `system` | session bootstrap | `session_id` (agent-assigned — persist it for resume), `model` |
+| `assistant` | one model message | iterate `message.content[]`: `text` → token/text event; `thinking` → thinking event; `tool_use` → tool-start event (`name`, `input`). `message.usage` gives live context numbers (its `output_tokens` is a placeholder, ignore) |
+| `user` | echoed tool results | `content[].type == "tool_result"` → tool-end event (`content` truncated, `is_error`) |
+| `result` | turn end | final text, `session_id`, token totals. **`subtype: "compact"/"compaction"` is MID-turn** — do not treat as turn completion (cc-connect issue #481) |
+| `control_request` | permission ask | see §3 |
+| `control_cancel_request` | CLI withdrew a pending ask | drop the matching pending approval |
+
+Unknown types: log at debug, never fail the stream (`session.go:587-594`).
+On process exit, surface stderr as an error event and complete the run exactly
+once (`session.go:512-535`).
+
+## 3. Permission relay (`--permission-prompt-tool stdio`)
+
+The CLI asks before each gated tool call:
+
+```json
+{"type":"control_request","request_id":"r1","request":{
+  "subtype":"can_use_tool","tool_name":"Bash","input":{"command":"rm -rf build"}}}
+```
+
+Executor decides locally (auto-allow for `bypassPermissions`-equivalent modes,
+auto-allow edit-tools for acceptEdits, etc.) or relays to the parent as a
+NeedsHuman-style event, then answers on stdin:
+
+```json
+{"type":"control_response","response":{
+  "subtype":"success","request_id":"r1",
+  "response":{"behavior":"allow","updatedInput":{"command":"rm -rf build"}}}}
+```
+
+Deny: `{"behavior":"deny","message":"user denied"}`. On allow, echo the tool
+`input` back as `updatedInput` (it may also be edited). `AskUserQuestion`
+control_requests carry structured questions — map to bamboo's QuestionDialog
+path rather than the permission path (`session.go:856-937`).
+
+In bamboo terms: emit a `NeedsHuman` event with `request_id`, park the pending
+approval in a map of oneshot channels, resolve it when the steer inbox delivers
+the decision — same shape as the codex app-server adapter in cc-connect
+(`appserver_session.go:542-617`).
+
+## 4. Session identity & resume
+
+- The session id is **agent-assigned**: read it from `system` / `result` events;
+  persist per bamboo child.
+- Live continuity = same process, more stdin writes. Resume after restart =
+  `--resume <persisted_id>`; the resumed process may assign a NEW id — keep a
+  history of prior ids if you need to recognize transcripts.
+- Transcripts live at `~/.claude/projects/<hashed-workdir>/<session_id>.jsonl`
+  if history listing is ever wanted (`claudecode.go:532-587`).
+
+## 5. Cancellation / shutdown
+
+Graceful 3-phase close (`session.go:1171-1228`):
+
+1. close stdin (EOF lets the CLI run its Stop hooks),
+2. wait up to ~120 s for exit,
+3. SIGTERM the process group, wait 5 s, SIGKILL the group.
+
+There is no reliable mid-turn interrupt over this protocol (cc-connect's `/stop`
+kills the process and resumes by id). Map `CancellationToken` → full close;
+rely on `--resume` for continuation.
+
+## 6. Billing note
+
+The spawned binary is official Claude Code with the user's own login; as of
+2026-07 subscription auth still covers `claude -p`/stream-json usage (the
+June 15 credit split was paused). If the host also configures `ANTHROPIC_API_KEY`
+in the child env, the CLI bills the API key instead — decide explicitly which
+one the executor forwards.
+
+## 7. Minimal executor sketch
+
+```rust
+pub struct ClaudeCodeExecutor { /* binary path, defaults */ }
+
+#[async_trait]
+impl ChildExecutor for ClaudeCodeExecutor {
+    async fn run(&self, spec: RunSpec, events: EventSink,
+                 steer: SteerInbox, cancel: CancellationToken) -> ChildOutcome {
+        // 1. spawn `claude` (fresh or --resume from spec metadata), own pgroup
+        // 2. write the assignment as a stream-json user message
+        // 3. select-loop:
+        //    - stdout line  → parse → events.emit(...)   (§2 table)
+        //      control_request → events.emit(NeedsHuman) + park oneshot
+        //    - steer msg    → permission decision → control_response
+        //                     | plain text → inject as next user message
+        //    - cancel       → §5 shutdown → ChildOutcome::Cancelled
+        //    - `result` with Done → drain, keep process warm or close per policy
+    }
+}
+```

--- a/src/broker_agent.rs
+++ b/src/broker_agent.rs
@@ -80,6 +80,16 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
         tracing::info!(id = %me.session_id, broker = %endpoint, "broker-agent serving from piped spec");
         let executor: Arc<dyn bamboo_subagent::ChildExecutor> = match spec.executor {
             ExecutorSpec::Echo => Arc::new(EchoExecutor),
+            ExecutorSpec::ClaudeCode {
+                ref binary,
+                ref model,
+                ref permission_mode,
+            } => Arc::new(crate::claude_code_executor::ClaudeCodeExecutor::new(
+                binary.clone(),
+                model.clone(),
+                permission_mode.clone(),
+                spec.workspace.clone(),
+            )),
             _ => Arc::new(BambooRuntimeExecutor::build(&spec).await?),
         };
         return bamboo_broker::serve_executor(&endpoint, me, &token, executor)

--- a/src/claude_code_executor.rs
+++ b/src/claude_code_executor.rs
@@ -1,0 +1,1040 @@
+//! `ClaudeCodeExecutor`: a [`ChildExecutor`] that drives the official Claude
+//! Code CLI (`claude`) as an external sub-agent engine over its stream-json
+//! wire protocol. See `docs/claude-code-executor.md` for the full protocol
+//! reference (spawn flags, NDJSON frame table, permission relay, shutdown)
+//! this implementation follows.
+//!
+//! MVP scope (issue #441): spawn a **fresh `claude` process per `run()` call**
+//! (one activation = one turn), map its stdout frames onto the same
+//! `AgentEvent`s the real bamboo runtime emits (so the parent's child preview
+//! renders identically — see [`BambooRuntimeExecutor`](crate::subagent_worker::BambooRuntimeExecutor)),
+//! and relay `can_use_tool` permission asks through [`EventSink::host`] when a
+//! host bridge is wired. Session resume (`--resume`) and mid-turn steering are
+//! explicitly out of scope — see the doc comment on [`ChildExecutor::run`]'s
+//! `steer` parameter below.
+
+use std::collections::HashMap;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::{mpsc, Mutex};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use bamboo_agent_core::{AgentEvent, TokenUsage, ToolResult};
+use bamboo_subagent::executor::{ChildExecutor, ChildOutcome, EventSink, HostBridge, SteerInbox};
+use bamboo_subagent::proto::RunSpec;
+
+/// Upper bound on a single stdout NDJSON line. Tool results can be huge (the
+/// protocol doc specifies a 10 MB scanner buffer at `docs/claude-code-executor.md`
+/// §2); enforced incrementally via `fill_buf`/`consume` in [`read_bounded_line`]
+/// so a runaway line is capped in memory as it streams in, not merely rejected
+/// after already having been buffered in full.
+const MAX_STDOUT_LINE_BYTES: usize = 10 * 1024 * 1024;
+
+/// Tail of stderr retained (for the error message on an exit with no `result`
+/// frame) — bounded so a chatty child can't grow this without limit.
+const STDERR_TAIL_BYTES: usize = 16 * 1024;
+
+/// Tool-result content is truncated to this many characters before riding the
+/// `ToolComplete`/`ToolError` event (doc's "truncate" guidance — the full
+/// result already lives in the Claude Code CLI's own transcript on disk).
+const TOOL_RESULT_TRUNCATE_CHARS: usize = 20_000;
+
+/// Phase 2 of shutdown (§5 of the protocol doc): bounded wait for a natural
+/// exit after stdin closes (lets the CLI run its Stop hooks). Shorter than
+/// cc-connect's 120s — this is a subagent activation, not an interactive
+/// session, and the caller (the actor transport) has its own outer timeout.
+const GRACEFUL_EXIT_WAIT: Duration = Duration::from_secs(5);
+/// Phase 3: bounded wait after SIGTERM before escalating to SIGKILL.
+const SIGTERM_WAIT: Duration = Duration::from_secs(2);
+
+/// Drives `claude --output-format stream-json --input-format stream-json ...`
+/// as the engine behind one sub-agent run.
+pub struct ClaudeCodeExecutor {
+    /// Executable to spawn. Defaults to `"claude"` (resolved via `PATH`);
+    /// tests override it with a stub script.
+    binary: String,
+    model: Option<String>,
+    permission_mode: Option<String>,
+    /// Working directory for the spawned CLI's file tools. `None` inherits the
+    /// worker process's own cwd (mirrors how [`BambooRuntimeExecutor`](crate::subagent_worker::BambooRuntimeExecutor)
+    /// treats an absent `ProvisionSpec.workspace`).
+    workspace: Option<String>,
+}
+
+impl ClaudeCodeExecutor {
+    pub fn new(
+        binary: Option<String>,
+        model: Option<String>,
+        permission_mode: Option<String>,
+        workspace: Option<String>,
+    ) -> Self {
+        Self {
+            binary: binary.unwrap_or_else(|| "claude".to_string()),
+            model,
+            permission_mode,
+            workspace,
+        }
+    }
+
+    fn build_command(&self) -> Command {
+        let mut cmd = Command::new(&self.binary);
+        cmd.arg("--output-format")
+            .arg("stream-json")
+            .arg("--input-format")
+            .arg("stream-json")
+            .arg("--permission-prompt-tool")
+            .arg("stdio")
+            .arg("--replay-user-messages")
+            .arg("--verbose");
+        if let Some(mode) = &self.permission_mode {
+            cmd.arg("--permission-mode").arg(mode);
+        }
+        if let Some(model) = &self.model {
+            cmd.arg("--model").arg(model);
+        }
+        // Nested-session detection: Claude Code misbehaves if it inherits its
+        // own env var from an outer session (docs/claude-code-executor.md §1).
+        cmd.env_remove("CLAUDECODE");
+        if let Some(ws) = &self.workspace {
+            cmd.current_dir(ws);
+        }
+        cmd.stdin(Stdio::piped());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        // Safety net: if this future is ever dropped without running our own
+        // shutdown sequence (panic, abort), don't leak the child.
+        cmd.kill_on_drop(true);
+        #[cfg(unix)]
+        {
+            // Own process group so shutdown can SIGTERM/SIGKILL the whole tree
+            // (claude → any MCP servers it spawns), not just the leader.
+            cmd.process_group(0);
+        }
+        cmd
+    }
+
+    /// Dispatch one parsed stdout frame. Returns `Some(outcome)` when the
+    /// frame is turn-terminal (a non-compaction `result`); `None` otherwise —
+    /// including for `control_request`/`control_cancel_request`, which are
+    /// handled here but never end the run themselves.
+    async fn handle_frame(
+        &self,
+        value: Value,
+        events: &EventSink,
+        write_tx: &mpsc::UnboundedSender<Value>,
+        pending: &mut HashMap<String, JoinHandle<()>>,
+        last_text: &mut String,
+    ) -> Option<ChildOutcome> {
+        let frame_type = value.get("type").and_then(Value::as_str).unwrap_or("");
+        match frame_type {
+            "system" => {
+                let session_id = value
+                    .get("session_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let model = value.get("model").and_then(|v| v.as_str()).unwrap_or("");
+                tracing::debug!(session_id, model, "claude code: session bootstrap");
+                None
+            }
+            "assistant" => {
+                if let Some(blocks) = value.pointer("/message/content").and_then(Value::as_array) {
+                    for block in blocks {
+                        emit_assistant_block(block, events, last_text);
+                    }
+                }
+                None
+            }
+            "user" => {
+                if let Some(blocks) = value.pointer("/message/content").and_then(Value::as_array) {
+                    for block in blocks {
+                        emit_tool_result_block(block, events);
+                    }
+                }
+                None
+            }
+            "result" => {
+                let subtype = value.get("subtype").and_then(Value::as_str).unwrap_or("");
+                if matches!(subtype, "compact" | "compaction") {
+                    // Mid-turn compaction, NOT completion (cc-connect issue #481
+                    // — see docs/claude-code-executor.md §2's `result` row).
+                    tracing::debug!("claude code: mid-turn compaction result, continuing");
+                    return None;
+                }
+                let final_text = value
+                    .get("result")
+                    .and_then(Value::as_str)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+                    .unwrap_or_else(|| last_text.clone());
+                let usage = value
+                    .get("usage")
+                    .map(|u| {
+                        let prompt = u.get("input_tokens").and_then(Value::as_u64).unwrap_or(0);
+                        let completion =
+                            u.get("output_tokens").and_then(Value::as_u64).unwrap_or(0);
+                        TokenUsage {
+                            prompt_tokens: prompt,
+                            completion_tokens: completion,
+                            total_tokens: prompt.saturating_add(completion),
+                        }
+                    })
+                    .unwrap_or_default();
+                events.emit(event_json(AgentEvent::Complete { usage }));
+                Some(ChildOutcome::completed(final_text))
+            }
+            "control_request" => {
+                self.handle_control_request(value, events, write_tx, pending);
+                None
+            }
+            "control_cancel_request" => {
+                let request_id = value
+                    .get("request_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if let Some(handle) = pending.remove(request_id) {
+                    handle.abort();
+                }
+                None
+            }
+            other => {
+                tracing::debug!(frame_type = other, "claude code: unrecognized stdout frame");
+                None
+            }
+        }
+    }
+
+    /// Handle one `control_request` (permission relay §3 of the protocol doc):
+    /// spawns a background task so the read loop keeps consuming stdout while
+    /// a (possibly slow, human-in-the-loop) approval decision is pending. The
+    /// task is tracked in `pending` so a later `control_cancel_request` can
+    /// abort it.
+    fn handle_control_request(
+        &self,
+        value: Value,
+        events: &EventSink,
+        write_tx: &mpsc::UnboundedSender<Value>,
+        pending: &mut HashMap<String, JoinHandle<()>>,
+    ) {
+        let request_id = value
+            .get("request_id")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let request = value.get("request").cloned().unwrap_or_else(|| json!({}));
+        let subtype = request.get("subtype").and_then(Value::as_str).unwrap_or("");
+        if subtype != "can_use_tool" {
+            // Only the tool-permission ask is understood in the MVP. Deny
+            // rather than ignore — an un-answered control_request otherwise
+            // hangs the CLI turn waiting for a response that never comes.
+            send_control_response(
+                write_tx,
+                &request_id,
+                false,
+                None,
+                Some(format!("unsupported control_request subtype '{subtype}'")),
+            );
+            return;
+        }
+        let tool_name = request
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let input = request.get("input").cloned().unwrap_or_else(|| json!({}));
+        let host = events.host().cloned();
+        let permission_mode = self.permission_mode.clone();
+        let write_tx = write_tx.clone();
+        let task_request_id = request_id.clone();
+        let handle = tokio::spawn(async move {
+            decide_and_respond(
+                host,
+                permission_mode,
+                &task_request_id,
+                &tool_name,
+                input,
+                &write_tx,
+            )
+            .await;
+        });
+        pending.insert(request_id, handle);
+    }
+
+    /// Graceful 3-phase close (§5 of the protocol doc): the caller has already
+    /// closed stdin (dropped every writer sender) before calling this — that
+    /// is what lets the CLI's Stop hooks observe EOF and run. From here:
+    /// bounded wait for a natural exit, then SIGTERM the process group, a
+    /// shorter wait, then SIGKILL the process group.
+    async fn shutdown_child(child: &mut Child) {
+        if tokio::time::timeout(GRACEFUL_EXIT_WAIT, child.wait())
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        signal_process_group(child, ProcessSignal::Term);
+        if tokio::time::timeout(SIGTERM_WAIT, child.wait())
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        signal_process_group(child, ProcessSignal::Kill);
+        let _ = child.wait().await;
+    }
+}
+
+#[async_trait]
+impl ChildExecutor for ClaudeCodeExecutor {
+    async fn run(
+        &self,
+        spec: RunSpec,
+        events: EventSink,
+        // Claude Code's stream-json protocol has no mid-turn user-message
+        // injection: a turn is one stdin write followed by a read to `result`
+        // (docs/claude-code-executor.md §5 — "no reliable mid-turn interrupt
+        // over this protocol"). Steering is drained (so an unbounded backlog
+        // can't build up on the sender side) but never acted on for this MVP;
+        // a future revision would need session resume (`--resume`) to turn a
+        // steer message into a genuinely new turn on the SAME session.
+        mut steer: SteerInbox,
+        cancel: CancellationToken,
+    ) -> ChildOutcome {
+        if !spec.messages.is_empty() {
+            // History rehydration is an explicit non-goal (issue #441) — the
+            // CLI has no equivalent of "replay this transcript then continue"
+            // without `--resume` against a persisted session id we don't
+            // track yet. Surface it at debug so a caller that shipped history
+            // (e.g. a reactivation) can see why it was ignored.
+            tracing::debug!(
+                messages = spec.messages.len(),
+                "claude code executor: ignoring shipped history (not yet supported)"
+            );
+        }
+
+        let mut child = match self.build_command().spawn() {
+            Ok(c) => c,
+            Err(e) => return ChildOutcome::error(format!("spawn '{}': {e}", self.binary)),
+        };
+        let Some(stdin) = child.stdin.take() else {
+            return ChildOutcome::error("claude child has no stdin pipe".to_string());
+        };
+        let Some(stdout) = child.stdout.take() else {
+            return ChildOutcome::error("claude child has no stdout pipe".to_string());
+        };
+        let stderr = child.stderr.take();
+
+        let stderr_tail = Arc::new(Mutex::new(String::new()));
+        let stderr_task = stderr.map(|stderr| {
+            let tail = stderr_tail.clone();
+            tokio::spawn(async move { drain_stderr_tail(stderr, tail).await })
+        });
+
+        let (write_tx, writer_handle) = spawn_stdin_writer(stdin);
+        let assignment_frame = json!({
+            "type": "user",
+            "message": { "role": "user", "content": spec.assignment },
+        });
+        if write_tx.send(assignment_frame).is_err() {
+            let _ = child.start_kill();
+            return ChildOutcome::error(
+                "claude code executor: failed to queue the assignment on stdin".to_string(),
+            );
+        }
+
+        // Ignore steer messages (see doc comment on `steer` above) but keep
+        // draining so the sender never sees an unbounded backlog.
+        let steer_drain = tokio::spawn(async move { while steer.recv().await.is_some() {} });
+
+        let mut reader = tokio::io::BufReader::with_capacity(64 * 1024, stdout);
+        let mut pending: HashMap<String, JoinHandle<()>> = HashMap::new();
+        let mut last_text = String::new();
+
+        let outcome = loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    break ChildOutcome::cancelled();
+                }
+                line = read_bounded_line(&mut reader, MAX_STDOUT_LINE_BYTES) => {
+                    match line {
+                        Ok(Some(bytes)) => {
+                            if bytes.iter().all(u8::is_ascii_whitespace) {
+                                continue;
+                            }
+                            let value: Value = match serde_json::from_slice(&bytes) {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    tracing::debug!("claude code: unparsable stdout line ({e}); skipping");
+                                    continue;
+                                }
+                            };
+                            if let Some(outcome) = self
+                                .handle_frame(value, &events, &write_tx, &mut pending, &mut last_text)
+                                .await
+                            {
+                                break outcome;
+                            }
+                        }
+                        Ok(None) => {
+                            // EOF with no terminal `result` frame — the process
+                            // exited (or closed stdout) unexpectedly.
+                            let code = child.wait().await.ok().and_then(|s| s.code());
+                            let tail = stderr_tail.lock().await.clone();
+                            break ChildOutcome::error(format!(
+                                "claude exited (code {code:?}) without a result frame; stderr tail: {}",
+                                if tail.is_empty() { "<empty>" } else { tail.trim() }
+                            ));
+                        }
+                        Err(e) => {
+                            break ChildOutcome::error(format!("claude stdout read error: {e}"));
+                        }
+                    }
+                }
+            }
+        };
+
+        steer_drain.abort();
+        for (_, handle) in pending.drain() {
+            handle.abort();
+        }
+        // Close stdin (phase 1 of shutdown): drop every sender clone so the
+        // writer task's channel drains and its `ChildStdin` is dropped, then
+        // give it a brief bounded moment to actually finish — an aborted
+        // control-request task's clone is dropped asynchronously, so this is
+        // best-effort, not a hard requirement (the graceful-exit wait below
+        // covers the remaining slack).
+        drop(write_tx);
+        let _ = tokio::time::timeout(Duration::from_millis(500), writer_handle).await;
+        if let Some(stderr_task) = stderr_task {
+            stderr_task.abort();
+        }
+
+        Self::shutdown_child(&mut child).await;
+        outcome
+    }
+}
+
+/// Which signal [`signal_process_group`] sends.
+enum ProcessSignal {
+    Term,
+    Kill,
+}
+
+/// Best-effort signal to the whole process group the child leads (its pgid
+/// equals its pid — `build_command` set `process_group(0)` at spawn on unix).
+/// No-op on non-unix targets in this MVP; the final phase there falls back to
+/// killing just the direct child via `Child::start_kill` in `shutdown_child`'s
+/// caller-visible behavior (still bounded — [`Child::wait`] then reaps it).
+#[cfg(unix)]
+fn signal_process_group(child: &Child, signal: ProcessSignal) {
+    if let Some(pid) = child.id() {
+        let signo = match signal {
+            ProcessSignal::Term => libc::SIGTERM,
+            ProcessSignal::Kill => libc::SIGKILL,
+        };
+        // SAFETY: `kill(2)` with a pid_t derived from our own child's pid and
+        // a fixed signal constant; a negative pid targets the whole process
+        // group. Failure (e.g. ESRCH — already exited) is fine to ignore,
+        // this call is best-effort cleanup.
+        unsafe {
+            libc::kill(-(pid as libc::pid_t), signo);
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn signal_process_group(_child: &Child, _signal: ProcessSignal) {}
+
+/// Serialize `value` to one NDJSON line and write it on the writer task owning
+/// stdin; drops silently if the writer is gone (matches [`EventSink::emit`]'s
+/// "dropped silently if the peer is gone" convention).
+fn spawn_stdin_writer(
+    mut stdin: tokio::process::ChildStdin,
+) -> (mpsc::UnboundedSender<Value>, JoinHandle<()>) {
+    let (tx, mut rx) = mpsc::unbounded_channel::<Value>();
+    let handle = tokio::spawn(async move {
+        while let Some(value) = rx.recv().await {
+            let Ok(mut line) = serde_json::to_vec(&value) else {
+                continue;
+            };
+            line.push(b'\n');
+            if stdin.write_all(&line).await.is_err() {
+                break;
+            }
+            if stdin.flush().await.is_err() {
+                break;
+            }
+        }
+        // `stdin` drops here (once every sender clone is gone and the channel
+        // drains), closing the write half — the EOF the CLI's Stop hooks see.
+    });
+    (tx, handle)
+}
+
+/// Read one NDJSON line, bounded to `max_bytes` (enforced incrementally via
+/// `fill_buf`/`consume`, not after buffering an unbounded amount). Returns
+/// `Ok(None)` on a clean EOF with no trailing partial line.
+async fn read_bounded_line<R>(reader: &mut R, max_bytes: usize) -> std::io::Result<Option<Vec<u8>>>
+where
+    R: tokio::io::AsyncBufRead + Unpin,
+{
+    let mut out = Vec::new();
+    loop {
+        let (found, consumed) = {
+            let available = reader.fill_buf().await?;
+            if available.is_empty() {
+                return Ok(if out.is_empty() { None } else { Some(out) });
+            }
+            match available.iter().position(|&b| b == b'\n') {
+                Some(pos) => {
+                    out.extend_from_slice(&available[..pos]);
+                    (true, pos + 1)
+                }
+                None => {
+                    out.extend_from_slice(available);
+                    (false, available.len())
+                }
+            }
+        };
+        reader.consume(consumed);
+        if found {
+            return Ok(Some(out));
+        }
+        if out.len() > max_bytes {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("stdout line exceeded {max_bytes} bytes"),
+            ));
+        }
+    }
+}
+
+/// Drain stderr into a bounded tail buffer (oldest bytes dropped once the cap
+/// is exceeded) for the "exited without a result frame" error message.
+async fn drain_stderr_tail(stderr: tokio::process::ChildStderr, tail: Arc<Mutex<String>>) {
+    let mut reader = BufReader::new(stderr);
+    let mut buf = Vec::new();
+    loop {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf).await {
+            Ok(0) | Err(_) => return,
+            Ok(_) => {
+                let mut t = tail.lock().await;
+                t.push_str(&String::from_utf8_lossy(&buf));
+                if t.len() > STDERR_TAIL_BYTES {
+                    let excess = t.len() - STDERR_TAIL_BYTES;
+                    let cut = t
+                        .char_indices()
+                        .map(|(i, _)| i)
+                        .find(|&i| i >= excess)
+                        .unwrap_or(t.len());
+                    t.drain(..cut);
+                }
+            }
+        }
+    }
+}
+
+/// Emit the `AgentEvent` for one `assistant` message content block (`text` /
+/// `thinking` / `tool_use`); unrecognized block types are ignored.
+fn emit_assistant_block(block: &Value, events: &EventSink, last_text: &mut String) {
+    match block.get("type").and_then(Value::as_str) {
+        Some("text") => {
+            let text = block.get("text").and_then(Value::as_str).unwrap_or("");
+            if !text.is_empty() {
+                last_text.push_str(text);
+                events.emit(event_json(AgentEvent::Token {
+                    content: text.to_string(),
+                }));
+            }
+        }
+        Some("thinking") => {
+            let text = block.get("thinking").and_then(Value::as_str).unwrap_or("");
+            if !text.is_empty() {
+                events.emit(event_json(AgentEvent::ReasoningToken {
+                    content: text.to_string(),
+                }));
+            }
+        }
+        Some("tool_use") => {
+            let tool_call_id = block
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let tool_name = block
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let arguments = block.get("input").cloned().unwrap_or_else(|| json!({}));
+            events.emit(event_json(AgentEvent::ToolStart {
+                tool_call_id,
+                tool_name,
+                arguments,
+            }));
+        }
+        _ => {}
+    }
+}
+
+/// Emit the `AgentEvent` for one `user` message content block, when it is a
+/// `tool_result` (other block types in an echoed user message are ignored).
+fn emit_tool_result_block(block: &Value, events: &EventSink) {
+    if block.get("type").and_then(Value::as_str) != Some("tool_result") {
+        return;
+    }
+    let tool_call_id = block
+        .get("tool_use_id")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let is_error = block
+        .get("is_error")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let text = truncate_chars(
+        &tool_result_text(block.get("content")),
+        TOOL_RESULT_TRUNCATE_CHARS,
+    );
+    let event = if is_error {
+        AgentEvent::ToolError {
+            tool_call_id,
+            error: text,
+        }
+    } else {
+        AgentEvent::ToolComplete {
+            tool_call_id,
+            result: ToolResult::text(true, text),
+        }
+    };
+    events.emit(event_json(event));
+}
+
+/// A `tool_result` block's `content` is either a plain string or an array of
+/// content blocks (Anthropic message shape); flatten either into plain text.
+fn tool_result_text(content: Option<&Value>) -> String {
+    match content {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(|b| b.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n"),
+        Some(other) => other.to_string(),
+        None => String::new(),
+    }
+}
+
+fn truncate_chars(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(max_chars).collect();
+    let dropped = s.chars().count() - max_chars;
+    format!("{head}\n… [truncated, {dropped} more chars]")
+}
+
+/// Decide a `can_use_tool` permission ask and write the `control_response`
+/// (§3 of the protocol doc). Runs off the read loop (spawned by the caller)
+/// so a slow human-in-the-loop decision doesn't block consuming other frames.
+async fn decide_and_respond(
+    host: Option<HostBridge>,
+    permission_mode: Option<String>,
+    request_id: &str,
+    tool_name: &str,
+    input: Value,
+    write_tx: &mpsc::UnboundedSender<Value>,
+) {
+    if tool_name == "AskUserQuestion" {
+        // Structured interactive questions need bamboo's QuestionDialog path,
+        // not the permission path (docs/claude-code-executor.md §3) — not
+        // wired yet. Deny promptly rather than hang the CLI turn.
+        send_control_response(
+            write_tx,
+            request_id,
+            false,
+            None,
+            Some(
+                "interactive questions are not supported by the Claude Code executor yet"
+                    .to_string(),
+            ),
+        );
+        return;
+    }
+
+    let (allow, deny_message) = if let Some(host) = host {
+        let body = json!({ "tool_name": tool_name, "input": input });
+        match host.approval_call(body).await {
+            Ok(reply) => {
+                let approved = reply
+                    .get("approved")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let msg = (!approved).then(|| "denied by host approver".to_string());
+                (approved, msg)
+            }
+            Err(e) => (false, Some(format!("approval relay failed: {e}"))),
+        }
+    } else if permission_mode.as_deref() == Some("bypassPermissions") {
+        (true, None)
+    } else {
+        (
+            false,
+            Some(
+                "permission relay unavailable; run with bypassPermissions or attach a host bridge"
+                    .to_string(),
+            ),
+        )
+    };
+    let updated_input = allow.then_some(input);
+    send_control_response(write_tx, request_id, allow, updated_input, deny_message);
+}
+
+/// Write one `control_response` frame (§3 of the protocol doc).
+fn send_control_response(
+    write_tx: &mpsc::UnboundedSender<Value>,
+    request_id: &str,
+    allow: bool,
+    updated_input: Option<Value>,
+    deny_message: Option<String>,
+) {
+    let response = if allow {
+        json!({
+            "behavior": "allow",
+            "updatedInput": updated_input.unwrap_or_else(|| json!({})),
+        })
+    } else {
+        json!({
+            "behavior": "deny",
+            "message": deny_message.unwrap_or_default(),
+        })
+    };
+    let frame = json!({
+        "type": "control_response",
+        "response": {
+            "subtype": "success",
+            "request_id": request_id,
+            "response": response,
+        },
+    });
+    let _ = write_tx.send(frame);
+}
+
+/// Serialize an `AgentEvent` for [`EventSink::emit`]. Mirrors how
+/// [`BambooRuntimeExecutor`](crate::subagent_worker::BambooRuntimeExecutor)
+/// forwards real engine events verbatim — this executor maps the Claude Code
+/// wire protocol onto the SAME event enum rather than hand-rolled JSON, so the
+/// parent's child preview renders identically regardless of which engine ran.
+fn event_json(event: AgentEvent) -> Value {
+    serde_json::to_value(event).unwrap_or_else(|_| json!({}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+
+    use bamboo_subagent::executor::EventSink;
+    use bamboo_subagent::proto::TerminalStatus;
+
+    /// Write an executable `sh` stub at `dir/claude` with `body` as its
+    /// script content, and return the path. Tests point `ClaudeCodeExecutor`'s
+    /// `binary` override at this instead of a real `claude` install.
+    fn write_stub(dir: &std::path::Path, body: &str) -> PathBuf {
+        let path = dir.join("claude");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "#!/bin/sh").unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
+        path
+    }
+
+    fn executor(binary: PathBuf) -> ClaudeCodeExecutor {
+        ClaudeCodeExecutor::new(
+            Some(binary.to_string_lossy().into_owned()),
+            None,
+            None,
+            None,
+        )
+    }
+
+    fn run_spec(assignment: &str) -> RunSpec {
+        RunSpec {
+            assignment: assignment.to_string(),
+            reasoning_effort: None,
+            messages: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn happy_path_streams_events_then_completes() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = write_stub(
+            dir.path(),
+            r#"
+read -r _assignment
+echo '{"type":"system","session_id":"s1","model":"stub-model"}'
+echo '{"type":"assistant","message":{"content":[{"type":"text","text":"Working on it"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"echo hi"}}]}}'
+echo '{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"hi","is_error":false}]}}'
+echo '{"type":"result","subtype":"success","result":"done: hi","usage":{"input_tokens":10,"output_tokens":5}}'
+"#,
+        );
+        let (sink, mut rx) = EventSink::channel();
+        let outcome = executor(bin)
+            .run(
+                run_spec("say hi"),
+                sink,
+                SteerInbox::disconnected(),
+                CancellationToken::new(),
+            )
+            .await;
+
+        assert_eq!(outcome.status, TerminalStatus::Completed);
+        assert_eq!(outcome.result.as_deref(), Some("done: hi"));
+
+        let mut events = Vec::new();
+        while let Ok(e) = rx.try_recv() {
+            events.push(e);
+        }
+        let types: Vec<&str> = events
+            .iter()
+            .map(|e| e["type"].as_str().unwrap_or(""))
+            .collect();
+        assert_eq!(
+            types,
+            vec!["token", "tool_start", "tool_complete", "complete"]
+        );
+        assert_eq!(events[0]["content"], "Working on it");
+        assert_eq!(events[1]["tool_name"], "Bash");
+        assert_eq!(events[2]["result"]["result"], "hi");
+        assert_eq!(events[3]["usage"]["prompt_tokens"], 10);
+        assert_eq!(events[3]["usage"]["completion_tokens"], 5);
+    }
+
+    #[tokio::test]
+    async fn compaction_result_does_not_complete_the_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = write_stub(
+            dir.path(),
+            r#"
+read -r _assignment
+echo '{"type":"result","subtype":"compact","result":"mid-turn compaction, ignore"}'
+echo '{"type":"assistant","message":{"content":[{"type":"text","text":"back after compaction"}]}}'
+echo '{"type":"result","subtype":"success","result":"final answer"}'
+"#,
+        );
+        let (sink, _rx) = EventSink::channel();
+        let outcome = executor(bin)
+            .run(
+                run_spec("do the thing"),
+                sink,
+                SteerInbox::disconnected(),
+                CancellationToken::new(),
+            )
+            .await;
+        assert_eq!(outcome.status, TerminalStatus::Completed);
+        assert_eq!(outcome.result.as_deref(), Some("final answer"));
+    }
+
+    #[tokio::test]
+    async fn control_request_with_no_host_denies_and_run_continues() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = write_stub(
+            dir.path(),
+            r#"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+read -r _assignment
+echo '{"type":"control_request","request_id":"r1","request":{"subtype":"can_use_tool","tool_name":"Bash","input":{"command":"rm -rf /"}}}'
+read -r control_response_line
+printf '%s\n' "$control_response_line" > "$DIR/control_response.json"
+echo '{"type":"result","subtype":"success","result":"continued after deny"}'
+"#,
+        );
+        let (sink, _rx) = EventSink::channel(); // no host bridge attached
+        let outcome = executor(bin.clone())
+            .run(
+                run_spec("do something dangerous"),
+                sink,
+                SteerInbox::disconnected(),
+                CancellationToken::new(),
+            )
+            .await;
+        assert_eq!(outcome.status, TerminalStatus::Completed);
+        assert_eq!(outcome.result.as_deref(), Some("continued after deny"));
+
+        let written = std::fs::read_to_string(dir.path().join("control_response.json")).unwrap();
+        let value: Value = serde_json::from_str(written.trim()).unwrap();
+        assert_eq!(value["response"]["request_id"], "r1");
+        assert_eq!(value["response"]["response"]["behavior"], "deny");
+        assert!(value["response"]["response"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("permission relay unavailable"));
+    }
+
+    #[tokio::test]
+    async fn control_request_with_host_bridge_relays_and_allows() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = write_stub(
+            dir.path(),
+            r#"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+read -r _assignment
+echo '{"type":"control_request","request_id":"r1","request":{"subtype":"can_use_tool","tool_name":"Write","input":{"file_path":"/tmp/x"}}}'
+read -r control_response_line
+printf '%s\n' "$control_response_line" > "$DIR/control_response.json"
+echo '{"type":"result","subtype":"success","result":"wrote file"}'
+"#,
+        );
+        let (bridge, mut req_rx) = HostBridge::channel();
+        let approver = tokio::spawn(async move {
+            let req = req_rx.recv().await.expect("a host approval request");
+            assert_eq!(req.body["tool_name"], "Write");
+            let _ = req.reply.send(json!({ "approved": true }));
+        });
+        let (sink, _rx) = EventSink::channel();
+        let sink = sink.with_host_bridge(bridge);
+        let outcome = executor(bin)
+            .run(
+                run_spec("write a file"),
+                sink,
+                SteerInbox::disconnected(),
+                CancellationToken::new(),
+            )
+            .await;
+        approver.await.unwrap();
+        assert_eq!(outcome.status, TerminalStatus::Completed);
+
+        let written = std::fs::read_to_string(dir.path().join("control_response.json")).unwrap();
+        let value: Value = serde_json::from_str(written.trim()).unwrap();
+        assert_eq!(value["response"]["response"]["behavior"], "allow");
+        assert_eq!(
+            value["response"]["response"]["updatedInput"]["file_path"],
+            "/tmp/x"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_kills_the_child_process_group() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = write_stub(
+            dir.path(),
+            r#"
+read -r _assignment
+echo '{"type":"system","session_id":"s1"}'
+sleep 30
+echo '{"type":"result","subtype":"success","result":"too late"}'
+"#,
+        );
+        let (sink, _rx) = EventSink::channel();
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+        let run = tokio::spawn(async move {
+            executor(bin)
+                .run(
+                    run_spec("a long task"),
+                    sink,
+                    SteerInbox::disconnected(),
+                    cancel_clone,
+                )
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        cancel.cancel();
+
+        let outcome = tokio::time::timeout(Duration::from_secs(15), run)
+            .await
+            .expect("run finished within the shutdown bound")
+            .unwrap();
+        assert_eq!(outcome.status, TerminalStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn oversized_single_stdout_line_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        // Build a >100KB single-line `assistant` frame plus a `result` frame,
+        // written from a small python-free shell using `yes`/`head` to avoid
+        // depending on any interpreter beyond POSIX sh + coreutils.
+        let big_text = "x".repeat(150_000);
+        let script = format!(
+            r#"
+read -r _assignment
+echo '{{"type":"assistant","message":{{"content":[{{"type":"text","text":"{big_text}"}}]}}}}'
+echo '{{"type":"result","subtype":"success","result":"ok"}}'
+"#
+        );
+        let bin = write_stub(dir.path(), &script);
+        let (sink, mut rx) = EventSink::channel();
+        let outcome = executor(bin)
+            .run(
+                run_spec("emit a huge line"),
+                sink,
+                SteerInbox::disconnected(),
+                CancellationToken::new(),
+            )
+            .await;
+        assert_eq!(outcome.status, TerminalStatus::Completed);
+        assert_eq!(outcome.result.as_deref(), Some("ok"));
+
+        let mut saw_big_token = false;
+        while let Ok(e) = rx.try_recv() {
+            if e["type"] == "token" {
+                assert_eq!(e["content"].as_str().unwrap().len(), 150_000);
+                saw_big_token = true;
+            }
+        }
+        assert!(saw_big_token, "expected the oversized token event");
+    }
+
+    #[tokio::test]
+    async fn missing_binary_errors_without_hanging() {
+        let (sink, _rx) = EventSink::channel();
+        let outcome = ClaudeCodeExecutor::new(
+            Some("/nonexistent/definitely-not-claude".into()),
+            None,
+            None,
+            None,
+        )
+        .run(
+            run_spec("hi"),
+            sink,
+            SteerInbox::disconnected(),
+            CancellationToken::new(),
+        )
+        .await;
+        assert_eq!(outcome.status, TerminalStatus::Error);
+        assert!(outcome.error.unwrap().contains("spawn"));
+    }
+
+    #[test]
+    fn truncate_chars_caps_and_reports_dropped_count() {
+        let long = "a".repeat(50);
+        let out = truncate_chars(&long, 10);
+        assert!(out.starts_with(&"a".repeat(10)));
+        assert!(out.contains("40 more chars"));
+        assert_eq!(truncate_chars("short", 10), "short");
+    }
+
+    #[test]
+    fn tool_result_text_flattens_string_and_block_array() {
+        assert_eq!(tool_result_text(Some(&json!("plain"))), "plain".to_string());
+        assert_eq!(
+            tool_result_text(Some(
+                &json!([{"type":"text","text":"a"},{"type":"text","text":"b"}])
+            )),
+            "a\nb".to_string()
+        );
+        assert_eq!(tool_result_text(None), "".to_string());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,10 @@ pub mod commands;
 /// The `bamboo subagent-worker` actor worker (provision via stdin, serve over WS).
 pub mod subagent_worker;
 
+/// `ClaudeCodeExecutor`: drives the official Claude Code CLI as a
+/// `ChildExecutor` (`ExecutorSpec::ClaudeCode`), sibling of `subagent_worker`.
+pub mod claude_code_executor;
+
 /// The `bamboo broker-agent serve` worker: connect to a central broker and
 /// answer Ask/Task (query/steer) for its mailbox; deployable local/Docker/remote.
 pub mod broker_agent;

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -35,6 +35,8 @@ use bamboo_subagent::provision::{ExecutorSpec, ProvisionSpec};
 use bamboo_subagent::transport::WsServer;
 use futures::StreamExt;
 
+use crate::claude_code_executor::ClaudeCodeExecutor;
+
 /// How long a finished actor's isolated storage is retained for debugging
 /// before background GC removes it.
 const STORAGE_RETENTION: std::time::Duration = std::time::Duration::from_secs(7 * 24 * 60 * 60);
@@ -63,6 +65,16 @@ pub async fn run() -> std::result::Result<(), String> {
     let executor: Arc<dyn ChildExecutor> = match &spec.executor {
         ExecutorSpec::Echo => Arc::new(EchoExecutor),
         ExecutorSpec::BambooRuntime => Arc::new(BambooRuntimeExecutor::build(&spec).await?),
+        ExecutorSpec::ClaudeCode {
+            binary,
+            model,
+            permission_mode,
+        } => Arc::new(ClaudeCodeExecutor::new(
+            binary.clone(),
+            model.clone(),
+            permission_mode.clone(),
+            spec.workspace.clone(),
+        )),
         ExecutorSpec::CliAdapter { .. } => {
             return Err("cli_adapter executor is not implemented yet".to_string());
         }


### PR DESCRIPTION
Closes #441.

Implements `ClaudeCodeExecutor` — a `ChildExecutor` that drives the official `claude` CLI over its stream-json wire protocol, so Claude Code can run as an external sub-agent engine inside the actor fleet.

## What's in here

- **`src/claude_code_executor.rs`** — the executor: spawns `claude --output-format stream-json --input-format stream-json --permission-prompt-tool stdio --replay-user-messages --verbose` per run, in its own process group, `CLAUDECODE` env stripped, cwd = provisioned workspace. Maps stdout frames onto the same `AgentEvent` enum the bamboo runtime emits (Token / ReasoningToken / ToolStart / ToolComplete / ToolError / Complete) so parent previews render identically. 10 MB stdout line bound; bounded stderr tail for diagnostics.
- **Permission relay**: `control_request{can_use_tool}` → `HostBridge::approval_call` when the run has a host bridge (decision proxied to the parent human/policy), else local policy (allow only under `bypassPermissions`, otherwise deny with an explanatory message). Approval decisions run as tracked background tasks so the read loop never blocks; `control_cancel_request` aborts them. `AskUserQuestion` and unknown subtypes are denied, never left hanging.
- **Turn end**: `result` frame → `ChildOutcome::completed`, except `subtype: compact/compaction` (mid-turn compaction — cc-connect issue #481).
- **Cancellation**: 3-phase — close stdin (Stop hooks see EOF) → bounded wait → SIGTERM process group → SIGKILL process group.
- **`ExecutorSpec::ClaudeCode { binary, model, permission_mode }`** (additive serde variant; `CliAdapter` untouched) + factory wiring in `subagent_worker.rs` and `broker_agent.rs` (the latter's wildcard arm would have silently misrouted the new spec into `BambooRuntimeExecutor`).
- **`external_agents`**: kind `"claude_code"` accepted in both runner builders (model/permission-mode config plumbing is a #441 follow-up; runs with CLI defaults for now).
- **`docs/claude-code-executor.md`** — the full protocol reference (frames, permission relay, shutdown, gotchas).

## Non-goals (follow-ups, per #441)

Mid-run steering (drained, ignored — the protocol has no mid-turn injection), history rehydration / `--resume` across activations, multimodal assignments, profile fields for binary/model/permission-mode.

## Test plan

9 tests using stub `claude` shell scripts (canned NDJSON): happy path event order + completion, mid-turn compaction continues, no-host deny path (asserted via control_response echo), host-bridge allow path with `updatedInput`, cancel kills the process group, 150 KB single line parses, missing binary errors fast, plus truncation/flatten unit tests.

Gates: `cargo fmt --all -- --check` clean; `cargo build --workspace --tests` green; clippy on touched crates no new warnings; `cargo test -p bamboo-agent claude_code_executor` 9/9, `-p bamboo-subagent` 48/48, `-p bamboo-engine external_agents` 43/43.

https://claude.ai/code/session_01Usp3jUXqDejy2eWuFWGsip
