### PR TITLE
fix(lint): resolve clippy errors that kept CI Lint chronically red

### DIFF
--- a/crates/app/bamboo-server/src/notify_sinks/desktop.rs
+++ b/crates/app/bamboo-server/src/notify_sinks/desktop.rs
@@ -7,6 +7,10 @@
 //! transient mac API error must never break a run.
 
 use std::sync::atomic::{AtomicBool, Ordering};
+// `Once` is only referenced inside the macOS-gated `warm_notification_center`
+// below; an unconditional import is an unused-import ERROR (`-D warnings`) on
+// the Linux CI lint runner.
+#[cfg(target_os = "macos")]
 use std::sync::Once;
 
 use super::{NotificationSink, SinkNotification};

--- a/crates/core/bamboo-agent-core/src/composition/executor.rs
+++ b/crates/core/bamboo-agent-core/src/composition/executor.rs
@@ -171,15 +171,11 @@ impl CompositionExecutor {
         let mut last_success = None;
 
         for result in results {
-            match result {
-                Ok(tool_result) => {
-                    if !tool_result.success {
-                        return Ok(tool_result);
-                    }
-                    last_success = Some(tool_result);
-                }
-                Err(error) => return Err(error),
+            let tool_result = result?;
+            if !tool_result.success {
+                return Ok(tool_result);
             }
+            last_success = Some(tool_result);
         }
 
         Ok(last_success.unwrap_or_else(|| Self::default_result("all branches completed", true)))
@@ -222,14 +218,10 @@ impl CompositionExecutor {
         let mut last_success = None;
 
         for result in results {
-            match result {
-                Ok(tool_result) => {
-                    if tool_result.success {
-                        success_count += 1;
-                        last_success = Some(tool_result);
-                    }
-                }
-                Err(error) => return Err(error),
+            let tool_result = result?;
+            if tool_result.success {
+                success_count += 1;
+                last_success = Some(tool_result);
             }
         }
 


### PR DESCRIPTION
Fixes the two `clippy::question_mark` errors in `bamboo-agent-core/src/composition/executor.rs` (`resolve_parallel_all` / `resolve_parallel_n`) that have kept the CI Lint job red on main for weeks — both are clippy's own suggested rewrite (`let x = result?;`), semantically identical.

Root cause of the local/CI disagreement: CI's `dtolnay/rust-toolchain@stable` is 1.97.0 where `question_mark` was extended; local 1.96.1 reported clean. Verified against the exact CI lint invocation from `.github/workflows/ci.yml` on 1.97.0: exit 0.

Gates: CI lint command clean on 1.97.0, `cargo fmt --all -- --check` clean, `cargo build --workspace --tests` green, `cargo test -p bamboo-agent-core` 112/112.

With this, main CI should go fully green — real regressions become visible again instead of hiding behind the chronic red.

https://claude.ai/code/session_01Usp3jUXqDejy2eWuFWGsip