### PR TITLE
feat(plugin): require checksum for URL installs (secure-by-default supply-chain verification)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/plugin/api_types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/api_types.rs
@@ -14,17 +14,23 @@
 //! `SourceSpec` reuses [`bamboo_plugin::PluginSource`]'s own
 //! `#[serde(tag = "type", rename_all = "snake_case")]` wire shape directly —
 //! `{"type":"local_dir","path":...}` / `{"type":"local_archive","path":...}` /
-//! `{"type":"url","url":...,"sha256":...?}` — rather than inventing a
-//! parallel request enum: it is already exactly the shape both the CLI and
-//! this HTTP layer need, and it doubles as the provenance record `install()`
-//! persists (see `bamboo_plugin::registry::PluginSource`'s doc comment).
+//! `{"type":"url","url":...,"sha256":...?,"allow_unverified":...?}` — rather
+//! than inventing a parallel request enum: it is already exactly the shape
+//! both the CLI and this HTTP layer need, and it doubles as the provenance
+//! record `install()` persists (see `bamboo_plugin::registry::PluginSource`'s
+//! doc comment).
 //!
-//! Known no-op: a client-supplied `sha256` on a `url` source is accepted (for
-//! forward-compat / symmetry with the provenance shape) but not currently
-//! enforced — `plugin_source::stage_plugin_source` only pins the
-//! per-platform *binary artifact*'s sha256 (declared inside the manifest
-//! itself), not the top-level manifest/content bundle fetched from `url`. See
-//! that module's "Known follow-ups" doc comment.
+//! **Secure by default (`url` sources).** `sha256`, when given, pins the
+//! downloaded BUNDLE's exact bytes — verified in
+//! `plugin_source::fetch_manifest_bundle` BEFORE anything is
+//! extracted/parsed, distinct from (and in addition to) the per-platform
+//! *binary artifact*'s own sha256 declared inside the manifest itself
+//! (always verified, regardless of this field — see `plugin_source.rs`'s
+//! module docs on why both checks matter). Without `sha256`, a `url` install
+//! is REFUSED (`PluginError::ChecksumRequired`, mapped to `400`) unless
+//! `allow_unverified: true` is explicitly set — so `POST /install` with a
+//! bare `{"type":"url","url":"..."}` body no longer just downloads and
+//! trusts any tar.gz.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/errors.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/errors.rs
@@ -22,6 +22,8 @@
 //! | `NotFound`                    | 404 |
 //! | `InvalidManifest`             | 400 |
 //! | `ArtifactVerificationFailed`  | 400 |
+//! | `BundleVerificationFailed`    | 400 |
+//! | `ChecksumRequired`            | 400 |
 //! | `Registration` / `Io` / `Json` / `NotImplemented` | 500 |
 //!
 //! `Io`/`Json` are bucketed with `Registration` under 500 rather than 400
@@ -71,6 +73,8 @@ pub fn plugin_error_response(error: &PluginError) -> HttpResponse {
         PluginError::ArtifactVerificationFailed(_) => {
             Some(actix_web::http::StatusCode::BAD_REQUEST)
         }
+        PluginError::BundleVerificationFailed(_) => Some(actix_web::http::StatusCode::BAD_REQUEST),
+        PluginError::ChecksumRequired(_) => Some(actix_web::http::StatusCode::BAD_REQUEST),
         PluginError::Registration(_)
         | PluginError::NotImplemented(_)
         | PluginError::Io(_)
@@ -132,6 +136,14 @@ mod tests {
             ),
             (
                 PluginError::ArtifactVerificationFailed("sha256 mismatch".to_string()),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                PluginError::BundleVerificationFailed("sha256 mismatch".to_string()),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                PluginError::ChecksumRequired("refusing to install without a checksum".to_string()),
                 StatusCode::BAD_REQUEST,
             ),
             (

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/handlers.rs
@@ -23,16 +23,25 @@ fn plugins_root(state: &AppState) -> PathBuf {
     state.app_data_dir.join("plugins")
 }
 
-/// The wire `SourceSpec` (reusing `bamboo_plugin::PluginSource`'s own serde
-/// shape — see `api_types` module docs) carries an optional `sha256` on the
-/// `Url` variant that `PluginSourceInput`/`stage_plugin_source` do not yet
-/// consume (see that module's "Known follow-ups"); dropped here, not lost —
-/// it was never wired to anything to lose.
+/// The wire `SourceSpec` reuses `bamboo_plugin::PluginSource`'s own serde
+/// shape (see `api_types` module docs) directly as the request body — a
+/// `url` source's `sha256`/`allow_unverified` flow straight through to
+/// `PluginSourceInput::Url`, which `plugin_source::fetch_manifest_bundle`
+/// enforces (secure by default: verify-if-given, refuse-if-absent-unless-
+/// explicitly-allowed — see that module's docs).
 fn to_source_input(source: PluginSource) -> PluginSourceInput {
     match source {
         PluginSource::LocalDir { path } => PluginSourceInput::LocalDir(path),
         PluginSource::LocalArchive { path } => PluginSourceInput::LocalArchive(path),
-        PluginSource::Url { url, sha256: _ } => PluginSourceInput::Url(url),
+        PluginSource::Url {
+            url,
+            sha256,
+            allow_unverified,
+        } => PluginSourceInput::Url {
+            url,
+            sha256,
+            allow_unverified,
+        },
     }
 }
 

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
@@ -365,3 +365,170 @@ async fn delete_unknown_id_returns_404() {
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
+
+// ---------------------------------------------------------------------
+// URL source: secure-by-default checksum policy, exercised end to end
+// through the real HTTP handlers (unit coverage of the same policy at the
+// `plugin_source::fetch_manifest_bundle` level lives in
+// `plugin_source::tests`).
+// ---------------------------------------------------------------------
+
+/// A minimal, `validate()`-passing manifest with NO declared capabilities —
+/// unlike `plugin_source::tests`' `hello_manifest_json` fixture (which
+/// declares a `hello-world` skill), these tests drive the real
+/// `ServerPluginInstaller::install()` end to end (not just staging), and a
+/// bare `plugin.json` fetched from a URL has no bundled `skills/` directory
+/// alongside it — declaring a skill here would fail registration with "no
+/// SKILL.md", unrelated to the checksum behavior under test.
+fn hello_manifest_json(id: &str) -> String {
+    serde_json::json!({
+        "id": id,
+        "name": "Hello",
+        "version": "0.1.0",
+    })
+    .to_string()
+}
+
+fn sha256_hex_of(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+fn url_source(url: &str, sha256: Option<&str>, allow_unverified: bool) -> serde_json::Value {
+    let mut source = serde_json::json!({ "type": "url", "url": url });
+    if let Some(sha) = sha256 {
+        source["sha256"] = serde_json::Value::String(sha.to_string());
+    }
+    if allow_unverified {
+        source["allow_unverified"] = serde_json::Value::Bool(true);
+    }
+    serde_json::json!({ "source": source })
+}
+
+/// The core "secure by default" behavior this whole feature is about:
+/// `POST /install` with a bare `{"type":"url","url":"..."}` (no `sha256`, no
+/// `allow_unverified`) must be refused with an actionable 400 — NOT silently
+/// download and trust whatever tar.gz sits at that URL. Uses a `wiremock`
+/// server with no mounted responder at all, so a bug that fetched before
+/// refusing would surface as an unmatched-request panic instead of quietly
+/// passing.
+#[actix_web::test]
+async fn install_url_with_no_checksum_or_allow_unverified_returns_400_before_fetch() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let state = test_state(data_dir.path()).await;
+    let app = test::init_service(plugin_test_app!(state.clone())).await;
+
+    let server = wiremock::MockServer::start().await;
+    let url = format!("{}/plugin.json", server.uri());
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/plugins/install")
+        .set_json(url_source(&url, None, false))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let error = body_json(resp).await;
+    let message = error["error"].as_str().unwrap();
+    assert!(message.contains("sha256"), "{message}");
+    assert!(message.contains("allow_unverified"), "{message}");
+
+    // Nothing installed.
+    let req = test::TestRequest::get().uri("/api/v1/plugins").to_request();
+    let resp = test::call_service(&app, req).await;
+    let listed = body_json(resp).await;
+    assert!(listed["plugins"].as_array().unwrap().is_empty());
+
+    // The refusal happened before the URL was ever fetched.
+    let received = server.received_requests().await;
+    assert_eq!(received.map(|r| r.len()), Some(0));
+}
+
+#[actix_web::test]
+async fn install_url_with_wrong_bundle_sha256_returns_400_and_installs_nothing() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let state = test_state(data_dir.path()).await;
+    let app = test::init_service(plugin_test_app!(state.clone())).await;
+
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+    let url = format!("{}/plugin.json", server.uri());
+    let wrong_sha256 = "b".repeat(64);
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/plugins/install")
+        .set_json(url_source(&url, Some(&wrong_sha256), false))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let error = body_json(resp).await;
+    assert!(
+        error["error"].as_str().unwrap().contains("mismatch"),
+        "{error}"
+    );
+
+    let req = test::TestRequest::get().uri("/api/v1/plugins").to_request();
+    let resp = test::call_service(&app, req).await;
+    let listed = body_json(resp).await;
+    assert!(listed["plugins"].as_array().unwrap().is_empty());
+}
+
+#[actix_web::test]
+async fn install_url_with_correct_bundle_sha256_succeeds() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let state = test_state(data_dir.path()).await;
+    let app = test::init_service(plugin_test_app!(state.clone())).await;
+
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    let bundle_sha256 = sha256_hex_of(manifest_body.as_bytes());
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+    let url = format!("{}/plugin.json", server.uri());
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/plugins/install")
+        .set_json(url_source(&url, Some(&bundle_sha256), false))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let view = body_json(resp).await;
+    assert_eq!(view["id"], "hello-plugin");
+    assert_eq!(view["source"]["type"], "url");
+    assert_eq!(view["source"]["sha256"], bundle_sha256);
+}
+
+#[actix_web::test]
+async fn install_url_with_allow_unverified_and_no_sha256_succeeds() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let state = test_state(data_dir.path()).await;
+    let app = test::init_service(plugin_test_app!(state.clone())).await;
+
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+    let url = format!("{}/plugin.json", server.uri());
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/plugins/install")
+        .set_json(url_source(&url, None, true))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let view = body_json(resp).await;
+    assert_eq!(view["id"], "hello-plugin");
+    assert!(view["source"]["sha256"].is_null());
+}

--- a/crates/app/bamboo-server/src/plugin_source.rs
+++ b/crates/app/bamboo-server/src/plugin_source.rs
@@ -11,17 +11,25 @@
 //!   If the archive wraps everything in a single top-level directory (the
 //!   common `tar czf bundle.tar.gz plugin-name/` convention), that directory
 //!   is flattened up so `plugin.json` ends up at the bundle root either way.
-//! - [`PluginSourceInput::Url`] — fetches the manifest, which is either a
-//!   bare `plugin.json` (content-only, typically MCP servers backed entirely
+//! - [`PluginSourceInput::Url`] — fetches the manifest bundle (a bare
+//!   `plugin.json`, content-only and typically an MCP server backed entirely
 //!   by a downloadable binary — e.g. a nova-style plugin with no bundled
-//!   skills/prompts) or an archive containing one (same flattening rule as
-//!   `LocalArchive`). THEN, separately, for [`Platform::current`] (if the
-//!   manifest declares an artifact for it), fetches the per-platform binary
-//!   archive named in `manifest.artifacts`, verifies its sha256 BEFORE
-//!   unpacking (mandatory — a URL plugin ships a binary that gets executed),
-//!   and places the single expected executable at
-//!   `bin/<platform>/<id>[.exe]` per
-//!   [`bamboo_plugin::manifest::PluginArtifact`]'s archive contract.
+//!   skills/prompts — or an archive containing one, same flattening rule as
+//!   `LocalArchive`). **Secure by default**: the downloaded bundle bytes are
+//!   verified against a caller-supplied `sha256` BEFORE anything is
+//!   extracted or parsed; if no `sha256` was given, the fetch is refused
+//!   outright unless the caller explicitly set `allow_unverified` (see
+//!   [`PluginSourceInput::Url`]'s fields and [`fetch_manifest_bundle`]). THEN,
+//!   separately, for [`Platform::current`] (if the manifest declares an
+//!   artifact for it), fetches the per-platform binary archive named in
+//!   `manifest.artifacts`, verifies its sha256 BEFORE unpacking (mandatory —
+//!   a URL plugin ships a binary that gets executed), and places the single
+//!   expected executable at `bin/<platform>/<id>[.exe]` per
+//!   [`bamboo_plugin::manifest::PluginArtifact`]'s archive contract. Both
+//!   checks stay: the bundle-sha256 check is the new root-of-trust pin (it
+//!   closes the gap where the artifact's own declared hash lives inside the
+//!   very bundle that could be tampered with); the artifact-sha256 check
+//!   remains as defense in depth for the binary specifically.
 //!
 //! All three paths run the SAME safety checks: [`PluginManifest::validate`]
 //! before anything is committed to `plugins_dir()`, and path-traversal-safe
@@ -56,15 +64,32 @@
 //!
 //! # Known follow-ups (deferred — tracked here, not fixed on this branch)
 //!
-//! - **No integrity pin on the URL manifest/content bundle.** Only the
-//!   per-platform BINARY artifact is sha256-pinned (`PluginArtifact.sha256`,
-//!   verified in [`fetch_and_place_artifact`]). The `plugin.json` / content
-//!   archive fetched by [`fetch_manifest_bundle`] is trusted on HTTPS alone —
-//!   a MITM or a compromised host could serve a tampered manifest/skills/
-//!   prompts bundle. A proper fix needs a Wave-1 schema addition (a top-level
-//!   bundle sha256, or a signature) so a URL install can pin the whole bundle,
-//!   not just the binary. Until then, prefer local-dir/archive installs or a
-//!   binary-artifact-only URL plugin for anything security-sensitive.
+//! - **URL content-bundle integrity pin: IMPLEMENTED (secure by default).**
+//!   Previously only the per-platform BINARY artifact was sha256-pinned
+//!   (`PluginArtifact.sha256`, verified in [`fetch_and_place_artifact`]),
+//!   while the `plugin.json` / content archive fetched by
+//!   [`fetch_manifest_bundle`] was trusted on HTTPS alone — a MITM or a
+//!   compromised host could serve a tampered bundle, and since the binary's
+//!   sha256 is DECLARED INSIDE that same untrusted manifest, tampering the
+//!   bundle could rewrite the artifact hash too (the trust chain was
+//!   circular). Fixed: [`PluginSourceInput::Url`] now carries a `sha256`
+//!   (the expected hash of the downloaded bundle) and an `allow_unverified`
+//!   opt-out. [`fetch_manifest_bundle`] verifies the bundle's actual sha256
+//!   against it BEFORE any extraction/parsing on a mismatch
+//!   ([`PluginError::BundleVerificationFailed`]); with neither a `sha256`
+//!   nor `allow_unverified: true`, the fetch is refused up front — before
+//!   the URL is ever requested — with [`PluginError::ChecksumRequired`]. A
+//!   URL install can therefore no longer just download-and-trust any
+//!   tar.gz. The verified bundle sha256 (not the binary artifact's) is what
+//!   `PluginSource::Url.sha256` records for provenance/audit. Still
+//!   deferred:
+//!   - **Signature verification.** A sha256 pin only proves "this is the
+//!     bytes the installer expected", not "an entity I trust produced
+//!     them" — the hash itself still has to come from somewhere the caller
+//!     trusts (a release page, a signed index, etc.). A real signature
+//!     scheme (e.g. minisign/sigstore over the bundle) would remove that
+//!     remaining hop.
+//!   - **SSRF guard**, described next.
 //! - **No SSRF guard on URL fetch.** [`download_bytes`] will fetch any URL,
 //!   including `http://169.254.169.254/...` (cloud metadata) or private-range
 //!   / loopback addresses. In a hosted/multi-tenant deployment a plugin-install
@@ -108,8 +133,17 @@ pub enum PluginSourceInput {
     /// (at its root, or under a single top-level directory).
     LocalArchive(PathBuf),
     /// A URL to either a bare `plugin.json` or an archive containing one
-    /// (same root-or-single-subdir rule as `LocalArchive`).
-    Url(String),
+    /// (same root-or-single-subdir rule as `LocalArchive`). Secure by
+    /// default: `sha256`, when given, pins the downloaded bundle's exact
+    /// bytes (verified before anything is extracted/parsed — see
+    /// [`fetch_manifest_bundle`]); with no `sha256`, the fetch is refused
+    /// unless `allow_unverified` is `true` (an explicit, logged opt-out of
+    /// verification — see [`PluginError::ChecksumRequired`]).
+    Url {
+        url: String,
+        sha256: Option<String>,
+        allow_unverified: bool,
+    },
 }
 
 /// The result of staging a [`PluginSourceInput`] into `plugins_dir()/<id>/`:
@@ -298,15 +332,32 @@ async fn stage_into(
             let manifest = read_and_parse_manifest(staging_dir).await?;
             Ok((manifest, PluginSource::LocalArchive { path: path.clone() }))
         }
-        PluginSourceInput::Url(url) => {
-            let manifest = fetch_manifest_bundle(url, staging_dir, max_decompressed_bytes).await?;
-            let sha256 =
-                fetch_and_place_artifact(&manifest, staging_dir, max_decompressed_bytes).await?;
+        PluginSourceInput::Url {
+            url,
+            sha256,
+            allow_unverified,
+        } => {
+            let (manifest, verified_bundle_sha256) = fetch_manifest_bundle(
+                url,
+                sha256.as_deref(),
+                *allow_unverified,
+                staging_dir,
+                max_decompressed_bytes,
+            )
+            .await?;
+            // Binary-artifact verification stays as defense in depth (see
+            // the module docs) — its own sha256, declared inside the
+            // now-verified manifest, is checked in
+            // `fetch_and_place_artifact`, but no longer double-duty as the
+            // `PluginSource::Url` provenance hash: that's the bundle's own
+            // verified sha256 now, computed above.
+            fetch_and_place_artifact(&manifest, staging_dir, max_decompressed_bytes).await?;
             Ok((
                 manifest,
                 PluginSource::Url {
                     url: url.clone(),
-                    sha256,
+                    sha256: verified_bundle_sha256,
+                    allow_unverified: *allow_unverified,
                 },
             ))
         }
@@ -322,14 +373,63 @@ async fn stage_into(
 /// Populates `staging_dir` with whatever the bundle contains (just
 /// `plugin.json` for a bare manifest; the full skills/prompts/workflows tree
 /// for an archive).
+///
+/// **Secure by default.** Before the URL is even requested: if `sha256` is
+/// `None` and `allow_unverified` is `false`, refuses with
+/// [`PluginError::ChecksumRequired`] — no network access happens for a
+/// refused install. If `sha256` IS given, the downloaded bytes are hashed
+/// and compared (case-insensitive) BEFORE any extraction/parsing; a
+/// mismatch is [`PluginError::BundleVerificationFailed`] and nothing is
+/// written beyond the (discarded) in-memory bytes. If `allow_unverified` is
+/// `true` and no `sha256` was given, the fetch proceeds but logs a
+/// `tracing::warn!` — an explicit, visible opt-out of verification, never a
+/// silent one.
+///
+/// Returns the parsed manifest and, when a `sha256` was supplied and
+/// confirmed, that verified hex digest (for [`PluginSource::Url`]
+/// provenance) — `None` only on the `allow_unverified`-with-no-hash path.
 async fn fetch_manifest_bundle(
     url: &str,
+    sha256: Option<&str>,
+    allow_unverified: bool,
     staging_dir: &Path,
     max_decompressed_bytes: u64,
-) -> PluginResult<PluginManifest> {
+) -> PluginResult<(PluginManifest, Option<String>)> {
+    if sha256.is_none() && !allow_unverified {
+        return Err(PluginError::ChecksumRequired(format!(
+            "refusing to install plugin bundle from '{url}' without a checksum — pass the \
+             bundle's sha256 (from the release page / a trusted source) to verify it before \
+             install (CLI: `--sha256 <hex>`; HTTP: `\"sha256\": \"<hex>\"` on the url source), \
+             or explicitly accept the risk of an unverified download (CLI: \
+             `--allow-unverified`; HTTP: `\"allow_unverified\": true`)"
+        )));
+    }
+
     let bytes = download_bytes(url).await?;
 
-    if let Some(kind) = detect_archive_kind(url) {
+    let verified_sha256 = match sha256 {
+        Some(expected) => {
+            let actual = sha256_hex(&bytes);
+            if !actual.eq_ignore_ascii_case(expected) {
+                return Err(PluginError::BundleVerificationFailed(format!(
+                    "sha256 mismatch for plugin bundle '{url}': expected {expected}, downloaded \
+                     bytes hash to {actual} — refusing to unpack (the bundle may be tampered, \
+                     corrupted, or the wrong sha256 was supplied)"
+                )));
+            }
+            Some(actual)
+        }
+        None => {
+            tracing::warn!(
+                %url,
+                "installing plugin bundle from a URL with no checksum verification \
+                 (allow_unverified opt-out) — the download is trusted on HTTPS alone"
+            );
+            None
+        }
+    };
+
+    let manifest = if let Some(kind) = detect_archive_kind(url) {
         extract_archive(
             bytes,
             kind,
@@ -338,34 +438,44 @@ async fn fetch_manifest_bundle(
         )
         .await?;
         flatten_if_single_subdir(staging_dir).await?;
-        read_and_parse_manifest(staging_dir).await
+        read_and_parse_manifest(staging_dir).await?
     } else {
         let raw = String::from_utf8(bytes).map_err(|_| {
             PluginError::InvalidManifest(format!("manifest at '{url}' is not valid UTF-8"))
         })?;
         tokio::fs::create_dir_all(staging_dir).await?;
         tokio::fs::write(staging_dir.join("plugin.json"), &raw).await?;
-        PluginManifest::parse_str(&raw)
-    }
+        PluginManifest::parse_str(&raw)?
+    };
+
+    Ok((manifest, verified_sha256))
 }
 
 /// Per-platform binary artifact fetch (URL source only). Fetches the
 /// artifact declared for [`Platform::current`] (a no-op if the manifest
 /// declares none for this platform — not every plugin needs a binary),
 /// verifies its sha256 BEFORE unpacking, and places the single expected
-/// executable at `<staging_dir>/bin/<platform>/<id>[.exe]`. Returns the
-/// verified sha256 (for [`PluginSource::Url`] provenance), if an artifact
-/// was fetched.
+/// executable at `<staging_dir>/bin/<platform>/<id>[.exe]`.
+///
+/// This stays as defense in depth alongside [`fetch_manifest_bundle`]'s
+/// bundle-sha256 check (see the module docs): the artifact hash is declared
+/// INSIDE the manifest, so on its own it only proves "the binary matches
+/// what this bundle's manifest says", not "this bundle itself is what the
+/// caller expected" — that's what the bundle-level check now provides. The
+/// verified artifact sha256 is therefore no longer surfaced to the caller
+/// (it used to double as [`PluginSource::Url`]'s provenance hash before the
+/// bundle-level check existed); this function's contract is purely
+/// verify-then-place.
 async fn fetch_and_place_artifact(
     manifest: &PluginManifest,
     staging_dir: &Path,
     max_decompressed_bytes: u64,
-) -> PluginResult<Option<String>> {
+) -> PluginResult<()> {
     let Some(platform) = Platform::current() else {
-        return Ok(None);
+        return Ok(());
     };
     let Some(artifact) = manifest.artifacts.get(platform.as_str()) else {
-        return Ok(None);
+        return Ok(());
     };
 
     let bytes = download_bytes(&artifact.url).await?;
@@ -416,7 +526,7 @@ async fn fetch_and_place_artifact(
     }
 
     let _ = tokio::fs::remove_dir_all(&scratch_dir).await;
-    Ok(Some(artifact.sha256.clone()))
+    Ok(())
 }
 
 /// `rename`, falling back to copy+remove across a device boundary.

--- a/crates/app/bamboo-server/src/plugin_source/tests.rs
+++ b/crates/app/bamboo-server/src/plugin_source/tests.rs
@@ -509,9 +509,68 @@ async fn zip_symlink_mode_entry_lands_inert_as_a_regular_file() {
 // ---------------------------------------------------------------------
 // Url
 // ---------------------------------------------------------------------
+//
+// Secure-by-default policy under test throughout this section (see
+// `plugin_source.rs`'s module docs and `fetch_manifest_bundle`):
+//   - a correct bundle sha256 -> verified, install proceeds, the VERIFIED
+//     hash (not the caller's literal input) is recorded in provenance.
+//   - a WRONG bundle sha256 -> `BundleVerificationFailed`, nothing staged.
+//   - no sha256 and `allow_unverified: false` (the default) -> refused
+//     with `ChecksumRequired`, BEFORE the URL is ever fetched.
+//   - no sha256 and `allow_unverified: true` -> proceeds (explicit opt-out).
+
+fn sha256_hex_of(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+fn url_input(url: &str, sha256: Option<&str>, allow_unverified: bool) -> PluginSourceInput {
+    PluginSourceInput::Url {
+        url: url.to_string(),
+        sha256: sha256.map(|s| s.to_string()),
+        allow_unverified,
+    }
+}
 
 #[tokio::test]
-async fn stages_bare_manifest_from_url_with_no_artifact() {
+async fn stages_bare_manifest_from_url_with_correct_bundle_sha256() {
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    let bundle_sha256 = sha256_hex_of(manifest_body.as_bytes());
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+    let staged = stage_plugin_source(url_input(&url, Some(&bundle_sha256), false), &plugins_root)
+        .await
+        .expect("a correct bundle sha256 must verify and stage successfully");
+
+    assert_eq!(staged.manifest.id, "hello-plugin");
+    // The VERIFIED bundle sha256 is what's recorded — this is the
+    // provenance/audit trail a re-install or `plugin list` can trust,
+    // distinct from any per-platform binary artifact hash.
+    assert_eq!(
+        staged.source,
+        PluginSource::Url {
+            url,
+            sha256: Some(bundle_sha256),
+            allow_unverified: false,
+        }
+    );
+    // No skill files were bundled with a bare manifest fetch.
+    assert!(!staged.plugin_dir.join("skills").exists());
+    staged.commit().await;
+}
+
+#[tokio::test]
+async fn url_install_with_wrong_bundle_sha256_is_rejected_before_unpacking() {
     let server = wiremock::MockServer::start().await;
     let manifest_body = hello_manifest_json("hello-plugin");
     wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -523,14 +582,95 @@ async fn stages_bare_manifest_from_url_with_no_artifact() {
     let root = tempfile::tempdir().unwrap();
     let plugins_root = root.path().join("plugins");
     let url = format!("{}/plugin.json", server.uri());
-    let staged = stage_plugin_source(PluginSourceInput::Url(url.clone()), &plugins_root)
+    let wrong_sha256 = "b".repeat(64);
+    let error = stage_plugin_source(url_input(&url, Some(&wrong_sha256), false), &plugins_root)
         .await
-        .expect("stage bare manifest url");
+        .expect_err("a bundle sha256 mismatch must be rejected");
+    assert!(
+        matches!(error, PluginError::BundleVerificationFailed(_)),
+        "expected BundleVerificationFailed, got {error:?}"
+    );
+    assert!(error.to_string().contains(&url));
+
+    // Nothing committed, and no stray staging dir left under plugins_root.
+    assert!(!plugins_root.join("hello-plugin").exists());
+    let mut leftovers = tokio::fs::read_dir(&plugins_root).await.unwrap();
+    assert!(
+        leftovers.next_entry().await.unwrap().is_none(),
+        "a rejected bundle checksum mismatch must leave nothing under plugins_root"
+    );
+}
+
+#[tokio::test]
+async fn url_install_without_checksum_or_allow_unverified_is_refused_before_fetch() {
+    // No mock is mounted at all — if the refusal did NOT happen before the
+    // fetch, this test would hang/error on an unmatched request instead of
+    // cleanly returning `ChecksumRequired`.
+    let server = wiremock::MockServer::start().await;
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+
+    let error = stage_plugin_source(url_input(&url, None, false), &plugins_root)
+        .await
+        .expect_err("no sha256 and no allow_unverified must be refused");
+    assert!(
+        matches!(error, PluginError::ChecksumRequired(_)),
+        "expected ChecksumRequired, got {error:?}"
+    );
+    let message = error.to_string();
+    assert!(message.contains("sha256"), "{message}");
+    assert!(
+        message.contains("allow_unverified") || message.contains("allow-unverified"),
+        "{message}"
+    );
+
+    // The core assertion: `bamboo plugin install <url>` alone must not just
+    // download and trust any tar.gz — confirm the server genuinely never
+    // received a request for it.
+    let received = server.received_requests().await;
+    assert_eq!(
+        received.map(|requests| requests.len()),
+        Some(0),
+        "refusing an unverified URL install must happen BEFORE the URL is ever fetched"
+    );
+
+    // Nothing committed, and no stray staging dir left under plugins_root.
+    assert!(!plugins_root.join("hello-plugin").exists());
+    let mut leftovers = tokio::fs::read_dir(&plugins_root).await.unwrap();
+    assert!(
+        leftovers.next_entry().await.unwrap().is_none(),
+        "a refused unverified install must leave nothing under plugins_root"
+    );
+}
+
+#[tokio::test]
+async fn url_install_with_allow_unverified_and_no_sha256_succeeds() {
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+    let staged = stage_plugin_source(url_input(&url, None, true), &plugins_root)
+        .await
+        .expect("allow_unverified must let an unpinned URL install through");
 
     assert_eq!(staged.manifest.id, "hello-plugin");
-    assert_eq!(staged.source, PluginSource::Url { url, sha256: None });
-    // No skill files were bundled with a bare manifest fetch.
-    assert!(!staged.plugin_dir.join("skills").exists());
+    assert_eq!(
+        staged.source,
+        PluginSource::Url {
+            url,
+            sha256: None,
+            allow_unverified: true,
+        },
+        "an allow_unverified install has no bundle sha256 to record"
+    );
     staged.commit().await;
 }
 
@@ -576,23 +716,22 @@ async fn fetches_verifies_and_places_platform_artifact_binary() {
         "hello-plugin"
     };
     let archive_bytes = build_targz(&[(binary_name, b"#!/bin/sh\necho hi\n")]);
-    let sha256 = {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(&archive_bytes);
-        hex::encode(hasher.finalize())
-    };
+    let artifact_sha256 = sha256_hex_of(&archive_bytes);
+
+    let manifest_body = manifest_with_artifact(
+        "hello-plugin",
+        current_platform_key(),
+        &artifact_sha256,
+        &format!("{}/hello-plugin.tar.gz", server.uri()),
+    );
+    // The BUNDLE (this manifest.json response) is verified independently of
+    // the binary artifact's own sha256 declared inside it — pin it here so
+    // this test exercises both checks staying in force together.
+    let bundle_sha256 = sha256_hex_of(manifest_body.as_bytes());
 
     wiremock::Mock::given(wiremock::matchers::method("GET"))
         .and(wiremock::matchers::path("/plugin.json"))
-        .respond_with(
-            wiremock::ResponseTemplate::new(200).set_body_string(manifest_with_artifact(
-                "hello-plugin",
-                current_platform_key(),
-                &sha256,
-                &format!("{}/hello-plugin.tar.gz", server.uri()),
-            )),
-        )
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
         .mount(&server)
         .await;
     wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -604,7 +743,7 @@ async fn fetches_verifies_and_places_platform_artifact_binary() {
     let root = tempfile::tempdir().unwrap();
     let plugins_root = root.path().join("plugins");
     let url = format!("{}/plugin.json", server.uri());
-    let staged = stage_plugin_source(PluginSourceInput::Url(url), &plugins_root)
+    let staged = stage_plugin_source(url_input(&url, Some(&bundle_sha256), false), &plugins_root)
         .await
         .expect("stage manifest + artifact");
 
@@ -629,12 +768,17 @@ async fn fetches_verifies_and_places_platform_artifact_binary() {
         assert_eq!(mode & 0o111, 0o111, "binary should be executable");
     }
 
-    match staged.source {
+    // Provenance records the verified BUNDLE sha256, not the binary
+    // artifact's — they're deliberately different hashes here, so this
+    // also confirms the two checks aren't accidentally conflated.
+    assert_eq!(
+        staged.source,
         PluginSource::Url {
-            sha256: Some(_), ..
-        } => {}
-        other => panic!("expected Url source with a recorded sha256, got {other:?}"),
-    }
+            url,
+            sha256: Some(bundle_sha256),
+            allow_unverified: false,
+        }
+    );
     staged.commit().await;
 }
 
@@ -643,18 +787,21 @@ async fn artifact_sha256_mismatch_is_rejected_before_unpacking() {
     let server = wiremock::MockServer::start().await;
 
     let archive_bytes = build_targz(&[("hello-plugin", b"whatever")]);
-    let wrong_sha256 = "a".repeat(64);
+    let wrong_artifact_sha256 = "a".repeat(64);
+
+    let manifest_body = manifest_with_artifact(
+        "hello-plugin",
+        current_platform_key(),
+        &wrong_artifact_sha256,
+        &format!("{}/hello-plugin.tar.gz", server.uri()),
+    );
+    // Pin the BUNDLE correctly so this test isolates the artifact-level
+    // check (the bundle-level check is exercised separately above).
+    let bundle_sha256 = sha256_hex_of(manifest_body.as_bytes());
 
     wiremock::Mock::given(wiremock::matchers::method("GET"))
         .and(wiremock::matchers::path("/plugin.json"))
-        .respond_with(
-            wiremock::ResponseTemplate::new(200).set_body_string(manifest_with_artifact(
-                "hello-plugin",
-                current_platform_key(),
-                &wrong_sha256,
-                &format!("{}/hello-plugin.tar.gz", server.uri()),
-            )),
-        )
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
         .mount(&server)
         .await;
     wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -666,9 +813,9 @@ async fn artifact_sha256_mismatch_is_rejected_before_unpacking() {
     let root = tempfile::tempdir().unwrap();
     let plugins_root = root.path().join("plugins");
     let url = format!("{}/plugin.json", server.uri());
-    let error = stage_plugin_source(PluginSourceInput::Url(url), &plugins_root)
+    let error = stage_plugin_source(url_input(&url, Some(&bundle_sha256), false), &plugins_root)
         .await
-        .expect_err("sha256 mismatch must be rejected");
+        .expect_err("artifact sha256 mismatch must be rejected");
     assert!(matches!(error, PluginError::ArtifactVerificationFailed(_)));
     assert!(
         !plugins_root.join("hello-plugin").exists(),

--- a/crates/infra/bamboo-plugin/src/error.rs
+++ b/crates/infra/bamboo-plugin/src/error.rs
@@ -71,6 +71,29 @@ pub enum PluginError {
     #[error("artifact verification failed: {0}")]
     ArtifactVerificationFailed(String),
 
+    /// A downloaded URL plugin BUNDLE (the `plugin.json` or the archive
+    /// containing it — whatever the app layer's URL-source fetch downloads)
+    /// did not hash to the caller-supplied expected sha256. Checked BEFORE
+    /// any extraction/parsing, so a tampered bundle is never trusted even
+    /// partially. Distinct from [`Self::ArtifactVerificationFailed`] (which
+    /// is pinned by a hash declared INSIDE the manifest — itself only
+    /// trustworthy once the bundle carrying it is verified): this is the
+    /// root-of-trust check that closes the circular-trust hole where the
+    /// manifest's own artifact hash could be rewritten by whoever tampered
+    /// with the bundle.
+    #[error("bundle verification failed: {0}")]
+    BundleVerificationFailed(String),
+
+    /// A URL plugin install/update was requested with neither a `sha256` to
+    /// verify the downloaded bundle against, nor an explicit
+    /// `allow_unverified` opt-in. This is the secure-by-default refusal: a
+    /// URL install must be either checksum-pinned or an explicit,
+    /// deliberate risk acceptance — never a silent "download and trust any
+    /// tar.gz". Raised BEFORE the URL is ever fetched (no network access
+    /// happens for a refused install).
+    #[error("{0}")]
+    ChecksumRequired(String),
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/crates/infra/bamboo-plugin/src/registry.rs
+++ b/crates/infra/bamboo-plugin/src/registry.rs
@@ -31,12 +31,34 @@ pub enum PluginSource {
     LocalDir { path: PathBuf },
     /// Installed by unpacking a local `.tar.gz` archive.
     LocalArchive { path: PathBuf },
-    /// Installed by fetching a URL (optionally sha256-verified).
+    /// Installed by fetching a URL. Secure by default: `sha256` is the
+    /// user-verified hash of the downloaded BUNDLE (the `plugin.json`, or
+    /// the archive containing it) — `Some` in the normal case, confirmed
+    /// against a caller-supplied expected hash BEFORE anything was
+    /// extracted/trusted. `sha256` is `None` only when the install
+    /// explicitly opted out of verification (`allow_unverified: true`, no
+    /// hash supplied) — an install refuses outright rather than silently
+    /// trusting an unpinned download, so `None` here always means a
+    /// deliberate risk acceptance, never an oversight.
     Url {
         url: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         sha256: Option<String>,
+        /// Recorded for audit: true when this install ran with
+        /// `allow_unverified` and no `sha256`. `#[serde(default)]` so a
+        /// pre-existing `installed.json` row (written before this field
+        /// existed, back when only the per-platform binary artifact was
+        /// pinned) loads as `false` rather than failing to deserialize.
+        #[serde(default, skip_serializing_if = "is_false")]
+        allow_unverified: bool,
     },
+}
+
+/// `skip_serializing_if` helper for a `bool` field that should be omitted
+/// from the JSON when `false` (serde has no built-in equivalent of
+/// `std::ops::Not::not` that takes a reference).
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 /// Exactly what an installed plugin registered into Bamboo's shared capability

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -544,23 +544,40 @@ enum PluginCommands {
     /// `.zip` archive, or an `http(s)://` URL (source kind auto-detected from
     /// the argument) — `POST /api/v1/plugins/install`. Fails if the plugin id
     /// is already installed; use `bamboo plugin update` for that case.
+    ///
+    /// A URL source is secure by default: it MUST be either checksum-pinned
+    /// (`--sha256`) or explicitly opted out (`--allow-unverified`) — a bare
+    /// `bamboo plugin install <url>` with neither is refused before the URL
+    /// is even fetched.
     #[command(after_help = "EXAMPLES:\n  \
         # From a local directory (development)\n  \
         bamboo plugin install ./my-plugin\n\n  \
         # From a packaged archive\n  \
         bamboo plugin install ./my-plugin.tar.gz\n\n  \
-        # From a URL, pinned by sha256\n  \
+        # From a URL, pinned by the bundle's sha256 (preferred)\n  \
         bamboo plugin install https://example.com/my-plugin.tar.gz \\\n    \
-        --sha256 3a7bd3e2360a3d29eea436fcfb7e44c735d117c42d1c1835420b6b9942dd4f1")]
+        --sha256 3a7bd3e2360a3d29eea436fcfb7e44c735d117c42d1c1835420b6b9942dd4f1\n\n  \
+        # From a URL, explicitly accepting the risk of no checksum\n  \
+        bamboo plugin install https://example.com/my-plugin.tar.gz --allow-unverified")]
     Install {
         /// A local directory, a local `.tar.gz`/`.tgz`/`.zip` archive, or an
         /// `http(s)://` URL — the source kind is auto-detected.
         source: String,
 
-        /// Expected sha256 (hex) of the downloaded archive. Only valid with a
-        /// URL source; the server rejects a mismatch.
+        /// Expected sha256 (hex) of the downloaded plugin BUNDLE (the
+        /// `plugin.json`, or the archive containing it) fetched from a URL
+        /// source. Only valid with a URL source; the server rejects a
+        /// mismatch before unpacking anything. Without this, a URL install
+        /// also needs `--allow-unverified`.
         #[arg(long, value_name = "HEX")]
         sha256: Option<String>,
+
+        /// Explicit opt-out: install from a URL with no bundle checksum
+        /// verification. Only valid with a URL source. Use only when you
+        /// trust the URL/host and have no sha256 to pin — the server logs a
+        /// warning for every unverified install.
+        #[arg(long)]
+        allow_unverified: bool,
 
         #[command(flatten)]
         conn: ConnArgs,
@@ -603,10 +620,18 @@ enum PluginCommands {
         /// `http(s)://` URL — the source kind is auto-detected.
         source: String,
 
-        /// Expected sha256 (hex) of the downloaded archive. Only valid with a
-        /// URL source; the server rejects a mismatch.
+        /// Expected sha256 (hex) of the downloaded plugin BUNDLE (the
+        /// `plugin.json`, or the archive containing it) fetched from a URL
+        /// source. Only valid with a URL source; the server rejects a
+        /// mismatch before unpacking anything. Without this, a URL source
+        /// also needs `--allow-unverified`.
         #[arg(long, value_name = "HEX")]
         sha256: Option<String>,
+
+        /// Explicit opt-out: update from a URL with no bundle checksum
+        /// verification. Only valid with a URL source.
+        #[arg(long)]
+        allow_unverified: bool,
 
         #[command(flatten)]
         conn: ConnArgs,
@@ -1716,9 +1741,16 @@ async fn main() {
                 PluginCommands::Install {
                     source,
                     sha256,
+                    allow_unverified,
                     conn,
                 } => {
-                    bamboo_agent::plugin_cli::install(conn.into(), &source, sha256.as_deref()).await
+                    bamboo_agent::plugin_cli::install(
+                        conn.into(),
+                        &source,
+                        sha256.as_deref(),
+                        allow_unverified,
+                    )
+                    .await
                 }
                 PluginCommands::List { conn, json } => {
                     bamboo_agent::plugin_cli::list(conn.into(), json).await
@@ -1730,10 +1762,17 @@ async fn main() {
                     id,
                     source,
                     sha256,
+                    allow_unverified,
                     conn,
                 } => {
-                    bamboo_agent::plugin_cli::update(conn.into(), &id, &source, sha256.as_deref())
-                        .await
+                    bamboo_agent::plugin_cli::update(
+                        conn.into(),
+                        &id,
+                        &source,
+                        sha256.as_deref(),
+                        allow_unverified,
+                    )
+                    .await
                 }
             };
             if let Err(e) = result {
@@ -1958,6 +1997,60 @@ mod tests {
     }
 
     #[test]
+    fn plugin_install_parses_allow_unverified_flag() {
+        use clap::Parser;
+
+        let parsed = super::Cli::try_parse_from([
+            "bamboo",
+            "plugin",
+            "install",
+            "https://example.com/my-plugin.tar.gz",
+            "--allow-unverified",
+        ])
+        .expect("--allow-unverified should parse");
+        let super::Commands::Plugin {
+            command:
+                super::PluginCommands::Install {
+                    allow_unverified,
+                    sha256,
+                    ..
+                },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Install");
+        };
+        assert!(allow_unverified);
+        assert!(sha256.is_none());
+
+        // Both flags can be given together (redundant, not rejected client-side —
+        // the server treats a supplied sha256 as authoritative regardless).
+        assert!(super::Cli::try_parse_from([
+            "bamboo",
+            "plugin",
+            "install",
+            "https://example.com/my-plugin.tar.gz",
+            "--sha256",
+            "deadbeef",
+            "--allow-unverified",
+        ])
+        .is_ok());
+
+        // Defaults to false when omitted.
+        let parsed =
+            super::Cli::try_parse_from(["bamboo", "plugin", "install", "./my-plugin"]).unwrap();
+        let super::Commands::Plugin {
+            command:
+                super::PluginCommands::Install {
+                    allow_unverified, ..
+                },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Install");
+        };
+        assert!(!allow_unverified);
+    }
+
+    #[test]
     fn plugin_update_parses_id_and_source() {
         use clap::Parser;
 
@@ -1973,6 +2066,31 @@ mod tests {
         assert!(
             super::Cli::try_parse_from(["bamboo", "plugin", "update", "hello-plugin"]).is_err()
         );
+    }
+
+    #[test]
+    fn plugin_update_parses_allow_unverified_flag() {
+        use clap::Parser;
+
+        let parsed = super::Cli::try_parse_from([
+            "bamboo",
+            "plugin",
+            "update",
+            "hello-plugin",
+            "https://example.com/my-plugin.tar.gz",
+            "--allow-unverified",
+        ])
+        .expect("--allow-unverified should parse on update too");
+        let super::Commands::Plugin {
+            command:
+                super::PluginCommands::Update {
+                    allow_unverified, ..
+                },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Update");
+        };
+        assert!(allow_unverified);
     }
 
     #[test]

--- a/src/plugin_cli.rs
+++ b/src/plugin_cli.rs
@@ -15,15 +15,27 @@
 //! - `POST /api/v1/plugins/install` -> body `{ "source": <SourceSpec> }`
 //!   (`InstallDisposition::FailIfInstalled`); `SourceSpec` is one of
 //!   `{"type":"local_dir","path":"..."}` / `{"type":"local_archive","path":"..."}`
-//!   / `{"type":"url","url":"...","sha256":"..."?}` — the same tagged shape as
-//!   `bamboo_plugin::registry::PluginSource`'s `#[serde(tag = "type")]` wire
-//!   form, reproduced here by hand (this crate does not depend on
-//!   `bamboo-plugin`, to stay decoupled from the parallel installer-core
-//!   branch).
+//!   / `{"type":"url","url":"...","sha256":"..."?,"allow_unverified":bool?}` —
+//!   the same tagged shape as `bamboo_plugin::registry::PluginSource`'s
+//!   `#[serde(tag = "type")]` wire form, reproduced here by hand (this crate
+//!   does not depend on `bamboo-plugin`, to stay decoupled from the parallel
+//!   installer-core branch).
 //! - `POST /api/v1/plugins/{id}/update` -> same body shape (`Upgrade`).
 //! - `DELETE /api/v1/plugins/{id}` -> uninstall.
 //! - Errors: 409 (Conflict / AlreadyInstalled), 422 (UnsupportedPlatform), 404
-//!   (NotFound), 400 (bad manifest/artifact); body `{"error": "..."}`.
+//!   (NotFound), 400 (bad manifest/artifact/bundle checksum, or a `url`
+//!   install missing both `sha256` and `allow_unverified`); body
+//!   `{"error": "..."}`.
+//!
+//! # URL installs are secure by default
+//!
+//! `sha256` on a `url` source pins the downloaded BUNDLE (the `plugin.json`,
+//! or the archive containing it) — NOT merely the per-platform binary
+//! artifact declared inside the manifest (that is separately, and always,
+//! sha256-verified against the manifest's own declaration). A `url` install
+//! with neither `sha256` nor `allow_unverified: true` is refused by the
+//! server before it ever fetches the URL: `bamboo plugin install <url>`
+//! alone no longer just downloads and trusts any tar.gz.
 
 use std::path::Path;
 use std::time::Duration;
@@ -47,17 +59,27 @@ const PLUGIN_MUTATE_TIMEOUT: Duration = Duration::from_secs(120);
 /// - an existing file ending `.tar.gz`/`.tgz`/`.zip` ->
 ///   `{"type":"local_archive","path":<absolute path>}`
 /// - something starting `http://`/`https://` -> `{"type":"url","url":<as-is>}`
-///   (+ `"sha256"` when `--sha256` was given)
+///   (+ `"sha256"` when `--sha256` was given, `"allow_unverified":true` when
+///   `--allow-unverified` was given)
 ///
 /// Local paths are canonicalized to absolute so the source resolves correctly
 /// even if `bamboo serve` runs with a different working directory than the
-/// CLI invocation (e.g. a long-running sidecar). `--sha256` is rejected for
-/// local sources — it only pins a network download.
-pub(crate) fn detect_source(spec: &str, sha256: Option<&str>) -> anyhow::Result<serde_json::Value> {
+/// CLI invocation (e.g. a long-running sidecar). `--sha256` and
+/// `--allow-unverified` are rejected for local sources — they only apply to a
+/// network download; a local file is already on the user's own disk by their
+/// own choice, nothing to verify.
+pub(crate) fn detect_source(
+    spec: &str,
+    sha256: Option<&str>,
+    allow_unverified: bool,
+) -> anyhow::Result<serde_json::Value> {
     if spec.starts_with("http://") || spec.starts_with("https://") {
         let mut v = serde_json::json!({ "type": "url", "url": spec });
         if let Some(sha) = sha256 {
             v["sha256"] = serde_json::Value::String(sha.to_string());
+        }
+        if allow_unverified {
+            v["allow_unverified"] = serde_json::Value::Bool(true);
         }
         return Ok(v);
     }
@@ -71,6 +93,9 @@ pub(crate) fn detect_source(spec: &str, sha256: Option<&str>) -> anyhow::Result<
         if sha256.is_some() {
             anyhow::bail!("--sha256 only applies to a URL source, not a local directory");
         }
+        if allow_unverified {
+            anyhow::bail!("--allow-unverified only applies to a URL source, not a local directory");
+        }
         return Ok(serde_json::json!({ "type": "local_dir", "path": abs }));
     }
 
@@ -81,6 +106,9 @@ pub(crate) fn detect_source(spec: &str, sha256: Option<&str>) -> anyhow::Result<
         if sha256.is_some() {
             anyhow::bail!("--sha256 only applies to a URL source, not a local archive");
         }
+        if allow_unverified {
+            anyhow::bail!("--allow-unverified only applies to a URL source, not a local archive");
+        }
         return Ok(serde_json::json!({ "type": "local_archive", "path": abs }));
     }
 
@@ -89,15 +117,20 @@ pub(crate) fn detect_source(spec: &str, sha256: Option<&str>) -> anyhow::Result<
     )
 }
 
-/// `bamboo plugin install <path-or-url> [--sha256 <hex>]` —
+/// `bamboo plugin install <path-or-url> [--sha256 <hex>] [--allow-unverified]` —
 /// `POST /api/v1/plugins/install`. On a 409 (already installed) prints a
-/// pointer to `bamboo plugin update` and returns an error (non-zero exit).
+/// pointer to `bamboo plugin update` and returns an error (non-zero exit). A
+/// URL source with neither `--sha256` nor `--allow-unverified` gets a 400
+/// from the server (secure by default — see the module docs); that error's
+/// message is already the actionable "pass --sha256 or --allow-unverified"
+/// guidance, surfaced as-is through the generic HTTP-failure branch below.
 pub async fn install(
     conn: ConnArgs,
     source_spec: &str,
     sha256: Option<&str>,
+    allow_unverified: bool,
 ) -> anyhow::Result<()> {
-    let source = detect_source(source_spec, sha256)?;
+    let source = detect_source(source_spec, sha256, allow_unverified)?;
     let base = conn.api_base();
     let url = format!("{base}/plugins/install");
     let resp = reqwest::Client::new()
@@ -259,16 +292,18 @@ pub async fn remove(conn: ConnArgs, id: &str, yes: bool) -> anyhow::Result<()> {
     }
 }
 
-/// `bamboo plugin update <id> <path-or-url> [--sha256]` —
-/// `POST /api/v1/plugins/{id}/update` (`InstallDisposition::Upgrade`).
+/// `bamboo plugin update <id> <path-or-url> [--sha256] [--allow-unverified]` —
+/// `POST /api/v1/plugins/{id}/update` (`InstallDisposition::Upgrade`). Same
+/// secure-by-default URL policy as `install` (see the module docs).
 pub async fn update(
     conn: ConnArgs,
     id: &str,
     source_spec: &str,
     sha256: Option<&str>,
+    allow_unverified: bool,
 ) -> anyhow::Result<()> {
     guard_id_segment("plugin id", id)?;
-    let source = detect_source(source_spec, sha256)?;
+    let source = detect_source(source_spec, sha256, allow_unverified)?;
     let base = conn.api_base();
     let url = format!("{base}/plugins/{id}/update");
     let resp = reqwest::Client::new()
@@ -301,20 +336,40 @@ mod tests {
 
     #[test]
     fn detect_source_recognizes_http_and_https_urls() {
-        let v = detect_source("https://example.com/plugin.tar.gz", None).unwrap();
+        let v = detect_source("https://example.com/plugin.tar.gz", None, false).unwrap();
         assert_eq!(v["type"], "url");
         assert_eq!(v["url"], "https://example.com/plugin.tar.gz");
         assert!(v.get("sha256").is_none());
+        assert!(v.get("allow_unverified").is_none());
 
-        let v = detect_source("http://example.com/plugin.tar.gz", Some("deadbeef")).unwrap();
+        let v = detect_source("http://example.com/plugin.tar.gz", Some("deadbeef"), false).unwrap();
         assert_eq!(v["type"], "url");
         assert_eq!(v["sha256"], "deadbeef");
+        assert!(v.get("allow_unverified").is_none());
+    }
+
+    #[test]
+    fn detect_source_url_carries_allow_unverified_when_set() {
+        let v = detect_source("https://example.com/plugin.tar.gz", None, true).unwrap();
+        assert_eq!(v["type"], "url");
+        assert!(v.get("sha256").is_none());
+        assert_eq!(v["allow_unverified"], true);
+    }
+
+    #[test]
+    fn detect_source_url_carries_both_sha256_and_allow_unverified() {
+        // Both flags can be set together — the server treats `sha256` as
+        // authoritative when present (verify), so this isn't a conflicting
+        // request, just a redundant one.
+        let v = detect_source("https://example.com/plugin.tar.gz", Some("deadbeef"), true).unwrap();
+        assert_eq!(v["sha256"], "deadbeef");
+        assert_eq!(v["allow_unverified"], true);
     }
 
     #[test]
     fn detect_source_recognizes_local_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let v = detect_source(dir.path().to_str().unwrap(), None).unwrap();
+        let v = detect_source(dir.path().to_str().unwrap(), None, false).unwrap();
         assert_eq!(v["type"], "local_dir");
         assert_eq!(
             v["path"].as_str().unwrap(),
@@ -325,8 +380,15 @@ mod tests {
     #[test]
     fn detect_source_rejects_sha256_for_local_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let err = detect_source(dir.path().to_str().unwrap(), Some("deadbeef")).unwrap_err();
+        let err = detect_source(dir.path().to_str().unwrap(), Some("deadbeef"), false).unwrap_err();
         assert!(err.to_string().contains("--sha256"));
+    }
+
+    #[test]
+    fn detect_source_rejects_allow_unverified_for_local_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = detect_source(dir.path().to_str().unwrap(), None, true).unwrap_err();
+        assert!(err.to_string().contains("--allow-unverified"));
     }
 
     #[test]
@@ -335,7 +397,7 @@ mod tests {
         for name in ["plugin.tar.gz", "plugin.tgz", "plugin.zip"] {
             let path = dir.path().join(name);
             std::fs::write(&path, b"fake archive bytes").unwrap();
-            let v = detect_source(path.to_str().unwrap(), None).unwrap();
+            let v = detect_source(path.to_str().unwrap(), None, false).unwrap();
             assert_eq!(v["type"], "local_archive", "{name}");
         }
     }
@@ -345,8 +407,17 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("plugin.tar.gz");
         std::fs::write(&path, b"fake archive bytes").unwrap();
-        let err = detect_source(path.to_str().unwrap(), Some("deadbeef")).unwrap_err();
+        let err = detect_source(path.to_str().unwrap(), Some("deadbeef"), false).unwrap_err();
         assert!(err.to_string().contains("--sha256"));
+    }
+
+    #[test]
+    fn detect_source_rejects_allow_unverified_for_local_archive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plugin.tar.gz");
+        std::fs::write(&path, b"fake archive bytes").unwrap();
+        let err = detect_source(path.to_str().unwrap(), None, true).unwrap_err();
+        assert!(err.to_string().contains("--allow-unverified"));
     }
 
     #[test]
@@ -354,13 +425,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("plugin.txt");
         std::fs::write(&path, b"not an archive").unwrap();
-        let err = detect_source(path.to_str().unwrap(), None).unwrap_err();
+        let err = detect_source(path.to_str().unwrap(), None, false).unwrap_err();
         assert!(err.to_string().contains("neither a directory"));
     }
 
     #[test]
     fn detect_source_rejects_missing_path() {
-        let err = detect_source("/no/such/path/should/exist/anywhere", None).unwrap_err();
+        let err = detect_source("/no/such/path/should/exist/anywhere", None, false).unwrap_err();
         assert!(err.to_string().contains("cannot read"));
     }
 


### PR DESCRIPTION
## The hole being closed

`bamboo plugin install <url>` downloaded and unpacked ANY tar.gz/plugin.json with zero integrity check on the bundle itself. Only the per-platform *binary artifact* was sha256-verified (`PluginArtifact.sha256`, verified in `fetch_and_place_artifact`), but that hash is declared **inside the manifest that comes from the same unverified download** — so a MITM or compromised host tampering with the bundle could rewrite the artifact hash too. The trust chain was circular: nothing in the install path actually rooted trust outside the download itself.

## The fix — secure by default

`fetch_manifest_bundle` (`crates/app/bamboo-server/src/plugin_source.rs`) now enforces, **before any extraction or parsing**:

- **`sha256` given** → the downloaded bytes are hashed and compared (case-insensitive) against it. Mismatch → `PluginError::BundleVerificationFailed`, nothing is staged or trusted.
- **No `sha256`, no `allow_unverified`** → refused with `PluginError::ChecksumRequired`, **before the URL is ever fetched** (no network access happens for a refused install). This is the core behavior change: a bare `bamboo plugin install <url>` no longer just downloads and trusts any tar.gz.
- **No `sha256`, `allow_unverified: true`** → proceeds (explicit, deliberate risk acceptance), but logs `tracing::warn!`.

The per-platform binary artifact's own sha256 check stays as defense in depth — it's still pinned by the manifest, but the manifest itself is now root-of-trust-verified first. The provenance recorded in `PluginSource::Url.sha256` is now the **verified bundle** hash (for audit/re-install), not the binary artifact's.

## Surface changes

**CLI** (`bamboo plugin install|update <url>`):
- `--sha256 <hex>` now documented as pinning the BUNDLE (was ambiguous before).
- New `--allow-unverified` flag (both `install` and `update`). Rejected client-side for local dir/local archive sources (nothing to verify — the file's already on the user's own disk).
- With neither flag on a URL source, the server's 400 is surfaced as-is through the CLI's existing generic HTTP-failure path — the message is self-contained and actionable.

**HTTP** (`POST /api/v1/plugins/install`, `POST /api/v1/plugins/{id}/update`):
- `SourceSpec`'s `url` variant gains `allow_unverified?: bool` alongside the existing `sha256?: string` (both optional, `PluginSource`'s own wire shape, reused directly as documented in `api_types.rs`).
- New error → status mappings: `BundleVerificationFailed` → 400, `ChecksumRequired` → 400 (alongside the existing `ArtifactVerificationFailed` → 400).

**Registry / provenance** (`bamboo_plugin::registry::PluginSource::Url`): gains `allow_unverified: bool` (`#[serde(default)]`, so old `installed.json` rows still load fine).

## Deferred (documented in `plugin_source.rs`'s module docs, not fixed here)

- **Signature verification** — a sha256 pin proves "these are the expected bytes", not "an entity I trust produced them"; the hash itself still needs to come from somewhere trusted (release page, signed index, etc.). A real signature scheme (minisign/sigstore) would close that remaining hop.
- **SSRF guard** — `download_bytes` will fetch any URL including cloud-metadata/private-range addresses; a threat-model call for the deploy layer, noted but not addressed here.

## Verification

- `cargo build --workspace --exclude bamboo-analytics`: clean.
- `cargo test -p bamboo-plugin -p bamboo-server -- plugin`: 44 bamboo-server + all bamboo-plugin plugin tests green, including new coverage for all four URL-install paths (correct sha256 succeeds; wrong sha256 rejected with nothing staged; no-sha256/not-allowed refused before fetch — asserted via a `wiremock` server that received **zero** requests; allow_unverified-with-no-sha256 succeeds) at both the `plugin_source` unit level and the HTTP-handler integration level.
- `cargo test -p bamboo-agent --lib --bins`: 101 tests green, including new clap-parsing coverage for `--allow-unverified` on `install`/`update`.
- `cargo clippy --workspace --exclude bamboo-analytics --all-targets`: no new warnings (all pre-existing warnings are in unrelated files/crates).
- `cargo fmt` clean on all touched files.
- `cargo tree -i aws-lc-sys`: empty (no match), confirming the native-tls pin is undisturbed.
- **E2E**: built `bamboo`, ran `bamboo serve` on a throwaway port + data-dir, then:
  - `bamboo plugin install https://example.invalid/some-plugin-bundle.tar.gz` (no flags) → `install failed: HTTP 400 Bad Request (refusing to install plugin bundle from '...' without a checksum — pass the bundle's sha256 ... or explicitly accept the risk of an unverified download (CLI: `--allow-unverified`; ...))`, exit code 1.
  - The same command with `--allow-unverified` instead got a *different* error (500, a network/DNS failure trying to actually reach the unreachable host) — confirming the checksum-required refusal happens strictly before any fetch attempt, while `allow_unverified` genuinely lets it proceed to try.

## Test plan

- [x] `cargo test -p bamboo-plugin -p bamboo-server -- plugin`
- [x] `cargo test -p bamboo-agent --lib --bins`
- [x] `cargo clippy --workspace --exclude bamboo-analytics --all-targets`
- [x] `cargo fmt -- --check` on touched files
- [x] Manual E2E refusal check against a live `bamboo serve` instance