### PR TITLE
feat(plugin): source trust — host allowlist + ed25519 signature verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,6 +1059,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1367,6 +1368,7 @@ dependencies = [
  "chrono-tz",
  "cron",
  "dashmap",
+ "ed25519-dalek",
  "flate2",
  "futures",
  "globset",

--- a/crates/app/bamboo-server/Cargo.toml
+++ b/crates/app/bamboo-server/Cargo.toml
@@ -103,6 +103,24 @@ url = "2"
 hex = "0.4"
 sha2 = "0.11"
 rand = "0.10"
+# Plugin source-trust (`src/plugin_source.rs`): ed25519 publisher-signature
+# verification for URL-installed plugin bundles, layered on top of the
+# checksum + host-allowlist checks. Pure-Rust (curve25519-dalek), no TLS/libc
+# crypto backend — must never pull in aws-lc-sys (would break the reqwest
+# native-tls pin; verify with `cargo tree -i aws-lc-sys`). Already resolved
+# transitively via `russh`'s SSH host-key support, so this adds no new crate
+# to the dependency tree, just a direct edge to one already in the lockfile.
+# Default features only: verification uses `VerifyingKey::from_bytes` +
+# `Verifier::verify`, and test keypairs use `SigningKey::from_bytes` (a fixed
+# 32-byte "secret"), so no CSPRNG feature (`rand_core`) is needed anywhere.
+#
+# Pinned to the exact prerelease `russh` (SSH deploy, `bamboo-broker`) already
+# requires (`=3.0.0-rc.1`) — a looser `"3"` requirement lets cargo prefer the
+# stable `3.0.0` release for THIS crate while russh is stuck on the `-rc.1`
+# exact pin, and cargo refuses to select two versions of the same crate for
+# one dependency graph; matching russh's exact pin keeps a single resolved
+# version (the one already in Cargo.lock, adding no new crate to the tree).
+ed25519-dalek = { version = "=3.0.0-rc.1" }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Plugin source staging (`src/plugin_source.rs`): unpacking a local/remote
 # `.tar.gz`/`.tgz` plugin bundle or platform-artifact archive. `flate2` is

--- a/crates/app/bamboo-server/Cargo.toml
+++ b/crates/app/bamboo-server/Cargo.toml
@@ -120,6 +120,7 @@ rand = "0.10"
 # exact pin, and cargo refuses to select two versions of the same crate for
 # one dependency graph; matching russh's exact pin keeps a single resolved
 # version (the one already in Cargo.lock, adding no new crate to the tree).
+# TODO: move to a stable release once russh's pin does.
 ed25519-dalek = { version = "=3.0.0-rc.1" }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Plugin source staging (`src/plugin_source.rs`): unpacking a local/remote

--- a/crates/app/bamboo-server/examples/install_plugin.rs
+++ b/crates/app/bamboo-server/examples/install_plugin.rs
@@ -53,10 +53,12 @@ async fn main() {
                 InstallDisposition::FailIfInstalled
             };
             let plugins_root = data_dir.join("plugins");
+            let trust = data.config.read().await.plugin_trust.clone();
             match install_plugin_from_source(
                 &installer,
                 PluginSourceInput::LocalDir(plugin_dir),
                 &plugins_root,
+                &trust,
                 disposition,
             )
             .await

--- a/crates/app/bamboo-server/src/config_manager.rs
+++ b/crates/app/bamboo-server/src/config_manager.rs
@@ -163,6 +163,7 @@ pub fn build_merged_config(
     new_config.preserve_env_sourced_provider_keys(current);
     new_config.normalize_tool_settings();
     new_config.normalize_skill_settings();
+    new_config.normalize_plugin_trust_settings();
 
     Ok(new_config)
 }

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/api_types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/api_types.rs
@@ -14,23 +14,38 @@
 //! `SourceSpec` reuses [`bamboo_plugin::PluginSource`]'s own
 //! `#[serde(tag = "type", rename_all = "snake_case")]` wire shape directly —
 //! `{"type":"local_dir","path":...}` / `{"type":"local_archive","path":...}` /
-//! `{"type":"url","url":...,"sha256":...?,"allow_unverified":...?}` — rather
-//! than inventing a parallel request enum: it is already exactly the shape
-//! both the CLI and this HTTP layer need, and it doubles as the provenance
-//! record `install()` persists (see `bamboo_plugin::registry::PluginSource`'s
-//! doc comment).
+//! `{"type":"url","url":...,"sha256":...?,"allow_unverified":...?,
+//! "allow_untrusted_host":...?,"allow_unsigned":...?}` — rather than
+//! inventing a parallel request enum: it is already exactly the shape both
+//! the CLI and this HTTP layer need, and it doubles as the provenance record
+//! `install()` persists (see `bamboo_plugin::registry::PluginSource`'s doc
+//! comment). `signed_by` is also part of that same wire shape but is
+//! response-only in practice — a request-supplied value is ignored (see
+//! `to_source_input`).
 //!
-//! **Secure by default (`url` sources).** `sha256`, when given, pins the
-//! downloaded BUNDLE's exact bytes — verified in
-//! `plugin_source::fetch_manifest_bundle` BEFORE anything is
-//! extracted/parsed, distinct from (and in addition to) the per-platform
-//! *binary artifact*'s own sha256 declared inside the manifest itself
-//! (always verified, regardless of this field — see `plugin_source.rs`'s
-//! module docs on why both checks matter). Without `sha256`, a `url` install
-//! is REFUSED (`PluginError::ChecksumRequired`, mapped to `400`) unless
-//! `allow_unverified: true` is explicitly set — so `POST /install` with a
-//! bare `{"type":"url","url":"..."}` body no longer just downloads and
-//! trusts any tar.gz.
+//! **Three trust layers (`url` sources), enforced together in
+//! `plugin_source::fetch_manifest_bundle`** (see that module's docs for the
+//! full precedence):
+//!
+//! 1. **Host allowlist.** The URL's host+path must match one of
+//!    `plugin_trust.trusted_hosts` (config.json) unless
+//!    `allow_untrusted_host: true` is set — refused with
+//!    `PluginError::UntrustedHost` (`403`) BEFORE any fetch.
+//! 2. **Signature.** The bundle's `<url>.sig` must verify against one of
+//!    `plugin_trust.trusted_keys` unless `allow_unsigned: true` is set —
+//!    refused with `PluginError::UnsignedOrUntrustedSignature` (`403`).
+//! 3. **Checksum.** `sha256`, when given, pins the downloaded BUNDLE's exact
+//!    bytes — verified BEFORE anything is extracted/parsed, distinct from
+//!    (and in addition to) the per-platform *binary artifact*'s own sha256
+//!    declared inside the manifest itself (always verified, regardless of
+//!    this field). Without `sha256`, a `url` install is REFUSED
+//!    (`PluginError::ChecksumRequired`, mapped to `400`) unless
+//!    `allow_unverified: true` is set OR the bundle was verified in step 2
+//!    (a valid signature satisfies the checksum requirement on its own — see
+//!    `plugin_source.rs`'s module docs).
+//!
+//! So `POST /install` with a bare `{"type":"url","url":"..."}` body no
+//! longer just downloads and trusts any tar.gz from any host.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/errors.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/errors.rs
@@ -24,7 +24,15 @@
 //! | `ArtifactVerificationFailed`  | 400 |
 //! | `BundleVerificationFailed`    | 400 |
 //! | `ChecksumRequired`            | 400 |
+//! | `UntrustedHost`               | 403 |
+//! | `UnsignedOrUntrustedSignature`| 403 |
 //! | `Registration` / `Io` / `Json` / `NotImplemented` | 500 |
+//!
+//! `UntrustedHost`/`UnsignedOrUntrustedSignature` are mapped to 403 rather
+//! than 400 (unlike the checksum/manifest variants above): both are
+//! source-TRUST/authorization refusals — "you may not install from here /
+//! from this publisher without an explicit opt-out" — not a malformed
+//! request, which 403 fits better than 400.
 //!
 //! `Io`/`Json` are bucketed with `Registration` under 500 rather than 400
 //! even though they can originate from a caller-supplied plugin bundle
@@ -75,6 +83,10 @@ pub fn plugin_error_response(error: &PluginError) -> HttpResponse {
         }
         PluginError::BundleVerificationFailed(_) => Some(actix_web::http::StatusCode::BAD_REQUEST),
         PluginError::ChecksumRequired(_) => Some(actix_web::http::StatusCode::BAD_REQUEST),
+        PluginError::UntrustedHost(_) => Some(actix_web::http::StatusCode::FORBIDDEN),
+        PluginError::UnsignedOrUntrustedSignature(_) => {
+            Some(actix_web::http::StatusCode::FORBIDDEN)
+        }
         PluginError::Registration(_)
         | PluginError::NotImplemented(_)
         | PluginError::Io(_)
@@ -145,6 +157,14 @@ mod tests {
             (
                 PluginError::ChecksumRequired("refusing to install without a checksum".to_string()),
                 StatusCode::BAD_REQUEST,
+            ),
+            (
+                PluginError::UntrustedHost("host not in trusted_hosts".to_string()),
+                StatusCode::FORBIDDEN,
+            ),
+            (
+                PluginError::UnsignedOrUntrustedSignature("bundle is unsigned".to_string()),
+                StatusCode::FORBIDDEN,
             ),
             (
                 PluginError::Registration("config write failed".to_string()),

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/errors.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/errors.rs
@@ -26,13 +26,16 @@
 //! | `ChecksumRequired`            | 400 |
 //! | `UntrustedHost`               | 403 |
 //! | `UnsignedOrUntrustedSignature`| 403 |
+//! | `RedirectRefused`             | 403 |
 //! | `Registration` / `Io` / `Json` / `NotImplemented` | 500 |
 //!
-//! `UntrustedHost`/`UnsignedOrUntrustedSignature` are mapped to 403 rather
-//! than 400 (unlike the checksum/manifest variants above): both are
-//! source-TRUST/authorization refusals — "you may not install from here /
-//! from this publisher without an explicit opt-out" — not a malformed
-//! request, which 403 fits better than 400.
+//! `UntrustedHost`/`UnsignedOrUntrustedSignature`/`RedirectRefused` are
+//! mapped to 403 rather than 400 (unlike the checksum/manifest variants
+//! above): all three are source-TRUST/authorization refusals — "you may not
+//! install from here / from this publisher / by following a redirect off the
+//! approved host without an explicit opt-out" — not a malformed request, and
+//! not a server bug (a redirect refusal must never look like a 500), which
+//! 403 fits better than either 400 or 500.
 //!
 //! `Io`/`Json` are bucketed with `Registration` under 500 rather than 400
 //! even though they can originate from a caller-supplied plugin bundle
@@ -87,6 +90,7 @@ pub fn plugin_error_response(error: &PluginError) -> HttpResponse {
         PluginError::UnsignedOrUntrustedSignature(_) => {
             Some(actix_web::http::StatusCode::FORBIDDEN)
         }
+        PluginError::RedirectRefused(_) => Some(actix_web::http::StatusCode::FORBIDDEN),
         PluginError::Registration(_)
         | PluginError::NotImplemented(_)
         | PluginError::Io(_)
@@ -164,6 +168,10 @@ mod tests {
             ),
             (
                 PluginError::UnsignedOrUntrustedSignature("bundle is unsigned".to_string()),
+                StatusCode::FORBIDDEN,
+            ),
+            (
+                PluginError::RedirectRefused("refused to follow a redirect".to_string()),
                 StatusCode::FORBIDDEN,
             ),
             (

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/handlers.rs
@@ -25,10 +25,13 @@ fn plugins_root(state: &AppState) -> PathBuf {
 
 /// The wire `SourceSpec` reuses `bamboo_plugin::PluginSource`'s own serde
 /// shape (see `api_types` module docs) directly as the request body — a
-/// `url` source's `sha256`/`allow_unverified` flow straight through to
-/// `PluginSourceInput::Url`, which `plugin_source::fetch_manifest_bundle`
-/// enforces (secure by default: verify-if-given, refuse-if-absent-unless-
-/// explicitly-allowed — see that module's docs).
+/// `url` source's `sha256`/`allow_unverified`/`allow_untrusted_host`/
+/// `allow_unsigned` flow straight through to `PluginSourceInput::Url`, which
+/// `plugin_source::fetch_manifest_bundle` enforces (the three-layer trust
+/// model: host allowlist, signature, checksum — see that module's docs).
+/// `signed_by` is a RESULT of staging (which key verified), never an input,
+/// so it's dropped here — the request-side `PluginSource::Url` field is
+/// meaningless on the way in and `fetch_manifest_bundle` recomputes it fresh.
 fn to_source_input(source: PluginSource) -> PluginSourceInput {
     match source {
         PluginSource::LocalDir { path } => PluginSourceInput::LocalDir(path),
@@ -37,10 +40,15 @@ fn to_source_input(source: PluginSource) -> PluginSourceInput {
             url,
             sha256,
             allow_unverified,
+            allow_untrusted_host,
+            allow_unsigned,
+            signed_by: _,
         } => PluginSourceInput::Url {
             url,
             sha256,
             allow_unverified,
+            allow_untrusted_host,
+            allow_unsigned,
         },
     }
 }
@@ -70,11 +78,13 @@ pub async fn install_plugin(
     let installer = ServerPluginInstaller::new(state.clone());
     let root = plugins_root(&state);
     let input = to_source_input(body.into_inner().source);
+    let trust = state.config.read().await.plugin_trust.clone();
 
     match install_plugin_from_source(
         &installer,
         input,
         &root,
+        &trust,
         InstallDisposition::FailIfInstalled,
     )
     .await
@@ -102,8 +112,9 @@ pub async fn update_plugin(
     let installer = ServerPluginInstaller::new(state.clone());
     let root = plugins_root(&state);
     let input = to_source_input(body.into_inner().source);
+    let trust = state.config.read().await.plugin_trust.clone();
 
-    let staged = match stage_plugin_source(input, &root).await {
+    let staged = match stage_plugin_source(input, &root, &trust).await {
         Ok(staged) => staged,
         Err(error) => return plugin_error_response(&error),
     };

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
@@ -396,7 +396,24 @@ fn sha256_hex_of(bytes: &[u8]) -> String {
     hex::encode(hasher.finalize())
 }
 
+/// Checksum-layer-only test helper (see the module docs on the three trust
+/// layers): bypasses the host-allowlist + signature layers
+/// (`allow_untrusted_host: true, allow_unsigned: true`), since every
+/// `wiremock` server in this file is plain `http://127.0.0.1:<port>` (never
+/// `https`, never in `plugin_trust.trusted_hosts`) and never mounts a `.sig`
+/// route. The host-allowlist layer gets its own dedicated test below using
+/// `url_source_full` (which does NOT bypass it).
 fn url_source(url: &str, sha256: Option<&str>, allow_unverified: bool) -> serde_json::Value {
+    url_source_full(url, sha256, allow_unverified, true, true)
+}
+
+fn url_source_full(
+    url: &str,
+    sha256: Option<&str>,
+    allow_unverified: bool,
+    allow_untrusted_host: bool,
+    allow_unsigned: bool,
+) -> serde_json::Value {
     let mut source = serde_json::json!({ "type": "url", "url": url });
     if let Some(sha) = sha256 {
         source["sha256"] = serde_json::Value::String(sha.to_string());
@@ -404,23 +421,78 @@ fn url_source(url: &str, sha256: Option<&str>, allow_unverified: bool) -> serde_
     if allow_unverified {
         source["allow_unverified"] = serde_json::Value::Bool(true);
     }
+    if allow_untrusted_host {
+        source["allow_untrusted_host"] = serde_json::Value::Bool(true);
+    }
+    if allow_unsigned {
+        source["allow_unsigned"] = serde_json::Value::Bool(true);
+    }
     serde_json::json!({ "source": source })
 }
 
-/// The core "secure by default" behavior this whole feature is about:
-/// `POST /install` with a bare `{"type":"url","url":"..."}` (no `sha256`, no
-/// `allow_unverified`) must be refused with an actionable 400 — NOT silently
-/// download and trust whatever tar.gz sits at that URL. Uses a `wiremock`
-/// server with no mounted responder at all, so a bug that fetched before
-/// refusing would surface as an unmatched-request panic instead of quietly
-/// passing.
+/// Source-TRUST layer 1 (host allowlist): `POST /install` with a `url` source
+/// whose host is not in `plugin_trust.trusted_hosts` (the default is
+/// `["github.com/bigduu/"]`; a local `wiremock` server never matches) must be
+/// refused with an actionable 403 — BEFORE the URL is ever fetched. Uses a
+/// `wiremock` server with no mounted responder at all, so a bug that fetched
+/// before refusing would surface as an unmatched-request panic instead of
+/// quietly passing.
 #[actix_web::test]
-async fn install_url_with_no_checksum_or_allow_unverified_returns_400_before_fetch() {
+async fn install_url_with_untrusted_host_returns_403_before_fetch() {
     let data_dir = tempfile::tempdir().unwrap();
     let state = test_state(data_dir.path()).await;
     let app = test::init_service(plugin_test_app!(state.clone())).await;
 
     let server = wiremock::MockServer::start().await;
+    let url = format!("{}/plugin.json", server.uri());
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/plugins/install")
+        .set_json(url_source_full(&url, None, false, false, false))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let error = body_json(resp).await;
+    let message = error["error"].as_str().unwrap();
+    assert!(message.contains("trusted_hosts"), "{message}");
+    assert!(
+        message.contains("allow_untrusted_host") || message.contains("allow-untrusted-host"),
+        "{message}"
+    );
+
+    // Nothing installed.
+    let req = test::TestRequest::get().uri("/api/v1/plugins").to_request();
+    let resp = test::call_service(&app, req).await;
+    let listed = body_json(resp).await;
+    assert!(listed["plugins"].as_array().unwrap().is_empty());
+
+    // The refusal happened before the URL was ever fetched.
+    let received = server.received_requests().await;
+    assert_eq!(received.map(|r| r.len()), Some(0));
+}
+
+/// Source-TRUST layer 3 (checksum), isolated from layers 1/2 via
+/// `allow_untrusted_host`/`allow_unsigned`: `POST /install` with neither
+/// `sha256` nor `allow_unverified` on a genuinely unsigned bundle must still
+/// be refused with an actionable 400 — the core "secure by default" behavior
+/// this whole feature started with. Unlike the host-layer test above, this
+/// one DOES fetch the bundle (and attempts its `.sig`) before refusing — see
+/// `plugin_source.rs`'s module docs on why the checksum gate can no longer
+/// run before any network access now that a valid signature can supersede it.
+#[actix_web::test]
+async fn install_url_with_no_checksum_or_allow_unverified_returns_400_after_host_and_signature_pass(
+) {
+    let data_dir = tempfile::tempdir().unwrap();
+    let state = test_state(data_dir.path()).await;
+    let app = test::init_service(plugin_test_app!(state.clone())).await;
+
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
     let url = format!("{}/plugin.json", server.uri());
 
     let req = test::TestRequest::post()
@@ -439,10 +511,6 @@ async fn install_url_with_no_checksum_or_allow_unverified_returns_400_before_fet
     let resp = test::call_service(&app, req).await;
     let listed = body_json(resp).await;
     assert!(listed["plugins"].as_array().unwrap().is_empty());
-
-    // The refusal happened before the URL was ever fetched.
-    let received = server.received_requests().await;
-    assert_eq!(received.map(|r| r.len()), Some(0));
 }
 
 #[actix_web::test]

--- a/crates/app/bamboo-server/src/plugin_source.rs
+++ b/crates/app/bamboo-server/src/plugin_source.rs
@@ -40,6 +40,14 @@
 //!   if the attacker controls the page the checksum was copied from — which
 //!   is why layers 1 and 2 exist independently of layer 3.
 //!
+//!   Byte-authenticity note: the host allowlist only vets the FIRST hop's
+//!   `<host><path>`, not wherever an HTTP redirect might lead — a signature
+//!   or checksum is what actually authenticates the downloaded bytes, so
+//!   redirects are followed whenever either will be checked, but disabled
+//!   entirely for the fully-opted-out `allow_unsigned && sha256.is_none()`
+//!   case, where the host allowlist is the sole control (see
+//!   [`http_client_no_redirects`]).
+//!
 //!   THEN, separately, for [`Platform::current`] (if the manifest declares an
 //!   artifact for it), fetches the per-platform binary archive named in
 //!   `manifest.artifacts`, verifies its sha256 BEFORE unpacking (mandatory —
@@ -494,11 +502,31 @@ async fn fetch_manifest_bundle(
         );
     }
 
-    let bytes = download_bytes(url).await?;
+    // Redirect policy (BLOCKER 1 fix): whether the downloaded bytes WILL be
+    // cryptographically authenticated determines whether it's safe to follow
+    // a redirect. A signature is REQUIRED whenever `!allow_unsigned` — even
+    // though it hasn't been fetched/checked yet, an unverified-but-required
+    // signature refuses the install below regardless of which host actually
+    // served the bytes, so following a redirect to get here is harmless.
+    // Likewise a supplied `sha256` is checked (and refused on mismatch) below
+    // regardless of the serving host. Only when NEITHER control is in play —
+    // `allow_unsigned` AND no `sha256` — is the host allowlist the SOLE
+    // authority over where these bytes came from; it only vetted this exact
+    // URL, so redirects must be disabled in that case (see
+    // `http_client_no_redirects`). The SAME client is used for both the
+    // bundle fetch and the `.sig` fetch below, for one install.
+    let bytes_will_be_authenticated = !allow_unsigned || sha256.is_some();
+    let client = if bytes_will_be_authenticated {
+        http_client_following_redirects()
+    } else {
+        http_client_no_redirects()
+    };
+
+    let bytes = download_bytes(client, url, MAX_DOWNLOAD_BYTES).await?;
 
     // Layer 2: signature — a valid signature is a STRONGER integrity +
     // authenticity guarantee than a pasted checksum (see layer 3 below).
-    let signed_by = fetch_and_verify_signature(url, &bytes, &trust.trusted_keys).await;
+    let signed_by = fetch_and_verify_signature(client, url, &bytes, &trust.trusted_keys).await;
     if signed_by.is_none() {
         if !allow_unsigned {
             return Err(PluginError::UnsignedOrUntrustedSignature(format!(
@@ -582,12 +610,21 @@ async fn fetch_manifest_bundle(
 /// not be distinguishable from "genuinely unsigned" by anything this
 /// function returns.
 async fn fetch_and_verify_signature(
+    client: &reqwest::Client,
     url: &str,
     bundle_bytes: &[u8],
     trusted_keys: &[bamboo_config::TrustedKey],
 ) -> Option<String> {
+    // Plain release-asset URLs (no query string) are the supported case: this
+    // just appends `.sig`, which would misplace the suffix AFTER a query
+    // string on a URL like `.../plugin.json?token=...` (`.../plugin.json?token=....sig`,
+    // not the sidecar). Plugin bundle URLs are typically bare release-asset
+    // URLs with no query string; if that ever needs to change, insert `.sig`
+    // before the `?` instead of blindly appending it.
     let sig_url = format!("{url}.sig");
-    let sig_bytes = download_bytes(&sig_url).await.ok()?;
+    let sig_bytes = download_bytes(client, &sig_url, MAX_SIGNATURE_DOWNLOAD_BYTES)
+        .await
+        .ok()?;
     let sig_text = String::from_utf8(sig_bytes).ok()?;
     let sig_raw = hex::decode(sig_text.trim()).ok()?;
     let sig_array: [u8; 64] = sig_raw.try_into().ok()?;
@@ -640,7 +677,16 @@ async fn fetch_and_place_artifact(
         return Ok(());
     };
 
-    let bytes = download_bytes(&artifact.url).await?;
+    // The artifact's sha256 is verified BELOW, unconditionally (no bypass
+    // flag exists for it — see this function's docs) — the downloaded bytes
+    // are always cryptographically authenticated here, so redirects are
+    // always safe to follow for this fetch.
+    let bytes = download_bytes(
+        http_client_following_redirects(),
+        &artifact.url,
+        MAX_DOWNLOAD_BYTES,
+    )
+    .await?;
     let actual_sha256 = sha256_hex(&bytes);
     if !actual_sha256.eq_ignore_ascii_case(&artifact.sha256) {
         return Err(PluginError::ArtifactVerificationFailed(format!(
@@ -706,12 +752,42 @@ async fn move_file(source: &Path, dest: &Path) -> PluginResult<()> {
 // HTTP fetch
 // ---------------------------------------------------------------------
 
-/// One shared `reqwest::Client` for plugin source fetches. Reuses the
-/// workspace's pinned (native-tls) `reqwest` — never construct a second
-/// client/connector here (see `notify_sinks::ntfy`'s identical pattern).
-fn http_client() -> &'static reqwest::Client {
+/// Client used whenever the downloaded bytes WILL be cryptographically
+/// authenticated — a signature is required (`!allow_unsigned`) or a `sha256`
+/// pin was supplied. Following redirects is safe here: whichever host
+/// actually served the final bytes, the signature/checksum check downstream
+/// refuses on a bad result regardless — this is what lets the default
+/// official-signed-via-CDN flow (GitHub Releases 302-redirecting to
+/// `objects.githubusercontent.com`) and the checksummed flow keep working.
+/// Reuses the workspace's pinned (native-tls) `reqwest` — never construct a
+/// second client/connector here (see `notify_sinks::ntfy`'s identical
+/// pattern).
+fn http_client_following_redirects() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT.get_or_init(reqwest::Client::new)
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::limited(10))
+            .build()
+            .expect("a reqwest client with only a redirect policy set always builds")
+    })
+}
+
+/// Client used whenever NEITHER a signature nor a checksum will authenticate
+/// the downloaded bytes (`allow_unsigned && sha256.is_none()` — the fully
+/// opted-out "host-only trust" case). The host allowlist (layer 1) only
+/// vetted the FIRST hop's `<host><path>`; a transparent redirect would let
+/// the bytes actually come from anywhere, silently defeating the allowlist
+/// as the sole control. Redirects are disabled so a server that tries to
+/// redirect is refused outright (see [`download_bytes`]) rather than quietly
+/// followed — the approved host must serve the bytes directly.
+fn http_client_no_redirects() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("a reqwest client with only a redirect policy set always builds")
+    })
 }
 
 /// Hard ceiling on any single plugin download (manifest, bundle, or binary
@@ -719,6 +795,14 @@ fn http_client() -> &'static reqwest::Client {
 /// stream an unbounded body into memory (OOM DoS). 256 MiB is generous for a
 /// plugin bundle + one platform binary while still bounding the worst case.
 const MAX_DOWNLOAD_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Hard ceiling on the `.sig` sidecar fetch specifically ([`fetch_and_verify_signature`]).
+/// A valid signature is exactly 128 hex chars (a raw 64-byte ed25519
+/// signature, hex-encoded) — 4 KiB is already wildly generous. Capping it far
+/// below [`MAX_DOWNLOAD_BYTES`] means a malicious/misconfigured host serving
+/// a `.sig` route can't force multiple hundreds of MiB into memory before the
+/// hex-decode simply fails on the (way too long) body.
+const MAX_SIGNATURE_DOWNLOAD_BYTES: u64 = 4 * 1024;
 
 /// Hard ceiling on the TOTAL decompressed bytes any single archive (zip or
 /// tar.gz) may expand to across ALL of its entries combined. Complements
@@ -735,13 +819,38 @@ const MAX_DOWNLOAD_BYTES: u64 = 256 * 1024 * 1024;
 /// plus, at most, one platform binary) while still bounding the worst case.
 const MAX_DECOMPRESSED_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 
-async fn download_bytes(url: &str) -> PluginResult<Vec<u8>> {
+/// Fetch `url` via `client`, capping the body at `max_bytes`. `client`'s
+/// redirect policy is the caller's decision (see
+/// [`http_client_following_redirects`] / [`http_client_no_redirects`]) — this
+/// function additionally refuses outright if the FINAL response it receives
+/// is itself still a redirect (3xx), which only happens when `client` was
+/// built with `redirect::Policy::none()` and the server actually tried to
+/// redirect: that means the request's trust flags decided the bytes must
+/// come from the vetted host directly (see BLOCKER 1 in the source-trust
+/// review / the module docs), so silently treating the redirect response
+/// as the payload would defeat that decision.
+async fn download_bytes(
+    client: &reqwest::Client,
+    url: &str,
+    max_bytes: u64,
+) -> PluginResult<Vec<u8>> {
     use futures::StreamExt;
 
     let response =
-        http_client().get(url).send().await.map_err(|error| {
+        client.get(url).send().await.map_err(|error| {
             PluginError::Registration(format!("failed to fetch '{url}': {error}"))
         })?;
+
+    if response.status().is_redirection() {
+        return Err(PluginError::Registration(format!(
+            "'{url}' responded with a redirect ({status}) instead of serving the bytes \
+             directly, and this fetch does not follow redirects — neither a signature nor a \
+             checksum will authenticate these bytes, so the host allowlist is the sole trust \
+             control and must not be defeated by a redirect to an unvetted host; refusing",
+            status = response.status(),
+        )));
+    }
+
     let response = response.error_for_status().map_err(|error| {
         PluginError::Registration(format!("'{url}' returned an error status: {error}"))
     })?;
@@ -749,10 +858,10 @@ async fn download_bytes(url: &str) -> PluginResult<Vec<u8>> {
     // Reject up front if the server ADVERTISES an over-cap body (cheap, avoids
     // streaming at all)...
     if let Some(len) = response.content_length() {
-        if len > MAX_DOWNLOAD_BYTES {
+        if len > max_bytes {
             return Err(PluginError::Registration(format!(
-                "'{url}' advertises a {len}-byte body, over the {MAX_DOWNLOAD_BYTES}-byte plugin \
-                 download cap; refusing"
+                "'{url}' advertises a {len}-byte body, over the {max_bytes}-byte download cap; \
+                 refusing"
             )));
         }
     }
@@ -765,10 +874,9 @@ async fn download_bytes(url: &str) -> PluginResult<Vec<u8>> {
         let chunk = chunk.map_err(|error| {
             PluginError::Registration(format!("failed to read response body of '{url}': {error}"))
         })?;
-        if buffer.len() as u64 + chunk.len() as u64 > MAX_DOWNLOAD_BYTES {
+        if buffer.len() as u64 + chunk.len() as u64 > max_bytes {
             return Err(PluginError::Registration(format!(
-                "'{url}' streamed more than the {MAX_DOWNLOAD_BYTES}-byte plugin download cap; \
-                 aborting"
+                "'{url}' streamed more than the {max_bytes}-byte download cap; aborting"
             )));
         }
         buffer.extend_from_slice(&chunk);

--- a/crates/app/bamboo-server/src/plugin_source.rs
+++ b/crates/app/bamboo-server/src/plugin_source.rs
@@ -822,13 +822,14 @@ const MAX_DECOMPRESSED_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 /// Fetch `url` via `client`, capping the body at `max_bytes`. `client`'s
 /// redirect policy is the caller's decision (see
 /// [`http_client_following_redirects`] / [`http_client_no_redirects`]) — this
-/// function additionally refuses outright if the FINAL response it receives
-/// is itself still a redirect (3xx), which only happens when `client` was
-/// built with `redirect::Policy::none()` and the server actually tried to
-/// redirect: that means the request's trust flags decided the bytes must
-/// come from the vetted host directly (see BLOCKER 1 in the source-trust
-/// review / the module docs), so silently treating the redirect response
-/// as the payload would defeat that decision.
+/// function additionally refuses outright, with [`PluginError::RedirectRefused`]
+/// (a clean 403-family trust refusal, NOT a 500), if the FINAL response it
+/// receives is itself still a redirect (3xx), which only happens when
+/// `client` was built with `redirect::Policy::none()` and the server actually
+/// tried to redirect: that means the request's trust flags decided the bytes
+/// must come from the vetted host directly (see BLOCKER 1 in the source-trust
+/// review / the module docs), so silently treating the redirect response as
+/// the payload would defeat that decision.
 async fn download_bytes(
     client: &reqwest::Client,
     url: &str,
@@ -842,12 +843,24 @@ async fn download_bytes(
         })?;
 
     if response.status().is_redirection() {
-        return Err(PluginError::Registration(format!(
-            "'{url}' responded with a redirect ({status}) instead of serving the bytes \
-             directly, and this fetch does not follow redirects — neither a signature nor a \
-             checksum will authenticate these bytes, so the host allowlist is the sole trust \
-             control and must not be defeated by a redirect to an unvetted host; refusing",
-            status = response.status(),
+        let status = response.status();
+        // Surface the redirect TARGET (host) so the caller can decide whether
+        // to trust it / add it to `trusted_hosts` — a redirect with no
+        // `Location`, or one whose value isn't valid UTF-8, degrades to a
+        // generic "(unspecified)" rather than failing differently.
+        let location = response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
+        let target = location.as_deref().unwrap_or("(unspecified)");
+        return Err(PluginError::RedirectRefused(format!(
+            "refused to follow an HTTP redirect ({status}) from '{url}' to '{target}': for an \
+             unverified install (no signature, no checksum) the approved host must serve the \
+             bytes directly, so redirects are not followed — install from the canonical/final \
+             URL, or provide a signature / `--sha256` (which authenticates the bytes regardless \
+             of which host serves them), or add the redirect target's host to \
+             `plugin_trust.trusted_hosts`"
         )));
     }
 

--- a/crates/app/bamboo-server/src/plugin_source.rs
+++ b/crates/app/bamboo-server/src/plugin_source.rs
@@ -15,21 +15,42 @@
 //!   `plugin.json`, content-only and typically an MCP server backed entirely
 //!   by a downloadable binary — e.g. a nova-style plugin with no bundled
 //!   skills/prompts — or an archive containing one, same flattening rule as
-//!   `LocalArchive`). **Secure by default**: the downloaded bundle bytes are
-//!   verified against a caller-supplied `sha256` BEFORE anything is
-//!   extracted or parsed; if no `sha256` was given, the fetch is refused
-//!   outright unless the caller explicitly set `allow_unverified` (see
-//!   [`PluginSourceInput::Url`]'s fields and [`fetch_manifest_bundle`]). THEN,
-//!   separately, for [`Platform::current`] (if the manifest declares an
+//!   `LocalArchive`). **Three trust layers, stacked, enforced in
+//!   [`fetch_manifest_bundle`] in this order:**
+//!
+//!   1. **Host allowlist (source authorization)** — is the URL's `<host><path>`
+//!      one the operator has trusted (`bamboo_config::PluginTrustConfig::trusted_hosts`)?
+//!      Refused BEFORE any network access ([`PluginError::UntrustedHost`])
+//!      unless `allow_untrusted_host` is set.
+//!   2. **Signature (publisher authenticity)** — after the bundle is
+//!      downloaded, does its `<url>.sig` sidecar (a raw 64-byte ed25519
+//!      signature, hex-encoded, over the exact bundle bytes) verify against
+//!      any `bamboo_config::TrustedKey` in `trusted_keys`? Refused
+//!      ([`PluginError::UnsignedOrUntrustedSignature`]) unless `allow_unsigned`
+//!      is set.
+//!   3. **Checksum (integrity)** — same sha256 pin as before, EXCEPT a
+//!      verified signature from layer 2 already proves integrity+authenticity
+//!      more strongly than a pasted hash could, so it SATISFIES this layer's
+//!      requirement even with neither `sha256` nor `allow_unverified` given
+//!      (an `allow_unsigned` bypass grants no such credit — an unsigned
+//!      install still needs its own sha256/allow_unverified exactly as
+//!      before). See [`fetch_manifest_bundle`] for the precise precedence.
+//!
+//!   A pasted checksum ALONE never establishes source trust — it is circular
+//!   if the attacker controls the page the checksum was copied from — which
+//!   is why layers 1 and 2 exist independently of layer 3.
+//!
+//!   THEN, separately, for [`Platform::current`] (if the manifest declares an
 //!   artifact for it), fetches the per-platform binary archive named in
 //!   `manifest.artifacts`, verifies its sha256 BEFORE unpacking (mandatory —
 //!   a URL plugin ships a binary that gets executed), and places the single
 //!   expected executable at `bin/<platform>/<id>[.exe]` per
-//!   [`bamboo_plugin::manifest::PluginArtifact`]'s archive contract. Both
-//!   checks stay: the bundle-sha256 check is the new root-of-trust pin (it
-//!   closes the gap where the artifact's own declared hash lives inside the
-//!   very bundle that could be tampered with); the artifact-sha256 check
-//!   remains as defense in depth for the binary specifically.
+//!   [`bamboo_plugin::manifest::PluginArtifact`]'s archive contract. This
+//!   artifact-sha256 check is unaffected by the host/signature layers above
+//!   (the artifact URL is declared inside a manifest that has ALREADY passed
+//!   all three trust layers) — it remains defense in depth for the binary
+//!   specifically, closing the gap where the artifact's own declared hash
+//!   lives inside the bundle that carries it.
 //!
 //! All three paths run the SAME safety checks: [`PluginManifest::validate`]
 //! before anything is committed to `plugins_dir()`, and path-traversal-safe
@@ -81,14 +102,17 @@
 //!   the URL is ever requested — with [`PluginError::ChecksumRequired`]. A
 //!   URL install can therefore no longer just download-and-trust any
 //!   tar.gz. The verified bundle sha256 (not the binary artifact's) is what
-//!   `PluginSource::Url.sha256` records for provenance/audit. Still
-//!   deferred:
-//!   - **Signature verification.** A sha256 pin only proves "this is the
-//!     bytes the installer expected", not "an entity I trust produced
-//!     them" — the hash itself still has to come from somewhere the caller
-//!     trusts (a release page, a signed index, etc.). A real signature
-//!     scheme (e.g. minisign/sigstore over the bundle) would remove that
-//!     remaining hop.
+//!   `PluginSource::Url.sha256` records for provenance/audit.
+//! - **Source-TRUST layer: IMPLEMENTED** (host allowlist + ed25519 publisher
+//!   signature — see the module-level "three trust layers" summary above and
+//!   [`fetch_manifest_bundle`]). A sha256 pin alone only proves "this is the
+//!   bytes the installer expected", not "an entity I trust produced them" —
+//!   and worse, a checksum pasted from the SAME page as a malicious URL is
+//!   circular, proving nothing about the source. `bamboo_config::PluginTrustConfig`
+//!   (`trusted_hosts` + `trusted_keys`, both user-editable in `config.json`)
+//!   closes that: a URL install now also needs an operator-trusted host and
+//!   (absent `allow_unsigned`) a bundle signature verifying against a trusted
+//!   key. Still deferred:
 //!   - **SSRF guard**, described next.
 //! - **No SSRF guard on URL fetch.** [`download_bytes`] will fetch any URL,
 //!   including `http://169.254.169.254/...` (cloud metadata) or private-range
@@ -118,11 +142,13 @@
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
+use bamboo_config::PluginTrustConfig;
 use bamboo_plugin::manifest::Platform;
 use bamboo_plugin::{
     InstallDisposition, InstalledPlugin, PluginError, PluginInstaller, PluginManifest,
     PluginResult, PluginSource,
 };
+use ed25519_dalek::Verifier;
 
 /// What the caller pointed the installer at.
 #[derive(Debug, Clone)]
@@ -133,16 +159,24 @@ pub enum PluginSourceInput {
     /// (at its root, or under a single top-level directory).
     LocalArchive(PathBuf),
     /// A URL to either a bare `plugin.json` or an archive containing one
-    /// (same root-or-single-subdir rule as `LocalArchive`). Secure by
-    /// default: `sha256`, when given, pins the downloaded bundle's exact
-    /// bytes (verified before anything is extracted/parsed — see
-    /// [`fetch_manifest_bundle`]); with no `sha256`, the fetch is refused
-    /// unless `allow_unverified` is `true` (an explicit, logged opt-out of
-    /// verification — see [`PluginError::ChecksumRequired`]).
+    /// (same root-or-single-subdir rule as `LocalArchive`). Three trust
+    /// layers, all enforced in [`fetch_manifest_bundle`] (see the module
+    /// docs' "three trust layers" summary):
+    ///
+    /// - `allow_untrusted_host`: opt out of the host allowlist
+    ///   (`bamboo_config::PluginTrustConfig::trusted_hosts`) — see
+    ///   [`PluginError::UntrustedHost`].
+    /// - `allow_unsigned`: opt out of requiring the bundle's `.sig` to verify
+    ///   against a trusted key — see [`PluginError::UnsignedOrUntrustedSignature`].
+    /// - `sha256`/`allow_unverified`: the checksum layer, unchanged from
+    ///   before EXCEPT a verified signature now also satisfies it (see
+    ///   [`fetch_manifest_bundle`]) — see [`PluginError::ChecksumRequired`].
     Url {
         url: String,
         sha256: Option<String>,
         allow_unverified: bool,
+        allow_untrusted_host: bool,
+        allow_unsigned: bool,
     },
 }
 
@@ -191,8 +225,9 @@ impl StagedPlugin {
 pub async fn stage_plugin_source(
     input: PluginSourceInput,
     plugins_root: &Path,
+    trust: &PluginTrustConfig,
 ) -> PluginResult<StagedPlugin> {
-    stage_plugin_source_inner(input, plugins_root, MAX_DECOMPRESSED_BYTES).await
+    stage_plugin_source_inner(input, plugins_root, trust, MAX_DECOMPRESSED_BYTES).await
 }
 
 /// Test-only seam for [`stage_plugin_source`] that lets a test inject a small
@@ -204,21 +239,23 @@ pub async fn stage_plugin_source(
 pub(crate) async fn stage_plugin_source_with_decompressed_cap(
     input: PluginSourceInput,
     plugins_root: &Path,
+    trust: &PluginTrustConfig,
     max_decompressed_bytes: u64,
 ) -> PluginResult<StagedPlugin> {
-    stage_plugin_source_inner(input, plugins_root, max_decompressed_bytes).await
+    stage_plugin_source_inner(input, plugins_root, trust, max_decompressed_bytes).await
 }
 
 async fn stage_plugin_source_inner(
     input: PluginSourceInput,
     plugins_root: &Path,
+    trust: &PluginTrustConfig,
     max_decompressed_bytes: u64,
 ) -> PluginResult<StagedPlugin> {
     tokio::fs::create_dir_all(plugins_root).await?;
     let staging_dir = plugins_root.join(format!(".staging-{}", uuid::Uuid::new_v4()));
     tokio::fs::create_dir_all(&staging_dir).await?;
 
-    let staged = stage_into(&input, &staging_dir, max_decompressed_bytes).await;
+    let staged = stage_into(&input, &staging_dir, trust, max_decompressed_bytes).await;
     let (manifest, source) = match staged {
         Ok(pair) => pair,
         Err(error) => {
@@ -274,9 +311,10 @@ pub async fn install_plugin_from_source(
     installer: &dyn PluginInstaller,
     input: PluginSourceInput,
     plugins_root: &Path,
+    trust: &PluginTrustConfig,
     disposition: InstallDisposition,
 ) -> PluginResult<InstalledPlugin> {
-    let staged = stage_plugin_source(input, plugins_root).await?;
+    let staged = stage_plugin_source(input, plugins_root, trust).await?;
     let manifest = staged.manifest.clone();
     let plugin_dir = staged.plugin_dir.clone();
     let source = staged.source.clone();
@@ -305,6 +343,7 @@ pub async fn install_plugin_from_source(
 async fn stage_into(
     input: &PluginSourceInput,
     staging_dir: &Path,
+    trust: &PluginTrustConfig,
     max_decompressed_bytes: u64,
 ) -> PluginResult<(PluginManifest, PluginSource)> {
     match input {
@@ -336,15 +375,18 @@ async fn stage_into(
             url,
             sha256,
             allow_unverified,
+            allow_untrusted_host,
+            allow_unsigned,
         } => {
-            let (manifest, verified_bundle_sha256) = fetch_manifest_bundle(
-                url,
-                sha256.as_deref(),
-                *allow_unverified,
-                staging_dir,
-                max_decompressed_bytes,
-            )
-            .await?;
+            let flags = UrlTrustFlags {
+                sha256: sha256.as_deref(),
+                allow_unverified: *allow_unverified,
+                allow_untrusted_host: *allow_untrusted_host,
+                allow_unsigned: *allow_unsigned,
+            };
+            let (manifest, verified_bundle_sha256, signed_by) =
+                fetch_manifest_bundle(url, flags, trust, staging_dir, max_decompressed_bytes)
+                    .await?;
             // Binary-artifact verification stays as defense in depth (see
             // the module docs) — its own sha256, declared inside the
             // now-verified manifest, is checked in
@@ -358,6 +400,9 @@ async fn stage_into(
                     url: url.clone(),
                     sha256: verified_bundle_sha256,
                     allow_unverified: *allow_unverified,
+                    allow_untrusted_host: *allow_untrusted_host,
+                    allow_unsigned: *allow_unsigned,
+                    signed_by,
                 },
             ))
         }
@@ -368,34 +413,110 @@ async fn stage_into(
 // Manifest bundle fetch (URL source)
 // ---------------------------------------------------------------------
 
+/// The caller-supplied bits of a [`PluginSourceInput::Url`] that
+/// [`fetch_manifest_bundle`] needs, grouped into one struct purely to keep
+/// that function's parameter count sane (`PluginSourceInput::Url` itself
+/// carries the same four fields, plus `url`, which stays a separate
+/// top-level parameter since [`fetch_and_verify_signature`] and the sha256
+/// helpers all key off it directly).
+struct UrlTrustFlags<'a> {
+    sha256: Option<&'a str>,
+    allow_unverified: bool,
+    allow_untrusted_host: bool,
+    allow_unsigned: bool,
+}
+
 /// Fetch `url`: either a bare `plugin.json` or an archive containing one
 /// (same root-or-single-subdir rule as [`PluginSourceInput::LocalArchive`]).
 /// Populates `staging_dir` with whatever the bundle contains (just
 /// `plugin.json` for a bare manifest; the full skills/prompts/workflows tree
 /// for an archive).
 ///
-/// **Secure by default.** Before the URL is even requested: if `sha256` is
-/// `None` and `allow_unverified` is `false`, refuses with
-/// [`PluginError::ChecksumRequired`] — no network access happens for a
-/// refused install. If `sha256` IS given, the downloaded bytes are hashed
-/// and compared (case-insensitive) BEFORE any extraction/parsing; a
-/// mismatch is [`PluginError::BundleVerificationFailed`] and nothing is
-/// written beyond the (discarded) in-memory bytes. If `allow_unverified` is
-/// `true` and no `sha256` was given, the fetch proceeds but logs a
-/// `tracing::warn!` — an explicit, visible opt-out of verification, never a
-/// silent one.
+/// **Three trust layers, enforced in this order** (see the module docs'
+/// summary):
 ///
-/// Returns the parsed manifest and, when a `sha256` was supplied and
-/// confirmed, that verified hex digest (for [`PluginSource::Url`]
-/// provenance) — `None` only on the `allow_unverified`-with-no-hash path.
+/// 1. **Host allowlist.** Before the URL is even requested: if it is not
+///    `https` with a `<host><path>` matching one of `trust.trusted_hosts` as a
+///    prefix, refuses with [`PluginError::UntrustedHost`] — no network access
+///    happens for a refused install — unless `allow_untrusted_host` is `true`
+///    (logged).
+/// 2. **Signature.** Once the bundle is downloaded, `<url>.sig` is fetched
+///    (a missing/unreachable sidecar is treated identically to a malformed
+///    one — see [`fetch_and_verify_signature`]) and checked against every
+///    `algorithm: "ed25519"` entry in `trust.trusted_keys`. A match records
+///    that key's label; no match refuses with
+///    [`PluginError::UnsignedOrUntrustedSignature`] unless `allow_unsigned`
+///    is `true` (logged).
+/// 3. **Checksum.** If `sha256` is `None`, `allow_unverified` is `false`, AND
+///    the bundle was NOT signature-verified in step 2, refuses with
+///    [`PluginError::ChecksumRequired`] — a verified signature already proves
+///    integrity+authenticity more strongly than a pasted hash, so it
+///    satisfies this layer on its own (an `allow_unsigned` bypass grants no
+///    such credit: an unsigned install still needs its own
+///    `sha256`/`allow_unverified`, exactly as before this branch). If
+///    `sha256` IS given (signed or not), the downloaded bytes are still
+///    hashed and compared (case-insensitive) BEFORE any extraction/parsing —
+///    a mismatch is [`PluginError::BundleVerificationFailed`] regardless of
+///    signature status.
+///
+/// Returns the parsed manifest, the verified bundle sha256 (`None` unless a
+/// `sha256` was supplied and confirmed — for [`PluginSource::Url`]
+/// provenance), and the trusted key label the signature verified against
+/// (`None` if the install proceeded unsigned via `allow_unsigned`).
 async fn fetch_manifest_bundle(
     url: &str,
-    sha256: Option<&str>,
-    allow_unverified: bool,
+    flags: UrlTrustFlags<'_>,
+    trust: &PluginTrustConfig,
     staging_dir: &Path,
     max_decompressed_bytes: u64,
-) -> PluginResult<(PluginManifest, Option<String>)> {
-    if sha256.is_none() && !allow_unverified {
+) -> PluginResult<(PluginManifest, Option<String>, Option<String>)> {
+    let UrlTrustFlags {
+        sha256,
+        allow_unverified,
+        allow_untrusted_host,
+        allow_unsigned,
+    } = flags;
+
+    // Layer 1: host allowlist — refuse BEFORE any network access.
+    if !trust.is_host_trusted(url) {
+        if !allow_untrusted_host {
+            return Err(PluginError::UntrustedHost(format!(
+                "refusing to install plugin bundle from '{url}': its host is not in the \
+                 `plugin_trust.trusted_hosts` allowlist (config.json) — add a matching \
+                 host+path prefix there, or explicitly accept the risk (CLI: \
+                 `--allow-untrusted-host`; HTTP: `\"allow_untrusted_host\": true`)"
+            )));
+        }
+        tracing::warn!(
+            %url,
+            "installing plugin bundle from a host outside `plugin_trust.trusted_hosts` \
+             (allow_untrusted_host opt-out)"
+        );
+    }
+
+    let bytes = download_bytes(url).await?;
+
+    // Layer 2: signature — a valid signature is a STRONGER integrity +
+    // authenticity guarantee than a pasted checksum (see layer 3 below).
+    let signed_by = fetch_and_verify_signature(url, &bytes, &trust.trusted_keys).await;
+    if signed_by.is_none() {
+        if !allow_unsigned {
+            return Err(PluginError::UnsignedOrUntrustedSignature(format!(
+                "refusing to install plugin bundle from '{url}': it is unsigned, or its \
+                 '{url}.sig' does not verify against any key in `plugin_trust.trusted_keys` \
+                 (config.json) — publish a signature from a trusted key, or explicitly accept \
+                 the risk (CLI: `--allow-unsigned`; HTTP: `\"allow_unsigned\": true`)"
+            )));
+        }
+        tracing::warn!(
+            %url,
+            "installing an unsigned (or untrusted-signature) plugin bundle (allow_unsigned opt-out)"
+        );
+    }
+
+    // Layer 3: checksum — superseded by a verified signature (layer 2), but
+    // otherwise unchanged.
+    if sha256.is_none() && !allow_unverified && signed_by.is_none() {
         return Err(PluginError::ChecksumRequired(format!(
             "refusing to install plugin bundle from '{url}' without a checksum — pass the \
              bundle's sha256 (from the release page / a trusted source) to verify it before \
@@ -404,8 +525,6 @@ async fn fetch_manifest_bundle(
              `--allow-unverified`; HTTP: `\"allow_unverified\": true`)"
         )));
     }
-
-    let bytes = download_bytes(url).await?;
 
     let verified_sha256 = match sha256 {
         Some(expected) => {
@@ -420,11 +539,13 @@ async fn fetch_manifest_bundle(
             Some(actual)
         }
         None => {
-            tracing::warn!(
-                %url,
-                "installing plugin bundle from a URL with no checksum verification \
-                 (allow_unverified opt-out) — the download is trusted on HTTPS alone"
-            );
+            if signed_by.is_none() {
+                tracing::warn!(
+                    %url,
+                    "installing plugin bundle from a URL with no checksum verification \
+                     (allow_unverified opt-out) — the download is trusted on HTTPS alone"
+                );
+            }
             None
         }
     };
@@ -448,7 +569,48 @@ async fn fetch_manifest_bundle(
         PluginManifest::parse_str(&raw)?
     };
 
-    Ok((manifest, verified_sha256))
+    Ok((manifest, verified_sha256, signed_by))
+}
+
+/// Fetch `<url>.sig` and verify it against `bundle_bytes` for every
+/// `algorithm: "ed25519"` entry in `trusted_keys`. Returns the label of the
+/// FIRST trusted key the signature verifies against, or `None` if the
+/// sidecar is missing/unfetchable, malformed (not 128 hex chars — a raw
+/// 64-byte ed25519 signature, trailing whitespace trimmed), or does not
+/// verify against any trusted key. All of those failure modes are treated
+/// identically on purpose: an attacker serving a garbage/absent `.sig` must
+/// not be distinguishable from "genuinely unsigned" by anything this
+/// function returns.
+async fn fetch_and_verify_signature(
+    url: &str,
+    bundle_bytes: &[u8],
+    trusted_keys: &[bamboo_config::TrustedKey],
+) -> Option<String> {
+    let sig_url = format!("{url}.sig");
+    let sig_bytes = download_bytes(&sig_url).await.ok()?;
+    let sig_text = String::from_utf8(sig_bytes).ok()?;
+    let sig_raw = hex::decode(sig_text.trim()).ok()?;
+    let sig_array: [u8; 64] = sig_raw.try_into().ok()?;
+    let signature = ed25519_dalek::Signature::from_bytes(&sig_array);
+
+    for key in trusted_keys {
+        if !key.algorithm.eq_ignore_ascii_case("ed25519") {
+            continue;
+        }
+        let Ok(pub_raw) = hex::decode(&key.public_key) else {
+            continue;
+        };
+        let Ok(pub_array) = <[u8; 32]>::try_from(pub_raw.as_slice()) else {
+            continue;
+        };
+        let Ok(verifying_key) = ed25519_dalek::VerifyingKey::from_bytes(&pub_array) else {
+            continue;
+        };
+        if verifying_key.verify(bundle_bytes, &signature).is_ok() {
+            return Some(key.label.clone());
+        }
+    }
+    None
 }
 
 /// Per-platform binary artifact fetch (URL source only). Fetches the

--- a/crates/app/bamboo-server/src/plugin_source/tests.rs
+++ b/crates/app/bamboo-server/src/plugin_source/tests.rs
@@ -1230,6 +1230,167 @@ async fn allow_unsigned_bypasses_the_signature_check_but_not_the_checksum_layer(
 }
 
 // ---------------------------------------------------------------------
+// Redirect policy (BLOCKER 1 fix): the host allowlist only vets the FIRST
+// hop's `<host><path>`. Whether it's safe to transparently follow an HTTP
+// redirect to a DIFFERENT host depends on whether the downloaded bytes will
+// be cryptographically authenticated afterward (signature and/or checksum).
+// See `http_client_following_redirects` / `http_client_no_redirects` /
+// `download_bytes` in `plugin_source.rs`.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn host_only_trust_install_refuses_a_redirect_instead_of_following_it() {
+    // allow_unsigned + allow_unverified, no sha256: NEITHER crypto layer will
+    // authenticate the downloaded bytes, so the host allowlist would be the
+    // SOLE control on where they actually come from — which a transparent
+    // redirect defeats. `allow_untrusted_host: true` here isolates the
+    // REDIRECT-POLICY behavior specifically from the host-allowlist layer's
+    // own check, exactly like the checksum/signature sections above isolate
+    // theirs (this wiremock server is plain http, never in `trusted_hosts`
+    // anyway, so it needs the bypass just to reach the fetch at all).
+    let server = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(302)
+                .insert_header("Location", format!("{}/elsewhere.json", server.uri())),
+        )
+        .mount(&server)
+        .await;
+    // Deliberately NOT mounting `/elsewhere.json` — if the redirect were
+    // followed despite the no-redirect policy, wiremock itself would 404
+    // rather than this specific refusal firing; either way the install must
+    // not succeed, but asserting the exact error keeps this test honest
+    // about which failure mode it's covering.
+
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+
+    let error = stage_plugin_source(
+        url_input_full(&url, None, true, true, true),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err(
+        "a redirect must be refused when neither a signature nor a checksum will authenticate \
+         the downloaded bytes",
+    );
+    assert!(
+        matches!(error, PluginError::Registration(_)),
+        "expected a Registration refusal for the un-followed redirect, got {error:?}"
+    );
+    assert!(!plugins_root.join("hello-plugin").exists());
+}
+
+#[tokio::test]
+async fn checksummed_install_still_follows_a_redirect() {
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    let bundle_sha256 = sha256_hex_of(manifest_body.as_bytes());
+
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(302)
+                .insert_header("Location", format!("{}/actual-bundle.json", server.uri())),
+        )
+        .mount(&server)
+        .await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/actual-bundle.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body.clone()))
+        .mount(&server)
+        .await;
+
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+
+    // `url_input` bypasses the host/signature layers (see the checksum
+    // section's docs above) so this test isolates: a sha256 pin means the
+    // bytes are authenticated regardless of which host actually served them,
+    // so the redirect is followed and the install still succeeds.
+    let staged = stage_plugin_source(
+        url_input(&url, Some(&bundle_sha256), false),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect("a checksum-pinned install must still follow a redirect to the real bytes");
+
+    assert_eq!(staged.manifest.id, "hello-plugin");
+    staged.commit().await;
+}
+
+#[tokio::test]
+async fn signed_install_still_follows_a_redirect() {
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    let signing_key = test_signing_key(11);
+    let signature = signing_key.sign(manifest_body.as_bytes());
+    let trust = PluginTrustConfig {
+        trusted_hosts: PluginTrustConfig::default().trusted_hosts,
+        trusted_keys: vec![trusted_key_for("test key", &signing_key)],
+    };
+
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(302)
+                .insert_header("Location", format!("{}/actual-bundle.json", server.uri())),
+        )
+        .mount(&server)
+        .await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/actual-bundle.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body.clone()))
+        .mount(&server)
+        .await;
+    // The `.sig` sidecar is derived from the ORIGINAL (pre-redirect) url, not
+    // the redirect target — see `fetch_and_verify_signature`'s doc comment —
+    // and is signed over the bytes actually downloaded (the redirected-to
+    // `manifest_body`).
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json.sig"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_string(hex::encode(signature.to_bytes())),
+        )
+        .mount(&server)
+        .await;
+
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+
+    // allow_untrusted_host: true isolates the redirect-policy behavior from
+    // the host-allowlist layer (same convention as the other sections);
+    // allow_unsigned: false so the signature is actually REQUIRED here.
+    let staged = stage_plugin_source(
+        url_input_full(&url, None, true, true, false),
+        &plugins_root,
+        &trust,
+    )
+    .await
+    .expect("a signature-verified install must still follow a redirect to the real bytes");
+
+    assert_eq!(staged.manifest.id, "hello-plugin");
+    assert_eq!(
+        staged.source,
+        PluginSource::Url {
+            url,
+            sha256: None,
+            allow_unverified: true,
+            allow_untrusted_host: true,
+            allow_unsigned: false,
+            signed_by: Some("test key".to_string()),
+        }
+    );
+    staged.commit().await;
+}
+
+// ---------------------------------------------------------------------
 // Local sources are UNAFFECTED by the host-allowlist/signature layers — those
 // layers are about remote fetch; a local path is already the user's own file.
 // ---------------------------------------------------------------------

--- a/crates/app/bamboo-server/src/plugin_source/tests.rs
+++ b/crates/app/bamboo-server/src/plugin_source/tests.rs
@@ -1277,10 +1277,24 @@ async fn host_only_trust_install_refuses_a_redirect_instead_of_following_it() {
         "a redirect must be refused when neither a signature nor a checksum will authenticate \
          the downloaded bytes",
     );
+    // A clean, dedicated trust refusal (maps to a 403, see the HTTP error
+    // status map) — NOT a generic `Registration` (500 "internal error"),
+    // which would make a security-policy refusal look like a server bug. A
+    // regression back to `Registration`/500 fails here.
     assert!(
-        matches!(error, PluginError::Registration(_)),
-        "expected a Registration refusal for the un-followed redirect, got {error:?}"
+        matches!(error, PluginError::RedirectRefused(_)),
+        "expected a RedirectRefused trust refusal for the un-followed redirect, got {error:?}"
     );
+    // The message must be actionable: it names the redirect target and tells
+    // the user the three ways forward (canonical URL, signature/sha256, or
+    // trusting the target host).
+    let message = error.to_string();
+    assert!(message.contains("/elsewhere.json"), "{message}");
+    assert!(
+        message.contains("--sha256") || message.contains("sha256"),
+        "{message}"
+    );
+    assert!(message.contains("trusted_hosts"), "{message}");
     assert!(!plugins_root.join("hello-plugin").exists());
 }
 

--- a/crates/app/bamboo-server/src/plugin_source/tests.rs
+++ b/crates/app/bamboo-server/src/plugin_source/tests.rs
@@ -1,11 +1,13 @@
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
+use bamboo_config::{PluginTrustConfig, TrustedKey};
 use bamboo_plugin::{
     InstallDisposition, InstalledPlugin, PluginError, PluginInstaller, PluginManifest,
     PluginResult, PluginSource,
 };
 use chrono::{DateTime, Utc};
+use ed25519_dalek::{Signer, SigningKey};
 
 use super::*;
 
@@ -50,6 +52,7 @@ async fn stages_local_dir_and_parses_manifest() {
     let staged = stage_plugin_source(
         PluginSourceInput::LocalDir(source_dir.clone()),
         &plugins_root,
+        &PluginTrustConfig::default(),
     )
     .await
     .expect("stage local dir");
@@ -80,9 +83,13 @@ async fn stages_local_dir_rejects_invalid_manifest_before_touching_plugins_root(
     .unwrap();
 
     let plugins_root = root.path().join("plugins");
-    let error = stage_plugin_source(PluginSourceInput::LocalDir(source_dir), &plugins_root)
-        .await
-        .expect_err("invalid manifest should fail staging");
+    let error = stage_plugin_source(
+        PluginSourceInput::LocalDir(source_dir),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err("invalid manifest should fail staging");
     assert!(matches!(error, PluginError::InvalidManifest(_)));
     assert!(
         !plugins_root.join("Bad Id!").exists(),
@@ -154,6 +161,7 @@ async fn stages_local_targz_archive_with_nested_top_level_dir() {
     let staged = stage_plugin_source(
         PluginSourceInput::LocalArchive(archive_path.clone()),
         &plugins_root,
+        &PluginTrustConfig::default(),
     )
     .await
     .expect("stage tar.gz archive");
@@ -189,6 +197,7 @@ async fn stages_local_zip_archive_at_root() {
     let staged = stage_plugin_source(
         PluginSourceInput::LocalArchive(archive_path.clone()),
         &plugins_root,
+        &PluginTrustConfig::default(),
     )
     .await
     .expect("stage zip archive");
@@ -247,9 +256,13 @@ async fn tar_archive_with_traversal_entry_is_rejected() {
         .unwrap();
 
     let plugins_root = root.path().join("plugins");
-    let error = stage_plugin_source(PluginSourceInput::LocalArchive(archive_path), &plugins_root)
-        .await
-        .expect_err("traversal entry must be rejected");
+    let error = stage_plugin_source(
+        PluginSourceInput::LocalArchive(archive_path),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err("traversal entry must be rejected");
     assert!(matches!(error, PluginError::InvalidManifest(_)));
 
     // The traversal target must never have been written, regardless of
@@ -288,9 +301,13 @@ async fn zip_archive_with_traversal_entry_is_rejected() {
     tokio::fs::write(&archive_path, &buffer).await.unwrap();
 
     let plugins_root = root.path().join("plugins");
-    let error = stage_plugin_source(PluginSourceInput::LocalArchive(archive_path), &plugins_root)
-        .await
-        .expect_err("traversal entry must be rejected");
+    let error = stage_plugin_source(
+        PluginSourceInput::LocalArchive(archive_path),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err("traversal entry must be rejected");
     assert!(matches!(error, PluginError::InvalidManifest(_)));
 
     let escaped = plugins_root
@@ -376,9 +393,13 @@ async fn tar_symlink_workflow_entry_is_rejected_no_exfiltration() {
         .unwrap();
 
     let plugins_root = root.path().join("plugins");
-    let error = stage_plugin_source(PluginSourceInput::LocalArchive(archive_path), &plugins_root)
-        .await
-        .expect_err("a symlink entry must be rejected");
+    let error = stage_plugin_source(
+        PluginSourceInput::LocalArchive(archive_path),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err("a symlink entry must be rejected");
     assert!(matches!(error, PluginError::InvalidManifest(_)));
     assert!(error.to_string().contains("symlink"));
 
@@ -418,9 +439,13 @@ async fn tar_symlink_top_level_dir_entry_is_rejected_no_destruction() {
         .unwrap();
 
     let plugins_root = root.path().join("plugins");
-    let error = stage_plugin_source(PluginSourceInput::LocalArchive(archive_path), &plugins_root)
-        .await
-        .expect_err("a symlink-to-dir entry must be rejected");
+    let error = stage_plugin_source(
+        PluginSourceInput::LocalArchive(archive_path),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err("a symlink-to-dir entry must be rejected");
     assert!(matches!(error, PluginError::InvalidManifest(_)));
 
     // The victim dir and its contents are fully intact.
@@ -452,9 +477,13 @@ async fn tar_hardlink_entry_is_rejected() {
         .unwrap();
 
     let plugins_root = root.path().join("plugins");
-    let error = stage_plugin_source(PluginSourceInput::LocalArchive(archive_path), &plugins_root)
-        .await
-        .expect_err("a hardlink entry must be rejected");
+    let error = stage_plugin_source(
+        PluginSourceInput::LocalArchive(archive_path),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err("a hardlink entry must be rejected");
     assert!(matches!(error, PluginError::InvalidManifest(_)));
     assert!(error.to_string().contains("hardlink"));
 }
@@ -488,9 +517,13 @@ async fn zip_symlink_mode_entry_lands_inert_as_a_regular_file() {
     tokio::fs::write(&archive_path, &buffer).await.unwrap();
 
     let plugins_root = root.path().join("plugins");
-    let staged = stage_plugin_source(PluginSourceInput::LocalArchive(archive_path), &plugins_root)
-        .await
-        .expect("a zip with a symlink-mode entry stages fine (entry lands inert)");
+    let staged = stage_plugin_source(
+        PluginSourceInput::LocalArchive(archive_path),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect("a zip with a symlink-mode entry stages fine (entry lands inert)");
 
     let landed = staged.plugin_dir.join("notes.txt");
     let meta = tokio::fs::symlink_metadata(&landed).await.unwrap();
@@ -510,14 +543,24 @@ async fn zip_symlink_mode_entry_lands_inert_as_a_regular_file() {
 // Url
 // ---------------------------------------------------------------------
 //
-// Secure-by-default policy under test throughout this section (see
+// Checksum-layer policy under test throughout THIS section (see
 // `plugin_source.rs`'s module docs and `fetch_manifest_bundle`):
 //   - a correct bundle sha256 -> verified, install proceeds, the VERIFIED
 //     hash (not the caller's literal input) is recorded in provenance.
 //   - a WRONG bundle sha256 -> `BundleVerificationFailed`, nothing staged.
 //   - no sha256 and `allow_unverified: false` (the default) -> refused
-//     with `ChecksumRequired`, BEFORE the URL is ever fetched.
+//     with `ChecksumRequired`.
 //   - no sha256 and `allow_unverified: true` -> proceeds (explicit opt-out).
+//
+// These tests isolate the CHECKSUM layer specifically, so `url_input` below
+// bypasses the other two trust layers (host allowlist, signature) via
+// `allow_untrusted_host: true, allow_unsigned: true` — every wiremock server
+// here is plain `http://127.0.0.1:<port>` (never `https`, never in
+// `trusted_hosts`) and never mounts a `.sig` route, so without the bypass
+// every one of these tests would be refused by an EARLIER layer before ever
+// reaching the checksum check under test. The host-allowlist and signature
+// layers get their own dedicated test sections further down using
+// `url_input_full` (which does NOT bypass them).
 
 fn sha256_hex_of(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
@@ -526,11 +569,28 @@ fn sha256_hex_of(bytes: &[u8]) -> String {
     hex::encode(hasher.finalize())
 }
 
+/// Checksum-layer-only test helper — see the section docs above for why
+/// `allow_untrusted_host`/`allow_unsigned` are hardcoded `true` here.
 fn url_input(url: &str, sha256: Option<&str>, allow_unverified: bool) -> PluginSourceInput {
+    url_input_full(url, sha256, allow_unverified, true, true)
+}
+
+/// Full constructor for `PluginSourceInput::Url` exercising all five fields —
+/// used directly by the host-allowlist/signature test sections, which need
+/// per-test control over `allow_untrusted_host`/`allow_unsigned`.
+fn url_input_full(
+    url: &str,
+    sha256: Option<&str>,
+    allow_unverified: bool,
+    allow_untrusted_host: bool,
+    allow_unsigned: bool,
+) -> PluginSourceInput {
     PluginSourceInput::Url {
         url: url.to_string(),
         sha256: sha256.map(|s| s.to_string()),
         allow_unverified,
+        allow_untrusted_host,
+        allow_unsigned,
     }
 }
 
@@ -548,9 +608,13 @@ async fn stages_bare_manifest_from_url_with_correct_bundle_sha256() {
     let root = tempfile::tempdir().unwrap();
     let plugins_root = root.path().join("plugins");
     let url = format!("{}/plugin.json", server.uri());
-    let staged = stage_plugin_source(url_input(&url, Some(&bundle_sha256), false), &plugins_root)
-        .await
-        .expect("a correct bundle sha256 must verify and stage successfully");
+    let staged = stage_plugin_source(
+        url_input(&url, Some(&bundle_sha256), false),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect("a correct bundle sha256 must verify and stage successfully");
 
     assert_eq!(staged.manifest.id, "hello-plugin");
     // The VERIFIED bundle sha256 is what's recorded — this is the
@@ -562,6 +626,11 @@ async fn stages_bare_manifest_from_url_with_correct_bundle_sha256() {
             url,
             sha256: Some(bundle_sha256),
             allow_unverified: false,
+            // `url_input` bypasses the host/signature layers for this
+            // checksum-focused test — see the section docs above.
+            allow_untrusted_host: true,
+            allow_unsigned: true,
+            signed_by: None,
         }
     );
     // No skill files were bundled with a bare manifest fetch.
@@ -583,9 +652,13 @@ async fn url_install_with_wrong_bundle_sha256_is_rejected_before_unpacking() {
     let plugins_root = root.path().join("plugins");
     let url = format!("{}/plugin.json", server.uri());
     let wrong_sha256 = "b".repeat(64);
-    let error = stage_plugin_source(url_input(&url, Some(&wrong_sha256), false), &plugins_root)
-        .await
-        .expect_err("a bundle sha256 mismatch must be rejected");
+    let error = stage_plugin_source(
+        url_input(&url, Some(&wrong_sha256), false),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err("a bundle sha256 mismatch must be rejected");
     assert!(
         matches!(error, PluginError::BundleVerificationFailed(_)),
         "expected BundleVerificationFailed, got {error:?}"
@@ -602,18 +675,38 @@ async fn url_install_with_wrong_bundle_sha256_is_rejected_before_unpacking() {
 }
 
 #[tokio::test]
-async fn url_install_without_checksum_or_allow_unverified_is_refused_before_fetch() {
-    // No mock is mounted at all — if the refusal did NOT happen before the
-    // fetch, this test would hang/error on an unmatched request instead of
-    // cleanly returning `ChecksumRequired`.
+async fn url_install_without_checksum_or_allow_unverified_is_refused_after_host_and_signature_layers_pass(
+) {
+    // This test isolates the CHECKSUM layer (see the section docs above):
+    // `url_input` bypasses the host + signature layers, so the bundle fetch
+    // and the (absent) `.sig` fetch both happen normally, and the install is
+    // refused ONLY at the checksum gate. Unlike the pre-source-trust
+    // behavior, the checksum check can no longer run before ANY network
+    // access: to know whether a valid signature supersedes it (see
+    // `fetch_manifest_bundle`), the bundle must already be downloaded and its
+    // `.sig` already checked. The HOST-ALLOWLIST layer is the one that keeps
+    // a genuine pre-fetch "zero requests" guarantee now — see
+    // `untrusted_host_is_refused_before_any_fetch` below.
     let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+    // Deliberately no `.sig` route mounted — the bundle is genuinely unsigned.
+
     let root = tempfile::tempdir().unwrap();
     let plugins_root = root.path().join("plugins");
     let url = format!("{}/plugin.json", server.uri());
 
-    let error = stage_plugin_source(url_input(&url, None, false), &plugins_root)
-        .await
-        .expect_err("no sha256 and no allow_unverified must be refused");
+    let error = stage_plugin_source(
+        url_input(&url, None, false),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err("no sha256, no allow_unverified, and unsigned must be refused");
     assert!(
         matches!(error, PluginError::ChecksumRequired(_)),
         "expected ChecksumRequired, got {error:?}"
@@ -625,14 +718,13 @@ async fn url_install_without_checksum_or_allow_unverified_is_refused_before_fetc
         "{message}"
     );
 
-    // The core assertion: `bamboo plugin install <url>` alone must not just
-    // download and trust any tar.gz — confirm the server genuinely never
-    // received a request for it.
-    let received = server.received_requests().await;
+    // The bundle AND its `.sig` sidecar were both fetched before the checksum
+    // gate refused — exactly 2 requests, none of them extraction/install.
+    let received = server.received_requests().await.unwrap_or_default();
     assert_eq!(
-        received.map(|requests| requests.len()),
-        Some(0),
-        "refusing an unverified URL install must happen BEFORE the URL is ever fetched"
+        received.len(),
+        2,
+        "expected exactly the bundle GET + the .sig GET attempt, got {received:?}"
     );
 
     // Nothing committed, and no stray staging dir left under plugins_root.
@@ -657,9 +749,13 @@ async fn url_install_with_allow_unverified_and_no_sha256_succeeds() {
     let root = tempfile::tempdir().unwrap();
     let plugins_root = root.path().join("plugins");
     let url = format!("{}/plugin.json", server.uri());
-    let staged = stage_plugin_source(url_input(&url, None, true), &plugins_root)
-        .await
-        .expect("allow_unverified must let an unpinned URL install through");
+    let staged = stage_plugin_source(
+        url_input(&url, None, true),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect("allow_unverified must let an unpinned URL install through");
 
     assert_eq!(staged.manifest.id, "hello-plugin");
     assert_eq!(
@@ -668,6 +764,9 @@ async fn url_install_with_allow_unverified_and_no_sha256_succeeds() {
             url,
             sha256: None,
             allow_unverified: true,
+            allow_untrusted_host: true,
+            allow_unsigned: true,
+            signed_by: None,
         },
         "an allow_unverified install has no bundle sha256 to record"
     );
@@ -743,9 +842,13 @@ async fn fetches_verifies_and_places_platform_artifact_binary() {
     let root = tempfile::tempdir().unwrap();
     let plugins_root = root.path().join("plugins");
     let url = format!("{}/plugin.json", server.uri());
-    let staged = stage_plugin_source(url_input(&url, Some(&bundle_sha256), false), &plugins_root)
-        .await
-        .expect("stage manifest + artifact");
+    let staged = stage_plugin_source(
+        url_input(&url, Some(&bundle_sha256), false),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect("stage manifest + artifact");
 
     let expected_bin = staged
         .plugin_dir
@@ -777,6 +880,9 @@ async fn fetches_verifies_and_places_platform_artifact_binary() {
             url,
             sha256: Some(bundle_sha256),
             allow_unverified: false,
+            allow_untrusted_host: true,
+            allow_unsigned: true,
+            signed_by: None,
         }
     );
     staged.commit().await;
@@ -813,14 +919,345 @@ async fn artifact_sha256_mismatch_is_rejected_before_unpacking() {
     let root = tempfile::tempdir().unwrap();
     let plugins_root = root.path().join("plugins");
     let url = format!("{}/plugin.json", server.uri());
-    let error = stage_plugin_source(url_input(&url, Some(&bundle_sha256), false), &plugins_root)
-        .await
-        .expect_err("artifact sha256 mismatch must be rejected");
+    let error = stage_plugin_source(
+        url_input(&url, Some(&bundle_sha256), false),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err("artifact sha256 mismatch must be rejected");
     assert!(matches!(error, PluginError::ArtifactVerificationFailed(_)));
     assert!(
         !plugins_root.join("hello-plugin").exists(),
         "a verification failure must never commit anything to plugins_root"
     );
+}
+
+// ---------------------------------------------------------------------
+// Source-TRUST layer: host allowlist (layer 1 of 3 — see plugin_source.rs's
+// module docs). `PluginTrustConfig::default()`'s `trusted_hosts` is
+// `["github.com/bigduu/"]`, so every `wiremock` server here (always plain
+// `http://127.0.0.1:<port>`) is untrusted BOTH by host and by scheme.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn untrusted_host_is_refused_before_any_fetch() {
+    // No mock is mounted at all — if the refusal did NOT happen before the
+    // fetch, this test would need a working mock to avoid an error/hang.
+    let server = wiremock::MockServer::start().await;
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+
+    let error = stage_plugin_source(
+        url_input_full(&url, None, false, false, false),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err("a host outside trusted_hosts must be refused");
+    assert!(
+        matches!(error, PluginError::UntrustedHost(_)),
+        "expected UntrustedHost, got {error:?}"
+    );
+    let message = error.to_string();
+    assert!(message.contains("trusted_hosts"), "{message}");
+    assert!(message.contains("allow-untrusted-host") || message.contains("allow_untrusted_host"));
+
+    // The core assertion (mirrors the checksum-layer "no fetch" test above):
+    // confirm the server genuinely never received a request for it.
+    let received = server.received_requests().await;
+    assert_eq!(
+        received.map(|requests| requests.len()),
+        Some(0),
+        "refusing an untrusted-host URL install must happen BEFORE the URL is ever fetched"
+    );
+
+    assert!(!plugins_root.join("hello-plugin").exists());
+    let mut leftovers = tokio::fs::read_dir(&plugins_root).await.unwrap();
+    assert!(
+        leftovers.next_entry().await.unwrap().is_none(),
+        "a refused untrusted-host install must leave nothing under plugins_root"
+    );
+}
+
+#[tokio::test]
+async fn allow_untrusted_host_bypasses_the_host_allowlist() {
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+
+    // allow_untrusted_host bypasses layer 1; allow_unverified + allow_unsigned
+    // bypass layers 3/2 too so this test isolates the host-allowlist bypass
+    // specifically (its own layers are covered by their dedicated sections).
+    let staged = stage_plugin_source(
+        url_input_full(&url, None, true, true, true),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect("allow_untrusted_host must let an untrusted-host URL install through");
+
+    assert_eq!(staged.manifest.id, "hello-plugin");
+    assert_eq!(
+        staged.source,
+        PluginSource::Url {
+            url,
+            sha256: None,
+            allow_unverified: true,
+            allow_untrusted_host: true,
+            allow_unsigned: true,
+            signed_by: None,
+        }
+    );
+    staged.commit().await;
+}
+
+// ---------------------------------------------------------------------
+// Source-TRUST layer: ed25519 publisher signature (layer 2 of 3). Test
+// keypairs use `SigningKey::from_bytes` (a fixed 32-byte "secret") rather
+// than a CSPRNG — deterministic and sufficient for exercising the verify
+// path; nova's REAL signing key is never used or needed here.
+// ---------------------------------------------------------------------
+
+fn test_signing_key(seed: u8) -> SigningKey {
+    SigningKey::from_bytes(&[seed; 32])
+}
+
+fn trusted_key_for(label: &str, signing_key: &SigningKey) -> TrustedKey {
+    TrustedKey {
+        label: label.to_string(),
+        algorithm: "ed25519".to_string(),
+        public_key: hex::encode(signing_key.verifying_key().to_bytes()),
+    }
+}
+
+#[tokio::test]
+async fn valid_signature_from_a_trusted_key_verifies_and_supersedes_the_checksum_requirement() {
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    let signing_key = test_signing_key(7);
+    let signature = signing_key.sign(manifest_body.as_bytes());
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body.clone()))
+        .mount(&server)
+        .await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json.sig"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_string(hex::encode(signature.to_bytes())),
+        )
+        .mount(&server)
+        .await;
+
+    let trust = PluginTrustConfig {
+        trusted_hosts: Vec::new(),
+        trusted_keys: vec![trusted_key_for("test-key", &signing_key)],
+    };
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+
+    // No `sha256` AND `allow_unverified: false` — a signed+verified bundle
+    // must NOT also require a pasted checksum (the precedence rule).
+    let staged = stage_plugin_source(
+        url_input_full(&url, None, false, true, false),
+        &plugins_root,
+        &trust,
+    )
+    .await
+    .expect("a valid signature from a trusted key must satisfy the checksum requirement too");
+
+    assert_eq!(staged.manifest.id, "hello-plugin");
+    assert_eq!(
+        staged.source,
+        PluginSource::Url {
+            url,
+            sha256: None,
+            allow_unverified: false,
+            allow_untrusted_host: true,
+            allow_unsigned: false,
+            signed_by: Some("test-key".to_string()),
+        },
+        "a verified signature is recorded in provenance and needs no bundle sha256"
+    );
+    staged.commit().await;
+}
+
+#[tokio::test]
+async fn absent_signature_is_refused_with_unsigned_or_untrusted_signature() {
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+    // Deliberately no `.sig` route mounted.
+
+    let signing_key = test_signing_key(9);
+    let trust = PluginTrustConfig {
+        trusted_hosts: Vec::new(),
+        trusted_keys: vec![trusted_key_for("test-key", &signing_key)],
+    };
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+
+    let error = stage_plugin_source(
+        url_input_full(&url, None, true, true, false),
+        &plugins_root,
+        &trust,
+    )
+    .await
+    .expect_err("an absent .sig must be refused unless allow_unsigned");
+    assert!(
+        matches!(error, PluginError::UnsignedOrUntrustedSignature(_)),
+        "expected UnsignedOrUntrustedSignature, got {error:?}"
+    );
+    assert!(
+        error.to_string().contains("allow-unsigned")
+            || error.to_string().contains("allow_unsigned")
+    );
+    assert!(!plugins_root.join("hello-plugin").exists());
+}
+
+#[tokio::test]
+async fn signature_from_a_non_trusted_key_is_refused() {
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    let signing_key = test_signing_key(11);
+    let other_key = test_signing_key(12);
+    let signature = signing_key.sign(manifest_body.as_bytes());
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body.clone()))
+        .mount(&server)
+        .await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json.sig"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_string(hex::encode(signature.to_bytes())),
+        )
+        .mount(&server)
+        .await;
+
+    // `trusted_keys` only has `other_key`'s pubkey — the bundle was signed by
+    // `signing_key`, a DIFFERENT (non-trusted) key.
+    let trust = PluginTrustConfig {
+        trusted_hosts: Vec::new(),
+        trusted_keys: vec![trusted_key_for("other-key", &other_key)],
+    };
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+
+    let error = stage_plugin_source(
+        url_input_full(&url, None, true, true, false),
+        &plugins_root,
+        &trust,
+    )
+    .await
+    .expect_err("a signature from a non-trusted key must be refused");
+    assert!(
+        matches!(error, PluginError::UnsignedOrUntrustedSignature(_)),
+        "expected UnsignedOrUntrustedSignature, got {error:?}"
+    );
+    assert!(!plugins_root.join("hello-plugin").exists());
+}
+
+#[tokio::test]
+async fn allow_unsigned_bypasses_the_signature_check_but_not_the_checksum_layer() {
+    // Precedence check: `allow_unsigned` only waives the SIGNATURE layer's
+    // own refusal. It grants no credit toward the checksum layer the way a
+    // genuinely verified signature does (see the "supersedes" test above) —
+    // an unsigned install still needs its own `sha256`/`allow_unverified`.
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+
+    // allow_unsigned: true, but neither sha256 nor allow_unverified given.
+    let error = stage_plugin_source(
+        url_input_full(&url, None, false, true, true),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err("allow_unsigned alone must not also waive the checksum requirement");
+    assert!(
+        matches!(error, PluginError::ChecksumRequired(_)),
+        "expected ChecksumRequired (not UnsignedOrUntrustedSignature), got {error:?}"
+    );
+
+    // Now also give allow_unverified: true — fully unsigned AND unverified,
+    // both explicitly accepted, must succeed with `signed_by: None`.
+    let staged = stage_plugin_source(
+        url_input_full(&url, None, true, true, true),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect("allow_unsigned + allow_unverified together must let the install through");
+    assert_eq!(
+        staged.source,
+        PluginSource::Url {
+            url,
+            sha256: None,
+            allow_unverified: true,
+            allow_untrusted_host: true,
+            allow_unsigned: true,
+            signed_by: None,
+        }
+    );
+    staged.commit().await;
+}
+
+// ---------------------------------------------------------------------
+// Local sources are UNAFFECTED by the host-allowlist/signature layers — those
+// layers are about remote fetch; a local path is already the user's own file.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn local_dir_install_ignores_a_hostile_trust_config() {
+    // An intentionally empty allowlist/keyset (the most restrictive possible
+    // `PluginTrustConfig`) must have ZERO effect on a local install — proves
+    // `stage_into`'s LocalDir arm never consults `trust` at all.
+    let hostile_trust = PluginTrustConfig {
+        trusted_hosts: Vec::new(),
+        trusted_keys: Vec::new(),
+    };
+    let root = tempfile::tempdir().unwrap();
+    let source_dir = root.path().join("source");
+    write_hello_plugin_dir(&source_dir, "hello-plugin").await;
+    let plugins_root = root.path().join("plugins");
+
+    let staged = stage_plugin_source(
+        PluginSourceInput::LocalDir(source_dir.clone()),
+        &plugins_root,
+        &hostile_trust,
+    )
+    .await
+    .expect("a local install must never consult the host/signature trust config");
+    assert_eq!(staged.manifest.id, "hello-plugin");
+    assert_eq!(staged.source, PluginSource::LocalDir { path: source_dir });
+    staged.commit().await;
 }
 
 // ---------------------------------------------------------------------
@@ -868,6 +1305,7 @@ async fn install_plugin_from_source_rolls_back_new_bundle_on_install_failure() {
         &AlwaysFailInstaller,
         PluginSourceInput::LocalDir(source_dir),
         &plugins_root,
+        &PluginTrustConfig::default(),
         InstallDisposition::FailIfInstalled,
     )
     .await
@@ -903,6 +1341,7 @@ async fn install_plugin_from_source_restores_previous_bundle_on_upgrade_failure(
         &AlwaysFailInstaller,
         PluginSourceInput::LocalDir(new_source_dir),
         &plugins_root,
+        &PluginTrustConfig::default(),
         InstallDisposition::Upgrade,
     )
     .await
@@ -958,6 +1397,7 @@ async fn targz_exceeding_decompressed_cap_is_rejected_and_nothing_left_under_plu
     let error = stage_plugin_source_with_decompressed_cap(
         PluginSourceInput::LocalArchive(archive_path),
         &plugins_root,
+        &PluginTrustConfig::default(),
         1024,
     )
     .await
@@ -994,6 +1434,7 @@ async fn zip_exceeding_decompressed_cap_is_rejected_and_nothing_left_under_plugi
     let error = stage_plugin_source_with_decompressed_cap(
         PluginSourceInput::LocalArchive(archive_path),
         &plugins_root,
+        &PluginTrustConfig::default(),
         1024,
     )
     .await
@@ -1031,6 +1472,7 @@ async fn archive_within_decompressed_cap_still_stages_normally() {
     let staged = stage_plugin_source_with_decompressed_cap(
         PluginSourceInput::LocalArchive(archive_path),
         &plugins_root,
+        &PluginTrustConfig::default(),
         1024 * 1024,
     )
     .await

--- a/crates/infra/bamboo-config/Cargo.toml
+++ b/crates/infra/bamboo-config/Cargo.toml
@@ -22,6 +22,7 @@ rand = "0.10"
 sha2 = "0.11"
 hex = "0.4"
 base64 = "0.22"
+url = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -584,6 +584,106 @@ pub struct NotificationsConfig {
     pub bark: BarkChannelConfig,
 }
 
+/// One publisher key trusted to sign plugin bundles.
+///
+/// `algorithm` is a plain string (not an enum) so an unrecognized future value
+/// in an old/new config just never matches during verification rather than
+/// failing to deserialize — additive/forward-compatible, matching this
+/// crate's other config sections. Only `"ed25519"` is understood today.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrustedKey {
+    /// Human-readable label (surfaced in logs/CLI output); purely descriptive.
+    pub label: String,
+    /// Signature algorithm. Only `"ed25519"` is currently verified.
+    pub algorithm: String,
+    /// Hex-encoded public key (32 raw bytes for ed25519).
+    pub public_key: String,
+}
+
+/// Nova's official plugin-signing key, trusted by default so an out-of-the-box
+/// `bamboo plugin install <official nova release url>` needs no
+/// `--allow-unsigned` once nova's release CI signs the bundle.
+fn default_trusted_keys() -> Vec<TrustedKey> {
+    vec![TrustedKey {
+        label: "nova (bigduu official)".to_string(),
+        algorithm: "ed25519".to_string(),
+        public_key: "e3c429e1be50098b12c6f45737abf457189b668535875b5b3e2b4349be86ea59".to_string(),
+    }]
+}
+
+/// Default trusted host+path prefix: the `bigduu` GitHub org/user's own repos
+/// (e.g. `github.com/bigduu/Nova/releases/...`).
+fn default_trusted_hosts() -> Vec<String> {
+    vec!["github.com/bigduu/".to_string()]
+}
+
+/// Plugin URL-install source-trust policy: a host allowlist (is the SOURCE
+/// authorized?) plus ed25519 publisher keys (is the PUBLISHER authentic?).
+/// This stacks on top of the checksum layer already enforced in
+/// `bamboo_plugin::registry::PluginSource::Url` (are the BYTES what the
+/// caller expected?) — see `bamboo-server`'s `plugin_source.rs` for where all
+/// three layers are enforced together. A pasted checksum alone cannot
+/// establish source trust (an attacker who controls the page a checksum was
+/// copied from can just publish a checksum for their own tampered bundle);
+/// the host allowlist and signature checks close that gap.
+///
+/// Both fields are user-editable (`config.json`, or the config-set HTTP/CLI
+/// path) so an operator can add their own trusted hosts/keys. Additive/
+/// back-compat: an absent `plugin_trust` key deserializes to
+/// [`PluginTrustConfig::default`] (the built-in defaults below), not an empty
+/// policy — so a fresh install can trust the official nova plugin out of the
+/// box.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PluginTrustConfig {
+    /// Host+path prefixes a `url` plugin source may be fetched from without
+    /// `--allow-untrusted-host`. A URL is host-trusted when its scheme is
+    /// `https` and `<host><path>` (host lowercased) starts with one of these
+    /// entries verbatim — scoped to an org/user path, not just a bare host.
+    #[serde(default = "default_trusted_hosts")]
+    pub trusted_hosts: Vec<String>,
+    /// Publisher keys a bundle's `.sig` signature may verify against without
+    /// `--allow-unsigned`.
+    #[serde(default = "default_trusted_keys")]
+    pub trusted_keys: Vec<TrustedKey>,
+}
+
+impl Default for PluginTrustConfig {
+    fn default() -> Self {
+        Self {
+            trusted_hosts: default_trusted_hosts(),
+            trusted_keys: default_trusted_keys(),
+        }
+    }
+}
+
+impl PluginTrustConfig {
+    /// True when `url` is `https` and its `<host><path>` matches one of
+    /// `trusted_hosts` as a literal prefix (host compared case-insensitively;
+    /// an unparseable URL or a non-`https` scheme is never trusted).
+    pub fn is_host_trusted(&self, url: &str) -> bool {
+        is_host_trusted(url, &self.trusted_hosts)
+    }
+}
+
+/// Free function backing [`PluginTrustConfig::is_host_trusted`] — exposed
+/// separately so callers (and tests) can check a candidate host list without
+/// constructing a full [`PluginTrustConfig`]/[`Config`].
+pub fn is_host_trusted(url: &str, trusted_hosts: &[String]) -> bool {
+    let Ok(parsed) = url::Url::parse(url) else {
+        return false;
+    };
+    if parsed.scheme() != "https" {
+        return false;
+    }
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    let candidate = format!("{}{}", host.to_ascii_lowercase(), parsed.path());
+    trusted_hosts
+        .iter()
+        .any(|prefix| candidate.starts_with(prefix.as_str()))
+}
+
 /// Main configuration structure for Bamboo agent
 ///
 /// Contains all settings needed to run the agent, including provider credentials,
@@ -735,6 +835,12 @@ pub struct Config {
     /// [`Config::refresh_notifications_encrypted`].
     #[serde(default)]
     pub notifications: NotificationsConfig,
+
+    /// Plugin URL-install source-trust policy (host allowlist + ed25519
+    /// publisher keys). See [`PluginTrustConfig`]'s docs for the three-layer
+    /// model this stacks with the checksum layer.
+    #[serde(default)]
+    pub plugin_trust: PluginTrustConfig,
 
     /// Extension fields stored at the root of `config.json`.
     ///
@@ -2253,6 +2359,7 @@ impl Config {
             memory: None,
             mcp: bamboo_domain::mcp_config::McpConfig::default(),
             notifications: NotificationsConfig::default(),
+            plugin_trust: PluginTrustConfig::default(),
             extra: BTreeMap::new(),
         }
     }

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -636,9 +636,15 @@ fn default_trusted_hosts() -> Vec<String> {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PluginTrustConfig {
     /// Host+path prefixes a `url` plugin source may be fetched from without
-    /// `--allow-untrusted-host`. A URL is host-trusted when its scheme is
-    /// `https` and `<host><path>` (host lowercased) starts with one of these
-    /// entries verbatim — scoped to an org/user path, not just a bare host.
+    /// `--allow-untrusted-host`, e.g. `"github.com/bigduu/"` (a bare host
+    /// with no `/`, e.g. `"example.com"`, matches any path on that exact
+    /// host). Each entry is split into a host component and a path-prefix
+    /// component and matched on PARSED URL components — whole-host equality
+    /// plus a `/`-boundary path-prefix check, never a raw string
+    /// `starts_with` — see [`is_host_trusted`] for the precise rule and why
+    /// (it closes a domain-gluing bypass like `example.com` matching
+    /// `example.com.evil.com`, and a sibling-path bypass like
+    /// `github.com/bigduu` matching `github.com/bigduu-evil/x`).
     #[serde(default = "default_trusted_hosts")]
     pub trusted_hosts: Vec<String>,
     /// Publisher keys a bundle's `.sig` signature may verify against without
@@ -657,17 +663,85 @@ impl Default for PluginTrustConfig {
 }
 
 impl PluginTrustConfig {
-    /// True when `url` is `https` and its `<host><path>` matches one of
-    /// `trusted_hosts` as a literal prefix (host compared case-insensitively;
-    /// an unparseable URL or a non-`https` scheme is never trusted).
+    /// True when `url` is `https` and its host+path match one of
+    /// `trusted_hosts` on parsed URL components (host compared
+    /// case-insensitively as a WHOLE string, path matched on a `/` boundary
+    /// — see the free function [`is_host_trusted`] for the precise rule; an
+    /// unparseable URL or a non-`https` scheme is never trusted).
     pub fn is_host_trusted(&self, url: &str) -> bool {
         is_host_trusted(url, &self.trusted_hosts)
     }
 }
 
+/// One `trusted_hosts` entry, split into its host and path-prefix
+/// components (see [`is_host_trusted`]). `path_prefix` is empty for a
+/// bare-host entry (e.g. `"example.com"`, meaning "any path on this exact
+/// host") or starts with `/` (e.g. `"/bigduu/"` from `"github.com/bigduu/"`).
+struct TrustedHostEntry<'a> {
+    host: &'a str,
+    path_prefix: &'a str,
+}
+
+/// Split a raw `trusted_hosts` entry at its first `/` into host + path
+/// components. Entries are compared against ALREADY-lowercased input by the
+/// caller ([`is_host_trusted`]), so this does no case normalization itself.
+fn parse_trusted_host_entry(entry: &str) -> TrustedHostEntry<'_> {
+    match entry.find('/') {
+        Some(index) => TrustedHostEntry {
+            host: &entry[..index],
+            path_prefix: &entry[index..],
+        },
+        None => TrustedHostEntry {
+            host: entry,
+            path_prefix: "",
+        },
+    }
+}
+
+/// True when `path` matches `prefix` on a `/` path-component boundary, never
+/// on a raw byte prefix: exactly equal to `prefix`, or `prefix` ends in `/`
+/// and `path` starts with it, or the character in `path` immediately
+/// following `prefix` is `/`. An empty `prefix` (a bare-host trusted_hosts
+/// entry) matches any path.
+///
+/// This is what stops a sibling path from passing as a prefix match — e.g.
+/// entry `github.com/bigduu` (no trailing slash) must NOT match
+/// `github.com/bigduu-evil/x`: `"/bigduu-evil/x"` starts with `"/bigduu"` as
+/// raw bytes, but the character right after the prefix is `-`, not `/`, so
+/// this correctly refuses it.
+fn path_matches_prefix(path: &str, prefix: &str) -> bool {
+    if prefix.is_empty() || path == prefix {
+        return true;
+    }
+    if prefix.ends_with('/') {
+        return path.starts_with(prefix);
+    }
+    path.starts_with(prefix) && path.as_bytes().get(prefix.len()) == Some(&b'/')
+}
+
 /// Free function backing [`PluginTrustConfig::is_host_trusted`] — exposed
 /// separately so callers (and tests) can check a candidate host list without
 /// constructing a full [`PluginTrustConfig`]/[`Config`].
+///
+/// Matches on PARSED URL COMPONENTS, not a raw string prefix: `url` must be
+/// `https`, its `host_str()` (already correct for userinfo — `user@host` or
+/// `host@evil.com`-style tricks resolve to the real host, not a decoy — and
+/// for an explicit port, which `host_str()` excludes) must EQUAL a
+/// `trusted_hosts` entry's host component (case-insensitively, WHOLE host —
+/// never a `starts_with`), and its (already dot-segment-normalized by
+/// `Url::parse`) path must match that entry's path-prefix component on a `/`
+/// boundary (see [`path_matches_prefix`]). A bare-host entry (no `/` in it)
+/// has an empty path-prefix, so it matches any path but ONLY on that exact
+/// host.
+///
+/// A prior raw-`starts_with` implementation was defeated by (1) gluing a
+/// trusted bare host into a longer attacker-controlled one, e.g.
+/// `trusted.example.com` matching `trusted.example.com.evil.com` /
+/// `trusted.example.comevil.com`, and (2) a sibling path prefix, e.g.
+/// `github.com/bigduu` (no trailing slash) matching
+/// `github.com/bigduu-evil/x`. Component-wise matching closes both: host
+/// comparison is whole-string equality (no gluing possible), and the path
+/// check enforces a `/` boundary (no sibling-prefix bypass possible).
 pub fn is_host_trusted(url: &str, trusted_hosts: &[String]) -> bool {
     let Ok(parsed) = url::Url::parse(url) else {
         return false;
@@ -678,10 +752,14 @@ pub fn is_host_trusted(url: &str, trusted_hosts: &[String]) -> bool {
     let Some(host) = parsed.host_str() else {
         return false;
     };
-    let candidate = format!("{}{}", host.to_ascii_lowercase(), parsed.path());
-    trusted_hosts
-        .iter()
-        .any(|prefix| candidate.starts_with(prefix.as_str()))
+    let host = host.to_ascii_lowercase();
+    let path = parsed.path();
+
+    trusted_hosts.iter().any(|raw_entry| {
+        let entry = raw_entry.trim().to_ascii_lowercase();
+        let parsed_entry = parse_trusted_host_entry(&entry);
+        host == parsed_entry.host && path_matches_prefix(path, parsed_entry.path_prefix)
+    })
 }
 
 /// Main configuration structure for Bamboo agent
@@ -1694,6 +1772,7 @@ impl Config {
         config.hydrate_notifications_from_encrypted();
         config.normalize_tool_settings();
         config.normalize_skill_settings();
+        config.normalize_plugin_trust_settings();
 
         // Legacy: `data_dir` is no longer a persisted config field. The data directory is
         // derived from runtime (BAMBOO_DATA_DIR or `${HOME}/.bamboo`).
@@ -2267,6 +2346,23 @@ impl Config {
     /// Normalize skill settings (trim / dedupe / sort).
     pub fn normalize_skill_settings(&mut self) {
         self.skills.disabled = self.disabled_skill_ids().into_iter().collect();
+    }
+
+    /// Normalize `plugin_trust.trusted_hosts` entries (trim / lowercase / drop
+    /// empties) so a hand-edited `config.json` doesn't silently accumulate
+    /// mixed-case or whitespace-padded entries. [`is_host_trusted`] itself
+    /// already matches case-insensitively regardless of how an entry is
+    /// stored, so this is defense in depth / a canonical on-disk form, not
+    /// the source of the security fix — that's the host/path-component
+    /// matching in [`is_host_trusted`] itself.
+    pub fn normalize_plugin_trust_settings(&mut self) {
+        self.plugin_trust.trusted_hosts = self
+            .plugin_trust
+            .trusted_hosts
+            .iter()
+            .map(|entry| entry.trim().to_ascii_lowercase())
+            .filter(|entry| !entry.is_empty())
+            .collect();
     }
 
     /// Return the effective default provider key.
@@ -4939,6 +5035,124 @@ mod tests {
         assert_eq!(
             config.get_memory_background_model(),
             Some("legacy-gpt-4o-mini".to_string())
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // `is_host_trusted` — plugin source-trust host allowlist (component
+    // matching, not raw string-prefix matching; see the function's own docs
+    // for the bypasses this closes).
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn is_host_trusted_requires_https_scheme() {
+        let hosts = vec!["github.com/bigduu/".to_string()];
+        assert!(!is_host_trusted("http://github.com/bigduu/x", &hosts));
+        assert!(is_host_trusted("https://github.com/bigduu/x", &hosts));
+    }
+
+    #[test]
+    fn is_host_trusted_is_case_insensitive_on_both_sides() {
+        // A lowercase URL host against a mixed-case config entry...
+        let hosts = vec!["GitHub.com/BigDuu/".to_string()];
+        assert!(is_host_trusted("https://github.com/bigduu/x", &hosts));
+        // ...and a mixed-case URL host against a lowercase config entry.
+        let hosts = vec!["github.com/bigduu/".to_string()];
+        assert!(is_host_trusted("https://GitHub.Com/bigduu/x", &hosts));
+    }
+
+    #[test]
+    fn is_host_trusted_refuses_domain_gluing_bypass_of_a_bare_host_entry() {
+        let hosts = vec!["trusted.example.com".to_string()];
+        assert!(is_host_trusted("https://trusted.example.com/x", &hosts));
+        // Both demonstrated bypasses of a raw string-prefix match: gluing a
+        // longer attacker-controlled label onto the trusted host, with or
+        // without a separating dot.
+        assert!(!is_host_trusted(
+            "https://trusted.example.com.evil.com/x",
+            &hosts
+        ));
+        assert!(!is_host_trusted(
+            "https://trusted.example.comevil.com/x",
+            &hosts
+        ));
+    }
+
+    #[test]
+    fn is_host_trusted_refuses_sibling_path_prefix_bypass() {
+        // No trailing slash on the config entry's path component.
+        let hosts = vec!["github.com/bigduu/".to_string()];
+        assert!(is_host_trusted("https://github.com/bigduu/x", &hosts));
+        assert!(!is_host_trusted("https://github.com/bigduu-evil/x", &hosts));
+    }
+
+    #[test]
+    fn is_host_trusted_bare_host_entry_matches_any_path_on_exactly_that_host() {
+        let hosts = vec!["example.com".to_string()];
+        assert!(is_host_trusted("https://example.com/", &hosts));
+        assert!(is_host_trusted("https://example.com/any/deep/path", &hosts));
+        // Still only that exact host — a bare-host entry must not become a
+        // blanket "any host containing this string" match.
+        assert!(!is_host_trusted("https://example.com.evil.com/", &hosts));
+        assert!(!is_host_trusted("https://evil-example.com/", &hosts));
+    }
+
+    #[test]
+    fn is_host_trusted_uses_the_real_host_not_userinfo() {
+        let hosts = vec!["github.com/bigduu/".to_string()];
+        // `user@host` userinfo does not change the actual host.
+        assert!(is_host_trusted(
+            "https://someuser@github.com/bigduu/x",
+            &hosts
+        ));
+        // A decoy host placed in the userinfo position must not be mistaken
+        // for the real host — the real host here is `evil.com`.
+        assert!(!is_host_trusted(
+            "https://github.com@evil.com/bigduu/",
+            &hosts
+        ));
+    }
+
+    #[test]
+    fn is_host_trusted_ignores_an_explicit_port() {
+        let hosts = vec!["github.com/bigduu/".to_string()];
+        assert!(is_host_trusted("https://github.com:443/bigduu/x", &hosts));
+    }
+
+    #[test]
+    fn is_host_trusted_malformed_url_is_refused_without_panicking() {
+        let hosts = vec!["github.com/bigduu/".to_string()];
+        assert!(!is_host_trusted("not a url at all", &hosts));
+        assert!(!is_host_trusted("", &hosts));
+        assert!(!is_host_trusted("github.com/bigduu/x", &hosts)); // no scheme
+    }
+
+    #[test]
+    fn is_host_trusted_normalizes_dot_segments_before_matching() {
+        let hosts = vec!["github.com/bigduu/".to_string()];
+        // `Url::parse` resolves `..` segments before `path()` is ever
+        // consulted, so this cannot be used to escape the trusted prefix.
+        assert!(!is_host_trusted(
+            "https://github.com/bigduu/../evil/x",
+            &hosts
+        ));
+        // A `..` that stays under the trusted prefix once resolved is fine.
+        assert!(is_host_trusted("https://github.com/bigduu/x/../y", &hosts));
+    }
+
+    #[test]
+    fn normalize_plugin_trust_settings_lowercases_and_trims_and_drops_empties() {
+        let mut config = Config::default();
+        config.plugin_trust.trusted_hosts = vec![
+            "  GitHub.com/BigDuu/ ".to_string(),
+            "".to_string(),
+            "   ".to_string(),
+            "Example.COM".to_string(),
+        ];
+        config.normalize_plugin_trust_settings();
+        assert_eq!(
+            config.plugin_trust.trusted_hosts,
+            vec!["github.com/bigduu/".to_string(), "example.com".to_string()]
         );
     }
 }

--- a/crates/infra/bamboo-plugin/src/error.rs
+++ b/crates/infra/bamboo-plugin/src/error.rs
@@ -114,6 +114,24 @@ pub enum PluginError {
     #[error("{0}")]
     UnsignedOrUntrustedSignature(String),
 
+    /// A URL plugin install whose bytes will NOT be cryptographically
+    /// authenticated (no signature required AND no `sha256` — the fully
+    /// opted-out `allow_unsigned && allow_unverified`, "host-only trust"
+    /// case) was served an HTTP redirect instead of the bytes. In that case
+    /// the host allowlist is the SOLE control over where the bytes come
+    /// from, and it only vetted the FIRST hop — transparently following the
+    /// redirect would let the bytes come from an unvetted host and silently
+    /// defeat the allowlist, so redirects are not followed and a redirect
+    /// response is refused. A trust/authorization refusal (same 403 family
+    /// as [`Self::UntrustedHost`] / [`Self::UnsignedOrUntrustedSignature`]),
+    /// NOT a server error — it tells the caller how to proceed (install from
+    /// the canonical/final URL, provide a signature/`--sha256`, or trust the
+    /// redirect target). Does not arise once a signature or checksum is in
+    /// play: those authenticate the bytes regardless of which host served
+    /// them, so redirects are followed in that case.
+    #[error("{0}")]
+    RedirectRefused(String),
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/crates/infra/bamboo-plugin/src/error.rs
+++ b/crates/infra/bamboo-plugin/src/error.rs
@@ -94,6 +94,26 @@ pub enum PluginError {
     #[error("{0}")]
     ChecksumRequired(String),
 
+    /// A URL plugin install/update's host (and path) is not in the
+    /// configured `plugin_trust.trusted_hosts` allowlist, and the request did
+    /// not set `allow_untrusted_host`. This is the SOURCE-authorization
+    /// layer (host allowlist) — distinct from [`Self::BundleVerificationFailed`]
+    /// (integrity) and [`Self::UnsignedOrUntrustedSignature`] (publisher
+    /// authenticity). Raised BEFORE the URL is ever fetched, same posture as
+    /// [`Self::ChecksumRequired`].
+    #[error("{0}")]
+    UntrustedHost(String),
+
+    /// A URL plugin bundle is unsigned, or its `.sig` sidecar does not verify
+    /// against any key in `plugin_trust.trusted_keys`, and the request did
+    /// not set `allow_unsigned`. This is the PUBLISHER-authenticity layer —
+    /// a signature proves who produced the bytes, which a bare sha256 (only
+    /// proving WHAT the bytes are) cannot. Raised after the bundle is
+    /// downloaded (the signature is verified over the downloaded bytes) but
+    /// before anything is extracted/parsed.
+    #[error("{0}")]
+    UnsignedOrUntrustedSignature(String),
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/crates/infra/bamboo-plugin/src/registry.rs
+++ b/crates/infra/bamboo-plugin/src/registry.rs
@@ -31,15 +31,30 @@ pub enum PluginSource {
     LocalDir { path: PathBuf },
     /// Installed by unpacking a local `.tar.gz` archive.
     LocalArchive { path: PathBuf },
-    /// Installed by fetching a URL. Secure by default: `sha256` is the
-    /// user-verified hash of the downloaded BUNDLE (the `plugin.json`, or
-    /// the archive containing it) — `Some` in the normal case, confirmed
-    /// against a caller-supplied expected hash BEFORE anything was
-    /// extracted/trusted. `sha256` is `None` only when the install
-    /// explicitly opted out of verification (`allow_unverified: true`, no
-    /// hash supplied) — an install refuses outright rather than silently
-    /// trusting an unpinned download, so `None` here always means a
-    /// deliberate risk acceptance, never an oversight.
+    /// Installed by fetching a URL. Three trust layers, all enforced by
+    /// `bamboo-server`'s `plugin_source.rs` before this record is written:
+    ///
+    /// 1. **Host allowlist** (source authorization) — was the URL's host
+    ///    fetched from an operator-trusted host (`allow_untrusted_host` opts
+    ///    out).
+    /// 2. **Signature** (publisher authenticity) — did the bundle's `.sig`
+    ///    verify against a trusted ed25519 key (`signed_by`; `allow_unsigned`
+    ///    opts out of requiring one).
+    /// 3. **Checksum** (integrity) — `sha256` is the user-verified hash of
+    ///    the downloaded BUNDLE (the `plugin.json`, or the archive containing
+    ///    it) — `Some` in the normal case, confirmed against a
+    ///    caller-supplied expected hash BEFORE anything was
+    ///    extracted/trusted.
+    ///
+    /// `sha256` is `None` either when the install explicitly opted out of
+    /// checksum verification (`allow_unverified: true`, no hash supplied), OR
+    /// when a verified signature (`signed_by: Some(_)`) already established
+    /// integrity+authenticity more strongly than a pasted checksum could —
+    /// see `plugin_source.rs`'s module docs for why a valid signature
+    /// supersedes the checksum requirement. An install refuses outright
+    /// rather than silently trusting an unpinned/unsigned download from an
+    /// untrusted host, so every `None`/`false` combination here always means
+    /// a deliberate, recorded risk acceptance, never an oversight.
     Url {
         url: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -51,6 +66,23 @@ pub enum PluginSource {
         /// pinned) loads as `false` rather than failing to deserialize.
         #[serde(default, skip_serializing_if = "is_false")]
         allow_unverified: bool,
+        /// Recorded for audit: true when this install ran with
+        /// `allow_untrusted_host` against a host outside
+        /// `plugin_trust.trusted_hosts`. `#[serde(default)]` for backward
+        /// compat with rows written before this field existed.
+        #[serde(default, skip_serializing_if = "is_false")]
+        allow_untrusted_host: bool,
+        /// Recorded for audit: true when this install ran with
+        /// `allow_unsigned` (no valid signature from a trusted key).
+        /// `#[serde(default)]` for backward compat.
+        #[serde(default, skip_serializing_if = "is_false")]
+        allow_unsigned: bool,
+        /// The label of the `plugin_trust.trusted_keys` entry the bundle's
+        /// `.sig` verified against, or `None` if the install proceeded
+        /// unsigned (`allow_unsigned: true`). `#[serde(default)]` for
+        /// backward compat with rows written before signing existed.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signed_by: Option<String>,
     },
 }
 

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -545,20 +545,29 @@ enum PluginCommands {
     /// the argument) — `POST /api/v1/plugins/install`. Fails if the plugin id
     /// is already installed; use `bamboo plugin update` for that case.
     ///
-    /// A URL source is secure by default: it MUST be either checksum-pinned
-    /// (`--sha256`) or explicitly opted out (`--allow-unverified`) — a bare
-    /// `bamboo plugin install <url>` with neither is refused before the URL
-    /// is even fetched.
+    /// A URL source is checked against three trust layers: a host allowlist
+    /// (`--allow-untrusted-host` opts out), an ed25519 publisher signature
+    /// (`--allow-unsigned` opts out), and a checksum (`--sha256` pins it, or
+    /// `--allow-unverified` opts out — waived automatically when the bundle
+    /// is signature-verified). The defaults trust nova's official plugin
+    /// from its GitHub release, so installing it needs NO flags at all once
+    /// it's signed; any other host/publisher needs the matching opt-out.
     #[command(after_help = "EXAMPLES:\n  \
         # From a local directory (development)\n  \
         bamboo plugin install ./my-plugin\n\n  \
         # From a packaged archive\n  \
         bamboo plugin install ./my-plugin.tar.gz\n\n  \
-        # From a URL, pinned by the bundle's sha256 (preferred)\n  \
+        # Official nova plugin from its trusted GitHub release — no flags\n  \
+        # needed once it's signed by nova's official key (both trusted by\n  \
+        # default; see `plugin_trust` in config.json)\n  \
+        bamboo plugin install https://github.com/bigduu/Nova/releases/download/v0.2.0/nova-plugin-v0.2.0.tar.gz\n\n  \
+        # From a URL, pinned by the bundle's sha256 (checksum layer only)\n  \
         bamboo plugin install https://example.com/my-plugin.tar.gz \\\n    \
-        --sha256 3a7bd3e2360a3d29eea436fcfb7e44c735d117c42d1c1835420b6b9942dd4f1\n\n  \
-        # From a URL, explicitly accepting the risk of no checksum\n  \
-        bamboo plugin install https://example.com/my-plugin.tar.gz --allow-unverified")]
+        --sha256 3a7bd3e2360a3d29eea436fcfb7e44c735d117c42d1c1835420b6b9942dd4f1 \\\n    \
+        --allow-untrusted-host --allow-unsigned\n\n  \
+        # From an untrusted host, explicitly accepting the risk\n  \
+        bamboo plugin install https://example.com/my-plugin.tar.gz \\\n    \
+        --allow-untrusted-host --allow-unsigned --allow-unverified")]
     Install {
         /// A local directory, a local `.tar.gz`/`.tgz`/`.zip` archive, or an
         /// `http(s)://` URL — the source kind is auto-detected.
@@ -568,7 +577,8 @@ enum PluginCommands {
         /// `plugin.json`, or the archive containing it) fetched from a URL
         /// source. Only valid with a URL source; the server rejects a
         /// mismatch before unpacking anything. Without this, a URL install
-        /// also needs `--allow-unverified`.
+        /// also needs `--allow-unverified` (unless the bundle is
+        /// signature-verified, which satisfies this on its own).
         #[arg(long, value_name = "HEX")]
         sha256: Option<String>,
 
@@ -578,6 +588,20 @@ enum PluginCommands {
         /// warning for every unverified install.
         #[arg(long)]
         allow_unverified: bool,
+
+        /// Explicit opt-out: install from a URL whose host is not in
+        /// `plugin_trust.trusted_hosts` (config.json; defaults to nova's
+        /// official GitHub org). Only valid with a URL source. The server
+        /// refuses BEFORE fetching unless this is set.
+        #[arg(long)]
+        allow_untrusted_host: bool,
+
+        /// Explicit opt-out: install a bundle that is unsigned, or whose
+        /// `.sig` does not verify against any key in
+        /// `plugin_trust.trusted_keys` (config.json; defaults to nova's
+        /// official signing key). Only valid with a URL source.
+        #[arg(long)]
+        allow_unsigned: bool,
 
         #[command(flatten)]
         conn: ConnArgs,
@@ -624,7 +648,8 @@ enum PluginCommands {
         /// `plugin.json`, or the archive containing it) fetched from a URL
         /// source. Only valid with a URL source; the server rejects a
         /// mismatch before unpacking anything. Without this, a URL source
-        /// also needs `--allow-unverified`.
+        /// also needs `--allow-unverified` (unless the bundle is
+        /// signature-verified, which satisfies this on its own).
         #[arg(long, value_name = "HEX")]
         sha256: Option<String>,
 
@@ -632,6 +657,17 @@ enum PluginCommands {
         /// verification. Only valid with a URL source.
         #[arg(long)]
         allow_unverified: bool,
+
+        /// Explicit opt-out: update from a URL whose host is not in
+        /// `plugin_trust.trusted_hosts`. Only valid with a URL source.
+        #[arg(long)]
+        allow_untrusted_host: bool,
+
+        /// Explicit opt-out: update from a bundle that is unsigned or not
+        /// signed by a key in `plugin_trust.trusted_keys`. Only valid with a
+        /// URL source.
+        #[arg(long)]
+        allow_unsigned: bool,
 
         #[command(flatten)]
         conn: ConnArgs,
@@ -1742,6 +1778,8 @@ async fn main() {
                     source,
                     sha256,
                     allow_unverified,
+                    allow_untrusted_host,
+                    allow_unsigned,
                     conn,
                 } => {
                     bamboo_agent::plugin_cli::install(
@@ -1749,6 +1787,8 @@ async fn main() {
                         &source,
                         sha256.as_deref(),
                         allow_unverified,
+                        allow_untrusted_host,
+                        allow_unsigned,
                     )
                     .await
                 }
@@ -1763,6 +1803,8 @@ async fn main() {
                     source,
                     sha256,
                     allow_unverified,
+                    allow_untrusted_host,
+                    allow_unsigned,
                     conn,
                 } => {
                     bamboo_agent::plugin_cli::update(
@@ -1771,6 +1813,8 @@ async fn main() {
                         &source,
                         sha256.as_deref(),
                         allow_unverified,
+                        allow_untrusted_host,
+                        allow_unsigned,
                     )
                     .await
                 }
@@ -2051,6 +2095,117 @@ mod tests {
     }
 
     #[test]
+    fn plugin_install_parses_allow_untrusted_host_flag() {
+        use clap::Parser;
+
+        let parsed = super::Cli::try_parse_from([
+            "bamboo",
+            "plugin",
+            "install",
+            "https://example.com/my-plugin.tar.gz",
+            "--allow-untrusted-host",
+        ])
+        .expect("--allow-untrusted-host should parse");
+        let super::Commands::Plugin {
+            command:
+                super::PluginCommands::Install {
+                    allow_untrusted_host,
+                    allow_unsigned,
+                    ..
+                },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Install");
+        };
+        assert!(allow_untrusted_host);
+        assert!(!allow_unsigned);
+
+        // Defaults to false when omitted.
+        let parsed =
+            super::Cli::try_parse_from(["bamboo", "plugin", "install", "./my-plugin"]).unwrap();
+        let super::Commands::Plugin {
+            command:
+                super::PluginCommands::Install {
+                    allow_untrusted_host,
+                    ..
+                },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Install");
+        };
+        assert!(!allow_untrusted_host);
+    }
+
+    #[test]
+    fn plugin_install_parses_allow_unsigned_flag() {
+        use clap::Parser;
+
+        let parsed = super::Cli::try_parse_from([
+            "bamboo",
+            "plugin",
+            "install",
+            "https://example.com/my-plugin.tar.gz",
+            "--allow-unsigned",
+        ])
+        .expect("--allow-unsigned should parse");
+        let super::Commands::Plugin {
+            command:
+                super::PluginCommands::Install {
+                    allow_unsigned,
+                    allow_untrusted_host,
+                    ..
+                },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Install");
+        };
+        assert!(allow_unsigned);
+        assert!(!allow_untrusted_host);
+
+        // All four flags/opts can be combined.
+        let parsed = super::Cli::try_parse_from([
+            "bamboo",
+            "plugin",
+            "install",
+            "https://example.com/my-plugin.tar.gz",
+            "--sha256",
+            "deadbeef",
+            "--allow-unverified",
+            "--allow-untrusted-host",
+            "--allow-unsigned",
+        ])
+        .expect("all four trust flags together should parse");
+        let super::Commands::Plugin {
+            command:
+                super::PluginCommands::Install {
+                    sha256,
+                    allow_unverified,
+                    allow_untrusted_host,
+                    allow_unsigned,
+                    ..
+                },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Install");
+        };
+        assert_eq!(sha256.as_deref(), Some("deadbeef"));
+        assert!(allow_unverified);
+        assert!(allow_untrusted_host);
+        assert!(allow_unsigned);
+
+        // Defaults to false when omitted.
+        let parsed =
+            super::Cli::try_parse_from(["bamboo", "plugin", "install", "./my-plugin"]).unwrap();
+        let super::Commands::Plugin {
+            command: super::PluginCommands::Install { allow_unsigned, .. },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Install");
+        };
+        assert!(!allow_unsigned);
+    }
+
+    #[test]
     fn plugin_update_parses_id_and_source() {
         use clap::Parser;
 
@@ -2091,6 +2246,58 @@ mod tests {
             panic!("expected Plugin::Update");
         };
         assert!(allow_unverified);
+    }
+
+    #[test]
+    fn plugin_update_parses_allow_untrusted_host_and_allow_unsigned_flags() {
+        use clap::Parser;
+
+        let parsed = super::Cli::try_parse_from([
+            "bamboo",
+            "plugin",
+            "update",
+            "hello-plugin",
+            "https://example.com/my-plugin.tar.gz",
+            "--allow-untrusted-host",
+            "--allow-unsigned",
+        ])
+        .expect("--allow-untrusted-host and --allow-unsigned should parse on update too");
+        let super::Commands::Plugin {
+            command:
+                super::PluginCommands::Update {
+                    allow_untrusted_host,
+                    allow_unsigned,
+                    ..
+                },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Update");
+        };
+        assert!(allow_untrusted_host);
+        assert!(allow_unsigned);
+
+        // Default to false when omitted.
+        let parsed = super::Cli::try_parse_from([
+            "bamboo",
+            "plugin",
+            "update",
+            "hello-plugin",
+            "./my-plugin-v2",
+        ])
+        .unwrap();
+        let super::Commands::Plugin {
+            command:
+                super::PluginCommands::Update {
+                    allow_untrusted_host,
+                    allow_unsigned,
+                    ..
+                },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Update");
+        };
+        assert!(!allow_untrusted_host);
+        assert!(!allow_unsigned);
     }
 
     #[test]

--- a/src/plugin_cli.rs
+++ b/src/plugin_cli.rs
@@ -15,27 +15,47 @@
 //! - `POST /api/v1/plugins/install` -> body `{ "source": <SourceSpec> }`
 //!   (`InstallDisposition::FailIfInstalled`); `SourceSpec` is one of
 //!   `{"type":"local_dir","path":"..."}` / `{"type":"local_archive","path":"..."}`
-//!   / `{"type":"url","url":"...","sha256":"..."?,"allow_unverified":bool?}` —
-//!   the same tagged shape as `bamboo_plugin::registry::PluginSource`'s
+//!   / `{"type":"url","url":"...","sha256":"..."?,"allow_unverified":bool?,
+//!   "allow_untrusted_host":bool?,"allow_unsigned":bool?}` — the same tagged
+//!   shape as `bamboo_plugin::registry::PluginSource`'s
 //!   `#[serde(tag = "type")]` wire form, reproduced here by hand (this crate
 //!   does not depend on `bamboo-plugin`, to stay decoupled from the parallel
 //!   installer-core branch).
 //! - `POST /api/v1/plugins/{id}/update` -> same body shape (`Upgrade`).
 //! - `DELETE /api/v1/plugins/{id}` -> uninstall.
 //! - Errors: 409 (Conflict / AlreadyInstalled), 422 (UnsupportedPlatform), 404
-//!   (NotFound), 400 (bad manifest/artifact/bundle checksum, or a `url`
+//!   (NotFound), 403 (`url` source: untrusted host / unsigned-or-untrusted
+//!   signature), 400 (bad manifest/artifact/bundle checksum, or a `url`
 //!   install missing both `sha256` and `allow_unverified`); body
 //!   `{"error": "..."}`.
 //!
-//! # URL installs are secure by default
+//! # URL installs: three trust layers, secure by default
 //!
-//! `sha256` on a `url` source pins the downloaded BUNDLE (the `plugin.json`,
-//! or the archive containing it) — NOT merely the per-platform binary
-//! artifact declared inside the manifest (that is separately, and always,
-//! sha256-verified against the manifest's own declaration). A `url` install
-//! with neither `sha256` nor `allow_unverified: true` is refused by the
-//! server before it ever fetches the URL: `bamboo plugin install <url>`
-//! alone no longer just downloads and trusts any tar.gz.
+//! A `url` source is checked against three independent, stacked layers (see
+//! `bamboo-server`'s `plugin_source.rs` module docs for the full precedence):
+//!
+//! 1. **Host allowlist** — the URL's host+path must match an operator-trusted
+//!    prefix (`plugin_trust.trusted_hosts` in `config.json`; the default
+//!    trusts `github.com/bigduu/`) unless `--allow-untrusted-host` is passed.
+//! 2. **Signature** — the bundle's `<url>.sig` must verify against an
+//!    operator-trusted ed25519 key (`plugin_trust.trusted_keys`; the default
+//!    trusts nova's official signing key) unless `--allow-unsigned` is
+//!    passed.
+//! 3. **Checksum** — `sha256` pins the downloaded BUNDLE (the `plugin.json`,
+//!    or the archive containing it) — NOT merely the per-platform binary
+//!    artifact declared inside the manifest (that is separately, and always,
+//!    sha256-verified against the manifest's own declaration). A `url`
+//!    install with neither `sha256` nor `allow_unverified: true` is refused
+//!    UNLESS layer 2 already verified a signature (a verified signature is a
+//!    stronger integrity+authenticity guarantee than a pasted checksum, so it
+//!    satisfies this layer on its own).
+//!
+//! Net effect: installing the OFFICIAL nova plugin from its GitHub release
+//! needs NO flags at all once nova's release CI signs the bundle (trusted
+//! host + verified signature). An install from an untrusted host or an
+//! unsigned/untrusted-signature bundle needs the matching explicit opt-out
+//! flag(s) — `bamboo plugin install <url>` alone no longer just downloads
+//! and trusts any tar.gz from any host.
 
 use std::path::Path;
 use std::time::Duration;
@@ -60,18 +80,23 @@ const PLUGIN_MUTATE_TIMEOUT: Duration = Duration::from_secs(120);
 ///   `{"type":"local_archive","path":<absolute path>}`
 /// - something starting `http://`/`https://` -> `{"type":"url","url":<as-is>}`
 ///   (+ `"sha256"` when `--sha256` was given, `"allow_unverified":true` when
-///   `--allow-unverified` was given)
+///   `--allow-unverified` was given, `"allow_untrusted_host":true` when
+///   `--allow-untrusted-host` was given, `"allow_unsigned":true` when
+///   `--allow-unsigned` was given)
 ///
 /// Local paths are canonicalized to absolute so the source resolves correctly
 /// even if `bamboo serve` runs with a different working directory than the
-/// CLI invocation (e.g. a long-running sidecar). `--sha256` and
-/// `--allow-unverified` are rejected for local sources — they only apply to a
+/// CLI invocation (e.g. a long-running sidecar). All four flags
+/// (`--sha256`/`--allow-unverified`/`--allow-untrusted-host`/
+/// `--allow-unsigned`) are rejected for local sources — they only apply to a
 /// network download; a local file is already on the user's own disk by their
-/// own choice, nothing to verify.
+/// own choice, nothing to verify/authorize.
 pub(crate) fn detect_source(
     spec: &str,
     sha256: Option<&str>,
     allow_unverified: bool,
+    allow_untrusted_host: bool,
+    allow_unsigned: bool,
 ) -> anyhow::Result<serde_json::Value> {
     if spec.starts_with("http://") || spec.starts_with("https://") {
         let mut v = serde_json::json!({ "type": "url", "url": spec });
@@ -80,6 +105,12 @@ pub(crate) fn detect_source(
         }
         if allow_unverified {
             v["allow_unverified"] = serde_json::Value::Bool(true);
+        }
+        if allow_untrusted_host {
+            v["allow_untrusted_host"] = serde_json::Value::Bool(true);
+        }
+        if allow_unsigned {
+            v["allow_unsigned"] = serde_json::Value::Bool(true);
         }
         return Ok(v);
     }
@@ -96,6 +127,14 @@ pub(crate) fn detect_source(
         if allow_unverified {
             anyhow::bail!("--allow-unverified only applies to a URL source, not a local directory");
         }
+        if allow_untrusted_host {
+            anyhow::bail!(
+                "--allow-untrusted-host only applies to a URL source, not a local directory"
+            );
+        }
+        if allow_unsigned {
+            anyhow::bail!("--allow-unsigned only applies to a URL source, not a local directory");
+        }
         return Ok(serde_json::json!({ "type": "local_dir", "path": abs }));
     }
 
@@ -109,6 +148,14 @@ pub(crate) fn detect_source(
         if allow_unverified {
             anyhow::bail!("--allow-unverified only applies to a URL source, not a local archive");
         }
+        if allow_untrusted_host {
+            anyhow::bail!(
+                "--allow-untrusted-host only applies to a URL source, not a local archive"
+            );
+        }
+        if allow_unsigned {
+            anyhow::bail!("--allow-unsigned only applies to a URL source, not a local archive");
+        }
         return Ok(serde_json::json!({ "type": "local_archive", "path": abs }));
     }
 
@@ -117,20 +164,30 @@ pub(crate) fn detect_source(
     )
 }
 
-/// `bamboo plugin install <path-or-url> [--sha256 <hex>] [--allow-unverified]` —
-/// `POST /api/v1/plugins/install`. On a 409 (already installed) prints a
-/// pointer to `bamboo plugin update` and returns an error (non-zero exit). A
-/// URL source with neither `--sha256` nor `--allow-unverified` gets a 400
-/// from the server (secure by default — see the module docs); that error's
-/// message is already the actionable "pass --sha256 or --allow-unverified"
-/// guidance, surfaced as-is through the generic HTTP-failure branch below.
+/// `bamboo plugin install <path-or-url> [--sha256 <hex>] [--allow-unverified]
+/// [--allow-untrusted-host] [--allow-unsigned]` — `POST /api/v1/plugins/install`.
+/// On a 409 (already installed) prints a pointer to `bamboo plugin update`
+/// and returns an error (non-zero exit). A URL source with neither `--sha256`
+/// nor `--allow-unverified` gets a 400 from the server (secure by default —
+/// see the module docs); a URL from a host outside `plugin_trust.trusted_hosts`
+/// or an unsigned/untrusted-signature bundle gets a 403 (unless the matching
+/// opt-out flag was passed). Every one of those error bodies is already the
+/// actionable "pass --X" guidance, surfaced as-is through the branches below.
 pub async fn install(
     conn: ConnArgs,
     source_spec: &str,
     sha256: Option<&str>,
     allow_unverified: bool,
+    allow_untrusted_host: bool,
+    allow_unsigned: bool,
 ) -> anyhow::Result<()> {
-    let source = detect_source(source_spec, sha256, allow_unverified)?;
+    let source = detect_source(
+        source_spec,
+        sha256,
+        allow_unverified,
+        allow_untrusted_host,
+        allow_unsigned,
+    )?;
     let base = conn.api_base();
     let url = format!("{base}/plugins/install");
     let resp = reqwest::Client::new()
@@ -165,6 +222,13 @@ pub async fn install(
         );
     } else if status.as_u16() == 422 {
         anyhow::bail!("unsupported platform {}", server_error_message(&body));
+    } else if status.as_u16() == 403 {
+        anyhow::bail!(
+            "install refused (source trust) {} — for an untrusted host, add it to \
+             `plugin_trust.trusted_hosts` in config.json or pass --allow-untrusted-host; for an \
+             unsigned/untrusted-signature bundle, pass --allow-unsigned",
+            server_error_message(&body)
+        );
     } else {
         anyhow::bail!(
             "install failed: HTTP {status} {}",
@@ -292,18 +356,27 @@ pub async fn remove(conn: ConnArgs, id: &str, yes: bool) -> anyhow::Result<()> {
     }
 }
 
-/// `bamboo plugin update <id> <path-or-url> [--sha256] [--allow-unverified]` —
+/// `bamboo plugin update <id> <path-or-url> [--sha256] [--allow-unverified]
+/// [--allow-untrusted-host] [--allow-unsigned]` —
 /// `POST /api/v1/plugins/{id}/update` (`InstallDisposition::Upgrade`). Same
-/// secure-by-default URL policy as `install` (see the module docs).
+/// three-layer source-trust policy as `install` (see the module docs).
 pub async fn update(
     conn: ConnArgs,
     id: &str,
     source_spec: &str,
     sha256: Option<&str>,
     allow_unverified: bool,
+    allow_untrusted_host: bool,
+    allow_unsigned: bool,
 ) -> anyhow::Result<()> {
     guard_id_segment("plugin id", id)?;
-    let source = detect_source(source_spec, sha256, allow_unverified)?;
+    let source = detect_source(
+        source_spec,
+        sha256,
+        allow_unverified,
+        allow_untrusted_host,
+        allow_unsigned,
+    )?;
     let base = conn.api_base();
     let url = format!("{base}/plugins/{id}/update");
     let resp = reqwest::Client::new()
@@ -322,6 +395,13 @@ pub async fn update(
         anyhow::bail!("plugin '{id}' not found (check `bamboo plugin list`)");
     } else if status.as_u16() == 422 {
         anyhow::bail!("unsupported platform {}", server_error_message(&body));
+    } else if status.as_u16() == 403 {
+        anyhow::bail!(
+            "update refused (source trust) {} — for an untrusted host, add it to \
+             `plugin_trust.trusted_hosts` in config.json or pass --allow-untrusted-host; for an \
+             unsigned/untrusted-signature bundle, pass --allow-unsigned",
+            server_error_message(&body)
+        );
     } else {
         anyhow::bail!(
             "update failed: HTTP {status} {}",
@@ -336,13 +416,29 @@ mod tests {
 
     #[test]
     fn detect_source_recognizes_http_and_https_urls() {
-        let v = detect_source("https://example.com/plugin.tar.gz", None, false).unwrap();
+        let v = detect_source(
+            "https://example.com/plugin.tar.gz",
+            None,
+            false,
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(v["type"], "url");
         assert_eq!(v["url"], "https://example.com/plugin.tar.gz");
         assert!(v.get("sha256").is_none());
         assert!(v.get("allow_unverified").is_none());
+        assert!(v.get("allow_untrusted_host").is_none());
+        assert!(v.get("allow_unsigned").is_none());
 
-        let v = detect_source("http://example.com/plugin.tar.gz", Some("deadbeef"), false).unwrap();
+        let v = detect_source(
+            "http://example.com/plugin.tar.gz",
+            Some("deadbeef"),
+            false,
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(v["type"], "url");
         assert_eq!(v["sha256"], "deadbeef");
         assert!(v.get("allow_unverified").is_none());
@@ -350,7 +446,14 @@ mod tests {
 
     #[test]
     fn detect_source_url_carries_allow_unverified_when_set() {
-        let v = detect_source("https://example.com/plugin.tar.gz", None, true).unwrap();
+        let v = detect_source(
+            "https://example.com/plugin.tar.gz",
+            None,
+            true,
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(v["type"], "url");
         assert!(v.get("sha256").is_none());
         assert_eq!(v["allow_unverified"], true);
@@ -361,15 +464,62 @@ mod tests {
         // Both flags can be set together — the server treats `sha256` as
         // authoritative when present (verify), so this isn't a conflicting
         // request, just a redundant one.
-        let v = detect_source("https://example.com/plugin.tar.gz", Some("deadbeef"), true).unwrap();
+        let v = detect_source(
+            "https://example.com/plugin.tar.gz",
+            Some("deadbeef"),
+            true,
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(v["sha256"], "deadbeef");
         assert_eq!(v["allow_unverified"], true);
     }
 
     #[test]
+    fn detect_source_url_carries_allow_untrusted_host_when_set() {
+        let v = detect_source(
+            "https://evil.example.com/plugin.tar.gz",
+            None,
+            true,
+            true,
+            false,
+        )
+        .unwrap();
+        assert_eq!(v["type"], "url");
+        assert_eq!(v["allow_untrusted_host"], true);
+        assert!(v.get("allow_unsigned").is_none());
+    }
+
+    #[test]
+    fn detect_source_url_carries_allow_unsigned_when_set() {
+        let v =
+            detect_source("https://example.com/plugin.tar.gz", None, true, false, true).unwrap();
+        assert_eq!(v["type"], "url");
+        assert!(v.get("allow_untrusted_host").is_none());
+        assert_eq!(v["allow_unsigned"], true);
+    }
+
+    #[test]
+    fn detect_source_url_carries_all_four_flags_together() {
+        let v = detect_source(
+            "https://example.com/plugin.tar.gz",
+            Some("deadbeef"),
+            true,
+            true,
+            true,
+        )
+        .unwrap();
+        assert_eq!(v["sha256"], "deadbeef");
+        assert_eq!(v["allow_unverified"], true);
+        assert_eq!(v["allow_untrusted_host"], true);
+        assert_eq!(v["allow_unsigned"], true);
+    }
+
+    #[test]
     fn detect_source_recognizes_local_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let v = detect_source(dir.path().to_str().unwrap(), None, false).unwrap();
+        let v = detect_source(dir.path().to_str().unwrap(), None, false, false, false).unwrap();
         assert_eq!(v["type"], "local_dir");
         assert_eq!(
             v["path"].as_str().unwrap(),
@@ -380,15 +530,39 @@ mod tests {
     #[test]
     fn detect_source_rejects_sha256_for_local_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let err = detect_source(dir.path().to_str().unwrap(), Some("deadbeef"), false).unwrap_err();
+        let err = detect_source(
+            dir.path().to_str().unwrap(),
+            Some("deadbeef"),
+            false,
+            false,
+            false,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("--sha256"));
     }
 
     #[test]
     fn detect_source_rejects_allow_unverified_for_local_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let err = detect_source(dir.path().to_str().unwrap(), None, true).unwrap_err();
+        let err =
+            detect_source(dir.path().to_str().unwrap(), None, true, false, false).unwrap_err();
         assert!(err.to_string().contains("--allow-unverified"));
+    }
+
+    #[test]
+    fn detect_source_rejects_allow_untrusted_host_for_local_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let err =
+            detect_source(dir.path().to_str().unwrap(), None, false, true, false).unwrap_err();
+        assert!(err.to_string().contains("--allow-untrusted-host"));
+    }
+
+    #[test]
+    fn detect_source_rejects_allow_unsigned_for_local_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let err =
+            detect_source(dir.path().to_str().unwrap(), None, false, false, true).unwrap_err();
+        assert!(err.to_string().contains("--allow-unsigned"));
     }
 
     #[test]
@@ -397,7 +571,7 @@ mod tests {
         for name in ["plugin.tar.gz", "plugin.tgz", "plugin.zip"] {
             let path = dir.path().join(name);
             std::fs::write(&path, b"fake archive bytes").unwrap();
-            let v = detect_source(path.to_str().unwrap(), None, false).unwrap();
+            let v = detect_source(path.to_str().unwrap(), None, false, false, false).unwrap();
             assert_eq!(v["type"], "local_archive", "{name}");
         }
     }
@@ -407,7 +581,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("plugin.tar.gz");
         std::fs::write(&path, b"fake archive bytes").unwrap();
-        let err = detect_source(path.to_str().unwrap(), Some("deadbeef"), false).unwrap_err();
+        let err = detect_source(
+            path.to_str().unwrap(),
+            Some("deadbeef"),
+            false,
+            false,
+            false,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("--sha256"));
     }
 
@@ -416,8 +597,26 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("plugin.tar.gz");
         std::fs::write(&path, b"fake archive bytes").unwrap();
-        let err = detect_source(path.to_str().unwrap(), None, true).unwrap_err();
+        let err = detect_source(path.to_str().unwrap(), None, true, false, false).unwrap_err();
         assert!(err.to_string().contains("--allow-unverified"));
+    }
+
+    #[test]
+    fn detect_source_rejects_allow_untrusted_host_for_local_archive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plugin.tar.gz");
+        std::fs::write(&path, b"fake archive bytes").unwrap();
+        let err = detect_source(path.to_str().unwrap(), None, false, true, false).unwrap_err();
+        assert!(err.to_string().contains("--allow-untrusted-host"));
+    }
+
+    #[test]
+    fn detect_source_rejects_allow_unsigned_for_local_archive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plugin.tar.gz");
+        std::fs::write(&path, b"fake archive bytes").unwrap();
+        let err = detect_source(path.to_str().unwrap(), None, false, false, true).unwrap_err();
+        assert!(err.to_string().contains("--allow-unsigned"));
     }
 
     #[test]
@@ -425,13 +624,20 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("plugin.txt");
         std::fs::write(&path, b"not an archive").unwrap();
-        let err = detect_source(path.to_str().unwrap(), None, false).unwrap_err();
+        let err = detect_source(path.to_str().unwrap(), None, false, false, false).unwrap_err();
         assert!(err.to_string().contains("neither a directory"));
     }
 
     #[test]
     fn detect_source_rejects_missing_path() {
-        let err = detect_source("/no/such/path/should/exist/anywhere", None, false).unwrap_err();
+        let err = detect_source(
+            "/no/such/path/should/exist/anywhere",
+            None,
+            false,
+            false,
+            false,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("cannot read"));
     }
 


### PR DESCRIPTION
## Summary

Adds the source-TRUST layer to bamboo's plugin URL install, stacking on the just-merged checksum layer (#449). Three layers together, all enforced in `plugin_source::fetch_manifest_bundle`:

1. **Checksum** (already merged) — the downloaded bytes are what you expect.
2. **Host allowlist** (new) — the source is authorized.
3. **Ed25519 signature** (new) — the publisher is authentic.

A pasted checksum alone doesn't establish source trust — it's circular if the attacker controls the page you copied it from. The host allowlist + signature close that gap.

### Enforcement order (in `fetch_manifest_bundle`)

1. **Host check** — refuse `PluginError::UntrustedHost` **before any fetch** unless `allow_untrusted_host`.
2. Fetch the bundle bytes (existing `download_bytes`, size-capped).
3. **Signature check** — fetch `<url>.sig`; verify against any `plugin_trust.trusted_keys` entry; refuse `PluginError::UnsignedOrUntrustedSignature` unless `allow_unsigned`.
4. **Checksum check** — unchanged, **except**: a verified signature from step 3 already proves integrity+authenticity more strongly than a pasted sha256, so it satisfies this layer on its own (no sha256/`allow_unverified` needed when signed). An `allow_unsigned` bypass grants **no** such credit — an unsigned install still needs its own sha256/`allow_unverified`.

Net effect: installing the official nova plugin from its GitHub release needs **no flags at all** once nova's release CI signs the bundle (trusted host + trusted key, both defaulted). Any other host/publisher needs the matching explicit opt-out.

### Config schema (new `plugin_trust` section, `Config`)

```jsonc
"plugin_trust": {
  "trusted_hosts": ["github.com/bigduu/"],           // default
  "trusted_keys": [
    { "label": "nova (bigduu official)", "algorithm": "ed25519",
      "public_key": "e3c429e1be50098b12c6f45737abf457189b668535875b5b3e2b4349be86ea59" }
  ]
}
```
- Host match: scheme must be `https`, and `<host><path>` (host lowercased) must start with a `trusted_hosts` entry — scopes to an org/user path, not just a bare host.
- Both fields user-editable via `config.json` / the config-set path; absent key deserializes to these defaults (not empty).

### Signature scheme (pinned)
- ed25519, raw 64-byte signature, signed over the **exact downloaded bundle bytes** (not its sha256).
- Sidecar at `<bundle-url>.sig`, containing the signature as lowercase hex (128 chars, trailing newline trimmed).
- Verified against every `algorithm: "ed25519"` entry in `trusted_keys`; first match wins (records that key's `label` in provenance as `signed_by`).

### Provenance (`PluginSource::Url`)
New fields `allow_untrusted_host`, `allow_unsigned` (both `bool`, default `false`, backward-compat), `signed_by: Option<String>` (the trusted key label that verified, if any).

### CLI / HTTP surface
- CLI: `--allow-untrusted-host` / `--allow-unsigned` on `plugin install`/`plugin update` (URL-only; rejected for local sources, mirroring `--sha256`/`--allow-unverified`).
- HTTP: `url` `SourceSpec` gains `allow_untrusted_host?`/`allow_unsigned?`. `UntrustedHost` / `UnsignedOrUntrustedSignature` → **403** (authorization/trust refusal, distinct from the 400s used for malformed-request/checksum-mismatch).

### Deferred (unchanged from #449)
- SSRF guard on the URL fetch (still noted in `plugin_source.rs`'s module docs, not addressed here).

## Verification
- `cargo build --workspace --exclude bamboo-analytics` — clean.
- `cargo test -p bamboo-plugin -p bamboo-server -p bamboo-config -- plugin` — 61 tests green (8 new host/signature/precedence tests in `plugin_source::tests`, 2 new/updated in the HTTP handler tests).
- `cargo test -p bamboo-agent --lib --bins` — 111 tests green (11 new CLI clap tests for the two flags).
- `cargo clippy` on touched crates — no new warnings (refactored `fetch_manifest_bundle`'s params into a `UrlTrustFlags` struct to stay under clippy's `too_many_arguments`).
- `cargo fmt --check` — clean (config.rs formatted surgically, not whole-file, per repo convention).
- `cargo tree -i aws-lc-sys` — **empty** (ed25519-dalek pinned to the exact prerelease `russh` already resolves, so it adds zero new crates to the tree — the native-tls/reqwest pin survives).
- E2e: built `bamboo`, served a throwaway `--data-dir`, ran `bamboo plugin install https://evil.example.com/x.tar.gz` → refused with `UntrustedHost` before any fetch, confirmed via `bamboo plugin list` showing nothing installed; a local-dir install in the same session still worked unaffected.

## Test plan
- [x] `plugin_source::tests`: host zero-fetch refusal + `allow_untrusted_host` bypass
- [x] `plugin_source::tests`: valid/absent/non-trusted-key signature outcomes
- [x] `plugin_source::tests`: signed-supersedes-checksum precedence; `allow_unsigned` does NOT also waive checksum
- [x] `plugin_source::tests`: local installs ignore a hostile trust config
- [x] HTTP handler tests updated for the new layers (403 host-untrusted test, checksum-after-fetch test)
- [x] CLI clap tests for both new flags on install and update