### PR TITLE
feat(subagent): harden ClaudeCodeExecutor — explicit permission mode, config isolation, env allowlist, relay timeout

### DIFF
--- a/crates/engine/bamboo-engine/src/external_agents/config.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/config.rs
@@ -34,9 +34,38 @@ pub struct ExternalAgentProfile {
     pub fabric_dir: Option<String>,
     /// Actor protocol only: which engine the worker runs.
     /// `"bamboo_runtime"` (default) for the real agent loop, `"echo"` for a
-    /// dependency-free smoke run through the whole chain.
+    /// dependency-free smoke run through the whole chain, `"claude_code"` to
+    /// drive the official Claude Code CLI (see the `claude_code_*` fields
+    /// below).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub executor: Option<String>,
+    /// `executor = "claude_code"` only: override the `claude` executable.
+    /// `None` runs `claude` resolved from `PATH`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_code_binary: Option<String>,
+    /// `executor = "claude_code"` only: `--model` override. `None` omits the
+    /// flag (CLI default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_code_model: Option<String>,
+    /// `executor = "claude_code"` only: `--permission-mode` override. `None`
+    /// still passes an EXPLICIT `default` to the CLI (issue #443 — the
+    /// headless stream-json default is `auto`, which self-approves every
+    /// tool and never asks); it does not mean "omit the flag".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_code_permission_mode: Option<String>,
+    /// `executor = "claude_code"` only: `true` lets the child inherit the
+    /// invoking user's `~/.claude` MCP servers/skills/settings. `false`/unset
+    /// (the default) isolates it (`--strict-mcp-config` +
+    /// `--setting-sources project`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_code_inherit_user_config: Option<bool>,
+    /// `executor = "claude_code"` only: extra env var NAMES forwarded
+    /// verbatim from this process's env to the child, on top of the fixed
+    /// HOME/PATH/SHELL/TERM/LANG/LC_*/TMPDIR/USER/LOGNAME allowlist.
+    /// Forwarding `ANTHROPIC_API_KEY` here is an explicit opt-in that flips
+    /// billing from the CLI's own subscription auth to the API key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_code_forward_env: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/engine/bamboo-engine/src/external_agents/runtime.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/runtime.rs
@@ -105,15 +105,14 @@ pub fn build_external_child_runner(config: &Config) -> Arc<dyn ExternalChildRunn
                 Some("bamboo_runtime") | None => {
                     bamboo_subagent::provision::ExecutorSpec::BambooRuntime
                 }
-                // The profile schema has no dedicated model/permission-mode
-                // fields yet for a non-bamboo_runtime executor (#441 follow-up);
-                // this kind runs with the CLI's own defaults (binary `claude`
-                // on PATH, default permission mode) until that's plumbed
-                // through.
+                // #443: binary/model/permission_mode/isolation/env-forward
+                // are plumbed from the profile's `claude_code_*` fields.
                 Some("claude_code") => bamboo_subagent::provision::ExecutorSpec::ClaudeCode {
-                    binary: None,
-                    model: None,
-                    permission_mode: None,
+                    binary: profile.claude_code_binary.clone(),
+                    model: profile.claude_code_model.clone(),
+                    permission_mode: profile.claude_code_permission_mode.clone(),
+                    inherit_user_config: profile.claude_code_inherit_user_config,
+                    forward_env: profile.claude_code_forward_env.clone(),
                 },
                 Some(other) => {
                     tracing::error!(
@@ -224,13 +223,15 @@ fn build_local_actor_runner(config: &Config) -> Result<Arc<dyn ExternalChildRunn
     let executor = match sub.executor.as_deref() {
         Some("echo") => bamboo_subagent::provision::ExecutorSpec::Echo,
         Some("bamboo_runtime") | None => bamboo_subagent::provision::ExecutorSpec::BambooRuntime,
-        // See the matching arm in `build_external_child_runner` above: no
-        // config field carries model/permission-mode for this kind yet, so it
-        // runs with the CLI's own defaults (#441 follow-up).
+        // #443: binary/model/permission_mode/isolation/env-forward are
+        // plumbed from `subagents.claude_code_*` — mirrors the matching arm
+        // in `build_external_child_runner` above.
         Some("claude_code") => bamboo_subagent::provision::ExecutorSpec::ClaudeCode {
-            binary: None,
-            model: None,
-            permission_mode: None,
+            binary: sub.claude_code_binary.clone(),
+            model: sub.claude_code_model.clone(),
+            permission_mode: sub.claude_code_permission_mode.clone(),
+            inherit_user_config: sub.claude_code_inherit_user_config,
+            forward_env: sub.claude_code_forward_env.clone(),
         },
         Some(other) => return Err(format!("unknown subagents.executor '{other}'")),
     };

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -365,9 +365,37 @@ pub struct SubagentsConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fabric_dir: Option<String>,
     /// Expert: `"echo"` swaps in a dependency-free smoke executor (no LLM)
-    /// to verify the actor chain end-to-end.
+    /// to verify the actor chain end-to-end; `"claude_code"` drives the
+    /// official Claude Code CLI (see the `claude_code_*` fields below).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub executor: Option<String>,
+    /// `executor = "claude_code"` only: override the `claude` executable.
+    /// `None` runs `claude` resolved from `PATH`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_code_binary: Option<String>,
+    /// `executor = "claude_code"` only: `--model` override. `None` omits the
+    /// flag (CLI default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_code_model: Option<String>,
+    /// `executor = "claude_code"` only: `--permission-mode` override. `None`
+    /// still passes an EXPLICIT `default` to the CLI (issue #443 — the
+    /// headless stream-json default is `auto`, which self-approves every
+    /// tool and never asks); it does not mean "omit the flag".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_code_permission_mode: Option<String>,
+    /// `executor = "claude_code"` only: `true` lets the child inherit the
+    /// invoking user's `~/.claude` MCP servers/skills/settings. `false`/unset
+    /// (the default) isolates it (`--strict-mcp-config` +
+    /// `--setting-sources project`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_code_inherit_user_config: Option<bool>,
+    /// `executor = "claude_code"` only: extra env var NAMES forwarded
+    /// verbatim from this process's env to the child, on top of the fixed
+    /// HOME/PATH/SHELL/TERM/LANG/LC_*/TMPDIR/USER/LOGNAME allowlist.
+    /// Forwarding `ANTHROPIC_API_KEY` here is an explicit opt-in that flips
+    /// billing from the CLI's own subscription auth to the API key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_code_forward_env: Option<Vec<String>>,
     /// The active message-broker endpoint the `ask_agent` tool / sub-agent bus
     /// dials. RUNTIME-ONLY (`#[serde(skip)]`): never read from nor written to
     /// `config.json`. It is populated in memory each boot by `maybe_embed_broker`

--- a/crates/infra/bamboo-subagent/src/provision.rs
+++ b/crates/infra/bamboo-subagent/src/provision.rs
@@ -222,9 +222,11 @@ pub enum ExecutorSpec {
     /// Drive the official Claude Code CLI (`claude`) as the engine over its
     /// stream-json wire protocol (see `docs/claude-code-executor.md`). `binary`
     /// overrides the executable (tests point it at a stub script); `None` runs
-    /// `claude` from `PATH`. `model`/`permission_mode` map to the CLI's
-    /// `--model` / `--permission-mode` flags; `None` omits the flag (CLI
-    /// default).
+    /// `claude` from `PATH`. `model` maps to the CLI's `--model` flag; `None`
+    /// omits it (CLI default). `permission_mode` maps to `--permission-mode`;
+    /// `None` no longer omits the flag — the executor passes an EXPLICIT
+    /// `default` (issue #443: the CLI's headless stream-json default is
+    /// `auto`, which self-approves every tool and never asks).
     ClaudeCode {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         binary: Option<String>,
@@ -232,6 +234,21 @@ pub enum ExecutorSpec {
         model: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         permission_mode: Option<String>,
+        /// Issue #443: `false`/`None` (the default) isolates the child from
+        /// the invoking user's `~/.claude` setup (`--strict-mcp-config` +
+        /// `--setting-sources project`) — an e2e run showed 6 MCP servers
+        /// (incl. desktop control), all skills, and ~8k cache-creation tokens
+        /// leaking in from global config. `Some(true)` opts back into the old
+        /// inherit-everything behavior.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        inherit_user_config: Option<bool>,
+        /// Issue #443: extra env var NAMES (verbatim, not values) forwarded
+        /// to the child from the parent process env, on top of the fixed
+        /// HOME/PATH/SHELL/TERM/LANG/LC_*/TMPDIR/USER/LOGNAME allowlist.
+        /// Forwarding `ANTHROPIC_API_KEY` here is an explicit opt-in that
+        /// flips billing from the CLI's own subscription auth to the API key.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        forward_env: Option<Vec<String>>,
     },
 }
 
@@ -548,10 +565,14 @@ mod tests {
             binary: Some("/usr/local/bin/claude".into()),
             model: Some("claude-sonnet-4-6".into()),
             permission_mode: Some("bypassPermissions".into()),
+            inherit_user_config: Some(true),
+            forward_env: Some(vec!["ANTHROPIC_API_KEY".into()]),
         };
         let vcc = serde_json::to_value(&claude_code).unwrap();
         assert_eq!(vcc["kind"], "claude_code");
         assert_eq!(vcc["binary"], "/usr/local/bin/claude");
+        assert_eq!(vcc["inherit_user_config"], true);
+        assert_eq!(vcc["forward_env"][0], "ANTHROPIC_API_KEY");
         // Round-trips.
         assert_eq!(
             serde_json::from_value::<ExecutorSpec>(vcc).unwrap(),
@@ -561,6 +582,8 @@ mod tests {
             binary: None,
             model: None,
             permission_mode: None,
+            inherit_user_config: None,
+            forward_env: None,
         };
         let vmin = serde_json::to_value(&minimal).unwrap();
         assert_eq!(vmin, serde_json::json!({"kind": "claude_code"}));

--- a/docs/claude-code-executor.md
+++ b/docs/claude-code-executor.md
@@ -39,7 +39,8 @@ claude \
   --permission-prompt-tool stdio \
   --replay-user-messages \
   --verbose \
-  [--permission-mode <acceptEdits|plan|bypassPermissions>]   # omit for "default"
+  --permission-mode <acceptEdits|plan|bypassPermissions|default>  # ALWAYS explicit — see below
+  [--strict-mcp-config] [--setting-sources project]               # isolation — see below
   [--resume <session_id>]                                    # omit for a fresh session
   [--model <model>]
   [--allowedTools a,b] [--disallowedTools a,b]
@@ -48,19 +49,53 @@ claude \
 
 (cc-connect: `agent/claudecode/session.go:234-322`)
 
-Environment:
-- **Strip `CLAUDECODE`** from the child env — otherwise Claude Code detects a
-  nested session and misbehaves (`session.go:372`).
+**`--permission-mode` is ALWAYS passed explicitly (issue #443, CRITICAL).**
+Real-machine e2e against claude 2.1.207 found that the headless stream-json
+default — when the flag is omitted entirely — is `auto`, which self-approves
+every tool and never emits a `can_use_tool` ask. `ClaudeCodeExecutor::build_command`
+therefore always sends `permission_mode` when configured, else the literal
+string `default` — never nothing. This is what makes the "no host bridge →
+deny unless `bypassPermissions`" local-decide policy in §3 actually trigger;
+before this fix it was unreachable dead code (every ask was auto-approved by
+the CLI itself, so `control_request` never fired for anything the executor
+would have denied).
+
+**Isolation from the invoking user's `~/.claude`, by default (issue #443).**
+The same e2e run showed the child loading the user's entire global config: 6
+MCP servers (including a desktop-control server), every installed skill, and
+memory paths — ~8k cache-creation tokens and a large ambient-authority surface
+for a single `touch`. Unless `inherit_user_config: true` is set on the
+`ClaudeCode` executor spec, `build_command` adds `--strict-mcp-config` and
+`--setting-sources project`, so the child sees only project-scoped config, not
+the user's global one.
+
+Environment (issue #443 — env allowlist supersedes the earlier
+strip-one-var approach):
+- The child is spawned under `env_clear()` **plus an explicit allowlist**:
+  `HOME`, `PATH`, `SHELL`, `TERM`, `LANG`, `LC_*` (prefix), `TMPDIR`, `USER`,
+  `LOGNAME`. Everything else in the parent process env — including any
+  `*_API_KEY` — is stripped by construction, not by a denylist.
+- `forward_env: Vec<String>` on the executor spec names EXTRA variables to
+  forward verbatim on top of the allowlist. Forwarding `ANTHROPIC_API_KEY`
+  this way is an explicit opt-in that flips billing from the CLI's own
+  subscription auth to the API key — see §6.
+- `CLAUDECODE` is still explicitly `env_remove`d after the allowlist pass —
+  redundant now that `env_clear()` means it can't leak in from the parent at
+  all, kept as executable documentation of the nested-session hazard below.
 - Put the child in its own **process group** so shutdown can kill the whole tree
   (claude → its MCP servers) (`session.go:369`).
-- Inject whatever env the executor wants the agent's shell tools to see
-  (cc-connect injects `CC_PROJECT` / `CC_SESSION_KEY` for its send-back IPC).
+
+Nested-session hazard: Claude Code detects its own `CLAUDECODE` env var and
+misbehaves if it inherits one from an outer session (`session.go:372`).
 
 Gotchas:
 - Drop `--verbose` when routing through claude-code-router — router output
   corrupts the JSON stream (`claudecode.go:524-526`).
 - `bypassPermissions` under euid 0 is rejected by the CLI; downgrade and surface
   a warning (`session.go:225-229`).
+- Even in `default` mode, the CLI's own sandbox auto-runs plain read-only
+  commands (e.g. a bare `echo`) without asking — exercising the permission
+  relay requires a command with a real side effect (a file write).
 
 ## 2. Wire protocol
 
@@ -130,6 +165,15 @@ approval in a map of oneshot channels, resolve it when the steer inbox delivers
 the decision — same shape as the codex app-server adapter in cc-connect
 (`appserver_session.go:542-617`).
 
+**Relay timeout (issue #443).** When a host bridge IS attached,
+`decide_and_respond` wraps `HostBridge::approval_call` in `tokio::time::timeout`
+bounded by `APPROVAL_RELAY_TIMEOUT` (300s). A host approver that never replies
+(crashed UI, orphaned session) no longer hangs the CLI turn forever — on
+expiry the executor denies with `"approval relay timed out after 300s;
+denying"` and the turn continues. This is distinct from `approval_call`'s
+existing error path (the reply `oneshot` sender dropped), which is still
+handled as an immediate deny.
+
 ## 4. Session identity & resume
 
 Implemented (issue #444) in `ClaudeCodeExecutor`. `RunSpec.messages` is the
@@ -185,10 +229,11 @@ machine entirely) treats the persisted id as unusable.
    other error is returned as-is.
 
 **Non-goals (still).** Mid-turn steering into a genuinely new turn on the same
-session, and multimodal/env-forwarding (#443) — unaffected by this change.
-Cross-machine resume is out of scope by construction (see the workspace/
-machine-locality note above); if the actor is redeployed to a different host
-or workspace, activation falls through to fallback rehydration automatically.
+session, and multimodal — unaffected by this change. Env-forwarding shipped
+as part of #443 (see §1/§6). Cross-machine resume is out of scope by
+construction (see the workspace/machine-locality note above); if the actor is
+redeployed to a different host or workspace, activation falls through to
+fallback rehydration automatically.
 
 ## 5. Cancellation / shutdown
 
@@ -206,9 +251,20 @@ rely on `--resume` for continuation.
 
 The spawned binary is official Claude Code with the user's own login; as of
 2026-07 subscription auth still covers `claude -p`/stream-json usage (the
-June 15 credit split was paused). If the host also configures `ANTHROPIC_API_KEY`
-in the child env, the CLI bills the API key instead — decide explicitly which
-one the executor forwards.
+June 15 credit split was paused). Real-machine e2e confirmed this: the
+`system.init` frame reported `apiKeySource: "none"` with no key in the child
+env — the subscription is what actually gets billed.
+
+**Env policy (issue #443, implemented).** The executor no longer forwards the
+parent process env wholesale. `build_command` runs the child under
+`env_clear()` plus a fixed allowlist — `HOME`, `PATH`, `SHELL`, `TERM`, `LANG`,
+`LC_*` (prefix), `TMPDIR`, `USER`, `LOGNAME` — which is enough for the CLI and
+its shell tools to function but excludes every `*_API_KEY` and other ambient
+secret by construction. `forward_env: Vec<String>` on the executor spec (and
+the matching `claude_code_forward_env` config field, §8) names EXTRA variables
+to forward verbatim; forwarding `ANTHROPIC_API_KEY` this way is an EXPLICIT
+opt-in that flips billing from the subscription to the API key — never the
+implicit default.
 
 ## 7. Executor shape (as implemented)
 
@@ -221,6 +277,15 @@ pub struct ClaudeCodeExecutor {
     /// Stable per-child dir the resumed-session state file lives in — see §4.
     /// `None` disables resume persistence (every activation is fresh).
     state_dir: Option<PathBuf>,
+    /// Issue #443: `false` (default) adds `--strict-mcp-config` +
+    /// `--setting-sources project` — see §1.
+    inherit_user_config: bool,
+    /// Issue #443: extra env var NAMES forwarded on top of the fixed
+    /// allowlist — see §1/§6.
+    forward_env: Vec<String>,
+    /// Issue #443: bound on the permission-relay `HostBridge::approval_call`
+    /// — see §3. Always `APPROVAL_RELAY_TIMEOUT` (300s) outside tests.
+    relay_timeout: Duration,
 }
 
 #[async_trait]
@@ -249,3 +314,25 @@ impl ChildExecutor for ClaudeCodeExecutor {
     }
 }
 ```
+
+## 8. Config plumbing (issue #443)
+
+`ExecutorSpec::ClaudeCode` (`bamboo-subagent::provision`) carries `binary`,
+`model`, `permission_mode`, `inherit_user_config: Option<bool>`, and
+`forward_env: Option<Vec<String>>`. Both factory arms that turn a spec into a
+running `ClaudeCodeExecutor` (`src/subagent_worker.rs`, `src/broker_agent.rs`)
+resolve `None` isolation/env fields to the hardened defaults
+(`inherit_user_config.unwrap_or(false)`, `forward_env.unwrap_or_default()`).
+
+Two config surfaces build a `ClaudeCode` spec from `executor = "claude_code"`:
+
+- `bamboo_config::SubagentsConfig` — the built-in local actor worker
+  (`subagents.claude_code_binary` / `_model` / `_permission_mode` /
+  `_inherit_user_config` / `_forward_env`).
+- `bamboo_engine::external_agents::config::ExternalAgentProfile` — a named
+  `externalAgents` profile using the actor protocol (same `claude_code_*`
+  field names).
+
+Both are resolved into the spec in
+`crates/engine/bamboo-engine/src/external_agents/runtime.rs`
+(`build_local_actor_runner` and `build_external_child_runner` respectively).

--- a/src/broker_agent.rs
+++ b/src/broker_agent.rs
@@ -84,6 +84,8 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
                 ref binary,
                 ref model,
                 ref permission_mode,
+                ref inherit_user_config,
+                ref forward_env,
             } => Arc::new(crate::claude_code_executor::ClaudeCodeExecutor::new(
                 binary.clone(),
                 model.clone(),
@@ -93,6 +95,8 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
                     &spec.storage_dir,
                     &spec.identity.child_id,
                 )),
+                inherit_user_config.unwrap_or(false),
+                forward_env.clone().unwrap_or_default(),
             )),
             _ => Arc::new(BambooRuntimeExecutor::build(&spec).await?),
         };

--- a/src/claude_code_executor.rs
+++ b/src/claude_code_executor.rs
@@ -62,6 +62,23 @@ const GRACEFUL_EXIT_WAIT: Duration = Duration::from_secs(5);
 /// Phase 3: bounded wait after SIGTERM before escalating to SIGKILL.
 const SIGTERM_WAIT: Duration = Duration::from_secs(2);
 
+/// Issue #443: how long [`decide_and_respond`] waits on [`HostBridge::approval_call`]
+/// before giving up and denying. A host-in-the-loop approver that never comes
+/// back (crashed UI, orphaned session, dropped WS with no error surfaced)
+/// would otherwise hang the CLI turn forever — this bounds the relay the same
+/// way the graceful-shutdown phases bound the process lifecycle.
+const APPROVAL_RELAY_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Issue #443: fixed env allowlist forwarded from the parent process env to
+/// every spawned `claude` child (on top of any executor-specific
+/// `forward_env` names) — `env_clear()` in [`ClaudeCodeExecutor::build_command`]
+/// strips everything else, including `*_API_KEY` and other ambient secrets.
+/// `LC_*` (locale vars: `LC_ALL`, `LC_CTYPE`, …) is matched by prefix, not
+/// listed here.
+const ENV_ALLOWLIST: &[&str] = &[
+    "HOME", "PATH", "SHELL", "TERM", "LANG", "TMPDIR", "USER", "LOGNAME",
+];
+
 /// Resolve this actor's stable per-child storage dir, exactly like
 /// [`BambooRuntimeExecutor::build`](crate::subagent_worker::BambooRuntimeExecutor::build)
 /// (`subagent_worker.rs:194-202`): `spec.storage_dir` when the parent already
@@ -118,15 +135,31 @@ pub struct ClaudeCodeExecutor {
     /// this constructor, so tests can point it at an isolated tempdir. `None`
     /// disables resume persistence entirely (every activation is fresh).
     state_dir: Option<PathBuf>,
+    /// Issue #443: `false` (the default) adds `--strict-mcp-config` and
+    /// `--setting-sources project` so the child does NOT load the invoking
+    /// user's `~/.claude` MCP servers/skills/settings. `true` omits both
+    /// flags (the old inherit-everything behavior).
+    inherit_user_config: bool,
+    /// Issue #443: extra env var NAMES forwarded verbatim from the parent
+    /// process env, on top of the fixed [`ENV_ALLOWLIST`].
+    forward_env: Vec<String>,
+    /// Issue #443: bound on [`HostBridge::approval_call`] in
+    /// [`decide_and_respond`]. Always [`APPROVAL_RELAY_TIMEOUT`] outside
+    /// tests; overridable via [`Self::with_relay_timeout_for_test`] so a unit
+    /// test exercising the expiry path doesn't have to wait 300s.
+    relay_timeout: Duration,
 }
 
 impl ClaudeCodeExecutor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         binary: Option<String>,
         model: Option<String>,
         permission_mode: Option<String>,
         workspace: Option<String>,
         state_dir: Option<PathBuf>,
+        inherit_user_config: bool,
+        forward_env: Vec<String>,
     ) -> Self {
         Self {
             binary: binary.unwrap_or_else(|| "claude".to_string()),
@@ -134,7 +167,19 @@ impl ClaudeCodeExecutor {
             permission_mode,
             workspace,
             state_dir,
+            inherit_user_config,
+            forward_env,
+            relay_timeout: APPROVAL_RELAY_TIMEOUT,
         }
+    }
+
+    /// Test-only override of [`Self::relay_timeout`] — production callers
+    /// always get [`APPROVAL_RELAY_TIMEOUT`]. Lets a unit test exercise the
+    /// timeout-expiry path in milliseconds instead of 300s.
+    #[cfg(test)]
+    fn with_relay_timeout_for_test(mut self, timeout: Duration) -> Self {
+        self.relay_timeout = timeout;
+        self
     }
 
     fn state_file_path(&self) -> Option<PathBuf> {
@@ -220,17 +265,53 @@ impl ClaudeCodeExecutor {
             .arg("stdio")
             .arg("--replay-user-messages")
             .arg("--verbose");
-        if let Some(mode) = &self.permission_mode {
-            cmd.arg("--permission-mode").arg(mode);
-        }
+        // Issue #443 CRITICAL: the CLI's headless stream-json default
+        // permission mode is `auto` (self-approve every tool, never asks) --
+        // NOT `default`. Passing no `--permission-mode` flag therefore means
+        // every actor silently self-approves. Always pass an EXPLICIT mode:
+        // the configured value when set, else `default` -- which actually
+        // engages the local-decide policy in `decide_and_respond` below
+        // ("no host bridge -> deny unless bypassPermissions") instead of
+        // that policy being unreachable dead code.
+        cmd.arg("--permission-mode")
+            .arg(self.permission_mode.as_deref().unwrap_or("default"));
         if let Some(model) = &self.model {
             cmd.arg("--model").arg(model);
         }
         if let Some(id) = resume_id {
             cmd.arg("--resume").arg(id);
         }
+        // Issue #443: isolate from the invoking user's ~/.claude setup by
+        // default -- an e2e run showed 6 MCP servers (incl. desktop
+        // control), every skill, and ~8k cache-creation tokens leaking in
+        // from global config for a single `touch`. `inherit_user_config:
+        // true` opts back into the CLI's normal (inherit-everything)
+        // behavior.
+        if !self.inherit_user_config {
+            cmd.arg("--strict-mcp-config");
+            cmd.arg("--setting-sources").arg("project");
+        }
+        // Issue #443: env allowlist. `env_clear()` plus an explicit forward
+        // list supersedes the old single `env_remove("CLAUDECODE")`
+        // hardening -- a cleared env can no longer carry a leaked CLAUDECODE
+        // (or any other ambient secret, e.g. `*_API_KEY`) from the parent at
+        // all. The `env_remove` call below is kept anyway as executable
+        // documentation of the specific nested-session hazard
+        // (docs/claude-code-executor.md, spawn flags section) and as
+        // defense-in-depth if the allowlist is ever loosened.
+        cmd.env_clear();
+        for (key, value) in std::env::vars() {
+            if ENV_ALLOWLIST.contains(&key.as_str()) || key.starts_with("LC_") {
+                cmd.env(key, value);
+            }
+        }
+        for name in &self.forward_env {
+            if let Ok(value) = std::env::var(name) {
+                cmd.env(name, value);
+            }
+        }
         // Nested-session detection: Claude Code misbehaves if it inherits its
-        // own env var from an outer session (docs/claude-code-executor.md §1).
+        // own env var from an outer session.
         cmd.env_remove("CLAUDECODE");
         if let Some(ws) = &self.workspace {
             cmd.current_dir(ws);
@@ -390,12 +471,14 @@ impl ClaudeCodeExecutor {
         let input = request.get("input").cloned().unwrap_or_else(|| json!({}));
         let host = events.host().cloned();
         let permission_mode = self.permission_mode.clone();
+        let relay_timeout = self.relay_timeout;
         let write_tx = write_tx.clone();
         let task_request_id = request_id.clone();
         let handle = tokio::spawn(async move {
             decide_and_respond(
                 host,
                 permission_mode,
+                relay_timeout,
                 &task_request_id,
                 &tool_name,
                 input,
@@ -955,6 +1038,7 @@ fn truncate_chars(s: &str, max_chars: usize) -> String {
 async fn decide_and_respond(
     host: Option<HostBridge>,
     permission_mode: Option<String>,
+    relay_timeout: Duration,
     request_id: &str,
     tool_name: &str,
     input: Value,
@@ -979,8 +1063,14 @@ async fn decide_and_respond(
 
     let (allow, deny_message) = if let Some(host) = host {
         let body = json!({ "tool_name": tool_name, "input": input });
-        match host.approval_call(body).await {
-            Ok(reply) => {
+        // Issue #443: bound the relay so a host-in-the-loop approver that
+        // never replies (crashed UI, orphaned session) can't hang this turn
+        // forever — `approval_call`'s own error path (the reply oneshot
+        // DROPPED) is already handled by the `Err(e)` arm below; this timeout
+        // covers the complementary case where the sender is held open but
+        // never sent.
+        match tokio::time::timeout(relay_timeout, host.approval_call(body)).await {
+            Ok(Ok(reply)) => {
                 let approved = reply
                     .get("approved")
                     .and_then(Value::as_bool)
@@ -988,7 +1078,14 @@ async fn decide_and_respond(
                 let msg = (!approved).then(|| "denied by host approver".to_string());
                 (approved, msg)
             }
-            Err(e) => (false, Some(format!("approval relay failed: {e}"))),
+            Ok(Err(e)) => (false, Some(format!("approval relay failed: {e}"))),
+            Err(_) => (
+                false,
+                Some(format!(
+                    "approval relay timed out after {}s; denying",
+                    relay_timeout.as_secs()
+                )),
+            ),
         }
     } else if permission_mode.as_deref() == Some("bypassPermissions") {
         (true, None)
@@ -1085,6 +1182,8 @@ mod tests {
             None,
             workspace,
             state_dir,
+            false,
+            Vec::new(),
         )
     }
 
@@ -1270,6 +1369,111 @@ echo '{"type":"result","subtype":"success","result":"wrote file"}'
     }
 
     #[tokio::test]
+    async fn control_request_approval_relay_times_out_and_denies() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = write_stub(
+            dir.path(),
+            r#"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+read -r _assignment
+echo '{"type":"control_request","request_id":"r1","request":{"subtype":"can_use_tool","tool_name":"Bash","input":{"command":"echo hi"}}}'
+read -r control_response_line
+printf '%s\n' "$control_response_line" > "$DIR/control_response.json"
+echo '{"type":"result","subtype":"success","result":"continued after timeout"}'
+"#,
+        );
+        let (bridge, mut req_rx) = HostBridge::channel();
+        // Hold the request (and its reply oneshot::Sender) alive without ever
+        // replying — exercises the "sender held open but never sent" path,
+        // distinct from `approval_call`'s already-handled "reply dropped"
+        // error (`control_request_with_no_host_denies_and_run_continues`
+        // covers the no-bridge-at-all case; this is the bridge-present,
+        // never-answers case).
+        let held = tokio::spawn(async move { req_rx.recv().await });
+        let (sink, _rx) = EventSink::channel();
+        let sink = sink.with_host_bridge(bridge);
+        let outcome = executor(bin)
+            .with_relay_timeout_for_test(Duration::from_millis(50))
+            .run(
+                run_spec("do something"),
+                sink,
+                SteerInbox::disconnected(),
+                CancellationToken::new(),
+            )
+            .await;
+        assert_eq!(outcome.status, TerminalStatus::Completed);
+        assert_eq!(outcome.result.as_deref(), Some("continued after timeout"));
+
+        let written = std::fs::read_to_string(dir.path().join("control_response.json")).unwrap();
+        let value: Value = serde_json::from_str(written.trim()).unwrap();
+        assert_eq!(value["response"]["response"]["behavior"], "deny");
+        let msg = value["response"]["response"]["message"].as_str().unwrap();
+        assert!(msg.contains("timed out"), "unexpected deny message: {msg}");
+        assert!(msg.contains("denying"), "unexpected deny message: {msg}");
+
+        // Keep the reply sender alive until here (past the run's completion)
+        // so the timeout path — not a dropped-sender race — is what fired.
+        let _req = held.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn env_allowlist_blocks_canary_secret_but_forwards_listed_var() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = write_stub(
+            dir.path(),
+            r#"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+env > "$DIR/env-dump.txt"
+read -r _assignment
+echo '{"type":"result","subtype":"success","result":"ok"}'
+"#,
+        );
+        // A secret-shaped var that must NOT reach the child (not on the fixed
+        // allowlist, not in `forward_env`), and a var that MUST reach it
+        // (explicitly named in `forward_env` — the billing opt-in escape
+        // hatch, e.g. for ANTHROPIC_API_KEY).
+        std::env::set_var("FAKE_SECRET_API_KEY", "leaked-if-broken");
+        std::env::set_var("BAMBOO_TEST_FORWARD_ME", "forwarded-value");
+
+        let exec = ClaudeCodeExecutor::new(
+            Some(bin.to_string_lossy().into_owned()),
+            None,
+            None,
+            None,
+            None,
+            false,
+            vec!["BAMBOO_TEST_FORWARD_ME".to_string()],
+        );
+        let (sink, _rx) = EventSink::channel();
+        let outcome = exec
+            .run(
+                run_spec("hi"),
+                sink,
+                SteerInbox::disconnected(),
+                CancellationToken::new(),
+            )
+            .await;
+
+        std::env::remove_var("FAKE_SECRET_API_KEY");
+        std::env::remove_var("BAMBOO_TEST_FORWARD_ME");
+
+        assert_eq!(outcome.status, TerminalStatus::Completed);
+        let dump = std::fs::read_to_string(dir.path().join("env-dump.txt")).unwrap();
+        assert!(
+            !dump.contains("FAKE_SECRET_API_KEY"),
+            "canary secret leaked into the child env:\n{dump}"
+        );
+        assert!(
+            dump.contains("BAMBOO_TEST_FORWARD_ME=forwarded-value"),
+            "forward_env-listed var missing from the child env:\n{dump}"
+        );
+        // Sanity: PATH (fixed allowlist) must still be present — otherwise
+        // the stub couldn't have run `env`/`cat`-family commands at all, and
+        // this test would be vacuously passing.
+        assert!(dump.contains("PATH="), "PATH missing from the child env");
+    }
+
+    #[tokio::test]
     async fn cancel_kills_the_child_process_group() {
         let dir = tempfile::tempdir().unwrap();
         let bin = write_stub(
@@ -1350,6 +1554,8 @@ echo '{{"type":"result","subtype":"success","result":"ok"}}'
             None,
             None,
             None,
+            false,
+            Vec::new(),
         )
         .run(
             run_spec("hi"),

--- a/src/claude_code_executor.rs
+++ b/src/claude_code_executor.rs
@@ -533,7 +533,7 @@ impl ClaudeCodeExecutor {
         events: &EventSink,
         cancel: &CancellationToken,
     ) -> (ChildOutcome, bool) {
-        let mut child = match self.build_command(resume_id).spawn() {
+        let mut child = match spawn_with_etxtbsy_retry(|| self.build_command(resume_id)).await {
             Ok(c) => c,
             Err(e) => {
                 return (
@@ -721,6 +721,29 @@ impl ChildExecutor for ClaudeCodeExecutor {
         steer_drain.abort();
         outcome
     }
+}
+
+/// Spawn with a short retry on `ETXTBSY` ("text file busy", raw os error 26
+/// on Linux). On Linux, exec-ing an executable that was written moments ago
+/// can transiently fail when ANOTHER thread in this process still holds a
+/// write fd to it at fork time (the fd is inherited across fork until the
+/// exec). In production the `claude` binary is never freshly written, so
+/// this never fires; in the stub-binary test suite, parallel test threads
+/// each writing their own stub make it a real (observed-on-CI) flake. A few
+/// 10ms retries are a complete cure and harmless otherwise.
+async fn spawn_with_etxtbsy_retry(mut build: impl FnMut() -> Command) -> std::io::Result<Child> {
+    let mut last_err = None;
+    for _ in 0..5 {
+        match build().spawn() {
+            Ok(child) => return Ok(child),
+            Err(e) if e.raw_os_error() == Some(26) => {
+                last_err = Some(e);
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Err(last_err.expect("retry loop always records an error before exhausting"))
 }
 
 /// Which signal [`signal_process_group`] sends.

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -69,6 +69,8 @@ pub async fn run() -> std::result::Result<(), String> {
             binary,
             model,
             permission_mode,
+            inherit_user_config,
+            forward_env,
         } => Arc::new(ClaudeCodeExecutor::new(
             binary.clone(),
             model.clone(),
@@ -78,6 +80,8 @@ pub async fn run() -> std::result::Result<(), String> {
                 &spec.storage_dir,
                 &spec.identity.child_id,
             )),
+            inherit_user_config.unwrap_or(false),
+            forward_env.clone().unwrap_or_default(),
         )),
         ExecutorSpec::CliAdapter { .. } => {
             return Err("cli_adapter executor is not implemented yet".to_string());

--- a/tests/e2e_claude_code_manual.rs
+++ b/tests/e2e_claude_code_manual.rs
@@ -1,0 +1,195 @@
+//! MANUAL e2e against the REAL `claude` CLI — never run in CI (all `#[ignore]`).
+//! Run: cargo test --test e2e_claude_code_manual -- --ignored --nocapture --test-threads=1
+//! Requires a logged-in Claude Code install on PATH.
+//!
+//! ## Findings baked into this file (issue #443)
+//!
+//! - **Default mode is `auto`, not `default`.** Against claude 2.1.207, the
+//!   `system.init` frame reports `permissionMode: "auto"` when no
+//!   `--permission-mode` flag is passed at all — the CLI self-approves every
+//!   tool and never emits a `can_use_tool` ask. `ClaudeCodeExecutor::build_command`
+//!   now always passes an EXPLICIT mode (the configured value, or `default`)
+//!   so `bypassPermissions`/`acceptEdits` are opt-in, not the silent norm.
+//! - **Sandbox-safe-echo caveat.** Even in `default` mode, the CLI's own
+//!   sandbox auto-runs plain read-only commands (e.g. `echo`) without asking
+//!   — a test exercising the approval relay MUST use a command with a side
+//!   effect (a file write) to actually force a permission ask; see
+//!   `real_claude_approval_relay_via_host_bridge` below.
+//! - **Billing is subscription, not API-key.** `apiKeySource: "none"` was
+//!   observed with no env key forwarded — confirms the CLI bills the logged-in
+//!   subscription by default. `ClaudeCodeExecutor::build_command` now runs the
+//!   child under `env_clear()` + a fixed allowlist (HOME/PATH/SHELL/TERM/LANG/
+//!   LC_*/TMPDIR/USER/LOGNAME); forwarding `ANTHROPIC_API_KEY` via
+//!   `forward_env` is an explicit opt-in that flips billing to the API key.
+
+use std::time::Duration;
+
+use bamboo_agent::claude_code_executor::ClaudeCodeExecutor;
+use bamboo_subagent::executor::{ChildExecutor, EventSink, HostBridge, SteerInbox};
+use bamboo_subagent::proto::{RunSpec, TerminalStatus};
+use tokio_util::sync::CancellationToken;
+
+fn spec(assignment: &str, messages: Vec<serde_json::Value>) -> RunSpec {
+    RunSpec {
+        assignment: assignment.to_string(),
+        reasoning_effort: None,
+        messages,
+    }
+}
+
+async fn drain_events(
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<serde_json::Value>,
+) -> Vec<serde_json::Value> {
+    let mut all = Vec::new();
+    while let Some(ev) = rx.recv().await {
+        println!("EVENT: {}", serde_json::to_string(&ev).unwrap());
+        all.push(ev);
+    }
+    all
+}
+
+#[tokio::test]
+#[ignore]
+async fn real_claude_fresh_then_resume() {
+    let ws = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let exec = ClaudeCodeExecutor::new(
+        None,
+        None,
+        Some("bypassPermissions".to_string()),
+        Some(ws.path().to_string_lossy().into_owned()),
+        Some(state.path().to_path_buf()),
+        // Default isolation (issue #443): the child does NOT load this
+        // machine's ~/.claude MCP servers/skills/settings, and forwards no
+        // extra env — matches production defaults.
+        false,
+        Vec::new(),
+    );
+
+    // Turn 1: fresh session.
+    let (sink, rx) = EventSink::channel();
+    let events = tokio::spawn(drain_events(rx));
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(180),
+        exec.run(
+            spec("Reply with exactly the word PONG and nothing else.", vec![]),
+            sink,
+            SteerInbox::disconnected(),
+            CancellationToken::new(),
+        ),
+    )
+    .await
+    .expect("turn 1 timed out");
+    println!("OUTCOME1: {outcome:?}");
+    assert_eq!(outcome.status, TerminalStatus::Completed);
+    assert!(outcome.result.as_deref().unwrap_or("").contains("PONG"));
+    let _ = events.await;
+
+    let state_file = state.path().join("claude-code-session.json");
+    let raw = std::fs::read_to_string(&state_file).expect("state file written");
+    println!("STATE: {raw}");
+
+    // Turn 2: reactivation (messages non-empty) → must --resume and remember.
+    let (sink, rx) = EventSink::channel();
+    let events = tokio::spawn(drain_events(rx));
+    let history = vec![serde_json::json!({
+        "role": "user",
+        "content": "Reply with exactly the word PONG and nothing else."
+    })];
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(180),
+        exec.run(
+            spec(
+                "Earlier in this same conversation I asked you to reply with one specific \
+                 uppercase word. Answer with just that word again.",
+                history,
+            ),
+            sink,
+            SteerInbox::disconnected(),
+            CancellationToken::new(),
+        ),
+    )
+    .await
+    .expect("turn 2 timed out");
+    println!("OUTCOME2: {outcome:?}");
+    assert_eq!(outcome.status, TerminalStatus::Completed);
+    assert!(
+        outcome.result.as_deref().unwrap_or("").contains("PONG"),
+        "resume did not carry context: {:?}",
+        outcome.result
+    );
+    let _ = events.await;
+}
+
+#[tokio::test]
+#[ignore]
+async fn real_claude_approval_relay_via_host_bridge() {
+    let ws = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    // EXPLICIT default mode: claude 2.1.207's headless stream-json default is
+    // "auto" (auto-approve, never asks) — discovered in this e2e; only an
+    // explicit --permission-mode default makes Bash gated and relayed. (As
+    // of #443 the executor always passes an explicit mode anyway, so `None`
+    // here would now behave identically — kept explicit for clarity.)
+    let exec = ClaudeCodeExecutor::new(
+        None,
+        None,
+        Some("default".to_string()),
+        Some(ws.path().to_string_lossy().into_owned()),
+        Some(state.path().to_path_buf()),
+        false,
+        Vec::new(),
+    );
+
+    let (bridge, mut req_rx) = HostBridge::channel();
+    let approvals = tokio::spawn(async move {
+        let mut seen = Vec::new();
+        while let Some(req) = req_rx.recv().await {
+            println!(
+                "APPROVAL_REQ: {}",
+                serde_json::to_string(&req.body).unwrap()
+            );
+            seen.push(req.body.clone());
+            let _ = req.reply.send(serde_json::json!({"approved": true}));
+        }
+        seen
+    });
+
+    let (sink, rx) = EventSink::channel();
+    let sink = sink.with_host_bridge(bridge);
+    let events = tokio::spawn(drain_events(rx));
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(240),
+        exec.run(
+            spec(
+                "Use the Bash tool to run exactly: touch approval-marker.txt && echo \
+                 wrote-approval-marker — then report the command's output back verbatim. \
+                 (A plain echo is auto-sandboxed as safe by the CLI; the file write is \
+                 what forces a permission ask.)",
+                vec![],
+            ),
+            sink,
+            SteerInbox::disconnected(),
+            CancellationToken::new(),
+        ),
+    )
+    .await
+    .expect("approval turn timed out");
+    println!("OUTCOME: {outcome:?}");
+    let _ = events.await;
+    let seen = approvals.await.unwrap();
+    assert_eq!(outcome.status, TerminalStatus::Completed);
+    assert!(
+        outcome
+            .result
+            .as_deref()
+            .unwrap_or("")
+            .contains("wrote-approval-marker"),
+        "bash output missing: {:?}",
+        outcome.result
+    );
+    assert!(
+        !seen.is_empty(),
+        "no approval request ever reached the host bridge"
+    );
+}


### PR DESCRIPTION
Closes #443.

Hardens `ClaudeCodeExecutor` based on real-machine e2e against claude CLI 2.1.207 (findings documented in the #443 addendum comment; the committed `#[ignore]` e2e suite reproduces them):

## Changes

1. **Explicit permission mode (CRITICAL)** — the CLI's headless stream-json default is `auto` (self-approves every tool, never asks), so every provisioned actor was silently self-approving. `build_command` now always passes `--permission-mode`, defaulting to `default`, which makes the relay/deny policy actually reachable. `bypassPermissions`/`acceptEdits` are explicit opt-ins.
2. **Config isolation by default** — e2e showed the child inheriting the invoking user's entire `~/.claude` (6 MCP servers incl. desktop control, all skills; ~8k cache tokens per spawn). Unless `inherit_user_config: true`, the executor passes `--strict-mcp-config` + `--setting-sources project`.
3. **Env allowlist** — `env_clear()` + allowlist (HOME/PATH/SHELL/TERM/LANG/LC_*/TMPDIR/USER/LOGNAME) + `forward_env` list on the spec. Forwarding `ANTHROPIC_API_KEY` is now an explicit opt-in that flips billing from subscription to API-key; nothing ambient leaks in.
4. **Approval relay timeout** — `decide_and_respond` bounds `HostBridge::approval_call` at 300s; expiry denies with an explanatory message (test uses an injected short timeout).
5. **Config plumbing** — `SubagentsConfig` + `ExternalAgentProfile` gain `claude_code_binary/_model/_permission_mode/_inherit_user_config/_forward_env`; both `ExecutorSpec::ClaudeCode` construction sites thread them through (spec fields are additive serde options).
6. **ETXTBSY spawn retry** — root-caused and fixed the flaky `oversized_single_stdout_line_parses` CI failure: parallel test threads write executable stubs, an inherited write fd across another thread's fork makes exec fail transiently with "text file busy" on Linux. Spawn now retries a few times on raw os error 26; never fires for a real binary.

Also commits the manual real-CLI e2e suite (`tests/e2e_claude_code_manual.rs`, all `#[ignore]`) with the findings baked into its header, and rewrites the affected doc sections (`docs/claude-code-executor.md` §1/§3/§6/§7 + new §8 config table).

## Verification

- Real-machine e2e (hardened build, claude 2.1.207): 2/2 pass — fresh→resume carries context; approval relay reaches the host bridge and the approved write executes. Notably ~2× faster per turn under isolation (no global-config cache creation).
- `cargo test -p bamboo-agent --lib claude_code_executor` 17/17; `-p bamboo-subagent` 48/48; `-p bamboo-engine external_agents` 43/43.
- Exact CI lint line clean workspace-wide on 1.97.0 (post-#448 rebase); `cargo fmt --all -- --check` clean; `cargo build --workspace --tests` green.

https://claude.ai/code/session_01Usp3jUXqDejy2eWuFWGsip
