### PR TITLE
feat(connect): bamboo-connect MVP — Telegram long-poll platform + session bridge

### DIFF
--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -1,6 +1,6 @@
 use super::init::{
-    build_provider_handles, build_schedule_manager, build_spawn_scheduler, init_mcp_manager,
-    init_metrics_service, init_schedule_store, init_skill_manager, init_storage,
+    build_connect_manager, build_provider_handles, build_schedule_manager, build_spawn_scheduler,
+    init_mcp_manager, init_metrics_service, init_schedule_store, init_skill_manager, init_storage,
     load_permission_checker, spawn_session_map_cleanup_task,
 };
 use super::tools::{build_base_tools, build_root_tools};
@@ -482,6 +482,25 @@ impl AppState {
             persistence.clone(),
         );
 
+        // bamboo-connect (#452 / epic #447): drives bamboo sessions from IM
+        // platforms (Telegram first). Fully inert when `config.connect.platforms`
+        // is empty — mirrors the schedule manager / notification relay's
+        // always-constructed-but-only-active-if-configured lifecycle.
+        let connect_manager = Arc::new(
+            build_connect_manager(
+                agent.clone(),
+                tool_factory.get(crate::tools::ToolSurface::Root),
+                session_repo.clone(),
+                agent_runners.clone(),
+                session_event_senders.clone(),
+                Some(account_sink.inbox()),
+                Some(data_dir.clone()),
+                config.clone(),
+                provider_registry.clone(),
+            )
+            .await,
+        );
+
         // Dedicated child-session adapter backing the guardian review spawner.
         // The guardian path passes an explicit model (no subagent_type routing)
         // and registers its parent wait at the terminal gate (not via the
@@ -540,6 +559,7 @@ impl AppState {
             bash_resume_hook,
             schedule_store,
             schedule_manager,
+            connect_manager,
             tool_factory,
             permission_checker,
             notification_service,

--- a/crates/app/bamboo-server/src/app_state/init.rs
+++ b/crates/app/bamboo-server/src/app_state/init.rs
@@ -427,6 +427,41 @@ pub fn build_schedule_manager(
     )))
 }
 
+/// Build (and start) the bamboo-connect manager (#452 / epic #447).
+///
+/// Reads `config`'s CURRENT snapshot for `connect.platforms` at construction
+/// time (connect platforms are not hot-reloadable in this MVP — a config
+/// change takes effect on the next restart, same as `subagents.broker`).
+/// Returns a manager with zero background tasks when `connect.platforms` is
+/// empty, so callers can always construct + store it unconditionally (mirrors
+/// [`build_schedule_manager`]'s always-on lifecycle).
+#[allow(clippy::too_many_arguments)]
+pub async fn build_connect_manager(
+    agent: Arc<Agent>,
+    tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor>,
+    session_repo: bamboo_engine::SessionRepository,
+    agent_runners: Arc<RwLock<HashMap<String, AgentRunner>>>,
+    session_event_senders: Arc<RwLock<HashMap<String, broadcast::Sender<AgentEvent>>>>,
+    account_feed_inbox: Option<bamboo_engine::execution::AccountFeedInbox>,
+    app_data_dir: Option<PathBuf>,
+    config: Arc<RwLock<Config>>,
+    provider_registry: Arc<bamboo_llm::ProviderRegistry>,
+) -> crate::connect::ConnectManager {
+    let config_snapshot = config.read().await.clone();
+    let ctx = crate::connect::ConnectContext {
+        agent,
+        tools,
+        session_repo,
+        agent_runners,
+        session_event_senders,
+        account_feed_inbox,
+        app_data_dir: app_data_dir.clone(),
+        config,
+        provider_registry,
+    };
+    crate::connect::ConnectManager::start(ctx, &config_snapshot, app_data_dir).await
+}
+
 #[cfg(test)]
 mod eviction_tests {
     use super::*;

--- a/crates/app/bamboo-server/src/app_state/mod.rs
+++ b/crates/app/bamboo-server/src/app_state/mod.rs
@@ -254,6 +254,12 @@ pub struct AppState {
     /// Background schedule manager that triggers scheduled runs.
     pub schedule_manager: Arc<ScheduleManager>,
 
+    /// bamboo-connect manager (#452 / epic #447): owns every configured IM
+    /// platform's long-poll/dispatch background task. Fully inert (zero
+    /// tasks) when `config.connect.platforms` is empty. Held so its tasks
+    /// live for the server's lifetime (`ConnectManager::drop` aborts them).
+    pub connect_manager: Arc<crate::connect::ConnectManager>,
+
     /// Tool surface factory providing pre-built tool executors for each session type.
     ///
     /// Use `state.tools_for(ToolSurface::Root)` for root sessions,

--- a/crates/app/bamboo-server/src/config_manager.rs
+++ b/crates/app/bamboo-server/src/config_manager.rs
@@ -27,8 +27,9 @@ use bamboo_llm::Config;
 // can import through `config_manager`.
 pub use bamboo_config::patch::{
     deep_merge_json, domains_for_root_patch, effects_for_root_patch, is_masked_api_key,
-    preserve_masked_notification_secrets, preserve_masked_provider_api_keys,
-    provider_api_key_intents, sanitize_root_patch, DomainChanges, PatchEffects, ReloadMode,
+    preserve_masked_connect_secrets, preserve_masked_notification_secrets,
+    preserve_masked_provider_api_keys, provider_api_key_intents, sanitize_root_patch,
+    DomainChanges, PatchEffects, ReloadMode,
 };
 
 pub fn sync_provider_api_keys_encrypted_for_patch(
@@ -156,6 +157,7 @@ pub fn build_merged_config(
     new_config.hydrate_mcp_secrets_from_encrypted();
     new_config.hydrate_env_vars_from_encrypted();
     new_config.hydrate_notifications_from_encrypted();
+    new_config.hydrate_connect_platform_tokens_from_encrypted();
     // The serde round-trip above drops every provider's `#[serde(skip_serializing)]`
     // `api_key`; hydration only restores ciphertext-backed keys, so an env-sourced
     // key (no ciphertext, #253) would be silently blanked by any settings PATCH.

--- a/crates/app/bamboo-server/src/connect/bridge.rs
+++ b/crates/app/bamboo-server/src/connect/bridge.rs
@@ -1,0 +1,1022 @@
+//! Chat ⇄ bamboo-session routing, busy lock + FIFO queue, and execution
+//! through the single canonical [`spawn_session_execution`] path.
+//!
+//! Reference: `schedule_app::manager::run_schedule_job` — the SAME
+//! `SessionExecutionArgs` + event-forwarder + reservation pattern is reused
+//! here (see `run_prompt`), rather than inventing a parallel loop.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex as StdMutex};
+
+use chrono::{DateTime, Utc};
+use tokio::sync::{broadcast, Mutex as AsyncMutex, RwLock as TokioRwLock};
+use tokio_util::sync::CancellationToken;
+
+use bamboo_agent_core::tools::ToolExecutor;
+use bamboo_agent_core::{AgentEvent, Message, Session};
+use bamboo_domain::reasoning::ReasoningEffort;
+use bamboo_engine::config::GoldConfig;
+use bamboo_engine::execution::runner_state::AgentRunner;
+use bamboo_engine::execution::{
+    create_event_forwarder, get_or_create_event_sender, spawn_session_execution,
+    try_reserve_runner, SessionExecutionArgs,
+};
+use bamboo_engine::{AuxiliaryModelConfig, ModelRoster, SessionRepository};
+use bamboo_llm::{Config, ProviderRegistry};
+
+use super::platform::{InboundMessage, OutboundMessage, Platform, ReplyCtx};
+use super::render;
+
+/// `platform:chat_id:user_id` — the chat-scoped routing key mapping to a
+/// bamboo session id (see epic #447's "Bridge" design).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SessionKey {
+    pub platform: String,
+    pub chat_id: String,
+    pub user_id: String,
+}
+
+impl SessionKey {
+    pub fn as_string(&self) -> String {
+        format!("{}:{}:{}", self.platform, self.chat_id, self.user_id)
+    }
+}
+
+/// Shared dependencies the bridge needs to run sessions through the
+/// canonical execution path. Cheap to clone (every field is an `Arc`, or
+/// small/`Clone`).
+#[derive(Clone)]
+pub struct ConnectContext {
+    pub agent: Arc<bamboo_engine::Agent>,
+    pub tools: Arc<dyn ToolExecutor>,
+    pub session_repo: SessionRepository,
+    pub agent_runners: Arc<TokioRwLock<HashMap<String, AgentRunner>>>,
+    pub session_event_senders: Arc<TokioRwLock<HashMap<String, broadcast::Sender<AgentEvent>>>>,
+    pub account_feed_inbox: Option<bamboo_engine::execution::AccountFeedInbox>,
+    pub app_data_dir: Option<PathBuf>,
+    pub config: Arc<tokio::sync::RwLock<Config>>,
+    pub provider_registry: Arc<ProviderRegistry>,
+}
+
+/// Per-chat runtime state: whether a run is currently executing, the FIFO
+/// queue of messages that arrived while busy (drained at run end — mirrors
+/// cc-connect engine.go's `queueMessageForBusySession`), and the cancel token
+/// of the in-flight run (if any) so `/stop` can reach it without waiting in
+/// the queue.
+#[derive(Default)]
+struct ChatState {
+    busy: bool,
+    queue: VecDeque<(Arc<dyn Platform>, InboundMessage)>,
+    cancel_token: Option<CancellationToken>,
+}
+
+/// Resolved model/prompt/workspace configuration for a connect-driven run,
+/// derived from the live global config. Mirrors
+/// `schedule_app::manager::ResolvedRunConfig`, minus the per-job overrides a
+/// scheduled run supports (a chat message has none).
+struct ResolvedConnectRunConfig {
+    model_roster: ModelRoster,
+    reasoning_effort: Option<ReasoningEffort>,
+    gold_config: Option<GoldConfig>,
+    system_prompt: String,
+    base_system_prompt: String,
+    workspace_path: Option<String>,
+}
+
+fn resolve_connect_run_config(
+    config_snapshot: &Config,
+    provider_registry: &Arc<ProviderRegistry>,
+) -> ResolvedConnectRunConfig {
+    let model = config_snapshot.get_model().unwrap_or_default();
+    let provider_name = Some(config_snapshot.effective_default_provider().to_string());
+    let provider_type = provider_name.as_deref().and_then(|name| {
+        bamboo_engine::model_config_helper::resolve_provider_type(
+            config_snapshot,
+            name,
+            provider_registry,
+        )
+    });
+    let capability_provider_name = provider_name
+        .as_deref()
+        .unwrap_or(config_snapshot.effective_default_provider());
+    // Auxiliary models are global (config-derived), never session-bound —
+    // same rationale as `schedule_app::manager::resolve_run_config_from_config`.
+    let areas = bamboo_engine::model_areas::resolve_global_area_models(
+        config_snapshot,
+        capability_provider_name,
+        provider_registry,
+    );
+    let reasoning_effort = config_snapshot.get_reasoning_effort();
+    let base_system_prompt =
+        bamboo_engine::prompt_defaults::read_global_default_system_prompt_template();
+    let workspace_path = config_snapshot
+        .get_default_work_area_path()
+        .map(|path| bamboo_config::paths::path_to_display_string(&path));
+    let system_prompt = bamboo_engine::context::assemble_system_prompt(
+        &base_system_prompt,
+        None,
+        workspace_path.as_deref(),
+    );
+    let model_roster = ModelRoster::from_areas(Some(model), provider_name, provider_type, areas);
+
+    ResolvedConnectRunConfig {
+        model_roster,
+        reasoning_effort,
+        gold_config: bamboo_engine::model_config_helper::resolve_gold_config(config_snapshot, None),
+        system_prompt,
+        base_system_prompt,
+        workspace_path,
+    }
+}
+
+/// Builds a fresh session for a connect chat key. Mirrors
+/// `schedule_app::session_factory::create_schedule_session`.
+///
+/// Sets `no_human_approver` (like a scheduled run): approvals/buttons are a
+/// later phase of epic #447 (#452 is text-only), so there is no channel to
+/// answer a gated-tool prompt yet — without this flag a gated action would
+/// hang waiting on an approver that can never respond.
+fn create_connect_session(
+    key: &str,
+    model: &str,
+    system_prompt: &str,
+    base_system_prompt: &str,
+    workspace_path: Option<&str>,
+    reasoning_effort: Option<ReasoningEffort>,
+) -> Session {
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let mut session = Session::new(session_id.clone(), model.to_string());
+    session.title = format!("Connect: {key}");
+    session
+        .metadata
+        .insert("created_by_connect_key".to_string(), key.to_string());
+    session.metadata.insert(
+        "base_system_prompt".to_string(),
+        base_system_prompt.to_string(),
+    );
+    if let Some(path) = workspace_path {
+        session.set_workspace_path_meta(path);
+        bamboo_tools::tools::workspace_state::ensure_session_workspace(
+            &session_id,
+            Some(PathBuf::from(path)),
+        );
+    }
+    if let Some(effort) = reasoning_effort {
+        session.set_reasoning_effort_meta(effort.as_str());
+    }
+    session.add_message(Message::system(system_prompt.to_string()));
+    bamboo_engine::runner::refresh_prompt_snapshot(&mut session);
+    session
+        .agent_runtime_state
+        .get_or_insert_with(bamboo_domain::AgentRuntimeState::default)
+        .no_human_approver = true;
+    session
+}
+
+/// Strips a Telegram-style `@BotName` command suffix (`/stop@MyBot` ->
+/// `/stop`) so mention-qualified commands still match in group chats.
+fn strip_command_suffix(text: &str) -> &str {
+    text.split('@').next().unwrap_or(text)
+}
+
+async fn reply_text(platform: &Arc<dyn Platform>, ctx: &ReplyCtx, text: impl Into<String>) {
+    if let Err(error) = platform.reply(ctx, OutboundMessage::text(text)).await {
+        tracing::warn!("connect: failed to send reply: {error}");
+    }
+}
+
+/// Routes inbound platform messages to bamboo sessions, enforces the
+/// per-platform allow-list + dedup, and serializes execution per chat behind
+/// a busy lock + FIFO queue.
+pub struct ConnectBridge {
+    ctx: ConnectContext,
+    /// `SessionKey::as_string()` -> bamboo session id. Persisted as JSON
+    /// (atomic write) so a chat's session survives a server restart.
+    session_map: TokioRwLock<HashMap<String, String>>,
+    map_path: Option<PathBuf>,
+    chat_state: AsyncMutex<HashMap<String, ChatState>>,
+    /// `platform:message_id` seen so far — dedup defense-in-depth alongside
+    /// each adapter's own transport-level dedup (e.g. Telegram's offset
+    /// advance). A `std::sync::Mutex` is fine here: only ever locked for a
+    /// single `HashSet::insert`, never held across an `.await`.
+    seen_message_ids: StdMutex<HashSet<String>>,
+    process_start: DateTime<Utc>,
+}
+
+impl ConnectBridge {
+    pub fn new(ctx: ConnectContext, map_path: Option<PathBuf>) -> Self {
+        Self {
+            ctx,
+            session_map: TokioRwLock::new(HashMap::new()),
+            map_path,
+            chat_state: AsyncMutex::new(HashMap::new()),
+            seen_message_ids: StdMutex::new(HashSet::new()),
+            process_start: Utc::now(),
+        }
+    }
+
+    /// Loads the persisted chat -> session map from disk, if a `map_path`
+    /// was configured. Tolerates a missing or corrupt file (starts empty,
+    /// logging a warning on corruption) — a fresh/lost map degrades to
+    /// "every chat starts a new session," never a hard failure.
+    pub async fn load_session_map(&self) {
+        let Some(path) = &self.map_path else {
+            return;
+        };
+        match tokio::fs::read(path).await {
+            Ok(bytes) => match serde_json::from_slice::<HashMap<String, String>>(&bytes) {
+                Ok(map) => *self.session_map.write().await = map,
+                Err(error) => {
+                    tracing::warn!(
+                        "connect: session map at {path:?} is corrupt, starting empty: {error}"
+                    );
+                }
+            },
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                tracing::warn!("connect: failed to read session map at {path:?}: {error}");
+            }
+        }
+    }
+
+    pub async fn session_id_for_key(&self, key: &str) -> Option<String> {
+        self.session_map.read().await.get(key).cloned()
+    }
+
+    async fn set_session_id_for_key(&self, key: &str, session_id: &str) {
+        {
+            let mut map = self.session_map.write().await;
+            map.insert(key.to_string(), session_id.to_string());
+        }
+        self.persist_session_map().await;
+    }
+
+    async fn rotate_session(&self, key: &str) {
+        {
+            let mut map = self.session_map.write().await;
+            map.remove(key);
+        }
+        self.persist_session_map().await;
+    }
+
+    async fn persist_session_map(&self) {
+        let Some(path) = &self.map_path else {
+            return;
+        };
+        let snapshot = self.session_map.read().await.clone();
+        let json = match serde_json::to_vec_pretty(&snapshot) {
+            Ok(json) => json,
+            Err(error) => {
+                tracing::warn!("connect: failed to serialize session map: {error}");
+                return;
+            }
+        };
+        if let Err(error) = atomic_write(path, &json).await {
+            tracing::warn!("connect: failed to persist session map at {path:?}: {error}");
+        }
+    }
+
+    async fn set_cancel_token(&self, key: &str, token: CancellationToken) {
+        let mut guard = self.chat_state.lock().await;
+        guard.entry(key.to_string()).or_default().cancel_token = Some(token);
+    }
+
+    async fn clear_cancel_token(&self, key: &str) {
+        let mut guard = self.chat_state.lock().await;
+        if let Some(state) = guard.get_mut(key) {
+            state.cancel_token = None;
+        }
+    }
+
+    /// Entry point for every inbound platform message. Enforces allow-list +
+    /// dedup, answers `/stop` and `/status` immediately (bypassing the busy
+    /// queue — a queued `/stop` could never reach a busy chat), and otherwise
+    /// either runs the message right away or queues it behind the chat's
+    /// current run.
+    ///
+    /// Takes `self: Arc<Self>` (not `&self`) so it can hand the bridge off to
+    /// a detached `tokio::spawn` for the actual (potentially long-running)
+    /// execution — this method itself returns as soon as the message is
+    /// either answered inline or queued, so one slow chat can never block
+    /// another chat's inbound dispatch loop.
+    pub async fn handle_inbound(
+        self: Arc<Self>,
+        platform: Arc<dyn Platform>,
+        allow_from: Vec<String>,
+        msg: InboundMessage,
+    ) {
+        if !allow_from.iter().any(|allowed| allowed == &msg.user_id) {
+            tracing::warn!(
+                platform = %msg.platform,
+                chat_id = %msg.chat_id,
+                user_id = %msg.user_id,
+                "connect: rejected inbound message — user not in allow_from"
+            );
+            return;
+        }
+
+        if msg.sent_at < self.process_start {
+            tracing::debug!(
+                platform = %msg.platform,
+                message_id = %msg.message_id,
+                "connect: dropping message older than process start"
+            );
+            return;
+        }
+
+        let dedup_key = format!("{}:{}", msg.platform, msg.message_id);
+        {
+            let mut seen = self.seen_message_ids.lock().unwrap();
+            if !seen.insert(dedup_key) {
+                tracing::debug!(
+                    platform = %msg.platform,
+                    message_id = %msg.message_id,
+                    "connect: dropping duplicate message_id"
+                );
+                return;
+            }
+        }
+
+        let key = SessionKey {
+            platform: msg.platform.clone(),
+            chat_id: msg.chat_id.clone(),
+            user_id: msg.user_id.clone(),
+        }
+        .as_string();
+
+        let command = strip_command_suffix(msg.text.trim());
+        if command.eq_ignore_ascii_case("/stop") {
+            self.handle_stop(&key, &platform, &msg.reply_ctx).await;
+            return;
+        }
+        if command.eq_ignore_ascii_case("/status") {
+            self.handle_status(&key, &platform, &msg.reply_ctx).await;
+            return;
+        }
+
+        let mut guard = self.chat_state.lock().await;
+        let state = guard.entry(key.clone()).or_default();
+        if state.busy {
+            state.queue.push_back((platform, msg));
+            return;
+        }
+        state.busy = true;
+        drop(guard);
+
+        let bridge = self.clone();
+        tokio::spawn(async move {
+            bridge.drain_chat(key, platform, msg).await;
+        });
+    }
+
+    /// Processes `msg`, then keeps draining `chat_state`'s queue for `key`
+    /// (FIFO) until it is empty, at which point the chat is marked idle
+    /// again. Runs in its own spawned task (see [`Self::handle_inbound`]).
+    async fn drain_chat(
+        self: Arc<Self>,
+        key: String,
+        mut platform: Arc<dyn Platform>,
+        mut msg: InboundMessage,
+    ) {
+        loop {
+            self.process_one(&key, platform.clone(), msg).await;
+
+            let next = {
+                let mut guard = self.chat_state.lock().await;
+                match guard.get_mut(&key) {
+                    Some(state) => match state.queue.pop_front() {
+                        Some(item) => Some(item),
+                        None => {
+                            state.busy = false;
+                            None
+                        }
+                    },
+                    None => None,
+                }
+            };
+
+            match next {
+                Some((p, m)) => {
+                    platform = p;
+                    msg = m;
+                }
+                None => break,
+            }
+        }
+    }
+
+    async fn process_one(&self, key: &str, platform: Arc<dyn Platform>, msg: InboundMessage) {
+        let command = strip_command_suffix(msg.text.trim());
+        if command.eq_ignore_ascii_case("/new") {
+            self.rotate_session(key).await;
+            reply_text(&platform, &msg.reply_ctx, "Started a new session.").await;
+            return;
+        }
+
+        let text = msg.text.trim();
+        if text.is_empty() {
+            return;
+        }
+
+        self.run_prompt(key, platform, &msg.reply_ctx, text).await;
+    }
+
+    async fn handle_stop(&self, key: &str, platform: &Arc<dyn Platform>, reply_ctx: &ReplyCtx) {
+        let token = {
+            self.chat_state
+                .lock()
+                .await
+                .get(key)
+                .and_then(|state| state.cancel_token.clone())
+        };
+        match token {
+            Some(token) => {
+                token.cancel();
+                reply_text(platform, reply_ctx, "Stopping the current run…").await;
+            }
+            None => {
+                reply_text(platform, reply_ctx, "Nothing is running.").await;
+            }
+        }
+    }
+
+    async fn handle_status(&self, key: &str, platform: &Arc<dyn Platform>, reply_ctx: &ReplyCtx) {
+        let session_id = self.session_id_for_key(key).await;
+        let busy = {
+            self.chat_state
+                .lock()
+                .await
+                .get(key)
+                .map(|state| state.busy)
+                .unwrap_or(false)
+        };
+        let text = match session_id {
+            Some(id) => format!(
+                "Session: {id}\nStatus: {}",
+                if busy { "busy" } else { "idle" }
+            ),
+            None => "No session yet. Send a message to start one.".to_string(),
+        };
+        reply_text(platform, reply_ctx, text).await;
+    }
+
+    async fn create_and_register_session(
+        &self,
+        key: &str,
+        resolved: &ResolvedConnectRunConfig,
+    ) -> Session {
+        let model = resolved.model_roster.model.clone().unwrap_or_default();
+        let session = create_connect_session(
+            key,
+            &model,
+            &resolved.system_prompt,
+            &resolved.base_system_prompt,
+            resolved.workspace_path.as_deref(),
+            resolved.reasoning_effort,
+        );
+        self.set_session_id_for_key(key, &session.id).await;
+        session
+    }
+
+    /// Runs `text` as a prompt for `key`'s session, through the canonical
+    /// `spawn_session_execution` path (reference:
+    /// `schedule_app::manager::run_schedule_job`), then renders the run's
+    /// live event stream back to the platform (`render::stream_execution`)
+    /// until it reaches a terminal state. Awaited inline by the caller (not
+    /// detached) so the run's completion IS this call's completion — that is
+    /// what lets [`Self::drain_chat`] serialize one run at a time per chat.
+    async fn run_prompt(
+        &self,
+        key: &str,
+        platform: Arc<dyn Platform>,
+        reply_ctx: &ReplyCtx,
+        text: &str,
+    ) {
+        let config_snapshot = self.ctx.config.read().await.clone();
+        let resolved = resolve_connect_run_config(&config_snapshot, &self.ctx.provider_registry);
+
+        if resolved
+            .model_roster
+            .model
+            .as_deref()
+            .unwrap_or("")
+            .trim()
+            .is_empty()
+        {
+            reply_text(
+                &platform,
+                reply_ctx,
+                "No model is configured for this bamboo instance; cannot run your request.",
+            )
+            .await;
+            return;
+        }
+
+        let existing_id = self.session_id_for_key(key).await;
+        let mut session = match existing_id {
+            Some(id) => match self.ctx.session_repo.load_merged(&id).await {
+                Some(session) => session,
+                None => self.create_and_register_session(key, &resolved).await,
+            },
+            None => self.create_and_register_session(key, &resolved).await,
+        };
+
+        session.add_message(Message::user(text.to_string()));
+        let session_id = session.id.clone();
+        self.ctx.session_repo.save_and_cache(&mut session).await;
+
+        let session_tx =
+            get_or_create_event_sender(&self.ctx.session_event_senders, &session_id).await;
+        let rx = session_tx.subscribe();
+
+        let Some(reservation) = try_reserve_runner(
+            &self.ctx.agent_runners,
+            &self.ctx.session_event_senders,
+            &session_id,
+            &session_tx,
+        )
+        .await
+        else {
+            reply_text(
+                &platform,
+                reply_ctx,
+                "This session is already running elsewhere; please wait for it to finish.",
+            )
+            .await;
+            return;
+        };
+
+        self.set_cancel_token(key, reservation.cancel_token.clone())
+            .await;
+
+        let (mpsc_tx, _forwarder_handle) = create_event_forwarder(
+            session_id.clone(),
+            session_tx.clone(),
+            self.ctx.agent_runners.clone(),
+            self.ctx.account_feed_inbox.clone(),
+        );
+
+        // Auxiliary (fast/background/summarization) model resolver — mirrors
+        // `schedule_app::manager::run_schedule_job` exactly.
+        let aux_fast_model = resolved.model_roster.fast_model();
+        let aux_fast_provider = resolved.model_roster.fast_model_provider();
+        let aux_background_model = resolved.model_roster.background_model();
+        let aux_background_provider = resolved.model_roster.background_model_provider();
+        let aux_summarization_model = resolved.model_roster.summarization_model();
+        let aux_summarization_provider = resolved.model_roster.summarization_model_provider();
+        let auxiliary_model_resolver = Arc::new(move || AuxiliaryModelConfig {
+            fast_model_name: aux_fast_model.clone(),
+            fast_model_provider: aux_fast_provider.clone(),
+            background_model_name: aux_background_model.clone(),
+            planning_model_name: None,
+            search_model_name: None,
+            summarization_model_name: aux_summarization_model.clone(),
+            background_model_provider: aux_background_provider.clone(),
+            summarization_model_provider: aux_summarization_provider.clone(),
+        });
+
+        spawn_session_execution(SessionExecutionArgs {
+            agent: self.ctx.agent.clone(),
+            session_id: session_id.clone(),
+            session,
+            tools_override: Some(self.ctx.tools.clone()),
+            provider_override: None,
+            model_roster: resolved.model_roster.clone(),
+            reasoning_effort: resolved.reasoning_effort,
+            reasoning_effort_source: "connect".to_string(),
+            auxiliary_model_resolver: Some(auxiliary_model_resolver),
+            disabled_filter_resolver: None,
+            disabled_tools: None,
+            disabled_skill_ids: None,
+            selected_skill_ids: None,
+            selected_skill_mode: None,
+            cancel_token: reservation.cancel_token,
+            mpsc_tx,
+            image_fallback: None,
+            gold_config: resolved.gold_config.clone(),
+            // Approvals (guardian, bash resume) are a later phase of epic
+            // #447 — MVP has no channel to answer them (see
+            // `create_connect_session`'s `no_human_approver` doc comment).
+            guardian_config: None,
+            guardian_spawner: None,
+            bash_resume_hook: None,
+            bash_completion_sink: None,
+            app_data_dir: self.ctx.app_data_dir.clone(),
+            runners: self.ctx.agent_runners.clone(),
+            sessions_cache: self.ctx.session_repo.cache().clone(),
+            on_complete: None,
+        });
+
+        render::stream_execution(platform, reply_ctx.clone(), rx).await;
+
+        self.clear_cancel_token(key).await;
+    }
+}
+
+/// Writes `bytes` to `path` atomically: temp file in the same directory,
+/// fsync, rename over the target. Mirrors
+/// `handlers::settings::bamboo_config::config_endpoints::common::atomic_write`
+/// (private there) so a crash mid-write leaves the old session map intact.
+async fn atomic_write(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let tmp = path.with_extension(format!("tmp.{}", uuid::Uuid::new_v4()));
+    {
+        let mut file = tokio::fs::File::create(&tmp).await?;
+        tokio::io::AsyncWriteExt::write_all(&mut file, bytes).await?;
+        file.sync_all().await?;
+    }
+    tokio::fs::rename(&tmp, path).await?;
+    if let Some(parent) = path.parent() {
+        if let Ok(dir) = tokio::fs::File::open(parent).await {
+            let _ = dir.sync_all().await;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_state::AppState;
+    use crate::tools::ToolSurface;
+    use std::time::Duration;
+    use tokio::sync::Mutex as TokioMutex;
+
+    /// mpsc-backed fake `Platform` (per issue #452's test spec): records every
+    /// `reply()` call instead of talking to a real IM API.
+    struct FakePlatform {
+        label: String,
+        sent: TokioMutex<Vec<String>>,
+    }
+
+    impl FakePlatform {
+        fn new(label: &str) -> Arc<Self> {
+            Arc::new(Self {
+                label: label.to_string(),
+                sent: TokioMutex::new(Vec::new()),
+            })
+        }
+
+        async fn sent_texts(&self) -> Vec<String> {
+            self.sent.lock().await.clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Platform for FakePlatform {
+        fn name(&self) -> &str {
+            &self.label
+        }
+        fn capabilities(&self) -> super::super::platform::Capabilities {
+            Default::default()
+        }
+        async fn start(
+            &self,
+            _inbound: tokio::sync::mpsc::Sender<InboundMessage>,
+        ) -> super::super::platform::PlatformResult<()> {
+            Ok(())
+        }
+        async fn reply(
+            &self,
+            _ctx: &ReplyCtx,
+            msg: OutboundMessage,
+        ) -> super::super::platform::PlatformResult<super::super::platform::MessageRef> {
+            self.sent.lock().await.push(msg.text);
+            Ok(super::super::platform::MessageRef(serde_json::Value::Null))
+        }
+        async fn edit(
+            &self,
+            _msg_ref: &super::super::platform::MessageRef,
+            _new: OutboundMessage,
+        ) -> super::super::platform::PlatformResult<()> {
+            Ok(())
+        }
+        async fn stop(&self) -> super::super::platform::PlatformResult<()> {
+            Ok(())
+        }
+    }
+
+    async fn test_context() -> (ConnectContext, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        // A full `AppState` gives the bridge a real `Agent`/tools/session-repo
+        // without a network call. A model IS configured (so `run_prompt`'s
+        // "no model configured" guard doesn't short-circuit before a session
+        // is even created) but with no api_key, so the provider falls back to
+        // `UnconfiguredProvider`: execution fails fast with an
+        // `AgentEvent::Error` (non-retryable auth error), which is exactly
+        // what these tests need to observe a run reach a terminal state
+        // quickly without any real network access.
+        let state = AppState::new(dir.path().to_path_buf())
+            .await
+            .expect("app state");
+        {
+            let mut cfg = state.config.write().await;
+            cfg.provider = "openai".to_string();
+            cfg.providers.openai = Some(bamboo_config::OpenAIConfig {
+                api_key: String::new(),
+                api_key_from_env: false,
+                api_key_encrypted: None,
+                base_url: None,
+                model: Some("gpt-4o-mini".to_string()),
+                fast_model: None,
+                vision_model: None,
+                reasoning_effort: None,
+                responses_only_models: Vec::new(),
+                request_overrides: None,
+                extra: Default::default(),
+            });
+        }
+        let ctx = ConnectContext {
+            agent: state.agent.clone(),
+            tools: state.tools_for(ToolSurface::Root),
+            session_repo: state.session_repo.clone(),
+            agent_runners: state.agent_runners.clone(),
+            session_event_senders: state.session_event_senders.clone(),
+            account_feed_inbox: None,
+            app_data_dir: Some(state.app_data_dir.clone()),
+            config: state.config.clone(),
+            provider_registry: state.provider_registry.clone(),
+        };
+        (ctx, dir)
+    }
+
+    fn inbound(chat_id: &str, user_id: &str, message_id: &str, text: &str) -> InboundMessage {
+        InboundMessage {
+            platform: "fake".to_string(),
+            chat_id: chat_id.to_string(),
+            user_id: user_id.to_string(),
+            message_id: message_id.to_string(),
+            sent_at: Utc::now(),
+            text: text.to_string(),
+            reply_ctx: ReplyCtx(serde_json::json!({ "chat_id": chat_id })),
+        }
+    }
+
+    fn key_for(chat_id: &str, user_id: &str) -> String {
+        SessionKey {
+            platform: "fake".to_string(),
+            chat_id: chat_id.to_string(),
+            user_id: user_id.to_string(),
+        }
+        .as_string()
+    }
+
+    #[test]
+    fn session_key_formats_as_platform_chat_user() {
+        let key = SessionKey {
+            platform: "telegram".to_string(),
+            chat_id: "42".to_string(),
+            user_id: "7".to_string(),
+        };
+        assert_eq!(key.as_string(), "telegram:42:7");
+    }
+
+    #[tokio::test]
+    async fn allow_from_denies_users_not_in_the_list() {
+        let (ctx, _dir) = test_context().await;
+        let bridge = Arc::new(ConnectBridge::new(ctx, None));
+        let platform = FakePlatform::new("fake");
+
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            vec!["allowed-user".to_string()],
+            inbound("chat1", "someone-else", "1", "hello"),
+        )
+        .await;
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(platform.sent_texts().await.is_empty());
+        assert!(bridge
+            .session_id_for_key(&key_for("chat1", "someone-else"))
+            .await
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn dedup_drops_repeated_message_ids() {
+        let (ctx, _dir) = test_context().await;
+        let bridge = Arc::new(ConnectBridge::new(ctx, None));
+        let platform = FakePlatform::new("fake");
+        let allow = vec!["u1".to_string()];
+
+        // `/status` replies synchronously with no engine/queue involved, so a
+        // duplicate delivery of the SAME message_id must yield exactly one
+        // reply, not two.
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            allow.clone(),
+            inbound("chat1", "u1", "dup-1", "/status"),
+        )
+        .await;
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            allow,
+            inbound("chat1", "u1", "dup-1", "/status"),
+        )
+        .await;
+
+        let sent = platform.sent_texts().await;
+        assert_eq!(
+            sent.len(),
+            1,
+            "duplicate message_id must be dropped: {sent:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn older_than_process_start_messages_are_dropped() {
+        let (ctx, _dir) = test_context().await;
+        let bridge = Arc::new(ConnectBridge::new(ctx, None));
+        let platform = FakePlatform::new("fake");
+        let mut msg = inbound("chat1", "u1", "1", "/status");
+        msg.sent_at = bridge.process_start - chrono::Duration::seconds(5);
+
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            msg,
+        )
+        .await;
+
+        assert!(platform.sent_texts().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn status_command_reports_idle_with_no_session_yet() {
+        let (ctx, _dir) = test_context().await;
+        let bridge = Arc::new(ConnectBridge::new(ctx, None));
+        let platform = FakePlatform::new("fake");
+
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            inbound("chat1", "u1", "1", "/status"),
+        )
+        .await;
+
+        let sent = platform.sent_texts().await;
+        assert_eq!(sent.len(), 1);
+        assert!(sent[0].contains("No session yet"), "got: {:?}", sent[0]);
+    }
+
+    #[tokio::test]
+    async fn stop_with_nothing_running_replies_nothing_running() {
+        let (ctx, _dir) = test_context().await;
+        let bridge = Arc::new(ConnectBridge::new(ctx, None));
+        let platform = FakePlatform::new("fake");
+
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            inbound("chat1", "u1", "1", "/stop"),
+        )
+        .await;
+
+        assert_eq!(
+            platform.sent_texts().await,
+            vec!["Nothing is running.".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn prompt_creates_a_session_and_maps_it_to_the_chat_key() {
+        let (ctx, _dir) = test_context().await;
+        let bridge = Arc::new(ConnectBridge::new(ctx, None));
+        let platform = FakePlatform::new("fake");
+        let key = key_for("chat1", "u1");
+
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            inbound("chat1", "u1", "1", "hello there"),
+        )
+        .await;
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            if bridge.session_id_for_key(&key).await.is_some() {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "session was never created for the chat key"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn new_command_rotates_the_session_mapping() {
+        let (ctx, _dir) = test_context().await;
+        let bridge = Arc::new(ConnectBridge::new(ctx, None));
+        let platform = FakePlatform::new("fake");
+        let key = key_for("chat1", "u1");
+
+        bridge
+            .set_session_id_for_key(&key, "pre-existing-session")
+            .await;
+        assert_eq!(
+            bridge.session_id_for_key(&key).await.as_deref(),
+            Some("pre-existing-session")
+        );
+
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            inbound("chat1", "u1", "1", "/new"),
+        )
+        .await;
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            if bridge.session_id_for_key(&key).await.is_none() {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "session mapping was never rotated away"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let sent = platform.sent_texts().await;
+        assert!(sent.iter().any(|t| t == "Started a new session."));
+    }
+
+    #[tokio::test]
+    async fn busy_queue_drains_a_second_message_after_the_first_finishes() {
+        let (ctx, _dir) = test_context().await;
+        let bridge = Arc::new(ConnectBridge::new(ctx, None));
+        let platform = FakePlatform::new("fake");
+        let allow = vec!["u1".to_string()];
+        let key = key_for("chat1", "u1");
+
+        // Two prompts arriving back-to-back for the SAME chat: the second
+        // must queue behind the first (busy lock) rather than racing it, and
+        // the chat must return to idle once both have run.
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            allow.clone(),
+            inbound("chat1", "u1", "1", "first"),
+        )
+        .await;
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            allow,
+            inbound("chat1", "u1", "2", "second"),
+        )
+        .await;
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            let idle = {
+                !bridge
+                    .chat_state
+                    .lock()
+                    .await
+                    .get(&key)
+                    .map(|state| state.busy)
+                    .unwrap_or(true)
+            };
+            if idle {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "chat never drained back to idle"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        assert!(bridge.session_id_for_key(&key).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn session_map_persists_and_reloads_across_bridge_instances() {
+        let (ctx, dir) = test_context().await;
+        let map_path = dir.path().join("connect_sessions.json");
+        let bridge = ConnectBridge::new(ctx.clone(), Some(map_path.clone()));
+        bridge.set_session_id_for_key("k1", "sess-1").await;
+
+        let bridge2 = ConnectBridge::new(ctx, Some(map_path));
+        bridge2.load_session_map().await;
+
+        assert_eq!(
+            bridge2.session_id_for_key("k1").await.as_deref(),
+            Some("sess-1")
+        );
+    }
+}

--- a/crates/app/bamboo-server/src/connect/mod.rs
+++ b/crates/app/bamboo-server/src/connect/mod.rs
@@ -1,0 +1,140 @@
+//! bamboo-connect: drive bamboo sessions from IM platforms (Telegram first).
+//!
+//! Issue #452 (MVP, phase 1 of epic #447). Sibling module of
+//! `schedule_app`/`notify_sinks` — the closest precedents: `notify_sinks` is
+//! one-way outbound, `schedule_app::manager` is the canonical
+//! background-execution pattern this module's [`bridge::ConnectBridge`]
+//! reuses verbatim (`spawn_session_execution`, event-forwarder, runner
+//! reservation).
+//!
+//! ```text
+//! connect/
+//!   platform.rs      — the Platform trait + Capabilities + message types
+//!   bridge.rs         — chat ⇄ bamboo-session routing, busy lock, queueing
+//!   render.rs         — AgentEvent stream → platform messages
+//!   platforms/telegram.rs — long-poll adapter
+//! ```
+//!
+//! [`ConnectManager`] is constructed once at server startup (mirrors
+//! `ScheduleManager` / the notification relay — see
+//! `app_state::init::build_connect_manager`) and is FULLY INERT when
+//! `config.connect.platforms` is empty: no `[connect]` section in
+//! `config.json` means zero background tasks are spawned.
+
+pub mod bridge;
+pub mod platform;
+pub mod platforms;
+pub mod render;
+
+pub use bridge::{ConnectBridge, ConnectContext, SessionKey};
+pub use platform::{
+    Capabilities, InboundMessage, MessageRef, OutboundMessage, Platform, PlatformError,
+    PlatformResult, ReplyCtx,
+};
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use bamboo_llm::Config;
+
+/// Owns every configured platform's long-poll/dispatch background task plus
+/// the shared [`ConnectBridge`]. All tasks are aborted when the manager
+/// drops (mirrors `app_state::builder::EmbeddedBroker`/`HealthMonitor`'s
+/// Drop-based stop — the closest server-lifecycle precedent for a
+/// fire-and-forget background subsystem).
+pub struct ConnectManager {
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl ConnectManager {
+    /// Builds the bridge, loads its persisted session map, and starts one
+    /// long-poll + one dispatch task per recognized platform entry in
+    /// `config_snapshot.connect.platforms`. An empty (or absent) `[connect]`
+    /// config starts zero tasks — fully inert by default, per #452.
+    pub async fn start(
+        ctx: ConnectContext,
+        config_snapshot: &Config,
+        data_dir: Option<PathBuf>,
+    ) -> Self {
+        let map_path = data_dir.map(|dir| dir.join("connect_sessions.json"));
+        let bridge = Arc::new(ConnectBridge::new(ctx, map_path));
+        bridge.load_session_map().await;
+
+        let mut tasks = Vec::new();
+        for platform_cfg in &config_snapshot.connect.platforms {
+            match platform_cfg.platform_type.as_str() {
+                "telegram" => {
+                    let token = platform_cfg.token.clone().unwrap_or_default();
+                    if token.trim().is_empty() {
+                        tracing::warn!(
+                            "connect: telegram platform configured without a token; skipping"
+                        );
+                        continue;
+                    }
+                    if platform_cfg.allow_from.is_empty() {
+                        tracing::warn!(
+                            "connect: telegram platform has an EMPTY allow_from list — every \
+                             inbound message will be denied until you add allowed user ids to \
+                             connect.platforms[].allow_from"
+                        );
+                    }
+
+                    let platform: Arc<dyn Platform> =
+                        Arc::new(platforms::telegram::TelegramPlatform::new(token));
+                    let allow_from = platform_cfg.allow_from.clone();
+                    let (tx, rx) = mpsc::channel(64);
+
+                    let platform_for_start = platform.clone();
+                    tasks.push(tokio::spawn(async move {
+                        if let Err(error) = platform_for_start.start(tx).await {
+                            tracing::warn!("connect: telegram platform loop exited: {error}");
+                        }
+                    }));
+
+                    let bridge_for_dispatch = bridge.clone();
+                    let platform_for_dispatch = platform.clone();
+                    tasks.push(tokio::spawn(dispatch_loop(
+                        bridge_for_dispatch,
+                        platform_for_dispatch,
+                        allow_from,
+                        rx,
+                    )));
+
+                    tracing::info!("connect: started telegram platform");
+                }
+                other => {
+                    tracing::warn!("connect: unknown platform type '{other}'; skipping");
+                }
+            }
+        }
+
+        Self { tasks }
+    }
+}
+
+impl Drop for ConnectManager {
+    fn drop(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+    }
+}
+
+/// Pulls inbound messages off a single platform's channel and hands each to
+/// the bridge. Kept as its OWN task per platform (not merged into the
+/// platform's `start()` loop) so a slow/queued chat can never stall the next
+/// `getUpdates` poll — `ConnectBridge::handle_inbound` itself returns quickly
+/// (it spawns the actual run), so this loop only ever blocks briefly.
+async fn dispatch_loop(
+    bridge: Arc<ConnectBridge>,
+    platform: Arc<dyn Platform>,
+    allow_from: Vec<String>,
+    mut rx: mpsc::Receiver<InboundMessage>,
+) {
+    while let Some(msg) = rx.recv().await {
+        ConnectBridge::handle_inbound(bridge.clone(), platform.clone(), allow_from.clone(), msg)
+            .await;
+    }
+}

--- a/crates/app/bamboo-server/src/connect/platform.rs
+++ b/crates/app/bamboo-server/src/connect/platform.rs
@@ -1,0 +1,113 @@
+//! The `Platform` trait + shared inbound/outbound message types.
+//!
+//! Per epic #447: cc-connect's proven 5-method core, with capabilities
+//! EXPLICIT (not type-asserted) so the bridge/render layer never guesses what
+//! an adapter can do. `ReplyCtx` is platform-opaque (`serde_json::Value`),
+//! carried on every [`InboundMessage`] and handed back to
+//! `Platform::reply`/`Platform::edit` unmodified — mirrors cc-connect's
+//! `replyCtx any` pattern.
+
+use tokio::sync::mpsc;
+
+/// What a platform adapter supports. MVP adapters (Telegram, phase 1) advertise
+/// everything `false` except plain text — buttons/streaming-edit are phase 2.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Capabilities {
+    /// Inline approval/action buttons on a message.
+    pub buttons: bool,
+    /// In-place message editing (`Platform::edit`) — used for streaming
+    /// edit-in-place in a later phase.
+    pub edit_message: bool,
+    /// Sending image attachments.
+    pub images: bool,
+    /// Sending file attachments.
+    pub files: bool,
+}
+
+/// Platform-opaque context handed back unmodified to `Platform::reply`/`edit`.
+/// Concrete shape is decided by each adapter (e.g. Telegram stores `chat_id`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReplyCtx(pub serde_json::Value);
+
+/// A reference to a previously-sent message, for `Platform::edit`
+/// (capability-gated on [`Capabilities::edit_message`]).
+#[derive(Debug, Clone, PartialEq)]
+pub struct MessageRef(pub serde_json::Value);
+
+/// A message received from a platform, normalized to the shape the bridge
+/// understands. Fields beyond `text`/`reply_ctx` exist to let the bridge
+/// enforce security policy (allow-list, dedup) generically across every
+/// platform adapter, without knowing platform-specific wire formats.
+#[derive(Debug, Clone)]
+pub struct InboundMessage {
+    /// Platform name (matches `Platform::name`), e.g. `"telegram"`.
+    pub platform: String,
+    /// Platform-scoped chat identifier.
+    pub chat_id: String,
+    /// Platform-scoped sender identifier (checked against `allow_from`).
+    pub user_id: String,
+    /// Platform-scoped, per-platform-unique message id used for dedup (e.g.
+    /// Telegram's `update_id`, stringified).
+    pub message_id: String,
+    /// When the platform says the message was sent — used to drop stale
+    /// backlog delivered right after a restart (older than process start).
+    pub sent_at: chrono::DateTime<chrono::Utc>,
+    /// Message text.
+    pub text: String,
+    /// Opaque context to hand back to `Platform::reply`/`edit`.
+    pub reply_ctx: ReplyCtx,
+}
+
+/// A message to send to a platform.
+#[derive(Debug, Clone)]
+pub struct OutboundMessage {
+    pub text: String,
+}
+
+impl OutboundMessage {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self { text: text.into() }
+    }
+}
+
+/// Error returned by a `Platform` adapter operation.
+#[derive(Debug, thiserror::Error)]
+pub enum PlatformError {
+    #[error("{0}")]
+    Other(String),
+}
+
+impl PlatformError {
+    pub fn other(msg: impl Into<String>) -> Self {
+        Self::Other(msg.into())
+    }
+}
+
+pub type PlatformResult<T> = std::result::Result<T, PlatformError>;
+
+/// An IM-platform adapter. cc-connect's proven 5-method core (`start`,
+/// `reply`, `edit`, `stop`, plus `capabilities`/`name`) — see epic #447.
+#[async_trait::async_trait]
+pub trait Platform: Send + Sync {
+    /// Short identifier, e.g. `"telegram"`. Matches [`InboundMessage::platform`].
+    fn name(&self) -> &str;
+
+    /// What this adapter supports.
+    fn capabilities(&self) -> Capabilities;
+
+    /// Start receiving inbound messages, sending each onto `inbound`.
+    /// Runs for the adapter's lifetime (a long-poll loop, a WS connection,
+    /// …); returns only on an unrecoverable error or `stop()`.
+    async fn start(&self, inbound: mpsc::Sender<InboundMessage>) -> PlatformResult<()>;
+
+    /// Send a message in reply to `ctx`.
+    async fn reply(&self, ctx: &ReplyCtx, msg: OutboundMessage) -> PlatformResult<MessageRef>;
+
+    /// Edit a previously-sent message in place. Capability-gated on
+    /// [`Capabilities::edit_message`]; adapters that don't support it may
+    /// return an error — callers must check the capability first.
+    async fn edit(&self, msg_ref: &MessageRef, new: OutboundMessage) -> PlatformResult<()>;
+
+    /// Stop the adapter (best-effort; graceful shutdown).
+    async fn stop(&self) -> PlatformResult<()>;
+}

--- a/crates/app/bamboo-server/src/connect/platforms/mod.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/mod.rs
@@ -1,0 +1,1 @@
+pub mod telegram;

--- a/crates/app/bamboo-server/src/connect/platforms/telegram.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/telegram.rs
@@ -149,6 +149,24 @@ impl TelegramPlatform {
         )
     }
 
+    /// Format a `reqwest::Error` for logs/errors WITHOUT the bot token.
+    ///
+    /// Telegram puts the token in the URL path (`/bot<token>/<method>`), and
+    /// `reqwest::Error`'s `Display` includes the request URL when one is
+    /// attached ("error sending request for url (…)"), so a naive
+    /// `format!("{error}")` on any transient network failure would print the
+    /// live token into ordinary server logs. Strip the URL from the error
+    /// (`without_url`) and, belt-and-braces, redact any literal token
+    /// occurrence in whatever text remains (e.g. proxy errors that embed the
+    /// target URL themselves).
+    fn sanitize_error(&self, error: reqwest::Error) -> String {
+        let text = error.without_url().to_string();
+        if self.token.is_empty() {
+            return text;
+        }
+        text.replace(&self.token, "[REDACTED]")
+    }
+
     async fn get_updates(
         &self,
         offset: i64,
@@ -166,11 +184,19 @@ impl TelegramPlatform {
             .timeout(Duration::from_secs(timeout_secs + 15))
             .send()
             .await
-            .map_err(|error| PlatformError::other(format!("getUpdates request failed: {error}")))?;
+            .map_err(|error| {
+                PlatformError::other(format!(
+                    "getUpdates request failed: {}",
+                    self.sanitize_error(error)
+                ))
+            })?;
 
         let parsed: TelegramResponse<Vec<TelegramUpdate>> =
             response.json().await.map_err(|error| {
-                PlatformError::other(format!("getUpdates response parse failed: {error}"))
+                PlatformError::other(format!(
+                    "getUpdates response parse failed: {}",
+                    self.sanitize_error(error)
+                ))
             })?;
 
         if !parsed.ok {
@@ -299,12 +325,18 @@ impl Platform for TelegramPlatform {
                 .send()
                 .await
                 .map_err(|error| {
-                    PlatformError::other(format!("sendMessage request failed: {error}"))
+                    PlatformError::other(format!(
+                        "sendMessage request failed: {}",
+                        self.sanitize_error(error)
+                    ))
                 })?;
 
             let parsed: TelegramResponse<TelegramMessage> =
                 response.json().await.map_err(|error| {
-                    PlatformError::other(format!("sendMessage response parse failed: {error}"))
+                    PlatformError::other(format!(
+                        "sendMessage response parse failed: {}",
+                        self.sanitize_error(error)
+                    ))
                 })?;
 
             if !parsed.ok {
@@ -582,5 +614,32 @@ mod tests {
         assert!(!caps.edit_message);
         assert!(!caps.images);
         assert!(!caps.files);
+    }
+
+    /// The bot token lives in the request URL path; `reqwest::Error`'s
+    /// `Display` would print it on any transport failure. Force a real
+    /// connection error (port 1 is unroutable/refused) and assert the token
+    /// never appears in the surfaced error text.
+    #[tokio::test]
+    async fn transport_errors_never_leak_the_bot_token() {
+        let token = "123456:SECRET-TOKEN-MUST-NOT-LEAK";
+        let platform = TelegramPlatform::with_options(
+            token.to_string(),
+            "http://127.0.0.1:1".to_string(),
+            Duration::from_millis(1),
+        );
+        let err = platform
+            .get_updates(0, 0)
+            .await
+            .expect_err("port 1 must refuse the connection");
+        let text = format!("{err}");
+        assert!(
+            !text.contains(token) && !text.contains("SECRET-TOKEN"),
+            "token leaked into error text: {text}"
+        );
+        assert!(
+            text.contains("getUpdates request failed"),
+            "unexpected error shape: {text}"
+        );
     }
 }

--- a/crates/app/bamboo-server/src/connect/platforms/telegram.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/telegram.rs
@@ -1,0 +1,586 @@
+//! Telegram long-poll platform adapter (issue #452, epic #447's first
+//! platform: no public IP, no webhook, no WS — just `getUpdates` over plain
+//! HTTPS).
+//!
+//! Buttons / `editMessageText` are NOT in this phase — [`Capabilities`]
+//! advertises them `false` (see epic #447's phase list).
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use tokio::sync::{mpsc, Mutex as AsyncMutex};
+
+use super::super::platform::{
+    Capabilities, InboundMessage, MessageRef, OutboundMessage, Platform, PlatformError,
+    PlatformResult, ReplyCtx,
+};
+use super::super::render::{chunk_message, MAX_MESSAGE_CHARS};
+
+const DEFAULT_BASE_URL: &str = "https://api.telegram.org";
+/// Telegram's own long-poll timeout — the server holds the `getUpdates`
+/// connection open for up to this many seconds waiting for a new update.
+const LONG_POLL_TIMEOUT_SECS: u64 = 30;
+/// Backoff between `getUpdates` retries after a transport/parse failure.
+const RETRY_BACKOFF: Duration = Duration::from_secs(5);
+/// Default outgoing rate limit: 1 message/second per chat (telegram-safe;
+/// Telegram's own documented soft limit is ~1 msg/sec per chat).
+const DEFAULT_RATE_LIMIT_INTERVAL: Duration = Duration::from_secs(1);
+
+/// One shared `reqwest::Client`. Reuses the workspace's pinned (native-tls)
+/// `reqwest` — never construct a second client/connector for this adapter
+/// (mirrors `notify_sinks::ntfy::http_client`).
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct TelegramResponse<T> {
+    ok: bool,
+    #[serde(default)]
+    result: Option<T>,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct TelegramUpdate {
+    update_id: i64,
+    #[serde(default)]
+    message: Option<TelegramMessage>,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+struct TelegramMessage {
+    #[serde(default)]
+    message_id: i64,
+    /// Unix timestamp (seconds) — Telegram's own message send time.
+    #[serde(default)]
+    date: i64,
+    #[serde(default)]
+    chat: TelegramChat,
+    #[serde(default)]
+    from: Option<TelegramUser>,
+    #[serde(default)]
+    text: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+struct TelegramChat {
+    #[serde(default)]
+    id: i64,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct TelegramUser {
+    id: i64,
+}
+
+/// Per-chat outgoing token bucket: blocks (never drops) until at least
+/// `min_interval` has elapsed since the last send to that chat. Reserves the
+/// next allowed slot atomically under a short-held lock, then sleeps
+/// OUTSIDE the lock — so a chat waiting on its slot never blocks a send to a
+/// different chat.
+struct RateLimiter {
+    next_allowed: AsyncMutex<HashMap<String, tokio::time::Instant>>,
+    min_interval: Duration,
+}
+
+impl RateLimiter {
+    fn new(min_interval: Duration) -> Self {
+        Self {
+            next_allowed: AsyncMutex::new(HashMap::new()),
+            min_interval,
+        }
+    }
+
+    async fn wait(&self, key: &str) {
+        let now = tokio::time::Instant::now();
+        let scheduled = {
+            let mut guard = self.next_allowed.lock().await;
+            let earliest = guard.get(key).copied().unwrap_or(now);
+            let scheduled = earliest.max(now);
+            guard.insert(key.to_string(), scheduled + self.min_interval);
+            scheduled
+        };
+        if scheduled > now {
+            tokio::time::sleep(scheduled - now).await;
+        }
+    }
+}
+
+pub struct TelegramPlatform {
+    token: String,
+    base_url: String,
+    offset: AtomicI64,
+    rate_limiter: RateLimiter,
+}
+
+impl TelegramPlatform {
+    /// Production constructor: official Telegram API base URL, 1 msg/s
+    /// per-chat rate limit.
+    pub fn new(token: String) -> Self {
+        Self::with_options(
+            token,
+            DEFAULT_BASE_URL.to_string(),
+            DEFAULT_RATE_LIMIT_INTERVAL,
+        )
+    }
+
+    /// Test/advanced constructor: override the base URL (a local HTTP stub)
+    /// and/or the rate-limit interval (kept tiny in tests so a
+    /// rate-limit-blocks assertion doesn't need a real second-plus sleep).
+    pub fn with_options(token: String, base_url: String, rate_limit_interval: Duration) -> Self {
+        Self {
+            token,
+            base_url,
+            offset: AtomicI64::new(0),
+            rate_limiter: RateLimiter::new(rate_limit_interval),
+        }
+    }
+
+    fn api_url(&self, method: &str) -> String {
+        format!(
+            "{}/bot{}/{method}",
+            self.base_url.trim_end_matches('/'),
+            self.token
+        )
+    }
+
+    async fn get_updates(
+        &self,
+        offset: i64,
+        timeout_secs: u64,
+    ) -> PlatformResult<Vec<TelegramUpdate>> {
+        let response = http_client()
+            .get(self.api_url("getUpdates"))
+            .query(&[
+                ("offset", offset.to_string()),
+                ("timeout", timeout_secs.to_string()),
+            ])
+            // Generous margin over Telegram's own long-poll timeout so the
+            // HTTP client doesn't time out the connection out from under a
+            // legitimately-long-held poll.
+            .timeout(Duration::from_secs(timeout_secs + 15))
+            .send()
+            .await
+            .map_err(|error| PlatformError::other(format!("getUpdates request failed: {error}")))?;
+
+        let parsed: TelegramResponse<Vec<TelegramUpdate>> =
+            response.json().await.map_err(|error| {
+                PlatformError::other(format!("getUpdates response parse failed: {error}"))
+            })?;
+
+        if !parsed.ok {
+            return Err(PlatformError::other(
+                parsed
+                    .description
+                    .unwrap_or_else(|| "getUpdates returned ok=false".to_string()),
+            ));
+        }
+        Ok(parsed.result.unwrap_or_default())
+    }
+
+    /// Converts a raw update into a bridge-facing [`InboundMessage`].
+    /// Returns `None` for updates this MVP doesn't handle (no `message`, no
+    /// text, no sender) — the caller still advances the offset for these so
+    /// Telegram never re-delivers them.
+    fn to_inbound_message(update: &TelegramUpdate) -> Option<InboundMessage> {
+        let message = update.message.as_ref()?;
+        let text = message.text.clone()?;
+        let from = message.from.as_ref()?;
+        let sent_at = chrono::DateTime::<chrono::Utc>::from_timestamp(message.date, 0)
+            .unwrap_or_else(chrono::Utc::now);
+        Some(InboundMessage {
+            platform: "telegram".to_string(),
+            chat_id: message.chat.id.to_string(),
+            user_id: from.id.to_string(),
+            message_id: update.update_id.to_string(),
+            sent_at,
+            text,
+            reply_ctx: ReplyCtx(serde_json::json!({ "chat_id": message.chat.id })),
+        })
+    }
+
+    /// One `getUpdates(offset, timeout_secs)` cycle: fetches, advances
+    /// `self.offset` past EVERY returned update (so Telegram never
+    /// re-delivers one this MVP skips), and returns the subset that convert
+    /// to an [`InboundMessage`]. Used both for `start()`'s drain-on-start
+    /// pass (`timeout_secs = 0`, result discarded) and its main long-poll
+    /// loop — factored out so tests can drive a single cycle deterministically
+    /// against a local HTTP stub without looping forever.
+    async fn poll_once(&self, timeout_secs: u64) -> PlatformResult<Vec<InboundMessage>> {
+        let offset = self.offset.load(Ordering::SeqCst);
+        let updates = self.get_updates(offset, timeout_secs).await?;
+
+        let mut messages = Vec::with_capacity(updates.len());
+        for update in &updates {
+            // Always advance past this update_id, whether or not we forward
+            // it — an un-forwarded update (no text, no sender, …) would
+            // otherwise be redelivered by Telegram forever.
+            self.offset.store(update.update_id + 1, Ordering::SeqCst);
+            if let Some(message) = Self::to_inbound_message(update) {
+                messages.push(message);
+            }
+        }
+        Ok(messages)
+    }
+
+    fn extract_chat_id(ctx: &ReplyCtx) -> PlatformResult<String> {
+        ctx.0
+            .get("chat_id")
+            .and_then(|v| {
+                v.as_i64()
+                    .map(|n| n.to_string())
+                    .or_else(|| v.as_str().map(|s| s.to_string()))
+            })
+            .ok_or_else(|| PlatformError::other("reply_ctx is missing chat_id"))
+    }
+}
+
+#[async_trait::async_trait]
+impl Platform for TelegramPlatform {
+    fn name(&self) -> &str {
+        "telegram"
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        // Buttons/edit-message/attachments are a later phase of epic #447.
+        Capabilities::default()
+    }
+
+    async fn start(&self, inbound: mpsc::Sender<InboundMessage>) -> PlatformResult<()> {
+        // Drain-on-start: fetch (and silently discard) any backlog that
+        // accumulated while the bot was offline, so a restart never replays
+        // a burst of stale prompts. A non-blocking (`timeout=0`) call.
+        match self.poll_once(0).await {
+            Ok(drained) if !drained.is_empty() => {
+                tracing::info!(
+                    "connect: telegram drained {} stale update(s) on start",
+                    drained.len()
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                tracing::warn!("connect: telegram drain-on-start failed (continuing): {error}");
+            }
+        }
+
+        loop {
+            match self.poll_once(LONG_POLL_TIMEOUT_SECS).await {
+                Ok(messages) => {
+                    for message in messages {
+                        if inbound.send(message).await.is_err() {
+                            // Receiver dropped: the manager is shutting down.
+                            return Ok(());
+                        }
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!("connect: telegram getUpdates failed, retrying: {error}");
+                    tokio::time::sleep(RETRY_BACKOFF).await;
+                }
+            }
+        }
+    }
+
+    async fn reply(&self, ctx: &ReplyCtx, msg: OutboundMessage) -> PlatformResult<MessageRef> {
+        let chat_id = Self::extract_chat_id(ctx)?;
+        let mut last_message_id = None;
+
+        for chunk in chunk_message(&msg.text, MAX_MESSAGE_CHARS) {
+            self.rate_limiter.wait(&chat_id).await;
+
+            let response = http_client()
+                .post(self.api_url("sendMessage"))
+                .form(&[("chat_id", chat_id.as_str()), ("text", chunk.as_str())])
+                .send()
+                .await
+                .map_err(|error| {
+                    PlatformError::other(format!("sendMessage request failed: {error}"))
+                })?;
+
+            let parsed: TelegramResponse<TelegramMessage> =
+                response.json().await.map_err(|error| {
+                    PlatformError::other(format!("sendMessage response parse failed: {error}"))
+                })?;
+
+            if !parsed.ok {
+                return Err(PlatformError::other(
+                    parsed
+                        .description
+                        .unwrap_or_else(|| "sendMessage returned ok=false".to_string()),
+                ));
+            }
+            last_message_id = parsed.result.map(|m| m.message_id);
+        }
+
+        Ok(MessageRef(serde_json::json!({
+            "chat_id": chat_id,
+            "message_id": last_message_id,
+        })))
+    }
+
+    async fn edit(&self, _msg_ref: &MessageRef, _new: OutboundMessage) -> PlatformResult<()> {
+        Err(PlatformError::other(
+            "telegram adapter does not support edit_message in this phase (#452)",
+        ))
+    }
+
+    async fn stop(&self) -> PlatformResult<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn platform_with_stub(base_url: String) -> TelegramPlatform {
+        TelegramPlatform::with_options(
+            "test-token".to_string(),
+            base_url,
+            Duration::from_millis(50),
+        )
+    }
+
+    async fn wait_for_requests(
+        server: &wiremock::MockServer,
+        expected: usize,
+    ) -> Vec<wiremock::Request> {
+        for _ in 0..100 {
+            if let Some(requests) = server.received_requests().await {
+                if requests.len() >= expected {
+                    return requests;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        server.received_requests().await.unwrap_or_default()
+    }
+
+    #[tokio::test]
+    async fn poll_once_advances_offset_past_every_returned_update() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/bottest-token/getUpdates"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "ok": true,
+                    "result": [
+                        {
+                            "update_id": 100,
+                            "message": {
+                                "message_id": 1,
+                                "date": 1_700_000_000,
+                                "chat": { "id": 42 },
+                                "from": { "id": 7 },
+                                "text": "hello"
+                            }
+                        },
+                        {
+                            "update_id": 101
+                            // no "message" -- must still advance the offset past it.
+                        }
+                    ]
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        let messages = platform.poll_once(30).await.expect("poll_once succeeds");
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].chat_id, "42");
+        assert_eq!(messages[0].user_id, "7");
+        assert_eq!(messages[0].message_id, "100");
+        assert_eq!(messages[0].text, "hello");
+        assert_eq!(platform.offset.load(Ordering::SeqCst), 102);
+    }
+
+    #[tokio::test]
+    async fn poll_once_next_call_requests_the_advanced_offset() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/bottest-token/getUpdates"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "ok": true,
+                "result": [
+                    {
+                        "update_id": 5,
+                        "message": {
+                            "message_id": 1, "date": 1, "chat": {"id": 1}, "from": {"id": 1}, "text": "hi"
+                        }
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        platform.poll_once(30).await.unwrap();
+        assert_eq!(platform.offset.load(Ordering::SeqCst), 6);
+
+        let requests = wait_for_requests(&server, 1).await;
+        let query: HashMap<String, String> = requests[0]
+            .url
+            .query_pairs()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        assert_eq!(query.get("offset"), Some(&"0".to_string()));
+
+        // A second poll must request the ADVANCED offset.
+        let _ = platform.poll_once(30).await;
+        let requests = wait_for_requests(&server, 2).await;
+        let query: HashMap<String, String> = requests[1]
+            .url
+            .query_pairs()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        assert_eq!(query.get("offset"), Some(&"6".to_string()));
+    }
+
+    #[tokio::test]
+    async fn reply_chunks_long_text_into_multiple_send_message_calls() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/bottest-token/sendMessage"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "ok": true,
+                    "result": { "message_id": 1, "date": 1, "chat": { "id": 1 } }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        let ctx = ReplyCtx(serde_json::json!({ "chat_id": 1 }));
+        let long_text = "a".repeat(9000); // -> 3 chunks at 4096
+
+        platform
+            .reply(&ctx, OutboundMessage::text(long_text))
+            .await
+            .expect("reply succeeds");
+
+        let requests = wait_for_requests(&server, 3).await;
+        assert_eq!(requests.len(), 3, "expected exactly 3 sendMessage calls");
+    }
+
+    #[tokio::test]
+    async fn reply_short_text_sends_exactly_one_message() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/bottest-token/sendMessage"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "ok": true,
+                    "result": { "message_id": 1, "date": 1, "chat": { "id": 1 } }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        let ctx = ReplyCtx(serde_json::json!({ "chat_id": 1 }));
+
+        platform
+            .reply(&ctx, OutboundMessage::text("hello"))
+            .await
+            .expect("reply succeeds");
+
+        let requests = wait_for_requests(&server, 1).await;
+        assert_eq!(requests.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn reply_rate_limits_consecutive_sends_to_the_same_chat() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/bottest-token/sendMessage"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "ok": true,
+                    "result": { "message_id": 1, "date": 1, "chat": { "id": 1 } }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        // 50ms rate-limit interval (see `platform_with_stub`) keeps the test fast.
+        let platform = platform_with_stub(server.uri());
+        let ctx = ReplyCtx(serde_json::json!({ "chat_id": 1 }));
+
+        let start = tokio::time::Instant::now();
+        platform
+            .reply(&ctx, OutboundMessage::text("first"))
+            .await
+            .unwrap();
+        platform
+            .reply(&ctx, OutboundMessage::text("second"))
+            .await
+            .unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_millis(50),
+            "second send to the same chat must block for the rate-limit interval, elapsed={elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reply_does_not_rate_limit_different_chats() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/bottest-token/sendMessage"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "ok": true,
+                    "result": { "message_id": 1, "date": 1, "chat": { "id": 1 } }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        let ctx_a = ReplyCtx(serde_json::json!({ "chat_id": 1 }));
+        let ctx_b = ReplyCtx(serde_json::json!({ "chat_id": 2 }));
+
+        let start = tokio::time::Instant::now();
+        platform
+            .reply(&ctx_a, OutboundMessage::text("first"))
+            .await
+            .unwrap();
+        platform
+            .reply(&ctx_b, OutboundMessage::text("second"))
+            .await
+            .unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "sends to DIFFERENT chats must not share a rate-limit slot, elapsed={elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_is_unsupported_in_this_phase() {
+        let platform = platform_with_stub("http://localhost:0".to_string());
+        let msg_ref = MessageRef(serde_json::json!({}));
+        let result = platform.edit(&msg_ref, OutboundMessage::text("x")).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn capabilities_advertise_nothing_in_this_phase() {
+        let platform = platform_with_stub("http://localhost:0".to_string());
+        let caps = platform.capabilities();
+        assert!(!caps.buttons);
+        assert!(!caps.edit_message);
+        assert!(!caps.images);
+        assert!(!caps.files);
+    }
+}

--- a/crates/app/bamboo-server/src/connect/render.rs
+++ b/crates/app/bamboo-server/src/connect/render.rs
@@ -1,0 +1,304 @@
+//! Renders a session's live [`AgentEvent`] stream into platform messages.
+//!
+//! MVP scope (issue #452): tool-use one-liners (`⚙ Bash: cargo test…`,
+//! truncated) as they happen, plus the final assistant text once the run
+//! reaches a terminal state. Streaming edit-in-place (capability-gated on
+//! [`crate::connect::platform::Capabilities::edit_message`]) is a later
+//! phase.
+//!
+//! [`stream_execution`] runs until the underlying broadcast stream reaches a
+//! terminal event (`Complete`/`Cancelled`/`Error`) or is closed. The bridge
+//! awaits it inline (not detached) so the run's completion doubles as this
+//! task's completion — see `bridge::ConnectBridge::run_prompt`.
+
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+
+use bamboo_agent_core::AgentEvent;
+
+use super::platform::{OutboundMessage, Platform, ReplyCtx};
+
+/// Telegram's hard message-length limit (in UTF-16 characters, but ASCII/most
+/// text is 1 UTF-8 char == 1 unit; treating it as a char-count chunk size is a
+/// safe, conservative approximation other adapters can share too).
+pub const MAX_MESSAGE_CHARS: usize = 4096;
+
+/// Longest a single tool-use one-liner is allowed to be before truncation,
+/// well under [`MAX_MESSAGE_CHARS`] so a chatty tool call never dominates the
+/// stream of updates.
+const TOOL_LINE_MAX_CHARS: usize = 300;
+
+/// Split `text` into chunks of at most `limit` **characters** (not bytes), so
+/// a multi-byte UTF-8 sequence is never split mid-codepoint. Returns an empty
+/// vec for empty input (callers should skip sending in that case).
+pub fn chunk_message(text: &str, limit: usize) -> Vec<String> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+    let chars: Vec<char> = text.chars().collect();
+    chars
+        .chunks(limit.max(1))
+        .map(|chunk| chunk.iter().collect())
+        .collect()
+}
+
+/// Truncate `text` to at most `max` characters, appending an ellipsis when cut.
+fn truncate_chars(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let mut out: String = text.chars().take(max).collect();
+    out.push('…');
+    out
+}
+
+/// Best-effort one-line human summary of a tool call's arguments, used to
+/// keep the one-liner scannable (`⚙ Bash: cargo test…`) instead of dumping
+/// raw JSON.
+fn summarize_arguments(arguments: &serde_json::Value) -> String {
+    let Some(obj) = arguments.as_object() else {
+        return arguments.to_string();
+    };
+    for key in ["command", "file_path", "path", "query", "pattern", "url"] {
+        if let Some(value) = obj.get(key).and_then(|v| v.as_str()) {
+            return value.to_string();
+        }
+    }
+    serde_json::to_string(arguments).unwrap_or_default()
+}
+
+/// Formats a `ToolStart` event as a one-liner, truncated to
+/// [`TOOL_LINE_MAX_CHARS`].
+fn format_tool_line(tool_name: &str, arguments: &serde_json::Value) -> String {
+    let summary = summarize_arguments(arguments);
+    truncate_chars(&format!("⚙ {tool_name}: {summary}"), TOOL_LINE_MAX_CHARS)
+}
+
+async fn send_chunks(platform: &Arc<dyn Platform>, ctx: &ReplyCtx, text: &str) {
+    for chunk in chunk_message(text, MAX_MESSAGE_CHARS) {
+        if let Err(error) = platform.reply(ctx, OutboundMessage::text(chunk)).await {
+            tracing::warn!("connect: failed to deliver reply: {error}");
+        }
+    }
+}
+
+/// Consume `rx` until a terminal `AgentEvent`, sending tool one-liners as
+/// they arrive and the final assistant text (or error/cancellation note) once
+/// the run ends. Returns once the stream reaches a terminal state or closes.
+pub async fn stream_execution(
+    platform: Arc<dyn Platform>,
+    reply_ctx: ReplyCtx,
+    mut rx: broadcast::Receiver<AgentEvent>,
+) {
+    let mut final_text = String::new();
+    let mut terminal_note: Option<String> = None;
+
+    loop {
+        match rx.recv().await {
+            Ok(AgentEvent::ToolStart {
+                tool_name,
+                arguments,
+                ..
+            }) => {
+                let line = format_tool_line(&tool_name, &arguments);
+                send_chunks(&platform, &reply_ctx, &line).await;
+            }
+            Ok(AgentEvent::Token { content }) => final_text.push_str(&content),
+            Ok(AgentEvent::Complete { .. }) => break,
+            Ok(AgentEvent::Cancelled { message }) => {
+                terminal_note = Some(message.unwrap_or_else(|| "Cancelled.".to_string()));
+                break;
+            }
+            Ok(AgentEvent::Error { message }) => {
+                terminal_note = Some(format!("Error: {message}"));
+                break;
+            }
+            Ok(_) => continue,
+            // A slow reader missed some events; the run is still live, keep going.
+            Err(broadcast::error::RecvError::Lagged(_)) => continue,
+            // Sender dropped without a terminal event (should not normally
+            // happen — treat as done rather than hanging forever).
+            Err(broadcast::error::RecvError::Closed) => break,
+        }
+    }
+
+    let body = terminal_note.unwrap_or(final_text);
+    if !body.trim().is_empty() {
+        send_chunks(&platform, &reply_ctx, &body).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunk_message_splits_on_char_boundaries_not_bytes() {
+        // Every char is 3 bytes in UTF-8 but 1 char; a byte-based chunker
+        // would split mid-codepoint at a limit of 2.
+        let text = "\u{4e2d}\u{6587}\u{6d4b}\u{8bd5}"; // 4 CJK chars, 12 bytes
+        let chunks = chunk_message(text, 2);
+        assert_eq!(chunks, vec!["\u{4e2d}\u{6587}", "\u{6d4b}\u{8bd5}"]);
+    }
+
+    #[test]
+    fn chunk_message_respects_the_4096_limit() {
+        let text = "a".repeat(10_000);
+        let chunks = chunk_message(&text, MAX_MESSAGE_CHARS);
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(chunks[0].chars().count(), MAX_MESSAGE_CHARS);
+        assert_eq!(chunks[1].chars().count(), MAX_MESSAGE_CHARS);
+        assert_eq!(chunks[2].chars().count(), 10_000 - 2 * MAX_MESSAGE_CHARS);
+    }
+
+    #[test]
+    fn chunk_message_empty_text_yields_no_chunks() {
+        assert!(chunk_message("", MAX_MESSAGE_CHARS).is_empty());
+    }
+
+    #[test]
+    fn format_tool_line_prefers_command_field_and_truncates() {
+        let args = serde_json::json!({ "command": "cargo test --workspace" });
+        let line = format_tool_line("Bash", &args);
+        assert_eq!(line, "⚙ Bash: cargo test --workspace");
+    }
+
+    #[test]
+    fn format_tool_line_truncates_long_summaries() {
+        let long_command = "x".repeat(1000);
+        let args = serde_json::json!({ "command": long_command });
+        let line = format_tool_line("Bash", &args);
+        assert!(line.chars().count() <= TOOL_LINE_MAX_CHARS + 1);
+        assert!(line.ends_with('…'));
+    }
+
+    #[test]
+    fn format_tool_line_falls_back_to_json_for_unknown_shape() {
+        let args = serde_json::json!({ "foo": "bar" });
+        let line = format_tool_line("CustomTool", &args);
+        assert!(line.starts_with("⚙ CustomTool: "));
+        assert!(line.contains("foo"));
+    }
+
+    struct RecordingPlatform {
+        sent: tokio::sync::Mutex<Vec<String>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Platform for RecordingPlatform {
+        fn name(&self) -> &str {
+            "recording"
+        }
+        fn capabilities(&self) -> super::super::platform::Capabilities {
+            Default::default()
+        }
+        async fn start(
+            &self,
+            _inbound: tokio::sync::mpsc::Sender<super::super::platform::InboundMessage>,
+        ) -> super::super::platform::PlatformResult<()> {
+            Ok(())
+        }
+        async fn reply(
+            &self,
+            _ctx: &ReplyCtx,
+            msg: OutboundMessage,
+        ) -> super::super::platform::PlatformResult<super::super::platform::MessageRef> {
+            self.sent.lock().await.push(msg.text);
+            Ok(super::super::platform::MessageRef(serde_json::Value::Null))
+        }
+        async fn edit(
+            &self,
+            _msg_ref: &super::super::platform::MessageRef,
+            _new: OutboundMessage,
+        ) -> super::super::platform::PlatformResult<()> {
+            Ok(())
+        }
+        async fn stop(&self) -> super::super::platform::PlatformResult<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_execution_renders_tool_lines_and_final_text() {
+        let (tx, rx) = broadcast::channel(16);
+        let platform = Arc::new(RecordingPlatform {
+            sent: tokio::sync::Mutex::new(Vec::new()),
+        });
+        let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
+
+        tx.send(AgentEvent::ToolStart {
+            tool_call_id: "1".to_string(),
+            tool_name: "Bash".to_string(),
+            arguments: serde_json::json!({ "command": "cargo test" }),
+        })
+        .unwrap();
+        tx.send(AgentEvent::Token {
+            content: "Hello ".to_string(),
+        })
+        .unwrap();
+        tx.send(AgentEvent::Token {
+            content: "world.".to_string(),
+        })
+        .unwrap();
+        tx.send(AgentEvent::Complete {
+            usage: bamboo_agent_core::TokenUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+            },
+        })
+        .unwrap();
+
+        stream_execution(platform.clone(), ctx, rx).await;
+
+        let sent = platform.sent.lock().await;
+        assert_eq!(sent.len(), 2);
+        assert_eq!(sent[0], "⚙ Bash: cargo test");
+        assert_eq!(sent[1], "Hello world.");
+    }
+
+    #[tokio::test]
+    async fn stream_execution_renders_error_note_instead_of_partial_text() {
+        let (tx, rx) = broadcast::channel(16);
+        let platform = Arc::new(RecordingPlatform {
+            sent: tokio::sync::Mutex::new(Vec::new()),
+        });
+        let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
+
+        tx.send(AgentEvent::Token {
+            content: "partial".to_string(),
+        })
+        .unwrap();
+        tx.send(AgentEvent::Error {
+            message: "boom".to_string(),
+        })
+        .unwrap();
+
+        stream_execution(platform.clone(), ctx, rx).await;
+
+        let sent = platform.sent.lock().await;
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0], "Error: boom");
+    }
+
+    #[tokio::test]
+    async fn stream_execution_returns_when_channel_closes_without_terminal_event() {
+        let (tx, rx) = broadcast::channel(16);
+        let platform = Arc::new(RecordingPlatform {
+            sent: tokio::sync::Mutex::new(Vec::new()),
+        });
+        let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
+        drop(tx);
+
+        // Must return promptly, not hang, when the sender is dropped.
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            stream_execution(platform.clone(), ctx, rx),
+        )
+        .await
+        .expect("stream_execution must not hang on a closed channel");
+
+        assert!(platform.sent.lock().await.is_empty());
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/common.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/common.rs
@@ -113,6 +113,7 @@ pub(super) async fn redacted_config_json(
     // refresh here too so the immediate response's redaction sees it as
     // "configured" (mirrors the provider-API-key refresh above).
     config_for_response.refresh_notifications_encrypted()?;
+    config_for_response.refresh_connect_platform_tokens_encrypted()?;
     let value = serde_json::to_value(&config_for_response)?;
     let mut redacted = redact_config_for_api(value, &config_for_response);
 

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
@@ -28,6 +28,7 @@ pub async fn set_bamboo_config(
                 let mut patch_obj = patch_obj;
                 config_manager::preserve_masked_provider_api_keys(&mut patch_obj, &current);
                 config_manager::preserve_masked_notification_secrets(&mut patch_obj, &current);
+                config_manager::preserve_masked_connect_secrets(&mut patch_obj, &current);
                 let mut new_config = config_manager::build_merged_config(&current, patch_obj)?;
                 new_config.extra.remove("model_limits");
                 config_manager::sync_provider_api_keys_encrypted_for_patch(

--- a/crates/app/bamboo-server/src/handlers/settings/redaction/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/redaction/mod.rs
@@ -158,6 +158,46 @@ pub fn redact_config_for_api(mut value: Value, config: &Config) -> Value {
         }
     }
 
+    // Redact bamboo-connect platform tokens (Telegram bot token, etc.).
+    // `token` is `#[serde(skip_serializing)]` on `Config` so it never appears
+    // here already; mirror the notification-channel pattern above by
+    // inserting a masked placeholder when configured. Platforms are matched
+    // POSITIONALLY against `config.connect.platforms` (see
+    // `bamboo_config::patch::preserve_masked_connect_secrets`'s doc comment
+    // for why array order is the contract here, same as `env_vars`).
+    if let Some(platforms) = root
+        .get_mut("connect")
+        .and_then(|c| c.get_mut("platforms"))
+        .and_then(|v| v.as_array_mut())
+    {
+        for (index, platform) in platforms.iter_mut().enumerate() {
+            let Some(obj) = platform.as_object_mut() else {
+                continue;
+            };
+            let configured = config
+                .connect
+                .platforms
+                .get(index)
+                .map(|p| {
+                    p.token
+                        .as_deref()
+                        .map(|s| !s.trim().is_empty())
+                        .unwrap_or(false)
+                        || p.token_encrypted.is_some()
+                })
+                .unwrap_or(false);
+            if configured {
+                obj.insert(
+                    "token".to_string(),
+                    Value::String("****...****".to_string()),
+                );
+            } else {
+                obj.remove("token");
+            }
+            obj.remove("token_encrypted");
+        }
+    }
+
     // Redact cluster-fabric SSH secrets on each node's placement.auth.
     if let Some(nodes) = root
         .get_mut("cluster_fabric")

--- a/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
@@ -353,6 +353,75 @@ fn redact_config_never_leaks_notification_ciphertext_even_when_client_supplied()
         .is_some_and(|obj| !obj.contains_key("device_key_encrypted")));
 }
 
+// ── bamboo-connect platform token redaction tests ────────────────────
+
+#[test]
+fn redact_config_masks_configured_connect_platform_token() {
+    let mut config = Config::default();
+    config.connect.platforms = vec![bamboo_config::ConnectPlatformConfig {
+        platform_type: "telegram".to_string(),
+        token: None,
+        token_encrypted: Some("enc-telegram".to_string()),
+        allow_from: vec!["123".to_string()],
+        admin_from: Vec::new(),
+    }];
+
+    let input = json!({
+        "connect": {
+            "platforms": [
+                { "type": "telegram", "allow_from": ["123"] }
+            ]
+        }
+    });
+
+    let redacted = redact_config_for_api(input, &config);
+
+    assert_eq!(redacted["connect"]["platforms"][0]["token"], "****...****");
+    assert!(redacted["connect"]["platforms"][0]
+        .as_object()
+        .is_some_and(|obj| !obj.contains_key("token_encrypted")));
+}
+
+#[test]
+fn redact_config_omits_unconfigured_connect_platform_token() {
+    let mut config = Config::default();
+    config.connect.platforms = vec![bamboo_config::ConnectPlatformConfig {
+        platform_type: "telegram".to_string(),
+        token: None,
+        token_encrypted: None,
+        allow_from: Vec::new(),
+        admin_from: Vec::new(),
+    }];
+
+    let input = json!({
+        "connect": { "platforms": [ { "type": "telegram" } ] }
+    });
+
+    let redacted = redact_config_for_api(input, &config);
+
+    assert!(redacted["connect"]["platforms"][0]
+        .as_object()
+        .is_some_and(|obj| !obj.contains_key("token")));
+}
+
+#[test]
+fn redact_config_never_leaks_connect_platform_ciphertext_even_when_client_supplied() {
+    let config = Config::default();
+    let input = json!({
+        "connect": {
+            "platforms": [
+                { "type": "telegram", "token_encrypted": "sneaky-cipher" }
+            ]
+        }
+    });
+
+    let redacted = redact_config_for_api(input, &config);
+
+    assert!(redacted["connect"]["platforms"][0]
+        .as_object()
+        .is_some_and(|obj| !obj.contains_key("token_encrypted")));
+}
+
 #[test]
 fn redact_config_defaults_secret_false_when_missing() {
     let config = Config::default();

--- a/crates/app/bamboo-server/src/lib.rs
+++ b/crates/app/bamboo-server/src/lib.rs
@@ -107,6 +107,7 @@
 pub mod app_state;
 pub mod config;
 pub mod config_manager;
+pub mod connect;
 pub mod error;
 pub mod events;
 pub mod handlers;

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -612,6 +612,52 @@ pub struct NotificationsConfig {
     pub bark: BarkChannelConfig,
 }
 
+/// One IM-platform bridge configured under `[[connect.platforms]]` —
+/// bamboo-connect (issue #452 / epic #447): drives a bamboo session from an
+/// external chat platform (Telegram first).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ConnectPlatformConfig {
+    /// Platform adapter selector, e.g. `"telegram"`. Unrecognized values are
+    /// skipped (with a startup warning) rather than failing config load —
+    /// forward-compatible with future adapters (Feishu/Slack).
+    #[serde(rename = "type")]
+    pub platform_type: String,
+    /// Platform bot/API token.
+    ///
+    /// Secret: encrypted at rest in `token_encrypted`; this plaintext field is
+    /// never serialized and is hydrated in memory on load (mirrors
+    /// [`NtfyChannelConfig::token`] / [`BarkChannelConfig::device_key`]).
+    #[serde(default, skip_serializing)]
+    pub token: Option<String>,
+    /// Encrypted ciphertext of `token` (the at-rest representation).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_encrypted: Option<String>,
+    /// Platform-scoped user ids allowed to drive a session. Deliberately
+    /// STRICTER than the general secret-mask precedents: an EMPTY list means
+    /// deny-all (every inbound message is rejected), not allow-all — a
+    /// startup warning is logged when a platform has no allowed users.
+    #[serde(default)]
+    pub allow_from: Vec<String>,
+    /// User ids allowed to run privileged/admin commands. Parsed from day one
+    /// but UNUSED in the MVP (#452) — no admin commands exist yet; reserved
+    /// for the approvals/admin phase of epic #447.
+    #[serde(default)]
+    pub admin_from: Vec<String>,
+}
+
+/// bamboo-connect platform bridges: drive bamboo sessions from IM platforms.
+/// Additive/back-compat: an absent `connect` key in `config.json`
+/// deserializes to an empty platform list — fully inert (#452).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ConnectConfig {
+    #[serde(default)]
+    pub platforms: Vec<ConnectPlatformConfig>,
+}
+
+fn connect_config_is_empty(config: &ConnectConfig) -> bool {
+    config.platforms.is_empty()
+}
+
 /// One publisher key trusted to sign plugin bundles.
 ///
 /// `algorithm` is a plain string (not an enum) so an unrecognized future value
@@ -941,6 +987,13 @@ pub struct Config {
     /// [`Config::refresh_notifications_encrypted`].
     #[serde(default)]
     pub notifications: NotificationsConfig,
+
+    /// bamboo-connect IM-platform bridges (Telegram first, #452 / epic #447).
+    /// Secrets (each platform's `token`) are encrypted at rest — see
+    /// [`Config::hydrate_connect_platform_tokens_from_encrypted`] /
+    /// [`Config::refresh_connect_platform_tokens_encrypted`].
+    #[serde(default, skip_serializing_if = "connect_config_is_empty")]
+    pub connect: ConnectConfig,
 
     /// Plugin URL-install source-trust policy (host allowlist + ed25519
     /// publisher keys). See [`PluginTrustConfig`]'s docs for the three-layer
@@ -1798,6 +1851,8 @@ impl Config {
         config.hydrate_broker_token_from_encrypted();
         // Decrypt encrypted notification-channel secrets into in-memory plaintext.
         config.hydrate_notifications_from_encrypted();
+        // Decrypt encrypted bamboo-connect platform tokens into in-memory plaintext.
+        config.hydrate_connect_platform_tokens_from_encrypted();
         config.normalize_tool_settings();
         config.normalize_skill_settings();
         config.normalize_plugin_trust_settings();
@@ -1947,6 +2002,7 @@ impl Config {
             config.hydrate_cluster_fabric_from_encrypted();
             config.hydrate_broker_token_from_encrypted();
             config.hydrate_notifications_from_encrypted();
+            config.hydrate_connect_platform_tokens_from_encrypted();
             config.normalize_tool_settings();
             config.normalize_skill_settings();
             config
@@ -2483,6 +2539,7 @@ impl Config {
             memory: None,
             mcp: bamboo_domain::mcp_config::McpConfig::default(),
             notifications: NotificationsConfig::default(),
+            connect: ConnectConfig::default(),
             plugin_trust: PluginTrustConfig::default(),
             extra: BTreeMap::new(),
         }
@@ -2524,6 +2581,7 @@ impl Config {
         // `subagents.broker` is `#[serde(skip)]` (runtime-only, lives in its own
         // broker.json / embedded in-process) — nothing to encrypt or persist here.
         to_save.refresh_notifications_encrypted()?;
+        to_save.refresh_connect_platform_tokens_encrypted()?;
         to_save.normalize_tool_settings();
         to_save.normalize_skill_settings();
         let content =

--- a/crates/infra/bamboo-config/src/config_crypto.rs
+++ b/crates/infra/bamboo-config/src/config_crypto.rs
@@ -500,6 +500,57 @@ impl Config {
         Ok(())
     }
 
+    // ── bamboo-connect platform tokens (Telegram bot token, etc.) ───────
+
+    /// Decrypt every configured platform's token into in-memory plaintext
+    /// after loading config. Mirrors [`Config::hydrate_notifications_from_encrypted`]:
+    /// `token` is `#[serde(skip_serializing)]` (never on disk), so this is the
+    /// only way it gets populated after a fresh load.
+    pub fn hydrate_connect_platform_tokens_from_encrypted(&mut self) {
+        for platform in &mut self.connect.platforms {
+            let has_plaintext = platform
+                .token
+                .as_deref()
+                .map(str::trim)
+                .map(|value| !value.is_empty())
+                .unwrap_or(false);
+            if has_plaintext {
+                continue;
+            }
+            if let Some(encrypted) = platform.token_encrypted.as_deref() {
+                match crate::encryption::decrypt(encrypted) {
+                    Ok(value) => platform.token = Some(value),
+                    Err(e) => tracing::warn!(
+                        "Failed to decrypt connect platform '{}' token: {}",
+                        platform.platform_type,
+                        e
+                    ),
+                }
+            }
+        }
+    }
+
+    /// Re-encrypt every configured platform's token from current in-memory
+    /// plaintext before persisting to disk. Mirrors
+    /// [`Config::refresh_notifications_encrypted`]: an empty/absent plaintext
+    /// leaves any existing ciphertext intact (a redacted round-trip where the
+    /// client never re-sent the secret keeps it).
+    pub fn refresh_connect_platform_tokens_encrypted(&mut self) -> Result<()> {
+        for platform in &mut self.connect.platforms {
+            let token = platform.token.as_deref().unwrap_or("").trim();
+            if !token.is_empty() {
+                platform.token_encrypted =
+                    Some(crate::encryption::encrypt(token).with_context(|| {
+                        format!(
+                            "Failed to encrypt connect platform '{}' token",
+                            platform.platform_type
+                        )
+                    })?);
+            }
+        }
+        Ok(())
+    }
+
     /// Restore env-sourced provider `api_key`s that a serde round-trip dropped.
     ///
     /// `api_key` is `#[serde(skip_serializing)]`, so serializing `previous` and

--- a/crates/infra/bamboo-config/src/patch.rs
+++ b/crates/infra/bamboo-config/src/patch.rs
@@ -216,6 +216,20 @@ pub fn sanitize_root_patch(patch_obj: &mut Map<String, Value>) {
         }
     }
 
+    // Never allow clients to set encrypted bamboo-connect platform tokens
+    // directly.
+    if let Some(platforms) = patch_obj
+        .get_mut("connect")
+        .and_then(|c| c.get_mut("platforms"))
+        .and_then(|v| v.as_array_mut())
+    {
+        for platform in platforms.iter_mut() {
+            if let Some(obj) = platform.as_object_mut() {
+                obj.remove("token_encrypted");
+            }
+        }
+    }
+
     // Never allow clients to set encrypted secret material directly.
     //
     // Canonical MCP format:
@@ -391,6 +405,39 @@ pub fn preserve_masked_notification_secrets(patch_obj: &mut Map<String, Value>, 
             "device_key",
             current.notifications.bark.device_key.as_deref(),
         );
+    }
+}
+
+/// Replace masked bamboo-connect platform `token` placeholders in a patch with
+/// the current config's plaintext values.
+///
+/// Mirrors [`preserve_masked_notification_secrets`]. `connect.platforms` is a
+/// list (not a single object like ntfy/bark), so entries are matched
+/// POSITIONALLY: patch index `i` is resolved against `current.connect.platforms[i]`.
+/// This mirrors how the settings UI round-trips the list (it always sends the
+/// full array back in the same order it was fetched in — the same convention
+/// `env_vars`' full-array replace relies on) — reordering platforms in the
+/// same request as leaving a token masked is not supported and drops that
+/// entry's token, same as no plaintext being configured yet.
+pub fn preserve_masked_connect_secrets(patch_obj: &mut Map<String, Value>, current: &Config) {
+    let Some(platforms) = patch_obj
+        .get_mut("connect")
+        .and_then(|c| c.get_mut("platforms"))
+        .and_then(|v| v.as_array_mut())
+    else {
+        return;
+    };
+
+    for (index, platform) in platforms.iter_mut().enumerate() {
+        let Some(obj) = platform.as_object_mut() else {
+            continue;
+        };
+        let existing_plain = current
+            .connect
+            .platforms
+            .get(index)
+            .and_then(|p| p.token.as_deref());
+        preserve_masked_secret_field(obj, "token", existing_plain);
     }
 }
 
@@ -590,5 +637,85 @@ mod tests {
         preserve_masked_notification_secrets(&mut patch, &current);
 
         assert_eq!(patch["notifications"]["ntfy"]["token"], "tk-real-new-value");
+    }
+
+    fn connect_platform(platform_type: &str, token: &str) -> crate::ConnectPlatformConfig {
+        crate::ConnectPlatformConfig {
+            platform_type: platform_type.to_string(),
+            token: Some(token.to_string()),
+            token_encrypted: None,
+            allow_from: Vec::new(),
+            admin_from: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn sanitize_root_patch_strips_connect_platform_encrypted_field() {
+        let mut patch = json!({
+            "connect": {
+                "platforms": [
+                    { "type": "telegram", "token": "new-token", "token_encrypted": "client-supplied-cipher" }
+                ]
+            }
+        });
+        let obj = patch.as_object_mut().unwrap();
+        sanitize_root_patch(obj);
+
+        let platform = &obj["connect"]["platforms"][0];
+        assert!(!platform
+            .as_object()
+            .unwrap()
+            .contains_key("token_encrypted"));
+        assert_eq!(platform["token"], "new-token");
+    }
+
+    #[test]
+    fn preserve_masked_connect_secrets_keeps_existing_plaintext_by_position() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![connect_platform("telegram", "existing-bot-token")];
+
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[{"type":"telegram","token":"****...****"}]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert_eq!(
+            patch["connect"]["platforms"][0]["token"],
+            "existing-bot-token"
+        );
+    }
+
+    #[test]
+    fn preserve_masked_connect_secrets_drops_mask_when_nothing_configured() {
+        let current = Config::default();
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[{"type":"telegram","token":"****...****"}]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert!(!patch["connect"]["platforms"][0]
+            .as_object()
+            .unwrap()
+            .contains_key("token"));
+    }
+
+    #[test]
+    fn preserve_masked_connect_secrets_leaves_real_values_untouched() {
+        let current = Config::default();
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[{"type":"telegram","token":"tg-real-new-value"}]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert_eq!(
+            patch["connect"]["platforms"][0]["token"],
+            "tg-real-new-value"
+        );
     }
 }


### PR DESCRIPTION
Phase 1 of epic #447; closes #452.

Adds `connect/` to bamboo-server: drive bamboo sessions from IM platforms, starting with Telegram. Architecture distilled from the cc-connect analysis (epic #447); where cc-connect wraps agent CLIs, this bridges straight into bamboo's own canonical execution path.

## What's here

- **Platform trait** (`connect/platform.rs`): name/capabilities/start/reply/edit/stop with explicit `Capabilities` (no type-assertion tricks), platform-opaque `ReplyCtx`.
- **Telegram adapter** (long-poll `getUpdates`, offset tracking, drain-on-start; `sendMessage` with 4096-char chunking; per-chat 1 msg/s token bucket, blocking not dropping). No public IP, no webhook. reqwest follows the workspace native-tls pin (`cargo tree -i aws-lc-sys` empty).
- **Session bridge**: `SessionKey = telegram:<chat>:<user>` → persistent session map; per-chat busy lock + FIFO queue drained at run end; execution through `try_reserve_runner` + `spawn_session_execution` — the same canonical path as the HTTP handler and schedule_app, no parallel loop. `/new` `/stop` `/status` built-ins; everything else is prompt text.
- **Rendering**: tool one-liners + final result only (streaming edit-in-place is phase 2). Connect runs set `no_human_approver = true` (like scheduled runs) until phase-2 approval buttons land.
- **Security**: `allow_from` allowlist, EMPTY = deny-all with startup warning; update-id dedup + older-than-process-start drop; outgoing rate limit. Telegram `token` participates in the secret-mask round-trip exactly like provider keys (redacted GET, all-`*` = keep on save, encrypted at rest).
- **Lifecycle**: `ConnectManager` starts with the server, fully inert when `[connect]` is absent.

## Tests

34 new (bridge with fake platform: mapping, busy queue, /new rotation, allow_from deny, dedup; telegram against local HTTP stub: offset advance, chunking, rate limit; redaction round-trip). `cargo test -p bamboo-server --lib` 1135/1135, `-p bamboo-config` 189/189; fmt clean; `cargo build --workspace --tests` green.

## Known limitation

Masked-token preservation matches `connect.platforms[]` by array index (same convention as `env_vars`): reordering platforms while a token is masked in the same request drops that token — documented in the patch/redaction doc comments.

https://claude.ai/code/session_01Usp3jUXqDejy2eWuFWGsip