### PR TITLE
feat(connect): persist connect config in standalone connect.json

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/common.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/common.rs
@@ -17,6 +17,13 @@ pub(super) fn model_limits_file_path(app_data_dir: &Path) -> PathBuf {
     app_data_dir.join("model_limits.json")
 }
 
+/// The standalone connect.json sibling of config.json (#455) — bamboo-connect
+/// platform-bridge credentials (bot tokens, allowlists) live here, split out
+/// of config.json by `Config::save_to_dir`/`Config::merge_connect_config`.
+pub(super) fn connect_file_path(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join("connect.json")
+}
+
 pub(super) async fn read_model_limits_file(app_data_dir: &Path) -> Result<Option<Value>, AppError> {
     let path = model_limits_file_path(app_data_dir);
     match tokio::fs::try_exists(&path).await {

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/reset.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/reset.rs
@@ -5,12 +5,19 @@ use tokio::fs;
 
 use crate::{app_state::AppState, error::AppError};
 
-use super::common::{config_file_path, model_limits_file_path};
+use super::common::{config_file_path, connect_file_path, model_limits_file_path};
 
 /// Resets (deletes) the Bamboo configuration file.
 pub async fn reset_bamboo_config(app_state: web::Data<AppState>) -> Result<HttpResponse, AppError> {
     remove_config_file_if_exists(&config_file_path(&app_state.app_data_dir)).await?;
     remove_config_file_if_exists(&model_limits_file_path(&app_state.app_data_dir)).await?;
+    // #455: connect.json is a sibling of config.json now, not an inline key —
+    // a full config reset must clear it too, or bamboo-connect bot
+    // tokens/allowlists would silently survive (and get re-merged back onto
+    // the freshly-defaulted config on the very next load). Mirrors
+    // config.json/model_limits.json above: only the primary file is removed,
+    // any .bak is left alone (same as config.json.bak today).
+    remove_config_file_if_exists(&connect_file_path(&app_state.app_data_dir)).await?;
 
     // Reset in-memory config and best-effort reload provider.
     let new_config = app_state.reload_config().await;

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
@@ -359,3 +359,227 @@ async fn set_then_get_bamboo_config_masks_and_preserves_ntfy_token() {
         "unrelated field change must apply"
     );
 }
+
+/// End-to-end for #455: a settings PATCH that sets a bamboo-connect platform
+/// must persist into the standalone `connect.json` — NOT into `config.json`
+/// — while the settings API (GET redaction, masked-token keep-on-save)
+/// behaves exactly as it did before the persistence split.
+#[actix_web::test]
+async fn set_bamboo_config_persists_connect_into_connect_json_only_and_preserves_masked_token() {
+    use crate::app_state::AppState;
+    use actix_web::{test, web, App};
+    use bamboo_config::encryption;
+
+    // NOTE: deliberately NOT using `encryption::set_test_encryption_key` here —
+    // the actual save happens inside `AppState::persist_config_snapshot`'s
+    // `tokio::task::spawn_blocking`, a different OS thread than this test body,
+    // and the test-key override is thread-local (by design, so parallel tests
+    // don't clobber a process-global override). An override set here would
+    // only apply to the `decrypt` calls below, not the `encrypt` that ran on
+    // the blocking pool thread, and the two would silently use different keys.
+    // The encryption key file itself is already stable for this whole test
+    // binary process (`bamboo_dir()`'s "first call wins" OnceLock — see
+    // `paths::tests::test_init_bamboo_dir_first_call_wins`), so plain
+    // `encryption::decrypt` here round-trips correctly against whatever key
+    // the blocking-thread `encrypt` used.
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let state = AppState::new(temp_dir.path().to_path_buf())
+        .await
+        .expect("app state should initialize");
+    let data_dir = state.app_data_dir.clone();
+    let app_state = web::Data::new(state);
+
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .route("/bamboo/config", web::get().to(super::get_bamboo_config))
+            .route("/bamboo/config", web::post().to(super::set_bamboo_config)),
+    )
+    .await;
+
+    // 1) Set a real Telegram bot token via the settings PATCH surface.
+    let post = test::TestRequest::post()
+        .uri("/bamboo/config")
+        .set_json(serde_json::json!({
+            "connect": {
+                "platforms": [
+                    { "type": "telegram", "token": "tg-real-secret", "allow_from": ["u1"] }
+                ]
+            }
+        }))
+        .to_request();
+    let post_resp = test::call_service(&app, post).await;
+    assert!(post_resp.status().is_success(), "set config should succeed");
+
+    // config.json must NOT carry the `connect` key at all (#455 split).
+    let config_text = tokio::fs::read_to_string(config_file_path(&data_dir))
+        .await
+        .expect("config.json should exist after set");
+    assert!(
+        !config_text.contains("\"connect\""),
+        "config.json must not persist the connect key"
+    );
+    assert!(
+        !config_text.contains("tg-real-secret"),
+        "plaintext connect token must never be persisted anywhere"
+    );
+
+    // connect.json holds the platform, encrypted at rest.
+    let connect_path = data_dir.join("connect.json");
+    let connect_text = tokio::fs::read_to_string(&connect_path)
+        .await
+        .expect("connect.json should exist after set");
+    assert!(
+        connect_text.contains("token_encrypted"),
+        "connect token must be persisted encrypted in connect.json"
+    );
+    assert!(
+        !connect_text.contains("tg-real-secret"),
+        "plaintext connect token must never be persisted in connect.json"
+    );
+    let connect_json: serde_json::Value =
+        serde_json::from_str(&connect_text).expect("connect.json should parse");
+    let token_encrypted = connect_json["platforms"][0]["token_encrypted"]
+        .as_str()
+        .expect("token_encrypted should be present")
+        .to_string();
+    assert_eq!(
+        encryption::decrypt(&token_encrypted).expect("token should decrypt"),
+        "tg-real-secret"
+    );
+
+    // 2) GET masks the token exactly as before the split (settings API surface
+    // is unchanged; it reads the in-memory Config, unaware of the file split).
+    let get = test::TestRequest::get().uri("/bamboo/config").to_request();
+    let body: serde_json::Value = test::call_and_read_body_json(&app, get).await;
+    assert_eq!(body["connect"]["platforms"][0]["token"], "****...****");
+    assert_eq!(body["connect"]["platforms"][0]["type"], "telegram");
+
+    // 3) Re-POST with the masked placeholder (as the UI echoes it back) plus
+    // an unrelated field change — the secret must survive untouched, and
+    // still land only in connect.json.
+    let post2 = test::TestRequest::post()
+        .uri("/bamboo/config")
+        .set_json(serde_json::json!({
+            "connect": {
+                "platforms": [
+                    { "type": "telegram", "token": "****...****", "allow_from": ["u1", "u2"] }
+                ]
+            }
+        }))
+        .to_request();
+    let post2_resp = test::call_service(&app, post2).await;
+    assert!(
+        post2_resp.status().is_success(),
+        "second set config should succeed"
+    );
+
+    let get2 = test::TestRequest::get().uri("/bamboo/config").to_request();
+    let body2: serde_json::Value = test::call_and_read_body_json(&app, get2).await;
+    assert_eq!(
+        body2["connect"]["platforms"][0]["token"], "****...****",
+        "token must still read as configured"
+    );
+    assert_eq!(
+        body2["connect"]["platforms"][0]["allow_from"],
+        serde_json::json!(["u1", "u2"]),
+        "unrelated field change must apply"
+    );
+
+    let connect_text_after = tokio::fs::read_to_string(&connect_path)
+        .await
+        .expect("connect.json should still exist");
+    let connect_json_after: serde_json::Value =
+        serde_json::from_str(&connect_text_after).expect("connect.json should parse");
+    let token_encrypted_after = connect_json_after["platforms"][0]["token_encrypted"]
+        .as_str()
+        .expect("token_encrypted should still be present")
+        .to_string();
+    assert_eq!(
+        encryption::decrypt(&token_encrypted_after).expect("token should decrypt"),
+        "tg-real-secret",
+        "masked round-trip preserves the real token across the split files"
+    );
+
+    let config_text_after = tokio::fs::read_to_string(config_file_path(&data_dir))
+        .await
+        .expect("config.json should still exist");
+    assert!(
+        !config_text_after.contains("\"connect\""),
+        "config.json must still not carry the connect key after the second PATCH"
+    );
+}
+
+/// #455 gap: a full config reset must also clear `connect.json`, or a
+/// bamboo-connect bot token would silently survive `POST
+/// /bamboo/config/reset` and get re-merged back onto the freshly-defaulted
+/// config on the very next load (`Config::merge_connect_config` adopts
+/// whatever connect.json still has).
+#[actix_web::test]
+async fn reset_bamboo_config_also_deletes_connect_json() {
+    use crate::app_state::AppState;
+    use actix_web::{test, web, App};
+
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let state = AppState::new(temp_dir.path().to_path_buf())
+        .await
+        .expect("app state should initialize");
+    let data_dir = state.app_data_dir.clone();
+    let app_state = web::Data::new(state);
+
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .route("/bamboo/config", web::get().to(super::get_bamboo_config))
+            .route("/bamboo/config", web::post().to(super::set_bamboo_config))
+            .route(
+                "/bamboo/config/reset",
+                web::post().to(super::reset_bamboo_config),
+            ),
+    )
+    .await;
+
+    // Configure a connect platform (creates connect.json).
+    let post = test::TestRequest::post()
+        .uri("/bamboo/config")
+        .set_json(serde_json::json!({
+            "connect": {
+                "platforms": [
+                    { "type": "telegram", "token": "tg-reset-me", "allow_from": ["u1"] }
+                ]
+            }
+        }))
+        .to_request();
+    assert!(test::call_service(&app, post).await.status().is_success());
+
+    let connect_path = data_dir.join("connect.json");
+    assert!(
+        connect_path.exists(),
+        "connect.json should exist before reset"
+    );
+
+    // Reset.
+    let reset = test::TestRequest::post()
+        .uri("/bamboo/config/reset")
+        .to_request();
+    assert!(
+        test::call_service(&app, reset).await.status().is_success(),
+        "reset should succeed"
+    );
+
+    assert!(
+        !connect_path.exists(),
+        "connect.json must be deleted by a full config reset"
+    );
+
+    // The in-memory config must also be clear, not silently re-merged.
+    let get = test::TestRequest::get().uri("/bamboo/config").to_request();
+    let body: serde_json::Value = test::call_and_read_body_json(&app, get).await;
+    assert!(
+        body["connect"]["platforms"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(true),
+        "connect config must be empty after reset, not re-adopted from a stale file"
+    );
+}

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -1851,6 +1851,11 @@ impl Config {
         config.hydrate_broker_token_from_encrypted();
         // Decrypt encrypted notification-channel secrets into in-memory plaintext.
         config.hydrate_notifications_from_encrypted();
+        // Merge the standalone connect.json (#455) onto `config.connect`,
+        // migrating a legacy inline `connect` key from config.json (#453
+        // state) when present. MUST run before the token hydration below so
+        // it decrypts the post-merge ciphertext, not a stale/legacy copy.
+        config.merge_connect_config(&data_dir);
         // Decrypt encrypted bamboo-connect platform tokens into in-memory plaintext.
         config.hydrate_connect_platform_tokens_from_encrypted();
         config.normalize_tool_settings();
@@ -1988,6 +1993,75 @@ impl Config {
     /// fallback as the normal load.
     pub fn from_data_dir_without_env(data_dir: Option<PathBuf>) -> Self {
         Self::from_data_dir_impl(data_dir, false, false)
+    }
+
+    /// Merge the standalone `connect.json` (#455) onto `self.connect`, the
+    /// load-side counterpart of [`save_connect_config`]. Called once per load,
+    /// BEFORE [`Config::hydrate_connect_platform_tokens_from_encrypted`] runs,
+    /// so hydration decrypts the POST-merge ciphertext rather than a stale
+    /// copy still embedded in `config.json`.
+    ///
+    /// - `connect.json` present & parseable: authoritative — OVERWRITES
+    ///   whatever `self.connect` currently holds. If `self.connect` was ALSO
+    ///   non-empty (a legacy inline `connect` key still in config.json, e.g.
+    ///   #453-era state, or written by an older binary), that's a stale
+    ///   duplicate: log a warning. connect.json wins; the config.json copy is
+    ///   dropped on the NEXT natural save (this call does not force one).
+    /// - `connect.json` present but corrupt/unparsable: fail SAFE for this
+    ///   security-sensitive feature. Log an error, quarantine the bad file to
+    ///   `connect.json.bak` (best-effort), and continue with an EMPTY
+    ///   `ConnectConfig` — never falls back to a legacy config.json copy.
+    /// - `connect.json` absent & `self.connect` non-empty (pure legacy
+    ///   state): migrate proactively. Adopt the legacy value (already parsed
+    ///   into `self`) and write BOTH files once via a full
+    ///   [`Config::save_to_dir`] (creates connect.json; rewrites config.json
+    ///   without the key), logged at info.
+    /// - `connect.json` absent & `self.connect` empty: nothing to do.
+    fn merge_connect_config(&mut self, data_dir: &std::path::Path) {
+        let connect_path = data_dir.join("connect.json");
+        match std::fs::read_to_string(&connect_path) {
+            Ok(content) => match serde_json::from_str::<ConnectConfig>(&content) {
+                Ok(connect) => {
+                    if !connect_config_is_empty(&self.connect) {
+                        tracing::warn!(
+                            "config.json still has a legacy `connect` key alongside \
+                             connect.json; connect.json takes precedence and the stale \
+                             key will be dropped on the next save"
+                        );
+                    }
+                    self.connect = connect;
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to parse {:?} ({}); continuing with an empty (inert) \
+                         connect config instead of falling back to a legacy config.json copy",
+                        connect_path,
+                        e
+                    );
+                    quarantine_corrupt_connect(&connect_path);
+                    self.connect = ConnectConfig::default();
+                }
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                if !connect_config_is_empty(&self.connect) {
+                    tracing::info!(
+                        "Migrating legacy `connect` config from config.json to a \
+                         standalone connect.json"
+                    );
+                    if let Err(e) = self.save_to_dir(data_dir.to_path_buf()) {
+                        tracing::error!("Failed to write connect.json during migration: {}", e);
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Failed to read {:?} ({}); continuing with an empty (inert) connect config",
+                    connect_path,
+                    e
+                );
+                self.connect = ConnectConfig::default();
+            }
+        }
     }
 
     /// Deserialize config JSON and run the in-memory hydration + normalization
@@ -2584,8 +2658,23 @@ impl Config {
         to_save.refresh_connect_platform_tokens_encrypted()?;
         to_save.normalize_tool_settings();
         to_save.normalize_skill_settings();
-        let content =
-            serde_json::to_string_pretty(&to_save).context("Failed to serialize config to JSON")?;
+
+        // Split `connect` (#455) out of the config.json document: bamboo-connect
+        // platform-bridge credentials (bot tokens, allowlists) get their own
+        // sibling file, connect.json (written below), instead of living in
+        // config.json — different sensitivity/lifecycle. The `connect` FIELD on
+        // `Config` keeps its normal serde shape unchanged (still required by the
+        // settings API / `preserve_masked_connect_secrets`, which operate on the
+        // in-memory struct) — only the serialized DOCUMENT that becomes
+        // config.json's bytes has the key stripped, and that's done on the
+        // `serde_json::Value` here, not via `#[serde(skip)]` on the field.
+        let mut config_value =
+            serde_json::to_value(&to_save).context("Failed to serialize config to JSON")?;
+        if let Some(obj) = config_value.as_object_mut() {
+            obj.remove("connect");
+        }
+        let content = serde_json::to_string_pretty(&config_value)
+            .context("Failed to serialize config to JSON")?;
 
         // Back up the current on-disk config (last-known-good) before overwriting,
         // so corruption (a bad/partial write, external edit, disk issue) stays
@@ -2611,7 +2700,52 @@ impl Config {
         write_atomic(&path, content.as_bytes())
             .with_context(|| format!("Failed to write config file: {:?}", path))?;
 
+        save_connect_config(&to_save.connect, &data_dir)?;
+
         Ok(())
+    }
+}
+
+/// Persist `connect` (#455) to its own sibling file, `connect.json`, next to
+/// config.json — the save-side counterpart of [`Config::merge_connect_config`].
+///
+/// Only writes when the config is non-empty OR the file already exists, so a
+/// fresh/default install with no platforms configured never gets a
+/// `connect.json` littering its data dir. Before an existing file is
+/// overwritten, it's copied aside to a single `connect.json.bak` generation
+/// (best-effort) — connect.json doesn't need config.json's multi-generation
+/// rotation, one last-known-good snapshot is enough.
+fn save_connect_config(connect: &ConnectConfig, data_dir: &std::path::Path) -> Result<()> {
+    let path = data_dir.join("connect.json");
+    if connect_config_is_empty(connect) && !path.exists() {
+        return Ok(());
+    }
+
+    if path.exists() {
+        let backup = path.with_extension("json.bak");
+        if let Err(e) = std::fs::copy(&path, &backup) {
+            tracing::warn!("Failed to back up connect.json before save: {}", e);
+        }
+    }
+
+    let content = serde_json::to_string_pretty(connect)
+        .context("Failed to serialize connect config to JSON")?;
+    write_atomic(&path, content.as_bytes())
+        .with_context(|| format!("Failed to write connect config file: {:?}", path))?;
+    Ok(())
+}
+
+/// Quarantine an unparsable `connect.json` to a single `connect.json.bak`
+/// generation (best-effort) so the bad content survives for inspection
+/// instead of being silently discarded. Unlike config.json's timestamped,
+/// N-generation quarantine, connect.json only needs one slot — it's a much
+/// smaller, less complex document and this is a fail-SAFE (empty/inert
+/// bridge), not a fail-recover, posture. #455.
+fn quarantine_corrupt_connect(connect_path: &std::path::Path) {
+    let backup = connect_path.with_extension("json.bak");
+    match std::fs::copy(connect_path, &backup) {
+        Ok(_) => tracing::warn!("Quarantined corrupt connect.json to {:?}", backup),
+        Err(e) => tracing::error!("Failed to quarantine corrupt connect.json: {}", e),
     }
 }
 
@@ -3562,6 +3696,279 @@ mod tests {
             backup.contains("http://good-bak"),
             "good last-known-good backup is preserved (not overwritten by corrupt config.json)"
         );
+    }
+
+    // ── connect.json split (#455) ────────────────────────────────────────
+
+    fn connect_platform_with_encrypted(
+        platform_type: &str,
+        token_encrypted: &str,
+    ) -> ConnectPlatformConfig {
+        ConnectPlatformConfig {
+            platform_type: platform_type.to_string(),
+            token: None,
+            token_encrypted: Some(token_encrypted.to_string()),
+            allow_from: vec!["user-1".to_string()],
+            admin_from: Vec::new(),
+        }
+    }
+
+    fn connect_json_path(temp: &TempHome) -> PathBuf {
+        temp.path.join("connect.json")
+    }
+
+    #[test]
+    fn save_splits_connect_into_sibling_connect_json() {
+        let _key = crate::encryption::set_test_encryption_key([0x42; 32]);
+        let temp = TempHome::new();
+
+        let mut config = Config::create_default();
+        config.connect.platforms = vec![connect_platform_with_encrypted("telegram", "")];
+        config.connect.platforms[0].token = Some("plain-bot-token".to_string());
+
+        config
+            .save_to_dir(temp.path.clone())
+            .expect("save succeeds");
+
+        let config_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(temp.path.join("config.json")).unwrap())
+                .unwrap();
+        assert!(
+            config_json.get("connect").is_none(),
+            "config.json must not carry the `connect` key after a save"
+        );
+
+        let connect_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(connect_json_path(&temp)).unwrap())
+                .unwrap();
+        assert_eq!(connect_json["platforms"][0]["type"], "telegram");
+        assert!(
+            connect_json["platforms"][0]["token_encrypted"]
+                .as_str()
+                .is_some_and(|v| !v.is_empty()),
+            "the token is persisted in its encrypted form in connect.json"
+        );
+        assert!(
+            connect_json["platforms"][0].get("token").is_none(),
+            "the plaintext token is never persisted (skip_serializing)"
+        );
+    }
+
+    #[test]
+    fn load_merges_connect_json_into_config() {
+        let temp = TempHome::new();
+        std::fs::write(
+            connect_json_path(&temp),
+            serde_json::json!({
+                "platforms": [
+                    { "type": "telegram", "token_encrypted": "cipher-abc", "allow_from": ["u1"] }
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let config = Config::from_data_dir_without_publish(Some(temp.path.clone()));
+        assert_eq!(config.connect.platforms.len(), 1);
+        assert_eq!(config.connect.platforms[0].platform_type, "telegram");
+        assert_eq!(
+            config.connect.platforms[0].token_encrypted.as_deref(),
+            Some("cipher-abc")
+        );
+    }
+
+    #[test]
+    fn load_without_connect_json_yields_empty_inert_connect_config() {
+        let temp = TempHome::new();
+        temp.set_config_json(r#"{"http_proxy":"http://x"}"#);
+
+        let config = Config::from_data_dir_without_publish(Some(temp.path.clone()));
+        assert!(
+            config.connect.platforms.is_empty(),
+            "no connect.json and no legacy key -> empty/inert connect config"
+        );
+        assert!(
+            !connect_json_path(&temp).exists(),
+            "load must not create connect.json when there is nothing to migrate"
+        );
+    }
+
+    #[test]
+    fn migration_adopts_legacy_connect_key_and_writes_both_files() {
+        let temp = TempHome::new();
+        // Legacy state (#453): connect lives inline in config.json, no connect.json yet.
+        temp.set_config_json(
+            &serde_json::json!({
+                "http_proxy": "http://keep-me",
+                "connect": {
+                    "platforms": [
+                        { "type": "telegram", "token_encrypted": "legacy-cipher", "allow_from": ["u1"] }
+                    ]
+                }
+            })
+            .to_string(),
+        );
+
+        let config = Config::from_data_dir_without_publish(Some(temp.path.clone()));
+
+        // In-memory: legacy value adopted.
+        assert_eq!(config.connect.platforms.len(), 1);
+        assert_eq!(
+            config.connect.platforms[0].token_encrypted.as_deref(),
+            Some("legacy-cipher")
+        );
+        // An unrelated field from the same load survives the migration rewrite.
+        assert_eq!(config.http_proxy, "http://keep-me");
+
+        // On disk: connect.json was created...
+        assert!(
+            connect_json_path(&temp).exists(),
+            "migration proactively creates connect.json"
+        );
+        let connect_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(connect_json_path(&temp)).unwrap())
+                .unwrap();
+        assert_eq!(
+            connect_json["platforms"][0]["token_encrypted"], "legacy-cipher",
+            "the encrypted value is preserved (encrypted form intact) by the migration"
+        );
+
+        // ...and config.json was rewritten without the `connect` key.
+        let config_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(temp.path.join("config.json")).unwrap())
+                .unwrap();
+        assert!(
+            config_json.get("connect").is_none(),
+            "config.json is rewritten without the legacy `connect` key"
+        );
+    }
+
+    #[test]
+    fn both_files_present_connect_json_wins() {
+        let temp = TempHome::new();
+        temp.set_config_json(
+            &serde_json::json!({
+                "connect": {
+                    "platforms": [
+                        { "type": "telegram", "token_encrypted": "stale-config-json-cipher" }
+                    ]
+                }
+            })
+            .to_string(),
+        );
+        std::fs::write(
+            connect_json_path(&temp),
+            serde_json::json!({
+                "platforms": [
+                    { "type": "telegram", "token_encrypted": "authoritative-cipher" }
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let config = Config::from_data_dir_without_publish(Some(temp.path.clone()));
+        assert_eq!(
+            config.connect.platforms[0].token_encrypted.as_deref(),
+            Some("authoritative-cipher"),
+            "connect.json wins over a stale legacy config.json key"
+        );
+    }
+
+    #[test]
+    fn corrupt_connect_json_yields_empty_connect_and_is_quarantined() {
+        let temp = TempHome::new();
+        temp.set_config_json("{}");
+        std::fs::write(connect_json_path(&temp), "{ not valid json").unwrap();
+
+        let config = Config::from_data_dir_without_publish(Some(temp.path.clone()));
+        assert!(
+            config.connect.platforms.is_empty(),
+            "corrupt connect.json fails SAFE to an empty/inert connect config"
+        );
+
+        let backup = connect_json_path(&temp).with_extension("json.bak");
+        assert!(
+            backup.exists(),
+            "the corrupt connect.json is quarantined to connect.json.bak"
+        );
+        assert!(
+            std::fs::read_to_string(backup)
+                .unwrap()
+                .contains("not valid json"),
+            "the quarantined copy holds the bad content"
+        );
+    }
+
+    #[test]
+    fn corrupt_connect_json_does_not_fall_back_to_legacy_config_json_copy() {
+        let temp = TempHome::new();
+        // A legacy inline `connect` key is present too — it must NOT be used as a
+        // fallback when connect.json is corrupt (security-sensitive: fail safe).
+        temp.set_config_json(
+            &serde_json::json!({
+                "connect": {
+                    "platforms": [
+                        { "type": "telegram", "token_encrypted": "legacy-should-not-be-used" }
+                    ]
+                }
+            })
+            .to_string(),
+        );
+        std::fs::write(connect_json_path(&temp), "{ not valid json").unwrap();
+
+        let config = Config::from_data_dir_without_publish(Some(temp.path.clone()));
+        assert!(
+            config.connect.platforms.is_empty(),
+            "corrupt connect.json must not fall back to the legacy config.json copy"
+        );
+    }
+
+    #[test]
+    fn empty_connect_config_with_no_existing_file_creates_no_connect_json() {
+        let temp = TempHome::new();
+        let config = Config::create_default();
+        assert!(config.connect.platforms.is_empty());
+
+        config
+            .save_to_dir(temp.path.clone())
+            .expect("save succeeds");
+
+        assert!(
+            !connect_json_path(&temp).exists(),
+            "an empty connect config with no pre-existing file must not create one"
+        );
+    }
+
+    #[test]
+    fn connect_json_backed_up_before_overwrite() {
+        let temp = TempHome::new();
+        std::fs::write(
+            connect_json_path(&temp),
+            serde_json::json!({
+                "platforms": [
+                    { "type": "telegram", "token_encrypted": "old-cipher" }
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let mut config = Config::create_default();
+        config.connect.platforms = vec![connect_platform_with_encrypted("telegram", "new-cipher")];
+        config
+            .save_to_dir(temp.path.clone())
+            .expect("save succeeds");
+
+        let backup = connect_json_path(&temp).with_extension("json.bak");
+        assert!(
+            std::fs::read_to_string(backup)
+                .unwrap()
+                .contains("old-cipher"),
+            "the previous connect.json is preserved as connect.json.bak before the overwrite"
+        );
+        let current = std::fs::read_to_string(connect_json_path(&temp)).unwrap();
+        assert!(current.contains("new-cipher"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #455.

IM-bridge connection info (bot tokens, allowlists) moves OUT of `config.json` into a sibling `<data_dir>/connect.json` — while `ConnectConfig` remains a normal sub-struct of `Config`: in-memory shape, serde attributes, settings GET/PATCH surface, secret-mask round-trip, and dot-path `config set` are all unchanged. Only persistence splits.

## Semantics

- **Save** (`Config::save_to_dir`, the single write choke point): the `connect` key is stripped from the serialized `config.json` document (Value-level, not `#[serde(skip)]`); `connect.json` is written atomically with the same `token_encrypted` at-rest form, only when non-empty or already present, with a single-generation `connect.json.bak` before each overwrite.
- **Load**: `connect.json` is authoritative when present (a stale legacy key in config.json logs a warning and is dropped on next save). A legacy `connect` key with no connect.json is **proactively migrated** on load (both files rewritten once, logged).
- **Corruption fails safe**: unparsable connect.json → error log + quarantine to `.bak` + EMPTY connect config (bridge inert) — it never takes the server down, never touches config.json's salvage machinery, and never falls back to a stale legacy copy.

## Audit findings (fixed in this PR)

Exhaustive save/load call-path audit confirmed `save_to_dir`/`from_data_dir*` are the only persistence paths. One real gap found and fixed: `reset_bamboo_config` deleted `config.json`/`model_limits.json` but would have left `connect.json` (a bot token silently surviving a full reset) — now deleted too, with a regression test. Noted, deliberately NOT changed: the cluster-fabric Docker worker seed copies config.json but not connect.json — workers are execution backends, and not shipping IM bot tokens to them is the safer default.

## Tests

+11 (9 in bamboo-config, 2 end-to-end in bamboo-server): save-split, load-merge, migration (ciphertext preserved), connect.json-wins conflict, corruption quarantine, settings PATCH lands in connect.json only (masked-token preserve intact), reset removes connect.json, no empty-file littering. `cargo test -p bamboo-config` 198/198, `-p bamboo-server --lib` 1138/1138; fmt clean; workspace build green; exact CI clippy line exit 0.

https://claude.ai/code/session_01Usp3jUXqDejy2eWuFWGsip