### PR TITLE
feat(connect): phase 2 — approval/question relay with inline buttons + streaming edit-in-place

### DIFF
--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -497,6 +497,7 @@ impl AppState {
                 Some(data_dir.clone()),
                 config.clone(),
                 provider_registry.clone(),
+                permission_checker.clone(),
             )
             .await,
         );

--- a/crates/app/bamboo-server/src/app_state/init.rs
+++ b/crates/app/bamboo-server/src/app_state/init.rs
@@ -446,6 +446,7 @@ pub async fn build_connect_manager(
     app_data_dir: Option<PathBuf>,
     config: Arc<RwLock<Config>>,
     provider_registry: Arc<bamboo_llm::ProviderRegistry>,
+    permission_checker: Arc<PermissionChecker>,
 ) -> crate::connect::ConnectManager {
     let config_snapshot = config.read().await.clone();
     let ctx = crate::connect::ConnectContext {
@@ -458,6 +459,7 @@ pub async fn build_connect_manager(
         app_data_dir: app_data_dir.clone(),
         config,
         provider_registry,
+        permission_checker,
     };
     crate::connect::ConnectManager::start(ctx, &config_snapshot, app_data_dir).await
 }

--- a/crates/app/bamboo-server/src/connect/approvals.rs
+++ b/crates/app/bamboo-server/src/connect/approvals.rs
@@ -1,0 +1,815 @@
+//! NeedsHuman/QuestionDialog → buttons/text replies → respond path (epic
+//! #447's planned `approvals.rs`, issue #458).
+//!
+//! Three concerns live here:
+//! - Rendering a [`PendingAsk`][render_pending_ask_type] as an outbound
+//!   message (buttons when the platform supports them, always ALSO a
+//!   numbered text list — text replies are first-class on every platform).
+//! - Matching an inbound text reply or button `callback_data` against a
+//!   [`ParkedAsk`], including the binary-ask keyword mapping
+//!   (允许/yes/allow vs deny/no).
+//! - The [`Responder`] seam: the ONLY resolution path is
+//!   `bamboo_engine::session_app::respond::submit_pending_response` followed
+//!   by `resume::resume_session_execution` — exactly what
+//!   `POST /sessions/{id}/respond` does. [`EngineResponder`] is the
+//!   production implementation (in-proc, via [`super::bridge::ConnectContext`]);
+//!   tests inject a fake instead of standing up a full `AppState`.
+//!
+//! [render_pending_ask_type]: crate::connect::render::PendingAsk
+
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+
+use bamboo_agent_core::tools::{ToolCall, ToolExecutionContext};
+use bamboo_agent_core::{AgentEvent, Session};
+use bamboo_engine::execution::{
+    create_event_forwarder, get_or_create_event_sender, try_reserve_runner, RunnerReservation,
+};
+use bamboo_engine::runtime::execution::agent_spawn::{
+    spawn_session_execution, SessionExecutionArgs,
+};
+use bamboo_engine::session_app::resolution::resolve_resume_config_snapshot;
+use bamboo_engine::session_app::respond::{
+    submit_pending_response, PERMISSION_REEXECUTE_METADATA_KEY,
+};
+use bamboo_engine::session_app::resume::{
+    resume_session_execution, ResumeExecutionPort, ResumeSpawnRequest,
+};
+use bamboo_engine::session_app::types::RespondInput;
+use bamboo_engine::{ModelRoster, RoleModel};
+
+use super::bridge::ConnectContext;
+use super::platform::{Button, OutboundMessage, Platform, PlatformResult, ReplyCtx};
+use super::render::PendingAsk;
+
+/// Longest a button's visible label is allowed to be — Telegram (and most IM
+/// platforms) truncate/reject very long inline-button text, so keep it well
+/// under any known limit.
+const BUTTON_LABEL_MAX_CHARS: usize = 48;
+
+// ---------------------------------------------------------------------------
+// ParkedAsk — the bridge's one-ask-per-chat state
+// ---------------------------------------------------------------------------
+
+/// A pending question rendered to a chat and awaiting resolution (button
+/// press or text reply). One per chat at a time (issue #458: "one parked ask
+/// per chat — session serializes asks").
+#[derive(Debug, Clone)]
+pub struct ParkedAsk {
+    /// Short nonce embedded in every button's `callback_data`
+    /// (`"{nonce}:{option_index}"`). Validated on every callback so
+    /// forged/stale data is ignored.
+    pub nonce: String,
+    pub session_id: String,
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub question: String,
+    pub options: Vec<String>,
+    pub allow_custom: bool,
+}
+
+impl ParkedAsk {
+    pub fn new(nonce: String, session_id: String, ask: &PendingAsk) -> Self {
+        Self {
+            nonce,
+            session_id,
+            tool_call_id: ask.tool_call_id.clone(),
+            tool_name: ask.tool_name.clone(),
+            question: ask.question.clone(),
+            options: ask.options.clone(),
+            allow_custom: ask.allow_custom,
+        }
+    }
+}
+
+/// A short, hard-to-guess nonce for one parked ask. Not cryptographically
+/// load-bearing on its own (it's paired with per-chat scoping + a single
+/// live ask at a time) — just enough entropy that a stale/forged
+/// `callback_data` from a different ask/session won't collide by accident.
+pub fn new_nonce() -> String {
+    let raw = uuid::Uuid::new_v4().to_string();
+    raw.split('-').next().unwrap_or(&raw).to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Rendering an ask
+// ---------------------------------------------------------------------------
+
+fn truncate_label(text: &str) -> String {
+    if text.chars().count() <= BUTTON_LABEL_MAX_CHARS {
+        return text.to_string();
+    }
+    let mut out: String = text.chars().take(BUTTON_LABEL_MAX_CHARS - 1).collect();
+    out.push('…');
+    out
+}
+
+/// Format the ask's question + a numbered option list (text replies remain
+/// first-class even when buttons are ALSO rendered).
+fn format_ask_text(ask: &ParkedAsk) -> String {
+    let mut text = ask.question.clone();
+    if !ask.options.is_empty() {
+        text.push_str("\n\n");
+        for (index, option) in ask.options.iter().enumerate() {
+            text.push_str(&format!("{}. {}\n", index + 1, option));
+        }
+    }
+    if ask.allow_custom {
+        text.push_str("\n(or reply with your own answer)");
+    }
+    text
+}
+
+/// Render `ask` to the chat: inline buttons (one per option, `callback_data =
+/// "{nonce}:{index}"`) when `buttons_capable`, always alongside the numbered
+/// text list — per issue #458, buttons are an enhancement, never a
+/// requirement. Returns the platform error (if the send failed) so the
+/// caller can log it; rendering failure does not itself invalidate the
+/// parked ask (a text reply can still resolve it).
+pub async fn render_ask(
+    platform: &Arc<dyn Platform>,
+    reply_ctx: &ReplyCtx,
+    ask: &ParkedAsk,
+    buttons_capable: bool,
+) -> PlatformResult<()> {
+    let text = format_ask_text(ask);
+    let outbound = if buttons_capable && !ask.options.is_empty() {
+        let rows: Vec<Vec<Button>> = ask
+            .options
+            .iter()
+            .enumerate()
+            .map(|(index, option)| {
+                vec![Button::new(
+                    truncate_label(option),
+                    format!("{}:{index}", ask.nonce),
+                )]
+            })
+            .collect();
+        OutboundMessage::text(text).with_buttons(rows)
+    } else {
+        OutboundMessage::text(text)
+    };
+    platform.reply(reply_ctx, outbound).await.map(|_| ())
+}
+
+// ---------------------------------------------------------------------------
+// Matching a text reply / callback against a ParkedAsk
+// ---------------------------------------------------------------------------
+
+const AFFIRMATIVE_KEYWORDS: &[&str] = &[
+    "允许", "同意", "确定", "是", "yes", "allow", "approve", "ok",
+];
+const NEGATIVE_KEYWORDS: &[&str] = &["拒绝", "不", "否", "no", "deny", "reject", "stay"];
+
+fn classify_intent(text: &str) -> Option<bool> {
+    let lower = text.trim().to_lowercase();
+    if AFFIRMATIVE_KEYWORDS.iter().any(|keyword| lower == *keyword) {
+        return Some(true);
+    }
+    if NEGATIVE_KEYWORDS.iter().any(|keyword| lower == *keyword) {
+        return Some(false);
+    }
+    None
+}
+
+/// "First-affirmative mapping": prefer an option whose OWN text already
+/// reads as affirmative/negative (e.g. "Approve" / "Deny"); for a plain
+/// 2-option ask with no such wording, fall back to treating the first option
+/// as the affirmative one.
+fn pick_option_by_intent(options: &[String], affirmative: bool) -> Option<String> {
+    let keywords: &[&str] = if affirmative {
+        AFFIRMATIVE_KEYWORDS
+    } else {
+        NEGATIVE_KEYWORDS
+    };
+    if let Some(option) = options.iter().find(|option| {
+        let lower = option.to_lowercase();
+        keywords.iter().any(|keyword| lower.contains(keyword))
+    }) {
+        return Some(option.clone());
+    }
+    if options.len() == 2 {
+        return Some(if affirmative {
+            options[0].clone()
+        } else {
+            options[1].clone()
+        });
+    }
+    None
+}
+
+/// Match a text reply against `ask`, returning the answer to submit, or
+/// `None` when it doesn't resolve the ask at all (issue #458: a non-matching
+/// text on a CLOSED ask — no free text allowed — falls through to the
+/// caller's normal busy-queue handling instead of being submitted as a
+/// doomed-to-fail answer).
+///
+/// Tried in order: 1-based numeric option index, exact (case-insensitive)
+/// option text, then — for a closed (non-`allow_custom`) ask — the
+/// affirmative/negative keyword mapping. An OPEN ask (`allow_custom`) always
+/// matches: any non-empty text IS the answer, verbatim (matching
+/// `validate_pending_response`'s server-side rule).
+pub fn match_text_answer(ask: &ParkedAsk, text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Ok(index) = trimmed.parse::<usize>() {
+        if index >= 1 && index <= ask.options.len() {
+            return Some(ask.options[index - 1].clone());
+        }
+    }
+    if let Some(option) = ask
+        .options
+        .iter()
+        .find(|option| option.eq_ignore_ascii_case(trimmed))
+    {
+        return Some(option.clone());
+    }
+    if !ask.allow_custom {
+        if let Some(intent) = classify_intent(trimmed) {
+            if let Some(option) = pick_option_by_intent(&ask.options, intent) {
+                return Some(option);
+            }
+        }
+    }
+    if ask.allow_custom {
+        return Some(trimmed.to_string());
+    }
+    None
+}
+
+/// Match a button press's `callback_data` (`"{nonce}:{index}"`) against
+/// `ask`. Returns `None` for anything that doesn't EXACTLY match the parked
+/// nonce and a valid option index — forged/stale data (issue #458: "always
+/// answerCallbackQuery, even stale" — the caller acks regardless, but never
+/// forwards a non-match as an answer).
+pub fn match_callback_data(ask: &ParkedAsk, data: &str) -> Option<String> {
+    let (nonce, index_str) = data.split_once(':')?;
+    if nonce != ask.nonce {
+        return None;
+    }
+    let index: usize = index_str.parse().ok()?;
+    ask.options.get(index).cloned()
+}
+
+// ---------------------------------------------------------------------------
+// Responder — the resolution seam
+// ---------------------------------------------------------------------------
+
+/// What happened after submitting an answer and attempting to resume.
+pub enum RespondAndResumeOutcome {
+    /// Execution resumed; `receiver` was subscribed BEFORE the resume was
+    /// triggered, so the caller can keep rendering without missing events.
+    Resumed(broadcast::Receiver<AgentEvent>),
+    /// The answer was recorded, but nothing (more) is running — e.g. the
+    /// runner slot was already taken by a concurrent run, or the session
+    /// vanished between answering and resuming. `reason` is a short,
+    /// user-facing explanation.
+    NotResumed(String),
+}
+
+/// Error submitting an answer (mirrors `bamboo_engine::session_app::errors::RespondError`,
+/// decoupled so `connect` doesn't leak that error type through its public
+/// surface).
+#[derive(Debug, thiserror::Error)]
+pub enum ResponderError {
+    #[error("session not found")]
+    NotFound,
+    #[error("no pending question waiting for a response")]
+    NoPendingQuestion,
+    #[error("invalid response: {0}")]
+    InvalidResponse(String),
+    #[error("{0}")]
+    Other(String),
+}
+
+/// The bridge's resolution seam (issue #458: "Design a small Responder seam
+/// on the bridge so tests inject a fake instead of full AppState"). The ONLY
+/// production implementation ([`EngineResponder`]) routes through
+/// `submit_pending_response` + `resume_session_execution` — the exact same
+/// use-case functions `POST /sessions/{id}/respond` calls — never a parallel
+/// path.
+#[async_trait::async_trait]
+pub trait Responder: Send + Sync {
+    async fn respond_and_resume(
+        &self,
+        session_id: &str,
+        answer: String,
+    ) -> Result<RespondAndResumeOutcome, ResponderError>;
+}
+
+fn map_respond_error(error: bamboo_engine::session_app::errors::RespondError) -> ResponderError {
+    use bamboo_engine::session_app::errors::RespondError;
+    match error {
+        RespondError::NotFound(_) => ResponderError::NotFound,
+        RespondError::NoPendingQuestion => ResponderError::NoPendingQuestion,
+        RespondError::InvalidResponse(message) => ResponderError::InvalidResponse(message),
+        other => ResponderError::Other(other.to_string()),
+    }
+}
+
+/// Production [`Responder`]: submits through `submit_pending_response`
+/// (`SessionAccess` is implemented directly by `SessionRepository`, no
+/// `AppState` wrapper needed), applies any permission grants the answer
+/// implied (mirrors `handlers::agent::respond::handlers::submit`), then
+/// resumes via [`ConnectResumePort`] — the connect-scoped
+/// `ResumeExecutionPort` implementation that spawns through the same
+/// crate-agnostic `spawn_session_execution` the bridge already uses for a
+/// fresh prompt (`bridge::ConnectBridge::run_prompt`), including re-running a
+/// gated tool call that was only a placeholder while awaiting approval.
+pub struct EngineResponder {
+    ctx: ConnectContext,
+}
+
+impl EngineResponder {
+    pub fn new(ctx: ConnectContext) -> Self {
+        Self { ctx }
+    }
+}
+
+#[async_trait::async_trait]
+impl Responder for EngineResponder {
+    async fn respond_and_resume(
+        &self,
+        session_id: &str,
+        answer: String,
+    ) -> Result<RespondAndResumeOutcome, ResponderError> {
+        let input = RespondInput {
+            session_id: session_id.to_string(),
+            user_response: answer,
+            model: None,
+            model_ref: None,
+            provider: None,
+            reasoning_effort: None,
+        };
+
+        let (session, _submitted_answer, plan_mode_transition, permission_grants) =
+            submit_pending_response(&self.ctx.session_repo, input)
+                .await
+                .map_err(map_respond_error)?;
+
+        // Mirrors `handlers::agent::respond::handlers::submit`: record any
+        // permission grant so the resumed re-execution of the gated tool
+        // passes the check without re-prompting.
+        for (perm_type, resource) in &permission_grants {
+            self.ctx
+                .permission_checker
+                .grant_session_permission(*perm_type, resource.clone());
+        }
+
+        // Subscribe BEFORE triggering resume so the `ExecutionStarted` event
+        // (and everything after) is never missed — same ordering
+        // `bridge::ConnectBridge::run_prompt` uses for a fresh prompt.
+        let session_tx =
+            get_or_create_event_sender(&self.ctx.session_event_senders, session_id).await;
+        let receiver = session_tx.subscribe();
+
+        if let Some(event) = plan_mode_transition_event(session_id, plan_mode_transition.as_ref()) {
+            let _ = session_tx.send(event);
+        }
+
+        let config_snapshot = self.ctx.config.read().await.clone();
+        let resume_config = resolve_resume_config_snapshot(
+            &config_snapshot,
+            &self.ctx.provider_registry,
+            &session,
+            None,
+        );
+
+        let port = ConnectResumePort {
+            ctx: self.ctx.clone(),
+        };
+        let outcome = resume_session_execution(&port, session_id, resume_config).await;
+
+        match outcome {
+            bamboo_engine::session_app::types::ResumeOutcome::Started { .. } => {
+                Ok(RespondAndResumeOutcome::Resumed(receiver))
+            }
+            bamboo_engine::session_app::types::ResumeOutcome::AlreadyRunning { .. } => Ok(
+                RespondAndResumeOutcome::NotResumed("this session is already running".to_string()),
+            ),
+            bamboo_engine::session_app::types::ResumeOutcome::Completed => Ok(
+                RespondAndResumeOutcome::NotResumed("nothing left to resume".to_string()),
+            ),
+            bamboo_engine::session_app::types::ResumeOutcome::NotFound => Ok(
+                RespondAndResumeOutcome::NotResumed("session no longer exists".to_string()),
+            ),
+        }
+    }
+}
+
+fn plan_mode_transition_event(
+    session_id: &str,
+    transition: Option<&bamboo_engine::session_app::respond::PlanModeTransition>,
+) -> Option<AgentEvent> {
+    use bamboo_engine::session_app::respond::PlanModeTransition;
+    transition.map(|transition| match transition {
+        PlanModeTransition::Entered {
+            reason,
+            pre_permission_mode,
+            entered_at,
+            status,
+            plan_file_path,
+        } => AgentEvent::PlanModeEntered {
+            session_id: session_id.to_string(),
+            reason: reason.clone(),
+            pre_permission_mode: pre_permission_mode.clone(),
+            entered_at: *entered_at,
+            status: *status,
+            plan_file_path: plan_file_path.clone(),
+        },
+        PlanModeTransition::Exited {
+            approved,
+            restored_mode,
+            plan,
+        } => AgentEvent::PlanModeExited {
+            session_id: session_id.to_string(),
+            approved: *approved,
+            restored_mode: restored_mode.clone(),
+            plan: plan.clone(),
+        },
+    })
+}
+
+// ---------------------------------------------------------------------------
+// ConnectResumePort — ResumeExecutionPort for connect-bridged sessions
+// ---------------------------------------------------------------------------
+
+/// [`ResumeExecutionPort`] backed by [`ConnectContext`] instead of `AppState`
+/// — the connect-scoped counterpart of the server's
+/// `app_state::resume_adapter::AppStateResumeRef`. Spawns through the
+/// crate-agnostic `spawn_session_execution` (matching
+/// `bridge::ConnectBridge::run_prompt`'s fresh-prompt spawn exactly: same
+/// tools/agent/model-roster resolution, no guardian/bash-resume-hook — those
+/// remain a later phase, same as the fresh-prompt path), rather than the
+/// server handler layer's `spawn_agent_execution` (which pulls in
+/// `AppState`-specific wiring connect deliberately doesn't use).
+struct ConnectResumePort {
+    ctx: ConnectContext,
+}
+
+#[async_trait::async_trait]
+impl ResumeExecutionPort for ConnectResumePort {
+    async fn load_session(&self, session_id: &str) -> Option<Session> {
+        self.ctx.session_repo.load_merged(session_id).await
+    }
+
+    async fn save_and_cache_session(&self, session: &mut Session) {
+        self.ctx.session_repo.save_and_cache(session).await;
+    }
+
+    async fn try_reserve_runner(
+        &self,
+        session_id: &str,
+        event_sender: &broadcast::Sender<AgentEvent>,
+    ) -> Option<RunnerReservation> {
+        try_reserve_runner(
+            &self.ctx.agent_runners,
+            &self.ctx.session_event_senders,
+            session_id,
+            event_sender,
+        )
+        .await
+    }
+
+    async fn get_existing_runner_run_id(&self, session_id: &str) -> Option<String> {
+        let runners = self.ctx.agent_runners.read().await;
+        runners.get(session_id).map(|runner| runner.run_id.clone())
+    }
+
+    async fn get_or_create_event_sender(&self, session_id: &str) -> broadcast::Sender<AgentEvent> {
+        get_or_create_event_sender(&self.ctx.session_event_senders, session_id).await
+    }
+
+    async fn spawn_resume_execution(&self, request: ResumeSpawnRequest) {
+        let ResumeSpawnRequest {
+            session_id,
+            session,
+            cancel_token,
+            run_id: _,
+            event_sender,
+            config,
+        } = request;
+
+        let model = session.model.clone();
+        let reasoning_effort = session.reasoning_effort;
+        let model_roster = ModelRoster {
+            model: Some(model),
+            provider_name: Some(config.provider_name.clone()),
+            provider_type: config.provider_type.clone(),
+            fast: RoleModel::from_parts(config.fast_model.clone(), None),
+            background: RoleModel::from_parts(
+                config.background_model.clone(),
+                config.background_model_provider.clone(),
+            ),
+            summarization: RoleModel::from_parts(
+                config.summarization_model.clone(),
+                config.summarization_model_provider.clone(),
+            ),
+        };
+
+        let (mpsc_tx, _forwarder_handle) = create_event_forwarder(
+            session_id.clone(),
+            event_sender,
+            self.ctx.agent_runners.clone(),
+            self.ctx.account_feed_inbox.clone(),
+        );
+
+        // If the user just approved a permission prompt, the gated tool call
+        // was intercepted before it ran — its recorded result is only a
+        // placeholder. Re-execute it for real now (the grant was already
+        // applied to `ctx.permission_checker` in `EngineResponder`), write
+        // the output back, then start the loop — mirrors
+        // `app_state::resume_adapter::AppStateResumeRef::spawn_resume_execution`
+        // exactly, minus the `AppState`-specific plumbing.
+        let reexecute_tool_call_id = session
+            .metadata
+            .get(PERMISSION_REEXECUTE_METADATA_KEY)
+            .cloned();
+
+        let Some(reexecute_tool_call_id) = reexecute_tool_call_id else {
+            spawn_session_execution(SessionExecutionArgs {
+                agent: self.ctx.agent.clone(),
+                session_id,
+                session,
+                tools_override: Some(self.ctx.tools.clone()),
+                provider_override: None,
+                model_roster,
+                reasoning_effort,
+                reasoning_effort_source: "connect_resume".to_string(),
+                auxiliary_model_resolver: None,
+                disabled_filter_resolver: None,
+                disabled_tools: Some(config.disabled_tools.clone()),
+                disabled_skill_ids: Some(config.disabled_skill_ids.clone()),
+                selected_skill_ids: None,
+                selected_skill_mode: None,
+                cancel_token,
+                mpsc_tx,
+                image_fallback: config.image_fallback.clone(),
+                gold_config: config.gold_config.clone(),
+                guardian_config: None,
+                guardian_spawner: None,
+                bash_resume_hook: None,
+                bash_completion_sink: None,
+                app_data_dir: self.ctx.app_data_dir.clone(),
+                runners: self.ctx.agent_runners.clone(),
+                sessions_cache: self.ctx.session_repo.cache().clone(),
+                on_complete: None,
+            });
+            return;
+        };
+
+        let ctx = self.ctx.clone();
+        tokio::spawn(async move {
+            let mut session = session;
+            session.metadata.remove(PERMISSION_REEXECUTE_METADATA_KEY);
+
+            if let Some(tool_call) = find_pending_tool_call(&session, &reexecute_tool_call_id) {
+                let executor = ctx.tools.clone();
+                let tool_name = tool_call.function.name.clone();
+                let is_mutating = bamboo_tools::orchestrator::classify_tool(&tool_name)
+                    == bamboo_tools::orchestrator::ToolMutability::Mutating;
+
+                let mut emitter =
+                    bamboo_tools::ToolEmitter::new(&tool_call.id, &tool_name, is_mutating);
+                emitter.set_auto_approved(true);
+                let _ = mpsc_tx
+                    .send(emitter.begin().clone().into_agent_event())
+                    .await;
+
+                let exec_result = {
+                    let exec_ctx = ToolExecutionContext {
+                        session_id: Some(session.id.as_str()),
+                        tool_call_id: reexecute_tool_call_id.as_str(),
+                        event_tx: Some(&mpsc_tx),
+                        available_tool_schemas: None,
+                        bypass_permissions: false,
+                        can_async_resume: false,
+                        bash_completion_sink: None,
+                        pre_parsed_args: None,
+                    };
+                    executor.execute_with_context(&tool_call, exec_ctx).await
+                };
+
+                let (content, success) = match exec_result {
+                    Ok(tool_result) => {
+                        let _ = mpsc_tx
+                            .send(
+                                emitter
+                                    .finish(Some("Re-executed after approval".to_string()))
+                                    .clone()
+                                    .into_agent_event(),
+                            )
+                            .await;
+                        let _ = mpsc_tx
+                            .send(AgentEvent::ToolComplete {
+                                tool_call_id: tool_call.id.clone(),
+                                result: tool_result.clone(),
+                            })
+                            .await;
+                        (tool_result.result, tool_result.success)
+                    }
+                    Err(error) => {
+                        let message = format!("Tool re-execution after approval failed: {error}");
+                        let _ = mpsc_tx
+                            .send(emitter.error(message.clone()).clone().into_agent_event())
+                            .await;
+                        (message, false)
+                    }
+                };
+
+                tracing::info!(
+                    "[{}] connect: re-executed approved tool '{}' ({}) -> success={}",
+                    session_id,
+                    tool_name,
+                    reexecute_tool_call_id,
+                    success
+                );
+                apply_tool_result(&mut session, &reexecute_tool_call_id, content, success);
+                ctx.session_repo.save_and_cache(&mut session).await;
+            } else {
+                tracing::warn!(
+                    "[{}] connect: permission re-exec marker set but tool call '{}' not found in history",
+                    session_id,
+                    reexecute_tool_call_id
+                );
+            }
+
+            spawn_session_execution(SessionExecutionArgs {
+                agent: ctx.agent.clone(),
+                session_id,
+                session,
+                tools_override: Some(ctx.tools.clone()),
+                provider_override: None,
+                model_roster,
+                reasoning_effort,
+                reasoning_effort_source: "connect_resume".to_string(),
+                auxiliary_model_resolver: None,
+                disabled_filter_resolver: None,
+                disabled_tools: Some(config.disabled_tools.clone()),
+                disabled_skill_ids: Some(config.disabled_skill_ids.clone()),
+                selected_skill_ids: None,
+                selected_skill_mode: None,
+                cancel_token,
+                mpsc_tx,
+                image_fallback: config.image_fallback.clone(),
+                gold_config: config.gold_config.clone(),
+                guardian_config: None,
+                guardian_spawner: None,
+                bash_resume_hook: None,
+                bash_completion_sink: None,
+                app_data_dir: ctx.app_data_dir.clone(),
+                runners: ctx.agent_runners.clone(),
+                sessions_cache: ctx.session_repo.cache().clone(),
+                on_complete: None,
+            });
+        });
+    }
+}
+
+/// Find the original tool call (with its arguments) by id in the session
+/// history. Mirrors `app_state::resume_adapter::find_pending_tool_call`.
+fn find_pending_tool_call(session: &Session, tool_call_id: &str) -> Option<ToolCall> {
+    session.messages.iter().find_map(|message| {
+        message
+            .tool_calls
+            .as_ref()
+            .and_then(|calls| calls.iter().find(|call| call.id == tool_call_id).cloned())
+    })
+}
+
+/// Overwrite the tool-result message for `tool_call_id` with the real tool
+/// output. Mirrors `app_state::resume_adapter::apply_tool_result`.
+fn apply_tool_result(session: &mut Session, tool_call_id: &str, content: String, success: bool) {
+    for message in &mut session.messages {
+        if message.tool_call_id.as_deref() == Some(tool_call_id) {
+            message.content = content;
+            message.tool_success = Some(success);
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ask(options: Vec<&str>, allow_custom: bool) -> ParkedAsk {
+        ParkedAsk {
+            nonce: "abc12345".to_string(),
+            session_id: "sess-1".to_string(),
+            tool_call_id: "call-1".to_string(),
+            tool_name: "conclusion_with_options".to_string(),
+            question: "Approve?".to_string(),
+            options: options.into_iter().map(str::to_string).collect(),
+            allow_custom,
+        }
+    }
+
+    #[test]
+    fn new_nonce_is_short_and_hex_like() {
+        let nonce = new_nonce();
+        assert!(!nonce.is_empty());
+        assert!(nonce.len() <= 16);
+        assert!(nonce.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn match_text_answer_numeric_index_selects_option() {
+        let pending = ask(vec!["Approve", "Deny"], false);
+        assert_eq!(
+            match_text_answer(&pending, "1"),
+            Some("Approve".to_string())
+        );
+        assert_eq!(match_text_answer(&pending, "2"), Some("Deny".to_string()));
+        assert_eq!(match_text_answer(&pending, "3"), None);
+    }
+
+    #[test]
+    fn match_text_answer_exact_text_is_case_insensitive() {
+        let pending = ask(vec!["Approve", "Deny"], false);
+        assert_eq!(
+            match_text_answer(&pending, "approve"),
+            Some("Approve".to_string())
+        );
+    }
+
+    #[test]
+    fn match_text_answer_binary_keyword_mapping() {
+        let pending = ask(vec!["Approve", "Deny"], false);
+        assert_eq!(
+            match_text_answer(&pending, "允许"),
+            Some("Approve".to_string())
+        );
+        assert_eq!(
+            match_text_answer(&pending, "yes"),
+            Some("Approve".to_string())
+        );
+        assert_eq!(
+            match_text_answer(&pending, "deny"),
+            Some("Deny".to_string())
+        );
+        assert_eq!(match_text_answer(&pending, "no"), Some("Deny".to_string()));
+    }
+
+    #[test]
+    fn match_text_answer_closed_ask_non_matching_text_falls_through() {
+        let pending = ask(vec!["Approve", "Deny"], false);
+        assert_eq!(match_text_answer(&pending, "banana"), None);
+    }
+
+    #[test]
+    fn match_text_answer_open_question_accepts_any_free_text() {
+        let pending = ask(vec!["OK", "Need changes"], true);
+        assert_eq!(
+            match_text_answer(&pending, "please add tests too"),
+            Some("please add tests too".to_string())
+        );
+    }
+
+    #[test]
+    fn match_text_answer_empty_text_never_matches() {
+        let pending = ask(vec!["OK", "Need changes"], true);
+        assert_eq!(match_text_answer(&pending, "   "), None);
+    }
+
+    #[test]
+    fn match_callback_data_requires_the_exact_nonce() {
+        let pending = ask(vec!["Approve", "Deny"], false);
+        assert_eq!(
+            match_callback_data(&pending, "abc12345:0"),
+            Some("Approve".to_string())
+        );
+        assert_eq!(match_callback_data(&pending, "stale-nonce:0"), None);
+    }
+
+    #[test]
+    fn match_callback_data_rejects_out_of_range_index() {
+        let pending = ask(vec!["Approve", "Deny"], false);
+        assert_eq!(match_callback_data(&pending, "abc12345:9"), None);
+    }
+
+    #[test]
+    fn match_callback_data_rejects_malformed_data() {
+        let pending = ask(vec!["Approve", "Deny"], false);
+        assert_eq!(match_callback_data(&pending, "not-a-valid-shape"), None);
+        assert_eq!(match_callback_data(&pending, "abc12345:not-a-number"), None);
+    }
+
+    #[test]
+    fn format_ask_text_numbers_every_option() {
+        let pending = ask(vec!["Approve", "Deny"], false);
+        let text = format_ask_text(&pending);
+        assert!(text.contains("1. Approve"));
+        assert!(text.contains("2. Deny"));
+        assert!(!text.contains("reply with your own answer"));
+    }
+
+    #[test]
+    fn format_ask_text_open_question_mentions_free_text() {
+        let pending = ask(vec!["OK", "Need changes"], true);
+        assert!(format_ask_text(&pending).contains("reply with your own answer"));
+    }
+}

--- a/crates/app/bamboo-server/src/connect/approvals.rs
+++ b/crates/app/bamboo-server/src/connect/approvals.rs
@@ -160,6 +160,14 @@ pub async fn render_ask(
 const AFFIRMATIVE_KEYWORDS: &[&str] = &[
     "允许", "同意", "确定", "是", "yes", "allow", "approve", "ok",
 ];
+/// "stay" comes from plan-mode's decline phrasing — ExitPlanMode's negative
+/// option is literally "Stay in plan mode" (see
+/// `session_app::respond::is_exit_plan_mode_approved`), so a user typing
+/// "stay" declines the plan approval. Safe to keep in this fallback list
+/// because [`match_text_answer`] tries EXACT (case-insensitive) option-text
+/// matching BEFORE the keyword fallback: an ask whose positive option is
+/// literally titled "Stay" resolves on the exact match and never reaches
+/// here.
 const NEGATIVE_KEYWORDS: &[&str] = &["拒绝", "不", "否", "no", "deny", "reject", "stay"];
 
 fn classify_intent(text: &str) -> Option<bool> {
@@ -752,6 +760,26 @@ mod tests {
             Some("Deny".to_string())
         );
         assert_eq!(match_text_answer(&pending, "no"), Some("Deny".to_string()));
+    }
+
+    /// Ordering guarantee documented on [`NEGATIVE_KEYWORDS`]: an option
+    /// literally titled "Stay" — even as the POSITIVE first choice — resolves
+    /// via exact option-text matching BEFORE the keyword fallback, so the
+    /// "stay"-is-negative heuristic can never misroute it.
+    #[test]
+    fn match_text_answer_exact_option_named_stay_beats_negative_keyword_fallback() {
+        let pending = ask(vec!["Stay", "Leave"], false);
+        assert_eq!(
+            match_text_answer(&pending, "stay"),
+            Some("Stay".to_string())
+        );
+        // And the fallback still works as intended for plan-mode phrasing,
+        // where "stay" appears INSIDE the negative option's text.
+        let plan_pending = ask(vec!["Approve", "Stay in plan mode"], false);
+        assert_eq!(
+            match_text_answer(&plan_pending, "stay"),
+            Some("Stay in plan mode".to_string())
+        );
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/connect/bridge.rs
+++ b/crates/app/bamboo-server/src/connect/bridge.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex as StdMutex};
 
 use chrono::{DateTime, Utc};
-use tokio::sync::{broadcast, Mutex as AsyncMutex, RwLock as TokioRwLock};
+use tokio::sync::{broadcast, mpsc, Mutex as AsyncMutex, RwLock as TokioRwLock};
 use tokio_util::sync::CancellationToken;
 
 use bamboo_agent_core::tools::ToolExecutor;
@@ -25,7 +25,8 @@ use bamboo_engine::execution::{
 use bamboo_engine::{AuxiliaryModelConfig, ModelRoster, SessionRepository};
 use bamboo_llm::{Config, ProviderRegistry};
 
-use super::platform::{InboundMessage, OutboundMessage, Platform, ReplyCtx};
+use super::approvals::{self, ParkedAsk, RespondAndResumeOutcome, Responder};
+use super::platform::{CallbackQuery, InboundMessage, OutboundMessage, Platform, ReplyCtx};
 use super::render;
 
 /// `platform:chat_id:user_id` — the chat-scoped routing key mapping to a
@@ -57,18 +58,48 @@ pub struct ConnectContext {
     pub app_data_dir: Option<PathBuf>,
     pub config: Arc<tokio::sync::RwLock<Config>>,
     pub provider_registry: Arc<ProviderRegistry>,
+    /// Shared with `AppState::permission_checker` — needed so an approved
+    /// permission prompt (a gated tool asked to run, answered through
+    /// connect) actually grants the session permission the re-executed tool
+    /// call is checked against on resume (issue #458; see
+    /// `approvals::EngineResponder`).
+    pub permission_checker: Arc<dyn bamboo_tools::permission::PermissionChecker>,
 }
 
 /// Per-chat runtime state: whether a run is currently executing, the FIFO
 /// queue of messages that arrived while busy (drained at run end — mirrors
-/// cc-connect engine.go's `queueMessageForBusySession`), and the cancel token
-/// of the in-flight run (if any) so `/stop` can reach it without waiting in
-/// the queue.
+/// cc-connect engine.go's `queueMessageForBusySession`), the cancel token of
+/// the in-flight run (if any) so `/stop` can reach it without waiting in the
+/// queue, and the chat's one parked ask (if any) — issue #458's
+/// approval/question relay.
 #[derive(Default)]
 struct ChatState {
     busy: bool,
     queue: VecDeque<(Arc<dyn Platform>, InboundMessage)>,
     cancel_token: Option<CancellationToken>,
+    /// The chat's single in-flight pending question, if the current run is
+    /// paused on one (issue #458: "one parked ask per chat").
+    pending_ask: Option<ParkedAsk>,
+    /// Resolver for `pending_ask`, held by the render task
+    /// (`ConnectBridge::render_until_settled`) that's waiting on it.
+    /// `handle_inbound`/`handle_callback` push a resolution here instead of
+    /// queuing a matching reply — this is what lets an answer "jump" the
+    /// busy queue while the run is genuinely suspended waiting for exactly
+    /// this. Buffered at 1 so a resolver can send without the render task
+    /// having reached its `recv().await` yet.
+    ask_resolution: Option<mpsc::Sender<AskResolution>>,
+}
+
+/// What resolved (or invalidated) a chat's parked ask.
+#[derive(Debug, Clone)]
+enum AskResolution {
+    /// A button press or text reply matched the parked ask; submit this as
+    /// the answer.
+    Answer(String),
+    /// `/new`, session rotation, or an explicit clear invalidated the ask
+    /// before it was answered — the waiting render task must stop rendering
+    /// this (now-abandoned) run rather than hang forever.
+    Invalidated,
 }
 
 /// Resolved model/prompt/workspace configuration for a connect-driven run,
@@ -133,10 +164,17 @@ fn resolve_connect_run_config(
 /// Builds a fresh session for a connect chat key. Mirrors
 /// `schedule_app::session_factory::create_schedule_session`.
 ///
-/// Sets `no_human_approver` (like a scheduled run): approvals/buttons are a
-/// later phase of epic #447 (#452 is text-only), so there is no channel to
-/// answer a gated-tool prompt yet — without this flag a gated action would
-/// hang waiting on an approver that can never respond.
+/// `no_human_approver = false` (issue #458, flipped from phase 1's `true`): a
+/// connect-bridged chat now HAS a human attached — the ConnectBridge itself,
+/// relaying questions/approvals to and from the chat platform — so gated
+/// actions and pending questions should escalate normally rather than being
+/// tagged "no interactive approver available" (that tag only actually
+/// changes behavior for out-of-process sub-agent workers routing to an
+/// off-loop model reviewer — see `subagent_worker`'s `ApprovalProxy`; an
+/// in-process run like this one was never auto-decided by it, so this flip
+/// is a correctness/semantics fix for anything that reads the flag — e.g.
+/// child-session inheritance — rather than a change to THIS run's own pause
+/// behavior).
 fn create_connect_session(
     key: &str,
     model: &str,
@@ -170,7 +208,7 @@ fn create_connect_session(
     session
         .agent_runtime_state
         .get_or_insert_with(bamboo_domain::AgentRuntimeState::default)
-        .no_human_approver = true;
+        .no_human_approver = false;
     session
 }
 
@@ -202,10 +240,28 @@ pub struct ConnectBridge {
     /// single `HashSet::insert`, never held across an `.await`.
     seen_message_ids: StdMutex<HashSet<String>>,
     process_start: DateTime<Utc>,
+    /// The resolution seam (issue #458): `submit_pending_response` +
+    /// `resume_session_execution`, or a fake in tests.
+    responder: Arc<dyn Responder>,
 }
 
 impl ConnectBridge {
+    /// Production constructor: wires up `approvals::EngineResponder` (the
+    /// in-proc respond+resume path) automatically. See [`Self::with_responder`]
+    /// for injecting a fake in tests.
     pub fn new(ctx: ConnectContext, map_path: Option<PathBuf>) -> Self {
+        let responder = Arc::new(approvals::EngineResponder::new(ctx.clone()));
+        Self::with_responder(ctx, map_path, responder)
+    }
+
+    /// Test/advanced constructor: inject a [`Responder`] seam instead of the
+    /// production `EngineResponder` (issue #458: "Design a small Responder
+    /// seam on the bridge so tests inject a fake instead of full AppState").
+    pub fn with_responder(
+        ctx: ConnectContext,
+        map_path: Option<PathBuf>,
+        responder: Arc<dyn Responder>,
+    ) -> Self {
         Self {
             ctx,
             session_map: TokioRwLock::new(HashMap::new()),
@@ -213,6 +269,7 @@ impl ConnectBridge {
             chat_state: AsyncMutex::new(HashMap::new()),
             seen_message_ids: StdMutex::new(HashSet::new()),
             process_start: Utc::now(),
+            responder,
         }
     }
 
@@ -252,12 +309,76 @@ impl ConnectBridge {
         self.persist_session_map().await;
     }
 
+    /// Rotates the chat's session mapping (`/new`). Also invalidates any
+    /// parked ask first (issue #458: "`/new` and session rotation invalidate
+    /// parked asks") — an ask answered after its session has been rotated
+    /// away would resolve a question nobody can see anymore.
     async fn rotate_session(&self, key: &str) {
+        self.invalidate_pending_ask(key).await;
         {
             let mut map = self.session_map.write().await;
             map.remove(key);
         }
         self.persist_session_map().await;
+    }
+
+    /// Whether `key`'s chat currently has a parked ask awaiting resolution.
+    async fn has_pending_ask(&self, key: &str) -> bool {
+        self.chat_state
+            .lock()
+            .await
+            .get(key)
+            .is_some_and(|state| state.pending_ask.is_some())
+    }
+
+    /// If `key` has a parked ask AND `resolve` matches it, atomically clears
+    /// the parked ask + its resolver (so a concurrent duplicate resolution —
+    /// e.g. a button press racing a text reply — finds nothing left to
+    /// match) and returns the answer plus the channel to notify the waiting
+    /// render task on. `resolve` runs while holding the chat-state lock, so
+    /// it must be cheap and non-async (pure pattern matching against the
+    /// parked ask — see `approvals::match_text_answer`/`match_callback_data`).
+    async fn try_resolve_pending_ask(
+        &self,
+        key: &str,
+        resolve: impl FnOnce(&ParkedAsk) -> Option<String>,
+    ) -> Option<(String, mpsc::Sender<AskResolution>)> {
+        let mut guard = self.chat_state.lock().await;
+        let state = guard.get_mut(key)?;
+        let ask_ref = state.pending_ask.as_ref()?;
+        let answer = resolve(ask_ref)?;
+        let sender = state.ask_resolution.take()?;
+        state.pending_ask = None;
+        Some((answer, sender))
+    }
+
+    /// Clears `key`'s parked ask (if any) and wakes its waiting render task
+    /// with [`AskResolution::Invalidated`] instead of an answer.
+    async fn invalidate_pending_ask(&self, key: &str) {
+        let sender = {
+            let mut guard = self.chat_state.lock().await;
+            match guard.get_mut(key) {
+                Some(state) => {
+                    state.pending_ask = None;
+                    state.ask_resolution.take()
+                }
+                None => None,
+            }
+        };
+        if let Some(sender) = sender {
+            let _ = sender.send(AskResolution::Invalidated).await;
+        }
+    }
+
+    /// Clears `key`'s parked ask + resolver without sending a resolution —
+    /// used once a render task has already consumed one (whether an answer
+    /// or an invalidation) so a stale entry never lingers.
+    async fn clear_pending_ask(&self, key: &str) {
+        let mut guard = self.chat_state.lock().await;
+        if let Some(state) = guard.get_mut(key) {
+            state.pending_ask = None;
+            state.ask_resolution = None;
+        }
     }
 
     async fn persist_session_map(&self) {
@@ -355,6 +476,30 @@ impl ConnectBridge {
             return;
         }
 
+        // Ask-resolution fast path (issue #458): a parked ask takes priority
+        // over normal busy/queue routing, even while `busy` is still true —
+        // the run backing it is genuinely suspended waiting for exactly this
+        // reply, so it must never sit behind the FIFO queue. A non-matching
+        // reply on a CLOSED ask (no free text allowed) falls through to the
+        // normal busy/queue handling below, exactly like any other message.
+        if let Some((answer, sender)) = self
+            .try_resolve_pending_ask(&key, |ask| approvals::match_text_answer(ask, &msg.text))
+            .await
+        {
+            let _ = sender.send(AskResolution::Answer(answer)).await;
+            return;
+        }
+
+        // `/new` is always an immediate escape hatch out of a parked ask
+        // (bypassing the queue, which would never drain while the chat waits
+        // on an answer nobody typed correctly) — the ordinary `/new` path in
+        // `process_one` still handles the non-paused case unchanged.
+        if command.eq_ignore_ascii_case("/new") && self.has_pending_ask(&key).await {
+            self.rotate_session(&key).await;
+            reply_text(&platform, &msg.reply_ctx, "Started a new session.").await;
+            return;
+        }
+
         let mut guard = self.chat_state.lock().await;
         let state = guard.entry(key.clone()).or_default();
         if state.busy {
@@ -406,6 +551,71 @@ impl ConnectBridge {
         }
     }
 
+    /// Entry point for every inbound button-press callback (issue #458).
+    /// Unlike text messages, a callback NEVER queues and NEVER starts a run —
+    /// it can only ever resolve (or fail to resolve) the chat's parked ask.
+    /// Per the design constraint, the platform is ALWAYS acked
+    /// (`answer_callback`), even for a stale/forged/non-matching one, and a
+    /// non-match is dropped silently rather than ever being forwarded as
+    /// user text.
+    pub async fn handle_callback(
+        self: Arc<Self>,
+        platform: Arc<dyn Platform>,
+        allow_from: Vec<String>,
+        callback: CallbackQuery,
+    ) {
+        if !allow_from
+            .iter()
+            .any(|allowed| allowed == &callback.user_id)
+        {
+            tracing::warn!(
+                platform = %callback.platform,
+                chat_id = %callback.chat_id,
+                user_id = %callback.user_id,
+                "connect: rejected callback query — user not in allow_from"
+            );
+            let _ = platform
+                .answer_callback(&callback.callback_query_id, None)
+                .await;
+            return;
+        }
+
+        let key = SessionKey {
+            platform: callback.platform.clone(),
+            chat_id: callback.chat_id.clone(),
+            user_id: callback.user_id.clone(),
+        }
+        .as_string();
+
+        let resolved = self
+            .try_resolve_pending_ask(&key, |ask| {
+                approvals::match_callback_data(ask, &callback.data)
+            })
+            .await;
+
+        match resolved {
+            Some((answer, sender)) => {
+                let _ = platform
+                    .answer_callback(&callback.callback_query_id, None)
+                    .await;
+                let _ = sender.send(AskResolution::Answer(answer)).await;
+            }
+            None => {
+                tracing::debug!(
+                    platform = %callback.platform,
+                    chat_id = %callback.chat_id,
+                    "connect: dropping stale/forged callback_data"
+                );
+                let _ = platform
+                    .answer_callback(
+                        &callback.callback_query_id,
+                        Some("This action has expired."),
+                    )
+                    .await;
+            }
+        }
+    }
+
     async fn process_one(&self, key: &str, platform: Arc<dyn Platform>, msg: InboundMessage) {
         let command = strip_command_suffix(msg.text.trim());
         if command.eq_ignore_ascii_case("/new") {
@@ -430,12 +640,28 @@ impl ConnectBridge {
                 .get(key)
                 .and_then(|state| state.cancel_token.clone())
         };
-        match token {
-            Some(token) => {
+        // A run paused on a parked ask has no live task for `cancel_token` to
+        // reach (the round that produced the question already returned) — an
+        // ask invalidation is what actually unblocks
+        // `render_until_settled`'s wait in that case.
+        let had_pending_ask = self.has_pending_ask(key).await;
+        if had_pending_ask {
+            self.invalidate_pending_ask(key).await;
+        }
+        match (token, had_pending_ask) {
+            (Some(token), _) => {
                 token.cancel();
                 reply_text(platform, reply_ctx, "Stopping the current run…").await;
             }
-            None => {
+            (None, true) => {
+                reply_text(
+                    platform,
+                    reply_ctx,
+                    "Stopped — the pending question was cancelled.",
+                )
+                .await;
+            }
+            (None, false) => {
                 reply_text(platform, reply_ctx, "Nothing is running.").await;
             }
         }
@@ -608,9 +834,89 @@ impl ConnectBridge {
             on_complete: None,
         });
 
-        render::stream_execution(platform, reply_ctx.clone(), rx).await;
+        self.render_until_settled(key, platform, reply_ctx.clone(), &session_id, rx)
+            .await;
 
         self.clear_cancel_token(key).await;
+    }
+
+    /// Renders one run to completion, looping back for as many
+    /// pause/answer/resume cycles as it takes to reach a genuinely terminal
+    /// state (issue #458). On [`render::RunOutcome::Paused`]: parks the ask,
+    /// renders it (buttons when the platform supports them, always also a
+    /// numbered text list), and waits for a resolution pushed by
+    /// `handle_inbound`'s ask-resolution fast path or `handle_callback` —
+    /// or an invalidation from `/new`/rotation/`/stop`. A resolved answer is
+    /// submitted through `self.responder`, which mirrors
+    /// `POST /sessions/{id}/respond`'s exact resolve-then-resume sequence;
+    /// the resumed run's fresh broadcast receiver is looped back into
+    /// another `render::stream_execution` call so the SAME chat keeps
+    /// watching the SAME (now-continuing) run.
+    async fn render_until_settled(
+        &self,
+        key: &str,
+        platform: Arc<dyn Platform>,
+        reply_ctx: ReplyCtx,
+        session_id: &str,
+        mut rx: broadcast::Receiver<AgentEvent>,
+    ) {
+        loop {
+            match render::stream_execution(platform.clone(), reply_ctx.clone(), rx).await {
+                render::RunOutcome::Terminal => return,
+                render::RunOutcome::Paused(ask) => {
+                    let caps = platform.capabilities();
+                    let parked =
+                        ParkedAsk::new(approvals::new_nonce(), session_id.to_string(), &ask);
+
+                    if let Err(error) =
+                        approvals::render_ask(&platform, &reply_ctx, &parked, caps.buttons).await
+                    {
+                        tracing::warn!("connect: failed to render pending ask: {error}");
+                    }
+
+                    let (ask_tx, mut ask_rx) = mpsc::channel(1);
+                    {
+                        let mut guard = self.chat_state.lock().await;
+                        let state = guard.entry(key.to_string()).or_default();
+                        state.pending_ask = Some(parked);
+                        state.ask_resolution = Some(ask_tx);
+                    }
+
+                    match ask_rx.recv().await {
+                        Some(AskResolution::Answer(answer)) => {
+                            match self.responder.respond_and_resume(session_id, answer).await {
+                                Ok(RespondAndResumeOutcome::Resumed(new_rx)) => {
+                                    rx = new_rx;
+                                    continue;
+                                }
+                                Ok(RespondAndResumeOutcome::NotResumed(reason)) => {
+                                    reply_text(&platform, &reply_ctx, format!("({reason})")).await;
+                                    return;
+                                }
+                                Err(error) => {
+                                    reply_text(
+                                        &platform,
+                                        &reply_ctx,
+                                        format!("Failed to record your answer: {error}"),
+                                    )
+                                    .await;
+                                    return;
+                                }
+                            }
+                        }
+                        Some(AskResolution::Invalidated) | None => {
+                            // Already cleared by the invalidator in the
+                            // common case; clear defensively so a stale entry
+                            // never lingers if the sender was dropped instead
+                            // (e.g. a bug elsewhere) rather than sending
+                            // `Invalidated` explicitly.
+                            self.clear_pending_ask(key).await;
+                            return;
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -646,17 +952,33 @@ mod tests {
     use tokio::sync::Mutex as TokioMutex;
 
     /// mpsc-backed fake `Platform` (per issue #452's test spec): records every
-    /// `reply()` call instead of talking to a real IM API.
+    /// `reply()`/`edit()`/`answer_callback()` call instead of talking to a
+    /// real IM API. `capabilities` is configurable (issue #458 tests need
+    /// buttons+edit_message; the original #452 tests want the all-`false`
+    /// default).
     struct FakePlatform {
         label: String,
+        capabilities: super::super::platform::Capabilities,
         sent: TokioMutex<Vec<String>>,
+        sent_messages: TokioMutex<Vec<OutboundMessage>>,
+        answered_callbacks: TokioMutex<Vec<(String, Option<String>)>>,
     }
 
     impl FakePlatform {
         fn new(label: &str) -> Arc<Self> {
+            Self::with_capabilities(label, Default::default())
+        }
+
+        fn with_capabilities(
+            label: &str,
+            capabilities: super::super::platform::Capabilities,
+        ) -> Arc<Self> {
             Arc::new(Self {
                 label: label.to_string(),
+                capabilities,
                 sent: TokioMutex::new(Vec::new()),
+                sent_messages: TokioMutex::new(Vec::new()),
+                answered_callbacks: TokioMutex::new(Vec::new()),
             })
         }
 
@@ -671,11 +993,11 @@ mod tests {
             &self.label
         }
         fn capabilities(&self) -> super::super::platform::Capabilities {
-            Default::default()
+            self.capabilities
         }
         async fn start(
             &self,
-            _inbound: tokio::sync::mpsc::Sender<InboundMessage>,
+            _inbound: tokio::sync::mpsc::Sender<super::super::platform::Inbound>,
         ) -> super::super::platform::PlatformResult<()> {
             Ok(())
         }
@@ -684,7 +1006,8 @@ mod tests {
             _ctx: &ReplyCtx,
             msg: OutboundMessage,
         ) -> super::super::platform::PlatformResult<super::super::platform::MessageRef> {
-            self.sent.lock().await.push(msg.text);
+            self.sent.lock().await.push(msg.text.clone());
+            self.sent_messages.lock().await.push(msg);
             Ok(super::super::platform::MessageRef(serde_json::Value::Null))
         }
         async fn edit(
@@ -694,8 +1017,112 @@ mod tests {
         ) -> super::super::platform::PlatformResult<()> {
             Ok(())
         }
+        async fn answer_callback(
+            &self,
+            callback_query_id: &str,
+            text: Option<&str>,
+        ) -> super::super::platform::PlatformResult<()> {
+            self.answered_callbacks
+                .lock()
+                .await
+                .push((callback_query_id.to_string(), text.map(str::to_string)));
+            Ok(())
+        }
         async fn stop(&self) -> super::super::platform::PlatformResult<()> {
             Ok(())
+        }
+    }
+
+    /// Fake [`Responder`] (issue #458: "tests inject a fake instead of full
+    /// AppState"): records every submitted answer and hands back a
+    /// broadcast receiver subscribed to a test-controlled sender, so a test
+    /// can drive the "resumed run" by sending events directly.
+    struct FakeResponder {
+        calls: TokioMutex<Vec<(String, String)>>,
+        resume_sender: broadcast::Sender<AgentEvent>,
+        fail_with: Option<String>,
+    }
+
+    impl FakeResponder {
+        fn new(resume_sender: broadcast::Sender<AgentEvent>) -> Arc<Self> {
+            Arc::new(Self {
+                calls: TokioMutex::new(Vec::new()),
+                resume_sender,
+                fail_with: None,
+            })
+        }
+
+        fn failing(resume_sender: broadcast::Sender<AgentEvent>, reason: &str) -> Arc<Self> {
+            Arc::new(Self {
+                calls: TokioMutex::new(Vec::new()),
+                resume_sender,
+                fail_with: Some(reason.to_string()),
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Responder for FakeResponder {
+        async fn respond_and_resume(
+            &self,
+            session_id: &str,
+            answer: String,
+        ) -> Result<RespondAndResumeOutcome, super::super::approvals::ResponderError> {
+            self.calls
+                .lock()
+                .await
+                .push((session_id.to_string(), answer));
+            if let Some(reason) = &self.fail_with {
+                return Err(super::super::approvals::ResponderError::Other(
+                    reason.clone(),
+                ));
+            }
+            Ok(RespondAndResumeOutcome::Resumed(
+                self.resume_sender.subscribe(),
+            ))
+        }
+    }
+
+    /// Polls `bridge`'s internal chat state until `key` has a parked ask (or
+    /// panics past a 5s deadline) — used to synchronize with
+    /// `render_until_settled`'s pause branch, which parks the ask
+    /// asynchronously.
+    async fn wait_for_parked_ask(bridge: &ConnectBridge, key: &str) -> ParkedAsk {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Some(ask) = bridge
+                .chat_state
+                .lock()
+                .await
+                .get(key)
+                .and_then(|state| state.pending_ask.clone())
+            {
+                return ask;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "ask was never parked for {key}"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    /// Polls until `responder` has recorded at least one call (or panics past
+    /// a 5s deadline) — used to synchronize with `FakeResponder::subscribe`
+    /// actually happening inside `render_until_settled`'s spawned task
+    /// BEFORE a test sends an event on the "resumed" broadcast channel
+    /// (`broadcast::Sender::send` errors with zero live subscribers).
+    async fn wait_for_responder_call(responder: &FakeResponder) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if !responder.calls.lock().await.is_empty() {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "responder was never called"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
     }
 
@@ -739,6 +1166,7 @@ mod tests {
             app_data_dir: Some(state.app_data_dir.clone()),
             config: state.config.clone(),
             provider_registry: state.provider_registry.clone(),
+            permission_checker: state.permission_checker.clone(),
         };
         (ctx, dir)
     }
@@ -1017,6 +1445,441 @@ mod tests {
         assert_eq!(
             bridge2.session_id_for_key("k1").await.as_deref(),
             Some("sess-1")
+        );
+    }
+
+    // ---- Issue #458: approval/question relay ----
+
+    fn buttons_and_edit_capabilities() -> super::super::platform::Capabilities {
+        super::super::platform::Capabilities {
+            buttons: true,
+            edit_message: true,
+            images: false,
+            files: false,
+        }
+    }
+
+    fn need_clarification_event(
+        question: &str,
+        options: Vec<&str>,
+        allow_custom: bool,
+    ) -> AgentEvent {
+        AgentEvent::NeedClarification {
+            question: question.to_string(),
+            options: Some(options.into_iter().map(str::to_string).collect()),
+            tool_call_id: Some("call-1".to_string()),
+            tool_name: Some("request_permissions".to_string()),
+            allow_custom,
+        }
+    }
+
+    #[tokio::test]
+    async fn paused_run_renders_buttons_with_nonce_and_resolves_via_callback() {
+        let (ctx, _dir) = test_context().await;
+        let resume_tx = broadcast::channel::<AgentEvent>(16).0;
+        let responder = FakeResponder::new(resume_tx.clone());
+        let bridge = Arc::new(ConnectBridge::with_responder(ctx, None, responder.clone()));
+        let platform = FakePlatform::with_capabilities("fake", buttons_and_edit_capabilities());
+        let key = key_for("chat1", "u1");
+        let reply_ctx = ReplyCtx(serde_json::json!({ "chat_id": "chat1" }));
+
+        let (tx, rx) = broadcast::channel(16);
+        tx.send(need_clarification_event(
+            "Approve?",
+            vec!["Approve", "Deny"],
+            false,
+        ))
+        .unwrap();
+
+        let render_handle = {
+            let bridge = bridge.clone();
+            let platform = platform.clone();
+            let reply_ctx = reply_ctx.clone();
+            let key = key.clone();
+            tokio::spawn(async move {
+                bridge
+                    .render_until_settled(&key, platform, reply_ctx, "sess-1", rx)
+                    .await;
+            })
+        };
+
+        let parked = wait_for_parked_ask(&bridge, &key).await;
+        assert_eq!(
+            parked.options,
+            vec!["Approve".to_string(), "Deny".to_string()]
+        );
+
+        // Buttons were rendered on the ask message, one per option, callback
+        // data carrying the nonce (never raw option text/user text).
+        let sent = platform.sent_messages.lock().await.clone();
+        let ask_message = sent
+            .iter()
+            .find(|message| message.buttons.is_some())
+            .expect("expected a buttoned ask message");
+        let buttons = ask_message.buttons.as_ref().unwrap();
+        assert_eq!(buttons.len(), 2);
+        assert_eq!(buttons[0][0].callback_data, format!("{}:0", parked.nonce));
+        assert_eq!(buttons[1][0].callback_data, format!("{}:1", parked.nonce));
+
+        let callback = CallbackQuery {
+            platform: "fake".to_string(),
+            chat_id: "chat1".to_string(),
+            user_id: "u1".to_string(),
+            callback_query_id: "cbq-1".to_string(),
+            data: format!("{}:0", parked.nonce),
+            reply_ctx: reply_ctx.clone(),
+        };
+        ConnectBridge::handle_callback(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            callback,
+        )
+        .await;
+
+        // Wait for `render_until_settled`'s spawned task to have actually
+        // called through to the responder (and thus subscribed to
+        // `resume_tx`) before sending on it — `broadcast::Sender::send`
+        // errors out with zero live subscribers.
+        wait_for_responder_call(&responder).await;
+
+        resume_tx
+            .send(AgentEvent::Complete {
+                usage: bamboo_agent_core::TokenUsage {
+                    prompt_tokens: 1,
+                    completion_tokens: 1,
+                    total_tokens: 2,
+                },
+            })
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), render_handle)
+            .await
+            .expect("render task must finish")
+            .unwrap();
+
+        assert_eq!(
+            responder.calls.lock().await.as_slice(),
+            &[("sess-1".to_string(), "Approve".to_string())]
+        );
+        assert_eq!(
+            platform.answered_callbacks.lock().await.as_slice(),
+            &[("cbq-1".to_string(), None)]
+        );
+        assert!(!bridge.has_pending_ask(&key).await);
+    }
+
+    #[tokio::test]
+    async fn stale_callback_nonce_is_dropped_and_acked_without_resolving() {
+        let (ctx, _dir) = test_context().await;
+        let resume_tx = broadcast::channel::<AgentEvent>(16).0;
+        let responder = FakeResponder::new(resume_tx.clone());
+        let bridge = Arc::new(ConnectBridge::with_responder(ctx, None, responder.clone()));
+        let platform = FakePlatform::with_capabilities("fake", buttons_and_edit_capabilities());
+        let key = key_for("chat1", "u1");
+        let reply_ctx = ReplyCtx(serde_json::json!({ "chat_id": "chat1" }));
+
+        let (tx, rx) = broadcast::channel(16);
+        tx.send(need_clarification_event(
+            "Approve?",
+            vec!["Approve", "Deny"],
+            false,
+        ))
+        .unwrap();
+
+        let render_handle = {
+            let bridge = bridge.clone();
+            let platform = platform.clone();
+            let reply_ctx = reply_ctx.clone();
+            let key = key.clone();
+            tokio::spawn(async move {
+                bridge
+                    .render_until_settled(&key, platform, reply_ctx, "sess-1", rx)
+                    .await;
+            })
+        };
+
+        wait_for_parked_ask(&bridge, &key).await;
+
+        let stale_callback = CallbackQuery {
+            platform: "fake".to_string(),
+            chat_id: "chat1".to_string(),
+            user_id: "u1".to_string(),
+            callback_query_id: "cbq-stale".to_string(),
+            data: "totally-wrong-nonce:0".to_string(),
+            reply_ctx: reply_ctx.clone(),
+        };
+        ConnectBridge::handle_callback(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            stale_callback,
+        )
+        .await;
+
+        // Acked (Telegram-style — always ack), but with an "expired" style
+        // note, and NOT forwarded as an answer.
+        let acked = platform.answered_callbacks.lock().await.clone();
+        assert_eq!(acked.len(), 1);
+        assert_eq!(acked[0].0, "cbq-stale");
+        assert!(acked[0].1.is_some());
+        assert!(responder.calls.lock().await.is_empty());
+        // The real ask is still parked — the stale callback never touched it.
+        assert!(bridge.has_pending_ask(&key).await);
+
+        bridge.invalidate_pending_ask(&key).await;
+        tokio::time::timeout(Duration::from_secs(5), render_handle)
+            .await
+            .expect("render task must finish")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn text_answer_resolves_an_open_question() {
+        let (ctx, _dir) = test_context().await;
+        let resume_tx = broadcast::channel::<AgentEvent>(16).0;
+        let responder = FakeResponder::new(resume_tx.clone());
+        let bridge = Arc::new(ConnectBridge::with_responder(ctx, None, responder.clone()));
+        let platform = FakePlatform::with_capabilities("fake", buttons_and_edit_capabilities());
+        let key = key_for("chat1", "u1");
+        let reply_ctx = ReplyCtx(serde_json::json!({ "chat_id": "chat1" }));
+
+        let (tx, rx) = broadcast::channel(16);
+        tx.send(need_clarification_event(
+            "Anything else?",
+            vec!["OK", "Need changes"],
+            true,
+        ))
+        .unwrap();
+
+        let render_handle = {
+            let bridge = bridge.clone();
+            let platform = platform.clone();
+            let reply_ctx = reply_ctx.clone();
+            let key = key.clone();
+            tokio::spawn(async move {
+                bridge
+                    .render_until_settled(&key, platform, reply_ctx, "sess-1", rx)
+                    .await;
+            })
+        };
+
+        wait_for_parked_ask(&bridge, &key).await;
+
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            inbound("chat1", "u1", "answer-1", "please also add tests"),
+        )
+        .await;
+
+        // Wait for `render_until_settled`'s spawned task to have actually
+        // called through to the responder (and thus subscribed to
+        // `resume_tx`) before sending on it — `broadcast::Sender::send`
+        // errors out with zero live subscribers.
+        wait_for_responder_call(&responder).await;
+
+        resume_tx
+            .send(AgentEvent::Complete {
+                usage: bamboo_agent_core::TokenUsage {
+                    prompt_tokens: 1,
+                    completion_tokens: 1,
+                    total_tokens: 2,
+                },
+            })
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), render_handle)
+            .await
+            .expect("render task must finish")
+            .unwrap();
+
+        assert_eq!(
+            responder.calls.lock().await.as_slice(),
+            &[("sess-1".to_string(), "please also add tests".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn binary_ask_keyword_mapping_resolves_via_text() {
+        let (ctx, _dir) = test_context().await;
+        let resume_tx = broadcast::channel::<AgentEvent>(16).0;
+        let responder = FakeResponder::new(resume_tx.clone());
+        let bridge = Arc::new(ConnectBridge::with_responder(ctx, None, responder.clone()));
+        let platform = FakePlatform::with_capabilities("fake", buttons_and_edit_capabilities());
+        let key = key_for("chat1", "u1");
+        let reply_ctx = ReplyCtx(serde_json::json!({ "chat_id": "chat1" }));
+
+        let (tx, rx) = broadcast::channel(16);
+        tx.send(need_clarification_event(
+            "Approve?",
+            vec!["Approve", "Deny"],
+            false,
+        ))
+        .unwrap();
+
+        let render_handle = {
+            let bridge = bridge.clone();
+            let platform = platform.clone();
+            let reply_ctx = reply_ctx.clone();
+            let key = key.clone();
+            tokio::spawn(async move {
+                bridge
+                    .render_until_settled(&key, platform, reply_ctx, "sess-1", rx)
+                    .await;
+            })
+        };
+
+        wait_for_parked_ask(&bridge, &key).await;
+
+        // "允许" (allow) is a first-affirmative keyword — resolves to
+        // whichever option reads as approval, NEVER the raw keyword text.
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            inbound("chat1", "u1", "answer-1", "允许"),
+        )
+        .await;
+
+        // Wait for `render_until_settled`'s spawned task to have actually
+        // called through to the responder (and thus subscribed to
+        // `resume_tx`) before sending on it — `broadcast::Sender::send`
+        // errors out with zero live subscribers.
+        wait_for_responder_call(&responder).await;
+
+        resume_tx
+            .send(AgentEvent::Complete {
+                usage: bamboo_agent_core::TokenUsage {
+                    prompt_tokens: 1,
+                    completion_tokens: 1,
+                    total_tokens: 2,
+                },
+            })
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), render_handle)
+            .await
+            .expect("render task must finish")
+            .unwrap();
+
+        assert_eq!(
+            responder.calls.lock().await.as_slice(),
+            &[("sess-1".to_string(), "Approve".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn new_command_invalidates_a_parked_ask_instead_of_answering_it() {
+        let (ctx, _dir) = test_context().await;
+        let resume_tx = broadcast::channel::<AgentEvent>(16).0;
+        let responder = FakeResponder::new(resume_tx.clone());
+        let bridge = Arc::new(ConnectBridge::with_responder(ctx, None, responder.clone()));
+        let platform = FakePlatform::with_capabilities("fake", buttons_and_edit_capabilities());
+        let key = key_for("chat1", "u1");
+        let reply_ctx = ReplyCtx(serde_json::json!({ "chat_id": "chat1" }));
+
+        bridge.set_session_id_for_key(&key, "sess-1").await;
+
+        let (tx, rx) = broadcast::channel(16);
+        tx.send(need_clarification_event(
+            "Approve?",
+            vec!["Approve", "Deny"],
+            false,
+        ))
+        .unwrap();
+
+        let render_handle = {
+            let bridge = bridge.clone();
+            let platform = platform.clone();
+            let reply_ctx = reply_ctx.clone();
+            let key = key.clone();
+            tokio::spawn(async move {
+                bridge
+                    .render_until_settled(&key, platform, reply_ctx, "sess-1", rx)
+                    .await;
+            })
+        };
+
+        wait_for_parked_ask(&bridge, &key).await;
+
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            inbound("chat1", "u1", "new-1", "/new"),
+        )
+        .await;
+
+        tokio::time::timeout(Duration::from_secs(5), render_handle)
+            .await
+            .expect("render task must finish")
+            .unwrap();
+
+        assert!(responder.calls.lock().await.is_empty());
+        assert!(!bridge.has_pending_ask(&key).await);
+        // Session mapping was rotated away, same as an ordinary `/new`.
+        assert!(bridge.session_id_for_key(&key).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn respond_error_reports_to_the_chat_without_hanging() {
+        let (ctx, _dir) = test_context().await;
+        let resume_tx = broadcast::channel::<AgentEvent>(16).0;
+        let responder = FakeResponder::failing(resume_tx.clone(), "boom");
+        let bridge = Arc::new(ConnectBridge::with_responder(ctx, None, responder.clone()));
+        let platform = FakePlatform::with_capabilities("fake", buttons_and_edit_capabilities());
+        let key = key_for("chat1", "u1");
+        let reply_ctx = ReplyCtx(serde_json::json!({ "chat_id": "chat1" }));
+
+        let (tx, rx) = broadcast::channel(16);
+        tx.send(need_clarification_event(
+            "Approve?",
+            vec!["Approve", "Deny"],
+            false,
+        ))
+        .unwrap();
+
+        let render_handle = {
+            let bridge = bridge.clone();
+            let platform = platform.clone();
+            let reply_ctx = reply_ctx.clone();
+            let key = key.clone();
+            tokio::spawn(async move {
+                bridge
+                    .render_until_settled(&key, platform, reply_ctx, "sess-1", rx)
+                    .await;
+            })
+        };
+
+        let parked = wait_for_parked_ask(&bridge, &key).await;
+        let callback = CallbackQuery {
+            platform: "fake".to_string(),
+            chat_id: "chat1".to_string(),
+            user_id: "u1".to_string(),
+            callback_query_id: "cbq-1".to_string(),
+            data: format!("{}:0", parked.nonce),
+            reply_ctx: reply_ctx.clone(),
+        };
+        ConnectBridge::handle_callback(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            callback,
+        )
+        .await;
+
+        tokio::time::timeout(Duration::from_secs(5), render_handle)
+            .await
+            .expect("render task must finish even when the responder errors")
+            .unwrap();
+
+        let sent = platform.sent_texts().await;
+        assert!(
+            sent.iter()
+                .any(|text| text.contains("Failed to record your answer")),
+            "expected an error report, got: {sent:?}"
         );
     }
 }

--- a/crates/app/bamboo-server/src/connect/bridge.rs
+++ b/crates/app/bamboo-server/src/connect/bridge.rs
@@ -850,8 +850,11 @@ impl ConnectBridge {
     /// submitted through `self.responder`, which mirrors
     /// `POST /sessions/{id}/respond`'s exact resolve-then-resume sequence;
     /// the resumed run's fresh broadcast receiver is looped back into
-    /// another `render::stream_execution` call so the SAME chat keeps
-    /// watching the SAME (now-continuing) run.
+    /// another `render::stream_execution` call — together with the streaming
+    /// renderer's carried-over [`render::StreamState`] — so the SAME chat
+    /// keeps watching the SAME (now-continuing) run in the SAME status
+    /// message (one "⏳ Working…" bubble per run, no matter how many times it
+    /// pauses).
     async fn render_until_settled(
         &self,
         key: &str,
@@ -860,10 +863,22 @@ impl ConnectBridge {
         session_id: &str,
         mut rx: broadcast::Receiver<AgentEvent>,
     ) {
+        let mut stream_state: Option<Box<render::StreamState>> = None;
         loop {
-            match render::stream_execution(platform.clone(), reply_ctx.clone(), rx).await {
+            match render::stream_execution(
+                platform.clone(),
+                reply_ctx.clone(),
+                rx,
+                stream_state.take(),
+            )
+            .await
+            {
                 render::RunOutcome::Terminal => return,
-                render::RunOutcome::Paused(ask) => {
+                render::RunOutcome::Paused {
+                    ask,
+                    stream_state: paused_state,
+                } => {
+                    stream_state = paused_state;
                     let caps = platform.capabilities();
                     let parked =
                         ParkedAsk::new(approvals::new_nonce(), session_id.to_string(), &ask);
@@ -961,6 +976,7 @@ mod tests {
         capabilities: super::super::platform::Capabilities,
         sent: TokioMutex<Vec<String>>,
         sent_messages: TokioMutex<Vec<OutboundMessage>>,
+        edits: TokioMutex<Vec<String>>,
         answered_callbacks: TokioMutex<Vec<(String, Option<String>)>>,
     }
 
@@ -978,6 +994,7 @@ mod tests {
                 capabilities,
                 sent: TokioMutex::new(Vec::new()),
                 sent_messages: TokioMutex::new(Vec::new()),
+                edits: TokioMutex::new(Vec::new()),
                 answered_callbacks: TokioMutex::new(Vec::new()),
             })
         }
@@ -1013,8 +1030,9 @@ mod tests {
         async fn edit(
             &self,
             _msg_ref: &super::super::platform::MessageRef,
-            _new: OutboundMessage,
+            new: OutboundMessage,
         ) -> super::super::platform::PlatformResult<()> {
+            self.edits.lock().await.push(new.text);
             Ok(())
         }
         async fn answer_callback(
@@ -1107,20 +1125,21 @@ mod tests {
         }
     }
 
-    /// Polls until `responder` has recorded at least one call (or panics past
-    /// a 5s deadline) — used to synchronize with `FakeResponder::subscribe`
-    /// actually happening inside `render_until_settled`'s spawned task
-    /// BEFORE a test sends an event on the "resumed" broadcast channel
-    /// (`broadcast::Sender::send` errors with zero live subscribers).
-    async fn wait_for_responder_call(responder: &FakeResponder) {
+    /// Polls until `responder` has recorded at least `count` calls (or panics
+    /// past a 5s deadline) — used to synchronize with
+    /// `FakeResponder::subscribe` actually happening inside
+    /// `render_until_settled`'s spawned task BEFORE a test sends an event on
+    /// the "resumed" broadcast channel (`broadcast::Sender::send` errors with
+    /// zero live subscribers).
+    async fn wait_for_responder_calls(responder: &FakeResponder, count: usize) {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
         loop {
-            if !responder.calls.lock().await.is_empty() {
+            if responder.calls.lock().await.len() >= count {
                 return;
             }
             assert!(
                 tokio::time::Instant::now() < deadline,
-                "responder was never called"
+                "responder never reached {count} call(s)"
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
@@ -1541,7 +1560,7 @@ mod tests {
         // called through to the responder (and thus subscribed to
         // `resume_tx`) before sending on it — `broadcast::Sender::send`
         // errors out with zero live subscribers.
-        wait_for_responder_call(&responder).await;
+        wait_for_responder_calls(&responder, 1).await;
 
         resume_tx
             .send(AgentEvent::Complete {
@@ -1678,7 +1697,7 @@ mod tests {
         // called through to the responder (and thus subscribed to
         // `resume_tx`) before sending on it — `broadcast::Sender::send`
         // errors out with zero live subscribers.
-        wait_for_responder_call(&responder).await;
+        wait_for_responder_calls(&responder, 1).await;
 
         resume_tx
             .send(AgentEvent::Complete {
@@ -1747,7 +1766,7 @@ mod tests {
         // called through to the responder (and thus subscribed to
         // `resume_tx`) before sending on it — `broadcast::Sender::send`
         // errors out with zero live subscribers.
-        wait_for_responder_call(&responder).await;
+        wait_for_responder_calls(&responder, 1).await;
 
         resume_tx
             .send(AgentEvent::Complete {
@@ -1880,6 +1899,263 @@ mod tests {
             sent.iter()
                 .any(|text| text.contains("Failed to record your answer")),
             "expected an error report, got: {sent:?}"
+        );
+    }
+
+    /// PR #459 review must-fix: a run that pauses (and resumes) MULTIPLE
+    /// times must keep exactly ONE status message — every resumed segment
+    /// keeps EDITING the original "⏳ Working…" bubble via the carried
+    /// `render::StreamState`, never opening a new one.
+    #[tokio::test]
+    async fn run_that_pauses_twice_keeps_a_single_status_message() {
+        let (ctx, _dir) = test_context().await;
+        let resume_tx = broadcast::channel::<AgentEvent>(16).0;
+        let responder = FakeResponder::new(resume_tx.clone());
+        let bridge = Arc::new(ConnectBridge::with_responder(ctx, None, responder.clone()));
+        let platform = FakePlatform::with_capabilities("fake", buttons_and_edit_capabilities());
+        let key = key_for("chat1", "u1");
+        let reply_ctx = ReplyCtx(serde_json::json!({ "chat_id": "chat1" }));
+
+        // Segment 1: text + pause #1.
+        let (tx, rx) = broadcast::channel(16);
+        tx.send(AgentEvent::Token {
+            content: "segment one ".to_string(),
+        })
+        .unwrap();
+        tx.send(need_clarification_event(
+            "First?",
+            vec!["Approve", "Deny"],
+            false,
+        ))
+        .unwrap();
+
+        let render_handle = {
+            let bridge = bridge.clone();
+            let platform = platform.clone();
+            let reply_ctx = reply_ctx.clone();
+            let key = key.clone();
+            tokio::spawn(async move {
+                bridge
+                    .render_until_settled(&key, platform, reply_ctx, "sess-1", rx)
+                    .await;
+            })
+        };
+
+        let first_ask = wait_for_parked_ask(&bridge, &key).await;
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            inbound("chat1", "u1", "a1", "1"),
+        )
+        .await;
+        wait_for_responder_calls(&responder, 1).await;
+
+        // Segment 2 (first resume): text + pause #2.
+        resume_tx
+            .send(AgentEvent::Token {
+                content: "segment two ".to_string(),
+            })
+            .unwrap();
+        resume_tx
+            .send(need_clarification_event(
+                "Second?",
+                vec!["Approve", "Deny"],
+                false,
+            ))
+            .unwrap();
+
+        // Wait until the SECOND ask is parked (a fresh nonce distinguishes
+        // it from the first, already-resolved one).
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let parked = {
+                bridge
+                    .chat_state
+                    .lock()
+                    .await
+                    .get(&key)
+                    .and_then(|state| state.pending_ask.clone())
+            };
+            if let Some(ask) = parked {
+                if ask.nonce != first_ask.nonce {
+                    break;
+                }
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "second ask was never parked"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            inbound("chat1", "u1", "a2", "1"),
+        )
+        .await;
+        wait_for_responder_calls(&responder, 2).await;
+
+        // Segment 3 (second resume): text + Complete.
+        resume_tx
+            .send(AgentEvent::Token {
+                content: "segment three".to_string(),
+            })
+            .unwrap();
+        resume_tx
+            .send(AgentEvent::Complete {
+                usage: bamboo_agent_core::TokenUsage {
+                    prompt_tokens: 1,
+                    completion_tokens: 1,
+                    total_tokens: 2,
+                },
+            })
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), render_handle)
+            .await
+            .expect("render task must finish")
+            .unwrap();
+
+        // Exactly ONE "⏳ Working…" status message across the whole
+        // twice-paused run; the other sends are the two ask messages.
+        let sent = platform.sent_texts().await;
+        let status_count = sent.iter().filter(|text| text.contains('⏳')).count();
+        assert_eq!(
+            status_count, 1,
+            "expected exactly one status bubble, got: {sent:?}"
+        );
+        assert_eq!(sent.len(), 3, "status + 2 asks expected, got: {sent:?}");
+
+        // Edits continued across both resumes: the final ✅ edit carries text
+        // from every segment (the buffer survived both pauses).
+        let edits = platform.edits.lock().await;
+        let last = edits.last().expect("expected a final edit");
+        assert!(last.starts_with('✅'), "final edit not a success: {last}");
+        assert!(last.contains("segment one"));
+        assert!(last.contains("segment two"));
+        assert!(last.contains("segment three"));
+    }
+
+    /// PR #459 review item 3: `/stop` while a run is paused on a parked ask
+    /// (no live cancel token — the round already returned) must invalidate
+    /// the ask, unblock the render task, and reply with the dedicated
+    /// "pending question was cancelled" message (the `(None, true)` branch).
+    #[tokio::test]
+    async fn stop_while_paused_cancels_the_pending_question() {
+        let (ctx, _dir) = test_context().await;
+        let resume_tx = broadcast::channel::<AgentEvent>(16).0;
+        let responder = FakeResponder::new(resume_tx.clone());
+        let bridge = Arc::new(ConnectBridge::with_responder(ctx, None, responder.clone()));
+        let platform = FakePlatform::with_capabilities("fake", buttons_and_edit_capabilities());
+        let key = key_for("chat1", "u1");
+        let reply_ctx = ReplyCtx(serde_json::json!({ "chat_id": "chat1" }));
+
+        let (tx, rx) = broadcast::channel(16);
+        tx.send(need_clarification_event(
+            "Approve?",
+            vec!["Approve", "Deny"],
+            false,
+        ))
+        .unwrap();
+
+        let render_handle = {
+            let bridge = bridge.clone();
+            let platform = platform.clone();
+            let reply_ctx = reply_ctx.clone();
+            let key = key.clone();
+            tokio::spawn(async move {
+                bridge
+                    .render_until_settled(&key, platform, reply_ctx, "sess-1", rx)
+                    .await;
+            })
+        };
+
+        wait_for_parked_ask(&bridge, &key).await;
+
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            inbound("chat1", "u1", "stop-1", "/stop"),
+        )
+        .await;
+
+        tokio::time::timeout(Duration::from_secs(5), render_handle)
+            .await
+            .expect("render task must finish after /stop invalidates the ask")
+            .unwrap();
+
+        let sent = platform.sent_texts().await;
+        assert!(
+            sent.iter()
+                .any(|text| text == "Stopped — the pending question was cancelled."),
+            "expected the pending-question-cancelled reply, got: {sent:?}"
+        );
+        assert!(!bridge.has_pending_ask(&key).await);
+        assert!(responder.calls.lock().await.is_empty());
+    }
+
+    /// The `(Some(token), true)` `/stop` branch: a parked ask AND a live
+    /// cancel token (e.g. `/stop` racing the pause) — the token is
+    /// cancelled, the ask is invalidated, and the generic "Stopping the
+    /// current run…" reply is used.
+    #[tokio::test]
+    async fn stop_while_paused_with_live_token_cancels_both() {
+        let (ctx, _dir) = test_context().await;
+        let resume_tx = broadcast::channel::<AgentEvent>(16).0;
+        let responder = FakeResponder::new(resume_tx.clone());
+        let bridge = Arc::new(ConnectBridge::with_responder(ctx, None, responder.clone()));
+        let platform = FakePlatform::with_capabilities("fake", buttons_and_edit_capabilities());
+        let key = key_for("chat1", "u1");
+        let reply_ctx = ReplyCtx(serde_json::json!({ "chat_id": "chat1" }));
+
+        let token = CancellationToken::new();
+        bridge.set_cancel_token(&key, token.clone()).await;
+
+        let (tx, rx) = broadcast::channel(16);
+        tx.send(need_clarification_event(
+            "Approve?",
+            vec!["Approve", "Deny"],
+            false,
+        ))
+        .unwrap();
+
+        let render_handle = {
+            let bridge = bridge.clone();
+            let platform = platform.clone();
+            let reply_ctx = reply_ctx.clone();
+            let key = key.clone();
+            tokio::spawn(async move {
+                bridge
+                    .render_until_settled(&key, platform, reply_ctx, "sess-1", rx)
+                    .await;
+            })
+        };
+
+        wait_for_parked_ask(&bridge, &key).await;
+
+        ConnectBridge::handle_inbound(
+            bridge.clone(),
+            platform.clone(),
+            vec!["u1".to_string()],
+            inbound("chat1", "u1", "stop-1", "/stop"),
+        )
+        .await;
+
+        tokio::time::timeout(Duration::from_secs(5), render_handle)
+            .await
+            .expect("render task must finish after /stop")
+            .unwrap();
+
+        assert!(token.is_cancelled(), "cancel token must be cancelled");
+        assert!(!bridge.has_pending_ask(&key).await);
+        let sent = platform.sent_texts().await;
+        assert!(
+            sent.iter().any(|text| text == "Stopping the current run…"),
+            "expected the stopping reply, got: {sent:?}"
         );
     }
 }

--- a/crates/app/bamboo-server/src/connect/mod.rs
+++ b/crates/app/bamboo-server/src/connect/mod.rs
@@ -21,6 +21,7 @@
 //! `config.connect.platforms` is empty: no `[connect]` section in
 //! `config.json` means zero background tasks are spawned.
 
+pub mod approvals;
 pub mod bridge;
 pub mod platform;
 pub mod platforms;
@@ -28,8 +29,8 @@ pub mod render;
 
 pub use bridge::{ConnectBridge, ConnectContext, SessionKey};
 pub use platform::{
-    Capabilities, InboundMessage, MessageRef, OutboundMessage, Platform, PlatformError,
-    PlatformResult, ReplyCtx,
+    Button, CallbackQuery, Capabilities, Inbound, InboundMessage, MessageRef, OutboundMessage,
+    Platform, PlatformError, PlatformResult, ReplyCtx,
 };
 
 use std::path::PathBuf;
@@ -122,19 +123,39 @@ impl Drop for ConnectManager {
     }
 }
 
-/// Pulls inbound messages off a single platform's channel and hands each to
-/// the bridge. Kept as its OWN task per platform (not merged into the
-/// platform's `start()` loop) so a slow/queued chat can never stall the next
-/// `getUpdates` poll — `ConnectBridge::handle_inbound` itself returns quickly
-/// (it spawns the actual run), so this loop only ever blocks briefly.
+/// Pulls inbound events (messages and button-press callbacks, issue #458)
+/// off a single platform's channel and hands each to the bridge. Kept as its
+/// OWN task per platform (not merged into the platform's `start()` loop) so
+/// a slow/queued chat can never stall the next `getUpdates` poll —
+/// `ConnectBridge::handle_inbound`/`handle_callback` themselves return
+/// quickly (a message spawns the actual run; a callback only ever
+/// acks+resolves), so this loop only ever blocks briefly.
 async fn dispatch_loop(
     bridge: Arc<ConnectBridge>,
     platform: Arc<dyn Platform>,
     allow_from: Vec<String>,
-    mut rx: mpsc::Receiver<InboundMessage>,
+    mut rx: mpsc::Receiver<Inbound>,
 ) {
-    while let Some(msg) = rx.recv().await {
-        ConnectBridge::handle_inbound(bridge.clone(), platform.clone(), allow_from.clone(), msg)
-            .await;
+    while let Some(event) = rx.recv().await {
+        match event {
+            Inbound::Message(msg) => {
+                ConnectBridge::handle_inbound(
+                    bridge.clone(),
+                    platform.clone(),
+                    allow_from.clone(),
+                    msg,
+                )
+                .await;
+            }
+            Inbound::Callback(callback) => {
+                ConnectBridge::handle_callback(
+                    bridge.clone(),
+                    platform.clone(),
+                    allow_from.clone(),
+                    callback,
+                )
+                .await;
+            }
+        }
     }
 }

--- a/crates/app/bamboo-server/src/connect/platform.rs
+++ b/crates/app/bamboo-server/src/connect/platform.rs
@@ -58,16 +58,77 @@ pub struct InboundMessage {
     pub reply_ctx: ReplyCtx,
 }
 
+/// One inline approval/action button (phase 2, issue #458). `callback_data`
+/// is echoed back verbatim on press — the ONLY thing it may carry is a short
+/// ask-nonce + option selector (`"{nonce}:{option_index}"`, see
+/// `connect::approvals`), NEVER raw user text or anything else sensitive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Button {
+    pub label: String,
+    pub callback_data: String,
+}
+
+impl Button {
+    pub fn new(label: impl Into<String>, callback_data: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            callback_data: callback_data.into(),
+        }
+    }
+}
+
 /// A message to send to a platform.
 #[derive(Debug, Clone)]
 pub struct OutboundMessage {
     pub text: String,
+    /// Inline keyboard rows (capability-gated on [`Capabilities::buttons`]).
+    /// Adapters that don't advertise `buttons` ignore this field.
+    pub buttons: Option<Vec<Vec<Button>>>,
 }
 
 impl OutboundMessage {
     pub fn text(text: impl Into<String>) -> Self {
-        Self { text: text.into() }
+        Self {
+            text: text.into(),
+            buttons: None,
+        }
     }
+
+    pub fn with_buttons(mut self, buttons: Vec<Vec<Button>>) -> Self {
+        self.buttons = Some(buttons);
+        self
+    }
+}
+
+/// An inline-button press received from a platform (capability-gated on
+/// [`Capabilities::buttons`]) — the counterpart to a text [`InboundMessage`].
+#[derive(Debug, Clone)]
+pub struct CallbackQuery {
+    /// Platform name (matches `Platform::name`), e.g. `"telegram"`.
+    pub platform: String,
+    /// Platform-scoped chat identifier.
+    pub chat_id: String,
+    /// Platform-scoped sender identifier (checked against `allow_from`,
+    /// exactly like [`InboundMessage::user_id`]).
+    pub user_id: String,
+    /// Platform-scoped callback-query identifier. Every callback query MUST
+    /// be acknowledged via `Platform::answer_callback` exactly once — success
+    /// or not (stale/forged data still gets acked, just silently dropped).
+    pub callback_query_id: String,
+    /// The pressed button's `callback_data`, verbatim.
+    pub data: String,
+    /// Opaque context to hand back to `Platform::reply`/`edit`.
+    pub reply_ctx: ReplyCtx,
+}
+
+/// Everything a platform can push onto its inbound channel: a text message or
+/// a button press. Kept as one enum (rather than two channels) so a platform
+/// whose transport interleaves both in a single feed (Telegram's
+/// `getUpdates`) preserves delivery order end to end.
+#[derive(Debug, Clone)]
+pub enum Inbound {
+    Message(InboundMessage),
+    Callback(CallbackQuery),
 }
 
 /// Error returned by a `Platform` adapter operation.
@@ -95,10 +156,11 @@ pub trait Platform: Send + Sync {
     /// What this adapter supports.
     fn capabilities(&self) -> Capabilities;
 
-    /// Start receiving inbound messages, sending each onto `inbound`.
-    /// Runs for the adapter's lifetime (a long-poll loop, a WS connection,
-    /// …); returns only on an unrecoverable error or `stop()`.
-    async fn start(&self, inbound: mpsc::Sender<InboundMessage>) -> PlatformResult<()>;
+    /// Start receiving inbound events (messages and/or button presses),
+    /// sending each onto `inbound`. Runs for the adapter's lifetime (a
+    /// long-poll loop, a WS connection, …); returns only on an unrecoverable
+    /// error or `stop()`.
+    async fn start(&self, inbound: mpsc::Sender<Inbound>) -> PlatformResult<()>;
 
     /// Send a message in reply to `ctx`.
     async fn reply(&self, ctx: &ReplyCtx, msg: OutboundMessage) -> PlatformResult<MessageRef>;
@@ -107,6 +169,20 @@ pub trait Platform: Send + Sync {
     /// [`Capabilities::edit_message`]; adapters that don't support it may
     /// return an error — callers must check the capability first.
     async fn edit(&self, msg_ref: &MessageRef, new: OutboundMessage) -> PlatformResult<()>;
+
+    /// Acknowledge a callback query (capability-gated on
+    /// [`Capabilities::buttons`] — adapters without button support never
+    /// receive one to acknowledge, so the default no-op is correct for them).
+    /// Telegram requires exactly one ack per callback query, success or not;
+    /// `text`, when `Some`, is shown as a brief toast (e.g. an "expired"
+    /// notice for a stale/forged nonce).
+    async fn answer_callback(
+        &self,
+        _callback_query_id: &str,
+        _text: Option<&str>,
+    ) -> PlatformResult<()> {
+        Ok(())
+    }
 
     /// Stop the adapter (best-effort; graceful shutdown).
     async fn stop(&self) -> PlatformResult<()>;

--- a/crates/app/bamboo-server/src/connect/platforms/telegram.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/telegram.rs
@@ -1,9 +1,6 @@
-//! Telegram long-poll platform adapter (issue #452, epic #447's first
-//! platform: no public IP, no webhook, no WS — just `getUpdates` over plain
-//! HTTPS).
-//!
-//! Buttons / `editMessageText` are NOT in this phase — [`Capabilities`]
-//! advertises them `false` (see epic #447's phase list).
+//! Telegram long-poll platform adapter (issue #452 phase 1 MVP; buttons +
+//! `editMessageText` + `callback_query` added in issue #458 phase 2): no
+//! public IP, no webhook, no WS — just `getUpdates` over plain HTTPS.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicI64, Ordering};
@@ -13,8 +10,8 @@ use std::time::Duration;
 use tokio::sync::{mpsc, Mutex as AsyncMutex};
 
 use super::super::platform::{
-    Capabilities, InboundMessage, MessageRef, OutboundMessage, Platform, PlatformError,
-    PlatformResult, ReplyCtx,
+    Button, CallbackQuery, Capabilities, Inbound, InboundMessage, MessageRef, OutboundMessage,
+    Platform, PlatformError, PlatformResult, ReplyCtx,
 };
 use super::super::render::{chunk_message, MAX_MESSAGE_CHARS};
 
@@ -50,6 +47,24 @@ struct TelegramUpdate {
     update_id: i64,
     #[serde(default)]
     message: Option<TelegramMessage>,
+    #[serde(default)]
+    callback_query: Option<TelegramCallbackQuery>,
+}
+
+/// An inline-button press (issue #458). `message` is the message the button
+/// was attached to — its `chat` gives us the chat to route the resolution
+/// against; a callback with no `message` (can happen for very old/inline
+/// messages) is dropped by [`TelegramPlatform::to_inbound_callback`], same
+/// treatment as a text update this MVP doesn't handle.
+#[derive(Debug, Clone, serde::Deserialize)]
+struct TelegramCallbackQuery {
+    id: String,
+    #[serde(default)]
+    from: Option<TelegramUser>,
+    #[serde(default)]
+    message: Option<TelegramMessage>,
+    #[serde(default)]
+    data: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, serde::Deserialize)]
@@ -172,11 +187,18 @@ impl TelegramPlatform {
         offset: i64,
         timeout_secs: u64,
     ) -> PlatformResult<Vec<TelegramUpdate>> {
+        // Issue #458: request `callback_query` updates alongside `message` —
+        // without `allowed_updates`, a bot that has never called `setWebhook`
+        // already receives both by default, but being explicit keeps this
+        // adapter correct even if that default ever changes upstream.
+        let allowed_updates =
+            serde_json::to_string(&["message", "callback_query"]).unwrap_or_default();
         let response = http_client()
             .get(self.api_url("getUpdates"))
             .query(&[
                 ("offset", offset.to_string()),
                 ("timeout", timeout_secs.to_string()),
+                ("allowed_updates", allowed_updates),
             ])
             // Generous margin over Telegram's own long-poll timeout so the
             // HTTP client doesn't time out the connection out from under a
@@ -230,32 +252,59 @@ impl TelegramPlatform {
         })
     }
 
+    /// Converts a raw update's `callback_query` into a bridge-facing
+    /// [`Inbound::Callback`]. Returns `None` when there's no
+    /// `callback_query`, or it's missing `from`/`message`/`data` (nothing to
+    /// route a resolution against) — the caller still advances the offset
+    /// for these.
+    fn to_inbound_callback(update: &TelegramUpdate) -> Option<Inbound> {
+        let callback_query = update.callback_query.as_ref()?;
+        let from = callback_query.from.as_ref()?;
+        let message = callback_query.message.as_ref()?;
+        let data = callback_query.data.clone()?;
+        Some(Inbound::Callback(CallbackQuery {
+            platform: "telegram".to_string(),
+            chat_id: message.chat.id.to_string(),
+            user_id: from.id.to_string(),
+            callback_query_id: callback_query.id.clone(),
+            data,
+            reply_ctx: ReplyCtx(serde_json::json!({ "chat_id": message.chat.id })),
+        }))
+    }
+
     /// One `getUpdates(offset, timeout_secs)` cycle: fetches, advances
     /// `self.offset` past EVERY returned update (so Telegram never
     /// re-delivers one this MVP skips), and returns the subset that convert
-    /// to an [`InboundMessage`]. Used both for `start()`'s drain-on-start
-    /// pass (`timeout_secs = 0`, result discarded) and its main long-poll
-    /// loop — factored out so tests can drive a single cycle deterministically
-    /// against a local HTTP stub without looping forever.
-    async fn poll_once(&self, timeout_secs: u64) -> PlatformResult<Vec<InboundMessage>> {
+    /// to an [`Inbound`] event (a text message or a button-press callback).
+    /// Used both for `start()`'s drain-on-start pass (`timeout_secs = 0`,
+    /// result discarded) and its main long-poll loop — factored out so tests
+    /// can drive a single cycle deterministically against a local HTTP stub
+    /// without looping forever.
+    async fn poll_once(&self, timeout_secs: u64) -> PlatformResult<Vec<Inbound>> {
         let offset = self.offset.load(Ordering::SeqCst);
         let updates = self.get_updates(offset, timeout_secs).await?;
 
-        let mut messages = Vec::with_capacity(updates.len());
+        let mut events = Vec::with_capacity(updates.len());
         for update in &updates {
             // Always advance past this update_id, whether or not we forward
             // it — an un-forwarded update (no text, no sender, …) would
             // otherwise be redelivered by Telegram forever.
             self.offset.store(update.update_id + 1, Ordering::SeqCst);
-            if let Some(message) = Self::to_inbound_message(update) {
-                messages.push(message);
+            if let Some(callback) = Self::to_inbound_callback(update) {
+                events.push(callback);
+            } else if let Some(message) = Self::to_inbound_message(update) {
+                events.push(Inbound::Message(message));
             }
         }
-        Ok(messages)
+        Ok(events)
     }
 
     fn extract_chat_id(ctx: &ReplyCtx) -> PlatformResult<String> {
-        ctx.0
+        Self::extract_chat_id_value(&ctx.0)
+    }
+
+    fn extract_chat_id_value(value: &serde_json::Value) -> PlatformResult<String> {
+        value
             .get("chat_id")
             .and_then(|v| {
                 v.as_i64()
@@ -263,6 +312,26 @@ impl TelegramPlatform {
                     .or_else(|| v.as_str().map(|s| s.to_string()))
             })
             .ok_or_else(|| PlatformError::other("reply_ctx is missing chat_id"))
+    }
+
+    /// Telegram's `reply_markup` inline-keyboard shape: `{"inline_keyboard":
+    /// [[{"text": ..., "callback_data": ...}], ...]}`, JSON-encoded as a
+    /// single form field (issue #458).
+    fn build_reply_markup(buttons: &[Vec<Button>]) -> String {
+        let rows: Vec<Vec<serde_json::Value>> = buttons
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .map(|button| {
+                        serde_json::json!({
+                            "text": button.label,
+                            "callback_data": button.callback_data,
+                        })
+                    })
+                    .collect()
+            })
+            .collect();
+        serde_json::json!({ "inline_keyboard": rows }).to_string()
     }
 }
 
@@ -273,11 +342,15 @@ impl Platform for TelegramPlatform {
     }
 
     fn capabilities(&self) -> Capabilities {
-        // Buttons/edit-message/attachments are a later phase of epic #447.
-        Capabilities::default()
+        Capabilities {
+            buttons: true,
+            edit_message: true,
+            images: false,
+            files: false,
+        }
     }
 
-    async fn start(&self, inbound: mpsc::Sender<InboundMessage>) -> PlatformResult<()> {
+    async fn start(&self, inbound: mpsc::Sender<Inbound>) -> PlatformResult<()> {
         // Drain-on-start: fetch (and silently discard) any backlog that
         // accumulated while the bot was offline, so a restart never replays
         // a burst of stale prompts. A non-blocking (`timeout=0`) call.
@@ -296,9 +369,9 @@ impl Platform for TelegramPlatform {
 
         loop {
             match self.poll_once(LONG_POLL_TIMEOUT_SECS).await {
-                Ok(messages) => {
-                    for message in messages {
-                        if inbound.send(message).await.is_err() {
+                Ok(events) => {
+                    for event in events {
+                        if inbound.send(event).await.is_err() {
                             // Receiver dropped: the manager is shutting down.
                             return Ok(());
                         }
@@ -315,13 +388,25 @@ impl Platform for TelegramPlatform {
     async fn reply(&self, ctx: &ReplyCtx, msg: OutboundMessage) -> PlatformResult<MessageRef> {
         let chat_id = Self::extract_chat_id(ctx)?;
         let mut last_message_id = None;
+        let reply_markup = msg.buttons.as_deref().map(Self::build_reply_markup);
+        let chunks = chunk_message(&msg.text, MAX_MESSAGE_CHARS);
+        let chunk_count = chunks.len();
 
-        for chunk in chunk_message(&msg.text, MAX_MESSAGE_CHARS) {
+        for (index, chunk) in chunks.into_iter().enumerate() {
             self.rate_limiter.wait(&chat_id).await;
+
+            let mut form: Vec<(&str, String)> = vec![("chat_id", chat_id.clone()), ("text", chunk)];
+            // Attach the keyboard only to the LAST chunk — buttons make sense
+            // on one message, not on earlier text-overflow spillover.
+            if index + 1 == chunk_count {
+                if let Some(markup) = &reply_markup {
+                    form.push(("reply_markup", markup.clone()));
+                }
+            }
 
             let response = http_client()
                 .post(self.api_url("sendMessage"))
-                .form(&[("chat_id", chat_id.as_str()), ("text", chunk.as_str())])
+                .form(&form)
                 .send()
                 .await
                 .map_err(|error| {
@@ -355,10 +440,95 @@ impl Platform for TelegramPlatform {
         })))
     }
 
-    async fn edit(&self, _msg_ref: &MessageRef, _new: OutboundMessage) -> PlatformResult<()> {
-        Err(PlatformError::other(
-            "telegram adapter does not support edit_message in this phase (#452)",
-        ))
+    async fn edit(&self, msg_ref: &MessageRef, new: OutboundMessage) -> PlatformResult<()> {
+        let chat_id = Self::extract_chat_id_value(&msg_ref.0)?;
+        let message_id = msg_ref
+            .0
+            .get("message_id")
+            .and_then(|v| v.as_i64())
+            .ok_or_else(|| PlatformError::other("message_ref is missing message_id"))?;
+
+        self.rate_limiter.wait(&chat_id).await;
+
+        let mut form: Vec<(&str, String)> = vec![
+            ("chat_id", chat_id),
+            ("message_id", message_id.to_string()),
+            ("text", new.text),
+        ];
+        if let Some(buttons) = &new.buttons {
+            form.push(("reply_markup", Self::build_reply_markup(buttons)));
+        }
+
+        let response = http_client()
+            .post(self.api_url("editMessageText"))
+            .form(&form)
+            .send()
+            .await
+            .map_err(|error| {
+                PlatformError::other(format!(
+                    "editMessageText request failed: {}",
+                    self.sanitize_error(error)
+                ))
+            })?;
+
+        let parsed: TelegramResponse<TelegramMessage> = response.json().await.map_err(|error| {
+            PlatformError::other(format!(
+                "editMessageText response parse failed: {}",
+                self.sanitize_error(error)
+            ))
+        })?;
+
+        if !parsed.ok {
+            // The caller (`connect::render::StreamingRenderer`) degrades to a
+            // fresh `reply()` on any edit error — a stale/too-old message, an
+            // unchanged-content 400, or anything else Telegram rejects.
+            return Err(PlatformError::other(parsed.description.unwrap_or_else(
+                || "editMessageText returned ok=false".to_string(),
+            )));
+        }
+        Ok(())
+    }
+
+    async fn answer_callback(
+        &self,
+        callback_query_id: &str,
+        text: Option<&str>,
+    ) -> PlatformResult<()> {
+        // Deliberately NOT rate-limited: `answerCallbackQuery` isn't a chat
+        // message (it dismisses the client's loading spinner) and Telegram
+        // expects it promptly — sharing the per-chat send throttle here would
+        // only risk the ack timing out.
+        let mut form: Vec<(&str, String)> =
+            vec![("callback_query_id", callback_query_id.to_string())];
+        if let Some(text) = text {
+            form.push(("text", text.to_string()));
+        }
+
+        let response = http_client()
+            .post(self.api_url("answerCallbackQuery"))
+            .form(&form)
+            .send()
+            .await
+            .map_err(|error| {
+                PlatformError::other(format!(
+                    "answerCallbackQuery request failed: {}",
+                    self.sanitize_error(error)
+                ))
+            })?;
+
+        let parsed: TelegramResponse<bool> = response.json().await.map_err(|error| {
+            PlatformError::other(format!(
+                "answerCallbackQuery response parse failed: {}",
+                self.sanitize_error(error)
+            ))
+        })?;
+
+        if !parsed.ok {
+            return Err(PlatformError::other(parsed.description.unwrap_or_else(
+                || "answerCallbackQuery returned ok=false".to_string(),
+            )));
+        }
+        Ok(())
     }
 
     async fn stop(&self) -> PlatformResult<()> {
@@ -423,13 +593,18 @@ mod tests {
             .await;
 
         let platform = platform_with_stub(server.uri());
-        let messages = platform.poll_once(30).await.expect("poll_once succeeds");
+        let events = platform.poll_once(30).await.expect("poll_once succeeds");
 
-        assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].chat_id, "42");
-        assert_eq!(messages[0].user_id, "7");
-        assert_eq!(messages[0].message_id, "100");
-        assert_eq!(messages[0].text, "hello");
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Inbound::Message(message) => {
+                assert_eq!(message.chat_id, "42");
+                assert_eq!(message.user_id, "7");
+                assert_eq!(message.message_id, "100");
+                assert_eq!(message.text, "hello");
+            }
+            Inbound::Callback(_) => panic!("expected a message event"),
+        }
         assert_eq!(platform.offset.load(Ordering::SeqCst), 102);
     }
 
@@ -599,21 +774,258 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn edit_is_unsupported_in_this_phase() {
+    async fn capabilities_advertise_buttons_and_edit_message() {
         let platform = platform_with_stub("http://localhost:0".to_string());
-        let msg_ref = MessageRef(serde_json::json!({}));
-        let result = platform.edit(&msg_ref, OutboundMessage::text("x")).await;
+        let caps = platform.capabilities();
+        assert!(caps.buttons);
+        assert!(caps.edit_message);
+        assert!(!caps.images);
+        assert!(!caps.files);
+    }
+
+    #[tokio::test]
+    async fn get_updates_requests_message_and_callback_query_updates() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/bottest-token/getUpdates"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": [] })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        platform.poll_once(30).await.unwrap();
+
+        let requests = wait_for_requests(&server, 1).await;
+        let query: HashMap<String, String> = requests[0]
+            .url
+            .query_pairs()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        let allowed: Vec<String> = serde_json::from_str(
+            query
+                .get("allowed_updates")
+                .expect("allowed_updates present"),
+        )
+        .unwrap();
+        assert_eq!(
+            allowed,
+            vec!["message".to_string(), "callback_query".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_once_converts_callback_query_updates_to_inbound_callbacks() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/bottest-token/getUpdates"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "ok": true,
+                    "result": [
+                        {
+                            "update_id": 200,
+                            "callback_query": {
+                                "id": "cbq-1",
+                                "from": { "id": 7 },
+                                "message": {
+                                    "message_id": 1,
+                                    "date": 1_700_000_000,
+                                    "chat": { "id": 42 }
+                                },
+                                "data": "nonce123:1"
+                            }
+                        }
+                    ]
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        let events = platform.poll_once(30).await.expect("poll_once succeeds");
+
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Inbound::Callback(callback) => {
+                assert_eq!(callback.platform, "telegram");
+                assert_eq!(callback.chat_id, "42");
+                assert_eq!(callback.user_id, "7");
+                assert_eq!(callback.callback_query_id, "cbq-1");
+                assert_eq!(callback.data, "nonce123:1");
+            }
+            Inbound::Message(_) => panic!("expected a callback event"),
+        }
+        assert_eq!(platform.offset.load(Ordering::SeqCst), 201);
+    }
+
+    #[tokio::test]
+    async fn reply_with_buttons_sends_inline_keyboard_reply_markup() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/bottest-token/sendMessage"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "ok": true,
+                    "result": { "message_id": 9, "date": 1, "chat": { "id": 1 } }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        let ctx = ReplyCtx(serde_json::json!({ "chat_id": 1 }));
+        let outbound = OutboundMessage::text("Approve?").with_buttons(vec![
+            vec![Button::new("Approve", "n1:0")],
+            vec![Button::new("Deny", "n1:1")],
+        ]);
+
+        let msg_ref = platform
+            .reply(&ctx, outbound)
+            .await
+            .expect("reply succeeds");
+        assert_eq!(
+            msg_ref.0.get("message_id").and_then(|v| v.as_i64()),
+            Some(9)
+        );
+
+        let requests = wait_for_requests(&server, 1).await;
+        let body = String::from_utf8(requests[0].body.clone()).unwrap();
+        let form: HashMap<String, String> = url::form_urlencoded::parse(body.as_bytes())
+            .into_owned()
+            .collect();
+        let markup: serde_json::Value =
+            serde_json::from_str(form.get("reply_markup").expect("reply_markup present")).unwrap();
+        assert_eq!(
+            markup["inline_keyboard"][0][0]["callback_data"],
+            serde_json::json!("n1:0")
+        );
+        assert_eq!(
+            markup["inline_keyboard"][1][0]["text"],
+            serde_json::json!("Deny")
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_sends_edit_message_text_with_the_stored_message_id() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/bottest-token/editMessageText"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "ok": true,
+                    "result": { "message_id": 9, "date": 1, "chat": { "id": 1 } }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        let msg_ref = MessageRef(serde_json::json!({ "chat_id": 1, "message_id": 9 }));
+
+        platform
+            .edit(&msg_ref, OutboundMessage::text("updated"))
+            .await
+            .expect("edit succeeds");
+
+        let requests = wait_for_requests(&server, 1).await;
+        let body = String::from_utf8(requests[0].body.clone()).unwrap();
+        let form: HashMap<String, String> = url::form_urlencoded::parse(body.as_bytes())
+            .into_owned()
+            .collect();
+        assert_eq!(form.get("message_id").map(String::as_str), Some("9"));
+        assert_eq!(form.get("text").map(String::as_str), Some("updated"));
+    }
+
+    #[tokio::test]
+    async fn edit_returns_an_error_on_a_400_response_instead_of_panicking() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/bottest-token/editMessageText"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "ok": false,
+                    "description": "Bad Request: message is not modified"
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        let msg_ref = MessageRef(serde_json::json!({ "chat_id": 1, "message_id": 9 }));
+
+        let result = platform
+            .edit(&msg_ref, OutboundMessage::text("same text"))
+            .await;
+        // The caller (`connect::render`) is responsible for degrading to a
+        // fresh send on this Err — verified in `render.rs`'s
+        // `streaming_mode_edit_failure_degrades_to_a_fresh_send` test.
         assert!(result.is_err());
     }
 
     #[tokio::test]
-    async fn capabilities_advertise_nothing_in_this_phase() {
-        let platform = platform_with_stub("http://localhost:0".to_string());
-        let caps = platform.capabilities();
-        assert!(!caps.buttons);
-        assert!(!caps.edit_message);
-        assert!(!caps.images);
-        assert!(!caps.files);
+    async fn answer_callback_posts_callback_query_id_and_optional_text() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/bottest-token/answerCallbackQuery",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": true })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        platform
+            .answer_callback("cbq-1", Some("This action has expired."))
+            .await
+            .expect("answer_callback succeeds");
+
+        let requests = wait_for_requests(&server, 1).await;
+        let body = String::from_utf8(requests[0].body.clone()).unwrap();
+        let form: HashMap<String, String> = url::form_urlencoded::parse(body.as_bytes())
+            .into_owned()
+            .collect();
+        assert_eq!(
+            form.get("callback_query_id").map(String::as_str),
+            Some("cbq-1")
+        );
+        assert_eq!(
+            form.get("text").map(String::as_str),
+            Some("This action has expired.")
+        );
+    }
+
+    #[tokio::test]
+    async fn answer_callback_round_trips_without_text() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/bottest-token/answerCallbackQuery",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "ok": true, "result": true })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        platform
+            .answer_callback("cbq-2", None)
+            .await
+            .expect("answer_callback succeeds");
+
+        let requests = wait_for_requests(&server, 1).await;
+        let body = String::from_utf8(requests[0].body.clone()).unwrap();
+        let form: HashMap<String, String> = url::form_urlencoded::parse(body.as_bytes())
+            .into_owned()
+            .collect();
+        assert!(!form.contains_key("text"));
     }
 
     /// The bot token lives in the request URL path; `reqwest::Error`'s

--- a/crates/app/bamboo-server/src/connect/render.rs
+++ b/crates/app/bamboo-server/src/connect/render.rs
@@ -1,23 +1,32 @@
 //! Renders a session's live [`AgentEvent`] stream into platform messages.
 //!
-//! MVP scope (issue #452): tool-use one-liners (`⚙ Bash: cargo test…`,
-//! truncated) as they happen, plus the final assistant text once the run
-//! reaches a terminal state. Streaming edit-in-place (capability-gated on
-//! [`crate::connect::platform::Capabilities::edit_message`]) is a later
-//! phase.
+//! Two rendering modes, chosen from `platform.capabilities().edit_message`:
+//! - **Legacy** (issue #452 MVP): tool-use one-liners and the final assistant
+//!   text are each sent as separate messages.
+//! - **Streaming edit-in-place** (issue #458 phase 2): one status message per
+//!   run, throttled-edited as tool lines/tokens arrive, replaced by a ✅/❌/⏹
+//!   final edit (or a short "done" edit + chunked follow-up when the final
+//!   text doesn't fit a single message).
 //!
-//! [`stream_execution`] runs until the underlying broadcast stream reaches a
-//! terminal event (`Complete`/`Cancelled`/`Error`) or is closed. The bridge
-//! awaits it inline (not detached) so the run's completion doubles as this
-//! task's completion — see `bridge::ConnectBridge::run_prompt`.
+//! Both modes stop at the same three terminal `AgentEvent`s
+//! (`Complete`/`Cancelled`/`Error`) — the phase-1 termination contract — and
+//! BOTH now also stop at `AgentEvent::NeedClarification`, returning
+//! [`RunOutcome::Paused`] instead of continuing to wait for a terminal event
+//! that will never come while the run is genuinely suspended on a pending
+//! question. The bridge (`bridge::ConnectBridge::render_until_settled`) is
+//! responsible for turning a `Paused` outcome into a rendered ask
+//! (`connect::approvals`) and, once answered, calling `stream_execution`
+//! again on the resumed run's stream.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::sync::broadcast;
+use tokio::time::Instant;
 
 use bamboo_agent_core::AgentEvent;
 
-use super::platform::{OutboundMessage, Platform, ReplyCtx};
+use super::platform::{MessageRef, OutboundMessage, Platform, ReplyCtx};
 
 /// Telegram's hard message-length limit (in UTF-16 characters, but ASCII/most
 /// text is 1 UTF-8 char == 1 unit; treating it as a char-count chunk size is a
@@ -28,6 +37,36 @@ pub const MAX_MESSAGE_CHARS: usize = 4096;
 /// well under [`MAX_MESSAGE_CHARS`] so a chatty tool call never dominates the
 /// stream of updates.
 const TOOL_LINE_MAX_CHARS: usize = 300;
+
+/// Minimum time between throttled status-message edits (cc-connect-tuned,
+/// issue #458).
+const EDIT_MIN_INTERVAL: Duration = Duration::from_millis(1500);
+/// Minimum new characters accumulated before a throttled edit fires, ANDed
+/// with [`EDIT_MIN_INTERVAL`] (issue #458).
+const EDIT_MIN_NEW_CHARS: usize = 30;
+
+/// What a live run's event stream settled into.
+#[derive(Debug)]
+pub enum RunOutcome {
+    /// Reached a terminal `AgentEvent` (or the stream closed) — nothing more
+    /// to render for this run.
+    Terminal,
+    /// Paused on `AgentEvent::NeedClarification` — a human decision is now
+    /// required before the run can continue.
+    Paused(PendingAsk),
+}
+
+/// The pause-worthy subset of `AgentEvent::NeedClarification`'s fields,
+/// decoupled from the wire event so `connect::approvals` doesn't need to
+/// match on `AgentEvent` itself.
+#[derive(Debug, Clone)]
+pub struct PendingAsk {
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub question: String,
+    pub options: Vec<String>,
+    pub allow_custom: bool,
+}
 
 /// Split `text` into chunks of at most `limit` **characters** (not bytes), so
 /// a multi-byte UTF-8 sequence is never split mid-codepoint. Returns an empty
@@ -51,6 +90,19 @@ fn truncate_chars(text: &str, max: usize) -> String {
     let mut out: String = text.chars().take(max).collect();
     out.push('…');
     out
+}
+
+/// Keep the LAST `max` characters of `text` (a "tail-keep" truncation, as
+/// opposed to [`truncate_chars`]'s head-keep) — used for the rolling
+/// streaming-edit body so a long run's most RECENT progress stays visible
+/// instead of getting stuck showing only the earliest lines.
+fn tail_chars(text: &str, max: usize) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    if chars.len() <= max {
+        return text.to_string();
+    }
+    let start = chars.len() - max;
+    chars[start..].iter().collect()
 }
 
 /// Best-effort one-line human summary of a tool call's arguments, used to
@@ -83,14 +135,48 @@ async fn send_chunks(platform: &Arc<dyn Platform>, ctx: &ReplyCtx, text: &str) {
     }
 }
 
-/// Consume `rx` until a terminal `AgentEvent`, sending tool one-liners as
-/// they arrive and the final assistant text (or error/cancellation note) once
-/// the run ends. Returns once the stream reaches a terminal state or closes.
+fn pending_ask_from_event(
+    question: String,
+    options: Option<Vec<String>>,
+    tool_call_id: Option<String>,
+    tool_name: Option<String>,
+    allow_custom: bool,
+) -> PendingAsk {
+    PendingAsk {
+        tool_call_id: tool_call_id.unwrap_or_default(),
+        tool_name: tool_name.unwrap_or_default(),
+        question,
+        options: options.unwrap_or_default(),
+        allow_custom,
+    }
+}
+
+/// Consume `rx` until a terminal `AgentEvent` or a pause, rendering into
+/// `platform` as it goes. Dispatches to the streaming edit-in-place mode when
+/// `platform.capabilities().edit_message`, else the legacy per-message mode
+/// (issue #452's original behavior, preserved verbatim for adapters that
+/// can't edit).
 pub async fn stream_execution(
     platform: Arc<dyn Platform>,
     reply_ctx: ReplyCtx,
+    rx: broadcast::Receiver<AgentEvent>,
+) -> RunOutcome {
+    if platform.capabilities().edit_message {
+        stream_execution_streaming(platform, reply_ctx, rx).await
+    } else {
+        stream_execution_legacy(platform, reply_ctx, rx).await
+    }
+}
+
+/// Legacy (issue #452) rendering: each tool one-liner and the final text (or
+/// error/cancellation note) is sent as its own message. Returns
+/// [`RunOutcome::Paused`] on `NeedClarification` instead of the old
+/// (pre-#458) behavior of silently ignoring it and waiting forever.
+async fn stream_execution_legacy(
+    platform: Arc<dyn Platform>,
+    reply_ctx: ReplyCtx,
     mut rx: broadcast::Receiver<AgentEvent>,
-) {
+) -> RunOutcome {
     let mut final_text = String::new();
     let mut terminal_note: Option<String> = None;
 
@@ -105,6 +191,21 @@ pub async fn stream_execution(
                 send_chunks(&platform, &reply_ctx, &line).await;
             }
             Ok(AgentEvent::Token { content }) => final_text.push_str(&content),
+            Ok(AgentEvent::NeedClarification {
+                question,
+                options,
+                tool_call_id,
+                tool_name,
+                allow_custom,
+            }) => {
+                return RunOutcome::Paused(pending_ask_from_event(
+                    question,
+                    options,
+                    tool_call_id,
+                    tool_name,
+                    allow_custom,
+                ));
+            }
             Ok(AgentEvent::Complete { .. }) => break,
             Ok(AgentEvent::Cancelled { message }) => {
                 terminal_note = Some(message.unwrap_or_else(|| "Cancelled.".to_string()));
@@ -127,11 +228,237 @@ pub async fn stream_execution(
     if !body.trim().is_empty() {
         send_chunks(&platform, &reply_ctx, &body).await;
     }
+    RunOutcome::Terminal
+}
+
+/// Accumulated state for the streaming edit-in-place renderer, plus the
+/// throttle/edit-degrade machinery (issue #458 §B).
+struct StreamingRenderer {
+    platform: Arc<dyn Platform>,
+    reply_ctx: ReplyCtx,
+    tool_lines: Vec<String>,
+    assistant_text: String,
+    status_ref: Option<MessageRef>,
+    last_edit_at: Option<Instant>,
+    chars_since_edit: usize,
+}
+
+impl StreamingRenderer {
+    fn new(platform: Arc<dyn Platform>, reply_ctx: ReplyCtx) -> Self {
+        Self {
+            platform,
+            reply_ctx,
+            tool_lines: Vec::new(),
+            assistant_text: String::new(),
+            status_ref: None,
+            last_edit_at: None,
+            chars_since_edit: 0,
+        }
+    }
+
+    async fn send_initial(&mut self) {
+        match self
+            .platform
+            .reply(&self.reply_ctx, OutboundMessage::text("⏳ Working…"))
+            .await
+        {
+            Ok(msg_ref) => self.status_ref = Some(msg_ref),
+            Err(error) => {
+                tracing::warn!("connect: failed to send initial status message: {error}")
+            }
+        }
+    }
+
+    /// Full body (tool lines + assistant text), untruncated — used for the
+    /// final "does it fit in one message" check.
+    fn full_body(&self) -> String {
+        let mut body = String::new();
+        for line in &self.tool_lines {
+            body.push_str(line);
+            body.push('\n');
+        }
+        if !self.assistant_text.is_empty() {
+            if !body.is_empty() {
+                body.push('\n');
+            }
+            body.push_str(&self.assistant_text);
+        }
+        body
+    }
+
+    /// Rolling display body, tail-truncated to [`MAX_MESSAGE_CHARS`] so the
+    /// most recent progress always stays visible in the status message.
+    fn display_tail(&self) -> String {
+        tail_chars(&self.full_body(), MAX_MESSAGE_CHARS)
+    }
+
+    /// Record `added_chars` of new content and fire a throttled edit if both
+    /// the interval and char-count thresholds are met.
+    async fn note_growth(&mut self, added_chars: usize) {
+        self.chars_since_edit += added_chars;
+        let now = Instant::now();
+        let interval_ok = self
+            .last_edit_at
+            .map(|at| now.duration_since(at) >= EDIT_MIN_INTERVAL)
+            .unwrap_or(true);
+        if !interval_ok || self.chars_since_edit < EDIT_MIN_NEW_CHARS {
+            return;
+        }
+        let text = self.display_tail();
+        self.apply_edit(text).await;
+        self.last_edit_at = Some(now);
+        self.chars_since_edit = 0;
+    }
+
+    /// Apply an edit unconditionally (bypassing the throttle) — used for
+    /// terminal/pause renders where the final content must land regardless of
+    /// timing. Degrades to a fresh `reply()` when there's no status message
+    /// yet, or when the edit itself fails (message too old / unchanged
+    /// content / any other 400) — an edit failure must never fail the run.
+    async fn apply_edit(&mut self, text: String) {
+        if text.trim().is_empty() {
+            return;
+        }
+        let Some(msg_ref) = self.status_ref.clone() else {
+            match self
+                .platform
+                .reply(&self.reply_ctx, OutboundMessage::text(text))
+                .await
+            {
+                Ok(new_ref) => self.status_ref = Some(new_ref),
+                Err(error) => {
+                    tracing::warn!("connect: failed to send status message: {error}")
+                }
+            }
+            return;
+        };
+        if let Err(error) = self
+            .platform
+            .edit(&msg_ref, OutboundMessage::text(text.clone()))
+            .await
+        {
+            tracing::warn!("connect: status edit failed, degrading to a fresh message: {error}");
+            match self
+                .platform
+                .reply(&self.reply_ctx, OutboundMessage::text(text))
+                .await
+            {
+                Ok(new_ref) => self.status_ref = Some(new_ref),
+                Err(error) => tracing::warn!("connect: fallback send also failed: {error}"),
+            }
+        }
+    }
+
+    /// Final render on success: the completed status message becomes "✅ " +
+    /// the full text when it fits in one message; otherwise a short "✅ done"
+    /// edit plus the full result sent as fresh chunked messages (issue #458
+    /// §B point 5).
+    async fn finalize_success(&mut self) {
+        let full = self.full_body();
+        if full.trim().is_empty() {
+            self.apply_edit("✅ Done.".to_string()).await;
+            return;
+        }
+        if full.chars().count() <= MAX_MESSAGE_CHARS {
+            self.apply_edit(format!("✅ {full}")).await;
+        } else {
+            self.apply_edit("✅ done".to_string()).await;
+            send_chunks(&self.platform, &self.reply_ctx, &full).await;
+        }
+    }
+
+    /// Final render on error/cancel: `icon` + `note`, replacing whatever
+    /// partial progress the status message was showing.
+    async fn finalize_terminal_note(&mut self, icon: &str, note: &str) {
+        self.apply_edit(format!("{icon} {note}")).await;
+    }
+
+    /// Courtesy edit marking the status message as paused, before the ask
+    /// itself is rendered as a separate message by `connect::approvals`.
+    async fn finalize_paused(&mut self) {
+        let mut text = self.display_tail();
+        if !text.is_empty() {
+            text.push_str("\n\n");
+        }
+        text.push_str("⏸ Waiting for your input…");
+        self.apply_edit(text).await;
+    }
+}
+
+/// Streaming edit-in-place (issue #458 §B) rendering mode.
+async fn stream_execution_streaming(
+    platform: Arc<dyn Platform>,
+    reply_ctx: ReplyCtx,
+    mut rx: broadcast::Receiver<AgentEvent>,
+) -> RunOutcome {
+    let mut renderer = StreamingRenderer::new(platform, reply_ctx);
+    renderer.send_initial().await;
+
+    loop {
+        match rx.recv().await {
+            Ok(AgentEvent::ToolStart {
+                tool_name,
+                arguments,
+                ..
+            }) => {
+                let line = format_tool_line(&tool_name, &arguments);
+                let added = line.chars().count();
+                renderer.tool_lines.push(line);
+                renderer.note_growth(added).await;
+            }
+            Ok(AgentEvent::Token { content }) => {
+                let added = content.chars().count();
+                renderer.assistant_text.push_str(&content);
+                renderer.note_growth(added).await;
+            }
+            Ok(AgentEvent::NeedClarification {
+                question,
+                options,
+                tool_call_id,
+                tool_name,
+                allow_custom,
+            }) => {
+                renderer.finalize_paused().await;
+                return RunOutcome::Paused(pending_ask_from_event(
+                    question,
+                    options,
+                    tool_call_id,
+                    tool_name,
+                    allow_custom,
+                ));
+            }
+            Ok(AgentEvent::Complete { .. }) => {
+                renderer.finalize_success().await;
+                return RunOutcome::Terminal;
+            }
+            Ok(AgentEvent::Cancelled { message }) => {
+                renderer
+                    .finalize_terminal_note(
+                        "⏹",
+                        &message.unwrap_or_else(|| "Cancelled.".to_string()),
+                    )
+                    .await;
+                return RunOutcome::Terminal;
+            }
+            Ok(AgentEvent::Error { message }) => {
+                renderer.finalize_terminal_note("❌ Error:", &message).await;
+                return RunOutcome::Terminal;
+            }
+            Ok(_) => continue,
+            Err(broadcast::error::RecvError::Lagged(_)) => continue,
+            // Sender dropped without a terminal event — matches the legacy
+            // mode's "treat as done, never hang" contract. Leave whatever
+            // partial status message is showing rather than editing it (no
+            // reliable terminal state to report).
+            Err(broadcast::error::RecvError::Closed) => return RunOutcome::Terminal,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::connect::platform::{Capabilities, InboundMessage};
 
     #[test]
     fn chunk_message_splits_on_char_boundaries_not_bytes() {
@@ -158,6 +485,13 @@ mod tests {
     }
 
     #[test]
+    fn tail_chars_keeps_the_last_n_characters() {
+        let text = "0123456789";
+        assert_eq!(tail_chars(text, 4), "6789");
+        assert_eq!(tail_chars(text, 100), text);
+    }
+
+    #[test]
     fn format_tool_line_prefers_command_field_and_truncates() {
         let args = serde_json::json!({ "command": "cargo test --workspace" });
         let line = format_tool_line("Bash", &args);
@@ -181,8 +515,25 @@ mod tests {
         assert!(line.contains("foo"));
     }
 
+    /// Records every `reply()`/`edit()` call. `edit_message` capability is
+    /// controlled by a constructor flag so the same fake drives both render
+    /// modes' tests.
     struct RecordingPlatform {
+        edit_message: bool,
         sent: tokio::sync::Mutex<Vec<String>>,
+        edits: tokio::sync::Mutex<Vec<String>>,
+        edit_should_fail: std::sync::atomic::AtomicBool,
+    }
+
+    impl RecordingPlatform {
+        fn new(edit_message: bool) -> Arc<Self> {
+            Arc::new(Self {
+                edit_message,
+                sent: tokio::sync::Mutex::new(Vec::new()),
+                edits: tokio::sync::Mutex::new(Vec::new()),
+                edit_should_fail: std::sync::atomic::AtomicBool::new(false),
+            })
+        }
     }
 
     #[async_trait::async_trait]
@@ -190,12 +541,17 @@ mod tests {
         fn name(&self) -> &str {
             "recording"
         }
-        fn capabilities(&self) -> super::super::platform::Capabilities {
-            Default::default()
+        fn capabilities(&self) -> Capabilities {
+            Capabilities {
+                buttons: false,
+                edit_message: self.edit_message,
+                images: false,
+                files: false,
+            }
         }
         async fn start(
             &self,
-            _inbound: tokio::sync::mpsc::Sender<super::super::platform::InboundMessage>,
+            _inbound: tokio::sync::mpsc::Sender<super::super::platform::Inbound>,
         ) -> super::super::platform::PlatformResult<()> {
             Ok(())
         }
@@ -205,13 +561,22 @@ mod tests {
             msg: OutboundMessage,
         ) -> super::super::platform::PlatformResult<super::super::platform::MessageRef> {
             self.sent.lock().await.push(msg.text);
-            Ok(super::super::platform::MessageRef(serde_json::Value::Null))
+            Ok(super::super::platform::MessageRef(serde_json::json!({
+                "id": self.sent.lock().await.len()
+            })))
         }
         async fn edit(
             &self,
             _msg_ref: &super::super::platform::MessageRef,
-            _new: OutboundMessage,
+            new: OutboundMessage,
         ) -> super::super::platform::PlatformResult<()> {
+            if self
+                .edit_should_fail
+                .load(std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(super::super::platform::PlatformError::other("edit failed"));
+            }
+            self.edits.lock().await.push(new.text);
             Ok(())
         }
         async fn stop(&self) -> super::super::platform::PlatformResult<()> {
@@ -219,12 +584,22 @@ mod tests {
         }
     }
 
+    fn ask_event(question: &str, options: Vec<&str>, allow_custom: bool) -> AgentEvent {
+        AgentEvent::NeedClarification {
+            question: question.to_string(),
+            options: Some(options.into_iter().map(str::to_string).collect()),
+            tool_call_id: Some("call-1".to_string()),
+            tool_name: Some("conclusion_with_options".to_string()),
+            allow_custom,
+        }
+    }
+
+    // ---- Legacy mode (edit_message = false) ----
+
     #[tokio::test]
     async fn stream_execution_renders_tool_lines_and_final_text() {
         let (tx, rx) = broadcast::channel(16);
-        let platform = Arc::new(RecordingPlatform {
-            sent: tokio::sync::Mutex::new(Vec::new()),
-        });
+        let platform = RecordingPlatform::new(false);
         let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
 
         tx.send(AgentEvent::ToolStart {
@@ -250,7 +625,8 @@ mod tests {
         })
         .unwrap();
 
-        stream_execution(platform.clone(), ctx, rx).await;
+        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        assert!(matches!(outcome, RunOutcome::Terminal));
 
         let sent = platform.sent.lock().await;
         assert_eq!(sent.len(), 2);
@@ -261,9 +637,7 @@ mod tests {
     #[tokio::test]
     async fn stream_execution_renders_error_note_instead_of_partial_text() {
         let (tx, rx) = broadcast::channel(16);
-        let platform = Arc::new(RecordingPlatform {
-            sent: tokio::sync::Mutex::new(Vec::new()),
-        });
+        let platform = RecordingPlatform::new(false);
         let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
 
         tx.send(AgentEvent::Token {
@@ -275,7 +649,7 @@ mod tests {
         })
         .unwrap();
 
-        stream_execution(platform.clone(), ctx, rx).await;
+        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
 
         let sent = platform.sent.lock().await;
         assert_eq!(sent.len(), 1);
@@ -285,20 +659,250 @@ mod tests {
     #[tokio::test]
     async fn stream_execution_returns_when_channel_closes_without_terminal_event() {
         let (tx, rx) = broadcast::channel(16);
-        let platform = Arc::new(RecordingPlatform {
-            sent: tokio::sync::Mutex::new(Vec::new()),
-        });
+        let platform = RecordingPlatform::new(false);
         let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
         drop(tx);
 
         // Must return promptly, not hang, when the sender is dropped.
         tokio::time::timeout(
             std::time::Duration::from_secs(5),
-            stream_execution(platform.clone(), ctx, rx),
+            stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx),
         )
         .await
         .expect("stream_execution must not hang on a closed channel");
 
         assert!(platform.sent.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stream_execution_legacy_pauses_on_need_clarification() {
+        let (tx, rx) = broadcast::channel(16);
+        let platform = RecordingPlatform::new(false);
+        let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
+
+        tx.send(ask_event("Pick one", vec!["A", "B"], false))
+            .unwrap();
+
+        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        match outcome {
+            RunOutcome::Paused(ask) => {
+                assert_eq!(ask.question, "Pick one");
+                assert_eq!(ask.options, vec!["A".to_string(), "B".to_string()]);
+                assert_eq!(ask.tool_call_id, "call-1");
+                assert!(!ask.allow_custom);
+            }
+            RunOutcome::Terminal => panic!("expected Paused"),
+        }
+        // No terminal note sent — the ask itself is rendered by the bridge,
+        // not by render.rs.
+        assert!(platform.sent.lock().await.is_empty());
+    }
+
+    // ---- Streaming edit-in-place mode (edit_message = true) ----
+
+    #[tokio::test]
+    async fn streaming_mode_sends_one_initial_status_message() {
+        let (_tx, rx) = broadcast::channel(16);
+        let platform = RecordingPlatform::new(true);
+        let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
+        drop(_tx);
+
+        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+
+        let sent = platform.sent.lock().await;
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0], "⏳ Working…");
+    }
+
+    #[tokio::test]
+    async fn streaming_mode_final_success_edits_status_with_checkmark() {
+        let (tx, rx) = broadcast::channel(16);
+        let platform = RecordingPlatform::new(true);
+        let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
+
+        tx.send(AgentEvent::Token {
+            content: "All done.".to_string(),
+        })
+        .unwrap();
+        tx.send(AgentEvent::Complete {
+            usage: bamboo_agent_core::TokenUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+            },
+        })
+        .unwrap();
+
+        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        assert!(matches!(outcome, RunOutcome::Terminal));
+
+        // The 9-char token is below the 30-char throttle, so no mid-run edit
+        // fires — only the unconditional final edit.
+        let edits = platform.edits.lock().await;
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0], "✅ All done.");
+        // Never sent as a separate chunked message (it fit in the edit).
+        assert_eq!(platform.sent.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn streaming_mode_final_error_edits_status_with_cross() {
+        let (tx, rx) = broadcast::channel(16);
+        let platform = RecordingPlatform::new(true);
+        let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
+
+        tx.send(AgentEvent::Error {
+            message: "boom".to_string(),
+        })
+        .unwrap();
+
+        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+
+        let edits = platform.edits.lock().await;
+        assert_eq!(edits.last().unwrap(), "❌ Error: boom");
+    }
+
+    #[tokio::test]
+    async fn streaming_mode_final_cancel_edits_status_with_stop_icon() {
+        let (tx, rx) = broadcast::channel(16);
+        let platform = RecordingPlatform::new(true);
+        let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
+
+        tx.send(AgentEvent::Cancelled {
+            message: Some("user requested /stop".to_string()),
+        })
+        .unwrap();
+
+        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+
+        let edits = platform.edits.lock().await;
+        assert_eq!(edits.last().unwrap(), "⏹ user requested /stop");
+    }
+
+    #[tokio::test]
+    async fn streaming_mode_pauses_on_need_clarification_with_courtesy_edit() {
+        let (tx, rx) = broadcast::channel(16);
+        let platform = RecordingPlatform::new(true);
+        let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
+
+        tx.send(AgentEvent::Token {
+            content: "Working on it".to_string(),
+        })
+        .unwrap();
+        tx.send(ask_event("Approve?", vec!["Approve", "Deny"], false))
+            .unwrap();
+
+        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        match outcome {
+            RunOutcome::Paused(ask) => assert_eq!(ask.question, "Approve?"),
+            RunOutcome::Terminal => panic!("expected Paused"),
+        }
+
+        let edits = platform.edits.lock().await;
+        assert!(edits.last().unwrap().contains("Waiting for your input"));
+    }
+
+    #[tokio::test]
+    async fn streaming_mode_throttle_skips_edits_below_the_char_threshold() {
+        let (tx, rx) = broadcast::channel(16);
+        let platform = RecordingPlatform::new(true);
+        let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
+
+        // Each token is well under the 30-char threshold; none should trigger
+        // a mid-run edit before the terminal event's unconditional edit.
+        for i in 0..5 {
+            tx.send(AgentEvent::Token {
+                content: format!("t{i} "),
+            })
+            .unwrap();
+        }
+        tx.send(AgentEvent::Complete {
+            usage: bamboo_agent_core::TokenUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+            },
+        })
+        .unwrap();
+
+        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+
+        // Exactly one edit: the final one.
+        assert_eq!(platform.edits.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn streaming_mode_long_final_text_chunks_instead_of_editing_in_full() {
+        let (tx, rx) = broadcast::channel(16);
+        let platform = RecordingPlatform::new(true);
+        let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
+
+        let long_text = "a".repeat(5000);
+        tx.send(AgentEvent::Token {
+            content: long_text.clone(),
+        })
+        .unwrap();
+        tx.send(AgentEvent::Complete {
+            usage: bamboo_agent_core::TokenUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+            },
+        })
+        .unwrap();
+
+        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+
+        // Final edit is the short "done" marker, not the full 5000 chars.
+        let edits = platform.edits.lock().await;
+        assert_eq!(edits.last().unwrap(), "✅ done");
+        // The full text was chunk-sent as fresh messages instead (2 chunks at
+        // 4096 + initial status message = 3 sends total).
+        let sent = platform.sent.lock().await;
+        assert_eq!(sent.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn streaming_mode_edit_failure_degrades_to_a_fresh_send() {
+        let (tx, rx) = broadcast::channel(16);
+        let platform = RecordingPlatform::new(true);
+        platform
+            .edit_should_fail
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
+
+        tx.send(AgentEvent::Complete {
+            usage: bamboo_agent_core::TokenUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+            },
+        })
+        .unwrap();
+
+        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        assert!(matches!(outcome, RunOutcome::Terminal));
+
+        // No successful edits recorded (they all failed) — but the run never
+        // errors out; it degrades to sending a fresh message instead.
+        assert!(platform.edits.lock().await.is_empty());
+        // Initial status + degraded final send.
+        assert_eq!(platform.sent.lock().await.len(), 2);
+    }
+
+    // Sanity: `InboundMessage` remains constructible with the same shape used
+    // elsewhere in the module (guards against an accidental field drift when
+    // `Inbound`/`CallbackQuery` were added alongside it).
+    #[test]
+    fn inbound_message_is_still_constructible() {
+        let _ = InboundMessage {
+            platform: "telegram".to_string(),
+            chat_id: "1".to_string(),
+            user_id: "1".to_string(),
+            message_id: "1".to_string(),
+            sent_at: chrono::Utc::now(),
+            text: "hi".to_string(),
+            reply_ctx: ReplyCtx(serde_json::Value::Null),
+        };
     }
 }

--- a/crates/app/bamboo-server/src/connect/render.rs
+++ b/crates/app/bamboo-server/src/connect/render.rs
@@ -53,7 +53,30 @@ pub enum RunOutcome {
     Terminal,
     /// Paused on `AgentEvent::NeedClarification` — a human decision is now
     /// required before the run can continue.
-    Paused(PendingAsk),
+    Paused {
+        ask: PendingAsk,
+        /// The streaming renderer's accumulated state (status `MessageRef` +
+        /// text buffers + throttle bookkeeping), handed back so the caller's
+        /// pause/answer/resume loop can pass it into the NEXT
+        /// [`stream_execution`] call — the resumed run keeps EDITING the same
+        /// status message instead of opening a fresh "⏳ Working…" bubble per
+        /// resume. `None` in legacy (non-`edit_message`) mode, which has no
+        /// cross-run state. Boxed to keep the enum's variants close in size
+        /// (clippy `large_enum_variant`).
+        stream_state: Option<Box<StreamState>>,
+    },
+}
+
+/// Opaque carrier for the streaming renderer's state across a pause/resume
+/// boundary (see [`RunOutcome::Paused::stream_state`]). Fields are private —
+/// callers only thread it through, they never inspect it.
+#[derive(Debug)]
+pub struct StreamState {
+    tool_lines: Vec<String>,
+    assistant_text: String,
+    status_ref: Option<MessageRef>,
+    last_edit_at: Option<Instant>,
+    chars_since_edit: usize,
 }
 
 /// The pause-worthy subset of `AgentEvent::NeedClarification`'s fields,
@@ -156,13 +179,19 @@ fn pending_ask_from_event(
 /// `platform.capabilities().edit_message`, else the legacy per-message mode
 /// (issue #452's original behavior, preserved verbatim for adapters that
 /// can't edit).
+///
+/// `prior` is the state a previous `stream_execution` call returned inside
+/// [`RunOutcome::Paused`] when the SAME logical run paused on a question and
+/// is now resuming after the answer — pass it back so the resumed run keeps
+/// editing the same status message. Pass `None` for a fresh run.
 pub async fn stream_execution(
     platform: Arc<dyn Platform>,
     reply_ctx: ReplyCtx,
     rx: broadcast::Receiver<AgentEvent>,
+    prior: Option<Box<StreamState>>,
 ) -> RunOutcome {
     if platform.capabilities().edit_message {
-        stream_execution_streaming(platform, reply_ctx, rx).await
+        stream_execution_streaming(platform, reply_ctx, rx, prior).await
     } else {
         stream_execution_legacy(platform, reply_ctx, rx).await
     }
@@ -198,13 +227,16 @@ async fn stream_execution_legacy(
                 tool_name,
                 allow_custom,
             }) => {
-                return RunOutcome::Paused(pending_ask_from_event(
-                    question,
-                    options,
-                    tool_call_id,
-                    tool_name,
-                    allow_custom,
-                ));
+                return RunOutcome::Paused {
+                    ask: pending_ask_from_event(
+                        question,
+                        options,
+                        tool_call_id,
+                        tool_name,
+                        allow_custom,
+                    ),
+                    stream_state: None,
+                };
             }
             Ok(AgentEvent::Complete { .. }) => break,
             Ok(AgentEvent::Cancelled { message }) => {
@@ -253,6 +285,39 @@ impl StreamingRenderer {
             status_ref: None,
             last_edit_at: None,
             chars_since_edit: 0,
+        }
+    }
+
+    /// Rebuild the renderer from state carried across a pause/resume boundary
+    /// (see [`StreamState`]) — same status message, same accumulated text.
+    fn resume(platform: Arc<dyn Platform>, reply_ctx: ReplyCtx, state: StreamState) -> Self {
+        let StreamState {
+            tool_lines,
+            assistant_text,
+            status_ref,
+            last_edit_at,
+            chars_since_edit,
+        } = state;
+        Self {
+            platform,
+            reply_ctx,
+            tool_lines,
+            assistant_text,
+            status_ref,
+            last_edit_at,
+            chars_since_edit,
+        }
+    }
+
+    /// Extract the carry-across-pause state (drops the platform/ctx handles,
+    /// which the resuming caller supplies again).
+    fn into_state(self) -> StreamState {
+        StreamState {
+            tool_lines: self.tool_lines,
+            assistant_text: self.assistant_text,
+            status_ref: self.status_ref,
+            last_edit_at: self.last_edit_at,
+            chars_since_edit: self.chars_since_edit,
         }
     }
 
@@ -385,14 +450,23 @@ impl StreamingRenderer {
     }
 }
 
-/// Streaming edit-in-place (issue #458 §B) rendering mode.
+/// Streaming edit-in-place (issue #458 §B) rendering mode. `prior`, when
+/// `Some`, resumes an earlier pause's renderer — same status message, no new
+/// "⏳ Working…" bubble.
 async fn stream_execution_streaming(
     platform: Arc<dyn Platform>,
     reply_ctx: ReplyCtx,
     mut rx: broadcast::Receiver<AgentEvent>,
+    prior: Option<Box<StreamState>>,
 ) -> RunOutcome {
-    let mut renderer = StreamingRenderer::new(platform, reply_ctx);
-    renderer.send_initial().await;
+    let mut renderer = match prior {
+        Some(state) => StreamingRenderer::resume(platform, reply_ctx, *state),
+        None => {
+            let mut renderer = StreamingRenderer::new(platform, reply_ctx);
+            renderer.send_initial().await;
+            renderer
+        }
+    };
 
     loop {
         match rx.recv().await {
@@ -419,13 +493,16 @@ async fn stream_execution_streaming(
                 allow_custom,
             }) => {
                 renderer.finalize_paused().await;
-                return RunOutcome::Paused(pending_ask_from_event(
-                    question,
-                    options,
-                    tool_call_id,
-                    tool_name,
-                    allow_custom,
-                ));
+                return RunOutcome::Paused {
+                    ask: pending_ask_from_event(
+                        question,
+                        options,
+                        tool_call_id,
+                        tool_name,
+                        allow_custom,
+                    ),
+                    stream_state: Some(Box::new(renderer.into_state())),
+                };
             }
             Ok(AgentEvent::Complete { .. }) => {
                 renderer.finalize_success().await;
@@ -625,7 +702,7 @@ mod tests {
         })
         .unwrap();
 
-        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx, None).await;
         assert!(matches!(outcome, RunOutcome::Terminal));
 
         let sent = platform.sent.lock().await;
@@ -649,7 +726,7 @@ mod tests {
         })
         .unwrap();
 
-        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx, None).await;
 
         let sent = platform.sent.lock().await;
         assert_eq!(sent.len(), 1);
@@ -666,7 +743,7 @@ mod tests {
         // Must return promptly, not hang, when the sender is dropped.
         tokio::time::timeout(
             std::time::Duration::from_secs(5),
-            stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx),
+            stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx, None),
         )
         .await
         .expect("stream_execution must not hang on a closed channel");
@@ -683,13 +760,15 @@ mod tests {
         tx.send(ask_event("Pick one", vec!["A", "B"], false))
             .unwrap();
 
-        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx, None).await;
         match outcome {
-            RunOutcome::Paused(ask) => {
+            RunOutcome::Paused { ask, stream_state } => {
                 assert_eq!(ask.question, "Pick one");
                 assert_eq!(ask.options, vec!["A".to_string(), "B".to_string()]);
                 assert_eq!(ask.tool_call_id, "call-1");
                 assert!(!ask.allow_custom);
+                // Legacy mode carries no streaming state.
+                assert!(stream_state.is_none());
             }
             RunOutcome::Terminal => panic!("expected Paused"),
         }
@@ -707,7 +786,7 @@ mod tests {
         let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
         drop(_tx);
 
-        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx, None).await;
 
         let sent = platform.sent.lock().await;
         assert_eq!(sent.len(), 1);
@@ -733,7 +812,7 @@ mod tests {
         })
         .unwrap();
 
-        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx, None).await;
         assert!(matches!(outcome, RunOutcome::Terminal));
 
         // The 9-char token is below the 30-char throttle, so no mid-run edit
@@ -756,7 +835,7 @@ mod tests {
         })
         .unwrap();
 
-        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx, None).await;
 
         let edits = platform.edits.lock().await;
         assert_eq!(edits.last().unwrap(), "❌ Error: boom");
@@ -773,7 +852,7 @@ mod tests {
         })
         .unwrap();
 
-        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx, None).await;
 
         let edits = platform.edits.lock().await;
         assert_eq!(edits.last().unwrap(), "⏹ user requested /stop");
@@ -792,14 +871,76 @@ mod tests {
         tx.send(ask_event("Approve?", vec!["Approve", "Deny"], false))
             .unwrap();
 
-        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx, None).await;
         match outcome {
-            RunOutcome::Paused(ask) => assert_eq!(ask.question, "Approve?"),
+            RunOutcome::Paused { ask, stream_state } => {
+                assert_eq!(ask.question, "Approve?");
+                // Streaming mode DOES carry state across the pause.
+                assert!(stream_state.is_some());
+            }
             RunOutcome::Terminal => panic!("expected Paused"),
         }
 
         let edits = platform.edits.lock().await;
         assert!(edits.last().unwrap().contains("Waiting for your input"));
+    }
+
+    #[tokio::test]
+    async fn streaming_mode_resume_keeps_editing_the_same_status_message() {
+        let platform = RecordingPlatform::new(true);
+        let ctx = ReplyCtx(serde_json::json!({"chat_id": "1"}));
+
+        // Segment 1: some text, then a pause.
+        let (tx1, rx1) = broadcast::channel(16);
+        tx1.send(AgentEvent::Token {
+            content: "Before the question. ".to_string(),
+        })
+        .unwrap();
+        tx1.send(ask_event("Approve?", vec!["Approve", "Deny"], false))
+            .unwrap();
+        let outcome = stream_execution(
+            platform.clone() as Arc<dyn Platform>,
+            ctx.clone(),
+            rx1,
+            None,
+        )
+        .await;
+        let state = match outcome {
+            RunOutcome::Paused { stream_state, .. } => stream_state,
+            RunOutcome::Terminal => panic!("expected Paused"),
+        };
+        assert!(state.is_some());
+
+        // Segment 2 (resumed run): more text, then Complete — passing the
+        // carried state back in.
+        let (tx2, rx2) = broadcast::channel(16);
+        tx2.send(AgentEvent::Token {
+            content: "After the answer.".to_string(),
+        })
+        .unwrap();
+        tx2.send(AgentEvent::Complete {
+            usage: bamboo_agent_core::TokenUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+            },
+        })
+        .unwrap();
+        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx2, state).await;
+
+        // Exactly ONE message was ever SENT — the initial "⏳ Working…"
+        // status bubble; the resumed segment kept EDITING it rather than
+        // opening a second one.
+        let sent = platform.sent.lock().await;
+        assert_eq!(sent.len(), 1, "expected a single status message: {sent:?}");
+        assert_eq!(sent[0], "⏳ Working…");
+        // The final edit carries text from BOTH segments (buffer survived
+        // the pause).
+        let edits = platform.edits.lock().await;
+        let last = edits.last().expect("expected a final edit");
+        assert!(last.starts_with('✅'), "final edit not a success: {last}");
+        assert!(last.contains("Before the question."));
+        assert!(last.contains("After the answer."));
     }
 
     #[tokio::test]
@@ -825,7 +966,7 @@ mod tests {
         })
         .unwrap();
 
-        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx, None).await;
 
         // Exactly one edit: the final one.
         assert_eq!(platform.edits.lock().await.len(), 1);
@@ -851,7 +992,7 @@ mod tests {
         })
         .unwrap();
 
-        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx, None).await;
 
         // Final edit is the short "done" marker, not the full 5000 chars.
         let edits = platform.edits.lock().await;
@@ -880,7 +1021,7 @@ mod tests {
         })
         .unwrap();
 
-        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx).await;
+        let outcome = stream_execution(platform.clone() as Arc<dyn Platform>, ctx, rx, None).await;
         assert!(matches!(outcome, RunOutcome::Terminal));
 
         // No successful edits recorded (they all failed) — but the run never


### PR DESCRIPTION
Phase 2 of epic #447; closes #458. Telegram chats can now ANSWER the agent (approvals, plan-mode confirmations, conclusion_with_options) and watch runs stream live.

## A. Approval / question relay

- The bridge's render loop now catches `AgentEvent::NeedClarification` (the uniform pause signal for conclusion_with_options / Enter/ExitPlanMode / permission-gated tools) and parks the ask per chat: question + options rendered as an inline keyboard when `capabilities().buttons` (callback_data = short nonce + option index — never raw text), always with numbered-text fallback; text replies stay first-class (option number, option keyword, 允许/yes/deny mapping on closed asks, free text on open asks).
- Resolution goes through the canonical path: `submit_pending_response` then explicit resume — mirroring the HTTP respond handler exactly, INCLUDING recording the permission grant before re-executing an approved gated tool (new `ConnectResumePort: ResumeExecutionPort`; `permission_checker` threaded into `ConnectContext`). After resume the SAME render loop continues on the new event receiver — multi-ask runs work.
- Lifecycle: one parked ask per chat; `/new`/rotation invalidates; stale/forged callbacks are nonce-checked, always `answerCallbackQuery`-acked, dropped silently; callback senders pass the same `allow_from` gate as messages. Non-matching text on a closed ask falls through to the normal busy queue.

## B. Streaming edit-in-place

- One editable status message per run: ⏳ → tool one-liners + rolling text tail → ✅ final (edit if it fits, else chunk-send) / ❌ error / ⏹ cancel. Throttle 1.5s + ≥30 chars, sharing the per-chat outgoing rate limiter; tail-keep at 4096; edit-400 degrades to a fresh send and never fails the run. Adapters without `edit_message` keep the phase-1 rendering.
- Telegram: `allowed_updates=["message","callback_query"]`, `reply_markup`, `editMessageText`, `answerCallbackQuery`; capabilities now advertise buttons + edit_message; new HTTP methods routed through the #453 token sanitizer.

## Notes for review

- `no_human_approver` flipped to `false` for correctness, but research showed it only affects out-of-process sub-agent workers — the actual pause/resume behavior comes from the NeedClarification handling above.
- `Responder` trait seam lets bridge tests run against a fake; production impl is the engine path.

## Tests

72 connect tests (35 → 72): ask rendering with nonce, callback resolution, stale-nonce drop+ack, text answers (closed keyword mapping + open free-text), /new invalidation, multi-ask resume loop, streaming throttle/tail-truncation/final-fits-vs-chunked/error render, telegram callback_query round-trip + reply_markup + editMessageText + allowed_updates + edit-400 degrade. Full `cargo test -p bamboo-server --lib` 1173/1173; fmt clean; workspace build green; exact CI clippy line exit 0; aws-lc-sys absent.

https://claude.ai/code/session_01Usp3jUXqDejy2eWuFWGsip