### PR TITLE
fix(connect): harden connect.json split — narrow migration write, .bak reset scrub, eager legacy-key strip, quarantine move

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/common.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/common.rs
@@ -24,6 +24,18 @@ pub(super) fn connect_file_path(app_data_dir: &Path) -> PathBuf {
     app_data_dir.join("connect.json")
 }
 
+/// The single best-effort backup connect.json's save path creates before an
+/// overwrite (see `bamboo_config::config::save_connect_config`) —
+/// `connect.json.bak`. #457: a full config reset must scrub this too, unlike
+/// `config.json.bak` (which is intentionally left alone — see
+/// `reset_bamboo_config`). connect.json(.bak) holds an encrypted IM bot
+/// token, an immediately-usable remote-control credential; leaving the
+/// backup behind after a reset means that credential stays live and
+/// recoverable even though the user asked for a full reset.
+pub(super) fn connect_backup_file_path(app_data_dir: &Path) -> PathBuf {
+    connect_file_path(app_data_dir).with_extension("json.bak")
+}
+
 pub(super) async fn read_model_limits_file(app_data_dir: &Path) -> Result<Option<Value>, AppError> {
     let path = model_limits_file_path(app_data_dir);
     match tokio::fs::try_exists(&path).await {

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/reset.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/reset.rs
@@ -5,7 +5,9 @@ use tokio::fs;
 
 use crate::{app_state::AppState, error::AppError};
 
-use super::common::{config_file_path, connect_file_path, model_limits_file_path};
+use super::common::{
+    config_file_path, connect_backup_file_path, connect_file_path, model_limits_file_path,
+};
 
 /// Resets (deletes) the Bamboo configuration file.
 pub async fn reset_bamboo_config(app_state: web::Data<AppState>) -> Result<HttpResponse, AppError> {
@@ -15,9 +17,16 @@ pub async fn reset_bamboo_config(app_state: web::Data<AppState>) -> Result<HttpR
     // a full config reset must clear it too, or bamboo-connect bot
     // tokens/allowlists would silently survive (and get re-merged back onto
     // the freshly-defaulted config on the very next load). Mirrors
-    // config.json/model_limits.json above: only the primary file is removed,
-    // any .bak is left alone (same as config.json.bak today).
+    // config.json/model_limits.json above: only the primary file is removed
+    // here — same as config.json.bak, which is intentionally left alone
+    // (it's a low-sensitivity, multi-generation config snapshot meant to
+    // survive a reset for recovery).
     remove_config_file_if_exists(&connect_file_path(&app_state.app_data_dir)).await?;
+    // #457: UNLIKE config.json.bak, connect.json.bak is NOT left alone — it
+    // holds an encrypted IM bot token, an immediately-usable remote-control
+    // credential, and a full reset must scrub it too or that token stays
+    // recoverable straight off disk after the user asked to wipe everything.
+    remove_config_file_if_exists(&connect_backup_file_path(&app_state.app_data_dir)).await?;
 
     // Reset in-memory config and best-effort reload provider.
     let new_config = app_state.reload_config().await;

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
@@ -6,8 +6,8 @@ use bamboo_config::OpenAIConfig;
 use bamboo_llm::Config;
 
 use super::common::{
-    config_file_path, model_limits_file_path, read_model_limits_file, redacted_config_json,
-    write_model_limits_file,
+    config_file_path, connect_backup_file_path, connect_file_path, model_limits_file_path,
+    read_model_limits_file, redacted_config_json, write_model_limits_file,
 };
 use super::reset::remove_config_file_if_exists;
 
@@ -23,6 +23,24 @@ fn model_limits_file_path_appends_model_limits_json_filename() {
     assert_eq!(
         model_limits_file_path(dir.path()),
         dir.path().join("model_limits.json")
+    );
+}
+
+#[test]
+fn connect_file_path_appends_connect_json_filename() {
+    let dir = tempdir().expect("temp dir should be created");
+    assert_eq!(
+        connect_file_path(dir.path()),
+        dir.path().join("connect.json")
+    );
+}
+
+#[test]
+fn connect_backup_file_path_appends_connect_json_bak_filename() {
+    let dir = tempdir().expect("temp dir should be created");
+    assert_eq!(
+        connect_backup_file_path(dir.path()),
+        dir.path().join("connect.json.bak")
     );
 }
 
@@ -581,5 +599,83 @@ async fn reset_bamboo_config_also_deletes_connect_json() {
             .map(|a| a.is_empty())
             .unwrap_or(true),
         "connect config must be empty after reset, not re-adopted from a stale file"
+    );
+}
+
+/// #457: a full config reset must also clear `connect.json.bak`. Unlike
+/// `config.json.bak` (a low-sensitivity config snapshot intentionally left
+/// alone by reset, for recovery), connect.json(.bak) holds an encrypted IM
+/// bot token — an immediately-usable remote-control credential — that must
+/// not stay recoverable straight off disk after the user asks for a full
+/// reset.
+#[actix_web::test]
+async fn reset_bamboo_config_also_deletes_connect_json_bak() {
+    use crate::app_state::AppState;
+    use actix_web::{test, web, App};
+
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let state = AppState::new(temp_dir.path().to_path_buf())
+        .await
+        .expect("app state should initialize");
+    let data_dir = state.app_data_dir.clone();
+    let app_state = web::Data::new(state);
+
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .route("/bamboo/config", web::get().to(super::get_bamboo_config))
+            .route("/bamboo/config", web::post().to(super::set_bamboo_config))
+            .route(
+                "/bamboo/config/reset",
+                web::post().to(super::reset_bamboo_config),
+            ),
+    )
+    .await;
+
+    // Configure a connect platform, then change it again so a
+    // `connect.json.bak` gets written (the save path backs up the previous
+    // connect.json before overwriting it).
+    for token in ["tg-first-token", "tg-second-token"] {
+        let post = test::TestRequest::post()
+            .uri("/bamboo/config")
+            .set_json(serde_json::json!({
+                "connect": {
+                    "platforms": [
+                        { "type": "telegram", "token": token, "allow_from": ["u1"] }
+                    ]
+                }
+            }))
+            .to_request();
+        assert!(test::call_service(&app, post).await.status().is_success());
+    }
+
+    let connect_path = data_dir.join("connect.json");
+    let connect_backup_path = data_dir.join("connect.json.bak");
+    assert!(
+        connect_path.exists(),
+        "connect.json should exist before reset"
+    );
+    assert!(
+        connect_backup_path.exists(),
+        "connect.json.bak should exist before reset (written by the second save)"
+    );
+
+    // Reset.
+    let reset = test::TestRequest::post()
+        .uri("/bamboo/config/reset")
+        .to_request();
+    assert!(
+        test::call_service(&app, reset).await.status().is_success(),
+        "reset should succeed"
+    );
+
+    assert!(
+        !connect_path.exists(),
+        "connect.json must be deleted by a full config reset"
+    );
+    assert!(
+        !connect_backup_path.exists(),
+        "connect.json.bak must also be deleted by a full config reset — it holds \
+         a live, immediately-usable bot token"
     );
 }

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -2005,31 +2005,40 @@ impl Config {
     ///   whatever `self.connect` currently holds. If `self.connect` was ALSO
     ///   non-empty (a legacy inline `connect` key still in config.json, e.g.
     ///   #453-era state, or written by an older binary), that's a stale
-    ///   duplicate: log a warning. connect.json wins; the config.json copy is
-    ///   dropped on the NEXT natural save (this call does not force one).
+    ///   duplicate: log a warning and proactively strip the superseded key
+    ///   from config.json now (#457) rather than waiting for the next
+    ///   natural save — cheap, and consistent with not spreading token
+    ///   ciphertext across files.
     /// - `connect.json` present but corrupt/unparsable: fail SAFE for this
     ///   security-sensitive feature. Log an error, quarantine the bad file to
     ///   `connect.json.bak` (best-effort), and continue with an EMPTY
     ///   `ConnectConfig` — never falls back to a legacy config.json copy.
     /// - `connect.json` absent & `self.connect` non-empty (pure legacy
     ///   state): migrate proactively. Adopt the legacy value (already parsed
-    ///   into `self`) and write BOTH files once via a full
-    ///   [`Config::save_to_dir`] (creates connect.json; rewrites config.json
-    ///   without the key), logged at info.
+    ///   into `self`) and persist it: strip the `connect` key from
+    ///   config.json and write connect.json (#457 — NOT a full
+    ///   [`Config::save_to_dir`], which would re-encrypt every OTHER secret
+    ///   in config.json and rotate its backups as a load-time side effect,
+    ///   even for a read-only command like `bamboo config get`), logged at
+    ///   info.
     /// - `connect.json` absent & `self.connect` empty: nothing to do.
     fn merge_connect_config(&mut self, data_dir: &std::path::Path) {
         let connect_path = data_dir.join("connect.json");
         match std::fs::read_to_string(&connect_path) {
             Ok(content) => match serde_json::from_str::<ConnectConfig>(&content) {
                 Ok(connect) => {
-                    if !connect_config_is_empty(&self.connect) {
+                    let legacy_key_present = !connect_config_is_empty(&self.connect);
+                    if legacy_key_present {
                         tracing::warn!(
                             "config.json still has a legacy `connect` key alongside \
-                             connect.json; connect.json takes precedence and the stale \
-                             key will be dropped on the next save"
+                             connect.json; connect.json takes precedence — dropping the \
+                             stale key from config.json now"
                         );
                     }
                     self.connect = connect;
+                    if legacy_key_present {
+                        strip_legacy_connect_key_from_config_json(data_dir);
+                    }
                 }
                 Err(e) => {
                     tracing::error!(
@@ -2048,7 +2057,11 @@ impl Config {
                         "Migrating legacy `connect` config from config.json to a \
                          standalone connect.json"
                     );
-                    if let Err(e) = self.save_to_dir(data_dir.to_path_buf()) {
+                    // Narrow migration write (#457): strip only the `connect` key
+                    // from config.json and write connect.json directly, instead of
+                    // routing through a full `save_to_dir` (see doc comment above).
+                    strip_legacy_connect_key_from_config_json(data_dir);
+                    if let Err(e) = save_connect_config(&self.connect, data_dir) {
                         tracing::error!("Failed to write connect.json during migration: {}", e);
                     }
                 }
@@ -2735,17 +2748,109 @@ fn save_connect_config(connect: &ConnectConfig, data_dir: &std::path::Path) -> R
     Ok(())
 }
 
+/// Remove the legacy inline `connect` key from `config.json` on disk, if
+/// present — the narrow, load-side counterpart of the full-document rewrite
+/// [`Config::save_to_dir`] would otherwise perform just to drop one stale
+/// key. Used by [`Config::merge_connect_config`] both when adopting a
+/// pure-legacy `connect` key (migration) and when a stale legacy key lingers
+/// alongside an authoritative connect.json. #457.
+///
+/// Operates on the raw `serde_json::Value` read straight from disk — NOT on
+/// the typed `Config` — so it touches nothing but the one key: no other
+/// secret gets re-encrypted, and no `config.json.bak` generation gets
+/// rotated, as a side effect of a load.
+///
+/// Best-effort: read/parse/write failures are logged, not propagated — this
+/// runs as a side effect of `Config::new()` / load, which has no `Result` to
+/// surface it through. A failure here just leaves the stale key in place
+/// until the next natural save; connect.json (written separately) is already
+/// authoritative in memory either way.
+fn strip_legacy_connect_key_from_config_json(data_dir: &std::path::Path) {
+    let config_path = data_dir.join("config.json");
+    let content = match std::fs::read_to_string(&config_path) {
+        Ok(content) => content,
+        Err(e) => {
+            tracing::error!(
+                "Failed to read config.json to strip legacy `connect` key: {}",
+                e
+            );
+            return;
+        }
+    };
+    let mut value: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(value) => value,
+        Err(e) => {
+            tracing::error!(
+                "Failed to parse config.json to strip legacy `connect` key: {}",
+                e
+            );
+            return;
+        }
+    };
+    let Some(obj) = value.as_object_mut() else {
+        return;
+    };
+    if obj.remove("connect").is_none() {
+        // Nothing to strip (e.g. raced with a concurrent save that already
+        // dropped it) — avoid an unnecessary rewrite.
+        return;
+    }
+    let rewritten = match serde_json::to_string_pretty(&value) {
+        Ok(rewritten) => rewritten,
+        Err(e) => {
+            tracing::error!(
+                "Failed to serialize config.json after stripping legacy `connect` key: {}",
+                e
+            );
+            return;
+        }
+    };
+    if let Err(e) = write_atomic(&config_path, rewritten.as_bytes()) {
+        tracing::error!(
+            "Failed to write config.json after stripping legacy `connect` key: {}",
+            e
+        );
+    }
+}
+
 /// Quarantine an unparsable `connect.json` to a single `connect.json.bak`
 /// generation (best-effort) so the bad content survives for inspection
 /// instead of being silently discarded. Unlike config.json's timestamped,
 /// N-generation quarantine, connect.json only needs one slot — it's a much
 /// smaller, less complex document and this is a fail-SAFE (empty/inert
 /// bridge), not a fail-recover, posture. #455.
+///
+/// MOVES the corrupt file rather than copying it (#457): a copy would leave
+/// the same corrupt `connect.json` sitting in the data dir right next to its
+/// own quarantine copy, which reads as confusing/ambiguous mid-incident
+/// (which one is live?). `rename` is used first (atomic, no partial-copy
+/// window); if that fails — e.g. `connect.json.bak` and the data dir are on
+/// different filesystems — fall back to copy-then-remove so the corrupt
+/// original still doesn't linger.
 fn quarantine_corrupt_connect(connect_path: &std::path::Path) {
     let backup = connect_path.with_extension("json.bak");
-    match std::fs::copy(connect_path, &backup) {
-        Ok(_) => tracing::warn!("Quarantined corrupt connect.json to {:?}", backup),
-        Err(e) => tracing::error!("Failed to quarantine corrupt connect.json: {}", e),
+    match std::fs::rename(connect_path, &backup) {
+        Ok(()) => tracing::warn!("Quarantined corrupt connect.json to {:?}", backup),
+        Err(e) => {
+            tracing::warn!(
+                "Failed to rename corrupt connect.json to {:?} ({}); falling back to copy+remove",
+                backup,
+                e
+            );
+            if let Err(e) = std::fs::copy(connect_path, &backup) {
+                tracing::error!("Failed to quarantine corrupt connect.json: {}", e);
+                return;
+            }
+            if let Err(e) = std::fs::remove_file(connect_path) {
+                tracing::error!(
+                    "Quarantined corrupt connect.json to {:?} but failed to remove the \
+                     original {:?}: {}",
+                    backup,
+                    connect_path,
+                    e
+                );
+            }
+        }
     }
 }
 
@@ -3843,6 +3948,65 @@ mod tests {
         );
     }
 
+    /// #457: the legacy-key migration must be a NARROW write (strip `connect`
+    /// from config.json + write connect.json) — not the full `save_to_dir`,
+    /// which would re-encrypt every OTHER secret in config.json and rotate a
+    /// `config.json.bak` generation as a load-time side effect. This matters
+    /// most for a purely READ-ONLY command (e.g. `bamboo config get`) run on a
+    /// machine that still has the legacy `connect` key: it must not silently
+    /// rewrite/re-encrypt unrelated secrets or spin up a backup.
+    #[test]
+    fn migration_write_is_narrow_and_does_not_rewrite_unrelated_secrets_or_backups() {
+        let _key = crate::encryption::set_test_encryption_key([0x77; 32]);
+        let temp = TempHome::new();
+
+        let original_api_key_encrypted =
+            crate::encryption::encrypt("sk-unrelated-secret").expect("encrypt succeeds");
+        temp.set_config_json(
+            &serde_json::json!({
+                "providers": {
+                    "openai": {
+                        "api_key_encrypted": original_api_key_encrypted,
+                    }
+                },
+                "connect": {
+                    "platforms": [
+                        { "type": "telegram", "token_encrypted": "legacy-cipher", "allow_from": ["u1"] }
+                    ]
+                }
+            })
+            .to_string(),
+        );
+
+        let config = Config::from_data_dir_without_publish(Some(temp.path.clone()));
+        assert_eq!(config.connect.platforms.len(), 1, "legacy key adopted");
+
+        // No `config.json.bak` — the narrow write does not rotate backups the
+        // way a full `save_to_dir` would.
+        assert!(
+            !temp.path.join("config.json.bak").exists(),
+            "a read-only load migrating a legacy `connect` key must not rotate \
+             config.json backups"
+        );
+
+        // The unrelated provider secret's ciphertext is byte-for-byte
+        // unchanged — proof it was never decrypted+re-encrypted (encryption
+        // uses a random nonce per call, so any re-encryption would change the
+        // bytes even for the same plaintext).
+        let config_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(temp.path.join("config.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            config_json["providers"]["openai"]["api_key_encrypted"], original_api_key_encrypted,
+            "an unrelated secret's ciphertext must not be touched by the connect \
+             migration's narrow write"
+        );
+        assert!(
+            config_json.get("connect").is_none(),
+            "config.json is still rewritten without the legacy `connect` key"
+        );
+    }
+
     #[test]
     fn both_files_present_connect_json_wins() {
         let temp = TempHome::new();
@@ -3875,6 +4039,53 @@ mod tests {
         );
     }
 
+    /// #457: when both files are present, the superseded `connect` key in
+    /// config.json must be stripped PROACTIVELY on load — not left to linger
+    /// until the next natural save, which spreads token ciphertext across two
+    /// files for longer than necessary.
+    #[test]
+    fn both_files_present_strips_stale_legacy_key_from_config_json_immediately() {
+        let temp = TempHome::new();
+        temp.set_config_json(
+            &serde_json::json!({
+                "http_proxy": "http://keep-me",
+                "connect": {
+                    "platforms": [
+                        { "type": "telegram", "token_encrypted": "stale-config-json-cipher" }
+                    ]
+                }
+            })
+            .to_string(),
+        );
+        std::fs::write(
+            connect_json_path(&temp),
+            serde_json::json!({
+                "platforms": [
+                    { "type": "telegram", "token_encrypted": "authoritative-cipher" }
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let config = Config::from_data_dir_without_publish(Some(temp.path.clone()));
+        assert_eq!(
+            config.connect.platforms[0].token_encrypted.as_deref(),
+            Some("authoritative-cipher")
+        );
+        // Unrelated field survives the strip.
+        assert_eq!(config.http_proxy, "http://keep-me");
+
+        let config_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(temp.path.join("config.json")).unwrap())
+                .unwrap();
+        assert!(
+            config_json.get("connect").is_none(),
+            "the stale legacy `connect` key must be stripped from config.json \
+             immediately on load, not left for the next natural save"
+        );
+    }
+
     #[test]
     fn corrupt_connect_json_yields_empty_connect_and_is_quarantined() {
         let temp = TempHome::new();
@@ -3897,6 +4108,15 @@ mod tests {
                 .unwrap()
                 .contains("not valid json"),
             "the quarantined copy holds the bad content"
+        );
+        // #457: quarantine MOVES the corrupt file rather than copying it, so
+        // the data dir doesn't end up with two copies of the same corrupt
+        // content (the live `connect.json` and its `.bak`) sitting side by
+        // side, which reads as confusing/ambiguous mid-incident.
+        assert!(
+            !connect_json_path(&temp).exists(),
+            "quarantine must MOVE the corrupt connect.json (not copy it) — no \
+             connect.json should remain after quarantine"
         );
     }
 


### PR DESCRIPTION
Closes #457 — the four non-blocking hardening items from the PR #456 review.

## Changes

1. **Narrow the legacy-key migration write** (`merge_connect_config`): the pure-legacy migration branch no longer routes through the full `save_to_dir` (which re-encrypts every other secret and rotates `config.json.bak` as a load-time side effect of read-only commands like `bamboo config get`). It now calls a new `strip_legacy_connect_key_from_config_json` helper — raw `serde_json::Value` edit that removes only the `connect` key, written atomically — plus `save_connect_config` directly.
2. **Reset scrubs `connect.json.bak`**: `reset_bamboo_config` now also deletes `connect.json.bak`. `config.json.bak` is deliberately still left alone (low-sensitivity recovery snapshot); connect.json.bak holds an encrypted IM bot token — an immediately-usable remote-control credential that must not survive a full reset.
3. **Eager stale-key strip**: in the both-files-present branch, the superseded `connect` key in config.json is stripped immediately on load via the same helper, instead of lingering until the next natural save.
4. **Quarantine moves, not copies**: `quarantine_corrupt_connect` now uses `std::fs::rename` (with copy+remove fallback for cross-filesystem cases), so the corrupt `connect.json` no longer sits next to its own `.bak` mid-incident.

## Tests

New/extended coverage per item: `migration_write_is_narrow_and_does_not_rewrite_unrelated_secrets_or_backups` (asserts the unrelated secret's ciphertext is byte-for-byte unchanged and no backup was rotated), `both_files_present_strips_stale_legacy_key_from_config_json_immediately`, `corrupt_connect_json_yields_empty_connect_and_is_quarantined` (now asserts the original is gone), `reset_bamboo_config_also_deletes_connect_json_bak` (end-to-end via the real HTTP endpoints), plus path-helper unit tests.

- `cargo test -p bamboo-config --lib`: 200 passed
- `cargo test -p bamboo-server --lib`: 1181 passed
- `cargo fmt --check` / `cargo clippy` on both crates: clean

## Notes for review

- `strip_legacy_connect_key_from_config_json` re-serializes config.json via generic `serde_json::Value` + `to_string_pretty`, so key ordering/whitespace of the rewritten file can differ from the typed-`Config` serialization path — field content is preserved exactly.
- The quarantine rename's cross-filesystem fallback (copy+remove) isn't unit-tested (hard to simulate cross-device); the common rename path is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jxUSVTtay3Usa6n8eUaFK

---
_Generated by [Claude Code](https://claude.ai/code/session_015jxUSVTtay3Usa6n8eUaFK)_