### PR TITLE
refactor(bamboo-server): share Governor+CORS wrap order between prod factories and tests

### DIFF
--- a/crates/app/bamboo-server/src/config.rs
+++ b/crates/app/bamboo-server/src/config.rs
@@ -22,12 +22,13 @@
 use actix_cors::Cors;
 use actix_governor::governor::middleware::NoOpMiddleware;
 use actix_governor::{
-    GovernorConfig, GovernorConfigBuilder, KeyExtractor, SimpleKeyExtractionError,
+    Governor, GovernorConfig, GovernorConfigBuilder, KeyExtractor, SimpleKeyExtractionError,
 };
 use actix_web::body::MessageBody;
-use actix_web::dev::{ServiceRequest, ServiceResponse};
+use actix_web::dev::{ServiceFactory, ServiceRequest, ServiceResponse};
 use actix_web::http::header;
-use actix_web::middleware::{DefaultHeaders, Next};
+use actix_web::middleware::{Condition, DefaultHeaders, Next};
+use actix_web::App;
 use std::collections::HashSet;
 use std::net::IpAddr;
 use tracing::info;
@@ -214,8 +215,29 @@ pub fn build_rate_limiter() -> GovernorConfig<ClientIpKeyExtractor, NoOpMiddlewa
 /// hashed `/assets/*` requests on load and would otherwise trip the 429 limit
 /// (`burst` default 20). Mirrors the loopback special-casing already used for
 /// CORS; network binds (`0.0.0.0`) are still throttled.
+///
+/// Classification is via [`IpAddr::is_loopback`] (so the whole `127.0.0.0/8`
+/// range, not just `127.0.0.1`, and a bracketed IPv6 literal like `[::1]` are
+/// correctly recognized) plus a literal `"localhost"` match, since that's a
+/// hostname rather than an address `IpAddr` can parse. #428: previously this
+/// was a strict string allowlist (`127.0.0.1` / `localhost` / `::1`), so e.g.
+/// `127.0.0.2` or `[::1]` were misclassified as non-loopback — which failed
+/// SAFE (the limiter was applied) but was still wrong.
 pub fn is_loopback_bind(bind: &str) -> bool {
-    matches!(bind, "127.0.0.1" | "localhost" | "::1")
+    let candidate = bind.trim();
+    let unbracketed = candidate
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+        .unwrap_or(candidate);
+
+    if unbracketed.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+
+    unbracketed
+        .parse::<IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
 }
 
 /// Bind-aware limiter guard (#169 part 3).
@@ -744,6 +766,59 @@ pub fn build_cors(bind_addr: &str, port: u16) -> Cors {
     cors
 }
 
+/// Apply the Governor (rate limiter) + CORS middleware pair to `app`, IN THE
+/// ORDER THAT MATTERS (#169 part 2, #428).
+///
+/// Governor is wrapped first (the INNER layer) and `build_cors` second (the
+/// OUTER layer). This ordering is load-bearing: (1) a genuine CORS preflight
+/// is short-circuited by CORS and never reaches Governor, so it isn't counted
+/// against the rate-limit bucket; and (2) a 429 from Governor propagates back
+/// OUT through CORS, which adds `Access-Control-Allow-Origin` so a browser
+/// receives a readable 429 instead of an opaque network error. Reversing the
+/// two wraps regresses both (see the `governor_inside_cors_*` /
+/// `governor_outside_cors_regression_*` tests below).
+///
+/// This is the ONE place the wrap order is spelled out — every production app
+/// factory (`entrypoints.rs`, `web_service.rs`) AND the ordering-invariant
+/// regression tests call this helper instead of each re-declaring the two
+/// `.wrap()` calls inline. That means a future edit can no longer swap the
+/// order in just one of those call sites without also changing this function,
+/// and changing this function is exactly what the regression tests cover
+/// (#428 — prior to this, the tests built their own hand-rolled `App` with the
+/// order spelled out separately from production, so a production-only swap
+/// would NOT have failed them).
+pub fn wrap_governor_and_cors<T, B>(
+    app: App<T>,
+    rate_limiter: &GovernorConfig<ClientIpKeyExtractor, NoOpMiddleware>,
+    apply_rate_limit: bool,
+    bind_addr: &str,
+    port: u16,
+) -> App<
+    impl ServiceFactory<
+        ServiceRequest,
+        Config = (),
+        Response = ServiceResponse<impl MessageBody>,
+        Error = actix_web::Error,
+        InitError = (),
+    >,
+>
+where
+    T: ServiceFactory<
+            ServiceRequest,
+            Config = (),
+            Response = ServiceResponse<B>,
+            Error = actix_web::Error,
+            InitError = (),
+        > + 'static,
+    B: MessageBody + 'static,
+{
+    app.wrap(Condition::new(
+        apply_rate_limit,
+        Governor::new(rate_limiter),
+    ))
+    .wrap(build_cors(bind_addr, port))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -768,6 +843,16 @@ mod tests {
         }
         for b in ["0.0.0.0", "192.168.1.10", "::"] {
             assert!(!is_loopback_bind(b), "{b} should be throttled");
+        }
+    }
+
+    #[test]
+    fn loopback_binds_recognizes_full_loopback_range_and_bracketed_ipv6() {
+        // #428: a strict `127.0.0.1`/`localhost`/`::1` string allowlist
+        // misclassifies other loopback forms as non-loopback (failing safe,
+        // but wrong). Classifying via `IpAddr::is_loopback` fixes it.
+        for b in ["127.0.0.2", "127.255.255.255", "[::1]", "LOCALHOST"] {
+            assert!(is_loopback_bind(b), "{b} is a loopback address/host");
         }
     }
 
@@ -1055,13 +1140,19 @@ mod tests {
         }};
     }
 
-    /// The production order (`.wrap(Governor).wrap(build_cors(...))` → Governor
-    /// INSIDE CORS) must give a browser a READABLE 429: the throttled response
-    /// carries `Access-Control-Allow-Origin`, and a CORS preflight is NOT counted
+    /// The production order — enforced by the shared [`wrap_governor_and_cors`]
+    /// helper (Governor inner, CORS outer) and used by BOTH the real app
+    /// factories (`entrypoints.rs`, `web_service.rs`) and this test — must give
+    /// a browser a READABLE 429: the throttled response carries
+    /// `Access-Control-Allow-Origin`, and a CORS preflight is NOT counted
     /// against the bucket (CORS answers it before it reaches Governor).
+    ///
+    /// Because this test calls the SAME helper the production factories call
+    /// (rather than hand-rolling the wrap order itself, #428), a future edit
+    /// that swaps the wrap order in `wrap_governor_and_cors` — the only place
+    /// production spells the order out — fails this test.
     #[actix_web::test]
     async fn governor_inside_cors_makes_429_cors_readable_and_exempts_preflight() {
-        use actix_governor::Governor;
         use actix_web::http::StatusCode;
         use actix_web::{test, web, App, HttpResponse};
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -1069,10 +1160,14 @@ mod tests {
         // burst=1: the 2nd GET from an IP is throttled.
         let conf = rate_limiter_config(1, 1, ClientIpKeyExtractor::peer_ip());
         let app = test::init_service(
-            App::new()
-                .wrap(Governor::new(&conf)) // inner
-                .wrap(build_cors("0.0.0.0", 9562)) // outer
-                .route("/", web::get().to(|| async { HttpResponse::Ok().finish() })),
+            wrap_governor_and_cors(
+                App::new(),
+                &conf,
+                /* apply_rate_limit */ true,
+                "0.0.0.0",
+                9562,
+            )
+            .route("/", web::get().to(|| async { HttpResponse::Ok().finish() })),
         )
         .await;
 
@@ -1100,9 +1195,11 @@ mod tests {
     /// Guards the ordering as load-bearing: the REVERSED order
     /// (`.wrap(build_cors).wrap(Governor)` → Governor OUTSIDE CORS) is the pre-fix
     /// state that motivated #169 — a 429 escapes without CORS headers and the
-    /// preflight is throttled. If a refactor ever flips the wrap order back, the
-    /// positive test above breaks; this test documents *why* by asserting the
-    /// broken behavior of the wrong order.
+    /// preflight is throttled. If a refactor ever flips the wrap order back
+    /// inside [`wrap_governor_and_cors`], the positive test above breaks; this
+    /// test intentionally does NOT use that helper — it hand-rolls the WRONG
+    /// order to document *why* the order matters, by asserting the broken
+    /// behavior that would result.
     #[actix_web::test]
     async fn governor_outside_cors_regression_drops_cors_and_throttles_preflight() {
         use actix_governor::Governor;

--- a/crates/app/bamboo-server/src/server/entrypoints.rs
+++ b/crates/app/bamboo-server/src/server/entrypoints.rs
@@ -12,13 +12,12 @@ use super::tls::build_rustls_config;
 use crate::app_state::AppState;
 use crate::config::{
     build_cors, build_rate_limiter, build_security_headers, is_loopback_bind,
-    require_limiter_for_nonloopback,
+    require_limiter_for_nonloopback, wrap_governor_and_cors,
 };
 use crate::routes::{configure_routes, configure_routes_with_rate_limiting};
 use crate::services::frontend_package::{
     ensure_current_frontend_dir_in, has_embedded_frontend_package, resolve_frontend_package_path,
 };
-use actix_governor::Governor;
 use bamboo_config::TlsConfig;
 
 fn canonicalize_static_dir(path: &Path) -> Result<PathBuf, String> {
@@ -284,6 +283,15 @@ pub async fn run_with_bind_and_static_tls(
 ) -> Result<(), String> {
     info!("Starting unified server on {}:{}...", bind, port);
 
+    // Loopback/desktop binds skip the limiter (see is_loopback_bind): the local
+    // frontend bursts ~45 asset requests on load. Network binds stay throttled.
+    let apply_rate_limit = !is_loopback_bind(bind);
+    // Bind-aware guard: a non-loopback bind must have the limiter applied (it is,
+    // below). Defends against a future edit that disables it for a routable bind.
+    // Checked BEFORE the async app-state/static-dir setup so a bad bind fails fast,
+    // consistent with `start_with_bind_tls`. #169, #428.
+    require_limiter_for_nonloopback(bind, apply_rate_limit)?;
+
     let static_dir = resolve_runtime_static_dir(&bamboo_home_dir, static_dir)?;
 
     let app_state = web::Data::new(
@@ -300,39 +308,31 @@ pub async fn run_with_bind_and_static_tls(
     // once and shared (Clone) across workers. It is wrapped so that a throttled
     // request is rejected with 429 before any handler work runs.
     let rate_limiter = build_rate_limiter();
-    // Loopback/desktop binds skip the limiter (see is_loopback_bind): the local
-    // frontend bursts ~45 asset requests on load. Network binds stay throttled.
-    let apply_rate_limit = !is_loopback_bind(bind);
-    // Bind-aware guard: a non-loopback bind must have the limiter applied (it is
-    // here). Defends against a future edit that disables it for a routable bind. #169.
-    require_limiter_for_nonloopback(bind, apply_rate_limit)?;
     let bind_for_cors = bind.to_string();
     let app_factory = move || {
         // Request size limits (base64-image chats) come from the one shared
         // factory used by every serve path — same limits everywhere, no drift
         // (#252).
-        let mut app = super::web_service::with_body_limits(App::new())
-            .app_data(app_state.clone())
-            // WRAP ORDER (#169 part 2): Governor is registered BEFORE `build_cors`,
-            // making CORS the OUTER layer and Governor the INNER one. This ordering
-            // is load-bearing: (1) a genuine CORS preflight is short-circuited by
-            // CORS and never reaches Governor, so it is not counted against the
-            // bucket; and (2) a 429 from Governor propagates back OUT through CORS,
-            // which adds `Access-Control-Allow-Origin` so a browser receives a
-            // readable 429 instead of an opaque network error. Reversing the two
-            // wraps regresses both (see config.rs `governor_*_cors_*` tests).
-            .wrap(actix_web::middleware::Condition::new(
-                apply_rate_limit,
-                Governor::new(&rate_limiter),
-            ))
-            .wrap(build_cors(&bind_for_cors, port))
-            .wrap(build_security_headers())
-            // Immutable long-cache for hashed `/assets/*` (Docker / `serve -s`
-            // path, fronted by a proxy/CDN — same fix as the other factories).
-            .wrap(actix_web::middleware::from_fn(
-                crate::config::add_asset_cache_headers,
-            ))
-            .configure(configure_routes_with_rate_limiting);
+        // WRAP ORDER (#169 part 2, #428): Governor + CORS are applied together,
+        // in the fixed order enforced by the shared `wrap_governor_and_cors`
+        // helper (Governor inner, CORS outer) — see its doc comment in
+        // config.rs for why the order is load-bearing, and the
+        // `governor_*_cors_*` regression tests there, which exercise this SAME
+        // helper so a swap can no longer regress in only one call site.
+        let mut app = wrap_governor_and_cors(
+            super::web_service::with_body_limits(App::new()).app_data(app_state.clone()),
+            &rate_limiter,
+            apply_rate_limit,
+            &bind_for_cors,
+            port,
+        )
+        .wrap(build_security_headers())
+        // Immutable long-cache for hashed `/assets/*` (Docker / `serve -s`
+        // path, fronted by a proxy/CDN — same fix as the other factories).
+        .wrap(actix_web::middleware::from_fn(
+            crate::config::add_asset_cache_headers,
+        ))
+        .configure(configure_routes_with_rate_limiting);
 
         if let Some(static_path) = &static_dir {
             let index_file = static_path.join("index.html");

--- a/crates/app/bamboo-server/src/server/web_service.rs
+++ b/crates/app/bamboo-server/src/server/web_service.rs
@@ -42,10 +42,9 @@ use super::tls::build_rustls_config;
 use crate::app_state::AppState;
 use crate::config::{
     build_cors, build_rate_limiter, build_security_headers, is_loopback_bind,
-    require_limiter_for_nonloopback,
+    require_limiter_for_nonloopback, wrap_governor_and_cors,
 };
 use crate::routes::{configure_routes, configure_routes_with_rate_limiting};
-use actix_governor::Governor;
 use bamboo_config::TlsConfig;
 
 /// Manageable web service with start/stop lifecycle
@@ -194,6 +193,18 @@ impl WebService {
             return Err("Web service is already running".to_string());
         }
 
+        // Per-IP rate limiter (#13) will be applied below for non-loopback binds.
+        // SKIPPED for loopback/desktop binds: the local frontend legitimately
+        // bursts ~45 hashed `/assets/*` requests on load and would otherwise be
+        // throttled to a 429 (chunk import fails / "Too many requests").
+        let apply_rate_limit = !is_loopback_bind(bind);
+        // Bind-aware guard: a non-loopback bind must have the limiter applied
+        // (it is here for non-loopback binds). Belt-and-suspenders against a
+        // future edit that flips `apply_rate_limit` off for a routable bind.
+        // Checked BEFORE the async app-state setup so a bad bind fails fast,
+        // consistent with `start_with_bind_tls`. #169, #428.
+        require_limiter_for_nonloopback(bind, apply_rate_limit)?;
+
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
         self.port = port;
 
@@ -215,51 +226,41 @@ impl WebService {
         // Retain a handle so stop()/Drop can stop AppState-owned background tasks. #119
         self.app_state = Some(app_state.clone());
         // Per-IP rate limiter for the network-exposed production server (#13).
-        // SKIPPED for loopback/desktop binds: the local frontend legitimately
-        // bursts ~45 hashed `/assets/*` requests on load and would otherwise be
-        // throttled to a 429 (chunk import fails / "Too many requests").
         let rate_limiter = build_rate_limiter();
-        let apply_rate_limit = !is_loopback_bind(bind);
-        // Bind-aware guard: a non-loopback bind must have the limiter applied
-        // (it is here for non-loopback binds). Belt-and-suspenders against a
-        // future edit that flips `apply_rate_limit` off for a routable bind. #169.
-        require_limiter_for_nonloopback(bind, apply_rate_limit)?;
         let bind_addr = bind.to_string();
         let listen_addr = format!("{bind}:{port}");
         let bind_for_log = bind_addr.clone();
 
         let server = HttpServer::new(move || {
-            with_body_limits(App::new())
-                .app_data(app_state.clone())
-                // WRAP ORDER (#169 part 2): Governor is registered BEFORE `build_cors`,
-                // so CORS is the OUTER layer and Governor the INNER one. This is
-                // load-bearing: (1) a genuine CORS preflight is answered by CORS and
-                // never reaches Governor, so it isn't counted against the bucket; and
-                // (2) a 429 from Governor propagates back OUT through CORS, which adds
-                // `Access-Control-Allow-Origin` so a browser sees a readable 429 rather
-                // than an opaque network error. Reversing these two wraps regresses both
-                // (see the config.rs `governor_inside_cors_*` / `governor_outside_cors_*`
-                // tests).
-                .wrap(actix_web::middleware::Condition::new(
-                    apply_rate_limit,
-                    Governor::new(&rate_limiter),
-                ))
-                .wrap(build_cors(&bind_addr, port))
-                .wrap(build_security_headers())
-                // Immutable long-cache for hashed `/assets/*` so a proxy/CDN
-                // (e.g. Cloudflare tunnel) caches chunks at the edge instead of
-                // round-tripping each one to origin (#preload-error fix).
-                .wrap(actix_web::middleware::from_fn(
-                    crate::config::add_asset_cache_headers,
-                ))
-                .configure(configure_routes_with_rate_limiting)
-                .service(
-                    fs::Files::new("/", static_dir.clone())
-                        .index_file("index.html")
-                        .prefer_utf8(true)
-                        .disable_content_disposition()
-                        .disable_content_disposition(),
-                )
+            // WRAP ORDER (#169 part 2, #428): Governor + CORS are applied
+            // together, in the fixed order enforced by the shared
+            // `wrap_governor_and_cors` helper (Governor inner, CORS outer) —
+            // see its doc comment in config.rs for why the order is
+            // load-bearing, and the `governor_*_cors_*` regression tests
+            // there, which exercise this SAME helper so a swap can no longer
+            // regress in only one call site.
+            wrap_governor_and_cors(
+                with_body_limits(App::new()).app_data(app_state.clone()),
+                &rate_limiter,
+                apply_rate_limit,
+                &bind_addr,
+                port,
+            )
+            .wrap(build_security_headers())
+            // Immutable long-cache for hashed `/assets/*` so a proxy/CDN
+            // (e.g. Cloudflare tunnel) caches chunks at the edge instead of
+            // round-tripping each one to origin (#preload-error fix).
+            .wrap(actix_web::middleware::from_fn(
+                crate::config::add_asset_cache_headers,
+            ))
+            .configure(configure_routes_with_rate_limiting)
+            .service(
+                fs::Files::new("/", static_dir.clone())
+                    .index_file("index.html")
+                    .prefer_utf8(true)
+                    .disable_content_disposition()
+                    .disable_content_disposition(),
+            )
         })
         .workers(DEFAULT_WORKER_COUNT);
 


### PR DESCRIPTION
Closes #428 — follow-up from the #427 (#169) review.

## Changes

**Main fix — shared wrap helper.** New `wrap_governor_and_cors` in `config.rs`: a generic `App`-wrapping helper that applies `.wrap(Condition::new(apply_rate_limit, Governor::new(...)))` then `.wrap(build_cors(...))` in that fixed, load-bearing order (Governor inner, CORS outer). Both production app factories (`entrypoints::run_with_bind_and_static_tls`, `WebService::start_with_bind_and_static_tls`) and the positive ordering-invariant test (`governor_inside_cors_makes_429_cors_readable_and_exempts_preflight`) now call this one helper instead of each spelling out the two `.wrap()` calls inline — so a production-only swap of the order is no longer possible, and a swap inside the helper fails the test. Verified by mutation: temporarily reversing the order inside the helper makes the test fail; reverting restores green.

`governor_outside_cors_regression_drops_cors_and_throttles_preflight` intentionally still hand-rolls the WRONG order — it documents the pre-#169 broken behavior; its doc comment now says so explicitly.

**Optional items from the same review (both done):**
- `is_loopback_bind` now classifies via `IpAddr::is_loopback()` (whole `127.0.0.0/8`, bracketed `[::1]`, case-insensitive `localhost`) instead of a strict 3-string allowlist. New test `loopback_binds_recognizes_full_loopback_range_and_bracketed_ipv6`.
- `require_limiter_for_nonloopback` guard moved before the async `AppState::new()`/static-dir work in `run_with_bind_and_static_tls` and `start_with_bind_and_static_tls`, matching the fail-fast placement in `start_with_bind_tls`.

Left untouched: the desktop-only paths (`run`/`run_with_tls`/`start_with_bind_tls`) that use `build_cors` without Governor (no ordering invariant there), and `build_cors`'s own separate loopback string check (a distinct CORS-trust decision, out of scope).

## Tests

- `cargo test -p bamboo-server`: 1179 lib passed (+1 new), 9 integration passed, 9 doc-tests passed — all green
- `cargo fmt --check` / `cargo clippy -p bamboo-server --all-targets`: clean in touched files

## Notes for review

- `wrap_governor_and_cors` returns `App<impl ServiceFactory<..., Response = ServiceResponse<impl MessageBody>, ...>>` — compiles cleanly against actix-web 4.14 / actix-cors 0.7.1 / actix-governor 0.10, but the generic bounds are the part worth a second look from someone familiar with actix internals.
- Behavior change worth noting: `127.0.0.2`-style binds and `[::1]` were previously treated as non-loopback (limiter applied / start refused on the no-limiter path); they are now correctly classified as loopback and skip the limiter, same as `127.0.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jxUSVTtay3Usa6n8eUaFK

---
_Generated by [Claude Code](https://claude.ai/code/session_015jxUSVTtay3Usa6n8eUaFK)_