### PR TITLE
fix(connect): bound dedup/rate-limit maps, guard multi-telegram session collision, type-check masked-token preserve

### DIFF
--- a/crates/app/bamboo-server/src/connect/bridge.rs
+++ b/crates/app/bamboo-server/src/connect/bridge.rs
@@ -44,6 +44,58 @@ impl SessionKey {
     }
 }
 
+/// Max entries [`BoundedSeenSet`] retains before evicting the oldest
+/// (issue #454 follow-up). This is defense-in-depth dedup, layered on top
+/// of each adapter's own transport-level dedup (e.g. Telegram's offset
+/// advance) — it only needs to cover the realistic in-flight
+/// redelivery/retry window, not serve as a permanent audit log. A few
+/// thousand entries comfortably covers any plausible burst across every
+/// configured chat while keeping memory bounded for the life of the
+/// process.
+const DEDUP_CAPACITY: usize = 10_000;
+
+/// A `HashSet` bounded to at most `capacity` entries via FIFO eviction:
+/// once full, inserting a new key evicts the oldest still-tracked key.
+/// Used for [`ConnectBridge::seen_message_ids`] — a plain `HashSet` there
+/// would gain one entry per distinct `platform:message_id` for the life of
+/// the process (issue #454 follow-up).
+struct BoundedSeenSet {
+    set: HashSet<String>,
+    order: VecDeque<String>,
+    capacity: usize,
+}
+
+impl BoundedSeenSet {
+    fn new(capacity: usize) -> Self {
+        Self {
+            set: HashSet::new(),
+            order: VecDeque::new(),
+            capacity: capacity.max(1),
+        }
+    }
+
+    /// Inserts `key`, evicting the oldest tracked key(s) if this pushes the
+    /// set past capacity. Returns `true` if `key` was newly inserted (i.e.
+    /// not a duplicate) — same contract as `HashSet::insert`.
+    fn insert(&mut self, key: String) -> bool {
+        if !self.set.insert(key.clone()) {
+            return false;
+        }
+        self.order.push_back(key);
+        while self.order.len() > self.capacity {
+            if let Some(oldest) = self.order.pop_front() {
+                self.set.remove(&oldest);
+            }
+        }
+        true
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.set.len()
+    }
+}
+
 /// Shared dependencies the bridge needs to run sessions through the
 /// canonical execution path. Cheap to clone (every field is an `Arc`, or
 /// small/`Clone`).
@@ -236,9 +288,11 @@ pub struct ConnectBridge {
     chat_state: AsyncMutex<HashMap<String, ChatState>>,
     /// `platform:message_id` seen so far — dedup defense-in-depth alongside
     /// each adapter's own transport-level dedup (e.g. Telegram's offset
-    /// advance). A `std::sync::Mutex` is fine here: only ever locked for a
-    /// single `HashSet::insert`, never held across an `.await`.
-    seen_message_ids: StdMutex<HashSet<String>>,
+    /// advance). Bounded (issue #454 follow-up: see [`BoundedSeenSet`]) so
+    /// it never grows without limit for the life of the process. A
+    /// `std::sync::Mutex` is fine here: only ever locked for a single
+    /// insert, never held across an `.await`.
+    seen_message_ids: StdMutex<BoundedSeenSet>,
     process_start: DateTime<Utc>,
     /// The resolution seam (issue #458): `submit_pending_response` +
     /// `resume_session_execution`, or a fake in tests.
@@ -267,7 +321,7 @@ impl ConnectBridge {
             session_map: TokioRwLock::new(HashMap::new()),
             map_path,
             chat_state: AsyncMutex::new(HashMap::new()),
-            seen_message_ids: StdMutex::new(HashSet::new()),
+            seen_message_ids: StdMutex::new(BoundedSeenSet::new(DEDUP_CAPACITY)),
             process_start: Utc::now(),
             responder,
         }
@@ -1219,6 +1273,45 @@ mod tests {
             user_id: "7".to_string(),
         };
         assert_eq!(key.as_string(), "telegram:42:7");
+    }
+
+    // ---- Issue #454 follow-up: bounded dedup set ----
+
+    #[test]
+    fn bounded_seen_set_evicts_the_oldest_entry_once_over_capacity() {
+        let mut set = BoundedSeenSet::new(2);
+        assert!(set.insert("a".to_string()));
+        assert!(set.insert("b".to_string()));
+        assert_eq!(set.len(), 2);
+
+        // Pushes past capacity: "a" (oldest) is evicted; "b" and "c" remain
+        // tracked as seen.
+        assert!(set.insert("c".to_string()));
+        assert_eq!(set.len(), 2);
+        assert!(!set.insert("b".to_string()), "b must still be tracked");
+        assert!(!set.insert("c".to_string()), "c must still be tracked");
+
+        // "a" was evicted — re-inserting it is treated as new, not a
+        // duplicate (which in turn evicts "b", the now-oldest entry).
+        assert!(set.insert("a".to_string()));
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn bounded_seen_set_still_dedups_within_capacity() {
+        let mut set = BoundedSeenSet::new(10);
+        assert!(set.insert("x".to_string()));
+        assert!(!set.insert("x".to_string()), "duplicate must be rejected");
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn bounded_seen_set_never_grows_past_capacity() {
+        let mut set = BoundedSeenSet::new(50);
+        for i in 0..5_000 {
+            set.insert(format!("msg-{i}"));
+        }
+        assert_eq!(set.len(), 50);
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/connect/mod.rs
+++ b/crates/app/bamboo-server/src/connect/mod.rs
@@ -38,6 +38,7 @@ use std::sync::Arc;
 
 use tokio::sync::mpsc;
 
+use bamboo_config::ConnectPlatformConfig;
 use bamboo_llm::Config;
 
 /// Owns every configured platform's long-poll/dispatch background task plus
@@ -64,13 +65,35 @@ impl ConnectManager {
         bridge.load_session_map().await;
 
         let mut tasks = Vec::new();
-        for platform_cfg in &config_snapshot.connect.platforms {
+        let telegram_start_ok = telegram_multi_bot_guard(&config_snapshot.connect.platforms);
+        for (index, platform_cfg) in config_snapshot.connect.platforms.iter().enumerate() {
             match platform_cfg.platform_type.as_str() {
                 "telegram" => {
                     let token = platform_cfg.token.clone().unwrap_or_default();
                     if token.trim().is_empty() {
                         tracing::warn!(
                             "connect: telegram platform configured without a token; skipping"
+                        );
+                        continue;
+                    }
+                    // Issue #454 follow-up: `SessionKey`/`InboundMessage.platform`
+                    // hardcode `"telegram"` for every adapter instance, so two
+                    // live telegram bots on one server would collide on
+                    // `telegram:<chat_id>:<user_id>` — a private chat's
+                    // `chat_id` equals the Telegram user id, so a user who
+                    // messages BOTH bots would silently share one bamboo
+                    // session across them. Until per-bot session keys are
+                    // supported, start at most the first validly-configured
+                    // telegram entry and reject the rest with a clear warning
+                    // rather than let them collide.
+                    if !telegram_start_ok[index] {
+                        tracing::warn!(
+                            "connect: multiple telegram platform entries are configured; only \
+                             the FIRST is started. A second telegram bot on this instance would \
+                             collide with the first on the same session-routing key \
+                             (`telegram:<chat_id>:<user_id>`), silently mixing sessions for any \
+                             user who messages both bots. Remove the extra entry, or track \
+                             issue #454 for per-bot session keys."
                         );
                         continue;
                     }
@@ -123,6 +146,54 @@ impl Drop for ConnectManager {
     }
 }
 
+/// Issue #454 follow-up (multi-bot session-key collision): for each entry in
+/// `platforms` (same order/length as the input), returns whether
+/// [`ConnectManager::start`] is allowed to start it as far as the
+/// "at most one live telegram bot" guard is concerned.
+///
+/// `SessionKey`/`InboundMessage.platform` hardcode `"telegram"` — there is no
+/// per-bot/config-index component in the session-routing key — so two
+/// telegram entries running at once would route messages from the SAME
+/// Telegram user (private-chat `chat_id` == user id) to different bots into
+/// the SAME bamboo session key, mixing their conversations. Rather than the
+/// more invasive fix of threading a bot identity through `SessionKey`
+/// (touching the routing key, the persisted session map's key format, and
+/// every call site that builds one), this rejects the collision at the
+/// source: only the FIRST validly-configured (`platform_type == "telegram"`
+/// and a non-empty token) entry is ever started; every other telegram entry
+/// is guarded off here regardless of how many are configured.
+///
+/// Entries with an empty/absent token are left `true` — they're handled by
+/// [`ConnectManager::start`]'s pre-existing "no token configured" skip, which
+/// doesn't count as a "started" telegram bot for this guard's purposes (so a
+/// blank placeholder entry followed by one real entry still starts the real
+/// one). Non-telegram entries are always `true` — this guard doesn't apply to
+/// them.
+fn telegram_multi_bot_guard(platforms: &[ConnectPlatformConfig]) -> Vec<bool> {
+    let mut seen_valid_telegram = false;
+    platforms
+        .iter()
+        .map(|platform_cfg| {
+            if platform_cfg.platform_type != "telegram" {
+                return true;
+            }
+            let has_token = platform_cfg
+                .token
+                .as_deref()
+                .is_some_and(|token| !token.trim().is_empty());
+            if !has_token {
+                return true;
+            }
+            if seen_valid_telegram {
+                false
+            } else {
+                seen_valid_telegram = true;
+                true
+            }
+        })
+        .collect()
+}
+
 /// Pulls inbound events (messages and button-press callbacks, issue #458)
 /// off a single platform's channel and hands each to the bridge. Kept as its
 /// OWN task per platform (not merged into the platform's `start()` loop) so
@@ -157,5 +228,71 @@ async fn dispatch_loop(
                 .await;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn platform(platform_type: &str, token: Option<&str>) -> ConnectPlatformConfig {
+        ConnectPlatformConfig {
+            platform_type: platform_type.to_string(),
+            token: token.map(str::to_string),
+            token_encrypted: None,
+            allow_from: Vec::new(),
+            admin_from: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn telegram_multi_bot_guard_allows_a_single_telegram_entry() {
+        let platforms = vec![platform("telegram", Some("tok-1"))];
+        assert_eq!(telegram_multi_bot_guard(&platforms), vec![true]);
+    }
+
+    #[test]
+    fn telegram_multi_bot_guard_rejects_every_telegram_entry_after_the_first() {
+        let platforms = vec![
+            platform("telegram", Some("tok-1")),
+            platform("telegram", Some("tok-2")),
+            platform("telegram", Some("tok-3")),
+        ];
+        assert_eq!(
+            telegram_multi_bot_guard(&platforms),
+            vec![true, false, false]
+        );
+    }
+
+    #[test]
+    fn telegram_multi_bot_guard_ignores_non_telegram_entries() {
+        let platforms = vec![
+            platform("telegram", Some("tok-1")),
+            platform("feishu", Some("tok-x")),
+            platform("telegram", Some("tok-2")),
+        ];
+        assert_eq!(
+            telegram_multi_bot_guard(&platforms),
+            vec![true, true, false]
+        );
+    }
+
+    /// A blank/absent-token entry doesn't count as a "started" telegram bot
+    /// for this guard — `ConnectManager::start`'s pre-existing empty-token
+    /// check skips it separately, so the NEXT (real) telegram entry must
+    /// still be allowed to start.
+    #[test]
+    fn telegram_multi_bot_guard_does_not_count_a_tokenless_entry_against_the_budget() {
+        let platforms = vec![
+            platform("telegram", None),
+            platform("telegram", Some("")),
+            platform("telegram", Some("tok-real")),
+        ];
+        assert_eq!(telegram_multi_bot_guard(&platforms), vec![true, true, true]);
+    }
+
+    #[test]
+    fn telegram_multi_bot_guard_handles_an_empty_platform_list() {
+        assert_eq!(telegram_multi_bot_guard(&[]), Vec::<bool>::new());
     }
 }

--- a/crates/app/bamboo-server/src/connect/platforms/telegram.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/telegram.rs
@@ -118,11 +118,27 @@ impl RateLimiter {
             let earliest = guard.get(key).copied().unwrap_or(now);
             let scheduled = earliest.max(now);
             guard.insert(key.to_string(), scheduled + self.min_interval);
+            // Bound growth (issue #454 follow-up): without this, the map
+            // gains one entry per distinct chat id for the life of the
+            // process, even after a chat goes permanently idle. Sweep out
+            // every entry whose reserved slot has ALREADY elapsed — safe
+            // because a swept key's next `wait()` falls back to `now` via
+            // `unwrap_or(now)` above, i.e. exactly the value we're
+            // discarding, so this never changes scheduling behavior. The
+            // entry this call just inserted is always `> now` (it's
+            // `scheduled + min_interval` with `scheduled >= now`), so it
+            // always survives its own sweep.
+            guard.retain(|_, next_allowed| *next_allowed > now);
             scheduled
         };
         if scheduled > now {
             tokio::time::sleep(scheduled - now).await;
         }
+    }
+
+    #[cfg(test)]
+    async fn tracked_chat_count(&self) -> usize {
+        self.next_allowed.lock().await.len()
     }
 }
 
@@ -771,6 +787,44 @@ mod tests {
             elapsed < Duration::from_millis(50),
             "sends to DIFFERENT chats must not share a rate-limit slot, elapsed={elapsed:?}"
         );
+    }
+
+    /// Issue #454 follow-up: `RateLimiter::next_allowed` must not grow one
+    /// entry per distinct chat for the life of the process — a chat's entry
+    /// is swept once its reserved slot has elapsed, rather than lingering
+    /// forever.
+    #[tokio::test]
+    async fn rate_limiter_sweeps_stale_entries_instead_of_growing_unbounded() {
+        let limiter = RateLimiter::new(Duration::from_millis(20));
+
+        limiter.wait("chat-1").await;
+        assert_eq!(limiter.tracked_chat_count().await, 1);
+
+        // Let chat-1's reserved slot fully elapse before any other chat is
+        // seen.
+        tokio::time::sleep(Duration::from_millis(40)).await;
+
+        // A wait for a DIFFERENT chat must sweep chat-1's now-stale entry
+        // out rather than accumulate it forever.
+        limiter.wait("chat-2").await;
+        assert_eq!(
+            limiter.tracked_chat_count().await,
+            1,
+            "stale chat-1 entry must have been swept when chat-2 was scheduled"
+        );
+
+        // Simulate many distinct, one-shot chats spaced far enough apart
+        // that each previous entry is stale by the time the next arrives —
+        // the tracked count must stay bounded to the currently-relevant
+        // entry/entries, not grow to the number of chats ever seen.
+        for i in 0..50 {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            limiter.wait(&format!("burst-chat-{i}")).await;
+            assert!(
+                limiter.tracked_chat_count().await <= 2,
+                "map grew unbounded after {i} one-shot chats"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-config/src/patch.rs
+++ b/crates/infra/bamboo-config/src/patch.rs
@@ -419,6 +419,20 @@ pub fn preserve_masked_notification_secrets(patch_obj: &mut Map<String, Value>, 
 /// `env_vars`' full-array replace relies on) — reordering platforms in the
 /// same request as leaving a token masked is not supported and drops that
 /// entry's token, same as no plaintext being configured yet.
+///
+/// Known limitation (issue #454 follow-up), still present: there is no
+/// stable per-entry id, so reordering two entries of the SAME
+/// `platform_type` (e.g. two `"telegram"` entries, once multi-bot is
+/// supported) at the same time as leaving one masked is indistinguishable
+/// from "not reordered" and can still attach the wrong token to an entry —
+/// fixing that needs a schema change (a stable id field) tracked separately.
+/// What IS fixed here: a reorder is now detected whenever it changes the
+/// `platform_type` at a given index (the common case today, since only one
+/// platform type — `"telegram"` — exists) — `type` is checked against
+/// `current`'s entry at the same index, and a mismatch is treated as
+/// "nothing configured at this position" (the token is dropped, same as no
+/// plaintext existing yet) instead of silently handing one platform's secret
+/// to a different one that happens to now sit at the same index.
 pub fn preserve_masked_connect_secrets(patch_obj: &mut Map<String, Value>, current: &Config) {
     let Some(platforms) = patch_obj
         .get_mut("connect")
@@ -432,11 +446,22 @@ pub fn preserve_masked_connect_secrets(patch_obj: &mut Map<String, Value>, curre
         let Some(obj) = platform.as_object_mut() else {
             continue;
         };
-        let existing_plain = current
-            .connect
-            .platforms
-            .get(index)
-            .and_then(|p| p.token.as_deref());
+        let existing = current.connect.platforms.get(index);
+        // A patch entry that names a "type" disagreeing with `current`'s
+        // entry at the same index means the array was reordered (or an
+        // entry was inserted/removed) since the client fetched it — the
+        // position no longer identifies the same logical platform, so don't
+        // resolve the mask against it. A patch entry with no "type" at all
+        // (shouldn't happen with a well-behaved client, which always echoes
+        // the whole object back) can't be checked and falls back to the
+        // pre-existing positional-only behavior.
+        let existing_plain = existing.and_then(|p| {
+            let type_matches = match obj.get("type").and_then(|v| v.as_str()) {
+                Some(patch_type) => patch_type == p.platform_type,
+                None => true,
+            };
+            type_matches.then_some(p).and_then(|p| p.token.as_deref())
+        });
         preserve_masked_secret_field(obj, "token", existing_plain);
     }
 }
@@ -716,6 +741,112 @@ mod tests {
         assert_eq!(
             patch["connect"]["platforms"][0]["token"],
             "tg-real-new-value"
+        );
+    }
+
+    /// Issue #454 follow-up: if the array was reordered/edited since the
+    /// client fetched it — detectable here because the patch entry's "type"
+    /// disagrees with `current`'s entry at the same index — a masked token
+    /// must NOT be resolved against the wrong (now co-located) platform's
+    /// plaintext; it must drop, exactly like "nothing configured yet".
+    #[test]
+    fn preserve_masked_connect_secrets_drops_mask_when_type_at_index_disagrees() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![connect_platform("telegram", "telegram-secret-token")];
+
+        // The patch's entry at index 0 claims to be a DIFFERENT platform type
+        // than what's actually at `current.connect.platforms[0]` — e.g. a
+        // reorder/insert raced the fetch that pre-filled this mask.
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[{"type":"feishu","token":"****...****"}]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert!(
+            !patch["connect"]["platforms"][0]
+                .as_object()
+                .unwrap()
+                .contains_key("token"),
+            "masked token must not be resolved against a different platform's secret"
+        );
+    }
+
+    /// The type-check is index-scoped, not "does this type appear anywhere
+    /// in current" — a mismatch at index 1 must not fall back to matching
+    /// against a same-typed entry that lives at a different index.
+    #[test]
+    fn preserve_masked_connect_secrets_type_check_does_not_search_other_indices() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![
+            connect_platform("telegram", "bot-a-token"),
+            connect_platform("feishu", "feishu-token"),
+        ];
+
+        // Patch entry at index 1 claims "telegram" (matches index 0's type,
+        // NOT index 1's) — must still drop, not borrow index 0's token.
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[
+                {"type":"telegram","token":"tg-real-value"},
+                {"type":"telegram","token":"****...****"}
+            ]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert_eq!(patch["connect"]["platforms"][0]["token"], "tg-real-value");
+        assert!(
+            !patch["connect"]["platforms"][1]
+                .as_object()
+                .unwrap()
+                .contains_key("token"),
+            "index 1's mismatched type must not resolve to index 0's token"
+        );
+    }
+
+    /// A patch entry with a matching "type" at its index is unaffected by
+    /// the new guard — this is the common case and must keep working exactly
+    /// as before.
+    #[test]
+    fn preserve_masked_connect_secrets_keeps_plaintext_when_type_at_index_matches() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![
+            connect_platform("telegram", "bot-a-token"),
+            connect_platform("telegram", "bot-b-token"),
+        ];
+
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[
+                {"type":"telegram","token":"****...****"},
+                {"type":"telegram","token":"****...****"}
+            ]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert_eq!(patch["connect"]["platforms"][0]["token"], "bot-a-token");
+        assert_eq!(patch["connect"]["platforms"][1]["token"], "bot-b-token");
+    }
+
+    /// A patch entry missing "type" entirely (shouldn't happen with a
+    /// well-behaved client) falls back to the pre-existing positional-only
+    /// behavior rather than being treated as an automatic mismatch.
+    #[test]
+    fn preserve_masked_connect_secrets_falls_back_to_positional_when_type_is_absent() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![connect_platform("telegram", "existing-bot-token")];
+
+        let mut patch: Map<String, Value> =
+            serde_json::from_str(r#"{"connect":{"platforms":[{"token":"****...****"}]}}"#).unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert_eq!(
+            patch["connect"]["platforms"][0]["token"],
+            "existing-bot-token"
         );
     }
 }


### PR DESCRIPTION
Closes #454 — the three non-blocking findings from the PR #453 review.

## Changes

1. **Bounded map growth**
   - `RateLimiter::wait` (telegram.rs) now sweeps entries whose reserved slot has already elapsed (`retain(|_, next| *next > now)` after each insert). Behavior-preserving by construction: a swept key's next `wait()` falls back to `now` via the existing `unwrap_or(now)`, which is exactly the discarded value. No timer/background task needed.
   - The bridge dedup set is now a `BoundedSeenSet` (FIFO eviction, capacity 10 000) instead of an unbounded `HashSet` — documented as defense-in-depth dedup layered on Telegram's own offset advance, not a permanent log.
2. **Multi-bot session-key collision**: chose the issue's validation option over threading bot identity through `SessionKey` (which would ripple into the routing-key format and the persisted session map). New pure `telegram_multi_bot_guard`: `ConnectManager::start` starts at most the FIRST validly-configured telegram entry and warn-skips the rest (naming the exact collision and this issue), matching the existing warn-and-skip pattern for other misconfigurations. Tokenless placeholder entries don't count against the budget.
3. **Positional masked-token preserve**: `preserve_masked_connect_secrets` now cross-checks the patch entry's `"type"` against `current.connect.platforms[index].platform_type`; on mismatch (evidence of reorder/insert) the masked token drops instead of resolving against the wrong platform's secret. The check is index-scoped (no cross-index search). Remaining limitation — same-type reorders are still undetectable without a stable per-entry id (schema change, out of scope) — is documented in the doc comment and pinned by a test.

## Tests

New coverage: `BoundedSeenSet` eviction/dedup/capacity (3 tests), rate-limiter sweep under many one-shot chats, `telegram_multi_bot_guard` (5 cases incl. tokenless placeholders and non-telegram entries), masked-token type-mismatch/index-scoping/matching/absent-type fallback (4 tests).

- `cargo test -p bamboo-server --lib`: 1187 passed
- `cargo test -p bamboo-config --lib`: 202 passed
- `cargo fmt --check` / `cargo clippy --all-targets` on both crates: clean in touched files

## Notes for review

- Item 2 is warn-and-degrade (only the first bot starts), not a hard startup failure — a hard failure would need `ConnectManager::start` to return `Result`, rippling into `app_state/builder.rs`. Flag if you'd prefer that instead.
- `BoundedSeenSet` eviction is capacity-based, not time-based; `RateLimiter`'s sweep is O(map) per `wait()` — both fine at connect-bot volumes, noted for future scale.
- Deliberately did not touch `config.rs` or `config_endpoints/{common,reset,tests}.rs` to avoid conflicting with #460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jxUSVTtay3Usa6n8eUaFK

---
_Generated by [Claude Code](https://claude.ai/code/session_015jxUSVTtay3Usa6n8eUaFK)_