### PR TITLE
feat(broker): wire the MCP proxy role allowlist end-to-end

### DIFF
--- a/crates/app/bamboo-broker/src/mcp.rs
+++ b/crates/app/bamboo-broker/src/mcp.rs
@@ -105,6 +105,31 @@ pub struct ProxiedResult {
 /// workers; the issue (#54) asks for restricted roles to be filtered while
 /// default/unrestricted roles keep all tools. Restrictions are therefore opt-in
 /// and explicit per role.
+///
+/// # Trust boundary: the role is SELF-ASSERTED, not authenticated
+///
+/// `serve_mcp_proxy` resolves the requesting role from `msg.from.role` — the
+/// `AgentRef` the connecting worker chose to Hello/subscribe with — not from any
+/// identity independently verified against the broker's auth (a shared bearer
+/// token authenticates the *connection*, not a claimed *role* on it). A worker
+/// that connects with a bearer token valid for the broker can claim ANY role
+/// string in its `AgentRef`, including one with a wider (or no) allowlist entry,
+/// and the proxy has no way to tell it apart from a legitimately-deployed worker
+/// of that role.
+///
+/// Concretely, this allowlist is:
+/// - **Adequate** against a confused/hallucinating worker running its assigned
+///   role honestly (the common case this issue targets — least-privilege
+///   scoping so an LLM's tool-call mistake can't reach `nova_screenshot` from a
+///   `researcher` role).
+/// - **Not** a security boundary against a worker that is compromised or
+///   deliberately malicious — such a worker can simply assert a role that is
+///   unrestricted (or has a wider allowlist) and bypass this policy entirely.
+///
+/// Closing that gap needs authenticating the role itself (e.g. per-role broker
+/// credentials, or signing the `AgentRef` at provisioning time) — out of scope
+/// for this issue; deployers who need that guarantee should not rely on this
+/// allowlist as their only control on a genuinely untrusted worker.
 #[derive(Debug, Clone, Default)]
 pub struct RoleToolAllowlist {
     /// role → set of tool names that role is allowed to proxy. A role absent from
@@ -143,6 +168,87 @@ impl RoleToolAllowlist {
         self.by_role
             .insert(role.into(), tools.into_iter().map(Into::into).collect());
         self
+    }
+
+    /// Build from config-sourced `(role, tools)` entries (issue #54), logging
+    /// load-time warnings for likely misconfiguration instead of silently
+    /// failing open. Exact-string matching means a typo'd role or tool name
+    /// has NO other signal: a misspelled role just never matches (looks
+    /// unrestricted to the operator, since the intended role falls through to
+    /// "no entry"), and a misspelled tool name silently grants nothing for the
+    /// tool the deployer actually meant to allow. This is the one point where
+    /// that can be caught.
+    ///
+    /// There is no fixed registry of valid ROLE names in this codebase (roles
+    /// are free-form profile ids assigned at deploy/spawn time), so role
+    /// validation here is structural only:
+    /// - A blank/whitespace-only role is dropped (warned) — it can never match
+    ///   a real `AgentRef.role`.
+    /// - A duplicate role entry: the later one wins (warned) — config authors
+    ///   should not rely on ordering.
+    ///
+    /// TOOL names, by contrast, CAN be checked against a real source of truth:
+    /// pass the backend's currently-registered tool names as `known_tools`
+    /// (empty ⇒ skip this check, e.g. when the backend's tool set is not yet
+    /// known at config-load time). A tool name not in `known_tools` is still
+    /// kept (still enforced — the backend can register tools after this
+    /// policy is built, so absence isn't proof of a typo) but is warned as a
+    /// likely typo.
+    pub fn from_config<R, T, I>(entries: I, known_tools: &HashSet<String>) -> Self
+    where
+        R: Into<String>,
+        T: Into<String>,
+        I: IntoIterator<Item = (R, Vec<T>)>,
+    {
+        let mut by_role: HashMap<String, HashSet<String>> = HashMap::new();
+        for (role, tools) in entries {
+            let role: String = role.into().trim().to_string();
+            if role.is_empty() {
+                tracing::warn!(
+                    "mcp role allowlist config: skipping an entry with a blank role name \
+                     (it could never match a real worker's role)"
+                );
+                continue;
+            }
+            if by_role.contains_key(&role) {
+                tracing::warn!(
+                    role = %role,
+                    "mcp role allowlist config: duplicate entry for this role; \
+                     the later entry replaces the earlier one"
+                );
+            }
+            let tool_set: HashSet<String> = tools
+                .into_iter()
+                .map(Into::into)
+                .filter_map(|t| {
+                    let t = t.trim().to_string();
+                    if t.is_empty() {
+                        tracing::warn!(
+                            role = %role,
+                            "mcp role allowlist config: skipping a blank tool name"
+                        );
+                        None
+                    } else {
+                        Some(t)
+                    }
+                })
+                .collect();
+            if !known_tools.is_empty() {
+                for tool in &tool_set {
+                    if !known_tools.contains(tool) {
+                        tracing::warn!(
+                            role = %role,
+                            tool = %tool,
+                            "mcp role allowlist config: tool name is not in the orchestrator's \
+                             current MCP tool set (check for a typo) — the entry is still \
+                             enforced, so a mistyped name silently grants nothing for it"
+                        );
+                    }
+                }
+            }
+            by_role.insert(role, tool_set);
+        }
+        Self { by_role }
     }
 
     /// Whether `role` is restricted (has an explicit allowlist entry). A `None`
@@ -438,16 +544,27 @@ impl McpProxyExecutor {
     /// Connect (as `proxy_id` — keep it distinct from the worker's main mailbox,
     /// e.g. `<worker-id>#mcp`), fetch the proxiable-tool manifest from
     /// `orchestrator`, and build. Returns a proxy advertising those tools.
+    ///
+    /// `role` is this worker's own role (e.g. `spec.identity.role`), advertised
+    /// on the `AgentRef` this connection Hello/subscribes with so the
+    /// orchestrator's [`RoleToolAllowlist`] (if configured) can scope the
+    /// manifest/calls to it — `None`/empty leaves the worker unrestricted
+    /// (matches pre-#54 behavior and any orchestrator with no allowlist
+    /// configured). Note this is SELF-ASSERTED by the worker, not
+    /// authenticated — see the trust-boundary section on
+    /// [`RoleToolAllowlist`]'s doc comment; do not treat it as a security
+    /// boundary against a malicious worker.
     pub async fn connect(
         endpoint: &str,
         proxy_id: impl Into<String>,
+        role: Option<String>,
         token: &str,
         orchestrator: impl Into<String>,
         timeout: Duration,
     ) -> BrokerResult<Self> {
         let me = AgentRef {
             session_id: proxy_id.into(),
-            role: None,
+            role,
         };
         let orchestrator = orchestrator.into();
         let mut client = BrokerClient::connect(endpoint, me.clone(), token).await?;
@@ -862,6 +979,66 @@ mod tests {
         assert_eq!(reply.result.expect("result").result, "ran nova_screenshot");
     }
 
+    /// Issue #54 item 3: `from_config` validates at load time — a blank role
+    /// name is dropped, a duplicate role keeps the LATER entry, a blank tool
+    /// name is dropped, and an unknown tool name (vs. `known_tools`, standing
+    /// in for the backend's real tool set) is still KEPT/enforced (it may just
+    /// not be registered yet) rather than silently dropped. None of this
+    /// panics or errors — misconfiguration only warns (fails open per the
+    /// existing unrestricted-by-default posture), which this test asserts by
+    /// checking the resulting allowlist's effective behavior.
+    #[test]
+    fn from_config_validates_and_normalizes_entries() {
+        let known_tools: HashSet<String> = ["fetch_url", "nova_click"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let allowlist = RoleToolAllowlist::from_config(
+            vec![
+                // Blank role: dropped entirely (can never match a real AgentRef.role).
+                ("   ".to_string(), vec!["fetch_url".to_string()]),
+                // Duplicate role "researcher": the second entry wins.
+                ("researcher".to_string(), vec!["nova_click".to_string()]),
+                (
+                    "researcher".to_string(),
+                    vec!["fetch_url".to_string(), "  ".to_string()],
+                ),
+                // Unknown tool name (typo) vs `known_tools`: still enforced.
+                ("typo-role".to_string(), vec!["fetch_urll".to_string()]),
+            ],
+            &known_tools,
+        );
+
+        // Blank role never matches anything, so it is unrestricted (absent),
+        // not restricted-to-nothing.
+        assert!(!allowlist.is_restricted(Some("   ")));
+
+        // The LATER "researcher" entry (fetch_url, blank dropped) won, not the
+        // earlier one (nova_click) — and the blank tool name was dropped.
+        assert!(allowlist.allows(Some("researcher"), "fetch_url"));
+        assert!(!allowlist.allows(Some("researcher"), "nova_click"));
+
+        // A tool name absent from `known_tools` (a likely typo) is still
+        // enforced — presence in `known_tools` is a validation SIGNAL
+        // (warned), not a hard filter.
+        assert!(allowlist.allows(Some("typo-role"), "fetch_urll"));
+        assert!(!allowlist.allows(Some("typo-role"), "fetch_url"));
+    }
+
+    /// `from_config` with an EMPTY `known_tools` set (e.g. the backend's tool
+    /// list is not available yet at config-load time) skips tool-name
+    /// validation entirely rather than flagging every configured tool as
+    /// unknown — the allowlist itself is unaffected either way.
+    #[test]
+    fn from_config_skips_tool_validation_when_known_tools_is_empty() {
+        let allowlist = RoleToolAllowlist::from_config(
+            vec![("researcher", vec!["anything_at_all"])],
+            &HashSet::new(),
+        );
+        assert!(allowlist.allows(Some("researcher"), "anything_at_all"));
+        assert!(!allowlist.allows(Some("researcher"), "other_tool"));
+    }
+
     /// A role mapped to an EMPTY allowlist is an explicit lockout (no tools),
     /// distinct from an absent role (unrestricted).
     #[tokio::test]
@@ -909,6 +1086,7 @@ mod tests {
         let proxy = McpProxyExecutor::connect(
             &endpoint,
             "worker#mcp",
+            None,
             TOKEN,
             "orchestrator",
             Duration::from_secs(5),
@@ -947,6 +1125,114 @@ mod tests {
         ));
     }
 
+    /// Issue #54, REAL path: drives `RoleToolAllowlist` filtering through the
+    /// ACTUAL production wiring — a real broker, `serve_mcp_proxy` reading the
+    /// role off the connecting worker's `AgentRef` (not `handle_mcp_request`
+    /// called directly with an explicit allowlist), and `McpProxyExecutor::
+    /// connect` advertising the worker's real role. Exercising only
+    /// `handle_mcp_request` (as the other unit tests in this module do) would
+    /// mask the exact bug #54 was reopened for: the role never reaching the
+    /// orchestrator-side filter in production because nothing threaded it
+    /// through the real connect/serve path.
+    #[tokio::test]
+    async fn proxy_executor_role_is_filtered_end_to_end_over_the_real_broker() {
+        let dir = tempfile::tempdir().unwrap();
+        let core = Arc::new(BrokerCore::new(dir.path()));
+        let server = Arc::new(BrokerServer::new(core, TOKEN));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = server.serve(listener).await;
+        });
+        let endpoint = format!("ws://{addr}");
+
+        // Orchestrator: "researcher" may only proxy the benign fetch tool.
+        let ep = endpoint.clone();
+        tokio::spawn(async move {
+            let _ = serve_mcp_proxy(
+                &ep,
+                AgentRef {
+                    session_id: "orchestrator".into(),
+                    role: None,
+                },
+                TOKEN,
+                Arc::new(MultiToolMcp),
+                Arc::new(RoleToolAllowlist::unrestricted().with_role("researcher", ["fetch_url"])),
+            )
+            .await;
+        });
+
+        // A worker connecting AS "researcher" — over the real broker, with its
+        // role threaded through `McpProxyExecutor::connect` exactly as
+        // `subagent_worker.rs` does in production — must see only its role's
+        // allowed tool in the manifest it fetches on connect.
+        let restricted = McpProxyExecutor::connect(
+            &endpoint,
+            "worker-researcher#mcp",
+            Some("researcher".to_string()),
+            TOKEN,
+            "orchestrator",
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("restricted proxy connects + fetches its role-scoped manifest");
+        let tools = restricted.list_tools();
+        assert_eq!(
+            tools
+                .iter()
+                .map(|t| t.function.name.clone())
+                .collect::<Vec<_>>(),
+            vec!["fetch_url".to_string()],
+            "a role WITH an allowlist entry must see only its allowed tools over the real path"
+        );
+
+        // The allowed tool executes normally...
+        let ok_call = ToolCall {
+            id: "c1".into(),
+            tool_type: "function".into(),
+            function: FunctionCall {
+                name: "fetch_url".into(),
+                arguments: "{}".into(),
+            },
+        };
+        let result = restricted
+            .execute(&ok_call)
+            .await
+            .expect("allowed tool call succeeds");
+        assert!(result.success);
+
+        // ...but a disallowed tool is invisible in the manifest, so the LOCAL
+        // "not in my manifest" check rejects it before it is even sent —
+        // proving the manifest filtering (not just the orchestrator's
+        // defense-in-depth Call check) actually took effect end-to-end.
+        let denied_call = ToolCall {
+            id: "c2".into(),
+            tool_type: "function".into(),
+            function: FunctionCall {
+                name: "nova_screenshot".into(),
+                arguments: "{}".into(),
+            },
+        };
+        assert!(matches!(
+            restricted.execute(&denied_call).await,
+            Err(ToolError::NotFound(_))
+        ));
+
+        // A worker connecting with NO role (unrestricted, back-compat) still
+        // sees the full tool set over the same real orchestrator/allowlist.
+        let unrestricted = McpProxyExecutor::connect(
+            &endpoint,
+            "worker-unrestricted#mcp",
+            None,
+            TOKEN,
+            "orchestrator",
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("unrestricted proxy connects");
+        assert_eq!(unrestricted.list_tools().len(), 3);
+    }
+
     #[tokio::test]
     async fn proxy_handles_concurrent_calls_correctly() {
         let dir = tempfile::tempdir().unwrap();
@@ -978,6 +1264,7 @@ mod tests {
             McpProxyExecutor::connect(
                 &endpoint,
                 "worker#mcp",
+                None,
                 TOKEN,
                 "orchestrator",
                 Duration::from_secs(5),
@@ -1079,6 +1366,7 @@ mod tests {
             McpProxyExecutor::connect(
                 &endpoint,
                 "worker#mcp",
+                None,
                 TOKEN,
                 "orchestrator",
                 Duration::from_secs(5),
@@ -1317,6 +1605,7 @@ mod tests {
         let proxy = McpProxyExecutor::connect(
             &endpoint,
             "worker#mcp",
+            None,
             TOKEN,
             "orchestrator",
             Duration::from_secs(5),

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -324,18 +324,61 @@ impl AppState {
                         mcp_manager.tool_index(),
                     ));
                 let shutdown = mcp_proxy_shutdown.clone();
+
+                // Build the orchestrator-side per-role MCP tool allowlist from
+                // config (issue #54). Enforcement lives HERE — never in the
+                // worker-facing `McpProxyConfig` a deployed worker receives —
+                // because a worker self-declaring its own allowlist would be
+                // insecure (it could simply claim to be unrestricted). Validate
+                // configured tool names against THIS backend's real, live tool
+                // set so a typo in `config.json` is surfaced at boot instead of
+                // silently granting nothing for the intended tool.
+                let role_entries: Vec<(String, Vec<String>)> = config_snapshot
+                    .subagents
+                    .mcp_role_allowlist
+                    .iter()
+                    .map(|e| (e.role.clone(), e.tools.clone()))
+                    .collect();
+                if role_entries.is_empty() {
+                    // Default behavior unchanged (issue #54 item 5): no policy
+                    // configured -> every role sees/can call every proxied
+                    // tool. Logged once here at boot (not per-request) so an
+                    // operator can tell the restriction is opt-in rather than
+                    // silently absent.
+                    tracing::info!(
+                        "mcp proxy: no subagents.mcp_role_allowlist configured — every worker \
+                         role sees/can call the full host-bound MCP tool set (opt in a role \
+                         policy in config.json to scope tools per role; see issue #54)"
+                    );
+                }
+                // NOTE: `init_mcp_manager` connects MCP servers in a background
+                // task so the HTTP API stays responsive at boot — this backend's
+                // `list_tools()` can legitimately be empty here if that task
+                // hasn't finished yet. `from_config` treats an empty set as "skip
+                // tool-name validation" rather than flagging every configured
+                // tool as an unknown typo, so warn separately here when that
+                // race means validation was effectively skipped.
+                let known_tools: std::collections::HashSet<String> = backend
+                    .list_tools()
+                    .into_iter()
+                    .map(|t| t.function.name)
+                    .collect();
+                if !role_entries.is_empty() && known_tools.is_empty() {
+                    tracing::warn!(
+                        "mcp role allowlist: the orchestrator's MCP tool set was empty at \
+                         policy-load time (servers may still be connecting in the background) — \
+                         skipped tool-name typo validation for subagents.mcp_role_allowlist"
+                    );
+                }
+                let allowlist = std::sync::Arc::new(bamboo_broker::RoleToolAllowlist::from_config(
+                    role_entries,
+                    &known_tools,
+                ));
                 tokio::spawn(async move {
                     let me = bamboo_broker::AgentRef {
                         session_id: bamboo_broker::ORCHESTRATOR_ID.to_string(),
                         role: Some("orchestrator".into()),
                     };
-                    // No per-role tool allowlist is configured here yet, so the
-                    // proxy is unrestricted (every role sees/can call all
-                    // host-bound tools) — identical to the pre-#54 behavior.
-                    // Wiring a config-driven allowlist in is a follow-up; the
-                    // filtering mechanism (RoleToolAllowlist) is now in place.
-                    let allowlist =
-                        std::sync::Arc::new(bamboo_broker::RoleToolAllowlist::unrestricted());
                     bamboo_broker::serve_mcp_proxy_supervised(
                         &broker.endpoint,
                         me,

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -425,6 +425,49 @@ pub struct SubagentsConfig {
     /// first in `build_spec`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub schedulable_placements: Vec<SchedulablePlacement>,
+    /// Per-role allowlist scoping which host-bound MCP tools a sub-agent role
+    /// may see/call through the orchestrator's MCP proxy (issue #54;
+    /// `bamboo_broker::RoleToolAllowlist`). Read and enforced
+    /// ORCHESTRATOR-side when wiring `serve_mcp_proxy` — this is deliberately
+    /// NOT part of the worker-facing `McpProxyConfig` a deployed worker
+    /// receives, because a worker self-declaring its own allowlist would be
+    /// insecure (it could simply claim to be unrestricted). A role absent
+    /// from this list is unrestricted (sees/can call every proxiable tool),
+    /// so adding this policy never silently strips tools from an
+    /// already-deployed role you have not listed here. Empty (the default)
+    /// keeps every role unrestricted — fully backward compatible with
+    /// pre-#54 behavior.
+    ///
+    /// Role AND tool names are matched by exact string equality against the
+    /// worker-asserted `AgentRef.role` / the requested tool name — see
+    /// `RoleToolAllowlist`'s doc comment for the resulting self-asserted-role
+    /// caveat (this policy is adequate against a confused/hallucinating
+    /// worker, not a malicious one that lies about its own role).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mcp_role_allowlist: Vec<McpRoleAllowlistEntry>,
+}
+
+/// One role's MCP proxy tool allowlist entry (issue #54). See
+/// [`SubagentsConfig::mcp_role_allowlist`].
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct McpRoleAllowlistEntry {
+    /// Sub-agent role this entry restricts — matches the worker-asserted
+    /// `AgentRef.role` (itself the child session's `subagent_type` /
+    /// `ChildIdentity.role`). There is no fixed registry of valid roles in
+    /// this codebase (roles are free-form profile ids), so a typo here is
+    /// NOT caught against a "known roles" list — only structurally (blank
+    /// names are dropped, duplicates warn) at load time. Double-check this
+    /// against the role string your profile/deploy config actually uses.
+    pub role: String,
+    /// Tool names this role may see in its manifest / call through the
+    /// proxy, matched by exact string equality against the backend's
+    /// registered tool name. An entry with an EMPTY list is an explicit
+    /// lockout (no tools) for that role, distinct from the role being absent
+    /// from this Vec entirely (unrestricted). Validated at load time against
+    /// the orchestrator's live MCP tool set where available — an unknown
+    /// name is still enforced (kept) but logged as a likely typo.
+    #[serde(default)]
+    pub tools: Vec<String>,
 }
 
 /// Routes a single sub-agent role to a registry-scheduled worker (remote-actor-
@@ -2999,6 +3042,44 @@ mod tests {
         assert_eq!(cfg, reparsed, "round-trip is stable");
         assert!(!back.contains("\"token_env\":null"));
         assert!(!back.contains("\"ca_cert_file\":null"));
+    }
+
+    #[test]
+    fn subagents_config_without_mcp_role_allowlist_deserializes_empty() {
+        // An OLD config (predating #54's wiring) has no `mcp_role_allowlist`
+        // key — it must still deserialize, with an empty list (default =
+        // every role unrestricted, identical to pre-#54 behavior).
+        let json = r#"{ "max_concurrent": 4 }"#;
+        let cfg: SubagentsConfig = serde_json::from_str(json).expect("old config deserializes");
+        assert!(cfg.mcp_role_allowlist.is_empty());
+        // An empty list is omitted on re-serialize (skip_if empty).
+        let back = serde_json::to_string(&cfg).unwrap();
+        assert!(
+            !back.contains("mcp_role_allowlist"),
+            "empty vec is skipped: {back}"
+        );
+    }
+
+    #[test]
+    fn mcp_role_allowlist_entry_round_trips() {
+        let json = r#"{
+            "mcp_role_allowlist": [
+                { "role": "researcher", "tools": ["fetch_url"] },
+                { "role": "sandboxed", "tools": [] }
+            ]
+        }"#;
+        let cfg: SubagentsConfig = serde_json::from_str(json).expect("populated config");
+        assert_eq!(cfg.mcp_role_allowlist.len(), 2);
+        assert_eq!(cfg.mcp_role_allowlist[0].role, "researcher");
+        assert_eq!(cfg.mcp_role_allowlist[0].tools, vec!["fetch_url"]);
+        // An empty `tools` list is an explicit lockout, distinct from the role
+        // being absent — it must round-trip as an empty (not omitted) list.
+        assert_eq!(cfg.mcp_role_allowlist[1].role, "sandboxed");
+        assert!(cfg.mcp_role_allowlist[1].tools.is_empty());
+
+        let back = serde_json::to_string(&cfg).unwrap();
+        let reparsed: SubagentsConfig = serde_json::from_str(&back).unwrap();
+        assert_eq!(cfg, reparsed, "round-trip is stable");
     }
 
     #[test]

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -191,11 +191,23 @@ bamboo broker-agent serve --broker ws://host:9600 --token $T \
 ```jsonc
 "subagents": {
   "max_concurrent": 8,
-  "broker": { "endpoint": "ws://broker-host:9600", "token": "…" }   // 启用 broker 工具 + MCP 代理服务
+  "broker": { "endpoint": "ws://broker-host:9600", "token": "…" },  // 启用 broker 工具 + MCP 代理服务
+  "mcp_role_allowlist": [                                          // 可选(issue #54):按角色收窄代理工具面
+    { "role": "researcher", "tools": ["fetch_url"] },
+    { "role": "sandboxed", "tools": [] }                           // 空数组 = 显式锁死(0 工具)
+  ]
 }
 ```
 配了 `subagents.broker` 才会:Root 工具面挂上 `deploy_agent`/`ask_agent`,且 server 启动
 `serve_mcp_proxy`。
+
+`mcp_role_allowlist` 为空(默认)= 每个角色都不受限,行为与 #54 之前完全一致。列出的角色只能
+看到/调用其 `tools` 里的工具(manifest 过滤 + Call 兜底拒绝双重生效);未列出的角色仍不受限。
+**信任边界**:这里的 `role` 取自连接 worker 自报的 `AgentRef.role`(`ChildIdentity.role`),
+**不是**经过 broker 鉴权验证的身份——同一个 bearer token 能连接的 worker 可以自称任意角色。
+所以这个 allowlist 只能防"跑歪了的/幻觉的"worker(它按分配到的角色老实上报),挡不住真正
+恶意、蓄意冒充其他角色的 worker;需要更强边界(per-role broker 凭证、签名 `AgentRef` 等)不在
+本 issue 范围内。
 
 ---
 

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -330,9 +330,18 @@ impl BambooRuntimeExecutor {
             spec.capabilities.mcp_proxy.as_ref()
         {
             let proxy_id = format!("{}#mcp", spec.identity.child_id);
+            // Thread this worker's REAL role (issue #54) so the orchestrator's
+            // per-role MCP allowlist — if configured — actually scopes it.
+            // Previously this hardcoded `None`, so the real worker-proxy path
+            // advertised no role and bypassed filtering even when configured.
+            // Blank role (`ChildIdentity::role` defaults to "") is normalized
+            // to `None` (unrestricted), matching the rest of the allowlist's
+            // "no role" semantics.
+            let role = (!spec.identity.role.trim().is_empty()).then(|| spec.identity.role.clone());
             match bamboo_broker::McpProxyExecutor::connect(
                 &proxy.endpoint,
                 proxy_id,
+                role,
                 &proxy.token,
                 &proxy.orchestrator,
                 std::time::Duration::from_secs(30),


### PR DESCRIPTION
Closes #54. The filtering mechanism (`RoleToolAllowlist` + manifest filter + defense-in-depth Call rejection) landed in #177; this PR closes the runtime gap the issue was reopened for.

## Changes

1. **Config source (orchestrator-side)**: new `SubagentsConfig.mcp_role_allowlist: Vec<McpRoleAllowlistEntry>` (`{role, tools}`). Deliberately NOT on the worker-facing `McpProxyConfig` — a worker self-declaring its allowlist would be insecure. `app_state/builder.rs` builds the policy via a new validating `RoleToolAllowlist::from_config` and passes it to `serve_mcp_proxy_supervised` instead of `unrestricted()`.
2. **Real worker role threading**: `McpProxyExecutor::connect` takes `role: Option<String>` instead of hardcoding `role: None`; `subagent_worker.rs` passes `spec.identity.role` (blank normalized to `None`) on the real worker-proxy path.
3. **Load-time validation**: blank role/tool names dropped (warned), duplicate roles warn (later wins), and tool names are checked against the backend's live `list_tools()` set — unknown names are still enforced but warned as likely typos. MCP servers connect in a background task, so an empty tool set at policy-build time skips the typo check with its own explicit warning instead of false-flagging everything.
4. **Self-asserted-role limitation documented**: trust-boundary section on `RoleToolAllowlist` (enforcement point), `connect`'s `role` param, the config fields, and `docs/architecture-overview.md` §6 — adequate against a confused/hallucinating worker, not a security boundary against a malicious one (that needs authenticated roles, out of scope per the issue).
5. **Default unchanged**: empty/absent `mcp_role_allowlist` → all tools for all roles (identical to pre-#54), with a one-time boot log so operators can tell the restriction is opt-in.

**Integration test on the REAL path**: `proxy_executor_role_is_filtered_end_to_end_over_the_real_broker` spins up a real `BrokerServer` + `serve_mcp_proxy` and connects via `McpProxyExecutor::connect` with `role: Some("researcher")` — asserting the manifest and calls are filtered over the wire, exactly the path the issue flagged as untested (driving `handle_mcp_request` directly would mask production never activating the filter). A no-role connect on the same orchestrator still sees the full tool set (back-compat).

## Tests

- `cargo test -p bamboo-broker --lib`: 56 passed (4 new)
- `cargo test -p bamboo-config --lib`: 200 passed (2 new, incl. old-config back-compat round-trip)
- `cargo test -p bamboo-server --lib`: 1178 passed; `cargo test -p bamboo-agent --lib`: 98 passed
- `cargo fmt --check` clean; clippy clean in all touched files

## Notes for review

- Tool-name typo validation is best-effort by timing (background MCP init) — an alternative is deferring policy construction until MCP init completes; flagged for your call.
- Role names have no registry to validate against (free-form profile ids) — a typo'd role only shows up as "never restricts anything"; called out in doc comments.
- The self-asserted-role gap is documented, not fixed, per the issue's scoping.
- Touches `bamboo-config/src/config.rs` in the `SubagentsConfig` region — far from #460's connect-function edits in the same file; conflict surface should be nil-to-trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jxUSVTtay3Usa6n8eUaFK

---
_Generated by [Claude Code](https://claude.ai/code/session_015jxUSVTtay3Usa6n8eUaFK)_