### PR TITLE
feat(plugin): --insecure flag + plugin_trust.enforcement=off to skip all trust checks

### DIFF
--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -51,6 +51,21 @@ impl AppState {
         // Load config from the specified data directory
         let config = Config::from_data_dir(Some(bamboo_home_dir.clone()));
 
+        // Loud, unmissable startup signal: `plugin_trust.enforcement: off`
+        // silently affects EVERY future `bamboo plugin install`/`update`
+        // (URL sources skip the host allowlist, signature, and checksum
+        // layers with no per-install flag needed — see
+        // `bamboo_server::plugin_source`'s module docs), not just one
+        // command invocation, so it gets its own warning here at boot in
+        // addition to the per-install warning `fetch_manifest_bundle` logs
+        // for each individual insecure install.
+        if config.plugin_trust.enforcement_is_off() {
+            tracing::warn!(
+                "plugin_trust.enforcement is OFF — plugin installs from ANY URL are accepted \
+                 without host/signature/checksum verification (config.json plugin_trust.enforcement)"
+            );
+        }
+
         let provider_registry =
             match bamboo_llm::ProviderRegistry::from_config(&config, bamboo_home_dir.clone()).await
             {

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -58,12 +58,12 @@ impl AppState {
         // `bamboo_server::plugin_source`'s module docs), not just one
         // command invocation, so it gets its own warning here at boot in
         // addition to the per-install warning `fetch_manifest_bundle` logs
-        // for each individual insecure install.
+        // for each individual insecure install. The live config-apply paths
+        // (`update_config`/`replace_config`) emit the SAME warning on a flip
+        // to `Off`, so no trigger — boot, `bamboo config set`, or an HTTP
+        // config PATCH — can relax it silently.
         if config.plugin_trust.enforcement_is_off() {
-            tracing::warn!(
-                "plugin_trust.enforcement is OFF — plugin installs from ANY URL are accepted \
-                 without host/signature/checksum verification (config.json plugin_trust.enforcement)"
-            );
+            super::config_runtime::warn_plugin_trust_enforcement_off();
         }
 
         let provider_registry =

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -148,12 +148,23 @@ impl AppState {
         // effects (provider reload) don't need to block reloads/other updates.
         let snapshot = {
             let _io = self.config_io_lock.lock().await;
-            let snapshot = {
+            let (snapshot, enforcement_newly_off) = {
                 let mut cfg = self.config.write().await;
+                let was_off = cfg.plugin_trust.enforcement_is_off();
                 update(&mut cfg)?;
                 cfg.publish_env_vars();
-                cfg.clone()
+                let newly_off = !was_off && cfg.plugin_trust.enforcement_is_off();
+                (cfg.clone(), newly_off)
             };
+            // Loud signal at the MOMENT plugin_trust.enforcement is flipped off
+            // live (e.g. via `bamboo config set plugin_trust.enforcement off`
+            // over HTTP), mirroring the boot-time warn in `AppState::new` — so
+            // this security-relevant relaxation is never applied silently. Only
+            // on the transition into `Off` (not every unrelated config write
+            // while already off).
+            if enforcement_newly_off {
+                warn_plugin_trust_enforcement_off();
+            }
             self.persist_config_snapshot(snapshot.clone())
                 .await
                 .map_err(|e| {
@@ -176,10 +187,18 @@ impl AppState {
         // config-IO lock so a reload can't interleave; effects run unlocked.
         {
             let _io = self.config_io_lock.lock().await;
-            {
+            let enforcement_newly_off = {
                 let mut cfg = self.config.write().await;
+                let was_off = cfg.plugin_trust.enforcement_is_off();
                 *cfg = new_config.clone();
                 cfg.publish_env_vars();
+                !was_off && cfg.plugin_trust.enforcement_is_off()
+            };
+            // Same live signal as `update_config` — a full-config replace (JSON
+            // merge / PATCH endpoints) that transitions plugin_trust.enforcement
+            // into `Off` must warn just as loudly as a targeted set.
+            if enforcement_newly_off {
+                warn_plugin_trust_enforcement_off();
             }
             self.persist_config_snapshot(new_config.clone())
                 .await
@@ -214,4 +233,20 @@ impl AppState {
 
         Ok(())
     }
+}
+
+/// The prominent warning emitted whenever `plugin_trust.enforcement` is (or
+/// becomes) `Off` — that setting silently downgrades EVERY subsequent `url`
+/// plugin install/update to skip the host allowlist, signature, and
+/// checksum-required-by-default layers, with no per-install flag needed (see
+/// `crate::plugin_source`'s module docs). Factored into one function so the
+/// boot-time signal (`AppState::new`) and the live-apply signal
+/// (`update_config`/`replace_config`, covering the HTTP `config set` / PATCH
+/// paths) emit the EXACT same message — no drift, and no trigger can flip
+/// enforcement off silently.
+pub(crate) fn warn_plugin_trust_enforcement_off() {
+    tracing::warn!(
+        "plugin_trust.enforcement is OFF — plugin installs from ANY URL are accepted \
+         without host/signature/checksum verification (config.json plugin_trust.enforcement)"
+    );
 }

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/api_types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/api_types.rs
@@ -15,13 +15,14 @@
 //! `#[serde(tag = "type", rename_all = "snake_case")]` wire shape directly —
 //! `{"type":"local_dir","path":...}` / `{"type":"local_archive","path":...}` /
 //! `{"type":"url","url":...,"sha256":...?,"allow_unverified":...?,
-//! "allow_untrusted_host":...?,"allow_unsigned":...?}` — rather than
-//! inventing a parallel request enum: it is already exactly the shape both
-//! the CLI and this HTTP layer need, and it doubles as the provenance record
-//! `install()` persists (see `bamboo_plugin::registry::PluginSource`'s doc
-//! comment). `signed_by` is also part of that same wire shape but is
-//! response-only in practice — a request-supplied value is ignored (see
-//! `to_source_input`).
+//! "allow_untrusted_host":...?,"allow_unsigned":...?,"insecure":...?}` —
+//! rather than inventing a parallel request enum: it is already exactly the
+//! shape both the CLI and this HTTP layer need, and it doubles as the
+//! provenance record `install()` persists (see
+//! `bamboo_plugin::registry::PluginSource`'s doc comment). `signed_by` is
+//! also part of that same wire shape but is response-only in practice — a
+//! request-supplied value is ignored (see `to_source_input`). `insecure`, by
+//! contrast, IS a real request-side input (see below).
 //!
 //! **Three trust layers (`url` sources), enforced together in
 //! `plugin_source::fetch_manifest_bundle`** (see that module's docs for the
@@ -46,6 +47,19 @@
 //!
 //! So `POST /install` with a bare `{"type":"url","url":"..."}` body no
 //! longer just downloads and trusts any tar.gz from any host.
+//!
+//! **`insecure` — the aggregate escape hatch.** `"insecure": true` on a `url`
+//! source is shorthand for setting `allow_untrusted_host`, `allow_unsigned`
+//! AND `allow_unverified` all at once for THIS request — see
+//! `plugin_source.rs`'s "`--insecure` / `plugin_trust.enforcement`" module
+//! docs section. A supplied `sha256` is still verified even with
+//! `insecure: true` (the aggregate only turns default-required checks OFF;
+//! it never turns off a check the caller explicitly opted into). The same
+//! aggregate also applies server-wide, with no per-request field needed, when
+//! `plugin_trust.enforcement` is `"off"` in `config.json`. This route sits
+//! behind the same `enforce_access_password_middleware` wrap as every other
+//! `/api/v1/plugins` route (see `routes::agent::plugin_scope`), so `insecure`
+//! is not an additional unauthenticated surface.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/handlers.rs
@@ -26,12 +26,18 @@ fn plugins_root(state: &AppState) -> PathBuf {
 /// The wire `SourceSpec` reuses `bamboo_plugin::PluginSource`'s own serde
 /// shape (see `api_types` module docs) directly as the request body — a
 /// `url` source's `sha256`/`allow_unverified`/`allow_untrusted_host`/
-/// `allow_unsigned` flow straight through to `PluginSourceInput::Url`, which
-/// `plugin_source::fetch_manifest_bundle` enforces (the three-layer trust
-/// model: host allowlist, signature, checksum — see that module's docs).
-/// `signed_by` is a RESULT of staging (which key verified), never an input,
-/// so it's dropped here — the request-side `PluginSource::Url` field is
-/// meaningless on the way in and `fetch_manifest_bundle` recomputes it fresh.
+/// `allow_unsigned`/`insecure` flow straight through to
+/// `PluginSourceInput::Url`, which `plugin_source::fetch_manifest_bundle`
+/// enforces (the three-layer trust model: host allowlist, signature,
+/// checksum — plus the `insecure`/`plugin_trust.enforcement` aggregate
+/// escape hatch over all three — see that module's docs). `signed_by` is a
+/// RESULT of staging (which key verified), never an input, so it's dropped
+/// here — the request-side `PluginSource::Url` field is meaningless on the
+/// way in and `fetch_manifest_bundle` recomputes it fresh. `insecure`, by
+/// contrast, genuinely IS an input here (the caller's `--insecure` /
+/// `"insecure": true` opt-in) — this authenticated/local-only HTTP surface
+/// is already behind the access-password middleware (see `routes`), same as
+/// every other `/api/v1/plugins` route.
 fn to_source_input(source: PluginSource) -> PluginSourceInput {
     match source {
         PluginSource::LocalDir { path } => PluginSourceInput::LocalDir(path),
@@ -43,12 +49,14 @@ fn to_source_input(source: PluginSource) -> PluginSourceInput {
             allow_untrusted_host,
             allow_unsigned,
             signed_by: _,
+            insecure,
         } => PluginSourceInput::Url {
             url,
             sha256,
             allow_unverified,
             allow_untrusted_host,
             allow_unsigned,
+            insecure,
         },
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
@@ -600,3 +600,128 @@ async fn install_url_with_allow_unverified_and_no_sha256_succeeds() {
     assert_eq!(view["id"], "hello-plugin");
     assert!(view["source"]["sha256"].is_null());
 }
+
+// ---------------------------------------------------------------------
+// `insecure` — the SourceSpec aggregate — and `plugin_trust.enforcement`
+// (the config-level form), exercised end to end through the real HTTP
+// handlers. Unit coverage of the same aggregate at the
+// `plugin_source::fetch_manifest_bundle` level lives in
+// `plugin_source::tests`.
+// ---------------------------------------------------------------------
+
+/// `SourceSpec` with `"insecure": true` and every individual `allow_*`
+/// omitted — proves the aggregate ALONE (not any per-layer flag) is what
+/// lets an untrusted-host, unsigned, unchecksummed install through.
+fn url_source_insecure(url: &str) -> serde_json::Value {
+    serde_json::json!({ "source": { "type": "url", "url": url, "insecure": true } })
+}
+
+#[actix_web::test]
+async fn install_url_with_insecure_true_bypasses_all_three_layers() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let state = test_state(data_dir.path()).await;
+    let app = test::init_service(plugin_test_app!(state.clone())).await;
+
+    // A plain wiremock server: never in `plugin_trust.trusted_hosts`, never
+    // https, no `.sig` mounted, no `sha256` given — every one of the three
+    // layers would refuse this under Strict with no flags.
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+    let url = format!("{}/plugin.json", server.uri());
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/plugins/install")
+        .set_json(url_source_insecure(&url))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let view = body_json(resp).await;
+    assert_eq!(view["id"], "hello-plugin");
+    assert_eq!(view["source"]["type"], "url");
+    assert!(view["source"]["sha256"].is_null());
+    // Provenance records the aggregate.
+    assert_eq!(view["source"]["insecure"], true);
+}
+
+#[actix_web::test]
+async fn install_url_with_insecure_true_still_refuses_a_wrong_sha256() {
+    // Precedence: `insecure: true` must not downgrade a caller-supplied
+    // checksum — a WRONG sha256 alongside it still refuses the install.
+    let data_dir = tempfile::tempdir().unwrap();
+    let state = test_state(data_dir.path()).await;
+    let app = test::init_service(plugin_test_app!(state.clone())).await;
+
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+    let url = format!("{}/plugin.json", server.uri());
+    let wrong_sha256 = "d".repeat(64);
+
+    let mut source = url_source_insecure(&url);
+    source["source"]["sha256"] = serde_json::Value::String(wrong_sha256);
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/plugins/install")
+        .set_json(source)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let error = body_json(resp).await;
+    assert!(
+        error["error"].as_str().unwrap().contains("mismatch"),
+        "{error}"
+    );
+
+    let req = test::TestRequest::get().uri("/api/v1/plugins").to_request();
+    let resp = test::call_service(&app, req).await;
+    let listed = body_json(resp).await;
+    assert!(listed["plugins"].as_array().unwrap().is_empty());
+}
+
+#[actix_web::test]
+async fn install_url_with_plugin_trust_enforcement_off_needs_no_per_request_flags() {
+    // The PERSISTENT, config-level form: flip `plugin_trust.enforcement` to
+    // `off` on this server's config, then install with a BARE `url` source —
+    // no `insecure`, no individual `allow_*` flags at all.
+    let data_dir = tempfile::tempdir().unwrap();
+    let state = test_state(data_dir.path()).await;
+    state
+        .update_config(
+            |cfg| {
+                cfg.plugin_trust.enforcement = bamboo_config::PluginTrustEnforcement::Off;
+                Ok(())
+            },
+            Default::default(),
+        )
+        .await
+        .expect("set plugin_trust.enforcement = off");
+    let app = test::init_service(plugin_test_app!(state.clone())).await;
+
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+    let url = format!("{}/plugin.json", server.uri());
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/plugins/install")
+        .set_json(serde_json::json!({ "source": { "type": "url", "url": url } }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let view = body_json(resp).await;
+    assert_eq!(view["id"], "hello-plugin");
+    assert_eq!(view["source"]["insecure"], true);
+}

--- a/crates/app/bamboo-server/src/plugin_source.rs
+++ b/crates/app/bamboo-server/src/plugin_source.rs
@@ -48,6 +48,44 @@
 //!   case, where the host allowlist is the sole control (see
 //!   [`http_client_no_redirects`]).
 //!
+//! # `--insecure` / `plugin_trust.enforcement`: skip ALL three layers at once
+//!
+//! The three `allow_*` opt-outs above are per-layer. On top of them,
+//! [`PluginSourceInput::Url::insecure`] is a convenience AGGREGATE — set it
+//! (CLI: `--insecure`; HTTP: `"insecure": true` on the `url` source) and
+//! [`fetch_manifest_bundle`] treats `allow_untrusted_host`, `allow_unsigned`
+//! AND `allow_unverified` as all `true` for that one install, without the
+//! caller spelling out all three. There is also a PERSISTENT, config-level
+//! form for an operator who never wants to pass flags at all:
+//! `bamboo_config::PluginTrustConfig::enforcement` set to
+//! `PluginTrustEnforcement::Off` makes EVERY `url` install/update behave as
+//! if `--insecure` were passed, with no per-install flag needed. Precedence,
+//! in both cases:
+//!
+//! - The aggregate ONLY turns per-layer checks OFF — it never turns off a
+//!   check the caller opted INTO. A supplied `sha256` is still hashed and
+//!   compared; a mismatch is still [`PluginError::BundleVerificationFailed`],
+//!   `--insecure`/`enforcement: off` or not. So `--insecure --sha256 <hex>`
+//!   means "skip host/signature enforcement AND the bare
+//!   sha256-required-by-default rule, but still verify THIS hash".
+//! - The per-layer flags keep working independently — a caller who wants to
+//!   waive just the host allowlist (say) still passes
+//!   `--allow-untrusted-host` alone; the aggregate is a shortcut for "all
+//!   three", not a replacement for them.
+//! - `plugin_trust.enforcement` defaults to `Strict` (secure by default) for
+//!   both a fresh config and one with no `plugin_trust.enforcement` key at
+//!   all — this is opt-in relaxation, never a silent weakening.
+//!
+//! Every install where the aggregate is active — via `insecure: true` on the
+//! request OR `plugin_trust.enforcement: off` — logs a prominent
+//! `tracing::warn!` naming the source URL, and records `insecure: true` in
+//! the resulting `PluginSource::Url` provenance (`bamboo plugin list`/audit
+//! can then tell these installs apart from ones where the same three
+//! individual `allow_*` flags merely happened to all be set). A server
+//! booting with `plugin_trust.enforcement: off` also logs its own startup
+//! warning (see `AppState::new`), since that setting silently affects EVERY
+//! future install, not just one command invocation.
+//!
 //!   THEN, separately, for [`Platform::current`] (if the manifest declares an
 //!   artifact for it), fetches the per-platform binary archive named in
 //!   `manifest.artifacts`, verifies its sha256 BEFORE unpacking (mandatory —
@@ -179,12 +217,21 @@ pub enum PluginSourceInput {
     /// - `sha256`/`allow_unverified`: the checksum layer, unchanged from
     ///   before EXCEPT a verified signature now also satisfies it (see
     ///   [`fetch_manifest_bundle`]) — see [`PluginError::ChecksumRequired`].
+    ///
+    /// Plus `insecure`: the convenience AGGREGATE opt-out over all three
+    /// above (equivalent to setting `allow_untrusted_host`, `allow_unsigned`
+    /// AND `allow_unverified` together for THIS install) — see the module
+    /// docs' "`--insecure` / `plugin_trust.enforcement`" section. A supplied
+    /// `sha256` is still verified even when `insecure` is set (`insecure`
+    /// only turns checks OFF; it never turns a check the caller opted INTO
+    /// off too).
     Url {
         url: String,
         sha256: Option<String>,
         allow_unverified: bool,
         allow_untrusted_host: bool,
         allow_unsigned: bool,
+        insecure: bool,
     },
 }
 
@@ -385,14 +432,16 @@ async fn stage_into(
             allow_unverified,
             allow_untrusted_host,
             allow_unsigned,
+            insecure,
         } => {
             let flags = UrlTrustFlags {
                 sha256: sha256.as_deref(),
                 allow_unverified: *allow_unverified,
                 allow_untrusted_host: *allow_untrusted_host,
                 allow_unsigned: *allow_unsigned,
+                insecure: *insecure,
             };
-            let (manifest, verified_bundle_sha256, signed_by) =
+            let fetched =
                 fetch_manifest_bundle(url, flags, trust, staging_dir, max_decompressed_bytes)
                     .await?;
             // Binary-artifact verification stays as defense in depth (see
@@ -401,16 +450,25 @@ async fn stage_into(
             // `fetch_and_place_artifact`, but no longer double-duty as the
             // `PluginSource::Url` provenance hash: that's the bundle's own
             // verified sha256 now, computed above.
-            fetch_and_place_artifact(&manifest, staging_dir, max_decompressed_bytes).await?;
+            fetch_and_place_artifact(&fetched.manifest, staging_dir, max_decompressed_bytes)
+                .await?;
             Ok((
-                manifest,
+                fetched.manifest,
                 PluginSource::Url {
                     url: url.clone(),
-                    sha256: verified_bundle_sha256,
+                    sha256: fetched.verified_sha256,
                     allow_unverified: *allow_unverified,
                     allow_untrusted_host: *allow_untrusted_host,
                     allow_unsigned: *allow_unsigned,
-                    signed_by,
+                    signed_by: fetched.signed_by,
+                    // The AGGREGATE, not the raw per-install `insecure` flag:
+                    // recorded `true` whenever ALL three layers were actually
+                    // skipped for this install, whether that came from the
+                    // per-install flag or from `plugin_trust.enforcement:
+                    // off` (see `fetch_manifest_bundle`) — either way, this is
+                    // the single source of truth for "was this install done
+                    // insecurely" that `plugin list`/audit needs.
+                    insecure: fetched.insecure_aggregate,
                 },
             ))
         }
@@ -424,7 +482,7 @@ async fn stage_into(
 /// The caller-supplied bits of a [`PluginSourceInput::Url`] that
 /// [`fetch_manifest_bundle`] needs, grouped into one struct purely to keep
 /// that function's parameter count sane (`PluginSourceInput::Url` itself
-/// carries the same four fields, plus `url`, which stays a separate
+/// carries the same five fields, plus `url`, which stays a separate
 /// top-level parameter since [`fetch_and_verify_signature`] and the sha256
 /// helpers all key off it directly).
 struct UrlTrustFlags<'a> {
@@ -432,6 +490,31 @@ struct UrlTrustFlags<'a> {
     allow_unverified: bool,
     allow_untrusted_host: bool,
     allow_unsigned: bool,
+    /// The per-install `--insecure` / `"insecure": true` aggregate opt-out
+    /// (see the module docs' "`--insecure` / `plugin_trust.enforcement`"
+    /// section). ORed with `trust.enforcement_is_off()` inside
+    /// [`fetch_manifest_bundle`] to compute the EFFECTIVE aggregate for this
+    /// install — a config-level `enforcement: off` has the same effect as
+    /// this flag without the caller having to set it.
+    insecure: bool,
+}
+
+/// Everything [`fetch_manifest_bundle`] hands back to [`stage_into`].
+struct FetchedBundle {
+    manifest: PluginManifest,
+    /// The verified bundle sha256 (`None` unless a `sha256` was supplied and
+    /// confirmed) — for [`PluginSource::Url`] provenance.
+    verified_sha256: Option<String>,
+    /// The trusted key label the signature verified against (`None` if the
+    /// install proceeded unsigned via `allow_unsigned`/the insecure
+    /// aggregate).
+    signed_by: Option<String>,
+    /// The EFFECTIVE aggregate for this install: `true` when ALL three trust
+    /// layers were skipped, whether that came from the per-install
+    /// `insecure` flag or from `plugin_trust.enforcement: off`. This is what
+    /// [`PluginSource::Url::insecure`] provenance records — see
+    /// [`stage_into`].
+    insecure_aggregate: bool,
 }
 
 /// Fetch `url`: either a bare `plugin.json` or an archive containing one
@@ -467,23 +550,53 @@ struct UrlTrustFlags<'a> {
 ///    a mismatch is [`PluginError::BundleVerificationFailed`] regardless of
 ///    signature status.
 ///
-/// Returns the parsed manifest, the verified bundle sha256 (`None` unless a
-/// `sha256` was supplied and confirmed — for [`PluginSource::Url`]
-/// provenance), and the trusted key label the signature verified against
-/// (`None` if the install proceeded unsigned via `allow_unsigned`).
+/// Before any of the three layers run, the EFFECTIVE aggregate is computed:
+/// `flags.insecure || trust.enforcement_is_off()`. When `true`,
+/// `allow_untrusted_host`/`allow_unsigned`/`allow_unverified` are all treated
+/// as `true` for the rest of this call (see the module docs'
+/// "`--insecure` / `plugin_trust.enforcement`" section) and a prominent
+/// `tracing::warn!` names the source URL — this does NOT waive the `sha256`
+/// check itself: a supplied hash is still verified in step 3 below.
+///
+/// Returns a [`FetchedBundle`]: the parsed manifest, the verified bundle
+/// sha256 (`None` unless a `sha256` was supplied and confirmed — for
+/// [`PluginSource::Url`] provenance), the trusted key label the signature
+/// verified against (`None` if the install proceeded unsigned via
+/// `allow_unsigned`/the aggregate), and the effective insecure-aggregate flag
+/// itself (for `PluginSource::Url::insecure` provenance).
 async fn fetch_manifest_bundle(
     url: &str,
     flags: UrlTrustFlags<'_>,
     trust: &PluginTrustConfig,
     staging_dir: &Path,
     max_decompressed_bytes: u64,
-) -> PluginResult<(PluginManifest, Option<String>, Option<String>)> {
+) -> PluginResult<FetchedBundle> {
     let UrlTrustFlags {
         sha256,
         allow_unverified,
         allow_untrusted_host,
         allow_unsigned,
+        insecure,
     } = flags;
+
+    // The convenience aggregate: a per-install `--insecure` flag OR a
+    // config-level `plugin_trust.enforcement: off` both mean "skip all three
+    // layers for this install" — computed once, up front, so every layer
+    // below sees the SAME effective flags regardless of which of the two
+    // triggered it. Shadowing the original `allow_*` bindings means the rest
+    // of this function needs no further special-casing.
+    let insecure_aggregate = insecure || trust.enforcement_is_off();
+    if insecure_aggregate {
+        tracing::warn!(
+            %url,
+            "installing plugin from '{url}' with ALL trust checks disabled (insecure) — host \
+             allowlist, signature and checksum-required-by-default are all skipped for this \
+             install (a supplied --sha256, if any, is still verified)"
+        );
+    }
+    let allow_untrusted_host = allow_untrusted_host || insecure_aggregate;
+    let allow_unsigned = allow_unsigned || insecure_aggregate;
+    let allow_unverified = allow_unverified || insecure_aggregate;
 
     // Layer 1: host allowlist — refuse BEFORE any network access.
     if !trust.is_host_trusted(url) {
@@ -597,7 +710,12 @@ async fn fetch_manifest_bundle(
         PluginManifest::parse_str(&raw)?
     };
 
-    Ok((manifest, verified_sha256, signed_by))
+    Ok(FetchedBundle {
+        manifest,
+        verified_sha256,
+        signed_by,
+        insecure_aggregate,
+    })
 }
 
 /// Fetch `<url>.sig` and verify it against `bundle_bytes` for every

--- a/crates/app/bamboo-server/src/plugin_source/tests.rs
+++ b/crates/app/bamboo-server/src/plugin_source/tests.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
-use bamboo_config::{PluginTrustConfig, TrustedKey};
+use bamboo_config::{PluginTrustConfig, PluginTrustEnforcement, TrustedKey};
 use bamboo_plugin::{
     InstallDisposition, InstalledPlugin, PluginError, PluginInstaller, PluginManifest,
     PluginResult, PluginSource,
@@ -575,9 +575,11 @@ fn url_input(url: &str, sha256: Option<&str>, allow_unverified: bool) -> PluginS
     url_input_full(url, sha256, allow_unverified, true, true)
 }
 
-/// Full constructor for `PluginSourceInput::Url` exercising all five fields —
-/// used directly by the host-allowlist/signature test sections, which need
-/// per-test control over `allow_untrusted_host`/`allow_unsigned`.
+/// Full constructor for `PluginSourceInput::Url` exercising the four
+/// per-layer fields — used directly by the host-allowlist/signature test
+/// sections, which need per-test control over
+/// `allow_untrusted_host`/`allow_unsigned`. Never sets `insecure` (that
+/// aggregate gets its own dedicated section/helper further down).
 fn url_input_full(
     url: &str,
     sha256: Option<&str>,
@@ -591,6 +593,21 @@ fn url_input_full(
         allow_unverified,
         allow_untrusted_host,
         allow_unsigned,
+        insecure: false,
+    }
+}
+
+/// `--insecure` aggregate test helper: every per-layer flag left `false`,
+/// only `insecure` set — proves the AGGREGATE alone (not any individual
+/// `allow_*`) is what waives all three layers.
+fn url_input_insecure(url: &str, sha256: Option<&str>) -> PluginSourceInput {
+    PluginSourceInput::Url {
+        url: url.to_string(),
+        sha256: sha256.map(|s| s.to_string()),
+        allow_unverified: false,
+        allow_untrusted_host: false,
+        allow_unsigned: false,
+        insecure: true,
     }
 }
 
@@ -631,6 +648,7 @@ async fn stages_bare_manifest_from_url_with_correct_bundle_sha256() {
             allow_untrusted_host: true,
             allow_unsigned: true,
             signed_by: None,
+            insecure: false,
         }
     );
     // No skill files were bundled with a bare manifest fetch.
@@ -767,6 +785,7 @@ async fn url_install_with_allow_unverified_and_no_sha256_succeeds() {
             allow_untrusted_host: true,
             allow_unsigned: true,
             signed_by: None,
+            insecure: false,
         },
         "an allow_unverified install has no bundle sha256 to record"
     );
@@ -883,6 +902,7 @@ async fn fetches_verifies_and_places_platform_artifact_binary() {
             allow_untrusted_host: true,
             allow_unsigned: true,
             signed_by: None,
+            insecure: false,
         }
     );
     staged.commit().await;
@@ -1016,6 +1036,7 @@ async fn allow_untrusted_host_bypasses_the_host_allowlist() {
             allow_untrusted_host: true,
             allow_unsigned: true,
             signed_by: None,
+            insecure: false,
         }
     );
     staged.commit().await;
@@ -1062,6 +1083,7 @@ async fn valid_signature_from_a_trusted_key_verifies_and_supersedes_the_checksum
     let trust = PluginTrustConfig {
         trusted_hosts: Vec::new(),
         trusted_keys: vec![trusted_key_for("test-key", &signing_key)],
+        enforcement: PluginTrustEnforcement::Strict,
     };
     let root = tempfile::tempdir().unwrap();
     let plugins_root = root.path().join("plugins");
@@ -1087,6 +1109,7 @@ async fn valid_signature_from_a_trusted_key_verifies_and_supersedes_the_checksum
             allow_untrusted_host: true,
             allow_unsigned: false,
             signed_by: Some("test-key".to_string()),
+            insecure: false,
         },
         "a verified signature is recorded in provenance and needs no bundle sha256"
     );
@@ -1108,6 +1131,7 @@ async fn absent_signature_is_refused_with_unsigned_or_untrusted_signature() {
     let trust = PluginTrustConfig {
         trusted_hosts: Vec::new(),
         trusted_keys: vec![trusted_key_for("test-key", &signing_key)],
+        enforcement: PluginTrustEnforcement::Strict,
     };
     let root = tempfile::tempdir().unwrap();
     let plugins_root = root.path().join("plugins");
@@ -1156,6 +1180,7 @@ async fn signature_from_a_non_trusted_key_is_refused() {
     let trust = PluginTrustConfig {
         trusted_hosts: Vec::new(),
         trusted_keys: vec![trusted_key_for("other-key", &other_key)],
+        enforcement: PluginTrustEnforcement::Strict,
     };
     let root = tempfile::tempdir().unwrap();
     let plugins_root = root.path().join("plugins");
@@ -1224,6 +1249,7 @@ async fn allow_unsigned_bypasses_the_signature_check_but_not_the_checksum_layer(
             allow_untrusted_host: true,
             allow_unsigned: true,
             signed_by: None,
+            insecure: false,
         }
     );
     staged.commit().await;
@@ -1347,6 +1373,7 @@ async fn signed_install_still_follows_a_redirect() {
     let trust = PluginTrustConfig {
         trusted_hosts: PluginTrustConfig::default().trusted_hosts,
         trusted_keys: vec![trusted_key_for("test key", &signing_key)],
+        enforcement: PluginTrustEnforcement::Strict,
     };
 
     wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -1399,9 +1426,224 @@ async fn signed_install_still_follows_a_redirect() {
             allow_untrusted_host: true,
             allow_unsigned: false,
             signed_by: Some("test key".to_string()),
+            insecure: false,
         }
     );
     staged.commit().await;
+}
+
+// ---------------------------------------------------------------------
+// `--insecure` / `plugin_trust.enforcement`: the convenience aggregate that
+// waives all three trust layers at once, per-install (`PluginSourceInput::
+// Url::insecure`) or persistently (`PluginTrustConfig::enforcement ==
+// PluginTrustEnforcement::Off`). A supplied `sha256` is still verified in
+// either case — the aggregate only turns OFF checks the caller didn't
+// otherwise opt into.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn insecure_flag_bypasses_untrusted_host_unsigned_and_no_checksum_all_at_once() {
+    // An install that would be refused on ALL THREE layers under Strict
+    // (untrusted host, no `.sig` mounted, no `sha256`/`allow_unverified`)
+    // must succeed once `insecure: true` is set — proving the aggregate
+    // really does waive all three, not just one.
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+    let url = format!("{}/plugin.json", server.uri());
+
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let staged = stage_plugin_source(
+        url_input_insecure(&url, None),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect("--insecure must waive the host/signature/checksum layers together");
+
+    assert_eq!(staged.manifest.id, "hello-plugin");
+    assert_eq!(
+        staged.source,
+        PluginSource::Url {
+            url,
+            sha256: None,
+            allow_unverified: false,
+            allow_untrusted_host: false,
+            allow_unsigned: false,
+            signed_by: None,
+            // The AGGREGATE is what gets recorded, distinguishing this from
+            // an install where the three `allow_*` flags happened to be set
+            // individually (those stay `false` here — only `insecure` was
+            // ever set).
+            insecure: true,
+        }
+    );
+    staged.commit().await;
+}
+
+#[tokio::test]
+async fn insecure_flag_still_honors_an_explicit_wrong_sha256() {
+    // Precedence check: `--insecure` never downgrades a checksum the caller
+    // actually supplied — a WRONG `sha256` must still refuse the install,
+    // exactly as it would without `--insecure`.
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+    let url = format!("{}/plugin.json", server.uri());
+    let wrong_sha256 = "c".repeat(64);
+
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let error = stage_plugin_source(
+        url_input_insecure(&url, Some(&wrong_sha256)),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err("--insecure must not waive a caller-supplied, mismatched sha256");
+    assert!(
+        matches!(error, PluginError::BundleVerificationFailed(_)),
+        "{error:?}"
+    );
+
+    // Nothing was left under plugins_root.
+    assert!(!plugins_root.join("hello-plugin").exists());
+}
+
+#[tokio::test]
+async fn insecure_flag_still_verifies_a_correct_explicit_sha256() {
+    // The mirror image of the above: a CORRECT `sha256` alongside `--insecure`
+    // is honored too (not merely tolerated) — it's still what gets recorded
+    // in provenance.
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    let bundle_sha256 = sha256_hex_of(manifest_body.as_bytes());
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+    let url = format!("{}/plugin.json", server.uri());
+
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let staged = stage_plugin_source(
+        url_input_insecure(&url, Some(&bundle_sha256)),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect("a correct sha256 alongside --insecure must still verify and stage");
+    assert_eq!(
+        staged.source,
+        PluginSource::Url {
+            url,
+            sha256: Some(bundle_sha256),
+            allow_unverified: false,
+            allow_untrusted_host: false,
+            allow_unsigned: false,
+            signed_by: None,
+            insecure: true,
+        }
+    );
+    staged.commit().await;
+}
+
+#[tokio::test]
+async fn enforcement_off_bypasses_all_layers_with_no_per_install_flags() {
+    // The PERSISTENT, config-level form: `plugin_trust.enforcement: off`
+    // must waive all three layers for a request that sets NONE of the
+    // per-install flags (not even `insecure`) — proving the config alone
+    // drives the aggregate, no per-call opt-in required.
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = hello_manifest_json("hello-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+    let url = format!("{}/plugin.json", server.uri());
+
+    let trust = PluginTrustConfig {
+        enforcement: PluginTrustEnforcement::Off,
+        ..PluginTrustConfig::default()
+    };
+
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    // Every trust flag left at its default (false) — no `--insecure` either.
+    let input = PluginSourceInput::Url {
+        url: url.clone(),
+        sha256: None,
+        allow_unverified: false,
+        allow_untrusted_host: false,
+        allow_unsigned: false,
+        insecure: false,
+    };
+    let staged = stage_plugin_source(input, &plugins_root, &trust)
+        .await
+        .expect("plugin_trust.enforcement: off must waive all layers with no per-call flags");
+
+    assert_eq!(staged.manifest.id, "hello-plugin");
+    assert_eq!(
+        staged.source,
+        PluginSource::Url {
+            url,
+            sha256: None,
+            allow_unverified: false,
+            allow_untrusted_host: false,
+            allow_unsigned: false,
+            signed_by: None,
+            // Recorded true even though NEITHER the request's `insecure` flag
+            // NOR any individual `allow_*` was set — the config drove it.
+            insecure: true,
+        }
+    );
+    staged.commit().await;
+}
+
+#[tokio::test]
+async fn enforcement_strict_is_the_default_and_still_refuses_an_untrusted_host() {
+    // Regression guard: `PluginTrustConfig::default()` (what a fresh/absent
+    // `plugin_trust` config section deserializes to) must remain Strict — an
+    // untrusted-host URL with no flags at all is refused exactly as before
+    // this feature existed.
+    assert_eq!(
+        PluginTrustConfig::default().enforcement,
+        PluginTrustEnforcement::Strict
+    );
+    assert!(!PluginTrustConfig::default().enforcement_is_off());
+
+    let server = wiremock::MockServer::start().await;
+    let url = format!("{}/plugin.json", server.uri());
+
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let input = PluginSourceInput::Url {
+        url,
+        sha256: None,
+        allow_unverified: false,
+        allow_untrusted_host: false,
+        allow_unsigned: false,
+        insecure: false,
+    };
+    let error = stage_plugin_source(input, &plugins_root, &PluginTrustConfig::default())
+        .await
+        .expect_err("Strict (the default) must still refuse an untrusted host with no flags");
+    assert!(matches!(error, PluginError::UntrustedHost(_)));
+
+    // The refusal happened before the URL was ever fetched.
+    let received = server.received_requests().await;
+    assert_eq!(received.map(|r| r.len()), Some(0));
 }
 
 // ---------------------------------------------------------------------
@@ -1417,6 +1659,7 @@ async fn local_dir_install_ignores_a_hostile_trust_config() {
     let hostile_trust = PluginTrustConfig {
         trusted_hosts: Vec::new(),
         trusted_keys: Vec::new(),
+        enforcement: PluginTrustEnforcement::Strict,
     };
     let root = tempfile::tempdir().unwrap();
     let source_dir = root.path().join("source");

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -725,6 +725,21 @@ pub struct PluginTrustConfig {
     /// `--allow-unsigned`.
     #[serde(default = "default_trusted_keys")]
     pub trusted_keys: Vec<TrustedKey>,
+    /// Persistent, config-level escape hatch for the whole three-layer
+    /// policy above: `Off` makes every `url` plugin install/update behave as
+    /// if `--insecure` (equivalently, `--allow-untrusted-host
+    /// --allow-unsigned --allow-unverified`) were passed, WITHOUT needing the
+    /// per-install flag every time — the "I run a private/dev bamboo and
+    /// don't want to pass flags on every install" customization. Defaults to
+    /// [`PluginTrustEnforcement::Strict`] — a fresh config, or one with no
+    /// `plugin_trust.enforcement` key at all, is secure by default; relaxing
+    /// it is always an explicit, user-initiated edit
+    /// (`bamboo config set plugin_trust.enforcement off`), never a silent
+    /// weakening. See `bamboo-server`'s `plugin_source.rs` for where this is
+    /// enforced, and `AppState::new` for the loud startup warning emitted
+    /// whenever a server boots with this set to `Off`.
+    #[serde(default)]
+    pub enforcement: PluginTrustEnforcement,
 }
 
 impl Default for PluginTrustConfig {
@@ -732,6 +747,7 @@ impl Default for PluginTrustConfig {
         Self {
             trusted_hosts: default_trusted_hosts(),
             trusted_keys: default_trusted_keys(),
+            enforcement: PluginTrustEnforcement::default(),
         }
     }
 }
@@ -744,6 +760,68 @@ impl PluginTrustConfig {
     /// unparseable URL or a non-`https` scheme is never trusted).
     pub fn is_host_trusted(&self, url: &str) -> bool {
         is_host_trusted(url, &self.trusted_hosts)
+    }
+
+    /// True when `enforcement` is [`PluginTrustEnforcement::Off`] — every
+    /// `url` plugin install/update should skip the host allowlist, signature,
+    /// and checksum-requirement layers, exactly as if `--insecure` were
+    /// passed to that individual install. See the field's doc comment for
+    /// the full rationale.
+    pub fn enforcement_is_off(&self) -> bool {
+        matches!(self.enforcement, PluginTrustEnforcement::Off)
+    }
+}
+
+/// `plugin_trust.enforcement`: the persistent, config-level form of the
+/// `--insecure` escape hatch (see [`PluginTrustConfig::enforcement`]).
+///
+/// Deserialization accepts either the canonical string form (`"strict"` /
+/// `"off"`, case-insensitive) or a bool-ish alias (`true` == `Strict`,
+/// `false` == `Off`) for a hand-edited `config.json` — `true`/`false` read
+/// naturally as "is enforcement on?". The string form is what
+/// `bamboo config set plugin_trust.enforcement off` writes (and the only
+/// form the generic dot-path setter's round-trip check accepts on write,
+/// since this type always *serializes* back out as a string — see
+/// `bamboo-config`'s `dot_path` module); the bool alias is a read-side
+/// convenience for whoever edits `config.json` directly.
+#[derive(Debug, Clone, Copy, Default, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PluginTrustEnforcement {
+    /// Secure by default: the host allowlist, signature, and checksum layers
+    /// are all enforced (each individually waivable via
+    /// `--allow-untrusted-host` / `--allow-unsigned` / `--allow-unverified`,
+    /// or all at once via `--insecure`).
+    #[default]
+    Strict,
+    /// Every `url` plugin install/update skips all three trust layers,
+    /// without needing any per-install flag. Opt-in only — never the
+    /// default for a fresh or pre-existing config.
+    Off,
+}
+
+impl<'de> Deserialize<'de> for PluginTrustEnforcement {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Bool(bool),
+            Str(String),
+        }
+        match Repr::deserialize(deserializer)? {
+            Repr::Bool(true) => Ok(PluginTrustEnforcement::Strict),
+            Repr::Bool(false) => Ok(PluginTrustEnforcement::Off),
+            Repr::Str(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+                "strict" => Ok(PluginTrustEnforcement::Strict),
+                "off" => Ok(PluginTrustEnforcement::Off),
+                other => Err(serde::de::Error::custom(format!(
+                    "invalid `plugin_trust.enforcement` value '{other}': expected \"strict\" or \
+                     \"off\""
+                ))),
+            },
+        }
     }
 }
 
@@ -5646,6 +5724,141 @@ mod tests {
         assert_eq!(
             config.plugin_trust.trusted_hosts,
             vec!["github.com/bigduu/".to_string(), "example.com".to_string()]
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // `plugin_trust.enforcement` — the persistent, config-level form of the
+    // `--insecure` escape hatch.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn plugin_trust_enforcement_defaults_to_strict_when_absent() {
+        // A fresh `Config::default()` (nothing on disk at all).
+        let config = Config::default();
+        assert_eq!(
+            config.plugin_trust.enforcement,
+            PluginTrustEnforcement::Strict
+        );
+        assert!(!config.plugin_trust.enforcement_is_off());
+
+        // A `plugin_trust` object present in JSON but with NO `enforcement`
+        // key at all (e.g. a config.json written before this field existed)
+        // must ALSO deserialize to Strict, not fail or silently do something
+        // else — additive/back-compat, matching `trusted_hosts`/
+        // `trusted_keys`'s own `#[serde(default = ...)]` behavior.
+        let json = serde_json::json!({
+            "trusted_hosts": ["example.com"],
+            "trusted_keys": [],
+        });
+        let trust: PluginTrustConfig = serde_json::from_value(json).expect("deserializes");
+        assert_eq!(trust.enforcement, PluginTrustEnforcement::Strict);
+    }
+
+    #[test]
+    fn plugin_trust_enforcement_off_string_parses_case_insensitively() {
+        for raw in ["off", "OFF", "Off", " off "] {
+            let trust: PluginTrustConfig = serde_json::from_value(serde_json::json!({
+                "enforcement": raw,
+            }))
+            .unwrap_or_else(|e| panic!("'{raw}' should parse as Off: {e}"));
+            assert_eq!(trust.enforcement, PluginTrustEnforcement::Off, "{raw}");
+            assert!(trust.enforcement_is_off());
+        }
+        for raw in ["strict", "STRICT", " Strict "] {
+            let trust: PluginTrustConfig = serde_json::from_value(serde_json::json!({
+                "enforcement": raw,
+            }))
+            .unwrap_or_else(|e| panic!("'{raw}' should parse as Strict: {e}"));
+            assert_eq!(trust.enforcement, PluginTrustEnforcement::Strict, "{raw}");
+        }
+
+        let err = serde_json::from_value::<PluginTrustConfig>(serde_json::json!({
+            "enforcement": "nonsense",
+        }))
+        .expect_err("an unrecognized string must be rejected, not silently default");
+        assert!(err.to_string().contains("nonsense"));
+    }
+
+    #[test]
+    fn plugin_trust_enforcement_accepts_a_bool_ish_alias() {
+        // A hand-edited config.json using a plain bool reads naturally: is
+        // enforcement ON (`true`) or OFF (`false`)?
+        let trust: PluginTrustConfig =
+            serde_json::from_value(serde_json::json!({ "enforcement": false })).unwrap();
+        assert_eq!(trust.enforcement, PluginTrustEnforcement::Off);
+
+        let trust: PluginTrustConfig =
+            serde_json::from_value(serde_json::json!({ "enforcement": true })).unwrap();
+        assert_eq!(trust.enforcement, PluginTrustEnforcement::Strict);
+    }
+
+    #[test]
+    fn plugin_trust_enforcement_always_serializes_as_the_canonical_string() {
+        // Regardless of which accepted input form produced it, the
+        // in-memory value always serializes back out as the canonical
+        // string — this is what the dot-path `config set` setter's
+        // round-trip check relies on (see `dot_path.rs`'s module docs).
+        let trust = PluginTrustConfig {
+            enforcement: PluginTrustEnforcement::Off,
+            ..PluginTrustConfig::default()
+        };
+        let json = serde_json::to_value(&trust).unwrap();
+        assert_eq!(json["enforcement"], "off");
+
+        let trust = PluginTrustConfig {
+            enforcement: PluginTrustEnforcement::Strict,
+            ..PluginTrustConfig::default()
+        };
+        let json = serde_json::to_value(&trust).unwrap();
+        assert_eq!(json["enforcement"], "strict");
+    }
+
+    #[test]
+    fn normalize_plugin_trust_settings_does_not_disturb_enforcement() {
+        // `normalize_plugin_trust_settings` only touches `trusted_hosts` —
+        // confirm it's a true no-op on `enforcement` either way.
+        let mut config = Config::default();
+        config.plugin_trust.enforcement = PluginTrustEnforcement::Off;
+        config.normalize_plugin_trust_settings();
+        assert_eq!(config.plugin_trust.enforcement, PluginTrustEnforcement::Off);
+    }
+
+    #[test]
+    fn config_set_plugin_trust_enforcement_off_round_trips_through_the_dot_path_setter() {
+        // Confirms the dot-path `bamboo config set plugin_trust.enforcement
+        // off` path actually works end to end through
+        // `crate::dot_path::apply_dot_path_set` (the generic JSON-patch
+        // setter), not just direct field assignment.
+        let config = Config::from_data_dir_without_env(Some(std::path::PathBuf::from(
+            "/nonexistent-bamboo-plugin-trust-enforcement-test-dir",
+        )));
+        assert_eq!(
+            config.plugin_trust.enforcement,
+            PluginTrustEnforcement::Strict
+        );
+
+        let outcome = crate::dot_path::apply_dot_path_set(
+            &config,
+            "plugin_trust.enforcement",
+            crate::dot_path::parse_cli_value("off"),
+        )
+        .expect("plugin_trust.enforcement should be settable via the generic dot-path setter");
+        assert_eq!(
+            outcome.config.plugin_trust.enforcement,
+            PluginTrustEnforcement::Off
+        );
+
+        // And back to strict.
+        let outcome = crate::dot_path::apply_dot_path_set(
+            &outcome.config,
+            "plugin_trust.enforcement",
+            crate::dot_path::parse_cli_value("strict"),
+        )
+        .expect("setting it back to strict should also round-trip");
+        assert_eq!(
+            outcome.config.plugin_trust.enforcement,
+            PluginTrustEnforcement::Strict
         );
     }
 }

--- a/crates/infra/bamboo-plugin/src/registry.rs
+++ b/crates/infra/bamboo-plugin/src/registry.rs
@@ -55,6 +55,19 @@ pub enum PluginSource {
     /// rather than silently trusting an unpinned/unsigned download from an
     /// untrusted host, so every `None`/`false` combination here always means
     /// a deliberate, recorded risk acceptance, never an oversight.
+    ///
+    /// `insecure` is the convenience AGGREGATE over the three per-layer
+    /// opt-outs above: `true` when this install waived all three at once,
+    /// either via a per-install `--insecure` flag / `"insecure": true` on the
+    /// request, or because `plugin_trust.enforcement` was `off` at install
+    /// time (see `bamboo-server`'s `plugin_source.rs` module docs). Recorded
+    /// separately from the three individual `allow_*` fields so `plugin
+    /// list`/audit can tell "an operator deliberately accepted ALL risk for
+    /// this source" apart from "these three flags happened to all be set
+    /// individually" — functionally identical, but a meaningfully different
+    /// signal for review. `#[serde(default)]` so a pre-existing
+    /// `installed.json` row (written before this field existed) loads as
+    /// `false` rather than failing to deserialize.
     Url {
         url: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -83,6 +96,13 @@ pub enum PluginSource {
         /// backward compat with rows written before signing existed.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         signed_by: Option<String>,
+        /// True when this install ran with ALL THREE trust layers waived at
+        /// once via the `--insecure` / `"insecure": true` aggregate opt-out,
+        /// or because `plugin_trust.enforcement` was `off` — see this
+        /// variant's doc comment above. `#[serde(default)]` for backward
+        /// compat with rows written before this field existed.
+        #[serde(default, skip_serializing_if = "is_false")]
+        insecure: bool,
     },
 }
 

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -551,7 +551,8 @@ enum PluginCommands {
     /// `--allow-unverified` opts out — waived automatically when the bundle
     /// is signature-verified). The defaults trust nova's official plugin
     /// from its GitHub release, so installing it needs NO flags at all once
-    /// it's signed; any other host/publisher needs the matching opt-out.
+    /// it's signed; any other host/publisher needs the matching opt-out (or
+    /// `--insecure` to waive all three at once).
     #[command(after_help = "EXAMPLES:\n  \
         # From a local directory (development)\n  \
         bamboo plugin install ./my-plugin\n\n  \
@@ -567,7 +568,9 @@ enum PluginCommands {
         --allow-untrusted-host --allow-unsigned\n\n  \
         # From an untrusted host, explicitly accepting the risk\n  \
         bamboo plugin install https://example.com/my-plugin.tar.gz \\\n    \
-        --allow-untrusted-host --allow-unsigned --allow-unverified")]
+        --allow-untrusted-host --allow-unsigned --allow-unverified\n\n  \
+        # Same as above, all at once (dev / self-hosted / custom setups only)\n  \
+        bamboo plugin install https://example.com/my-plugin.tar.gz --insecure")]
     Install {
         /// A local directory, a local `.tar.gz`/`.tgz`/`.zip` archive, or an
         /// `http(s)://` URL — the source kind is auto-detected.
@@ -578,7 +581,10 @@ enum PluginCommands {
         /// source. Only valid with a URL source; the server rejects a
         /// mismatch before unpacking anything. Without this, a URL install
         /// also needs `--allow-unverified` (unless the bundle is
-        /// signature-verified, which satisfies this on its own).
+        /// signature-verified, which satisfies this on its own). Honored even
+        /// alongside `--insecure`: a supplied sha256 is a check you opted
+        /// INTO, so it is still verified (a mismatch still refuses the
+        /// install) — `--insecure` only turns default-required checks off.
         #[arg(long, value_name = "HEX")]
         sha256: Option<String>,
 
@@ -602,6 +608,17 @@ enum PluginCommands {
         /// official signing key). Only valid with a URL source.
         #[arg(long)]
         allow_unsigned: bool,
+
+        /// Skip ALL plugin trust checks (host allowlist, signature,
+        /// checksum) for this install — use only for sources you fully
+        /// trust; equivalent to --allow-untrusted-host --allow-unsigned
+        /// --allow-unverified. Only valid with a URL source. A `--sha256`
+        /// passed alongside this is still verified (this flag only turns
+        /// checks OFF, never off a check you opted into). The server logs a
+        /// prominent warning naming the source for every insecure install and
+        /// records it in provenance (see `bamboo plugin list --json`).
+        #[arg(long)]
+        insecure: bool,
 
         #[command(flatten)]
         conn: ConnArgs,
@@ -649,7 +666,8 @@ enum PluginCommands {
         /// source. Only valid with a URL source; the server rejects a
         /// mismatch before unpacking anything. Without this, a URL source
         /// also needs `--allow-unverified` (unless the bundle is
-        /// signature-verified, which satisfies this on its own).
+        /// signature-verified, which satisfies this on its own). Honored even
+        /// alongside `--insecure` — see that flag's doc.
         #[arg(long, value_name = "HEX")]
         sha256: Option<String>,
 
@@ -668,6 +686,15 @@ enum PluginCommands {
         /// URL source.
         #[arg(long)]
         allow_unsigned: bool,
+
+        /// Skip ALL plugin trust checks (host allowlist, signature,
+        /// checksum) for this update — use only for sources you fully trust;
+        /// equivalent to --allow-untrusted-host --allow-unsigned
+        /// --allow-unverified. Only valid with a URL source. A `--sha256`
+        /// passed alongside this is still verified. The server logs a
+        /// prominent warning naming the source and records it in provenance.
+        #[arg(long)]
+        insecure: bool,
 
         #[command(flatten)]
         conn: ConnArgs,
@@ -1780,6 +1807,7 @@ async fn main() {
                     allow_unverified,
                     allow_untrusted_host,
                     allow_unsigned,
+                    insecure,
                     conn,
                 } => {
                     bamboo_agent::plugin_cli::install(
@@ -1789,6 +1817,7 @@ async fn main() {
                         allow_unverified,
                         allow_untrusted_host,
                         allow_unsigned,
+                        insecure,
                     )
                     .await
                 }
@@ -1805,6 +1834,7 @@ async fn main() {
                     allow_unverified,
                     allow_untrusted_host,
                     allow_unsigned,
+                    insecure,
                     conn,
                 } => {
                     bamboo_agent::plugin_cli::update(
@@ -1815,6 +1845,7 @@ async fn main() {
                         allow_unverified,
                         allow_untrusted_host,
                         allow_unsigned,
+                        insecure,
                     )
                     .await
                 }
@@ -2206,6 +2237,77 @@ mod tests {
     }
 
     #[test]
+    fn plugin_install_parses_insecure_flag() {
+        use clap::Parser;
+
+        let parsed = super::Cli::try_parse_from([
+            "bamboo",
+            "plugin",
+            "install",
+            "https://example.com/my-plugin.tar.gz",
+            "--insecure",
+        ])
+        .expect("--insecure should parse");
+        let super::Commands::Plugin {
+            command:
+                super::PluginCommands::Install {
+                    insecure,
+                    allow_unverified,
+                    allow_untrusted_host,
+                    allow_unsigned,
+                    ..
+                },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Install");
+        };
+        assert!(insecure);
+        // `--insecure` alone does NOT flip the individual `allow_*` clap
+        // fields themselves (those stay whatever was literally passed on the
+        // command line) — the aggregate is applied by `detect_source` when
+        // building the JSON request body, exercised in `plugin_cli`'s own
+        // tests (`detect_source_insecure_...`).
+        assert!(!allow_unverified);
+        assert!(!allow_untrusted_host);
+        assert!(!allow_unsigned);
+
+        // `--insecure` combined with an explicit `--sha256` parses too (the
+        // checksum stays honored — see `plugin_cli::detect_source`'s docs).
+        let parsed = super::Cli::try_parse_from([
+            "bamboo",
+            "plugin",
+            "install",
+            "https://example.com/my-plugin.tar.gz",
+            "--insecure",
+            "--sha256",
+            "deadbeef",
+        ])
+        .expect("--insecure with --sha256 should parse");
+        let super::Commands::Plugin {
+            command:
+                super::PluginCommands::Install {
+                    insecure, sha256, ..
+                },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Install");
+        };
+        assert!(insecure);
+        assert_eq!(sha256.as_deref(), Some("deadbeef"));
+
+        // Defaults to false when omitted.
+        let parsed =
+            super::Cli::try_parse_from(["bamboo", "plugin", "install", "./my-plugin"]).unwrap();
+        let super::Commands::Plugin {
+            command: super::PluginCommands::Install { insecure, .. },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Install");
+        };
+        assert!(!insecure);
+    }
+
+    #[test]
     fn plugin_update_parses_id_and_source() {
         use clap::Parser;
 
@@ -2298,6 +2400,45 @@ mod tests {
         };
         assert!(!allow_untrusted_host);
         assert!(!allow_unsigned);
+    }
+
+    #[test]
+    fn plugin_update_parses_insecure_flag() {
+        use clap::Parser;
+
+        let parsed = super::Cli::try_parse_from([
+            "bamboo",
+            "plugin",
+            "update",
+            "hello-plugin",
+            "https://example.com/my-plugin.tar.gz",
+            "--insecure",
+        ])
+        .expect("--insecure should parse on update too");
+        let super::Commands::Plugin {
+            command: super::PluginCommands::Update { insecure, .. },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Update");
+        };
+        assert!(insecure);
+
+        // Defaults to false when omitted.
+        let parsed = super::Cli::try_parse_from([
+            "bamboo",
+            "plugin",
+            "update",
+            "hello-plugin",
+            "./my-plugin-v2",
+        ])
+        .unwrap();
+        let super::Commands::Plugin {
+            command: super::PluginCommands::Update { insecure, .. },
+        } = parsed.command.expect("a subcommand was given")
+        else {
+            panic!("expected Plugin::Update");
+        };
+        assert!(!insecure);
     }
 
     #[test]

--- a/src/plugin_cli.rs
+++ b/src/plugin_cli.rs
@@ -16,8 +16,8 @@
 //!   (`InstallDisposition::FailIfInstalled`); `SourceSpec` is one of
 //!   `{"type":"local_dir","path":"..."}` / `{"type":"local_archive","path":"..."}`
 //!   / `{"type":"url","url":"...","sha256":"..."?,"allow_unverified":bool?,
-//!   "allow_untrusted_host":bool?,"allow_unsigned":bool?}` — the same tagged
-//!   shape as `bamboo_plugin::registry::PluginSource`'s
+//!   "allow_untrusted_host":bool?,"allow_unsigned":bool?,"insecure":bool?}` —
+//!   the same tagged shape as `bamboo_plugin::registry::PluginSource`'s
 //!   `#[serde(tag = "type")]` wire form, reproduced here by hand (this crate
 //!   does not depend on `bamboo-plugin`, to stay decoupled from the parallel
 //!   installer-core branch).
@@ -56,6 +56,25 @@
 //! unsigned/untrusted-signature bundle needs the matching explicit opt-out
 //! flag(s) — `bamboo plugin install <url>` alone no longer just downloads
 //! and trusts any tar.gz from any host.
+//!
+//! # `--insecure`: skip ALL three layers at once
+//!
+//! `--insecure` (`install`/`update`) is a convenience AGGREGATE over the
+//! three flags above — equivalent to passing `--allow-untrusted-host
+//! --allow-unsigned --allow-unverified` together, for the one install it's
+//! given on. It only turns default-required checks OFF: a `--sha256` passed
+//! alongside `--insecure` is still verified (a mismatch still refuses the
+//! install) — the flag never downgrades a check the caller explicitly opted
+//! into. There's also a persistent, config-level form for a private/dev
+//! bamboo instance that never wants to pass flags at all:
+//! `bamboo config set plugin_trust.enforcement off` makes EVERY `url`
+//! install/update behave this way with no per-install flag needed
+//! (`plugin_trust.enforcement` defaults to `"strict"`, so this is always an
+//! explicit opt-in relaxation). Use either only for sources you fully trust
+//! (dev/self-hosted/custom setups) — the server logs a prominent warning for
+//! every insecure install (plus its own startup warning when
+//! `plugin_trust.enforcement` is `off`) and records the aggregate in
+//! provenance, visible via `bamboo plugin list --json`.
 
 use std::path::Path;
 use std::time::Duration;
@@ -82,21 +101,37 @@ const PLUGIN_MUTATE_TIMEOUT: Duration = Duration::from_secs(120);
 ///   (+ `"sha256"` when `--sha256` was given, `"allow_unverified":true` when
 ///   `--allow-unverified` was given, `"allow_untrusted_host":true` when
 ///   `--allow-untrusted-host` was given, `"allow_unsigned":true` when
-///   `--allow-unsigned` was given)
+///   `--allow-unsigned` was given, and — when `--insecure` was given —
+///   `"insecure":true` PLUS `"allow_untrusted_host"`/`"allow_unsigned"`/
+///   `"allow_unverified"` all forced to `true` too, so the built request is
+///   self-describing (see the `--insecure` section below))
 ///
 /// Local paths are canonicalized to absolute so the source resolves correctly
 /// even if `bamboo serve` runs with a different working directory than the
-/// CLI invocation (e.g. a long-running sidecar). All four flags
+/// CLI invocation (e.g. a long-running sidecar). All five flags
 /// (`--sha256`/`--allow-unverified`/`--allow-untrusted-host`/
-/// `--allow-unsigned`) are rejected for local sources — they only apply to a
-/// network download; a local file is already on the user's own disk by their
-/// own choice, nothing to verify/authorize.
+/// `--allow-unsigned`/`--insecure`) are rejected for local sources — they
+/// only apply to a network download; a local file is already on the user's
+/// own disk by their own choice, nothing to verify/authorize.
+///
+/// # `--insecure`: the convenience aggregate
+///
+/// `--insecure` is shorthand for `--allow-untrusted-host --allow-unsigned
+/// --allow-unverified` together — skip ALL THREE trust layers (host
+/// allowlist, signature, checksum-required-by-default) for this one install.
+/// Precedence: it only turns OFF checks the caller didn't otherwise ask for —
+/// a `--sha256` passed alongside `--insecure` is still honored (the server
+/// verifies it regardless; a wrong hash still refuses the install). Use only
+/// for sources you fully trust (dev/self-hosted/custom setups); the server
+/// logs a prominent warning for every insecure install and records it in
+/// provenance (`bamboo plugin list`).
 pub(crate) fn detect_source(
     spec: &str,
     sha256: Option<&str>,
     allow_unverified: bool,
     allow_untrusted_host: bool,
     allow_unsigned: bool,
+    insecure: bool,
 ) -> anyhow::Result<serde_json::Value> {
     if spec.starts_with("http://") || spec.starts_with("https://") {
         let mut v = serde_json::json!({ "type": "url", "url": spec });
@@ -111,6 +146,17 @@ pub(crate) fn detect_source(
         }
         if allow_unsigned {
             v["allow_unsigned"] = serde_json::Value::Bool(true);
+        }
+        if insecure {
+            // The aggregate: mark the request as insecure AND set the three
+            // individual flags it implies, so the built request is
+            // self-describing on the wire (and would behave identically even
+            // against an older server that only understood the three
+            // per-layer flags and not `insecure` itself).
+            v["insecure"] = serde_json::Value::Bool(true);
+            v["allow_untrusted_host"] = serde_json::Value::Bool(true);
+            v["allow_unsigned"] = serde_json::Value::Bool(true);
+            v["allow_unverified"] = serde_json::Value::Bool(true);
         }
         return Ok(v);
     }
@@ -135,6 +181,9 @@ pub(crate) fn detect_source(
         if allow_unsigned {
             anyhow::bail!("--allow-unsigned only applies to a URL source, not a local directory");
         }
+        if insecure {
+            anyhow::bail!("--insecure only applies to a URL source, not a local directory");
+        }
         return Ok(serde_json::json!({ "type": "local_dir", "path": abs }));
     }
 
@@ -156,6 +205,9 @@ pub(crate) fn detect_source(
         if allow_unsigned {
             anyhow::bail!("--allow-unsigned only applies to a URL source, not a local archive");
         }
+        if insecure {
+            anyhow::bail!("--insecure only applies to a URL source, not a local archive");
+        }
         return Ok(serde_json::json!({ "type": "local_archive", "path": abs }));
     }
 
@@ -165,14 +217,16 @@ pub(crate) fn detect_source(
 }
 
 /// `bamboo plugin install <path-or-url> [--sha256 <hex>] [--allow-unverified]
-/// [--allow-untrusted-host] [--allow-unsigned]` — `POST /api/v1/plugins/install`.
+/// [--allow-untrusted-host] [--allow-unsigned] [--insecure]` —
+/// `POST /api/v1/plugins/install`.
 /// On a 409 (already installed) prints a pointer to `bamboo plugin update`
 /// and returns an error (non-zero exit). A URL source with neither `--sha256`
 /// nor `--allow-unverified` gets a 400 from the server (secure by default —
 /// see the module docs); a URL from a host outside `plugin_trust.trusted_hosts`
 /// or an unsigned/untrusted-signature bundle gets a 403 (unless the matching
-/// opt-out flag was passed). Every one of those error bodies is already the
-/// actionable "pass --X" guidance, surfaced as-is through the branches below.
+/// opt-out flag, or `--insecure`, was passed). Every one of those error bodies
+/// is already the actionable "pass --X" guidance, surfaced as-is through the
+/// branches below.
 pub async fn install(
     conn: ConnArgs,
     source_spec: &str,
@@ -180,6 +234,7 @@ pub async fn install(
     allow_unverified: bool,
     allow_untrusted_host: bool,
     allow_unsigned: bool,
+    insecure: bool,
 ) -> anyhow::Result<()> {
     let source = detect_source(
         source_spec,
@@ -187,6 +242,7 @@ pub async fn install(
         allow_unverified,
         allow_untrusted_host,
         allow_unsigned,
+        insecure,
     )?;
     let base = conn.api_base();
     let url = format!("{base}/plugins/install");
@@ -226,7 +282,8 @@ pub async fn install(
         anyhow::bail!(
             "install refused (source trust) {} — for an untrusted host, add it to \
              `plugin_trust.trusted_hosts` in config.json or pass --allow-untrusted-host; for an \
-             unsigned/untrusted-signature bundle, pass --allow-unsigned",
+             unsigned/untrusted-signature bundle, pass --allow-unsigned; or skip all three trust \
+             checks at once with --insecure (only for sources you fully trust)",
             server_error_message(&body)
         );
     } else {
@@ -357,9 +414,11 @@ pub async fn remove(conn: ConnArgs, id: &str, yes: bool) -> anyhow::Result<()> {
 }
 
 /// `bamboo plugin update <id> <path-or-url> [--sha256] [--allow-unverified]
-/// [--allow-untrusted-host] [--allow-unsigned]` —
+/// [--allow-untrusted-host] [--allow-unsigned] [--insecure]` —
 /// `POST /api/v1/plugins/{id}/update` (`InstallDisposition::Upgrade`). Same
-/// three-layer source-trust policy as `install` (see the module docs).
+/// three-layer source-trust policy (plus the `--insecure` aggregate) as
+/// `install` (see the module docs).
+#[allow(clippy::too_many_arguments)]
 pub async fn update(
     conn: ConnArgs,
     id: &str,
@@ -368,6 +427,7 @@ pub async fn update(
     allow_unverified: bool,
     allow_untrusted_host: bool,
     allow_unsigned: bool,
+    insecure: bool,
 ) -> anyhow::Result<()> {
     guard_id_segment("plugin id", id)?;
     let source = detect_source(
@@ -376,6 +436,7 @@ pub async fn update(
         allow_unverified,
         allow_untrusted_host,
         allow_unsigned,
+        insecure,
     )?;
     let base = conn.api_base();
     let url = format!("{base}/plugins/{id}/update");
@@ -399,7 +460,8 @@ pub async fn update(
         anyhow::bail!(
             "update refused (source trust) {} — for an untrusted host, add it to \
              `plugin_trust.trusted_hosts` in config.json or pass --allow-untrusted-host; for an \
-             unsigned/untrusted-signature bundle, pass --allow-unsigned",
+             unsigned/untrusted-signature bundle, pass --allow-unsigned; or skip all three trust \
+             checks at once with --insecure (only for sources you fully trust)",
             server_error_message(&body)
         );
     } else {
@@ -422,6 +484,7 @@ mod tests {
             false,
             false,
             false,
+            false,
         )
         .unwrap();
         assert_eq!(v["type"], "url");
@@ -434,6 +497,7 @@ mod tests {
         let v = detect_source(
             "http://example.com/plugin.tar.gz",
             Some("deadbeef"),
+            false,
             false,
             false,
             false,
@@ -450,6 +514,7 @@ mod tests {
             "https://example.com/plugin.tar.gz",
             None,
             true,
+            false,
             false,
             false,
         )
@@ -470,6 +535,7 @@ mod tests {
             true,
             false,
             false,
+            false,
         )
         .unwrap();
         assert_eq!(v["sha256"], "deadbeef");
@@ -484,6 +550,7 @@ mod tests {
             true,
             true,
             false,
+            false,
         )
         .unwrap();
         assert_eq!(v["type"], "url");
@@ -493,8 +560,15 @@ mod tests {
 
     #[test]
     fn detect_source_url_carries_allow_unsigned_when_set() {
-        let v =
-            detect_source("https://example.com/plugin.tar.gz", None, true, false, true).unwrap();
+        let v = detect_source(
+            "https://example.com/plugin.tar.gz",
+            None,
+            true,
+            false,
+            true,
+            false,
+        )
+        .unwrap();
         assert_eq!(v["type"], "url");
         assert!(v.get("allow_untrusted_host").is_none());
         assert_eq!(v["allow_unsigned"], true);
@@ -508,6 +582,7 @@ mod tests {
             true,
             true,
             true,
+            false,
         )
         .unwrap();
         assert_eq!(v["sha256"], "deadbeef");
@@ -519,7 +594,15 @@ mod tests {
     #[test]
     fn detect_source_recognizes_local_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let v = detect_source(dir.path().to_str().unwrap(), None, false, false, false).unwrap();
+        let v = detect_source(
+            dir.path().to_str().unwrap(),
+            None,
+            false,
+            false,
+            false,
+            false,
+        )
+        .unwrap();
         assert_eq!(v["type"], "local_dir");
         assert_eq!(
             v["path"].as_str().unwrap(),
@@ -536,6 +619,7 @@ mod tests {
             false,
             false,
             false,
+            false,
         )
         .unwrap_err();
         assert!(err.to_string().contains("--sha256"));
@@ -544,24 +628,45 @@ mod tests {
     #[test]
     fn detect_source_rejects_allow_unverified_for_local_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let err =
-            detect_source(dir.path().to_str().unwrap(), None, true, false, false).unwrap_err();
+        let err = detect_source(
+            dir.path().to_str().unwrap(),
+            None,
+            true,
+            false,
+            false,
+            false,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("--allow-unverified"));
     }
 
     #[test]
     fn detect_source_rejects_allow_untrusted_host_for_local_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let err =
-            detect_source(dir.path().to_str().unwrap(), None, false, true, false).unwrap_err();
+        let err = detect_source(
+            dir.path().to_str().unwrap(),
+            None,
+            false,
+            true,
+            false,
+            false,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("--allow-untrusted-host"));
     }
 
     #[test]
     fn detect_source_rejects_allow_unsigned_for_local_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let err =
-            detect_source(dir.path().to_str().unwrap(), None, false, false, true).unwrap_err();
+        let err = detect_source(
+            dir.path().to_str().unwrap(),
+            None,
+            false,
+            false,
+            true,
+            false,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("--allow-unsigned"));
     }
 
@@ -571,7 +676,8 @@ mod tests {
         for name in ["plugin.tar.gz", "plugin.tgz", "plugin.zip"] {
             let path = dir.path().join(name);
             std::fs::write(&path, b"fake archive bytes").unwrap();
-            let v = detect_source(path.to_str().unwrap(), None, false, false, false).unwrap();
+            let v =
+                detect_source(path.to_str().unwrap(), None, false, false, false, false).unwrap();
             assert_eq!(v["type"], "local_archive", "{name}");
         }
     }
@@ -587,6 +693,7 @@ mod tests {
             false,
             false,
             false,
+            false,
         )
         .unwrap_err();
         assert!(err.to_string().contains("--sha256"));
@@ -597,7 +704,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("plugin.tar.gz");
         std::fs::write(&path, b"fake archive bytes").unwrap();
-        let err = detect_source(path.to_str().unwrap(), None, true, false, false).unwrap_err();
+        let err =
+            detect_source(path.to_str().unwrap(), None, true, false, false, false).unwrap_err();
         assert!(err.to_string().contains("--allow-unverified"));
     }
 
@@ -606,7 +714,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("plugin.tar.gz");
         std::fs::write(&path, b"fake archive bytes").unwrap();
-        let err = detect_source(path.to_str().unwrap(), None, false, true, false).unwrap_err();
+        let err =
+            detect_source(path.to_str().unwrap(), None, false, true, false, false).unwrap_err();
         assert!(err.to_string().contains("--allow-untrusted-host"));
     }
 
@@ -615,7 +724,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("plugin.tar.gz");
         std::fs::write(&path, b"fake archive bytes").unwrap();
-        let err = detect_source(path.to_str().unwrap(), None, false, false, true).unwrap_err();
+        let err =
+            detect_source(path.to_str().unwrap(), None, false, false, true, false).unwrap_err();
         assert!(err.to_string().contains("--allow-unsigned"));
     }
 
@@ -624,7 +734,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("plugin.txt");
         std::fs::write(&path, b"not an archive").unwrap();
-        let err = detect_source(path.to_str().unwrap(), None, false, false, false).unwrap_err();
+        let err =
+            detect_source(path.to_str().unwrap(), None, false, false, false, false).unwrap_err();
         assert!(err.to_string().contains("neither a directory"));
     }
 
@@ -636,9 +747,83 @@ mod tests {
             false,
             false,
             false,
+            false,
         )
         .unwrap_err();
         assert!(err.to_string().contains("cannot read"));
+    }
+
+    // ---------------------------------------------------------------------
+    // `--insecure`: the convenience aggregate over the three per-layer flags.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn detect_source_insecure_implies_all_three_allow_flags() {
+        // `insecure: true` with every individual `allow_*` flag left `false`
+        // must still produce a request with all three set — that's the
+        // whole point of the aggregate.
+        let v = detect_source(
+            "https://example.com/my-plugin.tar.gz",
+            None,
+            false,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
+        assert_eq!(v["type"], "url");
+        assert_eq!(v["insecure"], true);
+        assert_eq!(v["allow_untrusted_host"], true);
+        assert_eq!(v["allow_unsigned"], true);
+        assert_eq!(v["allow_unverified"], true);
+        assert!(v.get("sha256").is_none());
+    }
+
+    #[test]
+    fn detect_source_insecure_with_explicit_sha256_keeps_the_checksum() {
+        // Precedence: `--insecure` only turns default-required checks OFF —
+        // a caller-supplied `--sha256` is a check they opted INTO, so it must
+        // still be carried through to the request (the server verifies it
+        // regardless of `insecure`; see `plugin_source.rs`).
+        let v = detect_source(
+            "https://example.com/my-plugin.tar.gz",
+            Some("deadbeef"),
+            false,
+            false,
+            false,
+            true,
+        )
+        .unwrap();
+        assert_eq!(v["insecure"], true);
+        assert_eq!(v["sha256"], "deadbeef");
+        assert_eq!(v["allow_untrusted_host"], true);
+        assert_eq!(v["allow_unsigned"], true);
+        assert_eq!(v["allow_unverified"], true);
+    }
+
+    #[test]
+    fn detect_source_rejects_insecure_for_local_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = detect_source(
+            dir.path().to_str().unwrap(),
+            None,
+            false,
+            false,
+            false,
+            true,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("--insecure"));
+    }
+
+    #[test]
+    fn detect_source_rejects_insecure_for_local_archive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plugin.tar.gz");
+        std::fs::write(&path, b"fake archive bytes").unwrap();
+        let err =
+            detect_source(path.to_str().unwrap(), None, false, false, false, true).unwrap_err();
+        assert!(err.to_string().contains("--insecure"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a single **"skip ALL plugin-install trust checks"** escape hatch on top of the existing three-layer trust system (host allowlist / ed25519 signature / checksum) and their per-layer opt-outs (`--allow-untrusted-host` / `--allow-unsigned` / `--allow-unverified`). For users who knowingly want to install from anywhere without verification (dev / self-hosted / custom setups).

Two forms, both aggregating over the same three layers:

1. **Per-install `--insecure` flag** (transient) — CLI (`bamboo plugin install|update ... --insecure`) and HTTP (`"insecure": true` on the `url` SourceSpec, which already carries this through since the HTTP layer reuses `PluginSource`'s own wire shape 1:1).
2. **`plugin_trust.enforcement` config toggle** (persistent) — `Strict` (default) / `Off`. `bamboo config set plugin_trust.enforcement off` makes *every* future `url` install/update behave as if `--insecure` were passed, with no per-call flag needed — for an operator running a private/dev bamboo who doesn't want to pass flags every time.

## Precedence (unchanged behavior guarantees)

- `enforcement=Off` (config) **OR** `--insecure` (per-install) → skip host-allowlist + signature + checksum-required-by-default enforcement.
- A **provided `--sha256`/`sha256`** is still verified either way — the aggregate only turns OFF checks the caller didn't opt into; it never downgrades a check they explicitly asked for. A wrong hash is still refused.
- The per-layer flags (`--allow-untrusted-host` etc.) keep working independently for anyone who wants to waive just one layer.
- `Strict` + no `--insecure` = today's secure-by-default behavior, byte-for-byte unchanged. `enforcement` defaults to `Strict` for both a fresh config and one with no `plugin_trust.enforcement` key at all — this is opt-in relaxation, never a silent weakening.

## Danger signals

- Every install where the aggregate is active (via either form) logs a prominent `tracing::warn!` naming the source URL: *"installing plugin from '<url>' with ALL trust checks disabled (insecure) — host allowlist, signature and checksum-required-by-default are all skipped for this install"*.
- A server booting with `plugin_trust.enforcement: off` logs its own startup warning in `AppState::new`: *"plugin_trust.enforcement is OFF — plugin installs from ANY URL are accepted without host/signature/checksum verification"* — since that setting silently affects every future install, not just one invocation.
- `PluginSource::Url` gains `insecure: bool` (serde default `false`) recording the *effective aggregate* (true whether triggered by the flag or by config), so `bamboo plugin list --json` / audit can distinguish "deliberately accepted ALL risk for this source" from "the three individual flags just happened to all be set".

## Key files

- `crates/infra/bamboo-config/src/config.rs` — `PluginTrustEnforcement` enum (`Strict`/`Off`, bool-ish alias accepted on read, always serializes to canonical string so the dot-path `config set` round-trip check keeps working) + `PluginTrustConfig.enforcement`.
- `crates/infra/bamboo-plugin/src/registry.rs` — `PluginSource::Url.insecure` provenance field.
- `crates/app/bamboo-server/src/plugin_source.rs` — the actual enforcement point: `PluginSourceInput::Url.insecure`, aggregate computed once in `fetch_manifest_bundle` and ORed into every existing check.
- `crates/app/bamboo-server/src/app_state/builder.rs` — startup warning.
- `crates/app/bamboo-server/src/handlers/agent/plugin/{api_types,handlers}.rs` — HTTP wiring (`SourceSpec` reuses `PluginSource`'s wire shape, so `insecure` flows through for free; still behind the existing `enforce_access_password_middleware`).
- `src/plugin_cli.rs`, `src/bin/bamboo.rs` — `--insecure` on `install`/`update`.

## Test plan

- [x] `cargo build --workspace --exclude bamboo-analytics` — clean
- [x] `cargo test -p bamboo-plugin -p bamboo-server -p bamboo-config -- plugin` — all green (63 + 10 + 4 relevant, including new aggregate/enforcement tests)
- [x] `cargo test -p bamboo-agent --lib --bins` — 102 + 17 green, including new `--insecure` clap-parse tests and `detect_source` aggregate tests
- [x] `cargo clippy` — no new warnings (added `#[allow(clippy::too_many_arguments)]` to `plugin_cli::update`, matching existing precedent elsewhere in the codebase, after the new `insecure` param pushed it to 8)
- [x] `cargo fmt --check` — clean (config.rs edited surgically, not whole-file)
- [x] `cargo tree -i aws-lc-sys` — empty
- [x] E2e: built `bamboo`, served a throwaway `--data-dir`:
  - `bamboo plugin install <unreachable-untrusted-url> --insecure` — logged the aggregate warning, reached the actual network fetch (failed only on DNS/connect, not a trust refusal) — proving `--insecure` bypasses the pre-fetch host refusal that the same command without `--insecure` hits (403 `UntrustedHost`, zero network access).
  - `bamboo config set plugin_trust.enforcement off` then restarted the server — startup warning fired; the same URL with **no flags at all** reached the fetch identically.
  - Full round-trip against a real local (untrusted-host, unsigned, no-checksum) plugin bundle via `--insecure`: install succeeded, and `bamboo plugin list --json` showed `"insecure": true` alongside `allow_untrusted_host`/`allow_unsigned`/`allow_unverified` all `true` in provenance.