### PR TITLE
feat(memory): track recall access frequency for L5 capacity scoring

### DIFF
--- a/crates/infra/bamboo-memory/src/memory_store/access_log.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/access_log.rs
@@ -1,0 +1,277 @@
+//! L5 cheap access-frequency signal (#264, follow-up to #263's `memory_value`).
+//!
+//! The RFC's intended L5 keep-value signal is `recency × access × confidence`,
+//! but the access term was omitted in #263 because it wasn't tracked:
+//! `DurableMemoryRetrieval::last_accessed_at` exists but writing it back onto the
+//! recalled document on the read path would force a full per-scope index rebuild
+//! on every recall (the store rebuilds all per-scope indexes on every document
+//! write) — unacceptable on a hot path.
+//!
+//! Instead, recall appends a tiny `{id, ts}` line to a per-scope append-only
+//! `access_log.jsonl` (see [`super::store::MemoryStore::record_memory_accesses`]):
+//! O(ids) appends, no document rewrite, no index rebuild. The capacity gardener
+//! reads/aggregates that log lazily (only when it actually runs an eviction pass —
+//! not on the hot path) into an [`AccessStats`] per memory id, and
+//! [`access_multiplier`] turns that into the multiplier `memory_value` documents
+//! as its seam.
+//!
+//! This module is pure logic (parsing, aggregation, the multiplier formula,
+//! compaction policy) with no I/O — [`super::store::MemoryStore`] owns reading,
+//! writing, locking, and compacting the actual file.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::parse_rfc3339;
+
+/// File name of the per-scope access log, alongside the existing audit logs in
+/// the scope's `logs/` dir (see `MemoryPathResolver::logs_dir`).
+pub(crate) const ACCESS_LOG_FILE: &str = "access_log.jsonl";
+
+/// Append-triggered compaction threshold: once the log exceeds this many bytes,
+/// the next append rewrites it via [`compact_entries`] instead of just appending.
+/// ~40-60 bytes/line (short id + rfc3339 ts) → 256 KiB is on the order of a few
+/// thousand entries per scope, generous for a hot scope while keeping the rewrite
+/// (a full read + filter + atomic write) cheap and infrequent — amortized O(1)
+/// per append, same idea as a growable vector's doubling.
+pub(crate) const ACCESS_LOG_COMPACT_TRIGGER_BYTES: u64 = 256 * 1024;
+
+/// Aging window for compaction: entries older than this are dropped. Matches the
+/// horizon over which "recently accessed" is a meaningful signal for keep-value
+/// scoring — an access from a year ago says nothing about whether a memory is
+/// worth keeping today.
+const ACCESS_LOG_AGING_WINDOW_DAYS: i64 = 90;
+
+/// Hard cap on retained entries after compaction (oldest dropped first, entries
+/// are stored in append/chronological order) — bounds the log's size even for a
+/// scope so hot that it fills the aging window with more than this many accesses
+/// before the byte trigger next fires.
+const ACCESS_LOG_MAX_RETAINED_ENTRIES: usize = 20_000;
+
+/// Half-life (days) used to decay an individual access event's contribution to
+/// [`AccessStats::score`]. Deliberately the same 30-day scale `memory_value` uses
+/// for `recency(updated_at)`, so the access signal ages on a comparable clock to
+/// the signal it multiplies.
+const ACCESS_DECAY_HALF_LIFE_DAYS: f64 = 30.0;
+
+/// Upper bound on how much a fully "hot" access history can multiply
+/// `memory_value` by. `access_multiplier` ranges over `[1.0, 1.0 + WEIGHT]`:
+/// `1.0` (neutral, no change) when a memory has no access-log data, rising
+/// monotonically with more/more-recent accesses but never dropping below `1.0`
+/// — so access data can only ever help a memory survive eviction, never newly
+/// penalize one for lacking it (many memories legitimately have none: this
+/// signal is new, and callers that don't wire the log at all keep scoring
+/// unchanged). Kept modest relative to the ~[0.125, 1.0] range of
+/// `confidence × stale_penalty` so access nudges close rankings rather than
+/// overriding strong recency/confidence/staleness signals.
+const ACCESS_MULTIPLIER_WEIGHT: f64 = 1.0;
+
+/// Saturation constant for the score → multiplier curve (see
+/// [`access_multiplier`]): the decayed-access score at which the multiplier has
+/// closed half the gap to its `1.0 + ACCESS_MULTIPLIER_WEIGHT` ceiling. Roughly
+/// "3 same-day accesses" (score ≈ 3) gets a memory halfway to the cap; a single
+/// stale access barely moves it.
+const ACCESS_SATURATION_K: f64 = 3.0;
+
+/// One `{id, ts}` line in a scope's `access_log.jsonl` — `ts` is UTC rfc3339.
+/// Deliberately minimal (no query text, no scope) so an append is as cheap as
+/// possible; the file's own path already carries the scope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct AccessLogEntry {
+    pub id: String,
+    pub ts: String,
+}
+
+/// Aggregated access history for one memory id, as of the aggregation time.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub(crate) struct AccessStats {
+    /// Raw count of log lines for this id (undecayed; informational / testable,
+    /// not itself used by [`access_multiplier`]).
+    pub count: usize,
+    /// Recency-decayed sum of access events — see [`ACCESS_DECAY_HALF_LIFE_DAYS`].
+    /// Always `>= 0.0`.
+    pub score: f64,
+}
+
+/// Parse a raw `access_log.jsonl` file's contents into entries, silently
+/// skipping blank and malformed lines — an access log is a best-effort signal,
+/// not a durability-critical artifact, so a torn or corrupt line should degrade
+/// the signal, not fail the read.
+pub(crate) fn parse_access_log(raw: &str) -> Vec<AccessLogEntry> {
+    raw.lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            serde_json::from_str::<AccessLogEntry>(trimmed).ok()
+        })
+        .collect()
+}
+
+/// Aggregate parsed log entries into per-id [`AccessStats`] as of `now`. Entries
+/// with an empty id or an unparseable timestamp are skipped (best-effort).
+pub(crate) fn aggregate_access_stats(
+    entries: &[AccessLogEntry],
+    now: DateTime<Utc>,
+) -> HashMap<String, AccessStats> {
+    let mut stats: HashMap<String, AccessStats> = HashMap::new();
+    for entry in entries {
+        let id = entry.id.trim();
+        if id.is_empty() {
+            continue;
+        }
+        let Some(ts) = parse_rfc3339(&entry.ts) else {
+            continue;
+        };
+        let age_days = (now - ts).num_days().max(0) as f64;
+        let weight = 0.5_f64.powf(age_days / ACCESS_DECAY_HALF_LIFE_DAYS);
+        let entry_stats = stats.entry(id.to_string()).or_default();
+        entry_stats.count += 1;
+        entry_stats.score += weight;
+    }
+    stats
+}
+
+/// The `memory_value` access-multiplier: `1.0` (neutral) with no data, rising
+/// monotonically toward `1.0 + ACCESS_MULTIPLIER_WEIGHT` as `stats.score` grows,
+/// via a hyperbolic saturation curve (`score / (score + K)`) that is
+/// self-bounding to `[0, 1)` by construction — no separate clamp needed to
+/// guarantee the multiplier never drops below `1.0` or exceeds the cap.
+pub(crate) fn access_multiplier(stats: Option<&AccessStats>) -> f64 {
+    let score = stats.map(|value| value.score).unwrap_or(0.0);
+    if score <= 0.0 {
+        return 1.0;
+    }
+    let normalized = score / (score + ACCESS_SATURATION_K);
+    1.0 + ACCESS_MULTIPLIER_WEIGHT * normalized
+}
+
+/// Compaction policy applied when the log exceeds
+/// [`ACCESS_LOG_COMPACT_TRIGGER_BYTES`]: drop entries older than
+/// [`ACCESS_LOG_AGING_WINDOW_DAYS`], then — if still over
+/// [`ACCESS_LOG_MAX_RETAINED_ENTRIES`] — drop the oldest until it fits. `entries`
+/// must be in append (chronological) order, which is how they're read back from
+/// the file.
+pub(crate) fn compact_entries(
+    mut entries: Vec<AccessLogEntry>,
+    now: DateTime<Utc>,
+) -> Vec<AccessLogEntry> {
+    entries.retain(|entry| {
+        parse_rfc3339(&entry.ts)
+            .map(|ts| (now - ts).num_days() <= ACCESS_LOG_AGING_WINDOW_DAYS)
+            // Malformed timestamp: can't tell its age, so don't keep it around
+            // forever — drop it on compaction.
+            .unwrap_or(false)
+    });
+    if entries.len() > ACCESS_LOG_MAX_RETAINED_ENTRIES {
+        let drop_count = entries.len() - ACCESS_LOG_MAX_RETAINED_ENTRIES;
+        entries.drain(0..drop_count);
+    }
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: &str, ts: DateTime<Utc>) -> AccessLogEntry {
+        AccessLogEntry {
+            id: id.to_string(),
+            ts: ts.to_rfc3339(),
+        }
+    }
+
+    #[test]
+    fn multiplier_is_neutral_with_no_data() {
+        assert_eq!(access_multiplier(None), 1.0);
+        assert_eq!(access_multiplier(Some(&AccessStats::default())), 1.0);
+    }
+
+    #[test]
+    fn multiplier_increases_monotonically_with_score_and_stays_bounded() {
+        let low = access_multiplier(Some(&AccessStats {
+            count: 1,
+            score: 0.5,
+        }));
+        let mid = access_multiplier(Some(&AccessStats {
+            count: 5,
+            score: 3.0,
+        }));
+        let high = access_multiplier(Some(&AccessStats {
+            count: 500,
+            score: 10_000.0,
+        }));
+        assert!(low > 1.0, "any positive score beats the 1.0 baseline");
+        assert!(mid > low);
+        assert!(high > mid);
+        assert!(
+            high < 1.0 + ACCESS_MULTIPLIER_WEIGHT,
+            "even an extreme score stays strictly below the cap"
+        );
+    }
+
+    #[test]
+    fn aggregate_counts_and_decays_by_age() {
+        let now = Utc::now();
+        let entries = vec![
+            entry("mem-a", now),
+            entry("mem-a", now - chrono::Duration::days(30)),
+            entry("mem-b", now - chrono::Duration::days(365)),
+        ];
+        let stats = aggregate_access_stats(&entries, now);
+        let a = stats.get("mem-a").unwrap();
+        assert_eq!(a.count, 2);
+        // today's access weighs 1.0, the 30-day-old one weighs 0.5 (one half-life).
+        assert!((a.score - 1.5).abs() < 0.01, "score = {}", a.score);
+
+        let b = stats.get("mem-b").unwrap();
+        assert_eq!(b.count, 1);
+        assert!(b.score > 0.0 && b.score < 0.01, "score = {}", b.score);
+    }
+
+    #[test]
+    fn aggregate_skips_malformed_entries() {
+        let now = Utc::now();
+        let entries = vec![
+            AccessLogEntry {
+                id: "".to_string(),
+                ts: now.to_rfc3339(),
+            },
+            AccessLogEntry {
+                id: "mem-c".to_string(),
+                ts: "not-a-timestamp".to_string(),
+            },
+        ];
+        let stats = aggregate_access_stats(&entries, now);
+        assert!(stats.is_empty());
+    }
+
+    #[test]
+    fn parse_access_log_skips_blank_and_malformed_lines() {
+        let raw = "{\"id\":\"a\",\"ts\":\"2026-01-01T00:00:00Z\"}\n\nnot json\n{\"id\":\"b\",\"ts\":\"2026-01-02T00:00:00Z\"}\n";
+        let entries = parse_access_log(raw);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].id, "a");
+        assert_eq!(entries[1].id, "b");
+    }
+
+    #[test]
+    fn compact_entries_drops_stale_and_bounds_retained_count() {
+        let now = Utc::now();
+        let mut entries = vec![entry("old", now - chrono::Duration::days(200))];
+        for i in 0..(ACCESS_LOG_MAX_RETAINED_ENTRIES + 500) {
+            entries.push(entry(&format!("mem-{i}"), now));
+        }
+        let compacted = compact_entries(entries, now);
+        assert!(!compacted.iter().any(|e| e.id == "old"), "aged out");
+        assert_eq!(compacted.len(), ACCESS_LOG_MAX_RETAINED_ENTRIES);
+        // Oldest-first drop: the earliest-pushed "recent" entries are the ones cut.
+        assert!(!compacted.iter().any(|e| e.id == "mem-0"));
+        assert!(compacted
+            .iter()
+            .any(|e| e.id == format!("mem-{}", ACCESS_LOG_MAX_RETAINED_ENTRIES + 499)));
+    }
+}

--- a/crates/infra/bamboo-memory/src/memory_store/mod.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/mod.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+mod access_log;
 pub mod embedding;
 pub mod freshness;
 mod lexical_bm25;

--- a/crates/infra/bamboo-memory/src/memory_store/store.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/store.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
@@ -9,6 +9,9 @@ use tokio::sync::Mutex;
 
 use bamboo_agent_core::workspace_state;
 
+use super::access_log::{
+    self, AccessLogEntry, AccessStats, ACCESS_LOG_COMPACT_TRIGGER_BYTES, ACCESS_LOG_FILE,
+};
 use super::lexical_bm25;
 use super::{
     build_dream_view, build_memory_markdown_view, build_recent_markdown_view,
@@ -77,12 +80,24 @@ enum WriteSimilarity {
 }
 
 /// Heuristic "keep value" of a memory for capacity eviction (L5), higher = more
-/// worth keeping. Recency (from `updated_at`) × confidence, with a penalty for
-/// Stale. Access frequency is NOT yet a factor: recall doesn't write back
-/// `last_accessed_at` (doing so on the read path would force an index rebuild per
-/// recall in this file-store), so it is omitted; when a cheap access signal exists
-/// it multiplies in here. Deterministic — no model, no embedding.
-fn memory_value(doc: &DurableMemoryDocument, now: chrono::DateTime<chrono::Utc>) -> f64 {
+/// worth keeping: `recency(updated_at) × confidence × stale_penalty ×
+/// access_multiplier`. Deterministic — no model, no embedding.
+///
+/// `access_multiplier` is the RFC's access-frequency term (#264, follow-up to
+/// #263 which shipped this function without it): recall can't write
+/// `last_accessed_at` back onto the recalled document without forcing a full
+/// per-scope index rebuild on that hot read path, so instead recall appends
+/// `{id, ts}` to a cheap per-scope `access_log.jsonl`
+/// ([`MemoryStore::record_memory_accesses`]) that the capacity gardener
+/// aggregates lazily into this multiplier ([`access_log::access_multiplier`]).
+/// Callers with no access-log data for a doc — or that don't wire the log at all
+/// — pass `1.0`, which is a true no-op here and reproduces the pre-#264 score
+/// exactly (back-compat).
+fn memory_value(
+    doc: &DurableMemoryDocument,
+    now: chrono::DateTime<chrono::Utc>,
+    access_multiplier: f64,
+) -> f64 {
     let confidence = match doc.frontmatter.confidence.as_deref() {
         Some("high") => 1.0,
         Some("low") => 0.25,
@@ -98,7 +113,7 @@ fn memory_value(doc: &DurableMemoryDocument, now: chrono::DateTime<chrono::Utc>)
     } else {
         1.0
     };
-    confidence * recency * stale_penalty
+    confidence * recency * stale_penalty * access_multiplier
 }
 
 /// Projected body length (chars) after appending `content` to `body` with the
@@ -512,6 +527,16 @@ impl MemoryStore {
         let remaining_count = remaining.len().saturating_sub(returned_count);
         let next_cursor =
             (remaining_count > 0).then(|| make_query_cursor(scope, offset + returned_count));
+
+        // L5 access signal (#264): log only the docs actually surfaced by this
+        // recall (the returned page), not every candidate that merely matched.
+        // Best-effort — see `record_memory_accesses` — so a log failure here can
+        // never turn a successful recall into an error.
+        if !items.is_empty() {
+            let accessed_ids: Vec<String> = items.iter().map(|item| item.id.clone()).collect();
+            self.record_memory_accesses(scope, project_key, &accessed_ids)
+                .await;
+        }
 
         Ok(MemoryQueryResult {
             items,
@@ -2024,12 +2049,30 @@ impl MemoryStore {
             return Ok(Vec::new());
         }
 
+        // Lazily aggregate the recall access log (#264) into the access-frequency
+        // multiplier `memory_value` folds in — only read here, on the
+        // infrequent gardener pass, never on the hot recall path. Best-effort: a
+        // read failure (or no log file yet) degrades to an empty map, which
+        // `access_log::access_multiplier` turns into the neutral `1.0` for every
+        // doc, i.e. identical to pre-#264 scoring.
+        let access_stats = self.access_log_stats(scope, project_key).await;
+
         // Lowest keep-value first; within a value tie, evict the OLDEST first (keep
         // the newer restatement). `updated_at` is UTC rfc3339 → string order is
         // chronological.
         evictable.sort_by(|a, b| {
-            memory_value(a, now)
-                .partial_cmp(&memory_value(b, now))
+            let value_a = memory_value(
+                a,
+                now,
+                access_log::access_multiplier(access_stats.get(&a.frontmatter.id)),
+            );
+            let value_b = memory_value(
+                b,
+                now,
+                access_log::access_multiplier(access_stats.get(&b.frontmatter.id)),
+            );
+            value_a
+                .partial_cmp(&value_b)
                 .unwrap_or(std::cmp::Ordering::Equal)
                 .then_with(|| a.frontmatter.updated_at.cmp(&b.frontmatter.updated_at))
         });
@@ -2624,6 +2667,162 @@ impl MemoryStore {
         // `flush()` on a tokio File is a no-op, and the old atomic_write path
         // did fsync. (Matches the store's #166 durability discipline.)
         file.sync_all().await
+    }
+
+    /// Append a `{id, ts}` line per recalled `ids` to the scope's
+    /// `access_log.jsonl` (#264) — the cheap access signal `memory_value` folds
+    /// into capacity-eviction scoring via [`access_log::access_multiplier`],
+    /// standing in for writing `last_accessed_at` back onto every recalled
+    /// document (which would force a full per-scope index rebuild per recall).
+    ///
+    /// Best-effort and O(ids): one file open, one buffered write, no fsync (this
+    /// is a soft signal, not an audit trail — losing a line just makes the access
+    /// signal for that memory slightly stale, whereas blocking or failing recall
+    /// on a log write is never acceptable). Any IO error is logged and swallowed;
+    /// callers on the recall path must be able to call this unconditionally.
+    async fn record_memory_accesses(
+        &self,
+        scope: MemoryScope,
+        project_key: Option<&str>,
+        ids: &[String],
+    ) {
+        if ids.is_empty() {
+            return;
+        }
+        let path = self
+            .resolver
+            .logs_dir(scope, project_key)
+            .join(ACCESS_LOG_FILE);
+        if let Err(error) = self.record_memory_accesses_inner(&path, ids).await {
+            tracing::debug!(
+                target: "bamboo_memory::access_log",
+                error = %error,
+                path = %path.display(),
+                "failed to append access log (best-effort; recall is unaffected)"
+            );
+        }
+    }
+
+    async fn record_memory_accesses_inner(&self, path: &Path, ids: &[String]) -> io::Result<()> {
+        // Guards the append + size-check + (rare) compaction as one critical
+        // section, scoped to just this scope's access-log file — NOT the
+        // scope-wide `scope_lock`, so a burst of concurrent recalls never
+        // contends with concurrent writers mutating the scope's memory docs.
+        let lock = self.path_lock(path.to_path_buf());
+        let _guard = lock.lock().await;
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        let ts = now_rfc3339();
+        let mut buf = String::new();
+        for id in ids {
+            let line = serde_json::to_string(&AccessLogEntry {
+                id: id.clone(),
+                ts: ts.clone(),
+            })
+            .map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("failed to serialize access log entry: {error}"),
+                )
+            })?;
+            buf.push_str(&line);
+            buf.push('\n');
+        }
+
+        use tokio::io::AsyncWriteExt;
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .await?;
+        file.write_all(buf.as_bytes()).await?;
+        file.flush().await?;
+        let size = file.metadata().await.map(|meta| meta.len()).unwrap_or(0);
+        drop(file);
+
+        if size > ACCESS_LOG_COMPACT_TRIGGER_BYTES {
+            self.compact_access_log_at(path).await?;
+        }
+        Ok(())
+    }
+
+    /// Rewrite the access log at `path` keeping only the entries
+    /// [`access_log::compact_entries`] retains — bounded size, safe under
+    /// concurrent recalls because the caller already holds `path`'s lock.
+    /// Not a hot-path operation: only runs when a scope's log crosses
+    /// [`ACCESS_LOG_COMPACT_TRIGGER_BYTES`], which — given the bound
+    /// `compact_entries` itself enforces — happens on the order of once per
+    /// several thousand recalls to that scope, not once per recall.
+    async fn compact_access_log_at(&self, path: &Path) -> io::Result<()> {
+        let raw = match fs::read_to_string(path).await {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        let entries = access_log::parse_access_log(&raw);
+        let compacted = access_log::compact_entries(entries, chrono::Utc::now());
+        let mut out = String::with_capacity(raw.len());
+        for entry in &compacted {
+            let line = serde_json::to_string(entry).map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("failed to serialize access log entry: {error}"),
+                )
+            })?;
+            out.push_str(&line);
+            out.push('\n');
+        }
+        crate::atomic_fs::atomic_write(path, out.as_bytes()).await
+    }
+
+    /// Lazily aggregate a scope's `access_log.jsonl` into per-id [`AccessStats`]
+    /// — called only from the (infrequent) capacity gardener pass, never from
+    /// the recall path. Best-effort: any read/parse failure (including "file
+    /// doesn't exist yet", the common case for a scope with no recall history
+    /// since #264 shipped) degrades to an empty map rather than failing the
+    /// caller, which via [`access_log::access_multiplier`] means every doc gets
+    /// the neutral `1.0` multiplier — i.e. scoring identical to before #264.
+    async fn access_log_stats(
+        &self,
+        scope: MemoryScope,
+        project_key: Option<&str>,
+    ) -> HashMap<String, AccessStats> {
+        let path = self
+            .resolver
+            .logs_dir(scope, project_key)
+            .join(ACCESS_LOG_FILE);
+        match self.read_access_log_stats_at(&path).await {
+            Ok(stats) => stats,
+            Err(error) => {
+                tracing::debug!(
+                    target: "bamboo_memory::access_log",
+                    error = %error,
+                    path = %path.display(),
+                    "failed to read access log (best-effort; scoring falls back to neutral)"
+                );
+                HashMap::new()
+            }
+        }
+    }
+
+    async fn read_access_log_stats_at(
+        &self,
+        path: &Path,
+    ) -> io::Result<HashMap<String, AccessStats>> {
+        let lock = self.path_lock(path.to_path_buf());
+        let _guard = lock.lock().await;
+        let raw = match fs::read_to_string(path).await {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(HashMap::new()),
+            Err(error) => return Err(error),
+        };
+        let entries = access_log::parse_access_log(&raw);
+        Ok(access_log::aggregate_access_stats(
+            &entries,
+            chrono::Utc::now(),
+        ))
     }
 
     async fn write_json_file<T: serde::Serialize>(
@@ -3761,6 +3960,269 @@ mod tests {
         assert!(docs
             .iter()
             .all(|d| d.frontmatter.status == DurableMemoryStatus::Active));
+    }
+
+    /// #264: a successful `query_scope` recall appends a `{id, ts}` line per
+    /// returned item to the scope's `access_log.jsonl` — the cheap signal that
+    /// stands in for writing `last_accessed_at` back onto the document.
+    #[tokio::test]
+    async fn query_scope_appends_access_log_for_returned_items() {
+        let dir = tempdir().unwrap();
+        let store = MemoryStore::new(dir.path());
+        let pk = Some("proj-1");
+
+        let doc = store
+            .write_memory(
+                MemoryScope::Project,
+                pk,
+                DurableMemoryType::Project,
+                "Release freeze begins next week",
+                "Merge freeze begins on Tuesday for mobile release cut.",
+                &[],
+                Some("session-1"),
+                "main-model",
+                true,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let log_path = store
+            .resolver()
+            .logs_dir(MemoryScope::Project, pk)
+            .join(ACCESS_LOG_FILE);
+        assert!(!log_path.exists(), "no access log before any recall");
+
+        let result = store
+            .query_scope(
+                MemoryScope::Project,
+                pk,
+                Some("release freeze"),
+                None,
+                None,
+                &MemoryQueryOptions {
+                    limit: Some(5),
+                    max_chars: Some(3000),
+                    cursor: None,
+                    include_related: false,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.items.len(), 1);
+
+        let raw = fs::read_to_string(&log_path).await.unwrap();
+        let entries = access_log::parse_access_log(&raw);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, doc.frontmatter.id);
+        assert!(parse_rfc3339(&entries[0].ts).is_some());
+
+        // A second recall appends a second line rather than rewriting the file.
+        store
+            .query_scope(
+                MemoryScope::Project,
+                pk,
+                Some("release freeze"),
+                None,
+                None,
+                &MemoryQueryOptions {
+                    limit: Some(5),
+                    max_chars: Some(3000),
+                    cursor: None,
+                    include_related: false,
+                },
+            )
+            .await
+            .unwrap();
+        let raw = fs::read_to_string(&log_path).await.unwrap();
+        assert_eq!(access_log::parse_access_log(&raw).len(), 2);
+    }
+
+    /// #264: recall must never fail because the (best-effort) access log couldn't
+    /// be written. Simulate a write failure by making the log's path itself a
+    /// directory, so `OpenOptions::append().open()` on it errors.
+    #[tokio::test]
+    async fn recall_succeeds_even_if_access_log_write_fails() {
+        let dir = tempdir().unwrap();
+        let store = MemoryStore::new(dir.path());
+        let pk = Some("proj-1");
+
+        let doc = store
+            .write_memory(
+                MemoryScope::Project,
+                pk,
+                DurableMemoryType::Project,
+                "Deploy pipeline rewritten",
+                "The deploy pipeline was rewritten to use the new build cache.",
+                &[],
+                Some("session-1"),
+                "main-model",
+                true,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let log_path = store
+            .resolver()
+            .logs_dir(MemoryScope::Project, pk)
+            .join(ACCESS_LOG_FILE);
+        // Force the append to fail: the log "file" path is actually a directory.
+        fs::create_dir_all(&log_path).await.unwrap();
+
+        let result = store
+            .query_scope(
+                MemoryScope::Project,
+                pk,
+                Some("deploy pipeline"),
+                None,
+                None,
+                &MemoryQueryOptions {
+                    limit: Some(5),
+                    max_chars: Some(3000),
+                    cursor: None,
+                    include_related: false,
+                },
+            )
+            .await
+            .expect("recall must succeed despite the access-log write failing");
+        assert_eq!(result.items.len(), 1);
+        assert_eq!(result.items[0].id, doc.frontmatter.id);
+    }
+
+    /// #264: with no access-log data at all (no file written), the multiplier is
+    /// neutral for every id — the exact back-compat guarantee `memory_value`'s
+    /// doc comment promises.
+    #[tokio::test]
+    async fn access_log_stats_defaults_to_empty_without_a_log_file() {
+        let dir = tempdir().unwrap();
+        let store = MemoryStore::new(dir.path());
+        let stats = store
+            .access_log_stats(MemoryScope::Project, Some("proj-1"))
+            .await;
+        assert!(stats.is_empty());
+        assert_eq!(access_log::access_multiplier(stats.get("anything")), 1.0);
+    }
+
+    /// L5 (#264): the access-frequency multiplier only ever helps a memory
+    /// survive capacity eviction. Two Project memories written back-to-back are
+    /// otherwise identical (same confidence, same status, same-day recency), so
+    /// with capacity forcing exactly one archival, the one with recall history
+    /// must be the one spared.
+    #[tokio::test]
+    async fn accessed_memory_outscores_unaccessed_peer_in_capacity_eviction() {
+        let dir = tempdir().unwrap();
+        let store = MemoryStore::new(dir.path());
+        let pk = Some("proj-1");
+
+        let accessed = store
+            .write_memory(
+                MemoryScope::Project,
+                pk,
+                DurableMemoryType::Project,
+                "Frequently recalled fact",
+                "This fact keeps getting pulled into context.",
+                &[],
+                Some("s"),
+                "m",
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+        let unaccessed = store
+            .write_memory(
+                MemoryScope::Project,
+                pk,
+                DurableMemoryType::Project,
+                "Never recalled fact",
+                "This fact has never been looked at since it was written.",
+                &[],
+                Some("s"),
+                "m",
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+
+        // Simulate recall history for `accessed` only, several times over.
+        let ids = vec![accessed.frontmatter.id.clone()];
+        for _ in 0..5 {
+            store
+                .record_memory_accesses(MemoryScope::Project, pk, &ids)
+                .await;
+        }
+
+        // capacity=1 with 2 scorable Project docs forces exactly one archival.
+        let archived = store
+            .enforce_scope_capacity(MemoryScope::Project, pk, 1, 10)
+            .await
+            .unwrap();
+        assert_eq!(archived, vec![unaccessed.frontmatter.id.clone()]);
+
+        let survivor = store
+            .get_memory(&accessed.frontmatter.id, pk)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(survivor.frontmatter.status, DurableMemoryStatus::Active);
+    }
+
+    /// #264: the log auto-compacts once it crosses the byte trigger, so it stays
+    /// bounded instead of growing forever. Seed it with many stale (aged-out)
+    /// entries past the compaction trigger size, then perform one more recall
+    /// access — which appends, checks the size, and (because the file is now
+    /// over the trigger) rewrites it via `compact_entries`, dropping everything
+    /// outside the aging window.
+    #[tokio::test]
+    async fn access_log_auto_compacts_when_over_byte_threshold() {
+        let dir = tempdir().unwrap();
+        let store = MemoryStore::new(dir.path());
+        let pk = Some("proj-1");
+        let log_path = store
+            .resolver()
+            .logs_dir(MemoryScope::Project, pk)
+            .join(ACCESS_LOG_FILE);
+        fs::create_dir_all(log_path.parent().unwrap())
+            .await
+            .unwrap();
+
+        // Well past both the 90-day aging window and the byte trigger.
+        let stale_ts = (chrono::Utc::now() - chrono::Duration::days(365)).to_rfc3339();
+        let mut raw = String::new();
+        for i in 0..6000 {
+            raw.push_str(
+                &serde_json::to_string(&AccessLogEntry {
+                    id: format!("stale-mem-{i}"),
+                    ts: stale_ts.clone(),
+                })
+                .unwrap(),
+            );
+            raw.push('\n');
+        }
+        assert!(
+            raw.len() as u64 > ACCESS_LOG_COMPACT_TRIGGER_BYTES,
+            "fixture must actually exceed the compaction trigger"
+        );
+        fs::write(&log_path, raw.as_bytes()).await.unwrap();
+
+        // One more access — triggers the size check + compaction inside the same
+        // best-effort append call.
+        store
+            .record_memory_accesses(MemoryScope::Project, pk, &["fresh-mem".to_string()])
+            .await;
+
+        let compacted_raw = fs::read_to_string(&log_path).await.unwrap();
+        assert!(
+            (compacted_raw.len() as u64) < ACCESS_LOG_COMPACT_TRIGGER_BYTES,
+            "compaction must bound the file back under the trigger size, got {} bytes",
+            compacted_raw.len()
+        );
+        let entries = access_log::parse_access_log(&compacted_raw);
+        // Every stale entry aged out; only the fresh one survives.
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, "fresh-mem");
     }
 
     /// Many `MemoryStore` instances pointed at the SAME data dir (the real


### PR DESCRIPTION
Closes #264 — fills the missing `access` term in `memory_value` (L5, #263) with the issue's proposed cheap access-log design.

## Changes

- **Recall appends, never rewrites**: `query_scope` appends `{id, ts}` JSONL lines to a per-scope `logs/access_log.jsonl` for the docs actually returned (not every candidate). One `OpenOptions::append` open per recall, no doc rewrite, no index rebuild. Best-effort: log failures are debug-logged and swallowed — recall's `Result` is never affected. `get_memory` is deliberately NOT instrumented (it's used ~15+ times internally for read-modify-write in merge/split/supersede; logging it would conflate internal reads with genuine recall).
- **Gardener aggregates lazily**: `enforce_scope_capacity` reads the log once per eviction pass into per-id `AccessStats` (count + 30-day-half-life decayed score) and folds it into the sort via `access_multiplier`.
- **Multiplier formula** (new pure-logic `access_log.rs`): `1.0 + score/(score + 3.0)` — exactly `1.0` (neutral) with no data, monotonic, self-bounded to `[1.0, 2.0)`. Access data can only ever HELP a memory survive; memories with no history score identically to pre-#264 (`memory_value(…, 1.0)` reproduces the old score bit-for-bit). Constants (30-day half-life matching `memory_value`'s recency clock, K=3, 2× cap) documented with rationale.
- **Compaction**: append path checks file size; over 256 KiB → atomic rewrite keeping entries younger than 90 days, capped at 20 000 newest. Amortized O(1) per append. Append+check+compact run under the store's existing per-path lock (scoped to the log file, so recalls never contend with scope doc writers).

## Tests

11 new tests: pure-logic (neutrality, monotonic+bounded multiplier, decay aggregation, malformed-line/entry skipping, compaction bounds) and store-level (append on recall, recall unaffected by log write failure, no-log-file back-compat, accessed-memory-outscores-unaccessed-peer in eviction, auto-compaction over threshold).

- `cargo test -p bamboo-memory`: 134 passed
- `cargo build` of all dependent crates (`bamboo-server-tools`, `bamboo-engine`, `bamboo-tools`, `bamboo-server`): clean — no public API change
- fmt clean; clippy warning set identical to origin/main baseline

## Notes for review

- Only search/recall (`query_scope`) builds access history; the `Get`-by-id tool path doesn't — flag if you want a hook at the `bamboo-server-tools` call site.
- Compaction is append-triggered only (no gardener-driven rotation); a scope that goes quiet right after crossing the threshold keeps its ≤256 KiB log at rest.
- Multiplier constants are judgment-calibrated ("noticeable but not dominant" vs the ~[0.125, 1.0] confidence×stale range), not empirically tuned.
- The freshness pass (issue says "optionally") was left untouched — capacity eviction was the stated scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jxUSVTtay3Usa6n8eUaFK

---
_Generated by [Claude Code](https://claude.ai/code/session_015jxUSVTtay3Usa6n8eUaFK)_