### PR TITLE
feat(cloud): converge default paths under data_dir — workspace root + subagent dirs

### DIFF
--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -24,6 +24,13 @@ impl AppState {
     ///   - workflows/: Workflow definitions
     ///   - cache/: Cached data
     ///   - runtime/: Runtime files
+    ///   - workspaces/: Default per-session workspace dirs (issue #217) — a
+    ///     session with no configured/explicit workspace gets
+    ///     `workspaces/{session_id}` here instead of the server process's
+    ///     cwd. Overridable via `BAMBOO_WORKSPACE_ROOT`.
+    ///   - subagents/: Local actor sub-agent fabric discovery + isolated
+    ///     per-child storage (issue #217) — replaces the old
+    ///     `env::temp_dir()/bamboo-subagents` default.
     ///
     /// # Returns
     ///
@@ -150,6 +157,23 @@ impl AppState {
                 },
             ));
         }
+
+        // Issue #217: wire the workspace-root + confinement policy into
+        // agent-core, mirroring the default-workspace provider just above.
+        // This is what lets `workspace_or_process_cwd` default a session with
+        // NO configured/explicit workspace to `data_dir/workspaces/{session}`
+        // instead of falling through to the server process's cwd, and lets
+        // `set_workspace` pin/relocate an explicit path when confinement is
+        // enabled (`BAMBOO_WORKSPACE_CONFINE` / `BAMBOO_WORKSPACE_ROOT`).
+        // Read fresh from the environment on every call (not captured here)
+        // so an operator-set env var is honored the same way `bamboo_dir()`
+        // itself is — no config-file knob needed.
+        bamboo_agent_core::workspace_state::set_workspace_root_provider(Box::new(|| {
+            bamboo_agent_core::workspace_state::WorkspaceRootConfig {
+                root: bamboo_config::paths::resolve_workspace_root(),
+                confine: bamboo_config::paths::workspace_confinement_enforced(),
+            }
+        }));
 
         let permission_checker = load_permission_checker(&bamboo_home_dir).await;
         let notification_service = Arc::new(bamboo_notification::NotificationService::new(

--- a/crates/core/bamboo-agent-core/src/workspace_state.rs
+++ b/crates/core/bamboo-agent-core/src/workspace_state.rs
@@ -1,5 +1,7 @@
 use dashmap::DashMap;
-use std::path::PathBuf;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::{Component, Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::Instant;
 
@@ -16,16 +18,28 @@ fn workspaces() -> &'static DashMap<String, WorkspaceEntry> {
     WORKSPACES.get_or_init(DashMap::new)
 }
 
-pub fn set_workspace(session_id: &str, workspace: PathBuf) {
+/// Assign `session_id`'s workspace, running the effective value through
+/// [`WORKSPACE_ROOT_PROVIDER`]'s pin/relocate policy (issue #217) if one is
+/// registered. Returns the FINAL stored path — which may differ from
+/// `workspace` when confinement relocated it — so callers that echo the
+/// workspace back (e.g. the `Workspace` tool's response) report the truth.
+///
+/// This is the single choke point every "explicit workspace assignment" path
+/// funnels through (the `Workspace` tool, [`ensure_session_workspace`]'s
+/// `preferred`/configured branches, child-session workspace inheritance) —
+/// see [`pin_workspace_path`] for the confinement policy itself.
+pub fn set_workspace(session_id: &str, workspace: PathBuf) -> PathBuf {
+    let workspace = pin_via_provider(workspace);
     let store = workspaces();
     store.insert(
         session_id.to_string(),
         WorkspaceEntry {
-            workspace,
+            workspace: workspace.clone(),
             last_touched: Instant::now(),
         },
     );
     evict_oldest_if_needed(store, MAX_TRACKED_WORKSPACES);
+    workspace
 }
 
 pub fn get_workspace(session_id: &str) -> Option<PathBuf> {
@@ -73,8 +87,7 @@ pub fn has_default_workspace_provider() -> bool {
 
 pub fn ensure_session_workspace(session_id: &str, preferred: Option<PathBuf>) -> Option<PathBuf> {
     if let Some(workspace) = preferred {
-        set_workspace(session_id, workspace.clone());
-        return Some(workspace);
+        return Some(set_workspace(session_id, workspace));
     }
 
     if let Some(existing) = get_workspace(session_id) {
@@ -82,20 +95,226 @@ pub fn ensure_session_workspace(session_id: &str, preferred: Option<PathBuf>) ->
     }
 
     if let Some(configured) = get_configured_default_workspace() {
-        set_workspace(session_id, configured.clone());
-        return Some(configured);
+        return Some(set_workspace(session_id, configured));
     }
 
     None
 }
 
+/// Resolve the working directory tools should use for `session_id`: the
+/// tracked/configured workspace if one exists, else (issue #217) a
+/// persistent, session-scoped directory under the registered workspace root
+/// (`WORKSPACE_ROOT_PROVIDER`'s `root`/`{session_id}`) — NOT the process
+/// working directory, so a server/orchestrator never leaks tool I/O into
+/// whatever directory it happened to boot in.
+///
+/// Back-compat (#217): when no [`WorkspaceRootProvider`] is registered — bare
+/// `agent-core`/tool unit tests, or any embedding that never called
+/// [`set_workspace_root_provider`] — this still falls back to the process
+/// `current_dir()`, identical to pre-#217 behavior. `session_id == None`
+/// (tool called with no session context at all) also falls back to
+/// `current_dir()`, since there is no session to scope a directory to.
 pub fn workspace_or_process_cwd(session_id: Option<&str>) -> PathBuf {
     if let Some(session_id) = session_id {
         if let Some(workspace) = ensure_session_workspace(session_id, None) {
             return workspace;
         }
+        if let Some(provider) = WORKSPACE_ROOT_PROVIDER.get() {
+            let cfg = provider();
+            let dir = default_session_workspace_dir(&cfg.root, session_id);
+            return set_workspace(session_id, dir);
+        }
     }
     std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+}
+
+/// Root + confinement policy for session workspaces, supplied by the
+/// composition root (server bootstrap / SDK builder) via
+/// [`set_workspace_root_provider`]. `agent-core` owns only this slot — see the
+/// [`DefaultWorkspaceProvider`] doc comment for why (agent-core must not
+/// depend on `bamboo-config`); the actual resolution rules (env var
+/// overrides, `bamboo_dir()` join) live there.
+#[derive(Clone, Debug)]
+pub struct WorkspaceRootConfig {
+    /// Directory new/relocated session workspaces are created under
+    /// (default `data_dir/workspaces`, overridable via `BAMBOO_WORKSPACE_ROOT`).
+    pub root: PathBuf,
+    /// Whether an explicitly-assigned workspace path must be canonicalized
+    /// and confined to `root` — escapes (`..`, a symlink pointing outside, or
+    /// an absolute path elsewhere on disk) are relocated to a deterministic
+    /// folder under `root` instead of honored as-is.
+    ///
+    /// OFF by default: local single-user back-compat (#217). A session's
+    /// workspace may point anywhere on disk, exactly as before this issue —
+    /// e.g. pointing bamboo at an existing project outside `~/.bamboo`. An
+    /// orchestrator opts into "one folder = one tenant" containment by
+    /// setting `BAMBOO_WORKSPACE_CONFINE=1` (or `BAMBOO_WORKSPACE_ROOT`).
+    pub confine: bool,
+}
+
+type WorkspaceRootProvider = Box<dyn Fn() -> WorkspaceRootConfig + Send + Sync>;
+static WORKSPACE_ROOT_PROVIDER: OnceLock<WorkspaceRootProvider> = OnceLock::new();
+
+/// Register the provider that resolves the workspace root + confinement
+/// policy. Called once at startup by the composition root (server bootstrap /
+/// SDK builder), mirroring [`set_default_workspace_provider`]. First
+/// registration wins; subsequent calls are ignored to keep the value stable.
+pub fn set_workspace_root_provider(provider: WorkspaceRootProvider) {
+    let _ = WORKSPACE_ROOT_PROVIDER.set(provider);
+}
+
+/// Whether a workspace-root provider has been registered.
+pub fn has_workspace_root_provider() -> bool {
+    WORKSPACE_ROOT_PROVIDER.get().is_some()
+}
+
+fn pin_via_provider(path: PathBuf) -> PathBuf {
+    match WORKSPACE_ROOT_PROVIDER.get() {
+        Some(provider) => {
+            let cfg = provider();
+            pin_workspace_path(&path, &cfg.root, cfg.confine)
+        }
+        None => path,
+    }
+}
+
+/// Sanitize an arbitrary string into a single, safe path component:
+/// alphanumeric / `-` / `_` / `.` only (anything else becomes `_`), with
+/// leading/trailing `.`/`_` trimmed and a length cap. A bare `.`/`..`/empty
+/// result falls back to `_`. Used to turn a session id — or an escaping
+/// path's leaf name — into a component that cannot itself traverse.
+pub fn sanitize_path_component(raw: &str) -> String {
+    let cleaned: String = raw
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let trimmed = cleaned.trim_matches(['.', '_']);
+    if trimmed.is_empty() || trimmed == "." || trimmed == ".." {
+        "_".to_string()
+    } else {
+        trimmed.chars().take(200).collect()
+    }
+}
+
+/// Lexically collapse `.`/`..` components WITHOUT touching the filesystem.
+/// Used as a fallback for paths that don't exist yet, where `canonicalize`
+/// can't resolve them.
+fn lexically_clean(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// Best-effort canonicalization: resolves symlinks + `..`/`.` for whatever
+/// prefix of `path` exists on disk, then lexically appends the remainder — so
+/// a not-yet-created target under an existing (possibly symlinked) parent
+/// still resolves to where it will actually land. Falls back to pure lexical
+/// cleaning if no ancestor exists at all (e.g. a fully hypothetical path).
+///
+/// This is a best-effort containment check, not adversarial sandboxing (see
+/// the crate-level scope note in the #217 tracking issue): it cannot see a
+/// symlink that gets created AFTER this check runs (TOCTOU), and a bash
+/// subprocess is free to do whatever it wants once it starts — that is the
+/// outer container's job, not this helper's.
+fn canonicalize_best_effort(path: &Path) -> PathBuf {
+    if let Ok(canon) = std::fs::canonicalize(path) {
+        return canon;
+    }
+    let mut remainder: Vec<std::ffi::OsString> = Vec::new();
+    let mut probe = path;
+    loop {
+        match probe.parent() {
+            Some(parent) => {
+                if let Some(name) = probe.file_name() {
+                    remainder.push(name.to_os_string());
+                }
+                if let Ok(canon_parent) = std::fs::canonicalize(parent) {
+                    let mut result = canon_parent;
+                    for part in remainder.into_iter().rev() {
+                        result.push(part);
+                    }
+                    return result;
+                }
+                probe = parent;
+            }
+            None => return lexically_clean(path),
+        }
+    }
+}
+
+/// Deterministically relocate an escaping path under `root`: derive a leaf
+/// name from the original path's last component (or a short hash of the full
+/// path if that's empty/unsafe/reserved) and create `root/<leaf>`.
+fn relocate_under_root(root: &Path, original: &Path) -> PathBuf {
+    let leaf = original
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(sanitize_path_component)
+        .filter(|s| s != "_");
+    let leaf = leaf.unwrap_or_else(|| {
+        let mut hasher = DefaultHasher::new();
+        original.hash(&mut hasher);
+        format!("relocated-{:x}", hasher.finish())
+    });
+    let target = root.join(leaf);
+    let _ = std::fs::create_dir_all(&target);
+    target
+}
+
+/// Resolve an explicitly-assigned workspace path against a root + policy
+/// (issue #217 acceptance criterion 2). Pure/directly-testable: takes the
+/// policy as plain parameters instead of reading the global provider (the
+/// provider itself is a thin wrapper calling this).
+///
+/// - `confine == false` (the default — local single-user back-compat):
+///   returns `requested` VERBATIM. A pure pass-through, byte-for-byte
+///   identical to pre-#217 `set_workspace` behavior: an explicit workspace
+///   may point anywhere on disk (e.g. an existing project outside
+///   `~/.bamboo`), and no canonicalization is imposed here — callers that
+///   want canonical paths (the `Workspace` tool, the chat handler) already
+///   canonicalize before storing, while `Config::get_default_work_area_path`
+///   DELIBERATELY returns a non-canonicalized path (macOS `/var` →
+///   `/private/var` rewrite is documented there as undesirable) and must not
+///   have canonicalization re-imposed on it.
+/// - `confine == true`: canonicalizes `requested` and requires the result to
+///   live under `root` (also canonicalized). An escape — `..`, a symlink
+///   pointing outside `root`, or an absolute path elsewhere — is RELOCATED to
+///   a deterministic folder under `root` rather than rejected outright, so a
+///   misbehaving/untrusted request degrades to a safe folder instead of hard
+///   -failing the whole session.
+pub fn pin_workspace_path(requested: &Path, root: &Path, confine: bool) -> PathBuf {
+    if !confine {
+        return requested.to_path_buf();
+    }
+    let canon_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let canon_requested = canonicalize_best_effort(requested);
+    if canon_requested.starts_with(&canon_root) {
+        return canon_requested;
+    }
+    relocate_under_root(&canon_root, requested)
+}
+
+/// Default per-session workspace directory under `root` (issue #217
+/// acceptance criterion 1): `root/<sanitized-session-id>`, created if
+/// missing. Pure/directly-testable, mirroring [`pin_workspace_path`].
+pub fn default_session_workspace_dir(root: &Path, session_id: &str) -> PathBuf {
+    let dir = root.join(sanitize_path_component(session_id));
+    let _ = std::fs::create_dir_all(&dir);
+    dir
 }
 
 fn evict_oldest_if_needed(store: &DashMap<String, WorkspaceEntry>, max_tracked_workspaces: usize) {
@@ -149,5 +368,202 @@ mod tests {
         assert!(!store.contains_key("s1"));
         assert!(store.contains_key("s2"));
         assert!(store.contains_key("s3"));
+    }
+
+    // ── #217: workspace-root resolution + confinement ────────────────────
+    //
+    // NOTE: none of these tests call `set_workspace_root_provider` — that
+    // OnceLock is process-global and first-registration-wins, so a test that
+    // sets it would permanently affect every other test in this binary
+    // (see the "workspace_or_process_cwd_falls_back_to_cwd_without_provider"
+    // test below, which relies on it staying unset). The provider-wiring
+    // itself is exercised end-to-end in `bamboo-tools` instead, in a
+    // separate test binary/process. Everything here tests the pure,
+    // parameterized helpers the provider wraps.
+
+    #[test]
+    fn sanitize_path_component_allows_safe_chars_untouched() {
+        assert_eq!(
+            sanitize_path_component("session-123_abc.def"),
+            "session-123_abc.def"
+        );
+    }
+
+    #[test]
+    fn sanitize_path_component_replaces_separators_and_traversal() {
+        // Leading `.`/`_` runs (including the `..` traversal tokens) are
+        // trimmed, so this can never reproduce a `..` component even though
+        // `.` itself is in the allowed charset.
+        assert_eq!(sanitize_path_component("../../etc/passwd"), "etc_passwd");
+        assert_eq!(sanitize_path_component("a/b\\c"), "a_b_c");
+    }
+
+    #[test]
+    fn sanitize_path_component_rejects_dot_and_dotdot_and_empty() {
+        assert_eq!(sanitize_path_component("."), "_");
+        assert_eq!(sanitize_path_component(".."), "_");
+        assert_eq!(sanitize_path_component(""), "_");
+        assert_eq!(sanitize_path_component("///"), "_");
+    }
+
+    #[test]
+    fn sanitize_path_component_caps_length() {
+        let long = "a".repeat(500);
+        assert_eq!(sanitize_path_component(&long).len(), 200);
+    }
+
+    /// Acceptance criterion 1: no explicit workspace path → default lands
+    /// under `root/{session}`.
+    #[test]
+    fn default_session_workspace_dir_lands_under_root_and_is_created() {
+        let root_dir = tempfile::tempdir().unwrap();
+        let root = root_dir.path().join("workspaces");
+
+        let dir = default_session_workspace_dir(&root, "session-abc-123");
+
+        assert_eq!(dir, root.join("session-abc-123"));
+        assert!(dir.is_dir(), "default workspace dir should be created");
+    }
+
+    #[test]
+    fn default_session_workspace_dir_sanitizes_unsafe_session_ids() {
+        let root_dir = tempfile::tempdir().unwrap();
+        let root = root_dir.path().join("workspaces");
+
+        let dir = default_session_workspace_dir(&root, "../../etc");
+
+        // The sanitized component can never escape `root` — it stays a
+        // single path segment directly under it.
+        assert_eq!(dir.parent().unwrap(), root);
+        assert!(dir.is_dir());
+    }
+
+    /// Acceptance criterion / back-compat: with confinement OFF (the
+    /// default), an explicit workspace path may point anywhere on disk,
+    /// exactly like pre-#217 behavior.
+    #[test]
+    fn pin_workspace_path_unconfined_allows_arbitrary_path_outside_root() {
+        let root_dir = tempfile::tempdir().unwrap();
+        let root = root_dir.path().join("workspaces");
+        let outside = tempfile::tempdir().unwrap();
+
+        let pinned = pin_workspace_path(outside.path(), &root, false);
+
+        // Verbatim pass-through: no canonicalization is imposed in
+        // unconfined mode (see the fn doc — `get_default_work_area_path`
+        // deliberately avoids canonical paths on macOS).
+        assert_eq!(pinned, outside.path());
+        assert!(!pinned.starts_with(&root));
+    }
+
+    /// Acceptance criterion 2: an explicit path already inside the root is
+    /// pinned (canonicalized) as-is when confinement is on.
+    #[test]
+    fn pin_workspace_path_confined_keeps_path_already_inside_root() {
+        let root_dir = tempfile::tempdir().unwrap();
+        let root = root_dir.path().join("workspaces");
+        let inside = root.join("my-project");
+        std::fs::create_dir_all(&inside).unwrap();
+
+        let pinned = pin_workspace_path(&inside, &root, true);
+
+        assert_eq!(pinned, inside.canonicalize().unwrap());
+        assert!(pinned.starts_with(root.canonicalize().unwrap()));
+    }
+
+    /// Acceptance criterion 2: a `..` traversal escape is relocated under
+    /// root rather than honored.
+    #[test]
+    fn pin_workspace_path_confined_relocates_dotdot_escape() {
+        let root_dir = tempfile::tempdir().unwrap();
+        let root = root_dir.path().join("workspaces");
+        std::fs::create_dir_all(&root).unwrap();
+        let escape = root.join("../escaped-outside");
+
+        let pinned = pin_workspace_path(&escape, &root, true);
+
+        let canon_root = root.canonicalize().unwrap();
+        assert!(
+            pinned.starts_with(&canon_root),
+            "escaping `..` path must be relocated under root, got {pinned:?}"
+        );
+        assert_eq!(pinned, canon_root.join("escaped-outside"));
+    }
+
+    /// Acceptance criterion 2: an absolute path pointing entirely outside
+    /// root is relocated under root rather than honored.
+    #[test]
+    fn pin_workspace_path_confined_relocates_absolute_escape() {
+        let root_dir = tempfile::tempdir().unwrap();
+        let root = root_dir.path().join("workspaces");
+        std::fs::create_dir_all(&root).unwrap();
+        let elsewhere = tempfile::tempdir().unwrap();
+        let absolute_escape = elsewhere.path().join("my-real-project");
+        std::fs::create_dir_all(&absolute_escape).unwrap();
+
+        let pinned = pin_workspace_path(&absolute_escape, &root, true);
+
+        let canon_root = root.canonicalize().unwrap();
+        assert!(
+            pinned.starts_with(&canon_root),
+            "escaping absolute path must be relocated under root, got {pinned:?}"
+        );
+        assert_eq!(pinned, canon_root.join("my-real-project"));
+    }
+
+    /// Acceptance criterion 2: a symlink that lives inside root but points
+    /// outside it is detected via canonicalize (which resolves symlinks) and
+    /// relocated rather than followed out of root.
+    #[test]
+    fn pin_workspace_path_confined_relocates_symlink_escape() {
+        let root_dir = tempfile::tempdir().unwrap();
+        let root = root_dir.path().join("workspaces");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let outside = tempfile::tempdir().unwrap();
+        let outside_target = outside.path().join("secret");
+        std::fs::create_dir_all(&outside_target).unwrap();
+
+        let symlink_path = root.join("link-to-outside");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside_target, &symlink_path).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(&outside_target, &symlink_path).unwrap();
+
+        let pinned = pin_workspace_path(&symlink_path, &root, true);
+
+        let canon_root = root.canonicalize().unwrap();
+        let canon_outside = outside_target.canonicalize().unwrap();
+        assert_ne!(
+            pinned, canon_outside,
+            "must not resolve to the symlink's real outside target"
+        );
+        assert!(
+            pinned.starts_with(&canon_root),
+            "symlink escape must be relocated under root, got {pinned:?}"
+        );
+    }
+
+    /// Back-compat (#217): with no workspace-root provider registered at all
+    /// (the state of this crate's own test binary — see the note above this
+    /// section), `workspace_or_process_cwd` falls back to the process
+    /// `current_dir()`, identical to pre-#217 behavior.
+    #[test]
+    fn workspace_or_process_cwd_falls_back_to_cwd_without_provider() {
+        assert!(!has_workspace_root_provider());
+        let session_id = format!("session_{}", uuid::Uuid::new_v4());
+
+        let resolved = workspace_or_process_cwd(Some(&session_id));
+
+        assert_eq!(resolved, std::env::current_dir().unwrap());
+    }
+
+    #[test]
+    fn workspace_or_process_cwd_without_session_id_falls_back_to_cwd() {
+        assert!(!has_workspace_root_provider());
+        assert_eq!(
+            workspace_or_process_cwd(None),
+            std::env::current_dir().unwrap()
+        );
     }
 }

--- a/crates/core/bamboo-agent-core/src/workspace_state.rs
+++ b/crates/core/bamboo-agent-core/src/workspace_state.rs
@@ -256,22 +256,43 @@ fn canonicalize_best_effort(path: &Path) -> PathBuf {
     }
 }
 
-/// Deterministically relocate an escaping path under `root`: derive a leaf
-/// name from the original path's last component (or a short hash of the full
-/// path if that's empty/unsafe/reserved) and create `root/<leaf>`.
+/// Deterministically relocate an escaping path under `root`.
+///
+/// The target MUST incorporate the full original path, not just its leaf —
+/// two different escaping paths that happen to share a basename (e.g.
+/// `/mnt/customer-a/project` and `/mnt/customer-b/project`) must land in
+/// DISTINCT directories, or tenant isolation (the entire point of
+/// confinement) collapses into cross-tenant data mixing. So the target is
+/// always `root/<sanitized-leaf>-<8-hex-hash-of-full-path>` (or a pure
+/// `root/relocated-<hash>` when the leaf is empty/unsafe/reserved) — a short
+/// deterministic hash of `original` suffixed onto a human-readable leaf,
+/// stable across calls/restarts since it's a pure function of the input path.
 fn relocate_under_root(root: &Path, original: &Path) -> PathBuf {
+    let mut hasher = DefaultHasher::new();
+    original.hash(&mut hasher);
+    let hash = hasher.finish();
+    // Truncate to exactly 8 hex chars (32 bits) for the leaf-suffixed form —
+    // short enough to stay a readable path component while still being
+    // vanishingly unlikely to collide for distinct real-world paths.
+    let short_hash = hash as u32;
+
     let leaf = original
         .file_name()
         .and_then(|s| s.to_str())
         .map(sanitize_path_component)
         .filter(|s| s != "_");
-    let leaf = leaf.unwrap_or_else(|| {
-        let mut hasher = DefaultHasher::new();
-        original.hash(&mut hasher);
-        format!("relocated-{:x}", hasher.finish())
-    });
-    let target = root.join(leaf);
-    let _ = std::fs::create_dir_all(&target);
+    let dir_name = match leaf {
+        Some(leaf) => format!("{leaf}-{short_hash:08x}"),
+        None => format!("relocated-{hash:x}"),
+    };
+    let target = root.join(dir_name);
+    if let Err(err) = std::fs::create_dir_all(&target) {
+        tracing::warn!(
+            path = %target.display(),
+            error = %err,
+            "relocate_under_root: failed to create relocated workspace directory"
+        );
+    }
     target
 }
 
@@ -300,6 +321,17 @@ pub fn pin_workspace_path(requested: &Path, root: &Path, confine: bool) -> PathB
     if !confine {
         return requested.to_path_buf();
     }
+    // Best-effort: make sure `root` exists before canonicalizing it, so a
+    // root that sits behind a symlink but hasn't been created yet doesn't
+    // silently fall back to its non-canonical form (which would spuriously
+    // fail the `starts_with` containment check below for every request).
+    if let Err(err) = std::fs::create_dir_all(root) {
+        tracing::warn!(
+            path = %root.display(),
+            error = %err,
+            "pin_workspace_path: failed to create workspace root directory"
+        );
+    }
     let canon_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     let canon_requested = canonicalize_best_effort(requested);
     if canon_requested.starts_with(&canon_root) {
@@ -313,7 +345,13 @@ pub fn pin_workspace_path(requested: &Path, root: &Path, confine: bool) -> PathB
 /// missing. Pure/directly-testable, mirroring [`pin_workspace_path`].
 pub fn default_session_workspace_dir(root: &Path, session_id: &str) -> PathBuf {
     let dir = root.join(sanitize_path_component(session_id));
-    let _ = std::fs::create_dir_all(&dir);
+    if let Err(err) = std::fs::create_dir_all(&dir) {
+        tracing::warn!(
+            path = %dir.display(),
+            error = %err,
+            "default_session_workspace_dir: failed to create session workspace directory"
+        );
+    }
     dir
 }
 
@@ -487,7 +525,14 @@ mod tests {
             pinned.starts_with(&canon_root),
             "escaping `..` path must be relocated under root, got {pinned:?}"
         );
-        assert_eq!(pinned, canon_root.join("escaped-outside"));
+        // The relocated leaf carries a hash suffix of the full original path
+        // (see `relocate_under_root`), not the bare basename.
+        let leaf = pinned.file_name().unwrap().to_str().unwrap();
+        assert!(
+            leaf.starts_with("escaped-outside-"),
+            "expected a hash-suffixed leaf, got {leaf:?}"
+        );
+        assert_eq!(pinned.parent().unwrap(), canon_root);
     }
 
     /// Acceptance criterion 2: an absolute path pointing entirely outside
@@ -508,7 +553,68 @@ mod tests {
             pinned.starts_with(&canon_root),
             "escaping absolute path must be relocated under root, got {pinned:?}"
         );
-        assert_eq!(pinned, canon_root.join("my-real-project"));
+        // The relocated leaf carries a hash suffix of the full original path
+        // (see `relocate_under_root`), not the bare basename.
+        let leaf = pinned.file_name().unwrap().to_str().unwrap();
+        assert!(
+            leaf.starts_with("my-real-project-"),
+            "expected a hash-suffixed leaf, got {leaf:?}"
+        );
+        assert_eq!(pinned.parent().unwrap(), canon_root);
+    }
+
+    /// HIGH finding (PR #467 review): two different escaping paths that
+    /// share the same basename must NOT collapse onto the same relocated
+    /// directory — that would silently mix state across tenants, defeating
+    /// the entire point of confinement. The relocation target must
+    /// incorporate a hash of the FULL original path, not just its leaf.
+    #[test]
+    fn pin_workspace_path_confined_relocates_same_basename_to_distinct_dirs() {
+        let root_dir = tempfile::tempdir().unwrap();
+        let root = root_dir.path().join("workspaces");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let tenant_a = tempfile::tempdir().unwrap();
+        let tenant_b = tempfile::tempdir().unwrap();
+        let path_a = tenant_a.path().join("project");
+        let path_b = tenant_b.path().join("project");
+        std::fs::create_dir_all(&path_a).unwrap();
+        std::fs::create_dir_all(&path_b).unwrap();
+
+        let pinned_a = pin_workspace_path(&path_a, &root, true);
+        let pinned_b = pin_workspace_path(&path_b, &root, true);
+
+        assert_ne!(
+            pinned_a, pinned_b,
+            "escaping paths sharing a basename must relocate to distinct directories, \
+             got {pinned_a:?} and {pinned_b:?}"
+        );
+        let canon_root = root.canonicalize().unwrap();
+        assert!(pinned_a.starts_with(&canon_root));
+        assert!(pinned_b.starts_with(&canon_root));
+    }
+
+    /// HIGH finding (PR #467 review): relocation must be deterministic — the
+    /// same original path pinned twice (e.g. across process restarts) lands
+    /// in the SAME relocated directory, so a session's confined workspace
+    /// stays stable.
+    #[test]
+    fn pin_workspace_path_confined_relocation_is_deterministic() {
+        let root_dir = tempfile::tempdir().unwrap();
+        let root = root_dir.path().join("workspaces");
+        std::fs::create_dir_all(&root).unwrap();
+
+        let elsewhere = tempfile::tempdir().unwrap();
+        let escape = elsewhere.path().join("repeatable-project");
+        std::fs::create_dir_all(&escape).unwrap();
+
+        let pinned_first = pin_workspace_path(&escape, &root, true);
+        let pinned_second = pin_workspace_path(&escape, &root, true);
+
+        assert_eq!(
+            pinned_first, pinned_second,
+            "pinning the same original path twice must produce the same relocated target"
+        );
     }
 
     /// Acceptance criterion 2: a symlink that lives inside root but points

--- a/crates/core/bamboo-agent-core/src/workspace_state.rs
+++ b/crates/core/bamboo-agent-core/src/workspace_state.rs
@@ -1,6 +1,4 @@
 use dashmap::DashMap;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::path::{Component, Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::Instant;
@@ -256,6 +254,24 @@ fn canonicalize_best_effort(path: &Path) -> PathBuf {
     }
 }
 
+/// 64-bit FNV-1a over raw bytes: a tiny, fully-specified, version-stable hash
+/// for deriving relocation directory names. Deliberately NOT `DefaultHasher`
+/// (SipHash with an unspecified, rustc-version-dependent algorithm) — the
+/// relocated directory name must stay identical across binary upgrades, or a
+/// confined tenant's relocated workspace silently changes paths after a
+/// rebuild. Not cryptographic; collision resistance here only needs to
+/// separate distinct real-world workspace paths.
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = FNV_OFFSET;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
 /// Deterministically relocate an escaping path under `root`.
 ///
 /// The target MUST incorporate the full original path, not just its leaf —
@@ -266,11 +282,12 @@ fn canonicalize_best_effort(path: &Path) -> PathBuf {
 /// always `root/<sanitized-leaf>-<8-hex-hash-of-full-path>` (or a pure
 /// `root/relocated-<hash>` when the leaf is empty/unsafe/reserved) — a short
 /// deterministic hash of `original` suffixed onto a human-readable leaf,
-/// stable across calls/restarts since it's a pure function of the input path.
+/// stable across calls/restarts AND binary upgrades since it's a pure,
+/// fixed-algorithm (FNV-1a, not std's version-unspecified `DefaultHasher`)
+/// function of the input path — a relocated tenant's directory must not
+/// silently move when bamboo is rebuilt with a newer toolchain.
 fn relocate_under_root(root: &Path, original: &Path) -> PathBuf {
-    let mut hasher = DefaultHasher::new();
-    original.hash(&mut hasher);
-    let hash = hasher.finish();
+    let hash = fnv1a_64(original.as_os_str().as_encoded_bytes());
     // Truncate to exactly 8 hex chars (32 bits) for the leaf-suffixed form —
     // short enough to stay a readable path component while still being
     // vanishingly unlikely to collide for distinct real-world paths.

--- a/crates/engine/bamboo-engine/src/external_agents/runtime.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/runtime.rs
@@ -95,11 +95,14 @@ pub fn build_external_child_runner(config: &Config) -> Arc<dyn ExternalChildRunn
                 );
                 continue;
             };
+            // #217: default under the persistent data-dir subagents home
+            // instead of `env::temp_dir()`, so fabric discovery state
+            // survives reboots and stays inside the tenant's data dir.
             let fabric_dir = profile
                 .fabric_dir
                 .clone()
                 .map(std::path::PathBuf::from)
-                .unwrap_or_else(|| std::env::temp_dir().join("bamboo-subagents"));
+                .unwrap_or_else(bamboo_config::paths::subagents_dir);
             let executor = match profile.executor.as_deref() {
                 Some("echo") => bamboo_subagent::provision::ExecutorSpec::Echo,
                 Some("bamboo_runtime") | None => {
@@ -214,11 +217,13 @@ fn build_local_actor_runner(config: &Config) -> Result<Arc<dyn ExternalChildRunn
         ),
     };
 
+    // #217: default under the persistent data-dir subagents home instead of
+    // `env::temp_dir()` (mirrors the `build_external_child_runner` arm above).
     let fabric_dir = sub
         .fabric_dir
         .clone()
         .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| std::env::temp_dir().join("bamboo-subagents"));
+        .unwrap_or_else(bamboo_config::paths::subagents_dir);
 
     let executor = match sub.executor.as_deref() {
         Some("echo") => bamboo_subagent::provision::ExecutorSpec::Echo,

--- a/crates/engine/bamboo-engine/src/sdk/spawn.rs
+++ b/crates/engine/bamboo-engine/src/sdk/spawn.rs
@@ -85,12 +85,17 @@ pub async fn run_child_spawn(ctx: SpawnContext, job: SpawnJob) -> Result<(), Str
     };
 
     // Register the child's workspace in the global state so tools
-    // (Read, Glob, Grep, Bash, etc.) can resolve relative paths.
+    // (Read, Glob, Grep, Bash, etc.) can resolve relative paths. `set_workspace`
+    // returns the FINAL stored path, which may differ from the requested one
+    // when workspace-root confinement (#217) relocated it — store that back
+    // onto the domain field so `session.workspace` never diverges from where
+    // tools actually run.
     if let Some(ref ws) = session.workspace {
-        bamboo_agent_core::workspace_state::set_workspace(
+        let stored = bamboo_agent_core::workspace_state::set_workspace(
             &session.id,
             std::path::PathBuf::from(ws),
         );
+        session.workspace = Some(stored.to_string_lossy().to_string());
     }
 
     if session.kind != SessionKind::Child {

--- a/crates/engine/bamboo-engine/src/session_app/child_session/actions.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_session/actions.rs
@@ -89,11 +89,15 @@ pub async fn create_child_action(
             .no_human_approver = true;
     }
 
-    child.workspace = Some(input.workspace.clone());
-    bamboo_agent_core::workspace_state::set_workspace(
+    // `set_workspace` returns the FINAL stored path, which may differ from
+    // the requested one when workspace-root confinement (#217) relocated it —
+    // store that back onto the domain field so `child.workspace` never
+    // diverges from where tools actually run.
+    let stored_workspace = bamboo_agent_core::workspace_state::set_workspace(
         &child.id,
         std::path::PathBuf::from(&input.workspace),
     );
+    child.workspace = Some(stored_workspace.to_string_lossy().to_string());
 
     child
         .metadata

--- a/crates/engine/bamboo-tools/src/tools/js_repl.rs
+++ b/crates/engine/bamboo-tools/src/tools/js_repl.rs
@@ -7,6 +7,8 @@ use std::process::Stdio;
 use tokio::process::Command;
 use tokio::time::{timeout, Duration};
 
+use super::workspace_state;
+
 const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 const MAX_TIMEOUT_MS: u64 = 120_000;
 const MAX_OUTPUT_BYTES: usize = 256 * 1024;
@@ -126,7 +128,7 @@ impl Tool for JsReplTool {
     async fn invoke(
         &self,
         args: serde_json::Value,
-        _ctx: ToolCtx,
+        ctx: ToolCtx,
     ) -> Result<ToolOutcome, ToolError> {
         let parsed: JsReplArgs = serde_json::from_value(args)
             .map_err(|e| ToolError::InvalidArguments(format!("Invalid js_repl args: {}", e)))?;
@@ -154,12 +156,23 @@ impl Tool for JsReplTool {
             code
         );
 
+        // #217: run in the session's workspace (falls back to the process cwd
+        // when no workspace is tracked — see `workspace_state::workspace_or_
+        // process_cwd`) instead of silently inheriting whatever directory the
+        // host process happens to be in. This is the same shared cwd
+        // resolution `Bash`/`Glob`/`Grep`/`Workspace`/`slash_command` already
+        // use, so relative paths in REPL code (`fs.writeFileSync('out.txt',
+        // ...)`) land in the same place a Bash command run in this session
+        // would land them.
+        let cwd = workspace_state::workspace_or_process_cwd(ctx.session_id());
+
         // `kill_on_drop(true)` ensures the child is killed when it goes out of
         // scope (i.e. on timeout). `wait_with_output()` takes ownership, so on
         // timeout the future is dropped and the child is killed automatically.
         let child = Command::new(&node_path)
             .arg("-e")
             .arg(&wrapper)
+            .current_dir(&cwd)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -266,6 +279,43 @@ mod tests {
         assert_eq!(payload["timed_out"], false);
         assert_eq!(payload["exit_code"], 0);
         assert!(payload["stdout"].as_str().unwrap().contains("4"));
+    }
+
+    /// Issue #217: `js_repl` must run in the session's tracked workspace, not
+    /// silently inherit the host process's cwd — the same shared cwd
+    /// resolution Bash/Glob/Grep/Workspace already use.
+    #[tokio::test]
+    async fn test_runs_in_session_workspace_not_process_cwd() {
+        if !has_node() {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let workspace = dir.path().canonicalize().unwrap();
+        let session = format!("session_{}", uuid::Uuid::new_v4());
+        workspace_state::set_workspace(&session, workspace.clone());
+
+        let tool = JsReplTool::new();
+        let ctx = ToolCtx {
+            session_id: Some(std::sync::Arc::from(session.as_str())),
+            tool_call_id: std::sync::Arc::from("call_1"),
+            event_tx: None,
+            available_tool_schemas: std::sync::Arc::from(Vec::new()),
+            bypass_permissions: false,
+            can_async_resume: false,
+            async_completion_sink: None,
+            bash_completion_sink: None,
+        };
+        let out = tool
+            .invoke(json!({ "code": "console.log(process.cwd())" }), ctx)
+            .await
+            .unwrap();
+        let ToolOutcome::Completed(result) = out else {
+            panic!("expected Completed")
+        };
+        assert!(result.success);
+        let payload: serde_json::Value = serde_json::from_str(&result.result).unwrap();
+        let stdout = payload["stdout"].as_str().unwrap().trim();
+        assert_eq!(PathBuf::from(stdout), workspace);
     }
 
     #[tokio::test]

--- a/crates/engine/bamboo-tools/src/tools/workspace.rs
+++ b/crates/engine/bamboo-tools/src/tools/workspace.rs
@@ -110,15 +110,25 @@ impl Tool for WorkspaceTool {
                     ToolError::Execution(format!("Failed to canonicalize path: {e}"))
                 })?;
 
-                workspace_state::set_workspace(session_id, absolute_path.clone());
+                // `set_workspace` returns the FINAL stored path, which may
+                // differ from `absolute_path` when workspace-root
+                // confinement (#217) relocated it — report the truth rather
+                // than the pre-relocation request.
+                let stored = workspace_state::set_workspace(session_id, absolute_path.clone());
+                let relocated = stored != absolute_path;
+
+                let mut payload = json!({
+                    "session_id": session_id,
+                    "workspace": bamboo_config::paths::path_to_display_string(&stored)
+                });
+                if relocated {
+                    payload["relocated_from"] =
+                        json!(bamboo_config::paths::path_to_display_string(&absolute_path));
+                }
 
                 Ok(ToolOutcome::Completed(ToolResult {
                     success: true,
-                    result: json!({
-                        "session_id": session_id,
-                        "workspace": bamboo_config::paths::path_to_display_string(&absolute_path)
-                    })
-                    .to_string(),
+                    result: payload.to_string(),
                     display_preference: Some("json".to_string()),
                     images: Vec::new(),
                 }))
@@ -301,4 +311,16 @@ mod tests {
             .expect_err("missing session should fail");
         assert!(matches!(err, ToolError::Execution(msg) if msg.contains("session_id")));
     }
+
+    // NOTE: the end-to-end test exercising `set_workspace_root_provider`
+    // (issue #217) lives in `tests/workspace_root_provider.rs`, NOT here.
+    // That `OnceLock` is process-global and first-registration-wins across
+    // this ENTIRE lib's unit-test binary (bash/glob/grep/slash_command/
+    // workspace tests all share one process) — registering it in-line here
+    // would non-deterministically poison every other test in the binary that
+    // assumes the pre-#217 unconfined default (e.g.
+    // `workspace_set_changes_session_workspace` below, which sets an
+    // arbitrary outside-any-root tempdir and expects it stored verbatim). A
+    // separate `tests/*.rs` integration file compiles to its own process, so
+    // it can safely register the provider without affecting anything here.
 }

--- a/crates/engine/bamboo-tools/tests/workspace_root_provider.rs
+++ b/crates/engine/bamboo-tools/tests/workspace_root_provider.rs
@@ -1,0 +1,104 @@
+//! Issue #217 end-to-end test for `bamboo_agent_core::workspace_state`'s
+//! `set_workspace_root_provider` wiring — the mechanism the server/SDK
+//! composition root uses to point tool cwd resolution at
+//! `data_dir/workspaces` instead of the process cwd, and to enable explicit
+//! -path confinement.
+//!
+//! This lives in its own integration-test binary (a separate process from
+//! `cargo test -p bamboo-tools --lib`) deliberately: `set_workspace_root_
+//! provider` is a process-global `OnceLock` (first-registration-wins), so
+//! registering it here would otherwise poison every unit test in the lib
+//! binary that assumes the pre-#217 unconfined default (e.g. `bash`/`glob`/
+//! `grep`/`workspace` tests that set a workspace to an arbitrary tempdir
+//! outside any root and expect it stored verbatim). The pure pin/relocate/
+//! default-dir ALGORITHMS are unit-tested exhaustively, with no global state,
+//! in `bamboo-agent-core::workspace_state`'s own test module — this file only
+//! proves the WIRING (does `workspace_or_process_cwd`/the `Workspace` tool
+//! actually consult the registered provider).
+
+use std::path::PathBuf;
+
+use bamboo_agent_core::workspace_state::{self, WorkspaceRootConfig};
+use bamboo_agent_core::{Tool, ToolCtx, ToolOutcome};
+use bamboo_tools::tools::WorkspaceTool;
+use serde_json::json;
+
+fn ctx_for(session: &str) -> ToolCtx {
+    ToolCtx {
+        session_id: Some(std::sync::Arc::from(session)),
+        tool_call_id: std::sync::Arc::from("call_1"),
+        event_tx: None,
+        available_tool_schemas: std::sync::Arc::from(Vec::new()),
+        bypass_permissions: false,
+        can_async_resume: false,
+        async_completion_sink: None,
+        bash_completion_sink: None,
+    }
+}
+
+/// Both acceptance-criterion angles (default-under-root, explicit-path
+/// confinement) are exercised together under the ONE provider policy this
+/// process registers — a second test in this file registering a DIFFERENT
+/// policy would be racy for the same first-wins-`OnceLock` reason described
+/// above.
+#[tokio::test]
+async fn workspace_provider_wiring_confines_and_defaults_end_to_end() {
+    let root_dir = tempfile::tempdir().unwrap();
+    let root = root_dir.path().join("workspaces");
+    workspace_state::set_workspace_root_provider(Box::new({
+        let root = root.clone();
+        move || WorkspaceRootConfig {
+            root: root.clone(),
+            confine: true,
+        }
+    }));
+
+    // Criterion 1: no explicit workspace path -> default lands under
+    // `root/{session}` (created), never the process cwd.
+    let session_a = format!("session_{}", uuid::Uuid::new_v4());
+    let default_dir = workspace_state::workspace_or_process_cwd(Some(&session_a));
+    let canon_root = root.canonicalize().unwrap();
+    assert!(
+        default_dir.starts_with(&canon_root),
+        "default workspace must land under the registered root, got {default_dir:?}"
+    );
+    assert!(default_dir.is_dir());
+    assert_ne!(default_dir, std::env::current_dir().unwrap());
+
+    // Criterion 2: an explicit path outside root, set via the Workspace
+    // tool, is relocated under root (confinement is enabled) rather than
+    // honored as-is — and the tool reports the ACTUAL stored path.
+    let outside = tempfile::tempdir().unwrap();
+    let real_project = outside.path().join("my-real-project");
+    tokio::fs::create_dir_all(&real_project).await.unwrap();
+    let session_b = format!("session_{}", uuid::Uuid::new_v4());
+
+    let tool = WorkspaceTool::new();
+    let out = tool
+        .invoke(
+            json!({"path": real_project.to_string_lossy()}),
+            ctx_for(&session_b),
+        )
+        .await
+        .unwrap();
+    let ToolOutcome::Completed(result) = out else {
+        panic!("expected Completed")
+    };
+    assert!(result.success);
+    let payload: serde_json::Value = serde_json::from_str(&result.result).unwrap();
+    let reported = PathBuf::from(payload["workspace"].as_str().unwrap());
+    assert!(
+        reported.starts_with(&canon_root),
+        "explicit outside-root path must be relocated under the confined root, got {reported:?}"
+    );
+    assert!(!reported.starts_with(outside.path().canonicalize().unwrap()));
+    assert!(
+        payload.get("relocated_from").is_some(),
+        "response should flag that relocation happened: {payload}"
+    );
+
+    // The session's tracked workspace matches what the tool reported —
+    // subsequent Bash/Glob/Grep calls in this session see the same dir.
+    let tracked = workspace_state::get_workspace(&session_b).unwrap();
+    assert_eq!(tracked, reported);
+}

--- a/crates/infra/bamboo-config/src/paths.rs
+++ b/crates/infra/bamboo-config/src/paths.rs
@@ -176,6 +176,66 @@ pub fn events_dir() -> PathBuf {
     bamboo_dir().join("events")
 }
 
+/// Get the local actor sub-agent state directory (`{bamboo_dir}/subagents`).
+///
+/// Issue #217: the persistent home for the sub-agent discovery fabric +
+/// isolated per-child storage, replacing the old `env::temp_dir()/bamboo-
+/// subagents` default so sub-agent state survives reboots and stays inside
+/// the tenant's data dir instead of scattering into `/tmp`.
+pub fn subagents_dir() -> PathBuf {
+    bamboo_dir().join("subagents")
+}
+
+/// Resolve the workspace root directory from runtime configuration.
+///
+/// Order:
+/// 1) `BAMBOO_WORKSPACE_ROOT` environment variable (an operator-chosen
+///    location — e.g. a mounted volume — that need not live under `bamboo_dir()`)
+/// 2) `{bamboo_dir}/workspaces`
+///
+/// This is the default home for a session's workspace when none is
+/// explicitly configured (issue #217 acceptance criterion 1), and the
+/// confinement root explicit workspace paths are pinned under when
+/// [`workspace_confinement_enforced`] is on (criterion 2).
+///
+/// Note: like [`resolve_bamboo_dir`], this does not consult an in-process
+/// global — it re-reads the environment every call, matching the pattern of
+/// [`resolve_bamboo_dir`] vs [`bamboo_dir`].
+pub fn resolve_workspace_root() -> PathBuf {
+    std::env::var("BAMBOO_WORKSPACE_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| bamboo_dir().join("workspaces"))
+}
+
+/// Alias for [`resolve_workspace_root`] — the workspaces root under the
+/// stabilized data dir (or its `BAMBOO_WORKSPACE_ROOT` override).
+pub fn workspaces_dir() -> PathBuf {
+    resolve_workspace_root()
+}
+
+/// Whether explicit workspace paths must be canonicalized and confined to
+/// [`resolve_workspace_root`] (issue #217 acceptance criterion 2) —
+/// escapes (`..`, a symlink pointing outside, or an absolute path elsewhere
+/// on disk) get relocated to a deterministic folder under the root instead of
+/// honored as-is.
+///
+/// OFF by default: local single-user back-compat. A session's workspace may
+/// point anywhere on disk exactly as before this issue — e.g. pointing bamboo
+/// at an existing project outside `~/.bamboo`. An orchestrator opts into
+/// "one folder = one tenant's entire state" containment by setting
+/// `BAMBOO_WORKSPACE_CONFINE=1`, or implicitly by setting
+/// `BAMBOO_WORKSPACE_ROOT` (choosing a dedicated workspace root is itself a
+/// signal the deployment wants containment).
+pub fn workspace_confinement_enforced() -> bool {
+    let explicit = std::env::var("BAMBOO_WORKSPACE_CONFINE")
+        .ok()
+        .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "True" | "yes" | "YES"));
+    match explicit {
+        Some(value) => value,
+        None => std::env::var_os("BAMBOO_WORKSPACE_ROOT").is_some(),
+    }
+}
+
 /// Load JSON config file
 pub fn load_config_json<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T, String> {
     if !path.exists() {
@@ -324,6 +384,94 @@ mod tests {
     #[test]
     fn test_sessions_dir_is_under_bamboo_dir() {
         assert_eq!(sessions_dir(), bamboo_dir().join("sessions"));
+    }
+
+    #[test]
+    fn test_subagents_dir_is_under_bamboo_dir() {
+        assert_eq!(subagents_dir(), bamboo_dir().join("subagents"));
+    }
+
+    #[test]
+    fn test_resolve_workspace_root_defaults_under_bamboo_dir() {
+        let _guard = crate::test_support::env_cache_lock_acquire();
+        let original = std::env::var_os("BAMBOO_WORKSPACE_ROOT");
+        std::env::remove_var("BAMBOO_WORKSPACE_ROOT");
+
+        assert_eq!(resolve_workspace_root(), bamboo_dir().join("workspaces"));
+        assert_eq!(workspaces_dir(), bamboo_dir().join("workspaces"));
+
+        if let Some(val) = original {
+            std::env::set_var("BAMBOO_WORKSPACE_ROOT", val);
+        }
+    }
+
+    #[test]
+    fn test_resolve_workspace_root_prefers_env_override() {
+        let _guard = crate::test_support::env_cache_lock_acquire();
+        let original = std::env::var_os("BAMBOO_WORKSPACE_ROOT");
+
+        std::env::set_var("BAMBOO_WORKSPACE_ROOT", "/mnt/tenant-workspaces");
+        assert_eq!(
+            resolve_workspace_root(),
+            PathBuf::from("/mnt/tenant-workspaces")
+        );
+
+        if let Some(val) = original {
+            std::env::set_var("BAMBOO_WORKSPACE_ROOT", val);
+        } else {
+            std::env::remove_var("BAMBOO_WORKSPACE_ROOT");
+        }
+    }
+
+    #[test]
+    fn test_workspace_confinement_off_by_default() {
+        let _guard = crate::test_support::env_cache_lock_acquire();
+        let original_confine = std::env::var_os("BAMBOO_WORKSPACE_CONFINE");
+        let original_root = std::env::var_os("BAMBOO_WORKSPACE_ROOT");
+        std::env::remove_var("BAMBOO_WORKSPACE_CONFINE");
+        std::env::remove_var("BAMBOO_WORKSPACE_ROOT");
+
+        assert!(!workspace_confinement_enforced());
+
+        if let Some(val) = original_confine {
+            std::env::set_var("BAMBOO_WORKSPACE_CONFINE", val);
+        }
+        if let Some(val) = original_root {
+            std::env::set_var("BAMBOO_WORKSPACE_ROOT", val);
+        }
+    }
+
+    #[test]
+    fn test_workspace_confinement_enabled_explicitly_or_via_root_override() {
+        let _guard = crate::test_support::env_cache_lock_acquire();
+        let original_confine = std::env::var_os("BAMBOO_WORKSPACE_CONFINE");
+        let original_root = std::env::var_os("BAMBOO_WORKSPACE_ROOT");
+
+        std::env::remove_var("BAMBOO_WORKSPACE_ROOT");
+        std::env::set_var("BAMBOO_WORKSPACE_CONFINE", "1");
+        assert!(workspace_confinement_enforced());
+
+        std::env::remove_var("BAMBOO_WORKSPACE_CONFINE");
+        std::env::set_var("BAMBOO_WORKSPACE_ROOT", "/mnt/tenant-workspaces");
+        assert!(
+            workspace_confinement_enforced(),
+            "setting a dedicated workspace root implicitly opts into confinement"
+        );
+
+        // An explicit `false` wins even when a root override is set.
+        std::env::set_var("BAMBOO_WORKSPACE_CONFINE", "false");
+        assert!(!workspace_confinement_enforced());
+
+        if let Some(val) = original_confine {
+            std::env::set_var("BAMBOO_WORKSPACE_CONFINE", val);
+        } else {
+            std::env::remove_var("BAMBOO_WORKSPACE_CONFINE");
+        }
+        if let Some(val) = original_root {
+            std::env::set_var("BAMBOO_WORKSPACE_ROOT", val);
+        } else {
+            std::env::remove_var("BAMBOO_WORKSPACE_ROOT");
+        }
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/paths.rs
+++ b/crates/infra/bamboo-config/src/paths.rs
@@ -207,12 +207,6 @@ pub fn resolve_workspace_root() -> PathBuf {
         .unwrap_or_else(|_| bamboo_dir().join("workspaces"))
 }
 
-/// Alias for [`resolve_workspace_root`] — the workspaces root under the
-/// stabilized data dir (or its `BAMBOO_WORKSPACE_ROOT` override).
-pub fn workspaces_dir() -> PathBuf {
-    resolve_workspace_root()
-}
-
 /// Whether explicit workspace paths must be canonicalized and confined to
 /// [`resolve_workspace_root`] (issue #217 acceptance criterion 2) —
 /// escapes (`..`, a symlink pointing outside, or an absolute path elsewhere
@@ -398,7 +392,6 @@ mod tests {
         std::env::remove_var("BAMBOO_WORKSPACE_ROOT");
 
         assert_eq!(resolve_workspace_root(), bamboo_dir().join("workspaces"));
-        assert_eq!(workspaces_dir(), bamboo_dir().join("workspaces"));
 
         if let Some(val) = original {
             std::env::set_var("BAMBOO_WORKSPACE_ROOT", val);

--- a/docs/guides/API.md
+++ b/docs/guides/API.md
@@ -480,6 +480,18 @@ bamboo serve --port 9562 --data-dir ~/.local/share/bamboo
 - `BAMBOO_PORT` - Server port (default: 9562)
 - `BAMBOO_DATA_DIR` - Data directory
 - `BAMBOO_BIND` - Bind address (default: 127.0.0.1)
+- `BAMBOO_WORKSPACE_ROOT` - Root directory for session workspaces that have no
+  explicit path (default: `<data-dir>/workspaces`). A session with no
+  configured/explicit workspace gets `<workspace-root>/<session-id>` instead
+  of the server process's working directory.
+- `BAMBOO_WORKSPACE_CONFINE` - Set to `1`/`true` to require every explicit
+  workspace path to be canonicalized and confined under
+  `BAMBOO_WORKSPACE_ROOT` (escapes via `..`, a symlink, or an absolute path
+  elsewhere are relocated under the root instead of honored as-is). Off by
+  default for local single-user use, where pointing bamboo at an existing
+  project directory anywhere on disk must keep working; implicitly enabled
+  when `BAMBOO_WORKSPACE_ROOT` is set explicitly. Intended for orchestrated /
+  multi-tenant deployments that want "one folder = one tenant's entire state".
 
 ---
 

--- a/src/actor_cli.rs
+++ b/src/actor_cli.rs
@@ -26,8 +26,12 @@ use bamboo_subagent::transport::{ChildClient, WsServer};
 use crate::subagent_worker::BambooRuntimeExecutor;
 
 /// Default fabric directory shared by all local actors.
+///
+/// #217: lives under the persistent data dir (`~/.bamboo/subagents` by
+/// default, or `BAMBOO_DATA_DIR`/`BAMBOO_WORKSPACE_ROOT`'s sibling) instead
+/// of `env::temp_dir()`, so actor discovery/storage state survives reboots.
 pub fn default_fabric_dir() -> PathBuf {
-    std::env::temp_dir().join("bamboo-subagents")
+    bamboo_config::paths::subagents_dir()
 }
 
 pub struct ActorRunArgs {

--- a/src/broker_agent.rs
+++ b/src/broker_agent.rs
@@ -154,8 +154,9 @@ fn build_spec(args: &BrokerAgentArgs) -> Result<ProvisionSpec, String> {
             depth: 0,
         },
         ExecutorSpec::BambooRuntime,
-        std::env::temp_dir()
-            .join("bamboo-broker-agents")
+        // #217: the persistent data-dir subagents home, not `env::temp_dir()`.
+        bamboo_config::paths::subagents_dir()
+            .join("broker-agents")
             .join(&args.id)
             .to_string_lossy()
             .into_owned(),

--- a/src/claude_code_executor.rs
+++ b/src/claude_code_executor.rs
@@ -88,10 +88,11 @@ const ENV_ALLOWLIST: &[&str] = &[
 /// [`ClaudeCodeExecutor::new`]'s `state_dir` a location the resumed-session
 /// state file (issue #444) survives in.
 pub fn resolve_claude_code_state_dir(storage_dir: &Option<String>, child_id: &str) -> PathBuf {
+    // #217: the persistent data-dir subagents home, not `env::temp_dir()`.
     storage_dir
         .clone()
         .map(PathBuf::from)
-        .unwrap_or_else(|| std::env::temp_dir().join("bamboo-subagents").join(child_id))
+        .unwrap_or_else(|| bamboo_config::paths::subagents_dir().join(child_id))
 }
 
 /// State file name inside a child's stable storage dir (issue #444). Holds the

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -50,8 +50,9 @@ pub async fn run() -> std::result::Result<(), String> {
 
     // Best-effort housekeeping while we boot: expire stale sibling storage
     // dirs (default retention 7 days) and stale fabric records.
+    // #217: the persistent data-dir subagents home, not `env::temp_dir()`.
     tokio::spawn(gc_stale_storage(
-        std::env::temp_dir().join("bamboo-subagents"),
+        bamboo_config::paths::subagents_dir(),
         STORAGE_RETENTION,
     ));
     {
@@ -199,15 +200,14 @@ impl BambooRuntimeExecutor {
     /// isolated storage/skills/metrics, builtin tools — never touching the user's
     /// `~/.bamboo` or persisting any secret.
     pub async fn build(spec: &ProvisionSpec) -> std::result::Result<Self, String> {
+        // #217: default under the persistent data-dir subagents home instead
+        // of `env::temp_dir()` (mirrors `resolve_claude_code_state_dir` in
+        // `claude_code_executor.rs`, which the doc comment there points at).
         let storage_dir = spec
             .storage_dir
             .clone()
             .map(PathBuf::from)
-            .unwrap_or_else(|| {
-                std::env::temp_dir()
-                    .join("bamboo-subagents")
-                    .join(&spec.identity.child_id)
-            });
+            .unwrap_or_else(|| bamboo_config::paths::subagents_dir().join(&spec.identity.child_id));
         tokio::fs::create_dir_all(&storage_dir)
             .await
             .map_err(|e| format!("create storage dir: {e}"))?;


### PR DESCRIPTION
Closes #217 — data_dir becomes the single persistent location: all default paths converge under it so an orchestrator can treat "one folder = one tenant's entire state".

## Changes (per acceptance criterion)

1. **Default workspace = `data_dir/workspaces/{session}`**: `workspace_or_process_cwd()` consults a new `WorkspaceRootProvider` (registered at server bootstrap) and defaults a session with no workspace to `resolve_workspace_root()/{sanitized-session-id}` (default `{data_dir}/workspaces`, overridable via `BAMBOO_WORKSPACE_ROOT`), memoized via `set_workspace`.
2. **Explicit paths pinned under a configurable root**: new pure `pin_workspace_path(requested, root, confine)` — with confinement ON, canonicalizes (symlink-resolving, best-effort for not-yet-existing suffixes) and requires the result under root; `..`/absolute/symlink escapes are RELOCATED to a deterministic folder under root (leaf name or hash), not honored. `set_workspace` is the single choke point, so every assignment path (Workspace tool, chat handler, schedule factory, connect bridge, child-session spawn) inherits the policy. The Workspace tool response reports the final stored path + `relocated_from`.
3. **Subagent run dir = `data_dir/subagents`**: all five production `env::temp_dir()/bamboo-subagents` defaults converged (`external_agents/runtime.rs` ×2, `actor_cli.rs`, `subagent_worker.rs` ×2, `claude_code_executor.rs`); `broker_agent.rs` → `data_dir/subagents/broker-agents`. New `bamboo_config::paths::subagents_dir()`.
4. **Repo-wide audit** (full per-hit disposition in the commit message body): 7 sites CONVERGED; RETAINED with rationale — fabric_deploy remote-host `/tmp` spec (executes on a remote host), SDK builder `project_dir=cwd` (read-only skill discovery), headless/actor CLI workspace=cwd (local interactive back-compat), TUI sidecar log, scp staging scratch, opt-in debug log, OCR scratch; everything else is test-only.
5. **One shared helper**: `workspace_state::workspace_or_process_cwd` is the single session-cwd resolver — bash/glob/grep/slash_command/workspace already used it; `js_repl` now routed through it (previously inherited host cwd). read/write/edit/notebook_edit are absolute-path-only by contract (no cwd resolution).
6. **Back-compat**: the new default activates only when a provider is registered (server/SDK root) — bare SDK/CLI/test embeddings keep byte-for-byte pre-#217 cwd fallback. Confinement is opt-in: `BAMBOO_WORKSPACE_CONFINE=1`, or implicitly via `BAMBOO_WORKSPACE_ROOT` (explicit `false` wins); unconfined mode is a pure pass-through (deliberately no canonicalization, preserving `get_default_work_area_path`'s documented non-canonical macOS behavior). **The one intentional observable change**: an unconfigured *server* session with no workspace now gets `~/.bamboo/workspaces/{session}` instead of the server process cwd — the issue's core ask, documented in `docs/guides/API.md`.

Scope note (per the issue): this is folder-based data/organizational isolation, NOT adversarial sandboxing — bash subprocesses can still escape; that's the outer container's job.

## Tests

19 new tests: sanitization (traversal tokens, length cap, dot/dotdot), lexical/best-effort canonicalization, escape relocation (`..`, absolute, real symlink in a tempdir), inside-root kept, unconfined pass-through, default-dir creation, js_repl cwd, paths.rs env-override/confinement-flag cases, plus an end-to-end provider-wiring integration test in its own process (`bamboo-tools/tests/workspace_root_provider.rs`) to avoid OnceLock cross-test poisoning.

- `cargo check --workspace`: clean
- `cargo test --lib`: bamboo-agent-core 125, bamboo-config 203, bamboo-tools 323 (+1 integration), bamboo-engine 907, bamboo-server 1178, bamboo-agent 98 — all passing
- fmt clean; clippy: zero warnings in touched files

## Notes for review

- `WORKSPACE_ROOT_PROVIDER` is a first-wins process-global `OnceLock` (same pattern as the existing `DEFAULT_WORKSPACE_PROVIDER`); two AppStates with different data dirs in one process share one policy.
- Relocation-not-rejection on escape is a design choice: a confined request for `/etc` becomes `root/etc` (Workspace tool surfaces `relocated_from`; non-tool paths relocate without a user-facing message). Flag if you'd rather hard-reject.
- Confinement is best-effort canonicalize-then-check (TOCTOU symlink swap not defended — outer container's job, per the issue's scope note).
- Stale pre-#217 `/tmp/bamboo-subagents` state is orphaned, not migrated (it was ephemeral by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jxUSVTtay3Usa6n8eUaFK

---
_Generated by [Claude Code](https://claude.ai/code/session_015jxUSVTtay3Usa6n8eUaFK)_