### PR TITLE
feat(connect): phase 3 — Feishu/Lark adapter (WS long-connection + interactive cards)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,6 +1363,7 @@ dependencies = [
  "bamboo-storage",
  "bamboo-subagent",
  "bamboo-tools",
+ "base64",
  "bytes",
  "chrono",
  "chrono-tz",
@@ -1377,6 +1378,7 @@ dependencies = [
  "mockall",
  "notify-rust",
  "parking_lot",
+ "prost",
  "rand 0.10.2",
  "regex",
  "reqwest 0.13.4",
@@ -1395,6 +1397,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-test",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -4993,6 +4996,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6813,7 +6839,9 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite 0.29.0",
 ]
 
@@ -7094,6 +7122,7 @@ dependencies = [
  "http 1.4.2",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.4",
  "sha1 0.10.6",
  "thiserror 2.0.18",

--- a/crates/app/bamboo-server/Cargo.toml
+++ b/crates/app/bamboo-server/Cargo.toml
@@ -103,6 +103,7 @@ url = "2"
 hex = "0.4"
 sha2 = "0.11"
 rand = "0.10"
+base64 = "0.22"
 # Plugin source-trust (`src/plugin_source.rs`): ed25519 publisher-signature
 # verification for URL-installed plugin bundles, layered on top of the
 # checksum + host-allowlist checks. Pure-Rust (curve25519-dalek), no TLS/libc
@@ -131,6 +132,16 @@ flate2 = "1"
 tar = "0.4"
 actix-governor = "0.10.0"
 notify-rust = "4.18"
+# Feishu/Lark connect adapter (`src/connect/platforms/feishu/`): the
+# `pbbp2.Frame`/`Header` wire types are hand-derived `prost::Message` impls
+# (no build.rs/protoc — see `feishu/pbbp2.rs`'s module doc), and the event
+# long-connection is a plain WS client. `native-tls` (NOT the default
+# rustls/aws-lc-rs feature set) to match this crate's reqwest pin — verify
+# with `cargo tree -i aws-lc-sys` after any version bump. `connect` pulls in
+# `connect_async` (TCP dialing) — `native-tls` alone only adds the TLS
+# stream wrapper, not dialing.
+prost = "0.13"
+tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "native-tls"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/app/bamboo-server/src/connect/mod.rs
+++ b/crates/app/bamboo-server/src/connect/mod.rs
@@ -13,6 +13,7 @@
 //!   bridge.rs         — chat ⇄ bamboo-session routing, busy lock, queueing
 //!   render.rs         — AgentEvent stream → platform messages
 //!   platforms/telegram.rs — long-poll adapter
+//!   platforms/feishu/     — Feishu/Lark WS long-connection adapter (phase 3)
 //! ```
 //!
 //! [`ConnectManager`] is constructed once at server startup (mirrors
@@ -65,7 +66,7 @@ impl ConnectManager {
         bridge.load_session_map().await;
 
         let mut tasks = Vec::new();
-        let telegram_start_ok = telegram_multi_bot_guard(&config_snapshot.connect.platforms);
+        let start_ok = multi_bot_guard(&config_snapshot.connect.platforms);
         for (index, platform_cfg) in config_snapshot.connect.platforms.iter().enumerate() {
             match platform_cfg.platform_type.as_str() {
                 "telegram" => {
@@ -86,7 +87,7 @@ impl ConnectManager {
                     // supported, start at most the first validly-configured
                     // telegram entry and reject the rest with a clear warning
                     // rather than let them collide.
-                    if !telegram_start_ok[index] {
+                    if !start_ok[index] {
                         tracing::warn!(
                             "connect: multiple telegram platform entries are configured; only \
                              the FIRST is started. A second telegram bot on this instance would \
@@ -107,26 +108,64 @@ impl ConnectManager {
 
                     let platform: Arc<dyn Platform> =
                         Arc::new(platforms::telegram::TelegramPlatform::new(token));
-                    let allow_from = platform_cfg.allow_from.clone();
-                    let (tx, rx) = mpsc::channel(64);
+                    spawn_platform_tasks(
+                        &mut tasks,
+                        &bridge,
+                        platform,
+                        platform_cfg.allow_from.clone(),
+                    );
+                }
+                "feishu" => {
+                    let app_id = platform_cfg.app_id.clone().unwrap_or_default();
+                    let app_secret = platform_cfg.app_secret.clone().unwrap_or_default();
+                    if app_id.trim().is_empty() || app_secret.trim().is_empty() {
+                        tracing::warn!(
+                            "connect: feishu platform configured without app_id/app_secret; \
+                             skipping"
+                        );
+                        continue;
+                    }
+                    // Same session-key collision as telegram's guard above:
+                    // `SessionKey` hardcodes "feishu", and two apps in one
+                    // group chat would also dedup-eat each other's copy of
+                    // the same message_id. At most one live feishu entry.
+                    if !start_ok[index] {
+                        tracing::warn!(
+                            "connect: multiple feishu platform entries are configured; only the \
+                             FIRST is started. A second feishu app on this instance would \
+                             collide with the first on the same session-routing key \
+                             (`feishu:<chat_id>:<open_id>`) and on inbound message dedup. \
+                             Remove the extra entry, or track issue #454 for per-bot session \
+                             keys."
+                        );
+                        continue;
+                    }
+                    let Some(base_url) = resolve_feishu_base_url(platform_cfg.domain.as_deref())
+                    else {
+                        tracing::warn!(
+                            domain = platform_cfg.domain.as_deref().unwrap_or_default(),
+                            "connect: feishu platform has an invalid domain (expected \"feishu\", \
+                             \"lark\", or an https:// base URL); skipping"
+                        );
+                        continue;
+                    };
+                    if platform_cfg.allow_from.is_empty() {
+                        tracing::warn!(
+                            "connect: feishu platform has an EMPTY allow_from list — every \
+                             inbound message will be denied until you add allowed open_ids to \
+                             connect.platforms[].allow_from"
+                        );
+                    }
 
-                    let platform_for_start = platform.clone();
-                    tasks.push(tokio::spawn(async move {
-                        if let Err(error) = platform_for_start.start(tx).await {
-                            tracing::warn!("connect: telegram platform loop exited: {error}");
-                        }
-                    }));
-
-                    let bridge_for_dispatch = bridge.clone();
-                    let platform_for_dispatch = platform.clone();
-                    tasks.push(tokio::spawn(dispatch_loop(
-                        bridge_for_dispatch,
-                        platform_for_dispatch,
-                        allow_from,
-                        rx,
-                    )));
-
-                    tracing::info!("connect: started telegram platform");
+                    let platform: Arc<dyn Platform> = Arc::new(
+                        platforms::feishu::FeishuPlatform::new(app_id, app_secret, base_url),
+                    );
+                    spawn_platform_tasks(
+                        &mut tasks,
+                        &bridge,
+                        platform,
+                        platform_cfg.allow_from.clone(),
+                    );
                 }
                 other => {
                     tracing::warn!("connect: unknown platform type '{other}'; skipping");
@@ -135,6 +174,53 @@ impl ConnectManager {
         }
 
         Self { tasks }
+    }
+}
+
+/// Spawns the pair of background tasks every platform entry needs — the
+/// adapter's own `start()` loop and its [`dispatch_loop`] — and logs the
+/// startup. Factored out of the per-platform match arms, which only differ in
+/// how they validate config and construct the adapter.
+fn spawn_platform_tasks(
+    tasks: &mut Vec<tokio::task::JoinHandle<()>>,
+    bridge: &Arc<ConnectBridge>,
+    platform: Arc<dyn Platform>,
+    allow_from: Vec<String>,
+) {
+    let name = platform.name().to_string();
+    let (tx, rx) = mpsc::channel(64);
+
+    let platform_for_start = platform.clone();
+    let name_for_start = name.clone();
+    tasks.push(tokio::spawn(async move {
+        if let Err(error) = platform_for_start.start(tx).await {
+            tracing::warn!("connect: {name_for_start} platform loop exited: {error}");
+        }
+    }));
+
+    tasks.push(tokio::spawn(dispatch_loop(
+        bridge.clone(),
+        platform,
+        allow_from,
+        rx,
+    )));
+
+    tracing::info!("connect: started {name} platform");
+}
+
+/// Resolves the `domain` config field of a feishu platform entry to an API
+/// base URL: absent/`"feishu"` → open.feishu.cn, `"lark"` → open.larksuite.com
+/// (Lark international), any `https://` value → private-deployment base used
+/// as-is (trailing slash trimmed). Anything else is invalid — the caller
+/// warns and skips the entry.
+fn resolve_feishu_base_url(domain: Option<&str>) -> Option<String> {
+    match domain.map(str::trim).filter(|d| !d.is_empty()) {
+        None | Some("feishu") => Some("https://open.feishu.cn".to_string()),
+        Some("lark") => Some("https://open.larksuite.com".to_string()),
+        Some(custom) if custom.starts_with("https://") => {
+            Some(custom.trim_end_matches('/').to_string())
+        }
+        Some(_) => None,
     }
 }
 
@@ -148,48 +234,44 @@ impl Drop for ConnectManager {
 
 /// Issue #454 follow-up (multi-bot session-key collision): for each entry in
 /// `platforms` (same order/length as the input), returns whether
-/// [`ConnectManager::start`] is allowed to start it as far as the
-/// "at most one live telegram bot" guard is concerned.
+/// [`ConnectManager::start`] is allowed to start it as far as the "at most
+/// one live bot PER PLATFORM TYPE" guard is concerned.
 ///
-/// `SessionKey`/`InboundMessage.platform` hardcode `"telegram"` — there is no
-/// per-bot/config-index component in the session-routing key — so two
-/// telegram entries running at once would route messages from the SAME
-/// Telegram user (private-chat `chat_id` == user id) to different bots into
-/// the SAME bamboo session key, mixing their conversations. Rather than the
-/// more invasive fix of threading a bot identity through `SessionKey`
-/// (touching the routing key, the persisted session map's key format, and
-/// every call site that builds one), this rejects the collision at the
-/// source: only the FIRST validly-configured (`platform_type == "telegram"`
-/// and a non-empty token) entry is ever started; every other telegram entry
-/// is guarded off here regardless of how many are configured.
+/// `SessionKey`/`InboundMessage.platform` hardcode the platform name — there
+/// is no per-bot/config-index component in the session-routing key — so two
+/// entries of the same type running at once would route messages from the
+/// SAME user to different bots into the SAME bamboo session key, mixing
+/// their conversations (and, since the inbound dedup key is
+/// `platform:message_id`, two feishu apps in one group chat would even eat
+/// each other's copy of the same message). Rather than the more invasive fix
+/// of threading a bot identity through `SessionKey` (touching the routing
+/// key, the persisted session map's key format, and every call site that
+/// builds one), this rejects the collision at the source: only the FIRST
+/// validly-configured entry of each platform type is ever started; every
+/// later same-type entry is guarded off regardless of how many are
+/// configured.
 ///
-/// Entries with an empty/absent token are left `true` — they're handled by
-/// [`ConnectManager::start`]'s pre-existing "no token configured" skip, which
-/// doesn't count as a "started" telegram bot for this guard's purposes (so a
-/// blank placeholder entry followed by one real entry still starts the real
-/// one). Non-telegram entries are always `true` — this guard doesn't apply to
-/// them.
-fn telegram_multi_bot_guard(platforms: &[ConnectPlatformConfig]) -> Vec<bool> {
-    let mut seen_valid_telegram = false;
+/// Entries with empty/absent credentials are left `true` — they're handled
+/// by [`ConnectManager::start`]'s pre-existing "not configured" skip, which
+/// doesn't count as a "started" bot for this guard's purposes (so a blank
+/// placeholder entry followed by one real entry still starts the real one).
+/// Unknown platform types are always `true` — `start` skips them anyway.
+fn multi_bot_guard(platforms: &[ConnectPlatformConfig]) -> Vec<bool> {
+    let mut seen_valid: std::collections::HashSet<&str> = std::collections::HashSet::new();
     platforms
         .iter()
         .map(|platform_cfg| {
-            if platform_cfg.platform_type != "telegram" {
+            let non_empty =
+                |field: &Option<String>| field.as_deref().is_some_and(|v| !v.trim().is_empty());
+            let valid = match platform_cfg.platform_type.as_str() {
+                "telegram" => non_empty(&platform_cfg.token),
+                "feishu" => non_empty(&platform_cfg.app_id) && non_empty(&platform_cfg.app_secret),
+                _ => return true,
+            };
+            if !valid {
                 return true;
             }
-            let has_token = platform_cfg
-                .token
-                .as_deref()
-                .is_some_and(|token| !token.trim().is_empty());
-            if !has_token {
-                return true;
-            }
-            if seen_valid_telegram {
-                false
-            } else {
-                seen_valid_telegram = true;
-                true
-            }
+            seen_valid.insert(platform_cfg.platform_type.as_str())
         })
         .collect()
 }
@@ -240,59 +322,111 @@ mod tests {
             platform_type: platform_type.to_string(),
             token: token.map(str::to_string),
             token_encrypted: None,
+            app_id: None,
+            app_secret: None,
+            app_secret_encrypted: None,
+            domain: None,
             allow_from: Vec::new(),
             admin_from: Vec::new(),
         }
     }
 
-    #[test]
-    fn telegram_multi_bot_guard_allows_a_single_telegram_entry() {
-        let platforms = vec![platform("telegram", Some("tok-1"))];
-        assert_eq!(telegram_multi_bot_guard(&platforms), vec![true]);
+    fn feishu_platform(app_id: Option<&str>, app_secret: Option<&str>) -> ConnectPlatformConfig {
+        ConnectPlatformConfig {
+            app_id: app_id.map(str::to_string),
+            app_secret: app_secret.map(str::to_string),
+            ..platform("feishu", None)
+        }
     }
 
     #[test]
-    fn telegram_multi_bot_guard_rejects_every_telegram_entry_after_the_first() {
+    fn multi_bot_guard_allows_a_single_telegram_entry() {
+        let platforms = vec![platform("telegram", Some("tok-1"))];
+        assert_eq!(multi_bot_guard(&platforms), vec![true]);
+    }
+
+    #[test]
+    fn multi_bot_guard_rejects_every_telegram_entry_after_the_first() {
         let platforms = vec![
             platform("telegram", Some("tok-1")),
             platform("telegram", Some("tok-2")),
             platform("telegram", Some("tok-3")),
         ];
-        assert_eq!(
-            telegram_multi_bot_guard(&platforms),
-            vec![true, false, false]
-        );
+        assert_eq!(multi_bot_guard(&platforms), vec![true, false, false]);
     }
 
+    /// The guard is PER platform type: one telegram and one feishu entry can
+    /// coexist, but a second live entry of the SAME type is rejected.
     #[test]
-    fn telegram_multi_bot_guard_ignores_non_telegram_entries() {
+    fn multi_bot_guard_is_scoped_per_platform_type() {
         let platforms = vec![
             platform("telegram", Some("tok-1")),
-            platform("feishu", Some("tok-x")),
+            feishu_platform(Some("cli_a"), Some("secret-a")),
             platform("telegram", Some("tok-2")),
+            feishu_platform(Some("cli_b"), Some("secret-b")),
         ];
-        assert_eq!(
-            telegram_multi_bot_guard(&platforms),
-            vec![true, true, false]
-        );
+        assert_eq!(multi_bot_guard(&platforms), vec![true, true, false, false]);
     }
 
-    /// A blank/absent-token entry doesn't count as a "started" telegram bot
-    /// for this guard — `ConnectManager::start`'s pre-existing empty-token
-    /// check skips it separately, so the NEXT (real) telegram entry must
-    /// still be allowed to start.
+    /// A blank/absent-credential entry doesn't count as a "started" bot for
+    /// this guard — `ConnectManager::start`'s pre-existing empty-credential
+    /// check skips it separately, so the NEXT (real) entry of the same type
+    /// must still be allowed to start.
     #[test]
-    fn telegram_multi_bot_guard_does_not_count_a_tokenless_entry_against_the_budget() {
+    fn multi_bot_guard_does_not_count_a_credentialless_entry_against_the_budget() {
         let platforms = vec![
             platform("telegram", None),
             platform("telegram", Some("")),
             platform("telegram", Some("tok-real")),
+            feishu_platform(Some("cli_a"), None),
+            feishu_platform(Some("cli_b"), Some("secret-real")),
         ];
-        assert_eq!(telegram_multi_bot_guard(&platforms), vec![true, true, true]);
+        assert_eq!(
+            multi_bot_guard(&platforms),
+            vec![true, true, true, true, true]
+        );
     }
 
     #[test]
-    fn telegram_multi_bot_guard_handles_an_empty_platform_list() {
-        assert_eq!(telegram_multi_bot_guard(&[]), Vec::<bool>::new());
+    fn multi_bot_guard_leaves_unknown_platform_types_alone() {
+        let platforms = vec![
+            platform("dingtalk", Some("x")),
+            platform("dingtalk", Some("y")),
+        ];
+        assert_eq!(multi_bot_guard(&platforms), vec![true, true]);
+    }
+
+    #[test]
+    fn multi_bot_guard_handles_an_empty_platform_list() {
+        assert_eq!(multi_bot_guard(&[]), Vec::<bool>::new());
+    }
+
+    #[test]
+    fn resolve_feishu_base_url_covers_the_three_domain_forms() {
+        assert_eq!(
+            resolve_feishu_base_url(None).as_deref(),
+            Some("https://open.feishu.cn")
+        );
+        assert_eq!(
+            resolve_feishu_base_url(Some("feishu")).as_deref(),
+            Some("https://open.feishu.cn")
+        );
+        assert_eq!(
+            resolve_feishu_base_url(Some("")).as_deref(),
+            Some("https://open.feishu.cn")
+        );
+        assert_eq!(
+            resolve_feishu_base_url(Some("lark")).as_deref(),
+            Some("https://open.larksuite.com")
+        );
+        assert_eq!(
+            resolve_feishu_base_url(Some("https://feishu.example.corp/")).as_deref(),
+            Some("https://feishu.example.corp")
+        );
+        assert_eq!(
+            resolve_feishu_base_url(Some("http://insecure.example")),
+            None
+        );
+        assert_eq!(resolve_feishu_base_url(Some("dingtalk")), None);
     }
 }

--- a/crates/app/bamboo-server/src/connect/platforms/feishu/api.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/feishu/api.rs
@@ -1,0 +1,418 @@
+//! Feishu/Lark REST calls: `tenant_access_token` cache, send/update message,
+//! bot self-info, and the per-chat outgoing rate limiter — the counterpart
+//! to `ws.rs`'s event long-connection.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use tokio::sync::Mutex as AsyncMutex;
+use tokio::time::Instant;
+
+use super::super::super::platform::{PlatformError, PlatformResult};
+
+/// One shared `reqwest::Client` for every Feishu REST call (bootstrap POST
+/// included — `ws.rs` reuses this too). Mirrors `telegram.rs`'s
+/// `http_client()` — the workspace's pinned (native-tls) `reqwest`, never a
+/// second connector.
+pub(super) fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+/// Formats a `reqwest::Error` for logs/errors WITHOUT `app_secret` or the
+/// current `tenant_access_token`. Both live in a request body/header (never
+/// the URL), so a plain `error.without_url()` is already secret-free for
+/// THIS adapter's error paths — but redact any literal occurrence anyway,
+/// belt-and-braces, the same way `telegram.rs::sanitize_error` does for the
+/// bot token (e.g. a misbehaving proxy that echoes the request body into its
+/// own error text).
+pub(super) fn sanitize_reqwest_error(error: reqwest::Error, secrets: &[&str]) -> String {
+    let mut text = error.without_url().to_string();
+    for secret in secrets {
+        if !secret.is_empty() {
+            text = text.replace(secret, "[REDACTED]");
+        }
+    }
+    text
+}
+
+const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(30 * 60);
+/// Feishu-documented invalid/expired tenant_access_token error codes — force
+/// a cache-busting refresh and retry exactly once.
+const TOKEN_INVALID_CODES: [i64; 2] = [99991663, 99991661];
+/// Rate-limit / quota error codes that must be waited out, never dropped.
+const RATE_LIMIT_CODES: [i64; 2] = [99991400, 230020];
+const RATE_LIMIT_HEADER: &str = "x-ogw-ratelimit-reset";
+/// Upper bound on retry-after-rate-limit attempts for one logical send, so a
+/// misbehaving/absent reset header can't hang a caller forever. Feishu's own
+/// documented limits reset in low single-digit seconds, so this is generous.
+const MAX_RATE_LIMIT_RETRIES: u32 = 5;
+const DEFAULT_RATE_LIMIT_WAIT: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Default)]
+struct TokenState {
+    token: String,
+    /// `None` until the first successful fetch — always treated as expired.
+    expires_at: Option<Instant>,
+}
+
+/// Caches the `tenant_access_token`, refreshing when fewer than
+/// [`TOKEN_REFRESH_MARGIN`] remain (or on-demand via [`TokenCache::invalidate`]
+/// after a `99991663`/`99991661` response). The whole refresh happens under
+/// the single lock, which gives single-flight behavior for free — concurrent
+/// callers simply queue on the mutex rather than firing parallel refreshes.
+pub(super) struct TokenCache {
+    state: AsyncMutex<TokenState>,
+}
+
+impl TokenCache {
+    pub fn new() -> Self {
+        Self {
+            state: AsyncMutex::new(TokenState::default()),
+        }
+    }
+
+    /// Returns a valid token, refreshing first if necessary.
+    pub async fn get(
+        &self,
+        base_url: &str,
+        app_id: &str,
+        app_secret: &str,
+    ) -> PlatformResult<String> {
+        let mut guard = self.state.lock().await;
+        let needs_refresh = match guard.expires_at {
+            Some(expires_at) => Instant::now() + TOKEN_REFRESH_MARGIN >= expires_at,
+            None => true,
+        };
+        if needs_refresh {
+            refresh_locked(&mut guard, base_url, app_id, app_secret).await?;
+        }
+        Ok(guard.token.clone())
+    }
+
+    /// Forces the NEXT [`TokenCache::get`] call to refresh, regardless of the
+    /// cached expiry — used after a `99991663`/`99991661` "invalid token"
+    /// response so a stale cached value is never retried a second time.
+    pub async fn invalidate(&self) {
+        let mut guard = self.state.lock().await;
+        guard.expires_at = None;
+    }
+}
+
+async fn refresh_locked(
+    state: &mut TokenState,
+    base_url: &str,
+    app_id: &str,
+    app_secret: &str,
+) -> PlatformResult<()> {
+    #[derive(serde::Deserialize)]
+    struct TokenResponse {
+        code: i64,
+        #[serde(default)]
+        msg: Option<String>,
+        #[serde(default)]
+        tenant_access_token: Option<String>,
+        #[serde(default)]
+        expire: Option<u64>,
+    }
+
+    let url = format!(
+        "{}/open-apis/auth/v3/tenant_access_token/internal",
+        base_url.trim_end_matches('/')
+    );
+    let response = http_client()
+        .post(url)
+        .json(&serde_json::json!({ "app_id": app_id, "app_secret": app_secret }))
+        .send()
+        .await
+        .map_err(|error| {
+            PlatformError::other(format!(
+                "tenant_access_token request failed: {}",
+                sanitize_reqwest_error(error, &[app_secret])
+            ))
+        })?;
+
+    let parsed: TokenResponse = response.json().await.map_err(|error| {
+        PlatformError::other(format!(
+            "tenant_access_token response parse failed: {}",
+            sanitize_reqwest_error(error, &[app_secret])
+        ))
+    })?;
+
+    if parsed.code != 0 {
+        return Err(PlatformError::other(format!(
+            "tenant_access_token refresh failed (code={}): {}",
+            parsed.code,
+            parsed.msg.unwrap_or_default()
+        )));
+    }
+    let token = parsed
+        .tenant_access_token
+        .ok_or_else(|| PlatformError::other("tenant_access_token response missing token"))?;
+    let expire = Duration::from_secs(parsed.expire.unwrap_or(7200));
+
+    state.token = token;
+    state.expires_at = Some(Instant::now() + expire);
+    Ok(())
+}
+
+/// Per-chat outgoing token bucket — identical shape/semantics to
+/// `telegram.rs::RateLimiter` (blocks, never drops; a waiting chat never
+/// blocks a send to a different chat).
+pub(super) struct RateLimiter {
+    next_allowed: AsyncMutex<HashMap<String, Instant>>,
+    min_interval: Duration,
+}
+
+impl RateLimiter {
+    pub fn new(min_interval: Duration) -> Self {
+        Self {
+            next_allowed: AsyncMutex::new(HashMap::new()),
+            min_interval,
+        }
+    }
+
+    pub async fn wait(&self, key: &str) {
+        let now = Instant::now();
+        let scheduled = {
+            let mut guard = self.next_allowed.lock().await;
+            let earliest = guard.get(key).copied().unwrap_or(now);
+            let scheduled = earliest.max(now);
+            guard.insert(key.to_string(), scheduled + self.min_interval);
+            scheduled
+        };
+        if scheduled > now {
+            tokio::time::sleep(scheduled - now).await;
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct FeishuEnvelope<T> {
+    code: i64,
+    #[serde(default)]
+    msg: Option<String>,
+    #[serde(default)]
+    data: Option<T>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct SendMessageData {
+    #[serde(default)]
+    message_id: Option<String>,
+}
+
+/// `x-ogw-ratelimit-reset` is documented as the number of seconds until the
+/// limit resets. Parsed defensively — an absent/unparseable header falls
+/// back to [`DEFAULT_RATE_LIMIT_WAIT`] rather than failing the send.
+fn rate_limit_wait_from_headers(headers: &reqwest::header::HeaderMap) -> Duration {
+    headers
+        .get(RATE_LIMIT_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_RATE_LIMIT_WAIT)
+}
+
+/// `POST /open-apis/im/v1/messages?receive_id_type=chat_id`. `content` is
+/// caller-supplied already-JSON-encoded-as-a-string (text: `{"text":"..."}`;
+/// interactive: the card JSON itself, string-encoded) per the API contract.
+/// Retries once on a stale token (`99991663`/`99991661`) and waits out (never
+/// drops) a rate-limit response, up to [`MAX_RATE_LIMIT_RETRIES`].
+pub(super) async fn send_message(
+    tokens: &TokenCache,
+    base_url: &str,
+    app_id: &str,
+    app_secret: &str,
+    chat_id: &str,
+    msg_type: &str,
+    content: &str,
+) -> PlatformResult<String> {
+    let url = format!(
+        "{}/open-apis/im/v1/messages?receive_id_type=chat_id",
+        base_url.trim_end_matches('/')
+    );
+    let body = serde_json::json!({
+        "receive_id": chat_id,
+        "msg_type": msg_type,
+        "content": content,
+    });
+
+    let mut token_retried = false;
+    let mut rate_limit_attempts = 0u32;
+    loop {
+        let token = tokens.get(base_url, app_id, app_secret).await?;
+        let response = http_client()
+            .post(&url)
+            .bearer_auth(&token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| {
+                PlatformError::other(format!(
+                    "im/v1/messages send failed: {}",
+                    sanitize_reqwest_error(error, &[app_secret, &token])
+                ))
+            })?;
+
+        let status = response.status();
+        let headers = response.headers().clone();
+        let parsed: FeishuEnvelope<SendMessageData> = response.json().await.map_err(|error| {
+            PlatformError::other(format!(
+                "im/v1/messages response parse failed: {}",
+                sanitize_reqwest_error(error, &[app_secret, &token])
+            ))
+        })?;
+
+        if parsed.code == 0 {
+            return parsed
+                .data
+                .and_then(|d| d.message_id)
+                .ok_or_else(|| PlatformError::other("im/v1/messages response missing message_id"));
+        }
+
+        if !token_retried && TOKEN_INVALID_CODES.contains(&parsed.code) {
+            token_retried = true;
+            tokens.invalidate().await;
+            continue;
+        }
+
+        if (status.as_u16() == 429 || RATE_LIMIT_CODES.contains(&parsed.code))
+            && rate_limit_attempts < MAX_RATE_LIMIT_RETRIES
+        {
+            rate_limit_attempts += 1;
+            let wait = rate_limit_wait_from_headers(&headers);
+            tracing::warn!(
+                "connect: feishu send rate-limited (code={}), waiting {wait:?} before retry {rate_limit_attempts}/{MAX_RATE_LIMIT_RETRIES}",
+                parsed.code
+            );
+            tokio::time::sleep(wait).await;
+            continue;
+        }
+
+        return Err(PlatformError::other(format!(
+            "im/v1/messages send failed (code={}): {}",
+            parsed.code,
+            parsed.msg.unwrap_or_default()
+        )));
+    }
+}
+
+/// `PATCH /open-apis/im/v1/messages/:message_id` — updates an interactive
+/// card's content in place. Same token-retry/rate-limit-wait treatment as
+/// [`send_message`].
+pub(super) async fn update_card(
+    tokens: &TokenCache,
+    base_url: &str,
+    app_id: &str,
+    app_secret: &str,
+    message_id: &str,
+    content: &str,
+) -> PlatformResult<()> {
+    let url = format!(
+        "{}/open-apis/im/v1/messages/{message_id}",
+        base_url.trim_end_matches('/')
+    );
+    let body = serde_json::json!({ "content": content });
+
+    let mut token_retried = false;
+    let mut rate_limit_attempts = 0u32;
+    loop {
+        let token = tokens.get(base_url, app_id, app_secret).await?;
+        let response = http_client()
+            .patch(&url)
+            .bearer_auth(&token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|error| {
+                PlatformError::other(format!(
+                    "im/v1/messages patch failed: {}",
+                    sanitize_reqwest_error(error, &[app_secret, &token])
+                ))
+            })?;
+
+        let status = response.status();
+        let headers = response.headers().clone();
+        let parsed: FeishuEnvelope<serde_json::Value> = response.json().await.map_err(|error| {
+            PlatformError::other(format!(
+                "im/v1/messages patch response parse failed: {}",
+                sanitize_reqwest_error(error, &[app_secret, &token])
+            ))
+        })?;
+
+        if parsed.code == 0 {
+            return Ok(());
+        }
+
+        if !token_retried && TOKEN_INVALID_CODES.contains(&parsed.code) {
+            token_retried = true;
+            tokens.invalidate().await;
+            continue;
+        }
+
+        if (status.as_u16() == 429 || RATE_LIMIT_CODES.contains(&parsed.code))
+            && rate_limit_attempts < MAX_RATE_LIMIT_RETRIES
+        {
+            rate_limit_attempts += 1;
+            let wait = rate_limit_wait_from_headers(&headers);
+            tokio::time::sleep(wait).await;
+            continue;
+        }
+
+        return Err(PlatformError::other(format!(
+            "im/v1/messages patch failed (code={}): {}",
+            parsed.code,
+            parsed.msg.unwrap_or_default()
+        )));
+    }
+}
+
+/// `GET /open-apis/bot/v3/info` — the bot's own `open_id`, fetched once at
+/// startup for @mention detection in group chats (`mod.rs`'s group-gating).
+pub(super) async fn fetch_bot_open_id(
+    tokens: &TokenCache,
+    base_url: &str,
+    app_id: &str,
+    app_secret: &str,
+) -> PlatformResult<String> {
+    #[derive(Default, serde::Deserialize)]
+    struct BotInfoData {
+        #[serde(default)]
+        open_id: Option<String>,
+    }
+
+    let url = format!("{}/open-apis/bot/v3/info", base_url.trim_end_matches('/'));
+    let token = tokens.get(base_url, app_id, app_secret).await?;
+    let response = http_client()
+        .get(url)
+        .bearer_auth(&token)
+        .send()
+        .await
+        .map_err(|error| {
+            PlatformError::other(format!(
+                "bot/v3/info request failed: {}",
+                sanitize_reqwest_error(error, &[app_secret, &token])
+            ))
+        })?;
+
+    let parsed: FeishuEnvelope<BotInfoData> = response.json().await.map_err(|error| {
+        PlatformError::other(format!(
+            "bot/v3/info response parse failed: {}",
+            sanitize_reqwest_error(error, &[app_secret, &token])
+        ))
+    })?;
+
+    if parsed.code != 0 {
+        return Err(PlatformError::other(format!(
+            "bot/v3/info failed (code={}): {}",
+            parsed.code,
+            parsed.msg.unwrap_or_default()
+        )));
+    }
+    parsed
+        .data
+        .and_then(|d| d.open_id)
+        .ok_or_else(|| PlatformError::other("bot/v3/info response missing open_id"))
+}

--- a/crates/app/bamboo-server/src/connect/platforms/feishu/api.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/feishu/api.rs
@@ -11,13 +11,24 @@ use tokio::time::Instant;
 
 use super::super::super::platform::{PlatformError, PlatformResult};
 
+/// Hard per-request deadline for every Feishu REST call. This matters more
+/// here than in `telegram.rs`: `TokenCache::get` holds its mutex across the
+/// token-refresh round-trip, so ONE hung response without a timeout would
+/// serialize (wedge) every outbound call for the adapter's lifetime.
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// One shared `reqwest::Client` for every Feishu REST call (bootstrap POST
 /// included — `ws.rs` reuses this too). Mirrors `telegram.rs`'s
 /// `http_client()` — the workspace's pinned (native-tls) `reqwest`, never a
-/// second connector.
+/// second connector — plus a client-wide [`HTTP_REQUEST_TIMEOUT`].
 pub(super) fn http_client() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT.get_or_init(reqwest::Client::new)
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .timeout(HTTP_REQUEST_TIMEOUT)
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new())
+    })
 }
 
 /// Formats a `reqwest::Error` for logs/errors WITHOUT `app_secret` or the
@@ -49,6 +60,11 @@ const RATE_LIMIT_HEADER: &str = "x-ogw-ratelimit-reset";
 /// documented limits reset in low single-digit seconds, so this is generous.
 const MAX_RATE_LIMIT_RETRIES: u32 = 5;
 const DEFAULT_RATE_LIMIT_WAIT: Duration = Duration::from_secs(1);
+/// Cap on a single server-instructed rate-limit wait. The reset header is
+/// server-supplied input — without a cap, one bogus/hostile `…-reset: 999999`
+/// makes a send block for an effectively unbounded wall-clock time. Feishu's
+/// documented limits reset within seconds; a minute is already extreme.
+const MAX_RATE_LIMIT_WAIT: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Default)]
 struct TokenState {
@@ -205,7 +221,8 @@ struct SendMessageData {
 
 /// `x-ogw-ratelimit-reset` is documented as the number of seconds until the
 /// limit resets. Parsed defensively — an absent/unparseable header falls
-/// back to [`DEFAULT_RATE_LIMIT_WAIT`] rather than failing the send.
+/// back to [`DEFAULT_RATE_LIMIT_WAIT`], and the server-supplied value is
+/// clamped to [`MAX_RATE_LIMIT_WAIT`] so it can't stall a send indefinitely.
 fn rate_limit_wait_from_headers(headers: &reqwest::header::HeaderMap) -> Duration {
     headers
         .get(RATE_LIMIT_HEADER)
@@ -213,6 +230,7 @@ fn rate_limit_wait_from_headers(headers: &reqwest::header::HeaderMap) -> Duratio
         .and_then(|value| value.parse::<u64>().ok())
         .map(Duration::from_secs)
         .unwrap_or(DEFAULT_RATE_LIMIT_WAIT)
+        .min(MAX_RATE_LIMIT_WAIT)
 }
 
 /// `POST /open-apis/im/v1/messages?receive_id_type=chat_id`. `content` is
@@ -415,4 +433,30 @@ pub(super) async fn fetch_bot_open_id(
         .data
         .and_then(|d| d.open_id)
         .ok_or_else(|| PlatformError::other("bot/v3/info response missing open_id"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limit_wait_clamps_a_huge_server_supplied_reset() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(RATE_LIMIT_HEADER, "999999".parse().unwrap());
+        assert_eq!(rate_limit_wait_from_headers(&headers), MAX_RATE_LIMIT_WAIT);
+    }
+
+    #[test]
+    fn rate_limit_wait_uses_sane_server_values_and_default_when_absent() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(RATE_LIMIT_HEADER, "3".parse().unwrap());
+        assert_eq!(
+            rate_limit_wait_from_headers(&headers),
+            Duration::from_secs(3)
+        );
+        assert_eq!(
+            rate_limit_wait_from_headers(&reqwest::header::HeaderMap::new()),
+            DEFAULT_RATE_LIMIT_WAIT
+        );
+    }
 }

--- a/crates/app/bamboo-server/src/connect/platforms/feishu/mod.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/feishu/mod.rs
@@ -455,6 +455,12 @@ fn strip_mentions(text: &str, mentions: &[EventMention], bot_open_id: Option<&st
 /// it @-mentions this bot (found in `mentions[].id.open_id`) or is an
 /// `@所有人`/`@_all` broadcast (`mentions` is empty for those — a literal
 /// substring check on the raw text is the documented way to detect it).
+/// KNOWN LIMITATION: the wire format makes a real `@所有人` mention
+/// indistinguishable from a member literally typing the characters `@_all`
+/// (both arrive as `{"text":"…@_all…"}` with zero mention entries), so the
+/// latter also passes this gate. Accepted: it only widens "processed vs
+/// ignored", never authorization — `allow_from` still gates the sender's
+/// identity downstream in the bridge.
 /// `bot_open_id: None` (the startup `bot/v3/info` fetch failed) means every
 /// group message is treated as unmentioned and dropped.
 fn passes_group_gate(

--- a/crates/app/bamboo-server/src/connect/platforms/feishu/mod.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/feishu/mod.rs
@@ -1,0 +1,1230 @@
+//! Feishu/Lark event long-connection platform adapter (epic #447 phase 3).
+//!
+//! No public IP / webhook: inbound events arrive over a WS long-connection
+//! (`ws.rs`); outbound sends and the `tenant_access_token` cache go over
+//! plain REST (`api.rs`); the wire frame shape is `pbbp2.rs`. See
+//! `docs/feishu-adapter-plan.md` §2c for the full protocol writeup this
+//! module implements.
+//!
+//! Module split:
+//! - `pbbp2.rs` — vendored `Frame`/`Header` proto2 wire types.
+//! - `ws.rs` — the long-connection client (bootstrap/ping/ack/reassembly/
+//!   reconnect), ignorant of Feishu's EVENT semantics (that's this file's
+//!   job, via the [`ws::EventSink`] trait).
+//! - `api.rs` — REST: token cache, send/update message, bot self-info, the
+//!   per-chat rate limiter.
+//! - `mod.rs` (this file) — [`FeishuPlatform`]: the `Platform` impl, inbound
+//!   event → `InboundMessage`/`CallbackQuery` mapping, outbound card
+//!   building, and the card-callback pending-ack map.
+
+mod api;
+mod pbbp2;
+mod ws;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{mpsc, oneshot, Mutex as AsyncMutex};
+
+use super::super::platform::{
+    Button, CallbackQuery, Capabilities, Inbound, InboundMessage, MessageRef, OutboundMessage,
+    Platform, PlatformError, PlatformResult, ReplyCtx,
+};
+use super::super::render::{chunk_message, MAX_MESSAGE_CHARS};
+
+/// Default outgoing rate limit: 1 message/second per chat (same
+/// conservative default as `telegram.rs`; Feishu's actual documented limits
+/// are more generous — 5 QPS/user in a p2p chat — but 1/s is a safe,
+/// simple default and matches the existing adapter's precedent).
+const DEFAULT_RATE_LIMIT_INTERVAL: Duration = Duration::from_secs(1);
+/// How long a `card.action.trigger`'s pending-ack waits for the bridge to
+/// call `answer_callback` before auto-acking with a bare `{"code":200}`
+/// (empty `data`). Kept comfortably under `ws.rs::ACK_HARD_DEADLINE`
+/// (2.9s) so the WS transport always has headroom to get the frame back.
+const ACK_SOFT_DEADLINE: Duration = Duration::from_millis(2500);
+/// The fixed `element_id` on every card's markdown body element (so
+/// `edit()`'s PATCH always targets the same element — not load-bearing for
+/// Feishu's API, which replaces the whole `content` string, but documents
+/// the stable shape).
+const MAIN_TEXT_ELEMENT_ID: &str = "main_text";
+
+pub struct FeishuPlatform {
+    app_id: String,
+    app_secret: String,
+    base_url: String,
+    tokens: api::TokenCache,
+    rate_limiter: api::RateLimiter,
+    /// This app's own `open_id`, fetched once in `start()` via
+    /// `GET /open-apis/bot/v3/info` — used for @mention detection in group
+    /// chats. `None` until fetched (or forever, if the fetch failed — group
+    /// messages are then treated as unmentioned/dropped, per plan).
+    bot_open_id: Arc<AsyncMutex<Option<String>>>,
+    /// `card.action.trigger` events parked here (keyed by `event_id`,
+    /// Feishu's `callback_query_id`) while `start()`'s WS event handler
+    /// waits for the bridge to call `answer_callback`.
+    pending_acks: Arc<AsyncMutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>,
+    /// Test seam: skip the real WS client entirely (`start()` returns
+    /// `Ok(())` immediately) so REST-only tests (reply/edit/rate-limit)
+    /// never touch the network for the long-connection.
+    ws_disabled: bool,
+}
+
+impl FeishuPlatform {
+    /// Production constructor. `base_url` is the ALREADY-RESOLVED REST/WS
+    /// bootstrap base (e.g. `https://open.feishu.cn`) — the
+    /// `feishu`/`lark`/custom-URL `domain` config field is resolved by the
+    /// server's registration arm (`connect/mod.rs`, owned by another agent
+    /// for this epic), not here; this constructor only ever sees a plain
+    /// string.
+    pub fn new(app_id: String, app_secret: String, base_url: String) -> Self {
+        Self::with_options(
+            app_id,
+            app_secret,
+            base_url,
+            DEFAULT_RATE_LIMIT_INTERVAL,
+            false,
+        )
+    }
+
+    /// Test/advanced constructor: override the rate-limit interval (kept
+    /// tiny in tests) and optionally disable the WS client entirely
+    /// (`ws_disabled`) so `start()` is a no-op — REST-only tests construct
+    /// the platform this way and never call `start()`'s WS half.
+    pub fn with_options(
+        app_id: String,
+        app_secret: String,
+        base_url: String,
+        rate_limit_interval: Duration,
+        ws_disabled: bool,
+    ) -> Self {
+        Self {
+            app_id,
+            app_secret,
+            base_url,
+            tokens: api::TokenCache::new(),
+            rate_limiter: api::RateLimiter::new(rate_limit_interval),
+            bot_open_id: Arc::new(AsyncMutex::new(None)),
+            pending_acks: Arc::new(AsyncMutex::new(HashMap::new())),
+            ws_disabled,
+        }
+    }
+
+    fn extract_chat_id(ctx: &serde_json::Value) -> PlatformResult<String> {
+        ctx.get("chat_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| PlatformError::other("reply_ctx is missing chat_id"))
+    }
+
+    fn extract_message_id(msg_ref: &serde_json::Value) -> PlatformResult<String> {
+        msg_ref
+            .get("message_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| PlatformError::other("message_ref is missing message_id"))
+    }
+}
+
+#[async_trait::async_trait]
+impl Platform for FeishuPlatform {
+    fn name(&self) -> &str {
+        "feishu"
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            buttons: true,
+            edit_message: true,
+            images: false,
+            files: false,
+        }
+    }
+
+    async fn start(&self, inbound: mpsc::Sender<Inbound>) -> PlatformResult<()> {
+        if self.ws_disabled {
+            return Ok(());
+        }
+
+        match api::fetch_bot_open_id(&self.tokens, &self.base_url, &self.app_id, &self.app_secret)
+            .await
+        {
+            Ok(open_id) => {
+                *self.bot_open_id.lock().await = Some(open_id);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "connect: feishu bot/v3/info failed ({error}); group messages will be \
+                     treated as unmentioned (dropped) until this succeeds"
+                );
+            }
+        }
+
+        let sink: Arc<dyn ws::EventSink> = Arc::new(FeishuEventSink {
+            bot_open_id: self.bot_open_id.clone(),
+            pending_acks: self.pending_acks.clone(),
+            inbound,
+            ack_soft_deadline: ACK_SOFT_DEADLINE,
+        });
+
+        ws::run_with_reconnect(
+            self.app_id.clone(),
+            self.app_secret.clone(),
+            self.base_url.clone(),
+            sink,
+        )
+        .await
+    }
+
+    async fn reply(&self, ctx: &ReplyCtx, msg: OutboundMessage) -> PlatformResult<MessageRef> {
+        let chat_id = Self::extract_chat_id(&ctx.0)?;
+        let chunks = chunk_message(&msg.text, MAX_MESSAGE_CHARS);
+        let chunk_count = chunks.len();
+        let mut last_message_id = String::new();
+
+        for (index, chunk) in chunks.into_iter().enumerate() {
+            self.rate_limiter.wait(&format!("chat:{chat_id}")).await;
+
+            // ALWAYS an interactive card (never plain "text"): render.rs
+            // calls `reply()` for the initial streaming status message too,
+            // and `edit()` can only PATCH a card — never a text message (the
+            // text PUT has a 20-edit cap). Sending a uniform card shape for
+            // every reply means this adapter never has to guess which call
+            // site it's serving. See `docs/feishu-adapter-plan.md` §2c
+            // outbound decision 4.
+            let buttons = if index + 1 == chunk_count {
+                msg.buttons.as_deref()
+            } else {
+                None
+            };
+            let card = build_card(&chunk, buttons);
+            let content = card.to_string();
+
+            last_message_id = api::send_message(
+                &self.tokens,
+                &self.base_url,
+                &self.app_id,
+                &self.app_secret,
+                &chat_id,
+                "interactive",
+                &content,
+            )
+            .await?;
+        }
+
+        Ok(MessageRef(serde_json::json!({
+            "chat_id": chat_id,
+            "message_id": last_message_id,
+        })))
+    }
+
+    async fn edit(&self, msg_ref: &MessageRef, new: OutboundMessage) -> PlatformResult<()> {
+        let message_id = Self::extract_message_id(&msg_ref.0)?;
+        self.rate_limiter.wait(&format!("msg:{message_id}")).await;
+
+        let card = build_card(&new.text, new.buttons.as_deref());
+        api::update_card(
+            &self.tokens,
+            &self.base_url,
+            &self.app_id,
+            &self.app_secret,
+            &message_id,
+            &card.to_string(),
+        )
+        .await
+    }
+
+    async fn answer_callback(
+        &self,
+        callback_query_id: &str,
+        text: Option<&str>,
+    ) -> PlatformResult<()> {
+        // NOT rate-limited: this resolves a parked WS frame ack, not a REST
+        // call — see `ws.rs::EventSink`/`FeishuEventSink::handle_card_action_event`.
+        let sender = self.pending_acks.lock().await.remove(callback_query_id);
+        if let Some(sender) = sender {
+            let value = match text {
+                Some(text) => serde_json::json!({ "toast": { "type": "info", "content": text } }),
+                None => serde_json::json!({}),
+            };
+            // A send error just means the WS event handler already gave up
+            // waiting (past its own soft deadline) — nothing left to do.
+            let _ = sender.send(value);
+        }
+        Ok(())
+    }
+
+    async fn stop(&self) -> PlatformResult<()> {
+        // Best-effort no-op, matching `telegram.rs`'s precedent: real
+        // cancellation happens via `ConnectManager`'s `Drop`, which aborts
+        // the JoinHandle running `start()` — that unwinds the whole WS
+        // connection (and its ping/ack machinery) at once.
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------
+// Outbound: card building
+// ---------------------------------------------------------------------
+
+/// Escapes characters Feishu's card markdown element treats specially, so
+/// arbitrary agent output (which render.rs treats as PLAIN TEXT — see
+/// `platform.rs`'s `OutboundMessage` doc, there is no markdown flag) never
+/// gets reinterpreted as markdown syntax or a `<at>`/`<a>` tag. This is a
+/// deliberately simple backslash-escape of the documented Feishu markdown
+/// special characters — NOT a general HTML/markdown sanitizer, and not
+/// exhaustive of every card-markdown edge case, but sufficient for MVP text
+/// (tool output, assistant replies) which is prose, not hand-crafted markup.
+fn escape_feishu_markdown(text: &str) -> String {
+    let mut escaped = String::with_capacity(text.len());
+    for ch in text.chars() {
+        if matches!(
+            ch,
+            '\\' | '`'
+                | '*'
+                | '_'
+                | '~'
+                | '#'
+                | '+'
+                | '-'
+                | '.'
+                | '!'
+                | '['
+                | ']'
+                | '('
+                | ')'
+                | '<'
+                | '>'
+                | '|'
+        ) {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
+/// Builds a schema-2.0 interactive card: `config.update_multi:true`, a
+/// markdown body element (fixed `element_id:"main_text"`, escaped text), and
+/// — when present — one `"action"` element per button row, per
+/// `docs/feishu-adapter-plan.md` §2c outbound decision 2. The exact button
+/// element wrapper (`tag:"action"` with a nested `"actions"` array) is this
+/// adapter's own choice: the plan pins ONLY the `behaviors`/`value.cb`
+/// shape, not the surrounding container, so this is the one place protocol
+/// shape was inferred rather than verified — flagged in the task report.
+fn build_card(text: &str, buttons: Option<&[Vec<Button>]>) -> serde_json::Value {
+    let mut elements = vec![serde_json::json!({
+        "tag": "markdown",
+        "element_id": MAIN_TEXT_ELEMENT_ID,
+        "content": escape_feishu_markdown(text),
+    })];
+
+    if let Some(rows) = buttons {
+        for row in rows {
+            let actions: Vec<serde_json::Value> = row
+                .iter()
+                .map(|button| {
+                    serde_json::json!({
+                        "tag": "button",
+                        "text": { "tag": "plain_text", "content": button.label },
+                        "type": "default",
+                        "behaviors": [
+                            { "type": "callback", "value": { "cb": button.callback_data } }
+                        ],
+                    })
+                })
+                .collect();
+            elements.push(serde_json::json!({ "tag": "action", "actions": actions }));
+        }
+    }
+
+    serde_json::json!({
+        "schema": "2.0",
+        "config": { "update_multi": true },
+        "elements": elements,
+    })
+}
+
+// ---------------------------------------------------------------------
+// Inbound: event envelope + mapping
+// ---------------------------------------------------------------------
+
+#[derive(Debug, serde::Deserialize)]
+struct EventEnvelope {
+    #[serde(default)]
+    #[allow(dead_code)]
+    // documents the wire shape; not branched on (only "2.0" is ever sent on this transport)
+    schema: Option<String>,
+    header: EventHeader,
+    event: serde_json::Value,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct EventHeader {
+    event_id: String,
+    event_type: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct MessageReceiveEvent {
+    sender: EventSender,
+    message: EventMessage,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct EventSender {
+    sender_id: EventSenderId,
+    #[serde(default)]
+    sender_type: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct EventSenderId {
+    open_id: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct EventMessage {
+    message_id: String,
+    chat_id: String,
+    #[serde(default)]
+    chat_type: String,
+    message_type: String,
+    content: String,
+    create_time: String,
+    #[serde(default)]
+    mentions: Vec<EventMention>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct EventMention {
+    key: String,
+    id: EventMentionId,
+    #[serde(default)]
+    name: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct EventMentionId {
+    open_id: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CardActionEvent {
+    operator: CardOperator,
+    context: CardContext,
+    action: CardAction,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CardOperator {
+    open_id: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CardContext {
+    open_chat_id: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CardAction {
+    value: serde_json::Value,
+}
+
+/// Replaces `@_user_N` placeholders in `text` per `mentions[].key`: the
+/// bot's OWN mention (`id.open_id == bot_open_id`) is dropped entirely, any
+/// other mention becomes `@{name}`. Leftover whitespace from a dropped
+/// placeholder is normalized (runs of whitespace collapsed to one space,
+/// trimmed) — a deliberate simplification (documented deviation: this does
+/// not preserve exact original whitespace/newline structure around a
+/// stripped mention, since MVP text is prose, not formatted markup).
+fn strip_mentions(text: &str, mentions: &[EventMention], bot_open_id: Option<&str>) -> String {
+    let mut result = text.to_string();
+    for mention in mentions {
+        let replacement = if Some(mention.id.open_id.as_str()) == bot_open_id {
+            String::new()
+        } else {
+            format!("@{}", mention.name)
+        };
+        result = result.replace(&mention.key, &replacement);
+    }
+    result.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Group-chat gating: p2p always passes; a group message passes only when
+/// it @-mentions this bot (found in `mentions[].id.open_id`) or is an
+/// `@所有人`/`@_all` broadcast (`mentions` is empty for those — a literal
+/// substring check on the raw text is the documented way to detect it).
+/// `bot_open_id: None` (the startup `bot/v3/info` fetch failed) means every
+/// group message is treated as unmentioned and dropped.
+fn passes_group_gate(
+    chat_type: &str,
+    raw_text: &str,
+    mentions: &[EventMention],
+    bot_open_id: Option<&str>,
+) -> bool {
+    if chat_type != "group" {
+        return true;
+    }
+    if raw_text.contains("@_all") {
+        return true;
+    }
+    match bot_open_id {
+        Some(id) => mentions.iter().any(|m| m.id.open_id == id),
+        None => false,
+    }
+}
+
+/// Maps one already-parsed `im.message.receive_v1` event body to an
+/// [`InboundMessage`], or `None` for anything this MVP doesn't forward:
+/// a bot sender, a non-text message, or a group message that fails the
+/// @mention gate. Pure/sync so it's directly unit-testable.
+fn map_message_event(
+    event: &MessageReceiveEvent,
+    bot_open_id: Option<&str>,
+) -> Option<InboundMessage> {
+    if event.sender.sender_type == "bot" {
+        return None;
+    }
+    if event.message.message_type != "text" {
+        return None;
+    }
+
+    let raw_text: String = serde_json::from_str::<serde_json::Value>(&event.message.content)
+        .ok()
+        .and_then(|v| {
+            v.get("text")
+                .and_then(|t| t.as_str())
+                .map(|s| s.to_string())
+        })
+        .unwrap_or_default();
+
+    if !passes_group_gate(
+        &event.message.chat_type,
+        &raw_text,
+        &event.message.mentions,
+        bot_open_id,
+    ) {
+        return None;
+    }
+
+    let text = strip_mentions(&raw_text, &event.message.mentions, bot_open_id);
+
+    let sent_at = event
+        .message
+        .create_time
+        .parse::<i64>()
+        .ok()
+        .and_then(chrono::DateTime::<chrono::Utc>::from_timestamp_millis)
+        .unwrap_or_else(chrono::Utc::now);
+
+    Some(InboundMessage {
+        platform: "feishu".to_string(),
+        chat_id: event.message.chat_id.clone(),
+        user_id: event.sender.sender_id.open_id.clone(),
+        message_id: event.message.message_id.clone(),
+        sent_at,
+        text,
+        reply_ctx: ReplyCtx(serde_json::json!({
+            "chat_id": event.message.chat_id,
+            "message_id": event.message.message_id,
+        })),
+    })
+}
+
+/// Maps one already-parsed `card.action.trigger` event body to a
+/// [`CallbackQuery`]. Returns `None` when `action.value` doesn't carry our
+/// `"cb"` key (not a button this adapter produced — nothing to route).
+fn map_card_action_event(event_id: &str, event: &CardActionEvent) -> Option<CallbackQuery> {
+    let data = event
+        .action
+        .value
+        .get("cb")
+        .and_then(|v| v.as_str())?
+        .to_string();
+    Some(CallbackQuery {
+        platform: "feishu".to_string(),
+        chat_id: event.context.open_chat_id.clone(),
+        user_id: event.operator.open_id.clone(),
+        callback_query_id: event_id.to_string(),
+        data,
+        reply_ctx: ReplyCtx(serde_json::json!({ "chat_id": event.context.open_chat_id })),
+    })
+}
+
+/// Bridges `ws.rs`'s transport-only [`ws::EventSink`] to Feishu event
+/// semantics. Holds only OWNED/`Arc`-cloned state (never `&FeishuPlatform`)
+/// so it satisfies `EventSink`'s `'static` bound — `start()` constructs one
+/// per WS connection lifetime from `self`'s `Arc`-wrapped fields.
+struct FeishuEventSink {
+    bot_open_id: Arc<AsyncMutex<Option<String>>>,
+    pending_acks: Arc<AsyncMutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>,
+    inbound: mpsc::Sender<Inbound>,
+    ack_soft_deadline: Duration,
+}
+
+impl FeishuEventSink {
+    async fn handle_message_event(&self, event: serde_json::Value) {
+        let parsed: MessageReceiveEvent = match serde_json::from_value(event) {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                tracing::warn!("connect: feishu im.message.receive_v1 parse failed: {error}");
+                return;
+            }
+        };
+        let bot_open_id = self.bot_open_id.lock().await.clone();
+        let Some(message) = map_message_event(&parsed, bot_open_id.as_deref()) else {
+            return;
+        };
+        // Per task spec: a send failure here means the bridge/manager is
+        // shutting down (the receiving end of `dispatch_loop`'s channel was
+        // dropped) — nothing more to do for this event; real cleanup of the
+        // WS connection itself happens via `ConnectManager`'s `Drop`
+        // (JoinHandle abort), not by this handler propagating an error.
+        let _ = self.inbound.send(Inbound::Message(message)).await;
+    }
+
+    /// Returns the ack payload to echo back over the WS frame: the
+    /// bridge-supplied toast (or `{}`) if `answer_callback` resolved the
+    /// pending-ack before `ack_soft_deadline`, otherwise `None` (a bare
+    /// `{"code":200}` ack with null `data`).
+    async fn handle_card_action_event(
+        &self,
+        event_id: String,
+        event: serde_json::Value,
+    ) -> Option<serde_json::Value> {
+        let parsed: CardActionEvent = match serde_json::from_value(event) {
+            Ok(parsed) => parsed,
+            Err(error) => {
+                tracing::warn!("connect: feishu card.action.trigger parse failed: {error}");
+                return None;
+            }
+        };
+        let Some(callback) = map_card_action_event(&event_id, &parsed) else {
+            tracing::debug!("connect: feishu card action missing our 'cb' value; ignoring");
+            return None;
+        };
+
+        let (tx, rx) = oneshot::channel();
+        self.pending_acks.lock().await.insert(event_id.clone(), tx);
+
+        if self
+            .inbound
+            .send(Inbound::Callback(callback))
+            .await
+            .is_err()
+        {
+            self.pending_acks.lock().await.remove(&event_id);
+            return None;
+        }
+
+        match tokio::time::timeout(self.ack_soft_deadline, rx).await {
+            Ok(Ok(value)) => Some(value),
+            Ok(Err(_)) => None, // sender dropped without resolving
+            Err(_elapsed) => {
+                self.pending_acks.lock().await.remove(&event_id);
+                None
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ws::EventSink for FeishuEventSink {
+    async fn handle_event(&self, payload: Vec<u8>) -> Option<serde_json::Value> {
+        let envelope: EventEnvelope = match serde_json::from_slice(&payload) {
+            Ok(envelope) => envelope,
+            Err(error) => {
+                tracing::warn!("connect: feishu event envelope parse failed: {error}");
+                return None;
+            }
+        };
+        match envelope.header.event_type.as_str() {
+            "im.message.receive_v1" => {
+                self.handle_message_event(envelope.event).await;
+                None
+            }
+            "card.action.trigger" => {
+                self.handle_card_action_event(envelope.header.event_id, envelope.event)
+                    .await
+            }
+            other => {
+                tracing::debug!("connect: feishu event type '{other}' not handled (MVP)");
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn platform_with_stub(base_url: String) -> FeishuPlatform {
+        FeishuPlatform::with_options(
+            "cli_test_app".to_string(),
+            "test-app-secret".to_string(),
+            base_url,
+            Duration::from_millis(50),
+            true,
+        )
+    }
+
+    async fn wait_for_requests(
+        server: &wiremock::MockServer,
+        expected: usize,
+    ) -> Vec<wiremock::Request> {
+        for _ in 0..200 {
+            if let Some(requests) = server.received_requests().await {
+                if requests.len() >= expected {
+                    return requests;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        server.received_requests().await.unwrap_or_default()
+    }
+
+    fn mount_token(server: &wiremock::MockServer) -> impl std::future::Future<Output = ()> + '_ {
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/open-apis/auth/v3/tenant_access_token/internal",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "code": 0,
+                    "msg": "ok",
+                    "tenant_access_token": "tok-abc",
+                    "expire": 7200
+                })),
+            )
+            .mount(server)
+    }
+
+    #[tokio::test]
+    async fn capabilities_advertise_buttons_and_edit_message_only() {
+        let platform = platform_with_stub("http://localhost:0".to_string());
+        let caps = platform.capabilities();
+        assert!(caps.buttons);
+        assert!(caps.edit_message);
+        assert!(!caps.images);
+        assert!(!caps.files);
+    }
+
+    #[tokio::test]
+    async fn reply_sends_an_interactive_card_with_escaped_markdown_content() {
+        let server = wiremock::MockServer::start().await;
+        mount_token(&server).await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/open-apis/im/v1/messages"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "code": 0,
+                    "data": { "message_id": "om_1" }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        let ctx = ReplyCtx(serde_json::json!({ "chat_id": "oc_1" }));
+        let msg_ref = platform
+            .reply(&ctx, OutboundMessage::text("hello *world*"))
+            .await
+            .expect("reply succeeds");
+        assert_eq!(
+            msg_ref.0.get("message_id").and_then(|v| v.as_str()),
+            Some("om_1")
+        );
+
+        let requests = wait_for_requests(&server, 1).await;
+        let send_request = requests
+            .iter()
+            .find(|r| r.url.path() == "/open-apis/im/v1/messages")
+            .expect("send request present");
+        let body: serde_json::Value = serde_json::from_slice(&send_request.body).unwrap();
+        assert_eq!(body["msg_type"], serde_json::json!("interactive"));
+        assert_eq!(body["receive_id"], serde_json::json!("oc_1"));
+        let content: serde_json::Value =
+            serde_json::from_str(body["content"].as_str().expect("content is a JSON string"))
+                .unwrap();
+        assert_eq!(content["schema"], serde_json::json!("2.0"));
+        assert_eq!(content["config"]["update_multi"], serde_json::json!(true));
+        let markdown_content = content["elements"][0]["content"].as_str().unwrap();
+        assert!(
+            markdown_content.contains("\\*world\\*"),
+            "got: {markdown_content}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reply_with_buttons_puts_callback_value_under_cb_key() {
+        let server = wiremock::MockServer::start().await;
+        mount_token(&server).await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/open-apis/im/v1/messages"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "code": 0,
+                    "data": { "message_id": "om_2" }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        let ctx = ReplyCtx(serde_json::json!({ "chat_id": "oc_1" }));
+        let outbound = OutboundMessage::text("Approve?")
+            .with_buttons(vec![vec![Button::new("Approve", "n1:0")]]);
+        platform
+            .reply(&ctx, outbound)
+            .await
+            .expect("reply succeeds");
+
+        let requests = wait_for_requests(&server, 2).await;
+        let send_request = requests
+            .iter()
+            .find(|r| r.url.path() == "/open-apis/im/v1/messages")
+            .expect("send request present");
+        let body: serde_json::Value = serde_json::from_slice(&send_request.body).unwrap();
+        let content: serde_json::Value =
+            serde_json::from_str(body["content"].as_str().unwrap()).unwrap();
+        let action = &content["elements"][1];
+        assert_eq!(action["tag"], serde_json::json!("action"));
+        assert_eq!(
+            action["actions"][0]["behaviors"][0]["value"]["cb"],
+            serde_json::json!("n1:0")
+        );
+    }
+
+    #[tokio::test]
+    async fn reply_chunks_long_text_into_multiple_card_sends() {
+        let server = wiremock::MockServer::start().await;
+        mount_token(&server).await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/open-apis/im/v1/messages"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "code": 0,
+                    "data": { "message_id": "om_3" }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        let ctx = ReplyCtx(serde_json::json!({ "chat_id": "oc_1" }));
+        let long_text = "a".repeat(9000); // -> 3 chunks at MAX_MESSAGE_CHARS=4096
+
+        platform
+            .reply(&ctx, OutboundMessage::text(long_text))
+            .await
+            .expect("reply succeeds");
+
+        let requests = wait_for_requests(&server, 3).await;
+        let send_requests: Vec<_> = requests
+            .iter()
+            .filter(|r| r.url.path() == "/open-apis/im/v1/messages")
+            .collect();
+        assert_eq!(send_requests.len(), 3, "expected exactly 3 card sends");
+    }
+
+    #[tokio::test]
+    async fn edit_patches_the_card_at_the_message_id() {
+        let server = wiremock::MockServer::start().await;
+        mount_token(&server).await;
+        wiremock::Mock::given(wiremock::matchers::method("PATCH"))
+            .and(wiremock::matchers::path("/open-apis/im/v1/messages/om_9"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "code": 0,
+                    "data": {}
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        let msg_ref = MessageRef(serde_json::json!({ "chat_id": "oc_1", "message_id": "om_9" }));
+        platform
+            .edit(&msg_ref, OutboundMessage::text("updated"))
+            .await
+            .expect("edit succeeds");
+
+        let requests = wait_for_requests(&server, 1).await;
+        let request = requests
+            .iter()
+            .find(|r| r.url.path() == "/open-apis/im/v1/messages/om_9")
+            .expect("patch request present");
+        let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+        let content: serde_json::Value =
+            serde_json::from_str(body["content"].as_str().unwrap()).unwrap();
+        assert_eq!(
+            content["elements"][0]["content"],
+            serde_json::json!("updated")
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_returns_err_on_api_error_instead_of_panicking() {
+        let server = wiremock::MockServer::start().await;
+        mount_token(&server).await;
+        wiremock::Mock::given(wiremock::matchers::method("PATCH"))
+            .and(wiremock::matchers::path("/open-apis/im/v1/messages/om_9"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "code": 230001,
+                    "msg": "card not found"
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        let msg_ref = MessageRef(serde_json::json!({ "chat_id": "oc_1", "message_id": "om_9" }));
+        let result = platform
+            .edit(&msg_ref, OutboundMessage::text("updated"))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn token_is_cached_across_two_sends_then_force_refreshed_on_99991663() {
+        let server = wiremock::MockServer::start().await;
+        // First token call returns tok-1; a SECOND call (post-invalidate)
+        // returns tok-2 — wiremock matches requests in mount order and
+        // dispatches the first that still has un-exhausted expectations, so
+        // an explicit `up_to_n_times` differentiates the two responses.
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/open-apis/auth/v3/tenant_access_token/internal",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "code": 0, "tenant_access_token": "tok-1", "expire": 7200
+                })),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/open-apis/auth/v3/tenant_access_token/internal",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "code": 0, "tenant_access_token": "tok-2", "expire": 7200
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        // First send: 99991663 (stale token) -> the adapter must invalidate
+        // and retry once, succeeding on the retry.
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/open-apis/im/v1/messages"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "code": 99991663, "msg": "invalid access token"
+                })),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/open-apis/im/v1/messages"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "code": 0, "data": { "message_id": "om_1" }
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let platform = platform_with_stub(server.uri());
+        let ctx = ReplyCtx(serde_json::json!({ "chat_id": "oc_1" }));
+
+        platform
+            .reply(&ctx, OutboundMessage::text("first"))
+            .await
+            .expect("reply succeeds after one token-invalid retry");
+
+        let token_requests = wait_for_requests(&server, 2).await;
+        let token_calls = token_requests
+            .iter()
+            .filter(|r| r.url.path() == "/open-apis/auth/v3/tenant_access_token/internal")
+            .count();
+        assert_eq!(
+            token_calls, 2,
+            "expected an initial fetch + one forced refresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn transport_errors_never_leak_the_app_secret() {
+        let secret = "SECRET-APP-SECRET-MUST-NOT-LEAK";
+        let platform = FeishuPlatform::with_options(
+            "cli_test_app".to_string(),
+            secret.to_string(),
+            "http://127.0.0.1:1".to_string(),
+            Duration::from_millis(1),
+            true,
+        );
+        let ctx = ReplyCtx(serde_json::json!({ "chat_id": "oc_1" }));
+        let err = platform
+            .reply(&ctx, OutboundMessage::text("hi"))
+            .await
+            .expect_err("port 1 must refuse the connection");
+        let text = format!("{err}");
+        assert!(
+            !text.contains(secret) && !text.contains("SECRET-APP-SECRET"),
+            "app_secret leaked into error text: {text}"
+        );
+    }
+
+    // -- inbound mapping -------------------------------------------------
+
+    fn message_event(
+        chat_type: &str,
+        text_json: &str,
+        sender_type: &str,
+        mentions: serde_json::Value,
+    ) -> MessageReceiveEvent {
+        let value = serde_json::json!({
+            "sender": { "sender_id": { "open_id": "ou_sender" }, "sender_type": sender_type },
+            "message": {
+                "message_id": "om_1",
+                "chat_id": "oc_1",
+                "chat_type": chat_type,
+                "message_type": "text",
+                "content": text_json,
+                "create_time": "1700000000000",
+                "mentions": mentions,
+            }
+        });
+        serde_json::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn map_message_event_maps_a_p2p_text_message() {
+        let event = message_event("p2p", "{\"text\":\"hello\"}", "user", serde_json::json!([]));
+        let message = map_message_event(&event, None).expect("maps");
+        assert_eq!(message.platform, "feishu");
+        assert_eq!(message.chat_id, "oc_1");
+        assert_eq!(message.user_id, "ou_sender");
+        assert_eq!(message.message_id, "om_1");
+        assert_eq!(message.text, "hello");
+        assert_eq!(
+            message.reply_ctx.0,
+            serde_json::json!({ "chat_id": "oc_1", "message_id": "om_1" })
+        );
+    }
+
+    #[test]
+    fn map_message_event_drops_bot_senders() {
+        let event = message_event("p2p", "{\"text\":\"hi\"}", "bot", serde_json::json!([]));
+        assert!(map_message_event(&event, None).is_none());
+    }
+
+    #[test]
+    fn map_message_event_strips_other_mentions_and_drops_own_bot_mention() {
+        let event = message_event(
+            "group",
+            "{\"text\":\"@_user_1 @_user_2 please review\"}",
+            "user",
+            serde_json::json!([
+                { "key": "@_user_1", "id": { "open_id": "ou_bot" }, "name": "MyBot" },
+                { "key": "@_user_2", "id": { "open_id": "ou_alice" }, "name": "Alice" }
+            ]),
+        );
+        let message =
+            map_message_event(&event, Some("ou_bot")).expect("group message w/ bot mention passes");
+        assert_eq!(message.text, "@Alice please review");
+    }
+
+    #[test]
+    fn map_message_event_group_without_mention_or_bot_open_id_is_dropped() {
+        let event = message_event(
+            "group",
+            "{\"text\":\"hello\"}",
+            "user",
+            serde_json::json!([]),
+        );
+        assert!(map_message_event(&event, Some("ou_bot")).is_none());
+        assert!(map_message_event(&event, None).is_none());
+    }
+
+    #[test]
+    fn map_message_event_group_at_all_passes_even_with_empty_mentions() {
+        let event = message_event(
+            "group",
+            "{\"text\":\"@_all please review\"}",
+            "user",
+            serde_json::json!([]),
+        );
+        let message =
+            map_message_event(&event, Some("ou_bot")).expect("@_all passes the group gate");
+        assert!(message.text.contains("please review"));
+    }
+
+    #[test]
+    fn map_message_event_drops_non_text_message_types() {
+        let value = serde_json::json!({
+            "sender": { "sender_id": { "open_id": "ou_sender" }, "sender_type": "user" },
+            "message": {
+                "message_id": "om_1", "chat_id": "oc_1", "chat_type": "p2p",
+                "message_type": "image", "content": "{}", "create_time": "1700000000000",
+                "mentions": []
+            }
+        });
+        let event: MessageReceiveEvent = serde_json::from_value(value).unwrap();
+        assert!(map_message_event(&event, None).is_none());
+    }
+
+    #[test]
+    fn map_card_action_event_extracts_cb_value_and_context() {
+        let value = serde_json::json!({
+            "operator": { "open_id": "ou_op" },
+            "context": { "open_chat_id": "oc_5" },
+            "action": { "value": { "cb": "nonce123:1" } }
+        });
+        let event: CardActionEvent = serde_json::from_value(value).unwrap();
+        let callback = map_card_action_event("ev_1", &event).expect("maps");
+        assert_eq!(callback.platform, "feishu");
+        assert_eq!(callback.chat_id, "oc_5");
+        assert_eq!(callback.user_id, "ou_op");
+        assert_eq!(callback.callback_query_id, "ev_1");
+        assert_eq!(callback.data, "nonce123:1");
+        assert_eq!(
+            callback.reply_ctx.0,
+            serde_json::json!({ "chat_id": "oc_5" })
+        );
+    }
+
+    #[test]
+    fn map_card_action_event_returns_none_without_cb_key() {
+        let value = serde_json::json!({
+            "operator": { "open_id": "ou_op" },
+            "context": { "open_chat_id": "oc_5" },
+            "action": { "value": { "other": "x" } }
+        });
+        let event: CardActionEvent = serde_json::from_value(value).unwrap();
+        assert!(map_card_action_event("ev_1", &event).is_none());
+    }
+
+    // -- pending-ack ------------------------------------------------------
+
+    fn card_action_payload(event_id: &str) -> Vec<u8> {
+        serde_json::json!({
+            "schema": "2.0",
+            "header": { "event_id": event_id, "event_type": "card.action.trigger" },
+            "event": {
+                "operator": { "open_id": "ou_op" },
+                "context": { "open_chat_id": "oc_5" },
+                "action": { "value": { "cb": "nonce1:0" } }
+            }
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    #[tokio::test]
+    async fn card_callback_resolves_pending_ack_with_toast_when_answered() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let sink = FeishuEventSink {
+            bot_open_id: Arc::new(AsyncMutex::new(None)),
+            pending_acks: Arc::new(AsyncMutex::new(HashMap::new())),
+            inbound: tx,
+            ack_soft_deadline: Duration::from_secs(5),
+        };
+        let pending_acks = sink.pending_acks.clone();
+
+        let handle = tokio::spawn(async move {
+            use ws::EventSink;
+            sink.handle_event(card_action_payload("ev_1")).await
+        });
+
+        // Wait until the CallbackQuery is on the inbound channel (which
+        // happens strictly AFTER the pending-ack oneshot is registered).
+        let inbound = rx.recv().await.expect("callback delivered");
+        match inbound {
+            Inbound::Callback(callback) => assert_eq!(callback.callback_query_id, "ev_1"),
+            Inbound::Message(_) => panic!("expected a callback"),
+        }
+
+        // Resolve it, mirroring `FeishuPlatform::answer_callback`.
+        let sender = pending_acks
+            .lock()
+            .await
+            .remove("ev_1")
+            .expect("pending ack present");
+        sender
+            .send(serde_json::json!({ "toast": { "type": "info", "content": "Approved" } }))
+            .expect("resolve succeeds");
+
+        let ack_response = handle.await.expect("task completes");
+        assert_eq!(
+            ack_response,
+            Some(serde_json::json!({ "toast": { "type": "info", "content": "Approved" } }))
+        );
+    }
+
+    #[tokio::test]
+    async fn card_callback_auto_acks_after_the_soft_deadline_when_unanswered() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let sink = FeishuEventSink {
+            bot_open_id: Arc::new(AsyncMutex::new(None)),
+            pending_acks: Arc::new(AsyncMutex::new(HashMap::new())),
+            inbound: tx,
+            ack_soft_deadline: Duration::from_millis(20),
+        };
+
+        let handle = tokio::spawn(async move {
+            use ws::EventSink;
+            sink.handle_event(card_action_payload("ev_2")).await
+        });
+
+        let _ = rx.recv().await.expect("callback delivered");
+        // Never call answer_callback — the soft deadline (20ms) must fire.
+        let ack_response = handle.await.expect("task completes");
+        assert_eq!(
+            ack_response, None,
+            "unanswered callback auto-acks with no toast data"
+        );
+    }
+
+    #[tokio::test]
+    async fn im_message_receive_event_reaches_the_inbound_channel() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let sink = FeishuEventSink {
+            bot_open_id: Arc::new(AsyncMutex::new(None)),
+            pending_acks: Arc::new(AsyncMutex::new(HashMap::new())),
+            inbound: tx,
+            ack_soft_deadline: Duration::from_secs(5),
+        };
+        let payload = serde_json::json!({
+            "schema": "2.0",
+            "header": { "event_id": "ev_3", "event_type": "im.message.receive_v1" },
+            "event": {
+                "sender": { "sender_id": { "open_id": "ou_1" }, "sender_type": "user" },
+                "message": {
+                    "message_id": "om_5", "chat_id": "oc_1", "chat_type": "p2p",
+                    "message_type": "text", "content": "{\"text\":\"hi there\"}",
+                    "create_time": "1700000000000", "mentions": []
+                }
+            }
+        })
+        .to_string()
+        .into_bytes();
+
+        use ws::EventSink;
+        let ack = sink.handle_event(payload).await;
+        assert_eq!(ack, None, "a plain message event acks with no toast data");
+
+        let inbound = rx.recv().await.expect("message delivered");
+        match inbound {
+            Inbound::Message(message) => assert_eq!(message.text, "hi there"),
+            Inbound::Callback(_) => panic!("expected a message"),
+        }
+    }
+}

--- a/crates/app/bamboo-server/src/connect/platforms/feishu/pbbp2.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/feishu/pbbp2.rs
@@ -1,0 +1,160 @@
+//! Vendored `pbbp2.Frame`/`pbbp2.Header` proto2 message types for Feishu/Lark's
+//! event long-connection (WS) wire protocol.
+//!
+//! This is a HAND-WRITTEN prost derive, not a `protoc`-generated one — there
+//! is no `build.rs`/`protoc` dependency in this crate, and the message shape
+//! (verified against the official Go SDK, see `docs/feishu-adapter-plan.md`
+//! §2c) is small and stable enough that deriving `prost::Message` directly
+//! on hand-written structs is simpler than vendoring a `.proto` + codegen
+//! pipeline. Field TAGS below are the wire contract; Rust field NAMES are
+//! ours to choose (prost's derive macro doesn't require them to match a
+//! `.proto` source, only the tag numbers/wire types need to match what the
+//! server sends).
+//!
+//! proto2 required vs optional matters here: `SeqID`/`LogID`/`service`/
+//! `method` are **required** (decode fails if absent — matches the
+//! protocol: every frame carries a sequence id, log id, service, and
+//! method). Fields 6/7/9 are `optional string` and Feishu is known to send
+//! EMPTY strings (not absent fields) for these on many frames (e.g. plain
+//! data frames have no `payload_encoding`/`payload_type` set); prost decodes
+//! an empty string as `Some(String::new())`, which callers must tolerate
+//! (never treat `Some("")` as an error — see `ws.rs` header lookups, which
+//! only special-case `None`/absence, not emptiness).
+
+use prost::Message;
+
+/// One key/value header entry on a [`Frame`].
+#[derive(Clone, PartialEq, Eq, Message)]
+pub struct Header {
+    #[prost(string, required, tag = "1")]
+    pub key: String,
+    #[prost(string, required, tag = "2")]
+    pub value: String,
+}
+
+impl Header {
+    pub fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            value: value.into(),
+        }
+    }
+}
+
+/// The binary wire frame for Feishu/Lark's event long-connection protocol
+/// (`pbbp2.Frame`). `method`: `0` = control (ping/pong/ack), `1` = data
+/// (event payloads).
+#[derive(Clone, PartialEq, Message)]
+pub struct Frame {
+    #[prost(uint64, required, tag = "1")]
+    pub seq_id: u64,
+    #[prost(uint64, required, tag = "2")]
+    pub log_id: u64,
+    #[prost(int32, required, tag = "3")]
+    pub service: i32,
+    #[prost(int32, required, tag = "4")]
+    pub method: i32,
+    #[prost(message, repeated, tag = "5")]
+    pub headers: Vec<Header>,
+    #[prost(string, optional, tag = "6")]
+    pub payload_encoding: Option<String>,
+    #[prost(string, optional, tag = "7")]
+    pub payload_type: Option<String>,
+    #[prost(bytes = "vec", optional, tag = "8")]
+    pub payload: Option<Vec<u8>>,
+    #[prost(string, optional, tag = "9")]
+    pub log_id_new: Option<String>,
+}
+
+impl Frame {
+    /// Looks up a header by key (first match; Feishu frames never repeat a
+    /// key). Returns `Some("")` for a present-but-empty value — callers that
+    /// care about emptiness must check the returned string themselves.
+    pub fn header(&self, key: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|h| h.key == key)
+            .map(|h| h.value.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_round_trips_through_encode_decode() {
+        let frame = Frame {
+            seq_id: 42,
+            log_id: 7,
+            service: 1,
+            method: 1,
+            headers: vec![
+                Header::new("type", "event"),
+                Header::new("message_id", "m-1"),
+            ],
+            payload_encoding: None,
+            payload_type: None,
+            payload: Some(b"{\"hello\":\"world\"}".to_vec()),
+            log_id_new: None,
+        };
+
+        let mut buf = Vec::new();
+        frame.encode(&mut buf).expect("encode succeeds");
+        let decoded = Frame::decode(buf.as_slice()).expect("decode succeeds");
+
+        assert_eq!(decoded.seq_id, 42);
+        assert_eq!(decoded.log_id, 7);
+        assert_eq!(decoded.service, 1);
+        assert_eq!(decoded.method, 1);
+        assert_eq!(decoded.header("type"), Some("event"));
+        assert_eq!(decoded.header("message_id"), Some("m-1"));
+        assert_eq!(
+            decoded.payload.as_deref(),
+            Some(b"{\"hello\":\"world\"}".as_slice())
+        );
+    }
+
+    #[test]
+    fn empty_optional_strings_decode_as_some_empty_not_error() {
+        let frame = Frame {
+            seq_id: 1,
+            log_id: 1,
+            service: 1,
+            method: 0,
+            headers: vec![],
+            payload_encoding: Some(String::new()),
+            payload_type: Some(String::new()),
+            payload: None,
+            log_id_new: Some(String::new()),
+        };
+
+        let mut buf = Vec::new();
+        frame.encode(&mut buf).expect("encode succeeds");
+        let decoded = Frame::decode(buf.as_slice()).expect("decode succeeds");
+
+        assert_eq!(decoded.payload_encoding.as_deref(), Some(""));
+        assert_eq!(decoded.payload_type.as_deref(), Some(""));
+        assert_eq!(decoded.log_id_new.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn decode_zero_fills_a_missing_required_field_rather_than_erroring() {
+        // prost's `required` attribute affects ENCODING (the field is never
+        // optional on the wire) but does NOT enforce presence on DECODE —
+        // a wire message missing a required field decodes successfully with
+        // that field defaulted (0 for numeric types), rather than erroring.
+        // This is documented here (not just asserted implicitly) because
+        // it's easy to assume proto2 "required" is enforced symmetrically;
+        // callers that care about a genuinely-absent `log_id`/`service`/
+        // `method` must check for `0` themselves if that matters.
+        let mut buf = Vec::new();
+        prost::encoding::uint64::encode(1, &1u64, &mut buf); // seq_id (tag 1) only
+        let decoded =
+            Frame::decode(buf.as_slice()).expect("decode succeeds despite missing required fields");
+        assert_eq!(decoded.seq_id, 1);
+        assert_eq!(decoded.log_id, 0);
+        assert_eq!(decoded.service, 0);
+        assert_eq!(decoded.method, 0);
+    }
+}

--- a/crates/app/bamboo-server/src/connect/platforms/feishu/ws.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/feishu/ws.rs
@@ -313,6 +313,17 @@ impl Reassembler {
                 received: std::collections::HashMap::new(),
                 first_seen: now,
             });
+        // Out-of-range `seq` must not count toward completion, or a malformed
+        // frame could inflate `received.len()` past `total` and "complete"
+        // the group with a truncated payload (the assembly loop below only
+        // reads indices 0..total).
+        if seq >= entry.total {
+            tracing::warn!(
+                "connect: feishu ws frame with out-of-range seq {seq} (sum {}); dropping part",
+                entry.total
+            );
+            return None;
+        }
         entry.received.insert(seq, payload);
 
         if entry.received.len() >= entry.total {
@@ -337,10 +348,18 @@ impl Reassembler {
 // Reconnect backoff
 // ---------------------------------------------------------------------
 
+/// Floor on the server-supplied fixed reconnect interval: a bootstrap
+/// response carrying `ReconnectInterval: 0` (buggy endpoint, or a tampered
+/// bootstrap) must not turn the reconnect loop into a tight
+/// bootstrap→connect→fail busy loop. Same defensive posture as the 1s
+/// ping-interval floor in `run_once`.
+const MIN_RECONNECT_INTERVAL: Duration = Duration::from_secs(5);
+
 /// `attempt` is the count of consecutive failed reconnect tries SINCE the
 /// last successful connection (0 = the first try right after a disconnect).
 /// Per spec: the first attempt waits a one-time random jitter in
-/// `[0, nonce]`; every attempt after that waits the fixed `interval`.
+/// `[0, nonce]`; every attempt after that waits the fixed `interval`
+/// (floored to [`MIN_RECONNECT_INTERVAL`]).
 pub(super) fn reconnect_delay(attempt: u32, nonce: Duration, interval: Duration) -> Duration {
     if attempt == 0 {
         let millis = nonce.as_millis() as u64;
@@ -351,7 +370,7 @@ pub(super) fn reconnect_delay(attempt: u32, nonce: Duration, interval: Duration)
             Duration::from_millis(rand::rng().random_range(0..=millis))
         }
     } else {
-        interval
+        interval.max(MIN_RECONNECT_INTERVAL)
     }
 }
 
@@ -862,6 +881,40 @@ mod tests {
         let interval = Duration::from_secs(120);
         assert_eq!(reconnect_delay(1, nonce, interval), interval);
         assert_eq!(reconnect_delay(5, nonce, interval), interval);
+    }
+
+    /// A server-supplied `ReconnectInterval: 0` (or any sub-floor value) must
+    /// not produce a tight reconnect busy loop.
+    #[test]
+    fn reconnect_delay_floors_a_zero_server_interval() {
+        let nonce = Duration::from_secs(30);
+        assert_eq!(
+            reconnect_delay(1, nonce, Duration::ZERO),
+            MIN_RECONNECT_INTERVAL
+        );
+        assert_eq!(
+            reconnect_delay(3, nonce, Duration::from_millis(10)),
+            MIN_RECONNECT_INTERVAL
+        );
+    }
+
+    /// A malformed/adversarial part with `seq >= sum` must be dropped, not
+    /// counted toward completion — otherwise the group could "complete" with
+    /// a truncated payload.
+    #[test]
+    fn reassembler_drops_out_of_range_seq_instead_of_completing_truncated() {
+        let mut reassembler = Reassembler::new(Duration::from_secs(5));
+        let now = Instant::now();
+
+        let part0 = data_frame("msg-oob", Some(2), Some(0), b"hello ");
+        let bogus = data_frame("msg-oob", Some(2), Some(7), b"evil");
+        assert_eq!(reassembler.feed(&part0, now), None);
+        // Out-of-range part: dropped, group must still be incomplete.
+        assert_eq!(reassembler.feed(&bogus, now), None);
+
+        // The real second part completes the group with the full payload.
+        let part1 = data_frame("msg-oob", Some(2), Some(1), b"world");
+        assert_eq!(reassembler.feed(&part1, now), Some(b"hello world".to_vec()));
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/connect/platforms/feishu/ws.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/feishu/ws.rs
@@ -1,0 +1,887 @@
+//! Feishu/Lark event long-connection (WS) client: bootstrap, ping, frame
+//! ack, multi-part reassembly, reconnect. No public IP / webhook needed —
+//! this is the sole inbound transport (see `docs/feishu-adapter-plan.md`
+//! §2c, protocol verified against the official Go SDK).
+//!
+//! Protocol logic (frame building/parsing, bootstrap-response
+//! classification, multi-part reassembly, reconnect backoff) is factored
+//! into small pure/near-pure functions so it's unit-testable without a live
+//! socket — the actual `tokio-tungstenite` connection driver
+//! ([`run_with_reconnect`]) is thin glue over them, per the task brief's
+//! "prefer unit-testing frame handling functions directly" guidance.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::{Sink, SinkExt, StreamExt};
+use prost::Message as _;
+use tokio::sync::mpsc;
+use tokio::time::Instant;
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+use super::super::super::platform::{PlatformError, PlatformResult};
+use super::api::{http_client, sanitize_reqwest_error};
+use super::pbbp2::{Frame, Header};
+
+/// Hard deadline (server-imposed) to ack a data frame — after this the
+/// server re-pushes the same event. [`ACK_SOFT_DEADLINE`] is what
+/// `mod.rs`'s pending-ack map self-imposes (auto-resolve with a default
+/// toast) so this transport-level wrapper always has headroom left to
+/// actually get the ack frame back onto the wire.
+const ACK_HARD_DEADLINE: Duration = Duration::from_millis(2900);
+/// How often to check for read-idle disconnects (frames NOT received for
+/// longer than `ping_interval * IDLE_TIMEOUT_MULTIPLIER`).
+const IDLE_CHECK_INTERVAL: Duration = Duration::from_secs(10);
+const IDLE_TIMEOUT_MULTIPLIER: u32 = 3;
+const MIN_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Multi-part reassembly TTL (5s per spec — a part that's been waiting on
+/// its siblings longer than this is dropped).
+const REASSEMBLY_TTL: Duration = Duration::from_secs(5);
+
+// ---------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------
+
+/// Server-provided long-connection tuning, seconds-denominated (PascalCase
+/// on the wire: `PingInterval`/`ReconnectInterval`/`ReconnectNonce`/
+/// `ReconnectCount`). Defaults match the documented Feishu defaults, used
+/// when a bootstrap response omits `ClientConfig` entirely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ClientConfig {
+    pub ping_interval: Duration,
+    pub reconnect_interval: Duration,
+    pub reconnect_nonce: Duration,
+    /// `-1` = infinite. This adapter always retries infinitely regardless
+    /// of this value (per task spec) — kept for completeness/logging only.
+    pub reconnect_count: i64,
+}
+
+impl Default for ClientConfig {
+    fn default() -> Self {
+        Self {
+            ping_interval: Duration::from_secs(120),
+            reconnect_interval: Duration::from_secs(120),
+            reconnect_nonce: Duration::from_secs(30),
+            reconnect_count: -1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct BootstrapReady {
+    pub url: String,
+    pub client_config: ClientConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum BootstrapOutcome {
+    Ready(BootstrapReady),
+    /// Transient bootstrap failure (code `1` or `1000040343`) — retry.
+    Retryable,
+    /// Unrecoverable — stop reconnecting entirely.
+    Fatal(String),
+}
+
+/// PascalCase bootstrap request body: `POST {base}/callback/ws/endpoint`.
+pub(super) fn build_bootstrap_body(app_id: &str, app_secret: &str) -> serde_json::Value {
+    serde_json::json!({
+        "AppID": app_id,
+        "AppSecret": app_secret,
+        "ClientAssertion": "",
+    })
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RawBootstrapResponse {
+    code: i64,
+    #[serde(default)]
+    msg: Option<String>,
+    #[serde(default)]
+    data: Option<RawBootstrapData>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RawBootstrapData {
+    #[serde(rename = "URL")]
+    url: String,
+    #[serde(rename = "ClientConfig", default)]
+    client_config: Option<RawClientConfig>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct RawClientConfig {
+    #[serde(rename = "PingInterval", default)]
+    ping_interval: Option<u64>,
+    #[serde(rename = "ReconnectInterval", default)]
+    reconnect_interval: Option<u64>,
+    #[serde(rename = "ReconnectNonce", default)]
+    reconnect_nonce: Option<u64>,
+    #[serde(rename = "ReconnectCount", default)]
+    reconnect_count: Option<i64>,
+}
+
+/// Classifies a bootstrap HTTP response body per the plan's verified
+/// contract: `code == 0` is success; `1` and `1000040343` are transient
+/// (retry); anything else is fatal (stop reconnecting entirely).
+pub(super) fn parse_bootstrap_response(body: &str) -> PlatformResult<BootstrapOutcome> {
+    let parsed: RawBootstrapResponse = serde_json::from_str(body).map_err(|error| {
+        PlatformError::other(format!("bootstrap response parse failed: {error}"))
+    })?;
+
+    match parsed.code {
+        0 => {
+            let data = parsed
+                .data
+                .ok_or_else(|| PlatformError::other("bootstrap response missing data"))?;
+            let defaults = ClientConfig::default();
+            let raw = data.client_config.unwrap_or_default();
+            let client_config = ClientConfig {
+                ping_interval: raw
+                    .ping_interval
+                    .map(Duration::from_secs)
+                    .unwrap_or(defaults.ping_interval),
+                reconnect_interval: raw
+                    .reconnect_interval
+                    .map(Duration::from_secs)
+                    .unwrap_or(defaults.reconnect_interval),
+                reconnect_nonce: raw
+                    .reconnect_nonce
+                    .map(Duration::from_secs)
+                    .unwrap_or(defaults.reconnect_nonce),
+                reconnect_count: raw.reconnect_count.unwrap_or(defaults.reconnect_count),
+            };
+            Ok(BootstrapOutcome::Ready(BootstrapReady {
+                url: data.url,
+                client_config,
+            }))
+        }
+        1 | 1_000_040_343 => Ok(BootstrapOutcome::Retryable),
+        other => Ok(BootstrapOutcome::Fatal(format!(
+            "bootstrap failed (code={other}): {}",
+            parsed.msg.unwrap_or_default()
+        ))),
+    }
+}
+
+async fn bootstrap_endpoint(
+    app_id: &str,
+    app_secret: &str,
+    base_url: &str,
+) -> PlatformResult<BootstrapOutcome> {
+    let url = format!("{}/callback/ws/endpoint", base_url.trim_end_matches('/'));
+    let body = build_bootstrap_body(app_id, app_secret);
+    let response = http_client()
+        .post(url)
+        .header("locale", "zh")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|error| {
+            PlatformError::other(format!(
+                "WS bootstrap request failed: {}",
+                sanitize_reqwest_error(error, &[app_secret])
+            ))
+        })?;
+    let text = response.text().await.map_err(|error| {
+        PlatformError::other(format!(
+            "WS bootstrap response read failed: {}",
+            sanitize_reqwest_error(error, &[app_secret])
+        ))
+    })?;
+    parse_bootstrap_response(&text)
+}
+
+/// Parses the `service_id` query parameter off the bootstrap-issued `wss://`
+/// URL — echoed back in every ping frame's `service` field.
+pub(super) fn parse_service_id(ws_url: &str) -> Option<i32> {
+    let parsed = url::Url::parse(ws_url).ok()?;
+    parsed
+        .query_pairs()
+        .find(|(key, _)| key == "service_id")
+        .and_then(|(_, value)| value.parse::<i32>().ok())
+}
+
+// ---------------------------------------------------------------------
+// Frame helpers
+// ---------------------------------------------------------------------
+
+pub(super) fn build_ping_frame(seq_id: u64, service_id: i32) -> Frame {
+    Frame {
+        seq_id,
+        log_id: seq_id,
+        service: service_id,
+        method: 0,
+        headers: vec![Header::new("type", "ping")],
+        payload_encoding: None,
+        payload_type: None,
+        payload: None,
+        log_id_new: None,
+    }
+}
+
+pub(super) fn is_event_frame(frame: &Frame) -> bool {
+    frame.header("type") == Some("event")
+}
+
+pub(super) fn is_pong_frame(frame: &Frame) -> bool {
+    frame.header("type") == Some("pong")
+}
+
+/// Builds the ack payload body: `{"code":200,"headers":null,"data":<base64
+/// or null>}`. `callback_response`, when `Some`, is the JSON value to
+/// base64-encode into `data` (used for `card.action.trigger` — the toast/
+/// updated-card response); `None` (a plain message event, or an unresolved
+/// card callback past its soft deadline) yields `data: null`.
+pub(super) fn build_ack_payload(callback_response: Option<&serde_json::Value>) -> Vec<u8> {
+    use base64::Engine;
+    let data = callback_response
+        .map(|value| base64::engine::general_purpose::STANDARD.encode(value.to_string()));
+    serde_json::json!({
+        "code": 200,
+        "headers": null,
+        "data": data,
+    })
+    .to_string()
+    .into_bytes()
+}
+
+/// Echoes `original` back with its payload replaced by the ack body — same
+/// `seq_id`/`log_id`/`service`/`method`/`headers`, per the protocol's "ack =
+/// echo the same frame" contract.
+pub(super) fn build_ack_frame(original: &Frame, ack_payload: Vec<u8>) -> Frame {
+    let mut frame = original.clone();
+    frame.payload = Some(ack_payload);
+    frame
+}
+
+// ---------------------------------------------------------------------
+// Multi-part reassembly
+// ---------------------------------------------------------------------
+
+struct PendingParts {
+    total: usize,
+    received: std::collections::HashMap<usize, Vec<u8>>,
+    first_seen: Instant,
+}
+
+/// Reassembles multi-part data frames keyed by their `message_id` header,
+/// using the `sum`/`seq` headers to know the total part count and this
+/// part's index. A frame with no `sum` header (or `sum <= 1`) is a
+/// single-part message and passes through immediately. Incomplete groups
+/// older than [`REASSEMBLY_TTL`] are dropped (never delivered, never acked
+/// as a group — an isolated stray part is harmless to lose).
+pub(super) struct Reassembler {
+    pending: std::collections::HashMap<String, PendingParts>,
+    ttl: Duration,
+}
+
+impl Reassembler {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            pending: std::collections::HashMap::new(),
+            ttl,
+        }
+    }
+
+    /// Feeds one data frame in `now` (threaded explicitly so tests can drive
+    /// TTL expiry deterministically). Returns the complete payload once
+    /// every part of a multi-part message has arrived.
+    pub fn feed(&mut self, frame: &Frame, now: Instant) -> Option<Vec<u8>> {
+        self.pending
+            .retain(|_, parts| now.duration_since(parts.first_seen) < self.ttl);
+
+        let payload = frame.payload.clone().unwrap_or_default();
+        let sum: usize = frame
+            .header("sum")
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(1);
+        if sum <= 1 {
+            return Some(payload);
+        }
+
+        let seq: usize = frame
+            .header("seq")
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(0);
+        let message_id = frame.header("message_id").unwrap_or_default().to_string();
+
+        let entry = self
+            .pending
+            .entry(message_id.clone())
+            .or_insert_with(|| PendingParts {
+                total: sum,
+                received: std::collections::HashMap::new(),
+                first_seen: now,
+            });
+        entry.received.insert(seq, payload);
+
+        if entry.received.len() >= entry.total {
+            let mut parts = self
+                .pending
+                .remove(&message_id)
+                .expect("just inserted above");
+            let mut full = Vec::new();
+            for index in 0..parts.total {
+                if let Some(chunk) = parts.received.remove(&index) {
+                    full.extend_from_slice(&chunk);
+                }
+            }
+            Some(full)
+        } else {
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// Reconnect backoff
+// ---------------------------------------------------------------------
+
+/// `attempt` is the count of consecutive failed reconnect tries SINCE the
+/// last successful connection (0 = the first try right after a disconnect).
+/// Per spec: the first attempt waits a one-time random jitter in
+/// `[0, nonce]`; every attempt after that waits the fixed `interval`.
+pub(super) fn reconnect_delay(attempt: u32, nonce: Duration, interval: Duration) -> Duration {
+    if attempt == 0 {
+        let millis = nonce.as_millis() as u64;
+        if millis == 0 {
+            Duration::ZERO
+        } else {
+            use rand::RngExt;
+            Duration::from_millis(rand::rng().random_range(0..=millis))
+        }
+    } else {
+        interval
+    }
+}
+
+/// Fatal handshake conditions per the plan: a `403` `Handshake-Status`
+/// header, or auth error code `1000040350` (>50 connections for this app)
+/// in `Handshake-Autherrcode`. Either stops reconnecting entirely — NOT a
+/// retryable condition.
+pub(super) fn fatal_handshake_reason(
+    headers: &tokio_tungstenite::tungstenite::http::HeaderMap,
+) -> Option<String> {
+    let status = headers
+        .get("Handshake-Status")
+        .and_then(|value| value.to_str().ok());
+    if status == Some("403") {
+        return Some("handshake rejected: Handshake-Status=403".to_string());
+    }
+    let autherrcode = headers
+        .get("Handshake-Autherrcode")
+        .and_then(|value| value.to_str().ok());
+    if autherrcode == Some("1000040350") {
+        return Some(
+            "handshake rejected: too many connections for this app (Handshake-Autherrcode=1000040350)"
+                .to_string(),
+        );
+    }
+    None
+}
+
+// ---------------------------------------------------------------------
+// Connection driver
+// ---------------------------------------------------------------------
+
+/// Handles ONE fully-reassembled event-data frame's plaintext schema-2.0 JSON
+/// payload. Implemented by `FeishuPlatform` (see `mod.rs`) — kept as a trait
+/// here so `ws.rs` stays ignorant of `im.message.receive_v1`/
+/// `card.action.trigger` semantics (that mapping, and the card-callback
+/// pending-ack map, are `mod.rs`'s job per the module split in the task
+/// brief). Returns the value to base64-encode into the frame ack's `data`
+/// field (`None` for a plain message event, or an unresolved card callback
+/// past ITS OWN soft deadline).
+#[async_trait::async_trait]
+pub(super) trait EventSink: Send + Sync {
+    async fn handle_event(&self, payload: Vec<u8>) -> Option<serde_json::Value>;
+}
+
+pub(super) enum ConnectionEnded {
+    /// Transient — reconnect (re-bootstrap from scratch).
+    Retry,
+    /// Unrecoverable — stop the platform's WS loop entirely.
+    Fatal(String),
+}
+
+struct RunOnceResult {
+    ended: ConnectionEnded,
+    /// Whether a WS connection was actually established this round (used to
+    /// reset the reconnect-attempt counter for jitter purposes even if the
+    /// connection died quickly afterward).
+    connected: bool,
+    /// The server's tuning for this round, when we got far enough to learn
+    /// it (used to compute the next reconnect delay with the real values
+    /// instead of hardcoded defaults).
+    client_config: Option<ClientConfig>,
+}
+
+async fn run_once(
+    app_id: &str,
+    app_secret: &str,
+    base_url: &str,
+    sink: &Arc<dyn EventSink>,
+) -> RunOnceResult {
+    let bootstrap = match bootstrap_endpoint(app_id, app_secret, base_url).await {
+        Ok(BootstrapOutcome::Ready(ready)) => ready,
+        Ok(BootstrapOutcome::Retryable) => {
+            tracing::warn!("connect: feishu WS bootstrap transient failure, retrying");
+            return RunOnceResult {
+                ended: ConnectionEnded::Retry,
+                connected: false,
+                client_config: None,
+            };
+        }
+        Ok(BootstrapOutcome::Fatal(reason)) => {
+            return RunOnceResult {
+                ended: ConnectionEnded::Fatal(reason),
+                connected: false,
+                client_config: None,
+            };
+        }
+        Err(error) => {
+            tracing::warn!("connect: feishu WS bootstrap failed, retrying: {error}");
+            return RunOnceResult {
+                ended: ConnectionEnded::Retry,
+                connected: false,
+                client_config: None,
+            };
+        }
+    };
+
+    let service_id = parse_service_id(&bootstrap.url).unwrap_or(0);
+    let client_config = bootstrap.client_config;
+
+    let (ws_stream, response) = match tokio_tungstenite::connect_async(&bootstrap.url).await {
+        Ok(pair) => pair,
+        Err(error) => {
+            tracing::warn!("connect: feishu WS connect failed, retrying: {error}");
+            return RunOnceResult {
+                ended: ConnectionEnded::Retry,
+                connected: false,
+                client_config: Some(client_config),
+            };
+        }
+    };
+
+    if let Some(reason) = fatal_handshake_reason(response.headers()) {
+        return RunOnceResult {
+            ended: ConnectionEnded::Fatal(reason),
+            connected: true,
+            client_config: Some(client_config),
+        };
+    }
+
+    tracing::info!("connect: feishu WS connected (service_id={service_id})");
+    let (mut write, mut read) = ws_stream.split();
+    let (ack_tx, mut ack_rx) = mpsc::channel::<Frame>(32);
+    let mut reassembler = Reassembler::new(REASSEMBLY_TTL);
+    let mut seq: u64 = 1;
+
+    let ping_interval = client_config.ping_interval.max(Duration::from_secs(1));
+    let idle_timeout = (ping_interval * IDLE_TIMEOUT_MULTIPLIER).max(MIN_IDLE_TIMEOUT);
+    let mut last_activity = Instant::now();
+
+    let mut ping_ticker = tokio::time::interval(ping_interval);
+    ping_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    ping_ticker.tick().await; // consume the immediate first tick
+    let mut idle_check = tokio::time::interval(IDLE_CHECK_INTERVAL);
+    idle_check.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    let ended = loop {
+        tokio::select! {
+            _ = ping_ticker.tick() => {
+                let frame = build_ping_frame(seq, service_id);
+                seq += 1;
+                if send_frame(&mut write, &frame).await.is_err() {
+                    break ConnectionEnded::Retry;
+                }
+            }
+            _ = idle_check.tick() => {
+                if last_activity.elapsed() > idle_timeout {
+                    tracing::warn!("connect: feishu WS idle for {:?}, reconnecting", last_activity.elapsed());
+                    break ConnectionEnded::Retry;
+                }
+            }
+            ack_frame = ack_rx.recv() => {
+                if let Some(ack_frame) = ack_frame {
+                    if send_frame(&mut write, &ack_frame).await.is_err() {
+                        break ConnectionEnded::Retry;
+                    }
+                }
+            }
+            incoming = read.next() => {
+                match incoming {
+                    Some(Ok(WsMessage::Binary(bytes))) => {
+                        last_activity = Instant::now();
+                        match Frame::decode(bytes.as_ref()) {
+                            Ok(frame) => {
+                                if is_pong_frame(&frame) {
+                                    continue;
+                                }
+                                if frame.method != 1 || !is_event_frame(&frame) {
+                                    continue;
+                                }
+                                if let Some(full_payload) = reassembler.feed(&frame, Instant::now()) {
+                                    let sink = sink.clone();
+                                    let ack_tx = ack_tx.clone();
+                                    let frame_for_ack = frame.clone();
+                                    tokio::spawn(async move {
+                                        let response = tokio::time::timeout(
+                                            ACK_HARD_DEADLINE,
+                                            sink.handle_event(full_payload),
+                                        )
+                                        .await
+                                        .unwrap_or(None);
+                                        let payload = build_ack_payload(response.as_ref());
+                                        let ack_frame = build_ack_frame(&frame_for_ack, payload);
+                                        let _ = ack_tx.send(ack_frame).await;
+                                    });
+                                }
+                            }
+                            Err(error) => {
+                                tracing::warn!("connect: feishu WS frame decode failed: {error}");
+                            }
+                        }
+                    }
+                    Some(Ok(WsMessage::Close(_))) | None => break ConnectionEnded::Retry,
+                    Some(Ok(_)) => {
+                        last_activity = Instant::now();
+                    }
+                    Some(Err(error)) => {
+                        tracing::warn!("connect: feishu WS read error, reconnecting: {error}");
+                        break ConnectionEnded::Retry;
+                    }
+                }
+            }
+        }
+    };
+
+    RunOnceResult {
+        ended,
+        connected: true,
+        client_config: Some(client_config),
+    }
+}
+
+async fn send_frame(
+    write: &mut (impl Sink<WsMessage, Error = tokio_tungstenite::tungstenite::Error> + Unpin),
+    frame: &Frame,
+) -> Result<(), ()> {
+    let mut buf = Vec::new();
+    if frame.encode(&mut buf).is_err() {
+        return Ok(()); // malformed outgoing frame — nothing to send, not a connection error
+    }
+    write
+        .send(WsMessage::Binary(buf.into()))
+        .await
+        .map_err(|_| ())
+}
+
+/// Runs the WS client for the adapter's lifetime: bootstrap → connect →
+/// drive frames → on disconnect, wait (jitter-then-fixed backoff) and
+/// re-bootstrap, forever — UNLESS a fatal condition is hit (bad
+/// credentials, handshake rejection, >50 connections for this app), which
+/// stops reconnecting and returns `Err`. Never runs two connections at
+/// once: each loop iteration fully awaits [`run_once`] (which owns the
+/// entire connection's lifetime) before starting the next one.
+pub(super) async fn run_with_reconnect(
+    app_id: String,
+    app_secret: String,
+    base_url: String,
+    sink: Arc<dyn EventSink>,
+) -> PlatformResult<()> {
+    let mut attempt: u32 = 0;
+    loop {
+        let result = run_once(&app_id, &app_secret, &base_url, &sink).await;
+        if result.connected {
+            attempt = 0;
+        }
+        match result.ended {
+            ConnectionEnded::Fatal(reason) => {
+                tracing::error!("connect: feishu WS stopped (fatal): {reason}");
+                return Err(PlatformError::other(format!("feishu WS fatal: {reason}")));
+            }
+            ConnectionEnded::Retry => {
+                let config = result.client_config.unwrap_or_default();
+                let delay =
+                    reconnect_delay(attempt, config.reconnect_nonce, config.reconnect_interval);
+                tracing::warn!("connect: feishu WS reconnecting in {delay:?} (attempt {attempt})");
+                tokio::time::sleep(delay).await;
+                attempt = attempt.saturating_add(1);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bootstrap_body_uses_pascal_case_keys() {
+        let body = build_bootstrap_body("cli_x", "secret_y");
+        assert_eq!(body["AppID"], serde_json::json!("cli_x"));
+        assert_eq!(body["AppSecret"], serde_json::json!("secret_y"));
+        assert_eq!(body["ClientAssertion"], serde_json::json!(""));
+    }
+
+    #[test]
+    fn bootstrap_response_code_zero_is_ready_with_defaults_when_client_config_absent() {
+        let body = serde_json::json!({
+            "code": 0,
+            "msg": "success",
+            "data": { "URL": "wss://example/?service_id=42" }
+        })
+        .to_string();
+        let outcome = parse_bootstrap_response(&body).expect("parses");
+        match outcome {
+            BootstrapOutcome::Ready(ready) => {
+                assert_eq!(ready.url, "wss://example/?service_id=42");
+                assert_eq!(ready.client_config, ClientConfig::default());
+            }
+            other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bootstrap_response_honors_explicit_client_config() {
+        let body = serde_json::json!({
+            "code": 0,
+            "data": {
+                "URL": "wss://example/?service_id=7",
+                "ClientConfig": {
+                    "PingInterval": 60,
+                    "ReconnectInterval": 45,
+                    "ReconnectNonce": 10,
+                    "ReconnectCount": -1
+                }
+            }
+        })
+        .to_string();
+        let outcome = parse_bootstrap_response(&body).expect("parses");
+        match outcome {
+            BootstrapOutcome::Ready(ready) => {
+                assert_eq!(ready.client_config.ping_interval, Duration::from_secs(60));
+                assert_eq!(
+                    ready.client_config.reconnect_interval,
+                    Duration::from_secs(45)
+                );
+                assert_eq!(ready.client_config.reconnect_nonce, Duration::from_secs(10));
+            }
+            other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bootstrap_response_codes_1_and_1000040343_are_retryable() {
+        for code in [1, 1_000_040_343] {
+            let body = serde_json::json!({ "code": code, "msg": "transient" }).to_string();
+            let outcome = parse_bootstrap_response(&body).expect("parses");
+            assert!(
+                matches!(outcome, BootstrapOutcome::Retryable),
+                "code {code} should be retryable"
+            );
+        }
+    }
+
+    #[test]
+    fn bootstrap_response_other_codes_are_fatal() {
+        let body = serde_json::json!({ "code": 10003, "msg": "invalid app" }).to_string();
+        let outcome = parse_bootstrap_response(&body).expect("parses");
+        assert!(matches!(outcome, BootstrapOutcome::Fatal(_)));
+    }
+
+    #[test]
+    fn parse_service_id_extracts_the_query_param() {
+        assert_eq!(
+            parse_service_id("wss://open.feishu.cn/ws?device_id=1&service_id=99&other=x"),
+            Some(99)
+        );
+        assert_eq!(
+            parse_service_id("wss://open.feishu.cn/ws?device_id=1"),
+            None
+        );
+        assert_eq!(parse_service_id("not a url"), None);
+    }
+
+    #[test]
+    fn ping_frame_has_method_zero_and_type_ping_header() {
+        let frame = build_ping_frame(5, 42);
+        assert_eq!(frame.method, 0);
+        assert_eq!(frame.service, 42);
+        assert_eq!(frame.header("type"), Some("ping"));
+    }
+
+    #[test]
+    fn ack_payload_encodes_callback_response_as_base64_data() {
+        let response = serde_json::json!({ "toast": { "type": "info", "content": "done" } });
+        let payload = build_ack_payload(Some(&response));
+        let value: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(value["code"], serde_json::json!(200));
+        assert!(value["headers"].is_null());
+        let data = value["data"].as_str().expect("data is a base64 string");
+        use base64::Engine;
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(data)
+            .unwrap();
+        let decoded_json: serde_json::Value = serde_json::from_slice(&decoded).unwrap();
+        assert_eq!(decoded_json, response);
+    }
+
+    #[test]
+    fn ack_payload_with_no_response_has_null_data() {
+        let payload = build_ack_payload(None);
+        let value: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(value["code"], serde_json::json!(200));
+        assert!(value["data"].is_null());
+    }
+
+    #[test]
+    fn ack_frame_echoes_seq_log_service_method_headers_with_new_payload() {
+        let original = Frame {
+            seq_id: 9,
+            log_id: 9,
+            service: 3,
+            method: 1,
+            headers: vec![
+                Header::new("type", "event"),
+                Header::new("message_id", "m-1"),
+            ],
+            payload_encoding: None,
+            payload_type: None,
+            payload: Some(b"original".to_vec()),
+            log_id_new: None,
+        };
+        let ack = build_ack_frame(&original, b"{\"code\":200}".to_vec());
+        assert_eq!(ack.seq_id, original.seq_id);
+        assert_eq!(ack.log_id, original.log_id);
+        assert_eq!(ack.service, original.service);
+        assert_eq!(ack.method, original.method);
+        assert_eq!(ack.headers, original.headers);
+        assert_eq!(ack.payload, Some(b"{\"code\":200}".to_vec()));
+    }
+
+    fn data_frame(
+        message_id: &str,
+        sum: Option<usize>,
+        seq: Option<usize>,
+        payload: &[u8],
+    ) -> Frame {
+        let mut headers = vec![
+            Header::new("type", "event"),
+            Header::new("message_id", message_id),
+        ];
+        if let Some(sum) = sum {
+            headers.push(Header::new("sum", sum.to_string()));
+        }
+        if let Some(seq) = seq {
+            headers.push(Header::new("seq", seq.to_string()));
+        }
+        Frame {
+            seq_id: 1,
+            log_id: 1,
+            service: 1,
+            method: 1,
+            headers,
+            payload_encoding: None,
+            payload_type: None,
+            payload: Some(payload.to_vec()),
+            log_id_new: None,
+        }
+    }
+
+    #[test]
+    fn reassembler_passes_through_single_part_frames_immediately() {
+        let mut reassembler = Reassembler::new(REASSEMBLY_TTL);
+        let now = Instant::now();
+        let frame = data_frame("m-1", None, None, b"hello");
+        assert_eq!(reassembler.feed(&frame, now), Some(b"hello".to_vec()));
+    }
+
+    #[test]
+    fn reassembler_reassembles_multi_part_frames_in_order() {
+        let mut reassembler = Reassembler::new(REASSEMBLY_TTL);
+        let now = Instant::now();
+        let part0 = data_frame("m-2", Some(2), Some(0), b"hel");
+        let part1 = data_frame("m-2", Some(2), Some(1), b"lo");
+
+        assert_eq!(
+            reassembler.feed(&part0, now),
+            None,
+            "incomplete group yields nothing yet"
+        );
+        let full = reassembler.feed(&part1, now).expect("group completes");
+        assert_eq!(full, b"hello".to_vec());
+    }
+
+    #[test]
+    fn reassembler_reorders_out_of_order_parts() {
+        let mut reassembler = Reassembler::new(REASSEMBLY_TTL);
+        let now = Instant::now();
+        let part1 = data_frame("m-3", Some(2), Some(1), b"lo");
+        let part0 = data_frame("m-3", Some(2), Some(0), b"hel");
+
+        assert_eq!(reassembler.feed(&part1, now), None);
+        let full = reassembler.feed(&part0, now).expect("group completes");
+        assert_eq!(full, b"hello".to_vec());
+    }
+
+    #[test]
+    fn reassembler_drops_groups_older_than_the_ttl() {
+        let mut reassembler = Reassembler::new(Duration::from_secs(5));
+        let start = Instant::now();
+        let part0 = data_frame("m-4", Some(2), Some(0), b"hel");
+        assert_eq!(reassembler.feed(&part0, start), None);
+
+        // Feed an unrelated frame long after the TTL to trigger pruning, then
+        // the second part of the ORIGINAL group must not complete it.
+        let later = start + Duration::from_secs(10);
+        let part1 = data_frame("m-4", Some(2), Some(1), b"lo");
+        // The stale part was pruned, so this now looks like the FIRST part of
+        // a fresh group — still incomplete.
+        assert_eq!(reassembler.feed(&part1, later), None);
+    }
+
+    #[test]
+    fn reconnect_delay_first_attempt_is_bounded_jitter() {
+        let nonce = Duration::from_secs(30);
+        let interval = Duration::from_secs(120);
+        for _ in 0..20 {
+            let delay = reconnect_delay(0, nonce, interval);
+            assert!(
+                delay <= nonce,
+                "jitter {delay:?} must be <= nonce {nonce:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn reconnect_delay_subsequent_attempts_are_the_fixed_interval() {
+        let nonce = Duration::from_secs(30);
+        let interval = Duration::from_secs(120);
+        assert_eq!(reconnect_delay(1, nonce, interval), interval);
+        assert_eq!(reconnect_delay(5, nonce, interval), interval);
+    }
+
+    #[test]
+    fn fatal_handshake_reason_detects_403_status_header() {
+        let mut headers = tokio_tungstenite::tungstenite::http::HeaderMap::new();
+        headers.insert("Handshake-Status", "403".parse().unwrap());
+        assert!(fatal_handshake_reason(&headers).is_some());
+    }
+
+    #[test]
+    fn fatal_handshake_reason_detects_too_many_connections_autherrcode() {
+        let mut headers = tokio_tungstenite::tungstenite::http::HeaderMap::new();
+        headers.insert("Handshake-Autherrcode", "1000040350".parse().unwrap());
+        assert!(fatal_handshake_reason(&headers).is_some());
+    }
+
+    #[test]
+    fn fatal_handshake_reason_is_none_for_ordinary_headers() {
+        let mut headers = tokio_tungstenite::tungstenite::http::HeaderMap::new();
+        headers.insert("Handshake-Status", "200".parse().unwrap());
+        assert!(fatal_handshake_reason(&headers).is_none());
+    }
+}

--- a/crates/app/bamboo-server/src/connect/platforms/mod.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/mod.rs
@@ -1,1 +1,2 @@
+pub mod feishu;
 pub mod telegram;

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
@@ -528,6 +528,152 @@ async fn set_bamboo_config_persists_connect_into_connect_json_only_and_preserves
     );
 }
 
+/// Feishu adapter config plumbing (epic #447 phase 3, §2a): `app_id`/`domain`
+/// are plain fields, `app_secret` follows the exact same encrypted-at-rest +
+/// masked-GET + masked-preserve-on-PATCH contract as the Telegram `token`
+/// above.
+#[actix_web::test]
+async fn set_bamboo_config_persists_feishu_app_secret_encrypted_and_preserves_masked_value() {
+    use crate::app_state::AppState;
+    use actix_web::{test, web, App};
+    use bamboo_config::encryption;
+
+    // See the long NOTE on the Telegram equivalent above for why the
+    // process-global (not thread-local) encryption key is relied on here.
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let state = AppState::new(temp_dir.path().to_path_buf())
+        .await
+        .expect("app state should initialize");
+    let data_dir = state.app_data_dir.clone();
+    let app_state = web::Data::new(state);
+
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .route("/bamboo/config", web::get().to(super::get_bamboo_config))
+            .route("/bamboo/config", web::post().to(super::set_bamboo_config)),
+    )
+    .await;
+
+    // 1) Set a Feishu entry with app_id, app_secret, domain via the settings
+    // PATCH surface.
+    let post = test::TestRequest::post()
+        .uri("/bamboo/config")
+        .set_json(serde_json::json!({
+            "connect": {
+                "platforms": [
+                    {
+                        "type": "feishu",
+                        "app_id": "cli_real_app_id",
+                        "app_secret": "feishu-real-secret",
+                        "domain": "lark",
+                        "allow_from": ["ou_1"]
+                    }
+                ]
+            }
+        }))
+        .to_request();
+    let post_resp = test::call_service(&app, post).await;
+    assert!(post_resp.status().is_success(), "set config should succeed");
+
+    // config.json must NOT carry the `connect` key at all (#455 split).
+    let config_text = tokio::fs::read_to_string(config_file_path(&data_dir))
+        .await
+        .expect("config.json should exist after set");
+    assert!(
+        !config_text.contains("\"connect\""),
+        "config.json must not persist the connect key"
+    );
+    assert!(
+        !config_text.contains("feishu-real-secret"),
+        "plaintext app_secret must never be persisted anywhere"
+    );
+
+    // connect.json holds app_id/domain in plain and app_secret encrypted.
+    let connect_path = data_dir.join("connect.json");
+    let connect_text = tokio::fs::read_to_string(&connect_path)
+        .await
+        .expect("connect.json should exist after set");
+    assert!(
+        connect_text.contains("app_secret_encrypted"),
+        "app_secret must be persisted encrypted in connect.json"
+    );
+    assert!(
+        !connect_text.contains("feishu-real-secret"),
+        "plaintext app_secret must never be persisted in connect.json"
+    );
+    let connect_json: serde_json::Value =
+        serde_json::from_str(&connect_text).expect("connect.json should parse");
+    assert_eq!(connect_json["platforms"][0]["app_id"], "cli_real_app_id");
+    assert_eq!(connect_json["platforms"][0]["domain"], "lark");
+    let app_secret_encrypted = connect_json["platforms"][0]["app_secret_encrypted"]
+        .as_str()
+        .expect("app_secret_encrypted should be present")
+        .to_string();
+    assert_eq!(
+        encryption::decrypt(&app_secret_encrypted).expect("app_secret should decrypt"),
+        "feishu-real-secret"
+    );
+
+    // 2) GET masks app_secret but leaves app_id/domain visible.
+    let get = test::TestRequest::get().uri("/bamboo/config").to_request();
+    let body: serde_json::Value = test::call_and_read_body_json(&app, get).await;
+    assert_eq!(body["connect"]["platforms"][0]["app_secret"], "****...****");
+    assert_eq!(body["connect"]["platforms"][0]["app_id"], "cli_real_app_id");
+    assert_eq!(body["connect"]["platforms"][0]["domain"], "lark");
+
+    // 3) Re-POST with the masked placeholder plus an unrelated field change —
+    // the secret must survive untouched.
+    let post2 = test::TestRequest::post()
+        .uri("/bamboo/config")
+        .set_json(serde_json::json!({
+            "connect": {
+                "platforms": [
+                    {
+                        "type": "feishu",
+                        "app_id": "cli_real_app_id",
+                        "app_secret": "****...****",
+                        "domain": "lark",
+                        "allow_from": ["ou_1", "ou_2"]
+                    }
+                ]
+            }
+        }))
+        .to_request();
+    let post2_resp = test::call_service(&app, post2).await;
+    assert!(
+        post2_resp.status().is_success(),
+        "second set config should succeed"
+    );
+
+    let get2 = test::TestRequest::get().uri("/bamboo/config").to_request();
+    let body2: serde_json::Value = test::call_and_read_body_json(&app, get2).await;
+    assert_eq!(
+        body2["connect"]["platforms"][0]["app_secret"], "****...****",
+        "app_secret must still read as configured"
+    );
+    assert_eq!(
+        body2["connect"]["platforms"][0]["allow_from"],
+        serde_json::json!(["ou_1", "ou_2"]),
+        "unrelated field change must apply"
+    );
+
+    let connect_text_after = tokio::fs::read_to_string(&connect_path)
+        .await
+        .expect("connect.json should still exist");
+    let connect_json_after: serde_json::Value =
+        serde_json::from_str(&connect_text_after).expect("connect.json should parse");
+    let app_secret_encrypted_after = connect_json_after["platforms"][0]["app_secret_encrypted"]
+        .as_str()
+        .expect("app_secret_encrypted should still be present")
+        .to_string();
+    assert_eq!(
+        encryption::decrypt(&app_secret_encrypted_after).expect("app_secret should decrypt"),
+        "feishu-real-secret",
+        "masked round-trip preserves the real app_secret across the split files"
+    );
+}
+
 /// #455 gap: a full config reset must also clear `connect.json`, or a
 /// bamboo-connect bot token would silently survive `POST
 /// /bamboo/config/reset` and get re-merged back onto the freshly-defaulted

--- a/crates/app/bamboo-server/src/handlers/settings/redaction/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/redaction/mod.rs
@@ -195,6 +195,30 @@ pub fn redact_config_for_api(mut value: Value, config: &Config) -> Value {
                 obj.remove("token");
             }
             obj.remove("token_encrypted");
+
+            // Feishu `app_secret` — same masking pattern; `app_id`/`domain`
+            // are not secrets and are left visible untouched.
+            let app_secret_configured = config
+                .connect
+                .platforms
+                .get(index)
+                .map(|p| {
+                    p.app_secret
+                        .as_deref()
+                        .map(|s| !s.trim().is_empty())
+                        .unwrap_or(false)
+                        || p.app_secret_encrypted.is_some()
+                })
+                .unwrap_or(false);
+            if app_secret_configured {
+                obj.insert(
+                    "app_secret".to_string(),
+                    Value::String("****...****".to_string()),
+                );
+            } else {
+                obj.remove("app_secret");
+            }
+            obj.remove("app_secret_encrypted");
         }
     }
 

--- a/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
@@ -362,6 +362,10 @@ fn redact_config_masks_configured_connect_platform_token() {
         platform_type: "telegram".to_string(),
         token: None,
         token_encrypted: Some("enc-telegram".to_string()),
+        app_id: None,
+        app_secret: None,
+        app_secret_encrypted: None,
+        domain: None,
         allow_from: vec!["123".to_string()],
         admin_from: Vec::new(),
     }];
@@ -389,6 +393,10 @@ fn redact_config_omits_unconfigured_connect_platform_token() {
         platform_type: "telegram".to_string(),
         token: None,
         token_encrypted: None,
+        app_id: None,
+        app_secret: None,
+        app_secret_encrypted: None,
+        domain: None,
         allow_from: Vec::new(),
         admin_from: Vec::new(),
     }];
@@ -420,6 +428,89 @@ fn redact_config_never_leaks_connect_platform_ciphertext_even_when_client_suppli
     assert!(redacted["connect"]["platforms"][0]
         .as_object()
         .is_some_and(|obj| !obj.contains_key("token_encrypted")));
+}
+
+// ── Feishu app_secret redaction tests (epic #447 phase 3) ────────────
+
+#[test]
+fn redact_config_masks_configured_connect_platform_app_secret_but_not_app_id_or_domain() {
+    let mut config = Config::default();
+    config.connect.platforms = vec![bamboo_config::ConnectPlatformConfig {
+        platform_type: "feishu".to_string(),
+        token: None,
+        token_encrypted: None,
+        app_id: Some("cli_x".to_string()),
+        app_secret: None,
+        app_secret_encrypted: Some("enc-feishu".to_string()),
+        domain: Some("lark".to_string()),
+        allow_from: vec!["ou_1".to_string()],
+        admin_from: Vec::new(),
+    }];
+
+    let input = json!({
+        "connect": {
+            "platforms": [
+                { "type": "feishu", "app_id": "cli_x", "domain": "lark", "allow_from": ["ou_1"] }
+            ]
+        }
+    });
+
+    let redacted = redact_config_for_api(input, &config);
+
+    assert_eq!(
+        redacted["connect"]["platforms"][0]["app_secret"],
+        "****...****"
+    );
+    assert!(redacted["connect"]["platforms"][0]
+        .as_object()
+        .is_some_and(|obj| !obj.contains_key("app_secret_encrypted")));
+    // Not secrets — left visible.
+    assert_eq!(redacted["connect"]["platforms"][0]["app_id"], "cli_x");
+    assert_eq!(redacted["connect"]["platforms"][0]["domain"], "lark");
+}
+
+#[test]
+fn redact_config_omits_unconfigured_connect_platform_app_secret() {
+    let mut config = Config::default();
+    config.connect.platforms = vec![bamboo_config::ConnectPlatformConfig {
+        platform_type: "feishu".to_string(),
+        token: None,
+        token_encrypted: None,
+        app_id: Some("cli_x".to_string()),
+        app_secret: None,
+        app_secret_encrypted: None,
+        domain: None,
+        allow_from: Vec::new(),
+        admin_from: Vec::new(),
+    }];
+
+    let input = json!({
+        "connect": { "platforms": [ { "type": "feishu", "app_id": "cli_x" } ] }
+    });
+
+    let redacted = redact_config_for_api(input, &config);
+
+    assert!(redacted["connect"]["platforms"][0]
+        .as_object()
+        .is_some_and(|obj| !obj.contains_key("app_secret")));
+}
+
+#[test]
+fn redact_config_never_leaks_connect_platform_app_secret_ciphertext_even_when_client_supplied() {
+    let config = Config::default();
+    let input = json!({
+        "connect": {
+            "platforms": [
+                { "type": "feishu", "app_secret_encrypted": "sneaky-cipher" }
+            ]
+        }
+    });
+
+    let redacted = redact_config_for_api(input, &config);
+
+    assert!(redacted["connect"]["platforms"][0]
+        .as_object()
+        .is_some_and(|obj| !obj.contains_key("app_secret_encrypted")));
 }
 
 #[test]

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -716,6 +716,27 @@ pub struct ConnectPlatformConfig {
     /// Encrypted ciphertext of `token` (the at-rest representation).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_encrypted: Option<String>,
+    /// Platform app id (Feishu `app_id`). Not a secret — serialized normally.
+    /// Unused by the Telegram adapter.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_id: Option<String>,
+    /// Platform app secret (Feishu `app_secret`).
+    ///
+    /// Secret: encrypted at rest in `app_secret_encrypted`; this plaintext
+    /// field is never serialized and is hydrated in memory on load (mirrors
+    /// `token` above).
+    #[serde(default, skip_serializing)]
+    pub app_secret: Option<String>,
+    /// Encrypted ciphertext of `app_secret` (the at-rest representation).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_secret_encrypted: Option<String>,
+    /// Platform domain/base-URL selector (Feishu-only today). Not a secret —
+    /// serialized normally. `None`/`"feishu"` -> open.feishu.cn, `"lark"` ->
+    /// open.larksuite.com, an `https://` value -> a private-deployment base
+    /// URL used verbatim. Validation happens in the server registration arm,
+    /// not here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
     /// Platform-scoped user ids allowed to drive a session. Deliberately
     /// STRICTER than the general secret-mask precedents: an EMPTY list means
     /// deny-all (every inbound message is rejected), not allow-all — a
@@ -4013,6 +4034,10 @@ mod tests {
             platform_type: platform_type.to_string(),
             token: None,
             token_encrypted: Some(token_encrypted.to_string()),
+            app_id: None,
+            app_secret: None,
+            app_secret_encrypted: None,
+            domain: None,
             allow_from: vec!["user-1".to_string()],
             admin_from: Vec::new(),
         }
@@ -4389,6 +4414,117 @@ mod tests {
         );
         let current = std::fs::read_to_string(connect_json_path(&temp)).unwrap();
         assert!(current.contains("new-cipher"));
+    }
+
+    // ── Feishu adapter config fields (epic #447 phase 3, §2a) ───────────
+
+    #[test]
+    fn save_splits_feishu_app_secret_into_connect_json_encrypted_alongside_app_id_and_domain() {
+        let _key = crate::encryption::set_test_encryption_key([0x42; 32]);
+        let temp = TempHome::new();
+
+        let mut config = Config::create_default();
+        config.connect.platforms = vec![ConnectPlatformConfig {
+            platform_type: "feishu".to_string(),
+            token: None,
+            token_encrypted: None,
+            app_id: Some("cli_real_app_id".to_string()),
+            app_secret: Some("plain-app-secret".to_string()),
+            app_secret_encrypted: None,
+            domain: Some("lark".to_string()),
+            allow_from: vec!["ou_1".to_string()],
+            admin_from: Vec::new(),
+        }];
+
+        config
+            .save_to_dir(temp.path.clone())
+            .expect("save succeeds");
+
+        let connect_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(connect_json_path(&temp)).unwrap())
+                .unwrap();
+        assert_eq!(connect_json["platforms"][0]["type"], "feishu");
+        assert_eq!(connect_json["platforms"][0]["app_id"], "cli_real_app_id");
+        assert_eq!(connect_json["platforms"][0]["domain"], "lark");
+        assert!(
+            connect_json["platforms"][0]["app_secret_encrypted"]
+                .as_str()
+                .is_some_and(|v| !v.is_empty()),
+            "app_secret is persisted in its encrypted form in connect.json"
+        );
+        assert!(
+            connect_json["platforms"][0].get("app_secret").is_none(),
+            "the plaintext app_secret is never persisted (skip_serializing)"
+        );
+    }
+
+    #[test]
+    fn load_hydrates_feishu_app_secret_from_encrypted() {
+        let _key = crate::encryption::set_test_encryption_key([0x42; 32]);
+        let temp = TempHome::new();
+
+        let mut config = Config::create_default();
+        config.connect.platforms = vec![ConnectPlatformConfig {
+            platform_type: "feishu".to_string(),
+            token: None,
+            token_encrypted: None,
+            app_id: Some("cli_real_app_id".to_string()),
+            app_secret: Some("plain-app-secret".to_string()),
+            app_secret_encrypted: None,
+            domain: Some("lark".to_string()),
+            allow_from: vec!["ou_1".to_string()],
+            admin_from: Vec::new(),
+        }];
+        config
+            .save_to_dir(temp.path.clone())
+            .expect("save succeeds");
+
+        let reloaded = Config::from_data_dir_without_publish(Some(temp.path.clone()));
+        assert_eq!(reloaded.connect.platforms.len(), 1);
+        assert_eq!(
+            reloaded.connect.platforms[0].app_secret.as_deref(),
+            Some("plain-app-secret"),
+            "reload hydrates app_secret from app_secret_encrypted"
+        );
+        assert_eq!(
+            reloaded.connect.platforms[0].app_id.as_deref(),
+            Some("cli_real_app_id")
+        );
+        assert_eq!(
+            reloaded.connect.platforms[0].domain.as_deref(),
+            Some("lark")
+        );
+    }
+
+    #[test]
+    fn legacy_telegram_only_connect_entry_without_feishu_fields_still_deserializes() {
+        let temp = TempHome::new();
+        std::fs::write(
+            connect_json_path(&temp),
+            serde_json::json!({
+                "platforms": [
+                    { "type": "telegram", "token_encrypted": "legacy-cipher", "allow_from": ["u1"] }
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let config = Config::from_data_dir_without_publish(Some(temp.path.clone()));
+
+        assert_eq!(config.connect.platforms.len(), 1);
+        assert_eq!(config.connect.platforms[0].platform_type, "telegram");
+        assert_eq!(
+            config.connect.platforms[0].token_encrypted.as_deref(),
+            Some("legacy-cipher")
+        );
+        assert_eq!(
+            config.connect.platforms[0].app_id, None,
+            "a legacy entry with no Feishu fields deserializes them as None"
+        );
+        assert_eq!(config.connect.platforms[0].app_secret, None);
+        assert_eq!(config.connect.platforms[0].app_secret_encrypted, None);
+        assert_eq!(config.connect.platforms[0].domain, None);
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/config_crypto.rs
+++ b/crates/infra/bamboo-config/src/config_crypto.rs
@@ -502,10 +502,11 @@ impl Config {
 
     // ── bamboo-connect platform tokens (Telegram bot token, etc.) ───────
 
-    /// Decrypt every configured platform's token into in-memory plaintext
-    /// after loading config. Mirrors [`Config::hydrate_notifications_from_encrypted`]:
-    /// `token` is `#[serde(skip_serializing)]` (never on disk), so this is the
-    /// only way it gets populated after a fresh load.
+    /// Decrypt every configured platform's token (and Feishu `app_secret`)
+    /// into in-memory plaintext after loading config. Mirrors
+    /// [`Config::hydrate_notifications_from_encrypted`]: both fields are
+    /// `#[serde(skip_serializing)]` (never on disk), so this is the only way
+    /// they get populated after a fresh load.
     pub fn hydrate_connect_platform_tokens_from_encrypted(&mut self) {
         for platform in &mut self.connect.platforms {
             let has_plaintext = platform
@@ -514,24 +515,42 @@ impl Config {
                 .map(str::trim)
                 .map(|value| !value.is_empty())
                 .unwrap_or(false);
-            if has_plaintext {
-                continue;
+            if !has_plaintext {
+                if let Some(encrypted) = platform.token_encrypted.as_deref() {
+                    match crate::encryption::decrypt(encrypted) {
+                        Ok(value) => platform.token = Some(value),
+                        Err(e) => tracing::warn!(
+                            "Failed to decrypt connect platform '{}' token: {}",
+                            platform.platform_type,
+                            e
+                        ),
+                    }
+                }
             }
-            if let Some(encrypted) = platform.token_encrypted.as_deref() {
-                match crate::encryption::decrypt(encrypted) {
-                    Ok(value) => platform.token = Some(value),
-                    Err(e) => tracing::warn!(
-                        "Failed to decrypt connect platform '{}' token: {}",
-                        platform.platform_type,
-                        e
-                    ),
+
+            let has_app_secret_plaintext = platform
+                .app_secret
+                .as_deref()
+                .map(str::trim)
+                .map(|value| !value.is_empty())
+                .unwrap_or(false);
+            if !has_app_secret_plaintext {
+                if let Some(encrypted) = platform.app_secret_encrypted.as_deref() {
+                    match crate::encryption::decrypt(encrypted) {
+                        Ok(value) => platform.app_secret = Some(value),
+                        Err(e) => tracing::warn!(
+                            "Failed to decrypt connect platform '{}' app_secret: {}",
+                            platform.platform_type,
+                            e
+                        ),
+                    }
                 }
             }
         }
     }
 
-    /// Re-encrypt every configured platform's token from current in-memory
-    /// plaintext before persisting to disk. Mirrors
+    /// Re-encrypt every configured platform's token (and Feishu `app_secret`)
+    /// from current in-memory plaintext before persisting to disk. Mirrors
     /// [`Config::refresh_notifications_encrypted`]: an empty/absent plaintext
     /// leaves any existing ciphertext intact (a redacted round-trip where the
     /// client never re-sent the secret keeps it).
@@ -543,6 +562,17 @@ impl Config {
                     Some(crate::encryption::encrypt(token).with_context(|| {
                         format!(
                             "Failed to encrypt connect platform '{}' token",
+                            platform.platform_type
+                        )
+                    })?);
+            }
+
+            let app_secret = platform.app_secret.as_deref().unwrap_or("").trim();
+            if !app_secret.is_empty() {
+                platform.app_secret_encrypted =
+                    Some(crate::encryption::encrypt(app_secret).with_context(|| {
+                        format!(
+                            "Failed to encrypt connect platform '{}' app_secret",
                             platform.platform_type
                         )
                     })?);

--- a/crates/infra/bamboo-config/src/patch.rs
+++ b/crates/infra/bamboo-config/src/patch.rs
@@ -216,8 +216,8 @@ pub fn sanitize_root_patch(patch_obj: &mut Map<String, Value>) {
         }
     }
 
-    // Never allow clients to set encrypted bamboo-connect platform tokens
-    // directly.
+    // Never allow clients to set encrypted bamboo-connect platform secrets
+    // (token, Feishu app_secret) directly.
     if let Some(platforms) = patch_obj
         .get_mut("connect")
         .and_then(|c| c.get_mut("platforms"))
@@ -226,6 +226,7 @@ pub fn sanitize_root_patch(patch_obj: &mut Map<String, Value>) {
         for platform in platforms.iter_mut() {
             if let Some(obj) = platform.as_object_mut() {
                 obj.remove("token_encrypted");
+                obj.remove("app_secret_encrypted");
             }
         }
     }
@@ -455,14 +456,16 @@ pub fn preserve_masked_connect_secrets(patch_obj: &mut Map<String, Value>, curre
         // (shouldn't happen with a well-behaved client, which always echoes
         // the whole object back) can't be checked and falls back to the
         // pre-existing positional-only behavior.
-        let existing_plain = existing.and_then(|p| {
-            let type_matches = match obj.get("type").and_then(|v| v.as_str()) {
-                Some(patch_type) => patch_type == p.platform_type,
-                None => true,
-            };
-            type_matches.then_some(p).and_then(|p| p.token.as_deref())
+        let guarded = existing.filter(|p| match obj.get("type").and_then(|v| v.as_str()) {
+            Some(patch_type) => patch_type == p.platform_type,
+            None => true,
         });
-        preserve_masked_secret_field(obj, "token", existing_plain);
+        preserve_masked_secret_field(obj, "token", guarded.and_then(|p| p.token.as_deref()));
+        preserve_masked_secret_field(
+            obj,
+            "app_secret",
+            guarded.and_then(|p| p.app_secret.as_deref()),
+        );
     }
 }
 
@@ -669,6 +672,10 @@ mod tests {
             platform_type: platform_type.to_string(),
             token: Some(token.to_string()),
             token_encrypted: None,
+            app_id: None,
+            app_secret: None,
+            app_secret_encrypted: None,
+            domain: None,
             allow_from: Vec::new(),
             admin_from: Vec::new(),
         }
@@ -692,6 +699,33 @@ mod tests {
             .unwrap()
             .contains_key("token_encrypted"));
         assert_eq!(platform["token"], "new-token");
+    }
+
+    #[test]
+    fn sanitize_root_patch_strips_connect_platform_app_secret_encrypted_field() {
+        let mut patch = json!({
+            "connect": {
+                "platforms": [
+                    {
+                        "type": "feishu",
+                        "app_id": "cli_x",
+                        "app_secret": "new-secret",
+                        "app_secret_encrypted": "client-supplied-cipher",
+                        "domain": "feishu"
+                    }
+                ]
+            }
+        });
+        let obj = patch.as_object_mut().unwrap();
+        sanitize_root_patch(obj);
+
+        let platform = &obj["connect"]["platforms"][0];
+        assert!(!platform
+            .as_object()
+            .unwrap()
+            .contains_key("app_secret_encrypted"));
+        assert_eq!(platform["app_secret"], "new-secret");
+        assert_eq!(platform["app_id"], "cli_x");
     }
 
     #[test]
@@ -847,6 +881,97 @@ mod tests {
         assert_eq!(
             patch["connect"]["platforms"][0]["token"],
             "existing-bot-token"
+        );
+    }
+
+    fn feishu_platform(app_secret: &str) -> crate::ConnectPlatformConfig {
+        crate::ConnectPlatformConfig {
+            platform_type: "feishu".to_string(),
+            token: None,
+            token_encrypted: None,
+            app_id: Some("cli_x".to_string()),
+            app_secret: Some(app_secret.to_string()),
+            app_secret_encrypted: None,
+            domain: Some("lark".to_string()),
+            allow_from: Vec::new(),
+            admin_from: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn preserve_masked_connect_secrets_keeps_existing_app_secret_by_position() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![feishu_platform("existing-app-secret")];
+
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[{"type":"feishu","app_id":"cli_x","app_secret":"****...****","domain":"lark"}]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert_eq!(
+            patch["connect"]["platforms"][0]["app_secret"],
+            "existing-app-secret"
+        );
+        // app_id/domain are untouched by the secret-preserve pass.
+        assert_eq!(patch["connect"]["platforms"][0]["app_id"], "cli_x");
+        assert_eq!(patch["connect"]["platforms"][0]["domain"], "lark");
+    }
+
+    #[test]
+    fn preserve_masked_connect_secrets_drops_app_secret_mask_when_nothing_configured() {
+        let current = Config::default();
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[{"type":"feishu","app_secret":"****...****"}]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert!(!patch["connect"]["platforms"][0]
+            .as_object()
+            .unwrap()
+            .contains_key("app_secret"));
+    }
+
+    #[test]
+    fn preserve_masked_connect_secrets_leaves_real_app_secret_untouched() {
+        let current = Config::default();
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[{"type":"feishu","app_secret":"feishu-real-new-value"}]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert_eq!(
+            patch["connect"]["platforms"][0]["app_secret"],
+            "feishu-real-new-value"
+        );
+    }
+
+    /// The #454 type-at-index guard applies to app_secret exactly as it does
+    /// to token: a reordered array must not resolve a masked app_secret
+    /// against whatever platform now sits at that index.
+    #[test]
+    fn preserve_masked_connect_secrets_drops_app_secret_mask_when_type_at_index_disagrees() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![feishu_platform("feishu-secret")];
+
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[{"type":"telegram","app_secret":"****...****"}]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert!(
+            !patch["connect"]["platforms"][0]
+                .as_object()
+                .unwrap()
+                .contains_key("app_secret"),
+            "masked app_secret must not be resolved against a different platform's secret"
         );
     }
 }

--- a/docs/feishu-adapter-plan.md
+++ b/docs/feishu-adapter-plan.md
@@ -1,0 +1,96 @@
+# Feishu adapter plan — epic #447 phase 3
+
+Analysis re-done 2026-07-13 (worktree `feat/feishu-adapter`, zero commits yet; based on origin/main after phase 1 #453 + phase 2 #459 + config split #456/#460 + review follow-ups #462).
+
+## 1. What already exists (reuse, do not touch)
+
+Generic and adapter-agnostic — a Feishu adapter inherits all of it:
+
+- `connect/mod.rs` `dispatch_loop` (mod.rs:133) routes `Inbound::Message/Callback` into the bridge.
+- `bridge.rs`: allow_from exact-match on `user_id` (bridge.rs:430), stale drop (`sent_at < process_start`, :440), dedup on `"{platform}:{message_id}"` (:449), `SessionKey = platform:chat_id:user_id` (:32), busy lock + FIFO queue, `/new` `/stop` `/status`, ask fast-path.
+- `render.rs`: mode picked by `capabilities().edit_message`; streaming edit-in-place throttle `EDIT_MIN_INTERVAL=1500ms` AND `EDIT_MIN_NEW_CHARS=30` (render.rs:43); `chunk_message` + `MAX_MESSAGE_CHARS=4096` exported for adapters; edit failure degrades to fresh reply (never fails the run). Output is **plain text only** (no markdown flag on `OutboundMessage`).
+- `approvals.rs`: `callback_data = "{nonce}:{option_index}"` (nonce = first UUID segment); numbered text list always sent, buttons are pure enhancement; text fallback (index / exact option / 中英 yes-no intent / custom); `answer_callback` must be acked exactly once, stale ⇒ `Some("This action has expired.")`; `EngineResponder` resolution path is platform-independent.
+- Test seams: adapter unit tests via `wiremock` (telegram.rs:539+ is the template incl. `with_options(token, base_url, tiny_rate_interval)` injection + token-never-leaks test); bridge/render tests use in-proc `FakePlatform`/`RecordingPlatform` — no new infra needed.
+
+Adapter-side responsibilities (Telegram precedent): outbound rate limiting (per-chat token bucket, telegram.rs:96), message chunking in `reply`, secret redaction in every error string (`sanitize_error`, telegram.rs:177), shared `OnceLock` reqwest client.
+
+## 2. New work items
+
+### 2a. Config + secret plumbing (largest cross-cutting change)
+
+`ConnectPlatformConfig` (bamboo-config config.rs:619) today has a single `token`/`token_encrypted` pair. Feishu needs **app_id (not secret) + app_secret (secret)**. Recommendation: add optional fields rather than overloading `token`:
+
+```rust
+pub app_id: Option<String>,                 // plain, serialized
+pub app_secret: Option<String>,             // skip_serializing, in-memory
+pub app_secret_encrypted: Option<String>,   // at-rest
+pub domain: Option<String>,                 // plain, serialized — DECIDED: required config surface
+```
+
+**`domain`(已决策,必做)**:默认 `"feishu"` → `https://open.feishu.cn`;`"lark"` → `https://open.larksuite.com`;任意 `https://` 开头的值 → 私有化部署 base URL 原样使用(cc-connect 同款三态语义)。REST 与 WS bootstrap(`/callback/ws/endpoint`)共用同一 base;适配器内只存解析后的 `base_url: String`,构造时归一化(去尾部 `/`),非法值(既不是预设名也不是 https URL)在注册 arm 里 warn+skip 该 entry,与空 token 同路径。非密钥,正常序列化进 connect.json,无需进 secret 管道。
+
+Extend all five secret round-trip sites in lockstep (the #430 contract):
+1. hydrate: `hydrate_connect_platform_tokens_from_encrypted` (config_crypto.rs:509)
+2. re-encrypt on save: `refresh_connect_platform_tokens_encrypted` (config_crypto.rs:538)
+3. GET redaction (redaction/mod.rs:161 — positional per `platforms[i]`)
+4. PATCH masked-preserve: `preserve_masked_connect_secrets` (patch.rs:422 — array order is the contract)
+5. struct + connect.json round-trip tests.
+
+Frontends must not prefill the `****...****` placeholder (existing contract).
+
+### 2b. Registration arm
+
+`mod.rs:68` `match platform_cfg.platform_type.as_str()` gains `"feishu" =>`: validate app_id/app_secret present, warn on empty `allow_from` (deny-all), construct `FeishuPlatform`, spawn `start()` + generic `dispatch_loop`.
+
+### 2c. `platforms/feishu.rs` — the adapter itself
+
+**Transport: 事件长连接 (WS), no public IP.** Protocol is SDK-only (not doc'd); verified shape:
+
+- Bootstrap: `POST https://open.feishu.cn/callback/ws/endpoint`, body PascalCase `{"AppID","AppSecret","ClientAssertion":""}` → `data.URL` (wss, single-use — re-fetch on every reconnect) + `ClientConfig{PingInterval(默认2min), ReconnectInterval(2min fixed), ReconnectNonce(30s jitter), ReconnectCount(-1)}`. Parse `service_id` from the wss URL query — echoed in ping frames. Fatal (stop reconnecting): non-{0,1,1000040343} bootstrap code, handshake `Handshake-Status:403`, `Handshake-Autherrcode:1000040350` (>50 conns/app).
+- Wire: binary proto2 `pbbp2.Frame{SeqID,LogID,service,method(0=ctrl/1=data),headers[{key,value}],payload,...}`. Ping = method 0 + header `type:ping` every PingInterval; pong may carry retuned ClientConfig JSON. Data frames: header `type:event`, payload = plaintext schema-2.0 event JSON (no encrypt-key on WS path). Multi-part: `sum`/`seq` headers keyed by `message_id`, 5s TTL, ack only when complete. **Ack = echo the same frame back with payload `{"code":200,"headers":null,"data":<base64>}` within 3s** or the server re-pushes; for `card.action.trigger` the base64 `data` carries the callback response JSON (toast/card).
+- Dependency: vendor `lark-websocket-protobuf` (MIT/Apache, prost Frame/Header only) + hand-rolled client on `reqwest + tokio-tungstenite + prost` (~1k lines; openlark-client is the reference implementation but pulls an 18-crate workspace and has no built-in reconnect anyway). **Check tokio-tungstenite TLS feature against the native-tls pin (no aws-lc-sys)** — `feishu-sdk` crate is rejected precisely for pinning rustls+aws-lc-rs. Prior art: github.com/linuxhenhao/beam (Rust, same stack, same use case).
+- REST: `tenant_access_token/internal` (7200s; Feishu returns the SAME token while ≥30min remain — refresh when <30min or on 99991663/99991661), send `POST /open-apis/im/v1/messages?receive_id_type=chat_id` (`content` is a JSON-escaped string; text 150KB / card 30KB; optional `uuid` send-dedup), card update `PATCH /open-apis/im/v1/messages/:message_id`.
+
+**Inbound mapping** (`im.message.receive_v1`, scopes `im:message.*`):
+- `chat_id` = `message.chat_id`; `user_id` = `sender.sender_id.open_id` (**allow_from entries are open_id** — document); `message_id` = `message.message_id` (official dedup guidance; NOT event_id for messages); `sent_at` = `message.create_time` (ms string); `text` = parse `content` JSON `{"text":...}`, strip `@_user_N` mention placeholders.
+- `reply_ctx` = `{"chat_id":..., "message_id":...}` (message_id enables threaded reply later).
+- Group gating (adapter-side; bridge has no such concept): MVP = p2p + @mention-required in groups (bot open_id in `mentions`), cc-connect precedent. Drop `sender_type:"bot"`.
+- Card callback (`card.action.trigger`): `user_id` = `operator.open_id`, `chat_id` = `context.open_chat_id`, `data` = `action.value` round-tripped verbatim (put bamboo's `"{nonce}:{index}"` inside `value`), dedup on `event_id` (create_time is **microseconds** here vs ms on messages).
+
+**Capabilities**: `{buttons:true, edit_message:true, images:false, files:false}`.
+
+**cc-connect 飞书源码验证过的坑** (github.com/chenhg5/cc-connect `platform/feishu/`, 2026-07-13 main):
+- **同 app 只能开一条 WS**: Feishu 对同一 app 的多条长连接做随机负载均衡(每个事件只发给一条连接),cc-connect 为此实现了 sharedWSGroup(首个实例持有连接、事件扇出给同 app 兄弟)。bamboo 一个 config entry = 一个连接,天然安全;但绝不能在重连时短暂并存两条连接处理逻辑。
+- Bot 自身 open_id 需启动时取一次 `GET /open-apis/bot/v3/info`(@mention 判定用);失败则降级为不做群过滤 + warn。
+- `@所有人` 消息 mentions 数组为空,文本含 `@_all` —— 单独的 substring 判断。
+- 文本里的 mention 是 `@_user_N` 占位符,按 `mentions[].key` 替换:bot 自己的删掉、他人替换为 `@显示名`。
+- msg_type 决策树:含 `<at>` 标签或纯文本 → `text`(mention 事件只在 text 消息触发);markdown 表格 >5 个 → `post`(card 超 5 表报 11310);其余 → `interactive` card。
+- 回调响应最佳实践:同步返回**替换后的卡片**(按钮消失 = 天然防双击),决定后的卡片内容(label/颜色/正文)直接塞在按钮 `value` 里,回调无需查状态。
+- 999916 63 invalid-token → 禁缓存强刷 token 重试一次;所有发送包 3 次指数退避 transient 重试(仅网络类错误)。
+- 流式 PUT 撞 230020 限流时直接丢帧(下一次 flush 会带全量文本),不重试。
+
+**Outbound mapping — key design decisions**:
+1. **The streaming status message must be an interactive card from the first send**, never text: text `PUT` edit has a 20-edit cap (230072) — unusable for streaming; card `PATCH` has no count cap, 5 QPS/message, 14-day window. render.rs throttle (≥1.5s between edits) stays well under 5 QPS. `MessageRef = {"message_id","msg_type"}`; `edit` on a text ref returns Err → render degrades gracefully.
+2. Card shape: schema 2.0, `config.update_multi:true`, markdown element with fixed `element_id:"main_text"`, buttons as `{"tag":"button","behaviors":[{"type":"callback","value":{"cb":"{nonce}:{idx}"}}]}`. Plain-text-in-markdown: escape or use plain_text element to avoid render.rs output being reinterpreted as markdown.
+3. Plain replies without buttons: `msg_type:"text"` and chunk with the shared `chunk_message` (Feishu text limit 150KB ≫ 4096, so the shared cap is safe).
+4. **answer_callback ≠ a REST call on Feishu — it IS the WS frame ack.** Adapter keeps a pending-ack map `callback_query_id → oneshot<frame-ack>`; `start()`'s card.action.trigger handler parks the frame, bridge calls `answer_callback(id, text?)` → resolve with `{"toast":{...}}` (and optionally a "decided" card); auto-ack `{"code":200}` after ~2.5s if the bridge hasn't responded (3s hard deadline). This is the one genuine impedance mismatch with the `Platform` trait — solve it inside the adapter, don't change the trait.
+5. Rate limiter: per-chat token bucket like Telegram (limits: 5 QPS/user p2p, 5 QPS/group shared by ALL bots, app 1000/min); honor `x-ogw-ratelimit-reset` on 99991400/429 and 230020; blocking, never dropping.
+6. Secrets: app_secret and tenant_access_token must never appear in errors/logs (Telegram `sanitize_error` + leak test pattern); token lives in the Authorization header (not URL, easier than Telegram).
+
+### 2d. Deferred (post-MVP, in-epic)
+- cardkit typewriter streaming (`POST /cardkit/v1/cards` streaming_mode + sequence PUTs, 10 calls/s/card; NOTE: once a message references a card entity, im/v1 PATCH silently no-ops — entity cards update only via cardkit).
+- Threaded reply / thread_isolation, group shared-session, reaction acks (👀/✅), images/files, Lark intl domain option (`open.larksuite.com`), webhook fallback mode.
+- Multi-bot `SessionKey` disambiguation: nothing today distinguishes two entries of the same platform type (shared dedup set + colliding SessionKey). Single feishu entry is fine; if multi-app needed, fold app_id into the `platform` string (`"feishu:cli_xxx"`) — cheaper than changing SessionKey.
+
+## 3. Suggested implementation order
+1. Config fields + 5-site secret plumbing + connect.json tests.
+2. Vendored pbbp2 proto + WS client (bootstrap/ping/ack/reassembly/reconnect) behind a trait-less internal module, unit-tested with a local WS stub.
+3. `FeishuPlatform` REST half (token cache, reply/edit/rate limiter) with wiremock tests mirroring telegram.rs.
+4. Registration arm + inbound mapping + pending-ack bridge for callbacks.
+5. Live spike with real app credentials (真机 e2e, like tg-e2e worktree did for Telegram) before PR.
+
+## 4. Open questions for the maintainer
+- allow_from ID type: open_id (app-scoped, recommended) vs user_id (tenant-scoped, needs extra scope)?
+- MVP group policy: p2p-only vs @mention-gated groups?
+
+Decided 2026-07-13: `domain` config field ships in the MVP (feishu/lark/自定义 https base URL,见 §2a) — maintainer confirmed Lark support is required.


### PR DESCRIPTION
Epic #447 phase 3: the Feishu (飞书) / Lark adapter for bamboo-connect, over the event long-connection (no public IP), with interactive-card approvals and card-PATCH streaming edit-in-place.

## What's new

**`connect/platforms/feishu/` (new module)**
- `pbbp2.rs` — vendored prost-derive `Frame`/`Header` proto2 types (no protoc/build.rs; the WS wire protocol is SDK-only, reverse-verified against the official Go SDK `v3_main` `ws/`).
- `ws.rs` — long-connection client: `POST /callback/ws/endpoint` bootstrap (re-fetched every reconnect), ping every server-tuned `PingInterval` with the wss URL's `service_id`, frame ack within the 3s re-push deadline, `sum`/`seq` multi-part reassembly (5s TTL), jitter-then-fixed reconnect, fatal handshake detection (`Handshake-Status: 403`, autherrcode `1000040350`). Protocol logic factored into pure functions with direct unit tests.
- `api.rs` — `tenant_access_token` cache (single-flight, refresh <30min remaining or on 99991663/99991661), `im/v1` send + card PATCH, per-key blocking rate limiter honoring `x-ogw-ratelimit-reset`/230020 (bounded retries).
- `mod.rs` — the `Platform` impl. Key decisions:
  - **Every reply is an interactive card** (never `msg_type=text`): Feishu's text edit (PUT) has a 20-edit cap, so the only streaming-safe edit path is card PATCH (no count cap, 5 QPS/message — comfortably above render.rs's 1.5s throttle). A uniform card shape means the adapter never has to guess whether a reply will later be edited.
  - Buttons = card 2.0 `behaviors: [{type: callback, value: {cb: "{nonce}:{idx}"}}]`; `answer_callback` resolves a **parked WS-frame ack** (Feishu's callback response IS the frame ack) with a toast, 2.5s auto-ack fallback under the 3s hard deadline.
  - Inbound: dedup on `message_id` (official guidance), `open_id` as the allow_from identity, mention-placeholder stripping, `@_all` handling, bot-sender drop; groups are @mention-gated (bot open_id fetched once via `bot/v3/info`, fail-safe to drop), p2p passes untouched.
  - Secret hygiene: `app_secret`/token never appear in error text (sanitizer + leak test, telegram precedent).

**Config (`ConnectPlatformConfig`)** — `app_id`, `app_secret`(+`_encrypted`), `domain` (`feishu` | `lark` | custom `https://` base for private deployments). `app_secret` is wired through every secret round-trip site (hydrate, re-encrypt-on-save, GET redaction, PATCH masked-preserve, sanitize) with connect.json round-trip + handler e2e tests.

**Registration** — `"feishu"` arm in `ConnectManager::start` with domain resolution; per-platform spawn boilerplate factored into `spawn_platform_tasks`.

**#462 interplay (rebased on top):**
- Generalized `telegram_multi_bot_guard` → `multi_bot_guard` (at most one live entry **per platform type**): two feishu apps would collide on `SessionKey` exactly like two telegram bots, and — worse — would dedup-eat each other's copy of the same group `message_id`.
- Fixed a semantic-merge gap: #454's type-at-index guard in `preserve_masked_connect_secrets` now covers `app_secret` too (a reordered array must not resolve a masked `app_secret` against whatever platform landed at that index). Test added.

## Deps
`prost` 0.13 (rust-version 1.84 constraint), `tokio-tungstenite` 0.29 (`native-tls`; `cargo tree -i aws-lc-sys` verified empty), `base64` 0.22.

## Tests
~60 new: 41 feishu adapter (wiremock REST, pbbp2 round-trip/reassembly/ack, bootstrap/reconnect classification, inbound mapping incl. mention/group gating, pending-ack lifecycle, secret-leak), 7 guard/domain-resolution, 16 config plumbing + handler e2e. `cargo build --workspace --tests` clean; `connect` suite 135/135; bamboo-config 220/220; fmt + clippy clean on touched crates.

## Not in this PR (deferred, tracked in docs/feishu-adapter-plan.md §2d)
cardkit typewriter streaming, threaded replies, images/files, reaction acks, webhook fallback mode, real-app e2e (next step, tg-e2e-style).

https://claude.ai/code/session_014UqJMdHmyooYbK6eDxdAVV