### PR TITLE
feat(server): connector-parity APIs — GET /execute/defaults, optional chat model, workspace_path on create

### DIFF
--- a/crates/app/bamboo-server/src/connect/bridge.rs
+++ b/crates/app/bamboo-server/src/connect/bridge.rs
@@ -16,13 +16,12 @@ use tokio_util::sync::CancellationToken;
 use bamboo_agent_core::tools::ToolExecutor;
 use bamboo_agent_core::{AgentEvent, Message, Session};
 use bamboo_domain::reasoning::ReasoningEffort;
-use bamboo_engine::config::GoldConfig;
 use bamboo_engine::execution::runner_state::AgentRunner;
 use bamboo_engine::execution::{
     create_event_forwarder, get_or_create_event_sender, spawn_session_execution,
     try_reserve_runner, SessionExecutionArgs,
 };
-use bamboo_engine::{AuxiliaryModelConfig, ModelRoster, SessionRepository};
+use bamboo_engine::{AuxiliaryModelConfig, SessionRepository};
 use bamboo_llm::{Config, ProviderRegistry};
 
 use super::approvals::{self, ParkedAsk, RespondAndResumeOutcome, Responder};
@@ -155,62 +154,20 @@ enum AskResolution {
 }
 
 /// Resolved model/prompt/workspace configuration for a connect-driven run,
-/// derived from the live global config. Mirrors
-/// `schedule_app::manager::ResolvedRunConfig`, minus the per-job overrides a
-/// scheduled run supports (a chat message has none).
-struct ResolvedConnectRunConfig {
-    model_roster: ModelRoster,
-    reasoning_effort: Option<ReasoningEffort>,
-    gold_config: Option<GoldConfig>,
-    system_prompt: String,
-    base_system_prompt: String,
-    workspace_path: Option<String>,
-}
+/// derived from the live global config.
+///
+/// This is a thin alias over [`bamboo_engine::resolved_defaults::ResolvedDefaultRunConfig`]
+/// — the SOLE implementation of this resolution cascade, shared with the
+/// public `GET /api/v1/execute/defaults` handler (issue #480). Do not
+/// reimplement the model/prompt/workspace cascade here; extend the shared
+/// helper instead.
+type ResolvedConnectRunConfig = bamboo_engine::resolved_defaults::ResolvedDefaultRunConfig;
 
 fn resolve_connect_run_config(
     config_snapshot: &Config,
     provider_registry: &Arc<ProviderRegistry>,
 ) -> ResolvedConnectRunConfig {
-    let model = config_snapshot.get_model().unwrap_or_default();
-    let provider_name = Some(config_snapshot.effective_default_provider().to_string());
-    let provider_type = provider_name.as_deref().and_then(|name| {
-        bamboo_engine::model_config_helper::resolve_provider_type(
-            config_snapshot,
-            name,
-            provider_registry,
-        )
-    });
-    let capability_provider_name = provider_name
-        .as_deref()
-        .unwrap_or(config_snapshot.effective_default_provider());
-    // Auxiliary models are global (config-derived), never session-bound —
-    // same rationale as `schedule_app::manager::resolve_run_config_from_config`.
-    let areas = bamboo_engine::model_areas::resolve_global_area_models(
-        config_snapshot,
-        capability_provider_name,
-        provider_registry,
-    );
-    let reasoning_effort = config_snapshot.get_reasoning_effort();
-    let base_system_prompt =
-        bamboo_engine::prompt_defaults::read_global_default_system_prompt_template();
-    let workspace_path = config_snapshot
-        .get_default_work_area_path()
-        .map(|path| bamboo_config::paths::path_to_display_string(&path));
-    let system_prompt = bamboo_engine::context::assemble_system_prompt(
-        &base_system_prompt,
-        None,
-        workspace_path.as_deref(),
-    );
-    let model_roster = ModelRoster::from_areas(Some(model), provider_name, provider_type, areas);
-
-    ResolvedConnectRunConfig {
-        model_roster,
-        reasoning_effort,
-        gold_config: bamboo_engine::model_config_helper::resolve_gold_config(config_snapshot, None),
-        system_prompt,
-        base_system_prompt,
-        workspace_path,
-    }
+    bamboo_engine::resolved_defaults::resolve_default_run_config(config_snapshot, provider_registry)
 }
 
 /// Builds a fresh session for a connect chat key. Mirrors

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
@@ -40,7 +40,23 @@ pub async fn handler(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
         parse_goal_command(&req.message).is_some(),
         req.images.as_ref().map(|i| i.len()).unwrap_or(0),
     );
-    let model = match request::validate_and_normalize_model(req.model.as_str()) {
+    // Only resolve the server-side default (a config read + the shared
+    // resolution cascade) when the request omitted `model` — the common case
+    // (an explicit model) pays none of that cost. #480: fall back to the SAME
+    // resolved default the connect bridge and `GET /execute/defaults` use, so
+    // there is one implementation of "what model does this server default to".
+    let default_model = if request::optional_non_empty(req.model.as_deref()).is_some() {
+        None
+    } else {
+        let config_snapshot = state.config.read().await.clone();
+        bamboo_engine::resolved_defaults::resolve_default_run_config(
+            &config_snapshot,
+            &state.provider_registry,
+        )
+        .model_roster
+        .model
+    };
+    let model = match request::resolve_model(req.model.as_deref(), default_model.as_deref()) {
         Ok(model) => model,
         Err(response) => return response,
     };

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/request.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/request.rs
@@ -7,15 +7,27 @@ pub(super) fn resolve_session_id(session_id: Option<&str>) -> String {
         .unwrap_or_else(|| Uuid::new_v4().to_string())
 }
 
-pub(super) fn validate_and_normalize_model(model: &str) -> Result<String, HttpResponse> {
-    let normalized = model.trim();
-    if normalized.is_empty() {
-        return Err(HttpResponse::BadRequest().json(serde_json::json!({
-            "error": "model is required"
-        })));
+/// Resolve the effective model for a chat turn: the request's `model` when
+/// non-empty, otherwise `default_model` (the server's resolved default —
+/// see `bamboo_engine::resolved_defaults::resolve_default_run_config`, the
+/// SAME resolution the connect bridge and `GET /execute/defaults` use).
+/// Errors only when NEITHER resolves to anything — i.e. the request omitted
+/// `model` and the server has no default model configured at all (issue
+/// #480: `model` is optional on `POST /chat`).
+pub(super) fn resolve_model(
+    requested_model: Option<&str>,
+    default_model: Option<&str>,
+) -> Result<String, HttpResponse> {
+    if let Some(model) = optional_non_empty(requested_model) {
+        return Ok(model.to_string());
     }
 
-    Ok(normalized.to_string())
+    match optional_non_empty(default_model) {
+        Some(model) => Ok(model.to_string()),
+        None => Err(HttpResponse::BadRequest().json(serde_json::json!({
+            "error": "model is required and no default model is configured on this server"
+        }))),
+    }
 }
 
 pub(super) fn optional_non_empty(value: Option<&str>) -> Option<&str> {

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
@@ -1,4 +1,4 @@
-use super::request::{optional_non_empty, resolve_session_id, validate_and_normalize_model};
+use super::request::{optional_non_empty, resolve_model, resolve_session_id};
 use super::sync_runtime_workspace;
 use bamboo_agent_core::Session;
 
@@ -75,15 +75,36 @@ async fn goal_off_and_clear_remove_stale_goal_state() {
 }
 
 #[test]
-fn validate_and_normalize_model_rejects_empty_values() {
-    let response = validate_and_normalize_model("   ").expect_err("model should be required");
+fn resolve_model_errors_when_neither_request_nor_default_resolve() {
+    let response = resolve_model(Some("   "), None).expect_err("no model should be required error");
     assert_eq!(response.status(), actix_web::http::StatusCode::BAD_REQUEST);
 }
 
 #[test]
-fn validate_and_normalize_model_trims_whitespace() {
-    let model = validate_and_normalize_model("  gpt-5  ").expect("model should be accepted");
+fn resolve_model_trims_whitespace_from_request_model() {
+    let model = resolve_model(Some("  gpt-5  "), None).expect("model should be accepted");
     assert_eq!(model, "gpt-5");
+}
+
+/// #480: an absent/blank request model falls back to the server's resolved
+/// default rather than erroring, as long as a default is available.
+#[test]
+fn resolve_model_falls_back_to_default_when_request_model_absent() {
+    let model = resolve_model(None, Some("gpt-default")).expect("default should be used");
+    assert_eq!(model, "gpt-default");
+}
+
+#[test]
+fn resolve_model_falls_back_to_default_when_request_model_blank() {
+    let model = resolve_model(Some("   "), Some("gpt-default")).expect("default should be used");
+    assert_eq!(model, "gpt-default");
+}
+
+#[test]
+fn resolve_model_prefers_explicit_request_model_over_default() {
+    let model =
+        resolve_model(Some("gpt-explicit"), Some("gpt-default")).expect("request model wins");
+    assert_eq!(model, "gpt-explicit");
 }
 
 #[test]
@@ -299,4 +320,141 @@ fn clear_skill_runtime_state_removes_loaded_skill_markers() {
     assert!(!session
         .metadata
         .contains_key("skill_runtime_last_loaded_skill_id"));
+}
+
+// ---- #480: POST /chat with an omitted `model` end-to-end ----
+
+mod optional_model_e2e {
+    use actix_web::{http::StatusCode, test, web, App};
+    use serde_json::Value;
+    use tempfile::tempdir;
+
+    use crate::routes::configure_routes;
+    use crate::AppState;
+
+    async fn new_state() -> web::Data<AppState> {
+        let temp_dir = tempdir().expect("tempdir");
+        bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
+        web::Data::new(
+            AppState::new(temp_dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        )
+    }
+
+    /// #480: omitting `model` on `POST /chat` falls back to the server's
+    /// resolved default (the same resolution `GET /execute/defaults` and the
+    /// connect bridge use) — the session ends up with the CONFIGURED default
+    /// model, not an error and not an empty model.
+    #[actix_web::test]
+    async fn chat_without_model_uses_resolved_default_model() {
+        let state = new_state().await;
+        {
+            let mut config = state.config.write().await;
+            config.provider = "openai".to_string();
+            config.providers.openai = Some(bamboo_config::OpenAIConfig {
+                model: Some("gpt-configured-default".to_string()),
+                ..Default::default()
+            });
+        }
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/chat")
+                .set_json(serde_json::json!({ "message": "hello" }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body: Value = test::read_body_json(resp).await;
+        let session_id = body["session_id"].as_str().expect("session_id").to_string();
+
+        let session = state
+            .storage
+            .load_session(&session_id)
+            .await
+            .expect("load")
+            .expect("session exists");
+        assert_eq!(session.model, "gpt-configured-default");
+    }
+
+    /// An explicit `model` on `POST /chat` is unchanged by #480 — it is used
+    /// as-is even when a different server default is configured.
+    #[actix_web::test]
+    async fn chat_with_explicit_model_is_unchanged() {
+        let state = new_state().await;
+        {
+            let mut config = state.config.write().await;
+            config.provider = "openai".to_string();
+            config.providers.openai = Some(bamboo_config::OpenAIConfig {
+                model: Some("gpt-configured-default".to_string()),
+                ..Default::default()
+            });
+        }
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/chat")
+                .set_json(serde_json::json!({
+                    "message": "hello",
+                    "model": "gpt-explicit-override"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body: Value = test::read_body_json(resp).await;
+        let session_id = body["session_id"].as_str().expect("session_id").to_string();
+
+        let session = state
+            .storage
+            .load_session(&session_id)
+            .await
+            .expect("load")
+            .expect("session exists");
+        assert_eq!(session.model, "gpt-explicit-override");
+    }
+
+    /// No request model AND no server default configured → 400, not a silent
+    /// empty-model session.
+    #[actix_web::test]
+    async fn chat_without_model_and_without_default_errors() {
+        let state = new_state().await;
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/chat")
+                .set_json(serde_json::json!({ "message": "hello" }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/chat/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/tests.rs
@@ -11,16 +11,20 @@ fn chat_request_deserialization_with_model() {
     let request: ChatRequest = serde_json::from_str(json).expect("chat request should deserialize");
     assert_eq!(request.message, "Hello");
     assert_eq!(request.session_id, Some("test-session".to_string()));
-    assert_eq!(request.model, "gpt-5");
+    assert_eq!(request.model.as_deref(), Some("gpt-5"));
 }
 
+/// #480: `model` is optional on `POST /chat` — omitting it must deserialize
+/// successfully (not error), leaving `model: None` for the handler to resolve
+/// against the server's default via `bamboo_engine::resolved_defaults`.
 #[test]
-fn chat_request_deserialization_without_model() {
+fn chat_request_deserialization_without_model_defaults_to_none() {
     let json = r#"{
             "message": "Hello"
         }"#;
-    let result: Result<ChatRequest, _> = serde_json::from_str(json);
-    assert!(result.is_err());
+    let request: ChatRequest =
+        serde_json::from_str(json).expect("model-less chat request should deserialize");
+    assert!(request.model.is_none());
 }
 
 #[test]
@@ -39,19 +43,21 @@ fn session_model_round_trip() {
     assert_eq!(deserialized.model, "gpt-5");
 }
 
+/// #480: `ChatRequest.model` is `Option<String>` (not a bare `String`) so a
+/// request can omit it and let the server resolve a default.
 #[test]
-fn chat_request_model_type_is_string_not_option() {
+fn chat_request_model_field_is_optional_string() {
     let json = r#"{
             "message": "Hello",
             "model": "claude-3-opus"
         }"#;
     let request: ChatRequest = serde_json::from_str(json).expect("chat request should deserialize");
-    let _model_str: &str = &request.model;
-    assert_eq!(request.model, "claude-3-opus");
+    let _model_opt: &Option<String> = &request.model;
+    assert_eq!(request.model.as_deref(), Some("claude-3-opus"));
 }
 
 #[test]
-fn chat_request_empty_model_fails_validation() {
+fn chat_request_blank_model_trims_to_empty() {
     let request = ChatRequest {
         message: "Hello".to_string(),
         session_id: None,
@@ -61,12 +67,14 @@ fn chat_request_empty_model_fails_validation() {
         workspace_path: None,
         selected_skill_ids: None,
         images: None,
-        model: "   ".to_string(),
+        model: Some("   ".to_string()),
         provider: None,
         model_ref: None,
     };
-    let model = request.model.trim();
-    assert!(model.is_empty(), "Empty model should fail validation");
+    // A whitespace-only model is treated the same as an absent one by the
+    // handler's `request::resolve_model` (falls back to the server default).
+    let model = request.model.as_deref().unwrap_or_default().trim();
+    assert!(model.is_empty(), "Blank model should be treated as absent");
 }
 
 #[test]

--- a/crates/app/bamboo-server/src/handlers/agent/chat/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/types.rs
@@ -12,7 +12,9 @@ use serde::{Deserialize, Serialize};
 /// * `copilot_conclusion_with_options_enhancement_enabled` - Optional flag for enabling copilot conclusion-with-options conclusion flow
 /// * `workspace_path` - Optional workspace path to include in the system prompt
 /// * `selected_skill_ids` - Optional explicit skill IDs selected for this request
-/// * `model` - Required model identifier (e.g., "gpt-4o-mini", "claude-3-opus")
+/// * `model` - Optional model identifier (e.g., "gpt-4o-mini", "claude-3-opus").
+///   When absent or empty, the server falls back to its resolved default model
+///   (issue #480) — the same resolution `GET /api/v1/execute/defaults` reports.
 #[derive(Debug, Deserialize)]
 pub struct ChatRequest {
     pub message: String,
@@ -30,7 +32,8 @@ pub struct ChatRequest {
     /// Optional image attachments (data URLs) associated with this message.
     #[serde(default)]
     pub images: Option<Vec<ChatImage>>,
-    pub model: String,
+    #[serde(default)]
+    pub model: Option<String>,
     #[serde(default)]
     pub provider: Option<String>,
     #[serde(default)]
@@ -78,7 +81,7 @@ mod tests {
         let json = r#"{"message":"Hello","model":"gpt-4"}"#;
         let req: ChatRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.message, "Hello");
-        assert_eq!(req.model, "gpt-4");
+        assert_eq!(req.model.as_deref(), Some("gpt-4"));
         assert!(req.session_id.is_none());
         assert!(req.system_prompt.is_none());
         assert!(req
@@ -113,7 +116,7 @@ mod tests {
             req.selected_skill_ids,
             Some(vec!["pdf".to_string(), "skill-creator".to_string()])
         );
-        assert_eq!(req.model, "claude-3");
+        assert_eq!(req.model.as_deref(), Some("claude-3"));
     }
 
     #[test]
@@ -154,7 +157,7 @@ mod tests {
             workspace_path: None,
             selected_skill_ids: None,
             images: None,
-            model: "gpt-4".to_string(),
+            model: Some("gpt-4".to_string()),
             provider: None,
             model_ref: None,
         };

--- a/crates/app/bamboo-server/src/handlers/agent/execute/defaults.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/defaults.rs
@@ -1,0 +1,209 @@
+//! `GET /api/v1/execute/defaults` — the public twin of the connect bridge's
+//! per-message run-config resolution (issue #480).
+//!
+//! An external connector (or any REST/WS client that isn't the in-proc
+//! connect bridge) needs to know "what model/provider/prompt/workspace/gold
+//! config would the server currently resolve for a run with no per-request
+//! overrides" — e.g. to display it, or to omit `model` on `POST /chat` and
+//! trust the server's resolution. Before this endpoint, the only way to get
+//! that was `GET /bamboo/config`, which returns the raw (redacted) `Config`
+//! and would force every external caller to reimplement the
+//! `model_areas`/`model_config_helper`/`prompt_defaults`/
+//! `context::assemble_system_prompt` resolution cascade by hand — and drift
+//! from it over time.
+//!
+//! This handler calls the SAME shared resolver
+//! ([`bamboo_engine::resolved_defaults::resolve_default_run_config`]) as the
+//! connect bridge (`connect::bridge::resolve_connect_run_config`) — there is
+//! exactly one implementation of this cascade.
+//!
+//! No secrets are surfaced: the response carries resolved model/provider
+//! *names*, the assembled system prompt, the workspace path, and
+//! `gold_config` (flags/goal text/prompt tuning only — see
+//! `bamboo_engine::config::GoldConfig`, which has no credential fields).
+
+use actix_web::{web, HttpResponse, Responder};
+use serde::Serialize;
+
+use bamboo_domain::reasoning::ReasoningEffort;
+use bamboo_engine::config::GoldConfig;
+
+use crate::app_state::AppState;
+
+/// Response body for `GET /api/v1/execute/defaults`.
+#[derive(Debug, Serialize)]
+pub struct ExecuteDefaultsResponse {
+    /// Primary (main chat) model the server would currently use. `None`/empty
+    /// when no model is configured at all.
+    pub model: Option<String>,
+    /// Provider routing key for the primary model.
+    pub provider: Option<String>,
+    /// Underlying provider type (e.g. `openai`, `anthropic`, `copilot`).
+    pub provider_type: Option<String>,
+    /// Resolved reasoning effort, if any.
+    pub reasoning_effort: Option<ReasoningEffort>,
+    /// Assembled system prompt (base template + workspace note) — what a new
+    /// session's first system message would contain.
+    pub system_prompt: String,
+    /// The base template alone, before workspace assembly.
+    pub base_system_prompt: String,
+    /// Default workspace path, if configured.
+    pub workspace_path: Option<String>,
+    /// Effective Gold config (global default; no session override applies
+    /// here since this endpoint has no session context).
+    pub gold_config: Option<GoldConfig>,
+    /// Fast/cheap auxiliary model.
+    pub fast_model: Option<String>,
+    /// Memory/background auxiliary model.
+    pub background_model: Option<String>,
+    /// Task-summary/compression auxiliary model.
+    pub summarization_model: Option<String>,
+}
+
+/// `GET /api/v1/execute/defaults`
+///
+/// Returns the server-side resolved run configuration with no per-request
+/// overrides applied — the same resolution a fresh `POST /chat` (with no
+/// explicit `model`) or a connect-bridged chat message would get.
+pub async fn handler(state: web::Data<AppState>) -> impl Responder {
+    let config_snapshot = state.config.read().await.clone();
+    let resolved = bamboo_engine::resolved_defaults::resolve_default_run_config(
+        &config_snapshot,
+        &state.provider_registry,
+    );
+
+    HttpResponse::Ok().json(ExecuteDefaultsResponse {
+        model: resolved.model_roster.model.clone(),
+        provider: resolved.model_roster.provider_name.clone(),
+        provider_type: resolved.model_roster.provider_type.clone(),
+        reasoning_effort: resolved.reasoning_effort,
+        system_prompt: resolved.system_prompt,
+        base_system_prompt: resolved.base_system_prompt,
+        workspace_path: resolved.workspace_path,
+        gold_config: resolved.gold_config,
+        fast_model: resolved.model_roster.fast_model(),
+        background_model: resolved.model_roster.background_model(),
+        summarization_model: resolved.model_roster.summarization_model(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_web::{test, web, App};
+    use serde_json::Value;
+    use tempfile::tempdir;
+
+    use crate::routes::configure_routes;
+    use crate::AppState;
+
+    async fn new_state() -> web::Data<AppState> {
+        let temp_dir = tempdir().expect("tempdir");
+        bamboo_config::paths::init_bamboo_dir(temp_dir.path().to_path_buf());
+        web::Data::new(
+            AppState::new(temp_dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        )
+    }
+
+    #[actix_web::test]
+    async fn defaults_endpoint_returns_resolved_area_models_not_raw_config_echo() {
+        let state = new_state().await;
+
+        // Configure distinct area models so a passing test proves RESOLUTION
+        // happened (fast/background/summarization differ from the chat model),
+        // not that the handler just echoed a single config field three times.
+        {
+            let mut config = state.config.write().await;
+            config.features.provider_model_ref = true;
+            config.provider = "openai".to_string();
+            // `resolve_fast_model`/`resolve_background_model`/`resolve_task_summary_model`
+            // route each `ProviderModelRef` through the live provider registry
+            // (`ProviderModelRouter::route`), which only succeeds for a provider
+            // that's actually registered — an API key is what registers it.
+            config.providers.openai = Some(bamboo_config::OpenAIConfig {
+                api_key: "test-key".to_string(),
+                ..Default::default()
+            });
+            config.defaults = Some(bamboo_config::DefaultsConfig {
+                chat: bamboo_domain::ProviderModelRef::new("openai", "gpt-chat"),
+                fast: Some(bamboo_domain::ProviderModelRef::new("openai", "gpt-fast")),
+                task_summary: Some(bamboo_domain::ProviderModelRef::new(
+                    "openai",
+                    "gpt-summary",
+                )),
+                vision: None,
+                memory_background: Some(bamboo_domain::ProviderModelRef::new(
+                    "openai",
+                    "gpt-memory",
+                )),
+                planning: None,
+                search: None,
+                code_review: None,
+                sub_agent: None,
+                subagent_models: Default::default(),
+            });
+            state
+                .provider_registry
+                .reload_from_config(&config, state.app_data_dir.clone())
+                .await
+                .expect("provider registry should reload with the openai provider registered");
+        }
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/execute/defaults")
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["model"], "gpt-chat");
+        assert_eq!(body["fast_model"], "gpt-fast");
+        assert_eq!(body["background_model"], "gpt-memory");
+        assert_eq!(body["summarization_model"], "gpt-summary");
+    }
+
+    #[actix_web::test]
+    async fn defaults_endpoint_never_leaks_api_keys() {
+        let state = new_state().await;
+        {
+            let mut config = state.config.write().await;
+            config.provider = "openai".to_string();
+            config.providers.openai = Some(bamboo_config::OpenAIConfig {
+                api_key: "sk-super-secret-value".to_string(),
+                model: Some("gpt-4o".to_string()),
+                ..Default::default()
+            });
+        }
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/execute/defaults")
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+        let body = test::read_body(resp).await;
+        let body_str = String::from_utf8_lossy(&body);
+        assert!(!body_str.contains("sk-super-secret-value"));
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/agent/execute/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/mod.rs
@@ -3,11 +3,13 @@
 //! This module provides the HTTP endpoint for triggering AI agent execution
 //! on a previously created chat session.
 
+pub(crate) mod defaults;
 mod handler;
 pub(crate) mod image_fallback;
 pub(crate) mod runtime;
 mod types;
 
+pub use defaults::handler as defaults_handler;
 pub use handler::handler;
 pub(crate) use runtime::{spawn_agent_execution, spawn_event_forwarder};
 pub use types::{

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
@@ -7,6 +7,19 @@ use bamboo_engine::model_config_helper::normalize_gold_config_json;
 
 use super::super::super::types::{CreateSessionRequest, CreateSessionResponse, SessionSummary};
 
+/// Sync runtime workspace so tools can resolve the working directory. Mirrors
+/// `chat::handler::sync_runtime_workspace` — #480 gives `POST /sessions` the
+/// same `workspace_path` semantics as `POST /chat`.
+fn sync_runtime_workspace(session_id: &str, workspace_path: Option<&str>) {
+    let preferred = workspace_path
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(std::path::PathBuf::from)
+        .and_then(|path| std::fs::canonicalize(&path).ok().or(Some(path)))
+        .filter(|path| path.is_dir());
+    let _ = bamboo_tools::tools::workspace_state::ensure_session_workspace(session_id, preferred);
+}
+
 /// `POST /api/v1/sessions`
 pub async fn create_session(
     state: web::Data<AppState>,
@@ -38,6 +51,10 @@ pub async fn create_session(
         global_default_prompt.as_str(),
         &config_snapshot,
     );
+
+    // Sync the runtime workspace directory on disk when the request set one
+    // (metadata-only write happened inside `build_new_session`).
+    sync_runtime_workspace(&id, req.workspace_path.as_deref());
 
     state
         .storage
@@ -98,6 +115,7 @@ fn build_new_session(
         model_ref: req.model_ref.clone(),
         reasoning_effort: req.reasoning_effort,
         gold_config_json,
+        workspace_path: req.workspace_path.clone(),
     };
     let create_config = CreateSessionConfig {
         default_model: config.get_model(),
@@ -155,5 +173,88 @@ mod tests {
             body["session"]["id"].as_str().is_some(),
             "response should carry the created session summary"
         );
+    }
+
+    /// #480: `POST /sessions` gets the same `workspace_path` semantics as
+    /// `POST /chat` — the created session's metadata carries the resolved
+    /// workspace path.
+    #[actix_web::test]
+    async fn create_session_with_workspace_path_sets_it() {
+        let state = new_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let workspace_dir = tempdir().expect("workspace tempdir");
+        let workspace_path = workspace_dir.path().to_string_lossy().to_string();
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/sessions")
+                .set_json(serde_json::json!({
+                    "title": "Session with workspace",
+                    "workspace_path": workspace_path,
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body: Value = test::read_body_json(resp).await;
+        let session_id = body["session"]["id"]
+            .as_str()
+            .expect("session id")
+            .to_string();
+
+        let session = state
+            .storage
+            .load_session(&session_id)
+            .await
+            .expect("load")
+            .expect("session exists");
+        assert_eq!(
+            session.workspace_path_meta().as_deref(),
+            Some(workspace_path.as_str())
+        );
+    }
+
+    /// Omitting `workspace_path` must NOT set any workspace metadata.
+    #[actix_web::test]
+    async fn create_session_without_workspace_path_leaves_it_unset() {
+        let state = new_state().await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/sessions")
+                .set_json(serde_json::json!({ "title": "No workspace" }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body: Value = test::read_body_json(resp).await;
+        let session_id = body["session"]["id"]
+            .as_str()
+            .expect("session id")
+            .to_string();
+
+        let session = state
+            .storage
+            .load_session(&session_id)
+            .await
+            .expect("load")
+            .expect("session exists");
+        assert!(session.workspace_path_meta().is_none());
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/tests.rs
@@ -50,6 +50,7 @@ fn build_new_session_applies_title_and_system_prompt_metadata() {
         model_ref: None,
         reasoning_effort: Some(ReasoningEffort::High),
         gold_config_json: None,
+        workspace_path: None,
     };
 
     let session = build_new_session(&input, &config_from_server(&config));
@@ -95,6 +96,7 @@ fn build_new_session_uses_global_default_template_when_request_prompt_is_missing
         model_ref: None,
         reasoning_effort: None,
         gold_config_json: None,
+        workspace_path: None,
     };
 
     let session = build_new_session(&input, &config_from_server(&config));

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/types.rs
@@ -202,6 +202,12 @@ pub struct CreateSessionRequest {
     pub reasoning_effort: Option<ReasoningEffort>,
     #[serde(default)]
     pub gold_config: Option<serde_json::Value>,
+    /// Optional workspace path, same semantics as `POST /chat`'s
+    /// `workspace_path` (#480): sets the session's default working directory
+    /// at creation time (connect sets workspace this way — see
+    /// `connect::bridge::create_connect_session`).
+    #[serde(default)]
+    pub workspace_path: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -333,6 +339,7 @@ mod tests {
             model_ref: None,
             reasoning_effort: None,
             gold_config: None,
+            workspace_path: None,
         };
 
         let debug_str = format!("{:?}", req);

--- a/crates/app/bamboo-server/src/routes/agent.rs
+++ b/crates/app/bamboo-server/src/routes/agent.rs
@@ -192,6 +192,14 @@ pub fn agent_routes(cfg: &mut web::ServiceConfig) {
             web::get().to(agent::schedules::list_runs_for_schedule),
         )
         // New separated execute + events endpoints
+        // `/execute/defaults` MUST be registered before the `/execute/{session_id}`
+        // dynamic route below (same precedent as `/sessions/cleanup` vs
+        // `/sessions/{session_id}` above) so a literal `defaults` path segment
+        // isn't swallowed as a session id.
+        .route(
+            "/execute/defaults",
+            web::get().to(agent::execute::defaults_handler),
+        )
         .route(
             "/execute/{session_id}",
             web::post().to(agent::execute::handler),

--- a/crates/engine/bamboo-engine/src/lib.rs
+++ b/crates/engine/bamboo-engine/src/lib.rs
@@ -12,6 +12,7 @@ pub mod message_hooks;
 pub mod model_areas;
 pub mod model_config_helper;
 pub mod prompt_defaults;
+pub mod resolved_defaults;
 pub mod runtime;
 pub mod sdk;
 pub mod session_app;

--- a/crates/engine/bamboo-engine/src/resolved_defaults.rs
+++ b/crates/engine/bamboo-engine/src/resolved_defaults.rs
@@ -1,0 +1,188 @@
+//! Single, shared implementation of "resolve the server's current effective
+//! run configuration purely from live `Config`" — no per-request overrides.
+//!
+//! This is the one place that combines [`crate::model_areas`]'s
+//! auxiliary-area resolution, [`crate::model_config_helper`]'s
+//! provider-type/gold-config resolution, [`crate::prompt_defaults`]'s
+//! template read, and [`crate::context::assemble_system_prompt`] into a
+//! single resolved snapshot. Two callers need EXACTLY this: `bamboo-server`'s
+//! connect bridge (`resolve_connect_run_config`, called once per inbound chat
+//! message) and the public `GET /api/v1/execute/defaults` HTTP handler (an
+//! external connector's "what would the server currently run with" probe,
+//! issue #480). Both call [`resolve_default_run_config`] rather than each
+//! reimplementing the cascade — that reimplementation is exactly the drift
+//! #480 set out to prevent.
+//!
+//! Deliberately mirrors `schedule_app::manager::resolve_run_config_from_config`
+//! minus the per-job overrides a scheduled run supports (a chat message or a
+//! defaults probe has none).
+
+use std::sync::Arc;
+
+use bamboo_domain::reasoning::ReasoningEffort;
+use bamboo_llm::{Config, ProviderRegistry};
+
+use crate::config::GoldConfig;
+use crate::ModelRoster;
+
+/// Resolved model/prompt/workspace configuration for a run that carries no
+/// per-request overrides, derived purely from the live global config.
+#[derive(Clone)]
+pub struct ResolvedDefaultRunConfig {
+    /// Primary + auxiliary model/provider selection. The primary model is
+    /// resolved via `model_roster.model` (may be `None`/empty if the server
+    /// has no model configured at all).
+    pub model_roster: ModelRoster,
+    pub reasoning_effort: Option<ReasoningEffort>,
+    pub gold_config: Option<GoldConfig>,
+    /// Assembled system prompt (base template + workspace note).
+    pub system_prompt: String,
+    pub base_system_prompt: String,
+    pub workspace_path: Option<String>,
+}
+
+/// Resolve the server's current effective run configuration purely from live
+/// `Config` — no per-request overrides. See the module docs for why this is
+/// the sole implementation of this cascade.
+pub fn resolve_default_run_config(
+    config_snapshot: &Config,
+    provider_registry: &Arc<ProviderRegistry>,
+) -> ResolvedDefaultRunConfig {
+    let model = config_snapshot.get_model().unwrap_or_default();
+    let provider_name = Some(config_snapshot.effective_default_provider().to_string());
+    let provider_type = provider_name.as_deref().and_then(|name| {
+        crate::model_config_helper::resolve_provider_type(config_snapshot, name, provider_registry)
+    });
+    let capability_provider_name = provider_name
+        .as_deref()
+        .unwrap_or(config_snapshot.effective_default_provider());
+    // Auxiliary models are global (config-derived), never session-bound —
+    // see `crate::model_areas`'s module docs.
+    let areas = crate::model_areas::resolve_global_area_models(
+        config_snapshot,
+        capability_provider_name,
+        provider_registry,
+    );
+    let reasoning_effort = config_snapshot.get_reasoning_effort();
+    let base_system_prompt = crate::prompt_defaults::read_global_default_system_prompt_template();
+    let workspace_path = config_snapshot
+        .get_default_work_area_path()
+        .map(|path| bamboo_config::paths::path_to_display_string(&path));
+    let system_prompt = crate::context::assemble_system_prompt(
+        &base_system_prompt,
+        None,
+        workspace_path.as_deref(),
+    );
+    let model_roster = ModelRoster::from_areas(Some(model), provider_name, provider_type, areas);
+
+    ResolvedDefaultRunConfig {
+        model_roster,
+        reasoning_effort,
+        gold_config: crate::model_config_helper::resolve_gold_config(config_snapshot, None),
+        system_prompt,
+        base_system_prompt,
+        workspace_path,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_agent_core::tools::ToolSchema;
+    use bamboo_agent_core::Message;
+    use bamboo_config::{DefaultsConfig, FeatureFlags, OpenAIConfig, ProviderConfigs};
+    use bamboo_domain::ProviderModelRef;
+    use bamboo_llm::{LLMError, LLMProvider, LLMStream};
+    use std::collections::HashMap;
+
+    struct NoopProvider;
+
+    #[async_trait::async_trait]
+    impl LLMProvider for NoopProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<LLMStream, LLMError> {
+            Err(LLMError::Api("noop".to_string()))
+        }
+    }
+
+    fn test_registry() -> Arc<ProviderRegistry> {
+        let mut providers: HashMap<String, Arc<dyn LLMProvider>> = HashMap::new();
+        providers.insert("openai".to_string(), Arc::new(NoopProvider));
+        Arc::new(ProviderRegistry::new(providers, "openai".to_string()))
+    }
+
+    fn config_with_area_defaults() -> Config {
+        let defaults = DefaultsConfig {
+            chat: ProviderModelRef::new("openai", "gpt-chat"),
+            fast: Some(ProviderModelRef::new("openai", "gpt-fast")),
+            task_summary: Some(ProviderModelRef::new("openai", "gpt-summary")),
+            vision: None,
+            memory_background: Some(ProviderModelRef::new("openai", "gpt-memory")),
+            planning: None,
+            search: None,
+            code_review: None,
+            sub_agent: None,
+            subagent_models: HashMap::new(),
+        };
+        Config {
+            provider: "openai".to_string(),
+            features: FeatureFlags {
+                provider_model_ref: true,
+                ..Default::default()
+            },
+            providers: ProviderConfigs {
+                openai: Some(OpenAIConfig {
+                    api_key: "test-secret-key".to_string(),
+                    model: Some("gpt-chat".to_string()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            defaults: Some(defaults),
+            ..Config::default()
+        }
+    }
+
+    /// The whole point of extraction: resolution must reflect *distinct*
+    /// area models, not just echo the raw chat model into every field.
+    #[test]
+    fn resolve_default_run_config_resolves_distinct_area_models() {
+        let config = config_with_area_defaults();
+        let registry = test_registry();
+
+        let resolved = resolve_default_run_config(&config, &registry);
+
+        assert_eq!(resolved.model_roster.model.as_deref(), Some("gpt-chat"));
+        assert_eq!(
+            resolved.model_roster.fast_model().as_deref(),
+            Some("gpt-fast")
+        );
+        assert_eq!(
+            resolved.model_roster.background_model().as_deref(),
+            Some("gpt-memory")
+        );
+        assert_eq!(
+            resolved.model_roster.summarization_model().as_deref(),
+            Some("gpt-summary")
+        );
+    }
+
+    #[test]
+    fn resolve_default_run_config_never_leaks_api_keys() {
+        let config = config_with_area_defaults();
+        let registry = test_registry();
+
+        let resolved = resolve_default_run_config(&config, &registry);
+
+        assert!(!resolved.system_prompt.contains("test-secret-key"));
+        assert!(!resolved.base_system_prompt.contains("test-secret-key"));
+        let gold_json =
+            serde_json::to_string(&resolved.gold_config).unwrap_or_else(|_| "null".to_string());
+        assert!(!gold_json.contains("test-secret-key"));
+    }
+}

--- a/crates/engine/bamboo-engine/src/session_app/session_create.rs
+++ b/crates/engine/bamboo-engine/src/session_app/session_create.rs
@@ -20,6 +20,13 @@ pub struct CreateSessionInput {
     pub model_ref: Option<ProviderModelRef>,
     pub reasoning_effort: Option<ReasoningEffort>,
     pub gold_config_json: Option<String>,
+    /// Optional workspace path, same semantics as `ChatTurnInput::workspace_path`
+    /// (#480: connect bridge sets workspace at session-creation; an external
+    /// connector using `POST /sessions` should be able to as well). Only the
+    /// metadata write happens here — syncing the runtime workspace directory
+    /// on disk (`ensure_session_workspace`) is a handler-layer concern, same
+    /// split as the chat turn use case.
+    pub workspace_path: Option<String>,
 }
 
 /// Configuration defaults for session creation.
@@ -52,6 +59,9 @@ pub fn build_new_session(input: &CreateSessionInput, config: &CreateSessionConfi
         session
             .metadata
             .insert(GOLD_CONFIG_METADATA_KEY.to_string(), gold_config_json);
+    }
+    if let Some(workspace_path) = trimmed_non_empty(input.workspace_path.as_deref()) {
+        session.set_workspace_path_meta(workspace_path);
     }
 
     if let Some(title) = trimmed_non_empty(input.title.as_deref()) {
@@ -163,6 +173,7 @@ mod tests {
             model_ref: None,
             reasoning_effort: Some(ReasoningEffort::High),
             gold_config_json: None,
+            workspace_path: None,
         };
         let session = build_new_session(&input, &default_config());
 
@@ -191,6 +202,7 @@ mod tests {
             model_ref: None,
             reasoning_effort: None,
             gold_config_json: None,
+            workspace_path: None,
         };
         let session = build_new_session(&input, &default_config());
 
@@ -218,6 +230,7 @@ mod tests {
             model_ref: None,
             reasoning_effort: None,
             gold_config_json: None,
+            workspace_path: None,
         };
         let session = build_new_session(&input, &config);
 
@@ -240,6 +253,7 @@ mod tests {
             model_ref: None,
             reasoning_effort: None,
             gold_config_json: None,
+            workspace_path: None,
         };
         let session = build_new_session(&input, &default_config());
 
@@ -259,6 +273,7 @@ mod tests {
             model_ref: Some(ProviderModelRef::new("anthropic", "claude-3-7-sonnet")),
             reasoning_effort: None,
             gold_config_json: None,
+            workspace_path: None,
         };
         let session = build_new_session(&input, &default_config());
 
@@ -271,5 +286,44 @@ mod tests {
             session.metadata.get("provider_name").map(String::as_str),
             Some("anthropic")
         );
+    }
+
+    /// #480: `POST /sessions` gets the same `workspace_path` semantics as
+    /// `POST /chat`'s `ChatTurnInput.workspace_path` — set at session creation.
+    #[test]
+    fn build_new_session_with_workspace_path_sets_workspace_metadata() {
+        let input = CreateSessionInput {
+            id: "session-6".to_string(),
+            title: None,
+            system_prompt: None,
+            model: Some("gpt-5".to_string()),
+            model_ref: None,
+            reasoning_effort: None,
+            gold_config_json: None,
+            workspace_path: Some("  /tmp/my-workspace  ".to_string()),
+        };
+        let session = build_new_session(&input, &default_config());
+
+        assert_eq!(
+            session.workspace_path_meta().as_deref(),
+            Some("/tmp/my-workspace")
+        );
+    }
+
+    #[test]
+    fn build_new_session_without_workspace_path_leaves_metadata_unset() {
+        let input = CreateSessionInput {
+            id: "session-7".to_string(),
+            title: None,
+            system_prompt: None,
+            model: Some("gpt-5".to_string()),
+            model_ref: None,
+            reasoning_effort: None,
+            gold_config_json: None,
+            workspace_path: None,
+        };
+        let session = build_new_session(&input, &default_config());
+
+        assert!(session.workspace_path_meta().is_none());
     }
 }


### PR DESCRIPTION
Closes #480 (API track of epic #477).

## What
1. **`GET /api/v1/execute/defaults`** — server-resolved effective run config: `model`, `provider`, `provider_type`, `reasoning_effort`, `system_prompt` (assembled), `base_system_prompt`, `workspace_path`, `gold_config`, `fast_model`, `background_model`, `summarization_model`. Registered before `POST /execute/{session_id}` (same precedent as `/sessions/cleanup`).
2. **Single resolution implementation**: new `bamboo-engine::resolved_defaults::resolve_default_run_config` — `connect/bridge.rs::resolve_connect_run_config`'s ~45-line inline cascade is deleted; the bridge and the new handler both call the shared helper (bridge tests unchanged and green).
3. **`POST /chat`: `model` now optional** — falls back to the resolved default; explicit-model path unchanged and pays no extra resolution cost; errors only when neither request nor server default resolves.
4. **`POST /sessions`: `workspace_path`** — parity with `ChatTurnInput`, incl. runtime-workspace sync mirroring the chat handler. (`model` was already optional on create — no change needed.)
5. `/turn` combined endpoint deliberately deferred per #480.

## Safety
- No secret leakage from `/execute/defaults` (test: `defaults_endpoint_never_leaks_api_keys`); `GoldConfig` carries no credentials.
- Struct-literal sweep done for `ChatRequest`/`CreateSessionRequest`/`CreateSessionInput` across the workspace.

## Tests
Resolution-not-echo proof (distinct area models via provider_registry reload), no-key-leak, `resolve_model_*` units, chat-without-model e2e (uses default / explicit unchanged / no-default errors), create-with/without-workspace_path, engine-level build_new_session workspace metadata. `cargo build --workspace --tests` clean; bamboo-engine 925 + bamboo-server 1288 lib tests green; fmt + clippy clean on touched crates.

Part of #477.

https://claude.ai/code/session_014UqJMdHmyooYbK6eDxdAVV