### PR TITLE
feat(plugin): `service` artifact kind — long-running service plugins

### DIFF
--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -628,6 +628,25 @@ impl AppState {
         // `Unreachable` so the UI/agent see reality (a redeploy brings it back).
         reconcile_fabric_on_boot(&config, &bamboo_home_dir).await;
 
+        // `ServiceManager` (issue #479 / epic #477 prereq): supervises
+        // long-running "service" plugins. Always constructed — fully inert
+        // until a plugin install or the boot-time reconcile below starts
+        // something — mirrors `mcp_manager`/`connect_manager`'s
+        // always-alive lifecycle.
+        let service_manager = Arc::new(crate::service_manager::ServiceManager::new());
+        {
+            // Backgrounded (mirrors `init_mcp_manager`'s background MCP
+            // bootstrap): a service that `installed.json` says should be
+            // running but isn't (the previous `bamboo serve` process, if
+            // any, died with everything it supervised) is started fresh.
+            let service_manager = service_manager.clone();
+            let app_data_dir = bamboo_home_dir.clone();
+            tokio::spawn(async move {
+                crate::plugin_installer::boot_reconcile_services(&app_data_dir, &service_manager)
+                    .await;
+            });
+        }
+
         Ok(Self {
             app_data_dir: bamboo_home_dir,
             config,
@@ -657,6 +676,7 @@ impl AppState {
             mcp_proxy_shutdown,
             skill_manager,
             mcp_manager,
+            service_manager,
             metrics_service,
             agent_runners,
             session_event_senders,

--- a/crates/app/bamboo-server/src/app_state/mod.rs
+++ b/crates/app/bamboo-server/src/app_state/mod.rs
@@ -305,6 +305,12 @@ pub struct AppState {
     /// including initialization, tool discovery, and shutdown.
     pub mcp_manager: Arc<McpServerManager>,
 
+    /// Supervises long-running "service" plugins (issue #479, prereq for
+    /// epic #477). Always constructed, fully inert until a plugin install
+    /// (or the boot-time reconcile) calls `start_service`. See
+    /// `crate::service_manager`'s module docs.
+    pub service_manager: Arc<crate::service_manager::ServiceManager>,
+
     /// Metrics collection and persistence service
     ///
     /// Tracks token usage, costs, and performance metrics

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/api_types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/api_types.rs
@@ -67,6 +67,8 @@ use bamboo_plugin::{
     InstalledPlugin, PluginInstallStatus, PluginManifest, PluginSource, RegisteredCapabilities,
 };
 
+use crate::service_manager::{ServiceManager, ServiceState};
+
 /// Shared body for `POST /install` and `POST /{id}/update`.
 #[derive(Debug, Deserialize)]
 pub struct InstallPluginRequest {
@@ -93,6 +95,28 @@ pub struct InstalledPluginView {
     pub source: PluginSource,
     pub status: PluginInstallStatus,
     pub registered: RegisteredCapabilities,
+    /// Live `ServiceManager` status for each id in `registered.service_ids`
+    /// (issue #479). Populated from the SAME `ServiceManager` snapshot the
+    /// list handler reads — see [`to_view`]. Empty for a plugin with no
+    /// services (the common case), same shape/emptiness convention as
+    /// `registered`'s other `Vec` fields.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub service_status: Vec<ServiceStatusView>,
+}
+
+/// Wire projection of [`crate::service_manager::ServiceStatusSnapshot`] —
+/// kept as a separate type (rather than reusing the internal snapshot
+/// directly) so this HTTP contract doesn't silently change shape if the
+/// internal one grows a field later.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServiceStatusView {
+    pub id: String,
+    pub state: ServiceState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+    pub restart_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
 }
 
 /// `GET /api/v1/plugins` response body.
@@ -110,8 +134,35 @@ pub struct PluginListResponse {
 /// a successful install/update) to recover it; `None` if that file is
 /// missing or fails to parse (e.g. hand-deleted out from under bamboo),
 /// matching the contract's optional `name?`.
-pub async fn to_view(entry: InstalledPlugin) -> InstalledPluginView {
+pub async fn to_view(
+    entry: InstalledPlugin,
+    service_manager: &ServiceManager,
+) -> InstalledPluginView {
     let name = read_manifest_name(&entry.plugin_dir).await;
+    let mut service_status = Vec::with_capacity(entry.registered.service_ids.len());
+    for service_id in &entry.registered.service_ids {
+        let view = match service_manager.status(service_id).await {
+            Some(snapshot) => ServiceStatusView {
+                id: snapshot.id,
+                state: snapshot.state,
+                pid: snapshot.pid,
+                restart_count: snapshot.restart_count,
+                last_error: snapshot.last_error,
+            },
+            // Not currently supervised (disabled in the manifest, or its
+            // supervisor task already unwound e.g. after `stop_service`) —
+            // still surface the id as `Stopped` rather than silently
+            // dropping it, so a caller sees every service this plugin owns.
+            None => ServiceStatusView {
+                id: service_id.clone(),
+                state: ServiceState::Stopped,
+                pid: None,
+                restart_count: 0,
+                last_error: None,
+            },
+        };
+        service_status.push(view);
+    }
     InstalledPluginView {
         id: entry.id,
         name,
@@ -119,6 +170,7 @@ pub async fn to_view(entry: InstalledPlugin) -> InstalledPluginView {
         source: entry.source,
         status: entry.status,
         registered: entry.registered,
+        service_status,
     }
 }
 

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/handlers.rs
@@ -68,7 +68,7 @@ pub async fn list_plugins(state: web::Data<AppState>) -> impl Responder {
         Ok(entries) => {
             let mut plugins = Vec::with_capacity(entries.len());
             for entry in entries {
-                plugins.push(to_view(entry).await);
+                plugins.push(to_view(entry, &state.service_manager).await);
             }
             HttpResponse::Ok().json(PluginListResponse { plugins })
         }
@@ -97,7 +97,7 @@ pub async fn install_plugin(
     )
     .await
     {
-        Ok(entry) => HttpResponse::Created().json(to_view(entry).await),
+        Ok(entry) => HttpResponse::Created().json(to_view(entry, &state.service_manager).await),
         Err(error) => plugin_error_response(&error),
     }
 }
@@ -122,13 +122,34 @@ pub async fn update_plugin(
     let input = to_source_input(body.into_inner().source);
     let trust = state.config.read().await.plugin_trust.clone();
 
+    // Same-id upgrade ordering (issue #479): `stage_plugin_source` below
+    // swaps `plugin_dir`'s ENTIRE contents (old bundle -> `.backup-*`,
+    // staged bundle -> `plugin_dir`) BEFORE `install()` ever runs — so any
+    // service this plugin currently owns must be stopped BEFORE staging,
+    // not after `install()`'s own `register_services` step, or the old
+    // process could still be holding the about-to-be-replaced binary open
+    // (and would otherwise briefly run stale code post-swap either way).
+    // `path_id` is the ONLY point in this flow where the target id is known
+    // up front (a fresh `install_plugin` has no prior id to look up). See
+    // `ServerPluginInstaller::stop_services_for_upgrade`'s doc comment for
+    // the full stop -> swap -> start sequencing this establishes.
+    let stopped_services = installer.stop_services_for_upgrade(&path_id).await;
+
     let staged = match stage_plugin_source(input, &root, &trust).await {
         Ok(staged) => staged,
-        Err(error) => return plugin_error_response(&error),
+        Err(error) => {
+            installer
+                .restart_services_after_failed_upgrade(&path_id, &stopped_services)
+                .await;
+            return plugin_error_response(&error);
+        }
     };
     if staged.manifest.id != path_id {
         let manifest_id = staged.manifest.id.clone();
         staged.rollback().await;
+        installer
+            .restart_services_after_failed_upgrade(&path_id, &stopped_services)
+            .await;
         return plugin_error_response(&PluginError::InvalidManifest(format!(
             "path id '{path_id}' does not match the source's manifest id '{manifest_id}'"
         )));
@@ -149,10 +170,15 @@ pub async fn update_plugin(
     {
         Ok(entry) => {
             staged.commit().await;
-            HttpResponse::Ok().json(to_view(entry).await)
+            HttpResponse::Ok().json(to_view(entry, &state.service_manager).await)
         }
         Err(error) => {
             staged.rollback().await;
+            // `plugin_dir` is now back to the pre-upgrade bundle's bytes —
+            // restart exactly what `stop_services_for_upgrade` stopped.
+            installer
+                .restart_services_after_failed_upgrade(&path_id, &stopped_services)
+                .await;
             plugin_error_response(&error)
         }
     }

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
@@ -725,3 +725,71 @@ async fn install_url_with_plugin_trust_enforcement_off_needs_no_per_request_flag
     assert_eq!(view["id"], "hello-plugin");
     assert_eq!(view["source"]["insecure"], true);
 }
+
+// ---------------------------------------------------------------------
+// Status surface (issue #479): `InstalledPluginView.service_status` is
+// populated from the live `ServiceManager`, keyed off
+// `registered.service_ids`.
+// ---------------------------------------------------------------------
+
+fn service_plugin_manifest_json(id: &str) -> String {
+    serde_json::json!({
+        "id": id,
+        "name": "Service Plugin",
+        "version": "1.0.0",
+        "provides": {
+            "services": [{"id": "svc", "command": "${platform_bin}"}]
+        }
+    })
+    .to_string()
+}
+
+async fn write_service_plugin_dir(dir: &Path, id: &str) {
+    tokio::fs::create_dir_all(dir).await.unwrap();
+    tokio::fs::write(dir.join("plugin.json"), service_plugin_manifest_json(id))
+        .await
+        .unwrap();
+}
+
+#[actix_web::test]
+async fn install_and_list_surface_service_status() {
+    let data_dir = tempfile::tempdir().unwrap();
+    let state = test_state(data_dir.path()).await;
+    let app = test::init_service(plugin_test_app!(state.clone())).await;
+
+    let source_dir = data_dir.path().join("svc-plugin-source");
+    write_service_plugin_dir(&source_dir, "svc-plugin").await;
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/plugins/install")
+        .set_json(local_dir_source(&source_dir))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let view = body_json(resp).await;
+    assert_eq!(
+        view["registered"]["service_ids"],
+        serde_json::json!(["svc"])
+    );
+    let service_status = view["service_status"]
+        .as_array()
+        .expect("service_status array");
+    assert_eq!(service_status.len(), 1);
+    assert_eq!(service_status[0]["id"], "svc");
+    // The binary doesn't exist on disk in this fixture, so the runtime
+    // never reaches `running` — but it MUST be present (best-effort start,
+    // ownership recorded regardless — matches the mcp contract) and report
+    // SOME state, not be silently absent from the response.
+    assert!(service_status[0]["state"].is_string());
+
+    // GET /plugins reflects the same live status.
+    let req = test::TestRequest::get().uri("/api/v1/plugins").to_request();
+    let resp = test::call_service(&app, req).await;
+    let listed = body_json(resp).await;
+    let plugins = listed["plugins"].as_array().unwrap();
+    assert_eq!(plugins.len(), 1);
+    assert_eq!(
+        plugins[0]["service_status"][0]["id"],
+        serde_json::json!("svc")
+    );
+}

--- a/crates/app/bamboo-server/src/lib.rs
+++ b/crates/app/bamboo-server/src/lib.rs
@@ -119,6 +119,7 @@ pub mod reloadable_provider;
 pub mod routes;
 pub mod schedule_app;
 pub mod server;
+pub mod service_manager;
 pub mod services;
 pub mod session_app;
 

--- a/crates/app/bamboo-server/src/plugin_installer.rs
+++ b/crates/app/bamboo-server/src/plugin_installer.rs
@@ -146,6 +146,7 @@ use tokio::fs;
 
 use bamboo_domain::mcp_config::McpServerConfig;
 use bamboo_plugin::installer::{load_previous_for_disposition, preflight_install};
+use bamboo_plugin::manifest::{Platform, ServiceManifestEntry};
 use bamboo_plugin::registry::{reconcile_exclusive, RegisteredCapabilities};
 use bamboo_plugin::{
     InstallDisposition, InstalledPlugin, InstalledPlugins, PluginError, PluginInstallStatus,
@@ -158,6 +159,7 @@ use crate::handlers::agent::mcp::upsert_server_by_id;
 use crate::handlers::agent::prompt_presets::{
     ensure_unique_preset_id, load_store, save_store, store_file_path, StoredPromptPreset,
 };
+use crate::service_manager::{ServiceManager, ServiceRuntimeConfig};
 
 /// Process-wide serialization of plugin install/uninstall operations.
 ///
@@ -209,6 +211,14 @@ struct InstallRollback {
     mcp_ids_started: Vec<String>,
     preset_ids_added: Vec<String>,
     workflow_files_added: Vec<String>,
+    /// Service ids this install claimed ownership of (whether or not the
+    /// actual `start_service` call succeeded — best-effort, same contract as
+    /// `mcp_ids_added`/`mcp_ids_started`).
+    service_ids_added: Vec<String>,
+    /// Subset of `service_ids_added` that actually got a running
+    /// `ServiceManager` runtime started — only these need `stop_service` on
+    /// rollback.
+    service_ids_started: Vec<String>,
 }
 
 impl ServerPluginInstaller {
@@ -230,6 +240,83 @@ impl ServerPluginInstaller {
 
     fn prompt_presets_path(&self) -> PathBuf {
         store_file_path(&self.state.app_data_dir)
+    }
+
+    /// `<data_dir>/plugin_service_config/<plugin_id>/config.json` — the
+    /// per-service user config path passed to services as
+    /// `BAMBOO_PLUGIN_SERVICE_CONFIG` (issue #479 open question 2).
+    ///
+    /// Deliberately NOT under `plugins_dir()/<plugin_id>/` (the
+    /// swap-managed `plugin_dir`): `plugin_source::stage_plugin_source`
+    /// upgrades a plugin by renaming the ENTIRE old `plugin_dir` aside and
+    /// swapping a freshly-staged directory into its place — any file living
+    /// inside `plugin_dir` would be swept away with the old bundle on
+    /// upgrade (or deleted outright on uninstall) unless bamboo specifically
+    /// carried it forward, which it does not. A sibling directory, named
+    /// only by `plugin_id`, is untouched by that swap and by
+    /// `uninstall`'s `remove_dir_all(plugin_dir)` — so a service's own
+    /// config (which may carry tokens/secrets a connector needs) survives
+    /// both an upgrade and an uninstall. bamboo only ever creates the PARENT
+    /// directory here (see [`Self::ensure_service_config_parent_dir`]) —
+    /// never writes or deletes `config.json` itself; on uninstall it is
+    /// deliberately left in place (not part of `remove_dir_all`), so a
+    /// later re-install of the same plugin id picks its old config back up
+    /// automatically.
+    fn service_config_path(&self, plugin_id: &str) -> PathBuf {
+        service_config_path_under(&self.state.app_data_dir, plugin_id)
+    }
+
+    async fn ensure_service_config_parent_dir(&self, plugin_id: &str) -> PluginResult<()> {
+        let path = self.service_config_path(plugin_id);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        Ok(())
+    }
+
+    /// Every service id currently owned by any OTHER installed plugin — the
+    /// "existing" side of [`reconcile_exclusive`] for services. There is no
+    /// single shared document analogous to `config.json` for services, so
+    /// provenance itself is the source of truth for "who owns this id".
+    ///
+    /// `exclude_plugin_id` MUST be the id of the plugin currently being
+    /// installed/upgraded and is always excluded — NOT an optional
+    /// nicety: by the time [`Self::register_services`] calls this,
+    /// `install()`'s crash-safety journal write has ALREADY upserted THIS
+    /// plugin's `Installing` row into `installed.json` with its full
+    /// INTENDED `service_ids` (see `install()`'s "Crash-safety journal"
+    /// step, which runs before every registration step). Without excluding
+    /// it, a plain fresh install would see its own not-yet-committed row as
+    /// a foreign owner of its own declared ids and refuse itself.
+    /// `previously_owned` (computed separately, from `previous` BEFORE that
+    /// journal write) is what still correctly classifies an upgrade's
+    /// re-declared ids as `OwnedReinstall` rather than `New`.
+    async fn existing_service_ids(&self, exclude_plugin_id: &str) -> PluginResult<Vec<String>> {
+        let store = InstalledPlugins::load(&self.installed_json_path()).await?;
+        Ok(store
+            .list()
+            .iter()
+            .filter(|plugin| plugin.id != exclude_plugin_id)
+            .flat_map(|plugin| plugin.registered.service_ids.iter().cloned())
+            .collect())
+    }
+
+    /// Resolve one manifest-declared service entry into a
+    /// [`ServiceRuntimeConfig`] ready for `ServiceManager::start_service`.
+    fn resolve_service_config(
+        &self,
+        plugin_id: &str,
+        entry: &ServiceManifestEntry,
+        plugin_dir: &Path,
+        platform: Platform,
+    ) -> ServiceRuntimeConfig {
+        resolve_service_config_under(
+            &self.state.app_data_dir,
+            plugin_id,
+            entry,
+            plugin_dir,
+            platform,
+        )
     }
 
     /// Every `.md` filename directly under `workflows_dir()` (created if
@@ -319,6 +406,16 @@ impl ServerPluginInstaller {
         }
     }
 
+    async fn remove_service(&self, id: &str) {
+        if let Err(error) = self.state.service_manager.stop_service(id).await {
+            tracing::warn!(
+                service_id = %id,
+                %error,
+                "failed to stop plugin-owned service; continuing"
+            );
+        }
+    }
+
     async fn remove_workflow_file(&self, filename: &str) {
         let path = self.workflows_dir().join(filename);
         match fs::remove_file(&path).await {
@@ -347,6 +444,9 @@ impl ServerPluginInstaller {
         for workflow_filename in &registered.workflow_filenames {
             self.remove_workflow_file(workflow_filename).await;
         }
+        for service_id in &registered.service_ids {
+            self.remove_service(service_id).await;
+        }
     }
 
     /// Best-effort undo of an `install()` that failed partway through steps
@@ -363,6 +463,9 @@ impl ServerPluginInstaller {
         }
         for file in &rollback.workflow_files_added {
             self.remove_workflow_file(file).await;
+        }
+        for id in &rollback.service_ids_started {
+            let _ = self.state.service_manager.stop_service(id).await;
         }
     }
 
@@ -524,6 +627,79 @@ impl ServerPluginInstaller {
         Ok(reconciliation.to_register)
     }
 
+    /// Step 1b: Services (issue #479, prereq for epic #477). Same
+    /// REFUSE-on-conflict + best-effort-start shape as [`Self::register_mcp`],
+    /// against [`Self::existing_service_ids`] instead of `config.json` (there
+    /// is no shared config document for services — provenance itself is the
+    /// ownership store, see that method's doc comment).
+    async fn register_services(
+        &self,
+        manifest: &PluginManifest,
+        plugin_dir: &Path,
+        previously_owned: &[String],
+        rollback: &mut InstallRollback,
+    ) -> PluginResult<Vec<String>> {
+        if manifest.provides.services.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let declared_ids: Vec<String> = manifest
+            .provides
+            .services
+            .iter()
+            .map(|entry| entry.id.clone())
+            .collect();
+        let existing_ids = self.existing_service_ids(&manifest.id).await?;
+        let reconciliation = reconcile_exclusive(&declared_ids, &existing_ids, previously_owned);
+        if !reconciliation.foreign_conflicts.is_empty() {
+            return Err(PluginError::Conflict {
+                kind: "service",
+                name: reconciliation.foreign_conflicts.join(", "),
+                plugin_id: manifest.id.clone(),
+            });
+        }
+
+        // Ownership is claimed regardless of individual start outcomes below
+        // (matches `register_mcp`'s "config write succeeded, so record
+        // ownership" contract — here there is no config write, so this is
+        // simply claimed up front).
+        rollback.service_ids_added = reconciliation.to_register.clone();
+
+        self.ensure_service_config_parent_dir(&manifest.id).await?;
+        let platform = Platform::current().unwrap_or(Platform::Linux);
+        let to_register: HashSet<&str> = reconciliation
+            .to_register
+            .iter()
+            .map(String::as_str)
+            .collect();
+
+        for entry in &manifest.provides.services {
+            if !to_register.contains(entry.id.as_str()) {
+                continue;
+            }
+            // Stop any stale running instance first — covers a leftover
+            // from a crashed install/upgrade recovery (a genuine same-id
+            // upgrade already had its old service stopped BEFORE staging by
+            // `stop_services_for_upgrade`, see the module docs' "Same-id
+            // upgrade ordering").
+            let _ = self.state.service_manager.stop_service(&entry.id).await;
+            if !entry.enabled {
+                continue;
+            }
+            let config = self.resolve_service_config(&manifest.id, entry, plugin_dir, platform);
+            match self.state.service_manager.start_service(config).await {
+                Ok(()) => rollback.service_ids_started.push(entry.id.clone()),
+                Err(error) => tracing::warn!(
+                    service_id = %entry.id,
+                    %error,
+                    "plugin-registered service failed to start; ownership kept (best-effort, matches mcp)"
+                ),
+            }
+        }
+
+        Ok(reconciliation.to_register)
+    }
+
     /// Step 2: Prompts. Rename-on-collision (never refuses) — returns the
     /// ACTUAL ids used (after any rename), which is what provenance must
     /// record.
@@ -618,6 +794,119 @@ impl ServerPluginInstaller {
 
         Ok(reconciliation.to_register)
     }
+
+    /// **Same-id upgrade ordering** (issue #479 "Install-flow deltas" /
+    /// "Same-id upgrade ordering bug risk"): `plugin_source::stage_plugin_source`
+    /// swaps `plugin_dir`'s ENTIRE contents (old bundle moved to a
+    /// `.backup-*` dir, staged bundle renamed into place) BEFORE
+    /// `install()` — and therefore [`Self::register_services`] — ever runs.
+    /// A still-running old service process holding the old binary open
+    /// during that swap is at best running stale code post-swap and at
+    /// worst (Windows) blocks the rename outright. The minimal seam that
+    /// fixes the ordering without restructuring `stage_plugin_source`/
+    /// `install()`: the HTTP `update_plugin` handler calls this BEFORE
+    /// `stage_plugin_source`, using the URL path's target id (known up
+    /// front for an upgrade, unlike a fresh `install`) to look up the
+    /// CURRENTLY-installed row's `registered.service_ids` and stop each one.
+    /// Net effect: stop (old binary) → swap (new binary) → start (new
+    /// binary, via `register_services` inside `install()`), exactly the
+    /// sequencing the issue calls for.
+    ///
+    /// Best-effort: returns exactly the ids that were actually running and
+    /// got stopped (not e.g. an already-stopped or unknown id), so a
+    /// subsequently-failed upgrade can restart precisely those — see
+    /// [`Self::restart_services_after_failed_upgrade`]. A plugin with no
+    /// prior install (or no services) returns an empty vec and stops
+    /// nothing.
+    pub async fn stop_services_for_upgrade(&self, plugin_id: &str) -> Vec<String> {
+        let store = match InstalledPlugins::load(&self.installed_json_path()).await {
+            Ok(store) => store,
+            Err(error) => {
+                tracing::warn!(
+                    %plugin_id,
+                    %error,
+                    "stop_services_for_upgrade: failed to load installed.json; skipping"
+                );
+                return Vec::new();
+            }
+        };
+        let Some(entry) = store.get(plugin_id) else {
+            return Vec::new();
+        };
+        let mut stopped = Vec::with_capacity(entry.registered.service_ids.len());
+        for service_id in &entry.registered.service_ids {
+            match self.state.service_manager.stop_service(service_id).await {
+                Ok(()) => stopped.push(service_id.clone()),
+                Err(error) => tracing::debug!(
+                    service_id = %service_id,
+                    %error,
+                    "stop_services_for_upgrade: service was not running; nothing to stop"
+                ),
+            }
+        }
+        stopped
+    }
+
+    /// Counterpart to [`Self::stop_services_for_upgrade`]: called after a
+    /// FAILED upgrade whose `StagedPlugin::rollback()` already restored
+    /// `plugin_dir` to the pre-upgrade bundle's bytes — re-reads that
+    /// (now-restored) OLD `plugin.json` and restarts exactly the services in
+    /// `stopped` that it still declares as `enabled`. Best-effort/
+    /// log-and-continue: a failure here leaves the affected service stopped
+    /// (a degraded-but-safe outcome — never silently double-runs an old and
+    /// a new instance) rather than panicking the request.
+    pub async fn restart_services_after_failed_upgrade(&self, plugin_id: &str, stopped: &[String]) {
+        if stopped.is_empty() {
+            return;
+        }
+        let store = match InstalledPlugins::load(&self.installed_json_path()).await {
+            Ok(store) => store,
+            Err(error) => {
+                tracing::warn!(
+                    %plugin_id,
+                    %error,
+                    "restart_services_after_failed_upgrade: failed to load installed.json"
+                );
+                return;
+            }
+        };
+        let Some(entry) = store.get(plugin_id) else {
+            return;
+        };
+        let manifest_path = entry.plugin_dir.join("plugin.json");
+        let manifest = match fs::read_to_string(&manifest_path)
+            .await
+            .ok()
+            .and_then(|raw| PluginManifest::parse_str(&raw).ok())
+        {
+            Some(manifest) => manifest,
+            None => {
+                tracing::warn!(
+                    %plugin_id,
+                    path = %manifest_path.display(),
+                    "restart_services_after_failed_upgrade: failed to read/parse the \
+                     rolled-back plugin.json; affected service(s) remain stopped"
+                );
+                return;
+            }
+        };
+        let platform = Platform::current().unwrap_or(Platform::Linux);
+        for svc in &manifest.provides.services {
+            if !stopped.contains(&svc.id) || !svc.enabled {
+                continue;
+            }
+            let config = self.resolve_service_config(plugin_id, svc, &entry.plugin_dir, platform);
+            if let Err(error) = self.state.service_manager.start_service(config).await {
+                tracing::warn!(
+                    service_id = %svc.id,
+                    %plugin_id,
+                    %error,
+                    "failed to restart service after a failed upgrade rolled back to the \
+                     previous plugin bundle; service remains stopped"
+                );
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -663,6 +952,12 @@ impl PluginInstaller for ServerPluginInstaller {
                 .map(|preset| preset.id.clone())
                 .collect(),
             workflow_filenames: manifest.provides.workflows.clone(),
+            service_ids: manifest
+                .provides
+                .services
+                .iter()
+                .map(|entry| entry.id.clone())
+                .collect(),
         };
 
         // Step 0: upgrade drop-diff. Computed from the NEW manifest's plain
@@ -680,6 +975,7 @@ impl PluginInstaller for ServerPluginInstaller {
                     dropped_mcp = ?dropped.mcp_server_ids,
                     dropped_presets = ?dropped.preset_ids,
                     dropped_workflows = ?dropped.workflow_filenames,
+                    dropped_services = ?dropped.service_ids,
                     "install drop-diff: de-registering capabilities the new/completed version no longer declares"
                 );
                 self.deregister_capabilities(&dropped).await;
@@ -693,6 +989,10 @@ impl PluginInstaller for ServerPluginInstaller {
         let previously_owned_workflows = previous
             .as_ref()
             .map(|p| p.registered.workflow_filenames.clone())
+            .unwrap_or_default();
+        let previously_owned_services = previous
+            .as_ref()
+            .map(|p| p.registered.service_ids.clone())
             .unwrap_or_default();
 
         // Crash-safety journal: write an `Installing` provenance row recording
@@ -722,6 +1022,30 @@ impl PluginInstaller for ServerPluginInstaller {
                 manifest,
                 resolved_mcp_servers,
                 &previously_owned_mcp,
+                &mut rollback,
+            )
+            .await
+        {
+            Ok(ids) => ids,
+            Err(error) => {
+                self.abort_install(&rollback, &previous, &manifest.id, &installed_json_path)
+                    .await;
+                return Err(error);
+            }
+        };
+
+        // Step 1b: Services (issue #479). Runs right after MCP, before the
+        // never-refusing Prompts step, so a services conflict fails the
+        // install as early as the other REFUSE-on-conflict kinds do. Note:
+        // for a same-id UPGRADE, the OLD service (if any) was already
+        // stopped by `stop_services_for_upgrade` before `stage_plugin_source`
+        // swapped `plugin_dir` — see that method's doc comment on the
+        // stop→swap→start sequencing.
+        let service_ids = match self
+            .register_services(
+                manifest,
+                plugin_dir,
+                &previously_owned_services,
                 &mut rollback,
             )
             .await
@@ -781,6 +1105,7 @@ impl PluginInstaller for ServerPluginInstaller {
             skill_dirs,
             preset_ids,
             workflow_filenames,
+            service_ids,
         };
         let entry = InstalledPlugin {
             id: manifest.id.clone(),
@@ -835,6 +1160,142 @@ impl PluginInstaller for ServerPluginInstaller {
     async fn list(&self) -> PluginResult<Vec<InstalledPlugin>> {
         let store = InstalledPlugins::load(&self.installed_json_path()).await?;
         Ok(store.plugins)
+    }
+}
+
+// ---------------------------------------------------------------------
+// Free helpers shared between `ServerPluginInstaller` (instance methods
+// above, which delegate here) and `boot_reconcile_services` (which has no
+// `ServerPluginInstaller`/`AppState` handle to call instance methods on —
+// see `app_state::builder`, which calls it before `AppState` finishes
+// constructing).
+// ---------------------------------------------------------------------
+
+/// See `ServerPluginInstaller::service_config_path`'s doc comment for the
+/// full rationale (kept there since that's the reader's first encounter).
+fn service_config_path_under(app_data_dir: &Path, plugin_id: &str) -> PathBuf {
+    app_data_dir
+        .join("plugin_service_config")
+        .join(plugin_id)
+        .join("config.json")
+}
+
+fn resolve_service_config_under(
+    app_data_dir: &Path,
+    plugin_id: &str,
+    entry: &ServiceManifestEntry,
+    plugin_dir: &Path,
+    platform: Platform,
+) -> ServiceRuntimeConfig {
+    let resolved = entry.resolve(plugin_dir, plugin_id, platform);
+    ServiceRuntimeConfig {
+        id: resolved.id,
+        plugin_id: plugin_id.to_string(),
+        name: resolved.name,
+        command: resolved.command,
+        args: resolved.args,
+        cwd: resolved.cwd,
+        env: resolved.env,
+        health_check: resolved.health_check,
+        restart_policy: resolved.restart_policy,
+        graceful_shutdown: resolved.graceful_shutdown,
+        user_config_path: service_config_path_under(app_data_dir, plugin_id),
+    }
+}
+
+/// Boot-time reconcile (issue #479): start every ENABLED, plugin-owned
+/// service that `installed.json` says should be running but has no live
+/// [`ServiceManager`] runtime — the previous `bamboo serve` process (if any)
+/// died along with every service it supervised (child processes are spawned
+/// `kill_on_drop`, and nothing about a running service persists
+/// cross-process). Called from `app_state::builder` the same way
+/// `app_state::init::init_mcp_manager` kicks off its background MCP
+/// bootstrap — the caller is expected to `tokio::spawn` this, NOT await it
+/// inline, so server startup is never blocked on plugin service spawns.
+///
+/// Deliberately reads `installed.json` + each plugin's on-disk
+/// `plugin.json` directly rather than going through `ServerPluginInstaller`
+/// (which needs a fully-built `web::Data<AppState>` this runs before).
+pub async fn boot_reconcile_services(app_data_dir: &Path, service_manager: &ServiceManager) {
+    let installed_json_path = app_data_dir.join("plugins").join("installed.json");
+    let store = match InstalledPlugins::load(&installed_json_path).await {
+        Ok(store) => store,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "service boot-reconcile: failed to load installed.json; skipping"
+            );
+            return;
+        }
+    };
+
+    let platform = Platform::current().unwrap_or(Platform::Linux);
+    for plugin in store.list() {
+        if plugin.registered.service_ids.is_empty() {
+            continue;
+        }
+        let manifest_path = plugin.plugin_dir.join("plugin.json");
+        let manifest = match fs::read_to_string(&manifest_path)
+            .await
+            .ok()
+            .and_then(|raw| PluginManifest::parse_str(&raw).ok())
+        {
+            Some(manifest) => manifest,
+            None => {
+                tracing::warn!(
+                    plugin_id = %plugin.id,
+                    path = %manifest_path.display(),
+                    "service boot-reconcile: failed to read/parse plugin.json; skipping this \
+                     plugin's services"
+                );
+                continue;
+            }
+        };
+
+        let owned: HashSet<&str> = plugin
+            .registered
+            .service_ids
+            .iter()
+            .map(String::as_str)
+            .collect();
+        for entry in &manifest.provides.services {
+            if !entry.enabled || !owned.contains(entry.id.as_str()) {
+                continue;
+            }
+            if service_manager.is_running(&entry.id) {
+                continue;
+            }
+            let config = resolve_service_config_under(
+                app_data_dir,
+                &plugin.id,
+                entry,
+                &plugin.plugin_dir,
+                platform,
+            );
+            if let Some(parent) = config.user_config_path.parent() {
+                if let Err(error) = fs::create_dir_all(parent).await {
+                    tracing::warn!(
+                        service_id = %entry.id,
+                        plugin_id = %plugin.id,
+                        %error,
+                        "service boot-reconcile: failed to create service config parent dir"
+                    );
+                }
+            }
+            match service_manager.start_service(config).await {
+                Ok(()) => tracing::info!(
+                    service_id = %entry.id,
+                    plugin_id = %plugin.id,
+                    "service boot-reconcile: started"
+                ),
+                Err(error) => tracing::warn!(
+                    service_id = %entry.id,
+                    plugin_id = %plugin.id,
+                    %error,
+                    "service boot-reconcile: failed to start"
+                ),
+            }
+        }
     }
 }
 

--- a/crates/app/bamboo-server/src/plugin_installer/tests.rs
+++ b/crates/app/bamboo-server/src/plugin_installer/tests.rs
@@ -48,6 +48,32 @@ fn mcp_manifest_json(id: &str, version: &str, mcp_ids: &[&str]) -> String {
     .to_string()
 }
 
+/// `command: "${platform_bin}"` resolves to `<plugin_dir>/bin/<platform>/<id>`,
+/// which none of these tests ever create on disk — `ServiceManager::start_service`
+/// therefore fails fast (`ENOENT`) exactly like `NONEXISTENT_COMMAND` does for
+/// MCP above, exercising the same "best-effort start, ownership still
+/// recorded" contract without spawning a real long-running process.
+fn service_manifest_json(id: &str, version: &str, service_ids: &[&str]) -> String {
+    let services: Vec<serde_json::Value> = service_ids
+        .iter()
+        .map(|service_id| {
+            serde_json::json!({
+                "id": service_id,
+                "command": "${platform_bin}"
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "id": id,
+        "name": "Test Service Plugin",
+        "version": version,
+        "provides": {
+            "services": services,
+        }
+    })
+    .to_string()
+}
+
 fn hello_plugin_example_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../infra/bamboo-plugin/examples/hello-plugin")
 }
@@ -724,4 +750,343 @@ async fn install_recovers_from_a_crashed_installing_leftover() {
     assert_eq!(listed[0].status, PluginInstallStatus::Installed);
     let config = state.config.read().await;
     assert!(config.mcp.servers.iter().any(|s| s.id == "leftover-mcp"));
+}
+
+// ---------------------------------------------------------------------
+// Services (issue #479, prereq for epic #477). Same shapes as the MCP
+// section above: REFUSE-on-foreign-conflict, best-effort start, upgrade
+// drop-diff — but reconciled against `installed.json` (via
+// `existing_service_ids`) rather than `config.json`, since there is no
+// single shared document for services. See `register_services`'s doc
+// comment.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn install_registers_service_with_provenance_even_when_the_binary_is_missing() {
+    let root = tempfile::tempdir().unwrap();
+    let (_state, installer) = new_installer(&root.path().join("bamboo-home")).await;
+
+    let plugin_dir = root.path().join("plugins").join("svc-plugin");
+    tokio::fs::create_dir_all(&plugin_dir).await.unwrap();
+    let manifest_json = service_manifest_json("svc-plugin", "1.0.0", &["svc"]);
+    tokio::fs::write(plugin_dir.join("plugin.json"), &manifest_json)
+        .await
+        .unwrap();
+    let manifest = PluginManifest::parse_str(&manifest_json).unwrap();
+
+    let entry = installer
+        .install(
+            &manifest,
+            &plugin_dir,
+            PluginSource::LocalDir {
+                path: plugin_dir.clone(),
+            },
+            InstallDisposition::FailIfInstalled,
+            Utc::now(),
+        )
+        .await
+        .expect("install with a service entry (binary missing) must still succeed");
+
+    // Ownership recorded regardless of the (missing-binary) start outcome —
+    // matches `register_mcp`'s best-effort contract.
+    assert_eq!(entry.registered.service_ids, vec!["svc".to_string()]);
+
+    let listed = installer.list().await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].registered.service_ids, vec!["svc".to_string()]);
+}
+
+#[tokio::test]
+async fn foreign_service_conflict_refuses_install_and_does_not_touch_the_owner() {
+    let root = tempfile::tempdir().unwrap();
+    let (_state, installer) = new_installer(&root.path().join("bamboo-home")).await;
+
+    // Seed provenance for a DIFFERENT, already-installed plugin that owns
+    // service id "shared-svc" (the services analog of "config.json already
+    // has this mcp server id" — there is no shared config document for
+    // services, so ownership lives entirely in `installed.json`).
+    let installed_json = root
+        .path()
+        .join("bamboo-home")
+        .join("plugins")
+        .join("installed.json");
+    let mut store = InstalledPlugins::default();
+    store.add(InstalledPlugin {
+        id: "owner-plugin".to_string(),
+        version: "1.0.0".to_string(),
+        source: PluginSource::LocalDir {
+            path: PathBuf::from("/tmp/owner"),
+        },
+        plugin_dir: root.path().join("plugins").join("owner-plugin"),
+        installed_at: Utc::now(),
+        status: PluginInstallStatus::Installed,
+        registered: RegisteredCapabilities {
+            service_ids: vec!["shared-svc".to_string()],
+            ..Default::default()
+        },
+    });
+    store.save(&installed_json).await.unwrap();
+
+    let plugin_dir = root.path().join("plugins").join("conflicting-svc-plugin");
+    tokio::fs::create_dir_all(&plugin_dir).await.unwrap();
+    let manifest_json = service_manifest_json("conflicting-svc-plugin", "1.0.0", &["shared-svc"]);
+    tokio::fs::write(plugin_dir.join("plugin.json"), &manifest_json)
+        .await
+        .unwrap();
+    let manifest = PluginManifest::parse_str(&manifest_json).unwrap();
+
+    let error = installer
+        .install(
+            &manifest,
+            &plugin_dir,
+            PluginSource::LocalDir {
+                path: plugin_dir.clone(),
+            },
+            InstallDisposition::FailIfInstalled,
+            Utc::now(),
+        )
+        .await
+        .expect_err("a foreign service id collision must refuse the install");
+    assert!(matches!(
+        error,
+        PluginError::Conflict {
+            kind: "service",
+            ..
+        }
+    ));
+
+    // The original owner's provenance is untouched; the conflicting install
+    // never got recorded.
+    let listed = installer.list().await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, "owner-plugin");
+    assert_eq!(
+        listed[0].registered.service_ids,
+        vec!["shared-svc".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn upgrade_deregisters_service_dropped_by_the_new_version_and_frees_the_id() {
+    let root = tempfile::tempdir().unwrap();
+    let (_state, installer) = new_installer(&root.path().join("bamboo-home")).await;
+
+    let plugin_dir = root.path().join("plugins").join("multi-svc-plugin");
+    tokio::fs::create_dir_all(&plugin_dir).await.unwrap();
+
+    let v1_json = service_manifest_json("multi-svc-plugin", "1.0.0", &["alpha", "beta"]);
+    tokio::fs::write(plugin_dir.join("plugin.json"), &v1_json)
+        .await
+        .unwrap();
+    let v1_manifest = PluginManifest::parse_str(&v1_json).unwrap();
+
+    let v1_entry = installer
+        .install(
+            &v1_manifest,
+            &plugin_dir,
+            PluginSource::LocalDir {
+                path: plugin_dir.clone(),
+            },
+            InstallDisposition::FailIfInstalled,
+            Utc::now(),
+        )
+        .await
+        .expect("install v1");
+    assert_eq!(
+        v1_entry.registered.service_ids,
+        vec!["alpha".to_string(), "beta".to_string()]
+    );
+
+    // "Upgrade" to v2, which only declares alpha.
+    let v2_json = service_manifest_json("multi-svc-plugin", "2.0.0", &["alpha"]);
+    tokio::fs::write(plugin_dir.join("plugin.json"), &v2_json)
+        .await
+        .unwrap();
+    let v2_manifest = PluginManifest::parse_str(&v2_json).unwrap();
+
+    let v2_entry = installer
+        .install(
+            &v2_manifest,
+            &plugin_dir,
+            PluginSource::LocalDir {
+                path: plugin_dir.clone(),
+            },
+            InstallDisposition::Upgrade,
+            Utc::now(),
+        )
+        .await
+        .expect("upgrade to v2");
+    assert_eq!(v2_entry.registered.service_ids, vec!["alpha".to_string()]);
+
+    // `beta` was dropped and de-registered — a DIFFERENT plugin can now
+    // claim that id without a foreign conflict, proving it was actually
+    // freed (not just absent from THIS plugin's own provenance row).
+    let other_plugin_dir = root.path().join("plugins").join("other-plugin");
+    tokio::fs::create_dir_all(&other_plugin_dir).await.unwrap();
+    let other_json = service_manifest_json("other-plugin", "1.0.0", &["beta"]);
+    tokio::fs::write(other_plugin_dir.join("plugin.json"), &other_json)
+        .await
+        .unwrap();
+    let other_manifest = PluginManifest::parse_str(&other_json).unwrap();
+    let other_entry = installer
+        .install(
+            &other_manifest,
+            &other_plugin_dir,
+            PluginSource::LocalDir {
+                path: other_plugin_dir.clone(),
+            },
+            InstallDisposition::FailIfInstalled,
+            Utc::now(),
+        )
+        .await
+        .expect("beta must be free for a different plugin to claim after the upgrade dropped it");
+    assert_eq!(other_entry.registered.service_ids, vec!["beta".to_string()]);
+}
+
+// ---------------------------------------------------------------------
+// Same-id upgrade ordering (issue #479): `stop_services_for_upgrade` /
+// `restart_services_after_failed_upgrade` are the seam the HTTP
+// `update_plugin` handler uses to stop a plugin's services BEFORE
+// `stage_plugin_source` swaps `plugin_dir`, and to restart them if the
+// upgrade subsequently fails and rolls back to the old bundle. Unit-tested
+// directly here (rather than only through the full HTTP+staging pipeline)
+// so the ordering contract is pinned precisely.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn stop_services_for_upgrade_stops_the_running_service_and_returns_its_id() {
+    let root = tempfile::tempdir().unwrap();
+    let (state, installer) = new_installer(&root.path().join("bamboo-home")).await;
+
+    let plugin_dir = root.path().join("plugins").join("svc-plugin");
+    tokio::fs::create_dir_all(&plugin_dir).await.unwrap();
+    let manifest_json = service_manifest_json("svc-plugin", "1.0.0", &["svc"]);
+    tokio::fs::write(plugin_dir.join("plugin.json"), &manifest_json)
+        .await
+        .unwrap();
+    let manifest = PluginManifest::parse_str(&manifest_json).unwrap();
+    installer
+        .install(
+            &manifest,
+            &plugin_dir,
+            PluginSource::LocalDir {
+                path: plugin_dir.clone(),
+            },
+            InstallDisposition::FailIfInstalled,
+            Utc::now(),
+        )
+        .await
+        .expect("install");
+    assert!(
+        state.service_manager.is_running("svc"),
+        "start_service must have registered a runtime even though the binary is missing \
+         (best-effort start, matches mcp)"
+    );
+
+    let stopped = installer.stop_services_for_upgrade("svc-plugin").await;
+    assert_eq!(stopped, vec!["svc".to_string()]);
+    assert!(
+        !state.service_manager.is_running("svc"),
+        "stop_services_for_upgrade must have actually stopped it before returning"
+    );
+}
+
+#[tokio::test]
+async fn stop_services_for_upgrade_on_a_plugin_with_no_services_is_a_harmless_noop() {
+    let root = tempfile::tempdir().unwrap();
+    let (_state, installer) = new_installer(&root.path().join("bamboo-home")).await;
+    let stopped = installer.stop_services_for_upgrade("never-installed").await;
+    assert!(stopped.is_empty());
+}
+
+#[tokio::test]
+async fn restart_services_after_failed_upgrade_restarts_from_the_still_installed_manifest() {
+    let root = tempfile::tempdir().unwrap();
+    let (state, installer) = new_installer(&root.path().join("bamboo-home")).await;
+
+    let plugin_dir = root.path().join("plugins").join("svc-plugin");
+    tokio::fs::create_dir_all(&plugin_dir).await.unwrap();
+    let manifest_json = service_manifest_json("svc-plugin", "1.0.0", &["svc"]);
+    tokio::fs::write(plugin_dir.join("plugin.json"), &manifest_json)
+        .await
+        .unwrap();
+    let manifest = PluginManifest::parse_str(&manifest_json).unwrap();
+    installer
+        .install(
+            &manifest,
+            &plugin_dir,
+            PluginSource::LocalDir {
+                path: plugin_dir.clone(),
+            },
+            InstallDisposition::FailIfInstalled,
+            Utc::now(),
+        )
+        .await
+        .expect("install");
+
+    // Simulate the handler's pre-stage stop (see `update_plugin`).
+    let stopped = installer.stop_services_for_upgrade("svc-plugin").await;
+    assert_eq!(stopped, vec!["svc".to_string()]);
+    assert!(!state.service_manager.is_running("svc"));
+
+    // Simulate a FAILED upgrade whose `StagedPlugin::rollback()` restored
+    // `plugin_dir` to the pre-upgrade bundle (here: nothing ever changed
+    // `plugin_dir`'s on-disk `plugin.json`, which is exactly what a
+    // successful rollback leaves behind).
+    installer
+        .restart_services_after_failed_upgrade("svc-plugin", &stopped)
+        .await;
+    assert!(
+        state.service_manager.is_running("svc"),
+        "the previously-stopped service must be running again after a failed upgrade"
+    );
+}
+
+#[tokio::test]
+async fn restart_services_after_failed_upgrade_skips_a_service_the_rolled_back_manifest_disabled() {
+    let root = tempfile::tempdir().unwrap();
+    let (state, installer) = new_installer(&root.path().join("bamboo-home")).await;
+
+    let plugin_dir = root.path().join("plugins").join("svc-plugin");
+    tokio::fs::create_dir_all(&plugin_dir).await.unwrap();
+    // Declare "svc" as DISABLED from the start.
+    let manifest_json = serde_json::json!({
+        "id": "svc-plugin",
+        "name": "Svc",
+        "version": "1.0.0",
+        "provides": {
+            "services": [{"id": "svc", "command": "${platform_bin}", "enabled": false}]
+        }
+    })
+    .to_string();
+    tokio::fs::write(plugin_dir.join("plugin.json"), &manifest_json)
+        .await
+        .unwrap();
+    let manifest = PluginManifest::parse_str(&manifest_json).unwrap();
+    installer
+        .install(
+            &manifest,
+            &plugin_dir,
+            PluginSource::LocalDir {
+                path: plugin_dir.clone(),
+            },
+            InstallDisposition::FailIfInstalled,
+            Utc::now(),
+        )
+        .await
+        .expect("install");
+    assert!(!state.service_manager.is_running("svc"));
+
+    // Nothing was running to begin with, so `stopped` is empty here — but
+    // exercise `restart_services_after_failed_upgrade` with a fabricated
+    // non-empty `stopped` list to prove it still respects `enabled: false`
+    // in the manifest it reads back, rather than blindly restarting
+    // whatever it's told.
+    installer
+        .restart_services_after_failed_upgrade("svc-plugin", &["svc".to_string()])
+        .await;
+    assert!(
+        !state.service_manager.is_running("svc"),
+        "a disabled service must never be started by the restart-after-rollback path"
+    );
 }

--- a/crates/app/bamboo-server/src/plugin_source.rs
+++ b/crates/app/bamboo-server/src/plugin_source.rs
@@ -444,6 +444,34 @@ async fn stage_into(
             let fetched =
                 fetch_manifest_bundle(url, flags, trust, staging_dir, max_decompressed_bytes)
                     .await?;
+
+            // Security (issue #479 §4 / open question 6): a manifest
+            // declaring `provides.services` is the highest-trust plugin
+            // artifact kind — a resident, unconstrained process — so it may
+            // NEVER install from a URL source whose bytes weren't
+            // cryptographically signed by a trusted key, no matter which
+            // opt-out flag got it this far (`allow_unsigned` explicitly, or
+            // the `--insecure`/`plugin_trust.enforcement: off` aggregate).
+            // `fetched.signed_by.is_none()` is exactly that "unsigned"
+            // signal regardless of WHY (genuinely unsigned bundle, or an
+            // opt-out that let an unsigned/mismatched one through) — see
+            // `fetch_manifest_bundle`'s layer-2 doc comment. Checked here
+            // (not in `PluginManifest::validate`, which has no visibility
+            // into install-time trust flags/signature results) and BEFORE
+            // the per-platform binary artifact is fetched, so a refused
+            // install downloads no executable at all.
+            if !fetched.manifest.provides.services.is_empty() && fetched.signed_by.is_none() {
+                return Err(PluginError::UnsignedOrUntrustedSignature(format!(
+                    "refusing to install plugin '{}' from '{url}': it declares `provides.services` \
+                     (long-running service plugins are the highest-trust artifact kind) but its \
+                     bundle is unsigned or its signature does not verify against a trusted key — \
+                     `--allow-unsigned`/`--insecure` and `plugin_trust.enforcement: off` are NOT \
+                     honoured for a services-declaring manifest; publish a signature from a \
+                     trusted key instead",
+                    fetched.manifest.id
+                )));
+            }
+
             // Binary-artifact verification stays as defense in depth (see
             // the module docs) — its own sha256, declared inside the
             // now-verified manifest, is checked in

--- a/crates/app/bamboo-server/src/plugin_source/tests.rs
+++ b/crates/app/bamboo-server/src/plugin_source/tests.rs
@@ -1256,6 +1256,132 @@ async fn allow_unsigned_bypasses_the_signature_check_but_not_the_checksum_layer(
 }
 
 // ---------------------------------------------------------------------
+// Issue #479 §4 / open question 6: a `provides.services`-declaring manifest
+// is NEVER installable from a URL source unless its bundle is
+// signature-verified — `allow_unsigned`/`--insecure`/
+// `plugin_trust.enforcement: off` are all NOT honoured for this artifact
+// kind (unlike every other capability). See `stage_into`'s services check.
+// ---------------------------------------------------------------------
+
+fn service_manifest_json(id: &str) -> String {
+    serde_json::json!({
+        "id": id,
+        "name": "Service Plugin",
+        "version": "0.1.0",
+        "provides": {
+            "services": [
+                {"id": "svc", "command": "${platform_bin}"}
+            ]
+        }
+    })
+    .to_string()
+}
+
+#[tokio::test]
+async fn services_manifest_with_allow_unsigned_is_refused_even_with_every_other_bypass() {
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = service_manifest_json("svc-plugin");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+    // Deliberately no `.sig` route mounted — this bundle is unsigned.
+
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+
+    // Every per-layer bypass set AND allow_unverified — proves the refusal
+    // is specific to `provides.services`, not just a re-run of the ordinary
+    // signature-required check (which `allow_unsigned` alone would satisfy).
+    let error = stage_plugin_source(
+        url_input_full(&url, None, true, true, true),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err("a services-declaring manifest must refuse an unsigned URL install");
+    assert!(
+        matches!(error, PluginError::UnsignedOrUntrustedSignature(_)),
+        "expected UnsignedOrUntrustedSignature, got {error:?}"
+    );
+    assert!(error.to_string().contains("provides.services"));
+    assert!(!plugins_root.join("svc-plugin").exists());
+}
+
+#[tokio::test]
+async fn services_manifest_with_insecure_aggregate_is_refused() {
+    // Same as above but via the `--insecure` aggregate rather than the
+    // individual `allow_unsigned` flag — the issue calls out BOTH must be
+    // refused for a services-declaring manifest.
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = service_manifest_json("svc-plugin-2");
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body))
+        .mount(&server)
+        .await;
+
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+
+    let error = stage_plugin_source(
+        url_input_insecure(&url, None),
+        &plugins_root,
+        &PluginTrustConfig::default(),
+    )
+    .await
+    .expect_err("a services-declaring manifest must refuse `--insecure` too");
+    assert!(matches!(
+        error,
+        PluginError::UnsignedOrUntrustedSignature(_)
+    ));
+}
+
+#[tokio::test]
+async fn services_manifest_with_a_valid_trusted_signature_is_accepted() {
+    // The refusal is specifically about being UNSIGNED — a genuinely
+    // signature-verified services bundle must install normally.
+    let server = wiremock::MockServer::start().await;
+    let manifest_body = service_manifest_json("svc-plugin-signed");
+    let signing_key = test_signing_key(42);
+    let signature = signing_key.sign(manifest_body.as_bytes());
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_string(manifest_body.clone()))
+        .mount(&server)
+        .await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/plugin.json.sig"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200).set_body_string(hex::encode(signature.to_bytes())),
+        )
+        .mount(&server)
+        .await;
+
+    let trust = PluginTrustConfig {
+        trusted_hosts: Vec::new(),
+        trusted_keys: vec![trusted_key_for("test-key", &signing_key)],
+        enforcement: PluginTrustEnforcement::Strict,
+    };
+    let root = tempfile::tempdir().unwrap();
+    let plugins_root = root.path().join("plugins");
+    let url = format!("{}/plugin.json", server.uri());
+
+    let staged = stage_plugin_source(
+        url_input_full(&url, None, false, true, false),
+        &plugins_root,
+        &trust,
+    )
+    .await
+    .expect("a signature-verified services manifest must install normally");
+    assert_eq!(staged.manifest.id, "svc-plugin-signed");
+    staged.commit().await;
+}
+
+// ---------------------------------------------------------------------
 // Redirect policy (BLOCKER 1 fix): the host allowlist only vets the FIRST
 // hop's `<host><path>`. Whether it's safe to transparently follow an HTTP
 // redirect to a DIFFERENT host depends on whether the downloaded bytes will

--- a/crates/app/bamboo-server/src/service_manager/lifecycle.rs
+++ b/crates/app/bamboo-server/src/service_manager/lifecycle.rs
@@ -1,0 +1,391 @@
+//! The supervisor task: spawn → run (crash/health-detect) → graceful-stop
+//! or restart-with-backoff. One task per service, owned entirely by
+//! [`super::ServiceManager::start_service`]/[`super::ServiceManager::stop_service`].
+
+use std::process::Stdio;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio_util::sync::CancellationToken;
+
+use bamboo_infrastructure::process::hide_window_for_tokio_command;
+use bamboo_plugin::manifest::{HealthCheckKind, ShutdownSignal};
+
+use super::{ServiceRuntime, ServiceState, ServiceStatusSnapshot};
+
+/// Minimal env allowlist applied BEFORE the manifest's declared `env` (see
+/// module docs' "Security: `env_clear()`"). Just enough for a normal
+/// self-contained binary to run: locate the dynamic loader / shared libs
+/// (`PATH`), find a home directory for any runtime that assumes one exists.
+const UNIX_ENV_ALLOWLIST: &[&str] = &["PATH", "HOME", "TMPDIR", "TEMP", "TMP", "LANG", "LC_ALL"];
+#[cfg(target_os = "windows")]
+const WINDOWS_ENV_ALLOWLIST: &[&str] = &[
+    "PATH",
+    "SystemRoot",
+    "SystemDrive",
+    "USERPROFILE",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "TEMP",
+    "TMP",
+];
+
+async fn set_state(runtime: &Arc<ServiceRuntime>, state: ServiceState) {
+    *runtime.state.write().await = state;
+}
+
+async fn set_last_error(runtime: &Arc<ServiceRuntime>, message: impl Into<String>) {
+    *runtime.last_error.write().await = Some(message.into());
+}
+
+pub(super) async fn snapshot(runtime: &Arc<ServiceRuntime>) -> ServiceStatusSnapshot {
+    let state = *runtime.state.read().await;
+    let pid_raw = runtime.pid.load(Ordering::SeqCst);
+    ServiceStatusSnapshot {
+        id: runtime.config.id.clone(),
+        plugin_id: runtime.config.plugin_id.clone(),
+        state,
+        pid: if pid_raw == 0 { None } else { Some(pid_raw) },
+        restart_count: runtime.restart_count.load(Ordering::SeqCst),
+        last_error: runtime.last_error.read().await.clone(),
+    }
+}
+
+/// Build the child command (`env_clear()`, the minimal allowlist, declared
+/// env, `BAMBOO_PLUGIN_SERVICE_CONFIG`, `kill_on_drop`, hidden window, piped
+/// stdio).
+///
+/// Spawning (not just building) is done here too, so a spawn failure
+/// (`ENOENT` etc.) is a single `io::Result` the caller can treat as a crash.
+fn spawn_child(config: &super::ServiceRuntimeConfig) -> std::io::Result<Child> {
+    let mut cmd = Command::new(&config.command);
+    hide_window_for_tokio_command(&mut cmd);
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        // Kill the child if this `Child` is dropped without going through
+        // our own graceful/hard-kill sequence (e.g. the supervisor task is
+        // aborted) — same rationale as `bamboo-mcp`'s stdio transport.
+        .kill_on_drop(true)
+        .args(&config.args)
+        // Security (issue #479 §2): clear bamboo-server's own environment
+        // first — a service must never inherit ambient secrets — then apply
+        // only the minimal allowlist below plus the manifest's declared env.
+        .env_clear();
+
+    #[cfg(not(target_os = "windows"))]
+    for key in UNIX_ENV_ALLOWLIST {
+        if let Ok(value) = std::env::var(key) {
+            cmd.env(key, value);
+        }
+    }
+    #[cfg(target_os = "windows")]
+    for key in WINDOWS_ENV_ALLOWLIST {
+        if let Ok(value) = std::env::var(key) {
+            cmd.env(key, value);
+        }
+    }
+
+    cmd.env("BAMBOO_PLUGIN_SERVICE_CONFIG", &config.user_config_path);
+    // Declared env applied LAST so a plugin author can deliberately override
+    // an allowlisted variable (e.g. a custom TMPDIR) if they need to.
+    cmd.envs(&config.env);
+
+    if let Some(cwd) = &config.cwd {
+        cmd.current_dir(cwd);
+    }
+
+    cmd.spawn()
+}
+
+/// Mirrors `bamboo_mcp::transports::stdio`'s stderr-logger pattern, applied
+/// to BOTH streams (a service has no stdin/stdout wire protocol to reserve —
+/// everything it prints is just a log line).
+fn spawn_stdio_logger(service_id: &str, child: &mut Child) {
+    if let Some(stdout) = child.stdout.take() {
+        let id = service_id.to_string();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                tracing::info!(service_id = %id, "[service stdout] {line}");
+            }
+        });
+    }
+    if let Some(stderr) = child.stderr.take() {
+        let id = service_id.to_string();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                tracing::warn!(service_id = %id, "[service stderr] {line}");
+            }
+        });
+    }
+}
+
+/// Send SIGTERM to `pid` by shelling out to `kill -TERM` — deliberately NOT
+/// `libc::kill`/`nix` (this workspace already ships a precedent for this
+/// exact approach in `bamboo_infrastructure::process::registry::ProcessRegistry::kill_process_by_pid`,
+/// and it avoids adding a new dependency). A best-effort signal: failure just
+/// means the graceful-timeout below falls through to a hard kill anyway.
+#[cfg(not(target_os = "windows"))]
+async fn send_graceful_signal(pid: u32) {
+    let _ = Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .status()
+        .await;
+}
+
+/// Windows has no SIGTERM equivalent worth shelling out for here; per issue
+/// #479's design ("Windows: kill after grace"), the grace period below is
+/// still honoured — this just skips sending an ineffective signal.
+#[cfg(target_os = "windows")]
+async fn send_graceful_signal(_pid: u32) {}
+
+/// Graceful (signal → poll up to `timeout_ms`) then hard (`SIGKILL`/
+/// `TerminateProcess` via `Child::start_kill`) stop of an already-spawned
+/// child. Always waits for the child to actually exit before returning (a
+/// stopped service must never straddle "we asked it to stop" and "it's
+/// actually gone" — the caller is about to report `Stopped`/restart).
+async fn terminate_child(child: &mut Child, graceful: &bamboo_plugin::manifest::GracefulShutdown) {
+    let pid = child.id();
+    if graceful.signal == ShutdownSignal::Term {
+        if let Some(pid) = pid {
+            send_graceful_signal(pid).await;
+        }
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(graceful.timeout_ms);
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => {
+                    if tokio::time::Instant::now() >= deadline {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+                Err(_) => break,
+            }
+        }
+    }
+    // Still alive (or `signal: none`) — escalate.
+    let _ = child.start_kill();
+    let _ = child.wait().await;
+}
+
+/// TCP/HTTP reachability probe. `ProcessAlive` is intentionally NOT handled
+/// here — its "health" is exactly "has the child not exited yet", which
+/// [`supervise_running_child`] already tracks via `child.wait()` without any
+/// separate polling.
+async fn probe_health(spec: &bamboo_plugin::manifest::HealthCheckSpec) -> Result<(), String> {
+    let timeout = Duration::from_millis(spec.timeout_ms.max(1));
+    match spec.kind {
+        HealthCheckKind::ProcessAlive => Ok(()),
+        HealthCheckKind::Tcp => {
+            let target = spec
+                .target
+                .as_deref()
+                .ok_or_else(|| "tcp health_check missing target".to_string())?;
+            match tokio::time::timeout(timeout, tokio::net::TcpStream::connect(target)).await {
+                Ok(Ok(_)) => Ok(()),
+                Ok(Err(error)) => Err(format!("tcp health check to '{target}' failed: {error}")),
+                Err(_) => Err(format!("tcp health check to '{target}' timed out")),
+            }
+        }
+        HealthCheckKind::Http => {
+            let target = spec
+                .target
+                .as_deref()
+                .ok_or_else(|| "http health_check missing target".to_string())?;
+            let client = reqwest::Client::new();
+            match tokio::time::timeout(timeout, client.get(target).send()).await {
+                Ok(Ok(response)) if response.status().is_success() => Ok(()),
+                Ok(Ok(response)) => Err(format!(
+                    "http health check to '{target}' returned status {}",
+                    response.status()
+                )),
+                Ok(Err(error)) => Err(format!("http health check to '{target}' failed: {error}")),
+                Err(_) => Err(format!("http health check to '{target}' timed out")),
+            }
+        }
+    }
+}
+
+enum RunOutcome {
+    /// `stop_service` was called while the child was running.
+    StoppedByRequest,
+    /// The child process exited on its own (crash, or a clean self-exit —
+    /// either way, unexpected for a service that's supposed to be
+    /// long-running).
+    Exited(String),
+    /// A `Tcp`/`Http` health check failed while the process was still alive.
+    /// The child is still running at this point — the caller kills it before
+    /// treating this like a crash.
+    Unhealthy(String),
+}
+
+/// Own the running child until it exits, is stopped, or (for `Tcp`/`Http`
+/// health checks) is found unhealthy. Generalizes
+/// `bamboo_mcp::manager::lifecycle::start_health_check`'s "ping on an
+/// interval; a single failure means degraded + reconnect" pattern.
+async fn supervise_running_child(
+    runtime: &Arc<ServiceRuntime>,
+    child: &mut Child,
+    stop_token: &CancellationToken,
+) -> RunOutcome {
+    let health = runtime.config.health_check.clone();
+    if matches!(health.kind, HealthCheckKind::ProcessAlive) {
+        return tokio::select! {
+            _ = stop_token.cancelled() => RunOutcome::StoppedByRequest,
+            result = child.wait() => RunOutcome::Exited(
+                result.map(|status| format!("process exited: {status}"))
+                    .unwrap_or_else(|error| format!("failed to wait on child: {error}")),
+            ),
+        };
+    }
+
+    let mut ticker = tokio::time::interval(Duration::from_millis(health.interval_ms.max(100)));
+    ticker.tick().await; // first tick is immediate; consume it to give the process startup grace before the first probe
+    loop {
+        tokio::select! {
+            _ = stop_token.cancelled() => return RunOutcome::StoppedByRequest,
+            result = child.wait() => {
+                return RunOutcome::Exited(
+                    result.map(|status| format!("process exited: {status}"))
+                        .unwrap_or_else(|error| format!("failed to wait on child: {error}")),
+                );
+            }
+            _ = ticker.tick() => {
+                match probe_health(&health).await {
+                    Ok(()) => {
+                        // Recovered from a prior Degraded tick.
+                        if *runtime.state.read().await == ServiceState::Degraded {
+                            set_state(runtime, ServiceState::Running).await;
+                        }
+                    }
+                    Err(reason) => {
+                        set_state(runtime, ServiceState::Degraded).await;
+                        return RunOutcome::Unhealthy(reason);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Compute the backoff (ms) for the given 1-based consecutive-attempt
+/// number, mirroring `bamboo_mcp::manager::reconnect::attempt_reconnection`'s
+/// exponential-doubling-with-ceiling.
+fn compute_backoff_ms(policy: &bamboo_domain::mcp_config::ReconnectConfig, attempt: u32) -> u64 {
+    let mut backoff = policy.initial_backoff_ms.max(1);
+    for _ in 1..attempt {
+        backoff = backoff.saturating_mul(2).min(policy.max_backoff_ms);
+    }
+    backoff.min(policy.max_backoff_ms.max(backoff))
+}
+
+/// After a crash/unhealthy exit: decide whether to restart, and if so, sleep
+/// out the backoff (interruptibly). Returns `true` to restart, `false` to
+/// settle into `Stopped`.
+async fn maybe_wait_before_restart(
+    runtime: &Arc<ServiceRuntime>,
+    stop_token: &CancellationToken,
+    consecutive_attempts: &mut u32,
+) -> bool {
+    if runtime.shutdown.load(Ordering::SeqCst) {
+        return false;
+    }
+    let policy = runtime.config.restart_policy.clone();
+    if !policy.enabled {
+        return false;
+    }
+    *consecutive_attempts += 1;
+    if policy.max_attempts > 0 && *consecutive_attempts > policy.max_attempts {
+        set_last_error(
+            runtime,
+            format!(
+                "max restart attempts ({}) reached for service '{}'",
+                policy.max_attempts, runtime.config.id
+            ),
+        )
+        .await;
+        return false;
+    }
+    runtime.restart_count.fetch_add(1, Ordering::SeqCst);
+    let backoff_ms = compute_backoff_ms(&policy, *consecutive_attempts);
+    set_state(runtime, ServiceState::Restarting).await;
+    tokio::select! {
+        _ = stop_token.cancelled() => false,
+        _ = tokio::time::sleep(Duration::from_millis(backoff_ms)) => !runtime.shutdown.load(Ordering::SeqCst),
+    }
+}
+
+/// The supervisor loop: spawn → run → (graceful stop | crash/unhealthy →
+/// maybe restart with backoff). Exits (task completes) exactly when the
+/// service settles into [`ServiceState::Stopped`] — either an intentional
+/// stop, `restart_policy.enabled == false`, or `max_attempts` reached.
+pub(super) async fn run_supervisor(runtime: Arc<ServiceRuntime>) {
+    let stop_token = runtime.stop_token.clone();
+    let mut consecutive_attempts: u32 = 0;
+
+    loop {
+        if runtime.shutdown.load(Ordering::SeqCst) {
+            set_state(&runtime, ServiceState::Stopped).await;
+            return;
+        }
+        set_state(&runtime, ServiceState::Starting).await;
+
+        let mut child = match spawn_child(&runtime.config) {
+            Ok(child) => child,
+            Err(error) => {
+                set_last_error(&runtime, format!("failed to spawn: {error}")).await;
+                set_state(&runtime, ServiceState::Crashed).await;
+                if !maybe_wait_before_restart(&runtime, &stop_token, &mut consecutive_attempts)
+                    .await
+                {
+                    set_state(&runtime, ServiceState::Stopped).await;
+                    return;
+                }
+                continue;
+            }
+        };
+
+        runtime.pid.store(child.id().unwrap_or(0), Ordering::SeqCst);
+        spawn_stdio_logger(&runtime.config.id, &mut child);
+        set_state(&runtime, ServiceState::Running).await;
+        // A genuinely-started child resets the backoff/attempt counter —
+        // only a crash-loop (never reaching Running) should escalate delay.
+        consecutive_attempts = 0;
+
+        let outcome = supervise_running_child(&runtime, &mut child, &stop_token).await;
+        runtime.pid.store(0, Ordering::SeqCst);
+
+        match outcome {
+            RunOutcome::StoppedByRequest => {
+                set_state(&runtime, ServiceState::Stopping).await;
+                terminate_child(&mut child, &runtime.config.graceful_shutdown).await;
+                set_state(&runtime, ServiceState::Stopped).await;
+                return;
+            }
+            RunOutcome::Exited(reason) => {
+                set_last_error(&runtime, reason).await;
+                set_state(&runtime, ServiceState::Crashed).await;
+            }
+            RunOutcome::Unhealthy(reason) => {
+                set_last_error(&runtime, reason).await;
+                terminate_child(&mut child, &runtime.config.graceful_shutdown).await;
+                set_state(&runtime, ServiceState::Crashed).await;
+            }
+        }
+
+        if runtime.shutdown.load(Ordering::SeqCst) {
+            set_state(&runtime, ServiceState::Stopped).await;
+            return;
+        }
+        if !maybe_wait_before_restart(&runtime, &stop_token, &mut consecutive_attempts).await {
+            set_state(&runtime, ServiceState::Stopped).await;
+            return;
+        }
+    }
+}

--- a/crates/app/bamboo-server/src/service_manager/lifecycle.rs
+++ b/crates/app/bamboo-server/src/service_manager/lifecycle.rs
@@ -278,11 +278,17 @@ async fn supervise_running_child(
 /// number, mirroring `bamboo_mcp::manager::reconnect::attempt_reconnection`'s
 /// exponential-doubling-with-ceiling.
 fn compute_backoff_ms(policy: &bamboo_domain::mcp_config::ReconnectConfig, attempt: u32) -> u64 {
-    let mut backoff = policy.initial_backoff_ms.max(1);
+    // The first attempt is clamped too: a manifest declaring
+    // initial_backoff_ms > max_backoff_ms (nothing validates against it)
+    // must not exceed the configured ceiling on attempt 1.
+    let mut backoff = policy
+        .initial_backoff_ms
+        .max(1)
+        .min(policy.max_backoff_ms.max(1));
     for _ in 1..attempt {
         backoff = backoff.saturating_mul(2).min(policy.max_backoff_ms);
     }
-    backoff.min(policy.max_backoff_ms.max(backoff))
+    backoff
 }
 
 /// After a crash/unhealthy exit: decide whether to restart, and if so, sleep
@@ -387,5 +393,38 @@ pub(super) async fn run_supervisor(runtime: Arc<ServiceRuntime>) {
             set_state(&runtime, ServiceState::Stopped).await;
             return;
         }
+    }
+}
+
+#[cfg(test)]
+mod backoff_tests {
+    use super::compute_backoff_ms;
+    use bamboo_domain::mcp_config::ReconnectConfig;
+
+    fn policy(initial: u64, max: u64) -> ReconnectConfig {
+        ReconnectConfig {
+            initial_backoff_ms: initial,
+            max_backoff_ms: max,
+            ..ReconnectConfig::default()
+        }
+    }
+
+    #[test]
+    fn backoff_doubles_and_clamps_to_ceiling() {
+        let p = policy(100, 500);
+        assert_eq!(compute_backoff_ms(&p, 1), 100);
+        assert_eq!(compute_backoff_ms(&p, 2), 200);
+        assert_eq!(compute_backoff_ms(&p, 3), 400);
+        assert_eq!(compute_backoff_ms(&p, 4), 500);
+        assert_eq!(compute_backoff_ms(&p, 10), 500);
+    }
+
+    /// A misconfigured manifest with initial > max must be clamped on the
+    /// FIRST attempt too (review finding on #482).
+    #[test]
+    fn backoff_first_attempt_is_clamped_when_initial_exceeds_max() {
+        let p = policy(10_000, 500);
+        assert_eq!(compute_backoff_ms(&p, 1), 500);
+        assert_eq!(compute_backoff_ms(&p, 2), 500);
     }
 }

--- a/crates/app/bamboo-server/src/service_manager/mod.rs
+++ b/crates/app/bamboo-server/src/service_manager/mod.rs
@@ -191,9 +191,6 @@ impl ServiceManager {
         config: ServiceRuntimeConfig,
     ) -> Result<(), ServiceManagerError> {
         let id = config.id.clone();
-        if self.runtimes.contains_key(&id) {
-            return Err(ServiceManagerError::AlreadyRunning(id));
-        }
         let runtime = Arc::new(ServiceRuntime {
             config,
             state: RwLock::new(ServiceState::Starting),
@@ -204,7 +201,22 @@ impl ServiceManager {
             stop_token: CancellationToken::new(),
             supervisor: RwLock::new(None),
         });
-        self.runtimes.insert(id, runtime.clone());
+        // Atomic check-and-insert via the entry API: a plain
+        // contains_key→insert would let two racing callers (boot reconcile —
+        // spawned outside PLUGIN_OP_LOCK — vs a concurrent install of the
+        // same plugin) both pass the check, the second overwriting the
+        // first's runtime and orphaning its supervisor task + child process
+        // beyond stop_service's reach.
+        match self.runtimes.entry(id) {
+            dashmap::mapref::entry::Entry::Occupied(occupied) => {
+                return Err(ServiceManagerError::AlreadyRunning(
+                    occupied.key().clone(),
+                ));
+            }
+            dashmap::mapref::entry::Entry::Vacant(vacant) => {
+                vacant.insert(runtime.clone());
+            }
+        }
         let handle = tokio::spawn(lifecycle::run_supervisor(runtime.clone()));
         *runtime.supervisor.write().await = Some(handle);
         Ok(())

--- a/crates/app/bamboo-server/src/service_manager/mod.rs
+++ b/crates/app/bamboo-server/src/service_manager/mod.rs
@@ -209,9 +209,7 @@ impl ServiceManager {
         // beyond stop_service's reach.
         match self.runtimes.entry(id) {
             dashmap::mapref::entry::Entry::Occupied(occupied) => {
-                return Err(ServiceManagerError::AlreadyRunning(
-                    occupied.key().clone(),
-                ));
+                return Err(ServiceManagerError::AlreadyRunning(occupied.key().clone()));
             }
             dashmap::mapref::entry::Entry::Vacant(vacant) => {
                 vacant.insert(runtime.clone());

--- a/crates/app/bamboo-server/src/service_manager/mod.rs
+++ b/crates/app/bamboo-server/src/service_manager/mod.rs
@@ -1,0 +1,261 @@
+//! `ServiceManager` — supervises long-running "service" plugins (issue #479,
+//! prereq for epic #477's standalone connectors distributed as plugins).
+//!
+//! Sibling of `connect::ConnectManager` / `schedule_app::ScheduleManager`:
+//! constructed once in `app_state::builder`, always alive, fully inert until
+//! `start_service` is called. Neither existing precedent fits a resident
+//! service process as-is:
+//!
+//! - `connect::ConnectManager` is too thin (no restart/health).
+//! - `bamboo_mcp::manager::McpServerManager` is JSON-RPC-coupled
+//!   (`ToolIndex`/QoS/circuit-breaker are meaningless for a service that
+//!   speaks no MCP protocol at all).
+//!
+//! This module instead reuses the SHAPE of two `bamboo-mcp` patterns without
+//! depending on that crate:
+//!
+//! - Spawn mechanics from `bamboo_mcp::transports::stdio` (`kill_on_drop`,
+//!   `hide_window_for_tokio_command`, piped stdout/stderr → log lines via a
+//!   dedicated reader task per stream — see [`lifecycle::spawn_stdio_logger`]).
+//! - The health-check-drives-restart pattern from
+//!   `bamboo_mcp::manager::lifecycle::start_health_check` /
+//!   `manager::reconnect::attempt_reconnection`, generalized to
+//!   [`bamboo_plugin::manifest::HealthCheckKind`]'s three kinds (process
+//!   liveness is just "has the child exited", so only `Tcp`/`Http` need an
+//!   actual polling task — see [`lifecycle::supervise_running_child`]) and to
+//!   `bamboo_plugin::manifest::ShutdownSignal`'s graceful-then-hard-kill
+//!   stop, mirroring `reconnect`'s exponential backoff.
+//!
+//! # Security: `env_clear()` before applying declared env
+//!
+//! Unlike `bamboo-mcp`'s stdio transport (which inherits bamboo-server's
+//! FULL process environment — deliberately left alone, see that crate's
+//! module docs), [`lifecycle::spawn_child`] calls `Command::env_clear()` and
+//! then applies only a minimal `PATH`/`HOME`(+platform-runtime-essential)
+//! allowlist before the manifest's declared `env` and
+//! `BAMBOO_PLUGIN_SERVICE_CONFIG`. A service is the highest-trust plugin
+//! artifact kind (a resident, unconstrained process) — see issue #479
+//! security §2 — so it must not silently see every secret bamboo-server's own
+//! environment happens to carry (API keys, tokens, etc).
+//!
+//! # `shutdown` vs `stop_token`
+//!
+//! Each [`ServiceRuntime`] carries a `shutdown: AtomicBool` (the issue's
+//! explicit requirement) — the single source of truth `lifecycle` consults
+//! after ANY wake to decide "was this an intentional stop" vs "should
+//! `restart_policy` fire" — plus a `tokio_util::sync::CancellationToken` used
+//! purely as the WAKE mechanism (interrupting an in-progress health-check
+//! wait or restart backoff sleep). A bare `tokio::sync::Notify` was
+//! considered and rejected: `notify_waiters` only wakes CURRENTLY-waiting
+//! tasks, so a stop request arriving before the supervisor reaches its
+//! `.notified().await` would be silently lost — `CancellationToken` has no
+//! such race (once cancelled, `cancelled()` resolves immediately regardless
+//! of call order).
+//!
+//! # Boot-time reconcile
+//!
+//! `app_state::builder` starts every ENABLED service from every plugin's
+//! `installed.json` row in the background (mirrors
+//! `app_state::init::init_mcp_manager`'s background MCP bootstrap) — a
+//! service that is "supposed to run" (declared, enabled, plugin installed)
+//! but has no live runtime (the previous `bamboo serve` process died) is
+//! started fresh. See `app_state::builder`'s `boot_reconcile_services`.
+
+mod lifecycle;
+#[cfg(test)]
+mod tests;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use serde::Serialize;
+use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
+
+use bamboo_domain::mcp_config::ReconnectConfig;
+use bamboo_plugin::manifest::{GracefulShutdown, HealthCheckSpec};
+
+/// Resolved, ready-to-spawn configuration for one service — the output of
+/// `ServiceManifestEntry::resolve` plus the owning plugin id and the
+/// per-service user config path (see the module docs on
+/// `BAMBOO_PLUGIN_SERVICE_CONFIG`). Built by
+/// `plugin_installer::ServerPluginInstaller` (the only place with both
+/// `AppState::app_data_dir` and a validated manifest).
+#[derive(Debug, Clone)]
+pub struct ServiceRuntimeConfig {
+    pub id: String,
+    pub plugin_id: String,
+    pub name: Option<String>,
+    pub command: PathBuf,
+    pub args: Vec<String>,
+    pub cwd: Option<PathBuf>,
+    pub env: HashMap<String, String>,
+    pub health_check: HealthCheckSpec,
+    pub restart_policy: ReconnectConfig,
+    pub graceful_shutdown: GracefulShutdown,
+    /// `<data_dir>/plugins/<plugin_id>/config.json`, passed to the child as
+    /// `BAMBOO_PLUGIN_SERVICE_CONFIG`. bamboo only ever creates the PARENT
+    /// directory (`plugin_installer::ServerPluginInstaller::resolve_service_config`)
+    /// — it never writes or deletes this file itself, so a user/service's own
+    /// config there survives an upgrade OR uninstall of the plugin bundle
+    /// (bundles are plaintext; connectors carry tokens that must not be
+    /// silently deleted when the bundle is — see issue #479 open question 2).
+    pub user_config_path: PathBuf,
+}
+
+/// Lifecycle state of one supervised service.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceState {
+    Starting,
+    Running,
+    Degraded,
+    Crashed,
+    Restarting,
+    Stopping,
+    Stopped,
+}
+
+/// Point-in-time status of one service — what the plugin-list HTTP surface
+/// (`InstalledPluginView::service_status`) and `bamboo plugin` status
+/// commands read.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServiceStatusSnapshot {
+    pub id: String,
+    pub plugin_id: String,
+    pub state: ServiceState,
+    pub pid: Option<u32>,
+    pub restart_count: u32,
+    pub last_error: Option<String>,
+}
+
+/// Errors [`ServiceManager`]'s public API can return. Deliberately tiny
+/// (unlike `bamboo_mcp::error::McpError`) — there is no protocol layer here
+/// to report errors from.
+#[derive(Debug, thiserror::Error)]
+pub enum ServiceManagerError {
+    #[error("service '{0}' is already running")]
+    AlreadyRunning(String),
+    #[error("service '{0}' is not running")]
+    NotRunning(String),
+}
+
+/// Per-service runtime state, shared between the public [`ServiceManager`]
+/// API and the supervisor task in [`lifecycle`].
+pub(crate) struct ServiceRuntime {
+    config: ServiceRuntimeConfig,
+    state: RwLock<ServiceState>,
+    /// `0` when no child is currently alive.
+    pid: AtomicU32,
+    /// Lifetime-cumulative count of restart attempts (exposed in status;
+    /// never resets). Distinct from `lifecycle`'s internal
+    /// consecutive-attempt counter, which DOES reset on every successful
+    /// `Running` transition and drives backoff/`max_attempts`.
+    restart_count: AtomicU32,
+    last_error: RwLock<Option<String>>,
+    /// Set by [`ServiceManager::stop_service`] BEFORE cancelling
+    /// `stop_token`. The supervisor consults this (not which `select!`
+    /// branch fired) after every wake to decide "intentional stop, don't
+    /// restart" vs "unexpected exit, `restart_policy` may apply". See the
+    /// module docs.
+    shutdown: AtomicBool,
+    stop_token: CancellationToken,
+    supervisor: RwLock<Option<tokio::task::JoinHandle<()>>>,
+}
+
+/// Owns every supervised service's runtime. Empty/inert until
+/// `start_service` is called — mirrors `McpServerManager`'s
+/// always-constructed-but-lazy lifecycle. Cheap to construct (`DashMap::new`,
+/// no I/O), so `AppState` builds exactly one and shares it via `Arc`.
+#[derive(Default)]
+pub struct ServiceManager {
+    runtimes: DashMap<String, Arc<ServiceRuntime>>,
+}
+
+impl ServiceManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Start supervising `config.id`. Spawns the child (or fails fast and
+    /// enters the restart-backoff loop immediately if the very first spawn
+    /// fails — matching `plugin_installer`'s "best-effort start, ownership
+    /// is still recorded" contract for MCP servers) and returns as soon as
+    /// the supervisor task is scheduled — does NOT wait for the child to
+    /// actually come up (the caller reads [`Self::status`] for that).
+    pub async fn start_service(
+        &self,
+        config: ServiceRuntimeConfig,
+    ) -> Result<(), ServiceManagerError> {
+        let id = config.id.clone();
+        if self.runtimes.contains_key(&id) {
+            return Err(ServiceManagerError::AlreadyRunning(id));
+        }
+        let runtime = Arc::new(ServiceRuntime {
+            config,
+            state: RwLock::new(ServiceState::Starting),
+            pid: AtomicU32::new(0),
+            restart_count: AtomicU32::new(0),
+            last_error: RwLock::new(None),
+            shutdown: AtomicBool::new(false),
+            stop_token: CancellationToken::new(),
+            supervisor: RwLock::new(None),
+        });
+        self.runtimes.insert(id, runtime.clone());
+        let handle = tokio::spawn(lifecycle::run_supervisor(runtime.clone()));
+        *runtime.supervisor.write().await = Some(handle);
+        Ok(())
+    }
+
+    /// Stop `id`: marks the runtime `shutdown` (so the supervisor never
+    /// restarts it), cancels its stop token (waking it out of any
+    /// health-check wait / backoff sleep / `child.wait()`), performs the
+    /// graceful-signal → timeout → hard-kill sequence (see
+    /// [`bamboo_plugin::manifest::GracefulShutdown`]), and awaits the
+    /// supervisor task's exit before returning. Idempotent-adjacent: a
+    /// second call on an already-removed id returns
+    /// [`ServiceManagerError::NotRunning`] rather than panicking, so callers
+    /// (uninstall/upgrade drop-diff, rollback) can treat it as best-effort
+    /// exactly like `mcp_manager.stop_server`.
+    pub async fn stop_service(&self, id: &str) -> Result<(), ServiceManagerError> {
+        let Some((_, runtime)) = self.runtimes.remove(id) else {
+            return Err(ServiceManagerError::NotRunning(id.to_string()));
+        };
+        runtime.shutdown.store(true, Ordering::SeqCst);
+        runtime.stop_token.cancel();
+        let handle = runtime.supervisor.write().await.take();
+        if let Some(handle) = handle {
+            let _ = handle.await;
+        }
+        Ok(())
+    }
+
+    pub fn is_running(&self, id: &str) -> bool {
+        self.runtimes.contains_key(id)
+    }
+
+    pub async fn status(&self, id: &str) -> Option<ServiceStatusSnapshot> {
+        let runtime = self.runtimes.get(id)?.clone();
+        Some(lifecycle::snapshot(&runtime).await)
+    }
+
+    /// Snapshot of every currently-supervised service (regardless of which
+    /// plugin owns it) — the raw material `handlers::agent::plugin`'s list
+    /// handler groups back by `plugin_id` into
+    /// `InstalledPluginView::service_status`.
+    pub async fn list_status(&self) -> Vec<ServiceStatusSnapshot> {
+        let runtimes: Vec<Arc<ServiceRuntime>> = self
+            .runtimes
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect();
+        let mut out = Vec::with_capacity(runtimes.len());
+        for runtime in &runtimes {
+            out.push(lifecycle::snapshot(runtime).await);
+        }
+        out
+    }
+}

--- a/crates/app/bamboo-server/src/service_manager/tests.rs
+++ b/crates/app/bamboo-server/src/service_manager/tests.rs
@@ -1,0 +1,241 @@
+//! `ServiceManager` unit tests against REAL trivial child processes (`/bin/sh
+//! -c ...`) — fast (sub-second) and mac/linux-safe. Windows-specific
+//! behavior (no SIGTERM shell-out) is exercised indirectly by every test
+//! here still passing on any platform (the graceful-shutdown tests only
+//! assert the child eventually stops, not which signal path was taken);
+//! [`stop_service_escalates_to_hard_kill_when_process_ignores_sigterm`] is
+//! gated `cfg(not(target_os = "windows"))` since it specifically exercises
+//! `trap '' TERM` + SIGTERM shell-out, which has no Windows equivalent here.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use bamboo_domain::mcp_config::ReconnectConfig;
+use bamboo_plugin::manifest::{GracefulShutdown, HealthCheckSpec, ShutdownSignal};
+
+use super::{ServiceManager, ServiceRuntimeConfig, ServiceState};
+
+fn base_config(id: &str, args: Vec<&str>) -> ServiceRuntimeConfig {
+    ServiceRuntimeConfig {
+        id: id.to_string(),
+        plugin_id: format!("{id}-plugin"),
+        name: None,
+        command: PathBuf::from("/bin/sh"),
+        args: args.into_iter().map(str::to_string).collect(),
+        cwd: None,
+        env: Default::default(),
+        health_check: HealthCheckSpec::default(),
+        restart_policy: ReconnectConfig {
+            enabled: false,
+            ..ReconnectConfig::default()
+        },
+        graceful_shutdown: GracefulShutdown::default(),
+        user_config_path: PathBuf::from("/tmp/bamboo-service-manager-tests/does-not-exist.json"),
+    }
+}
+
+/// Poll `f` until it returns `Some`, or panic after `timeout`.
+async fn poll_until<T, F, Fut>(timeout: Duration, mut f: F) -> T
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Option<T>>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Some(value) = f().await {
+            return value;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("condition not met within {timeout:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test]
+async fn start_service_spawns_process_and_reports_running_with_pid() {
+    let manager = ServiceManager::new();
+    let config = base_config("sleeper", vec!["-c", "sleep 5"]);
+    manager.start_service(config).await.expect("start");
+
+    let status = poll_until(Duration::from_secs(2), || async {
+        let status = manager.status("sleeper").await?;
+        (status.state == ServiceState::Running).then_some(status)
+    })
+    .await;
+    assert!(status.pid.is_some(), "a running service must report a pid");
+    assert_eq!(status.restart_count, 0);
+
+    manager.stop_service("sleeper").await.expect("stop");
+    assert!(!manager.is_running("sleeper"));
+    assert!(manager.status("sleeper").await.is_none());
+}
+
+#[tokio::test]
+async fn starting_an_already_running_service_id_is_rejected() {
+    let manager = ServiceManager::new();
+    manager
+        .start_service(base_config("dup", vec!["-c", "sleep 5"]))
+        .await
+        .expect("first start");
+
+    let error = manager
+        .start_service(base_config("dup", vec!["-c", "sleep 5"]))
+        .await
+        .expect_err("duplicate id must be rejected");
+    assert!(matches!(
+        error,
+        super::ServiceManagerError::AlreadyRunning(_)
+    ));
+
+    manager.stop_service("dup").await.expect("cleanup stop");
+}
+
+#[tokio::test]
+async fn stop_service_on_a_process_alive_service_is_graceful_and_fast() {
+    let manager = ServiceManager::new();
+    manager
+        .start_service(base_config("graceful", vec!["-c", "sleep 30"]))
+        .await
+        .expect("start");
+    poll_until(Duration::from_secs(2), || async {
+        let status = manager.status("graceful").await?;
+        (status.state == ServiceState::Running).then_some(())
+    })
+    .await;
+
+    let started = tokio::time::Instant::now();
+    manager.stop_service("graceful").await.expect("stop");
+    // `sleep` terminates immediately on SIGTERM (its default disposition),
+    // so a graceful stop must complete WAY under the 5s default
+    // `graceful_shutdown.timeout_ms` — proves the SIGTERM path (not just the
+    // hard-kill-after-timeout fallback) actually ran.
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "graceful stop of a SIGTERM-responsive process took {:?}, expected well under 2s",
+        started.elapsed()
+    );
+    assert!(!manager.is_running("graceful"));
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tokio::test]
+async fn stop_service_escalates_to_hard_kill_when_process_ignores_sigterm() {
+    let manager = ServiceManager::new();
+    let mut config = base_config("stubborn", vec!["-c", "trap '' TERM; sleep 30"]);
+    config.graceful_shutdown = GracefulShutdown {
+        signal: ShutdownSignal::Term,
+        timeout_ms: 300,
+    };
+    manager.start_service(config).await.expect("start");
+    poll_until(Duration::from_secs(2), || async {
+        let status = manager.status("stubborn").await?;
+        (status.state == ServiceState::Running).then_some(())
+    })
+    .await;
+
+    let started = tokio::time::Instant::now();
+    manager.stop_service("stubborn").await.expect("stop");
+    let elapsed = started.elapsed();
+    // Must have waited out (roughly) the grace period before the hard kill,
+    // but still completed promptly rather than hanging forever.
+    assert!(
+        elapsed >= Duration::from_millis(250) && elapsed < Duration::from_secs(5),
+        "expected the grace period then a hard kill, got {elapsed:?}"
+    );
+    assert!(!manager.is_running("stubborn"));
+}
+
+#[tokio::test]
+async fn crash_triggers_restart_with_backoff_and_can_still_be_stopped() {
+    let manager = ServiceManager::new();
+    let mut config = base_config("crasher", vec!["-c", "exit 1"]);
+    config.restart_policy = ReconnectConfig {
+        enabled: true,
+        initial_backoff_ms: 20,
+        max_backoff_ms: 50,
+        max_attempts: 0, // unlimited — the test stops it explicitly
+    };
+    manager.start_service(config).await.expect("start");
+
+    // A process that spawns fine but exits immediately must eventually be
+    // observed restarting (restart_count > 0) rather than just settling
+    // into Crashed forever.
+    poll_until(Duration::from_secs(3), || async {
+        let status = manager.status("crasher").await?;
+        (status.restart_count > 0).then_some(())
+    })
+    .await;
+
+    // Must still be stoppable (and promptly) while it's crash-looping,
+    // whether it's caught mid-run or mid-backoff-sleep — this is the
+    // `shutdown` AtomicBool / stop_token cancellation contract.
+    let started = tokio::time::Instant::now();
+    manager.stop_service("crasher").await.expect("stop");
+    assert!(started.elapsed() < Duration::from_secs(2));
+    assert!(!manager.is_running("crasher"));
+}
+
+#[tokio::test]
+async fn unspawnable_command_respects_max_attempts_and_settles_stopped() {
+    let manager = ServiceManager::new();
+    let mut config = base_config("ghost", vec![]);
+    config.command = PathBuf::from("/nonexistent/bamboo-service-manager-test-binary");
+    config.restart_policy = ReconnectConfig {
+        enabled: true,
+        initial_backoff_ms: 10,
+        max_backoff_ms: 20,
+        max_attempts: 2,
+    };
+    manager.start_service(config).await.expect("start");
+
+    let status = poll_until(Duration::from_secs(3), || async {
+        let status = manager.status("ghost").await?;
+        (status.state == ServiceState::Stopped).then_some(status)
+    })
+    .await;
+    assert_eq!(
+        status.restart_count, 2,
+        "a command that never spawns must stop after exactly max_attempts restarts, not loop forever"
+    );
+    assert!(status.last_error.is_some());
+    // Settled on its own (no explicit stop_service call) — still present in
+    // the manager (only `stop_service` removes the entry), just Stopped.
+    assert!(manager.is_running("ghost"));
+}
+
+#[tokio::test]
+async fn intentional_stop_during_backoff_sleep_does_not_restart() {
+    let manager = ServiceManager::new();
+    let mut config = base_config("loopy", vec![]);
+    config.command = PathBuf::from("/nonexistent/bamboo-service-manager-test-binary-2");
+    config.restart_policy = ReconnectConfig {
+        enabled: true,
+        initial_backoff_ms: 5_000, // long enough that the test reliably lands mid-sleep
+        max_backoff_ms: 5_000,
+        max_attempts: 0,
+    };
+    manager.start_service(config).await.expect("start");
+
+    // Give the supervisor a moment to hit its first crash and enter the
+    // (5s) backoff sleep, then stop it — this must cancel the sleep rather
+    // than block until it elapses.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let started = tokio::time::Instant::now();
+    manager.stop_service("loopy").await.expect("stop");
+    assert!(
+        started.elapsed() < Duration::from_secs(1),
+        "stop_service must interrupt an in-progress backoff sleep, took {:?}",
+        started.elapsed()
+    );
+    assert!(!manager.is_running("loopy"));
+}
+
+#[tokio::test]
+async fn process_alive_health_check_is_the_default() {
+    let spec = HealthCheckSpec::default();
+    assert_eq!(
+        spec.kind,
+        bamboo_plugin::manifest::HealthCheckKind::ProcessAlive
+    );
+}

--- a/crates/infra/bamboo-plugin/src/lib.rs
+++ b/crates/infra/bamboo-plugin/src/lib.rs
@@ -43,8 +43,9 @@ pub use installer::{
     LocalPluginInstaller, PluginInstaller,
 };
 pub use manifest::{
-    McpServerManifestEntry, McpTransportManifest, Platform, PluginArtifact, PluginManifest,
-    PluginPromptPreset, PluginProvides,
+    platform_bin_path, GracefulShutdown, HealthCheckKind, HealthCheckSpec, McpServerManifestEntry,
+    McpTransportManifest, Platform, PluginArtifact, PluginManifest, PluginPromptPreset,
+    PluginProvides, ResolvedServiceEntry, ServiceManifestEntry, ShutdownSignal, PLATFORM_BIN_TOKEN,
 };
 pub use registry::{
     classify_ownership, reconcile_exclusive, ExclusiveReconciliation, InstalledPlugin,

--- a/crates/infra/bamboo-plugin/src/manifest.rs
+++ b/crates/infra/bamboo-plugin/src/manifest.rs
@@ -277,6 +277,197 @@ pub fn platform_bin_path(plugin_dir: &Path, plugin_id: &str, platform: Platform)
         .join(filename)
 }
 
+/// Literal token a [`ServiceManifestEntry::command`] must equal EXACTLY (no
+/// PATH resolution, no ambient binaries — see [`ServiceManifestEntry`]'s
+/// docs and `PluginManifest::validate`). Also used by
+/// [`PluginManifest::uses_platform_bin_token`].
+pub const PLATFORM_BIN_TOKEN: &str = "${platform_bin}";
+
+/// How [`ServiceManager`](../../bamboo_server/service_manager/index.html)
+/// (bamboo-server) should poll a running service for liveness. `ProcessAlive`
+/// is the v1 default (no `target`); `Tcp`/`Http` additionally require a
+/// `target` (validated in [`PluginManifest::validate`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HealthCheckKind {
+    ProcessAlive,
+    Tcp,
+    Http,
+}
+
+fn default_health_interval_ms() -> u64 {
+    15_000
+}
+
+fn default_health_timeout_ms() -> u64 {
+    5_000
+}
+
+/// Health-check policy for a [`ServiceManifestEntry`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthCheckSpec {
+    pub kind: HealthCheckKind,
+    /// Required (non-empty) for `Tcp` (`host:port`) / `Http` (a URL);
+    /// unused for `ProcessAlive`. Validated in [`PluginManifest::validate`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(default = "default_health_interval_ms")]
+    pub interval_ms: u64,
+    #[serde(default = "default_health_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+impl Default for HealthCheckSpec {
+    fn default() -> Self {
+        Self {
+            kind: HealthCheckKind::ProcessAlive,
+            target: None,
+            interval_ms: default_health_interval_ms(),
+            timeout_ms: default_health_timeout_ms(),
+        }
+    }
+}
+
+/// Signal a service's graceful shutdown sends before escalating to a hard
+/// kill. `Term` (SIGTERM on unix; a best-effort equivalent request on
+/// Windows before `TerminateProcess`) is the default; `None` skips the
+/// graceful signal entirely and kills immediately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShutdownSignal {
+    #[default]
+    Term,
+    None,
+}
+
+fn default_shutdown_timeout_ms() -> u64 {
+    5_000
+}
+
+/// Graceful-shutdown policy for a [`ServiceManifestEntry`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GracefulShutdown {
+    #[serde(default)]
+    pub signal: ShutdownSignal,
+    /// How long to wait after `signal` before escalating to SIGKILL /
+    /// `TerminateProcess`.
+    #[serde(default = "default_shutdown_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+impl Default for GracefulShutdown {
+    fn default() -> Self {
+        Self {
+            signal: ShutdownSignal::default(),
+            timeout_ms: default_shutdown_timeout_ms(),
+        }
+    }
+}
+
+/// A long-running service this plugin wants supervised (issue #479, prereq
+/// for epic #477 — standalone connectors distributed as plugins). The
+/// highest-trust artifact kind a plugin can declare: unlike an MCP stdio
+/// server (whose `command` is free-form — see [`McpServerManifestEntry`]), a
+/// service's `command` MUST be exactly [`PLATFORM_BIN_TOKEN`] — no PATH
+/// resolution, no ambient binaries. It may only ever execute the plugin's
+/// own verified, sha256-pinned per-platform binary (see
+/// [`PluginArtifact`]'s archive contract) resolved via
+/// [`platform_bin_path`].
+///
+/// `args`/`cwd`/`env` (values only) accept the same `${plugin_dir}`/
+/// `${platform_bin}` substitution as MCP stdio entries — see
+/// [`substitute_tokens`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceManifestEntry {
+    /// Service id — becomes the key bamboo-server's `ServiceManager` and
+    /// provenance (`RegisteredCapabilities::service_ids`) key off.
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// MUST validate as exactly [`PLATFORM_BIN_TOKEN`] — see the type docs.
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// May contain `${plugin_dir}` / `${platform_bin}`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    /// Values (not keys) may contain `${plugin_dir}` / `${platform_bin}`.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    #[serde(default)]
+    pub health_check: HealthCheckSpec,
+    /// Reuses [`bamboo_domain::mcp_config::ReconnectConfig`]'s shape
+    /// (enabled/initial_backoff_ms/max_backoff_ms/max_attempts) per the
+    /// issue's design.
+    #[serde(default)]
+    pub restart_policy: bamboo_domain::mcp_config::ReconnectConfig,
+    #[serde(default)]
+    pub graceful_shutdown: GracefulShutdown,
+}
+
+/// A [`ServiceManifestEntry`] with all `${...}` tokens substituted and
+/// `command` resolved to the concrete per-platform binary path — pure, ready
+/// for bamboo-server's `ServiceManager` to spawn. Analogous to
+/// [`McpServerManifestEntry::resolve`]'s `McpServerConfig` output.
+#[derive(Debug, Clone)]
+pub struct ResolvedServiceEntry {
+    pub id: String,
+    pub name: Option<String>,
+    pub enabled: bool,
+    pub command: PathBuf,
+    pub args: Vec<String>,
+    pub cwd: Option<PathBuf>,
+    pub env: HashMap<String, String>,
+    pub health_check: HealthCheckSpec,
+    pub restart_policy: bamboo_domain::mcp_config::ReconnectConfig,
+    pub graceful_shutdown: GracefulShutdown,
+}
+
+impl ServiceManifestEntry {
+    /// Resolve this manifest entry against a concrete `plugin_dir`/platform.
+    /// Pure — does not touch disk, does not spawn anything. `command` is
+    /// always [`platform_bin_path`] (never `substitute_tokens`'d from
+    /// `self.command`) — validation already pins `self.command` to exactly
+    /// [`PLATFORM_BIN_TOKEN`], and `platform_bin_path` IS that token's
+    /// resolution.
+    pub fn resolve(
+        &self,
+        plugin_dir: &Path,
+        plugin_id: &str,
+        platform: Platform,
+    ) -> ResolvedServiceEntry {
+        ResolvedServiceEntry {
+            id: self.id.clone(),
+            name: self.name.clone(),
+            enabled: self.enabled,
+            command: platform_bin_path(plugin_dir, plugin_id, platform),
+            args: self
+                .args
+                .iter()
+                .map(|value| substitute_tokens(value, plugin_dir, plugin_id, platform))
+                .collect(),
+            cwd: self.cwd.as_deref().map(|value| {
+                PathBuf::from(substitute_tokens(value, plugin_dir, plugin_id, platform))
+            }),
+            env: self
+                .env
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        key.clone(),
+                        substitute_tokens(value, plugin_dir, plugin_id, platform),
+                    )
+                })
+                .collect(),
+            health_check: self.health_check.clone(),
+            restart_policy: self.restart_policy.clone(),
+            graceful_shutdown: self.graceful_shutdown.clone(),
+        }
+    }
+}
+
 /// Inline prompt preset, mirroring bamboo-server's
 /// `StoredPromptPreset { id, name, description?, content }` (see
 /// `crates/app/bamboo-server/src/handlers/agent/prompt_presets/types.rs`).
@@ -339,6 +530,10 @@ pub struct PluginProvides {
     /// (workflows have no discovery-dir mechanism, unlike skills).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub workflows: Vec<String>,
+    /// Long-running services this plugin wants supervised — see
+    /// [`ServiceManifestEntry`]. Issue #479 (prereq for epic #477).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub services: Vec<ServiceManifestEntry>,
 }
 
 impl PluginProvides {
@@ -347,6 +542,7 @@ impl PluginProvides {
             && self.skills.is_empty()
             && self.prompts.is_empty()
             && self.workflows.is_empty()
+            && self.services.is_empty()
     }
 }
 
@@ -515,6 +711,56 @@ impl PluginManifest {
             }
         }
 
+        let mut seen_service_ids = std::collections::HashSet::new();
+        for entry in &self.provides.services {
+            if entry.id.trim().is_empty() {
+                return Err(PluginError::InvalidManifest(
+                    "service entries must have a non-empty id".to_string(),
+                ));
+            }
+            if !seen_service_ids.insert(entry.id.clone()) {
+                return Err(PluginError::InvalidManifest(format!(
+                    "duplicate service id '{}' in provides.services",
+                    entry.id
+                )));
+            }
+            if entry.command.trim().is_empty() {
+                return Err(PluginError::InvalidManifest(format!(
+                    "service '{}' has an empty command",
+                    entry.id
+                )));
+            }
+            // Services are the highest-trust artifact kind: no PATH
+            // resolution, no ambient binaries. `command` must be EXACTLY the
+            // substitution token, never a literal path or shell command —
+            // stricter than MCP's free-form stdio `command`.
+            if entry.command != PLATFORM_BIN_TOKEN {
+                return Err(PluginError::InvalidManifest(format!(
+                    "service '{}' command must be exactly '{PLATFORM_BIN_TOKEN}' — services may \
+                     only execute the plugin's own verified per-platform binary, never an \
+                     arbitrary command",
+                    entry.id
+                )));
+            }
+            match entry.health_check.kind {
+                HealthCheckKind::Tcp | HealthCheckKind::Http => {
+                    let target_ok = entry
+                        .health_check
+                        .target
+                        .as_deref()
+                        .map(|value| !value.trim().is_empty())
+                        .unwrap_or(false);
+                    if !target_ok {
+                        return Err(PluginError::InvalidManifest(format!(
+                            "service '{}' health_check.kind={:?} requires a non-empty target",
+                            entry.id, entry.health_check.kind
+                        )));
+                    }
+                }
+                HealthCheckKind::ProcessAlive => {}
+            }
+        }
+
         for skill_dir in &self.provides.skills {
             if !is_safe_relative_name(skill_dir) {
                 return Err(PluginError::InvalidManifest(format!(
@@ -640,8 +886,8 @@ impl PluginManifest {
     /// whether this plugin needs a per-platform binary to run. Drives the
     /// artifacts/platform cross-check in [`Self::validate`].
     pub fn uses_platform_bin_token(&self) -> bool {
-        const TOKEN: &str = "${platform_bin}";
-        self.provides.mcp_servers.iter().any(|entry| {
+        const TOKEN: &str = PLATFORM_BIN_TOKEN;
+        let mcp_uses = self.provides.mcp_servers.iter().any(|entry| {
             let McpTransportManifest::Stdio {
                 command,
                 args,
@@ -655,7 +901,22 @@ impl PluginManifest {
                 || args.iter().any(|value| value.contains(TOKEN))
                 || cwd.as_deref().is_some_and(|value| value.contains(TOKEN))
                 || env.values().any(|value| value.contains(TOKEN))
-        })
+        });
+        // Services validate to command == PLATFORM_BIN_TOKEN exactly, but
+        // this helper must stay correct even against a not-yet-validated
+        // manifest (it feeds the artifacts/platform cross-check inside
+        // `validate()` itself), so check `.contains` the same way MCP does
+        // rather than assuming validity.
+        let service_uses = self.provides.services.iter().any(|entry| {
+            entry.command.contains(TOKEN)
+                || entry.args.iter().any(|value| value.contains(TOKEN))
+                || entry
+                    .cwd
+                    .as_deref()
+                    .is_some_and(|value| value.contains(TOKEN))
+                || entry.env.values().any(|value| value.contains(TOKEN))
+        });
+        mcp_uses || service_uses
     }
 }
 
@@ -973,6 +1234,175 @@ mod tests {
         assert!(!is_plausible_semver("latest"));
         assert!(!is_plausible_semver(""));
         assert!(!is_plausible_semver("v1.2.3"));
+    }
+
+    fn service_manifest_json(id: &str, command: &str) -> String {
+        serde_json::json!({
+            "id": "svc-plugin",
+            "name": "Svc Plugin",
+            "version": "1.0.0",
+            "provides": {
+                "services": [
+                    {"id": id, "command": command}
+                ]
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn parses_and_validates_minimal_service_entry() {
+        let json = service_manifest_json("svc", PLATFORM_BIN_TOKEN);
+        let manifest = PluginManifest::parse_str(&json).unwrap();
+        manifest.validate().expect("minimal service entry is valid");
+        let entry = &manifest.provides.services[0];
+        assert!(entry.enabled);
+        assert_eq!(entry.health_check.kind, HealthCheckKind::ProcessAlive);
+        assert_eq!(entry.graceful_shutdown.signal, ShutdownSignal::Term);
+        assert!(manifest.uses_platform_bin_token());
+    }
+
+    #[test]
+    fn rejects_service_command_that_is_not_exactly_the_platform_bin_token() {
+        for bad_command in ["/usr/bin/env", "nova", "${platform_bin} --serve", ""] {
+            let json = service_manifest_json("svc", bad_command);
+            let manifest = PluginManifest::parse_str(&json).unwrap();
+            let error = manifest
+                .validate()
+                .expect_err("non-token service command must be rejected");
+            assert!(matches!(error, PluginError::InvalidManifest(_)));
+        }
+    }
+
+    #[test]
+    fn rejects_duplicate_service_ids() {
+        let json = serde_json::json!({
+            "id": "svc-plugin",
+            "name": "Svc",
+            "version": "1.0.0",
+            "provides": {
+                "services": [
+                    {"id": "a", "command": PLATFORM_BIN_TOKEN},
+                    {"id": "a", "command": PLATFORM_BIN_TOKEN}
+                ]
+            }
+        })
+        .to_string();
+        let manifest = PluginManifest::parse_str(&json).unwrap();
+        let error = manifest
+            .validate()
+            .expect_err("duplicate service id should fail");
+        assert!(error.to_string().contains("duplicate service id"));
+    }
+
+    #[test]
+    fn rejects_tcp_and_http_health_check_missing_target() {
+        for kind in ["tcp", "http"] {
+            let json = serde_json::json!({
+                "id": "svc-plugin",
+                "name": "Svc",
+                "version": "1.0.0",
+                "provides": {
+                    "services": [
+                        {"id": "a", "command": PLATFORM_BIN_TOKEN, "health_check": {"kind": kind}}
+                    ]
+                }
+            })
+            .to_string();
+            let manifest = PluginManifest::parse_str(&json).unwrap();
+            let error = manifest
+                .validate()
+                .expect_err("tcp/http health_check without a target should fail");
+            assert!(error.to_string().contains("target"));
+        }
+    }
+
+    #[test]
+    fn accepts_tcp_health_check_with_target() {
+        let json = serde_json::json!({
+            "id": "svc-plugin",
+            "name": "Svc",
+            "version": "1.0.0",
+            "provides": {
+                "services": [
+                    {"id": "a", "command": PLATFORM_BIN_TOKEN, "health_check": {"kind": "tcp", "target": "127.0.0.1:9000"}}
+                ]
+            }
+        })
+        .to_string();
+        let manifest = PluginManifest::parse_str(&json).unwrap();
+        manifest
+            .validate()
+            .expect("tcp health_check with target is valid");
+    }
+
+    #[test]
+    fn services_missing_artifact_for_a_supported_platform_is_rejected() {
+        // Mirrors `rejects_platform_bin_plugin_missing_an_artifact_for_a_supported_platform`
+        // but via `provides.services` instead of `provides.mcp_servers` — the
+        // artifacts/platform cross-check must cover services too (issue #479).
+        let json = serde_json::json!({
+            "id": "svc-plugin",
+            "name": "Svc",
+            "version": "1.0.0",
+            "provides": {
+                "services": [
+                    {"id": "a", "command": PLATFORM_BIN_TOKEN}
+                ]
+            },
+            "artifacts": {
+                "macos": {"url": "https://example.com/x-macos.tar.gz", "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                "windows": {"url": "https://example.com/x-windows.zip", "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+            }
+        })
+        .to_string();
+        let manifest = PluginManifest::parse_str(&json).unwrap();
+        let error = manifest
+            .validate()
+            .expect_err("missing linux artifact for a service-only plugin should fail");
+        assert!(error.to_string().contains("linux"));
+    }
+
+    #[test]
+    fn resolve_service_entry_substitutes_tokens_and_pins_command_to_platform_bin() {
+        let json = serde_json::json!({
+            "id": "svc-plugin",
+            "name": "Svc",
+            "version": "1.0.0",
+            "provides": {
+                "services": [
+                    {
+                        "id": "a",
+                        "command": PLATFORM_BIN_TOKEN,
+                        "args": ["--config", "${plugin_dir}/data"],
+                        "cwd": "${plugin_dir}",
+                        "env": {"HOME_DIR": "${plugin_dir}/home"}
+                    }
+                ]
+            }
+        })
+        .to_string();
+        let manifest = PluginManifest::parse_str(&json).unwrap();
+        manifest.validate().expect("valid");
+        let entry = &manifest.provides.services[0];
+        let plugin_dir = Path::new("/home/user/.bamboo/plugins/svc-plugin");
+        let resolved = entry.resolve(plugin_dir, &manifest.id, Platform::Linux);
+        assert_eq!(
+            resolved.command,
+            PathBuf::from("/home/user/.bamboo/plugins/svc-plugin/bin/linux/svc-plugin")
+        );
+        assert_eq!(
+            resolved.args,
+            vec![
+                "--config".to_string(),
+                "/home/user/.bamboo/plugins/svc-plugin/data".to_string()
+            ]
+        );
+        assert_eq!(resolved.cwd, Some(plugin_dir.to_path_buf()));
+        assert_eq!(
+            resolved.env.get("HOME_DIR").map(String::as_str),
+            Some("/home/user/.bamboo/plugins/svc-plugin/home")
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-plugin/src/registry.rs
+++ b/crates/infra/bamboo-plugin/src/registry.rs
@@ -133,6 +133,11 @@ pub struct RegisteredCapabilities {
     /// Filenames copied into `bamboo_config::paths::workflows_dir()`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub workflow_filenames: Vec<String>,
+    /// Ids started via bamboo-server's `ServiceManager` (issue #479, prereq
+    /// for epic #477). `#[serde(default)]` so an `installed.json` written
+    /// before services existed loads with an empty set.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub service_ids: Vec<String>,
 }
 
 impl RegisteredCapabilities {
@@ -141,6 +146,7 @@ impl RegisteredCapabilities {
             && self.skill_dirs.is_empty()
             && self.preset_ids.is_empty()
             && self.workflow_filenames.is_empty()
+            && self.service_ids.is_empty()
     }
 
     /// The capabilities present in `old` (a prior install's registered set)
@@ -159,6 +165,7 @@ impl RegisteredCapabilities {
             skill_dirs: subtract(&old.skill_dirs, &self.skill_dirs),
             preset_ids: subtract(&old.preset_ids, &self.preset_ids),
             workflow_filenames: subtract(&old.workflow_filenames, &self.workflow_filenames),
+            service_ids: subtract(&old.service_ids, &self.service_ids),
         }
     }
 }
@@ -393,6 +400,7 @@ mod tests {
                 skill_dirs: vec!["hello-world".to_string()],
                 preset_ids: vec!["hello_preset".to_string()],
                 workflow_filenames: vec![],
+                service_ids: vec![],
             },
         }
     }
@@ -543,13 +551,15 @@ mod tests {
             skill_dirs: vec!["skill-a".to_string()],
             preset_ids: vec!["preset-a".to_string(), "preset-b".to_string()],
             workflow_filenames: vec!["wf-a.md".to_string()],
+            service_ids: vec!["svc-a".to_string(), "svc-b".to_string()],
         };
-        // New version drops srv-b and preset-a, keeps the rest, adds srv-c.
+        // New version drops srv-b, preset-a, and svc-b; keeps the rest; adds srv-c.
         let new = RegisteredCapabilities {
             mcp_server_ids: vec!["srv-a".to_string(), "srv-c".to_string()],
             skill_dirs: vec!["skill-a".to_string()],
             preset_ids: vec!["preset-b".to_string()],
             workflow_filenames: vec!["wf-a.md".to_string()],
+            service_ids: vec!["svc-a".to_string()],
         };
 
         let removed = new.removed_since(&old);
@@ -557,6 +567,21 @@ mod tests {
         assert!(removed.skill_dirs.is_empty());
         assert_eq!(removed.preset_ids, vec!["preset-a".to_string()]);
         assert!(removed.workflow_filenames.is_empty());
+        assert_eq!(removed.service_ids, vec!["svc-b".to_string()]);
+    }
+
+    #[test]
+    fn reconcile_exclusive_covers_service_ids_same_as_other_kinds() {
+        // `reconcile_exclusive` is capability-kind-agnostic (plain `Vec<String>`
+        // in/out), but exercise it explicitly against service ids since
+        // that's a new call site (issue #479's install step).
+        let declared = vec!["svc-a".to_string(), "svc-b".to_string()];
+        let existing = vec!["svc-b".to_string(), "other-plugins-svc".to_string()];
+        let owned_previously: Vec<String> = vec![];
+
+        let reconciliation = reconcile_exclusive(&declared, &existing, &owned_previously);
+        assert_eq!(reconciliation.to_register, vec!["svc-a".to_string()]);
+        assert_eq!(reconciliation.foreign_conflicts, vec!["svc-b".to_string()]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #479 (plugin track of epic #477 — the standalone connector will ship as a plugin carrying a resident service binary).

## What
**Manifest** (`bamboo-plugin`): `PluginProvides.services` — the 5th capability kind. Entries: id/name/enabled, command/args/cwd/env (`${plugin_dir}`/`${platform_bin}` substitution), `health_check` (`process_alive` default | tcp | http), `restart_policy` (mirrors `ReconnectConfig`), `graceful_shutdown{signal, timeout_ms}`. Binaries ride the existing per-platform `artifacts` map + unconditional sha256 + 0o755.

**`ServiceManager`** (bamboo-server, new): supervised spawn → health task → crash restart with backoff; `Starting/Running/Degraded/Crashed/Restarting/Stopping/Stopped`; intentional stops (uninstall/upgrade) never trigger the restart policy; stop = SIGTERM → grace timeout → SIGKILL (Windows: grace then hard kill).

**Installer**: `register_services` step following the `register_mcp` pattern (reconcile_exclusive REFUSE-on-conflict, `InstallRollback.service_ids_started`, drop-diff dereg on upgrade, `previously_owned_services`); **same-id upgrade stops the old service BEFORE the binary swap** (`stop_services_for_upgrade` around `stage_plugin_source`, restart-after-failed-upgrade re-reads the rollback-restored manifest); boot-time reconcile restarts services recorded in installed.json.

**Status surface**: `InstalledPluginView.service_status` (state/pid/restart_count/last_error).

## Security invariants
- `command` MUST be exactly `${platform_bin}` — validated, no PATH/ambient-binary execution (stricter than MCP's free-form command)
- `env_clear()` + minimal allowlist before declared env — a service never inherits bamboo-server's environment (MCP children DO inherit it today; deliberately not retrofitted here)
- bundles declaring `services` REFUSE `allow_unsigned`/insecure URL installs (local dir/archive carry no trust flags — refusal applies where flags exist)
- per-service user config lives OUTSIDE the swap-managed plugin dir: `<data_dir>/plugin_service_config/<plugin_id>/config.json` via `BAMBOO_PLUGIN_SERVICE_CONFIG` (the issue's suggested path was accidentally inside the swap tree — corrected)
- `kill_on_drop` as crash safety-net; real stops go through the graceful path

## Bug found while testing
`install()`'s crash-safety journal pre-writes the plugin's own intended `service_ids` into installed.json before `register_services` runs — the ownership reconcile must exclude the installing plugin's own id (MCP doesn't hit this: it reconciles against config.json, untouched by the journal write).

## Tests
29 new: manifest validation (8, incl. command≠platform_bin rejection), registry reconcile (2), ServiceManager real-process tests against /bin/sh (8: graceful SIGTERM / hard-kill escalation / crash+backoff / max_attempts / intentional-stop-cancels-backoff), installer service steps (7, real ServiceManager with unspawnable bin — the MCP NONEXISTENT_COMMAND trick), insecure-refusal (3), status surface (1). bamboo-server 1297 + bamboo-plugin 44 green; `cargo build --workspace --tests` clean; zero new deps (Cargo.lock untouched); fmt/clippy clean.

Part of #477.

https://claude.ai/code/session_014UqJMdHmyooYbK6eDxdAVV