### PR TITLE
feat(plugin-trust): trust magpie's official signing key by default

### DIFF
--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -779,15 +779,27 @@ pub struct TrustedKey {
     pub public_key: String,
 }
 
-/// Nova's official plugin-signing key, trusted by default so an out-of-the-box
-/// `bamboo plugin install <official nova release url>` needs no
-/// `--allow-unsigned` once nova's release CI signs the bundle.
+/// The official plugin-signing keys trusted by default, so an out-of-the-box
+/// `bamboo plugin install <official release url>` needs no `--allow-unsigned`
+/// for a bundle those repos' release CI signed. One entry per first-party
+/// plugin publisher; each repo commits its public half as
+/// `packaging/plugin/signing-key.pub` (nova) / `plugin/signing-key.pub`
+/// (magpie) for cross-checking.
 fn default_trusted_keys() -> Vec<TrustedKey> {
-    vec![TrustedKey {
-        label: "nova (bigduu official)".to_string(),
-        algorithm: "ed25519".to_string(),
-        public_key: "e3c429e1be50098b12c6f45737abf457189b668535875b5b3e2b4349be86ea59".to_string(),
-    }]
+    vec![
+        TrustedKey {
+            label: "nova (bigduu official)".to_string(),
+            algorithm: "ed25519".to_string(),
+            public_key: "e3c429e1be50098b12c6f45737abf457189b668535875b5b3e2b4349be86ea59"
+                .to_string(),
+        },
+        TrustedKey {
+            label: "magpie (bigduu official)".to_string(),
+            algorithm: "ed25519".to_string(),
+            public_key: "47e971c39cd93adb18cff50e097cb387df49e9c4d33b0ed62f693eabbe7fc66e"
+                .to_string(),
+        },
+    ]
 }
 
 /// Default trusted host+path prefix: the `bigduu` GitHub org/user's own repos


### PR DESCRIPTION
Epic #477's signed-release tail: Magpie's release CI now ed25519-signs its plugin bundle (bigduu/Magpie#1, same pinned scheme as nova — raw 64-byte sig over the exact bundle bytes, hex .sig sidecar). This adds magpie's public key to `default_trusted_keys()` beside nova's so an official signed Magpie release installs with no `--allow-unsigned`.

- Key cross-check: `plugin/signing-key.pub` in the Magpie repo commits the same hex (`47e971c3…7fc66e`); the private half exists only as that repo's `MAGPIE_PLUGIN_SIGNING_KEY` Actions secret.
- Function-body-only change (no struct/field changes — no struct-literal sweep exposure); no test asserts on the defaults' count/order.
- `cargo test -p bamboo-config`: 220 passed. rustfmt-clean (targeted check on config.rs, not a whole-file reflow).

https://claude.ai/code/session_014iw5PBsSzDFHus1GfkAK4y