### PR TITLE
fix(connect/feishu): nest card elements under body — schema 2.0 rejects top-level elements

### DIFF
--- a/crates/app/bamboo-server/src/connect/platforms/feishu/mod.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/feishu/mod.rs
@@ -341,7 +341,11 @@ fn build_card(text: &str, buttons: Option<&[Vec<Button>]>) -> serde_json::Value 
     serde_json::json!({
         "schema": "2.0",
         "config": { "update_multi": true },
-        "elements": elements,
+        // Schema 2.0 nests `elements` under `body` — a top-level `elements`
+        // key is the v1 location and the real API rejects the card with
+        // `200621 parse card json err: unknown property "elements"` (caught
+        // in Magpie's 2026-07-15 real-device e2e; same builder, same bug).
+        "body": { "elements": elements },
     })
 }
 
@@ -756,7 +760,7 @@ mod tests {
                 .unwrap();
         assert_eq!(content["schema"], serde_json::json!("2.0"));
         assert_eq!(content["config"]["update_multi"], serde_json::json!(true));
-        let markdown_content = content["elements"][0]["content"].as_str().unwrap();
+        let markdown_content = content["body"]["elements"][0]["content"].as_str().unwrap();
         assert!(
             markdown_content.contains("\\*world\\*"),
             "got: {markdown_content}"
@@ -795,7 +799,7 @@ mod tests {
         let body: serde_json::Value = serde_json::from_slice(&send_request.body).unwrap();
         let content: serde_json::Value =
             serde_json::from_str(body["content"].as_str().unwrap()).unwrap();
-        let action = &content["elements"][1];
+        let action = &content["body"]["elements"][1];
         assert_eq!(action["tag"], serde_json::json!("action"));
         assert_eq!(
             action["actions"][0]["behaviors"][0]["value"]["cb"],
@@ -866,7 +870,7 @@ mod tests {
         let content: serde_json::Value =
             serde_json::from_str(body["content"].as_str().unwrap()).unwrap();
         assert_eq!(
-            content["elements"][0]["content"],
+            content["body"]["elements"][0]["content"],
             serde_json::json!("updated")
         );
     }


### PR DESCRIPTION
Magpie's first real-device Feishu e2e (bigduu/Magpie#3, epic #477 tail) caught this in the PORTED copy of this exact builder — the in-proc original has the identical defect, and during the dual-ship window it still ships with bamboo releases:

    im/v1/messages → code=230099 / ErrCode 200621: parse card json err —
    unknown property: elements, path: []

Schema-2.0 cards nest `elements` under `body`; a top-level `elements` is the v1 location, so **every in-proc feishu card send/edit fails against the real API** (the #476 adapter was never live-tested — this is exactly the gap).

**Fix**: `"body": {"elements": […]}` (send + PATCH edit share the builder). Wiremock assertions updated. `cargo test -p bamboo-server --lib connect::platforms::feishu`: 45 passed. rustfmt-clean.

**Live-verified** via magpie's identical builder against real Feishu: message → agent run → card reply renders.

https://claude.ai/code/session_014iw5PBsSzDFHus1GfkAK4y