### PR TITLE
fix(connect/feishu): schema-2.0 dropped the v1 action container — lay button rows out with column_set

### DIFF
--- a/crates/app/bamboo-server/src/connect/platforms/feishu/mod.rs
+++ b/crates/app/bamboo-server/src/connect/platforms/feishu/mod.rs
@@ -306,9 +306,9 @@ fn escape_feishu_markdown(text: &str) -> String {
 
 /// Builds a schema-2.0 interactive card: `config.update_multi:true`, a
 /// markdown body element (fixed `element_id:"main_text"`, escaped text), and
-/// — when present — one `"action"` element per button row, per
-/// `docs/feishu-adapter-plan.md` §2c outbound decision 2. The exact button
-/// element wrapper (`tag:"action"` with a nested `"actions"` array) is this
+/// — when present — one `column_set` element per button row (one weighted
+/// column per button), per `docs/feishu-adapter-plan.md` §2c outbound
+/// decision 2. The exact button element wrapper is this
 /// adapter's own choice: the plan pins ONLY the `behaviors`/`value.cb`
 /// shape, not the surrounding container, so this is the one place protocol
 /// shape was inferred rather than verified — flagged in the task report.
@@ -321,20 +321,30 @@ fn build_card(text: &str, buttons: Option<&[Vec<Button>]>) -> serde_json::Value 
 
     if let Some(rows) = buttons {
         for row in rows {
-            let actions: Vec<serde_json::Value> = row
+            // Schema 2.0 dropped the v1 `tag:"action"` row container (the
+            // real API rejects it with `200861 unsupported tag action` —
+            // Magpie e2e 2026-07-15, bigduu/Magpie#7): rows are laid out as
+            // a `column_set` with one weighted column per button instead.
+            let columns: Vec<serde_json::Value> = row
                 .iter()
                 .map(|button| {
                     serde_json::json!({
-                        "tag": "button",
-                        "text": { "tag": "plain_text", "content": button.label },
-                        "type": "default",
-                        "behaviors": [
-                            { "type": "callback", "value": { "cb": button.callback_data } }
-                        ],
+                        "tag": "column",
+                        "width": "weighted",
+                        "weight": 1,
+                        "elements": [{
+                            "tag": "button",
+                            "text": { "tag": "plain_text", "content": button.label },
+                            "type": "default",
+                            "width": "fill",
+                            "behaviors": [
+                                { "type": "callback", "value": { "cb": button.callback_data } }
+                            ],
+                        }],
                     })
                 })
                 .collect();
-            elements.push(serde_json::json!({ "tag": "action", "actions": actions }));
+            elements.push(serde_json::json!({ "tag": "column_set", "columns": columns }));
         }
     }
 
@@ -799,10 +809,12 @@ mod tests {
         let body: serde_json::Value = serde_json::from_slice(&send_request.body).unwrap();
         let content: serde_json::Value =
             serde_json::from_str(body["content"].as_str().unwrap()).unwrap();
-        let action = &content["body"]["elements"][1];
-        assert_eq!(action["tag"], serde_json::json!("action"));
+        let row = &content["body"]["elements"][1];
+        assert_eq!(row["tag"], serde_json::json!("column_set"));
+        let button = &row["columns"][0]["elements"][0];
+        assert_eq!(button["tag"], serde_json::json!("button"));
         assert_eq!(
-            action["actions"][0]["behaviors"][0]["value"]["cb"],
+            button["behaviors"][0]["value"]["cb"],
             serde_json::json!("n1:0")
         );
     }


### PR DESCRIPTION
Port of bigduu/Magpie#7, completing the card-2.0 pair started in #484: after the `body` nesting fix, the REAL API still rejects any card with buttons —

    im/v1/messages → 200861: cards of schema V2 no longer support this
    capability — ErrPath ROOT -> body -> elements -> [1](tag: action)

The v1 `tag:"action"` row container no longer exists in schema 2.0. Button rows become a `column_set` (one `weighted` column per button, `width: fill`); the pinned `behaviors`/`value.cb` callback payload is unchanged, so `map_card_action_event` is unaffected.

**Live-verified** via magpie's identical builder against real Feishu: the options-question card renders with working buttons, and the ask card PATCH-edits to ✅ on answer. Without this, every in-proc feishu approval/question card (the phase-2/3 core flows) fails to send during the dual-ship window.

`cargo test -p bamboo-server --lib connect::platforms::feishu`: 45 passed. rustfmt-clean.

https://claude.ai/code/session_014iw5PBsSzDFHus1GfkAK4y