### PR TITLE
fix(broker): graceful shutdown for broker-agent worker

### DIFF
--- a/crates/app/bamboo-broker/src/deploy.rs
+++ b/crates/app/bamboo-broker/src/deploy.rs
@@ -11,9 +11,19 @@
 
 use async_trait::async_trait;
 use std::path::PathBuf;
+use std::time::Duration;
 use tokio::process::Command;
 
 use crate::error::{BrokerError, BrokerResult};
+
+/// Default grace window between SIGTERM and the hard `SIGKILL`/`TerminateProcess`
+/// fallback when stopping a locally-deployed worker: long enough for
+/// `serve_loop`'s drain (finish whatever Ask is in flight, deliver + ack its
+/// reply) to complete under normal load, bounded so a wedged/unresponsive
+/// worker can't hang `action=stop` forever. `shutdown()` uses this; tests use
+/// [`DeployedAgent::shutdown_with_timeout`] with a short one instead of a
+/// real-time wait. #49.
+pub const DEFAULT_GRACEFUL_STOP_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// What to deploy: one broker-agent's identity + how it reaches the broker.
 #[derive(Debug, Clone)]
@@ -128,11 +138,52 @@ impl DeployedAgent {
         }
     }
 
-    /// Stop the deployment: kill the launched process / remote worker, then run
-    /// cleanup if any.
+    /// Stop the deployment: SIGTERM the launched process / remote worker, then
+    /// run cleanup if any. Uses [`DEFAULT_GRACEFUL_STOP_TIMEOUT`] as the grace
+    /// window before falling back to a hard kill; see
+    /// [`Self::shutdown_with_timeout`] for the full behavior.
     pub async fn shutdown(self) {
+        self.shutdown_with_timeout(DEFAULT_GRACEFUL_STOP_TIMEOUT)
+            .await
+    }
+
+    /// Stop the deployment with an explicit grace window: for a local process,
+    /// send SIGTERM and poll for up to `timeout` for it to exit on its own —
+    /// giving a worker built on [`crate::serve::serve_executor_with_shutdown`]
+    /// a chance to drain its in-flight Ask/Task/Run and reply cleanly — before
+    /// falling back to a hard `SIGKILL` (`Child::start_kill`). A worker with no
+    /// signal handler (e.g. an old binary) or one that's genuinely wedged still
+    /// gets killed once `timeout` elapses, so `action=stop` is always bounded.
+    /// Remote deployments delegate to [`RemoteDeployment::shutdown`] unchanged
+    /// (out of scope for #49 — see the issue's evidence, which is specific to
+    /// the local-process `start_kill()` path). #49.
+    pub async fn shutdown_with_timeout(self, timeout: Duration) {
         match self.inner {
             DeployedInner::Process { mut child, cleanup } => {
+                if let Some(pid) = child.id() {
+                    send_sigterm(pid).await;
+                    let deadline = tokio::time::Instant::now() + timeout;
+                    loop {
+                        match child.try_wait() {
+                            // Exited on its own within the grace window — done,
+                            // no need for the SIGKILL fallback below.
+                            Ok(Some(_)) => break,
+                            Ok(None) => {
+                                if tokio::time::Instant::now() >= deadline {
+                                    break;
+                                }
+                                tokio::time::sleep(Duration::from_millis(50)).await;
+                            }
+                            // wait() error (e.g. already reaped elsewhere): stop
+                            // polling and let the fallback below settle it.
+                            Err(_) => break,
+                        }
+                    }
+                }
+                // Still alive after the grace window (or no pid captured, or the
+                // process never had a chance to install a handler) — escalate.
+                // A no-op if it already exited above (start_kill/wait on an
+                // exited child just observe the cached status).
                 let _ = child.start_kill();
                 let _ = child.wait().await;
                 if let Some(args) = cleanup {
@@ -145,6 +196,27 @@ impl DeployedAgent {
         }
     }
 }
+
+/// Send SIGTERM to `pid` by shelling out to `kill -TERM` — deliberately NOT
+/// `libc::kill`/`nix` (mirrors the precedent in
+/// `bamboo_server::service_manager::lifecycle::send_graceful_signal`, which
+/// notes this avoids adding a new dependency for one best-effort signal). A
+/// failure (e.g. the process already exited) just means the polling loop
+/// above falls straight through to the hard-kill fallback.
+#[cfg(not(target_os = "windows"))]
+async fn send_sigterm(pid: u32) {
+    let _ = Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .status()
+        .await;
+}
+
+/// No SIGTERM equivalent on Windows worth shelling out for here; the grace
+/// window in `shutdown_with_timeout` still elapses before the hard-kill
+/// fallback (`Child::start_kill` → `TerminateProcess`). Mirrors
+/// `lifecycle::send_graceful_signal`'s Windows arm.
+#[cfg(target_os = "windows")]
+async fn send_sigterm(_pid: u32) {}
 
 /// The `broker-agent serve …` argv (token is NOT here — it rides the env).
 pub(crate) fn agent_argv(d: &AgentDeployment) -> Vec<String> {
@@ -880,6 +952,93 @@ mod tests {
                 .ends_with("> '.bamboo-deploy/node-x.log' 2>&1"),
             "got: {remote}"
         );
+    }
+
+    /// Graceful stop (#49): a worker that handles SIGTERM gets to exit on its
+    /// own terms — shutdown sends TERM first and waits, rather than opening
+    /// with SIGKILL. The child traps TERM and touches a marker before exiting;
+    /// the marker existing after shutdown proves the graceful path ran.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shutdown_sends_sigterm_before_hard_kill() {
+        let marker = std::env::temp_dir().join(format!(
+            "bamboo_deploy_sigterm_{}_{:?}.marker",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let ready = marker.with_extension("ready");
+        let _ = std::fs::remove_file(&marker);
+        let _ = std::fs::remove_file(&ready);
+
+        // The child touches a READY file only after its TERM trap is installed;
+        // the test waits for that before shutting down, so the SIGTERM can never
+        // race the trap installation (which would take the default kill path
+        // and fail the assertion spuriously).
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg(format!(
+                "trap 'touch {m}; exit 0' TERM; touch {r}; while :; do sleep 0.05; done",
+                m = marker.display(),
+                r = ready.display()
+            ))
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn TERM-trapping child");
+        let agent = DeployedAgent::from_parts("graceful", child, None);
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while !ready.exists() {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "child never signalled readiness"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        agent.shutdown_with_timeout(Duration::from_secs(5)).await;
+
+        assert!(
+            marker.exists(),
+            "child must have received SIGTERM and exited gracefully (marker written by its TERM trap)"
+        );
+        let _ = std::fs::remove_file(&marker);
+        let _ = std::fs::remove_file(&ready);
+    }
+
+    /// Graceful stop is BOUNDED (#49): a worker that ignores SIGTERM is still
+    /// hard-killed once the grace window elapses — `action=stop` can never hang
+    /// on a wedged worker.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shutdown_hard_kills_after_grace_window_when_sigterm_ignored() {
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("trap '' TERM; while :; do sleep 0.05; done")
+            .kill_on_drop(true)
+            .spawn()
+            .expect("spawn TERM-ignoring child");
+        let pid = child.id().expect("child has a pid");
+        let agent = DeployedAgent::from_parts("wedged", child, None);
+
+        // Short grace so the test stays fast; the child ignores TERM, so this
+        // must fall through to the SIGKILL path and still return.
+        tokio::time::timeout(
+            Duration::from_secs(10),
+            agent.shutdown_with_timeout(Duration::from_millis(300)),
+        )
+        .await
+        .expect("shutdown must be bounded even when SIGTERM is ignored");
+
+        let alive = std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        assert!(!alive, "TERM-ignoring worker must be hard-killed");
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-broker/src/lib.rs
+++ b/crates/app/bamboo-broker/src/lib.rs
@@ -53,6 +53,9 @@ pub use crate::mcp::{
 };
 pub use crate::mux::MultiplexedClient;
 pub use crate::proto::{BrokerFrame, ClientFrame};
-pub use crate::serve::{serve_executor, serve_loop, serve_mailbox, serve_with, Handled};
+pub use crate::serve::{
+    serve_executor, serve_executor_with_shutdown, serve_loop, serve_mailbox,
+    serve_mailbox_with_shutdown, serve_with, Handled,
+};
 pub use crate::server::BrokerServer;
 pub use bamboo_subagent::AgentRef;

--- a/crates/app/bamboo-broker/src/serve.rs
+++ b/crates/app/bamboo-broker/src/serve.rs
@@ -43,9 +43,31 @@ where
     H: Fn(InboxMessage, CancellationToken) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Handled> + Send + 'static,
 {
+    // A fresh, never-cancelled token: identical behavior to before graceful
+    // shutdown existed — no external caller of this entry point can trip it.
+    serve_mailbox_with_shutdown(endpoint, me, token, handler, CancellationToken::new()).await
+}
+
+/// Like [`serve_mailbox`], but stops pulling NEW inbound messages once
+/// `shutdown` is cancelled — any handlers already in flight still run to
+/// completion and their replies are still delivered + acked (via the same
+/// drain [`serve_loop`] performs on connection close) before this returns.
+/// This is the hook a process-level signal handler (SIGTERM/ctrl_c) wires
+/// into, so stopping a worker doesn't have to hard-kill it mid-Ask. #49.
+pub async fn serve_mailbox_with_shutdown<H, Fut>(
+    endpoint: &str,
+    me: AgentRef,
+    token: &str,
+    handler: H,
+    shutdown: CancellationToken,
+) -> BrokerResult<()>
+where
+    H: Fn(InboxMessage, CancellationToken) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Handled> + Send + 'static,
+{
     let mut client = BrokerClient::connect(endpoint, me.clone(), token).await?;
     client.subscribe().await?;
-    serve_loop(&mut client, &me, handler).await
+    serve_loop(&mut client, &me, handler, shutdown).await
 }
 
 /// One finished handler routed back to the single client owner for delivery+ack.
@@ -73,10 +95,17 @@ struct Completion {
 /// run: each run still gets its own token (now tracked in a live map so a cancel
 /// can find it after we've moved on to the next message), and ack still happens
 /// only AFTER the reply is delivered. #45.
+///
+/// `shutdown`: once cancelled, the loop stops pulling new inbound messages
+/// (same as a closed connection) but keeps draining in-flight handlers through
+/// arm A until they've all completed, THEN returns — so a graceful stop lets
+/// the current Ask finish and its reply get delivered+acked instead of being
+/// abandoned. #49.
 pub async fn serve_loop<H, Fut>(
     client: &mut BrokerClient,
     me: &AgentRef,
     handler: H,
+    shutdown: CancellationToken,
 ) -> BrokerResult<()>
 where
     H: Fn(InboxMessage, CancellationToken) -> Fut + Send + Sync + 'static,
@@ -100,12 +129,14 @@ where
     let mut messages_open = true;
     loop {
         tokio::select! {
-            // `biased`: drain finished handlers (arm A) ahead of pulling new
-            // work/cancels (arm B) so completed replies are delivered+acked and
-            // their in-flight entries cleared promptly, bounding memory under load.
-            // (#144's serve_mcp_proxy is unbiased; here arm B internally biases the
-            // cancel lane, so cancel latency stays prompt — completions are gated by
-            // real agent work, so arm B is always reached between them.)
+            // `biased`: drain finished handlers (arm A) ahead of a graceful-stop
+            // signal (arm B) ahead of pulling new work/cancels (arm C), so
+            // completed replies are delivered+acked and their in-flight entries
+            // cleared promptly (bounding memory under load), and a shutdown
+            // request is noticed before another inbound message is pulled.
+            // (#144's serve_mcp_proxy is unbiased; here arm C internally biases
+            // the cancel lane, so cancel latency stays prompt — completions are
+            // gated by real agent work, so arm C is always reached between them.)
             biased;
             // A. A finished handler: deliver its reply (if any) then ack — the ack
             //    still strictly follows a delivered reply, as before. Done on the
@@ -133,7 +164,17 @@ where
                     Handled::Leave => {}
                 }
             }
-            // B. The next inbound message OR out-of-band cancel (demuxed over one
+            // B. Graceful stop requested (#49): stop pulling new work — mirrors
+            //    the `Message(None)` connection-closed case below — but leave
+            //    the connection open so arm A can keep delivering+acking
+            //    replies for handlers already in flight. Guarded on
+            //    `messages_open` so a signal that fires more than once (or
+            //    after we've already stopped pulling) doesn't re-trigger.
+            _ = shutdown.cancelled(), if messages_open => {
+                tracing::info!("broker worker: graceful shutdown requested — draining in-flight work");
+                messages_open = false;
+            }
+            // C. The next inbound message OR out-of-band cancel (demuxed over one
             //    `&mut client` borrow). A cancel trips the matching in-flight run's
             //    token (#50); a new message registers a fresh token and spawns the
             //    handler on its own task — so concurrent Asks overlap their work and
@@ -229,6 +270,26 @@ pub async fn serve_executor<E>(
 where
     E: bamboo_subagent::ChildExecutor + ?Sized,
 {
+    // A fresh, never-cancelled token: identical behavior to before graceful
+    // shutdown existed — no external caller of this entry point can trip it.
+    serve_executor_with_shutdown(endpoint, me, token, executor, CancellationToken::new()).await
+}
+
+/// Like [`serve_executor`], but stops accepting new Ask/Task/Run work once
+/// `shutdown` is cancelled while letting whatever is already in flight finish
+/// and reply normally (see [`serve_mailbox_with_shutdown`]). Wire this to a
+/// process-level SIGTERM/ctrl_c handler so `deploy_agent action=stop` (or an
+/// orchestrator exit) doesn't abandon an in-progress Ask. #49.
+pub async fn serve_executor_with_shutdown<E>(
+    endpoint: &str,
+    me: AgentRef,
+    token: &str,
+    executor: Arc<E>,
+    shutdown: CancellationToken,
+) -> BrokerResult<()>
+where
+    E: bamboo_subagent::ChildExecutor + ?Sized,
+{
     let context: Arc<tokio::sync::Mutex<Vec<serde_json::Value>>> =
         Arc::new(tokio::sync::Mutex::new(Vec::new()));
     // Per-run coordination so a SEPARATE Steer / ApprovalReply mailbox message can
@@ -239,70 +300,76 @@ where
     let endpoint_owned = endpoint.to_string();
     let token_owned = token.to_string();
     let me_owned = me.clone();
-    serve_mailbox(endpoint, me, token, move |msg, cancel| {
-        let executor = Arc::clone(&executor);
-        let context = Arc::clone(&context);
-        let coords = Arc::clone(&coords);
-        let waiters = Arc::clone(&waiters);
-        let endpoint = endpoint_owned.clone();
-        let token = token_owned.clone();
-        let me = me_owned.clone();
-        async move {
-            match msg.kind {
-                // A full child session over the bus (the actor-over-mailbox path):
-                // stream events back to the parent live, then the terminal outcome.
-                InboxKind::Run => {
-                    handle_run(
-                        executor.as_ref(),
-                        &endpoint,
-                        &token,
-                        &me,
-                        msg,
-                        cancel,
-                        &coords,
-                        &waiters,
-                    )
-                    .await
-                }
-                // In-band steer for a running Run: route to its steer inbox.
-                InboxKind::Steer => {
-                    if let Some(run_id) = &msg.correlation_id {
-                        let text = msg
+    serve_mailbox_with_shutdown(
+        endpoint,
+        me,
+        token,
+        move |msg, cancel| {
+            let executor = Arc::clone(&executor);
+            let context = Arc::clone(&context);
+            let coords = Arc::clone(&coords);
+            let waiters = Arc::clone(&waiters);
+            let endpoint = endpoint_owned.clone();
+            let token = token_owned.clone();
+            let me = me_owned.clone();
+            async move {
+                match msg.kind {
+                    // A full child session over the bus (the actor-over-mailbox path):
+                    // stream events back to the parent live, then the terminal outcome.
+                    InboxKind::Run => {
+                        handle_run(
+                            executor.as_ref(),
+                            &endpoint,
+                            &token,
+                            &me,
+                            msg,
+                            cancel,
+                            &coords,
+                            &waiters,
+                        )
+                        .await
+                    }
+                    // In-band steer for a running Run: route to its steer inbox.
+                    InboxKind::Steer => {
+                        if let Some(run_id) = &msg.correlation_id {
+                            let text = msg
+                                .body
+                                .get("text")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default()
+                                .to_string();
+                            if let Some(coord) = coords.lock().await.get(run_id) {
+                                let _ = coord.steer_tx.send(text);
+                            }
+                        }
+                        Handled::Ack
+                    }
+                    // Approval decision for a gated tool a Run proxied up: wake the
+                    // waiting tool call, keyed by the approval-request id in the body.
+                    InboxKind::ApprovalReply => {
+                        let id = msg
                             .body
-                            .get("text")
+                            .get("id")
                             .and_then(|v| v.as_str())
                             .unwrap_or_default()
                             .to_string();
-                        if let Some(coord) = coords.lock().await.get(run_id) {
-                            let _ = coord.steer_tx.send(text);
+                        let approved = msg
+                            .body
+                            .get("approved")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        if let Some(tx) = waiters.lock().await.remove(&id) {
+                            let _ = tx.send(approved);
                         }
+                        Handled::Ack
                     }
-                    Handled::Ack
+                    // Ask/Task: the conversational query/steer path (unchanged).
+                    _ => handle_with_executor(executor.as_ref(), &context, msg, cancel).await,
                 }
-                // Approval decision for a gated tool a Run proxied up: wake the
-                // waiting tool call, keyed by the approval-request id in the body.
-                InboxKind::ApprovalReply => {
-                    let id = msg
-                        .body
-                        .get("id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or_default()
-                        .to_string();
-                    let approved = msg
-                        .body
-                        .get("approved")
-                        .and_then(|v| v.as_bool())
-                        .unwrap_or(false);
-                    if let Some(tx) = waiters.lock().await.remove(&id) {
-                        let _ = tx.send(approved);
-                    }
-                    Handled::Ack
-                }
-                // Ask/Task: the conversational query/steer path (unchanged).
-                _ => handle_with_executor(executor.as_ref(), &context, msg, cancel).await,
             }
-        }
-    })
+        },
+        shutdown,
+    )
     .await
 }
 
@@ -1081,6 +1148,146 @@ mod tests {
         assert!(events >= 1, "expected streamed events, got {events}");
         let oc: bamboo_subagent::ChildOutcome = serde_json::from_value(outcome.body).unwrap();
         assert_eq!(oc.result.as_deref(), Some("echo: ping pong"));
+    }
+
+    /// Graceful shutdown (#49): tripping the shutdown token while an Ask is in
+    /// flight must NOT abandon it — the worker finishes the run, delivers the
+    /// reply (delivered + acked), and only THEN does the serve future return.
+    #[tokio::test]
+    async fn graceful_shutdown_drains_in_flight_ask_then_exits() {
+        use bamboo_subagent::{ChildExecutor, ChildOutcome, EventSink, RunSpec, SteerInbox};
+
+        // An executor slow enough that the shutdown signal provably lands while
+        // the run is still in flight.
+        struct SlowEcho;
+        #[async_trait::async_trait]
+        impl ChildExecutor for SlowEcho {
+            async fn run(
+                &self,
+                spec: RunSpec,
+                _events: EventSink,
+                _steer: SteerInbox,
+                _cancel: CancellationToken,
+            ) -> ChildOutcome {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                ChildOutcome::completed(format!("echo: {}", spec.assignment))
+            }
+        }
+
+        let (endpoint, _dir) = start().await;
+        let shutdown = CancellationToken::new();
+        let worker_ep = endpoint.clone();
+        let worker_shutdown = shutdown.clone();
+        let worker = tokio::spawn(async move {
+            serve_executor_with_shutdown(
+                &worker_ep,
+                AgentRef {
+                    session_id: "worker".into(),
+                    role: None,
+                },
+                TOKEN,
+                Arc::new(SlowEcho),
+                worker_shutdown,
+            )
+            .await
+        });
+
+        let mut orch = BrokerClient::connect(
+            &endpoint,
+            AgentRef {
+                session_id: "orch".into(),
+                role: None,
+            },
+            TOKEN,
+        )
+        .await
+        .unwrap();
+        orch.subscribe().await.unwrap();
+
+        // Probe round-trip so the worker is provably subscribed before the
+        // in-flight ask + shutdown race begins.
+        let probe = ask("orch", "ping");
+        let probe_id = probe.id.clone();
+        orch.deliver("worker", probe).await.unwrap();
+        let r0 = tokio::time::timeout(Duration::from_secs(5), orch.next_message())
+            .await
+            .expect("probe reply")
+            .expect("present");
+        assert_eq!(r0.correlation_id, Some(probe_id));
+
+        // Fire the slow ask, then request graceful shutdown while it's running.
+        let q = ask("orch", "slow one");
+        let qid = q.id.clone();
+        orch.deliver("worker", q).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await; // let the run start
+        shutdown.cancel();
+
+        // The in-flight ask still completes and its reply is delivered — a
+        // graceful stop is a drain, not an abandonment.
+        let reply = tokio::time::timeout(Duration::from_secs(5), orch.next_message())
+            .await
+            .expect("in-flight ask must be drained, not lost")
+            .expect("present");
+        assert_eq!(reply.correlation_id, Some(qid));
+        let body: ReplyBody = serde_json::from_value(reply.body).unwrap();
+        assert_eq!(body.answer, "echo: slow one");
+
+        // And the serve future itself returns (cleanly) once drained.
+        let served = tokio::time::timeout(Duration::from_secs(5), worker)
+            .await
+            .expect("serve_executor_with_shutdown returns after the drain")
+            .expect("worker task not panicked");
+        assert!(served.is_ok(), "graceful shutdown exits Ok: {served:?}");
+    }
+
+    /// Graceful shutdown with an idle worker: no in-flight work means the serve
+    /// future returns promptly on cancel (no wedge waiting for work that will
+    /// never arrive). #49.
+    #[tokio::test]
+    async fn graceful_shutdown_idle_worker_exits_promptly() {
+        let (endpoint, _dir) = start().await;
+        let shutdown = CancellationToken::new();
+        let worker_shutdown = shutdown.clone();
+        let worker_ep = endpoint.clone();
+        let worker = tokio::spawn(async move {
+            serve_executor_with_shutdown(
+                &worker_ep,
+                AgentRef {
+                    session_id: "idle".into(),
+                    role: None,
+                },
+                TOKEN,
+                Arc::new(bamboo_subagent::EchoExecutor),
+                worker_shutdown,
+            )
+            .await
+        });
+
+        // Prove it's up (subscribed) with a probe round-trip.
+        let mut orch = BrokerClient::connect(
+            &endpoint,
+            AgentRef {
+                session_id: "orch".into(),
+                role: None,
+            },
+            TOKEN,
+        )
+        .await
+        .unwrap();
+        orch.subscribe().await.unwrap();
+        let probe = ask("orch", "ping");
+        orch.deliver("idle", probe).await.unwrap();
+        let _ = tokio::time::timeout(Duration::from_secs(5), orch.next_message())
+            .await
+            .expect("probe reply")
+            .expect("present");
+
+        shutdown.cancel();
+        let served = tokio::time::timeout(Duration::from_secs(5), worker)
+            .await
+            .expect("idle worker exits promptly on graceful shutdown")
+            .expect("worker task not panicked");
+        assert!(served.is_ok(), "graceful shutdown exits Ok: {served:?}");
     }
 
     /// The bus answers "who's connected serving role X" over the WS protocol — the

--- a/crates/app/bamboo-server-tools/src/deploy_agent.rs
+++ b/crates/app/bamboo-server-tools/src/deploy_agent.rs
@@ -190,12 +190,16 @@ impl DeployAgentTool {
     }
 
     async fn stop(&self, id: String) -> Result<ToolResult, ToolError> {
-        match self
+        // Take the entry out FIRST, then shut down without holding the registry
+        // lock: shutdown is now graceful (SIGTERM + drain grace window, #49), so
+        // it can take seconds — other deploy/stop/list calls must not serialize
+        // behind it.
+        let removed = self
             .registry
             .lock()
             .await
-            .remove(&crate::registry_keys::agent_key(&id))
-        {
+            .remove(&crate::registry_keys::agent_key(&id));
+        match removed {
             Some(d) => {
                 d.handle.shutdown().await;
                 Ok(tool_json(json!({ "id": id, "status": "stopped" })))

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -203,13 +203,15 @@ impl FabricDeployer {
         };
 
         // Release any prior worker FIRST so its reverse tunnel frees the broker
-        // port before the new deploy requests the same forward.
-        if let Some(prev) = self
+        // port before the new deploy requests the same forward. Remove under the
+        // lock, shut down outside it: shutdown is graceful now (SIGTERM + drain
+        // grace, #49) and must not hold the shared registry for its duration.
+        let prev = self
             .registry
             .lock()
             .await
-            .remove(&crate::registry_keys::node_key(node_id))
-        {
+            .remove(&crate::registry_keys::node_key(node_id));
+        if let Some(prev) = prev {
             prev.handle.shutdown().await;
         }
 
@@ -280,12 +282,13 @@ impl FabricDeployer {
         };
         if let Err(e) = verify {
             // Tear the half-dead worker down and report the real failure.
-            if let Some(d) = self
+            // (Remove under the lock, shut down outside it — see deploy above.)
+            let dead = self
                 .registry
                 .lock()
                 .await
-                .remove(&crate::registry_keys::node_key(node_id))
-            {
+                .remove(&crate::registry_keys::node_key(node_id));
+            if let Some(d) = dead {
                 d.handle.shutdown().await;
             }
             let msg = format!(
@@ -337,12 +340,14 @@ impl FabricDeployer {
             let cfg = self.config.read().await;
             self.node_snapshot(&cfg, node_id)?;
         }
-        if let Some(d) = self
+        // Remove under the lock, shut down outside it: shutdown is graceful now
+        // (SIGTERM + drain grace, #49) and must not hold the shared registry.
+        let removed = self
             .registry
             .lock()
             .await
-            .remove(&crate::registry_keys::node_key(node_id))
-        {
+            .remove(&crate::registry_keys::node_key(node_id));
+        if let Some(d) = removed {
             d.handle.shutdown().await;
         }
         tracing::info!(

--- a/src/broker_agent.rs
+++ b/src/broker_agent.rs
@@ -11,8 +11,60 @@ use std::sync::Arc;
 
 use bamboo_subagent::provision::{ChildIdentity, ExecutorSpec, ModelRefSpec, ProvisionSpec};
 use bamboo_subagent::{AgentRef, EchoExecutor};
+use tokio_util::sync::CancellationToken;
 
 use crate::subagent_worker::BambooRuntimeExecutor;
+
+/// Install a graceful-stop signal handler and return the [`CancellationToken`]
+/// it trips: SIGTERM (or ctrl_c, if SIGTERM can't be installed / on non-unix)
+/// wired into [`bamboo_broker::serve_executor_with_shutdown`] so the worker
+/// stops pulling new Ask/Task/Run work and drains whatever's in flight instead
+/// of being hard-killed mid-answer when `deploy_agent action=stop` (or an
+/// orchestrator exit) sends SIGTERM. #49.
+fn install_shutdown_signal() -> CancellationToken {
+    let token = CancellationToken::new();
+    let tripped = token.clone();
+    tokio::spawn(async move {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{signal, SignalKind};
+            match signal(SignalKind::terminate()) {
+                Ok(mut term) => {
+                    tokio::select! {
+                        _ = term.recv() => {
+                            tracing::info!("broker-agent: SIGTERM received — draining in-flight work before exit");
+                        }
+                        r = tokio::signal::ctrl_c() => {
+                            if r.is_ok() {
+                                tracing::info!("broker-agent: ctrl-c received — draining in-flight work before exit");
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "broker-agent: failed to install SIGTERM handler ({e}); falling back to ctrl-c only"
+                    );
+                    if tokio::signal::ctrl_c().await.is_ok() {
+                        tracing::info!(
+                            "broker-agent: ctrl-c received — draining in-flight work before exit"
+                        );
+                    }
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                tracing::info!(
+                    "broker-agent: ctrl-c received — draining in-flight work before exit"
+                );
+            }
+        }
+        tripped.cancel();
+    });
+    token
+}
 
 /// Parameters for `broker-agent serve`.
 pub struct BrokerAgentArgs {
@@ -44,8 +96,14 @@ pub struct BrokerAgentArgs {
     pub spec_file: Option<String>,
 }
 
-/// Connect to the broker and serve until the connection drops.
+/// Connect to the broker and serve until the connection drops or a graceful
+/// stop signal (SIGTERM/ctrl_c) has been received and in-flight work drained.
 pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
+    // Graceful stop (#49): SIGTERM/ctrl_c trips this token; the serve loop then
+    // stops pulling new work, finishes + replies to the in-flight Ask/Task/Run,
+    // and returns — instead of the process dying mid-answer.
+    let shutdown = install_shutdown_signal();
+
     // Parent-shipped bootstrap: read the authoritative ProvisionSpec the
     // orchestrator resolved (identity, bus, model, creds, MCP) — from an uploaded
     // file (remote deploy) or stdin (local). Unifies the deployed-actor path with
@@ -100,9 +158,11 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
             )),
             _ => Arc::new(BambooRuntimeExecutor::build(&spec).await?),
         };
-        return bamboo_broker::serve_executor(&endpoint, me, &token, executor)
-            .await
-            .map_err(|e| format!("broker-agent (spec) failed: {e}"));
+        return bamboo_broker::serve_executor_with_shutdown(
+            &endpoint, me, &token, executor, shutdown,
+        )
+        .await
+        .map_err(|e| format!("broker-agent (spec) failed: {e}"));
     }
 
     // Legacy self-resolve path: build the spec from local config + CLI args.
@@ -113,11 +173,12 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
     tracing::info!(id = %args.id, broker = %args.broker, echo = args.echo, "broker-agent connecting");
 
     if args.echo {
-        return bamboo_broker::serve_executor(
+        return bamboo_broker::serve_executor_with_shutdown(
             &args.broker,
             me,
             &args.token,
             Arc::new(EchoExecutor),
+            shutdown,
         )
         .await
         .map_err(|e| format!("broker-agent (echo) failed: {e}"));
@@ -125,9 +186,15 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
 
     let spec = build_spec(&args)?;
     let executor = BambooRuntimeExecutor::build(&spec).await?;
-    bamboo_broker::serve_executor(&args.broker, me, &args.token, Arc::new(executor))
-        .await
-        .map_err(|e| format!("broker-agent failed: {e}"))
+    bamboo_broker::serve_executor_with_shutdown(
+        &args.broker,
+        me,
+        &args.token,
+        Arc::new(executor),
+        shutdown,
+    )
+    .await
+    .map_err(|e| format!("broker-agent failed: {e}"))
 }
 
 /// Build a `ProvisionSpec` from the local config + CLI args — the standalone


### PR DESCRIPTION
## What

Fixes #49: a broker-agent worker had no graceful shutdown — `deploy_agent action=stop` (and orchestrator exit via `kill_on_drop`) hard-killed the process with SIGKILL, abandoning any in-flight Ask. The message stayed in `cur/` for redelivery, but the worker was dead and the requesting orchestrator surfaced an opaque ask timeout.

## How

Three layers, exactly as the issue proposed:

1. **Serve loop drain** (`crates/app/bamboo-broker/src/serve.rs`): `serve_loop` now takes a `shutdown: CancellationToken`. When tripped, the loop stops pulling new inbound messages — mirroring the existing connection-closed path — but keeps the connection open and drains every in-flight handler through the completion arm, so their replies are still **delivered + acked** before the loop returns. New public wrappers `serve_mailbox_with_shutdown` / `serve_executor_with_shutdown`; the existing `serve_mailbox` / `serve_executor` keep their signatures (they pass a fresh, never-cancelled token — zero behavior change for other callers).

2. **Signal handler** (`src/broker_agent.rs`): `broker_agent::run()` installs a SIGTERM + ctrl_c handler (ctrl_c-only on non-unix) that trips the token, wired into all three `serve_executor` call sites (piped-spec, echo, legacy self-resolve). A signalled worker finishes its current Ask/Task/Run, replies, and exits cleanly.

3. **SIGTERM-then-grace stop** (`crates/app/bamboo-broker/src/deploy.rs`): `DeployedAgent::shutdown` now sends SIGTERM first (shelling out to `kill -TERM`, matching the existing `service_manager::lifecycle::send_graceful_signal` precedent — no new dependency), polls for exit up to a grace window (30s default; `shutdown_with_timeout` exposes it for callers/tests), then falls back to the hard `start_kill`. A wedged worker or an old binary with no handler is still killed — `action=stop` stays bounded.

Follow-up hardening in the same change: `deploy_agent.rs` stop and `fabric_deploy.rs` (deploy-replace / verify-fail teardown / stop) now remove registry entries **before** awaiting shutdown — previously the shared registry `MutexGuard` (a match/if-let scrutinee temporary) was held across the await, which was fine when shutdown was an instant kill but would serialize all deploy/stop/list calls behind a graceful grace window.

Out of scope (per the issue's local-process evidence): `RemoteDeployment::shutdown` (russh `pkill`) still kills directly — the remote worker now at least drains on the SIGTERM `pkill` sends by default.

## Tested

- New tests:
  - `serve::tests::graceful_shutdown_drains_in_flight_ask_then_exits` — shutdown tripped mid-Ask: the reply still arrives and the serve future returns Ok.
  - `serve::tests::graceful_shutdown_idle_worker_exits_promptly` — idle worker exits promptly on cancel (no wedge).
  - `deploy::tests::shutdown_sends_sigterm_before_hard_kill` — a TERM-trapping child exits via its trap (readiness-gated to avoid racing trap installation).
  - `deploy::tests::shutdown_hard_kills_after_grace_window_when_sigterm_ignored` — a TERM-ignoring child is still killed, bounded.
- `cargo test -p bamboo-broker` — 60 + 2 + 1 + 5 passed, 0 failed.
- `cargo test -p bamboo-server-tools` — 75 + 3 passed, 0 failed.
- `cargo build --workspace --tests` — green.
- `cargo fmt -- --check` clean on touched crates; `cargo clippy -p bamboo-broker -p bamboo-server-tools --tests` — no new warnings (remaining warnings are pre-existing in bamboo-engine/bamboo-agent-core).

Closes #49

https://claude.ai/code/session_01Ux4nHUqFjEEGV3rX1x3V9Y