### PR TITLE
fix(broker): connection + message rate limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,7 @@ dependencies = [
  "bamboo-subagent",
  "chrono",
  "futures-util",
+ "governor",
  "russh",
  "russh-sftp",
  "serde",

--- a/crates/app/bamboo-broker/Cargo.toml
+++ b/crates/app/bamboo-broker/Cargo.toml
@@ -22,6 +22,12 @@ tokio-tungstenite = "0.29"
 russh = { version = "0.62", default-features = false, features = ["ring", "flate2", "rsa"] }
 russh-sftp = "2.3.0"
 sha2 = "0.11"
+# Per-connection message-rate limiting (#53). Raw `governor`, not
+# `actix-governor` (bamboo-server's HTTP dep) — the broker is a plain
+# WebSocket/tokio server, not actix. Pinned to the same major/minor already
+# resolved transitively via bamboo-server's actix-governor so the workspace
+# doesn't grow a second `governor` semver line in Cargo.lock.
+governor = "0.10"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/crates/app/bamboo-broker/src/client.rs
+++ b/crates/app/bamboo-broker/src/client.rs
@@ -42,6 +42,11 @@ pub struct BrokerClient {
     sink: WsSink,
     messages: mpsc::UnboundedReceiver<InboxMessage>,
     delivered: mpsc::UnboundedReceiver<MsgId>,
+    /// Correlated rejections for an in-flight `Deliver` (e.g. `MailboxFull`),
+    /// demuxed independently of `delivered` so `deliver()` can distinguish
+    /// "the broker turned this down" from "no receipt arrived in time" — see
+    /// [`BrokerClient::deliver_with_receipt_timeout`]. #491/#53.
+    errors: mpsc::UnboundedReceiver<(MsgId, String)>,
     /// Out-of-band cancel signals (the timed-out ask's correlation id), demuxed
     /// by the background reader independently of `messages` — so a Cancel reaches
     /// the worker even while its work loop is blocked on an in-flight run. #50.
@@ -85,7 +90,7 @@ impl BrokerClient {
             match source.next().await {
                 Some(Ok(Message::Text(t))) => match BrokerFrame::from_text(&t) {
                     Ok(BrokerFrame::Welcome) => break,
-                    Ok(BrokerFrame::Error { reason }) => return Err(BrokerError::Auth(reason)),
+                    Ok(BrokerFrame::Error { reason, .. }) => return Err(BrokerError::Auth(reason)),
                     Ok(_) => continue,
                     Err(e) => return Err(BrokerError::Protocol(format!("bad broker frame: {e}"))),
                 },
@@ -97,10 +102,12 @@ impl BrokerClient {
 
         let (msg_tx, messages) = mpsc::unbounded_channel();
         let (del_tx, delivered) = mpsc::unbounded_channel();
+        let (err_tx, errors) = mpsc::unbounded_channel();
         let (cancel_tx, cancels) = mpsc::unbounded_channel();
         let (conn_tx, connected) = mpsc::unbounded_channel();
-        // The demux loop pushes `Message`/`Delivered`/`Cancel` frames into their
-        // respective channels and ends when the stream closes or errors.
+        // The demux loop pushes `Message`/`Delivered`/`Cancel`/`Error` frames
+        // into their respective channels and ends when the stream closes or
+        // errors.
         let reader = tokio::spawn(async move {
             while let Some(frame) = source.next().await {
                 match frame {
@@ -110,6 +117,24 @@ impl BrokerClient {
                         }
                         Ok(BrokerFrame::Delivered { id }) => {
                             let _ = del_tx.send(id);
+                        }
+                        // Correlated to a specific `Deliver` (e.g.
+                        // `MailboxFull`) — route it to `errors` so the waiting
+                        // `deliver()` call can see the REASON instead of just
+                        // timing out. An uncorrelated `Error` (id: None) post-
+                        // handshake has no in-flight waiter to route to (the
+                        // handshake is the only pre-`Welcome` request); log it
+                        // rather than silently dropping it. #491/#53.
+                        Ok(BrokerFrame::Error {
+                            reason,
+                            id: Some(id),
+                        }) => {
+                            let _ = err_tx.send((id, reason));
+                        }
+                        Ok(BrokerFrame::Error { reason, id: None }) => {
+                            tracing::warn!(
+                                "broker sent an uncorrelated error frame post-handshake: {reason}"
+                            );
                         }
                         Ok(BrokerFrame::Cancel { correlation_id }) => {
                             let _ = cancel_tx.send(correlation_id);
@@ -138,6 +163,7 @@ impl BrokerClient {
             sink,
             messages,
             delivered,
+            errors,
             cancels,
             connected,
             reader_alive,
@@ -171,30 +197,53 @@ impl BrokerClient {
             message,
         })
         .await?;
-        // CORRELATE the receipt to THIS message's id. `delivered` is a shared
-        // receipt stream on a reused connection: a late `Delivered` from a PRIOR
-        // deliver() that timed out (broker stalled but stayed connected) can still
-        // be sitting in the channel, and returning it would hand back a stale,
-        // wrong id. So skip any receipt that isn't ours. Deliver is `&mut self`, so
-        // only one deliver awaits at a time — every non-matching id is therefore a
-        // stale prior receipt, safe to drop. The single timeout bounds the whole
-        // correlation loop (deadline, not per-recv). #114.
+        // CORRELATE the outcome to THIS message's id, racing TWO lanes: the
+        // `delivered` receipt (success) and the `errors` lane (an explicit
+        // broker rejection, e.g. `MailboxFull` — #491/#53). Both are shared
+        // streams on a reused connection: a late arrival from a PRIOR
+        // deliver() that already timed out (broker stalled but stayed
+        // connected) can still be sitting in either channel, and returning it
+        // would hand back a stale, wrong outcome. So skip anything that isn't
+        // ours. Deliver is `&mut self`, so only one deliver awaits at a time —
+        // every non-matching id is therefore a stale prior outcome, safe to
+        // drop. The single timeout bounds the whole correlation loop
+        // (deadline, not per-recv). #114.
         let deadline = tokio::time::Instant::now() + receipt_timeout;
-        loop {
-            match tokio::time::timeout_at(deadline, self.delivered.recv()).await {
-                Ok(Some(id)) if id == expected => return Ok(id),
-                Ok(Some(_stale)) => continue,
-                Ok(None) => {
-                    return Err(BrokerError::Transport(
-                        "connection closed before delivery receipt".into(),
-                    ))
-                }
-                Err(_) => {
-                    return Err(BrokerError::Transport(
-                        "timed out waiting for delivery receipt from broker".into(),
-                    ))
+        let correlate = async {
+            loop {
+                tokio::select! {
+                    biased;
+                    // Bias the rejection lane: an explicit "no" is a clear,
+                    // actionable signal (back off) and should win a race
+                    // against a coincidentally-arriving stale receipt.
+                    err = self.errors.recv() => match err {
+                        Some((id, reason)) if id == expected => {
+                            return Err(BrokerError::Rejected(reason));
+                        }
+                        Some(_stale) => continue,
+                        None => {
+                            return Err(BrokerError::Transport(
+                                "connection closed before delivery receipt".into(),
+                            ));
+                        }
+                    },
+                    id = self.delivered.recv() => match id {
+                        Some(id) if id == expected => return Ok(id),
+                        Some(_stale) => continue,
+                        None => {
+                            return Err(BrokerError::Transport(
+                                "connection closed before delivery receipt".into(),
+                            ));
+                        }
+                    },
                 }
             }
+        };
+        match tokio::time::timeout_at(deadline, correlate).await {
+            Ok(outcome) => outcome,
+            Err(_) => Err(BrokerError::Transport(
+                "timed out waiting for delivery receipt from broker".into(),
+            )),
         }
     }
 
@@ -592,6 +641,162 @@ mod tests {
             res_b.expect("deliver(B) succeeds"),
             id_b,
             "deliver(B) returns its own id, not A's stale receipt"
+        );
+    }
+
+    /// A broker that completes the handshake then, for every `Deliver`, replies
+    /// with a correlated `Error` frame (as `BrokerServer` now does for
+    /// `MailboxFull`, #491/#53) instead of `Delivered` — never acking the
+    /// message. The connection is held open so the client can only learn the
+    /// outcome from the `Error` frame, never a `recv() -> None`.
+    async fn broker_that_rejects_every_deliver(reason: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let ws = accept_async(stream).await.expect("ws upgrade");
+            let (mut sink, mut source) = ws.split();
+            if let Some(Ok(Message::Text(_))) = source.next().await {
+                let _ = sink
+                    .send(Message::text(BrokerFrame::Welcome.to_text()))
+                    .await;
+            }
+            while let Some(Ok(Message::Text(txt))) = source.next().await {
+                if let Ok(ClientFrame::Deliver { message, .. }) = ClientFrame::from_text(&txt) {
+                    let _ = sink
+                        .send(Message::text(
+                            BrokerFrame::Error {
+                                reason: reason.to_string(),
+                                id: Some(message.id),
+                            }
+                            .to_text(),
+                        ))
+                        .await;
+                }
+            }
+        });
+        format!("ws://{addr}")
+    }
+
+    /// Regression for the review finding on #491/#53: a `MailboxFull` (or any
+    /// other) rejection of a `Deliver` must reach the CALLER of `deliver()` as
+    /// a distinct, fast `BrokerError::Rejected` — not get silently dropped by
+    /// the post-handshake demux, leaving the caller to burn the full receipt
+    /// timeout and see a misleading `BrokerError::Transport("timed out...")`
+    /// that looks like a lost/stalled connection rather than an explicit "no".
+    #[tokio::test]
+    async fn deliver_returns_rejected_when_broker_sends_a_correlated_error() {
+        let endpoint =
+            broker_that_rejects_every_deliver("mailbox 'child' is full (2 pending messages)").await;
+        let mut client = BrokerClient::connect(&endpoint, test_agent("parent"), "ignored")
+            .await
+            .expect("handshake completes");
+
+        let started = std::time::Instant::now();
+        // Real (non-test-only) `deliver()`, with the production 30s timeout —
+        // if the rejection were still being swallowed, this would hang for the
+        // full 30s instead of returning promptly.
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(2),
+            client.deliver("child", test_ask("parent")),
+        )
+        .await
+        .expect("deliver() resolves promptly instead of hanging out the receipt timeout");
+
+        match outcome {
+            Err(BrokerError::Rejected(reason)) => {
+                assert!(
+                    reason.contains("full"),
+                    "rejection reason should be the broker's verbatim message, got: {reason}"
+                );
+            }
+            other => panic!("expected BrokerError::Rejected, got {other:?}"),
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "the rejection must reach the caller fast, not via the receipt timeout, took {:?}",
+            started.elapsed(),
+        );
+    }
+
+    /// Mirrors #114 (stale-receipt skip) for the new rejection lane: after a
+    /// `deliver()` times out, a LATE `Error` for that same timed-out call must
+    /// not be mistaken for the outcome of a SUBSEQUENT `deliver()` on the reused
+    /// client.
+    #[tokio::test]
+    async fn deliver_skips_a_stale_error_from_a_prior_timed_out_deliver() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let endpoint = format!("ws://{addr}");
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let ws = accept_async(stream).await.expect("ws upgrade");
+            let (mut sink, mut source) = ws.split();
+            if let Some(Ok(Message::Text(_))) = source.next().await {
+                let _ = sink
+                    .send(Message::text(BrokerFrame::Welcome.to_text()))
+                    .await;
+            }
+            // First Deliver (A): reply with its Error only after a delay, so
+            // deliver(A)'s tiny timeout expires first and the Error lands late.
+            if let Some(Ok(Message::Text(txt))) = source.next().await {
+                if let Ok(ClientFrame::Deliver { message, .. }) = ClientFrame::from_text(&txt) {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    let _ = sink
+                        .send(Message::text(
+                            BrokerFrame::Error {
+                                reason: "stale rejection for A".into(),
+                                id: Some(message.id),
+                            }
+                            .to_text(),
+                        ))
+                        .await;
+                }
+            }
+            // Second Deliver (B): reply promptly with a real Delivered receipt.
+            if let Some(Ok(Message::Text(txt))) = source.next().await {
+                if let Ok(ClientFrame::Deliver { message, .. }) = ClientFrame::from_text(&txt) {
+                    let _ = sink
+                        .send(Message::text(
+                            BrokerFrame::Delivered { id: message.id }.to_text(),
+                        ))
+                        .await;
+                }
+            }
+            // Hold the connection open (as `broker_that_never_acks` above
+            // does, for the same reason): dropping `sink`/`source` here would
+            // close the socket right after the send, racing the client's
+            // demux for no reason this test cares about. Just drain.
+            while let Some(Ok(_)) = source.next().await {}
+        });
+
+        let mut client = BrokerClient::connect(&endpoint, test_agent("parent"), "ignored")
+            .await
+            .expect("connect");
+
+        let msg_a = test_ask("a");
+        let id_a = msg_a.id.clone();
+        let res_a = client
+            .deliver_with_receipt_timeout("target", msg_a, Duration::from_millis(10))
+            .await;
+        assert!(res_a.is_err(), "deliver(A) times out before its rejection");
+
+        // Let A's late Error arrive and buffer in the errors channel.
+        tokio::time::sleep(Duration::from_millis(120)).await;
+
+        let msg_b = test_ask("b");
+        let id_b = msg_b.id.clone();
+        assert_ne!(id_a, id_b);
+        let res_b = client
+            .deliver_with_receipt_timeout("target", msg_b, Duration::from_secs(5))
+            .await;
+        assert_eq!(
+            res_b.expect("deliver(B) succeeds, not misrouted to A's stale rejection"),
+            id_b,
         );
     }
 }

--- a/crates/app/bamboo-broker/src/core.rs
+++ b/crates/app/bamboo-broker/src/core.rs
@@ -21,7 +21,15 @@ use std::time::Duration;
 use bamboo_subagent::{InboxMessage, Mailbox, MsgId};
 use tokio::sync::{mpsc, Mutex};
 
-use crate::error::BrokerResult;
+use crate::error::{BrokerError, BrokerResult};
+
+/// Default cap on a single mailbox's pending (undelivered-or-unacked) message
+/// count (#53). Generous: a live streaming Run can legitimately push
+/// hundreds of `Event`s while its subscriber briefly lags, and this only
+/// bites when nobody is draining at all (offline/never-subscribed session) —
+/// so it exists to bound worst-case disk use from a flood, not to throttle
+/// normal traffic. Override via [`BrokerCore::with_max_pending_per_mailbox`].
+pub const DEFAULT_MAX_PENDING_PER_MAILBOX: usize = 50_000;
 
 /// An item pushed to a live subscriber's sink: either a durable mailbox message
 /// or an ephemeral out-of-band control signal. Both ride the same subscriber
@@ -51,6 +59,9 @@ pub struct BrokerCore {
     root: PathBuf,
     /// session_id -> live subscriber. Present only while a client is subscribed.
     subscribers: Mutex<HashMap<String, Subscriber>>,
+    /// Per-mailbox pending-message cap (#53); see
+    /// [`DEFAULT_MAX_PENDING_PER_MAILBOX`].
+    max_pending_per_mailbox: usize,
 }
 
 impl BrokerCore {
@@ -58,7 +69,16 @@ impl BrokerCore {
         Self {
             root: root.into(),
             subscribers: Mutex::new(HashMap::new()),
+            max_pending_per_mailbox: DEFAULT_MAX_PENDING_PER_MAILBOX,
         }
+    }
+
+    /// Override the per-mailbox pending-message cap (#53) from
+    /// [`DEFAULT_MAX_PENDING_PER_MAILBOX`]. Builder-style — chain onto
+    /// [`Self::new`] before wrapping in `Arc`.
+    pub fn with_max_pending_per_mailbox(mut self, max: usize) -> Self {
+        self.max_pending_per_mailbox = max;
+        self
     }
 
     /// Mailbox for one session: `<root>/mailboxes/<session_id>`.
@@ -68,8 +88,23 @@ impl BrokerCore {
 
     /// Durably enqueue `msg` into `to`'s mailbox, then — if `to` is currently
     /// subscribed — claim and push it immediately. Returns the stored [`MsgId`].
+    ///
+    /// Rejects with [`BrokerError::MailboxFull`] once `to`'s mailbox already
+    /// holds `max_pending_per_mailbox` pending messages (#53) — a backlog cap
+    /// against a flood aimed at an offline/never-draining mailbox. The check
+    /// races benignly with concurrent delivers (worst case a few messages
+    /// over the cap land before the count is next observed); it is a
+    /// best-effort bound, not a hard invariant.
     pub async fn deliver(&self, to: &str, msg: &InboxMessage) -> BrokerResult<MsgId> {
-        let id = self.mailbox(to).deliver(msg).await?;
+        let mailbox = self.mailbox(to);
+        let pending = mailbox.pending_count().await?;
+        if pending >= self.max_pending_per_mailbox {
+            return Err(BrokerError::MailboxFull {
+                session: to.to_string(),
+                limit: self.max_pending_per_mailbox,
+            });
+        }
+        let id = mailbox.deliver(msg).await?;
         self.push_new(to).await?;
         Ok(id)
     }
@@ -451,5 +486,64 @@ mod tests {
         assert_eq!(c.gc_empty_mailboxes().await, 1);
         // pending (non-empty) + live (subscribed) survive a second sweep.
         assert_eq!(c.gc_empty_mailboxes().await, 0);
+    }
+
+    /// Mailbox-flood DoS defense (#53): once a session's mailbox holds
+    /// `max_pending_per_mailbox` pending messages, further `deliver`s are
+    /// rejected with [`BrokerError::MailboxFull`] rather than accepted
+    /// unboundedly — the concrete vector is a client delivering to an
+    /// offline/never-draining session to fill disk.
+    #[tokio::test]
+    async fn deliver_rejects_once_pending_cap_reached() {
+        let d = TempDir::new().unwrap();
+        let c = BrokerCore::new(d.path()).with_max_pending_per_mailbox(2);
+
+        // No subscriber for "hoard" -> messages accumulate in new/, uncapped
+        // until the cap check kicks in.
+        c.deliver("hoard", &msg(1)).await.expect("1st under cap");
+        c.deliver("hoard", &msg(2)).await.expect("2nd reaches cap");
+
+        let err = c.deliver("hoard", &msg(3)).await;
+        assert!(
+            matches!(
+                err,
+                Err(BrokerError::MailboxFull {
+                    ref session,
+                    limit: 2
+                }) if session == "hoard"
+            ),
+            "delivery beyond the cap must be rejected: {err:?}"
+        );
+
+        // A different session's mailbox is unaffected — the cap is per-session.
+        c.deliver("other", &msg(4))
+            .await
+            .expect("cap is per-mailbox, not global");
+    }
+
+    /// The cap tracks the LIVE pending count, not a one-shot budget (#53):
+    /// once a message is claimed+acked (freeing a slot), `deliver` succeeds
+    /// again.
+    #[tokio::test]
+    async fn deliver_succeeds_again_after_ack_frees_a_slot() {
+        let d = TempDir::new().unwrap();
+        let c = BrokerCore::new(d.path()).with_max_pending_per_mailbox(1);
+
+        let m1 = msg(1);
+        c.deliver("hoard", &m1).await.expect("1st reaches cap");
+        assert!(
+            c.deliver("hoard", &msg(2)).await.is_err(),
+            "2nd delivery is over the cap"
+        );
+
+        // Claim + ack the pending message, freeing its slot.
+        let mut rx = c.subscribe("hoard", None).await.unwrap();
+        let got = expect_message(rx.recv().await.unwrap());
+        assert_eq!(got.id, m1.id);
+        c.ack("hoard", &got.id).await.unwrap();
+
+        c.deliver("hoard", &msg(3))
+            .await
+            .expect("delivery succeeds again once a slot is freed");
     }
 }

--- a/crates/app/bamboo-broker/src/core.rs
+++ b/crates/app/bamboo-broker/src/core.rs
@@ -62,6 +62,16 @@ pub struct BrokerCore {
     /// Per-mailbox pending-message cap (#53); see
     /// [`DEFAULT_MAX_PENDING_PER_MAILBOX`].
     max_pending_per_mailbox: usize,
+    /// Live per-mailbox pending-message counter, seeded from a single
+    /// directory scan the first time a session is touched by THIS
+    /// `BrokerCore` (via [`pending_count_for`](Self::pending_count_for)),
+    /// then kept current in-memory on every `deliver` (+1) / `ack` that
+    /// actually removes a message (-1) — instead of rescanning `new/` +
+    /// `cur/` on every single `deliver` call. The scan-per-call design was
+    /// O(backlog) work on every write, so a legitimate burst against a
+    /// lagging subscriber paid ~O(backlog²) total directory-scan work
+    /// climbing toward the cap (review finding #2 on #491/#53).
+    pending_counts: Mutex<HashMap<String, usize>>,
 }
 
 impl BrokerCore {
@@ -70,6 +80,7 @@ impl BrokerCore {
             root: root.into(),
             subscribers: Mutex::new(HashMap::new()),
             max_pending_per_mailbox: DEFAULT_MAX_PENDING_PER_MAILBOX,
+            pending_counts: Mutex::new(HashMap::new()),
         }
     }
 
@@ -96,17 +107,45 @@ impl BrokerCore {
     /// over the cap land before the count is next observed); it is a
     /// best-effort bound, not a hard invariant.
     pub async fn deliver(&self, to: &str, msg: &InboxMessage) -> BrokerResult<MsgId> {
-        let mailbox = self.mailbox(to);
-        let pending = mailbox.pending_count().await?;
+        let pending = self.pending_count_for(to).await?;
         if pending >= self.max_pending_per_mailbox {
             return Err(BrokerError::MailboxFull {
                 session: to.to_string(),
                 limit: self.max_pending_per_mailbox,
             });
         }
-        let id = mailbox.deliver(msg).await?;
+        let id = self.mailbox(to).deliver(msg).await?;
+        *self
+            .pending_counts
+            .lock()
+            .await
+            .entry(to.to_string())
+            .or_insert(0) += 1;
         self.push_new(to).await?;
         Ok(id)
+    }
+
+    /// Current pending count for `session_id`'s mailbox — an in-memory
+    /// HashMap lookup after the first call for that session, not a directory
+    /// scan (see [`Self::pending_counts`]). The first call for a given
+    /// session performs the ONE directory scan (via
+    /// [`Mailbox::pending_count`]) that seeds its baseline, deliberately done
+    /// OFF the map lock (it's the only await here that touches disk) so a
+    /// slow scan for one mailbox never stalls lookups for others.
+    ///
+    /// Concurrent first-touches of the same never-before-seen mailbox can
+    /// race this seed — both scan, both see the same pre-write disk state,
+    /// and `or_insert` keeps whichever wins, while EVERY caller still applies
+    /// its own subsequent `+1`/`-1` on top — so the final count stays
+    /// correct regardless of which scan wins. No less precise than the
+    /// scan-per-call design's own already-documented benign races.
+    async fn pending_count_for(&self, session_id: &str) -> BrokerResult<usize> {
+        if let Some(&c) = self.pending_counts.lock().await.get(session_id) {
+            return Ok(c);
+        }
+        let scanned = self.mailbox(session_id).pending_count().await?;
+        let mut counts = self.pending_counts.lock().await;
+        Ok(*counts.entry(session_id.to_string()).or_insert(scanned))
     }
 
     /// Register a subscriber for `session_id` and return the stream of pushed
@@ -161,9 +200,22 @@ impl BrokerCore {
         self.subscribers.lock().await.remove(session_id);
     }
 
-    /// Acknowledge a processed message: delete it from `session_id`'s mailbox.
+    /// Acknowledge a processed message: delete it from `session_id`'s mailbox,
+    /// and — if it was actually removed — decrement the live pending counter
+    /// (#53 follow-up; see [`Self::pending_counts`]).
     pub async fn ack(&self, session_id: &str, id: &MsgId) -> BrokerResult<()> {
-        self.mailbox(session_id).ack(id).await?;
+        // Seed the counter from a scan BEFORE the delete below if this
+        // session hasn't been touched by this `BrokerCore` yet — the
+        // baseline must include the message we're about to remove, or the
+        // decrement would double-count it (seeding AFTER the delete would
+        // scan a count that already excludes it).
+        let _ = self.pending_count_for(session_id).await;
+        let removed = self.mailbox(session_id).ack(id).await?;
+        if removed {
+            if let Some(c) = self.pending_counts.lock().await.get_mut(session_id) {
+                *c = c.saturating_sub(1);
+            }
+        }
         Ok(())
     }
 
@@ -239,6 +291,14 @@ impl BrokerCore {
             .await
             .unwrap_or(false);
             if removed {
+                // Drop the stale counter entry too, so `pending_counts` doesn't
+                // grow unbounded in lockstep with the mailbox dirs it just
+                // stopped tracking (#53 follow-up). The dir was confirmed
+                // empty immediately before removal, so its live count (if
+                // seeded at all) is 0 — nothing here relies on that, but it
+                // means dropping the entry loses no information; the next
+                // deliver/ack for this id re-seeds fresh from disk.
+                self.pending_counts.lock().await.remove(&id);
                 purged += 1;
             }
         }
@@ -545,5 +605,82 @@ mod tests {
         c.deliver("hoard", &msg(3))
             .await
             .expect("delivery succeeds again once a slot is freed");
+    }
+
+    /// The pending counter's baseline for a session is SCANNED from disk on
+    /// first touch (#53 follow-up: an in-memory counter replacing the old
+    /// per-call directory rescan), not assumed to start at 0 — so a mailbox
+    /// that already has a backlog when this `BrokerCore` starts (e.g. after a
+    /// broker restart) is correctly capped from the very first `deliver`
+    /// call, not just after enough in-process deliveries accumulate.
+    #[tokio::test]
+    async fn pending_count_seeds_from_preexisting_disk_backlog_on_first_touch() {
+        let d = TempDir::new().unwrap();
+        // Simulate pre-existing backlog: deliver 2 messages directly via a raw
+        // `Mailbox` handle, bypassing `BrokerCore` entirely — as if a PRIOR
+        // broker process wrote them before this `BrokerCore` ever started.
+        let raw = Mailbox::at(d.path().join("mailboxes").join("hoard"));
+        raw.deliver(&msg(1)).await.unwrap();
+        raw.deliver(&msg(2)).await.unwrap();
+
+        let c = BrokerCore::new(d.path()).with_max_pending_per_mailbox(2);
+        // First-ever `deliver` call from THIS `BrokerCore` must already see
+        // the 2 pre-existing messages and reject — not treat its in-memory
+        // count as starting fresh at 0.
+        let err = c.deliver("hoard", &msg(3)).await;
+        assert!(
+            matches!(err, Err(BrokerError::MailboxFull { limit: 2, .. })),
+            "the cap must account for backlog that predates this BrokerCore, got {err:?}"
+        );
+    }
+
+    /// The live in-memory counter (#53 follow-up, replacing a per-call
+    /// directory rescan) must stay a FAITHFUL count under concurrent
+    /// deliveries — not drift from the on-disk truth, and not corrupt itself
+    /// (lost updates / double counts) under concurrent map access. Fires
+    /// many concurrent `deliver`s at the same never-subscribed (so nothing
+    /// drains it) mailbox and checks the in-memory count agrees with a
+    /// fresh, direct on-disk scan afterward.
+    ///
+    /// NOTE: this deliberately does NOT assert on how many of the 100 calls
+    /// succeeded vs. were `MailboxFull`-rejected. The cap's check-then-write
+    /// is, and always has been, a documented BEST-EFFORT race, not a hard
+    /// invariant (see `deliver`'s doc comment) — under enough concurrency,
+    /// many callers can observe the same under-cap count before any of
+    /// their writes lands, so "how many landed over the cap" is inherently
+    /// a race outcome, not a fixed number this test can pin down. What
+    /// MUST hold unconditionally is that the counter tracking whatever DID
+    /// land is accurate.
+    #[tokio::test]
+    async fn pending_count_stays_consistent_with_disk_under_concurrent_delivers() {
+        let d = TempDir::new().unwrap();
+        let c = Arc::new(BrokerCore::new(d.path()).with_max_pending_per_mailbox(20));
+
+        let mut handles = Vec::new();
+        for i in 0..100u32 {
+            let c = c.clone();
+            handles.push(tokio::spawn(
+                async move { c.deliver("hoard", &msg(i)).await },
+            ));
+        }
+        let mut succeeded = 0usize;
+        for h in handles {
+            if h.await.unwrap().is_ok() {
+                succeeded += 1;
+            }
+        }
+        assert!(succeeded > 0, "at least some concurrent deliveries land");
+
+        // The in-memory count must match reality: a direct on-disk scan (the
+        // OLD, ground-truth mechanism) agrees with what the new in-memory
+        // counter believes — no lost updates, no double counts.
+        let on_disk = Mailbox::at(d.path().join("mailboxes").join("hoard"))
+            .pending_count()
+            .await
+            .unwrap();
+        assert_eq!(
+            on_disk, succeeded,
+            "the in-memory counter must not drift from the on-disk message count"
+        );
     }
 }

--- a/crates/app/bamboo-broker/src/error.rs
+++ b/crates/app/bamboo-broker/src/error.rs
@@ -23,6 +23,17 @@ pub enum BrokerError {
     /// auth failure.
     #[error("mailbox '{session}' is full ({limit} pending messages)")]
     MailboxFull { session: String, limit: usize },
+    /// The broker explicitly REJECTED a request (e.g. [`Self::MailboxFull`])
+    /// and told the caller so via a correlated [`crate::proto::BrokerFrame::Error`]
+    /// — as opposed to [`Self::Transport`], which means the RPC never got a
+    /// definitive answer at all (network stall, broker crash, timeout). This
+    /// distinction is the point: `BrokerClient::deliver` returns this the
+    /// instant the broker's rejection arrives, instead of the caller burning
+    /// the full receipt timeout to learn the same thing. `reason` is the
+    /// broker's stringified error (client-side; the original `BrokerError`
+    /// variant on the broker doesn't cross the wire, only its `Display`).
+    #[error("broker rejected the request: {0}")]
+    Rejected(String),
 }
 
 pub type BrokerResult<T> = Result<T, BrokerError>;

--- a/crates/app/bamboo-broker/src/error.rs
+++ b/crates/app/bamboo-broker/src/error.rs
@@ -16,6 +16,13 @@ pub enum BrokerError {
     /// WebSocket / IO transport failure.
     #[error("transport: {0}")]
     Transport(String),
+    /// `deliver` refused: the target session's mailbox already holds
+    /// `limit` pending (undelivered-or-unacked) messages — a backlog cap
+    /// against a flood aimed at an offline/never-draining mailbox filling
+    /// disk (#53). The sender should back off; this is not a transport or
+    /// auth failure.
+    #[error("mailbox '{session}' is full ({limit} pending messages)")]
+    MailboxFull { session: String, limit: usize },
 }
 
 pub type BrokerResult<T> = Result<T, BrokerError>;

--- a/crates/app/bamboo-broker/src/lib.rs
+++ b/crates/app/bamboo-broker/src/lib.rs
@@ -40,7 +40,7 @@ pub const ORCHESTRATOR_ID: &str = "bamboo-orchestrator";
 pub use crate::ask::{ask_agent, ask_over, request_over};
 pub use crate::child_link::BrokerChildLink;
 pub use crate::client::BrokerClient;
-pub use crate::core::BrokerCore;
+pub use crate::core::{BrokerCore, DEFAULT_MAX_PENDING_PER_MAILBOX};
 pub use crate::deploy::{
     AgentDeployment, DeployedAgent, Deployer, DockerDeployer, LocalProcessDeployer,
     RemoteDeployment, SshDeployer, UploadSpec,
@@ -54,5 +54,5 @@ pub use crate::mcp::{
 pub use crate::mux::MultiplexedClient;
 pub use crate::proto::{BrokerFrame, ClientFrame};
 pub use crate::serve::{serve_executor, serve_loop, serve_mailbox, serve_with, Handled};
-pub use crate::server::BrokerServer;
+pub use crate::server::{BrokerLimits, BrokerServer};
 pub use bamboo_subagent::AgentRef;

--- a/crates/app/bamboo-broker/src/proto.rs
+++ b/crates/app/bamboo-broker/src/proto.rs
@@ -43,7 +43,19 @@ pub enum BrokerFrame {
     Welcome,
     /// Handshake or request rejected; the broker closes the connection after
     /// an auth error.
-    Error { reason: String },
+    ///
+    /// `id` correlates the rejection back to the [`ClientFrame::Deliver`]
+    /// that caused it (e.g. `MailboxFull`) — [`Some`] the message's own
+    /// [`MsgId`] when the broker rejected a specific `Deliver`, `None` for
+    /// rejections with nothing to correlate to (bad handshake, a malformed
+    /// frame). Lets `BrokerClient::deliver` route the rejection back to the
+    /// waiting caller instead of the caller only ever seeing a generic
+    /// receipt timeout (review finding on #491/#53).
+    Error {
+        reason: String,
+        #[serde(default)]
+        id: Option<MsgId>,
+    },
     /// A message pushed from the subscriber's mailbox.
     Message { message: InboxMessage },
     /// Receipt that a [`ClientFrame::Deliver`] was durably enqueued.
@@ -145,6 +157,11 @@ mod tests {
             BrokerFrame::Welcome,
             BrokerFrame::Error {
                 reason: "bad token".into(),
+                id: None,
+            },
+            BrokerFrame::Error {
+                reason: "mailbox 'child' is full (2 pending messages)".into(),
+                id: Some(MsgId::new()),
             },
             BrokerFrame::Message { message: ask_msg() },
             BrokerFrame::Delivered { id: MsgId::new() },
@@ -158,5 +175,22 @@ mod tests {
         for f in frames {
             assert_eq!(BrokerFrame::from_text(&f.to_text()).unwrap(), f);
         }
+    }
+
+    /// A legacy `Error` frame serialized without the `id` field (as every
+    /// `Error` was before this correlation id existed) still parses, with
+    /// `id` defaulting to `None` — so an older broker (or a captured/replayed
+    /// frame) never fails a newer client's deserialization.
+    #[test]
+    fn error_frame_without_id_defaults_to_none() {
+        let legacy = serde_json::json!({ "kind": "error", "reason": "bad token" });
+        let parsed: BrokerFrame = serde_json::from_value(legacy).unwrap();
+        assert_eq!(
+            parsed,
+            BrokerFrame::Error {
+                reason: "bad token".into(),
+                id: None,
+            }
+        );
     }
 }

--- a/crates/app/bamboo-broker/src/server.rs
+++ b/crates/app/bamboo-broker/src/server.rs
@@ -164,6 +164,7 @@ impl BrokerServer {
                         &mut sink,
                         BrokerFrame::Error {
                             reason: "invalid token".into(),
+                            id: None,
                         },
                     )
                     .await;
@@ -178,6 +179,7 @@ impl BrokerServer {
                     &mut sink,
                     BrokerFrame::Error {
                         reason: "expected hello".into(),
+                        id: None,
                     },
                 )
                 .await;
@@ -199,7 +201,26 @@ impl BrokerServer {
                             // (delay) rather than drop/disconnect, so a legitimate
                             // burst (e.g. overlapping event streams) just waits
                             // instead of losing the connection or the message.
+                            //
+                            // NOTE: this `.await` runs inside the `select!`'s
+                            // frame-read arm, so while it's pending the sibling
+                            // `pushed = next_pushed(...)` arm is NOT polled — a
+                            // connection that is BOTH delivering and subscribed
+                            // (the protocol allows one connection to do both)
+                            // has its own inbound pushes queue in the unbounded
+                            // channel for the throttle's duration. Given the
+                            // generous defaults and the "backpressure, don't
+                            // punish" intent this is an accepted tradeoff, not a
+                            // bug — flagged here so it isn't rediscovered as a
+                            // surprise (review finding on #491/#53).
                             deliver_limiter.until_ready().await;
+                            // Keep the id BEFORE `core.deliver` takes `&message`,
+                            // so a rejection (e.g. `MailboxFull`) can be
+                            // correlated back to THIS `Deliver` — otherwise the
+                            // sender only ever sees a generic receipt timeout,
+                            // never the specific reason (review finding #1 on
+                            // #491/#53).
+                            let msg_id = message.id.clone();
                             match self.core.deliver(&to, &message).await {
                                 Ok(id) => {
                                     if send(&mut sink, BrokerFrame::Delivered { id }).await.is_err() {
@@ -207,19 +228,26 @@ impl BrokerServer {
                                     }
                                 }
                                 Err(e) => {
-                                    let _ = send(&mut sink, BrokerFrame::Error { reason: e.to_string() }).await;
+                                    let _ = send(
+                                        &mut sink,
+                                        BrokerFrame::Error {
+                                            reason: e.to_string(),
+                                            id: Some(msg_id),
+                                        },
+                                    )
+                                    .await;
                                 }
                             }
                         }
                         Ok(Some(ClientFrame::Subscribe)) => match self.core.subscribe(&session_id, role.as_deref()).await {
                             Ok(rx) => sub_rx = Some(rx),
                             Err(e) => {
-                                let _ = send(&mut sink, BrokerFrame::Error { reason: e.to_string() }).await;
+                                let _ = send(&mut sink, BrokerFrame::Error { reason: e.to_string(), id: None }).await;
                             }
                         },
                         Ok(Some(ClientFrame::Ack { id })) => {
                             if let Err(e) = self.core.ack(&session_id, &id).await {
-                                let _ = send(&mut sink, BrokerFrame::Error { reason: e.to_string() }).await;
+                                let _ = send(&mut sink, BrokerFrame::Error { reason: e.to_string(), id: None }).await;
                             }
                         }
                         // A second Hello is meaningless mid-session; ignore.

--- a/crates/app/bamboo-broker/src/server.rs
+++ b/crates/app/bamboo-broker/src/server.rs
@@ -6,12 +6,16 @@
 //! on any address (`0.0.0.0:PORT`) so workers deployed via subprocess / Docker /
 //! SSH can dial home over the network.
 
+use std::num::NonZeroU32;
 use std::sync::Arc;
 
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
+use governor::clock::DefaultClock;
+use governor::state::{InMemoryState, NotKeyed};
+use governor::{Quota, RateLimiter};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Semaphore};
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{accept_async, WebSocketStream};
 
@@ -20,36 +24,122 @@ use crate::error::{BrokerError, BrokerResult};
 use crate::proto::{BrokerFrame, ClientFrame};
 
 type Ws = WebSocketStream<TcpStream>;
+/// Un-keyed (single-bucket) token-bucket limiter for one connection's
+/// `Deliver` rate (#53).
+type DeliverLimiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock>;
 
-/// The network front-end. Holds the routing [`BrokerCore`] and the expected
-/// Bearer token; clones cheaply (everything behind `Arc`).
+/// Bounded, configurable limits [`BrokerServer`] enforces against a
+/// malicious/misbehaving client (#53 — connection-flood and message-flood DoS
+/// defense). Defaults are deliberately generous:
+///
+/// - The broker is reachable on any address by design — subprocess/Docker/SSH
+///   workers dial home over the network — so unlike bamboo-server's HTTP
+///   sidecar (loopback-only, see `is_loopback_bind`), there is no "trusted
+///   local caller" to exempt here. Loopback and remote connections share the
+///   one limit.
+/// - A single connection relaying a live Run's LLM token stream
+///   (`serve::handle_run`) can legitimately emit 100+ `Deliver`s/sec — so
+///   `messages_per_second`/`message_burst` are sized well above that, and
+///   exceeding them backpressures (delays) the connection rather than
+///   dropping it, so a brief legitimate burst is absorbed instead of
+///   punished.
+#[derive(Debug, Clone, Copy)]
+pub struct BrokerLimits {
+    /// Max concurrent accepted WebSocket connections. Beyond this, new
+    /// connections are dropped immediately (no WS handshake attempted) until
+    /// a slot frees up — bounds the "open thousands of connections" memory
+    /// exhaustion vector.
+    pub max_connections: usize,
+    /// Sustained per-connection `Deliver`-frame rate (frames/sec) — the
+    /// specific frame kind that writes into a mailbox and can flood disk (the
+    /// concrete vector in #53). Other frame kinds (`Ack`/`Cancel`/
+    /// `ListConnected`/`Subscribe`) are not gated by this bucket.
+    pub messages_per_second: NonZeroU32,
+    /// Burst allowance layered on `messages_per_second` (token-bucket
+    /// capacity) — absorbs short bursts (e.g. several event streams
+    /// overlapping) without delaying them.
+    pub message_burst: NonZeroU32,
+}
+
+impl Default for BrokerLimits {
+    fn default() -> Self {
+        Self {
+            max_connections: 1000,
+            // SAFETY-of-intent: literals are non-zero; `NonZeroU32::new(..).unwrap()`
+            // in a const fn context is not stable here, so this is a plain runtime
+            // unwrap of a value we control.
+            messages_per_second: NonZeroU32::new(500).expect("500 is non-zero"),
+            message_burst: NonZeroU32::new(1000).expect("1000 is non-zero"),
+        }
+    }
+}
+
+/// The network front-end. Holds the routing [`BrokerCore`], the expected
+/// Bearer token, and the DoS-defense [`BrokerLimits`]; clones cheaply
+/// (everything behind `Arc`).
 pub struct BrokerServer {
     core: Arc<BrokerCore>,
     token: String,
+    limits: BrokerLimits,
+    /// One permit per currently-accepted connection, capacity ==
+    /// `limits.max_connections`. Held for the lifetime of each connection's
+    /// task (#53).
+    connection_slots: Arc<Semaphore>,
 }
 
 impl BrokerServer {
+    /// Serve with [`BrokerLimits::default`].
     pub fn new(core: Arc<BrokerCore>, token: impl Into<String>) -> Self {
+        Self::with_limits(core, token, BrokerLimits::default())
+    }
+
+    /// Serve with explicit connection/message limits (#53).
+    pub fn with_limits(
+        core: Arc<BrokerCore>,
+        token: impl Into<String>,
+        limits: BrokerLimits,
+    ) -> Self {
         Self {
             core,
             token: token.into(),
+            connection_slots: Arc::new(Semaphore::new(limits.max_connections)),
+            limits,
         }
     }
 
     /// Accept connections forever, one task each. Returns only on a listener
     /// error (per-connection errors are logged and isolated).
+    ///
+    /// Enforces `limits.max_connections`: once the pool of connection slots is
+    /// exhausted, a newly-accepted TCP stream is dropped immediately — no WS
+    /// handshake is attempted for a connection we're refusing, so an
+    /// over-the-cap flood costs us only an `accept()` + drop, not a full
+    /// handshake dance. #53.
     pub async fn serve(self: Arc<Self>, listener: TcpListener) -> BrokerResult<()> {
         loop {
-            let (stream, _peer) = listener
+            let (stream, peer) = listener
                 .accept()
                 .await
                 .map_err(|e| BrokerError::Transport(format!("accept: {e}")))?;
             let server = Arc::clone(&self);
-            tokio::spawn(async move {
-                if let Err(e) = server.handle_conn(stream).await {
-                    tracing::debug!("broker connection ended: {e}");
+            match Arc::clone(&server.connection_slots).try_acquire_owned() {
+                Ok(permit) => {
+                    tokio::spawn(async move {
+                        let _permit = permit; // held for the connection's lifetime
+                        if let Err(e) = server.handle_conn(stream).await {
+                            tracing::debug!("broker connection ended: {e}");
+                        }
+                    });
                 }
-            });
+                Err(_) => {
+                    tracing::warn!(
+                        max_connections = server.limits.max_connections,
+                        %peer,
+                        "broker: max_connections reached — rejecting connection"
+                    );
+                    drop(stream);
+                }
+            }
         }
     }
 
@@ -58,6 +148,13 @@ impl BrokerServer {
             .await
             .map_err(|e| BrokerError::Transport(format!("ws accept: {e}")))?;
         let (mut sink, mut source) = ws.split();
+        // One token bucket per connection for `Deliver` frames (#53) — sized
+        // per `limits`, generous enough for a single live event stream (see
+        // [`BrokerLimits`]'s doc comment).
+        let deliver_limiter: DeliverLimiter = RateLimiter::direct(
+            Quota::per_second(self.limits.messages_per_second)
+                .allow_burst(self.limits.message_burst),
+        );
 
         // 1. Handshake — the first frame must be a Hello with a valid token.
         let (session_id, role) = match read_client_frame(&mut source).await? {
@@ -98,6 +195,11 @@ impl BrokerServer {
                 frame = read_client_frame(&mut source) => {
                     match frame {
                         Ok(Some(ClientFrame::Deliver { to, message })) => {
+                            // Per-connection Deliver throttle (#53): backpressure
+                            // (delay) rather than drop/disconnect, so a legitimate
+                            // burst (e.g. overlapping event streams) just waits
+                            // instead of losing the connection or the message.
+                            deliver_limiter.until_ready().await;
                             match self.core.deliver(&to, &message).await {
                                 Ok(id) => {
                                     if send(&mut sink, BrokerFrame::Delivered { id }).await.is_err() {

--- a/crates/app/bamboo-broker/tests/ws_roundtrip.rs
+++ b/crates/app/bamboo-broker/tests/ws_roundtrip.rs
@@ -2,10 +2,11 @@
 //! ask/reply over the network (loopback), exercising auth, deliver, durable
 //! backlog, push, ack, and correlation.
 
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
 
-use bamboo_broker::{BrokerClient, BrokerCore, BrokerServer};
+use bamboo_broker::{BrokerClient, BrokerCore, BrokerLimits, BrokerServer};
 use bamboo_subagent::{AgentRef, AskBody, AskMode, InboxKind, InboxMessage, MsgId, ReplyBody};
 use chrono::Utc;
 use tempfile::TempDir;
@@ -16,9 +17,16 @@ const TOKEN: &str = "secret-token";
 /// Returns the `ws://` endpoint plus the mailbox-root guard — the caller must
 /// hold the guard for the test's lifetime (the broker reads/writes under it).
 async fn start_broker() -> (String, TempDir) {
+    start_broker_with_limits(BrokerLimits::default()).await
+}
+
+/// Like [`start_broker`], with explicit DoS-defense limits (#53) instead of
+/// the generous defaults — lets tests exercise `max_connections` /
+/// `messages_per_second` without waiting out production-sized quotas.
+async fn start_broker_with_limits(limits: BrokerLimits) -> (String, TempDir) {
     let dir = tempfile::tempdir().expect("tempdir");
     let core = Arc::new(BrokerCore::new(dir.path()));
-    let server = Arc::new(BrokerServer::new(core, TOKEN));
+    let server = Arc::new(BrokerServer::with_limits(core, TOKEN, limits));
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
     let addr = listener.local_addr().expect("local_addr");
     tokio::spawn(async move {
@@ -278,4 +286,112 @@ async fn unacked_messages_redelivered_after_broker_crash_and_restart() {
     );
 
     server2.abort();
+}
+
+/// Connection-flood DoS defense (#53): once `max_connections` accepted slots
+/// are all held, a new connection attempt must be rejected rather than
+/// accepted (which would let an attacker keep opening connections without
+/// bound).
+#[tokio::test]
+async fn max_connections_rejects_beyond_cap() {
+    let (endpoint, _dir) = start_broker_with_limits(BrokerLimits {
+        max_connections: 1,
+        ..BrokerLimits::default()
+    })
+    .await;
+
+    // Take the one available slot and keep it alive for the test.
+    let _first = BrokerClient::connect(&endpoint, agent("first"), TOKEN)
+        .await
+        .expect("first connection takes the only slot");
+
+    // A second connection attempt has nowhere to land — the server drops the
+    // raw stream before even attempting the WS handshake, so this must fail
+    // (not hang, not silently succeed).
+    let second = tokio::time::timeout(
+        Duration::from_secs(5),
+        BrokerClient::connect(&endpoint, agent("second"), TOKEN),
+    )
+    .await
+    .expect("connection attempt does not hang");
+    assert!(
+        second.is_err(),
+        "a connection beyond max_connections must be rejected"
+    );
+}
+
+/// The connection cap is a live pool, not a one-shot budget (#53): once a
+/// connection holding a slot disconnects, that slot becomes available again
+/// for a new connection.
+#[tokio::test]
+async fn max_connections_slot_frees_on_disconnect() {
+    let (endpoint, _dir) = start_broker_with_limits(BrokerLimits {
+        max_connections: 1,
+        ..BrokerLimits::default()
+    })
+    .await;
+    let addr = endpoint.strip_prefix("ws://").expect("ws:// endpoint");
+
+    {
+        // Take the one slot with a raw TCP connection — the semaphore permit
+        // is acquired and held for the connection task's whole lifetime
+        // regardless of whether the WS/Hello handshake ever completes, so
+        // this alone is enough to occupy the slot. (`BrokerClient` isn't used
+        // here because its background reader task outlives a mere `drop`,
+        // which would make this test about the client's lifecycle rather
+        // than the server's slot accounting.)
+        let _raw = tokio::net::TcpStream::connect(addr)
+            .await
+            .expect("raw tcp connects");
+        // Dropped at end of scope: the reset tears down the server's
+        // accept_async/handle_conn task, releasing its permit.
+    }
+
+    // Give the server task a moment to notice the closed connection and
+    // release its semaphore permit.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let second = tokio::time::timeout(
+        Duration::from_secs(5),
+        BrokerClient::connect(&endpoint, agent("second"), TOKEN),
+    )
+    .await
+    .expect("connection attempt does not hang");
+    assert!(second.is_ok(), "a freed slot must admit a new connection");
+}
+
+/// Message-flood DoS defense (#53): a connection sending `Deliver` frames
+/// faster than `messages_per_second`/`message_burst` allow is backpressured
+/// (delayed), not instantly served — a flood can't write to the mailbox
+/// store at unbounded speed. Delivery still eventually SUCCEEDS (this is a
+/// throttle, not a hard reject), so a legitimate connection that briefly
+/// bursts is merely slowed, never disconnected or dropped.
+#[tokio::test]
+async fn deliver_rate_limit_backpressures_a_flooding_connection() {
+    let (endpoint, _dir) = start_broker_with_limits(BrokerLimits {
+        // 1 msg/sec, no burst: the 2nd and 3rd delivers in immediate
+        // succession must each wait ~1s for the bucket to refill.
+        messages_per_second: NonZeroU32::new(5).unwrap(),
+        message_burst: NonZeroU32::new(1).unwrap(),
+        ..BrokerLimits::default()
+    })
+    .await;
+
+    let mut sender = BrokerClient::connect(&endpoint, agent("flooder"), TOKEN)
+        .await
+        .expect("connects");
+
+    let started = std::time::Instant::now();
+    for _ in 0..3 {
+        sender
+            .deliver("victim", ask("flooder"))
+            .await
+            .expect("throttled delivery still eventually succeeds");
+    }
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed >= Duration::from_millis(150),
+        "a burst beyond the token bucket must be delayed, not accepted \
+         instantly (took {elapsed:?})"
+    );
 }

--- a/crates/app/bamboo-broker/tests/ws_roundtrip.rs
+++ b/crates/app/bamboo-broker/tests/ws_roundtrip.rs
@@ -347,17 +347,29 @@ async fn max_connections_slot_frees_on_disconnect() {
         // accept_async/handle_conn task, releasing its permit.
     }
 
-    // Give the server task a moment to notice the closed connection and
-    // release its semaphore permit.
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
-    let second = tokio::time::timeout(
-        Duration::from_secs(5),
-        BrokerClient::connect(&endpoint, agent("second"), TOKEN),
-    )
-    .await
-    .expect("connection attempt does not hang");
-    assert!(second.is_ok(), "a freed slot must admit a new connection");
+    // Poll for the slot to free (short retry interval, bounded overall
+    // timeout) instead of a single fixed sleep + one connect attempt: the
+    // server needs a moment to notice the closed raw TCP connection and
+    // release its semaphore permit, but exactly how long is timing-dependent
+    // — a fixed sleep is a (low-probability but real) source of CI flakiness
+    // under load. Retrying until it succeeds or the deadline passes gets the
+    // same guarantee without a hardcoded margin (review finding on #491/#53).
+    let second = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if BrokerClient::connect(&endpoint, agent("second"), TOKEN)
+                .await
+                .is_ok()
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    assert!(
+        second.is_ok(),
+        "a freed slot must admit a new connection within 5s of the old one closing"
+    );
 }
 
 /// Message-flood DoS defense (#53): a connection sending `Deliver` frames
@@ -393,5 +405,61 @@ async fn deliver_rate_limit_backpressures_a_flooding_connection() {
         elapsed >= Duration::from_millis(150),
         "a burst beyond the token bucket must be delayed, not accepted \
          instantly (took {elapsed:?})"
+    );
+}
+
+/// Mailbox-flood rejection reaches the SENDER end-to-end over a real
+/// WebSocket connection (review finding #1 on PR #491/#53): once a mailbox
+/// is at its pending cap, `deliver()` must return a fast, clear
+/// `BrokerError::Rejected` — not the generic 30s `DELIVER_RECEIPT_TIMEOUT` a
+/// caller would otherwise burn waiting for a `Delivered` receipt the broker
+/// will never send.
+#[tokio::test]
+async fn mailbox_full_rejection_reaches_the_delivering_client() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let core = Arc::new(BrokerCore::new(dir.path()).with_max_pending_per_mailbox(1));
+    let server = Arc::new(BrokerServer::new(core, TOKEN));
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    tokio::spawn(async move {
+        let _ = server.serve(listener).await;
+    });
+    let endpoint = format!("ws://{addr}");
+
+    let mut sender = BrokerClient::connect(&endpoint, agent("flooder2"), TOKEN)
+        .await
+        .expect("connects");
+
+    // 1st delivery reaches the cap — nobody ever subscribes to "hoard", so
+    // nothing drains it.
+    sender
+        .deliver("hoard", ask("flooder2"))
+        .await
+        .expect("1st delivery is under the cap");
+
+    // 2nd delivery must be rejected promptly (well under the 30s production
+    // receipt timeout), not silently swallowed and left to time out.
+    let started = std::time::Instant::now();
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(5),
+        sender.deliver("hoard", ask("flooder2")),
+    )
+    .await
+    .expect("deliver() resolves promptly instead of hanging out the 30s receipt timeout");
+
+    match outcome {
+        Err(bamboo_broker::BrokerError::Rejected(reason)) => {
+            assert!(
+                reason.contains("full"),
+                "expected the MailboxFull reason to reach the caller verbatim, got: {reason}"
+            );
+        }
+        other => panic!("expected BrokerError::Rejected, got {other:?}"),
+    }
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "the rejection must reach the caller fast, not via the 30s receipt \
+         timeout — took {:?}",
+        started.elapsed(),
     );
 }

--- a/crates/infra/bamboo-subagent/src/mailbox.rs
+++ b/crates/infra/bamboo-subagent/src/mailbox.rs
@@ -242,15 +242,21 @@ impl Mailbox {
         }
     }
 
-    /// Acknowledge a processed message by id: delete it from `cur/`.
+    /// Acknowledge a processed message by id: delete it from `cur/`. Returns
+    /// `true` if a message was actually found and removed, `false` if it was
+    /// already gone (idempotent no-op — a double-ack, or an id that was never
+    /// claimed into `cur/`) — a caller that keeps a live pending-count
+    /// alongside the mailbox (e.g. `bamboo-broker`'s `BrokerCore`, #53
+    /// follow-up) needs this to decrement exactly once per message actually
+    /// removed, not once per `ack` call.
     /// O(n) directory scan — prefer [`ack_delivered`](Self::ack_delivered)
     /// when you still hold the [`Delivered`]. Idempotent (no-op if gone).
-    pub async fn ack(&self, id: &MsgId) -> Result<()> {
+    pub async fn ack(&self, id: &MsgId) -> Result<bool> {
         let needle = format!("-{}.json", id.0);
         let cur = self.cur_dir();
         let mut rd = match tokio::fs::read_dir(&cur).await {
             Ok(rd) => rd,
-            Err(e) if e.kind() == ErrorKind::NotFound => return Ok(()),
+            Err(e) if e.kind() == ErrorKind::NotFound => return Ok(false),
             Err(e) => return Err(StoreError::io(&cur, e)),
         };
         while let Some(ent) = rd.next_entry().await.map_err(|e| StoreError::io(&cur, e))? {
@@ -259,10 +265,10 @@ impl Mailbox {
                 tokio::fs::remove_file(ent.path())
                     .await
                     .map_err(|e| StoreError::io(ent.path(), e))?;
-                return Ok(());
+                return Ok(true);
             }
         }
-        Ok(())
+        Ok(false)
     }
 
     /// Re-yield messages left in `cur/` by a previous (crashed) activation, in order.

--- a/crates/infra/bamboo-subagent/src/mailbox.rs
+++ b/crates/infra/bamboo-subagent/src/mailbox.rs
@@ -290,6 +290,17 @@ impl Mailbox {
         Ok(self.sorted_json_names(&self.new_dir()).await?.is_empty())
     }
 
+    /// Count of messages currently pending in this mailbox: not-yet-claimed
+    /// (`new/`) plus claimed-but-unacked (`cur/`). A real reader claims (drain)
+    /// and acks promptly, so this only grows unbounded when nobody is
+    /// consuming — used to cap a session's backlog against a `deliver` flood
+    /// aimed at an offline/never-draining mailbox (disk-exhaustion DoS
+    /// defense, #53).
+    pub async fn pending_count(&self) -> Result<usize> {
+        Ok(self.sorted_json_names(&self.new_dir()).await?.len()
+            + self.sorted_json_names(&self.cur_dir()).await?.len())
+    }
+
     async fn sorted_json_names(&self, dir: &std::path::Path) -> Result<Vec<String>> {
         let mut rd = match tokio::fs::read_dir(dir).await {
             Ok(rd) => rd,

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -136,6 +136,23 @@ fn resolve_config_data_dir(path: &std::path::Path) -> Result<PathBuf, String> {
     }
 }
 
+/// `clap` `value_parser` for `broker serve --messages-per-second` /
+/// `--message-burst`: rejects `0` with a clear CLI error instead of letting
+/// it through and silently falling back to the default deep inside
+/// `BrokerLimits` construction (review finding on #491/#53) — an operator
+/// passing `0` almost certainly wants a hard error, not a quiet no-op.
+fn parse_nonzero_u32(s: &str) -> Result<u32, String> {
+    let n: u32 = s.parse().map_err(|e| format!("invalid number: {e}"))?;
+    if n == 0 {
+        return Err(
+            "must be greater than 0 (0 would silently fall back to the default, not enforce \
+             a stricter limit)"
+                .to_string(),
+        );
+    }
+    Ok(n)
+}
+
 /// Spawn the sidecar orphan guard: a dedicated OS thread that exits the process
 /// when the shell that spawned us goes away.
 ///
@@ -981,12 +998,17 @@ enum BrokerCommands {
 
         /// Sustained per-connection `Deliver`-frame rate, frames/sec (#53).
         /// Exceeding it delays (not disconnects) the connection. Default is
-        /// well above a single live event-streaming Run's normal rate.
-        #[arg(long, default_value_t = bamboo_broker::BrokerLimits::default().messages_per_second.get())]
+        /// well above a single live event-streaming Run's normal rate. Must
+        /// be nonzero — `0` is rejected outright rather than silently
+        /// falling back to the default, since a `0` is almost certainly a
+        /// misconfiguration (an operator trying to be maximally strict, or a
+        /// scripting bug), not an intentional "block everything".
+        #[arg(long, default_value_t = bamboo_broker::BrokerLimits::default().messages_per_second.get(), value_parser = parse_nonzero_u32)]
         messages_per_second: u32,
 
-        /// Burst allowance layered on `--messages-per-second` (#53).
-        #[arg(long, default_value_t = bamboo_broker::BrokerLimits::default().message_burst.get())]
+        /// Burst allowance layered on `--messages-per-second` (#53). Must be
+        /// nonzero (see `--messages-per-second`).
+        #[arg(long, default_value_t = bamboo_broker::BrokerLimits::default().message_burst.get(), value_parser = parse_nonzero_u32)]
         message_burst: u32,
 
         /// Max pending (undelivered-or-unacked) messages a single session's
@@ -1628,10 +1650,13 @@ async fn main() {
                 .spawn_mailbox_gc(std::time::Duration::from_secs(300));
             let limits = bamboo_broker::BrokerLimits {
                 max_connections,
+                // `parse_nonzero_u32` (the clap `value_parser` on both flags)
+                // already rejected `0` at CLI-parse time, so these are
+                // infallible here — no silent fallback needed.
                 messages_per_second: std::num::NonZeroU32::new(messages_per_second)
-                    .unwrap_or(bamboo_broker::BrokerLimits::default().messages_per_second),
+                    .expect("clap value_parser rejects 0"),
                 message_burst: std::num::NonZeroU32::new(message_burst)
-                    .unwrap_or(bamboo_broker::BrokerLimits::default().message_burst),
+                    .expect("clap value_parser rejects 0"),
             };
             let server = std::sync::Arc::new(bamboo_broker::BrokerServer::with_limits(
                 core, token, limits,

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -918,6 +918,29 @@ enum BrokerCommands {
         /// Durable mailbox storage root. Defaults to `<bamboo_dir>/broker`.
         #[arg(long)]
         root: Option<PathBuf>,
+
+        /// Max concurrent WebSocket connections (#53 DoS defense). Beyond
+        /// this, new connections are dropped immediately. Default is
+        /// generous — sized well above a normal multi-worker fabric.
+        #[arg(long, default_value_t = bamboo_broker::BrokerLimits::default().max_connections)]
+        max_connections: usize,
+
+        /// Sustained per-connection `Deliver`-frame rate, frames/sec (#53).
+        /// Exceeding it delays (not disconnects) the connection. Default is
+        /// well above a single live event-streaming Run's normal rate.
+        #[arg(long, default_value_t = bamboo_broker::BrokerLimits::default().messages_per_second.get())]
+        messages_per_second: u32,
+
+        /// Burst allowance layered on `--messages-per-second` (#53).
+        #[arg(long, default_value_t = bamboo_broker::BrokerLimits::default().message_burst.get())]
+        message_burst: u32,
+
+        /// Max pending (undelivered-or-unacked) messages a single session's
+        /// mailbox may hold before `deliver` starts refusing more (#53) — a
+        /// backlog cap against a flood aimed at an offline/never-draining
+        /// mailbox.
+        #[arg(long, default_value_t = bamboo_broker::DEFAULT_MAX_PENDING_PER_MAILBOX)]
+        max_pending_per_mailbox: usize,
     },
 }
 
@@ -1465,7 +1488,15 @@ async fn main() {
         }
 
         Commands::Broker { command } => {
-            let BrokerCommands::Serve { bind, token, root } = command;
+            let BrokerCommands::Serve {
+                bind,
+                token,
+                root,
+                max_connections,
+                messages_per_second,
+                message_burst,
+                max_pending_per_mailbox,
+            } = command;
             let token = match token
                 .or_else(|| std::env::var("BAMBOO_BROKER_TOKEN").ok())
                 .filter(|t| !t.is_empty())
@@ -1491,13 +1522,33 @@ async fn main() {
                 .local_addr()
                 .map(|a| a.to_string())
                 .unwrap_or_else(|_| bind.clone());
-            tracing::info!(%addr, root = %root.display(), "bamboo broker serving");
-            let core = std::sync::Arc::new(bamboo_broker::BrokerCore::new(root));
+            tracing::info!(
+                %addr,
+                root = %root.display(),
+                max_connections,
+                messages_per_second,
+                message_burst,
+                max_pending_per_mailbox,
+                "bamboo broker serving"
+            );
+            let core = std::sync::Arc::new(
+                bamboo_broker::BrokerCore::new(root)
+                    .with_max_pending_per_mailbox(max_pending_per_mailbox),
+            );
             // Reclaim empty, unsubscribed mailbox dirs every 5 minutes.
             let _gc = core
                 .clone()
                 .spawn_mailbox_gc(std::time::Duration::from_secs(300));
-            let server = std::sync::Arc::new(bamboo_broker::BrokerServer::new(core, token));
+            let limits = bamboo_broker::BrokerLimits {
+                max_connections,
+                messages_per_second: std::num::NonZeroU32::new(messages_per_second)
+                    .unwrap_or(bamboo_broker::BrokerLimits::default().messages_per_second),
+                message_burst: std::num::NonZeroU32::new(message_burst)
+                    .unwrap_or(bamboo_broker::BrokerLimits::default().message_burst),
+            };
+            let server = std::sync::Arc::new(bamboo_broker::BrokerServer::with_limits(
+                core, token, limits,
+            ));
             if let Err(e) = server.serve(listener).await {
                 eprintln!("broker server failed: {e}");
                 std::process::exit(1);


### PR DESCRIPTION
## Problem

`BrokerServer::serve()`'s accept loop (`server.rs`) had no cap on concurrent connections — each accepted connection spawned an unbounded tokio task. `BrokerCore::deliver()` (`core.rs`) had no per-session message rate limit — any authenticated client could flood a mailbox with unlimited `Deliver` frames. Verified against current `main` (post-#207 refactor); both gaps still exist at the cited call sites (line numbers have shifted slightly since the issue was filed but the code shape is unchanged).

- Connection flood: opening thousands of WS connections exhausts memory.
- Message flood: unlimited `Deliver`s to any session mailbox exhausts disk.

## Fix

Three bounded, configurable defenses, all landed as opt-in-by-default via new `BrokerLimits` (server) and a `BrokerCore` builder method — existing `BrokerServer::new`/`BrokerCore::new` callers are unaffected (they get the new defaults automatically) and needed no changes.

1. **`max_connections`** (default **1000**): the accept loop now gates each accepted connection on a `tokio::sync::Semaphore` permit (`try_acquire_owned`). Once the pool is exhausted, a new TCP stream is dropped immediately — **no WS handshake is attempted** for a connection we're refusing, so an over-the-cap flood costs only an `accept()` + drop.
2. **`messages_per_second` / `message_burst`** (default **500/1000**): a `governor` token bucket, one per connection, gates `ClientFrame::Deliver` specifically (the frame kind that writes into a mailbox — the concrete disk-flood vector). Exceeding it **backpressures (delays) the connection rather than disconnecting it**, so a legitimate burst is merely slowed, never punished.
3. **`max_pending_per_mailbox`** (default **50,000**): `BrokerCore::deliver` now checks the target mailbox's live pending count (`new/` + `cur/`, via a new `Mailbox::pending_count()`) and rejects with a new `BrokerError::MailboxFull` once it's at cap — bounds worst-case disk use from a flood aimed at an offline/never-draining mailbox. The check races benignly with concurrent delivers (best-effort bound, not a hard invariant).

All three are wired into the standalone `bamboo broker serve` CLI as new flags (`--max-connections`, `--messages-per-second`, `--message-burst`, `--max-pending-per-mailbox`) with the same defaults.

## Design choices

- **Defaults are deliberately generous.** I traced the broker's live event-streaming path (`serve::handle_run`, forwarding `EventSink` → `BrokerClient::deliver`) and confirmed a single actively-streaming Run can legitimately emit **100+ `Deliver`s/sec** (one per LLM SSE token/reasoning-token/tool-output chunk, unbatched — see `chunk_handling.rs`). `messages_per_second=500`/`burst=1000` sits well above that with headroom, so normal multi-worker fabric / deploy-test traffic never trips it, while still meaningfully bounding a "millions of frames" flood.
- **Deliver throttle backpressures, doesn't disconnect.** `until_ready().await` (governor's async wait) instead of `check()` + hard-reject — a burst just delays that connection's next Deliver instead of killing the connection or dropping the message. This avoids punishing a legitimate connection for a brief overlap of concurrent event streams.
- **No loopback exemption**, unlike bamboo-server's HTTP sidecar bug (#13-adjacent — `is_loopback_bind`, where local desktop traffic was wrongly rate-limited). The broker's own doc comment states it's "reachable on any address... so workers deployed via subprocess/Docker/SSH can dial home over the network" — there's no "trusted local caller" concept here, so loopback and remote connections share one limit pool.
- **`max_connections` rejection is a hard drop, not a queue.** Chose immediate-drop-before-handshake over accepting-then-queuing so an attacker gains nothing by holding many pending accepts (bounded resource use even under a connection flood).

## Distinct from #13

#13 (referenced in the original issue) is the HTTP API server (`bamboo-server`, `actix-governor`); this is the separate WebSocket broker surface (`bamboo-broker`, raw `governor` — not actix-based, so `actix-governor` doesn't apply here).

## Conflict note (#488)

PR #488 (`fix/49-broker-graceful-shutdown`) touches `serve.rs`/`lib.rs` (adds `serve_loop`/`serve_executor`/`serve_mailbox` shutdown-token variants) but does **not** touch `server.rs` or `core.rs` — no overlapping regions with this PR. Composes fine regardless of merge order.

## Tests

Added to `crates/app/bamboo-broker/tests/ws_roundtrip.rs` (real WS server + real client, existing harness pattern):
- `max_connections_rejects_beyond_cap`
- `max_connections_slot_frees_on_disconnect`
- `deliver_rate_limit_backpressures_a_flooding_connection`

Added to `crates/app/bamboo-broker/src/core.rs` (in-process `BrokerCore` unit tests):
- `deliver_rejects_once_pending_cap_reached`
- `deliver_succeeds_again_after_ack_frees_a_slot`

## Quality gates

- `cargo fmt -p bamboo-broker -p bamboo-subagent -p bamboo-agent -- --check` — clean
- `cargo clippy -p bamboo-broker -p bamboo-subagent --all-targets` — no new warnings (one pre-existing `too_many_arguments` warning in `bamboo-agent-core::tools::context.rs`, unrelated to this change, not touched)
- `cargo build --workspace --tests` — succeeds (only pre-existing unrelated warnings elsewhere, e.g. `bamboo-llm`/`bamboo-memory`/`bamboo-engine` dead-code/unused-import warnings)
- `cargo test -p bamboo-broker -p bamboo-subagent` — all pass (58 + 8 + 2 + 1 in bamboo-broker; 46 + 2 in bamboo-subagent)

Closes #53.