### PR TITLE
fix(config): type-based fallback for masked connect-secret preservation

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
@@ -674,6 +674,120 @@ async fn set_bamboo_config_persists_feishu_app_secret_encrypted_and_preserves_ma
     );
 }
 
+/// #490 end-to-end: the settings PATCH surface must preserve a masked secret
+/// even when a preceding platform entry is removed in the same request,
+/// shifting the kept entry's array index. Stored platforms are
+/// `[telegram, feishu]`; the client disables telegram and re-POSTs only the
+/// (still-masked) feishu entry, which now lands at index 0 instead of 1.
+/// Before the #490 fix, the positional type-guard (added for #454) saw
+/// telegram≠feishu at index 0 and silently dropped the feishu app_secret.
+#[actix_web::test]
+async fn set_bamboo_config_preserves_masked_secret_when_preceding_platform_removed() {
+    use crate::app_state::AppState;
+    use actix_web::{test, web, App};
+    use bamboo_config::encryption;
+
+    // See the long NOTE on the Telegram test above for why the process-global
+    // (not thread-local) encryption key is relied on here.
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let state = AppState::new(temp_dir.path().to_path_buf())
+        .await
+        .expect("app state should initialize");
+    let data_dir = state.app_data_dir.clone();
+    let app_state = web::Data::new(state);
+
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .route("/bamboo/config", web::get().to(super::get_bamboo_config))
+            .route("/bamboo/config", web::post().to(super::set_bamboo_config)),
+    )
+    .await;
+
+    // 1) Set both a Telegram bot token and a Feishu app_secret, in that order.
+    let post = test::TestRequest::post()
+        .uri("/bamboo/config")
+        .set_json(serde_json::json!({
+            "connect": {
+                "platforms": [
+                    { "type": "telegram", "token": "tg-real-secret", "allow_from": ["u1"] },
+                    {
+                        "type": "feishu",
+                        "app_id": "cli_real_app_id",
+                        "app_secret": "feishu-real-secret",
+                        "domain": "lark",
+                        "allow_from": ["ou_1"]
+                    }
+                ]
+            }
+        }))
+        .to_request();
+    let post_resp = test::call_service(&app, post).await;
+    assert!(post_resp.status().is_success(), "set config should succeed");
+
+    // 2) GET, confirm both entries round-trip masked, in stored order.
+    let get = test::TestRequest::get().uri("/bamboo/config").to_request();
+    let body: serde_json::Value = test::call_and_read_body_json(&app, get).await;
+    assert_eq!(body["connect"]["platforms"][0]["type"], "telegram");
+    assert_eq!(body["connect"]["platforms"][1]["type"], "feishu");
+    assert_eq!(body["connect"]["platforms"][1]["app_secret"], "****...****");
+
+    // 3) Re-POST with telegram removed — the UI's echoed feishu entry (still
+    // masked) now sits at index 0, not index 1 where it was stored.
+    let post2 = test::TestRequest::post()
+        .uri("/bamboo/config")
+        .set_json(serde_json::json!({
+            "connect": {
+                "platforms": [
+                    {
+                        "type": "feishu",
+                        "app_id": "cli_real_app_id",
+                        "app_secret": "****...****",
+                        "domain": "lark",
+                        "allow_from": ["ou_1"]
+                    }
+                ]
+            }
+        }))
+        .to_request();
+    let post2_resp = test::call_service(&app, post2).await;
+    assert!(
+        post2_resp.status().is_success(),
+        "second set config should succeed"
+    );
+
+    // The feishu app_secret must still read as configured, not wiped.
+    let get2 = test::TestRequest::get().uri("/bamboo/config").to_request();
+    let body2: serde_json::Value = test::call_and_read_body_json(&app, get2).await;
+    assert_eq!(
+        body2["connect"]["platforms"][0]["type"], "feishu",
+        "telegram entry should be gone, feishu now at index 0"
+    );
+    assert_eq!(
+        body2["connect"]["platforms"][0]["app_secret"], "****...****",
+        "app_secret must still read as configured after the index shift"
+    );
+
+    // And the plaintext on disk (encrypted at rest) must be unchanged, not
+    // wiped by the removed-entry-shifted-index case.
+    let connect_path = data_dir.join("connect.json");
+    let connect_text_after = tokio::fs::read_to_string(&connect_path)
+        .await
+        .expect("connect.json should still exist");
+    let connect_json_after: serde_json::Value =
+        serde_json::from_str(&connect_text_after).expect("connect.json should parse");
+    assert_eq!(connect_json_after["platforms"].as_array().unwrap().len(), 1);
+    let app_secret_encrypted_after = connect_json_after["platforms"][0]["app_secret_encrypted"]
+        .as_str()
+        .expect("app_secret_encrypted should still be present")
+        .to_string();
+    assert_eq!(
+        encryption::decrypt(&app_secret_encrypted_after).expect("app_secret should decrypt"),
+        "feishu-real-secret",
+        "masked secret must resolve by type after a preceding entry was removed, not be dropped"
+    );
+}
+
 /// #455 gap: a full config reset must also clear `connect.json`, or a
 /// bamboo-connect bot token would silently survive `POST
 /// /bamboo/config/reset` and get re-merged back onto the freshly-defaulted

--- a/crates/infra/bamboo-config/src/patch.rs
+++ b/crates/infra/bamboo-config/src/patch.rs
@@ -427,13 +427,17 @@ pub fn preserve_masked_notification_secrets(patch_obj: &mut Map<String, Value>, 
 /// supported) at the same time as leaving one masked is indistinguishable
 /// from "not reordered" and can still attach the wrong token to an entry —
 /// fixing that needs a schema change (a stable id field) tracked separately.
-/// What IS fixed here: a reorder is now detected whenever it changes the
-/// `platform_type` at a given index (the common case today, since only one
-/// platform type — `"telegram"` — exists) — `type` is checked against
-/// `current`'s entry at the same index, and a mismatch is treated as
-/// "nothing configured at this position" (the token is dropped, same as no
-/// plaintext existing yet) instead of silently handing one platform's secret
-/// to a different one that happens to now sit at the same index.
+/// What IS fixed here: a reorder is detected whenever it changes the
+/// `platform_type` at a given index — `type` is checked against `current`'s
+/// entry at the same index, and a mismatch (or an index beyond
+/// `current.connect.platforms`, e.g. a preceding entry was removed) no
+/// longer drops the secret outright. Instead (issue #490) it falls back to a
+/// type-based lookup: `current.connect.platforms.iter().find(|p|
+/// p.platform_type == patch_type)`. This is safe because `multi_bot_guard`
+/// (#462) means only the FIRST entry of a given type is ever started, so
+/// resolving to any same-typed entry is strictly better than silently
+/// wiping the secret. Only when no entry of that type exists anywhere in
+/// `current` does the mask get dropped, same as "nothing configured yet".
 pub fn preserve_masked_connect_secrets(patch_obj: &mut Map<String, Value>, current: &Config) {
     let Some(platforms) = patch_obj
         .get_mut("connect")
@@ -447,19 +451,31 @@ pub fn preserve_masked_connect_secrets(patch_obj: &mut Map<String, Value>, curre
         let Some(obj) = platform.as_object_mut() else {
             continue;
         };
+        let patch_type = obj.get("type").and_then(|v| v.as_str());
         let existing = current.connect.platforms.get(index);
         // A patch entry that names a "type" disagreeing with `current`'s
-        // entry at the same index means the array was reordered (or an
-        // entry was inserted/removed) since the client fetched it — the
-        // position no longer identifies the same logical platform, so don't
-        // resolve the mask against it. A patch entry with no "type" at all
-        // (shouldn't happen with a well-behaved client, which always echoes
-        // the whole object back) can't be checked and falls back to the
-        // pre-existing positional-only behavior.
-        let guarded = existing.filter(|p| match obj.get("type").and_then(|v| v.as_str()) {
-            Some(patch_type) => patch_type == p.platform_type,
-            None => true,
-        });
+        // entry at the same index (or an index beyond `current`'s array)
+        // means the array was reordered/shrunk since the client fetched it
+        // — the position no longer identifies the same logical platform, so
+        // don't resolve the mask against it positionally. A patch entry with
+        // no "type" at all (shouldn't happen with a well-behaved client,
+        // which always echoes the whole object back) can't be checked and
+        // falls back to the pre-existing positional-only behavior (no
+        // type-based fallback either, since there's no type to search by).
+        let guarded = existing
+            .filter(|p| match patch_type {
+                Some(patch_type) => patch_type == p.platform_type,
+                None => true,
+            })
+            .or_else(|| {
+                patch_type.and_then(|patch_type| {
+                    current
+                        .connect
+                        .platforms
+                        .iter()
+                        .find(|p| p.platform_type == patch_type)
+                })
+            });
         preserve_masked_secret_field(obj, "token", guarded.and_then(|p| p.token.as_deref()));
         preserve_masked_secret_field(
             obj,
@@ -807,19 +823,23 @@ mod tests {
         );
     }
 
-    /// The type-check is index-scoped, not "does this type appear anywhere
-    /// in current" — a mismatch at index 1 must not fall back to matching
-    /// against a same-typed entry that lives at a different index.
+    /// #490: when the type at an index mismatches, the guard now falls back
+    /// to a type-based lookup across all of `current.connect.platforms`
+    /// rather than dropping outright. Here index 1's patch entry claims
+    /// "telegram" (matching index 0's type, not index 1's) — the mismatch at
+    /// index 1 is detected, but since a "telegram" entry DOES exist
+    /// elsewhere in `current` (at index 0), the mask resolves to it. This is
+    /// safe because `multi_bot_guard` (#462) only ever starts the first
+    /// entry of a given type, so resolving to any same-typed entry is
+    /// strictly better than wiping the secret.
     #[test]
-    fn preserve_masked_connect_secrets_type_check_does_not_search_other_indices() {
+    fn preserve_masked_connect_secrets_type_mismatch_falls_back_to_type_lookup() {
         let mut current = Config::default();
         current.connect.platforms = vec![
             connect_platform("telegram", "bot-a-token"),
             connect_platform("feishu", "feishu-token"),
         ];
 
-        // Patch entry at index 1 claims "telegram" (matches index 0's type,
-        // NOT index 1's) — must still drop, not borrow index 0's token.
         let mut patch: Map<String, Value> = serde_json::from_str(
             r#"{"connect":{"platforms":[
                 {"type":"telegram","token":"tg-real-value"},
@@ -831,12 +851,9 @@ mod tests {
         preserve_masked_connect_secrets(&mut patch, &current);
 
         assert_eq!(patch["connect"]["platforms"][0]["token"], "tg-real-value");
-        assert!(
-            !patch["connect"]["platforms"][1]
-                .as_object()
-                .unwrap()
-                .contains_key("token"),
-            "index 1's mismatched type must not resolve to index 0's token"
+        assert_eq!(
+            patch["connect"]["platforms"][1]["token"], "bot-a-token",
+            "index 1's mismatched type must fall back to the same-typed entry found elsewhere in current"
         );
     }
 
@@ -972,6 +989,99 @@ mod tests {
                 .unwrap()
                 .contains_key("app_secret"),
             "masked app_secret must not be resolved against a different platform's secret"
+        );
+    }
+
+    /// #490 regression: the exact scenario from the issue. Stored platforms
+    /// are `[telegram, feishu]`; the client disables telegram and echoes
+    /// back only the (still-masked) feishu entry, which now shifts to index
+    /// 0. The positional guard sees telegram≠feishu at index 0 and used to
+    /// drop the mask outright, silently wiping the feishu app_secret on
+    /// save. It must now fall back to a type-based lookup and resolve to the
+    /// stored feishu plaintext.
+    #[test]
+    fn preserve_masked_connect_secrets_resolves_by_type_when_preceding_entry_removed() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![
+            connect_platform("telegram", "telegram-token"),
+            feishu_platform("existing-app-secret"),
+        ];
+
+        // telegram was removed client-side; only the feishu entry (still
+        // masked) is echoed back, now at index 0.
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[
+                {"type":"feishu","app_id":"cli_x","app_secret":"****...****","domain":"lark"}
+            ]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert_eq!(
+            patch["connect"]["platforms"][0]["app_secret"], "existing-app-secret",
+            "masked app_secret must resolve via type fallback after a preceding entry was removed"
+        );
+    }
+
+    /// #490: an index beyond `current.connect.platforms` (the patch array
+    /// grew, e.g. a new platform was added client-side before saving) must
+    /// also fall back to the type-based lookup rather than dropping the mask
+    /// when a same-typed entry exists elsewhere in `current`.
+    #[test]
+    fn preserve_masked_connect_secrets_resolves_by_type_when_index_out_of_range() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![
+            connect_platform("telegram", "telegram-token"),
+            feishu_platform("existing-app-secret"),
+        ];
+
+        // Patch has 3 entries; index 2 is beyond `current`'s 2-entry array
+        // (a new telegram entry was inserted at index 1 client-side), but
+        // its masked feishu app_secret should still resolve by type.
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[
+                {"type":"telegram","token":"tg-real-value"},
+                {"type":"telegram","token":"new-bot-token"},
+                {"type":"feishu","app_id":"cli_x","app_secret":"****...****","domain":"lark"}
+            ]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert_eq!(
+            patch["connect"]["platforms"][2]["app_secret"], "existing-app-secret",
+            "masked app_secret at an out-of-range index must resolve via type fallback"
+        );
+    }
+
+    /// #490: the type-based fallback only searches by type — if the patched
+    /// type doesn't exist anywhere in `current`, the mask still drops, same
+    /// as before. Unchanged behavior, exercised here with a multi-entry
+    /// `current` (not just the empty-config case already covered above).
+    #[test]
+    fn preserve_masked_connect_secrets_drops_mask_when_type_absent_from_current_entirely() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![connect_platform("telegram", "telegram-token")];
+
+        // No feishu entry exists anywhere in `current` — the type-based
+        // fallback has nothing to resolve against.
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[
+                {"type":"feishu","app_id":"cli_x","app_secret":"****...****","domain":"lark"}
+            ]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert!(
+            !patch["connect"]["platforms"][0]
+                .as_object()
+                .unwrap()
+                .contains_key("app_secret"),
+            "mask must still drop when no entry of that type exists anywhere in current"
         );
     }
 }


### PR DESCRIPTION
## Summary

`preserve_masked_connect_secrets` (`crates/infra/bamboo-config/src/patch.rs`) resolved an echoed `****...****` mask **positionally**, guarded by `platform_type` equality at the same index. If a client removed an entry that precedes a kept-masked entry — e.g. stored `[telegram, feishu]`, user disables telegram, patch = `[{type: feishu, app_secret: "****...****"}]` — the feishu entry shifts to index 0, the type guard sees `telegram≠feishu`, and the mask was silently **dropped**, wiping the feishu `app_secret` on save. Same bug class as #430.

## Fix

When the positional entry's type disagrees with the patch entry's `type` (or the patch index is beyond `current.connect.platforms`), fall back to a type-based lookup: `current.connect.platforms.iter().find(|p| p.platform_type == patch_type)`, before dropping the mask. This is safe because `multi_bot_guard` (#462) means only the first entry per type is ever started, so resolving to any same-typed entry is strictly better than silently wiping the secret. Positional-only behavior is unchanged when the patch entry has no `type` field at all.

## Tests

- `crates/infra/bamboo-config/src/patch.rs` (unit tests, `bamboo-config`):
  - `preserve_masked_connect_secrets_resolves_by_type_when_preceding_entry_removed` — the exact issue scenario: stored `[telegram, feishu]`, patch `[feishu-masked]` at index 0 → resolves to the stored feishu plaintext.
  - `preserve_masked_connect_secrets_resolves_by_type_when_index_out_of_range` — patch index beyond `current`'s array, matching type exists elsewhere → resolves.
  - `preserve_masked_connect_secrets_drops_mask_when_type_absent_from_current_entirely` — type present in patch but absent anywhere in `current` → mask still drops (unchanged behavior), exercised with a multi-entry `current`.
  - `preserve_masked_connect_secrets_type_mismatch_falls_back_to_type_lookup` — rewritten from the old `..._type_check_does_not_search_other_indices` test, which asserted the pre-#490 "never search other indices" behavior; updated to assert the new type-fallback resolution (documented inline why the old assertion no longer holds).
  - All prior positional tests (matching-type-at-index, no-type-field positional fallback, drops-when-nothing-configured, etc.) still pass unmodified.
- `crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs` (e2e via the real `/bamboo/config` HTTP surface, `bamboo-server`): added `set_bamboo_config_preserves_masked_secret_when_preceding_platform_removed`, a companion to the existing connect.json split e2e tests (#456) — sets `[telegram, feishu]`, removes telegram via PATCH, verifies the feishu `app_secret` (both over GET and decrypted on disk in `connect.json`) survives the index shift instead of being wiped.

## Build/test results

- `cargo build --workspace --tests`: green (only pre-existing unrelated warnings — dead imports in `bamboo-memory`/`bamboo-llm`, `too_many_arguments`/`type_complexity` clippy lints in `bamboo-engine`/`bamboo-server` untouched by this change).
- `cargo test -p bamboo-config`: 228 passed.
- `cargo test -p bamboo-server config_endpoints`: 21 passed (includes the new e2e test).
- `cargo fmt -- --check`: clean.
- `cargo clippy -p bamboo-config -p bamboo-server --tests --all-targets`: no warnings in touched files; pre-existing warnings elsewhere untouched.

Closes #490. Unblocks bigduu/Lotus#55.

https://claude.ai/code/session_01Ux4nHUqFjEEGV3rX1x3V9Y