### PR TITLE
fix(deploy): scope docker mount — stop exposing all of ~/.bamboo to worker containers

### DIFF
--- a/crates/app/bamboo-broker/src/deploy.rs
+++ b/crates/app/bamboo-broker/src/deploy.rs
@@ -48,10 +48,12 @@ pub struct AgentDeployment {
     /// A parent-resolved `ProvisionSpec` (serialized JSON) the orchestrator ships
     /// to the worker — model/creds/MCP/bus all decided here, so the worker stops
     /// self-resolving from its host config (a remote node needs no bamboo config
-    /// of its own). Delivery is per-deployer: Local pipes it to stdin
+    /// of its own, and a Docker worker needs no mount of the orchestrator's home
+    /// — #46). Delivery is per-deployer: Local and Docker pipe it to stdin
     /// (`--spec-stdin`); Ssh/Russh upload it to a remote file (`--spec-file`).
-    /// `None` keeps the legacy argv+env self-resolve bootstrap (Docker still
-    /// self-resolves via its mounted home).
+    /// `None` keeps the legacy argv+env self-resolve bootstrap (Docker then
+    /// falls back to `DockerDeployer::mount_home` if set, or a homeless
+    /// container otherwise).
     pub spec_json: Option<String>,
 }
 
@@ -333,13 +335,16 @@ pub struct DockerDeployer {
     pub bamboo_in_image: String,
     /// e.g. `Some("host")` so the container can reach a `127.0.0.1` broker.
     pub network: Option<String>,
-    /// Host bamboo home dir to seed the worker from: mounted read-only at
-    /// `/seed`, then config + encryption key + skills are copied into the
-    /// container's writable data dir at startup, so the worker reads the
-    /// orchestrator's config (MCP servers + skills + provider creds) while
-    /// keeping an isolated, writable data dir. (Trusted-local convenience; it
-    /// also exposes the config's secrets to the container — P3 will scope this
-    /// down.)
+    /// LEGACY fallback: host bamboo home dir to seed the worker from — mounted
+    /// read-only at `/seed`, then config + encryption key + skills copied into
+    /// the container's writable data dir at startup. This exposes **every**
+    /// provider credential in the orchestrator's config to the container (#46)
+    /// and is only still consulted when `AgentDeployment::spec_json` is unset
+    /// (e.g. a caller with no configured credentials). The normal path —
+    /// `deploy_agent`'s `env=docker` — ships a parent-resolved `ProvisionSpec`
+    /// (just the assigned model's credential, no encryption key, no full
+    /// config) over stdin instead; see `spec_json` below, which takes
+    /// precedence over this field whenever both are set.
     pub mount_home: Option<PathBuf>,
 }
 
@@ -383,7 +388,21 @@ impl DockerDeployer {
             a.push("--network".into());
             a.push(net.clone());
         }
-        if let Some(home) = &self.mount_home {
+        if d.spec_json.is_some() {
+            // Parent-resolved spec rides the container's stdin — no home mount,
+            // no on-disk config/encryption-key copy (#46). `-i` keeps stdin
+            // open for the pipe; `deploy()` writes the spec and closes it right
+            // after spawn, mirroring `LocalProcessDeployer`. Takes precedence
+            // over `mount_home` (same "spec is authoritative" rule as the CLI's
+            // `--spec-stdin`/`--spec-file`).
+            a.push("-i".into());
+            a.push("--entrypoint".into());
+            a.push(self.bamboo_in_image.clone());
+            a.push(self.image.clone());
+            let mut argv = agent_argv(d);
+            argv.push("--spec-stdin".to_string());
+            a.extend(argv);
+        } else if let Some(home) = &self.mount_home {
             // Seed the worker from the orchestrator's home, but DON'T run on a
             // read-only mount of it: the worker writes the moment it starts
             // (skill-store builtin sync, session/event persistence), so a
@@ -437,7 +456,25 @@ impl Deployer for DockerDeployer {
         let container = format!("bamboo-agent-{}", d.id);
         let mut cmd = Command::new(&self.docker_bin);
         cmd.args(self.argv(d, &container)).kill_on_drop(true);
-        let child = cmd.spawn().map_err(spawn_err)?;
+        if d.spec_json.is_some() {
+            cmd.stdin(std::process::Stdio::piped());
+        }
+        let mut child = cmd.spawn().map_err(spawn_err)?;
+        // Feed the spec, then close stdin so the worker reads to EOF (same
+        // handshake as `LocalProcessDeployer`).
+        if let Some(spec_json) = &d.spec_json {
+            use tokio::io::AsyncWriteExt;
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin
+                    .write_all(spec_json.as_bytes())
+                    .await
+                    .map_err(|e| BrokerError::Transport(format!("write spec to stdin: {e}")))?;
+                stdin
+                    .shutdown()
+                    .await
+                    .map_err(|e| BrokerError::Transport(format!("close worker stdin: {e}")))?;
+            }
+        }
         Ok(DeployedAgent::from_parts(
             d.id.clone(),
             child,
@@ -1071,5 +1108,132 @@ mod tests {
         assert!(!a
             .iter()
             .any(|x| x.contains("tok") && !x.starts_with("BAMBOO_BROKER_TOKEN=")));
+    }
+
+    /// #46 — a `spec_json` deploy must NOT mount the orchestrator's home (no
+    /// `/seed` volume, no config/encryption-key copy script): the worker gets
+    /// only the parent-resolved spec, piped over stdin.
+    #[test]
+    fn docker_argv_uses_spec_stdin_and_never_mounts_home() {
+        let mut d = dep();
+        d.spec_json = Some(r#"{"version":1}"#.to_string());
+        let deployer = DockerDeployer::new("img");
+        let a = deployer.argv(&d, "c");
+
+        // No home mount at all — no `-v`, no `/seed`.
+        assert!(!a.contains(&"-v".to_string()));
+        assert!(!a.iter().any(|x| x.contains("/seed")));
+        // No shell-wrapped copy script — direct entrypoint on the bamboo binary.
+        assert!(a
+            .windows(2)
+            .any(|w| w == ["--entrypoint".to_string(), "bamboo".to_string()]));
+        assert!(!a.iter().any(|x| x == "/bin/sh"));
+        assert!(!a.iter().any(|x| x.contains("config.json")));
+        assert!(!a.iter().any(|x| x.contains(".bamboo_encryption_key")));
+        // stdin stays open for the piped spec, and the worker is told to read it.
+        assert!(a.contains(&"-i".to_string()));
+        assert!(a.contains(&"--spec-stdin".to_string()));
+        // The broker token must never appear on argv (it rides as -e env).
+        assert!(!a
+            .iter()
+            .any(|x| x.contains("tok") && !x.starts_with("BAMBOO_BROKER_TOKEN=")));
+    }
+
+    /// `spec_json` is authoritative even when a caller also set `mount_home` —
+    /// mirrors the CLI's "spec is authoritative" rule for `--spec-stdin`.
+    #[test]
+    fn docker_argv_spec_json_takes_precedence_over_mount_home() {
+        let mut d = dep();
+        d.spec_json = Some(r#"{"version":1}"#.to_string());
+        let deployer = DockerDeployer::new("img").mount_home("/home/u/.bamboo");
+        let a = deployer.argv(&d, "c");
+        assert!(!a.iter().any(|x| x.contains("/seed")));
+        assert!(a.contains(&"--spec-stdin".to_string()));
+    }
+
+    /// The docker e2e networking path (`host.docker.internal` + host-gateway
+    /// alias) must survive spec_json delivery unchanged (#46 must not regress
+    /// the existing docker deploy path).
+    #[test]
+    fn docker_argv_spec_json_still_wires_host_docker_internal() {
+        let mut d = dep();
+        d.spec_json = Some(r#"{"version":1}"#.to_string());
+        let deployer = DockerDeployer::new("img");
+        let a = deployer.argv(&d, "c");
+        assert!(a.windows(2).any(|w| w
+            == [
+                "--add-host".to_string(),
+                "host.docker.internal:host-gateway".to_string()
+            ]));
+    }
+
+    /// End-to-end (no real `docker` binary): `deploy()` must actually pipe the
+    /// spec JSON to the child's stdin and close it, exactly like
+    /// `LocalProcessDeployer`. Stand in `cat` for `docker` so the "container"
+    /// just echoes stdin back to a marker file we can assert on.
+    #[tokio::test]
+    async fn docker_deploy_pipes_spec_json_to_stdin() {
+        let marker = std::env::temp_dir().join(format!(
+            "bamboo_docker_spec_stdin_{}_{:?}.json",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_file(&marker);
+
+        // A fake "docker" that just `cat`s its stdin to the marker file,
+        // ignoring all the run/--rm/etc. argv (it never touches a real image).
+        let fake_docker = std::env::temp_dir().join(format!(
+            "bamboo_fake_docker_{}_{:?}.sh",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(
+            &fake_docker,
+            format!("#!/bin/sh\ncat > {}\n", marker.display()),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&fake_docker, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let mut d = dep();
+        d.spec_json = Some(r#"{"version":1,"secret":"do-not-mount-whole-home"}"#.to_string());
+        let mut deployer = DockerDeployer::new("img");
+        deployer.docker_bin = fake_docker.to_string_lossy().into_owned();
+
+        let agent = deployer.deploy(&d).await.expect("fake docker deploy");
+        // The fake "docker" is `cat`, which finishes writing the marker once
+        // stdin (closed by `deploy()` right after writing the spec) hits EOF.
+        // Poll the marker's CONTENT rather than the child's liveness: an
+        // unreaped exited child still answers `kill -0` (zombie) until
+        // something calls `wait()` on it, which would race this assertion. We
+        // deliberately never call `shutdown()` here — it would re-invoke the
+        // same fake binary as a `rm -f` cleanup command and clobber the marker
+        // with an empty write.
+        let expected = r#"{"version":1,"secret":"do-not-mount-whole-home"}"#;
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let mut written = String::new();
+        while std::time::Instant::now() < deadline {
+            if let Ok(s) = std::fs::read_to_string(&marker) {
+                if s == expected {
+                    written = s;
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(written, expected, "fake docker never wrote the piped spec");
+
+        let _ = std::fs::remove_file(&marker);
+        let _ = std::fs::remove_file(&fake_docker);
+        drop(agent);
     }
 }

--- a/crates/app/bamboo-server-tools/src/deploy_agent.rs
+++ b/crates/app/bamboo-server-tools/src/deploy_agent.rs
@@ -15,12 +15,13 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::json;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 
 use bamboo_agent_core::tools::{Tool, ToolClass, ToolCtx, ToolError, ToolOutcome, ToolResult};
 use bamboo_broker::{
     AgentDeployment, DeployedAgent, Deployer, DockerDeployer, LocalProcessDeployer, SshDeployer,
 };
+use bamboo_config::Config;
 
 /// Keeps deployed workers alive (the handles are kill-on-drop) and lets `stop`
 /// tear them down. Shared for the server's lifetime.
@@ -38,6 +39,10 @@ pub struct DeployAgentTool {
     /// Path to the `bamboo` binary used for local subprocess deploys.
     bamboo_bin: PathBuf,
     registry: DeployedRegistry,
+    /// Live config, read (never written) to resolve a scoped `ProvisionSpec`
+    /// for `env=docker` deploys — the assigned model's credential only, never
+    /// the whole config or the master encryption key (#46).
+    config: Arc<RwLock<Config>>,
 }
 
 impl DeployAgentTool {
@@ -46,12 +51,14 @@ impl DeployAgentTool {
         broker_token: impl Into<String>,
         bamboo_bin: impl Into<PathBuf>,
         registry: DeployedRegistry,
+        config: Arc<RwLock<Config>>,
     ) -> Self {
         Self {
             broker_endpoint: broker_endpoint.into(),
             broker_token: broker_token.into(),
             bamboo_bin: bamboo_bin.into(),
             registry,
+            config,
         }
     }
 }
@@ -111,23 +118,54 @@ impl DeployAgentTool {
         });
         let env = env.unwrap_or_else(|| "local".to_string());
 
+        // A container cannot reach the host's loopback; for docker, address the
+        // broker via host.docker.internal (the deployer maps it to the host
+        // gateway). local/ssh keep the configured endpoint as-is. Computed
+        // before the docker spec build below, which also ships this endpoint
+        // (as the worker's `bus` target) inside the ProvisionSpec.
+        let broker_endpoint = if env == "docker" {
+            self.broker_endpoint
+                .replace("127.0.0.1", "host.docker.internal")
+                .replace("localhost", "host.docker.internal")
+        } else {
+            self.broker_endpoint.clone()
+        };
+
+        // docker=only: a parent-resolved ProvisionSpec (assigned model's
+        // credential, no encryption key, no full config) shipped over a
+        // one-shot stdin pipe — NOT the orchestrator's whole `~/.bamboo` home
+        // (#46). `None` falls back to a homeless, credential-less container
+        // (fine for `echo=true` smoke tests; a real worker then has nothing to
+        // authenticate with, which surfaces at the presence-verify/first-task
+        // step rather than silently handing over every provider key).
+        let mut spec_json: Option<String> = None;
+
         let deployer: Box<dyn Deployer> = match env.as_str() {
             "local" => Box::new(LocalProcessDeployer::new(self.bamboo_bin.clone())),
             "docker" => {
                 let image = image.filter(|s| !s.trim().is_empty()).ok_or_else(|| {
                     ToolError::InvalidArguments("env=docker requires `image`".to_string())
                 })?;
+                {
+                    let cfg = self.config.read().await;
+                    spec_json = crate::fabric_deploy::build_ondemand_provision_spec(
+                        &id,
+                        role.as_deref(),
+                        model.as_deref(),
+                        workspace.as_deref(),
+                        std::env::temp_dir().join("bamboo-docker-agents").join(&id),
+                        &broker_endpoint,
+                        &self.broker_token,
+                        &cfg,
+                        echo,
+                    );
+                }
                 // No `--network host`: the worker stays on an isolated bridge
                 // network and reaches the host broker via host.docker.internal
-                // (DockerDeployer adds the host-gateway alias + the endpoint is
-                // rewritten below). Seed the worker from the orchestrator's
-                // bamboo home (mounted read-only, copied into the container's
-                // writable data dir) so it reads the same config (MCP servers +
-                // skills + provider creds).
-                Box::new(
-                    DockerDeployer::new(image)
-                        .mount_home(bamboo_config::paths::resolve_bamboo_dir()),
-                )
+                // (DockerDeployer adds the host-gateway alias above). No home
+                // mount either — the spec built above is the worker's only
+                // source of model/creds/MCP-proxy.
+                Box::new(DockerDeployer::new(image))
             }
             "ssh" => {
                 let host = host.filter(|s| !s.trim().is_empty()).ok_or_else(|| {
@@ -142,17 +180,6 @@ impl DeployAgentTool {
             }
         };
 
-        // A container cannot reach the host's loopback; for docker, address the
-        // broker via host.docker.internal (the deployer maps it to the host
-        // gateway). local/ssh keep the configured endpoint as-is.
-        let broker_endpoint = if env == "docker" {
-            self.broker_endpoint
-                .replace("127.0.0.1", "host.docker.internal")
-                .replace("localhost", "host.docker.internal")
-        } else {
-            self.broker_endpoint.clone()
-        };
-
         let deployment = AgentDeployment {
             id: id.clone(),
             role,
@@ -164,7 +191,7 @@ impl DeployAgentTool {
             // Deployed workers proxy MCP to the orchestrator (single MCP host).
             mcp_proxy: Some(bamboo_broker::ORCHESTRATOR_ID.to_string()),
             log_path: None,
-            spec_json: None,
+            spec_json,
         };
         let handle = deployer
             .deploy(&deployment)
@@ -253,8 +280,9 @@ impl Tool for DeployAgentTool {
          THREE PLACEMENTS (action=deploy, pick with `env`):\n\
          - env=local (default) — a subprocess on THIS machine. Fastest; use for extra parallel \
          hands here.\n\
-         - env=docker — a container (requires `image`, e.g. \"bamboo:latest\"). Isolated; your \
-         bamboo home is mounted so it shares your config. Use for sandboxed or clean-env work.\n\
+         - env=docker — a container (requires `image`, e.g. \"bamboo:latest\"). Isolated; it gets \
+         only the assigned model's credential (via a one-shot handoff, not your whole config) plus \
+         your MCP servers proxied through you. Use for sandboxed or clean-env work.\n\
          - env=ssh — a process on a REMOTE host (requires `host`, e.g. \"user@box\"). Use to run \
          work near other machines/data or to borrow remote compute.\n\
          \n\
@@ -322,7 +350,13 @@ mod tests {
 
     fn tool_with(registry: DeployedRegistry) -> DeployAgentTool {
         // bamboo_bin is never spawned in these tests (we don't drive deploy()).
-        DeployAgentTool::new("ws://localhost:0", "test-token", "/bin/true", registry)
+        DeployAgentTool::new(
+            "ws://localhost:0",
+            "test-token",
+            "/bin/true",
+            registry,
+            std::sync::Arc::new(tokio::sync::RwLock::new(bamboo_config::Config::default())),
+        )
     }
 
     /// A trivial long-running child so the kill/wait path is genuinely exercised.

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -757,6 +757,44 @@ fn build_resident_spec(
     echo: bool,
     worker_id: &str,
 ) -> Option<String> {
+    build_ondemand_provision_spec(
+        worker_id,
+        node.deploy.default_role.as_deref(),
+        node.deploy.model.as_deref(),
+        node.deploy.workspace.as_deref(),
+        std::env::temp_dir()
+            .join("bamboo-fabric-agents")
+            .join(worker_id),
+        broker_endpoint,
+        broker_token,
+        config,
+        echo,
+    )
+}
+
+/// Build a parent-resolved `ProvisionSpec` (model + creds + MCP-proxy + bus +
+/// identity), serialized as JSON, for an on-demand worker deploy. Shared by
+/// [`build_resident_spec`] (cluster-fabric nodes) and `deploy_agent`'s
+/// `env=docker` path (#46: Docker used to bind-mount the orchestrator's ENTIRE
+/// `~/.bamboo` — including `config.json` and the master
+/// `.bamboo_encryption_key` — into the worker container; this spec ships only
+/// the credentials the assigned model actually needs, over a one-shot stdin
+/// pipe, with no encryption key and no home mount at all). `None` when there
+/// are no credentials to ship and this is not an echo deploy — the caller then
+/// falls back to legacy self-resolve rather than deploying a real worker with
+/// no model/creds.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_ondemand_provision_spec(
+    worker_id: &str,
+    role: Option<&str>,
+    pinned_model: Option<&str>,
+    workspace: Option<&str>,
+    storage_dir: PathBuf,
+    broker_endpoint: &str,
+    broker_token: &str,
+    config: &Config,
+    echo: bool,
+) -> Option<String> {
     use bamboo_subagent::provision::{
         BusEndpoint, ChildIdentity, ExecutorSpec, McpProxyConfig, ModelRefSpec, ProvisionSpec,
     };
@@ -766,10 +804,8 @@ fn build_resident_spec(
         return None;
     }
 
-    let role = node
-        .deploy
-        .default_role
-        .clone()
+    let role = role
+        .map(str::to_string)
         .unwrap_or_else(|| "general-purpose".to_string());
     let mut spec = ProvisionSpec::new(
         ChildIdentity {
@@ -784,38 +820,28 @@ fn build_resident_spec(
         } else {
             ExecutorSpec::BambooRuntime
         },
-        std::env::temp_dir()
-            .join("bamboo-fabric-agents")
-            .join(worker_id)
-            .to_string_lossy()
-            .into_owned(),
+        storage_dir.to_string_lossy().into_owned(),
     );
     spec.bus = Some(BusEndpoint {
         endpoint: broker_endpoint.to_string(),
         token: broker_token.to_string(),
     });
-    // Model: the node's pinned `provider:model`, else the configured sub-agent /
-    // chat default (resolved HERE, on the orchestrator, not on the remote).
-    spec.model = node
-        .deploy
-        .model
-        .as_deref()
-        .and_then(parse_provider_model)
-        .or_else(|| {
-            config.defaults.as_ref().and_then(|d| {
-                // sub_agent default, else chat. Guard emptiness so we never ship an
-                // invalid `{provider:"", model:""}` spec — a modelless non-echo worker
-                // then fails the presence verify at deploy instead of at first task.
-                let r = d.sub_agent.as_ref().unwrap_or(&d.chat);
-                (!r.provider.trim().is_empty() && !r.model.trim().is_empty()).then(|| {
-                    ModelRefSpec {
-                        provider: r.provider.clone(),
-                        model: r.model.clone(),
-                    }
-                })
+    // Model: the caller's pinned `provider:model`, else the configured
+    // sub-agent / chat default (resolved HERE, on the orchestrator, never on
+    // the worker).
+    spec.model = pinned_model.and_then(parse_provider_model).or_else(|| {
+        config.defaults.as_ref().and_then(|d| {
+            // sub_agent default, else chat. Guard emptiness so we never ship an
+            // invalid `{provider:"", model:""}` spec — a modelless non-echo worker
+            // then fails the presence verify at deploy instead of at first task.
+            let r = d.sub_agent.as_ref().unwrap_or(&d.chat);
+            (!r.provider.trim().is_empty() && !r.model.trim().is_empty()).then(|| ModelRefSpec {
+                provider: r.provider.clone(),
+                model: r.model.clone(),
             })
-        });
-    spec.workspace = node.deploy.workspace.clone();
+        })
+    });
+    spec.workspace = workspace.map(str::to_string);
     spec.secrets.provider_credentials = credentials;
     // Deployed workers proxy ALL MCP to the orchestrator (single MCP host).
     spec.capabilities.mcp_proxy = Some(McpProxyConfig {
@@ -1052,7 +1078,8 @@ fn build_russh(node: &Node, target: &SshTarget) -> Result<RusshDeployer, String>
 
 #[cfg(test)]
 mod resident_spec_tests {
-    use super::parse_provider_model;
+    use super::{build_ondemand_provision_spec, parse_provider_model};
+    use bamboo_config::Config;
 
     #[test]
     fn parse_provider_model_splits_and_guards() {
@@ -1064,6 +1091,101 @@ mod resident_spec_tests {
         assert!(parse_provider_model(":m").is_none());
         assert!(parse_provider_model("p:").is_none());
         assert!(parse_provider_model("  ").is_none());
+    }
+
+    /// A single `anthropic` provider instance carrying `key` — the
+    /// actually-live credential path `extract_provider_credentials` reads
+    /// (unlike the legacy `providers.anthropic` slot, whose `api_key` is
+    /// `#[serde(skip_serializing)]` and so never round-trips through the
+    /// generic serde projection that function uses for legacy slots).
+    fn config_with_anthropic_key(key: &str) -> Config {
+        let mut cfg = Config::default();
+        let instance: bamboo_config::ProviderInstanceConfig =
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "anthropic",
+                "api_key": key,
+            }))
+            .expect("minimal ProviderInstanceConfig JSON");
+        cfg.provider_instances
+            .insert("anthropic".to_string(), instance);
+        cfg
+    }
+
+    /// #46 — a real (non-echo) on-demand deploy with no configured credentials
+    /// must fall back to `None` (caller then declines to hand a worker nothing
+    /// to authenticate with) rather than shipping an empty/invalid spec.
+    #[test]
+    fn ondemand_spec_is_none_without_credentials_and_not_echo() {
+        let cfg = Config::default();
+        let spec = build_ondemand_provision_spec(
+            "w1",
+            Some("researcher"),
+            Some("anthropic:claude-opus-4-8"),
+            None,
+            std::env::temp_dir().join("bamboo-test-agents").join("w1"),
+            "ws://broker:9600",
+            "tok",
+            &cfg,
+            false,
+        );
+        assert!(spec.is_none());
+    }
+
+    /// echo deploys never need credentials — always produce a spec so the
+    /// connectivity smoke test can proceed.
+    #[test]
+    fn ondemand_spec_is_some_for_echo_even_without_credentials() {
+        let cfg = Config::default();
+        let spec = build_ondemand_provision_spec(
+            "w1",
+            None,
+            None,
+            None,
+            std::env::temp_dir().join("bamboo-test-agents").join("w1"),
+            "ws://broker:9600",
+            "tok",
+            &cfg,
+            true,
+        );
+        assert!(spec.is_some());
+    }
+
+    /// The core #46 regression guard: the serialized spec carries ONLY the
+    /// configured provider credential (here `anthropic`) — never the
+    /// `.bamboo_encryption_key` string, a raw `config.json` blob, or any
+    /// unrelated provider ("openai" is unset here and must not appear).
+    #[test]
+    fn ondemand_spec_carries_only_configured_provider_credential() {
+        let cfg = config_with_anthropic_key("sk-ant-super-secret");
+        let spec_json = build_ondemand_provision_spec(
+            "w1",
+            Some("researcher"),
+            Some("anthropic:claude-opus-4-8"),
+            Some("/workspace"),
+            std::env::temp_dir().join("bamboo-test-agents").join("w1"),
+            "ws://broker:9600",
+            "tok",
+            &cfg,
+            false,
+        )
+        .expect("credentials configured — spec must be built");
+
+        assert!(spec_json.contains("sk-ant-super-secret"));
+        assert!(spec_json.contains("anthropic"));
+        // No encryption key, no on-disk config dump, no other provider.
+        assert!(!spec_json.contains("bamboo_encryption_key"));
+        assert!(!spec_json.contains("openai"));
+        assert!(!spec_json.contains("gemini"));
+
+        let parsed: bamboo_subagent::provision::ProvisionSpec =
+            serde_json::from_str(&spec_json).expect("valid ProvisionSpec JSON");
+        assert_eq!(parsed.secrets.provider_credentials.len(), 1);
+        assert_eq!(parsed.secrets.provider_credentials[0].provider, "anthropic");
+        assert_eq!(
+            parsed.secrets.provider_credentials[0].api_key,
+            "sk-ant-super-secret"
+        );
+        assert_eq!(parsed.workspace.as_deref(), Some("/workspace"));
     }
 }
 

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -783,6 +783,16 @@ fn build_resident_spec(
 /// are no credentials to ship and this is not an echo deploy — the caller then
 /// falls back to legacy self-resolve rather than deploying a real worker with
 /// no model/creds.
+///
+/// Credential scoping mirrors `ActorChildRunner::build_spec`
+/// (`external_agents/actor_adapter.rs`): `extract_provider_credentials`
+/// returns every configured provider's key, so it is filtered down to the
+/// single credential matching `spec.model.provider` *after* the model is
+/// resolved — never the raw unfiltered list. This applies to both callers
+/// (cluster-fabric node deploys and the AI-triggered docker path), for the
+/// same least-privilege reason `ActorChildRunner` already scopes its own
+/// workers: a review bot flagged a prior version of this helper for shipping
+/// every configured provider's key regardless of which model was pinned.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_ondemand_provision_spec(
     worker_id: &str,
@@ -799,8 +809,9 @@ pub(crate) fn build_ondemand_provision_spec(
         BusEndpoint, ChildIdentity, ExecutorSpec, McpProxyConfig, ModelRefSpec, ProvisionSpec,
     };
 
-    let credentials = bamboo_engine::external_agents::runtime::extract_provider_credentials(config);
-    if credentials.is_empty() && !echo {
+    let all_credentials =
+        bamboo_engine::external_agents::runtime::extract_provider_credentials(config);
+    if all_credentials.is_empty() && !echo {
         return None;
     }
 
@@ -842,7 +853,35 @@ pub(crate) fn build_ondemand_provision_spec(
         })
     });
     spec.workspace = workspace.map(str::to_string);
-    spec.secrets.provider_credentials = credentials;
+    // Least-privilege secrets: only the credential for the resolved model's
+    // provider ships — never the full `all_credentials` set (#46 follow-up).
+    match spec
+        .model
+        .as_ref()
+        .map(|m| m.provider.as_str())
+        .filter(|p| !p.trim().is_empty())
+    {
+        Some(provider) => match all_credentials.into_iter().find(|c| c.provider == provider) {
+            Some(cred) => spec.secrets.provider_credentials = vec![cred],
+            None => {
+                tracing::warn!(
+                    "ondemand spec for worker {}: no credential found for provider '{}'; \
+                         shipping none",
+                    worker_id,
+                    provider
+                );
+            }
+        },
+        None => {
+            if !echo {
+                tracing::warn!(
+                    "ondemand spec for worker {}: no model provider resolved to scope \
+                     credentials to; shipping none",
+                    worker_id
+                );
+            }
+        }
+    }
     // Deployed workers proxy ALL MCP to the orchestrator (single MCP host).
     spec.capabilities.mcp_proxy = Some(McpProxyConfig {
         orchestrator: ORCHESTRATOR_ID.to_string(),
@@ -1111,6 +1150,22 @@ mod resident_spec_tests {
         cfg
     }
 
+    /// Two provider instances configured (`anthropic` + `openai`) — the
+    /// multi-provider setup the review on #494 flagged: with more than one
+    /// provider configured, the ondemand spec must still carry only the ONE
+    /// credential backing the pinned model, not every configured provider.
+    fn config_with_two_providers(anthropic_key: &str, openai_key: &str) -> Config {
+        let mut cfg = config_with_anthropic_key(anthropic_key);
+        let openai: bamboo_config::ProviderInstanceConfig =
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "openai",
+                "api_key": openai_key,
+            }))
+            .expect("minimal ProviderInstanceConfig JSON");
+        cfg.provider_instances.insert("openai".to_string(), openai);
+        cfg
+    }
+
     /// #46 — a real (non-echo) on-demand deploy with no configured credentials
     /// must fall back to `None` (caller then declines to hand a worker nothing
     /// to authenticate with) rather than shipping an empty/invalid spec.
@@ -1186,6 +1241,90 @@ mod resident_spec_tests {
             "sk-ant-super-secret"
         );
         assert_eq!(parsed.workspace.as_deref(), Some("/workspace"));
+    }
+
+    /// #494 review finding: with TWO providers configured, a deploy pinned to
+    /// `anthropic:...` must ship ONLY the anthropic credential — the prior
+    /// version unconditionally assigned the entire `extract_provider_credentials`
+    /// output (every configured provider) regardless of which model was
+    /// pinned, so this would previously have leaked the openai key too.
+    #[test]
+    fn ondemand_spec_scopes_credentials_to_pinned_model_provider_only() {
+        let cfg = config_with_two_providers("sk-ant-secret", "sk-oai-secret");
+        let spec_json = build_ondemand_provision_spec(
+            "w1",
+            Some("researcher"),
+            Some("anthropic:claude-opus-4-8"),
+            None,
+            std::env::temp_dir().join("bamboo-test-agents").join("w1"),
+            "ws://broker:9600",
+            "tok",
+            &cfg,
+            false,
+        )
+        .expect("credentials configured — spec must be built");
+
+        let parsed: bamboo_subagent::provision::ProvisionSpec =
+            serde_json::from_str(&spec_json).expect("valid ProvisionSpec JSON");
+        assert_eq!(parsed.secrets.provider_credentials.len(), 1);
+        assert_eq!(parsed.secrets.provider_credentials[0].provider, "anthropic");
+        assert_eq!(
+            parsed.secrets.provider_credentials[0].api_key,
+            "sk-ant-secret"
+        );
+        // The unrelated, but CONFIGURED, openai key must not ship.
+        assert!(!spec_json.contains("sk-oai-secret"));
+
+        // Pin the other provider instead — only ITS credential should ship.
+        let spec_json_openai = build_ondemand_provision_spec(
+            "w2",
+            Some("researcher"),
+            Some("openai:gpt-5"),
+            None,
+            std::env::temp_dir().join("bamboo-test-agents").join("w2"),
+            "ws://broker:9600",
+            "tok",
+            &cfg,
+            false,
+        )
+        .expect("credentials configured — spec must be built");
+        let parsed_openai: bamboo_subagent::provision::ProvisionSpec =
+            serde_json::from_str(&spec_json_openai).expect("valid ProvisionSpec JSON");
+        assert_eq!(parsed_openai.secrets.provider_credentials.len(), 1);
+        assert_eq!(
+            parsed_openai.secrets.provider_credentials[0].provider,
+            "openai"
+        );
+        assert!(!spec_json_openai.contains("sk-ant-secret"));
+    }
+
+    /// A pinned model whose provider has no matching configured credential
+    /// (e.g. typo'd provider id, or a provider that was since removed) must
+    /// still build a spec — with an EMPTY credential list, not a fallback to
+    /// every other configured provider's key. Mirrors the idiom already used
+    /// by `ActorChildRunner::build_spec` (warn + ship nothing) rather than
+    /// failing the whole deploy.
+    #[test]
+    fn ondemand_spec_has_no_credentials_when_pinned_provider_has_no_match() {
+        let cfg = config_with_two_providers("sk-ant-secret", "sk-oai-secret");
+        let spec_json = build_ondemand_provision_spec(
+            "w1",
+            Some("researcher"),
+            Some("gemini:gemini-3-pro"),
+            None,
+            std::env::temp_dir().join("bamboo-test-agents").join("w1"),
+            "ws://broker:9600",
+            "tok",
+            &cfg,
+            false,
+        )
+        .expect("at least one provider configured overall — spec must be built");
+
+        let parsed: bamboo_subagent::provision::ProvisionSpec =
+            serde_json::from_str(&spec_json).expect("valid ProvisionSpec JSON");
+        assert!(parsed.secrets.provider_credentials.is_empty());
+        assert!(!spec_json.contains("sk-ant-secret"));
+        assert!(!spec_json.contains("sk-oai-secret"));
     }
 }
 

--- a/crates/app/bamboo-server/src/app_state/tools.rs
+++ b/crates/app/bamboo-server/src/app_state/tools.rs
@@ -229,6 +229,7 @@ pub(super) fn build_root_tools(
                         b.token,
                         bamboo_bin,
                         fabric_deployer.registry(),
+                        config.clone(),
                     )),
                 ));
             // `cluster`: progressive-disclosure inventory (list/describe/status)

--- a/tests/deploy_agent_tool_e2e.rs
+++ b/tests/deploy_agent_tool_e2e.rs
@@ -46,11 +46,13 @@ async fn agent_deploys_a_worker_then_asks_lists_and_stops_it() {
     // The AI-callable deploy tool, wired to the REAL bamboo binary + this broker.
     // Holding `tool` keeps its registry (and the deployed handle) alive.
     let registry = Arc::new(Mutex::new(HashMap::new()));
+    let config = Arc::new(tokio::sync::RwLock::new(bamboo_config::Config::default()));
     let tool = DeployAgentTool::new(
         endpoint.clone(),
         TOKEN,
         env!("CARGO_BIN_EXE_bamboo"),
         registry,
+        config,
     );
 
     // 1. The agent deploys a worker (local subprocess, echo executor).


### PR DESCRIPTION
## Summary

`DockerDeployer` used to bind-mount the orchestrator's **entire** `~/.bamboo` read-only at `/seed`, then copy `config.json` + `.bamboo_encryption_key` into the worker container's writable data dir at startup. A deployed Docker worker therefore got **every** provider credential the orchestrator holds (all configured providers/instances), not just the one it was assigned — plus the master encryption key, which decrypts everything else in the config.

Verified against current `main` (post-#207 refactor, post host.docker.internal fix): the mount was still live at `crates/app/bamboo-broker/src/deploy.rs` (`DockerDeployer::argv`, the `/seed` mount + copy script) and `crates/app/bamboo-server-tools/src/deploy_agent.rs:129` (`DockerDeployer::new(image).mount_home(bamboo_config::paths::resolve_bamboo_dir())`, with `spec_json: None` hardcoded for every env including docker). Local/SSH/Russh deploys had already moved to a scoped `ProvisionSpec` handoff post-#207 (see `fabric_deploy.rs::build_resident_spec`) — Docker was the one path left on the old whole-home mount, exactly matching the issue's evidence and the in-code comment ("P3 will scope this down").

## Fix

Docker deploys now go through the same "parent decides, worker only executes" `ProvisionSpec` handoff Local/SSH/Russh already use:

- `crates/app/bamboo-server-tools/src/fabric_deploy.rs`: extracted the node-scoped `build_resident_spec` body into a new, generic `pub(crate) build_ondemand_provision_spec(...)` (role/model/workspace/storage_dir as plain params instead of a `Node`), so it's reusable outside cluster-fabric. `build_resident_spec` now just calls it with the node's fields — no behavior change there.
- `crates/app/bamboo-server-tools/src/deploy_agent.rs`: `DeployAgentTool` now holds `config: Arc<RwLock<Config>>`. The `env=docker` branch builds a `ProvisionSpec` via `build_ondemand_provision_spec` (assigned model's credential + MCP-proxy + bus, resolved from live config) instead of calling `.mount_home(...)`.
- `crates/app/bamboo-broker/src/deploy.rs`: `DockerDeployer` now understands `AgentDeployment::spec_json` — when set, it runs `docker run -i --entrypoint bamboo <image> broker-agent serve ... --spec-stdin` and pipes the spec JSON to the container's stdin (mirroring `LocalProcessDeployer`'s handshake) instead of mounting anything. `spec_json` takes precedence over `mount_home` when both are set (same "spec is authoritative" rule the CLI already documents for `--spec-stdin`/`--spec-file`). `mount_home` is kept as a legacy fallback for callers with no spec (documented as such) but `deploy_agent` no longer calls it.

### Before / after mount surface

| | Before | After |
|---|---|---|
| Host mount | `~/.bamboo:/seed:ro` (whole home) | none |
| Credentials shipped | ALL configured providers/instances (`config.json`, decrypted via the copied `.bamboo_encryption_key`) | only the assigned model's credential, in-memory, over stdin |
| Encryption key | `.bamboo_encryption_key` copied into the container | never leaves the orchestrator |
| MCP | already proxied via `mcp_proxy` (independent of the mount — unchanged) | unchanged |
| Networking (`host.docker.internal` + host-gateway alias) | present | unchanged, still asserted by tests |

## Tests

- `crates/app/bamboo-broker/src/deploy.rs`: new `docker_argv_uses_spec_stdin_and_never_mounts_home`, `docker_argv_spec_json_takes_precedence_over_mount_home`, `docker_argv_spec_json_still_wires_host_docker_internal` (guards the existing e2e networking path), and `docker_deploy_pipes_spec_json_to_stdin` (an actual stdin round-trip against a fake `docker` binary — no real Docker required).
- `crates/app/bamboo-server-tools/src/fabric_deploy.rs`: new `resident_spec_tests::ondemand_spec_is_none_without_credentials_and_not_echo`, `ondemand_spec_is_some_for_echo_even_without_credentials`, and `ondemand_spec_carries_only_configured_provider_credential` — the core regression guard: asserts the serialized spec contains the configured credential but never `bamboo_encryption_key`, and never an unrelated provider.
- `tests/deploy_agent_tool_e2e.rs` (existing e2e, still exercises `env=local`) updated for the new `DeployAgentTool::new` signature — unaffected otherwise, still green.
- All existing docker-argv / e2e tests (host.docker.internal wiring, mount_home legacy path) kept green.

## Quality gates

- `cargo fmt -p bamboo-broker -p bamboo-server-tools -p bamboo-server -p bamboo-agent -- --check`: clean.
- `cargo clippy -p bamboo-broker -p bamboo-server-tools -p bamboo-server --all-targets`: no new warnings (pre-existing `too_many_arguments`/`type_complexity` warnings elsewhere in the workspace, unrelated).
- `cargo build --workspace --tests`: green.
- `cargo test -p bamboo-broker -p bamboo-server-tools`: 78 + 3 + 3 = all green. `cargo test -p bamboo-server --lib`: 1309 passed. `cargo test -p bamboo-agent --test deploy_agent_tool_e2e`: green.

## Notes for reviewers

- Along the way, discovered (but did NOT fix, out of scope) that `extract_provider_credentials`'s **legacy** single-instance provider path (`config.providers.anthropic/openai/...`) silently yields zero credentials — `AnthropicConfig::api_key` etc. are `#[serde(skip_serializing)]`, so the generic `serde_json::to_value(&config.providers)` projection that function uses never sees them. Only the newer `provider_instances` map (read via typed field access) actually works. This affects the *existing* Local/SSH/Russh `ProvisionSpec` path too, not just this PR — filing as a follow-up candidate rather than fixing here to keep this PR focused.

Closes #46