### PR TITLE
fix(deploy): typed extraction of legacy provider credentials in ProvisionSpec

### DIFF
--- a/crates/engine/bamboo-engine/src/external_agents/runtime.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/runtime.rs
@@ -421,31 +421,43 @@ fn resolve_remote_placements(
 }
 
 /// Snapshot per-provider credentials from the parent config for actor
-/// provisioning. Serialized generically so this code does not chase the
-/// per-provider config struct shapes — any slot with a non-empty `api_key`
-/// yields a scoped credential (plus `base_url` when present).
+/// provisioning. `api_key` (plaintext, in-memory only) is `#[serde(skip_serializing)]`
+/// on every legacy single-instance provider struct — it's hydrated from
+/// `api_key_encrypted` at load time but deliberately never round-tripped
+/// through serde, so a `serde_json::to_value` projection of `config.providers`
+/// sees none of it (#495). Read each typed struct's `api_key` field directly
+/// instead, mirroring how `provider_instances` below already has to.
 pub fn extract_provider_credentials(
     config: &Config,
 ) -> Vec<bamboo_subagent::provision::ScopedCredential> {
     let mut out = Vec::new();
 
-    // Legacy single-instance slots: providers.anthropic / openai / …
-    if let Ok(serde_json::Value::Object(providers)) = serde_json::to_value(&config.providers) {
-        out.extend(providers.into_iter().filter_map(|(name, slot)| {
-            let api_key = slot.get("api_key")?.as_str()?.trim().to_string();
-            if api_key.is_empty() {
-                return None;
-            }
-            Some(bamboo_subagent::provision::ScopedCredential {
-                provider: name.clone(),
-                api_key,
-                base_url: slot
-                    .get("base_url")
-                    .and_then(|v| v.as_str())
-                    .map(str::to_string),
-                provider_type: Some(name),
-            })
-        }));
+    // Legacy single-instance slots: providers.anthropic / openai / gemini /
+    // bodhi. `copilot` is intentionally omitted — it authenticates via device
+    // flow and has no `api_key` field to extract.
+    let mut push_legacy = |name: &str, api_key: &str, base_url: Option<String>| {
+        let api_key = api_key.trim().to_string();
+        if api_key.is_empty() {
+            return;
+        }
+        out.push(bamboo_subagent::provision::ScopedCredential {
+            provider: name.to_string(),
+            api_key,
+            base_url,
+            provider_type: Some(name.to_string()),
+        });
+    };
+    if let Some(c) = &config.providers.openai {
+        push_legacy("openai", &c.api_key, c.base_url.clone());
+    }
+    if let Some(c) = &config.providers.anthropic {
+        push_legacy("anthropic", &c.api_key, c.base_url.clone());
+    }
+    if let Some(c) = &config.providers.gemini {
+        push_legacy("gemini", &c.api_key, c.base_url.clone());
+    }
+    if let Some(c) = &config.providers.bodhi {
+        push_legacy("bodhi", &c.api_key, c.base_url.clone());
     }
 
     // Multi-instance providers: provider_instances keyed by instance id; the
@@ -466,6 +478,114 @@ pub fn extract_provider_credentials(
     }));
 
     out
+}
+
+#[cfg(test)]
+mod extract_provider_credentials_tests {
+    use super::extract_provider_credentials;
+    use bamboo_config::{
+        AnthropicConfig, BodhiConfig, Config, OpenAIConfig, ProviderInstanceConfig,
+    };
+
+    fn instance(provider_type: &str, api_key: &str) -> ProviderInstanceConfig {
+        ProviderInstanceConfig {
+            provider_type: provider_type.to_string(),
+            label: None,
+            api_key: api_key.to_string(),
+            api_key_encrypted: None,
+            base_url: None,
+            model: None,
+            fast_model: None,
+            vision_model: None,
+            reasoning_effort: None,
+            responses_only_models: Vec::new(),
+            request_overrides: None,
+            enabled: true,
+            extra: Default::default(),
+        }
+    }
+
+    #[test]
+    fn no_config_yields_no_credentials() {
+        let config = Config::default();
+        assert!(extract_provider_credentials(&config).is_empty());
+    }
+
+    /// #495 — a legacy single-instance provider (`config.providers.anthropic`
+    /// etc.) must yield its `api_key` even though the field is
+    /// `#[serde(skip_serializing)]`, because the extraction now reads the
+    /// typed struct instead of projecting through `serde_json::to_value`.
+    #[test]
+    fn legacy_only_config_yields_credential() {
+        let mut config = Config::default();
+        config.providers.anthropic = Some(AnthropicConfig {
+            api_key: "sk-ant-legacy".to_string(),
+            base_url: Some("https://api.anthropic.com".to_string()),
+            ..Default::default()
+        });
+
+        let creds = extract_provider_credentials(&config);
+        assert_eq!(creds.len(), 1);
+        let c = &creds[0];
+        assert_eq!(c.provider, "anthropic");
+        assert_eq!(c.api_key, "sk-ant-legacy");
+        assert_eq!(c.base_url.as_deref(), Some("https://api.anthropic.com"));
+        assert_eq!(c.provider_type.as_deref(), Some("anthropic"));
+    }
+
+    /// `bodhi` doesn't derive `Default`, so it's exercised separately —
+    /// covers the last of the four legacy structs the fix touches
+    /// (openai/anthropic/gemini already share the `Default`-derive path).
+    #[test]
+    fn legacy_bodhi_config_yields_credential() {
+        let mut config = Config::default();
+        config.providers.bodhi = Some(BodhiConfig {
+            api_key: "bhi_sk_legacy".to_string(),
+            api_key_encrypted: None,
+            base_url: None,
+            target_provider: None,
+            reasoning_effort: None,
+            extra: Default::default(),
+        });
+
+        let creds = extract_provider_credentials(&config);
+        assert_eq!(creds.len(), 1);
+        assert_eq!(creds[0].provider, "bodhi");
+        assert_eq!(creds[0].api_key, "bhi_sk_legacy");
+    }
+
+    /// A legacy slot with an empty `api_key` (struct present but never
+    /// configured) must not produce a bogus empty credential.
+    #[test]
+    fn legacy_config_with_empty_api_key_is_skipped() {
+        let mut config = Config::default();
+        config.providers.openai = Some(OpenAIConfig::default());
+        assert!(extract_provider_credentials(&config).is_empty());
+    }
+
+    /// Legacy + `provider_instances` coexisting: both must surface, with no
+    /// duplication/clobbering between the two sources.
+    #[test]
+    fn legacy_and_instances_both_present_no_duplicates() {
+        let mut config = Config::default();
+        config.providers.anthropic = Some(AnthropicConfig {
+            api_key: "sk-ant-legacy".to_string(),
+            ..Default::default()
+        });
+        config
+            .provider_instances
+            .insert("openai-work".to_string(), instance("openai", "sk-oai-work"));
+
+        let mut creds = extract_provider_credentials(&config);
+        creds.sort_by(|a, b| a.provider.cmp(&b.provider));
+
+        assert_eq!(creds.len(), 2);
+        assert_eq!(creds[0].provider, "anthropic");
+        assert_eq!(creds[0].api_key, "sk-ant-legacy");
+        assert_eq!(creds[1].provider, "openai-work");
+        assert_eq!(creds[1].api_key, "sk-oai-work");
+        assert_eq!(creds[1].provider_type.as_deref(), Some("openai"));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

`extract_provider_credentials` (`crates/engine/bamboo-engine/src/external_agents/runtime.rs`) projected `config.providers` through `serde_json::to_value` to read each legacy single-instance provider's `api_key`. But `api_key` is `#[serde(skip_serializing)]` on every legacy provider struct (`AnthropicConfig`, `OpenAIConfig`, `GeminiConfig`, `BodhiConfig`) — it's hydrated in memory from `api_key_encrypted` at load time but deliberately never round-tripped through serde (so it's never baked back into `config.json`). That meant the serde projection silently saw **none** of those keys, and a legacy-only-configured instance produced zero credentials in the `ProvisionSpec` for every deploy path (Local, SSH/Russh, and Docker via #494).

## Fix

Replaced the serde projection with typed field access for each legacy struct (openai/anthropic/gemini/bodhi), mirroring the pattern `provider_instances` already used a few lines below (which reads `inst.api_key` directly for the same reason). `copilot` is intentionally skipped — it authenticates via device flow and has no `api_key` field.

## Tests added

`extract_provider_credentials_tests` in the same file:
- `no_config_yields_no_credentials` — empty config → empty vec.
- `legacy_only_config_yields_credential` — a legacy-only `providers.anthropic` config now yields its credential (the regression case from #495).
- `legacy_bodhi_config_yields_credential` — covers `BodhiConfig`, which doesn't derive `Default` so needed a separate manual-construction test.
- `legacy_config_with_empty_api_key_is_skipped` — a present-but-unconfigured legacy struct doesn't produce a bogus empty credential.
- `legacy_and_instances_both_present_no_duplicates` — legacy `providers.anthropic` + `provider_instances["openai-work"]` coexist, both surface, no clobbering.

## Overlap with open PRs

- **PR #494** (docker mount scope, open) touches `bamboo-broker/src/deploy.rs`, `bamboo-server-tools/src/deploy_agent.rs`, and `bamboo-server-tools/src/fabric_deploy.rs` — this PR only touches `crates/engine/bamboo-engine/src/external_agents/runtime.rs` (where `extract_provider_credentials` is defined), so there are **no overlapping hunks**. #494 calls this function from `fabric_deploy.rs::build_resident_spec`/`build_ondemand_provision_spec`; this fix makes that call actually return legacy credentials instead of silently dropping them. Either PR can merge first.
- **PR #491** (broker rate limiting) — no file overlap.

## Test plan
- [x] `cargo fmt -p bamboo-engine`
- [x] `cargo clippy -p bamboo-engine --tests --all-targets` — no new warnings (all pre-existing warnings are in other files: `runtime/runtime.rs`, `external_agents/actor_adapter.rs`, `external_agents/config.rs`, `llm_summarizer.rs`)
- [x] `cargo build --workspace --tests` — green
- [x] `cargo test -p bamboo-engine` — 932 passed (927 pre-existing + 5 new)
- [x] `cargo test -p bamboo-server-tools` — 83 passed (unchanged; this fix doesn't touch that crate but its `fabric_deploy.rs` calls the function under test)

Closes #495