### PR TITLE
feat(memory): wire granularity budget segmentation into prompt assembly

### DIFF
--- a/crates/app/bamboo-server-tools/src/memory/mod.rs
+++ b/crates/app/bamboo-server-tools/src/memory/mod.rs
@@ -118,7 +118,30 @@ impl Tool for MemoryTool {
                 "pieces": {"type": "array", "items": {"type": "object"}},
                 "ids": {"type": "array", "items": {"type": "string"}},
                 "min_score": {"type": "number"},
-                "filters": {"type": "object"},
+                "filters": {
+                    "type": "object",
+                    "description": "Optional narrowing for `query`/`purge`. Each sub-filter is independent and defaults to unfiltered when omitted or empty.",
+                    "properties": {
+                        "type": {
+                            "type": "array",
+                            "items": {"type": "string", "enum": ["user", "feedback", "project", "reference"]},
+                            "description": "Restrict results to these memory types. Omit for no type filtering."
+                        },
+                        "status": {
+                            "type": "array",
+                            "items": {"type": "string", "enum": ["active", "stale", "superseded", "contradicted", "archived"]},
+                            "description": "Restrict results to these statuses. Omit for no status filtering."
+                        },
+                        "granularity": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": ["day", "week", "month", "quarter", "year"]
+                            },
+                            "description": "Restrict results to these temporal granularities: day (today's working context), week (sprint), month, quarter (direction), year (long-term goals). This is a hard filter (unlike the passive recall-into-prompt ordering): a memory whose granularity doesn't appear in this list is excluded entirely, and a memory with no granularity never matches a non-empty filter here. Omit for no granularity filtering."
+                        }
+                    }
+                },
                 "options": {"type": "object"},
                 "reason": {"type": "string"}
             },

--- a/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/external_memory.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/prompt_context/external_memory.rs
@@ -5,11 +5,13 @@ use crate::runtime::config::PromptMemoryFlags;
 use bamboo_agent_core::{PromptMemoryObservability, Session};
 use bamboo_domain::ledger::LedgerScope;
 use bamboo_llm::LLMProvider;
+use bamboo_memory::budget::{segment_by_granularity_budget, GranularityBudgetItem};
 use bamboo_memory::ledger_store::{AgendaItem, AgendaSnapshot, LedgerStore};
 use bamboo_memory::memory_store::{
     project_key_from_path, render_memory_freshness_note, select_relevant_memories,
     truncate_chars as memory_truncate_chars, FreshnessKind, MemoryRecallCandidate,
     MemoryRecallOptions, MemoryRecallRerankContext, MemoryRecallStrategy, MemoryScope, MemoryStore,
+    TemporalGranularity,
 };
 use bamboo_tools::tools::workspace_state;
 
@@ -84,12 +86,18 @@ struct ProjectDreamSnippet {
 
 #[derive(Debug, Clone)]
 struct RelevantMemorySnippet {
+    id: String,
     title: String,
     scope: MemoryScope,
     status: String,
     score: f64,
     summary: String,
     freshness_note: Option<String>,
+    /// Temporal granularity of the source memory, carried through so the render
+    /// step can route this item into the coarse (prefix) or fine (suffix)
+    /// prompt-cache-stability segment (see `budget::segment_by_granularity_budget`,
+    /// issue #61).
+    granularity: Option<TemporalGranularity>,
 }
 
 #[derive(Clone)]
@@ -617,6 +625,7 @@ fn build_relevant_memory_snippet(
     }
 
     Some(RelevantMemorySnippet {
+        id: candidate.id,
         title: candidate.title,
         scope: candidate.scope,
         status: candidate.status.as_str().to_string(),
@@ -626,6 +635,7 @@ fn build_relevant_memory_snippet(
             &candidate.updated_at,
             FreshnessKind::RecalledMemory,
         ),
+        granularity: candidate.granularity,
     })
 }
 
@@ -994,6 +1004,40 @@ fn render_session_note_section(snippets: &[TopicSnippet]) -> String {
     section
 }
 
+/// Render a single recalled memory's bullet block, in the same per-item format
+/// used before granularity segmentation was wired in. Only the ORDERING of items
+/// within the section changed (coarse-before-fine, see below) — this per-item
+/// format is unchanged.
+fn render_relevant_memory_item(snippet: &RelevantMemorySnippet) -> String {
+    let mut item = String::new();
+    item.push_str(&format!(
+        "- [{}][{}] {} (score {:.2})\n",
+        snippet.status,
+        snippet.scope.as_str(),
+        snippet.title,
+        snippet.score
+    ));
+    item.push_str(&format!("  Summary: {}\n", snippet.summary));
+    if let Some(note) = snippet.freshness_note.as_deref() {
+        item.push_str(&format!("  {}\n", note));
+    }
+    item
+}
+
+/// Render the "Relevant Durable Memories" section body. Recalled items are routed
+/// through [`segment_by_granularity_budget`] (issue #61 phase 2) so coarse
+/// (untagged/month/quarter/year) memories always render before fine (week/day)
+/// ones, keeping the coarse content's bytes stable against fine-grained churn for
+/// prompt-prefix-cache friendliness. `RELEVANT_MEMORY_TOTAL_MAX_CHARS` is reused
+/// as-is as the segmentation's `total_budget_chars` rather than inventing a new
+/// limit — it is the same budget `load_relevant_memory_snippets` already targets
+/// when shortlisting candidates.
+///
+/// Back-compat: when every item is coarse (the common case for memories written
+/// before granularity existed — `None` is coarse per
+/// `TemporalGranularity::is_high_churn`), the suffix segment is empty and
+/// `segments.combined()` degenerates to exactly the old flat concatenation in the
+/// same relative order, with no separator inserted.
 fn render_relevant_memory_section(snippets: &[RelevantMemorySnippet]) -> String {
     let mut section = String::new();
     section.push_str("### Relevant Durable Memories\n");
@@ -1001,19 +1045,21 @@ fn render_relevant_memory_section(snippets: &[RelevantMemorySnippet]) -> String 
         "Turn-specific historical memories shortlisted for the latest user request. Verify them against current tools/files before treating them as live state.\n",
     );
 
-    for snippet in snippets {
-        section.push_str(&format!(
-            "- [{}][{}] {} (score {:.2})\n",
-            snippet.status,
-            snippet.scope.as_str(),
-            snippet.title,
-            snippet.score
-        ));
-        section.push_str(&format!("  Summary: {}\n", snippet.summary));
-        if let Some(note) = snippet.freshness_note.as_deref() {
-            section.push_str(&format!("  {}\n", note));
-        }
-    }
+    let items: Vec<GranularityBudgetItem> = snippets
+        .iter()
+        .map(|snippet| {
+            GranularityBudgetItem::new(
+                snippet.id.clone(),
+                snippet.granularity,
+                render_relevant_memory_item(snippet),
+            )
+        })
+        .collect();
+    let segments = segment_by_granularity_budget(&items, RELEVANT_MEMORY_TOTAL_MAX_CHARS);
+    // `combined()` is prefix followed by suffix with no separator — for the
+    // all-coarse case the suffix is empty and this is byte-identical to the old
+    // flat per-snippet loop.
+    section.push_str(&segments.combined());
     section.push('\n');
     section
 }
@@ -1107,4 +1153,167 @@ fn render_context_pressure_warning(session: &Session) -> Option<String> {
     Some(format!(
         "\n> ⚠️ **Context window filling up (~{pct:.0}% used).** Older messages will soon be compressed and summarized. Save any important context (key decisions, file paths, architecture notes, progress state) to `{EXTERNAL_MEMORY_TOOL_NAME}` now so it persists across the compression boundary.\n"
     ))
+}
+
+#[cfg(test)]
+mod granularity_prompt_wiring_tests {
+    use super::*;
+
+    fn snippet(
+        id: &str,
+        granularity: Option<TemporalGranularity>,
+        title: &str,
+        summary: &str,
+    ) -> RelevantMemorySnippet {
+        RelevantMemorySnippet {
+            id: id.to_string(),
+            title: title.to_string(),
+            scope: MemoryScope::Project,
+            status: "active".to_string(),
+            score: 0.5,
+            summary: summary.to_string(),
+            freshness_note: None,
+            granularity,
+        }
+    }
+
+    /// Faithful copy of `render_relevant_memory_section`'s pre-#497 body (flat,
+    /// unsegmented render loop) — kept only in this test to pin the exact
+    /// byte-for-byte output the all-coarse case must still produce.
+    fn old_style_relevant_memory_section(snippets: &[RelevantMemorySnippet]) -> String {
+        let mut section = String::new();
+        section.push_str("### Relevant Durable Memories\n");
+        section.push_str(
+            "Turn-specific historical memories shortlisted for the latest user request. Verify them against current tools/files before treating them as live state.\n",
+        );
+        for snippet in snippets {
+            section.push_str(&format!(
+                "- [{}][{}] {} (score {:.2})\n",
+                snippet.status,
+                snippet.scope.as_str(),
+                snippet.title,
+                snippet.score
+            ));
+            section.push_str(&format!("  Summary: {}\n", snippet.summary));
+            if let Some(note) = snippet.freshness_note.as_deref() {
+                section.push_str(&format!("  {}\n", note));
+            }
+        }
+        section.push('\n');
+        section
+    }
+
+    #[test]
+    fn all_untagged_memories_render_identically_to_pre_segmentation_format() {
+        let snippets = vec![
+            snippet("a", None, "Alpha decision", "alpha summary"),
+            snippet("b", None, "Beta preference", "beta summary"),
+            snippet("c", None, "Gamma reference", "gamma summary"),
+        ];
+
+        assert_eq!(
+            render_relevant_memory_section(&snippets),
+            old_style_relevant_memory_section(&snippets),
+            "an all-coarse (untagged) config must render byte-identical to the pre-#497 flat format"
+        );
+    }
+
+    #[test]
+    fn mixed_coarse_and_fine_renders_coarse_before_fine() {
+        // Day placed first in priority/input order — output must still group
+        // coarse (year) ahead of fine (day) regardless of input order.
+        let day = snippet(
+            "day-1",
+            Some(TemporalGranularity::Day),
+            "Day Title Marker",
+            "day summary",
+        );
+        let year = snippet(
+            "year-1",
+            Some(TemporalGranularity::Year),
+            "Year Title Marker",
+            "year summary",
+        );
+
+        let section = render_relevant_memory_section(&[day, year]);
+
+        let day_pos = section
+            .find("Day Title Marker")
+            .expect("day item should still render");
+        let year_pos = section
+            .find("Year Title Marker")
+            .expect("year item should still render");
+        assert!(
+            year_pos < day_pos,
+            "coarse (year) memory must render before fine (day) memory"
+        );
+    }
+
+    #[test]
+    fn changing_or_adding_a_day_memory_leaves_prefix_segment_bytes_unchanged() {
+        let year = snippet(
+            "year-1",
+            Some(TemporalGranularity::Year),
+            "Year Title",
+            "year summary",
+        );
+        let quarter = snippet(
+            "quarter-1",
+            Some(TemporalGranularity::Quarter),
+            "Quarter Title",
+            "quarter summary",
+        );
+        let day_before = snippet(
+            "day-1",
+            Some(TemporalGranularity::Day),
+            "Day Title",
+            "day summary before",
+        );
+        let day_after = snippet(
+            "day-1",
+            Some(TemporalGranularity::Day),
+            "Day Title",
+            "day summary after, rewritten with more detail",
+        );
+        let day_new = snippet(
+            "day-2",
+            Some(TemporalGranularity::Day),
+            "Brand New Day Title",
+            "brand new day summary",
+        );
+
+        let before = render_relevant_memory_section(&[year.clone(), quarter.clone(), day_before]);
+        let after_changed =
+            render_relevant_memory_section(&[year.clone(), quarter.clone(), day_after]);
+        let after_added = render_relevant_memory_section(&[year.clone(), quarter.clone(), day_new]);
+
+        let mut expected_prefix = String::new();
+        expected_prefix.push_str("### Relevant Durable Memories\n");
+        expected_prefix.push_str(
+            "Turn-specific historical memories shortlisted for the latest user request. Verify them against current tools/files before treating them as live state.\n",
+        );
+        expected_prefix.push_str(&render_relevant_memory_item(&year));
+        expected_prefix.push_str(&render_relevant_memory_item(&quarter));
+
+        assert!(
+            before.starts_with(&expected_prefix),
+            "prefix segment bytes must match the coarse items' rendered form exactly"
+        );
+        assert!(
+            after_changed.starts_with(&expected_prefix),
+            "prefix segment must be unaffected by rewriting a day memory"
+        );
+        assert!(
+            after_added.starts_with(&expected_prefix),
+            "prefix segment must be unaffected by adding a new day memory"
+        );
+        assert_ne!(
+            before, after_changed,
+            "the suffix (day) content is expected to change"
+        );
+        assert_ne!(
+            before, after_added,
+            "the suffix (day) content is expected to change"
+        );
+    }
 }

--- a/crates/infra/bamboo-memory/src/memory_store/types.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/types.rs
@@ -33,6 +33,16 @@ impl MemoryScope {
 /// coarser-grained memories (year/quarter) are low-frequency and cache-friendly and
 /// sort earlier (toward the stable prefix); finer-grained memories (day/week) change
 /// more often and sort later (toward the volatile suffix). See issue #61.
+///
+/// This warning is specifically about the passive recall-into-prompt path (auto-
+/// injected "Relevant Durable Memories" in the system prompt, ranked/segmented by
+/// `budget::segment_by_granularity_budget`) — that subset must stay prefix-cache
+/// stable across turns, so it is never hard-filtered by granularity. It does NOT
+/// apply to the explicit `filters.granularity` query path (the `memory` tool's
+/// `query`/`purge` actions): when a user or the LLM deliberately asks to see only
+/// e.g. this week's memories, that is a one-shot, caller-driven request outside the
+/// auto-injected prompt prefix, so hard-filtering there is fine and expected — see
+/// `bamboo-server-tools`' `MemoryTool::parse_query_filters`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum TemporalGranularity {


### PR DESCRIPTION
Closes #497 — makes #61's "Prefix Cache Friendly" constraint actually load-bearing in production prompts (PR #470 landed `segment_by_granularity_budget` fully tested but uncalled).

## Changes

1. **Prompt-assembly wiring** (`external_memory.rs`): `RelevantMemorySnippet` carries `id` + `granularity`; the per-item bullet format is extracted unchanged into `render_relevant_memory_item`; `render_relevant_memory_section` routes items through `GranularityBudgetItem` + `segment_by_granularity_budget` and appends `segments.combined()` (prefix then suffix, no separator). Coarse (untagged/month/quarter/year) memories now always render before fine (week/day) ones, so day-level churn can't perturb the coarse region's bytes. The segmentation reuses the section's existing `RELEVANT_MEMORY_TOTAL_MAX_CHARS` (1,600) — no new limit invented.
2. **`filters` schema discoverability**: the `memory` tool's `filters` schema now documents `type`/`status`/`granularity` sub-properties with enums and descriptions (previously a bare `{"type":"object"}` — LLM callers couldn't discover the new granularity filter). Parsing/behavior unchanged.
3. **`TemporalGranularity` doc comment**: clarifies that the "not a hard recall filter" warning is about the passive recall-into-prompt path, and doesn't contradict the explicit `filters.granularity` hard filter.

## Back-compat

When every item is coarse (all pre-granularity memories are untagged = coarse), the suffix is empty and `combined()` degenerates to exactly the old flat concatenation — pinned by `all_untagged_memories_render_identically_to_pre_segmentation_format`, which compares against a frozen byte-for-byte copy of the pre-change render loop.

## Tests

3 new engine tests (byte-identity for all-untagged, coarse-before-fine ordering, day-churn leaves prefix bytes unchanged).
- `cargo test -p bamboo-engine --lib`: 930 passed
- `cargo test -p bamboo-memory`: 169 passed; `-p bamboo-server-tools`: 83 passed
- fmt clean; clippy: zero warnings in touched files

## Notes for review

- The 1,600-char budget is now enforced at render time by real char-accounting, where previously it was only an estimate-based cutoff at candidate-selection time (with a +48/item fudge factor). Traced the fixed overheads — they agree in practice — but this is a slight behavior tightening, not a pure no-op: an item that squeaked past the estimate could in principle now be dropped at render. Both enums feeding the format are small and closed, so divergence is unlikely.
- `GranularityBudgetItem.id` uniqueness isn't required by the segmentation (ids only surface in `*_dropped_ids`); noted for future observability use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jxUSVTtay3Usa6n8eUaFK

---
_Generated by [Claude Code](https://claude.ai/code/session_015jxUSVTtay3Usa6n8eUaFK)_