### PR TITLE
fix(deploy): keep SSH session + reverse tunnel alive through bounded graceful drain on remote shutdown

### DIFF
--- a/crates/app/bamboo-broker/src/deploy.rs
+++ b/crates/app/bamboo-broker/src/deploy.rs
@@ -80,16 +80,32 @@ pub trait Deployer: Send + Sync {
 
 /// A handle to a deployment that is NOT a local child process (e.g. a remote
 /// worker reached over an in-process `russh` session). Owning this keeps the
-/// remote alive; `shutdown` tears it down (kill the remote process + close the
-/// connection/tunnel).
+/// remote alive; `shutdown`/`shutdown_with_timeout` tear it down (kill the
+/// remote process + close the connection/tunnel).
 #[async_trait]
 pub trait RemoteDeployment: Send + Sync {
     /// Remote OS pid of the launched worker, if the deployer captured one.
     fn remote_pid(&self) -> Option<u32> {
         None
     }
-    /// Tear down the remote worker and release the connection/tunnel.
-    async fn shutdown(&self);
+
+    /// Tear down the remote worker and release the connection/tunnel, using
+    /// [`DEFAULT_GRACEFUL_STOP_TIMEOUT`] as the grace window. See
+    /// [`Self::shutdown_with_timeout`].
+    async fn shutdown(&self) {
+        self.shutdown_with_timeout(DEFAULT_GRACEFUL_STOP_TIMEOUT)
+            .await;
+    }
+
+    /// Tear down the remote worker with an explicit grace window: signal the
+    /// worker to stop and poll for it to exit on its own — keeping the SSH
+    /// session (and therefore the reverse tunnel the worker drains its
+    /// in-flight Ask/Task/Run through) alive the whole time — before falling
+    /// back to a hard kill and only THEN closing the connection/tunnel. #489
+    /// (follow-up to #49/#488: the local-process path already does this via
+    /// [`DeployedAgent::shutdown_with_timeout`]; this is the remote-path
+    /// parity fix).
+    async fn shutdown_with_timeout(&self, timeout: Duration);
 }
 
 /// A running deployment. Killed on drop (`kill_on_drop`); `shutdown` also runs
@@ -156,9 +172,11 @@ impl DeployedAgent {
     /// falling back to a hard `SIGKILL` (`Child::start_kill`). A worker with no
     /// signal handler (e.g. an old binary) or one that's genuinely wedged still
     /// gets killed once `timeout` elapses, so `action=stop` is always bounded.
-    /// Remote deployments delegate to [`RemoteDeployment::shutdown`] unchanged
-    /// (out of scope for #49 — see the issue's evidence, which is specific to
-    /// the local-process `start_kill()` path). #49.
+    /// Remote deployments delegate to
+    /// [`RemoteDeployment::shutdown_with_timeout`] with the same `timeout`,
+    /// so a remotely-deployed worker gets the identical bounded-grace
+    /// treatment — SSH session and reverse tunnel stay up until the worker
+    /// exits or the window elapses (#489, closing the gap #49 left open).
     pub async fn shutdown_with_timeout(self, timeout: Duration) {
         match self.inner {
             DeployedInner::Process { mut child, cleanup } => {
@@ -194,7 +212,7 @@ impl DeployedAgent {
                     }
                 }
             }
-            DeployedInner::Remote(h) => h.shutdown().await,
+            DeployedInner::Remote(h) => h.shutdown_with_timeout(timeout).await,
         }
     }
 }

--- a/crates/app/bamboo-broker/src/deploy_russh.rs
+++ b/crates/app/bamboo-broker/src/deploy_russh.rs
@@ -12,11 +12,15 @@
 //! 5. `exec` the worker pointed at the tunnel mouth.
 //!
 //! The returned [`DeployedAgent`] owns the live `russh` session: keeping it
-//! alive keeps the tunnel + worker up; `shutdown` kills the remote worker and
-//! disconnects (session-bound lifetime, like the system-ssh path — true
-//! survive-restart durability is a later phase).
+//! alive keeps the tunnel + worker up; `shutdown`/`shutdown_with_timeout`
+//! signal the remote worker and POLL for it to exit — keeping the session and
+//! reverse tunnel up throughout, so an in-flight reply can drain through it —
+//! before hard-killing and disconnecting (session-bound lifetime, like the
+//! system-ssh path — true survive-restart durability is a later phase). #489.
 
+use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use russh::client::{self, Handle, Msg};
@@ -33,6 +37,11 @@ use crate::deploy::{
     UploadSpec,
 };
 use crate::error::{BrokerError, BrokerResult};
+
+/// Interval between `pgrep` liveness polls during the graceful-drain window in
+/// [`RusshHandle::shutdown_with_timeout`]. Short enough to notice a fast exit
+/// promptly, long enough not to hammer the SSH connection with exec requests.
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 /// Decrypted SSH credentials for the russh path (the fabric layer decrypts the
 /// at-rest ciphertext before constructing the deployer).
@@ -215,7 +224,8 @@ impl client::Handler for FabricHandler {
 }
 
 /// Live remote handle: owns the `russh` session (keeping the tunnel + worker
-/// alive). `shutdown` kills the worker by id and disconnects.
+/// alive). `shutdown`/`shutdown_with_timeout` signal the worker by id, poll for
+/// its exit through the still-open tunnel, then hard-kill + disconnect (#489).
 struct RusshHandle {
     session: Mutex<Option<Handle<FabricHandler>>>,
     worker_id: String,
@@ -227,15 +237,57 @@ struct RusshHandle {
 
 #[async_trait]
 impl RemoteDeployment for RusshHandle {
-    async fn shutdown(&self) {
+    /// #489: `pkill` only SIGNALS the worker — it does not wait for it to
+    /// exit. The previous implementation disconnected (tearing down the SSH
+    /// session and, with it, the reverse tunnel the worker drains its
+    /// in-flight Ask/Task/Run reply through) immediately after issuing the
+    /// signal, severing the graceful drain #488 added mid-reply. Fix: signal,
+    /// then POLL the remote for the worker's exit — keeping the session/tunnel
+    /// alive — for up to `timeout` (mirrors `DeployedAgent::shutdown_with_timeout`'s
+    /// local-process SIGTERM-then-poll pattern), THEN hard-kill as a fallback
+    /// and only then disconnect.
+    async fn shutdown_with_timeout(&self, timeout: Duration) {
         let Some(session) = self.session.lock().await.take() else {
             return;
         };
-        // Best-effort: kill the worker (anchored on its unique spec path when
-        // present — the truncated worker_id can substring-collide), remove the
-        // creds-bearing spec file, then disconnect (tears down the reverse tunnel).
+        // Anchored on the unique spec path when present — the truncated
+        // worker_id can substring-collide across nodes.
         let kill_anchor = self.remote_spec_path.as_deref().unwrap_or(&self.worker_id);
-        let mut cmd = format!("pkill -f {}", sh_quote(kill_anchor));
+
+        // 1. SIGTERM (pkill's default signal): give the worker's own shutdown
+        //    handler a chance to drain cleanly, same as the local-process path.
+        let term_cmd = format!("pkill -f {}", sh_quote(kill_anchor));
+        if let Ok(channel) = session.channel_open_session().await {
+            let _ = channel.exec(false, term_cmd).await;
+        }
+
+        // 2. Poll for the worker's exit within the grace window. The session
+        //    (and therefore the reverse tunnel) stays open the entire time, so
+        //    a reply the worker is still draining through it can complete.
+        //    Best-effort: a poll that errors (e.g. a transient exec hiccup) is
+        //    treated as "still alive" rather than aborting the wait early.
+        poll_until_exited(
+            || async {
+                exec_capture(
+                    &session,
+                    &format!(
+                        "pgrep -f {} >/dev/null 2>&1 && echo 1 || echo 0",
+                        sh_quote(kill_anchor)
+                    ),
+                )
+                .await
+                .map(|out| out.trim() == "1")
+                .unwrap_or(true)
+            },
+            timeout,
+            POLL_INTERVAL,
+        )
+        .await;
+
+        // 3. Hard-kill fallback (harmless no-op if it already exited above) +
+        //    remove the creds-bearing spec file, THEN disconnect — only now is
+        //    the reverse tunnel torn down.
+        let mut cmd = format!("pkill -9 -f {}", sh_quote(kill_anchor));
         if let Some(spec) = &self.remote_spec_path {
             cmd.push_str(&format!("; rm -f {}", sh_quote(spec)));
         }
@@ -245,6 +297,32 @@ impl RemoteDeployment for RusshHandle {
         let _ = session
             .disconnect(russh::Disconnect::ByApplication, "", "")
             .await;
+    }
+}
+
+/// Poll `is_alive` every `interval` until it reports `false` (exited on its
+/// own) or `timeout` elapses (still alive at the deadline — caller should
+/// escalate to a hard kill). Returns `true` iff it exited within the window.
+///
+/// Factored out of [`RusshHandle::shutdown_with_timeout`] so the bounded-grace
+/// polling behavior is unit-testable without a live SSH session — see the
+/// `poll_until_exited_*` tests below. Mirrors the shape of the local-process
+/// poll loop in [`DeployedAgent::shutdown_with_timeout`], just driven by an
+/// arbitrary async liveness check instead of `Child::try_wait`.
+async fn poll_until_exited<F, Fut>(mut is_alive: F, timeout: Duration, interval: Duration) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if !is_alive().await {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(interval).await;
     }
 }
 
@@ -618,5 +696,81 @@ mod tests {
     #[test]
     fn parse_private_key_rejects_garbage() {
         assert!(parse_private_key("not a key", None).is_err());
+    }
+
+    // #489: `poll_until_exited` backs `RusshHandle::shutdown_with_timeout`'s
+    // grace-window wait. It can't be exercised against a real remote without a
+    // live SSH session (see `tests/russh_live.rs`, gated behind
+    // `BAMBOO_RUSSH_LIVE=1`), so these tests drive it directly with a fake
+    // liveness check instead — the polling/timeout behavior is identical
+    // either way, since `poll_until_exited` doesn't know or care that the real
+    // liveness check is an SSH `pgrep` exec.
+
+    /// A worker that exits partway through the grace window: `is_alive` flips
+    /// to `false` after a couple of polls. Must return `true` (exited on its
+    /// own) well before the timeout elapses.
+    #[tokio::test]
+    async fn poll_until_exited_returns_true_once_alive_check_goes_false() {
+        let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let calls2 = calls.clone();
+        let start = tokio::time::Instant::now();
+        let exited = poll_until_exited(
+            move || {
+                let calls = calls2.clone();
+                async move {
+                    // Alive for the first two checks, exited by the third.
+                    calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) < 2
+                }
+            },
+            Duration::from_secs(5),
+            Duration::from_millis(10),
+        )
+        .await;
+        assert!(exited, "must report exited once is_alive returns false");
+        assert!(
+            calls.load(std::sync::atomic::Ordering::SeqCst) >= 3,
+            "must have polled past the two `alive` responses"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "must return promptly once the worker exits, not wait out the full timeout"
+        );
+    }
+
+    /// A worker that never exits (e.g. ignores the signal, mirroring the
+    /// SIGTERM-ignoring case #49 tests for the local-process path): the poll
+    /// must be BOUNDED — return `false` once `timeout` elapses rather than
+    /// hanging forever — so the caller's hard-kill fallback always runs.
+    #[tokio::test]
+    async fn poll_until_exited_returns_false_when_still_alive_at_deadline() {
+        let exited = tokio::time::timeout(
+            Duration::from_secs(5),
+            poll_until_exited(
+                || async { true }, // always "still alive"
+                Duration::from_millis(150),
+                Duration::from_millis(20),
+            ),
+        )
+        .await
+        .expect("poll_until_exited must be bounded by its own timeout");
+        assert!(!exited, "must report NOT exited once the deadline elapses");
+    }
+
+    /// A worker that's already gone by the first check: must return
+    /// immediately without waiting a full `interval`.
+    #[tokio::test]
+    async fn poll_until_exited_returns_true_immediately_when_already_dead() {
+        let start = tokio::time::Instant::now();
+        let exited = poll_until_exited(
+            || async { false },
+            Duration::from_secs(5),
+            Duration::from_secs(10), // deliberately long — must not be waited on
+        )
+        .await;
+        assert!(exited);
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "first is_alive()==false must short-circuit, not wait an interval"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Follow-up to #49/#488. `RemoteDeployment::shutdown` (the `russh` deploy path) sent SIGTERM via `pkill` and then immediately closed the SSH session, severing the reverse tunnel a remotely-deployed worker drains its in-flight Ask/Task/Run reply through — cutting the graceful drain #488 shipped short for remote workers.
- `RemoteDeployment::shutdown_with_timeout` now mirrors `DeployedAgent::shutdown_with_timeout`'s local-process pattern: `pkill` (SIGTERM) → poll the remote for exit (via `pgrep`) for up to the grace window, keeping the SSH session/reverse tunnel alive throughout → `pkill -9` hard-kill fallback → disconnect only then.
- `DeployedAgent::shutdown_with_timeout`'s `Remote` arm now forwards its `timeout` to `RemoteDeployment::shutdown_with_timeout` instead of calling the old no-args `shutdown()`, so a caller-supplied grace window applies uniformly to local and remote deployments. `RemoteDeployment::shutdown()` keeps working as a default-timeout (`DEFAULT_GRACEFUL_STOP_TIMEOUT`, 30s) convenience wrapper.
- The signal-then-poll loop is factored out into `poll_until_exited` (generic over an async liveness check) so its bounded-timeout behavior is unit-testable without a live SSH session.

## Testing
- New unit tests in `deploy_russh.rs`: `poll_until_exited_returns_true_once_alive_check_goes_false`, `poll_until_exited_returns_false_when_still_alive_at_deadline`, `poll_until_exited_returns_true_immediately_when_already_dead` — drive the polling/timeout logic directly with a fake liveness check (the real `RusshHandle::shutdown_with_timeout` path exercises the same loop over a real `pgrep` exec, which needs a live SSH session — see the existing `BAMBOO_RUSSH_LIVE=1`-gated `tests/russh_live.rs`, not runnable in this sandbox/CI).
- `cargo test -p bamboo-broker` — 74 lib tests + `bus_e2e` (2) + `russh_live` (1, no-op without `BAMBOO_RUSSH_LIVE=1`) + `ws_roundtrip` (9) all pass.
- `cargo test -p bamboo-server-tools` — 85 lib tests + `ask_agent_tool` (3) all pass (covers `DeployedAgent::shutdown` callers).
- `cargo build --workspace --tests` — green (only pre-existing unrelated warnings in other crates: unused imports in `bamboo-llm`/`bamboo-memory`, dead_code in `bamboo-engine`).
- `cargo fmt -p bamboo-broker -- --check` — clean.
- `cargo clippy -p bamboo-broker --lib --tests` — clean for touched files; a pre-existing `too_many_arguments` error in the unrelated `bamboo-agent-core` crate (untouched by this PR, confirmed via `git diff`) blocks `-D warnings` clippy across the whole dependency graph — not introduced by this change.

## Test plan
- [x] Unit tests for the bounded-grace polling logic
- [x] Full `bamboo-broker` + `bamboo-server-tools` test suites
- [x] Workspace build
- [ ] Live-SSH exercise of the actual drain-through-tunnel behavior (needs `BAMBOO_RUSSH_LIVE=1` + a Linux sshd container fixture — out of scope for this sandbox)

Closes #489.

https://claude.ai/code/session_01Ux4nHUqFjEEGV3rX1x3V9Y