### PR TITLE
test: deflake token-usage/mcp-proxy/backup-rotation/plugin-installer tests

### DIFF
--- a/crates/app/bamboo-broker/src/mcp.rs
+++ b/crates/app/bamboo-broker/src/mcp.rs
@@ -1302,15 +1302,37 @@ mod tests {
 
     #[tokio::test]
     async fn concurrent_proxy_calls_overlap_at_the_orchestrator() {
-        use std::time::Instant;
-
-        // A host-bound backend where each call takes 200ms. Serial handling of N
-        // calls would take N*200ms; concurrent handling overlaps to ~200ms.
-        struct SlowMcp;
+        // Prove overlap DIRECTLY (issue #486) instead of inferring it from
+        // wall-clock duration: earlier this asserted `elapsed < N ms`
+        // against a `sleep(200ms)` backend, which raced CI load — a loaded
+        // runner can push even genuinely-concurrent calls past any fixed
+        // real-ms bound, producing a one-off failure with no code
+        // regression. (A `tokio::time::pause()` virtual-clock variant was
+        // tried and discarded: it doesn't compose safely with this test's
+        // REAL TCP/WebSocket IO — auto-advance raced the broker
+        // connect/handshake against the proxy's timeout-and-reconnect path,
+        // spuriously triggering reconnect/backoff and making the measured
+        // "elapsed" worse, not more deterministic.)
+        //
+        // Instead, `SlowMcp` tracks its own instantaneous concurrency: bump
+        // `in_flight` before the (still real, still 200ms — exercising the
+        // exact same overlap window) sleep, record the high-water mark via
+        // `fetch_max`, then decrement after. Serial handling could never
+        // observe more than 1 in flight at a time; genuine overlap of the 4
+        // spawned calls must observe all 4 at some point. Zero dependency on
+        // how fast or slow the host happens to be.
+        struct SlowMcp {
+            in_flight: AtomicU32,
+            max_in_flight: AtomicU32,
+        }
         #[async_trait]
         impl ToolExecutor for SlowMcp {
             async fn execute(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+                let now_in_flight = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                self.max_in_flight
+                    .fetch_max(now_in_flight, Ordering::SeqCst);
                 tokio::time::sleep(Duration::from_millis(200)).await;
+                self.in_flight.fetch_sub(1, Ordering::SeqCst);
                 Ok(ToolResult {
                     success: true,
                     result: format!("done {}", call.function.arguments),
@@ -1336,6 +1358,10 @@ mod tests {
                 }]
             }
         }
+        let slow_mcp = Arc::new(SlowMcp {
+            in_flight: AtomicU32::new(0),
+            max_in_flight: AtomicU32::new(0),
+        });
 
         let dir = tempfile::tempdir().unwrap();
         let core = Arc::new(BrokerCore::new(dir.path()));
@@ -1348,6 +1374,7 @@ mod tests {
         let endpoint = format!("ws://{addr}");
 
         let ep = endpoint.clone();
+        let mcp_for_server = slow_mcp.clone();
         tokio::spawn(async move {
             let _ = serve_mcp_proxy(
                 &ep,
@@ -1356,7 +1383,7 @@ mod tests {
                     role: None,
                 },
                 TOKEN,
-                Arc::new(SlowMcp),
+                mcp_for_server,
                 Arc::new(RoleToolAllowlist::unrestricted()),
             )
             .await;
@@ -1375,8 +1402,8 @@ mod tests {
             .expect("proxy connects"),
         );
 
-        // 4 concurrent 200ms calls: serial would be ~800ms, concurrent ~200ms.
-        let start = Instant::now();
+        // 4 concurrent 200ms calls; `SlowMcp::max_in_flight` records the
+        // high-water mark of calls it observed simultaneously in progress.
         let mut handles = Vec::new();
         for i in 0..4u32 {
             let p = proxy.clone();
@@ -1395,17 +1422,12 @@ mod tests {
         for h in handles {
             h.await.unwrap();
         }
-        let elapsed = start.elapsed();
-        // Serial execution is unavoidably >= 4 * 200ms = 800ms, so any bound safely
-        // below 800ms proves the calls overlapped. Use 700ms (not a tight 500ms):
-        // overlapping calls take ~200ms + proxy/bus + scheduling overhead, which a
-        // loaded CI runner can push past 500ms — the gap to the 800ms serial floor
-        // is what matters, not a tight absolute time. Keeps the overlap assertion
-        // meaningful while removing the timing flake.
-        assert!(
-            elapsed < Duration::from_millis(700),
-            "4 concurrent 200ms proxy calls must OVERLAP at the orchestrator \
-             (serial would be >= 800ms); took {elapsed:?}"
+        let max_in_flight = slow_mcp.max_in_flight.load(Ordering::SeqCst);
+        assert_eq!(
+            max_in_flight, 4,
+            "4 concurrent proxy calls must OVERLAP at the orchestrator (serial handling \
+             could never observe more than 1 in flight at once); observed max_in_flight = \
+             {max_in_flight}"
         );
     }
 

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -658,18 +658,25 @@ impl AppState {
         // something — mirrors `mcp_manager`/`connect_manager`'s
         // always-alive lifecycle.
         let service_manager = Arc::new(crate::service_manager::ServiceManager::new());
-        {
-            // Backgrounded (mirrors `init_mcp_manager`'s background MCP
-            // bootstrap): a service that `installed.json` says should be
-            // running but isn't (the previous `bamboo serve` process, if
-            // any, died with everything it supervised) is started fresh.
+        // Backgrounded (mirrors `init_mcp_manager`'s background MCP
+        // bootstrap): a service that `installed.json` says should be
+        // running but isn't (the previous `bamboo serve` process, if
+        // any, died with everything it supervised) is started fresh.
+        //
+        // The `JoinHandle` is kept (not discarded) purely so tests can
+        // deterministically wait it out via
+        // `AppState::wait_for_boot_reconcile_services` instead of racing
+        // this unsynchronized pass — see that method's doc comment and issue
+        // #486. Production code never awaits it; server startup is never
+        // blocked on plugin service spawns.
+        let boot_reconcile_services_handle = {
             let service_manager = service_manager.clone();
             let app_data_dir = bamboo_home_dir.clone();
             tokio::spawn(async move {
                 crate::plugin_installer::boot_reconcile_services(&app_data_dir, &service_manager)
                     .await;
-            });
-        }
+            })
+        };
 
         Ok(Self {
             app_data_dir: bamboo_home_dir,
@@ -701,6 +708,9 @@ impl AppState {
             skill_manager,
             mcp_manager,
             service_manager,
+            boot_reconcile_services_handle: tokio::sync::Mutex::new(Some(
+                boot_reconcile_services_handle,
+            )),
             metrics_service,
             agent_runners,
             session_event_senders,

--- a/crates/app/bamboo-server/src/app_state/mod.rs
+++ b/crates/app/bamboo-server/src/app_state/mod.rs
@@ -311,6 +311,22 @@ pub struct AppState {
     /// `crate::service_manager`'s module docs.
     pub service_manager: Arc<crate::service_manager::ServiceManager>,
 
+    /// Handle to the background boot-time service reconcile pass
+    /// (`plugin_installer::boot_reconcile_services`, spawned fire-and-forget
+    /// by `app_state::builder` — see its comment). It is deliberately NOT
+    /// synchronized against `plugin_installer::PLUGIN_OP_LOCK`, so it can, in
+    /// principle, race a `ServerPluginInstaller::install`/
+    /// `stop_services_for_upgrade` call that lands on the SAME data dir
+    /// while it is still in flight (e.g. immediately after construction).
+    /// Production code never touches this field; it exists purely as a
+    /// test-only synchronization point (see
+    /// [`AppState::wait_for_boot_reconcile_services`]) so
+    /// `plugin_installer::tests` can deterministically drain that one-shot
+    /// pass before exercising service install/stop/upgrade, instead of
+    /// racing it under CI scheduling jitter (issue #486).
+    #[doc(hidden)]
+    pub boot_reconcile_services_handle: tokio::sync::Mutex<Option<tokio::task::JoinHandle<()>>>,
+
     /// Metrics collection and persistence service
     ///
     /// Tracks token usage, costs, and performance metrics
@@ -398,6 +414,19 @@ impl AppState {
     /// Release the title-generation slot for `session_id`. Idempotent.
     pub fn title_gen_release(&self, session_id: &str) {
         self.title_gen_in_flight.remove(session_id);
+    }
+
+    /// Test-only synchronization point (see
+    /// [`boot_reconcile_services_handle`](Self::boot_reconcile_services_handle)'s
+    /// doc comment): wait for the background boot-time service reconcile
+    /// pass to finish. Idempotent — a second call (or a call after
+    /// production code never having populated the handle) is a no-op.
+    #[doc(hidden)]
+    pub async fn wait_for_boot_reconcile_services(&self) {
+        let handle = self.boot_reconcile_services_handle.lock().await.take();
+        if let Some(handle) = handle {
+            let _ = handle.await;
+        }
     }
 }
 

--- a/crates/app/bamboo-server/src/plugin_installer/tests.rs
+++ b/crates/app/bamboo-server/src/plugin_installer/tests.rs
@@ -22,6 +22,20 @@ async fn new_installer(data_dir: &Path) -> (web::Data<AppState>, ServerPluginIns
     let state = AppState::new(data_dir.to_path_buf())
         .await
         .expect("app state should initialize");
+    // `AppState::new` fires the boot-time service reconcile pass
+    // (`plugin_installer::boot_reconcile_services`) in the background,
+    // unsynchronized against `PLUGIN_OP_LOCK` (see that function's doc
+    // comment). On a fresh `data_dir` it is a same-tick no-op (nothing in
+    // `installed.json` yet) — UNLESS it is still in flight when a
+    // service-lifecycle test below writes `installed.json` and starts/stops
+    // a service moments later, in which case it can race back in and
+    // resurrect (or fail to see) a service the test just
+    // installed/stopped, producing exactly the `is_running` flakes tracked
+    // by issue #486. Draining it here (once, before any test touches
+    // `installed.json`) removes that race entirely: by construction it can
+    // only observe an empty store at this point, so this always resolves
+    // near-instantly.
+    state.wait_for_boot_reconcile_services().await;
     let data = web::Data::new(state);
     let installer = ServerPluginInstaller::new(data.clone());
     (data, installer)

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -3304,11 +3304,29 @@ fn write_atomic(path: &std::path::Path, content: &[u8]) -> std::io::Result<()> {
 
     // Write to a temp file in the same directory then rename to ensure atomic replace.
     // (Rename is atomic on Unix when source/dest are on the same filesystem.)
+    //
+    // The temp name must be unique PER CALL, not just per-process (issue
+    // #486): it used to be derived from `process_id()` alone, which is
+    // IDENTICAL across every thread of the same process. Two `write_atomic`
+    // calls racing on the same directory (observed: two `#[test]` fns in
+    // this file's suite, run concurrently by the default multi-threaded
+    // test harness) therefore computed the exact same `tmp_path`. Whichever
+    // caller's `File::create` ran second truncated the first caller's
+    // in-flight temp file out from under it; whichever caller's `rename`
+    // then lost the race failed with ENOENT (its temp file had already been
+    // renamed away by the other caller) — reproducing
+    // `save_rotates_backup_generations`'s exact CI failure: "Failed to
+    // write config file ... No such file or directory (os error 2)". A
+    // monotonic per-process counter alongside the PID makes every call's
+    // temp file distinct, regardless of how many callers target the same
+    // directory concurrently.
+    static NEXT_TMP_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let unique = NEXT_TMP_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let file_name = path
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("config.json");
-    let tmp_name = format!(".{}.tmp.{}", file_name, std::process::id());
+    let tmp_name = format!(".{}.tmp.{}.{}", file_name, std::process::id(), unique);
     let tmp_path = parent.join(tmp_name);
 
     {
@@ -3672,14 +3690,29 @@ mod tests {
 
     impl TempHome {
         fn new() -> Self {
+            // `pid + nanos` alone is NOT collision-free (issue #486): every
+            // test in this binary shares the pid, and two tests started
+            // concurrently by the multi-threaded harness can observe the
+            // same `SystemTime` nanos tick. Two `TempHome`s colliding on one
+            // path means they share a directory — and the first test's
+            // `Drop` (`remove_dir_all`) then yanks the directory out from
+            // under the other test's in-flight `save_to_dir`, whose
+            // tmp-file+rename dance fails with ENOENT ("Failed to write
+            // config file ... os error 2" — `save_rotates_backup_generations`'s
+            // exact one-off CI failure mode). A per-process atomic counter
+            // in the name makes each instance unique unconditionally.
+            static NEXT_TEMP_HOME_ID: std::sync::atomic::AtomicU64 =
+                std::sync::atomic::AtomicU64::new(0);
+            let unique = NEXT_TEMP_HOME_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let nanos = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .expect("clock should be after unix epoch")
                 .as_nanos();
             let path = std::env::temp_dir().join(format!(
-                "chat-core-config-test-{}-{}",
+                "chat-core-config-test-{}-{}-{}",
                 std::process::id(),
-                nanos
+                nanos,
+                unique
             ));
             std::fs::create_dir_all(&path).expect("failed to create temp home dir");
             Self { path }
@@ -5923,6 +5956,16 @@ mod tests {
 
     #[test]
     fn publish_and_current_env_vars_round_trip() {
+        // `publish_env_vars` REPLACES the process-global env-vars cache
+        // wholesale, so every test that touches that cache must hold the
+        // crate-wide env lock. This test didn't (issue #486): running
+        // concurrently with a lock-holding cache test (e.g.
+        // `from_data_dir_without_publish_does_not_clobber_global_cache`) it
+        // wiped that test's just-seeded marker out of the cache mid-assert —
+        // and its own 10x retry loop below was itself a symptom of losing
+        // the same race in the other direction. With the lock held, one
+        // publish is deterministic.
+        let _lock = crate::test_support::env_cache_lock_acquire();
         let config = Config {
             env_vars: vec![EnvVarEntry {
                 name: "TEST_PUBLISH".to_string(),
@@ -5934,14 +5977,13 @@ mod tests {
             ..Default::default()
         };
 
-        for _ in 0..10 {
-            config.publish_env_vars();
-            let map = Config::current_env_vars();
-            if map.get("TEST_PUBLISH") == Some(&"pub_value".to_string()) {
-                return;
-            }
-        }
-        panic!("TEST_PUBLISH not found in cache after retries");
+        config.publish_env_vars();
+        assert_eq!(
+            Config::current_env_vars()
+                .get("TEST_PUBLISH")
+                .map(String::as_str),
+            Some("pub_value")
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -1354,6 +1354,20 @@ impl Storage for SessionStoreV2 {
             .open(&path)
             .await?;
         file.write_all(line.as_bytes()).await?;
+        // `flush` is LOAD-BEARING, not cosmetic (issues #378/#486):
+        // `tokio::fs::File::write_all` only copies the bytes into the File's
+        // internal buffer and schedules the actual OS write on the blocking
+        // thread pool — it does NOT wait for it. Dropping the File does not
+        // wait either (the write still happens "eventually" on the pool, and
+        // any error is silently discarded). So without this flush a caller
+        // that appends and then promptly reads the file back — exactly what
+        // `append_token_usage_record_writes_jsonl_in_session_dir` does — can
+        // observe the file BEFORE a still-in-flight append lands, which on a
+        // loaded CI runner (saturated blocking pool) manifested as the
+        // one-off "1 line instead of 2 / lost second append" failure.
+        // `flush().await` drives the pending background write to completion
+        // (and surfaces its error) before we return.
+        file.flush().await?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Root-causes and fixes all four flaky-test families tracked in #486. **Two of the four turned out to be real product bugs**, not test-side timing assumptions — flagged loudly below.

## Per-test root cause + fix

### 1. `v2::tests::append_token_usage_record_writes_jsonl_in_session_dir` (bamboo-storage) — **PRODUCT BUG**

`append_token_usage_record` called `tokio::fs::File::write_all` and returned **without `flush()`**. Tokio's `File::write_all` only copies the bytes into the File's internal buffer and *schedules* the OS write on the blocking thread pool; dropping the File does not await it (and discards its error). A caller that appends then promptly reads the file back — exactly what the test does — can observe the file **before the append lands**. On a loaded CI runner (saturated blocking pool) this is the one-off "1 line instead of 2" failure, and it finally explains #378's "lost second append" data point (the round-1 write lands because the round-2 *open* queues behind it on the pool; round-2's write is the one still in flight at read time).

**Reproduced deterministically** in a standalone harness (tokio runtime with `max_blocking_threads(1)` + a blocking-pool hog): **10–27/200 iterations lost the append without flush; 0/200 with flush**, with the exact CI failure signature (`"{\"round\":1}\n"` only).

Fix (production code, `v2.rs`): `file.flush().await?` after `write_all` — drives the pending background write to completion and surfaces its error.

### 2. `config::tests::save_rotates_backup_generations` (bamboo-config) — **PRODUCT BUG** + test-fixture bug

The CI failure was `Failed to write config file ... No such file or directory` from inside `write_atomic`. Two independent same-directory races produce exactly that ENOENT:

- **Product bug** (`write_atomic`): the temp filename was derived from `process::id()` **alone** — identical across every thread of the process — so two concurrent `write_atomic` calls on the same directory compute the *same* tmp path; one truncates the other's in-flight temp file and the rename loser fails ENOENT. Fixed with a per-call atomic counter in the tmp name. (In the server, `config_io_lock` mostly serializes config saves, but the function itself was unsafe under any concurrent use.)
- **Test fixture** (`TempHome::new`): directory name = `pid + SystemTime nanos`, which can tie between two tests started concurrently by the multithreaded harness → shared directory → the first test's `Drop` (`remove_dir_all`) yanks the dir out from under the other's in-flight save. Added an atomic counter to the name.

Evidence the fixture race is real and fixed: pristine `main` fails **15/30** full `config::tests` suite runs at `--test-threads=64` (across many TempHome-using backup/quarantine/recovery tests); this branch: **0/90** at `--test-threads=8/32/64`.

Drive-by (same family, found by the 64-thread loop): `publish_and_current_env_vars_round_trip` published to the process-global env-var cache **without** the crate-wide env lock, wholesale-replacing the cache under lock-holding tests (e.g. `from_data_dir_without_publish_does_not_clobber_global_cache`); its own 10x retry loop was a symptom of losing the same race in the other direction. Now takes the lock, retry loop removed.

### 3. `mcp::tests::concurrent_proxy_calls_overlap_at_the_orchestrator` (bamboo-broker) — test determinism

The test inferred overlap from wall-clock: 4 concurrent 200ms calls must finish `< 700ms` (serial floor 800ms). A loaded runner can push even genuinely-overlapping calls past any fixed real-ms bound. Overlap is now proven **directly**: the `SlowMcp` stub tracks its instantaneous in-flight count and records the high-water mark via `fetch_max`; the test asserts `max_in_flight == 4`. Serial handling could never observe more than 1 in flight — zero timing dependency remains. (A `tokio::time::pause()` virtual-clock variant was tried first and discarded: it doesn't compose with this test's real TCP/WebSocket IO — auto-advance spuriously fired the proxy's timeout/reconnect path.)

### 4. `plugin_installer::tests` service-lifecycle family (bamboo-server) — test determinism

Per the issue body, the assertions race the best-effort-start machinery — but the concrete unsynchronized actor is `boot_reconcile_services`: `AppState::new` fires it in the background, **outside `PLUGIN_OP_LOCK`**, and the test fixture returned while it could still be in flight; it can then race the test's install/stop bookkeeping. `AppState` now retains the reconcile task's `JoinHandle` (doc-hidden field + `wait_for_boot_reconcile_services()` accessor, production behavior unchanged — still fire-and-forget), and the test fixture drains it before any test logic. On a fresh data dir it's a no-op pass, so the wait resolves instantly.

## Stability loops (all green)

| Target | Loop | Result |
|---|---|---|
| plugin_installer 2 flaky tests | 60 runs @ 16 threads | 60/60 |
| plugin_installer full module | 100 runs @ threads 1/2/4/8/16 | 100/100 |
| broker overlap test | 100 runs @ threads 1/2/4/8/16 + 30 runs under full CPU stress | 130/130 |
| storage token-usage test | 80 runs @ 64 threads under IO stress + fd-limit 256 | 80/80 |
| storage v2 full module | 90 runs @ threads 4/16/64 under IO stress | 90/90 |
| config full `config::tests` | 90 runs @ threads 8/32/64 | 90/90 (main: 15/30 fail @64) |
| config rotation test isolated | 50 runs | 50/50 |

## Quality gates

- `cargo fmt` on all 4 touched crates
- `cargo clippy --tests` on all 4 touched crates — only pre-existing warnings in untouched files (`bamboo-agent-core`, `bamboo-engine`, `bamboo-memory`, `handlers/agent/execute/handler/ready.rs`)
- `cargo build --workspace --tests` green
- Full `cargo test -p` green: bamboo-broker 71+13, bamboo-storage 66, bamboo-config 237, bamboo-server 1318

Addresses #486 — all four listed cases root-caused and fixed (none left unreproduced; the two "unreproducible" ones from prior investigations, #378's lost append and the rotation ENOENT, both reproduce mechanically once the real cause is known).

https://claude.ai/code/session_01Ux4nHUqFjEEGV3rX1x3V9Y