### PR TITLE
chore(ci/docker): cargo-chef layer caching + supply-chain hardening (audit pin, cargo-deny, image scan)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,27 @@
+# cargo-audit configuration — tracks advisories we deliberately ignore, with
+# justification and a review trigger, instead of burying them as bare
+# `--ignore` flags on the CI command line (bamboo-agent#254).
+#
+# Review policy: re-check each entry whenever `cargo audit` is next run
+# against an updated Cargo.lock (dependabot bump, manual upgrade) — drop the
+# ignore as soon as a fixed version is available and pulled in.
+
+[advisories]
+ignore = [
+    # RUSTSEC-2023-0071 — rsa crate: Marvin timing/padding oracle sidechannel
+    # in PKCS#1 v1.5 decryption. NO fixed release exists in ANY rsa version,
+    # including the 0.10-rc pulled in transitively via russh 0.60's ssh-key
+    # RSA key support. bamboo's only RSA exposure is operator-initiated SSH
+    # deploy (bamboo-deploy), a low-frequency, operator-controlled path — not
+    # a network-facing decryption oracle. Re-check: any rsa release that
+    # addresses RUSTSEC-2023-0071, or a russh release that drops the
+    # transitive dependency.
+    "RUSTSEC-2023-0071",
+
+    # RUSTSEC-2025-0134 — rustls-pemfile is unmaintained (informational, no
+    # known vulnerability); repository archived since 2025-08. Transitive
+    # dependency pulled in by the TLS stack. Re-check: when the pulling crate
+    # migrates PEM parsing to rustls-pki-types >=1.9 (the upstream-suggested
+    # replacement) or another maintained fork.
+    "RUSTSEC-2025-0134",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,14 @@ jobs:
       # Pinned by commit SHA (not just the `v2` tag) for supply-chain
       # reproducibility — deny.toml at the repo root is tuned to be green
       # against the current dependency tree (bamboo-agent#254).
+      #
+      # IMPORTANT: this action release bundles cargo-deny 0.20.2 (see the
+      # `deny_version` in the action's Dockerfile at this commit); deny.toml
+      # was validated against that exact cargo-deny version. Older releases
+      # (e.g. v2.0.11 = cargo-deny 0.18.2) fail on deny.toml's newer schema
+      # ([bans] allow-workspace) and license-expression syntax — when bumping
+      # this pin, re-run `cargo deny check` locally with the matching version.
       - name: cargo-deny check
-        uses: EmbarkStudios/cargo-deny-action@34899fc7ba81ca6268d5947a7a16b4649013fea1 # v2.0.11
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1 (cargo-deny 0.20.2)
         with:
           command: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,19 +150,31 @@ jobs:
           cache-on-failure: true
 
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        # Pinned + --locked for reproducible, non-drifting CI runs (was
+        # `cargo install cargo-audit` unpinned — bamboo-agent#254).
+        run: cargo install cargo-audit --version 0.22.2 --locked
 
       - name: Run security audit
         # RUSTSEC-2026-0154 (russh) + RUSTSEC-2026-0153 (russh-cryptovec) are now
         # FIXED by upgrading russh 0.52 -> 0.60.3 (ring backend, no aws-lc/cmake).
         #
-        # Remaining ignore (transitive, no safe in-tree fix):
-        #   RUSTSEC-2023-0071  rsa (Marvin timing sidechannel) — NO fixed release
-        #     exists in ANY rsa version (incl. the 0.10-rc pulled by russh 0.60);
-        #     transitive via russh's ssh-key RSA support. bamboo's only RSA use is
-        #     operator-initiated SSH deploy (low exposure).
-        run: |
-          cargo audit \
-            --ignore RUSTSEC-2024-0384 \
-            --ignore RUSTSEC-2025-0134 \
-            --ignore RUSTSEC-2023-0071
+        # The remaining ignore list moved out of this CLI invocation into the
+        # tracked `.cargo/audit.toml` config (cargo-audit's documented
+        # discovery path — a bare root-level `audit.toml` is NOT picked up),
+        # where each entry carries a justification and a re-check trigger
+        # instead of being a silent, undocumented flag (bamboo-agent#254).
+        run: cargo audit
+
+  deny:
+    name: cargo-deny (licenses/bans/advisories/sources)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # Pinned by commit SHA (not just the `v2` tag) for supply-chain
+      # reproducibility — deny.toml at the repo root is tuned to be green
+      # against the current dependency tree (bamboo-agent#254).
+      - name: cargo-deny check
+        uses: EmbarkStudios/cargo-deny-action@34899fc7ba81ca6268d5947a7a16b4649013fea1 # v2.0.11
+        with:
+          command: check

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -176,3 +176,38 @@ jobs:
       - name: Inspect published image
         run: |
           docker buildx imagetools inspect ${{ steps.repo.outputs.name }}:latest
+
+  image-scan:
+    name: Scan published image (Trivy)
+    runs-on: ubuntu-latest
+    needs: merge
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image repo (lowercase)
+        id: repo
+        run: echo "name=$(echo '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      # CVE scan of the image actually published to GHCR. Starts warn-only
+      # (exit-code 0, ignore-unfixed) so pre-existing, not-yet-patched
+      # base-image CVEs don't block publishing — tighten once the baseline is
+      # triaged. Pinned by commit SHA: trivy-action's tags were compromised
+      # in a supply-chain attack in 2026-03 (credential-stealer injected into
+      # tags 0.0.1-0.34.2); this SHA is a signed, verified post-incident
+      # release. (bamboo-agent#254)
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ steps.repo.outputs.name }}:latest
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "0"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,255 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# Root options
+
+# The graph table configures how the dependency graph is constructed and thus
+# which crates the checks are performed against
+[graph]
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #"x86_64-unknown-linux-musl",
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = false
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+
+# The output table provides options for how/if diagnostics are outputted
+[output]
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+#
+# NOTE: this is a SEPARATE ignore list from the CI `cargo audit` step's
+# tracked `.cargo/audit.toml` (bamboo-agent#254) — cargo-deny does not read
+# .cargo/audit.toml. Keep the two lists in sync; see .cargo/audit.toml for the fuller
+# per-advisory justification and re-check triggers.
+[advisories]
+ignore = [
+    { id = "RUSTSEC-2023-0071", reason = "rsa Marvin timing sidechannel — no fixed release exists (incl. the 0.10-rc pulled by russh 0.62's ssh-key RSA support); bamboo's only RSA use is operator-initiated SSH deploy. See .cargo/audit.toml." },
+    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is unmaintained (informational, not a vulnerability); repo archived 2025-08. Transitive via the TLS stack. See .cargo/audit.toml." },
+]
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# Permissive licenses actually present across the current dependency tree
+# (derived from `cargo deny check licenses` against the real Cargo.lock —
+# bamboo-agent#254). Extend this list deliberately when a new dependency
+# needs a license not already covered; don't widen it speculatively.
+# See https://spdx.org/licenses/ for the list of possible licenses.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "0BSD",
+    "BSL-1.0",
+    "MPL-2.0",
+    "Unlicense",
+    "Unicode-3.0",
+    "CDLA-Permissive-2.0",
+]
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list.
+#
+# actix-governor (the actix-web integration for the `governor` rate limiter,
+# used by bamboo-server's rate-limit middleware) is GPL-3.0-or-later — unlike
+# the MIT/Apache-2.0 `governor` crate it wraps. This is a real license-compat
+# question for a binary distribution (not a cargo-deny config problem to
+# paper over), so it's an explicit, narrowly-scoped exception rather than a
+# blanket GPL allowance, and is flagged for follow-up (new-issue candidate,
+# bamboo-agent#254 PR description) rather than silently resolved here.
+exceptions = [
+    { allow = ["GPL-3.0-or-later"], crate = "actix-governor" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The package spec the clarification applies to
+#crate = "ring"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overridden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overridden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
+]
+# If true, workspace members are automatically allowed even when using deny-by-default
+# This is useful for organizations that want to deny all external dependencies by default
+# but allow their own workspace crates without having to explicitly list them
+allow-workspace = false
+# List of crates to deny
+deny = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
+]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#crate = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
+    #{ crate = "ansi_term@0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+# github.com organizations to allow git sources for
+github = []
+# gitlab.com organizations to allow git sources for
+gitlab = []
+# bitbucket.org organizations to allow git sources for
+bitbucket = []

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,13 +12,43 @@
 #   /lib/.../libc.so.6: version `GLIBC_2.39' not found
 # Keep builder+runtime aligned to avoid glibc ABI mismatches.
 
-FROM rust:1-bookworm AS builder
+FROM rust:1-bookworm AS chef
+
+# cargo-chef splits the build into a dependency layer (cached across
+# source-only changes) and a workspace layer. Without it, `COPY . .`
+# immediately before `cargo build` invalidates the single build layer on ANY
+# source change, forcing a full recompile of ~25 workspace crates' worth of
+# dependencies every time (worsened by `lto = true` + `opt-level = 3`). Pinned
+# version, `--locked`, matches the repo's build reproducibility conventions.
+RUN cargo install cargo-chef --version 0.1.77 --locked
 
 WORKDIR /app
 
-# Copy the full workspace. `.dockerignore` keeps target/ and .git out;
-# builtin_skills/ is embedded by bamboo-skills' build.rs (include_bytes!), so it
-# must stay in the build context (do NOT exclude **/*.md).
+FROM chef AS planner
+
+# `.dockerignore` keeps target/ and .git out; builtin_skills/ is embedded by
+# bamboo-skills' build.rs (include_bytes!), so it must stay in the build
+# context (do NOT exclude **/*.md).
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+
+WORKDIR /app
+
+# Builds ONLY the dependency graph (crates.io deps) described by recipe.json.
+# This layer is invalidated by a Cargo.toml/Cargo.lock change, NOT by a
+# source-only change, so it's reused across builds where just application
+# code changed. bamboo-skills' and bamboo-server's build.rs scripts probe for
+# builtin_skills/ and frontend_package/ and degrade gracefully (empty
+# skill list / no embedded frontend) when those directories aren't present
+# yet at this stage — real content lands in the COPY below.
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --locked --bin bamboo --recipe-path recipe.json
+
+# Now copy the full workspace (same .dockerignore exclusions as above) and
+# build the workspace's own crates. Dependencies are already compiled by the
+# `chef cook` layer, so this only recompiles bamboo's own source.
 COPY . .
 
 # Build from crates.io (default sparse registry). Builds on CI runners with


### PR DESCRIPTION
## Summary

Implements the two build/release-health gaps from #254 (build machinery is otherwise mature and well done):

### 1. Dockerfile cargo-chef layer caching
`docker/Dockerfile`'s builder stage previously did `COPY . .` immediately before `cargo build --release --locked --bin bamboo`, so **any** workspace source change busted the single build layer and forced a full dependency recompile (worsened by `lto = true` + `opt-level = 3` across ~25 crates). Split into `chef` → `planner` → `builder`:
- `planner` runs `cargo chef prepare` to fingerprint the dependency graph into `recipe.json`.
- `builder` runs `cargo chef cook --release --locked --bin bamboo` against that recipe — a layer invalidated only by a `Cargo.toml`/`Cargo.lock` change, not by source edits.
- Then `COPY . .` + the real `cargo build` recompiles only the workspace's own crates, reusing the cached dependency layer.

`bamboo-skills`' and `bamboo-server`'s `build.rs` (which `include_bytes!` `builtin_skills/` and `frontend_package/`) already degrade gracefully when those directories are absent (empty skill list / no embedded frontend), so they're safe to run during the deps-only `chef cook` stage before the real content lands.

Builder/runtime stay on `bookworm` (glibc-matched, per the existing comment); ENTRYPOINT/CMD/ports/runtime image are untouched. cargo-chef pinned to `0.1.77` (`--locked`).

### 2. CI supply-chain hardening
- `cargo-audit` install is now pinned (`--version 0.22.2 --locked`) instead of unpinned `cargo install cargo-audit`.
- The ignored-advisory list moved out of an undocumented `--ignore` CLI flag into **`.cargo/audit.toml`** (cargo-audit's actual config-discovery path — confirmed by testing; a bare root-level `audit.toml` is silently ignored). Each entry has a justification + re-check trigger. Dropped a stale ignore, `RUSTSEC-2024-0384` (`instant`) — that crate is no longer in the dependency tree at all.
- Added a `deny` CI job running `cargo-deny check` (`EmbarkStudios/cargo-deny-action`, pinned by commit SHA) against a new `deny.toml` tuned to be green on the **current** `Cargo.lock` (licenses/bans/advisories/sources all `ok`).
- Added a Trivy image-scan job to `docker-publish.yml` (`aquasecurity/trivy-action`, pinned by commit SHA to a verified post-incident release — trivy-action's tags 0.0.1–0.34.2 were compromised in a 2026-03 supply-chain attack) against the freshly published GHCR image. Warn-only (`exit-code: 0`, `ignore-unfixed: true`) so pre-existing base-image CVEs don't block publishing.

No dependency bumps in this PR (dependabot handles those separately).

### New-issue candidate surfaced, not fixed here
`cargo deny check licenses` found **`actix-governor` (bamboo-server's rate-limit middleware) is GPL-3.0-or-later** — unlike the MIT/Apache-2.0 `governor` crate it wraps. bamboo-agent itself is MIT-licensed. This is a real license-compatibility question for a binary distribution, not a cargo-deny config problem — I added a narrowly-scoped `deny.toml` exception (not a blanket GPL allowance) so the check reflects reality instead of silently permitting future GPL deps, and I'm flagging it here for a maintainer license-compliance decision (keep as-is / vendor a replacement middleware over the MIT/Apache `governor` core / other). Happy to file a tracking issue if wanted.

## Test plan
- [x] `docker build -f docker/Dockerfile .` — full local build succeeds (cold, no cache); resulting image runs (`bamboo --version` → `bamboo 0.0.0`)
- [x] `cargo tree -i aws-lc-sys` — empty (reqwest stays native-tls, per prior Docker-breakage history)
- [x] `cargo audit` — clean (0 findings) with `.cargo/audit.toml` in place
- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- [x] `cargo build --workspace --tests --exclude bamboo-analytics` — succeeds, only pre-existing warnings
- [x] `actionlint` — only a pre-existing, unrelated shellcheck warning on an untouched line in `docker-publish.yml` (verified present on `main` too)

Closes #254

Claude-Session: https://claude.ai/code/session_01Ux4nHUqFjEEGV3rX1x3V9Y