### PR TITLE
refactor(server): unify API surface — version prefix, error envelope, health (phase 1 of #251)

### DIFF
--- a/crates/app/bamboo-server/src/error.rs
+++ b/crates/app/bamboo-server/src/error.rs
@@ -78,6 +78,30 @@ struct JsonErrorWrapper {
     error: JsonError,
 }
 
+/// The value of the `"error"` key in bamboo's canonical error envelope
+/// (`{"error": {"message", "type", "code"}}`, matching [`AppError`]'s
+/// [`ResponseError::error_response`] body) — for the minority of handlers
+/// that are not (yet) modeled as an `AppError` variant but still need to
+/// return extra sibling fields alongside the error (e.g. `session_id`,
+/// `message_id`) that a bare `AppError` has no place for.
+///
+/// Prefer returning `Result<_, AppError>` directly when there are no extra
+/// sibling fields — this helper exists only to converge the remaining
+/// hand-written `HttpResponse::X().json(json!({"error": "<flat string>", ...}))`
+/// call sites (#251 finding 2) onto the SAME envelope shape as `AppError`,
+/// without forcing every one of them through a full `AppError` variant.
+///
+/// # Example
+/// ```ignore
+/// HttpResponse::NotFound().json(serde_json::json!({
+///     "error": error_value("Session not found"),
+///     "session_id": session_id,
+/// }))
+/// ```
+pub fn error_value(message: impl Into<String>) -> serde_json::Value {
+    serde_json::json!({ "message": message.into(), "type": "api_error" })
+}
+
 impl ResponseError for AppError {
     fn status_code(&self) -> StatusCode {
         match self {
@@ -253,5 +277,28 @@ mod tests {
         let json_err = serde_json::from_str::<bool>("not a bool").unwrap_err();
         let app_error: AppError = json_err.into();
         assert!(matches!(app_error, AppError::SerializationError(_)));
+    }
+
+    /// The canonical envelope is a nested `{"error": {"message", "type"}}` —
+    /// `AppError::error_response` and [`error_value`] must agree on the same
+    /// shape (modulo the extra sibling fields `error_value` callers add
+    /// alongside `"error"`). #251 (finding 2).
+    #[actix_web::test]
+    async fn app_error_and_error_value_agree_on_envelope_shape() {
+        let resp = AppError::NotFound("Session".to_string()).error_response();
+        let bytes = actix_web::body::to_bytes(resp.into_body()).await.unwrap();
+        let app_err_body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(app_err_body["error"]["type"], "api_error");
+        assert!(app_err_body["error"]["message"].is_string());
+
+        let helper_error = error_value("Session not found");
+        assert_eq!(helper_error["type"], "api_error");
+        assert_eq!(helper_error["message"], "Session not found");
+
+        // Same "type" tag on both shapes.
+        assert_eq!(
+            app_err_body["error"]["type"], helper_error["type"],
+            "AppError and error_value must use the same error \"type\" tag"
+        );
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/history.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/history.rs
@@ -136,14 +136,17 @@ pub async fn handler(
         match state.storage.load_session(&session_id).await {
             Ok(Some(s)) => session = Some(s),
             Ok(None) => {
+                // Canonical nested error envelope — matches `AppError`'s shape
+                // (#251 finding 2), with `session_id` kept as a sibling field
+                // for callers that already read it off this endpoint.
                 return HttpResponse::NotFound().json(serde_json::json!({
-                    "error": "Session not found",
+                    "error": crate::error::error_value("Session not found"),
                     "session_id": session_id
                 }));
             }
             Err(e) => {
                 return HttpResponse::InternalServerError().json(serde_json::json!({
-                    "error": format!("Failed to load session: {e}"),
+                    "error": crate::error::error_value(format!("Failed to load session: {e}")),
                     "session_id": session_id
                 }));
             }
@@ -152,7 +155,7 @@ pub async fn handler(
 
     let Some(session) = session else {
         return HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": "Session load unexpectedly returned no data",
+            "error": crate::error::error_value("Session load unexpectedly returned no data"),
             "session_id": session_id
         }));
     };
@@ -464,5 +467,56 @@ mod tests {
         let body: Value = test::read_body_json(resp).await;
         assert_eq!(body["is_delta"], false);
         assert_eq!(seqs(&body["messages"]), vec!["a", "b"]);
+    }
+
+    /// `GET /api/v1/history/{id}` on an unknown session must use the
+    /// canonical nested error envelope, not the old flat
+    /// `{"error": "<string>"}` shape. #251 (finding 2).
+    #[actix_web::test]
+    async fn history_not_found_uses_canonical_error_envelope() {
+        let (state, _id) = app_state_with_session(vec![]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/history/does-not-exist")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"]["type"], "api_error");
+        assert_eq!(body["error"]["message"], "Session not found");
+        assert_eq!(body["session_id"], "does-not-exist");
+    }
+
+    /// The same nested history endpoint reachable via its canonical
+    /// `/api/v1/sessions/{id}/history` path (#251 finding 4) returns
+    /// identical data to the legacy flat `/api/v1/history/{id}` alias.
+    #[actix_web::test]
+    async fn history_is_reachable_via_canonical_nested_path() {
+        let (state, id) = app_state_with_session(vec![Message::user("hi")]).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let resp: Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/api/v1/sessions/{id}/history"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(seqs(&resp["messages"]), vec!["hi"]);
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/messages/delete.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/messages/delete.rs
@@ -18,8 +18,10 @@ pub async fn delete_message(
     }
 
     let Some(mut session) = load_session_or_404(&state, &session_id).await? else {
+        // Canonical nested error envelope — matches `AppError`'s shape (#251
+        // finding 2), with `session_id` kept as a sibling field.
         return Ok(HttpResponse::NotFound().json(serde_json::json!({
-            "error": "Session not found",
+            "error": crate::error::error_value("Session not found"),
             "session_id": session_id
         })));
     };
@@ -30,7 +32,7 @@ pub async fn delete_message(
 
     if before == after {
         return Ok(HttpResponse::NotFound().json(serde_json::json!({
-            "error": "Message not found",
+            "error": crate::error::error_value("Message not found"),
             "session_id": session_id,
             "message_id": message_id,
         })));

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
@@ -37,8 +37,11 @@ pub async fn create_session(
     {
         Ok(value) => value,
         Err(error) => {
+            // Canonical nested error envelope (#251 finding 2); `message` is kept
+            // as a top-level sibling field too since existing callers already
+            // read the detail from there, not from `error.message`.
             return Ok(HttpResponse::BadRequest().json(serde_json::json!({
-                "error": "Invalid gold_config",
+                "error": crate::error::error_value("Invalid gold_config"),
                 "message": error.to_string()
             })));
         }
@@ -90,7 +93,7 @@ pub async fn create_session(
             session: SessionSummary::from_entry(entry, false),
         })),
         None => Ok(HttpResponse::InternalServerError().json(serde_json::json!({
-            "error": "Session created but missing from index",
+            "error": crate::error::error_value("Session created but missing from index"),
             "session_id": id
         }))),
     }

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/query.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/query.rs
@@ -115,7 +115,9 @@ pub async fn get_session(
             Ok(response.json(GetSessionResponse { session: summary }))
         }
         None => Ok(HttpResponse::NotFound().json(serde_json::json!({
-            "error": "Session not found",
+            // Canonical nested error envelope — matches `AppError`'s shape
+            // (#251 finding 2), with `session_id` kept as a sibling field.
+            "error": crate::error::error_value("Session not found"),
             "session_id": session_id
         }))),
     }
@@ -242,5 +244,34 @@ mod pagination_http_tests {
         assert_eq!(page2["offset"], 2);
         assert_eq!(page2["sessions"].as_array().unwrap().len(), 1);
         assert!(page2.get("next_offset").is_none() || page2["next_offset"].is_null());
+    }
+
+    /// `GET /api/v1/sessions/{id}` on an unknown id must use the canonical
+    /// nested error envelope (`{"error": {"message", "type"}}`, matching
+    /// `AppError`), not the old flat `{"error": "<string>"}` shape. #251
+    /// (finding 2).
+    #[actix_web::test]
+    async fn get_session_not_found_uses_canonical_error_envelope() {
+        let state = app_state_with_sessions(0).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+
+        let resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/sessions/does-not-exist")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(resp.status(), actix_web::http::StatusCode::NOT_FOUND);
+
+        let body: Value = test::read_body_json(resp).await;
+        assert_eq!(body["error"]["type"], "api_error");
+        assert_eq!(body["error"]["message"], "Session not found");
+        assert_eq!(body["session_id"], "does-not-exist");
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/access_control.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/access_control.rs
@@ -443,16 +443,30 @@ fn build_access_verified_cookie(config: &Config, secure: bool) -> Option<Cookie<
     )
 }
 
+/// Public route suffixes reachable under BOTH of bamboo's native-API version
+/// prefixes (`/api/v1` canonical, `/v1` legacy alias — see
+/// `routes::bamboo_v1_routes` / #251 finding 1). Kept as one list so a route
+/// that's public under one prefix can't silently end up gated under its alias
+/// — the exact drift `is_public_access_route` used to be exposed to when each
+/// prefix's public paths were hand-listed separately (#251 finding 7).
+const PUBLIC_VERSIONED_SUFFIXES: &[&str] =
+    &["/health", "/bamboo/access/status", "/bamboo/access/verify"];
+
 fn is_public_access_route(path: &str) -> bool {
+    for prefix in ["/api/v1", "/v1"] {
+        if let Some(suffix) = path.strip_prefix(prefix) {
+            if PUBLIC_VERSIONED_SUFFIXES.contains(&suffix) {
+                return true;
+            }
+        }
+    }
+
     matches!(
         path,
-        "/api/v1/health"
-            // Unversioned liveness/readiness probes for load balancers / k8s —
-            // must be reachable without a credential. #251 (finding 6).
-            | "/healthz"
+        // Unversioned liveness/readiness probes for load balancers / k8s —
+        // must be reachable without a credential. #251 (finding 6).
+        "/healthz"
             | "/readyz"
-            | "/v1/bamboo/access/status"
-            | "/v1/bamboo/access/verify"
             // v2-P2 (#181): a brand-new device has no credential yet, so the
             // pairing endpoint must be reachable unauthenticated. It self-gates
             // by requiring the owner root password in its body.
@@ -1620,6 +1634,31 @@ mod tests {
         assert!(is_public_access_route("/healthz"));
         assert!(is_public_access_route("/readyz"));
         assert!(is_public_access_route("/api/v1/health"));
+    }
+
+    #[test]
+    fn public_access_status_routes_are_public_under_both_version_prefixes() {
+        // #251 (finding 1 + 7): `/v1/bamboo/access/*` is aliased at the new
+        // canonical `/api/v1/bamboo/access/*` prefix — a route that's public
+        // under one prefix must stay public under its alias, or a legitimate
+        // pre-auth client (checking whether a password is required at all)
+        // would get locked out simply for calling the canonical path.
+        for prefix in ["/v1", "/api/v1"] {
+            assert!(
+                is_public_access_route(&format!("{prefix}/bamboo/access/status")),
+                "{prefix}/bamboo/access/status must be public"
+            );
+            assert!(
+                is_public_access_route(&format!("{prefix}/bamboo/access/verify")),
+                "{prefix}/bamboo/access/verify must be public"
+            );
+            // The sibling password-UPDATE route must stay gated under both
+            // prefixes — only status/verify are pre-auth.
+            assert!(
+                !is_public_access_route(&format!("{prefix}/bamboo/access/password")),
+                "{prefix}/bamboo/access/password must stay gated"
+            );
+        }
     }
 
     // ── v2-P2 pairing codes + brute-force guard (#181, slice 2) ────────────

--- a/crates/app/bamboo-server/src/routes/agent.rs
+++ b/crates/app/bamboo-server/src/routes/agent.rs
@@ -71,7 +71,14 @@ fn ledger_scope() -> impl HttpServiceFactory {
 
 /// Configure agent API routes (core agent functionality)
 ///
-/// Routes for chat, execute, events, stop, history, task, respond, delete, health, metrics, mcp
+/// Routes for chat, execute, events, stop, history, task, respond, delete, health, metrics, mcp.
+///
+/// Per-session actions (execute/events/stop/history/task/respond/child-approval)
+/// are registered TWICE: once under the canonical nested
+/// `/sessions/{session_id}/…` form, and once more under their original flat
+/// `/…/{session_id}` form as a legacy alias to the identical handler — see the
+/// "canonical nested form" / "legacy flat aliases" comment blocks below.
+/// #251 (finding 4).
 pub fn agent_routes(cfg: &mut web::ServiceConfig) {
     let mut scope = web::scope("/api/v1")
         .wrap(actix_web::middleware::from_fn(
@@ -200,6 +207,55 @@ pub fn agent_routes(cfg: &mut web::ServiceConfig) {
             "/execute/defaults",
             web::get().to(agent::execute::defaults_handler),
         )
+        // ── Session sub-resources — canonical nested form (#251 finding 4) ──
+        // Every per-session action below is nested under `/sessions/{session_id}/…`,
+        // matching the already-nested `messages`/`attachments` sub-resources. The
+        // flat root-level siblings further down (`/execute/{id}`, `/events/{id}`,
+        // `/stop/{id}`, `/history/{id}`, `/task/{id}`, `/respond/{id}`,
+        // `/child-approval/{id}`) are kept registered as LEGACY ALIASES pointing at
+        // the exact same handlers — old clients (Lotus, bamboo CLI/SDK, magpie)
+        // keep working unchanged. New callers should prefer the nested form.
+        .route(
+            "/sessions/{session_id}/execute",
+            web::post().to(agent::execute::handler),
+        )
+        .route(
+            "/sessions/{session_id}/events",
+            web::get().to(agent::events::handler),
+        )
+        .route(
+            "/sessions/{session_id}/stop",
+            web::post().to(agent::stop::handler),
+        )
+        .route(
+            "/sessions/{session_id}/history",
+            web::get().to(agent::history::handler),
+        )
+        .route(
+            "/sessions/{session_id}/task",
+            web::get().to(agent::task::get_task_list),
+        )
+        .route(
+            "/sessions/{session_id}/task/exists",
+            web::get().to(agent::task::has_task_list),
+        )
+        .route(
+            "/sessions/{session_id}/respond",
+            web::post().to(agent::respond::submit_response),
+        )
+        .route(
+            "/sessions/{session_id}/respond/pending",
+            web::get().to(agent::respond::get_pending_question),
+        )
+        // Phase 2: deliver a human approval decision to a child sub-agent's
+        // blocked gated tool (surfaced via AgentEvent::ChildApprovalRequested).
+        .route(
+            "/sessions/{child_session_id}/child-approval",
+            web::post().to(agent::child_approval::handler),
+        )
+        // ── Legacy flat aliases (#251 finding 4) — kept byte-identical to their
+        // pre-refactor paths, wired to the SAME handlers as the nested routes
+        // above, so no existing client breaks.
         .route(
             "/execute/{session_id}",
             web::post().to(agent::execute::handler),
@@ -212,8 +268,6 @@ pub fn agent_routes(cfg: &mut web::ServiceConfig) {
         // sessions (multi-client sync, replaces session-index polling).
         .route("/stream", web::get().to(agent::stream::handler))
         .route("/stop/{session_id}", web::post().to(agent::stop::handler))
-        // Phase 2: deliver a human approval decision to a child sub-agent's
-        // blocked gated tool (surfaced via AgentEvent::ChildApprovalRequested).
         .route(
             "/child-approval/{child_session_id}",
             web::post().to(agent::child_approval::handler),
@@ -324,6 +378,24 @@ pub fn agent_routes(cfg: &mut web::ServiceConfig) {
     if dev_endpoints_enabled() {
         scope = scope.route("/dev/reset", web::post().to(agent::dev::reset));
     }
+
+    // Bamboo internal routes (commands/settings/skills/tools/workspace/
+    // copilot/provider-catalog/provider-instances/cluster-fabric) — nested
+    // into this SAME `/api/v1` scope (not a second competing
+    // `Scope("/api/v1")`) so they become reachable at the canonical prefix
+    // while a separate `/v1` scope (`routes::bamboo_v1::bamboo_v1_routes`)
+    // keeps mounting the identical routes as a legacy alias. #251 (finding 1)
+    // — see `bamboo_v1::bamboo_relative_routes`'s doc comment for why this
+    // must be a nested `.service()` call rather than its own top-level scope.
+    // MUST be registered LAST in this scope: its own path prefix is empty
+    // (`""`), which matches as a prefix of every remaining path — actix hands
+    // a matched scope the whole request and does not fall through to
+    // resources registered after it, so anything registered later here would
+    // be silently shadowed (caught by
+    // `dev_reset_route_registered_when_dev_endpoints_enabled` during
+    // development, when `/dev/reset` 404'd after being registered before
+    // this line).
+    scope = scope.service(super::bamboo_v1::bamboo_relative_routes());
 
     cfg.service(scope);
 

--- a/crates/app/bamboo-server/src/routes/bamboo_v1.rs
+++ b/crates/app/bamboo-server/src/routes/bamboo_v1.rs
@@ -2,11 +2,31 @@ use actix_web::{dev::HttpServiceFactory, web};
 
 use crate::handlers::{command, copilot_auth, settings, skill, tools, workspace};
 
-fn bamboo_v1_scope() -> impl HttpServiceFactory {
-    web::scope("/v1")
-        .wrap(actix_web::middleware::from_fn(
-            settings::enforce_access_password_middleware,
-        ))
+/// Builds the full Bamboo internal route table (commands / settings / skills /
+/// tools / workspace / copilot-auth / provider-catalog / provider-instances /
+/// cluster-fabric) as a set of routes relative to whatever scope mounts them —
+/// this factory adds NO path prefix and NO middleware wrap of its own.
+///
+/// Nested TWICE (#251 finding 1):
+///   - inside `routes::agent::agent_routes`'s single `/api/v1` scope (the
+///     canonical mount — see that function's `.service(bamboo_v1::bamboo_relative_routes())`
+///     call), so it inherits that scope's prefix AND its
+///     `enforce_access_password_middleware` wrap;
+///   - inside [`bamboo_v1_routes`]'s own `/v1` scope below, as a permanent
+///     back-compat alias for existing clients (Lotus, bamboo CLI/SDK, magpie)
+///     that still call bare `/v1/*`.
+///
+/// Deliberately NOT a second top-level `Scope("/api/v1")`: actix-web routes a
+/// request to the FIRST registered `Scope` whose prefix matches and then hands
+/// it the whole sub-tree — an unmatched path inside that scope 404s directly,
+/// it does not fall through to try a sibling scope with an identical prefix.
+/// Two competing `Scope("/api/v1")` registrations would therefore silently
+/// shadow one other (this exact bug was caught by
+/// `routes::tests::bamboo_v1_routes_resolve_under_both_canonical_and_legacy_prefix`
+/// during development). Nesting inside the ONE scope `agent_routes` already
+/// owns is the only pattern that works here.
+pub(crate) fn bamboo_relative_routes() -> impl HttpServiceFactory {
+    web::scope("")
         // Command routes
         .route("/commands", web::get().to(command::list_commands))
         .route(
@@ -277,9 +297,27 @@ fn bamboo_v1_scope() -> impl HttpServiceFactory {
         )
 }
 
-/// Configure Bamboo internal `/v1/*` routes.
+/// Configure the legacy `/v1/*` alias for Bamboo's internal routes.
+///
+/// Three native-API prefixes used to coexist (`/api/v1` for the agent surface,
+/// bare `/v1` for settings/skills/tools/workspace/copilot/cluster, `/v2` for
+/// pairing/devices/ws) — pure historical drift for the first two, since both
+/// are bamboo's own API and nothing distinguishes them by version or
+/// capability. `/api/v1` is now canonical for ALL of bamboo's native REST
+/// surface (mounted by `routes::agent::agent_routes`, which nests
+/// [`bamboo_relative_routes`] into its own `/api/v1` scope); `/v1` here is
+/// kept mounted as a permanent back-compat alias (not scheduled for removal —
+/// no deprecation window has been announced to consumers). `/v2` is a
+/// distinct, intentionally-versioned newer generation (the WS multiplex +
+/// device pairing) and is unaffected by this alias. #251 (finding 1).
 ///
 /// OpenAI-compatible forwarding endpoints live under `/openai/v1/*`.
 pub fn bamboo_v1_routes(cfg: &mut web::ServiceConfig) {
-    cfg.service(bamboo_v1_scope());
+    cfg.service(
+        web::scope("/v1")
+            .wrap(actix_web::middleware::from_fn(
+                settings::enforce_access_password_middleware,
+            ))
+            .service(bamboo_relative_routes()),
+    );
 }

--- a/crates/app/bamboo-server/src/routes/tests.rs
+++ b/crates/app/bamboo-server/src/routes/tests.rs
@@ -78,6 +78,110 @@ async fn configure_routes_with_rate_limiting_registers_expected_api_prefixes() {
     }
 }
 
+/// #251 (finding 1): every route that used to live ONLY under bare `/v1/*`
+/// (commands/settings/skills/tools/workspace/copilot/cluster) must now ALSO
+/// resolve under the canonical `/api/v1/*` prefix — proving the alias in
+/// `routes::bamboo_v1::bamboo_v1_routes` actually mounts both prefixes, not
+/// just the legacy one.
+#[actix_web::test]
+async fn bamboo_v1_routes_resolve_under_both_canonical_and_legacy_prefix() {
+    let app = test::init_service(App::new().configure(configure_routes)).await;
+
+    // A representative sample spanning every route group registered by
+    // `bamboo_routes_scope` (commands / settings / skills / tools / workspace /
+    // copilot / provider-catalog / provider-instances / cluster nodes).
+    let relative_paths = [
+        "/commands",
+        "/bamboo/workflows",
+        "/bamboo/setup/status",
+        "/bamboo/config",
+        "/bamboo/access/status",
+        "/bamboo/model-limits/defaults",
+        "/bamboo/tools",
+        "/bamboo/env-vars",
+        "/skills",
+        "/skills/available-tools",
+        "/workspace/recent",
+        "/bamboo/provider-catalog",
+        "/bamboo/settings/provider-instances",
+        "/bamboo/settings/nodes",
+    ];
+
+    for relative in relative_paths {
+        for prefix in ["/api/v1", "/v1"] {
+            let uri = format!("{prefix}{relative}");
+            let req = test::TestRequest::get()
+                .uri(&uri)
+                .insert_header((header::HOST, "localhost:9562"))
+                .to_request();
+            let resp = test::call_service(&app, req).await;
+            assert_ne!(
+                resp.status(),
+                StatusCode::NOT_FOUND,
+                "expected {uri} to be registered (alias parity, #251 finding 1)"
+            );
+        }
+    }
+}
+
+/// #251 (finding 4): per-session actions (execute/events/stop/history/task/
+/// respond/child-approval) must resolve under BOTH their new canonical nested
+/// `/sessions/{id}/…` form AND their original flat `/…/{id}` form — the flat
+/// form is a permanent legacy alias to the same handler, not a breaking move.
+#[actix_web::test]
+async fn session_subresource_routes_resolve_under_nested_and_flat_alias() {
+    let app = test::init_service(App::new().configure(configure_routes)).await;
+
+    // (method, nested path, flat legacy alias path)
+    let pairs: Vec<(&str, String, String)> = vec![
+        (
+            "GET",
+            "/api/v1/sessions/example/history".to_string(),
+            "/api/v1/history/example".to_string(),
+        ),
+        (
+            "GET",
+            "/api/v1/sessions/example/task".to_string(),
+            "/api/v1/task/example".to_string(),
+        ),
+        (
+            "GET",
+            "/api/v1/sessions/example/task/exists".to_string(),
+            "/api/v1/task/example/exists".to_string(),
+        ),
+        (
+            "GET",
+            "/api/v1/sessions/example/respond/pending".to_string(),
+            "/api/v1/respond/example/pending".to_string(),
+        ),
+        (
+            "POST",
+            "/api/v1/sessions/example/stop".to_string(),
+            "/api/v1/stop/example".to_string(),
+        ),
+        (
+            "POST",
+            "/api/v1/sessions/example/child-approval".to_string(),
+            "/api/v1/child-approval/example".to_string(),
+        ),
+    ];
+
+    for (method, nested, flat) in pairs {
+        for uri in [&nested, &flat] {
+            let req = match method {
+                "POST" => test::TestRequest::post().uri(uri).to_request(),
+                _ => test::TestRequest::get().uri(uri).to_request(),
+            };
+            let resp = test::call_service(&app, req).await;
+            assert_ne!(
+                resp.status(),
+                StatusCode::NOT_FOUND,
+                "expected {method} {uri} to be registered (nested/alias parity, #251 finding 4)"
+            );
+        }
+    }
+}
+
 #[actix_web::test]
 async fn remote_unverified_request_is_blocked_by_access_middleware() {
     let data_dir = tempdir().unwrap();

--- a/crates/app/bamboo-server/src/server/entrypoints.rs
+++ b/crates/app/bamboo-server/src/server/entrypoints.rs
@@ -20,6 +20,23 @@ use crate::services::frontend_package::{
 };
 use bamboo_config::TlsConfig;
 
+/// Whether `path` belongs to bamboo's API surface (as opposed to a SPA
+/// frontend route the static-file fallback should serve `index.html` for).
+///
+/// Shared by both SPA-fallback closures below (desktop + production/Docker
+/// serve paths) so the allow-list can't drift between them — previously each
+/// closure hand-duplicated this list and neither included `/v2/` (the pairing/
+/// device/WS-multiplex prefix), so an unmatched `/v2/*` path would silently
+/// fall through to `index.html` instead of a real 404. #251 (finding 7).
+fn is_api_path(path: &str) -> bool {
+    path.starts_with("/api/")
+        || path.starts_with("/v1/")
+        || path.starts_with("/v2/")
+        || path.starts_with("/openai/")
+        || path.starts_with("/anthropic/")
+        || path.starts_with("/gemini/")
+}
+
 fn canonicalize_static_dir(path: &Path) -> Result<PathBuf, String> {
     let canonicalized = path
         .canonicalize()
@@ -139,12 +156,7 @@ pub async fn run_with_tls(
                         let index_file = index_file.clone();
                         async move {
                             let path = req.path().to_string();
-                            if path.starts_with("/api/")
-                                || path.starts_with("/v1/")
-                                || path.starts_with("/openai/")
-                                || path.starts_with("/anthropic/")
-                                || path.starts_with("/gemini/")
-                            {
+                            if is_api_path(&path) {
                                 let response = HttpResponse::NotFound().finish();
                                 return Ok(ServiceResponse::new(req.into_parts().0, response));
                             }
@@ -346,12 +358,7 @@ pub async fn run_with_bind_and_static_tls(
                         let index_file = index_file.clone();
                         async move {
                             let path = req.path().to_string();
-                            if path.starts_with("/api/")
-                                || path.starts_with("/v1/")
-                                || path.starts_with("/openai/")
-                                || path.starts_with("/anthropic/")
-                                || path.starts_with("/gemini/")
-                            {
+                            if is_api_path(&path) {
                                 let response = HttpResponse::NotFound().finish();
                                 return Ok(ServiceResponse::new(req.into_parts().0, response));
                             }
@@ -438,5 +445,29 @@ mod tests {
                 .expect("configured static dir should be returned");
 
         assert_eq!(resolved, static_dir.path().canonicalize().unwrap());
+    }
+
+    #[test]
+    fn is_api_path_covers_every_registered_version_prefix() {
+        // #251 (finding 7): every prefix `routes::configure_routes` actually
+        // registers must be recognized here, or an unmatched sub-path under it
+        // would wrongly fall through to the SPA `index.html` instead of a 404.
+        for api_path in [
+            "/api/v1/sessions",
+            "/v1/bamboo/workflows",
+            "/v2/unknown",
+            "/openai/v1/models",
+            "/anthropic/v1/messages",
+            "/gemini/v1beta/models",
+        ] {
+            assert!(is_api_path(api_path), "{api_path} must be an API path");
+        }
+
+        for frontend_path in ["/", "/index.html", "/assets/app.js", "/settings"] {
+            assert!(
+                !is_api_path(frontend_path),
+                "{frontend_path} must NOT be treated as an API path"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Phase 1 of #251 ("API surface consistency"). Converges bamboo-server's native API onto one canonical shape per finding, while keeping every existing consumer (Lotus web app, bamboo CLI/SDK, magpie IM bridge) working unchanged — no route was moved or removed, only aliased/nested.

## Inventory (as found on `main` before this branch)

| # | Finding | Status before this PR |
|---|---|---|
| 1 | 3 version prefixes for bamboo's own API: `/api/v1` (agent surface), bare `/v1` (settings/skills/tools/workspace/copilot/cluster), `/v2` (pairing/devices/WS) | Open |
| 2 | 2 error envelopes: nested `AppError` `{"error":{message,type,code}}` vs. ~49 hand-written flat `{"error":"<string>", ...}` handlers | Open |
| 3 | 200 vs 201 on `POST /api/v1/sessions` | **Already fixed** — PR #386 |
| 4 | Flat root-level sub-resources (`/history/{id}`, `/task/{id}`, `/execute/{id}`, `/events/{id}`, `/stop/{id}`, `/respond/{id}`, `/child-approval/{id}`) vs. nested `/sessions/{id}/messages/...` | Open |
| 5 | Duplicate settings route declaration (`handlers/settings/mod.rs` vs `routes/bamboo_v1.rs`) | **Already fixed** — PR #384 |
| 6 | No unversioned health endpoint for LBs/k8s | **Already fixed** — PR #382 (`/healthz`, `/readyz`) |
| 7 | Public-route allow-list exact-string matched, drifts silently when a path is renamed/aliased | Open |

Findings 3/5/6 landed in earlier PRs before this branch was cut off `main`; this PR addresses 1, 4, 7, and a scoped slice of 2.

## What changed vs. what was aliased

**Finding 1 — one canonical prefix, `/v1` kept as a permanent alias.**
`routes::bamboo_v1::bamboo_relative_routes()` now builds the commands/settings/skills/tools/workspace/copilot-auth/provider-catalog/provider-instances/cluster-fabric route table as *prefix-less* routes, nested into TWO places:
- `routes::agent::agent_routes`'s existing single `/api/v1` scope (new canonical mount), appended **last** in that scope's builder chain;
- `routes::bamboo_v1::bamboo_v1_routes`'s own `/v1` scope (unchanged legacy alias).

`/v2` (pairing/devices/WS multiplex) is untouched — it's an intentionally distinct newer generation, not prefix drift, matching the issue's own framing.

Non-obvious gotcha hit during development: a *second* top-level `Scope("/api/v1")` does **not** work — actix hands the whole sub-tree to the first scope whose prefix matches, so an unmatched path inside it 404s directly instead of falling through to a sibling scope with the same prefix. Fixed by nesting one shared, prefix-less builder into the ONE scope `agent_routes` already owns (caught by a new test, see below). Also had to register that nested builder *last* within the scope's chain, since its own path (`""`) matches as a prefix of everything and would otherwise shadow anything registered after it (caught the `/dev/reset` route regressing this way during development).

**Finding 4 — nested canonical form + legacy flat alias, both wired to the same handler.**
`execute`, `events`, `stop`, `history`, `task` (+`/exists`), `respond` (+`/pending`), `child-approval` are now registered twice in `routes/agent.rs`: once at `/sessions/{session_id}/<action>` (new canonical), once at the original flat `/​<action>​/{session_id}` (kept, byte-identical, as a permanent alias). No handler code changed — all handlers already extracted the id positionally via `web::Path<String>`.

**Finding 7 — allow-lists de-duplicated to remove the drift vector.**
- `handlers::settings::access_control::is_public_access_route`: replaced two separately-hardcoded exact-path lists with one `PUBLIC_VERSIONED_SUFFIXES` list checked against both `/api/v1` and `/v1`, so a route public under one prefix can't silently end up gated under its new alias.
- `server::entrypoints`: the SPA-fallback "is this an API path or a frontend route" check was hand-duplicated in the desktop and production/Docker serve closures, and neither included `/v2/` (so an unmatched `/v2/*` path silently fell through to `index.html` instead of a 404). Both closures now call one shared `is_api_path` helper, which includes `/v2/`.

**Finding 2 — partial.** Added `error::error_value(message) -> serde_json::Value`, producing the same `{"message","type":"api_error"}` shape `AppError::error_response` already uses, for handlers that need sibling fields (`session_id`, `message_id`) a bare `AppError` variant has no room for. Migrated the 4 call sites the issue named by file:line:
- `handlers/agent/history.rs` (3 not-found/error branches)
- `handlers/agent/sessions/handlers/crud/query.rs` (`get_session` 404)
- `handlers/agent/sessions/handlers/crud/create.rs` (invalid gold_config + missing-from-index)
- `handlers/agent/messages/delete.rs` (session/message 404)

**This is a loud, deliberate breaking change** to those 4 endpoints only: their `error` field flips from a JSON string to a `{"message","type"}` object. Any caller doing `body.error` as a string on exactly these 4 endpoints needs to switch to `body.error.message`. Every other field on these responses (`session_id`, `message_id`, etc.) is untouched.

## Compat guarantees

- No route was removed, moved, or given a new required parameter.
- Every pre-existing path (`/v1/*`, `/history/{id}`, `/task/{id}`, `/execute/{id}`, `/events/{id}`, `/stop/{id}`, `/respond/{id}(/pending)`, `/child-approval/{id}`) still resolves to the exact same handler.
- `/v2/*` behavior is unchanged.
- Only the 4 handlers listed above have a response-shape change (`error` string → object) — confined to their `error` field.

## Phase 2 remainder (not done here)

~45 more handlers still return the flat `{"error":"<string>", ...}` shape (grep `"error":` under `crates/app/bamboo-server/src/handlers`, excluding the 4 migrated above and `plugin/errors.rs`'s already-documented flat shape):

```
agent/chat/handler/{images,mod,request}.rs, agent/delete.rs, agent/events/handler.rs,
agent/execute/handler/{mod,response}.rs, agent/ledger/handlers.rs,
agent/mcp/{mod,server_handlers/{connections,crud,import,query},tool_handlers}.rs,
agent/messages/{patch,restore/mod,shared,truncate}.rs,
agent/metrics/{core_handlers/{chat,memory},mod}.rs, agent/notifications.rs,
agent/prompt_presets/handlers.rs, agent/respond/handlers/{pending,submit}.rs,
agent/schedules/{handlers/response,validation}.rs,
agent/sessions/handlers/{attachments,maintenance,crud/{discoverable_tools,patch,regenerate_title,system_prompt}}.rs,
agent/task/handlers.rs, anthropic/{complete/stream,messages/stream}.rs,
copilot_auth/{legacy,start_complete,status_logout}.rs,
openai/{chat/stream/sse,responses/stream/events}.rs,
settings/provider/endpoints/{reload,update}.rs
```

Each needs its own look at what a caller actually reads off the body (some pack extra fields, some are hot SSE paths) before converging — bigger blast radius than this PR's scope, so left as a follow-up (recommend filing as a dedicated sub-issue off #251 before starting).

Also out of scope for this PR (per the issue's own checklist, unaffected by anything here): nothing else — 3/5/6 were already done, 1/4/7 are done, 2 is partially done.

## Tests

New:
- `routes::tests::bamboo_v1_routes_resolve_under_both_canonical_and_legacy_prefix` — alias-parity across `/api/v1` and `/v1` for a representative sample of every route group.
- `routes::tests::session_subresource_routes_resolve_under_nested_and_flat_alias` — nested + flat-alias parity for execute/events/stop/history/task/respond/child-approval.
- `handlers::settings::access_control::tests::public_access_status_routes_are_public_under_both_version_prefixes` — allow-list parity + negative case (password-update route stays gated under both prefixes).
- `server::entrypoints::tests::is_api_path_covers_every_registered_version_prefix` — covers all 5 registered prefixes + negative frontend-path cases.
- `error::tests::app_error_and_error_value_agree_on_envelope_shape`, `history::tests::history_not_found_uses_canonical_error_envelope`, `history::tests::history_is_reachable_via_canonical_nested_path`, `sessions::crud::query::tests::get_session_not_found_uses_canonical_error_envelope`.

## Build/test results

- `cargo fmt -p bamboo-server -- --check` — clean.
- `cargo clippy -p bamboo-server --tests --all-targets` — only pre-existing warnings in files this PR doesn't touch (`too_many_arguments` in `execute/handler/ready.rs`, unrelated crates); no new warnings.
- `cargo build --workspace --tests` — green (only pre-existing unused-import/dead-code warnings in `bamboo-llm`/`bamboo-memory`/`bamboo-engine`, unrelated to this change).
- `cargo test -p bamboo-server` — **1326 lib tests + 9 `ws_v2_live` integration tests + 9 doc-tests, all passing**, 0 failures.

## New-issue candidates

- Phase 2: migrate the ~45 remaining flat-error handlers listed above onto `error::error_value`/`AppError` (recommend a dedicated sub-issue off #251).
- Optional follow-up: consider a compile-time or test-time route-table dump (e.g. iterate `ServiceConfig`) instead of the current hand-picked sample list in the alias-parity tests, so a FUTURE route addition can't silently skip the canonical-prefix check. Not done here — actix-web doesn't expose an easy runtime route enumeration API without deeper plumbing, and the current sample already covers every route group.

Addresses #251 (findings 1, 4, 7, partial 2 — not using `Closes` since 2 has a documented phase-2 remainder).
