### PR TITLE
feat(sdk): cancellation, approval+resume, session ergonomics, typed errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,17 +1315,21 @@ dependencies = [
 name = "bamboo-sdk"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "bamboo-agent-core",
  "bamboo-config",
  "bamboo-domain",
  "bamboo-engine",
  "bamboo-infrastructure",
  "bamboo-llm",
+ "bamboo-mcp",
  "bamboo-metrics",
  "bamboo-skills",
  "bamboo-storage",
  "bamboo-tools",
  "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -261,6 +261,14 @@ async fn main() -> anyhow::Result<()> {
 
 > Don't need the event stream? `agent.run(&mut session, input).await?` drives the turn to completion and leaves the answer as the last message on `session`. For full control over per-request overrides (split fast/background/summarization models, skill selection, provider handles, …) build an `ExecuteRequest` with `ExecuteRequestBuilder` (both re-exported from `bamboo_sdk::agent`) and call `agent.execute(&mut session, req)` — the same canonical engine path `run` / `run_stream` funnel into.
 
+**Approval / clarification + resume.** A run can pause mid-loop waiting for input — a `conclusion_with_options` clarification, or a gated tool call under a configured `PermissionChecker` — surfaced as `AgentEvent::NeedClarification` / `ToolApprovalRequested`. Resolve it with `agent.answer(session_id, "Approve").await?` (the in-process equivalent of the HTTP `POST /sessions/{id}/respond` endpoint — same use-case function under the hood, so behavior matches exactly), then continue with `agent.resume_stream(outcome.session)` / `agent.resume(&mut session)` — or do both in one call with `agent.answer_and_resume_stream(session_id, "Approve").await?`. `AnswerOutcome` also carries any plan-mode transition and the permission grants an approval implied (auto-applied to the builder's `.permission_checker(...)`, if one was configured).
+
+**Session ergonomics.** `agent.list_sessions()` (most-recently-updated first), `agent.get_session(id)`, `agent.session_history(id)`, `agent.delete_session(id)` — no need to reach for `agent.storage()` directly for the common cases. `list_sessions` needs the concrete session-index handle `with_defaults_for_data_dir` assembles.
+
+**MCP.** `.mcp_server(config)` / `.mcp_servers([...])` on the builder connect MCP servers (in `with_defaults_for_data_dir`) and merge their tools into the built-in tool surface via `CompositeToolExecutor` — each server's `initialize` instructions are folded into the tool guidance automatically.
+
+**Typed errors.** `with_defaults_for_data_dir` / `build` / `answer` / the session-ergonomics methods all return `Result<_, SdkError>` — a `thiserror` enum (`ProviderInit`, `StoreInit`, `SkillInit`, `McpServerStart`, `SessionNotFound`, `NoPendingQuestion`, `InvalidResponse`, …) instead of a bare `String`, so callers can match on the failure kind. `SdkError` also wraps `AgentError` (`#[from]`) so it composes with `run`/`run_stream`'s existing typed error in a function returning `Result<_, SdkError>`.
+
 Add the facade crate as a dependency (path or git):
 
 ```toml

--- a/crates/app/bamboo-sdk/Cargo.toml
+++ b/crates/app/bamboo-sdk/Cargo.toml
@@ -21,6 +21,7 @@ bamboo-metrics = { path = "../../infra/bamboo-metrics" }
 bamboo-skills = { path = "../../infra/bamboo-skills" }
 bamboo-storage = { path = "../../infra/bamboo-storage" }
 bamboo-tools = { path = "../../engine/bamboo-tools" }
+bamboo-mcp = { path = "../../infra/bamboo-mcp" }
 
 # Async runtime (sync: mpsc/RwLock; rt: tokio::spawn)
 tokio = { version = "1", features = ["sync", "rt"] }
@@ -29,5 +30,13 @@ tokio-util = "0.7"
 # Serialization (fabricate a minimal provider stanza for `.api_key()`)
 serde_json = "1"
 
+# Typed errors + the `SessionAccess` trait implementation on `Agent`.
+thiserror = "2"
+async-trait = "0.1"
+
 # Logging
 tracing = "0.1"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/app/bamboo-sdk/src/agent/builder.rs
+++ b/crates/app/bamboo-sdk/src/agent/builder.rs
@@ -26,11 +26,16 @@ use tokio::sync::RwLock;
 use bamboo_agent_core::tools::{Tool, ToolExecutor};
 use bamboo_engine::AgentBuilder as EngineAgentBuilder;
 use bamboo_llm::{create_provider_with_dir, Config, LLMProvider};
+use bamboo_mcp::executor::{CompositeToolExecutor, McpToolExecutor};
+use bamboo_mcp::manager::McpServerManager;
+use bamboo_mcp::McpServerConfig;
 use bamboo_metrics::{MetricsCollector, SqliteMetricsStorage};
 use bamboo_skills::{SkillManager, SkillStoreConfig};
 use bamboo_storage::{LockedSessionStore, SessionStoreV2};
+use bamboo_tools::permission::PermissionChecker;
 use bamboo_tools::ToolRegistry;
 
+use super::error::SdkError;
 use super::Agent;
 
 /// Default metrics retention window (days), mirroring `MetricsService::new`.
@@ -59,6 +64,20 @@ pub struct AgentBuilder {
     provider_name: Option<String>,
     /// API key applied to the active provider's config before provider creation.
     api_key: Option<String>,
+    /// MCP servers to connect and merge into the tool surface in
+    /// `with_defaults_for_data_dir`. See [`mcp_server`](Self::mcp_server).
+    mcp_servers: Vec<McpServerConfig>,
+    /// Permission checker applied to the built-in tool executor assembled by
+    /// `with_defaults_for_data_dir`. `None` (the default) means no permission
+    /// gating at all — every tool call runs unprompted. See
+    /// [`permission_checker`](Self::permission_checker).
+    permission_checker: Option<Arc<dyn PermissionChecker>>,
+    /// Concrete session-index handle assembled by `with_defaults_for_data_dir`
+    /// (internal — not settable directly). Carried onto [`Agent`] to back the
+    /// session-listing ergonomics ([`Agent::list_sessions`](super::Agent::list_sessions)),
+    /// which need the concrete `SessionStoreV2` rather than the type-erased
+    /// `Arc<dyn Storage>` the engine builder takes.
+    session_store: Option<Arc<SessionStoreV2>>,
 }
 
 impl AgentBuilder {
@@ -71,6 +90,9 @@ impl AgentBuilder {
             model: None,
             provider_name: None,
             api_key: None,
+            mcp_servers: Vec::new(),
+            permission_checker: None,
+            session_store: None,
         }
     }
 
@@ -146,6 +168,93 @@ impl AgentBuilder {
         self
     }
 
+    /// Connect an MCP server and merge its tools into the agent's tool surface.
+    ///
+    /// Only takes effect via
+    /// [`with_defaults_for_data_dir`](Self::with_defaults_for_data_dir), which
+    /// starts every configured server (in call order) and composes their tools
+    /// with the built-in surface via
+    /// [`CompositeToolExecutor`](bamboo_mcp::executor::CompositeToolExecutor) —
+    /// built-ins are tried first, falling back to MCP on `NotFound`. Each
+    /// server's `initialize` `instructions` (if any) are folded into the tool
+    /// guidance the engine injects into the system prompt automatically (no
+    /// extra wiring needed).
+    ///
+    /// A later [`tools`](Self::tools)/[`tool`](Self::tool) selection REPLACES
+    /// the whole assembled executor at [`build`](Self::build) time (existing
+    /// behavior, unchanged by this method) — so an explicit tool selection
+    /// currently excludes MCP tools. Select tools via `allowed_tools` on the
+    /// server config instead if you need to restrict without losing MCP.
+    ///
+    /// ```rust,ignore
+    /// use bamboo_sdk::agent::McpServerConfig;
+    /// use bamboo_mcp::{StdioConfig, TransportConfig};
+    ///
+    /// let agent = Agent::builder()
+    ///     .model("claude-sonnet-4-6")
+    ///     .mcp_server(McpServerConfig {
+    ///         id: "fs".into(),
+    ///         name: Some("filesystem".into()),
+    ///         enabled: true,
+    ///         transport: TransportConfig::Stdio(StdioConfig {
+    ///             command: "npx".into(),
+    ///             args: vec!["-y".into(), "@modelcontextprotocol/server-filesystem".into()],
+    ///             cwd: None,
+    ///             env: Default::default(),
+    ///             env_encrypted: Default::default(),
+    ///             startup_timeout_ms: 20_000,
+    ///         }),
+    ///         request_timeout_ms: 60_000,
+    ///         healthcheck_interval_ms: 30_000,
+    ///         reconnect: Default::default(),
+    ///         allowed_tools: Vec::new(),
+    ///         denied_tools: Vec::new(),
+    ///     })
+    ///     .with_defaults_for_data_dir(data_dir).await?
+    ///     .build()?;
+    /// ```
+    pub fn mcp_server(mut self, config: McpServerConfig) -> Self {
+        self.mcp_servers.push(config);
+        self
+    }
+
+    /// Connect multiple MCP servers. See [`mcp_server`](Self::mcp_server).
+    pub fn mcp_servers<I>(mut self, configs: I) -> Self
+    where
+        I: IntoIterator<Item = McpServerConfig>,
+    {
+        self.mcp_servers.extend(configs);
+        self
+    }
+
+    /// Gate the built-in tool executor behind a permission checker (e.g.
+    /// `bamboo_tools::permission::ConfigPermissionChecker`).
+    ///
+    /// Only takes effect via
+    /// [`with_defaults_for_data_dir`](Self::with_defaults_for_data_dir). The
+    /// SDK's historical default (no checker configured) is **bypass
+    /// everything** — no tool call is ever gated — so this is purely opt-in;
+    /// see [`bypass_permissions`](Self::bypass_permissions) to make that intent
+    /// explicit at the call site.
+    ///
+    /// Once gated, a tool call that needs approval suspends the run (a
+    /// `NeedClarification`/`ToolApprovalRequested` event, session
+    /// `pending_question` set) exactly like a `conclusion_with_options`
+    /// clarification — resolve it with [`Agent::answer`](super::Agent::answer).
+    pub fn permission_checker(mut self, checker: Arc<dyn PermissionChecker>) -> Self {
+        self.permission_checker = Some(checker);
+        self
+    }
+
+    /// Explicitly request the SDK's default: no permission checker, so every
+    /// tool call runs unprompted. A no-op relative to never calling
+    /// [`permission_checker`](Self::permission_checker) — provided so callers
+    /// can say what they mean instead of relying on silent default behavior.
+    pub fn bypass_permissions(mut self) -> Self {
+        self.permission_checker = None;
+        self
+    }
+
     // -- Explicit dependency injection (passthrough) ------------------------
 
     /// Inject a pre-built LLM provider, bypassing config-driven creation.
@@ -189,11 +298,18 @@ impl AgentBuilder {
     /// `<data_dir>/config.json` must define the active provider with a non-empty
     /// `api_key` (the same config `bamboo serve` reads). A fresh data dir with no
     /// `config.json` defaults to the `anthropic` provider with no key, so step 6
-    /// (`create_provider_with_dir`) returns `Err("failed to create provider: …")`.
+    /// (`create_provider_with_dir`) returns [`SdkError::ProviderInit`].
     /// The `copilot` provider is the only one that can authenticate keyless (via
     /// its cached OAuth token). Set the key via the config file, or pass it on the
     /// builder with [`api_key`](Self::api_key) **before** calling this method.
-    pub async fn with_defaults_for_data_dir(mut self, data_dir: PathBuf) -> Result<Self, String> {
+    ///
+    /// If [`mcp_server`](Self::mcp_server)/[`mcp_servers`](Self::mcp_servers) were
+    /// configured, each server is connected here (in call order) and its tools
+    /// merged into the built-in tool surface; a connection failure fails the
+    /// whole call with [`SdkError::McpServerStart`]. If
+    /// [`permission_checker`](Self::permission_checker) was configured, it gates
+    /// the built-in tool executor from this point on.
+    pub async fn with_defaults_for_data_dir(mut self, data_dir: PathBuf) -> Result<Self, SdkError> {
         // 1. Config.
         let mut config = Config::from_data_dir(Some(data_dir.clone()));
         // Select the provider first, so `api_key` and provider creation both act
@@ -208,19 +324,46 @@ impl AgentBuilder {
         // 6. Provider (created before config is moved into the shared lock).
         let provider = create_provider_with_dir(&config, data_dir.clone())
             .await
-            .map_err(|e| format!("failed to create provider: {e}"))?;
+            .map_err(|e| SdkError::ProviderInit(e.to_string()))?;
 
-        // 7. Default tools (builtin + config-aware).
+        // 7. Default tools (builtin + config-aware), optionally gated by a
+        // permission checker and merged with any configured MCP servers.
         let config = Arc::new(RwLock::new(config));
-        let default_tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(
-            bamboo_tools::BuiltinToolExecutor::new_with_config(config.clone()),
-        );
+        let builtin_tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> =
+            match self.permission_checker.clone() {
+                Some(checker) => Arc::new(
+                    bamboo_tools::BuiltinToolExecutor::new_with_config_and_permissions(
+                        config.clone(),
+                        checker,
+                    ),
+                ),
+                None => Arc::new(bamboo_tools::BuiltinToolExecutor::new_with_config(
+                    config.clone(),
+                )),
+            };
+        let default_tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> =
+            if self.mcp_servers.is_empty() {
+                builtin_tools
+            } else {
+                let mcp_manager = Arc::new(McpServerManager::new_with_config(config.clone()));
+                for server_config in &self.mcp_servers {
+                    let server_id = server_config.id.clone();
+                    mcp_manager
+                        .start_server(server_config.clone())
+                        .await
+                        .map_err(|source| SdkError::McpServerStart { server_id, source })?;
+                }
+                let mcp_tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(
+                    McpToolExecutor::new(mcp_manager.clone(), mcp_manager.tool_index()),
+                );
+                Arc::new(CompositeToolExecutor::new(builtin_tools, mcp_tools))
+            };
 
         // 2/3. Storage + persistence + attachment reader.
         let store = Arc::new(
             SessionStoreV2::new(data_dir.clone())
                 .await
-                .map_err(|e| format!("failed to initialize session store: {e}"))?,
+                .map_err(|e| SdkError::StoreInit(e.to_string()))?,
         );
         let persistence = Arc::new(LockedSessionStore::new(store.clone()));
 
@@ -233,7 +376,7 @@ impl AgentBuilder {
         skill_manager
             .initialize()
             .await
-            .map_err(|e| format!("failed to initialize skill manager: {e}"))?;
+            .map_err(|e| SdkError::SkillInit(e.to_string()))?;
 
         // 5. Metrics collector.
         let metrics_storage: Arc<dyn bamboo_metrics::storage::MetricsStorage> =
@@ -241,6 +384,7 @@ impl AgentBuilder {
         let metrics_collector =
             MetricsCollector::spawn(metrics_storage, DEFAULT_METRICS_RETENTION_DAYS);
 
+        self.session_store = Some(store.clone());
         self.inner = self
             .inner
             .storage(store.clone())
@@ -259,11 +403,14 @@ impl AgentBuilder {
     ///
     /// If a tool set was configured via [`tools`](Self::tools) / [`tool`](Self::tool),
     /// the agent's default tool executor is built from exactly those tools, so
-    /// the advertised tool surface is precisely the caller's selection. With no
-    /// selection, the full default built-in surface is used. The configured
+    /// the advertised tool surface is precisely the caller's selection (this
+    /// REPLACES any MCP composition from
+    /// [`mcp_server`](Self::mcp_server)/[`mcp_servers`](Self::mcp_servers) —
+    /// existing behavior, unchanged). With no selection, the full default
+    /// built-in (+ MCP, if configured) surface is used. The configured
     /// `instruction` and `model` are carried onto the `Agent` for
     /// [`Agent::run`](super::Agent::run).
-    pub fn build(mut self) -> Result<Agent, String> {
+    pub fn build(mut self) -> Result<Agent, SdkError> {
         if !self.tools.is_empty() {
             let registry = ToolRegistry::new();
             for tool in &self.tools {
@@ -274,11 +421,16 @@ impl AgentBuilder {
             self.inner = self.inner.default_tools(executor);
         }
 
-        let runtime = self.inner.build().map_err(|e| e.to_string())?;
+        let runtime = self
+            .inner
+            .build()
+            .map_err(|e| SdkError::Build(e.to_string()))?;
         Ok(Agent::from_runtime_with_config(
             runtime,
             self.system_prompt,
             self.model,
+            self.session_store,
+            self.permission_checker,
         ))
     }
 }

--- a/crates/app/bamboo-sdk/src/agent/error.rs
+++ b/crates/app/bamboo-sdk/src/agent/error.rs
@@ -1,0 +1,122 @@
+//! Typed SDK error surface.
+//!
+//! Replaces the stringly-typed `Result<_, String>` the builder previously
+//! returned (`with_defaults_for_data_dir` / `build`) with a single
+//! `#[derive(thiserror::Error)]` enum, matching the runtime's own [`AgentError`]
+//! (`bamboo_agent_core::AgentError`) instead of forcing callers to match on
+//! substrings. Every fallible SDK entry point added alongside cancellation /
+//! approval+resume / session ergonomics returns `Result<_, SdkError>`.
+//!
+//! `run` / `run_stream` and friends keep returning [`AgentError`] directly (it
+//! was already typed) — [`SdkError::Agent`] lets callers unify the two with `?`
+//! in a function that returns `Result<_, SdkError>`.
+
+use bamboo_agent_core::AgentError;
+use bamboo_engine::session_app::errors::{RespondError, SessionLoadError, SessionSaveError};
+
+/// Errors surfaced by the `bamboo_sdk` facade.
+#[derive(Debug, thiserror::Error)]
+pub enum SdkError {
+    /// A run/resume of the underlying agent loop failed. Wraps the runtime's
+    /// own typed error so `?` composes across `Agent::run*` and the newer
+    /// facade methods in a function returning `Result<_, SdkError>`.
+    #[error(transparent)]
+    Agent(#[from] AgentError),
+
+    /// `AgentBuilder::build()` failed — the wrapped engine builder rejected an
+    /// incomplete or inconsistent dependency set (e.g. a required dependency
+    /// was never supplied).
+    #[error("agent builder error: {0}")]
+    Build(String),
+
+    /// `with_defaults_for_data_dir` failed to read/parse `config.json`.
+    #[error("configuration error: {0}")]
+    Config(String),
+
+    /// `with_defaults_for_data_dir` failed to construct the configured LLM
+    /// provider — commonly a missing/invalid API key. See
+    /// [`AgentBuilder::api_key`](super::AgentBuilder::api_key) and
+    /// [`AgentBuilder::provider_name`](super::AgentBuilder::provider_name).
+    #[error("provider initialization failed: {0}")]
+    ProviderInit(String),
+
+    /// `with_defaults_for_data_dir` failed to open the session store at the
+    /// given data directory.
+    #[error("session store initialization failed: {0}")]
+    StoreInit(String),
+
+    /// `with_defaults_for_data_dir` failed to initialize the skill manager.
+    #[error("skill manager initialization failed: {0}")]
+    SkillInit(String),
+
+    /// An MCP server failed to start (see
+    /// [`AgentBuilder::mcp_server`](super::AgentBuilder::mcp_server)).
+    #[error("MCP server '{server_id}' failed to start: {source}")]
+    McpServerStart {
+        server_id: String,
+        #[source]
+        source: bamboo_mcp::McpError,
+    },
+
+    /// The requested session does not exist.
+    #[error("session not found: {0}")]
+    SessionNotFound(String),
+
+    /// Loading a session from storage failed.
+    #[error("session load failed: {0}")]
+    SessionLoad(String),
+
+    /// Persisting a session failed.
+    #[error("session save failed: {0}")]
+    SessionSave(String),
+
+    /// [`Agent::answer`](super::Agent::answer) was called on a session with no
+    /// pending question / approval to respond to.
+    #[error("no pending question waiting for response")]
+    NoPendingQuestion,
+
+    /// The response passed to [`Agent::answer`](super::Agent::answer) did not
+    /// match one of the pending question's fixed options (and it does not
+    /// allow a custom response).
+    #[error("invalid response: {0}")]
+    InvalidResponse(String),
+
+    /// A capability that requires `with_defaults_for_data_dir` (e.g. session
+    /// listing, which needs the concrete session-index handle) was called on
+    /// an `Agent` assembled from manually-injected dependencies.
+    #[error("unsupported: {0}")]
+    Unsupported(String),
+
+    /// Underlying I/O failure (session store reads/writes, etc).
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl From<SessionLoadError> for SdkError {
+    fn from(error: SessionLoadError) -> Self {
+        match error {
+            SessionLoadError::NotFound(id) => SdkError::SessionNotFound(id),
+            SessionLoadError::StorageError(message) => SdkError::SessionLoad(message),
+        }
+    }
+}
+
+impl From<SessionSaveError> for SdkError {
+    fn from(error: SessionSaveError) -> Self {
+        match error {
+            SessionSaveError::StorageError(message) => SdkError::SessionSave(message),
+        }
+    }
+}
+
+impl From<RespondError> for SdkError {
+    fn from(error: RespondError) -> Self {
+        match error {
+            RespondError::NotFound(id) => SdkError::SessionNotFound(id),
+            RespondError::LoadFailed(inner) => inner.into(),
+            RespondError::SaveFailed(inner) => inner.into(),
+            RespondError::NoPendingQuestion => SdkError::NoPendingQuestion,
+            RespondError::InvalidResponse(message) => SdkError::InvalidResponse(message),
+        }
+    }
+}

--- a/crates/app/bamboo-sdk/src/agent/mod.rs
+++ b/crates/app/bamboo-sdk/src/agent/mod.rs
@@ -37,14 +37,21 @@
 //! `bamboo_engine::Agent::execute` (the single canonical execution path).
 
 mod builder;
+mod error;
 mod execute_request;
 mod tools;
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
 pub use builder::AgentBuilder;
 pub use execute_request::ExecuteRequestBuilder;
 use tokio::sync::mpsc;
+
+use bamboo_engine::session_app::errors::{SessionLoadError, SessionSaveError};
+use bamboo_engine::session_app::repository::SessionAccess;
+use bamboo_engine::session_app::respond::submit_pending_response;
+use bamboo_engine::session_app::types::RespondInput;
 
 // Re-exported so callers can name the token returned by the `*_cancellable` /
 // `*_with_cancel` run helpers without depending on `tokio-util` directly.
@@ -53,14 +60,22 @@ pub use tools::{
     builtin_tool_names, builtin_tool_specs, BuiltinTool, ToolSpec, CANONICAL_TOOL_NAMES,
 };
 
+pub use error::SdkError;
+
 // Convenience re-exports of commonly used types (single source of truth — these
 // supersede the old duplicate re-export chain, resolving TD-2).
 pub use bamboo_agent_core::{
-    AgentError, AgentEvent, Message, MessageContent, Role, Session, TokenBudgetUsage, TokenUsage,
+    AgentError, AgentEvent, Message, MessageContent, PendingQuestion, Role, Session,
+    TokenBudgetUsage, TokenUsage,
 };
 pub use bamboo_domain::{TaskItem, TaskItemStatus, TaskList};
+pub use bamboo_engine::session_app::respond::PlanModeTransition;
 pub use bamboo_engine::ExecuteRequest;
 pub use bamboo_llm::LLMProvider;
+pub use bamboo_mcp::manager::McpServerManager;
+pub use bamboo_mcp::McpServerConfig;
+pub use bamboo_storage::SessionIndexEntry;
+pub use bamboo_tools::permission::{PermissionChecker, PermissionType};
 pub use bamboo_tools::{BuiltinToolExecutor, BuiltinToolExecutorBuilder, ToolOutputManager};
 
 /// Default event-channel buffer used by [`Agent::run`].
@@ -78,6 +93,17 @@ pub struct Agent {
     system_prompt: Option<String>,
     /// Model override applied to the session at `run` time.
     model: Option<String>,
+    /// Concrete session-index handle, present only when assembled via
+    /// [`AgentBuilder::with_defaults_for_data_dir`]. Backs
+    /// [`list_sessions`](Self::list_sessions) — the type-erased
+    /// `Arc<dyn Storage>` the engine builder takes can't list.
+    session_store: Option<Arc<bamboo_storage::SessionStoreV2>>,
+    /// Permission checker configured via
+    /// [`AgentBuilder::permission_checker`], if any. Used by
+    /// [`answer`](Self::answer) to apply permission grants implied by an
+    /// approved permission prompt, mirroring what the HTTP `/respond` handler
+    /// does for `state.permission_checker`.
+    permission_checker: Option<Arc<dyn bamboo_tools::permission::PermissionChecker>>,
 }
 
 impl Agent {
@@ -93,6 +119,8 @@ impl Agent {
             inner,
             system_prompt: None,
             model: None,
+            session_store: None,
+            permission_checker: None,
         }
     }
 
@@ -102,11 +130,15 @@ impl Agent {
         inner: bamboo_engine::Agent,
         system_prompt: Option<String>,
         model: Option<String>,
+        session_store: Option<Arc<bamboo_storage::SessionStoreV2>>,
+        permission_checker: Option<Arc<dyn bamboo_tools::permission::PermissionChecker>>,
     ) -> Self {
         Self {
             inner,
             system_prompt,
             model,
+            session_store,
+            permission_checker,
         }
     }
 
@@ -323,5 +355,539 @@ impl Agent {
     /// Access the runtime persistence adapter.
     pub fn persistence(&self) -> &Arc<dyn bamboo_domain::RuntimeSessionPersistence> {
         self.inner.persistence()
+    }
+
+    // ------------------------------------------------------------------
+    // Permission / approval + resume
+    // ------------------------------------------------------------------
+
+    /// Answer a suspended session's pending question — a
+    /// `conclusion_with_options` clarification OR a permission-approval
+    /// prompt (`NeedClarification` / `ToolApprovalRequested` events; both
+    /// suspend via the same `session.pending_question` mechanism, per
+    /// `bamboo_engine::session_app::respond`). This is the in-process
+    /// equivalent of the HTTP `POST /api/v1/sessions/{id}/respond` endpoint —
+    /// same use case function (`submit_pending_response`), so behavior
+    /// (validation, plan-mode transitions, permission-grant extraction)
+    /// matches exactly.
+    ///
+    /// `response` must be one of the pending question's `options` unless it
+    /// `allow_custom`s a free-form answer (returns
+    /// [`SdkError::InvalidResponse`] otherwise). Loads the session by ID from
+    /// [`storage`](Self::storage), so the run must have already suspended
+    /// (and thus persisted) before calling this — the session is NOT taken
+    /// from an in-memory handle.
+    ///
+    /// If this `Agent` was built with
+    /// [`AgentBuilder::permission_checker`](AgentBuilder::permission_checker),
+    /// any permission grants implied by an approved permission prompt are
+    /// applied to it automatically (mirroring what the HTTP handler does for
+    /// `state.permission_checker`), so the resumed re-attempt of the gated
+    /// operation passes the checker without prompting again.
+    ///
+    /// After answering, resume execution with [`resume`](Self::resume) /
+    /// [`resume_stream`](Self::resume_stream) on the returned
+    /// [`AnswerOutcome::session`] — or use
+    /// [`answer_and_resume_stream`](Self::answer_and_resume_stream) to do both
+    /// in one call.
+    ///
+    /// NOTE: unlike the HTTP server's `/respond` handler, this does NOT
+    /// re-execute a gated tool call after approval — the tool never actually
+    /// ran (the permission gate intercepted it before execution), so the
+    /// resumed loop sees only the synthetic "Selected response: Approve" tool
+    /// result rather than the operation's real output. Full re-execution
+    /// parity (`PERMISSION_REEXECUTE_METADATA_KEY`) is server-adapter logic
+    /// not yet ported to the SDK.
+    ///
+    /// NOTE: `ChildApprovalRequested` (an out-of-process sub-agent worker's
+    /// gated tool, proxied over the actor protocol) is a SEPARATE mechanism
+    /// from `pending_question`/`respond` and is not covered by this method.
+    pub async fn answer(
+        &self,
+        session_id: impl Into<String>,
+        response: impl Into<String>,
+    ) -> Result<AnswerOutcome, SdkError> {
+        let input = RespondInput {
+            session_id: session_id.into(),
+            user_response: response.into(),
+            model: None,
+            model_ref: None,
+            provider: None,
+            reasoning_effort: None,
+        };
+        let (session, response, plan_mode_transition, permission_grants) =
+            submit_pending_response(self, input).await?;
+
+        if let Some(checker) = &self.permission_checker {
+            for (perm_type, resource) in &permission_grants {
+                checker.grant_session_permission(*perm_type, resource.clone());
+            }
+        }
+
+        Ok(AnswerOutcome {
+            session,
+            response,
+            plan_mode_transition,
+            permission_grants,
+        })
+    }
+
+    /// Resume execution on `session` — i.e. continue the agent loop from its
+    /// current state (e.g. the tool result [`answer`](Self::answer) just
+    /// appended) WITHOUT appending a new user turn, draining events
+    /// internally until completion. An alias for
+    /// [`run_session`](Self::run_session) that documents intent at the call
+    /// site: the engine's execution entry point always resumes from whatever
+    /// is already in `session.messages` (`run`/`run_stream` are the ones that
+    /// append a fresh turn first).
+    pub async fn resume(&self, session: &mut Session) -> Result<(), AgentError> {
+        self.run_session(session).await
+    }
+
+    /// Like [`resume`](Self::resume), but driven by a caller-owned
+    /// [`CancellationToken`].
+    pub async fn resume_with_cancel(
+        &self,
+        session: &mut Session,
+        cancel_token: CancellationToken,
+    ) -> Result<(), AgentError> {
+        self.run_session_with_cancel(session, cancel_token).await
+    }
+
+    /// Like [`resume`](Self::resume), but streams [`AgentEvent`]s instead of
+    /// draining them. An alias for
+    /// [`run_stream_session`](Self::run_stream_session).
+    pub fn resume_stream(&self, session: Session) -> mpsc::Receiver<AgentEvent> {
+        self.run_stream_session(session)
+    }
+
+    /// Like [`resume_stream`](Self::resume_stream), but also returns a
+    /// [`CancellationToken`] for the resumed run.
+    pub fn resume_stream_cancellable(
+        &self,
+        session: Session,
+    ) -> (mpsc::Receiver<AgentEvent>, CancellationToken) {
+        self.run_stream_session_cancellable(session)
+    }
+
+    /// Convenience: [`answer`](Self::answer) a pending question, then
+    /// immediately [`resume_stream`](Self::resume_stream) on the resulting
+    /// session — the common "ask → answer → resume" flow in one call.
+    pub async fn answer_and_resume_stream(
+        &self,
+        session_id: impl Into<String>,
+        response: impl Into<String>,
+    ) -> Result<mpsc::Receiver<AgentEvent>, SdkError> {
+        let outcome = self.answer(session_id, response).await?;
+        Ok(self.resume_stream(outcome.session))
+    }
+
+    // ------------------------------------------------------------------
+    // Session ergonomics
+    // ------------------------------------------------------------------
+
+    /// List every session in the data directory, most-recently-updated first.
+    ///
+    /// Only available when this `Agent` was built via
+    /// [`AgentBuilder::with_defaults_for_data_dir`] (which assembles the
+    /// concrete session-index handle this needs) — returns
+    /// [`SdkError::Unsupported`] otherwise.
+    pub async fn list_sessions(&self) -> Result<Vec<bamboo_storage::SessionIndexEntry>, SdkError> {
+        let store = self.session_store.as_ref().ok_or_else(|| {
+            SdkError::Unsupported(
+                "list_sessions requires an Agent built via with_defaults_for_data_dir".to_string(),
+            )
+        })?;
+        Ok(store.list_index_entries().await)
+    }
+
+    /// Load a session by ID (its full message history + runtime state), or
+    /// `Ok(None)` if it doesn't exist.
+    pub async fn get_session(&self, session_id: &str) -> Result<Option<Session>, SdkError> {
+        self.storage()
+            .load_session(session_id)
+            .await
+            .map_err(SdkError::Io)
+    }
+
+    /// The message history for a session, or [`SdkError::SessionNotFound`] if
+    /// it doesn't exist.
+    pub async fn session_history(&self, session_id: &str) -> Result<Vec<Message>, SdkError> {
+        self.get_session(session_id)
+            .await?
+            .map(|session| session.messages)
+            .ok_or_else(|| SdkError::SessionNotFound(session_id.to_string()))
+    }
+
+    /// Delete a session. Returns `true` if a session was actually deleted.
+    pub async fn delete_session(&self, session_id: &str) -> Result<bool, SdkError> {
+        self.storage()
+            .delete_session(session_id)
+            .await
+            .map_err(SdkError::Io)
+    }
+}
+
+/// Outcome of [`Agent::answer`] — the updated session, the recorded response,
+/// and any side effects `submit_pending_response` computed (plan-mode
+/// transitions, permission grants implied by an approval).
+#[derive(Debug)]
+pub struct AnswerOutcome {
+    /// The session after the pending question was answered (tool result
+    /// recorded, `pending_question` cleared, resume markers set).
+    pub session: Session,
+    /// The response text that was recorded.
+    pub response: String,
+    /// Plan-mode entered/exited transition, if the answered question was
+    /// `EnterPlanMode`/`ExitPlanMode`.
+    pub plan_mode_transition: Option<PlanModeTransition>,
+    /// `(PermissionType, resource)` grants implied by approving a permission
+    /// prompt (empty unless the pending question was a permission approval).
+    /// Already applied to this `Agent`'s configured
+    /// [`permission_checker`](AgentBuilder::permission_checker), if any.
+    pub permission_grants: Vec<(bamboo_tools::permission::PermissionType, String)>,
+}
+
+/// [`SessionAccess`] for [`Agent`], backed by [`Agent::storage`] (reads) and
+/// [`Agent::persistence`] (writes) — no separate cache tier, unlike the
+/// server's cache+storage+persistence-backed `SessionRepository`, since the
+/// SDK has no cross-request cache to keep coherent. This is what lets
+/// [`Agent::answer`] call the same `bamboo_engine::session_app::respond`
+/// use-case function the HTTP `/respond` handler calls on `AppState`.
+#[async_trait]
+impl SessionAccess for Agent {
+    async fn load_session(&self, id: &str) -> Result<Option<Session>, SessionLoadError> {
+        self.storage()
+            .load_session(id)
+            .await
+            .map_err(|e| SessionLoadError::StorageError(e.to_string()))
+    }
+
+    async fn load_or_create(&self, id: &str, model: &str) -> Result<Session, SessionLoadError> {
+        match SessionAccess::load_session(self, id).await? {
+            Some(session) => Ok(session),
+            None => Ok(Session::new(id.to_string(), model.to_string())),
+        }
+    }
+
+    async fn load_merged(&self, id: &str) -> Result<Option<Session>, SessionLoadError> {
+        // No separate cache tier — storage is the single source of truth.
+        SessionAccess::load_session(self, id).await
+    }
+
+    async fn save_session(&self, session: &mut Session) -> Result<(), SessionSaveError> {
+        self.persistence()
+            .save_runtime_session(session)
+            .await
+            .map_err(|e| SessionSaveError::StorageError(e.to_string()))
+    }
+
+    async fn save_and_cache(&self, session: &mut Session) -> Result<(), SessionSaveError> {
+        SessionAccess::save_session(self, session).await
+    }
+}
+
+#[cfg(test)]
+mod approval_and_session_tests {
+    use super::*;
+    use bamboo_tools::permission::{
+        PermissionChecker, PermissionContext, PermissionError, PermissionMode, PermissionType,
+    };
+    use std::sync::Mutex as StdMutex;
+
+    /// A minimal data dir with a keyless-but-constructible provider config, so
+    /// `with_defaults_for_data_dir` succeeds without any network I/O — mirrors
+    /// `tests/agent_sdk.rs`'s `s_t4_3` setup.
+    async fn build_test_agent(data_dir: std::path::PathBuf) -> Agent {
+        let config_json = r#"{
+            "provider": "anthropic",
+            "providers": {
+                "anthropic": { "api_key": "test-key", "model": "claude-test" }
+            }
+        }"#;
+        std::fs::write(data_dir.join("config.json"), config_json).expect("write config");
+
+        AgentBuilder::new()
+            .model("claude-test")
+            .instruction("test agent")
+            .with_defaults_for_data_dir(data_dir)
+            .await
+            .expect("defaults should assemble")
+            .build()
+            .expect("agent should build")
+    }
+
+    fn seed_session_with_pending_question(
+        session_id: &str,
+        options: Vec<String>,
+        allow_custom: bool,
+    ) -> Session {
+        let mut session = Session::new(session_id.to_string(), "claude-test".to_string());
+        session.set_pending_question(
+            "call-1".to_string(),
+            "ConclusionWithOptions".to_string(),
+            "Pick one".to_string(),
+            options,
+            allow_custom,
+        );
+        session
+    }
+
+    #[tokio::test]
+    async fn answer_resolves_pending_question_and_persists() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agent = build_test_agent(tmp.path().to_path_buf()).await;
+
+        let session = seed_session_with_pending_question(
+            "sess-answer-ok",
+            vec!["A".to_string(), "B".to_string()],
+            false,
+        );
+        agent
+            .storage()
+            .save_session(&session)
+            .await
+            .expect("seed session");
+
+        let outcome = agent
+            .answer("sess-answer-ok", "A")
+            .await
+            .expect("answer should succeed");
+        assert_eq!(outcome.response, "A");
+        assert!(outcome.session.pending_question.is_none());
+        assert!(outcome.permission_grants.is_empty());
+
+        // Persisted: reloading independently shows the same state.
+        let reloaded = agent
+            .storage()
+            .load_session("sess-answer-ok")
+            .await
+            .expect("load")
+            .expect("present");
+        assert!(reloaded.pending_question.is_none());
+        assert!(reloaded
+            .messages
+            .iter()
+            .any(|m| m.tool_call_id.as_deref() == Some("call-1")
+                && m.content.contains("Selected response: A")));
+    }
+
+    #[tokio::test]
+    async fn answer_rejects_response_outside_fixed_options() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agent = build_test_agent(tmp.path().to_path_buf()).await;
+
+        let session = seed_session_with_pending_question(
+            "sess-answer-invalid",
+            vec!["A".to_string(), "B".to_string()],
+            false,
+        );
+        agent
+            .storage()
+            .save_session(&session)
+            .await
+            .expect("seed session");
+
+        let error = agent
+            .answer("sess-answer-invalid", "not-an-option")
+            .await
+            .expect_err("response outside options should be rejected");
+        assert!(matches!(error, SdkError::InvalidResponse(_)));
+    }
+
+    #[tokio::test]
+    async fn answer_errors_when_no_pending_question() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agent = build_test_agent(tmp.path().to_path_buf()).await;
+
+        let session = Session::new("sess-no-pending".to_string(), "claude-test".to_string());
+        agent
+            .storage()
+            .save_session(&session)
+            .await
+            .expect("seed session");
+
+        let error = agent
+            .answer("sess-no-pending", "anything")
+            .await
+            .expect_err("no pending question should error");
+        assert!(matches!(error, SdkError::NoPendingQuestion));
+    }
+
+    #[tokio::test]
+    async fn answer_errors_when_session_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agent = build_test_agent(tmp.path().to_path_buf()).await;
+
+        let error = agent
+            .answer("does-not-exist", "anything")
+            .await
+            .expect_err("missing session should error");
+        assert!(matches!(error, SdkError::SessionNotFound(id) if id == "does-not-exist"));
+    }
+
+    #[tokio::test]
+    async fn session_ergonomics_list_get_history_delete_round_trip() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agent = build_test_agent(tmp.path().to_path_buf()).await;
+
+        let mut session_a = Session::new("sess-a".to_string(), "claude-test".to_string());
+        session_a.add_message(Message::user("hello"));
+        agent
+            .storage()
+            .save_session(&session_a)
+            .await
+            .expect("save a");
+
+        let session_b = Session::new("sess-b".to_string(), "claude-test".to_string());
+        agent
+            .storage()
+            .save_session(&session_b)
+            .await
+            .expect("save b");
+
+        let listed = agent.list_sessions().await.expect("list_sessions");
+        let ids: Vec<&str> = listed.iter().map(|entry| entry.id.as_str()).collect();
+        assert!(ids.contains(&"sess-a"));
+        assert!(ids.contains(&"sess-b"));
+
+        let history = agent
+            .session_history("sess-a")
+            .await
+            .expect("session_history");
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].content, "hello");
+
+        let missing_history = agent.session_history("does-not-exist").await;
+        assert!(matches!(
+            missing_history,
+            Err(SdkError::SessionNotFound(id)) if id == "does-not-exist"
+        ));
+
+        let deleted = agent.delete_session("sess-a").await.expect("delete");
+        assert!(deleted);
+        assert!(agent
+            .get_session("sess-a")
+            .await
+            .expect("get_session")
+            .is_none());
+    }
+
+    /// A stub `PermissionChecker` that only records `grant_session_permission`
+    /// calls, so the test can assert `Agent::answer` applies the permission
+    /// grants `submit_pending_response` extracts from an approved permission
+    /// prompt — mirroring what the HTTP `/respond` handler does explicitly for
+    /// `state.permission_checker`.
+    #[derive(Default)]
+    struct RecordingPermissionChecker {
+        grants: StdMutex<Vec<(PermissionType, String)>>,
+    }
+
+    #[async_trait]
+    impl PermissionChecker for RecordingPermissionChecker {
+        async fn needs_confirmation(&self, _perm_type: PermissionType, _resource: &str) -> bool {
+            false
+        }
+
+        async fn request_confirmation(
+            &self,
+            _ctx: PermissionContext,
+        ) -> Result<bool, PermissionError> {
+            Ok(true)
+        }
+
+        fn grant_session_permission(&self, perm_type: PermissionType, resource: String) {
+            self.grants.lock().unwrap().push((perm_type, resource));
+        }
+
+        fn set_permission_mode(&self, _mode: PermissionMode) {}
+    }
+
+    #[tokio::test]
+    async fn answer_applies_permission_grants_to_configured_checker() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let config_json = r#"{
+            "provider": "anthropic",
+            "providers": {
+                "anthropic": { "api_key": "test-key", "model": "claude-test" }
+            }
+        }"#;
+        std::fs::write(tmp.path().join("config.json"), config_json).expect("write config");
+
+        let checker = Arc::new(RecordingPermissionChecker::default());
+        let agent = AgentBuilder::new()
+            .model("claude-test")
+            .permission_checker(checker.clone())
+            .with_defaults_for_data_dir(tmp.path().to_path_buf())
+            .await
+            .expect("defaults should assemble")
+            .build()
+            .expect("agent should build");
+
+        // Seed a session suspended on an approved permission prompt: the
+        // synthesized `awaiting_permission_approval` tool-result payload
+        // `check_permissions_for` writes before pausing (see
+        // `bamboo_tools::executor` / `session_app::respond`).
+        let mut session = Session::new("sess-permission".to_string(), "claude-test".to_string());
+        session.set_pending_question(
+            "call-perm-1".to_string(),
+            "Write".to_string(),
+            "Permission required".to_string(),
+            vec!["Approve".to_string(), "Deny".to_string()],
+            false,
+        );
+        session.add_message(Message::tool_result(
+            "call-perm-1",
+            serde_json::json!({
+                "status": "awaiting_permission_approval",
+                "question": "Permission required",
+                "permission_type": "write_file",
+                "resource": "/tmp/example.txt",
+                "options": ["Approve", "Deny"],
+                "allow_custom": false,
+            })
+            .to_string(),
+        ));
+        agent
+            .storage()
+            .save_session(&session)
+            .await
+            .expect("seed session");
+
+        let outcome = agent
+            .answer("sess-permission", "Approve")
+            .await
+            .expect("answer should succeed");
+        assert_eq!(
+            outcome.permission_grants,
+            vec![(PermissionType::WriteFile, "/tmp/example.txt".to_string())]
+        );
+
+        let recorded = checker.grants.lock().unwrap();
+        assert_eq!(
+            *recorded,
+            vec![(PermissionType::WriteFile, "/tmp/example.txt".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn list_sessions_unsupported_without_defaults_for_data_dir() {
+        // An Agent wrapped directly via `from_runtime` (no session_store
+        // handle) should report `Unsupported`, not panic.
+        // Building one still needs a real engine Agent, so reuse the defaults
+        // path and drop the handle to simulate a manually-injected Agent.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agent = build_test_agent(tmp.path().to_path_buf()).await;
+        let bare = Agent::from_runtime_with_config(
+            // Reuse the inner engine agent — only the SDK-level session_store
+            // handle is what `list_sessions` checks.
+            agent.inner.clone(),
+            None,
+            None,
+            None,
+            None,
+        );
+        let result = bare.list_sessions().await;
+        assert!(matches!(result, Err(SdkError::Unsupported(_))));
     }
 }

--- a/examples/sdk_quickstart.rs
+++ b/examples/sdk_quickstart.rs
@@ -12,8 +12,23 @@
 //! It requires `~/.bamboo/config.json` to define a provider + API key (the same
 //! config `bamboo serve` reads); `with_defaults_for_data_dir` wires the runtime
 //! dependencies from that directory.
+//!
+//! This example also demonstrates the two interactive capabilities layered on
+//! top of "start a run and stream events" (bamboo-agent#244):
+//!
+//! - **Cancellation**: `run_stream_cancellable` hands back a `CancellationToken`
+//!   alongside the event receiver; a background watchdog cancels the run if it
+//!   runs unexpectedly long.
+//! - **Approval / clarification + resume**: if the model calls a tool that
+//!   pauses for user input (`conclusion_with_options`, or a gated tool under a
+//!   configured `PermissionChecker`), the event loop sees
+//!   `AgentEvent::NeedClarification` / `ToolApprovalRequested`, answers it via
+//!   `Agent::answer`, and resumes the run via `Agent::resume_stream` — the
+//!   "ask → answer → resume" flow.
 
-use bamboo_sdk::agent::{Agent, Session};
+use std::time::Duration;
+
+use bamboo_sdk::agent::{Agent, AgentEvent, Session};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -31,16 +46,50 @@ async fn main() -> anyhow::Result<()> {
         .build()
         .expect("agent fully configured");
 
-    // Stream one turn: `run_stream` appends the user message, runs the loop on
-    // a background task, and hands back a receiver of AgentEvents.
-    let session = Session::new("demo-session", "claude-sonnet-4-6");
-    let mut rx = agent.run_stream(
+    let session_id = "demo-session".to_string();
+    let session = Session::new(session_id.clone(), "claude-sonnet-4-6");
+
+    // Stream one turn: `run_stream_cancellable` appends the user message, runs
+    // the loop on a background task, and hands back a receiver of AgentEvents
+    // PLUS a `CancellationToken` — call `.cancel()` from any other task to
+    // interrupt the run at its next check point.
+    let (mut rx, cancel_token) = agent.run_stream_cancellable(
         session,
         "List the files here and tell me what this project does.",
     );
+
+    // Cancellation demo: a watchdog that stops a run which takes too long.
+    // (In a real app this would be wired to a user-facing "Stop" button
+    // instead of a fixed timeout.)
+    let watchdog_token = cancel_token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(120)).await;
+        watchdog_token.cancel();
+    });
+
     while let Some(event) = rx.recv().await {
-        // assistant text, tool calls, tool results, token usage, completion
+        // Approval / clarification + resume demo: the loop suspended waiting
+        // for input (a `conclusion_with_options` call, or a gated tool under a
+        // configured permission checker). Both suspend via the same
+        // `session.pending_question` mechanism, so both are answered the same
+        // way. Answer it, then resume the run from where it left off.
+        let needs_answer = matches!(
+            event,
+            AgentEvent::NeedClarification { .. } | AgentEvent::ToolApprovalRequested { .. }
+        );
         println!("{event:?}");
+
+        if needs_answer {
+            println!("agent is asking for input — auto-approving");
+            let mut resumed_rx = agent
+                .answer_and_resume_stream(session_id.clone(), "Approve")
+                .await
+                .expect("answer + resume");
+            while let Some(event) = resumed_rx.recv().await {
+                println!("{event:?}");
+            }
+            break;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Addresses bigduu/Bamboo-agent#244 ("[bamboo-sdk] Facade capability & ergonomics"). Cancellation and `.provider_name()` (the issue's #1/#5 suggestions) already shipped in a prior PR (`e0e5ddf2`); this PR closes the remaining highest-leverage gaps:

- **Permission/approval + resume** — `Agent::answer(session_id, response)` resolves a suspended session's pending question (a `conclusion_with_options` clarification OR a permission-approval prompt — both suspend via the same `session.pending_question` mechanism) by calling the same `session_app::respond::submit_pending_response` use case the HTTP `/respond` handler calls, via a new `impl SessionAccess for Agent`. Permission grants an approval implies are auto-applied to a configured `.permission_checker(...)`. `Agent::resume()` / `resume_stream()` / `resume_stream_cancellable()` name+document the existing "continue from current session state" entry point (the engine always resumes from `session.messages`, so `run_session` already *is* resume). `answer_and_resume_stream()` does both in one call.
- **Session ergonomics** — `list_sessions()`, `get_session()`, `session_history()`, `delete_session()`.
- **MCP ergonomics** — `.mcp_server(config)` / `.mcp_servers([...])` on the builder connect MCP servers and merge their tools into the built-in surface via `CompositeToolExecutor` (server `initialize` instructions fold into tool guidance automatically, no extra wiring).
- **Permission opt-in** — `.permission_checker(checker)` / `.bypass_permissions()`: previously the SDK had no way to enable permission gating at all (bypass was the only reachable behavior).
- **Typed errors** — `SdkError` (thiserror) replaces `with_defaults_for_data_dir`/`build`'s `Result<_, String>`; wraps `AgentError` via `#[from]` so it composes with `run`/`run_stream` in a function returning `Result<_, SdkError>`.
- `examples/sdk_quickstart.rs` (the compile-checked README twin) now demonstrates `run_stream_cancellable` + a watchdog cancellation, and the ask → answer → resume flow.

Only `bamboo-sdk` is touched — no engine/tools/mcp crate changes needed; the SDK composes existing public APIs (`session_app::respond`, `SessionAccess`, `CompositeToolExecutor`, `McpServerManager`, `BuiltinToolExecutor::new_with_config_and_permissions`).

**Deliberately not covered** (documented in `Agent::answer`'s doc comment — candidates for follow-up issues):
- Re-executing a gated tool call after approval so the resumed loop sees the real output instead of the synthetic "Selected response: Approve" (the HTTP server's `resume_adapter.rs` `PERMISSION_REEXECUTE_METADATA_KEY` logic — server-adapter-specific, not yet ported).
- `ChildApprovalRequested` (an out-of-process sub-agent's gated tool, proxied over the actor protocol) — a separate mechanism from `pending_question`/`respond`, not covered by `answer()`.
- Duplicate `Agent`/`AgentBuilder`/`ExecuteRequestBuilder` names across crates, compile-checked doctests, `.no_tools()` (issue's #8/#10) — lower-leverage per the issue's own ranking, left as-is.

## Test plan

- [x] `cargo fmt -- --check` — clean.
- [x] `cargo clippy -p bamboo-sdk --all-targets` — only 2 pre-existing warnings (unrelated `#[cfg(test)]` code, `field_reassign_with_default`), no new warnings.
- [x] `cargo build --workspace --tests` (excl. `bamboo-analytics`) — green.
- [x] `cargo test -p bamboo-sdk` — 17 passed (7 new: answer resolves/persists/rejects-invalid/no-pending/missing-session, session list/get/history/delete round-trip, permission grants applied to a stub checker, `list_sessions` `Unsupported` without `with_defaults_for_data_dir`).
- [x] `cargo test --test agent_sdk` (root package) — 3 passed, unaffected by the `String` → `SdkError` return-type change (`.expect()` is error-type-agnostic).
- [x] `cargo check --example sdk_quickstart` — compiles.
- [x] `cargo doc -p bamboo-sdk --no-deps` — only 1 pre-existing broken-intra-doc-link warning (unrelated file), no new ones.

https://claude.ai/code/session_01Ux4nHUqFjEEGV3rX1x3V9Y