### PR TITLE
feat(config): stable id for connect.platforms entries + id-first masked-secret resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -159,6 +159,12 @@ impl AppState {
                 reject_if_recovery_pending(&cfg)?;
                 let was_off = cfg.plugin_trust.enforcement_is_off();
                 update(&mut cfg)?;
+                // Backfill any missing connect.platforms id (#496) on the live
+                // in-memory config itself — not just inside `save_to_dir`'s
+                // internal save-copy — so the response this update returns
+                // (and any GET immediately after) already reflects the id a
+                // client can round-trip on its next PATCH.
+                cfg.assign_connect_platform_ids();
                 cfg.publish_env_vars();
                 let newly_off = !was_off && cfg.plugin_trust.enforcement_is_off();
                 (cfg.clone(), newly_off)
@@ -187,9 +193,16 @@ impl AppState {
     /// Replace the full config (used for JSON merge endpoints).
     pub async fn replace_config(
         &self,
-        new_config: Config,
+        mut new_config: Config,
         effects: ConfigUpdateEffects,
     ) -> Result<Config, AppError> {
+        // Backfill any missing connect.platforms id (#496) up front, before
+        // any of the clones below are taken, so the in-memory config, the
+        // disk-persisted snapshot, and the value this call returns to the
+        // caller (the settings-merge HTTP response) all agree on the same
+        // ids — mirrors the `update_config` treatment above.
+        new_config.assign_connect_platform_ids();
+
         // Same #126 serialization as update_config: mutate + persist under the
         // config-IO lock so a reload can't interleave; effects run unlocked.
         {

--- a/crates/app/bamboo-server/src/connect/mod.rs
+++ b/crates/app/bamboo-server/src/connect/mod.rs
@@ -319,6 +319,7 @@ mod tests {
 
     fn platform(platform_type: &str, token: Option<&str>) -> ConnectPlatformConfig {
         ConnectPlatformConfig {
+            id: None,
             platform_type: platform_type.to_string(),
             token: token.map(str::to_string),
             token_encrypted: None,

--- a/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
@@ -359,6 +359,7 @@ fn redact_config_never_leaks_notification_ciphertext_even_when_client_supplied()
 fn redact_config_masks_configured_connect_platform_token() {
     let mut config = Config::default();
     config.connect.platforms = vec![bamboo_config::ConnectPlatformConfig {
+        id: None,
         platform_type: "telegram".to_string(),
         token: None,
         token_encrypted: Some("enc-telegram".to_string()),
@@ -390,6 +391,7 @@ fn redact_config_masks_configured_connect_platform_token() {
 fn redact_config_omits_unconfigured_connect_platform_token() {
     let mut config = Config::default();
     config.connect.platforms = vec![bamboo_config::ConnectPlatformConfig {
+        id: None,
         platform_type: "telegram".to_string(),
         token: None,
         token_encrypted: None,
@@ -436,6 +438,7 @@ fn redact_config_never_leaks_connect_platform_ciphertext_even_when_client_suppli
 fn redact_config_masks_configured_connect_platform_app_secret_but_not_app_id_or_domain() {
     let mut config = Config::default();
     config.connect.platforms = vec![bamboo_config::ConnectPlatformConfig {
+        id: None,
         platform_type: "feishu".to_string(),
         token: None,
         token_encrypted: None,
@@ -473,6 +476,7 @@ fn redact_config_masks_configured_connect_platform_app_secret_but_not_app_id_or_
 fn redact_config_omits_unconfigured_connect_platform_app_secret() {
     let mut config = Config::default();
     config.connect.platforms = vec![bamboo_config::ConnectPlatformConfig {
+        id: None,
         platform_type: "feishu".to_string(),
         token: None,
         token_encrypted: None,

--- a/crates/infra/bamboo-config/Cargo.toml
+++ b/crates/infra/bamboo-config/Cargo.toml
@@ -23,6 +23,7 @@ sha2 = "0.11"
 hex = "0.4"
 base64 = "0.22"
 url = "2"
+uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -716,6 +716,21 @@ pub struct NotificationsConfig {
 /// external chat platform (Telegram first).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ConnectPlatformConfig {
+    /// Stable per-entry identifier (#496). Not part of the original schema —
+    /// absent on legacy/hand-written entries and on a freshly-echoed new
+    /// entry from a client. [`Config::save_to_dir`] assigns one (a random
+    /// UUID) to any entry that lacks it as part of the normal save path
+    /// (migration-on-write); load never mutates/rewrites the config to
+    /// backfill it, per #493's never-overwrite-until-confirmed semantics.
+    ///
+    /// Used by [`crate::patch::preserve_masked_connect_secrets`] as the
+    /// FIRST resolution strategy for a masked secret in a settings PATCH,
+    /// ahead of the positional/`type`-based fallbacks (#490/#492) — an exact
+    /// id match unambiguously identifies the same logical entry even when
+    /// two entries share the same `platform_type` and have been reordered,
+    /// which position+type alone cannot always disambiguate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     /// Platform adapter selector, e.g. `"telegram"`. Unrecognized values are
     /// skipped (with a startup warning) rather than failing config load —
     /// forward-compatible with future adapters (Feishu/Slack).
@@ -2964,6 +2979,29 @@ impl Config {
         Ok(())
     }
 
+    /// Assign a stable [`ConnectPlatformConfig::id`] to every `connect.platforms`
+    /// entry that doesn't already have one (#496).
+    ///
+    /// Migration-on-write: [`Config::save_to_dir`] always calls this on its
+    /// internal save-copy before persisting, so every path that writes
+    /// `connect.json` gets ids backfilled. Callers that mutate the *live*
+    /// in-memory config as part of a save (e.g. the server's settings-PATCH
+    /// handler) should also call this directly on that in-memory value
+    /// before responding, so a client that echoes the response straight
+    /// back round-trips the id immediately rather than only after the next
+    /// reload/restart. Never called from load — a config that's never saved
+    /// again (e.g. one sitting in an unconfirmed-recovery state, see #493)
+    /// is never rewritten just to backfill ids. An entry that already has
+    /// an id keeps it unchanged; ids are never reassigned or deduplicated
+    /// once set.
+    pub fn assign_connect_platform_ids(&mut self) {
+        for platform in &mut self.connect.platforms {
+            if platform.id.is_none() {
+                platform.id = Some(uuid::Uuid::new_v4().to_string());
+            }
+        }
+    }
+
     /// Save configuration to disk under the provided data directory.
     ///
     /// Configuration is always stored as `{data_dir}/config.json`.
@@ -3007,6 +3045,7 @@ impl Config {
         // `subagents.broker` is `#[serde(skip)]` (runtime-only, lives in its own
         // broker.json / embedded in-process) — nothing to encrypt or persist here.
         to_save.refresh_notifications_encrypted()?;
+        to_save.assign_connect_platform_ids();
         to_save.refresh_connect_platform_tokens_encrypted()?;
         to_save.normalize_tool_settings();
         to_save.normalize_skill_settings();
@@ -4437,6 +4476,7 @@ mod tests {
         token_encrypted: &str,
     ) -> ConnectPlatformConfig {
         ConnectPlatformConfig {
+            id: None,
             platform_type: platform_type.to_string(),
             token: None,
             token_encrypted: Some(token_encrypted.to_string()),
@@ -4487,6 +4527,118 @@ mod tests {
         assert!(
             connect_json["platforms"][0].get("token").is_none(),
             "the plaintext token is never persisted (skip_serializing)"
+        );
+    }
+
+    // ── stable connect.platforms id (#496) ───────────────────────────────
+
+    #[test]
+    fn save_assigns_a_missing_connect_platform_id() {
+        let _key = crate::encryption::set_test_encryption_key([0x42; 32]);
+        let temp = TempHome::new();
+
+        let mut config = Config::create_default();
+        config.connect.platforms = vec![connect_platform_with_encrypted("telegram", "cipher")];
+        assert!(
+            config.connect.platforms[0].id.is_none(),
+            "precondition: the entry starts without an id"
+        );
+
+        config
+            .save_to_dir(temp.path.clone())
+            .expect("save succeeds");
+
+        let connect_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(connect_json_path(&temp)).unwrap())
+                .unwrap();
+        let persisted_id = connect_json["platforms"][0]["id"]
+            .as_str()
+            .expect("save_to_dir must backfill a missing id onto the persisted entry");
+        assert!(!persisted_id.is_empty());
+
+        let reloaded = Config::from_data_dir_without_publish(Some(temp.path.clone()));
+        assert_eq!(
+            reloaded.connect.platforms[0].id.as_deref(),
+            Some(persisted_id),
+            "the assigned id round-trips through a reload"
+        );
+    }
+
+    #[test]
+    fn save_never_reassigns_an_existing_connect_platform_id() {
+        let _key = crate::encryption::set_test_encryption_key([0x42; 32]);
+        let temp = TempHome::new();
+
+        let mut config = Config::create_default();
+        let mut platform = connect_platform_with_encrypted("telegram", "cipher");
+        platform.id = Some("stable-id-123".to_string());
+        config.connect.platforms = vec![platform];
+
+        config
+            .save_to_dir(temp.path.clone())
+            .expect("first save succeeds");
+        // Save again (e.g. an unrelated settings change) — the id must not change.
+        config
+            .save_to_dir(temp.path.clone())
+            .expect("second save succeeds");
+
+        let connect_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(connect_json_path(&temp)).unwrap())
+                .unwrap();
+        assert_eq!(connect_json["platforms"][0]["id"], "stable-id-123");
+    }
+
+    #[test]
+    fn save_assigns_distinct_ids_to_duplicate_platform_type_entries() {
+        let _key = crate::encryption::set_test_encryption_key([0x42; 32]);
+        let temp = TempHome::new();
+
+        let mut config = Config::create_default();
+        config.connect.platforms = vec![
+            connect_platform_with_encrypted("telegram", "cipher-a"),
+            connect_platform_with_encrypted("telegram", "cipher-b"),
+        ];
+
+        config
+            .save_to_dir(temp.path.clone())
+            .expect("save succeeds");
+
+        let connect_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(connect_json_path(&temp)).unwrap())
+                .unwrap();
+        let id_a = connect_json["platforms"][0]["id"].as_str().unwrap();
+        let id_b = connect_json["platforms"][1]["id"].as_str().unwrap();
+        assert_ne!(
+            id_a, id_b,
+            "two entries sharing platform_type must still get distinct ids"
+        );
+    }
+
+    #[test]
+    fn load_never_assigns_or_persists_an_id_by_itself() {
+        let temp = TempHome::new();
+        std::fs::write(
+            connect_json_path(&temp),
+            serde_json::json!({
+                "platforms": [
+                    { "type": "telegram", "token_encrypted": "cipher-abc", "allow_from": ["u1"] }
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let connect_json_before = std::fs::read_to_string(connect_json_path(&temp)).unwrap();
+
+        let config = Config::from_data_dir_without_publish(Some(temp.path.clone()));
+
+        assert!(
+            config.connect.platforms[0].id.is_none(),
+            "load alone must not backfill an id in memory"
+        );
+        let connect_json_after = std::fs::read_to_string(connect_json_path(&temp)).unwrap();
+        assert_eq!(
+            connect_json_before, connect_json_after,
+            "load must never rewrite connect.json on disk just to backfill an id (#493)"
         );
     }
 
@@ -4831,6 +4983,7 @@ mod tests {
 
         let mut config = Config::create_default();
         config.connect.platforms = vec![ConnectPlatformConfig {
+            id: None,
             platform_type: "feishu".to_string(),
             token: None,
             token_encrypted: None,
@@ -4871,6 +5024,7 @@ mod tests {
 
         let mut config = Config::create_default();
         config.connect.platforms = vec![ConnectPlatformConfig {
+            id: None,
             platform_type: "feishu".to_string(),
             token: None,
             token_encrypted: None,

--- a/crates/infra/bamboo-config/src/patch.rs
+++ b/crates/infra/bamboo-config/src/patch.rs
@@ -413,31 +413,35 @@ pub fn preserve_masked_notification_secrets(patch_obj: &mut Map<String, Value>, 
 /// the current config's plaintext values.
 ///
 /// Mirrors [`preserve_masked_notification_secrets`]. `connect.platforms` is a
-/// list (not a single object like ntfy/bark), so entries are matched
-/// POSITIONALLY: patch index `i` is resolved against `current.connect.platforms[i]`.
-/// This mirrors how the settings UI round-trips the list (it always sends the
-/// full array back in the same order it was fetched in — the same convention
-/// `env_vars`' full-array replace relies on) — reordering platforms in the
-/// same request as leaving a token masked is not supported and drops that
-/// entry's token, same as no plaintext being configured yet.
+/// list (not a single object like ntfy/bark), so each patch entry is resolved
+/// against a `current.connect.platforms` entry via three strategies, tried in
+/// order:
 ///
-/// Known limitation (issue #454 follow-up), still present: there is no
-/// stable per-entry id, so reordering two entries of the SAME
-/// `platform_type` (e.g. two `"telegram"` entries, once multi-bot is
-/// supported) at the same time as leaving one masked is indistinguishable
-/// from "not reordered" and can still attach the wrong token to an entry —
-/// fixing that needs a schema change (a stable id field) tracked separately.
-/// What IS fixed here: a reorder is detected whenever it changes the
-/// `platform_type` at a given index — `type` is checked against `current`'s
-/// entry at the same index, and a mismatch (or an index beyond
-/// `current.connect.platforms`, e.g. a preceding entry was removed) no
-/// longer drops the secret outright. Instead (issue #490) it falls back to a
-/// type-based lookup: `current.connect.platforms.iter().find(|p|
-/// p.platform_type == patch_type)`. This is safe because `multi_bot_guard`
-/// (#462) means only the FIRST entry of a given type is ever started, so
-/// resolving to any same-typed entry is strictly better than silently
-/// wiping the secret. Only when no entry of that type exists anywhere in
-/// `current` does the mask get dropped, same as "nothing configured yet".
+/// 1. **Id match (#496)** — if the patch entry carries an `id` and some entry
+///    in `current` has the same [`crate::ConnectPlatformConfig::id`], that
+///    entry is authoritative, full stop. A stable server-assigned id
+///    unambiguously identifies the same logical platform regardless of
+///    position or `platform_type` — this is the only strategy that correctly
+///    disambiguates two entries that share the same `platform_type` and have
+///    been reordered relative to each other (the scenario #490/#492's
+///    type+positional fallback cannot fully resolve; see the regression test
+///    `preserve_masked_connect_secrets_resolves_duplicate_type_by_id_even_when_reordered`
+///    below). Legacy entries without an id (or a patch from a client that
+///    doesn't echo it back) simply fall through to strategy 2.
+/// 2. **Positional + type guard** — patch index `i` is resolved against
+///    `current.connect.platforms[i]`, guarded by `type` equality at that
+///    index. This mirrors how the settings UI round-trips the list (it
+///    always sends the full array back in the same order it was fetched in
+///    — the same convention `env_vars`' full-array replace relies on).
+/// 3. **Type-based fallback (#490)** — when the positional entry's type
+///    disagrees with the patch entry's `type` (or the patch index is beyond
+///    `current.connect.platforms`), fall back to
+///    `current.connect.platforms.iter().find(|p| p.platform_type == patch_type)`.
+///    This is safe because `multi_bot_guard` (#462) means only the FIRST
+///    entry of a given type is ever started, so resolving to any same-typed
+///    entry is strictly better than silently wiping the secret. Only when no
+///    entry of that type exists anywhere in `current` does the mask get
+///    dropped, same as "nothing configured yet".
 pub fn preserve_masked_connect_secrets(patch_obj: &mut Map<String, Value>, current: &Config) {
     let Some(platforms) = patch_obj
         .get_mut("connect")
@@ -452,6 +456,23 @@ pub fn preserve_masked_connect_secrets(patch_obj: &mut Map<String, Value>, curre
             continue;
         };
         let patch_type = obj.get("type").and_then(|v| v.as_str());
+        let patch_id = obj.get("id").and_then(|v| v.as_str());
+
+        // Strategy 1 (#496): an id match is authoritative and unambiguous —
+        // it doesn't need (and isn't guarded by) a type/position check,
+        // since a server-assigned id already uniquely identifies one entry.
+        let by_id = patch_id.and_then(|patch_id| {
+            current
+                .connect
+                .platforms
+                .iter()
+                .find(|p| p.id.as_deref() == Some(patch_id))
+        });
+
+        // Strategies 2/3 (#490/#492): positional + type guard, falling back
+        // to a type-only lookup — unchanged, and only consulted when there
+        // was no id (or the id didn't match anything in `current`, e.g. a
+        // stale id echoed after the entry was removed).
         let existing = current.connect.platforms.get(index);
         // A patch entry that names a "type" disagreeing with `current`'s
         // entry at the same index (or an index beyond `current`'s array)
@@ -462,20 +483,22 @@ pub fn preserve_masked_connect_secrets(patch_obj: &mut Map<String, Value>, curre
         // which always echoes the whole object back) can't be checked and
         // falls back to the pre-existing positional-only behavior (no
         // type-based fallback either, since there's no type to search by).
-        let guarded = existing
-            .filter(|p| match patch_type {
-                Some(patch_type) => patch_type == p.platform_type,
-                None => true,
-            })
-            .or_else(|| {
-                patch_type.and_then(|patch_type| {
-                    current
-                        .connect
-                        .platforms
-                        .iter()
-                        .find(|p| p.platform_type == patch_type)
+        let guarded = by_id.or_else(|| {
+            existing
+                .filter(|p| match patch_type {
+                    Some(patch_type) => patch_type == p.platform_type,
+                    None => true,
                 })
-            });
+                .or_else(|| {
+                    patch_type.and_then(|patch_type| {
+                        current
+                            .connect
+                            .platforms
+                            .iter()
+                            .find(|p| p.platform_type == patch_type)
+                    })
+                })
+        });
         preserve_masked_secret_field(obj, "token", guarded.and_then(|p| p.token.as_deref()));
         preserve_masked_secret_field(
             obj,
@@ -685,6 +708,7 @@ mod tests {
 
     fn connect_platform(platform_type: &str, token: &str) -> crate::ConnectPlatformConfig {
         crate::ConnectPlatformConfig {
+            id: None,
             platform_type: platform_type.to_string(),
             token: Some(token.to_string()),
             token_encrypted: None,
@@ -694,6 +718,17 @@ mod tests {
             domain: None,
             allow_from: Vec::new(),
             admin_from: Vec::new(),
+        }
+    }
+
+    fn connect_platform_with_id(
+        id: &str,
+        platform_type: &str,
+        token: &str,
+    ) -> crate::ConnectPlatformConfig {
+        crate::ConnectPlatformConfig {
+            id: Some(id.to_string()),
+            ..connect_platform(platform_type, token)
         }
     }
 
@@ -901,8 +936,99 @@ mod tests {
         );
     }
 
+    /// #496 — the exact scenario the issue is about: two entries share the
+    /// same `platform_type` ("telegram") AND have been reordered, so the
+    /// type+positional guard alone can't tell they were swapped (the type at
+    /// each index still matches "telegram" either way). Without an id, this
+    /// class of reorder can attach the wrong sibling's secret. With a
+    /// server-assigned id present on both, resolution is unambiguous
+    /// regardless of position.
+    #[test]
+    fn preserve_masked_connect_secrets_resolves_duplicate_type_by_id_even_when_reordered() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![
+            connect_platform_with_id("id-a", "telegram", "bot-a-token"),
+            connect_platform_with_id("id-b", "telegram", "bot-b-token"),
+        ];
+
+        // The client echoes the array back SWAPPED: id-b now at index 0,
+        // id-a now at index 1. Positional+type resolution alone would
+        // (wrongly) resolve index 0 against current[0] (id-a's token) since
+        // both are "telegram" — the id lets us catch the swap.
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[
+                {"id":"id-b","type":"telegram","token":"****...****"},
+                {"id":"id-a","type":"telegram","token":"****...****"}
+            ]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert_eq!(
+            patch["connect"]["platforms"][0]["token"], "bot-b-token",
+            "index 0 (id-b) must resolve to id-b's own token, not the positionally-co-located id-a"
+        );
+        assert_eq!(
+            patch["connect"]["platforms"][1]["token"], "bot-a-token",
+            "index 1 (id-a) must resolve to id-a's own token"
+        );
+    }
+
+    /// A patch entry whose `id` doesn't match anything in `current` (e.g. a
+    /// brand-new entry a client invented an id for, or a stale id echoed
+    /// after the entry was removed) falls through to the existing
+    /// positional/type-based resolution rather than treating the mismatch
+    /// as fatal.
+    #[test]
+    fn preserve_masked_connect_secrets_falls_back_when_id_not_found_in_current() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![connect_platform("telegram", "existing-bot-token")];
+
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[{"id":"unknown-id","type":"telegram","token":"****...****"}]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert_eq!(
+            patch["connect"]["platforms"][0]["token"], "existing-bot-token",
+            "an id absent from `current` falls back to the positional+type guard"
+        );
+    }
+
+    /// Back-compat: a patch entry with no "id" field at all (legacy client,
+    /// or an entry created before ids existed) is unaffected by the new
+    /// id-matching branch and goes straight to the existing
+    /// positional/type-based resolution — exercised here with `current`
+    /// entries that DO have ids (post-migration) to prove the id branch is
+    /// skipped cleanly rather than erroring on the missing field.
+    #[test]
+    fn preserve_masked_connect_secrets_ignores_id_branch_when_patch_omits_id() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![connect_platform_with_id(
+            "id-a",
+            "telegram",
+            "existing-bot-token",
+        )];
+
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[{"type":"telegram","token":"****...****"}]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert_eq!(
+            patch["connect"]["platforms"][0]["token"],
+            "existing-bot-token"
+        );
+    }
+
     fn feishu_platform(app_secret: &str) -> crate::ConnectPlatformConfig {
         crate::ConnectPlatformConfig {
+            id: None,
             platform_type: "feishu".to_string(),
             token: None,
             token_encrypted: None,

--- a/crates/infra/bamboo-config/src/patch.rs
+++ b/crates/infra/bamboo-config/src/patch.rs
@@ -418,16 +418,26 @@ pub fn preserve_masked_notification_secrets(patch_obj: &mut Map<String, Value>, 
 /// order:
 ///
 /// 1. **Id match (#496)** — if the patch entry carries an `id` and some entry
-///    in `current` has the same [`crate::ConnectPlatformConfig::id`], that
-///    entry is authoritative, full stop. A stable server-assigned id
-///    unambiguously identifies the same logical platform regardless of
-///    position or `platform_type` — this is the only strategy that correctly
+///    in `current` has the same [`crate::ConnectPlatformConfig::id`] AND a
+///    consistent `platform_type`, that entry is authoritative. A stable
+///    server-assigned id unambiguously identifies the same logical platform
+///    regardless of position — this is the only strategy that correctly
 ///    disambiguates two entries that share the same `platform_type` and have
 ///    been reordered relative to each other (the scenario #490/#492's
 ///    type+positional fallback cannot fully resolve; see the regression test
 ///    `preserve_masked_connect_secrets_resolves_duplicate_type_by_id_even_when_reordered`
-///    below). Legacy entries without an id (or a patch from a client that
-///    doesn't echo it back) simply fall through to strategy 2.
+///    below). The id match is guarded by the same type-consistency check as
+///    strategy 2: a patch entry whose `type` DISAGREES with the id-matched
+///    entry's `platform_type` (e.g. a stale/reused id after a client-side
+///    bug, or a flow that repurposes an entry's identity for a different
+///    platform) must not inherit the differently-typed entry's secret — a
+///    Telegram bot token pasted into a Feishu adapter is never right. Such
+///    a mismatch falls through to strategies 2/3 (which will also refuse a
+///    cross-type resolution, dropping the mask — same as "nothing configured
+///    yet"). A patch entry with an `id` but no `type` at all can't be
+///    checked and resolves on id alone, mirroring strategy 2's handling of
+///    a missing `type`. Legacy entries without an id (or a patch from a
+///    client that doesn't echo it back) simply fall through to strategy 2.
 /// 2. **Positional + type guard** — patch index `i` is resolved against
 ///    `current.connect.platforms[i]`, guarded by `type` equality at that
 ///    index. This mirrors how the settings UI round-trips the list (it
@@ -458,21 +468,27 @@ pub fn preserve_masked_connect_secrets(patch_obj: &mut Map<String, Value>, curre
         let patch_type = obj.get("type").and_then(|v| v.as_str());
         let patch_id = obj.get("id").and_then(|v| v.as_str());
 
-        // Strategy 1 (#496): an id match is authoritative and unambiguous —
-        // it doesn't need (and isn't guarded by) a type/position check,
-        // since a server-assigned id already uniquely identifies one entry.
+        // Strategy 1 (#496): an id match is position-independent, but it is
+        // still guarded by the SAME type-consistency check strategies 2/3
+        // enforce — an id pointing at a differently-typed entry (stale or
+        // repurposed id) must not leak that entry's secret into an adapter
+        // of another type. A patch entry with no "type" can't be checked and
+        // resolves on id alone (mirrors strategy 2's missing-"type" case).
         let by_id = patch_id.and_then(|patch_id| {
-            current
-                .connect
-                .platforms
-                .iter()
-                .find(|p| p.id.as_deref() == Some(patch_id))
+            current.connect.platforms.iter().find(|p| {
+                p.id.as_deref() == Some(patch_id)
+                    && match patch_type {
+                        Some(patch_type) => patch_type == p.platform_type,
+                        None => true,
+                    }
+            })
         });
 
         // Strategies 2/3 (#490/#492): positional + type guard, falling back
         // to a type-only lookup — unchanged, and only consulted when there
-        // was no id (or the id didn't match anything in `current`, e.g. a
-        // stale id echoed after the entry was removed).
+        // was no id, the id didn't match anything in `current` (e.g. a
+        // stale id echoed after the entry was removed), or the id-matched
+        // entry failed the type-consistency guard above.
         let existing = current.connect.platforms.get(index);
         // A patch entry that names a "type" disagreeing with `current`'s
         // entry at the same index (or an index beyond `current`'s array)
@@ -995,6 +1011,95 @@ mod tests {
         assert_eq!(
             patch["connect"]["platforms"][0]["token"], "existing-bot-token",
             "an id absent from `current` falls back to the positional+type guard"
+        );
+    }
+
+    /// PR #510 review: the id branch is guarded by the same type-consistency
+    /// check as the positional branch. A patch entry whose `id` matches a
+    /// `current` entry of a DIFFERENT `platform_type` (stale/reused id, or a
+    /// flow repurposing an entry's identity for another platform) must NOT
+    /// inherit that entry's secret — with no same-typed entry anywhere in
+    /// `current`, the mask drops, same as "nothing configured yet".
+    #[test]
+    fn preserve_masked_connect_secrets_rejects_id_match_when_type_differs() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![connect_platform_with_id(
+            "id-a",
+            "telegram",
+            "telegram-secret-token",
+        )];
+
+        // The patch reuses stored entry id-a's id but claims to be a Feishu
+        // adapter — resolving the mask against the Telegram entry would paste
+        // a Telegram bot token into a Feishu config.
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[{"id":"id-a","type":"feishu","token":"****...****"}]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert!(
+            !patch["connect"]["platforms"][0]
+                .as_object()
+                .unwrap()
+                .contains_key("token"),
+            "an id match with a disagreeing type must not resolve the mask from that entry"
+        );
+    }
+
+    /// The type-mismatched-id fall-through still reaches strategies 2/3: if a
+    /// same-typed entry DOES exist elsewhere in `current`, the type-based
+    /// fallback (#490) resolves the mask against it — the bad id only
+    /// disqualifies the id branch, it doesn't poison the whole resolution.
+    #[test]
+    fn preserve_masked_connect_secrets_type_mismatched_id_still_falls_through_to_type_lookup() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![
+            connect_platform_with_id("id-a", "telegram", "telegram-secret-token"),
+            connect_platform_with_id("id-b", "feishu", "feishu-secret-token"),
+        ];
+
+        // id-a belongs to the telegram entry, but the patch entry says
+        // "feishu" (at index 0, where current has telegram): the id branch
+        // and the positional branch both refuse, and the type-based fallback
+        // resolves against the feishu entry at index 1.
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[{"id":"id-a","type":"feishu","token":"****...****"}]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert_eq!(
+            patch["connect"]["platforms"][0]["token"], "feishu-secret-token",
+            "the fall-through must resolve via the type lookup, never via the mismatched id"
+        );
+    }
+
+    /// A patch entry with an `id` but no `type` at all can't be
+    /// type-checked and resolves on id alone — mirrors the positional
+    /// branch's handling of a missing `type` (documented in the id-branch
+    /// guard). Placed at an out-of-range index to prove it's the id doing
+    /// the work, not position.
+    #[test]
+    fn preserve_masked_connect_secrets_id_without_type_resolves_on_id_alone() {
+        let mut current = Config::default();
+        current.connect.platforms = vec![
+            connect_platform_with_id("id-a", "telegram", "bot-a-token"),
+            connect_platform_with_id("id-b", "telegram", "bot-b-token"),
+        ];
+
+        let mut patch: Map<String, Value> = serde_json::from_str(
+            r#"{"connect":{"platforms":[{"id":"id-b","token":"****...****"}]}}"#,
+        )
+        .unwrap();
+
+        preserve_masked_connect_secrets(&mut patch, &current);
+
+        assert_eq!(
+            patch["connect"]["platforms"][0]["token"], "bot-b-token",
+            "with no type to check, the id match resolves to its own entry, not the positional one"
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #490/#492, filed as #496 by the automated issue loop. With two `connect.platforms` entries sharing the same `platform_type` (e.g. two `"telegram"` bots, once multi-bot is supported), the existing positional+type-guard mask resolution in `preserve_masked_connect_secrets` cannot always tell them apart — a reorder of the two same-typed entries is invisible to a `type`-equality check. Today's impact is theoretical (the UI only ever writes one entry per type, and `multi_bot_guard` only starts the first per type), but the schema had no way to close the gap properly.

## What changed

1. **`ConnectPlatformConfig` gains an optional stable `id: Option<String>`** (`crates/infra/bamboo-config/src/config.rs`). Absent on legacy entries and back-compat by default (`#[serde(default, skip_serializing_if = "Option::is_none")]`).
2. **`Config::assign_connect_platform_ids`** (new, `pub`) backfills a random UUID (`uuid` v4, added as a `bamboo-config` dependency via the existing workspace pin) onto any `connect.platforms` entry missing one. Called:
   - Inside `Config::save_to_dir` on its internal save-copy, so *every* path that persists `connect.json` gets ids backfilled (CLI `config set`, fabric-deploy snapshots, permission storage, the settings HTTP endpoints, etc).
   - Directly in `AppState::update_config` / `AppState::replace_config` (`crates/app/bamboo-server/src/app_state/config_runtime.rs`) on the *live* in-memory config, so a PATCH's own HTTP response (and any GET immediately after, before a restart) already reflects the assigned id — not just the next reload.
   - **Never** on load — a config that's mid an unconfirmed corruption-recovery (#493) is never rewritten just to backfill an id; ids only get persisted through the normal save path.
3. **`preserve_masked_connect_secrets`** (`crates/infra/bamboo-config/src/patch.rs`) now tries, in order:
   1. **Id match** (new) — if the patch entry carries an `id` matching one in `current`, that entry is authoritative, independent of position or `platform_type`. This is the only strategy that correctly disambiguates two same-typed entries that were reordered relative to each other.
   2. Positional + `type` guard (existing).
   3. Type-based fallback across all of `current` (existing, #490).
   
   A patch entry with no `id` (legacy/back-compat) or an `id` that doesn't match anything in `current` (e.g. a brand-new entry, or a stale id after removal) falls straight through to strategies 2/3 unchanged.

## Tests

- `bamboo-config` (`patch.rs`): all existing `preserve_masked_connect_secrets_*` cases still pass unmodified (back-compat), plus new cases:
  - `preserve_masked_connect_secrets_resolves_duplicate_type_by_id_even_when_reordered` — the exact scenario from #496: two `"telegram"` entries, swapped positions, both masked — id resolves each to its own token instead of the wrong sibling's.
  - `preserve_masked_connect_secrets_falls_back_when_id_not_found_in_current` — an unmatched id falls through to positional/type resolution.
  - `preserve_masked_connect_secrets_ignores_id_branch_when_patch_omits_id` — a patch without `id` is unaffected even when `current` entries do have ids.
- `bamboo-config` (`config.rs`): `save_assigns_a_missing_connect_platform_id`, `save_never_reassigns_an_existing_connect_platform_id`, `save_assigns_distinct_ids_to_duplicate_platform_type_entries`, `load_never_assigns_or_persists_an_id_by_itself` (proves load leaves `connect.json` byte-for-byte untouched, per #493).
- Updated 9 existing `ConnectPlatformConfig { .. }` struct literals across `bamboo-config` and `bamboo-server` (incl. `redaction/tests.rs`) to add the new field — grepped repo-wide, no literal missed.

### Results
- `cargo fmt -p bamboo-config -p bamboo-server -- --check` — clean
- `cargo clippy -p bamboo-config -p bamboo-server --all-targets --no-deps` — no new warnings (one pre-existing unrelated `too_many_arguments` warning, same one noted in #493)
- `cargo build --workspace --tests` — green
- `cargo test -p bamboo-config --lib` — 244 passed
- `cargo test -p bamboo-server --lib` — 1318 passed

## Lotus follow-up (not done in this PR)

Lotus's connect settings tab (Lotus PR #55) currently echoes whole `connect.platforms` entries back verbatim on save, which means it will automatically round-trip the new `id` once the backend starts returning it — **no Lotus change is required for correctness**. Suggested future improvement for Lotus, once/if multi-bot (multiple entries of the same `platform_type`) ships in the UI: key list rows by `id` (falling back to array index for legacy entries with no id) instead of array index alone, so reordering rows in the UI can't itself become a source of confusion on the frontend side, mirroring the backend's new resolution order.

Closes #496.