### PR TITLE
test(broker): force deterministic rendezvous in overlap tests

### DIFF
--- a/crates/app/bamboo-broker/src/mcp.rs
+++ b/crates/app/bamboo-broker/src/mcp.rs
@@ -1303,27 +1303,29 @@ mod tests {
     #[tokio::test]
     async fn concurrent_proxy_calls_overlap_at_the_orchestrator() {
         // Prove overlap DIRECTLY (issue #486) instead of inferring it from
-        // wall-clock duration: earlier this asserted `elapsed < N ms`
-        // against a `sleep(200ms)` backend, which raced CI load — a loaded
-        // runner can push even genuinely-concurrent calls past any fixed
-        // real-ms bound, producing a one-off failure with no code
-        // regression. (A `tokio::time::pause()` virtual-clock variant was
-        // tried and discarded: it doesn't compose safely with this test's
-        // REAL TCP/WebSocket IO — auto-advance raced the broker
-        // connect/handshake against the proxy's timeout-and-reconnect path,
-        // spuriously triggering reconnect/backoff and making the measured
-        // "elapsed" worse, not more deterministic.)
+        // wall-clock duration: this originally asserted `elapsed < N ms`
+        // against a `sleep(200ms)` backend, which raced CI load. Then #502
+        // switched to a high-water-mark (`fetch_max` of instantaneous
+        // `in_flight`), which is deterministic in the "genuinely serial"
+        // direction but still racy in the "CPU-starved" direction: under
+        // extreme scheduler pressure the 4 spawned calls might never all
+        // actually be polled at once, so the observed high-water mark can
+        // top out below 4 even though the orchestrator itself doesn't
+        // serialize anything — a false failure with no code regression.
         //
-        // Instead, `SlowMcp` tracks its own instantaneous concurrency: bump
-        // `in_flight` before the (still real, still 200ms — exercising the
-        // exact same overlap window) sleep, record the high-water mark via
-        // `fetch_max`, then decrement after. Serial handling could never
-        // observe more than 1 in flight at a time; genuine overlap of the 4
-        // spawned calls must observe all 4 at some point. Zero dependency on
-        // how fast or slow the host happens to be.
+        // Fix: force the rendezvous instead of hoping for it. `SlowMcp`
+        // bumps `in_flight`/`max_in_flight` and then blocks each call on a
+        // `Barrier` sized for all 4 concurrent calls — nobody proceeds until
+        // all 4 have arrived. That makes `max_in_flight == 4` deterministic
+        // regardless of how loaded the host is. If the orchestrator ever
+        // regresses to serializing these calls, only 1 of the 4 barrier
+        // parties will ever arrive and the wait deadlocks — bounded by the
+        // outer `tokio::time::timeout` below, which turns that regression
+        // into a clear, fast test failure instead of a hang.
         struct SlowMcp {
             in_flight: AtomicU32,
             max_in_flight: AtomicU32,
+            rendezvous: tokio::sync::Barrier,
         }
         #[async_trait]
         impl ToolExecutor for SlowMcp {
@@ -1331,7 +1333,11 @@ mod tests {
                 let now_in_flight = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
                 self.max_in_flight
                     .fetch_max(now_in_flight, Ordering::SeqCst);
-                tokio::time::sleep(Duration::from_millis(200)).await;
+                // Forced rendezvous: block until all 4 concurrent calls have
+                // arrived here. This is what makes the overlap deterministic
+                // rather than probabilistic.
+                self.rendezvous.wait().await;
+                tokio::time::sleep(Duration::from_millis(50)).await;
                 self.in_flight.fetch_sub(1, Ordering::SeqCst);
                 Ok(ToolResult {
                     success: true,
@@ -1358,9 +1364,11 @@ mod tests {
                 }]
             }
         }
+        const N: u32 = 4;
         let slow_mcp = Arc::new(SlowMcp {
             in_flight: AtomicU32::new(0),
             max_in_flight: AtomicU32::new(0),
+            rendezvous: tokio::sync::Barrier::new(N as usize),
         });
 
         let dir = tempfile::tempdir().unwrap();
@@ -1402,10 +1410,11 @@ mod tests {
             .expect("proxy connects"),
         );
 
-        // 4 concurrent 200ms calls; `SlowMcp::max_in_flight` records the
-        // high-water mark of calls it observed simultaneously in progress.
+        // N concurrent 50ms calls, forced to rendezvous inside `SlowMcp`;
+        // `max_in_flight` records the high-water mark of calls it observed
+        // simultaneously in progress.
         let mut handles = Vec::new();
-        for i in 0..4u32 {
+        for i in 0..N {
             let p = proxy.clone();
             handles.push(tokio::spawn(async move {
                 let call = ToolCall {
@@ -1419,13 +1428,21 @@ mod tests {
                 p.execute(&call).await.expect("returns")
             }));
         }
-        for h in handles {
-            h.await.unwrap();
-        }
+        tokio::time::timeout(Duration::from_secs(20), async {
+            for h in handles {
+                h.await.unwrap();
+            }
+        })
+        .await
+        .expect(
+            "timed out waiting for the 4 concurrent proxy calls to complete — this means \
+             the orchestrator is serializing them (only some of the 4 ever reached the \
+             rendezvous barrier), which is the regression this test guards against",
+        );
         let max_in_flight = slow_mcp.max_in_flight.load(Ordering::SeqCst);
         assert_eq!(
-            max_in_flight, 4,
-            "4 concurrent proxy calls must OVERLAP at the orchestrator (serial handling \
+            max_in_flight, N,
+            "{N} concurrent proxy calls must OVERLAP at the orchestrator (serial handling \
              could never observe more than 1 in flight at once); observed max_in_flight = \
              {max_in_flight}"
         );

--- a/crates/app/bamboo-broker/src/serve.rs
+++ b/crates/app/bamboo-broker/src/serve.rs
@@ -879,11 +879,34 @@ mod tests {
     #[tokio::test]
     async fn concurrent_asks_to_one_worker_overlap() {
         use bamboo_subagent::{ChildExecutor, ChildOutcome, EventSink, RunSpec, SteerInbox};
-        use std::time::Instant;
+        use std::sync::atomic::{AtomicU32, Ordering};
 
-        // An executor where each run takes 200ms. Serial handling of N asks to ONE
-        // worker would take ~N*200ms; concurrent (per-ask spawn) overlaps to ~200ms.
-        struct SlowEcho;
+        // N concurrent asks to ONE worker. Prove overlap DIRECTLY (issue #486)
+        // instead of inferring it from wall-clock duration: this originally
+        // asserted `elapsed < 500ms` against a `sleep(200ms)` backend, which
+        // raced CI load — a loaded runner can push even genuinely-concurrent
+        // asks past any fixed real-ms bound, producing a one-off failure with
+        // no code regression.
+        //
+        // Fix: `SlowEcho` tracks its own instantaneous concurrency
+        // (`in_flight` / `max_in_flight` high-water mark via `fetch_max`) AND
+        // forces the rendezvous instead of hoping the scheduler produces it:
+        // each of the N batch runs blocks on a `Barrier` sized for N until
+        // all N have arrived, so `max_in_flight == N` is deterministic
+        // regardless of host load. If per-ask spawn ever regresses to serial
+        // handling, only 1 of the N barrier parties will ever arrive and the
+        // wait deadlocks — bounded by the outer `tokio::time::timeout` below,
+        // turning that regression into a clear, fast failure instead of a
+        // hang. The preceding subscription probe ("ping") is exempted from
+        // the barrier — it runs alone, before the batch, specifically to
+        // confirm subscription, and would otherwise deadlock waiting for N-1
+        // batch calls that haven't been sent yet.
+        const N: usize = 4;
+        struct SlowEcho {
+            in_flight: AtomicU32,
+            max_in_flight: AtomicU32,
+            rendezvous: tokio::sync::Barrier,
+        }
         #[async_trait::async_trait]
         impl ChildExecutor for SlowEcho {
             async fn run(
@@ -893,13 +916,29 @@ mod tests {
                 _steer: SteerInbox,
                 _cancel: CancellationToken,
             ) -> ChildOutcome {
-                tokio::time::sleep(Duration::from_millis(200)).await;
+                if spec.assignment == "ping" {
+                    return ChildOutcome::completed(format!("done: {}", spec.assignment));
+                }
+                let now_in_flight = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                self.max_in_flight
+                    .fetch_max(now_in_flight, Ordering::SeqCst);
+                // Forced rendezvous: block until all N concurrent batch asks
+                // have arrived here.
+                self.rendezvous.wait().await;
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                self.in_flight.fetch_sub(1, Ordering::SeqCst);
                 ChildOutcome::completed(format!("done: {}", spec.assignment))
             }
         }
+        let slow_echo = Arc::new(SlowEcho {
+            in_flight: AtomicU32::new(0),
+            max_in_flight: AtomicU32::new(0),
+            rendezvous: tokio::sync::Barrier::new(N),
+        });
 
         let (endpoint, _dir) = start().await;
         let worker_ep = endpoint.clone();
+        let slow_echo_for_worker = slow_echo.clone();
         tokio::spawn(async move {
             let _ = serve_executor(
                 &worker_ep,
@@ -908,7 +947,7 @@ mod tests {
                     role: None,
                 },
                 TOKEN,
-                Arc::new(SlowEcho),
+                slow_echo_for_worker,
             )
             .await;
         });
@@ -942,30 +981,37 @@ mod tests {
         }
 
         // Fire N concurrent (Query) Asks to the SAME worker, then await all N
-        // correlated replies. Serial would be ~N*200ms; concurrent ~200ms.
-        const N: usize = 4;
+        // correlated replies. Each batch run is forced to rendezvous inside
+        // `SlowEcho` (see above), so genuine overlap is deterministic rather
+        // than inferred from wall-clock duration.
         let mut want: std::collections::HashSet<MsgId> = std::collections::HashSet::new();
-        let start = Instant::now();
         for i in 0..N {
             let q = ask("orch", &format!("q{i}"));
             want.insert(q.id.clone());
             orch.deliver("worker", q).await.unwrap();
         }
-        while !want.is_empty() {
-            let r = tokio::time::timeout(Duration::from_secs(5), orch.next_message())
-                .await
-                .expect("a reply arrives")
-                .expect("present");
-            if let Some(cid) = &r.correlation_id {
-                want.remove(cid);
+        tokio::time::timeout(Duration::from_secs(20), async {
+            while !want.is_empty() {
+                let r = tokio::time::timeout(Duration::from_secs(5), orch.next_message())
+                    .await
+                    .expect("a reply arrives")
+                    .expect("present");
+                if let Some(cid) = &r.correlation_id {
+                    want.remove(cid);
+                }
             }
-        }
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed < Duration::from_millis(500),
-            "{N} concurrent 200ms Asks to ONE worker must OVERLAP \
-             (serial would be ~{}ms); took {elapsed:?}",
-            N * 200
+        })
+        .await
+        .expect(
+            "timed out waiting for the N concurrent Asks to complete — this means the \
+             per-ask spawn is serializing them (only some of the N ever reached the \
+             rendezvous barrier), which is the regression this test guards against",
+        );
+        let max_in_flight = slow_echo.max_in_flight.load(Ordering::SeqCst);
+        assert_eq!(
+            max_in_flight, N as u32,
+            "{N} concurrent Asks to ONE worker must OVERLAP (serial handling could never \
+             observe more than 1 in flight at once); observed max_in_flight = {max_in_flight}"
         );
     }
 


### PR DESCRIPTION
## Problem

Two broker overlap tests are chronic CI flakes tracked in #486, and both failed again TODAY (2026-07-16) even after #502's deflake pass:

- `mcp::tests::concurrent_proxy_calls_overlap_at_the_orchestrator` — failed on the PR #508 run, despite #502 having already moved it from wall-clock timing to an in-flight high-water-mark assertion (`max_in_flight == 4`).
- `serve::tests::concurrent_asks_to_one_worker_overlap` (serve.rs:964) — failed on the PR #499 and #508 runs; it still asserted `elapsed < 500ms` against 4×200ms sleeps.

Root cause: both tests assert "concurrency happened" by observing the scheduler. That is deterministic in the *genuinely serial* direction, but still racy in the *CPU-starved* direction — on a loaded runner the N spawned calls may simply never all be polled at once, so the high-water mark tops out below N (or the wall clock blows the bound) with no code regression.

## Fix

Force the rendezvous instead of hoping for it. In both tests the stub executor now blocks each call on a `tokio::sync::Barrier` sized for N (4) until all N concurrent calls have arrived, then releases them together:

- `max_in_flight == N` becomes deterministic regardless of host load — starvation can delay the rendezvous but can't break it.
- If the code under test ever regresses to serializing the calls, only one barrier party arrives and the wait deadlocks — bounded by a generous outer `tokio::time::timeout(20s)` whose expect message names the serialization regression explicitly. That deadlock-into-clear-failure IS the regression signal the tests exist for.
- The serve.rs test's wall-clock `elapsed < 500ms` assertion is replaced by the same high-water-mark assertion; its pre-batch subscription probe ("ping") is exempted from the barrier (it runs alone before the batch and would otherwise deadlock).
- Post-barrier sleeps trimmed 200ms → 50ms (they no longer carry the overlap-window burden).

Assertion *intent* is unchanged: calls to one orchestrator/worker CAN overlap, i.e. handling is not serialized.

## Stability evidence

- 300 iterations green: 100 each at `--test-threads` 1 / 8 / 64.
- 150 further iterations green (50 per thread-count) while 20 busy-loop CPU hogs pinned a 10-core host at load avg >150 — the exact starvation regime that produced today's CI failures.
- `cargo fmt` / clippy clean for the crate; `cargo build --workspace --tests` green; full `cargo test -p bamboo-broker` green (86 tests).

Addresses #486 (post-#502 residual flakes).

https://claude.ai/code/session_01Ux4nHUqFjEEGV3rX1x3V9Y