### PR TITLE
fix: previous_response_not_found — stop chaining previous_response_id onto store=false Responses turns

### DIFF
--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
@@ -64,6 +64,35 @@ fn provider_supports_previous_response_id(provider_type: Option<&str>) -> bool {
     !matches!(provider_type.map(str::trim), Some("copilot"))
 }
 
+/// The engine's Responses-API request POLICY — store / verbosity / reasoning
+/// summary / include list — defined in ONE place so the continuation gate below
+/// and the planned request can never disagree about `store`.
+fn engine_responses_policy() -> ResponsesRequestOptions {
+    ResponsesRequestOptions {
+        store: Some(false),
+        // Encourage the model to emit visible narration alongside tool calls.
+        text_verbosity: Some("high".to_string()),
+        reasoning_summary: Some("auto".to_string()),
+        include: Some(vec!["reasoning.encrypted_content".to_string()]),
+        ..Default::default()
+    }
+}
+
+/// Whether the stateful Responses continuation (`previous_response_id`) may be
+/// used under the given request policy. Chaining requires the PREVIOUS turn to
+/// have been stored upstream: with `store=false` the upstream never persists a
+/// turn, so referencing its id on the next round fails with HTTP 400
+/// `invalid_request_error` / `previous_response_not_found`. Since the engine
+/// always sends the full input array alongside the id, omitting it under a
+/// stateless policy loses nothing. Copilot's HTTP /responses endpoint rejects
+/// the parameter outright, so it is excluded regardless of policy.
+fn responses_continuation_enabled(
+    policy: &ResponsesRequestOptions,
+    provider_type: Option<&str>,
+) -> bool {
+    policy.store == Some(true) && provider_supports_previous_response_id(provider_type)
+}
+
 fn format_reqwest_transport_error(error: &reqwest::Error) -> String {
     let mut kinds = Vec::new();
     if error.is_timeout() {
@@ -604,14 +633,7 @@ fn plan_llm_request(
     // The engine sets request POLICY only. The Responses prompt wire view
     // (instructions / input_messages / previous_response_id) is derived by the
     // OpenAI/Copilot adapter from the IR via `responses_request_options`.
-    let responses_options = ResponsesRequestOptions {
-        store: Some(false),
-        // Encourage the model to emit visible narration alongside tool calls.
-        text_verbosity: Some("high".to_string()),
-        reasoning_summary: Some("auto".to_string()),
-        include: Some(vec!["reasoning.encrypted_content".to_string()]),
-        ..Default::default()
-    };
+    let responses_options = engine_responses_policy();
 
     let request_options = LLMRequestOptions {
         session_id: Some(session_id.to_string()),
@@ -682,10 +704,14 @@ pub(super) async fn execute_llm_stream(
     let session_id = frame.session_id;
 
     let llm_started_at = std::time::Instant::now();
-    let supports_previous_response_id = provider_supports_previous_response_id(provider_type);
+    // Stateful chaining is gated on the request policy: a `store=false` turn is
+    // never persisted upstream, so its id must not be sent back (it would 400
+    // with `previous_response_not_found`) nor kept in session metadata.
+    let responses_policy = engine_responses_policy();
+    let continuation_enabled = responses_continuation_enabled(&responses_policy, provider_type);
     // Owned (not borrowed) so the immutable borrow of `session` ends here and the
     // drift diagnostic below can take `&mut session`.
-    let previous_response_id = if supports_previous_response_id {
+    let previous_response_id = if continuation_enabled {
         session_previous_response_id(session).map(str::to_string)
     } else {
         None
@@ -730,10 +756,11 @@ pub(super) async fn execute_llm_stream(
         reasoning_effort,
         tool_schemas.len(),
     );
-    if !supports_previous_response_id {
+    if !continuation_enabled {
         tracing::debug!(
-            "[{}] Responses API previous_response_id disabled for provider={}",
+            "[{}] Responses API previous_response_id disabled (store={:?}, provider={})",
             session_id,
+            responses_policy.store,
             provider_name.unwrap_or("unknown")
         );
     }
@@ -876,7 +903,7 @@ pub(super) async fn execute_llm_stream(
         }
     }
 
-    if supports_previous_response_id {
+    if continuation_enabled {
         if let Some(response_id) = stream_output
             .response_id
             .as_deref()

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
@@ -1511,7 +1511,13 @@ fn ir_responses_view_orders_guide_skill_conversation_and_lifts_system_to_instruc
 }
 
 #[tokio::test]
-async fn execute_llm_stream_continues_responses_turn_with_delta_messages() {
+async fn execute_llm_stream_ignores_previous_response_id_under_stateless_store_policy() {
+    // The engine's Responses policy is stateless (`store=false`): the upstream
+    // never persists a turn, so a chained `previous_response_id` is guaranteed to
+    // fail with `previous_response_not_found`. A session that still carries a
+    // stale id (persisted by a pre-fix build) must be sent as a FULL request with
+    // NO continuation, the stale id must be scrubbed from metadata, and the new
+    // response id must NOT be persisted for the next round.
     let _env_lock = isolate_prompt_safe_env_cache();
     let mut session = Session::new("session-stream-2", "test-model");
     session.metadata.insert(
@@ -1569,17 +1575,17 @@ async fn execute_llm_stream_continues_responses_turn_with_delta_messages() {
         .lock()
         .expect("messages lock")
         .clone();
-    assert_eq!(requested_messages.len(), 1);
-    assert!(matches!(requested_messages[0].role, Role::Tool));
-    assert!(requested_messages
-        .iter()
-        .all(|message| !matches!(message.role, Role::System)));
+    // FULL request (no continuation delta): system field + whole conversation.
+    assert_eq!(requested_messages.len(), 4);
+    assert!(matches!(requested_messages[0].role, Role::System));
+    assert!(matches!(requested_messages[3].role, Role::Tool));
+    // The stale id is NOT sent to the provider.
     assert_eq!(
         llm.requested_previous_response_id
             .lock()
             .expect("previous_response_id lock")
             .as_deref(),
-        Some("resp_prev")
+        None
     );
     assert_eq!(
         llm.requested_instructions
@@ -1617,20 +1623,60 @@ async fn execute_llm_stream_continues_responses_turn_with_delta_messages() {
             .as_deref(),
         Some("session-stream-2")
     );
+    // The stream still surfaces the upstream response id, but under a stateless
+    // store policy the engine neither keeps the stale id nor persists the new
+    // one — the metadata key is scrubbed entirely.
     assert_eq!(stream_output.response_id.as_deref(), Some("resp_next"));
-    assert_eq!(
-        session
-            .metadata
-            .get("responses.previous_response_id")
-            .map(String::as_str),
-        Some("resp_next")
-    );
+    assert!(!session
+        .metadata
+        .contains_key("responses.previous_response_id"));
+}
+
+#[test]
+fn responses_continuation_enabled_requires_store_true_and_supported_provider() {
+    use bamboo_llm::provider::ResponsesRequestOptions;
+
+    // The engine's shipped policy is stateless — this is the invariant that
+    // guarantees no `previous_response_id` ever rides a `store=false` turn
+    // (OpenAI rejects that with 400 `previous_response_not_found`).
+    let shipped = super::engine_responses_policy();
+    assert_eq!(shipped.store, Some(false));
+    assert!(!super::responses_continuation_enabled(
+        &shipped,
+        Some("openai")
+    ));
+
+    // A stateful (store=true) policy re-enables chaining for providers that
+    // support the parameter…
+    let stateful = ResponsesRequestOptions {
+        store: Some(true),
+        ..Default::default()
+    };
+    assert!(super::responses_continuation_enabled(
+        &stateful,
+        Some("openai")
+    ));
+    assert!(super::responses_continuation_enabled(&stateful, None));
+    // …but never for Copilot, whose HTTP /responses endpoint rejects it.
+    assert!(!super::responses_continuation_enabled(
+        &stateful,
+        Some("copilot")
+    ));
+
+    // store unset defaults to the stateless wire value (false) → disabled.
+    let unset = ResponsesRequestOptions::default();
+    assert!(!super::responses_continuation_enabled(
+        &unset,
+        Some("openai")
+    ));
 }
 
 #[tokio::test]
-async fn execute_llm_stream_continuation_includes_external_memory_dynamic_block() {
+async fn execute_llm_stream_includes_external_memory_volatile_block() {
     let _env_lock = isolate_prompt_safe_env_cache();
     let mut session = Session::new("session-stream-2a", "test-model");
+    // A stale continuation id may still be present (pre-fix persistence); under
+    // the stateless store policy it is ignored and the request is sent in full.
     session.metadata.insert(
         "responses.previous_response_id".to_string(),
         "resp_prev".to_string(),
@@ -1692,21 +1738,31 @@ async fn execute_llm_stream_continuation_includes_external_memory_dynamic_block(
         .lock()
         .expect("messages lock")
         .clone();
-    // Volatile context (external memory) is re-sent in the delta but now at the
-    // tail, after the conversation continuation.
-    assert_eq!(requested_messages.len(), 2);
-    assert!(matches!(requested_messages[0].role, Role::Tool));
-    assert!(matches!(requested_messages[1].role, Role::User));
-    assert!(requested_messages[1]
+    // Full request: system field, whole conversation, then the volatile external
+    // memory block at the tail (out of the cacheable prefix).
+    assert_eq!(requested_messages.len(), 5);
+    assert!(matches!(requested_messages[0].role, Role::System));
+    assert!(matches!(requested_messages[3].role, Role::Tool));
+    assert!(matches!(requested_messages[4].role, Role::User));
+    assert!(requested_messages[4]
         .content
         .contains("context_type: external_memory"));
-    assert!(requested_messages[1].content.contains("Session note body"));
+    assert!(requested_messages[4].content.contains("Session note body"));
+    // The stale continuation id was ignored, not forwarded.
+    assert_eq!(
+        llm.requested_previous_response_id
+            .lock()
+            .expect("previous_response_id lock")
+            .as_deref(),
+        None
+    );
 }
 
 #[tokio::test]
-async fn execute_llm_stream_continuation_includes_plan_mode_and_runtime_dynamic_blocks() {
+async fn execute_llm_stream_includes_plan_mode_and_runtime_volatile_blocks() {
     let _env_lock = isolate_prompt_safe_env_cache();
     let mut session = Session::new("session-stream-2plan", "test-model");
+    // Stale continuation id: ignored under the stateless store policy.
     session.metadata.insert(
         "responses.previous_response_id".to_string(),
         "resp_prev".to_string(),
@@ -1777,29 +1833,31 @@ async fn execute_llm_stream_continuation_includes_plan_mode_and_runtime_dynamic_
         .lock()
         .expect("messages lock")
         .clone();
-    // Conversation continuation first, then the volatile plan blocks at the tail
-    // (in push order: plan_runtime, then plan_mode).
-    assert_eq!(requested_messages.len(), 3);
-    assert!(matches!(requested_messages[0].role, Role::Tool));
-    assert!(matches!(requested_messages[1].role, Role::User));
-    assert!(requested_messages[1]
+    // Full request: system field + conversation, then the volatile plan blocks
+    // at the tail (in push order: plan_runtime, then plan_mode).
+    assert_eq!(requested_messages.len(), 6);
+    assert!(matches!(requested_messages[0].role, Role::System));
+    assert!(matches!(requested_messages[3].role, Role::Tool));
+    assert!(matches!(requested_messages[4].role, Role::User));
+    assert!(requested_messages[4]
         .content
         .contains("context_type: plan_runtime_state"));
-    assert!(requested_messages[1]
+    assert!(requested_messages[4]
         .content
         .contains("DURABLE PLAN EXECUTION CONTEXT"));
-    assert!(matches!(requested_messages[2].role, Role::User));
-    assert!(requested_messages[2]
+    assert!(matches!(requested_messages[5].role, Role::User));
+    assert!(requested_messages[5]
         .content
         .contains("context_type: plan_mode_state"));
-    assert!(requested_messages[2].content.contains("PLAN MODE ACTIVE"));
+    assert!(requested_messages[5].content.contains("PLAN MODE ACTIVE"));
 }
 
 #[tokio::test]
-async fn execute_llm_stream_keeps_previous_response_id_when_local_summary_or_compression_is_active()
-{
+async fn execute_llm_stream_sends_full_request_with_summary_when_compression_is_active() {
     let _env_lock = isolate_prompt_safe_env_cache();
     let mut session = Session::new("session-stream-2b", "test-model");
+    // Stale continuation id: ignored under the stateless store policy — the
+    // request rides the full lanes wire with the summary as dynamic context.
     session.metadata.insert(
         "responses.previous_response_id".to_string(),
         "resp_prev".to_string(),
@@ -1861,26 +1919,30 @@ async fn execute_llm_stream_keeps_previous_response_id_when_local_summary_or_com
         .lock()
         .expect("messages lock")
         .clone();
-    assert_eq!(requested_messages.len(), 3);
-    assert!(matches!(requested_messages[0].role, Role::User));
-    assert!(requested_messages[0]
+    // Full request: system field, the summary as dynamic context, then the whole
+    // (compressed) conversation window.
+    assert_eq!(requested_messages.len(), 6);
+    assert!(matches!(requested_messages[0].role, Role::System));
+    assert!(matches!(requested_messages[1].role, Role::User));
+    assert!(requested_messages[1]
         .content
         .contains("context_type: conversation_summary"));
-    assert!(requested_messages[0]
+    assert!(requested_messages[1]
         .content
         .contains("Older work has been summarized locally."));
-    assert!(matches!(requested_messages[1].role, Role::User));
+    assert!(matches!(requested_messages[2].role, Role::User));
     assert_eq!(
-        requested_messages[1].content,
-        "continue from the compressed state"
+        requested_messages[2].content,
+        "previous work was compressed"
     );
-    assert!(matches!(requested_messages[2].role, Role::Tool));
+    assert!(matches!(requested_messages[5].role, Role::Tool));
+    // The stale continuation id was ignored, not forwarded.
     assert_eq!(
         llm.requested_previous_response_id
             .lock()
             .expect("previous_response_id lock")
             .as_deref(),
-        Some("resp_prev")
+        None
     );
     assert_eq!(
         llm.requested_instructions

--- a/crates/infra/bamboo-llm/src/prompt_ir.rs
+++ b/crates/infra/bamboo-llm/src/prompt_ir.rs
@@ -398,7 +398,6 @@ mod tests {
 
     #[test]
     fn responses_request_options_omits_instructions_when_system_blank() {
-        use crate::provider::ResponsesRequestOptions;
         let ir = PromptIR {
             system_text: "   ".to_string(),
             ..PromptIR::default()

--- a/crates/infra/bamboo-llm/src/providers/common/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/mod.rs
@@ -45,6 +45,72 @@ pub(crate) fn looks_like_reasoning_unsupported_error(
     mentions_reasoning && indicates_unsupported
 }
 
+/// Whether an error response means the referenced `previous_response_id` does
+/// not exist upstream (OpenAI's `previous_response_not_found`), so a single
+/// retry WITHOUT the stateful continuation is warranted. Bamboo always sends
+/// the full input array alongside the id, so dropping it loses no context.
+///
+/// This fires for ids that reference a `store=false` (never persisted) turn,
+/// ids past the upstream retention window, ids minted under a different
+/// key/org, and fabricated ids a compat-proxy client chained back. It must NOT
+/// fire on other "not found" errors (e.g. an unknown model), so it requires an
+/// explicit mention of the previous-response parameter.
+pub(crate) fn looks_like_previous_response_not_found_error(
+    status: reqwest::StatusCode,
+    body: &str,
+) -> bool {
+    if !(status == 400 || status == 404) {
+        return false;
+    }
+    let b = body.to_ascii_lowercase();
+    if b.contains("previous_response_not_found") {
+        return true;
+    }
+    let mentions_previous_response =
+        b.contains("previous_response_id") || b.contains("previous response");
+    let indicates_missing =
+        b.contains("not found") || b.contains("not_found") || b.contains("does not exist");
+    mentions_previous_response && indicates_missing
+}
+
+#[cfg(test)]
+mod previous_response_not_found_tests {
+    use super::looks_like_previous_response_not_found_error as f;
+    use reqwest::StatusCode;
+
+    #[test]
+    fn fires_on_openai_previous_response_not_found_error() {
+        let bad = StatusCode::BAD_REQUEST;
+        // The exact OpenAI error shape (code = previous_response_not_found).
+        assert!(f(
+            bad,
+            r#"{"error":{"message":"Previous response with id 'resp_123' not found.","type":"invalid_request_error","param":"previous_response_id","code":"previous_response_not_found"}}"#
+        ));
+        // Message-only variants, with and without the structured code.
+        assert!(f(bad, "Previous response with id 'resp_x' not found."));
+        assert!(f(bad, "previous_response_id 'resp_x' does not exist"));
+        assert!(f(StatusCode::NOT_FOUND, "previous_response_not_found"));
+    }
+
+    #[test]
+    fn does_not_fire_on_unrelated_errors() {
+        let bad = StatusCode::BAD_REQUEST;
+        // Other "not found" errors must not trigger a continuation-stripping retry.
+        assert!(!f(bad, "The model `gpt-x` does not exist or is not found"));
+        assert!(!f(bad, "Invalid value for 'previous_response_id'")); // bad VALUE, not missing
+        assert!(!f(
+            bad,
+            "previous_response_id is not supported for this model"
+        )); // Copilot-style unsupported, handled separately
+            // Non-4xx statuses never qualify.
+        assert!(!f(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "previous_response_not_found"
+        ));
+        assert!(!f(StatusCode::UNAUTHORIZED, "previous response not found"));
+    }
+}
+
 #[cfg(test)]
 mod reasoning_heuristic_tests {
     use super::looks_like_reasoning_unsupported_error as f;

--- a/crates/infra/bamboo-llm/src/providers/openai/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/openai/mod.rs
@@ -219,6 +219,75 @@ impl OpenAIProvider {
             let status = response.status();
             let text = response.text().await?;
 
+            // The upstream can no longer resolve the stateful continuation id —
+            // e.g. the referenced turn was never stored (`store=false`), aged out
+            // of retention, or belongs to another key/org. The full input array
+            // is sent alongside the id, so retrying once WITHOUT the continuation
+            // is lossless and keeps the session alive instead of hard-failing.
+            let sent_previous_response_id = responses_options
+                .and_then(|opts| opts.previous_response_id.as_deref())
+                .map(str::trim)
+                .is_some_and(|value| !value.is_empty());
+            if sent_previous_response_id
+                && crate::providers::common::looks_like_previous_response_not_found_error(
+                    status, &text,
+                )
+            {
+                tracing::warn!(
+                    "OpenAI /responses could not find previous_response_id for model '{}'; retrying without stateful continuation. Upstream response: {}",
+                    model,
+                    text
+                );
+
+                let mut fallback_options = responses_options.cloned().unwrap_or_default();
+                fallback_options.previous_response_id = None;
+                let mut fallback_body = build_responses_body(
+                    model,
+                    messages,
+                    tools,
+                    max_output_tokens,
+                    reasoning_effort,
+                    Some(&fallback_options),
+                    parallel_tool_calls,
+                );
+                request_overrides::apply_overrides_to_body(
+                    &mut fallback_body,
+                    self.request_overrides.as_ref(),
+                    request_overrides::ENDPOINT_RESPONSES,
+                    Some(model),
+                );
+                crate::masking::mask_outbound_body(&mut fallback_body, &self.masking_config);
+                let fallback_headers =
+                    self.build_headers(request_overrides::ENDPOINT_RESPONSES, Some(model))?;
+                let fallback =
+                    crate::retry::send_with_retry(crate::retry::global(), "OpenAI", || {
+                        self.client
+                            .post(&responses_url)
+                            .headers(fallback_headers.clone())
+                            .json(&fallback_body)
+                    })
+                    .await?;
+
+                if !fallback.status().is_success() {
+                    let fallback_status = fallback.status();
+                    let fallback_text = fallback.text().await?;
+                    return Err(LLMError::Api(format!(
+                        "HTTP {}: {}",
+                        fallback_status, fallback_text
+                    )));
+                }
+
+                let mut parser =
+                    ResponsesSseParser::new_with_context("OpenAI", model, reasoning_effort);
+                let model_for_debug = model.to_string();
+                let stream = llm_stream_from_sse(fallback, move |event, data| {
+                    let parsed = parser.handle_event(event, data);
+                    append_responses_sse_record("OpenAI", &model_for_debug, event, data, &parsed);
+                    parsed
+                });
+                return Ok(stream);
+            }
+
             if reasoning_effort.is_some()
                 && Self::looks_like_reasoning_unsupported_error(status, &text)
             {
@@ -874,5 +943,161 @@ mod tests {
         // Model is passed to chat_stream() as a parameter
 
         assert_eq!(provider.base_url, "https://custom.api.com");
+    }
+
+    // ===== /responses previous_response_not_found fallback (wiremock) =====
+
+    use futures::StreamExt;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+    const PREVIOUS_RESPONSE_NOT_FOUND_BODY: &str = r#"{"error":{"message":"Previous response with id 'resp_stale' not found.","type":"invalid_request_error","param":"previous_response_id","code":"previous_response_not_found"}}"#;
+
+    const RESPONSES_SSE_OK: &str = "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\nevent: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_new\"}}\n\n";
+
+    /// Emulates the real OpenAI contract: a request chaining a stale (or never
+    /// stored) `previous_response_id` fails with 400
+    /// `previous_response_not_found`; a request without it streams normally.
+    struct PreviousResponseNotFoundResponder;
+
+    impl Respond for PreviousResponseNotFoundResponder {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            let body: serde_json::Value =
+                serde_json::from_slice(&request.body).expect("JSON request body");
+            if body.get("previous_response_id").is_some() {
+                ResponseTemplate::new(400).set_body_string(PREVIOUS_RESPONSE_NOT_FOUND_BODY)
+            } else {
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(RESPONSES_SSE_OK)
+            }
+        }
+    }
+
+    fn responses_provider(server: &MockServer) -> OpenAIProvider {
+        OpenAIProvider::new("test-key")
+            .with_base_url(server.uri())
+            .with_responses_only_models(vec!["gpt-5*".to_string()])
+    }
+
+    fn options_with_previous_response_id(id: Option<&str>) -> LLMRequestOptions {
+        LLMRequestOptions {
+            responses: Some(ResponsesRequestOptions {
+                previous_response_id: id.map(str::to_string),
+                store: Some(false),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    async fn collect_tokens(mut stream: LLMStream) -> String {
+        let mut text = String::new();
+        while let Some(chunk) = stream.next().await {
+            match chunk.expect("stream chunk") {
+                LLMChunk::Token(token) => text.push_str(&token),
+                LLMChunk::Done => break,
+                _ => {}
+            }
+        }
+        text
+    }
+
+    #[tokio::test]
+    async fn responses_retries_without_previous_response_id_on_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(PreviousResponseNotFoundResponder)
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let provider = responses_provider(&server);
+        let options = options_with_previous_response_id(Some("resp_stale"));
+        let stream = provider
+            .chat_stream_with_options(
+                &[Message::user("hello")],
+                &[],
+                None,
+                "gpt-5.2",
+                Some(&options),
+            )
+            .await
+            .expect("fallback retry without previous_response_id must succeed");
+
+        assert_eq!(collect_tokens(stream).await, "hi");
+
+        // First request chained the stale id; the retry dropped it but kept the
+        // full input array, so no context was lost.
+        let requests = server.received_requests().await.expect("requests recorded");
+        assert_eq!(requests.len(), 2);
+        let first: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+        let second: serde_json::Value = serde_json::from_slice(&requests[1].body).unwrap();
+        assert_eq!(first["previous_response_id"], "resp_stale");
+        assert!(second.get("previous_response_id").is_none());
+        assert_eq!(first["input"], second["input"]);
+    }
+
+    #[tokio::test]
+    async fn responses_does_not_retry_unrelated_400_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(ResponseTemplate::new(400).set_body_string(
+                r#"{"error":{"message":"The model `gpt-x` does not exist","type":"invalid_request_error","param":"model","code":"model_not_found"}}"#,
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider = responses_provider(&server);
+        let options = options_with_previous_response_id(Some("resp_stale"));
+        let error = match provider
+            .chat_stream_with_options(
+                &[Message::user("hello")],
+                &[],
+                None,
+                "gpt-5.2",
+                Some(&options),
+            )
+            .await
+        {
+            Ok(_) => panic!("unrelated 400 must not trigger the continuation fallback"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("model_not_found"));
+    }
+
+    #[tokio::test]
+    async fn responses_does_not_retry_not_found_when_no_continuation_was_sent() {
+        // A broken upstream that answers `previous_response_not_found` even though
+        // no id was sent must NOT put the provider into a retry loop.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(
+                ResponseTemplate::new(400).set_body_string(PREVIOUS_RESPONSE_NOT_FOUND_BODY),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider = responses_provider(&server);
+        let options = options_with_previous_response_id(None);
+        let error = match provider
+            .chat_stream_with_options(
+                &[Message::user("hello")],
+                &[],
+                None,
+                "gpt-5.2",
+                Some(&options),
+            )
+            .await
+        {
+            Ok(_) => panic!("no continuation sent → surface the upstream error as-is"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("previous_response_not_found"));
     }
 }


### PR DESCRIPTION
## Problem

Multi-round agent sessions against OpenAI's Responses API fail with:

```
HTTP 400 invalid_request_error, param: previous_response_id, code: previous_response_not_found
```

**Root cause:** the engine's Responses request policy is stateless (`store: false`), so the upstream never persists a turn — yet the engine persisted each turn's `response_id` and chained it back as `previous_response_id` on the next round. Referencing an unstored turn is guaranteed to 400 against any validating upstream. (The pre-existing doc comment on `Continuation` already flagged `store=false + previous_response_id` as a questionable contract — this confirms it and resolves it.)

A second exposure: the OpenAI-compat proxy (`/v1/responses`) fabricates `resp_<uuid>` ids when the upstream emits none (`non_stream.rs`); a client chaining that id back gets it forwarded verbatim upstream → same error.

## Fix (two layers)

**Engine** (`stream_execution.rs`)
- Responses policy extracted to `engine_responses_policy()` — single source of truth for `store`.
- New gate `responses_continuation_enabled(policy, provider_type)`: chaining requires `store == Some(true)` AND a provider that supports the param (Copilot excluded as before).
- Under the shipped stateless policy: no `previous_response_id` is sent, no response ids are persisted, and a stale id left by pre-fix builds is scrubbed from session metadata.
- Lossless by construction: the full input array was always sent alongside the id (`responses_continuation_uses_full_input_not_the_delta`), so dropping it changes nothing else on the wire.

**OpenAI provider** (`openai/mod.rs`, `providers/common`)
- New detector `looks_like_previous_response_not_found_error` (mirrors the reasoning-unsupported heuristic; requires an explicit previous-response mention so unrelated "not found" errors never trigger it).
- If a request that DID chain an id fails with it (store=true configs, expired/foreign ids, compat-proxy clients), retry once WITHOUT the continuation instead of hard-failing the session.

## Tests
- Continuation gate matrix (store × provider), incl. locking the shipped policy at `store=Some(false)`.
- `execute_llm_stream`: stale id ignored + scrubbed, full-request wire shape (volatile blocks/summary now asserted on the full wire), new response id not persisted.
- Detector positives (exact OpenAI error JSON) and negatives (model-not-found, bad-value, Copilot-style unsupported, non-4xx).
- wiremock provider tests: retry drops the id but keeps identical `input`; unrelated 400s not retried; not-found without a sent id not retried (no loop).

`cargo test -p bamboo-llm --lib` 465 ✓ · `cargo test -p bamboo-engine --lib` 926 ✓ · `cargo check --workspace --tests` ✓ · fmt ✓

https://claude.ai/code/session_014iw5PBsSzDFHus1GfkAK4y