### PR TITLE
fix(config): stop settings PATCHes from wiping provider api_key_encrypted (#516)

### DIFF
--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -165,6 +165,18 @@ impl AppState {
                 // (and any GET immediately after) already reflects the id a
                 // client can round-trip on its next PATCH.
                 cfg.assign_connect_platform_ids();
+                // Same live-vs-save-copy treatment for ciphertext (#516):
+                // `save_to_dir` refreshes `*_encrypted` only on its save-time
+                // clone, so a secret set through this entrypoint (e.g. a
+                // provider instance created over HTTP) would otherwise stay
+                // plaintext-only in memory — and the next settings-PATCH merge
+                // (`build_merged_config`'s serde round-trip drops plaintext)
+                // would lose the key entirely.
+                cfg.refresh_encrypted_secrets().map_err(|e| {
+                    AppError::InternalError(anyhow::anyhow!(
+                        "Failed to refresh encrypted secrets: {e}"
+                    ))
+                })?;
                 cfg.publish_env_vars();
                 let newly_off = !was_off && cfg.plugin_trust.enforcement_is_off();
                 (cfg.clone(), newly_off)
@@ -202,6 +214,11 @@ impl AppState {
         // caller (the settings-merge HTTP response) all agree on the same
         // ids — mirrors the `update_config` treatment above.
         new_config.assign_connect_platform_ids();
+        // Keep ciphertext in sync with plaintext on the config that becomes
+        // the live in-memory state — same #516 rationale as `update_config`.
+        new_config.refresh_encrypted_secrets().map_err(|e| {
+            AppError::InternalError(anyhow::anyhow!("Failed to refresh encrypted secrets: {e}"))
+        })?;
 
         // Same #126 serialization as update_config: mutate + persist under the
         // config-IO lock so a reload can't interleave; effects run unlocked.

--- a/crates/app/bamboo-server/src/config_manager.rs
+++ b/crates/app/bamboo-server/src/config_manager.rs
@@ -28,8 +28,8 @@ use bamboo_llm::Config;
 pub use bamboo_config::patch::{
     deep_merge_json, domains_for_root_patch, effects_for_root_patch, is_masked_api_key,
     preserve_masked_connect_secrets, preserve_masked_notification_secrets,
-    preserve_masked_provider_api_keys, provider_api_key_intents, sanitize_root_patch,
-    DomainChanges, PatchEffects, ReloadMode,
+    preserve_masked_provider_api_keys, preserve_unpatched_provider_secrets,
+    provider_api_key_intents, sanitize_root_patch, DomainChanges, PatchEffects, ReloadMode,
 };
 
 pub fn sync_provider_api_keys_encrypted_for_patch(
@@ -144,6 +144,11 @@ pub fn build_merged_config(
     current: &Config,
     patch_obj: Map<String, Value>,
 ) -> Result<Config, AppError> {
+    // Captured before the merge consumes the patch: which providers/instances
+    // this patch explicitly sets or clears — those must NOT get their dropped
+    // key carried forward below (#516).
+    let api_key_intents = provider_api_key_intents(&patch_obj);
+
     let mut merged = serde_json::to_value(current)
         .map_err(|e| AppError::InternalError(anyhow::anyhow!("Failed to serialize config: {e}")))?;
 
@@ -163,6 +168,12 @@ pub fn build_merged_config(
     // key (no ciphertext, #253) would be silently blanked by any settings PATCH.
     // Copy env-sourced keys back from the live `current` config. #373.
     new_config.preserve_env_sourced_provider_keys(current);
+    // Same round-trip hazard for any OTHER plaintext-only key (ciphertext still
+    // `None` in the live config — e.g. a provider instance freshly created via
+    // the instance CRUD endpoints): hydration has nothing to decrypt and the
+    // key would vanish from config.json on the next persist. Carry unpatched
+    // keys forward from the live config. #516.
+    preserve_unpatched_provider_secrets(&mut new_config, current, &api_key_intents);
     new_config.normalize_tool_settings();
     new_config.normalize_skill_settings();
     new_config.normalize_plugin_trust_settings();
@@ -255,5 +266,67 @@ mod tests {
         );
         assert!(openai.api_key_from_env);
         assert!(openai.api_key_encrypted.is_none(), "still not persisted");
+    }
+
+    /// The live in-memory state right after `POST /provider-instances`:
+    /// plaintext key, ciphertext still `None` (ciphertext is only ever computed
+    /// on `save_to_dir`'s save-time clone).
+    fn config_with_plaintext_only_instance(api_key: &str) -> Config {
+        let mut config = Config::default();
+        let instance: bamboo_config::ProviderInstanceConfig =
+            serde_json::from_value(serde_json::json!({
+                "provider_type": "openai",
+                "api_key": api_key,
+            }))
+            .expect("valid instance");
+        config
+            .provider_instances
+            .insert("uuid-1".to_string(), instance);
+        config
+    }
+
+    // #516 regression: the lotus instance-mode 保存配置 sends a defaults/features
+    // patch that never mentions the instance. The merge round-trip drops the
+    // `skip_serializing` plaintext, hydration has no ciphertext to restore, and
+    // the freshly-created instance's key was silently wiped from config.json
+    // (config.json.bak kept the previous good copy).
+    #[test]
+    fn unrelated_patch_preserves_plaintext_only_instance_key() {
+        let current = config_with_plaintext_only_instance("sk-instance-live");
+
+        let patch: Map<String, Value> =
+            serde_json::from_str(r#"{"features":{"provider_model_ref":true}}"#).unwrap();
+        let intents = provider_api_key_intents(&patch);
+        assert!(intents.provider_instances.is_empty());
+
+        let mut merged = build_merged_config(&current, patch).expect("merge");
+        sync_provider_api_keys_encrypted_for_patch(&mut merged, &intents).expect("sync");
+
+        let instance = merged.provider_instances.get("uuid-1").expect("instance");
+        assert_eq!(
+            instance.api_key, "sk-instance-live",
+            "an unrelated settings PATCH must not lose the instance key (#516)"
+        );
+    }
+
+    // The carry-forward must not resurrect a key the patch explicitly cleared.
+    #[test]
+    fn explicit_instance_key_clear_still_clears() {
+        let current = config_with_plaintext_only_instance("sk-old");
+
+        let patch: Map<String, Value> =
+            serde_json::from_str(r#"{"provider_instances":{"uuid-1":{"api_key":""}}}"#).unwrap();
+        let intents = provider_api_key_intents(&patch);
+        assert!(
+            intents.provider_instances.contains("uuid-1"),
+            "empty string is a clear intent"
+        );
+
+        let mut merged = build_merged_config(&current, patch).expect("merge");
+        sync_provider_api_keys_encrypted_for_patch(&mut merged, &intents).expect("sync");
+
+        let instance = merged.provider_instances.get("uuid-1").expect("instance");
+        assert!(instance.api_key.is_empty(), "explicit clear must win");
+        assert!(instance.api_key_encrypted.is_none());
     }
 }

--- a/crates/app/bamboo-server/src/config_manager.rs
+++ b/crates/app/bamboo-server/src/config_manager.rs
@@ -26,10 +26,11 @@ use bamboo_llm::Config;
 // Re-export pure domain logic from the config crate so server consumers
 // can import through `config_manager`.
 pub use bamboo_config::patch::{
-    deep_merge_json, domains_for_root_patch, effects_for_root_patch, is_masked_api_key,
-    preserve_masked_connect_secrets, preserve_masked_notification_secrets,
-    preserve_masked_provider_api_keys, preserve_unpatched_provider_secrets,
-    provider_api_key_intents, sanitize_root_patch, DomainChanges, PatchEffects, ReloadMode,
+    clear_provider_ciphertext_for_explicit_clears, deep_merge_json, domains_for_root_patch,
+    effects_for_root_patch, is_masked_api_key, preserve_masked_connect_secrets,
+    preserve_masked_notification_secrets, preserve_masked_provider_api_keys,
+    preserve_unpatched_provider_secrets, provider_api_key_intents, sanitize_root_patch,
+    DomainChanges, PatchEffects, ReloadMode,
 };
 
 pub fn sync_provider_api_keys_encrypted_for_patch(
@@ -156,6 +157,10 @@ pub fn build_merged_config(
 
     let mut new_config: Config = serde_json::from_value(merged)
         .map_err(|e| AppError::BadRequest(format!("Invalid configuration JSON: {e}")))?;
+    // An explicit `api_key: ""` clear must drop the round-tripped ciphertext
+    // BEFORE hydration — otherwise hydration refills the plaintext from it and
+    // the subsequent sync/save re-encrypts, silently undoing the clear (#516).
+    clear_provider_ciphertext_for_explicit_clears(&mut new_config, &api_key_intents);
     new_config.hydrate_proxy_auth_from_encrypted();
     new_config.hydrate_provider_api_keys_from_encrypted();
     new_config.hydrate_provider_instance_api_keys_from_encrypted();
@@ -328,5 +333,36 @@ mod tests {
         let instance = merged.provider_instances.get("uuid-1").expect("instance");
         assert!(instance.api_key.is_empty(), "explicit clear must win");
         assert!(instance.api_key_encrypted.is_none());
+    }
+
+    // An explicit clear must also win when the live config holds ciphertext in
+    // memory — the normal state now that update_config keeps ciphertext in sync
+    // (#516). Without the pre-hydration ciphertext drop, hydration would refill
+    // the plaintext from the round-tripped ciphertext and sync would re-encrypt
+    // it, silently undoing the clear.
+    #[test]
+    fn explicit_instance_key_clear_wins_over_in_memory_ciphertext() {
+        let mut current = config_with_plaintext_only_instance("sk-old");
+        current.refresh_encrypted_secrets().expect("refresh");
+        assert!(
+            current.provider_instances["uuid-1"]
+                .api_key_encrypted
+                .is_some(),
+            "precondition: live config holds ciphertext"
+        );
+
+        let patch: Map<String, Value> =
+            serde_json::from_str(r#"{"provider_instances":{"uuid-1":{"api_key":""}}}"#).unwrap();
+        let intents = provider_api_key_intents(&patch);
+
+        let mut merged = build_merged_config(&current, patch).expect("merge");
+        sync_provider_api_keys_encrypted_for_patch(&mut merged, &intents).expect("sync");
+
+        let instance = merged.provider_instances.get("uuid-1").expect("instance");
+        assert!(instance.api_key.is_empty(), "explicit clear must win");
+        assert!(
+            instance.api_key_encrypted.is_none(),
+            "ciphertext must be cleared too"
+        );
     }
 }

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -3035,18 +3035,12 @@ impl Config {
         to_save.extra.remove("data_dir");
         // Root-level `model` is deprecated; do not persist it.
         to_save.extra.remove("model");
-        to_save.refresh_proxy_auth_encrypted()?;
-        to_save.refresh_provider_api_keys_encrypted()?;
-        to_save.refresh_provider_instance_api_keys_encrypted()?;
-        to_save.refresh_env_vars_encrypted()?;
-        to_save.sanitize_env_vars_for_disk();
-        to_save.refresh_cluster_fabric_encrypted()?;
-        to_save.sanitize_cluster_fabric_for_disk();
         // `subagents.broker` is `#[serde(skip)]` (runtime-only, lives in its own
         // broker.json / embedded in-process) — nothing to encrypt or persist here.
-        to_save.refresh_notifications_encrypted()?;
+        to_save.refresh_encrypted_secrets()?;
+        to_save.sanitize_env_vars_for_disk();
+        to_save.sanitize_cluster_fabric_for_disk();
         to_save.assign_connect_platform_ids();
-        to_save.refresh_connect_platform_tokens_encrypted()?;
         to_save.normalize_tool_settings();
         to_save.normalize_skill_settings();
 
@@ -5278,6 +5272,45 @@ mod tests {
         assert!(
             !enc.is_empty() && enc != "stale-ciphertext",
             "plaintext re-encrypted"
+        );
+    }
+
+    #[test]
+    fn refresh_encrypted_secrets_makes_instance_key_survive_serde_roundtrip() {
+        // #516: `save_to_dir` refreshes ciphertext only on its save-time clone,
+        // so a provider instance created over HTTP stays plaintext-only in the
+        // live config. Serializing that live config (as the settings-PATCH
+        // merge does) drops the `skip_serializing` plaintext and the key is
+        // gone. `refresh_encrypted_secrets` on the live config closes the gap.
+        let mut config = Config::default();
+        let instance: ProviderInstanceConfig = serde_json::from_value(serde_json::json!({
+            "provider_type": "openai",
+            "api_key": "sk-instance-live",
+        }))
+        .expect("valid instance");
+        config
+            .provider_instances
+            .insert("work".to_string(), instance);
+
+        config.refresh_encrypted_secrets().expect("refresh");
+        assert!(
+            config.provider_instances["work"]
+                .api_key_encrypted
+                .is_some(),
+            "live config must hold ciphertext after refresh"
+        );
+
+        // The build_merged_config-style round-trip.
+        let value = serde_json::to_value(&config).expect("serialize");
+        let mut back: Config = serde_json::from_value(value).expect("deserialize");
+        assert!(
+            back.provider_instances["work"].api_key.is_empty(),
+            "plaintext is skip_serializing"
+        );
+        back.hydrate_provider_instance_api_keys_from_encrypted();
+        assert_eq!(
+            back.provider_instances["work"].api_key, "sk-instance-live",
+            "key must be recoverable from the round-tripped ciphertext"
         );
     }
 

--- a/crates/infra/bamboo-config/src/config_crypto.rs
+++ b/crates/infra/bamboo-config/src/config_crypto.rs
@@ -614,4 +614,27 @@ impl Config {
         restore_env_key!(anthropic);
         restore_env_key!(gemini);
     }
+
+    /// Re-encrypt every secret domain's `*_encrypted` field from current
+    /// in-memory plaintext, without the disk-only sanitization steps.
+    ///
+    /// `Config::save_to_dir` runs these refreshes on a save-time clone, so the
+    /// live in-memory config never sees the resulting ciphertext: a provider
+    /// instance created over HTTP keeps `api_key_encrypted: None` in memory for
+    /// the rest of the session. Any code that then serializes the live config
+    /// and deserializes it back — the settings-PATCH merge in
+    /// `config_manager::build_merged_config` — drops the
+    /// `#[serde(skip_serializing)]` plaintext and is left with neither field,
+    /// permanently losing the key on the next persist (#516). Call this after
+    /// mutating the live config so ciphertext stays in sync with plaintext.
+    pub fn refresh_encrypted_secrets(&mut self) -> Result<()> {
+        self.refresh_proxy_auth_encrypted()?;
+        self.refresh_provider_api_keys_encrypted()?;
+        self.refresh_provider_instance_api_keys_encrypted()?;
+        self.refresh_env_vars_encrypted()?;
+        self.refresh_cluster_fabric_encrypted()?;
+        self.refresh_notifications_encrypted()?;
+        self.refresh_connect_platform_tokens_encrypted()?;
+        Ok(())
+    }
 }

--- a/crates/infra/bamboo-config/src/patch.rs
+++ b/crates/infra/bamboo-config/src/patch.rs
@@ -374,6 +374,69 @@ pub fn preserve_masked_provider_api_keys(patch_obj: &mut Map<String, Value>, cur
     }
 }
 
+/// Carry provider secrets that the merge round-trip dropped forward from the
+/// live config.
+///
+/// `config_manager::build_merged_config` serializes the live config before
+/// merging a patch, which drops every `#[serde(skip_serializing)]` plaintext
+/// `api_key`. Hydration afterwards only restores ciphertext-backed keys — but
+/// the live config can legitimately hold a plaintext-only secret whose
+/// `api_key_encrypted` is still `None` (ciphertext is only ever computed on
+/// `save_to_dir`'s save-time clone; a provider instance freshly created via
+/// the instance CRUD endpoints stays plaintext-only in memory). The merged
+/// config then ends up with NEITHER field and the key is silently lost on the
+/// next persist: config.json loses `api_key_encrypted` while config.json.bak
+/// keeps it (#516).
+///
+/// Restores `api_key`/`api_key_encrypted` from `current` for every legacy
+/// provider and provider instance that the patch did not explicitly set or
+/// clear (per `intents`), whenever the merge left neither field behind.
+/// Generalizes the env-sourced rescue of
+/// [`Config::preserve_env_sourced_provider_keys`] (#373).
+pub fn preserve_unpatched_provider_secrets(
+    merged: &mut Config,
+    current: &Config,
+    intents: &ProviderApiKeyIntents,
+) {
+    macro_rules! carry_forward {
+        ($field:ident) => {
+            if !intents.providers.contains(stringify!($field)) {
+                if let (Some(new_cfg), Some(prev)) = (
+                    merged.providers.$field.as_mut(),
+                    current.providers.$field.as_ref(),
+                ) {
+                    if new_cfg.api_key.trim().is_empty()
+                        && new_cfg.api_key_encrypted.is_none()
+                        && (!prev.api_key.trim().is_empty() || prev.api_key_encrypted.is_some())
+                    {
+                        new_cfg.api_key = prev.api_key.clone();
+                        new_cfg.api_key_encrypted = prev.api_key_encrypted.clone();
+                    }
+                }
+            }
+        };
+    }
+    carry_forward!(openai);
+    carry_forward!(anthropic);
+    carry_forward!(gemini);
+    carry_forward!(bodhi);
+
+    for (id, instance) in merged.provider_instances.iter_mut() {
+        if intents.provider_instances.contains(id) {
+            continue;
+        }
+        if !instance.api_key.trim().is_empty() || instance.api_key_encrypted.is_some() {
+            continue;
+        }
+        if let Some(prev) = current.provider_instances.get(id) {
+            if !prev.api_key.trim().is_empty() || prev.api_key_encrypted.is_some() {
+                instance.api_key = prev.api_key.clone();
+                instance.api_key_encrypted = prev.api_key_encrypted.clone();
+            }
+        }
+    }
+}
+
 /// Replace masked notification-channel secret placeholders (ntfy `token`, Bark
 /// `device_key`) in a patch with the current config's plaintext values.
 ///
@@ -626,6 +689,106 @@ mod tests {
         assert!(!intents.providers.contains("openai"));
         assert!(intents.provider_instances.contains("personal-openai"));
         assert!(!intents.provider_instances.contains("work-openai"));
+    }
+
+    /// Build a provider instance via serde (the struct has no `Default`), so
+    /// the tests stay robust to new fields.
+    fn instance(api_key: &str, encrypted: Option<&str>) -> crate::ProviderInstanceConfig {
+        serde_json::from_value(json!({
+            "provider_type": "openai",
+            "api_key": api_key,
+            "api_key_encrypted": encrypted,
+        }))
+        .expect("valid instance")
+    }
+
+    #[test]
+    fn preserve_unpatched_provider_secrets_restores_roundtrip_dropped_keys() {
+        // #516: the live config can hold a plaintext-only secret (ciphertext is
+        // computed only on save_to_dir's save-time clone). The merge round-trip
+        // drops the `skip_serializing` plaintext, leaving neither field.
+        let mut current = Config::default();
+        current
+            .provider_instances
+            .insert("uuid-1".to_string(), instance("sk-instance-live", None));
+        current.providers.openai = Some(crate::OpenAIConfig {
+            api_key: "sk-legacy-live".to_string(),
+            ..Default::default()
+        });
+
+        // Simulate the post-round-trip merge result: both fields lost.
+        let mut merged = Config::default();
+        merged
+            .provider_instances
+            .insert("uuid-1".to_string(), instance("", None));
+        merged.providers.openai = Some(crate::OpenAIConfig::default());
+
+        preserve_unpatched_provider_secrets(
+            &mut merged,
+            &current,
+            &ProviderApiKeyIntents::default(),
+        );
+
+        assert_eq!(
+            merged.provider_instances["uuid-1"].api_key,
+            "sk-instance-live"
+        );
+        assert_eq!(
+            merged.providers.openai.as_ref().unwrap().api_key,
+            "sk-legacy-live"
+        );
+    }
+
+    #[test]
+    fn preserve_unpatched_provider_secrets_carries_ciphertext_only_keys() {
+        // A key whose plaintext failed to hydrate (#268) must still carry its
+        // ciphertext forward instead of being dropped.
+        let mut current = Config::default();
+        current
+            .provider_instances
+            .insert("uuid-1".to_string(), instance("", Some("preexisting-ct")));
+
+        let mut merged = Config::default();
+        merged
+            .provider_instances
+            .insert("uuid-1".to_string(), instance("", None));
+
+        preserve_unpatched_provider_secrets(
+            &mut merged,
+            &current,
+            &ProviderApiKeyIntents::default(),
+        );
+
+        assert_eq!(
+            merged.provider_instances["uuid-1"]
+                .api_key_encrypted
+                .as_deref(),
+            Some("preexisting-ct")
+        );
+    }
+
+    #[test]
+    fn preserve_unpatched_provider_secrets_respects_explicit_intents() {
+        // A provider/instance the patch explicitly set or cleared must not have
+        // the old key resurrected.
+        let mut current = Config::default();
+        current
+            .provider_instances
+            .insert("uuid-1".to_string(), instance("sk-old", None));
+
+        let mut merged = Config::default();
+        merged
+            .provider_instances
+            .insert("uuid-1".to_string(), instance("", None));
+
+        let mut intents = ProviderApiKeyIntents::default();
+        intents.provider_instances.insert("uuid-1".to_string());
+
+        preserve_unpatched_provider_secrets(&mut merged, &current, &intents);
+
+        let cleared = &merged.provider_instances["uuid-1"];
+        assert!(cleared.api_key.is_empty(), "explicit clear must win");
+        assert!(cleared.api_key_encrypted.is_none());
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/patch.rs
+++ b/crates/infra/bamboo-config/src/patch.rs
@@ -437,6 +437,43 @@ pub fn preserve_unpatched_provider_secrets(
     }
 }
 
+/// Make an explicit `api_key: ""` clear actually clear.
+///
+/// The merge round-trip carries the live config's `api_key_encrypted` into the
+/// merged value; hydration would then refill the plaintext from it and the
+/// subsequent sync/save would re-encrypt — silently undoing the clear. For
+/// every provider/instance the patch explicitly touched whose merged plaintext
+/// is empty (a clear, not a set), drop the round-tripped ciphertext BEFORE
+/// hydration so nothing refills the key (#516).
+pub fn clear_provider_ciphertext_for_explicit_clears(
+    merged: &mut Config,
+    intents: &ProviderApiKeyIntents,
+) {
+    macro_rules! clear_ciphertext {
+        ($field:ident) => {
+            if intents.providers.contains(stringify!($field)) {
+                if let Some(cfg) = merged.providers.$field.as_mut() {
+                    if cfg.api_key.trim().is_empty() {
+                        cfg.api_key_encrypted = None;
+                    }
+                }
+            }
+        };
+    }
+    clear_ciphertext!(openai);
+    clear_ciphertext!(anthropic);
+    clear_ciphertext!(gemini);
+    clear_ciphertext!(bodhi);
+
+    for id in intents.provider_instances.iter() {
+        if let Some(instance) = merged.provider_instances.get_mut(id) {
+            if instance.api_key.trim().is_empty() {
+                instance.api_key_encrypted = None;
+            }
+        }
+    }
+}
+
 /// Replace masked notification-channel secret placeholders (ntfy `token`, Bark
 /// `device_key`) in a patch with the current config's plaintext values.
 ///
@@ -789,6 +826,67 @@ mod tests {
         let cleared = &merged.provider_instances["uuid-1"];
         assert!(cleared.api_key.is_empty(), "explicit clear must win");
         assert!(cleared.api_key_encrypted.is_none());
+    }
+
+    #[test]
+    fn clear_provider_ciphertext_drops_roundtripped_ciphertext_on_clear_intents() {
+        // Merged state right after deserialization of a clear patch: empty
+        // plaintext from the patch, ciphertext carried over by the round-trip
+        // of the live config. Hydration must find nothing to refill.
+        let mut merged = Config::default();
+        merged
+            .provider_instances
+            .insert("uuid-1".to_string(), instance("", Some("roundtripped-ct")));
+        merged.providers.openai = Some(crate::OpenAIConfig {
+            api_key_encrypted: Some("legacy-ct".to_string()),
+            ..Default::default()
+        });
+
+        let mut intents = ProviderApiKeyIntents::default();
+        intents.provider_instances.insert("uuid-1".to_string());
+        intents.providers.insert("openai".to_string());
+
+        clear_provider_ciphertext_for_explicit_clears(&mut merged, &intents);
+
+        assert!(merged.provider_instances["uuid-1"]
+            .api_key_encrypted
+            .is_none());
+        assert!(merged
+            .providers
+            .openai
+            .as_ref()
+            .unwrap()
+            .api_key_encrypted
+            .is_none());
+    }
+
+    #[test]
+    fn clear_provider_ciphertext_leaves_set_intents_and_unpatched_alone() {
+        // A SET intent (non-empty merged plaintext) keeps its ciphertext (the
+        // later sync overwrites it), and an instance without any intent is
+        // untouched.
+        let mut merged = Config::default();
+        merged
+            .provider_instances
+            .insert("uuid-1".to_string(), instance("sk-new", Some("stale-ct")));
+        merged
+            .provider_instances
+            .insert("uuid-2".to_string(), instance("", Some("kept-ct")));
+
+        let mut intents = ProviderApiKeyIntents::default();
+        intents.provider_instances.insert("uuid-1".to_string());
+
+        clear_provider_ciphertext_for_explicit_clears(&mut merged, &intents);
+
+        assert!(merged.provider_instances["uuid-1"]
+            .api_key_encrypted
+            .is_some());
+        assert_eq!(
+            merged.provider_instances["uuid-2"]
+                .api_key_encrypted
+                .as_deref(),
+            Some("kept-ct")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem (#516)

Add a provider instance in lotus → key lands in `config.json` correctly. Select a model (auto-saves `{defaults, features}` via `POST /bamboo/config`) → the newly written `config.json` no longer has `provider_instances.<id>.api_key_encrypted`, while `config.json.bak` still does.

Root cause is two defects composing:

1. **In-memory ciphertext staleness** — the instance CRUD handlers insert `{api_key: plaintext, api_key_encrypted: None}` into the live config; `save_to_dir` computes ciphertext only on its save-time clone, so the live config stays plaintext-only for the rest of the session.
2. **`build_merged_config` round-trip** — serializing the live config drops the `#[serde(skip_serializing)]` plaintext, and with in-memory ciphertext `None` the merged instance has *neither* field. Hydration has nothing to decrypt; the merged config replaces the in-memory state and is persisted. The #268 "empty plaintext preserves ciphertext" guard preserves `None`.

Only reproduces same-session (after a restart, load hydrates plaintext AND keeps ciphertext in memory). Legacy providers were shielded on their own save path by `sync_provider_api_keys_encrypted_for_patch`; instances had no equivalent. Adversarially verified by a 15-agent trace: the only surviving root-cause candidates are this chain and its legacy-endpoint twin (`POST /bamboo/settings/provider`), both covered here.

## Fix (two layers)

- **Root**: new `Config::refresh_encrypted_secrets()` (all `refresh_*_encrypted` domains, no disk-only sanitization) called on the live config in `update_config`/`replace_config` — same live-vs-save-copy rationale as the #496 connect-id backfill. `save_to_dir` now reuses the helper, so the refresh list can't drift.
- **Safety net**: `preserve_unpatched_provider_secrets` in `build_merged_config` carries `api_key`/`api_key_encrypted` forward from the live config for every legacy provider and instance the patch did not explicitly set/clear (generalizes the #373 env-key rescue). Explicit clears still win (intent-gated).

## Tests

- `unrelated_patch_preserves_plaintext_only_instance_key` — the exact #516 repro at the merge layer
- `explicit_instance_key_clear_still_clears` — carry-forward must not resurrect cleared keys
- `preserve_unpatched_provider_secrets_*` ×3 — restore, ciphertext-only carry, intent skip
- `refresh_encrypted_secrets_makes_instance_key_survive_serde_roundtrip` — the in-memory invariant
- Full suites green: bamboo-config 251, bamboo-server 1328; `cargo build --workspace --tests` clean; fmt/clippy clean on touched crates.

https://claude.ai/code/session_013oUofGqYAwMfpR2s1CteY9