### PR TITLE
fix(config): clear-intent mechanism for notification + connect secrets

### DIFF
--- a/crates/app/bamboo-server/src/config_manager.rs
+++ b/crates/app/bamboo-server/src/config_manager.rs
@@ -26,11 +26,14 @@ use bamboo_llm::Config;
 // Re-export pure domain logic from the config crate so server consumers
 // can import through `config_manager`.
 pub use bamboo_config::patch::{
-    clear_provider_ciphertext_for_explicit_clears, deep_merge_json, domains_for_root_patch,
-    effects_for_root_patch, is_masked_api_key, preserve_masked_connect_secrets,
-    preserve_masked_notification_secrets, preserve_masked_provider_api_keys,
-    preserve_unpatched_provider_secrets, provider_api_key_intents, sanitize_root_patch,
-    DomainChanges, PatchEffects, ReloadMode,
+    clear_connect_ciphertext_for_explicit_clears,
+    clear_notification_ciphertext_for_explicit_clears,
+    clear_provider_ciphertext_for_explicit_clears, connect_secret_intents, deep_merge_json,
+    domains_for_root_patch, effects_for_root_patch, is_masked_api_key, notification_secret_intents,
+    preserve_masked_connect_secrets, preserve_masked_notification_secrets,
+    preserve_masked_provider_api_keys, preserve_unpatched_provider_secrets,
+    provider_api_key_intents, sanitize_root_patch, ConnectSecretIntents, DomainChanges,
+    NotificationSecretIntents, PatchEffects, ReloadMode,
 };
 
 pub fn sync_provider_api_keys_encrypted_for_patch(
@@ -149,6 +152,11 @@ pub fn build_merged_config(
     // this patch explicitly sets or clears — those must NOT get their dropped
     // key carried forward below (#516).
     let api_key_intents = provider_api_key_intents(&patch_obj);
+    // Same capture for the other secret domains that flow through this merge
+    // (#521 — ntfy `token` / Bark `device_key` / connect `token` and Feishu
+    // `app_secret`): must be read before the patch is consumed below.
+    let notification_intents = notification_secret_intents(&patch_obj);
+    let connect_intents = connect_secret_intents(&patch_obj);
 
     let mut merged = serde_json::to_value(current)
         .map_err(|e| AppError::InternalError(anyhow::anyhow!("Failed to serialize config: {e}")))?;
@@ -161,6 +169,10 @@ pub fn build_merged_config(
     // BEFORE hydration — otherwise hydration refills the plaintext from it and
     // the subsequent sync/save re-encrypts, silently undoing the clear (#516).
     clear_provider_ciphertext_for_explicit_clears(&mut new_config, &api_key_intents);
+    // Same treatment for notification/connect secrets (#521) — same rationale,
+    // same ordering requirement (before hydration below).
+    clear_notification_ciphertext_for_explicit_clears(&mut new_config, &notification_intents);
+    clear_connect_ciphertext_for_explicit_clears(&mut new_config, &connect_intents);
     new_config.hydrate_proxy_auth_from_encrypted();
     new_config.hydrate_provider_api_keys_from_encrypted();
     new_config.hydrate_provider_instance_api_keys_from_encrypted();
@@ -397,5 +409,261 @@ mod tests {
             Some(prev_ciphertext.as_str()),
             "ciphertext must survive an unrelated save"
         );
+    }
+
+    // ── #521: full-pipeline coverage for notification secrets ──────────
+    //
+    // Mirrors set_bamboo_config's actual call order: preserve_masked_* first
+    // (mutating the patch against `current`), THEN build_merged_config, THEN
+    // the post-merge re-encrypt (`refresh_notifications_encrypted`, run in
+    // production by `Config::refresh_encrypted_secrets` inside
+    // `AppState::update_config`).
+
+    fn config_with_notification_secrets(ntfy_token: &str, bark_key: &str) -> Config {
+        let mut config = Config::default();
+        config.notifications.ntfy.token = Some(ntfy_token.to_string());
+        config.notifications.bark.device_key = Some(bark_key.to_string());
+        config.refresh_encrypted_secrets().expect("refresh");
+        config
+    }
+
+    fn merge_notifications_patch(current: &Config, patch_json: &str) -> Config {
+        let mut patch_obj: Map<String, Value> = serde_json::from_str(patch_json).unwrap();
+        preserve_masked_notification_secrets(&mut patch_obj, current);
+        let mut merged = build_merged_config(current, patch_obj).expect("merge");
+        merged.refresh_encrypted_secrets().expect("refresh");
+        merged
+    }
+
+    #[test]
+    fn explicit_notification_secret_clear_wins_over_in_memory_ciphertext() {
+        let current = config_with_notification_secrets("ntfy-secret", "bark-secret");
+        assert!(current.notifications.ntfy.token_encrypted.is_some());
+        assert!(current.notifications.bark.device_key_encrypted.is_some());
+
+        let merged = merge_notifications_patch(
+            &current,
+            r#"{"notifications":{"ntfy":{"token":""},"bark":{"device_key":""}}}"#,
+        );
+
+        assert!(
+            merged
+                .notifications
+                .ntfy
+                .token
+                .as_deref()
+                .unwrap_or("")
+                .is_empty(),
+            "explicit clear must win"
+        );
+        assert!(
+            merged.notifications.ntfy.token_encrypted.is_none(),
+            "ciphertext must be cleared too (#521)"
+        );
+        assert!(merged
+            .notifications
+            .bark
+            .device_key
+            .as_deref()
+            .unwrap_or("")
+            .is_empty());
+        assert!(merged.notifications.bark.device_key_encrypted.is_none());
+    }
+
+    #[test]
+    fn unrelated_patch_preserves_notification_secrets() {
+        // NOTE: unlike providers (whose ciphertext is only touched by the
+        // explicit-intent-gated `sync_provider_api_keys_encrypted_for_patch`),
+        // notification ciphertext is unconditionally recomputed by
+        // `refresh_encrypted_secrets` on every write (pre-existing,
+        // out-of-scope-for-#521 design) — so only plaintext survival and
+        // ciphertext presence are asserted, not exact ciphertext bytes.
+        let current = config_with_notification_secrets("ntfy-secret", "bark-secret");
+
+        let merged =
+            merge_notifications_patch(&current, r#"{"http_proxy":"http://example.invalid:8080"}"#);
+
+        assert_eq!(
+            merged.notifications.ntfy.token.as_deref(),
+            Some("ntfy-secret"),
+            "an unrelated settings PATCH must not lose the ntfy token"
+        );
+        assert!(merged.notifications.ntfy.token_encrypted.is_some());
+        assert_eq!(
+            merged.notifications.bark.device_key.as_deref(),
+            Some("bark-secret"),
+            "an unrelated settings PATCH must not lose the Bark device key"
+        );
+        assert!(merged.notifications.bark.device_key_encrypted.is_some());
+    }
+
+    #[test]
+    fn masked_notification_secret_placeholder_preserves_value() {
+        let current = config_with_notification_secrets("ntfy-secret", "bark-secret");
+
+        let merged = merge_notifications_patch(
+            &current,
+            r#"{"notifications":{"ntfy":{"token":"****...****"},"bark":{"device_key":"****...****"}}}"#,
+        );
+
+        assert_eq!(
+            merged.notifications.ntfy.token.as_deref(),
+            Some("ntfy-secret")
+        );
+        assert!(merged.notifications.ntfy.token_encrypted.is_some());
+        assert_eq!(
+            merged.notifications.bark.device_key.as_deref(),
+            Some("bark-secret")
+        );
+        assert!(merged.notifications.bark.device_key_encrypted.is_some());
+    }
+
+    #[test]
+    fn new_notification_secret_value_replaces_and_encrypts() {
+        let current = config_with_notification_secrets("ntfy-old", "bark-old");
+
+        let merged = merge_notifications_patch(
+            &current,
+            r#"{"notifications":{"ntfy":{"token":"ntfy-new"},"bark":{"device_key":"bark-new"}}}"#,
+        );
+
+        assert_eq!(merged.notifications.ntfy.token.as_deref(), Some("ntfy-new"));
+        assert!(merged.notifications.ntfy.token_encrypted.is_some());
+        assert_eq!(
+            merged.notifications.bark.device_key.as_deref(),
+            Some("bark-new")
+        );
+        assert!(merged.notifications.bark.device_key_encrypted.is_some());
+    }
+
+    // ── #521: full-pipeline coverage for connect platform secrets ──────
+
+    fn config_with_connect_platform(platform_type: &str, token: &str) -> Config {
+        let mut config = Config::default();
+        let platform: bamboo_config::ConnectPlatformConfig =
+            serde_json::from_value(serde_json::json!({
+                "type": platform_type,
+                "token": token,
+            }))
+            .expect("valid platform");
+        config.connect.platforms = vec![platform];
+        config.refresh_encrypted_secrets().expect("refresh");
+        config
+    }
+
+    fn merge_connect_patch(current: &Config, patch_json: &str) -> Config {
+        let mut patch_obj: Map<String, Value> = serde_json::from_str(patch_json).unwrap();
+        preserve_masked_connect_secrets(&mut patch_obj, current);
+        let mut merged = build_merged_config(current, patch_obj).expect("merge");
+        merged.refresh_encrypted_secrets().expect("refresh");
+        merged
+    }
+
+    #[test]
+    fn explicit_connect_token_clear_wins_over_in_memory_ciphertext() {
+        let current = config_with_connect_platform("telegram", "tg-secret-token");
+        assert!(current.connect.platforms[0].token_encrypted.is_some());
+
+        let merged = merge_connect_patch(
+            &current,
+            r#"{"connect":{"platforms":[{"type":"telegram","token":""}]}}"#,
+        );
+
+        assert!(
+            merged.connect.platforms[0]
+                .token
+                .as_deref()
+                .unwrap_or("")
+                .is_empty(),
+            "explicit clear must win"
+        );
+        assert!(
+            merged.connect.platforms[0].token_encrypted.is_none(),
+            "ciphertext must be cleared too (#521)"
+        );
+    }
+
+    #[test]
+    fn explicit_connect_app_secret_clear_wins_over_in_memory_ciphertext() {
+        let mut current = Config::default();
+        let platform: bamboo_config::ConnectPlatformConfig =
+            serde_json::from_value(serde_json::json!({
+                "type": "feishu",
+                "app_id": "cli_x",
+                "app_secret": "feishu-secret",
+            }))
+            .expect("valid platform");
+        current.connect.platforms = vec![platform];
+        current.refresh_encrypted_secrets().expect("refresh");
+        assert!(current.connect.platforms[0].app_secret_encrypted.is_some());
+
+        let merged = merge_connect_patch(
+            &current,
+            r#"{"connect":{"platforms":[{"type":"feishu","app_id":"cli_x","app_secret":""}]}}"#,
+        );
+
+        assert!(
+            merged.connect.platforms[0]
+                .app_secret
+                .as_deref()
+                .unwrap_or("")
+                .is_empty(),
+            "explicit clear must win"
+        );
+        assert!(
+            merged.connect.platforms[0].app_secret_encrypted.is_none(),
+            "ciphertext must be cleared too (#521)"
+        );
+    }
+
+    #[test]
+    fn unrelated_patch_preserves_connect_token() {
+        // Same NOTE as `unrelated_patch_preserves_notification_secrets`: connect
+        // ciphertext is unconditionally recomputed by `refresh_encrypted_secrets`
+        // on every write, so only plaintext survival + ciphertext presence are
+        // asserted.
+        let current = config_with_connect_platform("telegram", "tg-secret-token");
+
+        let merged =
+            merge_connect_patch(&current, r#"{"http_proxy":"http://example.invalid:8080"}"#);
+
+        assert_eq!(
+            merged.connect.platforms[0].token.as_deref(),
+            Some("tg-secret-token"),
+            "an unrelated settings PATCH must not lose the connect platform token"
+        );
+        assert!(merged.connect.platforms[0].token_encrypted.is_some());
+    }
+
+    #[test]
+    fn masked_connect_token_placeholder_preserves_value() {
+        let current = config_with_connect_platform("telegram", "tg-secret-token");
+
+        let merged = merge_connect_patch(
+            &current,
+            r#"{"connect":{"platforms":[{"type":"telegram","token":"****...****"}]}}"#,
+        );
+
+        assert_eq!(
+            merged.connect.platforms[0].token.as_deref(),
+            Some("tg-secret-token")
+        );
+        assert!(merged.connect.platforms[0].token_encrypted.is_some());
+    }
+
+    #[test]
+    fn new_connect_token_value_replaces_and_encrypts() {
+        let current = config_with_connect_platform("telegram", "tg-old-token");
+
+        let merged = merge_connect_patch(
+            &current,
+            r#"{"connect":{"platforms":[{"type":"telegram","token":"tg-new-token"}]}}"#,
+        );
+
+        assert_eq!(
+            merged.connect.platforms[0].token.as_deref(),
+            Some("tg-new-token")
+        );
+        assert!(merged.connect.platforms[0].token_encrypted.is_some());
     }
 }

--- a/crates/infra/bamboo-config/src/patch.rs
+++ b/crates/infra/bamboo-config/src/patch.rs
@@ -474,6 +474,188 @@ pub fn clear_provider_ciphertext_for_explicit_clears(
     }
 }
 
+/// Extract notification-channel secret update intents (ntfy `token`, Bark
+/// `device_key`) from a config patch.
+///
+/// Mirrors [`provider_api_key_intents`]: masked placeholders are ignored
+/// (they signal "keep existing secret"); an explicit empty string is a
+/// genuine intent (a clear), same as a genuine new value (a set). Must be
+/// read from the patch AFTER [`preserve_masked_notification_secrets`] has
+/// resolved masked placeholders — same calling convention as the provider
+/// intents (#521).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NotificationSecretIntents {
+    pub ntfy_token: bool,
+    pub bark_device_key: bool,
+}
+
+pub fn notification_secret_intents(patch_obj: &Map<String, Value>) -> NotificationSecretIntents {
+    let mut intents = NotificationSecretIntents::default();
+
+    let Some(notifications) = patch_obj.get("notifications").and_then(|v| v.as_object()) else {
+        return intents;
+    };
+
+    if let Some(token) = notifications
+        .get("ntfy")
+        .and_then(|v| v.as_object())
+        .and_then(|o| o.get("token"))
+        .and_then(|v| v.as_str())
+    {
+        if !is_masked_api_key(token) {
+            intents.ntfy_token = true;
+        }
+    }
+
+    if let Some(device_key) = notifications
+        .get("bark")
+        .and_then(|v| v.as_object())
+        .and_then(|o| o.get("device_key"))
+        .and_then(|v| v.as_str())
+    {
+        if !is_masked_api_key(device_key) {
+            intents.bark_device_key = true;
+        }
+    }
+
+    intents
+}
+
+/// Make an explicit `token: ""` / `device_key: ""` clear actually clear.
+///
+/// Generalizes [`clear_provider_ciphertext_for_explicit_clears`] (#521) to
+/// notification-channel secrets: `notifications.ntfy.token_encrypted` /
+/// `notifications.bark.device_key_encrypted` are NOT `skip_serializing` (only
+/// `skip_serializing_if = "Option::is_none"`), so the merge round-trip in
+/// `config_manager::build_merged_config` carries the live config's ciphertext
+/// straight into the merged value even when the patch explicitly cleared the
+/// plaintext. `hydrate_notifications_from_encrypted` would then refill the
+/// plaintext from that ciphertext, and the subsequent
+/// `Config::refresh_notifications_encrypted` (which deliberately preserves
+/// ciphertext when plaintext is empty, #268) would leave it in place —
+/// silently undoing the clear. For every field the patch explicitly touched
+/// whose merged plaintext is empty (a clear, not a set), drop the
+/// round-tripped ciphertext BEFORE hydration so nothing refills it.
+pub fn clear_notification_ciphertext_for_explicit_clears(
+    merged: &mut Config,
+    intents: &NotificationSecretIntents,
+) {
+    if intents.ntfy_token
+        && merged
+            .notifications
+            .ntfy
+            .token
+            .as_deref()
+            .unwrap_or("")
+            .trim()
+            .is_empty()
+    {
+        merged.notifications.ntfy.token_encrypted = None;
+    }
+
+    if intents.bark_device_key
+        && merged
+            .notifications
+            .bark
+            .device_key
+            .as_deref()
+            .unwrap_or("")
+            .trim()
+            .is_empty()
+    {
+        merged.notifications.bark.device_key_encrypted = None;
+    }
+}
+
+/// Extract bamboo-connect platform secret update intents (`token`,
+/// `app_secret`) from a config patch, keyed by the platform's position in the
+/// patch's `connect.platforms` array.
+///
+/// `connect.platforms` is a full-array replace (the settings UI always
+/// round-trips the whole list back in the same order it was fetched in — see
+/// [`preserve_masked_connect_secrets`]'s module docs), so
+/// `config_manager::build_merged_config`'s merged `connect.platforms[i]`
+/// always originates verbatim from the patch's `connect.platforms[i]` —
+/// position `i` in the patch and position `i` in the merged config always
+/// refer to the same logical entry, regardless of how that entry's position
+/// relates to `current.connect.platforms` (id/type resolution, #490/#492/#496,
+/// happens earlier and only rewrites the VALUE at a given patch index, never
+/// its position). Masked placeholders are ignored — mirrors
+/// [`provider_api_key_intents`]; must be read from the patch AFTER
+/// [`preserve_masked_connect_secrets`] has resolved them (#521).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ConnectSecretIntents {
+    pub token: std::collections::BTreeSet<usize>,
+    pub app_secret: std::collections::BTreeSet<usize>,
+}
+
+pub fn connect_secret_intents(patch_obj: &Map<String, Value>) -> ConnectSecretIntents {
+    let mut intents = ConnectSecretIntents::default();
+
+    let Some(platforms) = patch_obj
+        .get("connect")
+        .and_then(|c| c.get("platforms"))
+        .and_then(|v| v.as_array())
+    else {
+        return intents;
+    };
+
+    for (index, platform) in platforms.iter().enumerate() {
+        let Some(obj) = platform.as_object() else {
+            continue;
+        };
+
+        if let Some(token) = obj.get("token").and_then(|v| v.as_str()) {
+            if !is_masked_api_key(token) {
+                intents.token.insert(index);
+            }
+        }
+
+        if let Some(app_secret) = obj.get("app_secret").and_then(|v| v.as_str()) {
+            if !is_masked_api_key(app_secret) {
+                intents.app_secret.insert(index);
+            }
+        }
+    }
+
+    intents
+}
+
+/// Make an explicit `token: ""` / `app_secret: ""` clear actually clear.
+///
+/// Generalizes [`clear_provider_ciphertext_for_explicit_clears`] (#521) to
+/// bamboo-connect platform secrets — same rationale as
+/// [`clear_notification_ciphertext_for_explicit_clears`]:
+/// `token_encrypted`/`app_secret_encrypted` are not `skip_serializing`, so an
+/// explicit clear's round-tripped ciphertext must be dropped BEFORE
+/// hydration or it silently refills the plaintext hydration cleared.
+pub fn clear_connect_ciphertext_for_explicit_clears(
+    merged: &mut Config,
+    intents: &ConnectSecretIntents,
+) {
+    for &index in intents.token.iter() {
+        if let Some(platform) = merged.connect.platforms.get_mut(index) {
+            if platform.token.as_deref().unwrap_or("").trim().is_empty() {
+                platform.token_encrypted = None;
+            }
+        }
+    }
+
+    for &index in intents.app_secret.iter() {
+        if let Some(platform) = merged.connect.platforms.get_mut(index) {
+            if platform
+                .app_secret
+                .as_deref()
+                .unwrap_or("")
+                .trim()
+                .is_empty()
+            {
+                platform.app_secret_encrypted = None;
+            }
+        }
+    }
+}
+
 /// Replace masked notification-channel secret placeholders (ntfy `token`, Bark
 /// `device_key`) in a patch with the current config's plaintext values.
 ///
@@ -885,6 +1067,176 @@ mod tests {
             merged.provider_instances["uuid-2"]
                 .api_key_encrypted
                 .as_deref(),
+            Some("kept-ct")
+        );
+    }
+
+    // ── #521: notification-secret clear intent ─────────────────────────
+
+    #[test]
+    fn notification_secret_intents_ignores_masked_placeholders() {
+        let patch = json!({
+            "notifications": {
+                "ntfy": { "token": "****...****" },
+                "bark": { "device_key": "tk-real-new-value" }
+            }
+        });
+        let intents = notification_secret_intents(patch.as_object().unwrap());
+        assert!(!intents.ntfy_token, "masked placeholder is not an intent");
+        assert!(intents.bark_device_key, "a real value is an intent");
+    }
+
+    #[test]
+    fn notification_secret_intents_detects_explicit_clear() {
+        let patch = json!({
+            "notifications": {
+                "ntfy": { "token": "" },
+                "bark": { "device_key": "" }
+            }
+        });
+        let intents = notification_secret_intents(patch.as_object().unwrap());
+        assert!(intents.ntfy_token, "empty string is a clear intent");
+        assert!(intents.bark_device_key, "empty string is a clear intent");
+    }
+
+    #[test]
+    fn notification_secret_intents_empty_when_untouched() {
+        let patch = json!({ "notifications": { "ntfy": { "enabled": true } } });
+        let intents = notification_secret_intents(patch.as_object().unwrap());
+        assert!(!intents.ntfy_token);
+        assert!(!intents.bark_device_key);
+    }
+
+    #[test]
+    fn clear_notification_ciphertext_drops_roundtripped_ciphertext_on_clear_intents() {
+        // Merged state right after deserialization of a clear patch: empty
+        // plaintext from the patch, ciphertext carried over by the round-trip
+        // of the live config. Hydration must find nothing to refill (#521).
+        let mut merged = Config::default();
+        merged.notifications.ntfy.token = None;
+        merged.notifications.ntfy.token_encrypted = Some("roundtripped-ntfy-ct".to_string());
+        merged.notifications.bark.device_key = None;
+        merged.notifications.bark.device_key_encrypted = Some("roundtripped-bark-ct".to_string());
+
+        let intents = NotificationSecretIntents {
+            ntfy_token: true,
+            bark_device_key: true,
+        };
+        clear_notification_ciphertext_for_explicit_clears(&mut merged, &intents);
+
+        assert!(merged.notifications.ntfy.token_encrypted.is_none());
+        assert!(merged.notifications.bark.device_key_encrypted.is_none());
+    }
+
+    #[test]
+    fn clear_notification_ciphertext_leaves_set_intents_and_unpatched_alone() {
+        let mut merged = Config::default();
+        // A SET intent (non-empty merged plaintext) keeps its ciphertext — the
+        // later refresh overwrites it with the new value's encryption.
+        merged.notifications.ntfy.token = Some("brand-new-token".to_string());
+        merged.notifications.ntfy.token_encrypted = Some("stale-ct".to_string());
+        // No intent at all: untouched regardless of plaintext/ciphertext state.
+        merged.notifications.bark.device_key = None;
+        merged.notifications.bark.device_key_encrypted = Some("kept-ct".to_string());
+
+        let intents = NotificationSecretIntents {
+            ntfy_token: true,
+            bark_device_key: false,
+        };
+        clear_notification_ciphertext_for_explicit_clears(&mut merged, &intents);
+
+        assert_eq!(
+            merged.notifications.ntfy.token_encrypted.as_deref(),
+            Some("stale-ct")
+        );
+        assert_eq!(
+            merged.notifications.bark.device_key_encrypted.as_deref(),
+            Some("kept-ct")
+        );
+    }
+
+    // ── #521: connect-secret clear intent ───────────────────────────────
+
+    #[test]
+    fn connect_secret_intents_ignores_masked_and_detects_clear_by_position() {
+        let patch = json!({
+            "connect": {
+                "platforms": [
+                    { "type": "telegram", "token": "****...****" },
+                    { "type": "telegram", "token": "" },
+                    { "type": "feishu", "app_secret": "real-new-secret" }
+                ]
+            }
+        });
+        let intents = connect_secret_intents(patch.as_object().unwrap());
+        assert!(
+            !intents.token.contains(&0),
+            "masked placeholder is not an intent"
+        );
+        assert!(intents.token.contains(&1), "empty string is a clear intent");
+        assert!(intents.app_secret.contains(&2), "a real value is an intent");
+    }
+
+    #[test]
+    fn connect_secret_intents_empty_when_no_platforms_patched() {
+        let patch = json!({ "http_proxy": "http://example.invalid:8080" });
+        let intents = connect_secret_intents(patch.as_object().unwrap());
+        assert!(intents.token.is_empty());
+        assert!(intents.app_secret.is_empty());
+    }
+
+    #[test]
+    fn clear_connect_ciphertext_drops_roundtripped_ciphertext_on_clear_intents() {
+        // Merged state right after deserialization of a clear patch: empty
+        // plaintext, ciphertext carried over by the round-trip of the live
+        // config at the SAME position the patch's full-array-replace put it
+        // (#521).
+        let mut merged = Config::default();
+        merged.connect.platforms = vec![
+            connect_platform("telegram", ""), // will be overwritten below
+            feishu_platform(""),
+        ];
+        merged.connect.platforms[0].token = None;
+        merged.connect.platforms[0].token_encrypted = Some("roundtripped-token-ct".to_string());
+        merged.connect.platforms[1].app_secret = None;
+        merged.connect.platforms[1].app_secret_encrypted =
+            Some("roundtripped-secret-ct".to_string());
+
+        let mut intents = ConnectSecretIntents::default();
+        intents.token.insert(0);
+        intents.app_secret.insert(1);
+
+        clear_connect_ciphertext_for_explicit_clears(&mut merged, &intents);
+
+        assert!(merged.connect.platforms[0].token_encrypted.is_none());
+        assert!(merged.connect.platforms[1].app_secret_encrypted.is_none());
+    }
+
+    #[test]
+    fn clear_connect_ciphertext_leaves_set_intents_and_unpatched_alone() {
+        let mut merged = Config::default();
+        merged.connect.platforms = vec![connect_platform("telegram", "brand-new-token")];
+        merged.connect.platforms[0].token_encrypted = Some("stale-ct".to_string());
+        // A second platform with no clear intent (untouched by the patch)
+        // must keep its ciphertext regardless of its plaintext state.
+        merged
+            .connect
+            .platforms
+            .push(connect_platform("feishu", ""));
+        merged.connect.platforms[1].token = None;
+        merged.connect.platforms[1].token_encrypted = Some("kept-ct".to_string());
+
+        let mut intents = ConnectSecretIntents::default();
+        intents.token.insert(0);
+
+        clear_connect_ciphertext_for_explicit_clears(&mut merged, &intents);
+
+        assert_eq!(
+            merged.connect.platforms[0].token_encrypted.as_deref(),
+            Some("stale-ct")
+        );
+        assert_eq!(
+            merged.connect.platforms[1].token_encrypted.as_deref(),
             Some("kept-ct")
         );
     }


### PR DESCRIPTION
## Summary

Follow-up to #516/#517: generalizes `clear_provider_ciphertext_for_explicit_clears`
to the other secret domains that flow through `config_manager::build_merged_config`,
per #521's audit — ntfy `token`, Bark `device_key`, and bamboo-connect platform
`token`/Feishu `app_secret`.

For each domain:
- **Intent extractor** (`notification_secret_intents`, `connect_secret_intents`) —
  mirrors `provider_api_key_intents`: reads the incoming patch (after
  `preserve_masked_*` has resolved masked placeholders) to determine which
  fields the client explicitly touched (masked placeholders are ignored — they
  mean "keep").
- **Pre-hydration clear** (`clear_notification_ciphertext_for_explicit_clears`,
  `clear_connect_ciphertext_for_explicit_clears`) — for every explicitly-touched
  field whose merged plaintext is empty (a genuine clear, not a set), nulls the
  round-tripped `*_encrypted` BEFORE `hydrate_notifications_from_encrypted` /
  `hydrate_connect_platform_tokens_from_encrypted` run, so there's nothing left
  to refill the plaintext from.

Both are wired into `build_merged_config` right where the provider clear runs,
before any hydration call.

## Composition with #510 / #492

`connect_secret_intents` is keyed by **position** in the patch's
`connect.platforms` array, not by id or index-in-`current`. This is safe
specifically because `connect.platforms` is a **full-array-replace** domain
(the settings UI always echoes the complete list back in the order it was
fetched in, and `deep_merge_json` treats a JSON array as a leaf — no
element-wise merge). So the patch's array becomes the merged array verbatim:
position `i` in the patch is always position `i` in the merged config,
regardless of how `preserve_masked_connect_secrets` resolved that entry's
*value* against `current` (id-first per #510, type+positional fallback per
#492/#490). Those resolution strategies only ever rewrite the VALUE at a given
patch index — never its position — so the clear-intent's position-based keying
composes cleanly with all three without needing to know which `current` index
a masked placeholder resolved against.

## Audit note (important for review)

Testing turned up an asymmetry between the two fixed domains:

- **Notifications**: `notifications.ntfy`/`notifications.bark` are plain
  objects, so `deep_merge_json` merges them field-by-field — any field the
  patch doesn't send (like `token_encrypted`, stripped by
  `sanitize_root_patch`) survives untouched from `current`'s serialization.
  This means the round-tripped ciphertext genuinely does reach
  `hydrate_notifications_from_encrypted` and resurrect a cleared secret without
  this fix — reproduced this exactly in
  `explicit_notification_secret_clear_wins_over_in_memory_ciphertext` (fails
  without the fix, passes with it).
- **Connect**: `connect.platforms` is a `Vec`, so the SAME patch key is a full
  **array replace**, not a field merge — `current`'s ciphertext for that array
  is discarded wholesale regardless of clear vs. keep vs. set, and
  `sanitize_root_patch` already strips any client-sent `*_encrypted` from each
  entry. Empirically (verified by temporarily removing the connect fix), the
  described resurrection does **not** currently reproduce via
  `build_merged_config` for connect — `token_encrypted`/`app_secret_encrypted`
  are already `None` post-merge for any patch touching the array, clear or not.

The connect fix is still included because it's what #521 asked for, is
correct, harmless (verified via the reproduction above and the accompanying
unit/integration tests), and is a defense-in-depth safety net matching the
codebase's existing belt-and-suspenders style — e.g. it would matter
immediately if `connect.platforms`' merge semantics were ever changed to
something id-keyed/element-wise (a plausible direction given #490/#492/#496/#510's
ongoing refinement of platform matching).

`proxy_auth` and secret `env_vars` (also named in #521 as "worth auditing")
were checked and are **not** affected: `proxy_auth` is fully stripped from the
generic PATCH by `sanitize_root_patch` (a dedicated `set_proxy_auth` endpoint
handles it via a direct config mutation, not `build_merged_config`), and
`env_vars` has its own CRUD endpoints (`upsert_env_var`/`replace_env_vars`)
that construct entries directly with `value_encrypted: None`, bypassing the
JSON-merge round-trip entirely.

## Tests

Per #517's precedent, for each of the four fields (ntfy token, bark
device_key, connect token, connect app_secret):
- explicit clear wins even with in-memory ciphertext (core regression)
- unrelated patch preserves the secret
- masked placeholder preserves the value
- a genuine new value replaces and re-encrypts

Plus pure-function unit tests for the two new intent extractors and
clear-ciphertext functions (masked-ignored, clear-detected, set/untouched
left alone), in `crates/infra/bamboo-config/src/patch.rs` and
`crates/app/bamboo-server/src/config_manager.rs`.

## Quality gates

- `cargo fmt -p bamboo-config -p bamboo-server -- --check` — clean
- `cargo clippy -p bamboo-config -p bamboo-server --all-targets` — no new
  warnings (all warnings shown are pre-existing, in files this PR doesn't
  touch: `bamboo-agent-core`, `bamboo-memory`, `bamboo-engine`,
  `handlers/agent/execute/handler/ready.rs`)
- `cargo build --workspace --tests` — clean
- `cargo test -p bamboo-config` — 262 passed
- `cargo test -p bamboo-server` — 1342 + 9 (ws_v2_live) + 9 doctests passed, 0
  failed

## New-issue candidates (not addressed here, out of scope for #521)

- `preserve_unpatched_provider_secrets`-style carry-forward for
  notification/connect secrets (mentioned in #521 as a non-blocking cleanup;
  no known live reproduction — every mutation path goes through
  `AppState::update_config`, which already calls `refresh_encrypted_secrets`
  after every write, so the live in-memory config is never observably
  plaintext-only for these two domains the way a freshly-created provider
  instance could be pre-#517).
- `replace_config` has no callers (dead code per #521's review notes).
- Every config write runs the full encryption refresh twice (live mutation +
  save-time clone) — noted in #521, not touched here.