### PR TITLE
fix(engine): survive mid-session cross-provider model switch

### DIFF
--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -1665,6 +1665,25 @@ pub struct AnthropicConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_overrides: Option<RequestOverridesConfig>,
 
+    /// Unconditionally replay a prior turn's `reasoning` as a `thinking`
+    /// content block, regardless of whether bamboo captured a valid signature
+    /// for it (issue #520).
+    ///
+    /// Defaults to `false`/absent, which is REQUIRED for real Anthropic: it
+    /// requires `thinking` input blocks to carry a signature it minted itself,
+    /// and bamboo never captures one, so an unconditionally-replayed block is
+    /// always rejected with a 400 (either because it's foreign — minted by a
+    /// different provider after a mid-session model switch — or because it's
+    /// an unsigned copy of Claude's own prior turn).
+    ///
+    /// Set this to `true` only when pointing `base_url` at an
+    /// Anthropic-COMPATIBLE upstream (e.g. GLM's `/anthropic` endpoint) that
+    /// has the opposite contract: it requires the `thinking` block to be
+    /// present whenever thinking is enabled, but never validates its
+    /// signature.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking_replay_always: Option<bool>,
+
     /// Preserve unknown keys under `providers.anthropic`.
     #[serde(default, flatten)]
     pub extra: BTreeMap<String, Value>,

--- a/crates/infra/bamboo-llm/src/provider_factory.rs
+++ b/crates/infra/bamboo-llm/src/provider_factory.rs
@@ -141,6 +141,9 @@ pub async fn create_provider_by_name(
 
             provider = provider.with_reasoning_effort(anthropic_config.reasoning_effort);
             provider = provider.with_request_overrides(anthropic_config.request_overrides.clone());
+            provider = provider.with_thinking_replay_always(
+                anthropic_config.thinking_replay_always.unwrap_or(false),
+            );
 
             Ok(Arc::new(provider.with_masking(masking_config.clone())))
         }
@@ -386,6 +389,7 @@ mod tests {
                     max_tokens: Some(4096),
                     reasoning_effort: None,
                     request_overrides: None,
+                    thinking_replay_always: None,
                     extra: Default::default(),
                 }),
                 ..ProviderConfigs::default()

--- a/crates/infra/bamboo-llm/src/provider_registry.rs
+++ b/crates/infra/bamboo-llm/src/provider_registry.rs
@@ -385,6 +385,14 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
                 max_tokens: None,
                 reasoning_effort: instance.reasoning_effort,
                 request_overrides: instance.request_overrides.clone(),
+                // Anthropic-compatible upstreams (e.g. GLM) that require
+                // unconditional `thinking`-block presence opt in via this
+                // instance's `extra.thinking_replay_always` (#520); real
+                // Anthropic must never set it.
+                thinking_replay_always: instance
+                    .extra
+                    .get("thinking_replay_always")
+                    .and_then(|v| v.as_bool()),
                 extra: Default::default(),
             });
         }
@@ -613,6 +621,75 @@ mod tests {
         );
         assert_eq!(openai.model.as_deref(), Some("gpt-4o"));
         assert_eq!(config.provider, "openai");
+    }
+
+    /// Issue #520: an Anthropic provider instance's `extra.thinking_replay_always`
+    /// (the GLM-style anthropic-compat opt-in) must project through to the
+    /// legacy `AnthropicConfig` slot `create_provider_by_name` reads.
+    #[test]
+    fn test_apply_instance_to_config_anthropic_projects_thinking_replay_always() {
+        let mut config = Config::default();
+        let mut extra = std::collections::BTreeMap::new();
+        extra.insert(
+            "thinking_replay_always".to_string(),
+            serde_json::json!(true),
+        );
+        let instance = ProviderInstanceConfig {
+            provider_type: "anthropic".to_string(),
+            label: Some("GLM compat".to_string()),
+            api_key: "glm-key".to_string(),
+            api_key_encrypted: None,
+            base_url: Some("https://glm.example.com/anthropic".to_string()),
+            model: Some("glm-4.6".to_string()),
+            fast_model: None,
+            vision_model: None,
+            reasoning_effort: None,
+            responses_only_models: vec![],
+            request_overrides: None,
+            enabled: true,
+            extra,
+        };
+
+        apply_instance_to_config(&mut config, &instance);
+
+        let anthropic = config
+            .providers
+            .anthropic
+            .as_ref()
+            .expect("anthropic should be set");
+        assert_eq!(anthropic.thinking_replay_always, Some(true));
+    }
+
+    /// Without the `extra.thinking_replay_always` key at all, the projected
+    /// config must leave it `None` — `create_provider_by_name` then defaults
+    /// to `false`, the safe real-Anthropic behavior (#520).
+    #[test]
+    fn test_apply_instance_to_config_anthropic_defaults_thinking_replay_always_to_none() {
+        let mut config = Config::default();
+        let instance = ProviderInstanceConfig {
+            provider_type: "anthropic".to_string(),
+            label: None,
+            api_key: "sk-ant-key".to_string(),
+            api_key_encrypted: None,
+            base_url: None,
+            model: None,
+            fast_model: None,
+            vision_model: None,
+            reasoning_effort: None,
+            responses_only_models: vec![],
+            request_overrides: None,
+            enabled: true,
+            extra: Default::default(),
+        };
+
+        apply_instance_to_config(&mut config, &instance);
+
+        let anthropic = config
+            .providers
+            .anthropic
+            .as_ref()
+            .expect("anthropic should be set");
+        assert_eq!(anthropic.thinking_replay_always, None);
     }
 
     /// A poisoned lock must not brick the registry: every subsequent operation

--- a/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
@@ -41,6 +41,24 @@ pub struct AnthropicProvider {
     default_reasoning_effort: Option<ReasoningEffort>,
     request_overrides: Option<RequestOverridesConfig>,
     masking_config: KeywordMaskingConfig,
+    /// Whether to replay a prior turn's `reasoning` text as a `thinking` content
+    /// block unconditionally (issue #520).
+    ///
+    /// The real Anthropic API requires `thinking` input blocks to carry a
+    /// `signature` it can cryptographically verify as its own — bamboo never
+    /// captures that signature (the SSE parser drops `signature_delta`), so any
+    /// block we replay is either foreign (minted by a different provider, e.g.
+    /// after a mid-session model switch) or an unsigned copy of Claude's own
+    /// prior thinking. Real Anthropic 400s on both. The safe default is to omit
+    /// the block entirely: Anthropic does not require prior-turn thinking to
+    /// continue a conversation.
+    ///
+    /// Some Anthropic-compatible upstreams (e.g. GLM's `/anthropic` endpoint)
+    /// have the opposite contract: they require the `thinking` block to be
+    /// PRESENT on every assistant turn once thinking is enabled, but never
+    /// validate its signature. Setting this to `true` restores the old
+    /// unconditional-emission behavior for that class of upstream.
+    thinking_replay_always: bool,
 }
 
 impl AnthropicProvider {
@@ -53,6 +71,7 @@ impl AnthropicProvider {
             default_reasoning_effort: None,
             request_overrides: None,
             masking_config: KeywordMaskingConfig::default(),
+            thinking_replay_always: false,
         }
     }
 
@@ -88,6 +107,15 @@ impl AnthropicProvider {
     /// Configure request overrides for this provider.
     pub fn with_request_overrides(mut self, overrides: Option<RequestOverridesConfig>) -> Self {
         self.request_overrides = overrides;
+        self
+    }
+
+    /// Opt into unconditional `thinking`-block replay (issue #520), for
+    /// Anthropic-compatible upstreams (e.g. GLM) that require the block to be
+    /// present regardless of signature. Real Anthropic should never set this —
+    /// it will reject an unsigned/foreign thinking block with a 400.
+    pub fn with_thinking_replay_always(mut self, always: bool) -> Self {
+        self.thinking_replay_always = always;
         self
     }
 
@@ -234,6 +262,7 @@ impl AnthropicProvider {
             reasoning_effort,
             parallel_tool_calls,
             cache_plan,
+            self.thinking_replay_always,
         );
         request_overrides::apply_overrides_to_body(
             &mut body,
@@ -344,6 +373,7 @@ impl AnthropicProvider {
                     None,
                     parallel_tool_calls,
                     cache_plan,
+                    self.thinking_replay_always,
                 );
                 request_overrides::apply_overrides_to_body(
                     &mut fallback_body,
@@ -446,6 +476,13 @@ pub fn build_anthropic_request(
     )
 }
 
+// NOTE: `build_anthropic_request` and `build_anthropic_request_with_cache` are
+// the widely-used simple entry points (production `Bodhi` proxy path + dozens
+// of tests unrelated to thinking replay); they always target real Anthropic,
+// so both hardcode `thinking_replay_always = false` inside
+// `build_anthropic_request_with_cache` below rather than growing another
+// public parameter every caller has to thread through.
+
 /// Build an Anthropic Messages API request body, placing prompt-cache
 /// breakpoints according to a provider-agnostic [`PromptCachePlan`].
 ///
@@ -481,6 +518,7 @@ pub fn build_anthropic_request_with_cache(
         reasoning_effort,
         parallel_tool_calls,
         cache,
+        false,
     )
 }
 
@@ -490,6 +528,14 @@ pub fn build_anthropic_request_with_cache(
 /// `cache_control` breakpoint still lands on the last block, so caching behavior
 /// is unchanged; only the structure (N text blocks vs one joined block) differs.
 /// With empty `system_blocks` this is byte-identical to the legacy path.
+///
+/// `thinking_replay_always`: see [`AnthropicProvider::with_thinking_replay_always`]
+/// (issue #520) — when `false` (the default for real Anthropic), a `thinking`
+/// block is never replayed from history since bamboo cannot prove it carries a
+/// signature Anthropic itself minted; when `true`, prior `reasoning` text is
+/// unconditionally re-emitted as a `thinking` block whenever the current
+/// request has thinking enabled, matching the legacy behavior some
+/// Anthropic-compatible upstreams (e.g. GLM) require.
 #[allow(clippy::too_many_arguments)]
 pub fn build_anthropic_request_with_cache_blocks(
     messages: &[Message],
@@ -501,6 +547,7 @@ pub fn build_anthropic_request_with_cache_blocks(
     reasoning_effort: Option<ReasoningEffort>,
     parallel_tool_calls: Option<bool>,
     cache: Option<&PromptCachePlan>,
+    thinking_replay_always: bool,
 ) -> Value {
     let default_plan = PromptCachePlan {
         cache_tools: true,
@@ -510,8 +557,17 @@ pub fn build_anthropic_request_with_cache_blocks(
     let plan = cache.unwrap_or(&default_plan);
     let ttl = plan.ttl;
 
-    let (mut system, mut anthropic_messages, message_ids) =
-        messages_to_anthropic_json(messages, system_blocks);
+    // Whether the CURRENT request enables extended thinking — a `thinking`
+    // block can never be replayed when it's disabled (Anthropic rejects it in
+    // that case too, issue #520).
+    let thinking_enabled = anthropic_thinking_from_effort(reasoning_effort, max_tokens).is_some();
+
+    let (mut system, mut anthropic_messages, message_ids) = messages_to_anthropic_json(
+        messages,
+        system_blocks,
+        thinking_enabled,
+        thinking_replay_always,
+    );
 
     // Anthropic honors at most MAX_ANTHROPIC_CACHE_BREAKPOINTS `cache_control`
     // markers per request. Spend the budget on the most stable regions first
@@ -650,9 +706,14 @@ fn system_blocks_to_anthropic_value(system_blocks: &[PromptBlock]) -> Option<Val
 /// When `system_blocks` is non-empty it is the canonical, structured source for
 /// the system field (each block → its own text block); otherwise the system field
 /// is the joined `System`-message text (legacy, byte-identical).
+///
+/// `thinking_enabled`/`thinking_replay_always` gate `thinking`-block replay on
+/// assistant turns — see [`build_anthropic_request_with_cache_blocks`] (#520).
 fn messages_to_anthropic_json(
     messages: &[Message],
     system_blocks: &[PromptBlock],
+    thinking_enabled: bool,
+    thinking_replay_always: bool,
 ) -> (Option<Value>, Vec<Value>, Vec<Vec<String>>) {
     let mut system_parts: Vec<&str> = Vec::new();
     let mut out: Vec<Value> = Vec::new();
@@ -680,7 +741,12 @@ fn messages_to_anthropic_json(
                 // System message; skip it (rather than emit a null/empty entry)
                 // so a malformed conversation never pollutes the `messages`
                 // array nor crashes the call (issue #22).
-                let Some(msg_json) = message_to_anthropic_json(m, keep_image) else {
+                let Some(msg_json) = message_to_anthropic_json(
+                    m,
+                    keep_image,
+                    thinking_enabled,
+                    thinking_replay_always,
+                ) else {
                     continue;
                 };
                 // Coalesce consecutive SAME-ROLE messages into one. Anthropic
@@ -770,7 +836,16 @@ fn message_has_image(message: &Message) -> bool {
 /// during an LLM call (issue #22). Callers consume this with `filter_map` /
 /// `let-else` so a skipped message is omitted entirely, never turned into a
 /// `null`/empty entry in the `messages` array.
-fn message_to_anthropic_json(message: &Message, keep_image: bool) -> Option<Value> {
+///
+/// `thinking_enabled`/`thinking_replay_always` gate whether `message.reasoning`
+/// is replayed as a `thinking` content block — see
+/// [`build_anthropic_request_with_cache_blocks`] (#520).
+fn message_to_anthropic_json(
+    message: &Message,
+    keep_image: bool,
+    thinking_enabled: bool,
+    thinking_replay_always: bool,
+) -> Option<Value> {
     match message.role {
         // A System message belongs in the top-level `system` field, not the
         // `messages` array; the caller (`messages_to_anthropic_json`) routes it
@@ -791,18 +866,30 @@ fn message_to_anthropic_json(message: &Message, keep_image: bool) -> Option<Valu
         Role::Assistant => {
             let mut blocks: Vec<Value> = Vec::new();
 
-            // When extended thinking was enabled, Anthropic requires the
-            // `thinking` content block to be present in every assistant
-            // message — including tool-call turns.  Without it the API
-            // returns HTTP 400:
-            //   "thinking is enabled but reasoning_content is missing in
-            //    assistant tool call message at index N"
-            if let Some(reasoning) = &message.reasoning {
-                if !reasoning.is_empty() {
-                    blocks.push(json!({
-                        "type": "thinking",
-                        "thinking": reasoning,
-                    }));
+            // Replay `message.reasoning` as a `thinking` content block ONLY
+            // when the current request has thinking enabled AND the upstream
+            // is explicitly known to require the block unconditionally
+            // (`thinking_replay_always`, e.g. a GLM-style anthropic-compat
+            // upstream that doesn't validate signatures).
+            //
+            // The real Anthropic API requires `thinking` input blocks to carry
+            // a `signature` it minted itself; bamboo never captures that
+            // signature (the SSE parser drops `signature_delta`), so any block
+            // we could replay here is either foreign (minted by a different
+            // provider after a mid-session model switch, #520) or an unsigned
+            // copy of Claude's own prior turn. Real Anthropic 400s on both, and
+            // also 400s if a thinking block is sent while thinking is
+            // disabled for the current request. Anthropic does not require
+            // prior-turn thinking to continue a conversation, so the safe
+            // default is to omit it entirely.
+            if thinking_enabled && thinking_replay_always {
+                if let Some(reasoning) = &message.reasoning {
+                    if !reasoning.is_empty() {
+                        blocks.push(json!({
+                            "type": "thinking",
+                            "thinking": reasoning,
+                        }));
+                    }
                 }
             }
 
@@ -1505,6 +1592,7 @@ mod anthropic_request_building {
             None,
             None,
             None,
+            false,
         );
 
         let system = out["system"].as_array().expect("system is a block array");
@@ -1544,6 +1632,7 @@ mod anthropic_request_building {
             None,
             None,
             None,
+            false,
         );
         let system = out["system"].as_array().expect("system array");
         assert_eq!(system.len(), 1);
@@ -1562,8 +1651,8 @@ mod anthropic_request_building {
                 data: "AAAA".to_string(),
             }],
         );
-        let v =
-            super::message_to_anthropic_json(&msg, true).expect("tool message should serialize");
+        let v = super::message_to_anthropic_json(&msg, true, false, false)
+            .expect("tool message should serialize");
         let block = &v["content"][0];
         assert_eq!(block["type"], "tool_result");
         assert_eq!(block["tool_use_id"], "toolu_1");
@@ -1586,8 +1675,8 @@ mod anthropic_request_building {
     fn tool_result_without_image_stays_plain_string() {
         // Regression: text-only tool results keep the cheap string form.
         let msg = Message::tool_result("toolu_2", "plain text");
-        let v =
-            super::message_to_anthropic_json(&msg, true).expect("tool message should serialize");
+        let v = super::message_to_anthropic_json(&msg, true, false, false)
+            .expect("tool message should serialize");
         assert_eq!(v["content"][0]["type"], "tool_result");
         assert_eq!(v["content"][0]["content"], "plain text");
     }
@@ -1605,8 +1694,8 @@ mod anthropic_request_building {
                 data: "OLD".to_string(),
             }],
         );
-        let v =
-            super::message_to_anthropic_json(&msg, false).expect("tool message should serialize");
+        let v = super::message_to_anthropic_json(&msg, false, false, false)
+            .expect("tool message should serialize");
         let content = &v["content"][0]["content"];
         // No image block — content is a plain string with the omission note.
         assert!(content.is_string(), "dropped image should leave a string");
@@ -1625,7 +1714,7 @@ mod anthropic_request_building {
         // (a) Direct: a System message serializes to None instead of panicking.
         let system_msg = Message::system("You are a robot.");
         assert!(
-            super::message_to_anthropic_json(&system_msg, true).is_none(),
+            super::message_to_anthropic_json(&system_msg, true, false, false).is_none(),
             "a System message must serialize to None (skipped), not panic"
         );
 
@@ -1640,7 +1729,7 @@ mod anthropic_request_building {
         ];
         let serialized: Vec<Value> = conversation
             .iter()
-            .filter_map(|m| super::message_to_anthropic_json(m, true))
+            .filter_map(|m| super::message_to_anthropic_json(m, true, false, false))
             .collect();
 
         // The System message is omitted; User + Assistant survive, in order.
@@ -1678,7 +1767,8 @@ mod anthropic_request_building {
         let assistant_id = assistant.id.clone();
 
         let messages = [system, user, assistant];
-        let (system_val, out, out_ids) = super::messages_to_anthropic_json(&messages, &[]);
+        let (system_val, out, out_ids) =
+            super::messages_to_anthropic_json(&messages, &[], false, false);
 
         // (a) The System message is routed into the top-level `system` field.
         let system_value =
@@ -1733,7 +1823,8 @@ mod anthropic_request_building {
             Message::user("Hello"),
             Message::assistant("Hi!", None),
         ];
-        let (system_val, out, out_ids) = super::messages_to_anthropic_json(&messages, &[]);
+        let (system_val, out, out_ids) =
+            super::messages_to_anthropic_json(&messages, &[], false, false);
 
         // Both system messages are joined into the system field.
         let system_value =
@@ -1812,7 +1903,8 @@ mod anthropic_request_building {
             Message::system("mid-conversation system"),
             Message::tool_result("call_1", "found it"),
         ];
-        let (system_val, out, out_ids) = super::messages_to_anthropic_json(&messages, &[]);
+        let (system_val, out, out_ids) =
+            super::messages_to_anthropic_json(&messages, &[], false, false);
 
         // The wedged System message is routed to the system field, not dropped.
         assert!(
@@ -2427,13 +2519,29 @@ mod anthropic_request_building {
         // Anthropic rejects a `thinking` block in any non-first position, so the
         // merged-in turn's thinking is dropped. (#101 invariant: coalescing never
         // produces an illegal block order, even for the assistant role.)
+        //
+        // This exercises the compat (`thinking_replay_always`) path directly —
+        // see `build_anthropic_request_with_cache_blocks` (#520) — since that's
+        // the only mode that still emits `thinking` blocks from history at all;
+        // the invariant under test (coalescing never produces an illegal block
+        // order) is orthogonal to that replay policy.
         let messages = vec![
             Message::assistant_with_reasoning("a1", None, Some("reason one".into())),
             Message::assistant_with_reasoning("a2", None, Some("reason two".into())),
         ];
 
-        let out =
-            super::build_anthropic_request(&messages, &[], "claude-test", 64, false, None, None);
+        let out = super::build_anthropic_request_with_cache_blocks(
+            &messages,
+            &[],
+            &[],
+            "claude-test",
+            2048,
+            false,
+            Some(bamboo_domain::ReasoningEffort::Medium),
+            None,
+            None,
+            true,
+        );
         let built = out["messages"].as_array().expect("messages array");
         assert_eq!(built.len(), 1, "the two assistant turns coalesced");
 
@@ -2895,15 +3003,100 @@ mod anthropic_request_building_edge_cases {
         assert_eq!(out["max_tokens"], 2048);
     }
 
+    /// Issue #520: by default (real Anthropic, `thinking_replay_always = false`)
+    /// a `thinking` block is NEVER replayed from history, even when the current
+    /// request has thinking enabled and the reasoning text is non-empty — bamboo
+    /// never captures the signature Anthropic requires on a replayed `thinking`
+    /// block, so sending one back unconditionally 400s. This is the direct
+    /// regression test for root cause 1's "pure-Anthropic multi-round" variant.
     #[test]
-    fn assistant_reasoning_included_as_thinking_block() {
+    fn assistant_reasoning_omitted_by_default_even_with_thinking_enabled() {
         let messages = vec![Message::assistant_with_reasoning(
             "Here is the answer.",
             None,
             Some("I thought about it.".to_string()),
         )];
-        let out =
-            super::build_anthropic_request(&messages, &[], "claude-test", 64, false, None, None);
+        let out = super::build_anthropic_request_with_cache_blocks(
+            &messages,
+            &[],
+            &[],
+            "claude-test",
+            2048,
+            false,
+            Some(bamboo_domain::ReasoningEffort::Medium),
+            None,
+            None,
+            false, // thinking_replay_always = false: the real-Anthropic default
+        );
+
+        let content = out["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(
+            content.len(),
+            1,
+            "no thinking block is replayed without a captured signature"
+        );
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "Here is the answer.");
+    }
+
+    /// Issue #520's named repro: history containing reasoning minted by a
+    /// DIFFERENT provider (e.g. a GPT Responses reasoning summary, persisted
+    /// into the same `Message.reasoning` field bamboo uses for every provider)
+    /// must never be replayed as an Anthropic `thinking` block after a
+    /// mid-session model switch to Claude — that block would carry text
+    /// Anthropic never signed, and real Anthropic 400s on it.
+    #[test]
+    fn foreign_reasoning_never_replayed_as_thinking_block_after_provider_switch() {
+        let messages = vec![Message::assistant_with_reasoning(
+            "Done reading the repo.",
+            None,
+            Some("GPT's own reasoning summary text.".to_string()),
+        )];
+        let out = super::build_anthropic_request_with_cache_blocks(
+            &messages,
+            &[],
+            &[],
+            "claude-fable-5",
+            2048,
+            false,
+            Some(bamboo_domain::ReasoningEffort::Medium),
+            None,
+            None,
+            false,
+        );
+
+        let content = out["messages"][0]["content"].as_array().unwrap();
+        assert!(
+            content
+                .iter()
+                .all(|b| b.get("type").and_then(|t| t.as_str()) != Some("thinking")),
+            "foreign reasoning must never surface as a `thinking` block: {content:?}"
+        );
+    }
+
+    /// Compat upstreams (e.g. GLM's anthropic-compat endpoint) require the
+    /// `thinking` block to be present unconditionally and don't validate its
+    /// signature — `thinking_replay_always = true` preserves that legacy
+    /// behavior for them.
+    #[test]
+    fn assistant_reasoning_included_as_thinking_block_in_compat_mode() {
+        let messages = vec![Message::assistant_with_reasoning(
+            "Here is the answer.",
+            None,
+            Some("I thought about it.".to_string()),
+        )];
+        let out = super::build_anthropic_request_with_cache_blocks(
+            &messages,
+            &[],
+            &[],
+            "claude-test",
+            2048,
+            false,
+            Some(bamboo_domain::ReasoningEffort::Medium),
+            None,
+            None,
+            true, // thinking_replay_always = true: compat mode
+        );
 
         let content = out["messages"][0]["content"].as_array().unwrap();
         assert_eq!(content.len(), 2);
@@ -2916,7 +3109,7 @@ mod anthropic_request_building_edge_cases {
     }
 
     #[test]
-    fn assistant_reasoning_included_with_tool_calls() {
+    fn assistant_reasoning_included_with_tool_calls_in_compat_mode() {
         use bamboo_domain::{FunctionCall, ToolCall};
         let tool_call = ToolCall {
             id: "call_1".to_string(),
@@ -2931,8 +3124,18 @@ mod anthropic_request_building_edge_cases {
             Some(vec![tool_call]),
             Some("Planning the search.".to_string()),
         )];
-        let out =
-            super::build_anthropic_request(&messages, &[], "claude-test", 64, false, None, None);
+        let out = super::build_anthropic_request_with_cache_blocks(
+            &messages,
+            &[],
+            &[],
+            "claude-test",
+            2048,
+            false,
+            Some(bamboo_domain::ReasoningEffort::Medium),
+            None,
+            None,
+            true, // thinking_replay_always = true: compat mode
+        );
 
         let content = out["messages"][0]["content"].as_array().unwrap();
         assert_eq!(content.len(), 2);
@@ -2941,6 +3144,38 @@ mod anthropic_request_building_edge_cases {
         assert_eq!(content[0]["thinking"], "Planning the search.");
         // Tool use block second (no text because content is empty)
         assert_eq!(content[1]["type"], "tool_use");
+    }
+
+    /// Even in compat mode, a thinking block must never be sent when the
+    /// CURRENT request has thinking disabled — Anthropic (and Anthropic-style
+    /// upstreams) reject a thinking block in that case too (#520).
+    #[test]
+    fn assistant_reasoning_omitted_in_compat_mode_when_thinking_disabled() {
+        let messages = vec![Message::assistant_with_reasoning(
+            "Here is the answer.",
+            None,
+            Some("I thought about it.".to_string()),
+        )];
+        let out = super::build_anthropic_request_with_cache_blocks(
+            &messages,
+            &[],
+            &[],
+            "claude-test",
+            64,
+            false,
+            None, // reasoning_effort = None -> thinking disabled for this request
+            None,
+            None,
+            true, // thinking_replay_always = true
+        );
+
+        let content = out["messages"][0]["content"].as_array().unwrap();
+        assert_eq!(
+            content.len(),
+            1,
+            "thinking disabled for this request always wins over compat mode"
+        );
+        assert_eq!(content[0]["type"], "text");
     }
 
     #[test]

--- a/tests/config_comprehensive.rs
+++ b/tests/config_comprehensive.rs
@@ -278,6 +278,7 @@ mod comprehensive_config_tests {
             reasoning_effort: None,
             max_tokens: None,
             request_overrides: None,
+            thinking_replay_always: None,
             extra: Default::default(),
         });
         original.server.port = 8888;


### PR DESCRIPTION
## Summary

Fixes root cause 1 of #520 — mid-session model switches (e.g. `gpt-5.6-sol` → `claude-fable-5`) 400ing on the first round after the switch because the Anthropic adapter unconditionally replayed `Message.reasoning` as a `thinking` content block, regardless of which provider actually minted it.

**Scope check (done first):** root cause 2 (stale `responses.previous_response_id` continuation across a provider switch) is already fixed on `main` by #513 (`stream_execution.rs` gates continuation on the `store=false` policy and scrubs stale ids). This PR only addresses the remaining gap: root cause 1.

## What was broken

`message_to_anthropic_json` (`crates/infra/bamboo-llm/src/providers/anthropic/mod.rs`) pushed a `{"type":"thinking","thinking":...}` block for every assistant message carrying `Message.reasoning`, unconditionally:

```rust
if let Some(reasoning) = &message.reasoning {
    if !reasoning.is_empty() {
        blocks.push(json!({ "type": "thinking", "thinking": reasoning }));
    }
}
```

- `Message.reasoning` is populated for **every** provider (it's canonical, provider-agnostic history) — for a GPT Responses round it holds GPT's reasoning-summary text.
- The real Anthropic API requires `thinking` input blocks to carry a `signature` it minted itself. bamboo never captures one (the Anthropic SSE parser drops `signature_delta` entirely — confirmed zero `signature` references anywhere in `bamboo-llm`/`bamboo-domain`).
- So after a mid-session switch to Claude, the next round replayed the prior provider's reasoning as an unsigned/foreign `thinking` block → Anthropic 400s.
- The same bug also breaks **pure-Anthropic** multi-round sessions with extended thinking enabled: Claude's own prior-turn thinking is replayed unsigned too (never captured), so a second round can 400 even with no provider switch involved.
- The block was also emitted regardless of whether the *current* request has thinking enabled, which Anthropic separately rejects.

The original unconditional-emit code was written against an error message ("thinking is enabled but reasoning_content is missing...") that turns out to be a GLM anthropic-compat error, not a real-Anthropic one — real Anthropic's contract is the opposite (signature-gated, tolerates omission).

## Fix

`message_to_anthropic_json`/`messages_to_anthropic_json`/`build_anthropic_request_with_cache_blocks` now gate `thinking`-block replay on two things:

1. **`thinking_enabled`** — whether the *current* request has extended thinking on (derived from `reasoning_effort`/`max_tokens`, same as the `thinking` request body field).
2. **`thinking_replay_always`** — a new `AnthropicProvider` capability flag (default `false`).

With the default (`false`, i.e. real Anthropic), a `thinking` block is **never** replayed from history — bamboo can't prove a captured signature, and Anthropic tolerates full omission (it isn't required to continue a conversation; the visible text/tool_use already reflects it). This fixes both the cross-provider case named in #520 and the pure-Anthropic same-provider case the issue also flagged.

Anthropic-**compatible** upstreams that require the block unconditionally and don't validate signatures (e.g. GLM's `/anthropic` endpoint) opt back into the legacy always-emit behavior via `thinking_replay_always = true`, wired through:
- `AnthropicConfig.thinking_replay_always: Option<bool>` (legacy single-provider config), and
- the multi-instance provider config's `extra.thinking_replay_always` (same passthrough pattern already used for Bodhi's `target_provider`).

Real Anthropic must never set this flag; it will 400 on the resulting unsigned/foreign block exactly as before.

## Not done (follow-up, out of scope here)

- Capturing the real Anthropic `signature_delta` and threading a genuine per-message signature through the engine so *same-provider* Claude sessions can safely replay their own signed thinking (richer continuity than "always omit"). This would touch the streaming `LLMChunk` enum (consumed by 15+ match sites across `bamboo-engine`/`bamboo-server`), the `Message` schema, and pipeline assembly — a materially larger, higher-risk change I scoped out in favor of the minimal, provider-boundary-only fix here. Filed as a natural follow-up if genuine cross-turn thinking continuity for real Anthropic sessions is wanted later.
- Root cause 2's residual risk (binding `previous_response_id` to `provider+model` if `store=true` ever ships) — already called out in #513/#520 as a future item, untouched here.

## Test plan

- [x] New unit tests in `providers::anthropic::anthropic_request_building_edge_cases`:
  - `assistant_reasoning_omitted_by_default_even_with_thinking_enabled` — direct regression test for the pure-Anthropic sub-bug.
  - `foreign_reasoning_never_replayed_as_thinking_block_after_provider_switch` — reproduces #520's named repro shape (foreign reasoning text must never surface as `type:"thinking"`).
  - `assistant_reasoning_included_as_thinking_block_in_compat_mode` / `..._with_tool_calls_in_compat_mode` — GLM-style compat path still works when opted in.
  - `assistant_reasoning_omitted_in_compat_mode_when_thinking_disabled` — thinking-disabled-for-this-request always wins over compat mode.
- [x] Updated `assistant_coalesce_drops_interior_thinking_block` to exercise the compat path directly (the block-ordering invariant it tests is orthogonal to replay policy).
- [x] New `provider_registry` tests covering `extra.thinking_replay_always` projection (present + absent) for the multi-instance path.
- [x] `cargo fmt` (touched crates) clean.
- [x] `cargo clippy -p bamboo-llm -p bamboo-config --tests -- -D warnings` clean.
- [x] `cargo build --workspace --tests` — full workspace builds clean (only pre-existing unrelated warnings in `bamboo-memory`/`bamboo-engine`).
- [x] `cargo test -p bamboo-llm` — 470 passed, 0 failed.
- [x] `cargo test -p bamboo-config` — 253 passed, 0 failed.
- [x] `cargo test -p bamboo-engine external_agents::` — 48 passed, 0 failed (covers the `AnthropicConfig` struct-literal call sites touched by the new field).
- [x] `cargo test --test config_comprehensive` — 18 passed, 0 failed.

Closes #520 (root cause 1 — the remaining open piece; root cause 2 was already closed by #513).

https://claude.ai/code/session_014iw5PBsSzDFHus1GfkAK4y