### PR TITLE
fix(server): Responses API tool-calling compatibility for Codex-style clients (#525)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/openai/helpers/conversion.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/helpers/conversion.rs
@@ -1,7 +1,9 @@
 use crate::error::AppError;
-use bamboo_agent_core::tools::ToolSchema;
+use bamboo_agent_core::tools::{FunctionSchema, ToolSchema};
 use bamboo_llm::api::models::ChatMessage;
 use bamboo_llm::protocol::FromProvider;
+
+use super::super::types::ResponsesToolParam;
 
 pub(super) fn convert_messages(
     messages: Vec<ChatMessage>,
@@ -30,4 +32,63 @@ pub(super) fn convert_tools(
             .collect(),
         None => Ok(vec![]),
     }
+}
+
+/// Convert Responses-API `tools[]` entries into internal tool schemas.
+///
+/// Flat function entries (the spec shape) map directly; nested
+/// Chat-Completions entries are tolerated for legacy clients; non-function
+/// tool types are skipped rather than failing the request. A function-typed
+/// entry that matched neither shape is malformed and gets a targeted error —
+/// the untagged-enum serde message would be useless to the caller. #525.
+pub(super) fn convert_responses_tools(
+    tools: Option<Vec<ResponsesToolParam>>,
+) -> Result<Vec<ToolSchema>, AppError> {
+    let Some(tools) = tools else {
+        return Ok(vec![]);
+    };
+
+    let mut converted = Vec::with_capacity(tools.len());
+    for tool in tools {
+        match tool {
+            ResponsesToolParam::Flat(flat) => {
+                if flat.tool_type != "function" {
+                    tracing::debug!(
+                        tool_type = %flat.tool_type,
+                        "Skipping unsupported Responses tool type"
+                    );
+                    continue;
+                }
+                converted.push(ToolSchema {
+                    schema_type: flat.tool_type,
+                    function: FunctionSchema {
+                        name: flat.name,
+                        description: flat.description.unwrap_or_default(),
+                        parameters: flat.parameters,
+                    },
+                });
+            }
+            ResponsesToolParam::Nested(tool) => {
+                converted.push(ToolSchema::from_provider(tool).map_err(|error| {
+                    AppError::InternalError(anyhow::anyhow!("Failed to convert tool: {}", error))
+                })?);
+            }
+            ResponsesToolParam::Other(value) => {
+                let tool_type = value
+                    .get("type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<missing>");
+                if tool_type == "function" {
+                    return Err(AppError::BadRequest(
+                        "Malformed function tool: expected the flat Responses shape \
+                         {\"type\":\"function\",\"name\":…,\"parameters\":…} (or the legacy \
+                         nested {\"type\",\"function\":{…}})"
+                            .to_string(),
+                    ));
+                }
+                tracing::debug!(%tool_type, "Skipping unsupported Responses tool type");
+            }
+        }
+    }
+    Ok(converted)
 }

--- a/crates/app/bamboo-server/src/handlers/openai/helpers/conversion.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/helpers/conversion.rs
@@ -18,18 +18,17 @@ pub(super) fn convert_messages(
         .collect()
 }
 
+fn nested_tool_to_schema(tool: bamboo_llm::api::models::Tool) -> Result<ToolSchema, AppError> {
+    ToolSchema::from_provider(tool).map_err(|error| {
+        AppError::InternalError(anyhow::anyhow!("Failed to convert tool: {}", error))
+    })
+}
+
 pub(super) fn convert_tools(
     tools: Option<Vec<bamboo_llm::api::models::Tool>>,
 ) -> Result<Vec<ToolSchema>, AppError> {
     match tools {
-        Some(tools) => tools
-            .into_iter()
-            .map(|tool| {
-                ToolSchema::from_provider(tool).map_err(|error| {
-                    AppError::InternalError(anyhow::anyhow!("Failed to convert tool: {}", error))
-                })
-            })
-            .collect(),
+        Some(tools) => tools.into_iter().map(nested_tool_to_schema).collect(),
         None => Ok(vec![]),
     }
 }
@@ -53,31 +52,44 @@ pub(super) fn convert_responses_tools(
         match tool {
             ResponsesToolParam::Flat(flat) => {
                 if flat.tool_type != "function" {
-                    tracing::debug!(
+                    // warn, not debug: a skipped `custom` (freeform) tool is a
+                    // capability the client expects the model to call — the
+                    // operator needs a visible signal, not a silent gap.
+                    tracing::warn!(
                         tool_type = %flat.tool_type,
-                        "Skipping unsupported Responses tool type"
+                        name = %flat.name,
+                        "Skipping unsupported Responses tool type (not forwarded to the model)"
                     );
                     continue;
                 }
+                // An omitted `parameters` deserializes to JSON null; normalize
+                // to an empty object schema so providers doing schema
+                // validation don't choke on `parameters: null`.
+                let parameters = if flat.parameters.is_null() {
+                    serde_json::json!({"type": "object", "properties": {}})
+                } else {
+                    flat.parameters
+                };
                 converted.push(ToolSchema {
                     schema_type: flat.tool_type,
                     function: FunctionSchema {
                         name: flat.name,
                         description: flat.description.unwrap_or_default(),
-                        parameters: flat.parameters,
+                        parameters,
                     },
                 });
             }
             ResponsesToolParam::Nested(tool) => {
-                converted.push(ToolSchema::from_provider(tool).map_err(|error| {
-                    AppError::InternalError(anyhow::anyhow!("Failed to convert tool: {}", error))
-                })?);
+                converted.push(nested_tool_to_schema(tool)?);
             }
             ResponsesToolParam::Other(value) => {
-                let tool_type = value
-                    .get("type")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("<missing>");
+                // A missing/non-string `type` is garbage, not an unsupported
+                // feature — fail fast like the old strict parsing did.
+                let Some(tool_type) = value.get("type").and_then(|v| v.as_str()) else {
+                    return Err(AppError::BadRequest(
+                        "Malformed tools[] entry: missing string `type` field".to_string(),
+                    ));
+                };
                 if tool_type == "function" {
                     return Err(AppError::BadRequest(
                         "Malformed function tool: expected the flat Responses shape \
@@ -86,7 +98,10 @@ pub(super) fn convert_responses_tools(
                             .to_string(),
                     ));
                 }
-                tracing::debug!(%tool_type, "Skipping unsupported Responses tool type");
+                tracing::warn!(
+                    %tool_type,
+                    "Skipping unsupported Responses tool type (not forwarded to the model)"
+                );
             }
         }
     }

--- a/crates/app/bamboo-server/src/handlers/openai/helpers/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/helpers/mod.rs
@@ -18,6 +18,12 @@ pub(super) fn convert_tools(
     conversion::convert_tools(tools)
 }
 
+pub(super) fn convert_responses_tools(
+    tools: Option<Vec<super::types::ResponsesToolParam>>,
+) -> Result<Vec<bamboo_agent_core::tools::ToolSchema>, crate::error::AppError> {
+    conversion::convert_responses_tools(tools)
+}
+
 pub(super) fn responses_input_to_chat_messages(
     input: serde_json::Value,
 ) -> Result<Vec<bamboo_llm::api::models::ChatMessage>, crate::error::AppError> {

--- a/crates/app/bamboo-server/src/handlers/openai/helpers/responses_input.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/helpers/responses_input.rs
@@ -76,15 +76,33 @@ pub(super) fn responses_input_to_chat_messages(
                 .unwrap_or("")
                 .to_string();
 
+            let call = ToolCall {
+                id: call_id,
+                tool_type: "function".to_string(),
+                function: FunctionCall { name, arguments },
+            };
+
+            // A function_call item belongs to the assistant turn immediately
+            // preceding it. Attach it there — one assistant message per turn
+            // with ALL of its tool_calls. Emitting one single-call assistant
+            // message per item breaks parallel tool calls: Chat-Completions
+            // upstreams reject an assistant tool_calls message that is not
+            // immediately followed by its tool results (#525).
+            if let Some(last) = messages.last_mut() {
+                if matches!(last.role, Role::Assistant) {
+                    match last.tool_calls.as_mut() {
+                        Some(calls) => calls.push(call),
+                        None => last.tool_calls = Some(vec![call]),
+                    }
+                    continue;
+                }
+            }
+
             messages.push(ChatMessage {
                 role: Role::Assistant,
                 content: Content::Text(String::new()),
                 phase: Some("commentary".to_string()),
-                tool_calls: Some(vec![ToolCall {
-                    id: call_id,
-                    tool_type: "function".to_string(),
-                    function: FunctionCall { name, arguments },
-                }]),
+                tool_calls: Some(vec![call]),
                 tool_call_id: None,
             });
             continue;

--- a/crates/app/bamboo-server/src/handlers/openai/helpers/responses_input.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/helpers/responses_input.rs
@@ -96,11 +96,21 @@ pub(super) fn responses_input_to_chat_messages(
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
-            let output = obj
-                .get("output")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
+            // `output` is a string OR an array of content parts
+            // (`[{type:"output_text", text}]`). Flatten parts to text instead
+            // of silently degrading non-string shapes to "" (#525).
+            let output = match obj.get("output") {
+                None | Some(serde_json::Value::Null) => String::new(),
+                Some(serde_json::Value::String(text)) => text.clone(),
+                Some(serde_json::Value::Array(parts)) => parts
+                    .iter()
+                    .filter_map(|part| part.as_object())
+                    .filter_map(|part| part.get("text").and_then(|t| t.as_str()))
+                    .collect::<Vec<_>>()
+                    .join(""),
+                // Any other shape: keep the raw JSON rather than dropping it.
+                Some(other) => other.to_string(),
+            };
 
             messages.push(ChatMessage {
                 role: Role::Tool,
@@ -109,6 +119,16 @@ pub(super) fn responses_input_to_chat_messages(
                 tool_calls: None,
                 tool_call_id: Some(call_id),
             });
+            continue;
+        }
+
+        // An item with an explicitly unknown `type` (Codex round-trips
+        // `reasoning` items, the spec has `web_search_call`, …) must be
+        // skipped: falling into the message branch fabricates an empty user
+        // message that pollutes the conversation (#525). Items WITHOUT a
+        // `type` key defaulted to "message" above and keep flowing.
+        if item_type != "message" {
+            tracing::debug!(item_type, "Skipping unsupported Responses input item type");
             continue;
         }
 

--- a/crates/app/bamboo-server/src/handlers/openai/responses/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/non_stream.rs
@@ -56,7 +56,9 @@ pub(super) async fn handle_non_streaming_response(
         .map_err(map_provider_error)?;
 
     let mut content = String::new();
-    let mut tool_calls: Vec<bamboo_agent_core::tools::ToolCall> = Vec::new();
+    // Merge partial tool-call fragments by index/id — a raw Vec shatters one
+    // call into N broken output items (#525). Same as the streaming worker.
+    let mut tool_calls = bamboo_agent_core::tools::ToolCallAccumulator::new();
     let mut upstream_response_id: Option<String> = None;
 
     while let Some(chunk_result) = stream.next().await {
@@ -68,9 +70,9 @@ pub(super) async fn handle_non_streaming_response(
             // Keep parity with streaming behavior: expose reasoning narration as text.
             Ok(bamboo_llm::types::LLMChunk::ReasoningToken(text)) => content.push_str(&text),
             Ok(bamboo_llm::types::LLMChunk::ToolCalls(calls)) => tool_calls.extend(calls),
-            // Indexed variant: drop indices, same behavior. #236.
+            // Indexed variant: route fragments by provider index (#236/#525).
             Ok(bamboo_llm::types::LLMChunk::ToolCallsIndexed(calls)) => {
-                tool_calls.extend(calls.into_iter().map(|(_, call)| call))
+                tool_calls.extend_indexed(calls)
             }
             Ok(bamboo_llm::types::LLMChunk::Done) => break,
             Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. })
@@ -99,7 +101,7 @@ pub(super) async fn handle_non_streaming_response(
     let message_id = format!("msg_{}", uuid::Uuid::new_v4());
     let created_at = now_unix_ts();
 
-    let output = build_output_items(&message_id, content, tool_calls);
+    let output = build_output_items(&message_id, content, tool_calls.finalize());
     let resp = build_completed_response(response_id, created_at, display_model, output);
 
     app_state.metrics_service.collector().forward_completed(

--- a/crates/app/bamboo-server/src/handlers/openai/responses/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/non_stream.rs
@@ -101,7 +101,17 @@ pub(super) async fn handle_non_streaming_response(
     let message_id = format!("msg_{}", uuid::Uuid::new_v4());
     let created_at = now_unix_ts();
 
-    let output = build_output_items(&message_id, content, tool_calls.finalize());
+    // Merged fragments whose name never arrived are dropped by finalize();
+    // make that visible instead of silently losing a call attempt (#525).
+    let fragment_groups = tool_calls.parts().len();
+    let finalized_calls = tool_calls.finalize();
+    if finalized_calls.len() < fragment_groups {
+        tracing::warn!(
+            dropped = fragment_groups - finalized_calls.len(),
+            "Dropping incomplete streamed tool call(s) whose name never arrived"
+        );
+    }
+    let output = build_output_items(&message_id, content, finalized_calls);
     let resp = build_completed_response(response_id, created_at, display_model, output);
 
     app_state.metrics_service.collector().forward_completed(

--- a/crates/app/bamboo-server/src/handlers/openai/responses/output.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/output.rs
@@ -19,6 +19,7 @@ pub(super) fn build_output_items(
             content_type: "output_text".to_string(),
             text: content,
         }],
+        status: Some("completed".to_string()),
     }));
 
     for (idx, tool_call) in tool_calls.into_iter().enumerate() {

--- a/crates/app/bamboo-server/src/handlers/openai/responses/output.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/output.rs
@@ -29,6 +29,7 @@ pub(super) fn build_output_items(
                 call_id: tool_call.id,
                 name: tool_call.function.name,
                 arguments: tool_call.function.arguments,
+                status: Some("completed".to_string()),
             },
         ));
     }

--- a/crates/app/bamboo-server/src/handlers/openai/responses/prepare.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/prepare.rs
@@ -3,7 +3,7 @@ use actix_web::web;
 use crate::{app_state::AppState, error::AppError};
 
 use super::super::helpers::{
-    convert_messages, convert_tools, parse_parallel_tool_calls, parse_reasoning_effort,
+    convert_messages, convert_responses_tools, parse_parallel_tool_calls, parse_reasoning_effort,
     parse_responses_request_options, responses_input_to_chat_messages,
 };
 use super::super::types::ResponsesCreateRequest;
@@ -58,7 +58,7 @@ pub(super) async fn prepare_request(
         }
     })?;
 
-    let internal_tools = convert_tools(request.tools)?;
+    let internal_tools = convert_responses_tools(request.tools)?;
 
     let max_tokens = request.max_output_tokens.or_else(|| {
         request

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/events.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/events.rs
@@ -1,7 +1,10 @@
 use bytes::Bytes;
 use serde::Serialize;
 
-use super::super::super::types::{ResponsesCreateResponse, ResponsesStreamEvent};
+use super::super::super::types::{
+    ResponsesCreateResponse, ResponsesFunctionCallOutputItem, ResponsesOutputItem,
+    ResponsesStreamEvent,
+};
 
 pub(super) fn created_event(
     response_id: String,
@@ -24,6 +27,8 @@ pub(super) fn created_event(
         output_index: None,
         content_index: None,
         delta: None,
+        item: None,
+        arguments: None,
     }
 }
 
@@ -40,6 +45,8 @@ pub(super) fn output_text_delta_event(
         output_index: Some(0),
         content_index: Some(0),
         delta: Some(delta),
+        item: None,
+        arguments: None,
     }
 }
 
@@ -54,7 +61,88 @@ pub(super) fn completed_event(
         output_index: None,
         content_index: None,
         delta: None,
+        item: None,
+        arguments: None,
     }
+}
+
+/// A bare event skeleton for the function-call item events below.
+fn item_event(
+    event_type: &str,
+    response_id: &str,
+    item_id: &str,
+    output_index: u32,
+) -> ResponsesStreamEvent<ResponsesCreateResponse> {
+    ResponsesStreamEvent {
+        event_type: event_type.to_string(),
+        response: None,
+        response_id: Some(response_id.to_string()),
+        item_id: Some(item_id.to_string()),
+        output_index: Some(output_index),
+        content_index: None,
+        delta: None,
+        item: None,
+        arguments: None,
+    }
+}
+
+/// The standard Responses event sequence for ONE completed function call,
+/// emitted before `response.completed` (#525):
+/// `response.output_item.added` (item, in_progress, empty arguments) →
+/// `response.function_call_arguments.delta` (full aggregated arguments — a
+/// single delta is spec-legal) → `response.function_call_arguments.done` →
+/// `response.output_item.done` (item, completed, full arguments).
+///
+/// Codex collects function calls from `response.output_item.done`.
+pub(super) fn function_call_item_events(
+    response_id: &str,
+    item: &ResponsesFunctionCallOutputItem,
+    output_index: u32,
+) -> Vec<ResponsesStreamEvent<ResponsesCreateResponse>> {
+    let mut added = item_event(
+        "response.output_item.added",
+        response_id,
+        &item.id,
+        output_index,
+    );
+    added.item = Some(ResponsesOutputItem::FunctionCall(
+        ResponsesFunctionCallOutputItem {
+            arguments: String::new(),
+            status: Some("in_progress".to_string()),
+            ..item.clone()
+        },
+    ));
+
+    let mut arguments_delta = item_event(
+        "response.function_call_arguments.delta",
+        response_id,
+        &item.id,
+        output_index,
+    );
+    arguments_delta.delta = Some(item.arguments.clone());
+
+    let mut arguments_done = item_event(
+        "response.function_call_arguments.done",
+        response_id,
+        &item.id,
+        output_index,
+    );
+    arguments_done.arguments = Some(item.arguments.clone());
+
+    let mut done = item_event(
+        "response.output_item.done",
+        response_id,
+        &item.id,
+        output_index,
+    );
+    done.item = Some(ResponsesOutputItem::FunctionCall(
+        ResponsesFunctionCallOutputItem {
+            status: Some("completed".to_string()),
+            ..item.clone()
+        },
+    ));
+
+    vec![added, arguments_delta, arguments_done, done]
 }
 
 pub(super) fn event_to_sse_bytes<T: Serialize>(event: &ResponsesStreamEvent<T>) -> Bytes {

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/events.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/events.rs
@@ -2,8 +2,8 @@ use bytes::Bytes;
 use serde::Serialize;
 
 use super::super::super::types::{
-    ResponsesCreateResponse, ResponsesFunctionCallOutputItem, ResponsesOutputItem,
-    ResponsesStreamEvent,
+    ResponsesCreateResponse, ResponsesFunctionCallOutputItem, ResponsesMessageOutputItem,
+    ResponsesOutputItem, ResponsesStreamEvent,
 };
 
 pub(super) fn created_event(
@@ -22,13 +22,7 @@ pub(super) fn created_event(
             output: Vec::new(),
             usage: None,
         }),
-        response_id: None,
-        item_id: None,
-        output_index: None,
-        content_index: None,
-        delta: None,
-        item: None,
-        arguments: None,
+        ..Default::default()
     }
 }
 
@@ -39,14 +33,12 @@ pub(super) fn output_text_delta_event(
 ) -> ResponsesStreamEvent<ResponsesCreateResponse> {
     ResponsesStreamEvent {
         event_type: "response.output_text.delta".to_string(),
-        response: None,
         response_id: Some(response_id.to_string()),
         item_id: Some(item_id.to_string()),
         output_index: Some(0),
         content_index: Some(0),
         delta: Some(delta),
-        item: None,
-        arguments: None,
+        ..Default::default()
     }
 }
 
@@ -56,17 +48,11 @@ pub(super) fn completed_event(
     ResponsesStreamEvent {
         event_type: "response.completed".to_string(),
         response: Some(response),
-        response_id: None,
-        item_id: None,
-        output_index: None,
-        content_index: None,
-        delta: None,
-        item: None,
-        arguments: None,
+        ..Default::default()
     }
 }
 
-/// A bare event skeleton for the function-call item events below.
+/// A bare event skeleton for the per-item events below.
 fn item_event(
     event_type: &str,
     response_id: &str,
@@ -75,15 +61,41 @@ fn item_event(
 ) -> ResponsesStreamEvent<ResponsesCreateResponse> {
     ResponsesStreamEvent {
         event_type: event_type.to_string(),
-        response: None,
         response_id: Some(response_id.to_string()),
         item_id: Some(item_id.to_string()),
         output_index: Some(output_index),
-        content_index: None,
-        delta: None,
-        item: None,
-        arguments: None,
+        ..Default::default()
     }
+}
+
+/// `response.output_item.added` for the assistant message item at
+/// output_index 0 (in_progress, empty content) — emitted right after
+/// `response.created`, so clients that assemble output from output_item
+/// events (Codex) see the message item, not just its text deltas (#525).
+pub(super) fn message_item_added_event(
+    response_id: &str,
+    message_id: &str,
+) -> ResponsesStreamEvent<ResponsesCreateResponse> {
+    let mut event = item_event("response.output_item.added", response_id, message_id, 0);
+    event.item = Some(ResponsesOutputItem::Message(ResponsesMessageOutputItem {
+        id: message_id.to_string(),
+        item_type: "message".to_string(),
+        role: "assistant".to_string(),
+        content: Vec::new(),
+        status: Some("in_progress".to_string()),
+    }));
+    event
+}
+
+/// `response.output_item.done` for the completed assistant message item
+/// (full text), emitted before the function-call item events (#525).
+pub(super) fn message_item_done_event(
+    response_id: &str,
+    item: &ResponsesMessageOutputItem,
+) -> ResponsesStreamEvent<ResponsesCreateResponse> {
+    let mut event = item_event("response.output_item.done", response_id, &item.id, 0);
+    event.item = Some(ResponsesOutputItem::Message(item.clone()));
+    event
 }
 
 /// The standard Responses event sequence for ONE completed function call,

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/tests.rs
@@ -99,3 +99,119 @@ fn map_provider_error_wraps_non_proxy_errors() {
         _ => panic!("expected internal error"),
     }
 }
+
+// ── #525: function-call streaming event sequence + fragment aggregation ─
+
+use super::events::function_call_item_events;
+use bamboo_agent_core::tools::{FunctionCall, ToolCall, ToolCallAccumulator};
+
+fn fragment(id: &str, name: &str, arguments: &str) -> ToolCall {
+    ToolCall {
+        id: id.to_string(),
+        tool_type: "function".to_string(),
+        function: FunctionCall {
+            name: name.to_string(),
+            arguments: arguments.to_string(),
+        },
+    }
+}
+
+// The exact upstream pattern that used to shatter one call into N broken
+// items: a metadata fragment followed by argument-only continuation fragments
+// (empty id/name), all sharing the provider index.
+#[test]
+fn indexed_fragments_aggregate_into_single_function_call_item() {
+    let mut acc = ToolCallAccumulator::new();
+    acc.extend_indexed(vec![(0, fragment("call_w1", "get_weather", ""))]);
+    acc.extend_indexed(vec![(0, fragment("", "", "{\"location\":"))]);
+    acc.extend_indexed(vec![(0, fragment("", "", "\"NYC\"}"))]);
+
+    let output = build_output_items("msg_1", String::new(), acc.finalize());
+
+    let function_items: Vec<_> = output
+        .iter()
+        .filter_map(|item| match item {
+            super::super::super::types::ResponsesOutputItem::FunctionCall(fc) => Some(fc),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        function_items.len(),
+        1,
+        "fragments must merge into ONE item"
+    );
+    assert_eq!(function_items[0].call_id, "call_w1");
+    assert_eq!(function_items[0].name, "get_weather");
+    assert_eq!(function_items[0].arguments, "{\"location\":\"NYC\"}");
+    assert_eq!(function_items[0].status.as_deref(), Some("completed"));
+}
+
+#[test]
+fn function_call_item_events_emit_standard_sequence() {
+    let output = build_output_items(
+        "msg_1",
+        String::new(),
+        vec![fragment("call_w1", "get_weather", "{\"location\":\"NYC\"}")],
+    );
+    let super::super::super::types::ResponsesOutputItem::FunctionCall(fc) = &output[1] else {
+        panic!("expected function_call item at output_index 1");
+    };
+
+    let events = function_call_item_events("resp_1", fc, 1);
+    let decoded: Vec<_> = events
+        .iter()
+        .map(|event| decode_sse_event(event_to_sse_bytes(event)))
+        .collect();
+
+    assert_eq!(
+        decoded
+            .iter()
+            .map(|(name, _)| name.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "response.output_item.added",
+            "response.function_call_arguments.delta",
+            "response.function_call_arguments.done",
+            "response.output_item.done",
+        ]
+    );
+
+    let (_, added) = &decoded[0];
+    assert_eq!(added["item"]["type"], "function_call");
+    assert_eq!(added["item"]["call_id"], "call_w1");
+    assert_eq!(added["item"]["status"], "in_progress");
+    assert_eq!(added["item"]["arguments"], "");
+    assert_eq!(added["output_index"], 1);
+
+    let (_, delta) = &decoded[1];
+    assert_eq!(delta["delta"], "{\"location\":\"NYC\"}");
+    assert_eq!(delta["item_id"], added["item"]["id"]);
+
+    let (_, args_done) = &decoded[2];
+    assert_eq!(args_done["arguments"], "{\"location\":\"NYC\"}");
+
+    let (_, item_done) = &decoded[3];
+    assert_eq!(item_done["item"]["status"], "completed");
+    assert_eq!(item_done["item"]["arguments"], "{\"location\":\"NYC\"}");
+    assert_eq!(item_done["item"]["name"], "get_weather");
+}
+
+#[test]
+fn completed_response_carries_aggregated_function_call() {
+    let mut acc = ToolCallAccumulator::new();
+    acc.extend(vec![fragment("call_1", "search", "{\"q\":")]);
+    acc.extend(vec![fragment("call_1", "", "\"hi\"}")]);
+
+    let output = build_output_items("msg_1", "text".to_string(), acc.finalize());
+    let response = build_completed_response("resp_1".to_string(), 1, "m".to_string(), output);
+    let event = completed_event(response);
+    let (_, payload) = decode_sse_event(event_to_sse_bytes(&event));
+
+    assert_eq!(payload["response"]["output"][0]["type"], "message");
+    assert_eq!(payload["response"]["output"][1]["type"], "function_call");
+    assert_eq!(
+        payload["response"]["output"][1]["arguments"],
+        "{\"q\":\"hi\"}"
+    );
+    assert!(payload["response"]["output"].as_array().unwrap().len() == 2);
+}

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/tests.rs
@@ -215,3 +215,32 @@ fn completed_response_carries_aggregated_function_call() {
     );
     assert!(payload["response"]["output"].as_array().unwrap().len() == 2);
 }
+
+// #525 review: the assistant message item must also surface via
+// output_item.added/done — clients that assemble output from output_item
+// events would otherwise never finalize the assistant's text.
+#[test]
+fn message_item_events_announce_and_finalize_the_message_item() {
+    use super::events::{message_item_added_event, message_item_done_event};
+
+    let (name, added) = decode_sse_event(event_to_sse_bytes(&message_item_added_event(
+        "resp_1", "msg_1",
+    )));
+    assert_eq!(name, "response.output_item.added");
+    assert_eq!(added["output_index"], 0);
+    assert_eq!(added["item"]["type"], "message");
+    assert_eq!(added["item"]["id"], "msg_1");
+    assert_eq!(added["item"]["status"], "in_progress");
+
+    let output = build_output_items("msg_1", "final text".to_string(), vec![]);
+    let super::super::super::types::ResponsesOutputItem::Message(message) = &output[0] else {
+        panic!("expected message item at output_index 0");
+    };
+    let (name, done) = decode_sse_event(event_to_sse_bytes(&message_item_done_event(
+        "resp_1", message,
+    )));
+    assert_eq!(name, "response.output_item.done");
+    assert_eq!(done["item"]["type"], "message");
+    assert_eq!(done["item"]["status"], "completed");
+    assert_eq!(done["item"]["content"][0]["text"], "final text");
+}

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/worker.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/worker.rs
@@ -12,7 +12,8 @@ use super::super::super::types::ResponsesOutputItem;
 use super::super::output::{build_completed_response, build_output_items};
 use super::events::{
     completed_event, created_event, done_sse_bytes, event_to_sse_bytes, failed_sse_bytes,
-    function_call_item_events, output_text_delta_event,
+    function_call_item_events, message_item_added_event, message_item_done_event,
+    output_text_delta_event,
 };
 use crate::handlers::llm_compat::usage::{build_estimated_usage, estimate_completion_tokens};
 
@@ -60,6 +61,13 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
             args.created_at,
         );
         if args.tx.send(Ok(event_to_sse_bytes(&event))).await.is_err() {
+            return false;
+        }
+        // The assistant message item (output_index 0) must be announced too —
+        // clients that assemble output from output_item events would
+        // otherwise never associate the text deltas with an item (#525).
+        let added = message_item_added_event(response_id, &args.message_id);
+        if args.tx.send(Ok(event_to_sse_bytes(&added))).await.is_err() {
             return false;
         }
         *created_sent = true;
@@ -156,35 +164,58 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
     if !ensure_created_event(&mut args, &final_response_id, &mut created_sent).await {
         return;
     }
-    let output = build_output_items(&args.message_id, content, tool_calls.finalize());
 
-    // Emit the standard per-call event sequence (output_item.added →
-    // function_call_arguments.delta/.done → output_item.done) before
-    // response.completed — Responses clients (Codex) collect function calls
-    // from output_item.done, not from the completed payload alone (#525).
+    // Merged fragments whose name never arrived are dropped by finalize();
+    // make that visible instead of silently losing a call attempt (#525).
+    let fragment_groups = tool_calls.parts().len();
+    let finalized_calls = tool_calls.finalize();
+    if finalized_calls.len() < fragment_groups {
+        tracing::warn!(
+            dropped = fragment_groups - finalized_calls.len(),
+            "Dropping incomplete streamed tool call(s) whose name never arrived"
+        );
+    }
+    let output = build_output_items(&args.message_id, content, finalized_calls);
+
+    // Emit the standard per-item event sequence before response.completed:
+    // output_item.done for the message item, then per function call
+    // output_item.added → function_call_arguments.delta/.done →
+    // output_item.done — Responses clients (Codex) collect items from
+    // output_item.done, not from the completed payload alone (#525).
     // build_output_items puts the message item at output_index 0 and function
     // calls after it, so enumerate() indices are already the output indices.
-    for (output_index, item) in output.iter().enumerate() {
-        let ResponsesOutputItem::FunctionCall(fc) = item else {
-            continue;
+    // If the client disconnects mid-burst, stop sending but fall through to
+    // the metrics accounting below.
+    let mut client_gone = false;
+    'items: for (output_index, item) in output.iter().enumerate() {
+        let events = match item {
+            ResponsesOutputItem::Message(message) => {
+                vec![message_item_done_event(&final_response_id, message)]
+            }
+            ResponsesOutputItem::FunctionCall(fc) => {
+                function_call_item_events(&final_response_id, fc, output_index as u32)
+            }
         };
-        for event in function_call_item_events(&final_response_id, fc, output_index as u32) {
+        for event in events {
             if args.tx.send(Ok(event_to_sse_bytes(&event))).await.is_err() {
-                return;
+                client_gone = true;
+                break 'items;
             }
         }
     }
 
-    let response = build_completed_response(
-        final_response_id,
-        args.created_at,
-        args.resolved_model,
-        output,
-    );
-    let complete = completed_event(response);
+    if !client_gone {
+        let response = build_completed_response(
+            final_response_id,
+            args.created_at,
+            args.resolved_model,
+            output,
+        );
+        let complete = completed_event(response);
 
-    let _ = args.tx.send(Ok(event_to_sse_bytes(&complete))).await;
-    let _ = args.tx.send(Ok(done_sse_bytes())).await;
+        let _ = args.tx.send(Ok(event_to_sse_bytes(&complete))).await;
+        let _ = args.tx.send(Ok(done_sse_bytes())).await;
+    }
 
     args.metrics.forward_completed(
         args.forward_id,

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/worker.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/worker.rs
@@ -6,10 +6,13 @@ use bamboo_llm::provider::LLMStream;
 use bamboo_llm::types::LLMChunk;
 use bamboo_metrics::{ForwardStatus, MetricsCollector};
 
+use bamboo_agent_core::tools::ToolCallAccumulator;
+
+use super::super::super::types::ResponsesOutputItem;
 use super::super::output::{build_completed_response, build_output_items};
 use super::events::{
     completed_event, created_event, done_sse_bytes, event_to_sse_bytes, failed_sse_bytes,
-    output_text_delta_event,
+    function_call_item_events, output_text_delta_event,
 };
 use crate::handlers::llm_compat::usage::{build_estimated_usage, estimate_completion_tokens};
 
@@ -35,7 +38,11 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
     let mut had_error = false;
     let mut error_message: Option<String> = None;
     let mut content = String::new();
-    let mut tool_calls: Vec<bamboo_agent_core::tools::ToolCall> = Vec::new();
+    // Providers stream PARTIAL tool-call fragments (argument-only continuation
+    // chunks with empty id/name). Merge them by provider index / call id via
+    // the engine's accumulator instead of collecting raw fragments — a raw Vec
+    // shatters one call into N broken output items (#525).
+    let mut tool_calls = ToolCallAccumulator::new();
     let mut response_id: Option<String> = None;
     let mut created_sent = false;
 
@@ -104,7 +111,7 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
                 }
                 tool_calls.extend(calls)
             }
-            // Indexed variant: drop indices, same behavior. #236.
+            // Indexed variant: route fragments by provider index (#236/#525).
             Ok(LLMChunk::ToolCallsIndexed(indexed)) => {
                 let active_response_id = response_id
                     .clone()
@@ -112,7 +119,7 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
                 if !ensure_created_event(&mut args, &active_response_id, &mut created_sent).await {
                     break;
                 }
-                tool_calls.extend(indexed.into_iter().map(|(_, call)| call))
+                tool_calls.extend_indexed(indexed)
             }
             Ok(LLMChunk::Done) => break,
             Ok(LLMChunk::CacheUsage { .. })
@@ -149,7 +156,25 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
     if !ensure_created_event(&mut args, &final_response_id, &mut created_sent).await {
         return;
     }
-    let output = build_output_items(&args.message_id, content, tool_calls);
+    let output = build_output_items(&args.message_id, content, tool_calls.finalize());
+
+    // Emit the standard per-call event sequence (output_item.added →
+    // function_call_arguments.delta/.done → output_item.done) before
+    // response.completed — Responses clients (Codex) collect function calls
+    // from output_item.done, not from the completed payload alone (#525).
+    // build_output_items puts the message item at output_index 0 and function
+    // calls after it, so enumerate() indices are already the output indices.
+    for (output_index, item) in output.iter().enumerate() {
+        let ResponsesOutputItem::FunctionCall(fc) = item else {
+            continue;
+        };
+        for event in function_call_item_events(&final_response_id, fc, output_index as u32) {
+            if args.tx.send(Ok(event_to_sse_bytes(&event))).await.is_err() {
+                return;
+            }
+        }
+    }
+
     let response = build_completed_response(
         final_response_id,
         args.created_at,

--- a/crates/app/bamboo-server/src/handlers/openai/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/tests.rs
@@ -273,3 +273,109 @@ async fn openai_config_registers_models_and_completion_routes() {
         );
     }
 }
+
+// ── #525: Responses-API tool declarations + input hardening ────────────
+
+#[test]
+fn convert_responses_tools_maps_flat_function_tool() {
+    let tools: Vec<super::types::ResponsesToolParam> = serde_json::from_value(serde_json::json!([
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather",
+            "strict": false,
+            "parameters": {"type": "object", "properties": {"location": {"type": "string"}}}
+        }
+    ]))
+    .unwrap();
+
+    let schemas = super::helpers::convert_responses_tools(Some(tools)).unwrap();
+    assert_eq!(schemas.len(), 1);
+    assert_eq!(schemas[0].schema_type, "function");
+    assert_eq!(schemas[0].function.name, "get_weather");
+    assert_eq!(schemas[0].function.description, "Get weather");
+    assert!(schemas[0].function.parameters.get("properties").is_some());
+}
+
+#[test]
+fn convert_responses_tools_accepts_legacy_nested_shape() {
+    let tools: Vec<super::types::ResponsesToolParam> = serde_json::from_value(serde_json::json!([
+        {
+            "type": "function",
+            "function": {"name": "search", "parameters": {"type": "object"}}
+        }
+    ]))
+    .unwrap();
+
+    let schemas = super::helpers::convert_responses_tools(Some(tools)).unwrap();
+    assert_eq!(schemas.len(), 1);
+    assert_eq!(schemas[0].function.name, "search");
+}
+
+#[test]
+fn convert_responses_tools_skips_non_function_tool_types() {
+    let tools: Vec<super::types::ResponsesToolParam> = serde_json::from_value(serde_json::json!([
+        {"type": "web_search"},
+        {"type": "function", "name": "search", "parameters": {"type": "object"}}
+    ]))
+    .unwrap();
+
+    let schemas = super::helpers::convert_responses_tools(Some(tools)).unwrap();
+    assert_eq!(schemas.len(), 1, "web_search skipped, function kept");
+    assert_eq!(schemas[0].function.name, "search");
+}
+
+#[test]
+fn convert_responses_tools_rejects_malformed_function_tool() {
+    // A function-typed entry matching neither the flat nor the nested shape
+    // (no name, no function object) must fail with a targeted message.
+    let tools: Vec<super::types::ResponsesToolParam> =
+        serde_json::from_value(serde_json::json!([{"type": "function"}])).unwrap();
+
+    let err = super::helpers::convert_responses_tools(Some(tools))
+        .expect_err("malformed function tool must be rejected");
+    assert!(matches!(err, crate::error::AppError::BadRequest(_)));
+}
+
+#[test]
+fn responses_input_function_call_output_accepts_content_part_array() {
+    // The spec allows `output` to be an array of content parts, which used to
+    // silently degrade to "" (#525).
+    let msgs = responses_input_to_chat_messages(serde_json::json!([
+        {
+            "type": "function_call_output",
+            "call_id": "call_abc",
+            "output": [
+                {"type": "output_text", "text": "72"},
+                {"type": "output_text", "text": "°F"}
+            ]
+        }
+    ]))
+    .unwrap();
+
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].role, Role::Tool);
+    assert_eq!(msgs[0].tool_call_id.as_deref(), Some("call_abc"));
+    match &msgs[0].content {
+        Content::Text(t) => assert_eq!(t, "72°F"),
+        _ => panic!("expected text content"),
+    }
+}
+
+#[test]
+fn responses_input_skips_unknown_item_types() {
+    // Codex round-trips `reasoning` items in `input`; they must be skipped,
+    // not turned into empty user messages that pollute the prompt (#525).
+    let msgs = responses_input_to_chat_messages(serde_json::json!([
+        {"type": "reasoning", "id": "rs_1", "summary": []},
+        {"role": "user", "content": "hello"}
+    ]))
+    .unwrap();
+
+    assert_eq!(msgs.len(), 1, "reasoning item skipped");
+    assert_eq!(msgs[0].role, Role::User);
+    match &msgs[0].content {
+        Content::Text(t) => assert_eq!(t, "hello"),
+        _ => panic!("expected text content"),
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/openai/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/tests.rs
@@ -379,3 +379,80 @@ fn responses_input_skips_unknown_item_types() {
         _ => panic!("expected text content"),
     }
 }
+
+#[test]
+fn convert_responses_tools_normalizes_missing_parameters_to_empty_schema() {
+    // An omitted `parameters` must not forward `parameters: null` upstream.
+    let tools: Vec<super::types::ResponsesToolParam> = serde_json::from_value(serde_json::json!([
+        {"type": "function", "name": "ping"}
+    ]))
+    .unwrap();
+
+    let schemas = super::helpers::convert_responses_tools(Some(tools)).unwrap();
+    assert_eq!(schemas.len(), 1);
+    assert_eq!(
+        schemas[0].function.parameters,
+        serde_json::json!({"type": "object", "properties": {}})
+    );
+}
+
+#[test]
+fn convert_responses_tools_rejects_entry_without_type() {
+    // A tools[] entry with no `type` at all is garbage, not an unsupported
+    // feature — fail fast like the old strict parsing did.
+    let tools: Vec<super::types::ResponsesToolParam> =
+        serde_json::from_value(serde_json::json!([{"name": "my_tool", "parameters": {}}])).unwrap();
+
+    let err = super::helpers::convert_responses_tools(Some(tools))
+        .expect_err("type-less tools entry must be rejected");
+    assert!(matches!(err, crate::error::AppError::BadRequest(_)));
+}
+
+// #525 review: parallel tool calls round-tripped as consecutive function_call
+// items must merge into ONE assistant message — one single-call assistant
+// message per item is rejected by Chat-Completions upstreams ("assistant
+// message with tool_calls must be followed by tool messages responding to
+// each tool_call_id").
+#[test]
+fn responses_input_merges_parallel_function_calls_into_one_assistant_turn() {
+    let msgs = responses_input_to_chat_messages(serde_json::json!([
+        {"type": "function_call", "call_id": "c1", "name": "read", "arguments": "{\"p\":\"a\"}"},
+        {"type": "function_call", "call_id": "c2", "name": "read", "arguments": "{\"p\":\"b\"}"},
+        {"type": "function_call_output", "call_id": "c1", "output": "A"},
+        {"type": "function_call_output", "call_id": "c2", "output": "B"}
+    ]))
+    .unwrap();
+
+    assert_eq!(msgs.len(), 3, "one assistant turn + two tool results");
+    assert_eq!(msgs[0].role, Role::Assistant);
+    let calls = msgs[0].tool_calls.as_ref().expect("tool_calls");
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].id, "c1");
+    assert_eq!(calls[1].id, "c2");
+    assert_eq!(msgs[1].role, Role::Tool);
+    assert_eq!(msgs[1].tool_call_id.as_deref(), Some("c1"));
+    assert_eq!(msgs[2].role, Role::Tool);
+    assert_eq!(msgs[2].tool_call_id.as_deref(), Some("c2"));
+}
+
+// A function_call following the assistant's text message from the same turn
+// attaches to that message (Chat-Completions puts tool_calls ON the assistant
+// message that carries the turn's content).
+#[test]
+fn responses_input_attaches_function_call_to_preceding_assistant_message() {
+    let msgs = responses_input_to_chat_messages(serde_json::json!([
+        {"role": "assistant", "content": "Let me check."},
+        {"type": "function_call", "call_id": "c1", "name": "search", "arguments": "{}"}
+    ]))
+    .unwrap();
+
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].role, Role::Assistant);
+    match &msgs[0].content {
+        Content::Text(t) => assert_eq!(t, "Let me check."),
+        _ => panic!("expected text content"),
+    }
+    let calls = msgs[0].tool_calls.as_ref().expect("tool_calls attached");
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].id, "c1");
+}

--- a/crates/app/bamboo-server/src/handlers/openai/types.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/types.rs
@@ -29,7 +29,7 @@ pub(super) struct Model {
 /// - `input` (string or array of message-like objects)
 /// - `instructions` (forwarded as top-level Responses API instructions)
 /// - `previous_response_id` (passed via flattened parameters for stateful continuation)
-/// - `tools` (OpenAI tool schema; reuses existing OpenAI-compatible tool model)
+/// - `tools` (Responses-API flat tool entries; legacy nested shape tolerated)
 /// - `stream`
 /// - `max_output_tokens` (mapped to provider max tokens)
 #[derive(Debug, Deserialize, Clone, Default)]
@@ -40,13 +40,49 @@ pub struct ResponsesCreateRequest {
     #[serde(default)]
     pub(super) instructions: Option<String>,
     #[serde(default)]
-    pub(super) tools: Option<Vec<Tool>>,
+    pub(super) tools: Option<Vec<ResponsesToolParam>>,
     #[serde(default)]
     pub(super) stream: Option<bool>,
     #[serde(default)]
     pub(super) max_output_tokens: Option<u32>,
     #[serde(flatten)]
     pub(super) parameters: HashMap<String, serde_json::Value>,
+}
+
+/// A Responses-API function tool declaration — FLAT, per the spec:
+/// `{"type":"function","name":"…","description":"…","parameters":{…},"strict":false}`.
+///
+/// The nested `{type, function:{name,…}}` shape belongs to the Chat Completions
+/// wire format; reusing that model here made every tools-bearing /responses
+/// request fail with `missing field 'function'` (#525).
+#[derive(Debug, Deserialize, Clone)]
+pub(super) struct ResponsesFunctionToolParam {
+    #[serde(rename = "type")]
+    pub(super) tool_type: String,
+    pub(super) name: String,
+    #[serde(default)]
+    pub(super) description: Option<String>,
+    #[serde(default)]
+    pub(super) parameters: serde_json::Value,
+    /// Accepted and ignored — bamboo does not enforce strict schemas upstream.
+    /// Kept as a real field (read in tests) to document the wire shape.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub(super) strict: Option<bool>,
+}
+
+/// A `tools[]` entry on POST /responses.
+///
+/// Untagged, tried in order: the flat Responses shape (spec), the nested
+/// Chat-Completions shape (legacy clients that already worked against this
+/// endpoint), then a raw catch-all so non-function tool types (`web_search`,
+/// …) can be skipped instead of failing the whole request. #525.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(untagged)]
+pub(super) enum ResponsesToolParam {
+    Flat(ResponsesFunctionToolParam),
+    Nested(Tool),
+    Other(serde_json::Value),
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -83,6 +119,10 @@ pub(super) struct ResponsesFunctionCallOutputItem {
     pub(super) call_id: String,
     pub(super) name: String,
     pub(super) arguments: String,
+    /// "in_progress" while streaming, "completed" in final output. Clients
+    /// (Codex) read the completed item off `response.output_item.done`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) status: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -120,6 +160,12 @@ pub(super) struct ResponsesStreamEvent<T> {
     pub(super) content_index: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) delta: Option<String>,
+    /// Full item object for `response.output_item.added` / `.done` (#525).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) item: Option<ResponsesOutputItem>,
+    /// Complete arguments for `response.function_call_arguments.done` (#525).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) arguments: Option<String>,
 }
 
 #[cfg(test)]
@@ -269,6 +315,7 @@ mod tests {
             call_id: "call-789".to_string(),
             name: "get_weather".to_string(),
             arguments: r#"{"location":"NYC"}"#.to_string(),
+            status: None,
         };
 
         let json = serde_json::to_string(&item).unwrap();
@@ -300,6 +347,7 @@ mod tests {
             call_id: "call-1".to_string(),
             name: "test".to_string(),
             arguments: "{}".to_string(),
+            status: None,
         };
 
         let output_item = ResponsesOutputItem::FunctionCall(fc_item.clone());
@@ -358,6 +406,8 @@ mod tests {
             output_index: None,
             content_index: None,
             delta: None,
+            item: None,
+            arguments: None,
         };
 
         let json = serde_json::to_string(&event).unwrap();
@@ -374,6 +424,8 @@ mod tests {
             output_index: Some(0),
             content_index: Some(0),
             delta: Some("Hello".to_string()),
+            item: None,
+            arguments: None,
         };
 
         let json = serde_json::to_string(&event).unwrap();
@@ -399,6 +451,69 @@ mod tests {
             req.parameters.get("previous_response_id").unwrap(),
             &serde_json::json!("resp_123")
         );
+    }
+
+    // #525: the Responses API sends function tools FLAT (name/parameters at the
+    // top level, `strict` present). This exact shape used to 400 with
+    // "missing field `function`" because the field reused the nested
+    // Chat-Completions Tool model.
+    #[test]
+    fn test_responses_create_request_with_flat_tools() {
+        let json = r#"{
+            "model":"gpt-5",
+            "input":"hi",
+            "tools":[{
+                "type":"function",
+                "name":"get_weather",
+                "description":"Get weather",
+                "strict":false,
+                "parameters":{"type":"object","properties":{"location":{"type":"string"}}}
+            }]
+        }"#;
+        let req: ResponsesCreateRequest = serde_json::from_str(json).unwrap();
+        let tools = req.tools.expect("tools parsed");
+        assert_eq!(tools.len(), 1);
+        match &tools[0] {
+            ResponsesToolParam::Flat(flat) => {
+                assert_eq!(flat.tool_type, "function");
+                assert_eq!(flat.name, "get_weather");
+                assert_eq!(flat.description.as_deref(), Some("Get weather"));
+                assert_eq!(flat.strict, Some(false));
+                assert!(flat.parameters.get("properties").is_some());
+            }
+            other => panic!("expected flat tool param, got {other:?}"),
+        }
+    }
+
+    // Legacy clients that already sent the nested Chat-Completions shape to
+    // this endpoint must keep working.
+    #[test]
+    fn test_responses_create_request_with_nested_tools_still_parses() {
+        let json = r#"{
+            "model":"gpt-5",
+            "tools":[{
+                "type":"function",
+                "function":{"name":"get_weather","parameters":{"type":"object"}}
+            }]
+        }"#;
+        let req: ResponsesCreateRequest = serde_json::from_str(json).unwrap();
+        let tools = req.tools.expect("tools parsed");
+        match &tools[0] {
+            ResponsesToolParam::Nested(tool) => {
+                assert_eq!(tool.function.name, "get_weather");
+            }
+            other => panic!("expected nested tool param, got {other:?}"),
+        }
+    }
+
+    // Non-function tool types (web_search, …) must not fail the request; they
+    // land in the catch-all and are skipped at conversion time.
+    #[test]
+    fn test_responses_create_request_tolerates_non_function_tools() {
+        let json = r#"{"model":"gpt-5","tools":[{"type":"web_search"}]}"#;
+        let req: ResponsesCreateRequest = serde_json::from_str(json).unwrap();
+        let tools = req.tools.expect("tools parsed");
+        assert!(matches!(&tools[0], ResponsesToolParam::Other(_)));
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/handlers/openai/types.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/types.rs
@@ -73,15 +73,19 @@ pub(super) struct ResponsesFunctionToolParam {
 
 /// A `tools[]` entry on POST /responses.
 ///
-/// Untagged, tried in order: the flat Responses shape (spec), the nested
-/// Chat-Completions shape (legacy clients that already worked against this
-/// endpoint), then a raw catch-all so non-function tool types (`web_search`,
-/// …) can be skipped instead of failing the whole request. #525.
+/// Untagged, tried in order: the nested Chat-Completions shape FIRST (legacy
+/// clients that already worked against this endpoint — and hybrid entries
+/// carrying both a top-level `name` and a `function` object must keep their
+/// real schema from `function.parameters`, which Flat would silently drop),
+/// then the flat Responses shape (spec), then a raw catch-all so non-function
+/// tool types (`web_search`, …) can be skipped instead of failing the whole
+/// request. A pure flat entry has no `function` key, so it cleanly falls
+/// through Nested. #525.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(untagged)]
 pub(super) enum ResponsesToolParam {
-    Flat(ResponsesFunctionToolParam),
     Nested(Tool),
+    Flat(ResponsesFunctionToolParam),
     Other(serde_json::Value),
 }
 
@@ -109,6 +113,9 @@ pub(super) struct ResponsesMessageOutputItem {
     pub(super) item_type: String, // "message"
     pub(super) role: String, // "assistant"
     pub(super) content: Vec<ResponsesTextContent>,
+    /// "in_progress" while streaming, "completed" in final output (#525).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) status: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -166,6 +173,24 @@ pub(super) struct ResponsesStreamEvent<T> {
     /// Complete arguments for `response.function_call_arguments.done` (#525).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) arguments: Option<String>,
+}
+
+/// Manual impl (not derived) so it doesn't require `T: Default` — event
+/// constructors set only the fields their event type carries. #525.
+impl<T> Default for ResponsesStreamEvent<T> {
+    fn default() -> Self {
+        Self {
+            event_type: String::new(),
+            response: None,
+            response_id: None,
+            item_id: None,
+            output_index: None,
+            content_index: None,
+            delta: None,
+            item: None,
+            arguments: None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -299,6 +324,7 @@ mod tests {
                 content_type: "output_text".to_string(),
                 text: "Response text".to_string(),
             }],
+            status: None,
         };
 
         let json = serde_json::to_string(&item).unwrap();
@@ -332,6 +358,7 @@ mod tests {
             item_type: "message".to_string(),
             role: "assistant".to_string(),
             content: vec![],
+            status: None,
         };
 
         let output_item = ResponsesOutputItem::Message(msg_item.clone());
@@ -400,14 +427,7 @@ mod tests {
     fn test_responses_stream_event_minimal() {
         let event: ResponsesStreamEvent<String> = ResponsesStreamEvent {
             event_type: "response.created".to_string(),
-            response: None,
-            response_id: None,
-            item_id: None,
-            output_index: None,
-            content_index: None,
-            delta: None,
-            item: None,
-            arguments: None,
+            ..Default::default()
         };
 
         let json = serde_json::to_string(&event).unwrap();
@@ -418,14 +438,12 @@ mod tests {
     fn test_responses_stream_event_with_delta() {
         let event: ResponsesStreamEvent<String> = ResponsesStreamEvent {
             event_type: "response.output_item.text.delta".to_string(),
-            response: None,
             response_id: Some("resp-123".to_string()),
             item_id: Some("item-456".to_string()),
             output_index: Some(0),
             content_index: Some(0),
             delta: Some("Hello".to_string()),
-            item: None,
-            arguments: None,
+            ..Default::default()
         };
 
         let json = serde_json::to_string(&event).unwrap();
@@ -514,6 +532,29 @@ mod tests {
         let req: ResponsesCreateRequest = serde_json::from_str(json).unwrap();
         let tools = req.tools.expect("tools parsed");
         assert!(matches!(&tools[0], ResponsesToolParam::Other(_)));
+    }
+
+    // A hybrid entry carrying BOTH a top-level `name` and a nested `function`
+    // object must resolve as Nested — matching Flat would silently drop the
+    // real schema living in function.parameters.
+    #[test]
+    fn test_responses_hybrid_tool_entry_prefers_nested_schema() {
+        let json = r#"{
+            "model":"gpt-5",
+            "tools":[{
+                "type":"function",
+                "name":"search",
+                "function":{"name":"search","parameters":{"type":"object","properties":{"q":{"type":"string"}}}}
+            }]
+        }"#;
+        let req: ResponsesCreateRequest = serde_json::from_str(json).unwrap();
+        let tools = req.tools.expect("tools parsed");
+        match &tools[0] {
+            ResponsesToolParam::Nested(tool) => {
+                assert!(tool.function.parameters.get("properties").is_some());
+            }
+            other => panic!("hybrid entry must prefer nested, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #525 — every tools-bearing `POST /openai/v1/responses` turn failed against Codex (`wire_api="responses"`). Three defects, all adversarially verified in the issue:

## ① Flat `tools[]` parsing (the blocker that masked everything)

`ResponsesCreateRequest.tools` reused the nested Chat-Completions `Tool` model, so the flat Responses shape `{type:"function", name, parameters, strict}` 400'd with `missing field 'function'` at the Json extractor. New `ResponsesToolParam` (untagged): flat (spec) → direct `ToolSchema` mapping; nested (legacy clients) → unchanged path; non-function tool types (`web_search`, …) → skipped instead of failing the request; a function-typed entry matching neither shape → targeted `BadRequest` (the untagged serde message is useless). The shared `Tool` model and `/chat/completions` are untouched.

## ② Fragment aggregation (streaming AND non-streaming)

Both paths collected raw provider fragments (`ToolCallsIndexed` dropped the provider index; blind `Vec::extend`), so one upstream call streamed in N fragments became N broken `function_call` items — items 2..N with empty `name`/`call_id` and truncated argument tails. Both now use the engine's `ToolCallAccumulator` (`extend` / `extend_indexed` / `finalize`, exactly like `chunk_handling.rs`) → exactly one completed item per call.

## ③ Standard streaming event sequence

The stream previously emitted no function-call events at all (buffered until `response.completed`). Each finalized call now emits, before `response.completed`:
`response.output_item.added` (item, `in_progress`, empty arguments) → `response.function_call_arguments.delta` (full aggregated arguments — single delta is spec-legal) → `response.function_call_arguments.done` → `response.output_item.done` (item, `completed`). Codex collects calls from `output_item.done`. `ResponsesStreamEvent` gained optional `item`/`arguments` fields; `function_call` items now carry `status`.

## Input hardening (from the issue's verification)

- `function_call_output.output` accepts content-part arrays (was string-only → silently `""`); other non-string shapes keep their raw JSON.
- Input items with unknown explicit `type` (Codex round-trips `reasoning` items) are skipped instead of fabricating empty user messages. Items without a `type` key keep defaulting to `message`.

## Tests

12 new: flat/nested/non-function/malformed tool parsing + conversion; content-part `output` flattening; unknown-item skip; fragment aggregation → single item; the exact 4-event sequence with payload assertions; aggregated `response.completed`. Full `bamboo-server` suite: 1365 passed. `cargo build --workspace --tests` clean; fmt/clippy clean.

Verification for the reporter: the issue's curl (flat tools + `strict`) now parses; turn-2 `function_call`/`function_call_output` (+`reasoning`) round-trip works; `codex --profile fable-5 exec` should complete a tool-using task.

https://claude.ai/code/session_013oUofGqYAwMfpR2s1CteY9