### PR TITLE
feat(ws_v2): app-level sys keepalive data frame for browser-observable liveness

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/envelope.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/envelope.rs
@@ -169,6 +169,18 @@ pub(crate) fn feed_reset_control(from_seq: u64) -> Value {
     serde_json::json!({ "type": "feed_reset", "from_seq": from_seq })
 }
 
+/// The app-level keepalive envelope sent on every ping tick (#533):
+/// `{ch:"sys", seq:0, control:{type:"keepalive"}}`.
+///
+/// Browsers never expose protocol-level ping frames to JS, so this DATA frame
+/// is the client's only observable liveness signal — the lotus watchdog forces
+/// a reconnect when it stops arriving (a half-open socket after sleep/wake or
+/// NAT idle eviction never fires `onclose` on its own). `seq` is fixed at 0:
+/// the `sys` channel carries no ordered stream to resume.
+pub(crate) fn sys_keepalive_envelope() -> ServerEnvelope {
+    ServerEnvelope::control("sys", 0, serde_json::json!({ "type": "keepalive" }))
+}
+
 /// A client→server frame, tagged by `type`.
 ///
 /// Unknown / malformed frames deserialize to [`ClientFrame::Unknown`] (via the
@@ -515,5 +527,17 @@ mod tests {
         );
         assert_eq!(Channel::parse("agent."), None);
         assert_eq!(Channel::parse("bogus"), None);
+    }
+
+    /// #533: the sys keepalive wire shape is a CONTRACT with the lotus
+    /// watchdog (`ch === "sys"` + `control.type === "keepalive"`) — lock the
+    /// exact JSON so a refactor can't silently break client liveness.
+    #[test]
+    fn sys_keepalive_wire_shape() {
+        let text = sys_keepalive_envelope().to_text().expect("serializes");
+        assert_eq!(
+            text,
+            r#"{"ch":"sys","seq":0,"control":{"type":"keepalive"}}"#
+        );
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -69,8 +69,8 @@ use tokio_stream::StreamMap;
 use serde::Deserialize;
 
 use self::envelope::{
-    decode_client_frame, Channel, ClientFrame, Encoding, OutFrame, SUBPROTOCOL_JSON,
-    SUBPROTOCOL_MSGPACK,
+    decode_client_frame, sys_keepalive_envelope, Channel, ClientFrame, Encoding, OutFrame,
+    SUBPROTOCOL_JSON, SUBPROTOCOL_MSGPACK,
 };
 use self::forwarders::{spawn_agent_forwarder, spawn_feed_forwarder, OutboundTx};
 use crate::app_state::AppState;
@@ -84,8 +84,25 @@ use crate::handlers::agent::stop::cancel_session;
 /// driver drains them with a fair merge.
 const OUTBOUND_BUFFER: usize = 64;
 
-/// WS ping interval (~15s), mirroring the v1 SSE `[KEEPALIVE]` cadence.
+/// WS ping interval (~15s), mirroring the v1 SSE `[KEEPALIVE]` cadence. Each
+/// tick sends BOTH the protocol-level ping (server-side write probe) and the
+/// app-level `sys` keepalive data frame (client-side liveness signal, #533).
 const PING_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Env var the live integration test sets to SHORTEN the ping interval so the
+/// `sys` keepalive cadence is asserted in milliseconds, not 15s. Read once per
+/// connection in [`drive`]. Production NEVER sets it.
+const PING_INTERVAL_OVERRIDE_ENV: &str = "BAMBOO_WS_PING_INTERVAL_MS";
+
+/// The effective ping interval: the [`PING_INTERVAL`] default unless
+/// [`PING_INTERVAL_OVERRIDE_ENV`] is set to a valid millisecond count (test-only).
+fn ping_interval() -> Duration {
+    std::env::var(PING_INTERVAL_OVERRIDE_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(PING_INTERVAL)
+}
 
 /// How long an UNAUTHORIZED connection may stay open before it must present a
 /// valid `hello` device token. A connection that opens the (now public) upgrade
@@ -339,7 +356,7 @@ async fn drive(
     // channel id and mutated together (see [`subscribe`] / unsubscribe / teardown).
     let mut forwarders: HashMap<String, tokio::task::JoinHandle<()>> = HashMap::new();
     let mut queues: StreamMap<String, ReceiverStream<OutFrame>> = StreamMap::new();
-    let mut ping = tokio::time::interval(PING_INTERVAL);
+    let mut ping = tokio::time::interval(ping_interval());
     ping.tick().await; // skip the immediate tick
 
     // Authorization state (#189). Seeded from the upgrade-time decision so local
@@ -379,13 +396,37 @@ async fn drive(
                     break;
                 }
             }
-            // Keepalive ping. Liveness is write-driven (a dead peer surfaces as a
+            // Keepalive. Liveness is write-driven (a dead peer surfaces as a
             // failed `ping`/`text` write); we do NOT track Pong arrivals or run a
             // pong timeout — same one-directional keepalive contract as the v1 SSE
             // stream.
+            //
+            // TWO frames go out per tick (#533):
+            // - a protocol-level ping — the server-side write probe (unchanged);
+            // - an app-level `{ch:"sys", control:{type:"keepalive"}}` DATA frame —
+            //   browsers never expose protocol pings to JS, so without a data
+            //   frame a client on a half-open socket (sleep/wake, NAT idle
+            //   eviction) has NO observable liveness signal and sits "open"
+            //   forever after the server tears down. The sys frame is what the
+            //   lotus watchdog keys on to force a reconnect. Old clients ignore
+            //   the unknown `sys` channel, so this is backward-compatible.
             _ = ping.tick() => {
                 if session.ping(b"").await.is_err() {
                     break;
+                }
+                // Only an AUTHORIZED connection gets the data frame: an
+                // unauthenticated socket is served nothing (same posture as
+                // channel data) and is closed by the auth deadline anyway.
+                if authorized {
+                    if let Some(frame) = sys_keepalive_envelope().encode(encoding) {
+                        let write = match frame {
+                            OutFrame::Text(s) => session.text(s).await,
+                            OutFrame::Binary(b) => session.binary(b).await,
+                        };
+                        if write.is_err() {
+                            break;
+                        }
+                    }
                 }
             }
             // Client frames. In JSON mode the client sends TEXT frames; in msgpack

--- a/crates/app/bamboo-server/tests/ws_v2_live.rs
+++ b/crates/app/bamboo-server/tests/ws_v2_live.rs
@@ -36,19 +36,31 @@ use tokio::net::TcpListener;
 /// short enough to assert the "no hello → closed" path quickly.
 const TEST_AUTH_DEADLINE_MS: u64 = 1500;
 
+/// The shortened ping interval for the whole test binary (#533): every
+/// authorized connection receives an app-level `sys` keepalive data frame at
+/// this cadence, so the keepalive tests resolve in milliseconds and every
+/// OTHER test doubles as an interleaving check (the generic envelope helpers
+/// skip `sys` frames exactly like a tolerant client does).
+const TEST_PING_INTERVAL_MS: u64 = 200;
+
 /// A generous-but-bounded ceiling for any single frame wait.
 const RECV_TIMEOUT: Duration = Duration::from_secs(5);
 
 static INIT: Once = Once::new();
 
-/// Shorten the ws_v2 unauthorized auth deadline process-wide. Production never
-/// sets this env var, so the 10s default is untouched; the test binary sets it
-/// once so the deadline-close path is fast and deterministic.
+/// Shorten the ws_v2 unauthorized auth deadline + ping interval process-wide.
+/// Production never sets these env vars, so the 10s/15s defaults are untouched;
+/// the test binary sets them once so the deadline-close path and the `sys`
+/// keepalive cadence are fast and deterministic.
 fn init_short_auth_deadline() {
     INIT.call_once(|| {
         std::env::set_var(
             "BAMBOO_WS_AUTH_DEADLINE_MS",
             TEST_AUTH_DEADLINE_MS.to_string(),
+        );
+        std::env::set_var(
+            "BAMBOO_WS_PING_INTERVAL_MS",
+            TEST_PING_INTERVAL_MS.to_string(),
         );
     });
 }
@@ -180,7 +192,12 @@ async fn next_msgpack_envelope(conn: &mut WsConn) -> Option<Value> {
             .expect("frame did not arrive before timeout")?;
         match frame.expect("ws protocol error") {
             ws::Frame::Binary(bytes) => {
-                return Some(rmp_serde::from_slice(&bytes).expect("envelope is msgpack"));
+                let value: Value = rmp_serde::from_slice(&bytes).expect("envelope is msgpack");
+                // Skip interleaved `sys` keepalives (#533), like a tolerant client.
+                if value["ch"] == "sys" {
+                    continue;
+                }
+                return Some(value);
             }
             ws::Frame::Text(bytes) => panic!(
                 "msgpack mode must yield BINARY frames, got text: {}",
@@ -211,11 +228,38 @@ async fn next_envelope(conn: &mut WsConn) -> Option<Value> {
             .expect("frame did not arrive before timeout")?;
         match frame.expect("ws protocol error") {
             ws::Frame::Text(bytes) => {
-                return Some(serde_json::from_slice(&bytes).expect("envelope is JSON"));
+                let value: Value = serde_json::from_slice(&bytes).expect("envelope is JSON");
+                // Skip interleaved `sys` keepalives (#533), like a tolerant client.
+                if value["ch"] == "sys" {
+                    continue;
+                }
+                return Some(value);
             }
             ws::Frame::Ping(_) | ws::Frame::Pong(_) => continue,
             ws::Frame::Close(_) => return None,
             other => panic!("unexpected ws frame: {other:?}"),
+        }
+    }
+}
+
+/// Receive the next `sys` keepalive envelope (skipping everything else) within
+/// [`RECV_TIMEOUT`]. Decodes text frames as JSON and binary frames as msgpack,
+/// so one helper serves both subprotocols.
+async fn next_sys_keepalive(conn: &mut WsConn) -> Value {
+    let deadline = tokio::time::Instant::now() + RECV_TIMEOUT;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let frame = tokio::time::timeout(remaining, conn.next())
+            .await
+            .expect("sys keepalive did not arrive before timeout")
+            .expect("connection closed while waiting for sys keepalive");
+        let value: Value = match frame.expect("ws protocol error") {
+            ws::Frame::Text(bytes) => serde_json::from_slice(&bytes).expect("envelope is JSON"),
+            ws::Frame::Binary(bytes) => rmp_serde::from_slice(&bytes).expect("envelope is msgpack"),
+            _ => continue,
+        };
+        if value["ch"] == "sys" {
+            return value;
         }
     }
 }
@@ -794,6 +838,62 @@ async fn no_subprotocol_stays_json_with_no_echo() {
         .await
         .expect("JSON feed envelope on the default path");
     assert_eq!(env["ch"], "feed");
+
+    server.stop().await;
+}
+
+// ── Scenario 6: app-level sys keepalive (#533) ──────────────────────────────
+
+/// An authorized JSON connection receives the `sys` keepalive DATA frame on the
+/// ping cadence — the browser-observable liveness signal (protocol pings are
+/// invisible to JS). Two in a row prove it's periodic, not a one-off.
+#[actix_web::test]
+async fn sys_keepalive_data_frames_arrive_on_json_connection() {
+    let server = TestServer::start(|_| {}).await;
+    let mut conn = connect_local(&server).await;
+
+    for _ in 0..2 {
+        let env = next_sys_keepalive(&mut conn).await;
+        assert_eq!(env["ch"], "sys");
+        assert_eq!(env["seq"], 0);
+        assert_eq!(env["control"]["type"], "keepalive");
+    }
+
+    server.stop().await;
+}
+
+/// The msgpack subprotocol carries the same keepalive as a BINARY frame with
+/// identical decoded shape.
+#[actix_web::test]
+async fn sys_keepalive_data_frames_arrive_on_msgpack_connection() {
+    let server = TestServer::start(|_| {}).await;
+    let (mut conn, subprotocol) = connect_local_msgpack(&server).await;
+    assert_eq!(subprotocol.as_deref(), Some("bamboo.v2.msgpack"));
+
+    let env = next_sys_keepalive(&mut conn).await;
+    assert_eq!(env["ch"], "sys");
+    assert_eq!(env["control"]["type"], "keepalive");
+
+    server.stop().await;
+}
+
+/// An UNAUTHORIZED connection gets NO `sys` keepalive: it is served nothing
+/// (same posture as channel data) and the auth deadline closes it. The frames
+/// observed until close must be protocol-level only.
+#[actix_web::test]
+async fn sys_keepalive_not_sent_to_unauthorized_connection() {
+    let mut captured = None;
+    let server = TestServer::start(|config| {
+        captured = Some(with_device(config));
+    })
+    .await;
+    let _ = captured; // a device exists → remotes require a hello.
+
+    let mut conn = connect_remote(&server).await;
+    // expect_closed panics on ANY text frame — which is exactly the assertion:
+    // no sys keepalive may be served before authorization, and the deadline
+    // (1.5s here) spans several ping ticks (200ms), so a leak would surface.
+    expect_closed(&mut conn).await;
 
     server.stop().await;
 }


### PR DESCRIPTION
Closes #533. Counterpart: bigduu/Lotus#87 (client watchdog).

## Why

Browsers never expose WS protocol-level pings to JS, so `/v2/stream`'s 15s ping is purely a server-side write probe — the client has NO observable liveness signal. A half-open socket (sleep/wake, Wi-Fi/VPN switch, NAT idle eviction during a long quiet Bash run) never fires `onclose` on the browser side: lotus sits "connected" forever while the server tore down minutes ago, leaving the UI stuck showing a Bash tool call as running after the run finished. The account feed rides the same socket, so the recovery signal dies with it; the only reconcile trigger (`visibilitychange`) never fires in an always-visible Bodhi window.

## What

- On every ping tick, ALSO send `{ch:"sys", seq:0, control:{type:"keepalive"}}` encoded per the connection's negotiated encoding (JSON text / msgpack binary), via `ServerEnvelope::control` — the frame the lotus watchdog keys on.
- AUTHORIZED connections only (same posture as channel data; the auth deadline governs unauthenticated sockets).
- Backward-compatible: old lotus ignores unknown channels (`frame.unknown_channel` debug path).
- `BAMBOO_WS_PING_INTERVAL_MS` test-only override (mirrors `BAMBOO_WS_AUTH_DEADLINE_MS`), production default unchanged at 15s.

## Tests

- Live (real bound server + awc client): keepalive cadence on JSON and msgpack connections (two consecutive frames), and NO keepalive served before authorization (the deadline window spans ~7 ping ticks, so a leak surfaces).
- The 200ms test-binary cadence makes every existing live test double as an interleaving-tolerance check (generic helpers skip `sys` like a tolerant client).
- Unit test locking the exact wire JSON — a contract with the lotus watchdog.

`ws_v2_live` 12 ✓ · `bamboo-server --lib ws_v2` 30 ✓ · `cargo check --workspace --tests` ✓ · fmt ✓

https://claude.ai/code/session_014iw5PBsSzDFHus1GfkAK4y