### PR TITLE
feat(broker): TLS listener + wss:// client support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,12 +1004,15 @@ dependencies = [
  "governor",
  "russh",
  "russh-sftp",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tokio-tungstenite 0.29.0",
  "tokio-util",
  "tracing",
@@ -5848,6 +5851,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6847,8 +6862,12 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tungstenite 0.29.0",
 ]
 
@@ -7131,6 +7150,8 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
 ]

--- a/crates/app/bamboo-broker/Cargo.toml
+++ b/crates/app/bamboo-broker/Cargo.toml
@@ -18,7 +18,26 @@ async-trait = "0.1"
 futures-util = "0.3"
 tokio = { version = "1", features = ["fs", "io-util", "rt", "rt-multi-thread", "sync", "macros", "net", "time"] }
 tokio-util = "0.7"
-tokio-tungstenite = "0.29"
+# `default-features = false` + explicit ["connect", "rustls-tls-native-roots"]:
+# no `native-tls` (keeps a single TLS stack in THIS crate's own build unit —
+# workspace-wide unification with bamboo-server's native-tls feature can still
+# happen when built together, that's fine, just not required here) and no
+# aws-lc-rs — `rustls-tls-native-roots` picks tokio-tungstenite's `rustls`
+# optional dep with ITS OWN default-features=false, so the crypto provider is
+# decided by whichever `rustls`/`ring` feature wins unification (ours, below)
+# rather than rustls' own default (`aws-lc-rs`). `native-roots` (not
+# `webpki-roots`) so a worker that trusts a homelab/internal CA via the OS
+# trust store (a common self-signed-cert workaround) just works with no extra
+# config; `client::client_config_trusting_cert` below covers the
+# no-OS-trust-store case explicitly. #48.
+tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
+# TLS termination for the broker's own listener (`wss://`, #48) — same
+# rustls/ring pin as bamboo-subagent's `WsServer::bind_tls` (#183/#48) so the
+# workspace resolves ONE crypto provider (never `aws-lc-sys`; verified via
+# `cargo tree -i aws-lc-sys`).
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
+rustls-pemfile = "2"
 russh = { version = "0.62", default-features = false, features = ["ring", "flate2", "rsa"] }
 russh-sftp = "2.3.0"
 sha2 = "0.11"

--- a/crates/app/bamboo-broker/src/client.rs
+++ b/crates/app/bamboo-broker/src/client.rs
@@ -2,7 +2,22 @@
 //! reader that demuxes incoming frames into a `messages` stream and a
 //! `delivered` receipt stream — so one connection can both deliver and
 //! subscribe (the parent does both: deliver an Ask, subscribe for the Reply).
+//!
+//! TLS (`wss://`, #48): a bare `ws://` endpoint always worked unencrypted; a
+//! `wss://` endpoint now works TWO ways —
+//! - **CA-signed cert** (Let's Encrypt, a corporate/internal CA already
+//!   installed in the OS trust store, …): zero configuration.
+//!   [`BrokerClient::connect`] negotiates TLS against the OS's native root
+//!   store (`tokio-tungstenite`'s `rustls-tls-native-roots` feature).
+//! - **Self-signed cert** (the common homelab/cross-network quick-start):
+//!   [`BrokerClient::connect_with_tls`] takes an explicit
+//!   `rustls::ClientConfig` — build one with
+//!   [`client_config_trusting_cert`] (or
+//!   `bamboo_subagent::transport::client_config_trusting_cert` directly) to
+//!   trust exactly the worker/broker's own cert with no OS trust-store
+//!   changes.
 
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -12,11 +27,24 @@ use futures_util::stream::SplitSink;
 use futures_util::{SinkExt, StreamExt};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::{
+    connect_async_tls_with_config, Connector, MaybeTlsStream, WebSocketStream,
+};
 
 use crate::error::{BrokerError, BrokerResult};
 use crate::proto::{BrokerFrame, ClientFrame};
+
+/// Build a rustls [`rustls::ClientConfig`] that trusts exactly the
+/// certificate(s) in `cert_file` (PEM) — for connecting to a broker or
+/// broker-agent serving a self-signed cert over `wss://` (#48). Thin wrapper
+/// over `bamboo_subagent::transport::client_config_trusting_cert` (same
+/// helper `ChildClient`'s direct-WS path already uses) that maps its
+/// `Result<_, String>` into [`BrokerError::Tls`].
+pub fn client_config_trusting_cert(cert_file: &Path) -> BrokerResult<rustls::ClientConfig> {
+    bamboo_subagent::transport::client_config_trusting_cert(cert_file).map_err(BrokerError::Tls)
+}
 
 pub(crate) type WsSink = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
 
@@ -69,8 +97,35 @@ pub struct BrokerClient {
 impl BrokerClient {
     /// Connect to `endpoint` (`ws://host:port` or `wss://…`), authenticate with
     /// `token`, and bind this connection to `agent.session_id`.
+    ///
+    /// A `wss://` endpoint is negotiated against the OS's native TLS root
+    /// store (works with any CA-signed cert, e.g. Let's Encrypt, or a
+    /// self-signed cert whose CA the operator already installed locally) — no
+    /// extra configuration. To trust a self-signed cert WITHOUT touching the
+    /// OS trust store (the common homelab/cross-network quick-start), use
+    /// [`connect_with_tls`](Self::connect_with_tls) with a config from
+    /// [`client_config_trusting_cert`]. #48.
     pub async fn connect(endpoint: &str, agent: AgentRef, token: &str) -> BrokerResult<Self> {
-        let (ws, _resp) = connect_async(endpoint)
+        Self::connect_with_tls(endpoint, agent, token, None).await
+    }
+
+    /// Like [`connect`](Self::connect), but for `wss://` lets the caller
+    /// supply a custom rustls [`rustls::ClientConfig`] — e.g. one built by
+    /// [`client_config_trusting_cert`] that trusts exactly a self-signed
+    /// worker/broker cert. `None` falls back to the OS native root store
+    /// (identical to [`connect`](Self::connect)). Ignored for plaintext
+    /// `ws://`. #48.
+    pub async fn connect_with_tls(
+        endpoint: &str,
+        agent: AgentRef,
+        token: &str,
+        tls_config: Option<rustls::ClientConfig>,
+    ) -> BrokerResult<Self> {
+        let request = endpoint
+            .into_client_request()
+            .map_err(|e| BrokerError::Transport(format!("bad endpoint '{endpoint}': {e}")))?;
+        let connector = tls_config.map(|cfg| Connector::Rustls(Arc::new(cfg)));
+        let (ws, _resp) = connect_async_tls_with_config(request, None, false, connector)
             .await
             .map_err(|e| BrokerError::Transport(format!("connect {endpoint}: {e}")))?;
         let (mut sink, mut source) = ws.split();

--- a/crates/app/bamboo-broker/src/deploy.rs
+++ b/crates/app/bamboo-broker/src/deploy.rs
@@ -55,6 +55,14 @@ pub struct AgentDeployment {
     /// falls back to `DockerDeployer::mount_home` if set, or a homeless
     /// container otherwise).
     pub spec_json: Option<String>,
+    /// Path (AS THE AGENT WILL REACH IT — same convention as `broker_endpoint`)
+    /// to a PEM CA cert the worker should trust for a `wss://` broker with a
+    /// self-signed cert, instead of the OS native root store (#48). Getting the
+    /// file onto the target host is the caller's/deployer-config's job — same
+    /// as `broker_endpoint` already assumes the address resolves from there.
+    /// `None` (the common case: CA-signed cert, or no TLS) uses the OS trust
+    /// store, i.e. `broker-agent serve` with no `--tls-ca-cert`.
+    pub tls_ca_cert: Option<String>,
 }
 
 /// Brings up a broker-agent in some environment and returns a handle to it.
@@ -266,6 +274,10 @@ pub(crate) fn agent_argv(d: &AgentDeployment) -> Vec<String> {
     if let Some(orchestrator) = &d.mcp_proxy {
         a.push("--mcp-proxy".into());
         a.push(orchestrator.clone());
+    }
+    if let Some(ca_cert) = &d.tls_ca_cert {
+        a.push("--tls-ca-cert".into());
+        a.push(ca_cert.clone());
     }
     a
 }
@@ -710,7 +722,8 @@ impl SshDeployer {
 
         let mut tunneled = d.clone();
         if let Some(p) = port {
-            tunneled.broker_endpoint = format!("ws://127.0.0.1:{p}");
+            let scheme = broker_scheme(&d.broker_endpoint);
+            tunneled.broker_endpoint = format!("{scheme}://127.0.0.1:{p}");
         }
         let mut remote = format!("BAMBOO_BROKER_TOKEN={}", sh_quote(&d.token));
         remote.push(' ');
@@ -849,6 +862,23 @@ pub(crate) fn broker_port(endpoint: &str) -> Option<u16> {
     after_host.split(['/', '?']).next()?.parse().ok()
 }
 
+/// The scheme (`"ws"` or `"wss"`) of a broker endpoint, for rewriting it to
+/// the tunnel mouth on `127.0.0.1` (SSH/russh deploy) WITHOUT silently
+/// downgrading a `wss://` broker to `ws://` (#48 — the reverse tunnel forwards
+/// raw bytes end-to-end, so the worker on the far side must still open a TLS
+/// handshake if the real broker terminates TLS; hardcoding `ws://` here would
+/// make the worker attempt a plaintext WS upgrade over what the broker treats
+/// as a TLS stream, and the connection fails). Defaults to `"ws"` for anything
+/// not literally prefixed `wss://` — i.e. unchanged behavior for every
+/// existing plaintext deployment.
+pub(crate) fn broker_scheme(endpoint: &str) -> &'static str {
+    if endpoint.starts_with("wss://") {
+        "wss"
+    } else {
+        "ws"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -865,6 +895,7 @@ mod tests {
             mcp_proxy: None,
             log_path: None,
             spec_json: None,
+            tls_ca_cert: None,
         }
     }
 

--- a/crates/app/bamboo-broker/src/deploy_russh.rs
+++ b/crates/app/bamboo-broker/src/deploy_russh.rs
@@ -33,8 +33,8 @@ use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 
 use crate::deploy::{
-    agent_argv, broker_port, sh_quote, AgentDeployment, DeployedAgent, Deployer, RemoteDeployment,
-    UploadSpec,
+    agent_argv, broker_port, broker_scheme, sh_quote, AgentDeployment, DeployedAgent, Deployer,
+    RemoteDeployment, UploadSpec,
 };
 use crate::error::{BrokerError, BrokerResult};
 
@@ -371,8 +371,12 @@ impl Deployer for RusshDeployer {
         };
 
         // 5. Launch the worker pointed at the tunnel mouth on the remote loopback.
+        // Scheme preserved from the original endpoint (#48): the tunnel forwards
+        // raw bytes end-to-end, so a `wss://` broker still needs the worker to
+        // open a TLS handshake over it — hardcoding `ws://` would break that.
         let mut tunneled = d.clone();
-        tunneled.broker_endpoint = format!("ws://127.0.0.1:{bport}");
+        tunneled.broker_endpoint =
+            format!("{}://127.0.0.1:{bport}", broker_scheme(&d.broker_endpoint));
         let remote_cmd = build_launch_cmd(
             &tunneled,
             &self.bamboo_on_remote,
@@ -643,6 +647,7 @@ mod tests {
             mcp_proxy: Some("bamboo-orchestrator".into()),
             log_path: None,
             spec_json: None,
+            tls_ca_cert: None,
         }
     }
 

--- a/crates/app/bamboo-broker/src/error.rs
+++ b/crates/app/bamboo-broker/src/error.rs
@@ -16,6 +16,13 @@ pub enum BrokerError {
     /// WebSocket / IO transport failure.
     #[error("transport: {0}")]
     Transport(String),
+    /// TLS configuration / handshake failure — bad/missing cert or key
+    /// (server `wss://` listener, #48), a bad custom CA (client-side
+    /// self-signed trust), or the TLS handshake itself failing. Kept distinct
+    /// from [`Self::Transport`] so callers/logs can tell "the TLS layer
+    /// rejected this" apart from a plain socket/WS-protocol failure.
+    #[error("tls: {0}")]
+    Tls(String),
     /// `deliver` refused: the target session's mailbox already holds
     /// `limit` pending (undelivered-or-unacked) messages — a backlog cap
     /// against a flood aimed at an offline/never-draining mailbox filling

--- a/crates/app/bamboo-broker/src/lib.rs
+++ b/crates/app/bamboo-broker/src/lib.rs
@@ -39,7 +39,7 @@ pub const ORCHESTRATOR_ID: &str = "bamboo-orchestrator";
 
 pub use crate::ask::{ask_agent, ask_over, request_over};
 pub use crate::child_link::BrokerChildLink;
-pub use crate::client::BrokerClient;
+pub use crate::client::{client_config_trusting_cert, BrokerClient};
 pub use crate::core::{BrokerCore, DEFAULT_MAX_PENDING_PER_MAILBOX};
 pub use crate::deploy::{
     AgentDeployment, DeployedAgent, Deployer, DockerDeployer, LocalProcessDeployer,
@@ -54,8 +54,8 @@ pub use crate::mcp::{
 pub use crate::mux::MultiplexedClient;
 pub use crate::proto::{BrokerFrame, ClientFrame};
 pub use crate::serve::{
-    serve_executor, serve_executor_with_shutdown, serve_loop, serve_mailbox,
-    serve_mailbox_with_shutdown, serve_with, Handled,
+    serve_executor, serve_executor_full, serve_executor_with_shutdown, serve_loop, serve_mailbox,
+    serve_mailbox_full, serve_mailbox_with_shutdown, serve_with, Handled,
 };
 pub use crate::server::{BrokerLimits, BrokerServer};
 pub use bamboo_subagent::AgentRef;

--- a/crates/app/bamboo-broker/src/serve.rs
+++ b/crates/app/bamboo-broker/src/serve.rs
@@ -65,9 +65,42 @@ where
     H: Fn(InboxMessage, CancellationToken) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Handled> + Send + 'static,
 {
-    let mut client = BrokerClient::connect(endpoint, me.clone(), token).await?;
+    serve_mailbox_full(endpoint, me, token, handler, shutdown, None).await
+}
+
+/// Like [`serve_mailbox_with_shutdown`], plus an optional rustls
+/// `ClientConfig` for `wss://` (e.g. [`crate::client::client_config_trusting_cert`]
+/// to trust a self-signed broker cert without touching the OS trust store).
+/// `None` behaves exactly like [`serve_mailbox_with_shutdown`] — the OS
+/// native root store. #48.
+pub async fn serve_mailbox_full<H, Fut>(
+    endpoint: &str,
+    me: AgentRef,
+    token: &str,
+    handler: H,
+    shutdown: CancellationToken,
+    tls_config: Option<Arc<rustls::ClientConfig>>,
+) -> BrokerResult<()>
+where
+    H: Fn(InboxMessage, CancellationToken) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Handled> + Send + 'static,
+{
+    let mut client =
+        BrokerClient::connect_with_tls(endpoint, me.clone(), token, clone_tls_config(&tls_config))
+            .await?;
     client.subscribe().await?;
     serve_loop(&mut client, &me, handler, shutdown).await
+}
+
+/// [`BrokerClient::connect_with_tls`] takes an owned `ClientConfig` (it hands
+/// it straight to `Connector::Rustls(Arc::new(cfg))`), but the serve chain
+/// here shares ONE config across the worker's own connection plus every
+/// per-run reconnect ([`handle_run`]'s forward/approval deliver
+/// connections) — so it's held as an `Arc` and cloned out (rustls
+/// `ClientConfig::clone` is cheap: its fields are themselves `Arc`-backed)
+/// at each call site instead of rebuilding it. #48.
+fn clone_tls_config(cfg: &Option<Arc<rustls::ClientConfig>>) -> Option<rustls::ClientConfig> {
+    cfg.as_deref().cloned()
 }
 
 /// One finished handler routed back to the single client owner for delivery+ack.
@@ -290,6 +323,26 @@ pub async fn serve_executor_with_shutdown<E>(
 where
     E: bamboo_subagent::ChildExecutor + ?Sized,
 {
+    serve_executor_full(endpoint, me, token, executor, shutdown, None).await
+}
+
+/// Like [`serve_executor_with_shutdown`], plus an optional rustls
+/// `ClientConfig` for `wss://` (see [`serve_mailbox_full`]) — threaded into
+/// BOTH the worker's own connection and [`handle_run`]'s per-run
+/// forward/approval reconnects, so a `Run`'s event/approval traffic uses the
+/// same self-signed-cert trust as the worker's primary connection. `None`
+/// behaves exactly like [`serve_executor_with_shutdown`]. #48.
+pub async fn serve_executor_full<E>(
+    endpoint: &str,
+    me: AgentRef,
+    token: &str,
+    executor: Arc<E>,
+    shutdown: CancellationToken,
+    tls_config: Option<Arc<rustls::ClientConfig>>,
+) -> BrokerResult<()>
+where
+    E: bamboo_subagent::ChildExecutor + ?Sized,
+{
     let context: Arc<tokio::sync::Mutex<Vec<serde_json::Value>>> =
         Arc::new(tokio::sync::Mutex::new(Vec::new()));
     // Per-run coordination so a SEPARATE Steer / ApprovalReply mailbox message can
@@ -300,7 +353,8 @@ where
     let endpoint_owned = endpoint.to_string();
     let token_owned = token.to_string();
     let me_owned = me.clone();
-    serve_mailbox_with_shutdown(
+    let tls_owned = tls_config.clone();
+    serve_mailbox_full(
         endpoint,
         me,
         token,
@@ -312,6 +366,7 @@ where
             let endpoint = endpoint_owned.clone();
             let token = token_owned.clone();
             let me = me_owned.clone();
+            let tls_config = tls_owned.clone();
             async move {
                 match msg.kind {
                     // A full child session over the bus (the actor-over-mailbox path):
@@ -326,6 +381,7 @@ where
                             cancel,
                             &coords,
                             &waiters,
+                            tls_config,
                         )
                         .await
                     }
@@ -369,6 +425,7 @@ where
             }
         },
         shutdown,
+        tls_config,
     )
     .await
 }
@@ -401,6 +458,7 @@ async fn handle_run<E>(
     cancel: CancellationToken,
     coords: &RunCoords,
     waiters: &ApprovalWaiters,
+    tls_config: Option<Arc<rustls::ClientConfig>>,
 ) -> Handled
 where
     E: bamboo_subagent::ChildExecutor + ?Sized,
@@ -439,8 +497,16 @@ where
     let me_fwd = me.clone();
     let parent_fwd = parent.clone();
     let (ep_fwd, tok_fwd) = (endpoint.clone(), token.clone());
+    let tls_fwd = tls_config.clone();
     let forward = tokio::spawn(async move {
-        let mut deliver = match BrokerClient::connect(&ep_fwd, me_fwd.clone(), &tok_fwd).await {
+        let mut deliver = match BrokerClient::connect_with_tls(
+            &ep_fwd,
+            me_fwd.clone(),
+            &tok_fwd,
+            tls_fwd.as_deref().cloned(),
+        )
+        .await
+        {
             Ok(c) => c,
             Err(e) => {
                 tracing::warn!("run {run_id_fwd:?}: event deliver connect failed: {e}");
@@ -479,7 +545,14 @@ where
     let waiters_drain = Arc::clone(waiters);
     let run_id_appr = run_id.clone();
     let approval = tokio::spawn(async move {
-        let mut deliver = match BrokerClient::connect(&endpoint, me.clone(), &token).await {
+        let mut deliver = match BrokerClient::connect_with_tls(
+            &endpoint,
+            me.clone(),
+            &token,
+            tls_config.as_deref().cloned(),
+        )
+        .await
+        {
             Ok(c) => c,
             Err(e) => {
                 tracing::warn!("run {run_id_appr:?}: approval deliver connect failed: {e}");

--- a/crates/app/bamboo-broker/src/server.rs
+++ b/crates/app/bamboo-broker/src/server.rs
@@ -5,8 +5,16 @@
 //! and forwards the subscription stream back out as `Message` frames. Reachable
 //! on any address (`0.0.0.0:PORT`) so workers deployed via subprocess / Docker /
 //! SSH can dial home over the network.
+//!
+//! TLS (`wss://`, #48): [`BrokerServer::with_tls`] wraps every accepted
+//! `TcpStream` in a `tokio_rustls::TlsAcceptor` before the WS upgrade, using
+//! the SAME cert/key-loading helper `bamboo-subagent`'s own `WsServer::bind_tls`
+//! uses (`bamboo_subagent::transport::build_server_config`) — one hardened
+//! implementation, two call sites. Plaintext `ws://` (no `with_tls` call)
+//! stays the default — zero regression for loopback/trusted-link use.
 
 use std::num::NonZeroU32;
+use std::path::Path;
 use std::sync::Arc;
 
 use futures_util::stream::{SplitSink, SplitStream};
@@ -14,8 +22,10 @@ use futures_util::{SinkExt, StreamExt};
 use governor::clock::DefaultClock;
 use governor::state::{InMemoryState, NotKeyed};
 use governor::{Quota, RateLimiter};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpListener;
 use tokio::sync::{mpsc, Semaphore};
+use tokio_rustls::TlsAcceptor;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{accept_async, WebSocketStream};
 
@@ -23,7 +33,6 @@ use crate::core::{BrokerCore, PushItem};
 use crate::error::{BrokerError, BrokerResult};
 use crate::proto::{BrokerFrame, ClientFrame};
 
-type Ws = WebSocketStream<TcpStream>;
 /// Un-keyed (single-bucket) token-bucket limiter for one connection's
 /// `Deliver` rate (#53).
 type DeliverLimiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock>;
@@ -85,6 +94,10 @@ pub struct BrokerServer {
     /// `limits.max_connections`. Held for the lifetime of each connection's
     /// task (#53).
     connection_slots: Arc<Semaphore>,
+    /// TLS acceptor for terminating `wss://` before the WS upgrade — `None`
+    /// (the default) keeps the historical bare-`TcpStream` `ws://` behavior.
+    /// Set via [`with_tls`](Self::with_tls). #48.
+    tls: Option<TlsAcceptor>,
 }
 
 impl BrokerServer {
@@ -104,7 +117,31 @@ impl BrokerServer {
             token: token.into(),
             connection_slots: Arc::new(Semaphore::new(limits.max_connections)),
             limits,
+            tls: None,
         }
+    }
+
+    /// Terminate TLS (`wss://`) on every accepted connection before the WS
+    /// upgrade, built from a PEM `cert_file`/`key_file` pair (#48). Reuses
+    /// `bamboo_subagent::transport::build_server_config` (rustls + explicit
+    /// `ring` provider) — the exact cert/key-loading logic
+    /// `bamboo-subagent`'s own `WsServer::bind_tls` uses — so the workspace
+    /// resolves a single crypto provider and never hits the rustls 0.23
+    /// no-default-provider panic.
+    ///
+    /// **Fail-fast:** a missing/unreadable/unparseable cert or key returns
+    /// `Err` immediately — this never silently falls back to plaintext.
+    pub fn with_tls(mut self, cert_file: &Path, key_file: &Path) -> BrokerResult<Self> {
+        let server_config = bamboo_subagent::transport::build_server_config(cert_file, key_file)
+            .map_err(BrokerError::Tls)?;
+        self.tls = Some(TlsAcceptor::from(Arc::new(server_config)));
+        Ok(self)
+    }
+
+    /// `true` once [`with_tls`](Self::with_tls) has configured a TLS acceptor
+    /// — i.e. this server terminates `wss://`, not bare `ws://`.
+    pub fn is_tls(&self) -> bool {
+        self.tls.is_some()
     }
 
     /// Accept connections forever, one task each. Returns only on a listener
@@ -126,7 +163,21 @@ impl BrokerServer {
                 Ok(permit) => {
                     tokio::spawn(async move {
                         let _permit = permit; // held for the connection's lifetime
-                        if let Err(e) = server.handle_conn(stream).await {
+                                              // The TLS handshake (when configured) runs inside this
+                                              // spawned task, not on the accept loop, so a slow/hostile
+                                              // client can't stall acceptance of other connections —
+                                              // mirrors `bamboo_subagent::transport::WsServer::serve`'s
+                                              // same tradeoff (#48).
+                        let result = match &server.tls {
+                            Some(acceptor) => match acceptor.accept(stream).await {
+                                Ok(tls_stream) => server.handle_conn(tls_stream).await,
+                                Err(e) => Err(BrokerError::Tls(format!(
+                                    "tls accept handshake ({peer}): {e}"
+                                ))),
+                            },
+                            None => server.handle_conn(stream).await,
+                        };
+                        if let Err(e) = result {
                             tracing::debug!("broker connection ended: {e}");
                         }
                     });
@@ -143,7 +194,15 @@ impl BrokerServer {
         }
     }
 
-    async fn handle_conn(&self, stream: TcpStream) -> BrokerResult<()> {
+    /// Perform the WS upgrade + serve loop over an already-TLS-terminated (or
+    /// plaintext) stream. Generic over the stream type so ONE implementation
+    /// serves both bare `TcpStream` (`ws://`) and `TlsStream<TcpStream>`
+    /// (`wss://`) connections (#48) — mirrors
+    /// `bamboo_subagent::transport::handle_conn`'s same genericization.
+    async fn handle_conn<S>(&self, stream: S) -> BrokerResult<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
         let ws = accept_async(stream)
             .await
             .map_err(|e| BrokerError::Transport(format!("ws accept: {e}")))?;
@@ -303,7 +362,15 @@ async fn next_pushed(rx: &mut Option<mpsc::UnboundedReceiver<PushItem>>) -> Opti
 }
 
 /// Read the next client frame, skipping ping/pong/binary. `Ok(None)` on close.
-async fn read_client_frame(source: &mut SplitStream<Ws>) -> BrokerResult<Option<ClientFrame>> {
+/// Generic over the underlying stream (plain `TcpStream` or
+/// `TlsStream<TcpStream>`, #48) so plaintext and TLS connections share one
+/// implementation.
+async fn read_client_frame<S>(
+    source: &mut SplitStream<WebSocketStream<S>>,
+) -> BrokerResult<Option<ClientFrame>>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     loop {
         match source.next().await {
             Some(Ok(Message::Text(t))) => {
@@ -318,7 +385,13 @@ async fn read_client_frame(source: &mut SplitStream<Ws>) -> BrokerResult<Option<
     }
 }
 
-async fn send(sink: &mut SplitSink<Ws, Message>, frame: BrokerFrame) -> BrokerResult<()> {
+async fn send<S>(
+    sink: &mut SplitSink<WebSocketStream<S>, Message>,
+    frame: BrokerFrame,
+) -> BrokerResult<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     sink.send(Message::text(frame.to_text()))
         .await
         .map_err(|e| BrokerError::Transport(format!("ws send: {e}")))

--- a/crates/app/bamboo-broker/tests/russh_live.rs
+++ b/crates/app/bamboo-broker/tests/russh_live.rs
@@ -84,6 +84,7 @@ async fn russh_deploys_through_reverse_tunnel() {
         mcp_proxy: None,
         log_path: None,
         spec_json: None,
+        tls_ca_cert: None,
     };
 
     let handle = deployer.deploy(&deployment).await.expect("russh deploy");

--- a/crates/app/bamboo-broker/tests/wss_roundtrip.rs
+++ b/crates/app/bamboo-broker/tests/wss_roundtrip.rs
@@ -1,0 +1,223 @@
+//! End-to-end: a real broker WS server terminating TLS (`wss://`, #48) + a
+//! real client, exchanging an ask/reply over an encrypted loopback connection
+//! — the `wss://` counterpart to `ws_roundtrip.rs`'s plaintext coverage.
+//!
+//! Generates a throwaway self-signed cert via `openssl` (mirrors
+//! `bamboo-server`'s `server/tls.rs` test precedent), skipping gracefully if
+//! `openssl` isn't available in the test environment. The cert carries a
+//! `subjectAltName=IP:127.0.0.1` extension so rustls's hostname verification
+//! (which — unlike some older stacks — checks ONLY the SAN, never falls back
+//! to the CN) accepts it for a `wss://127.0.0.1:PORT` endpoint.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bamboo_broker::{BrokerClient, BrokerCore, BrokerServer};
+use bamboo_subagent::{AgentRef, AskBody, AskMode, InboxKind, InboxMessage, MsgId, ReplyBody};
+use chrono::Utc;
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+
+const TOKEN: &str = "secret-token";
+
+fn agent(id: &str) -> AgentRef {
+    AgentRef {
+        session_id: id.into(),
+        role: None,
+    }
+}
+
+fn ask(from: &str) -> InboxMessage {
+    InboxMessage {
+        id: MsgId::new(),
+        from: agent(from),
+        kind: InboxKind::Ask,
+        body: serde_json::to_value(AskBody {
+            question: "what's your status?".into(),
+            mode: AskMode::Query,
+        })
+        .unwrap(),
+        created_at: Utc::now(),
+        correlation_id: None,
+    }
+}
+
+async fn recv(client: &mut BrokerClient) -> InboxMessage {
+    tokio::time::timeout(Duration::from_secs(5), client.next_message())
+        .await
+        .expect("timed out waiting for message")
+        .expect("connection closed")
+}
+
+/// Generate a throwaway self-signed cert + PKCS#8 key via `openssl`, with:
+/// - `subjectAltName=IP:127.0.0.1` so a live TLS handshake against
+///   `wss://127.0.0.1:PORT` passes hostname verification (rustls checks ONLY
+///   the SAN, never falls back to the CN), and
+/// - `basicConstraints=critical,CA:FALSE`, overriding openssl 3.x's default
+///   of `CA:TRUE` on an `-x509` self-signed cert. `client_config_trusting_cert`
+///   adds this SAME cert directly to the client's `RootCertStore` (as its own
+///   trust anchor) while the server presents it as the TLS end-entity/leaf
+///   certificate; current `rustls-webpki` rejects a leaf cert that is marked
+///   as a CA (`CaUsedAsEndEntity`) — being a trust anchor doesn't need
+///   `CA:TRUE` (anchors aren't constraint-checked the way intermediate/leaf
+///   certs are), so `CA:FALSE` satisfies both roles at once.
+/// Returns `None` (skip) if `openssl` is unavailable or too old to support
+/// `-addext`.
+fn gen_self_signed(dir: &Path) -> Option<(PathBuf, PathBuf)> {
+    let cert = dir.join("cert.pem");
+    let key = dir.join("key.pem");
+    let status = Command::new("openssl")
+        .args([
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            key.to_str().unwrap(),
+            "-out",
+            cert.to_str().unwrap(),
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=127.0.0.1",
+            "-addext",
+            "subjectAltName=IP:127.0.0.1",
+            "-addext",
+            "basicConstraints=critical,CA:FALSE",
+        ])
+        .status();
+    match status {
+        Ok(s) if s.success() => Some((cert, key)),
+        _ => None,
+    }
+}
+
+/// Start a TLS-terminated broker; returns the `wss://` endpoint, the cert
+/// path (for the client to trust), and the mailbox-root guard.
+async fn start_tls_broker(cert: &Path, key: &Path) -> (String, TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let core = Arc::new(BrokerCore::new(dir.path()));
+    let server = Arc::new(
+        BrokerServer::new(core, TOKEN)
+            .with_tls(cert, key)
+            .expect("valid self-signed cert/key builds a TLS acceptor"),
+    );
+    assert!(server.is_tls(), "with_tls must flip is_tls() on");
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    tokio::spawn(async move {
+        let _ = server.serve(listener).await;
+    });
+    (format!("wss://{addr}"), dir)
+}
+
+#[tokio::test]
+async fn ask_reply_round_trip_over_wss_with_trusted_self_signed_cert() {
+    let cert_dir = tempfile::tempdir().expect("tempdir");
+    let Some((cert, key)) = gen_self_signed(cert_dir.path()) else {
+        eprintln!("skipping wss round-trip test: openssl unavailable");
+        return;
+    };
+    let (endpoint, _mailbox_dir) = start_tls_broker(&cert, &key).await;
+
+    // Trust EXACTLY this self-signed cert (the homelab/cross-network
+    // quick-start path, #48) — no OS trust-store changes.
+    let tls_config = bamboo_broker::client_config_trusting_cert(&cert)
+        .expect("client_config_trusting_cert builds from the same cert");
+
+    let mut child =
+        BrokerClient::connect_with_tls(&endpoint, agent("child"), TOKEN, Some(tls_config.clone()))
+            .await
+            .expect("child connects over wss://");
+    child.subscribe().await.expect("child subscribes");
+
+    let mut parent =
+        BrokerClient::connect_with_tls(&endpoint, agent("parent"), TOKEN, Some(tls_config))
+            .await
+            .expect("parent connects over wss://");
+    parent.subscribe().await.expect("parent subscribes");
+
+    let the_ask = ask("parent");
+    let delivered_id = parent
+        .deliver("child", the_ask.clone())
+        .await
+        .expect("deliver ask over TLS");
+    assert_eq!(delivered_id, the_ask.id);
+
+    let got = recv(&mut child).await;
+    assert_eq!(got.id, the_ask.id);
+    assert_eq!(got.kind, InboxKind::Ask);
+    child.ack(got.id.clone()).await.expect("child acks ask");
+
+    let reply = InboxMessage {
+        id: MsgId::new(),
+        from: agent("child"),
+        kind: InboxKind::Reply,
+        body: serde_json::to_value(ReplyBody {
+            answer: "all systems nominal, encrypted".into(),
+        })
+        .unwrap(),
+        created_at: Utc::now(),
+        correlation_id: Some(the_ask.id.clone()),
+    };
+    child
+        .deliver("parent", reply)
+        .await
+        .expect("deliver reply over TLS");
+
+    let got_reply = recv(&mut parent).await;
+    assert_eq!(got_reply.kind, InboxKind::Reply);
+    assert_eq!(got_reply.correlation_id, Some(the_ask.id));
+    let body: ReplyBody = serde_json::from_value(got_reply.body).unwrap();
+    assert_eq!(body.answer, "all systems nominal, encrypted");
+}
+
+/// Security regression: a client that does NOT explicitly trust the
+/// self-signed cert (i.e. plain [`BrokerClient::connect`], the OS native root
+/// store) must be REJECTED — a self-signed cert must never be silently
+/// trusted by default. This is the negative twin of the round-trip test
+/// above: it proves `connect_with_tls(..., None)` and `connect_with_tls(...,
+/// Some(trusting_config))` behave differently, i.e. the trust config is
+/// actually being applied, not ignored.
+#[tokio::test]
+async fn wss_with_untrusted_self_signed_cert_is_rejected() {
+    let cert_dir = tempfile::tempdir().expect("tempdir");
+    let Some((cert, key)) = gen_self_signed(cert_dir.path()) else {
+        eprintln!("skipping untrusted-cert rejection test: openssl unavailable");
+        return;
+    };
+    let (endpoint, _mailbox_dir) = start_tls_broker(&cert, &key).await;
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        BrokerClient::connect(&endpoint, agent("untrusting"), TOKEN),
+    )
+    .await
+    .expect("connect attempt does not hang");
+    assert!(
+        result.is_err(),
+        "a self-signed cert must be rejected when the client doesn't explicitly trust it"
+    );
+}
+
+/// `with_tls` is fail-fast (#48): a missing cert/key must error out of
+/// `BrokerServer` construction, never silently fall back to plaintext.
+#[tokio::test]
+async fn with_tls_fails_fast_on_missing_cert() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let core = Arc::new(BrokerCore::new(dir.path()));
+    let result = BrokerServer::new(core, TOKEN).with_tls(
+        Path::new("/nonexistent/bamboo-broker/cert.pem"),
+        Path::new("/nonexistent/bamboo-broker/key.pem"),
+    );
+    match result {
+        Err(bamboo_broker::BrokerError::Tls(m)) => {
+            assert!(m.contains("cert_file"), "error should name cert_file: {m}");
+        }
+        Err(other) => panic!("expected a Tls error naming cert_file, got {other:?}"),
+        Ok(_) => panic!("missing cert must fail, not build a BrokerServer"),
+    }
+}

--- a/crates/app/bamboo-server-tools/src/deploy_agent.rs
+++ b/crates/app/bamboo-server-tools/src/deploy_agent.rs
@@ -192,6 +192,11 @@ impl DeployAgentTool {
             mcp_proxy: Some(bamboo_broker::ORCHESTRATOR_ID.to_string()),
             log_path: None,
             spec_json,
+            // No self-signed CA to trust: on-demand-deploy targets (local/docker/
+            // ssh via this tool) don't yet expose a per-deploy `--tls-ca-cert`
+            // param; `wss://` still works here against a CA-signed broker cert
+            // (or a self-signed one whose CA is already in the OS trust store).
+            tls_ca_cert: None,
         };
         let handle = deployer
             .deploy(&deployment)

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -200,6 +200,11 @@ impl FabricDeployer {
             mcp_proxy: Some(ORCHESTRATOR_ID.to_string()),
             log_path: Some(log_path.clone()),
             spec_json,
+            // Fabric config doesn't yet expose a per-node CA-cert path (#48
+            // wires the capability into `AgentDeployment`/the CLI; a fast-follow
+            // can add `node.deploy.tls_ca_cert` if fabric nodes need self-signed
+            // `wss://` brokers without an OS-trust-store install).
+            tls_ca_cert: None,
         };
 
         // Release any prior worker FIRST so its reverse tunnel frees the broker

--- a/crates/infra/bamboo-subagent/src/transport.rs
+++ b/crates/infra/bamboo-subagent/src/transport.rs
@@ -318,7 +318,17 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 
 /// Build a rustls [`rustls::ServerConfig`] from PEM cert/key files against an
 /// explicit `ring` provider (mirrors `bamboo-server`'s `build_rustls_config`).
-fn build_server_config(cert_file: &Path, key_file: &Path) -> Result<rustls::ServerConfig, String> {
+///
+/// `pub` (not crate-private) so a sibling network-facing crate — e.g.
+/// `bamboo-broker`'s own WS listener (#48) — can build a `TlsAcceptor` from
+/// the exact same, already-hardened cert/key-loading logic instead of
+/// duplicating it. Keeps the workspace's "single crypto provider" invariant
+/// (see this function's own `ring` provider construction below) enforced in
+/// one place.
+pub fn build_server_config(
+    cert_file: &Path,
+    key_file: &Path,
+) -> Result<rustls::ServerConfig, String> {
     use std::fs::File;
     use std::io::BufReader;
 

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -973,7 +973,10 @@ enum BrokerCommands {
         # Local-only broker (loopback), token from the env var\n  \
         BAMBOO_BROKER_TOKEN=secret bamboo broker serve\n\n  \
         # Accept remote / containerized workers on all interfaces\n  \
-        bamboo broker serve --bind 0.0.0.0:9600 --token secret")]
+        bamboo broker serve --bind 0.0.0.0:9600 --token secret\n\n  \
+        # wss:// for cross-network deployment (#48) — PEM cert/key pair\n  \
+        bamboo broker serve --bind 0.0.0.0:9600 --token secret \\\n    \
+        --cert /etc/bamboo/broker.crt --key /etc/bamboo/broker.key")]
     Serve {
         /// Bind address. Use `0.0.0.0:9600` to accept connections from remote /
         /// containerized workers; `127.0.0.1:9600` for local-only.
@@ -989,6 +992,19 @@ enum BrokerCommands {
         /// Durable mailbox storage root. Defaults to `<bamboo_dir>/broker`.
         #[arg(long)]
         root: Option<PathBuf>,
+
+        /// PEM certificate for `wss://` (#48). Requires `--key`; both present
+        /// switches the listener from plaintext `ws://` to TLS-terminated
+        /// `wss://` — the bearer token and all mailbox traffic (including
+        /// proxied MCP tool arguments) are otherwise sent in the clear, which
+        /// is fine on loopback but unsafe across a network. Omit both for the
+        /// unchanged plaintext default.
+        #[arg(long, requires = "key")]
+        cert: Option<PathBuf>,
+
+        /// PEM private key for `wss://` (#48). Requires `--cert`.
+        #[arg(long, requires = "cert")]
+        key: Option<PathBuf>,
 
         /// Max concurrent WebSocket connections (#53 DoS defense). Beyond
         /// this, new connections are dropped immediately. Default is
@@ -1075,6 +1091,13 @@ enum BrokerAgentCommands {
         /// uploads it next to the binary). Takes precedence over --spec-stdin.
         #[arg(long = "spec-file")]
         spec_file: Option<String>,
+
+        /// PEM CA cert to trust for a `wss://` broker with a self-signed cert
+        /// (#48), instead of the OS native root store. Omit for a CA-signed
+        /// cert (Let's Encrypt, etc.) or a self-signed cert whose CA is
+        /// already installed in the OS trust store — both work with no flag.
+        #[arg(long = "tls-ca-cert")]
+        tls_ca_cert: Option<String>,
     },
 }
 
@@ -1601,6 +1624,8 @@ async fn main() {
                 bind,
                 token,
                 root,
+                cert,
+                key,
                 max_connections,
                 messages_per_second,
                 message_burst,
@@ -1631,9 +1656,14 @@ async fn main() {
                 .local_addr()
                 .map(|a| a.to_string())
                 .unwrap_or_else(|_| bind.clone());
+            // #48: `--cert`/`--key` (clap `requires` enforces both-or-neither)
+            // switch the listener to `wss://`. `is_tls` only for the log line
+            // below — the boolean itself never gates anything security-relevant.
+            let is_tls = cert.is_some();
             tracing::info!(
                 %addr,
                 root = %root.display(),
+                tls = is_tls,
                 max_connections,
                 messages_per_second,
                 message_burst,
@@ -1658,9 +1688,19 @@ async fn main() {
                 message_burst: std::num::NonZeroU32::new(message_burst)
                     .expect("clap value_parser rejects 0"),
             };
-            let server = std::sync::Arc::new(bamboo_broker::BrokerServer::with_limits(
-                core, token, limits,
-            ));
+            let mut server = bamboo_broker::BrokerServer::with_limits(core, token, limits);
+            // Fail-fast (#48): a bad/missing cert or key must abort startup, never
+            // silently downgrade to plaintext.
+            if let (Some(cert), Some(key)) = (&cert, &key) {
+                server = match server.with_tls(cert, key) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        eprintln!("broker: failed to load TLS cert/key: {e}");
+                        std::process::exit(1);
+                    }
+                };
+            }
+            let server = std::sync::Arc::new(server);
             if let Err(e) = server.serve(listener).await {
                 eprintln!("broker server failed: {e}");
                 std::process::exit(1);
@@ -1679,6 +1719,7 @@ async fn main() {
                 mcp_proxy,
                 spec_stdin,
                 spec_file,
+                tls_ca_cert,
             } = command;
             let token = match token
                 .or_else(|| std::env::var("BAMBOO_BROKER_TOKEN").ok())
@@ -1704,6 +1745,7 @@ async fn main() {
                     mcp_proxy,
                     spec_stdin,
                     spec_file,
+                    tls_ca_cert,
                 })
                 .await;
             if let Err(e) = result {

--- a/src/broker_agent.rs
+++ b/src/broker_agent.rs
@@ -94,6 +94,11 @@ pub struct BrokerAgentArgs {
     /// (the delivery a remote deployer uses — it SFTP/scp-uploads the spec next to
     /// the binary rather than piping a TTY'd stdin).
     pub spec_file: Option<String>,
+    /// Path to a PEM CA cert to trust for a `wss://` broker with a self-signed
+    /// cert, instead of the OS native root store (#48). `None` (the common
+    /// case: CA-signed cert, no TLS, or a self-signed cert whose CA is already
+    /// in the OS trust store) uses the OS store.
+    pub tls_ca_cert: Option<String>,
 }
 
 /// Connect to the broker and serve until the connection drops or a graceful
@@ -103,6 +108,17 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
     // stops pulling new work, finishes + replies to the in-flight Ask/Task/Run,
     // and returns — instead of the process dying mid-answer.
     let shutdown = install_shutdown_signal();
+
+    // #48: an explicit CA cert to trust for a self-signed `wss://` broker,
+    // instead of the OS native root store. Built once and shared (as an `Arc`)
+    // across the worker's own connection and every per-Run reconnect.
+    let tls_config = match &args.tls_ca_cert {
+        Some(path) => Some(Arc::new(
+            bamboo_broker::client_config_trusting_cert(std::path::Path::new(path))
+                .map_err(|e| format!("broker-agent: --tls-ca-cert '{path}': {e}"))?,
+        )),
+        None => None,
+    };
 
     // Parent-shipped bootstrap: read the authoritative ProvisionSpec the
     // orchestrator resolved (identity, bus, model, creds, MCP) — from an uploaded
@@ -158,8 +174,8 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
             )),
             _ => Arc::new(BambooRuntimeExecutor::build(&spec).await?),
         };
-        return bamboo_broker::serve_executor_with_shutdown(
-            &endpoint, me, &token, executor, shutdown,
+        return bamboo_broker::serve_executor_full(
+            &endpoint, me, &token, executor, shutdown, tls_config,
         )
         .await
         .map_err(|e| format!("broker-agent (spec) failed: {e}"));
@@ -173,12 +189,13 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
     tracing::info!(id = %args.id, broker = %args.broker, echo = args.echo, "broker-agent connecting");
 
     if args.echo {
-        return bamboo_broker::serve_executor_with_shutdown(
+        return bamboo_broker::serve_executor_full(
             &args.broker,
             me,
             &args.token,
             Arc::new(EchoExecutor),
             shutdown,
+            tls_config,
         )
         .await
         .map_err(|e| format!("broker-agent (echo) failed: {e}"));
@@ -186,12 +203,13 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
 
     let spec = build_spec(&args)?;
     let executor = BambooRuntimeExecutor::build(&spec).await?;
-    bamboo_broker::serve_executor_with_shutdown(
+    bamboo_broker::serve_executor_full(
         &args.broker,
         me,
         &args.token,
         Arc::new(executor),
         shutdown,
+        tls_config,
     )
     .await
     .map_err(|e| format!("broker-agent failed: {e}"))

--- a/tests/broker_deploy_e2e.rs
+++ b/tests/broker_deploy_e2e.rs
@@ -65,6 +65,7 @@ async fn deploy_local_broker_agent_and_ask_it_query_and_steer() {
             mcp_proxy: None,
             log_path: None,
             spec_json: None,
+            tls_ca_cert: None,
         })
         .await
         .expect("deploy local broker-agent subprocess");
@@ -123,6 +124,7 @@ async fn orchestrator_commands_two_deployed_agents_independently() {
                     mcp_proxy: None,
                     log_path: None,
                     spec_json: None,
+                    tls_ca_cert: None,
                 })
                 .await
                 .expect("deploy agent"),
@@ -187,6 +189,7 @@ async fn docker_deploy_gated() {
             mcp_proxy: None,
             log_path: None,
             spec_json: None,
+            tls_ca_cert: None,
         })
         .await
         .expect("docker run broker-agent");


### PR DESCRIPTION
## Summary

The broker listener spoke bare `ws://` only — the bearer token and all mailbox traffic (including proxied MCP tool arguments) crossed the wire in cleartext. Fine on loopback, unsafe across a network; the SSH-tunnel deploy path was the only existing workaround. Closes #48.

- **Server** (`crates/app/bamboo-broker/src/server.rs`): `BrokerServer::with_tls(cert_file, key_file)` terminates TLS before the WS upgrade — genericized `handle_conn`/`read_client_frame`/`send` over the stream type so one implementation serves both plain `TcpStream` (`ws://`) and `TlsStream<TcpStream>` (`wss://`). The TLS handshake runs inside the per-connection spawned task, not the accept loop, so a slow/hostile client can't stall other connections. Fail-fast: a bad/missing cert or key errors out of construction, never silently falls back to plaintext. Plaintext `ws://` (no `with_tls` call) is unchanged — zero regression.
- **CLI**: `bamboo broker serve --cert <pem> --key <pem>` (clap `requires` enforces both-or-neither) switches the bind to `wss://`. `bamboo broker-agent serve --tls-ca-cert <pem>` lets a worker trust a self-signed broker cert without touching the OS trust store.
- **Client** (`crates/app/bamboo-broker/src/client.rs`): `BrokerClient::connect_with_tls(endpoint, agent, token, tls_config: Option<rustls::ClientConfig>)` — `connect()` now delegates to it with `None`. A `wss://` endpoint with `None` negotiates against the OS's native TLS root store automatically (`tokio-tungstenite`'s `rustls-tls-native-roots` feature) — zero config for a CA-signed cert (Let's Encrypt, a corporate CA, or a self-signed cert whose CA is already installed locally). For the common homelab "no CA install" case, `client_config_trusting_cert(cert_file)` (thin wrapper over `bamboo_subagent::transport::client_config_trusting_cert`, which `ChildClient`'s direct-WS path already used) builds a config that trusts exactly that cert.
- **Worker dial-home threading**: new `serve_executor_full`/`serve_mailbox_full` (additive — `serve_executor`/`serve_executor_with_shutdown`/`serve_mailbox`/`serve_mailbox_with_shutdown` are unchanged thin wrappers, so no ripple through the many existing callers across bamboo-engine/bamboo-server-tools/src/subagent_worker.rs) thread an optional `Arc<rustls::ClientConfig>` into BOTH the worker's own connection and `handle_run`'s per-Run forward/approval reconnects, so a `Run`'s event/approval traffic shares the same self-signed-cert trust as the worker's primary connection.
- **Deploy paths**: `AgentDeployment` gained `tls_ca_cert: Option<String>` → `--tls-ca-cert` on the spawned `broker-agent serve` argv (local/docker/ssh/russh). Also fixed a real latent bug found while auditing the deploy paths: the SSH/russh tunnel rewrite (`tunneled.broker_endpoint = format!("ws://127.0.0.1:{port}")`) hardcoded `ws://` regardless of the original scheme — a `wss://` broker deployed via SSH tunnel would have its worker silently downgraded to a plaintext WS handshake over what the broker treats as a TLS stream, breaking the connection. Added `broker_scheme()` and fixed both call sites (`deploy.rs`'s system-ssh path, `deploy_russh.rs`'s in-process path).

## Library choice + aws-lc-sys verification

Chose **rustls with the explicit `ring` crypto provider** (not `aws-lc`), matching the two existing TLS faces already in this codebase:
- `bamboo-subagent::transport::WsServer::bind_tls` / `client_config_trusting_cert` (the direct actor-link TLS path, #183) — reused directly rather than reimplemented (`build_server_config` made `pub`).
- `bamboo-server`'s HTTP `server/tls.rs` (`build_rustls_config`).

Both already pin `rustls`/`tokio-rustls` with `default-features = false` + `["ring", ...]`, so this PR follows the same pin in `bamboo-broker/Cargo.toml`. For the client, `tokio-tungstenite`'s `rustls-tls-native-roots` feature (also `default-features = false`) was chosen over `native-tls` for consistency with the rest of the workspace's rustls usage, and over `rustls-tls-webpki-roots` so a worker automatically picks up any CA an operator has already installed in the OS trust store (a common homelab/internal-CA pattern) with zero bamboo-specific config.

Verified `cargo tree -i aws-lc-sys` returns **no matches** (empty) both before and after this change — the reqwest native-tls pin's underlying concern (memory: `reqwest-native-tls-pin.md`) is about `aws-lc-sys` specifically breaking Docker builds, not about rustls itself; rustls+ring never pulls it in.

## Tests

New `crates/app/bamboo-broker/tests/wss_roundtrip.rs` (mirrors the existing `ws_roundtrip.rs` precedent), generating a throwaway self-signed cert via `openssl` (skips gracefully if unavailable), same pattern as `bamboo-server`'s `server/tls.rs` test module:
- `ask_reply_round_trip_over_wss_with_trusted_self_signed_cert` — full ask/reply round trip over a live TLS connection with `client_config_trusting_cert`.
- `wss_with_untrusted_self_signed_cert_is_rejected` — security regression: a client that doesn't explicitly trust the self-signed cert (default OS root store) must be rejected, not silently accepted.
- `with_tls_fails_fast_on_missing_cert` — construction-time fail-fast.

Notable gotcha hit and fixed while writing the cert-generation helper: openssl 3.x's `req -x509` defaults to `basicConstraints critical,CA:TRUE` on the self-signed cert; `client_config_trusting_cert` adds that same cert directly to the client's `RootCertStore` as a trust anchor while the server presents it as the TLS leaf/end-entity cert — current `rustls-webpki` rejects a leaf cert marked as a CA (`CaUsedAsEndEntity`). Fixed by explicitly generating with `CA:FALSE` (a trust anchor doesn't need `CA:TRUE`; only the end-entity role does).

Existing `ws_roundtrip.rs` (plaintext) passes unchanged — zero regression on the loopback default.

## Quality gates

- `cargo fmt` on touched crates: clean (`-- --check` passes).
- `cargo clippy --workspace --all-targets`: zero errors; only pre-existing warnings in files this PR doesn't touch.
- `cargo build --workspace --tests`: clean.
- `cargo test -p bamboo-broker`: 74 lib tests + `bus_e2e` (2) + `russh_live` (1) + `ws_roundtrip` (9) + new `wss_roundtrip` (3) — all pass.
- `cargo test -p bamboo-subagent`: 46 lib tests + `e2e_subprocess` (2) — all pass.
- `cargo test -p bamboo-server-tools`: 85 lib tests + `ask_agent_tool` (3) — all pass.
- `cargo tree -i aws-lc-sys`: empty (no matches).

## Known follow-ups (out of scope here)

- `ask.rs`/`mcp.rs`/`child_link.rs`'s direct connections still use the default (OS-trust-store) `connect()` — self-signed-cert trust for those paths isn't threaded yet (only the primary worker dial-home path is). Fine for CA-signed certs; a self-signed-cert user on those paths needs to install the CA in the OS trust store as a workaround today.
- Fabric-deploy config (`fabric_deploy.rs`) doesn't yet expose a per-node `tls_ca_cert` — `AgentDeployment` carries the field, but `node.deploy` config schema would need a matching field to wire it from `fabric.toml`.
- `ProvisionSpec`/`BusEndpoint` doesn't carry a CA-cert path inline — a piped spec (`--spec-file`/`--spec-stdin`) whose `spec.bus` overrides the endpoint currently reuses the CLI's `--tls-ca-cert` rather than a spec-carried one.

https://claude.ai/code/session_01Ux4nHUqFjEEGV3rX1x3V9Y