### PR TITLE
docs(llm): update stale Responses continuation contract comment (Closes #64)

### DIFF
--- a/crates/infra/bamboo-llm/src/prompt_ir.rs
+++ b/crates/infra/bamboo-llm/src/prompt_ir.rs
@@ -86,15 +86,27 @@ pub enum SegmentRole {
 /// difference is deliberate + byte-faithful to the pre-IR engine:
 /// - OpenAI/Copilot **Responses** path: sends the FULL [`PromptIR::responses_input`]
 ///   as `input` together with `previous_response_id` (NOT the delta). This mirrors
-///   the legacy `responses_input_messages` exactly; `store=false` is used, so the
-///   request is effectively stateless and `previous_response_id` rides along for
-///   reasoning continuity rather than to elide history.
+///   the legacy `responses_input_messages` exactly.
 /// - Chat-Completions path: sends [`PromptIR::continuation_delta`] (the delta after
 ///   `last_committed_assistant_id`). No Responses-only provider takes this path
 ///   today, so the delta lowering is currently exercised only by tests.
 ///
-/// (Whether `store=false` + `previous_response_id` is the ideal Responses contract
-/// is a PRE-EXISTING question, untouched by the IR rewrite — see the PR discussion.)
+/// `PromptIR.continuation` only ever carries a `Some` value when the caller has
+/// already confirmed the referenced turn was stored upstream — the engine's
+/// shipped Responses policy is `store=false`, under which
+/// `stream_execution::responses_continuation_enabled` never constructs a
+/// `Continuation` in the first place, so `previous_response_id` is never sent and
+/// never persisted (see `engine_responses_policy` /
+/// `responses_continuation_enabled` in
+/// `runtime::runner::round_lifecycle::stream_execution`). Resolved by #513: a
+/// `store=false` turn is never persisted upstream, so referencing its id on the
+/// next round 400s with `previous_response_not_found` — confirmed against
+/// production traffic. This struct/lowering path stays live as the (currently
+/// unused) `store=true` case: a provider or future policy that DOES store turns
+/// server-side can still chain `previous_response_id`, and
+/// `openai/mod.rs::looks_like_previous_response_not_found_error` retries once
+/// without it if the upstream can't resolve it (expired id / different key/org /
+/// a client-forwarded id). See #64 for the original investigation.
 #[derive(Debug, Clone)]
 pub struct Continuation {
     pub previous_response_id: String,


### PR DESCRIPTION
## Summary

#64 asked to investigate what `store=false` + `previous_response_id` + full `input` actually does against the real OpenAI Responses API, and to decide a consistent contract. That investigation played out organically as production bug #513, which already shipped the fix and the answer:

- **Empirically confirmed** (sub-question 1): `store=false` + a chained `previous_response_id` errors — HTTP 400 `invalid_request_error` / `previous_response_not_found`. Not "ignore", not "append".
- **Contract decided** (sub-question 3): stateless — full `input` every turn, `previous_response_id` dropped. Shipped as `engine_responses_policy()` hardcoding `store: Some(false)` in `crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs:70-79`, gated by `responses_continuation_enabled()` (same file, `:89-94`) which requires `store == Some(true)` before a `Continuation` is ever attached to the IR or a `previous_response_id` sent/persisted.
- **Fallback added** (sub-question 4): `looks_like_previous_response_not_found_error` + retry-without-continuation in `crates/infra/bamboo-llm/src/providers/openai/mod.rs:218-254` (detector in `providers/common/mod.rs:58`) — covers `store=true` configs or compat-proxy clients that forward a stale/foreign id.
- **Sub-question 2** (was `previous_response_id` needed only for encrypted-reasoning continuity): moot now — it's never sent under the shipped policy, so nothing relies on it. The `include: ["reasoning.encrypted_content"]` request flag is retained but its output isn't round-tripped into any subsequent request today (grepped — no consumer); it's a harmless no-op wart, not a correctness issue, and out of scope for this doc fix.

Everything is covered by tests already on `main`: `responses_continuation_enabled_requires_store_true_and_supported_provider`, `execute_llm_stream_ignores_previous_response_id_under_stateless_store_policy`, `execute_llm_stream_disables_previous_response_id_for_copilot(*)`, `responses_continuation_uses_full_input_not_the_delta` (bamboo-engine), and `responses_retries_without_previous_response_id_on_not_found`, `responses_does_not_retry_unrelated_400_errors`, `responses_does_not_retry_not_found_when_no_continuation_was_sent` (bamboo-llm).

## What this PR actually changes

The one loose end: `PromptIR::Continuation`'s doc comment (`crates/infra/bamboo-llm/src/prompt_ir.rs`) still described `store=false` + `previous_response_id` as an open "PRE-EXISTING question... see the PR discussion" — stale since #513 shipped the resolution. This PR updates the comment to state the resolved contract, cite the code that enforces it, and reference #64/#513 instead of leaving future readers to re-investigate a closed question. No behavior change.

## Test plan

- `cargo fmt -p bamboo-llm` clean
- `cargo clippy -p bamboo-llm --lib --tests -- -D warnings` clean
- `cargo test -p bamboo-llm --lib` — 480 passed, 0 failed

Closes #64

https://claude.ai/code/session_01Ux4nHUqFjEEGV3rX1x3V9Y