### PR TITLE
feat(engine): per-run token budget with graceful stop-when-exceeded

### DIFF
--- a/crates/app/bamboo-client-core/src/lib.rs
+++ b/crates/app/bamboo-client-core/src/lib.rs
@@ -120,6 +120,15 @@ pub enum AgentEvent {
         #[serde(default)]
         content_summary: Option<String>,
     },
+    /// A per-run token/tool-call/subagent budget tripped and the run was
+    /// gracefully stopped (issue #221).
+    BudgetExceeded {
+        /// Which budget tripped: `"max_total_tokens"` | `"max_tool_calls"` |
+        /// `"max_subagents"`.
+        kind: String,
+        limit: u64,
+        actual: u64,
+    },
     Complete {
         usage: TokenUsage,
     },

--- a/crates/app/bamboo-server/src/app_state/resume_adapter.rs
+++ b/crates/app/bamboo-server/src/app_state/resume_adapter.rs
@@ -185,6 +185,9 @@ impl ResumeExecutionPort for AppStateResumeRef {
                     image_fallback,
                     gold_config,
                     app_data_dir: Some(state.app_data_dir.clone()),
+                    // Resume has no per-request override channel; the
+                    // config-level default (issue #221) still applies.
+                    run_budget: None,
                 });
                 return;
             }
@@ -287,6 +290,9 @@ impl ResumeExecutionPort for AppStateResumeRef {
                 image_fallback,
                 gold_config,
                 app_data_dir: Some(state.app_data_dir.clone()),
+                // Resume has no per-request override channel; the
+                // config-level default (issue #221) still applies.
+                run_budget: None,
             });
         });
     }

--- a/crates/app/bamboo-server/src/connect/approvals.rs
+++ b/crates/app/bamboo-server/src/connect/approvals.rs
@@ -562,6 +562,9 @@ impl ResumeExecutionPort for ConnectResumePort {
                 bash_resume_hook: None,
                 bash_completion_sink: None,
                 app_data_dir: self.ctx.app_data_dir.clone(),
+                // No per-request override on this path; the config-level
+                // default (issue #221) still applies.
+                run_budget: None,
                 runners: self.ctx.agent_runners.clone(),
                 sessions_cache: self.ctx.session_repo.cache().clone(),
                 on_complete: None,
@@ -669,6 +672,9 @@ impl ResumeExecutionPort for ConnectResumePort {
                 bash_resume_hook: None,
                 bash_completion_sink: None,
                 app_data_dir: ctx.app_data_dir.clone(),
+                // No per-request override on this path; the config-level
+                // default (issue #221) still applies.
+                run_budget: None,
                 runners: ctx.agent_runners.clone(),
                 sessions_cache: ctx.session_repo.cache().clone(),
                 on_complete: None,

--- a/crates/app/bamboo-server/src/connect/bridge.rs
+++ b/crates/app/bamboo-server/src/connect/bridge.rs
@@ -840,6 +840,9 @@ impl ConnectBridge {
             bash_resume_hook: None,
             bash_completion_sink: None,
             app_data_dir: self.ctx.app_data_dir.clone(),
+            // No per-request override on this path; the config-level default
+            // (issue #221) still applies.
+            run_budget: None,
             runners: self.ctx.agent_runners.clone(),
             sessions_cache: self.ctx.session_repo.cache().clone(),
             on_complete: None,

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
@@ -164,6 +164,7 @@ pub async fn handler(
                     reasoning_source,
                     is_child_session,
                     no_human_approver: req.no_human_approver,
+                    run_budget: req.run_budget,
                 },
                 &config,
                 &config_snapshot,

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
@@ -37,6 +37,9 @@ pub(super) struct ReadyExecution {
     /// The `no_human_approver` posture from THIS execute request. #74: re-derived
     /// per user-initiated execute and written over the session's persisted flag.
     pub no_human_approver: bool,
+    /// Optional per-run resource guardrail override from THIS execute request
+    /// (issue #221). `None` uses the config-level default.
+    pub run_budget: Option<bamboo_config::RunBudgetConfig>,
 }
 
 /// Reserve the runner, persist, and spawn the agent loop for a ready session.
@@ -181,6 +184,7 @@ pub(super) async fn handle_execute_ready(
         image_fallback,
         gold_config,
         app_data_dir: Some(state.app_data_dir.clone()),
+        run_budget: ready.run_budget,
     });
 
     started_response(session_id, sync_info, run_id)

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/events.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/events.rs
@@ -22,6 +22,7 @@ fn is_critical_event(event: &AgentEvent) -> bool {
             | AgentEvent::SessionPinnedUpdated { .. }
             | AgentEvent::PlanModeEntered { .. }
             | AgentEvent::PlanModeExited { .. }
+            | AgentEvent::BudgetExceeded { .. }
     )
 }
 

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
@@ -45,6 +45,9 @@ pub(crate) struct SpawnAgentExecution {
     pub(crate) image_fallback: Option<ImageFallbackConfig>,
     pub(crate) gold_config: Option<GoldConfig>,
     pub(crate) app_data_dir: Option<std::path::PathBuf>,
+    /// Optional per-run resource guardrail override from the `POST /execute`
+    /// request body (issue #221). `None` uses the config-level default.
+    pub(crate) run_budget: Option<bamboo_config::RunBudgetConfig>,
 }
 
 pub(super) fn execution_tool_surface(is_child_session: bool) -> ToolSurface {
@@ -210,6 +213,7 @@ pub(crate) fn spawn_agent_execution(args: SpawnAgentExecution) {
         // the next round boundary, issue #84 Phase 2b follow-up).
         bash_completion_sink: Some(args.state.child_completion_coordinator.clone()),
         app_data_dir: args.app_data_dir,
+        run_budget: args.run_budget,
         runners: args.state.agent_runners.clone(),
         sessions_cache: args.state.sessions.clone(),
         on_complete: None,

--- a/crates/app/bamboo-server/src/handlers/agent/execute/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/tests.rs
@@ -76,6 +76,7 @@ fn execute_request_empty_model_normalizes_to_compat_absent() {
         reasoning_effort: None,
         client_sync: None,
         no_human_approver: false,
+        run_budget: None,
     };
 
     let model = request.model.as_deref().unwrap_or("").trim();

--- a/crates/app/bamboo-server/src/handlers/agent/execute/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/types.rs
@@ -139,10 +139,12 @@ pub struct ExecuteRequest {
     #[serde(default)]
     pub no_human_approver: bool,
     /// Optional per-run resource guardrail override (issue #221): token /
-    /// tool-call / subagent budget for THIS execution. Each field falls back
-    /// independently to the config-level `run_budget` default when unset —
-    /// `None` here does not mean "unlimited", it means "use the config
-    /// default" (which may itself be unlimited).
+    /// tool-call / subagent budget for THIS execution. TIGHTEN-ONLY: per
+    /// field, the effective limit is the minimum of this override and the
+    /// config-level `run_budget` default — a client can lower the operator's
+    /// ceiling for one run but can never raise or remove it (a looser value
+    /// is silently clamped to the config default). An unset field keeps the
+    /// config default, which may itself be unlimited.
     #[serde(default)]
     pub run_budget: Option<bamboo_config::RunBudgetConfig>,
 }

--- a/crates/app/bamboo-server/src/handlers/agent/execute/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/types.rs
@@ -138,6 +138,13 @@ pub struct ExecuteRequest {
     /// so a within-run resume keeps the persisted posture.
     #[serde(default)]
     pub no_human_approver: bool,
+    /// Optional per-run resource guardrail override (issue #221): token /
+    /// tool-call / subagent budget for THIS execution. Each field falls back
+    /// independently to the config-level `run_budget` default when unset —
+    /// `None` here does not mean "unlimited", it means "use the config
+    /// default" (which may itself be unlimited).
+    #[serde(default)]
+    pub run_budget: Option<bamboo_config::RunBudgetConfig>,
 }
 
 #[cfg(test)]
@@ -195,6 +202,31 @@ mod tests {
         assert!(req.skill_mode.is_none());
         assert!(req.reasoning_effort.is_none());
         assert!(req.client_sync.is_none());
+        assert!(
+            req.run_budget.is_none(),
+            "omitted run_budget means \"use the config default\", not \"unlimited\""
+        );
+    }
+
+    /// Issue #221 plumb-through: a client can set a per-run token/tool-call/
+    /// subagent budget override on the `POST /execute` body, and it decodes
+    /// into the same `bamboo_config::RunBudgetConfig` the config-level default
+    /// uses — no separate wire DTO to keep in sync.
+    #[test]
+    fn test_execute_request_deserializes_run_budget_override() {
+        let json = r#"{
+            "model": "claude-3-opus",
+            "run_budget": { "max_total_tokens": 50000, "max_subagents": 2 }
+        }"#;
+        let req: ExecuteRequest = serde_json::from_str(json).unwrap();
+
+        let run_budget = req.run_budget.expect("run_budget should deserialize");
+        assert_eq!(run_budget.max_total_tokens, Some(50_000));
+        assert_eq!(
+            run_budget.max_tool_calls, None,
+            "an omitted field within run_budget falls back to the config default, not zero"
+        );
+        assert_eq!(run_budget.max_subagents, Some(2));
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -595,6 +595,9 @@ async fn run_schedule_job(
         // (consistent with `can_async_resume: false` on this path).
         bash_completion_sink: None,
         app_data_dir: ctx.app_data_dir.clone(),
+        // Scheduled runs have no per-request override channel; the
+        // config-level default (issue #221) still applies.
+        run_budget: None,
         runners: ctx.agent_runners.clone(),
         sessions_cache: ctx.sessions_cache.clone(),
         on_complete: Some(on_complete),

--- a/crates/app/bamboo-tui/src/app.rs
+++ b/crates/app/bamboo-tui/src/app.rs
@@ -2151,6 +2151,20 @@ impl App {
                 self.notify(NoticeLevel::Error, format!("Error: {message}"));
                 self.finalize_streaming();
             }
+            AgentEvent::BudgetExceeded {
+                kind,
+                limit,
+                actual,
+            } => {
+                // Precedes the run's normal `Complete`/`Cancelled` terminal
+                // event (see bamboo_agent_core::AgentEvent::BudgetExceeded) —
+                // just surface why the run is about to stop; the terminal
+                // event still finalizes streaming.
+                self.notify(
+                    NoticeLevel::Warn,
+                    format!("Run budget exceeded ({kind}: {actual}/{limit}) — stopping."),
+                );
+            }
             AgentEvent::ToolToken { content, .. } => {
                 // Deliberately not routed into the matching ToolCallDisplay by
                 // `tool_call_id`: today's rendering already prints tool output

--- a/crates/core/bamboo-agent-core/src/agent/events.rs
+++ b/crates/core/bamboo-agent-core/src/agent/events.rs
@@ -79,6 +79,10 @@ use serde::{Deserialize, Serialize};
 /// - `SubAgentHeartbeat` - Periodic heartbeat while the child is running
 /// - `SubAgentCompleted` - Child session finished (completed/cancelled/error)
 ///
+/// ## Resource Guardrails
+/// - `BudgetExceeded` - A per-run token/tool-call/subagent budget tripped and
+///   the run was gracefully stopped (issue #221)
+///
 /// ## Terminal Events
 /// - `Complete` - Execution finished successfully
 /// - `Cancelled` - Execution was cancelled by the user
@@ -542,6 +546,27 @@ pub enum AgentEvent {
         resource: String,
     },
 
+    /// A per-run resource guardrail (token / tool-call / subagent budget)
+    /// tripped and the run was gracefully stopped — issue #221.
+    ///
+    /// Mirrors the `runtime.completion_reason = "budget_exceeded"` session
+    /// metadata stamp (see `bamboo_engine::runtime::config::AgentLoopConfig`)
+    /// as a structured, client-observable signal so a caller can display it
+    /// and (per the issue's "熔断" ask) react without polling session state.
+    /// The run still finalizes exactly like a normal completion — this event
+    /// precedes `Complete` in the stream, it does not replace it.
+    BudgetExceeded {
+        /// Session identifier.
+        session_id: String,
+        /// Which budget tripped: `"max_total_tokens"` | `"max_tool_calls"` |
+        /// `"max_subagents"`.
+        kind: String,
+        /// The configured limit that was exceeded.
+        limit: u64,
+        /// The actual cumulative usage observed when the guardrail tripped.
+        actual: u64,
+    },
+
     /// Agent execution completed successfully.
     Complete {
         /// Final token usage statistics
@@ -618,6 +643,7 @@ impl AgentEvent {
             | AgentEvent::SessionCleared { session_id, .. }
             | AgentEvent::MessageAppended { session_id, .. }
             | AgentEvent::ExecutionStarted { session_id, .. }
+            | AgentEvent::BudgetExceeded { session_id, .. }
             | AgentEvent::Notification { session_id, .. } => Some(session_id.as_str()),
             AgentEvent::SubAgentStarted {
                 parent_session_id, ..
@@ -666,6 +692,7 @@ impl AgentEvent {
                 | AgentEvent::NeedClarification { .. }
                 | AgentEvent::ToolApprovalRequested { .. }
                 | AgentEvent::ExecutionStarted { .. }
+                | AgentEvent::BudgetExceeded { .. }
                 | AgentEvent::Complete { .. }
                 | AgentEvent::Cancelled { .. }
                 | AgentEvent::Error { .. }

--- a/crates/core/bamboo-domain/src/session/runtime_state.rs
+++ b/crates/core/bamboo-domain/src/session/runtime_state.rs
@@ -41,9 +41,22 @@ pub struct RoundRuntimeState {
     pub max_rounds: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_round_id: Option<String>,
+    /// Cumulative tool calls issued across every round of this run so far.
+    /// Consulted by the per-run `max_tool_calls` budget guardrail (issue #221).
     pub total_tool_calls: u32,
+    /// Cumulative actual (provider-reported) prompt tokens across every round
+    /// of this run so far. Consulted by the per-run `max_total_tokens` budget
+    /// guardrail (issue #221).
     pub total_prompt_tokens: u64,
+    /// Cumulative actual (provider-reported) completion tokens across every
+    /// round of this run so far. Consulted by the per-run `max_total_tokens`
+    /// budget guardrail (issue #221).
     pub total_completion_tokens: u64,
+    /// Cumulative `SubAgent` create calls issued across every round of this
+    /// run so far. Consulted by the per-run `max_subagents` budget guardrail
+    /// (issue #221).
+    #[serde(default)]
+    pub total_subagents_spawned: u32,
 }
 
 /// Prompt assembly tracking.

--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -492,6 +492,12 @@ pub struct AgentLoopConfig {
     /// and appended to the tool-guide section of the system prompt, so a server's
     /// own how-to-use notes appear only while that server is loaded for the run.
     pub(crate) mcp_tool_guidance: Option<String>,
+    /// Per-run resource guardrails (issue #221): already resolved — the
+    /// per-request override merged over the config-level default (see
+    /// [`AgentRuntime::execute`](crate::runtime::runtime::AgentRuntime::execute)).
+    /// Checked after every round; exceeding a configured limit gracefully
+    /// stops the run (mirrors the `max_rounds` exhaustion path).
+    pub(crate) run_budget: bamboo_config::RunBudgetConfig,
 }
 
 impl Default for AgentLoopConfig {
@@ -545,6 +551,7 @@ impl Default for AgentLoopConfig {
             auxiliary_model_resolver: None,
             disabled_filter_resolver: None,
             mcp_tool_guidance: None,
+            run_budget: bamboo_config::RunBudgetConfig::default(),
         }
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
@@ -151,6 +151,9 @@ pub struct SessionExecutionArgs {
     /// Late-bound bash completion sink (issue #84 Phase 2b follow-up).
     pub bash_completion_sink: Option<Arc<dyn BashCompletionSink>>,
     pub app_data_dir: Option<std::path::PathBuf>,
+    /// Per-run resource guardrail override (issue #221). `None` uses the
+    /// config-level `Config::run_budget` default unmodified.
+    pub run_budget: Option<bamboo_config::RunBudgetConfig>,
 
     // Post-execution resources.
     pub runners: Arc<RwLock<HashMap<String, AgentRunner>>>,
@@ -189,6 +192,7 @@ struct ExecuteRequestParams {
     bash_resume_hook: Option<Arc<dyn BashResumeHook>>,
     bash_completion_sink: Option<Arc<dyn BashCompletionSink>>,
     app_data_dir: Option<std::path::PathBuf>,
+    run_budget: Option<bamboo_config::RunBudgetConfig>,
 }
 
 /// Assemble an [`ExecuteRequest`] from the resolved spawn parameters via the
@@ -221,6 +225,7 @@ fn build_execute_request(
         bash_resume_hook,
         bash_completion_sink,
         app_data_dir,
+        run_budget,
     } = params;
 
     let mut builder = ExecuteRequestBuilder::new(initial_message, event_tx, cancel_token)
@@ -230,6 +235,10 @@ fn build_execute_request(
         .guardian_spawner(guardian_spawner)
         .bash_resume_hook(bash_resume_hook)
         .bash_completion_sink(bash_completion_sink);
+
+    if let Some(run_budget) = run_budget {
+        builder = builder.run_budget(run_budget);
+    }
 
     if let Some(tools) = tools {
         builder = builder.tools(tools);
@@ -306,6 +315,7 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
                 bash_resume_hook,
                 bash_completion_sink,
                 app_data_dir,
+                run_budget,
                 runners,
                 sessions_cache,
                 on_complete,
@@ -371,6 +381,7 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
                     bash_resume_hook,
                     bash_completion_sink,
                     app_data_dir,
+                    run_budget,
                 },
             );
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -84,6 +84,87 @@ struct TurnOutcome {
     sent_complete: bool,
 }
 
+// ---- Per-run resource guardrails (issue #221) ----
+
+/// The `SubAgent` tool's name (see `bamboo-server-tools::sub_agent::SubAgentTool`).
+/// Duplicated here as a plain string — the engine has no dependency on the
+/// server-tools crate that owns the tool — purely to COUNT spawn attempts for
+/// the per-run `max_subagents` budget guardrail below; it never affects
+/// dispatch. A tool rename must update both sites.
+const SUBAGENT_TOOL_NAME: &str = "SubAgent";
+
+/// True when `call` is a `SubAgent` tool call that creates a NEW child: its
+/// `action` argument is `"create"`, or the argument is absent/unparsable (the
+/// tool's own legacy default — see `SubAgentArgs`'s `#[serde(tag = "action")]`
+/// in `bamboo-server-tools`). Every other action (`wait`/`list`/`get`/
+/// `update`/`run`/`send_message`/`cancel`/`delete`/`list_models`) manages an
+/// EXISTING child and is not counted against the spawn budget.
+fn is_subagent_create_call(call: &bamboo_agent_core::tools::ToolCall) -> bool {
+    if call.function.name != SUBAGENT_TOOL_NAME {
+        return false;
+    }
+    serde_json::from_str::<serde_json::Value>(&call.function.arguments)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("action")
+                .and_then(|a| a.as_str())
+                .map(str::to_string)
+        })
+        .is_none_or(|action| action == "create")
+}
+
+/// A per-run resource guardrail that has just tripped: which budget, its
+/// configured limit, and the actual cumulative usage observed.
+struct RunBudgetExceeded {
+    kind: &'static str,
+    limit: u64,
+    actual: u64,
+}
+
+/// Checks the run's cumulative activity (already accumulated into `round` —
+/// see `RoundRuntimeState::total_*`) against the resolved per-run budget.
+/// Checked in a fixed priority order (tokens, then tool calls, then
+/// subagents) so exactly one guardrail is reported when several trip in the
+/// same round. Mirrors the `max_rounds` exhaustion check in spirit: this is a
+/// graceful-stop trigger, not an error.
+fn check_run_budget_exceeded(
+    round: &bamboo_domain::session::runtime_state::RoundRuntimeState,
+    budget: &bamboo_config::RunBudgetConfig,
+) -> Option<RunBudgetExceeded> {
+    let total_tokens = round
+        .total_prompt_tokens
+        .saturating_add(round.total_completion_tokens);
+    if let Some(limit) = budget.max_total_tokens {
+        if total_tokens >= limit {
+            return Some(RunBudgetExceeded {
+                kind: "max_total_tokens",
+                limit,
+                actual: total_tokens,
+            });
+        }
+    }
+    if let Some(limit) = budget.max_tool_calls {
+        if round.total_tool_calls >= limit {
+            return Some(RunBudgetExceeded {
+                kind: "max_tool_calls",
+                limit: limit as u64,
+                actual: round.total_tool_calls as u64,
+            });
+        }
+    }
+    if let Some(limit) = budget.max_subagents {
+        if round.total_subagents_spawned >= limit {
+            return Some(RunBudgetExceeded {
+                kind: "max_subagents",
+                limit: limit as u64,
+                actual: round.total_subagents_spawned as u64,
+            });
+        }
+    }
+    None
+}
+
 /// Terminal child run statuses, as mirrored into the session index.
 fn is_terminal_child_status(status: &str) -> bool {
     matches!(
@@ -1223,6 +1304,10 @@ pub(super) async fn run_pipeline(
     // session, so a normal completion is never misread as exhaustion (mirrors
     // how `runtime.suspend_reason` is cleared on resume).
     let mut max_rounds_summary_used = false;
+    // One-shot sentinel for the run-budget summary turn (issue #221), mirroring
+    // `max_rounds_summary_used` above: the first guard hit grants one final
+    // summary round; the next hit stops unconditionally.
+    let mut budget_summary_used = false;
     session.metadata.remove("runtime.completion_reason");
 
     loop {
@@ -1346,6 +1431,17 @@ pub(super) async fn run_pipeline(
         let mut overflow_recovery_attempted = false;
         let mut turn_outcome: Option<TurnOutcome> = None;
         let mut terminal_error: Option<AgentError> = None;
+
+        // Actual (provider-reported) usage + activity for THIS round, captured
+        // the moment `stream_output` becomes available (below) — before it is
+        // consumed by `handle_no_tool_calls`/`handle_tool_calls_path` — so the
+        // per-run budget guardrails (issue #221) can accumulate real numbers,
+        // not the heuristic `round_usage` estimate used for metrics. Reset
+        // every round; a retried/failed attempt leaves these at 0.
+        let mut round_prompt_tokens: u64 = 0;
+        let mut round_completion_tokens: u64 = 0;
+        let mut round_tool_call_count: u32 = 0;
+        let mut round_subagent_spawn_count: u32 = 0;
 
         for attempt in 1..=MAX_LLM_TURN_ATTEMPTS {
             let llm_output = match crate::runtime::runner::round_lifecycle::execute_llm_round(
@@ -1487,6 +1583,17 @@ pub(super) async fn run_pipeline(
 
             // --- Handle LLM output ---
             let stream_output = llm_output.stream_output;
+
+            // Capture this round's ACTUAL usage/activity before `stream_output`
+            // is consumed below (issue #221 — see the declaration above).
+            round_prompt_tokens = stream_output.input_tokens;
+            round_completion_tokens = stream_output.output_tokens;
+            round_tool_call_count = stream_output.tool_calls.len() as u32;
+            round_subagent_spawn_count = stream_output
+                .tool_calls
+                .iter()
+                .filter(|call| is_subagent_create_call(call))
+                .count() as u32;
 
             if stream_output.tool_calls.is_empty() {
                 // Safety net: if the model is about to finish but left background
@@ -1806,6 +1913,32 @@ pub(super) async fn run_pipeline(
             _ => {}
         }
 
+        // Accumulate this round's actual usage/activity into the run-level
+        // totals BEFORE persisting the runtime state snapshot below, so the
+        // per-run budget guardrails (issue #221) — checked further down — see
+        // up-to-date numbers, and a resumed/inspected session's runtime state
+        // reflects them immediately.
+        state.runtime_state.round.total_prompt_tokens = state
+            .runtime_state
+            .round
+            .total_prompt_tokens
+            .saturating_add(round_prompt_tokens);
+        state.runtime_state.round.total_completion_tokens = state
+            .runtime_state
+            .round
+            .total_completion_tokens
+            .saturating_add(round_completion_tokens);
+        state.runtime_state.round.total_tool_calls = state
+            .runtime_state
+            .round
+            .total_tool_calls
+            .saturating_add(round_tool_call_count);
+        state.runtime_state.round.total_subagents_spawned = state
+            .runtime_state
+            .round
+            .total_subagents_spawned
+            .saturating_add(round_subagent_spawn_count);
+
         state_bridge::write_runtime_state(session, &state.runtime_state);
 
         sent_complete = sent_complete || outcome.sent_complete;
@@ -1855,6 +1988,61 @@ pub(super) async fn run_pipeline(
         }
 
         turn_counter += 1;
+
+        // --- Guard against the per-run resource budget (issue #221) ---
+        //
+        // Checked BEFORE max_rounds so a budget trip is reported with its own
+        // reason even on a run that would also be about to hit max_rounds.
+        // Mirrors the max_rounds guard exactly: one graceful summary turn,
+        // then an unconditional stop — never a hard error, so the run stays
+        // resumable and the session's history reads like a normal completion
+        // plus a clear reason.
+        if let Some(exceeded) =
+            check_run_budget_exceeded(&state.runtime_state.round, &config.run_budget)
+        {
+            if !budget_summary_used {
+                tracing::warn!(
+                    "[{}] Run budget exceeded ({} limit={} actual={}) — granting one summary turn before stopping.",
+                    state.session_id,
+                    exceeded.kind,
+                    exceeded.limit,
+                    exceeded.actual,
+                );
+                session.metadata.insert(
+                    "runtime.completion_reason".to_string(),
+                    "budget_exceeded".to_string(),
+                );
+                session.metadata.insert(
+                    "runtime.budget_exceeded_kind".to_string(),
+                    exceeded.kind.to_string(),
+                );
+                session.add_message(Message::user(format!(
+                    "The run's resource budget ({}, limit={}, reached={}) was exceeded; the \
+                     task was stopped before completion. Stop working now and summarize your \
+                     progress so far and what remains.",
+                    exceeded.kind, exceeded.limit, exceeded.actual
+                )));
+                let _ = event_tx
+                    .send(AgentEvent::BudgetExceeded {
+                        session_id: state.session_id.clone(),
+                        kind: exceeded.kind.to_string(),
+                        limit: exceeded.limit,
+                        actual: exceeded.actual,
+                    })
+                    .await;
+                budget_summary_used = true;
+                continue;
+            }
+
+            tracing::warn!(
+                "[{}] Run budget exceeded ({} limit={} actual={}) — stopping the run before completion.",
+                state.session_id,
+                exceeded.kind,
+                exceeded.limit,
+                exceeded.actual,
+            );
+            break;
+        }
 
         // --- Guard against max_rounds (issue #29) ---
         //
@@ -1973,8 +2161,9 @@ fn heuristic_complexity(
 mod tests {
     use super::super::startup::OverflowRecoveryState;
     use super::{
-        build_guardian_review_prompt, is_overflow_recoverable, is_terminal_child_status,
-        map_turn_error_status, maybe_spawn_guardian_review, maybe_suspend_for_orphaned_children,
+        build_guardian_review_prompt, check_run_budget_exceeded, is_overflow_recoverable,
+        is_subagent_create_call, is_terminal_child_status, map_turn_error_status,
+        maybe_spawn_guardian_review, maybe_suspend_for_orphaned_children,
         maybe_suspend_for_outstanding_bash, should_retry_turn_error, suspend_to_wait_for_bash,
     };
     use crate::runtime::config::{AgentLoopConfig, GuardianConfig, GuardianSpawner};
@@ -2988,6 +3177,409 @@ mod tests {
             completes, 0,
             "no Complete emitted during this worst-case run"
         );
+    }
+
+    // ---- Per-run resource guardrails (issue #221) ----
+
+    /// Emits one tool-call round with configurable ACTUAL (provider-reported)
+    /// usage per call, so `round.total_prompt_tokens`/`total_completion_tokens`
+    /// accumulate real numbers the budget guard can trip on — mirrors
+    /// `MaxRoundsProvider` but adds `CacheUsage`/`UsageSummary` chunks.
+    struct UsageProvider {
+        calls: std::sync::atomic::AtomicUsize,
+        prompt_tokens_per_round: u64,
+        completion_tokens_per_round: u64,
+        /// When `true`, every emitted tool call is a `SubAgent` create (issue
+        /// #221's subagent-budget guard); otherwise a plain `noop` call.
+        subagent_calls: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl LLMProvider for UsageProvider {
+        async fn chat_stream(
+            &self,
+            _: &[Message],
+            _: &[bamboo_agent_core::tools::ToolSchema],
+            _: Option<u32>,
+            _: &str,
+        ) -> Result<LLMStream, LLMError> {
+            Ok(Box::pin(stream::iter(vec![Ok(LLMChunk::Done)])))
+        }
+
+        async fn chat_stream_with_options(
+            &self,
+            _: &[Message],
+            _: &[bamboo_agent_core::tools::ToolSchema],
+            _: Option<u32>,
+            _: &str,
+            _: Option<&bamboo_llm::LLMRequestOptions>,
+        ) -> Result<LLMStream, LLMError> {
+            let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let (name, arguments) = if self.subagent_calls {
+                (
+                    "SubAgent".to_string(),
+                    r#"{"action":"create","prompt":"do work"}"#.to_string(),
+                )
+            } else {
+                ("noop".to_string(), "{}".to_string())
+            };
+            let call = bamboo_agent_core::tools::ToolCall {
+                id: format!("tool-{n}"),
+                tool_type: "function".to_string(),
+                function: bamboo_agent_core::tools::FunctionCall { name, arguments },
+            };
+            Ok(Box::pin(stream::iter(vec![
+                Ok(LLMChunk::CacheUsage {
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 0,
+                    input_tokens: self.prompt_tokens_per_round,
+                }),
+                Ok(LLMChunk::ToolCalls(vec![call])),
+                Ok(LLMChunk::UsageSummary {
+                    output_tokens: self.completion_tokens_per_round,
+                    thinking_tokens: 0,
+                }),
+                Ok(LLMChunk::Done),
+            ])))
+        }
+    }
+
+    #[tokio::test]
+    async fn run_budget_token_limit_stops_run_gracefully() {
+        use crate::runtime::config::PromptMemoryFlags;
+
+        // 15 actual tokens/round (10 prompt + 5 completion); limit=20 trips
+        // partway through round 2 (round1 total=15 < 20; round2 total=30 >= 20).
+        let mut session = Session::new("session-token-budget", "model");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let provider = Arc::new(UsageProvider {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            prompt_tokens_per_round: 10,
+            completion_tokens_per_round: 5,
+            subagent_calls: false,
+        });
+        let llm: Arc<dyn LLMProvider> = provider.clone();
+        let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(AlwaysOkExecutor);
+        let config = AgentLoopConfig {
+            max_rounds: 50, // high enough that max_rounds never fires first
+            prompt_memory_flags: PromptMemoryFlags {
+                project_prompt_injection: false,
+                relevant_recall: false,
+                relevant_recall_rerank: false,
+                project_first_dream: false,
+                ledger_agenda: false,
+            },
+            model_name: Some("model".to_string()),
+            run_budget: bamboo_config::RunBudgetConfig {
+                max_total_tokens: Some(20),
+                max_tool_calls: None,
+                max_subagents: None,
+            },
+            ..AgentLoopConfig::default()
+        };
+        let mut state = e2e_loop_state("session-token-budget");
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let sent_complete =
+            super::run_pipeline(&mut session, &tx, llm, tools, &cancel, &config, &mut state)
+                .await
+                .expect("pipeline runs to completion");
+
+        assert_eq!(
+            session
+                .metadata
+                .get("runtime.completion_reason")
+                .map(String::as_str),
+            Some("budget_exceeded"),
+            "budget trip must be stamped in session metadata"
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get("runtime.budget_exceeded_kind")
+                .map(String::as_str),
+            Some("max_total_tokens"),
+        );
+        assert!(
+            session
+                .messages
+                .iter()
+                .any(|m| m.content.contains("max_total_tokens")),
+            "a visible budget-exceeded notification message must be appended"
+        );
+        assert!(
+            !sent_complete,
+            "budget trip does not send a normal complete"
+        );
+
+        // Exactly one extra summary round after the trip (round1, round2-trip,
+        // round3-summary), mirroring the max_rounds grace-turn contract.
+        assert_eq!(provider.calls.load(std::sync::atomic::Ordering::SeqCst), 3);
+
+        drop(tx);
+        let mut budget_events = Vec::new();
+        while let Some(event) = rx.recv().await {
+            if let AgentEvent::BudgetExceeded {
+                kind,
+                limit,
+                actual,
+                ..
+            } = event
+            {
+                budget_events.push((kind, limit, actual));
+            }
+        }
+        assert_eq!(
+            budget_events.len(),
+            1,
+            "exactly one structured BudgetExceeded event must be emitted"
+        );
+        let (kind, limit, actual) = &budget_events[0];
+        assert_eq!(kind, "max_total_tokens");
+        assert_eq!(*limit, 20);
+        assert_eq!(*actual, 30, "trips on round 2's cumulative total (15+15)");
+    }
+
+    #[tokio::test]
+    async fn run_budget_tool_call_limit_stops_run_gracefully() {
+        use crate::runtime::config::PromptMemoryFlags;
+
+        let mut session = Session::new("session-tool-call-budget", "model");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let provider = Arc::new(UsageProvider {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            prompt_tokens_per_round: 0,
+            completion_tokens_per_round: 0,
+            subagent_calls: false,
+        });
+        let llm: Arc<dyn LLMProvider> = provider.clone();
+        let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(AlwaysOkExecutor);
+        let config = AgentLoopConfig {
+            max_rounds: 50,
+            prompt_memory_flags: PromptMemoryFlags {
+                project_prompt_injection: false,
+                relevant_recall: false,
+                relevant_recall_rerank: false,
+                project_first_dream: false,
+                ledger_agenda: false,
+            },
+            model_name: Some("model".to_string()),
+            run_budget: bamboo_config::RunBudgetConfig {
+                max_total_tokens: None,
+                max_tool_calls: Some(2),
+                max_subagents: None,
+            },
+            ..AgentLoopConfig::default()
+        };
+        let mut state = e2e_loop_state("session-tool-call-budget");
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let _ = super::run_pipeline(&mut session, &tx, llm, tools, &cancel, &config, &mut state)
+            .await
+            .expect("pipeline runs to completion");
+
+        assert_eq!(
+            session
+                .metadata
+                .get("runtime.budget_exceeded_kind")
+                .map(String::as_str),
+            Some("max_tool_calls"),
+        );
+        // One tool call per round: round1 total=1 (<2, continue), round2
+        // total=2 (>=2, trip+grace), round3 (unconditional stop) = 3 calls.
+        assert_eq!(provider.calls.load(std::sync::atomic::Ordering::SeqCst), 3);
+        drop(tx);
+        drain(&mut rx).await;
+    }
+
+    #[tokio::test]
+    async fn run_budget_subagent_limit_counts_only_create_calls() {
+        use crate::runtime::config::PromptMemoryFlags;
+
+        let mut session = Session::new("session-subagent-budget", "model");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let provider = Arc::new(UsageProvider {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            prompt_tokens_per_round: 0,
+            completion_tokens_per_round: 0,
+            subagent_calls: true,
+        });
+        let llm: Arc<dyn LLMProvider> = provider.clone();
+        let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(AlwaysOkExecutor);
+        let config = AgentLoopConfig {
+            max_rounds: 50,
+            prompt_memory_flags: PromptMemoryFlags {
+                project_prompt_injection: false,
+                relevant_recall: false,
+                relevant_recall_rerank: false,
+                project_first_dream: false,
+                ledger_agenda: false,
+            },
+            model_name: Some("model".to_string()),
+            run_budget: bamboo_config::RunBudgetConfig {
+                max_total_tokens: None,
+                max_tool_calls: None,
+                max_subagents: Some(1),
+            },
+            ..AgentLoopConfig::default()
+        };
+        let mut state = e2e_loop_state("session-subagent-budget");
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let _ = super::run_pipeline(&mut session, &tx, llm, tools, &cancel, &config, &mut state)
+            .await
+            .expect("pipeline runs to completion");
+
+        assert_eq!(
+            session
+                .metadata
+                .get("runtime.budget_exceeded_kind")
+                .map(String::as_str),
+            Some("max_subagents"),
+        );
+        // One SubAgent create call per round: round1 total=1 (>=1, trip+grace
+        // immediately), round2 (unconditional stop) = 2 calls.
+        assert_eq!(provider.calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+        drop(tx);
+        drain(&mut rx).await;
+    }
+
+    #[tokio::test]
+    async fn run_under_budget_is_unaffected() {
+        use crate::runtime::config::PromptMemoryFlags;
+
+        // A generous budget that a short run never approaches must leave
+        // completion behavior byte-for-byte identical to the no-budget case
+        // (no stamped reason, no injected message, no BudgetExceeded event).
+        let mut session = Session::new("session-under-budget", "model");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let provider = Arc::new(MaxRoundsProvider {
+            main_calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let llm: Arc<dyn LLMProvider> = provider.clone();
+        let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(AlwaysOkExecutor);
+        let config = AgentLoopConfig {
+            max_rounds: 2,
+            prompt_memory_flags: PromptMemoryFlags {
+                project_prompt_injection: false,
+                relevant_recall: false,
+                relevant_recall_rerank: false,
+                project_first_dream: false,
+                ledger_agenda: false,
+            },
+            model_name: Some("model".to_string()),
+            run_budget: bamboo_config::RunBudgetConfig {
+                max_total_tokens: Some(1_000_000),
+                max_tool_calls: Some(1_000_000),
+                max_subagents: Some(1_000_000),
+            },
+            ..AgentLoopConfig::default()
+        };
+        let mut state = e2e_loop_state("session-under-budget");
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let _ = super::run_pipeline(&mut session, &tx, llm, tools, &cancel, &config, &mut state)
+            .await
+            .expect("pipeline runs to completion");
+
+        assert_eq!(
+            session
+                .metadata
+                .get("runtime.completion_reason")
+                .map(String::as_str),
+            Some("max_rounds_reached"),
+            "an under-budget run still hits its real stop reason (max_rounds here), not budget_exceeded"
+        );
+        assert!(!session
+            .metadata
+            .contains_key("runtime.budget_exceeded_kind"));
+        drop(tx);
+        let mut budget_events = 0;
+        while let Some(event) = rx.recv().await {
+            if matches!(event, AgentEvent::BudgetExceeded { .. }) {
+                budget_events += 1;
+            }
+        }
+        assert_eq!(budget_events, 0, "no budget event for an under-budget run");
+    }
+
+    async fn drain(rx: &mut tokio::sync::mpsc::Receiver<AgentEvent>) {
+        while rx.recv().await.is_some() {}
+    }
+
+    #[test]
+    fn is_subagent_create_call_counts_default_and_explicit_create_only() {
+        let call = |arguments: &str| bamboo_agent_core::tools::ToolCall {
+            id: "id".to_string(),
+            tool_type: "function".to_string(),
+            function: bamboo_agent_core::tools::FunctionCall {
+                name: "SubAgent".to_string(),
+                arguments: arguments.to_string(),
+            },
+        };
+        assert!(
+            is_subagent_create_call(&call(r#"{"action":"create","prompt":"x"}"#)),
+            "explicit action=create counts"
+        );
+        assert!(
+            is_subagent_create_call(&call(r#"{"prompt":"x"}"#)),
+            "missing action defaults to the tool's legacy create behavior"
+        );
+        assert!(
+            !is_subagent_create_call(&call(r#"{"action":"wait"}"#)),
+            "action=wait manages an existing child, not a spawn"
+        );
+        assert!(
+            !is_subagent_create_call(&call(r#"{"action":"list"}"#)),
+            "action=list is read-only, not a spawn"
+        );
+
+        let mut other_tool = call(r#"{"action":"create"}"#);
+        other_tool.function.name = "Bash".to_string();
+        assert!(
+            !is_subagent_create_call(&other_tool),
+            "a differently named tool is never counted, regardless of args"
+        );
+    }
+
+    #[test]
+    fn check_run_budget_exceeded_reports_first_tripped_kind_in_priority_order() {
+        use bamboo_domain::session::runtime_state::RoundRuntimeState;
+
+        let unlimited = bamboo_config::RunBudgetConfig::default();
+        let round = RoundRuntimeState {
+            total_prompt_tokens: 5,
+            total_completion_tokens: 5,
+            total_tool_calls: 3,
+            total_subagents_spawned: 1,
+            ..Default::default()
+        };
+        assert!(
+            check_run_budget_exceeded(&round, &unlimited).is_none(),
+            "unlimited config never trips"
+        );
+
+        // Tokens win when multiple limits are simultaneously exceeded.
+        let all_exceeded = bamboo_config::RunBudgetConfig {
+            max_total_tokens: Some(5),
+            max_tool_calls: Some(1),
+            max_subagents: Some(1),
+        };
+        let exceeded =
+            check_run_budget_exceeded(&round, &all_exceeded).expect("some guardrail trips");
+        assert_eq!(exceeded.kind, "max_total_tokens");
+        assert_eq!(exceeded.actual, 10);
+
+        // Only tool_calls exceeded.
+        let tool_calls_only = bamboo_config::RunBudgetConfig {
+            max_total_tokens: None,
+            max_tool_calls: Some(3),
+            max_subagents: None,
+        };
+        let exceeded =
+            check_run_budget_exceeded(&round, &tool_calls_only).expect("tool-call guardrail trips");
+        assert_eq!(exceeded.kind, "max_tool_calls");
+        assert_eq!(exceeded.actual, 3);
     }
 
     #[derive(Default)]

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -122,6 +122,51 @@ struct RunBudgetExceeded {
     actual: u64,
 }
 
+/// One round's ACTUAL (provider-reported) usage + activity, accumulated
+/// across the round's retry attempts for the per-run budget guardrails
+/// (issue #221).
+///
+/// ACCUMULATES (`saturating_add`), never overwrites: a successful LLM call
+/// whose post-LLM handling then fails retryably re-enters the attempt loop
+/// and calls the LLM again, and the earlier attempt's tokens were already
+/// billed by the provider. Overwriting per attempt would silently drop that
+/// real spend from the budget (fail-open undercount — PR #539 review #1);
+/// summing keeps the budget fail-closed. Tool-call/subagent counts follow the
+/// same rule: a retried attempt's calls may have partially executed, and
+/// counting them errs on the safe (tighter) side.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct RoundActivity {
+    prompt_tokens: u64,
+    completion_tokens: u64,
+    tool_call_count: u32,
+    subagent_spawn_count: u32,
+}
+
+impl RoundActivity {
+    /// Absorb one LLM attempt's billed usage/activity into this round's
+    /// totals. Called once per successful `execute_llm_round` return, the
+    /// moment `stream_output` becomes available — before it is consumed by
+    /// `handle_no_tool_calls`/`handle_tool_calls_path`.
+    fn absorb_attempt(&mut self, stream_output: &StreamHandlingOutput) {
+        self.prompt_tokens = self
+            .prompt_tokens
+            .saturating_add(stream_output.input_tokens);
+        self.completion_tokens = self
+            .completion_tokens
+            .saturating_add(stream_output.output_tokens);
+        self.tool_call_count = self
+            .tool_call_count
+            .saturating_add(stream_output.tool_calls.len() as u32);
+        self.subagent_spawn_count = self.subagent_spawn_count.saturating_add(
+            stream_output
+                .tool_calls
+                .iter()
+                .filter(|call| is_subagent_create_call(call))
+                .count() as u32,
+        );
+    }
+}
+
 /// Checks the run's cumulative activity (already accumulated into `round` —
 /// see `RoundRuntimeState::total_*`) against the resolved per-run budget.
 /// Checked in a fixed priority order (tokens, then tool calls, then
@@ -1309,6 +1354,11 @@ pub(super) async fn run_pipeline(
     // summary round; the next hit stops unconditionally.
     let mut budget_summary_used = false;
     session.metadata.remove("runtime.completion_reason");
+    // Same hygiene for the budget-trip detail key (issue #221): without this,
+    // one tripped run would leave `budget_exceeded_kind` on the session
+    // forever, misleading clients on every later run that stops for an
+    // unrelated reason (or completes normally).
+    session.metadata.remove("runtime.budget_exceeded_kind");
 
     loop {
         refresh_auxiliary_models_for_round(state, config);
@@ -1432,16 +1482,13 @@ pub(super) async fn run_pipeline(
         let mut turn_outcome: Option<TurnOutcome> = None;
         let mut terminal_error: Option<AgentError> = None;
 
-        // Actual (provider-reported) usage + activity for THIS round, captured
-        // the moment `stream_output` becomes available (below) — before it is
-        // consumed by `handle_no_tool_calls`/`handle_tool_calls_path` — so the
-        // per-run budget guardrails (issue #221) can accumulate real numbers,
-        // not the heuristic `round_usage` estimate used for metrics. Reset
-        // every round; a retried/failed attempt leaves these at 0.
-        let mut round_prompt_tokens: u64 = 0;
-        let mut round_completion_tokens: u64 = 0;
-        let mut round_tool_call_count: u32 = 0;
-        let mut round_subagent_spawn_count: u32 = 0;
+        // Actual (provider-reported) usage + activity for THIS round for the
+        // per-run budget guardrails (issue #221) — real numbers, not the
+        // heuristic `round_usage` estimate used for metrics. Reset every
+        // round; accumulated across the retry attempts below (see
+        // `RoundActivity` for why it must sum, never overwrite); an attempt
+        // that errors before streaming contributes 0.
+        let mut round_activity = RoundActivity::default();
 
         for attempt in 1..=MAX_LLM_TURN_ATTEMPTS {
             let llm_output = match crate::runtime::runner::round_lifecycle::execute_llm_round(
@@ -1584,16 +1631,11 @@ pub(super) async fn run_pipeline(
             // --- Handle LLM output ---
             let stream_output = llm_output.stream_output;
 
-            // Capture this round's ACTUAL usage/activity before `stream_output`
-            // is consumed below (issue #221 — see the declaration above).
-            round_prompt_tokens = stream_output.input_tokens;
-            round_completion_tokens = stream_output.output_tokens;
-            round_tool_call_count = stream_output.tool_calls.len() as u32;
-            round_subagent_spawn_count = stream_output
-                .tool_calls
-                .iter()
-                .filter(|call| is_subagent_create_call(call))
-                .count() as u32;
+            // Absorb this attempt's ACTUAL usage/activity before
+            // `stream_output` is consumed below — every successful LLM call in
+            // this round was billed, even if its post-LLM handling then fails
+            // and triggers a retry (issue #221 — see `RoundActivity`).
+            round_activity.absorb_attempt(&stream_output);
 
             if stream_output.tool_calls.is_empty() {
                 // Safety net: if the model is about to finish but left background
@@ -1922,22 +1964,22 @@ pub(super) async fn run_pipeline(
             .runtime_state
             .round
             .total_prompt_tokens
-            .saturating_add(round_prompt_tokens);
+            .saturating_add(round_activity.prompt_tokens);
         state.runtime_state.round.total_completion_tokens = state
             .runtime_state
             .round
             .total_completion_tokens
-            .saturating_add(round_completion_tokens);
+            .saturating_add(round_activity.completion_tokens);
         state.runtime_state.round.total_tool_calls = state
             .runtime_state
             .round
             .total_tool_calls
-            .saturating_add(round_tool_call_count);
+            .saturating_add(round_activity.tool_call_count);
         state.runtime_state.round.total_subagents_spawned = state
             .runtime_state
             .round
             .total_subagents_spawned
-            .saturating_add(round_subagent_spawn_count);
+            .saturating_add(round_activity.subagent_spawn_count);
 
         state_bridge::write_runtime_state(session, &state.runtime_state);
 
@@ -3505,6 +3547,174 @@ mod tests {
 
     async fn drain(rx: &mut tokio::sync::mpsc::Receiver<AgentEvent>) {
         while rx.recv().await.is_some() {}
+    }
+
+    /// PR #539 review #1: a round's billed usage must ACCUMULATE across retry
+    /// attempts, never be overwritten. Attempt 1 can succeed at the LLM (real,
+    /// billed tokens) and then fail retryably in post-LLM handling; attempt 2
+    /// calls the LLM again. Both attempts' tokens must count against the
+    /// budget — overwriting would fail open (undercount real spend).
+    #[test]
+    fn round_activity_accumulates_across_retry_attempts_instead_of_overwriting() {
+        use crate::runtime::stream::handler::StreamHandlingOutput;
+
+        fn attempt(input: u64, output: u64, tool_calls: Vec<&str>) -> StreamHandlingOutput {
+            StreamHandlingOutput {
+                response_id: None,
+                content: "x".to_string(),
+                reasoning_content: String::new(),
+                reasoning_signature: None,
+                token_count: 0,
+                tool_calls: tool_calls
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, name)| bamboo_agent_core::tools::ToolCall {
+                        id: format!("t{i}"),
+                        tool_type: "function".to_string(),
+                        function: bamboo_agent_core::tools::FunctionCall {
+                            name: name.to_string(),
+                            arguments: "{}".to_string(),
+                        },
+                    })
+                    .collect(),
+                output_tokens: output,
+                thinking_tokens: 0,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                input_tokens: input,
+            }
+        }
+
+        let mut activity = super::RoundActivity::default();
+
+        // Attempt 1: billed 100 in / 50 out, one Bash + one SubAgent create.
+        activity.absorb_attempt(&attempt(100, 50, vec!["Bash", "SubAgent"]));
+        assert_eq!(activity.prompt_tokens, 100);
+        assert_eq!(activity.completion_tokens, 50);
+        assert_eq!(activity.tool_call_count, 2);
+        assert_eq!(activity.subagent_spawn_count, 1);
+
+        // Post-LLM handling fails retryably; attempt 2 is billed too. Totals
+        // must be the SUM of both attempts, not attempt 2's numbers alone.
+        activity.absorb_attempt(&attempt(120, 30, vec!["Bash"]));
+        assert_eq!(
+            activity.prompt_tokens, 220,
+            "attempt 1's billed prompt tokens must not be dropped on retry"
+        );
+        assert_eq!(activity.completion_tokens, 80);
+        assert_eq!(activity.tool_call_count, 3);
+        assert_eq!(activity.subagent_spawn_count, 1);
+
+        // Saturates rather than wrapping on absurd totals.
+        activity.absorb_attempt(&attempt(u64::MAX, u64::MAX, vec![]));
+        assert_eq!(activity.prompt_tokens, u64::MAX);
+        assert_eq!(activity.completion_tokens, u64::MAX);
+    }
+
+    /// PR #539 review #2: `runtime.budget_exceeded_kind` must be cleared at
+    /// the start of every run, exactly like `runtime.completion_reason` — a
+    /// run that tripped the budget once must not leave stale trip metadata on
+    /// the session for later runs that stop for unrelated reasons.
+    #[tokio::test]
+    async fn budget_exceeded_kind_metadata_is_cleared_on_the_next_run() {
+        use crate::runtime::config::PromptMemoryFlags;
+
+        let flags = PromptMemoryFlags {
+            project_prompt_injection: false,
+            relevant_recall: false,
+            relevant_recall_rerank: false,
+            project_first_dream: false,
+            ledger_agenda: false,
+        };
+
+        // Run 1: trips the tool-call budget immediately.
+        let mut session = Session::new("session-budget-metadata-hygiene", "model");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let provider = Arc::new(UsageProvider {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+            prompt_tokens_per_round: 0,
+            completion_tokens_per_round: 0,
+            subagent_calls: false,
+        });
+        let llm: Arc<dyn LLMProvider> = provider.clone();
+        let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(AlwaysOkExecutor);
+        let tripping_config = AgentLoopConfig {
+            max_rounds: 50,
+            prompt_memory_flags: flags,
+            model_name: Some("model".to_string()),
+            run_budget: bamboo_config::RunBudgetConfig {
+                max_total_tokens: None,
+                max_tool_calls: Some(1),
+                max_subagents: None,
+            },
+            ..AgentLoopConfig::default()
+        };
+        let mut state = e2e_loop_state("session-budget-metadata-hygiene");
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let _ = super::run_pipeline(
+            &mut session,
+            &tx,
+            llm,
+            tools.clone(),
+            &cancel,
+            &tripping_config,
+            &mut state,
+        )
+        .await
+        .expect("run 1 completes");
+        drop(tx);
+        drain(&mut rx).await;
+        assert_eq!(
+            session
+                .metadata
+                .get("runtime.budget_exceeded_kind")
+                .map(String::as_str),
+            Some("max_tool_calls"),
+            "run 1 must stamp the trip detail"
+        );
+
+        // Run 2 on the SAME session, no budget: stops via max_rounds instead.
+        // Both budget metadata keys from run 1 must be gone.
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let provider2 = Arc::new(MaxRoundsProvider {
+            main_calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let llm2: Arc<dyn LLMProvider> = provider2.clone();
+        let unlimited_config = AgentLoopConfig {
+            max_rounds: 2,
+            prompt_memory_flags: flags,
+            model_name: Some("model".to_string()),
+            ..AgentLoopConfig::default()
+        };
+        let mut state2 = e2e_loop_state("session-budget-metadata-hygiene");
+        let _ = super::run_pipeline(
+            &mut session,
+            &tx,
+            llm2,
+            tools,
+            &cancel,
+            &unlimited_config,
+            &mut state2,
+        )
+        .await
+        .expect("run 2 completes");
+        drop(tx);
+        drain(&mut rx).await;
+
+        assert!(
+            !session
+                .metadata
+                .contains_key("runtime.budget_exceeded_kind"),
+            "stale budget trip detail must be cleared by the next run"
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get("runtime.completion_reason")
+                .map(String::as_str),
+            Some("max_rounds_reached"),
+            "run 2's own stop reason replaces run 1's budget_exceeded"
+        );
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -240,6 +240,13 @@ pub struct ExecuteRequest {
     pub bash_completion_sink: Option<Arc<dyn BashCompletionSink>>,
     /// Bamboo application data directory (typically `~/.bamboo`).
     pub app_data_dir: Option<std::path::PathBuf>,
+    /// Per-run resource guardrail override (issue #221): token / tool-call /
+    /// subagent budget for THIS execution. Each field falls back independently
+    /// to the config-level `Config::run_budget` default when unset (`None`
+    /// here does not mean "unlimited" — it means "use the config default",
+    /// which may itself be unlimited). See
+    /// [`bamboo_config::RunBudgetConfig::merged_with_override`].
+    pub run_budget: Option<bamboo_config::RunBudgetConfig>,
 }
 
 // ---------------------------------------------------------------------------
@@ -291,6 +298,7 @@ pub struct ExecuteRequestBuilder {
     bash_resume_hook: Option<Arc<dyn BashResumeHook>>,
     bash_completion_sink: Option<Arc<dyn BashCompletionSink>>,
     app_data_dir: Option<std::path::PathBuf>,
+    run_budget: Option<bamboo_config::RunBudgetConfig>,
 }
 
 impl ExecuteRequestBuilder {
@@ -330,6 +338,7 @@ impl ExecuteRequestBuilder {
             bash_resume_hook: None,
             bash_completion_sink: None,
             app_data_dir: None,
+            run_budget: None,
         }
     }
 
@@ -516,6 +525,14 @@ impl ExecuteRequestBuilder {
         self
     }
 
+    /// Set the per-run resource guardrail override (issue #221). Each field of
+    /// `v` falls back independently to the config-level default; see
+    /// [`bamboo_config::RunBudgetConfig::merged_with_override`].
+    pub fn run_budget(mut self, v: bamboo_config::RunBudgetConfig) -> Self {
+        self.run_budget = Some(v);
+        self
+    }
+
     /// Materialize the underlying [`ExecuteRequest`].
     ///
     /// `gold_config` is an internal feature flag with only a crate-visible
@@ -556,6 +573,7 @@ impl ExecuteRequestBuilder {
             bash_resume_hook: self.bash_resume_hook,
             bash_completion_sink: self.bash_completion_sink,
             app_data_dir: self.app_data_dir,
+            run_budget: self.run_budget,
         }
     }
 }
@@ -610,6 +628,7 @@ impl AgentRuntime {
             bash_resume_hook,
             bash_completion_sink,
             app_data_dir,
+            run_budget,
         } = req;
         let tools = tools.unwrap_or_else(|| self.default_tools.clone());
         let llm = provider_override.unwrap_or_else(|| self.provider.clone());
@@ -700,6 +719,11 @@ impl AgentRuntime {
             // servers' `instructions`) once, so it lands in the system prompt only
             // while those servers are loaded for this run.
             mcp_tool_guidance: tools.tool_guidance(),
+            // Config-level default, per-field-overridden by the request (issue
+            // #221). Merging here (rather than in the HTTP layer) means every
+            // caller — HTTP, schedules, connect, the in-proc SDK — gets the
+            // same config-default fallback for free.
+            run_budget: config.run_budget.merged_with_override(run_budget.as_ref()),
             ..Default::default()
         };
 

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -241,10 +241,11 @@ pub struct ExecuteRequest {
     /// Bamboo application data directory (typically `~/.bamboo`).
     pub app_data_dir: Option<std::path::PathBuf>,
     /// Per-run resource guardrail override (issue #221): token / tool-call /
-    /// subagent budget for THIS execution. Each field falls back independently
-    /// to the config-level `Config::run_budget` default when unset (`None`
-    /// here does not mean "unlimited" — it means "use the config default",
-    /// which may itself be unlimited). See
+    /// subagent budget for THIS execution. TIGHTEN-ONLY: per field, the
+    /// effective limit is the minimum of this override and the config-level
+    /// `Config::run_budget` default — a request can lower the operator's
+    /// ceiling but never raise or remove it. An unset field (`None`) keeps
+    /// the config default (which may itself be unlimited). See
     /// [`bamboo_config::RunBudgetConfig::merged_with_override`].
     pub run_budget: Option<bamboo_config::RunBudgetConfig>,
 }
@@ -525,9 +526,10 @@ impl ExecuteRequestBuilder {
         self
     }
 
-    /// Set the per-run resource guardrail override (issue #221). Each field of
-    /// `v` falls back independently to the config-level default; see
-    /// [`bamboo_config::RunBudgetConfig::merged_with_override`].
+    /// Set the per-run resource guardrail override (issue #221). TIGHTEN-ONLY:
+    /// per field, the effective limit is the minimum of `v` and the
+    /// config-level default — this can never loosen the operator's ceiling;
+    /// see [`bamboo_config::RunBudgetConfig::merged_with_override`].
     pub fn run_budget(mut self, v: bamboo_config::RunBudgetConfig) -> Self {
         self.run_budget = Some(v);
         self
@@ -719,10 +721,11 @@ impl AgentRuntime {
             // servers' `instructions`) once, so it lands in the system prompt only
             // while those servers are loaded for this run.
             mcp_tool_guidance: tools.tool_guidance(),
-            // Config-level default, per-field-overridden by the request (issue
-            // #221). Merging here (rather than in the HTTP layer) means every
-            // caller — HTTP, schedules, connect, the in-proc SDK — gets the
-            // same config-default fallback for free.
+            // Config-level default, tighten-only-merged with the request's
+            // override (issue #221): per field the minimum wins, so no caller
+            // can loosen the operator's ceiling. Merging here (rather than in
+            // the HTTP layer) means every caller — HTTP, schedules, connect,
+            // the in-proc SDK — gets the same clamped fallback for free.
             run_budget: config.run_budget.merged_with_override(run_budget.as_ref()),
             ..Default::default()
         };

--- a/crates/engine/bamboo-engine/src/runtime/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/tests.rs
@@ -43,6 +43,46 @@ fn agent_loop_config_default() {
     assert!(config.selected_skill_ids.is_none());
     assert!(config.disabled_tools.is_empty());
     assert!(!config.skip_initial_user_message);
+    // Issue #221: no budget configured anywhere means unlimited, matching
+    // every other resource knob's opt-in-only default.
+    assert_eq!(config.run_budget, bamboo_config::RunBudgetConfig::default());
+}
+
+/// Issue #221 plumb-through (engine hop): `ExecuteRequestBuilder::run_budget`
+/// is the exact setter the server's `agent_spawn::build_execute_request`
+/// calls when the HTTP request carried an override — verify it lands
+/// unmodified on the built `ExecuteRequest`, ready for
+/// `AgentRuntime::execute` to merge against the config-level default.
+#[test]
+fn execute_request_builder_carries_run_budget_override_through_to_the_request() {
+    use super::runtime::ExecuteRequestBuilder;
+    use tokio_util::sync::CancellationToken;
+
+    let (tx, _rx) = mpsc::channel(1);
+    let override_budget = bamboo_config::RunBudgetConfig {
+        max_total_tokens: Some(42_000),
+        max_tool_calls: Some(7),
+        max_subagents: None,
+    };
+
+    let request = ExecuteRequestBuilder::new("hello", tx, CancellationToken::new())
+        .run_budget(override_budget)
+        .build();
+
+    assert_eq!(request.run_budget, Some(override_budget));
+}
+
+/// Building WITHOUT `.run_budget(..)` leaves it `None` — `AgentRuntime::execute`
+/// must read that as "use the config-level default", not "unlimited".
+#[test]
+fn execute_request_builder_defaults_run_budget_to_none() {
+    use super::runtime::ExecuteRequestBuilder;
+    use tokio_util::sync::CancellationToken;
+
+    let (tx, _rx) = mpsc::channel(1);
+    let request = ExecuteRequestBuilder::new("hello", tx, CancellationToken::new()).build();
+
+    assert!(request.run_budget.is_none());
 }
 
 #[test]

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -785,6 +785,9 @@ impl ResumeExecutionPort for ChildCompletionCoordinator {
                 Some(sink)
             },
             app_data_dir: Some(self.app_data_dir.clone()),
+            // Resume does not carry a fresh per-request override; the
+            // config-level default (issue #221) still applies.
+            run_budget: None,
             runners: self.agent_runners.clone(),
             sessions_cache: self.sessions.clone(),
             on_complete: None,

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -394,6 +394,56 @@ fn default_true_memory_project_first_dream() -> bool {
     true
 }
 
+/// Per-run resource guardrails (issue #221): a cost/resource ceiling applied
+/// across an entire `AgentRuntime::execute()` call (i.e. one user turn's worth
+/// of internal rounds — the same "run" granularity `max_rounds` already uses).
+///
+/// Every field is `None` by default (unlimited), matching the rest of this
+/// config's opt-in-only posture. A per-request `ExecuteRequest::run_budget`
+/// override (HTTP `POST /execute` body) takes precedence per-field over this
+/// config-level default; see `bamboo_engine::runtime::runtime::AgentRuntime::execute`.
+///
+/// Exceeding any configured limit gracefully stops the run (mirrors the
+/// `max_rounds` exhaustion path: one final summary turn, then a terminal stop
+/// with `runtime.completion_reason = "budget_exceeded"` on the session, plus a
+/// structured `AgentEvent::BudgetExceeded`) rather than erroring out — the run
+/// stays resumable.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct RunBudgetConfig {
+    /// Maximum total tokens (prompt + completion, actual provider-reported
+    /// usage summed across the run's rounds) before the run is stopped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_total_tokens: Option<u64>,
+    /// Maximum total tool calls (across every round of the run, not just one
+    /// round — see `max_tool_calls_per_round` for the existing per-round cap)
+    /// before the run is stopped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tool_calls: Option<u32>,
+    /// Maximum total `SubAgent` create calls (across the whole run) before the
+    /// run is stopped. Distinct from `subagents.max_concurrent`, which caps how
+    /// many child actor processes run AT ONCE, not how many a single run may
+    /// spawn in total over its lifetime.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_subagents: Option<u32>,
+}
+
+impl RunBudgetConfig {
+    /// Merge a per-request override on top of this config-level default:
+    /// each field falls back independently, so a request can raise/lower one
+    /// knob (e.g. `max_total_tokens`) while leaving the others at the config
+    /// default.
+    pub fn merged_with_override(&self, request_override: Option<&RunBudgetConfig>) -> Self {
+        let Some(over) = request_override else {
+            return *self;
+        };
+        Self {
+            max_total_tokens: over.max_total_tokens.or(self.max_total_tokens),
+            max_tool_calls: over.max_tool_calls.or(self.max_tool_calls),
+            max_subagents: over.max_subagents.or(self.max_subagents),
+        }
+    }
+}
+
 /// Sub-agent execution settings.
 ///
 /// Sub-agents always run as independent **actor** processes — an isolated OS
@@ -1188,6 +1238,12 @@ pub struct Config {
     /// (`max_concurrent`, `broker`, remote/schedulable placements) are advanced.
     #[serde(default)]
     pub subagents: SubagentsConfig,
+
+    /// Config-level default per-run token/tool-call/subagent budget (issue
+    /// #221). `None` fields are unlimited. A per-request `ExecuteRequest`
+    /// override takes precedence per-field; see [`RunBudgetConfig`].
+    #[serde(default)]
+    pub run_budget: RunBudgetConfig,
 
     /// Remote Cluster Fabric: operator-managed nodes & clusters for deploying
     /// `broker-agent` workers locally or over SSH. Additive/back-compat: absent
@@ -2926,6 +2982,7 @@ impl Config {
             proxy_auth_encrypted: None,
             headless_auth: false,
             subagents: SubagentsConfig::default(),
+            run_budget: RunBudgetConfig::default(),
             cluster_fabric: crate::cluster_fabric::ClusterFabricConfig::default(),
             provider: default_provider(),
             providers: ProviderConfigs::default(),
@@ -3425,6 +3482,64 @@ mod tests {
                 None => std::env::remove_var(self.key),
             }
         }
+    }
+
+    #[test]
+    fn run_budget_config_merges_per_field_with_request_override_taking_precedence() {
+        let config_default = RunBudgetConfig {
+            max_total_tokens: Some(100_000),
+            max_tool_calls: Some(500),
+            max_subagents: Some(10),
+        };
+
+        // No override at all: config default passes through unchanged.
+        assert_eq!(
+            config_default.merged_with_override(None),
+            config_default,
+            "no override falls back to the config default entirely"
+        );
+
+        // Override raises exactly one field; the other two keep the config
+        // default (per-field fallback, not all-or-nothing).
+        let partial_override = RunBudgetConfig {
+            max_total_tokens: Some(5_000),
+            max_tool_calls: None,
+            max_subagents: None,
+        };
+        let merged = config_default.merged_with_override(Some(&partial_override));
+        assert_eq!(merged.max_total_tokens, Some(5_000));
+        assert_eq!(merged.max_tool_calls, Some(500));
+        assert_eq!(merged.max_subagents, Some(10));
+
+        // An unlimited config default stays unlimited on fields the request
+        // does not override.
+        let unlimited_default = RunBudgetConfig::default();
+        let merged = unlimited_default.merged_with_override(Some(&partial_override));
+        assert_eq!(merged.max_total_tokens, Some(5_000));
+        assert_eq!(merged.max_tool_calls, None);
+        assert_eq!(merged.max_subagents, None);
+    }
+
+    #[test]
+    fn run_budget_config_json_round_trips_and_defaults_are_unlimited() {
+        assert_eq!(RunBudgetConfig::default().max_total_tokens, None);
+        assert_eq!(RunBudgetConfig::default().max_tool_calls, None);
+        assert_eq!(RunBudgetConfig::default().max_subagents, None);
+
+        let json = r#"{ "max_total_tokens": 250000, "max_subagents": 3 }"#;
+        let cfg: RunBudgetConfig = serde_json::from_str(json).expect("deserializes");
+        assert_eq!(cfg.max_total_tokens, Some(250_000));
+        assert_eq!(
+            cfg.max_tool_calls, None,
+            "absent field defaults to unlimited"
+        );
+        assert_eq!(cfg.max_subagents, Some(3));
+
+        // Absent fields are omitted on serialize (skip_serializing_if), so an
+        // all-default config round-trips to `{}` rather than three explicit
+        // nulls.
+        let empty = serde_json::to_string(&RunBudgetConfig::default()).unwrap();
+        assert_eq!(empty, "{}");
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -400,8 +400,10 @@ fn default_true_memory_project_first_dream() -> bool {
 ///
 /// Every field is `None` by default (unlimited), matching the rest of this
 /// config's opt-in-only posture. A per-request `ExecuteRequest::run_budget`
-/// override (HTTP `POST /execute` body) takes precedence per-field over this
-/// config-level default; see `bamboo_engine::runtime::runtime::AgentRuntime::execute`.
+/// override (HTTP `POST /execute` body) may only TIGHTEN this config-level
+/// default, never loosen it — per field, the effective limit is the minimum
+/// of the two (see [`RunBudgetConfig::merged_with_override`] and
+/// `bamboo_engine::runtime::runtime::AgentRuntime::execute`).
 ///
 /// Exceeding any configured limit gracefully stops the run (mirrors the
 /// `max_rounds` exhaustion path: one final summary turn, then a terminal stop
@@ -427,19 +429,40 @@ pub struct RunBudgetConfig {
     pub max_subagents: Option<u32>,
 }
 
+/// Tighten-only per-field merge: the effective limit is the MINIMUM of the
+/// config default and the request override, with `None` = unlimited.
+fn min_limit<T: Ord + Copy>(config_default: Option<T>, request: Option<T>) -> Option<T> {
+    match (config_default, request) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
 impl RunBudgetConfig {
-    /// Merge a per-request override on top of this config-level default:
-    /// each field falls back independently, so a request can raise/lower one
-    /// knob (e.g. `max_total_tokens`) while leaving the others at the config
-    /// default.
+    /// Merge a per-request override with this config-level default,
+    /// **tighten-only** (issue #221, PR #539 review): per field, the
+    /// effective limit is the MINIMUM of the two (`None` = unlimited), so a
+    /// `POST /execute` caller can lower a budget below the operator's
+    /// configured ceiling but can never raise or remove it.
+    ///
+    /// Rationale: `run_budget` is a defensive cost circuit-breaker, and the
+    /// server's other guardrails (`max_rounds`, per-round tool caps, …) are
+    /// not client-overridable at all. A client-loosenable ceiling would be no
+    /// ceiling: any caller of `/execute` could send
+    /// `max_total_tokens: u64::MAX` and erase the operator's cap. Overrides
+    /// looser than the config default are silently clamped to it rather than
+    /// rejected — the caller still gets the strictest applicable budget,
+    /// which is always a safe interpretation of their request.
     pub fn merged_with_override(&self, request_override: Option<&RunBudgetConfig>) -> Self {
         let Some(over) = request_override else {
             return *self;
         };
         Self {
-            max_total_tokens: over.max_total_tokens.or(self.max_total_tokens),
-            max_tool_calls: over.max_tool_calls.or(self.max_tool_calls),
-            max_subagents: over.max_subagents.or(self.max_subagents),
+            max_total_tokens: min_limit(self.max_total_tokens, over.max_total_tokens),
+            max_tool_calls: min_limit(self.max_tool_calls, over.max_tool_calls),
+            max_subagents: min_limit(self.max_subagents, over.max_subagents),
         }
     }
 }
@@ -1241,7 +1264,8 @@ pub struct Config {
 
     /// Config-level default per-run token/tool-call/subagent budget (issue
     /// #221). `None` fields are unlimited. A per-request `ExecuteRequest`
-    /// override takes precedence per-field; see [`RunBudgetConfig`].
+    /// override may only tighten these ceilings, never loosen them; see
+    /// [`RunBudgetConfig::merged_with_override`].
     #[serde(default)]
     pub run_budget: RunBudgetConfig,
 
@@ -3596,7 +3620,7 @@ mod tests {
     }
 
     #[test]
-    fn run_budget_config_merges_per_field_with_request_override_taking_precedence() {
+    fn run_budget_config_merge_is_tighten_only_per_field() {
         let config_default = RunBudgetConfig {
             max_total_tokens: Some(100_000),
             max_tool_calls: Some(500),
@@ -3610,22 +3634,46 @@ mod tests {
             "no override falls back to the config default entirely"
         );
 
-        // Override raises exactly one field; the other two keep the config
-        // default (per-field fallback, not all-or-nothing).
-        let partial_override = RunBudgetConfig {
+        // Override TIGHTENS exactly one field; the other two keep the config
+        // default (per-field, not all-or-nothing).
+        let tighten_one = RunBudgetConfig {
             max_total_tokens: Some(5_000),
             max_tool_calls: None,
             max_subagents: None,
         };
-        let merged = config_default.merged_with_override(Some(&partial_override));
+        let merged = config_default.merged_with_override(Some(&tighten_one));
         assert_eq!(merged.max_total_tokens, Some(5_000));
         assert_eq!(merged.max_tool_calls, Some(500));
         assert_eq!(merged.max_subagents, Some(10));
 
-        // An unlimited config default stays unlimited on fields the request
-        // does not override.
+        // A LOOSER override is clamped to the config default: a client can
+        // never raise the operator's ceiling (PR #539 review, finding #3).
+        let loosen_attempt = RunBudgetConfig {
+            max_total_tokens: Some(999_999_999),
+            max_tool_calls: Some(10_000),
+            max_subagents: Some(1_000),
+        };
+        assert_eq!(
+            config_default.merged_with_override(Some(&loosen_attempt)),
+            config_default,
+            "looser per-request values must be clamped to the config ceiling"
+        );
+
+        // Nor can it REMOVE a configured ceiling by omitting the field: an
+        // absent override field keeps the config default, it does not mean
+        // unlimited.
+        let empty_override = RunBudgetConfig::default();
+        assert_eq!(
+            config_default.merged_with_override(Some(&empty_override)),
+            config_default,
+            "an all-absent override body keeps every configured ceiling"
+        );
+
+        // An unlimited config default CAN be tightened by the request (the
+        // request is the only ceiling then), and stays unlimited on fields the
+        // request does not set.
         let unlimited_default = RunBudgetConfig::default();
-        let merged = unlimited_default.merged_with_override(Some(&partial_override));
+        let merged = unlimited_default.merged_with_override(Some(&tighten_one));
         assert_eq!(merged.max_total_tokens, Some(5_000));
         assert_eq!(merged.max_tool_calls, None);
         assert_eq!(merged.max_subagents, None);

--- a/crates/infra/bamboo-notification/src/policy.rs
+++ b/crates/infra/bamboo-notification/src/policy.rs
@@ -40,6 +40,9 @@ pub enum NotificationCategory {
     RunCompleted,
     /// A run failed (`AgentEvent::Error`).
     RunFailed,
+    /// A per-run token/tool-call/subagent budget tripped and the run was
+    /// gracefully stopped (`AgentEvent::BudgetExceeded`, issue #221).
+    BudgetExceeded,
     /// A caller-supplied notification minted directly by the `notify` tool
     /// rather than derived from a specific `AgentEvent` variant.
     Custom,
@@ -56,6 +59,7 @@ impl NotificationCategory {
             NotificationCategory::BackgroundTaskCompleted => "background_task_completed",
             NotificationCategory::RunCompleted => "run_completed",
             NotificationCategory::RunFailed => "run_failed",
+            NotificationCategory::BudgetExceeded => "budget_exceeded",
             NotificationCategory::Custom => "custom",
         }
     }
@@ -267,6 +271,31 @@ pub fn classify(
                 title: "Run failed".to_string(),
                 body: truncate(message, RUN_FAILED_BODY_MAX),
                 dedup_key: format!("run:{session_id}:failed"),
+            })
+        }
+
+        AgentEvent::BudgetExceeded {
+            kind,
+            limit,
+            actual,
+            ..
+        } => {
+            // No dedicated preference for this category yet; gated on
+            // `on_run_failed` since a budget-exceeded stop is, like a failure,
+            // an abnormal (non-`Complete`) run termination the user should
+            // learn about promptly.
+            if !prefs.on_run_failed {
+                return None;
+            }
+            Some(ClassifiedNotification {
+                category: NotificationCategory::BudgetExceeded,
+                priority: NotificationPriority::High,
+                title: "Run stopped: budget exceeded".to_string(),
+                body: truncate(
+                    &format!("{kind} reached {actual}/{limit}; the run was stopped."),
+                    RUN_FAILED_BODY_MAX,
+                ),
+                dedup_key: format!("run:{session_id}:budget_exceeded"),
             })
         }
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -421,6 +421,10 @@ pub async fn run(args: HeadlessArgs) -> Result<(), String> {
             // its sub-agents (which inherit it) route gated actions to the
             // off-loop model-reviewer instead of escalating to an absent human.
             no_human_approver: true,
+            // No `--budget-*` CLI flags yet (issue #221 follow-up); a headless
+            // run gets the config-level `run_budget` default like every other
+            // path.
+            run_budget: None,
         }),
     )
     .await;


### PR DESCRIPTION
## Summary

Implements issue #221's three confirmed-missing pieces (per the issue's own scope-narrowing comment — many other guardrails like `max_rounds`/`max_tool_calls_per_round`/`per_tool_timeout_secs`/`subagents.max_concurrent` already existed and are unaffected):

1. **Per-run spend budget** (`max_total_tokens`) — real, provider-reported token usage (not the metrics heuristic) accumulates per run; exceeding the limit gracefully stops the run.
2. **Per-run TOTAL counts** (`max_tool_calls`, `max_subagents`) — total across the whole run, distinct from the pre-existing *per-round* tool-call cap and *concurrent* subagent cap.
3. **Structured `BudgetExceeded` event** for real-time client observability ("熔断").

Cross-subagent-tree aggregation (a parent's budget covering its children's spend) is explicitly deferred per the issue's own scope note ("跨子 agent 树聚合作为后续") — out of scope here.

### Config surface
- `bamboo_config::RunBudgetConfig { max_total_tokens, max_tool_calls, max_subagents }` (all `Option`, default unlimited) — new `Config.run_budget` field (config-level default).
- HTTP `POST /execute` body gets an optional `run_budget` field of the same shape (per-request override); each field falls back independently to the config default (`RunBudgetConfig::merged_with_override`).
- Threaded end-to-end: HTTP `ExecuteRequest` → `SpawnAgentExecution` → `SessionExecutionArgs` → engine `ExecuteRequest`/`ExecuteRequestBuilder` → `AgentLoopConfig.run_budget` (resolved once in `AgentRuntime::execute`, the sealed engine loop's sole entry point — `AgentLoopConfig` stays unconstructible outside `bamboo-engine`).

### Enforcement + finalization
- Real per-round usage (provider `input_tokens`/`output_tokens` from the LLM stream, not the existing heuristic `round_usage` used for metrics) and tool-call/`SubAgent`-create counts accumulate into `AgentRuntimeState.round.total_prompt_tokens`/`total_completion_tokens`/`total_tool_calls`/`total_subagents_spawned` — fields that already existed on `RoundRuntimeState` but were dead code (declared, never populated); this PR wires them up as part of the budget feature.
- After each round, a guard checks the accumulated totals against the resolved budget — placed right next to (and modeled exactly on) the existing `max_rounds` exhaustion guard: **one graceful summary turn, then an unconditional stop**, never a hard error. The session stays resumable.
- On trip: `session.metadata["runtime.completion_reason"] = "budget_exceeded"` (+ `"runtime.budget_exceeded_kind"`), a visible summary-prompting message is injected, and a new `AgentEvent::BudgetExceeded { session_id, kind, limit, actual }` is emitted (rides the per-session SSE/WS stream, the late-subscriber replay cache, and the durable account change feed) — plus a notification-policy classification (`bamboo-notification`) and minimal TUI/client-core wire support.
- `SubAgent` spawn counting only counts `action=create` (or the tool's own legacy default when `action` is omitted) — `wait`/`list`/`get`/`update`/etc. don't consume the budget.

### Deferred / explicitly out of scope
- Cross-subagent-tree budget aggregation (issue's own "后续" note).
- No `--budget-*` CLI flags on `bamboo -p` yet (headless path gets the config-level default like every other path).
- No dedicated notification preference toggle for `budget_exceeded`; reuses `on_run_failed` (documented in code) rather than adding new preference-settings surface.

## Test plan
- [x] `cargo fmt` on every touched crate
- [x] `cargo clippy --all-targets` on every touched crate — zero new warnings (verified by diffing warning locations against my changed files)
- [x] `cargo build --workspace --tests` — clean
- [x] `cargo test -p bamboo-engine --lib` — 946/946 pass (6 new: token/tool-call/subagent trip-at-right-round + one-shot grace turn + structured event + under-budget-unaffected + `is_subagent_create_call`/`check_run_budget_exceeded` unit tests)
- [x] `cargo test -p bamboo-server --lib` — 1372/1372 pass (new HTTP JSON-decode plumb-through tests for `run_budget`)
- [x] `cargo test -p bamboo-config --lib` — 279/279 pass (new `RunBudgetConfig` merge-precedence + serde-defaults tests)
- [x] `cargo test -p bamboo-domain -p bamboo-agent-core -p bamboo-notification -p bamboo-client-core -p bamboo-tui --lib` — all pass

Closes #221 (deferring cross-tree aggregation as noted above and in the issue itself).

https://claude.ai/code/session_01Ux4nHUqFjEEGV3rX1x3V9Y