### PR TITLE
feat(session): honor a mid-run bypass_permissions toggle on the current run (#540)

### DIFF
--- a/crates/app/bamboo-server-tools/src/sub_agent.rs
+++ b/crates/app/bamboo-server-tools/src/sub_agent.rs
@@ -616,8 +616,11 @@ impl Tool for SubAgentTool {
                                 .get_or_insert_with(bamboo_domain::AgentRuntimeState::default);
                             rs.bypass_permissions = parent_bypass;
                             rs.no_human_approver = parent_no_human;
+                            // Authoritative flag write: persist the freshly
+                            // mirrored posture as-is; the adopting save would
+                            // revert bypass to the child's stale disk value. #540/#74.
                             self.sessions
-                                .save_child_session(&mut child)
+                                .save_child_session_authoritative_flags(&mut child)
                                 .await
                                 .map_err(tool_error_from_child_session)?;
                         }

--- a/crates/app/bamboo-server/src/tools/child_session_adapter.rs
+++ b/crates/app/bamboo-server/src/tools/child_session_adapter.rs
@@ -486,8 +486,13 @@ impl ChildSessionPort for ChildSessionAdapter {
     }
 
     async fn save_child_session(&self, child: &mut Session) -> Result<(), ChildSessionError> {
+        // Parent-side control write: the parent authoritatively sets the child's
+        // posture (e.g. the #74 resident-reuse bypass/no-human re-seed), so this
+        // must persist the in-memory flags as-is, NOT adopt the child's stale
+        // on-disk bypass (which the loop-protection in `merge_save_runtime`
+        // would). #540.
         self.persistence
-            .merge_save_runtime(child)
+            .save_runtime_authoritative_flags(child)
             .await
             .map_err(|error| {
                 ChildSessionError::Execution(format!("failed to save child session: {error}"))

--- a/crates/app/bamboo-server/src/tools/child_session_adapter.rs
+++ b/crates/app/bamboo-server/src/tools/child_session_adapter.rs
@@ -486,11 +486,31 @@ impl ChildSessionPort for ChildSessionAdapter {
     }
 
     async fn save_child_session(&self, child: &mut Session) -> Result<(), ChildSessionError> {
-        // Parent-side control write: the parent authoritatively sets the child's
-        // posture (e.g. the #74 resident-reuse bypass/no-human re-seed), so this
-        // must persist the in-memory flags as-is, NOT adopt the child's stale
-        // on-disk bypass (which the loop-protection in `merge_save_runtime`
-        // would). #540.
+        // Adopting save: most child actions (update/run/send_message/cancel)
+        // don't touch bypass_permissions, so a concurrent `PATCH` to a running
+        // child must still win over this control write. #540.
+        self.persistence
+            .merge_save_runtime(child)
+            .await
+            .map_err(|error| {
+                ChildSessionError::Execution(format!("failed to save child session: {error}"))
+            })?;
+
+        self.sessions_cache.insert(
+            child.id.clone(),
+            Arc::new(parking_lot::RwLock::new(child.clone())),
+        );
+
+        Ok(())
+    }
+
+    async fn save_child_session_authoritative_flags(
+        &self,
+        child: &mut Session,
+    ) -> Result<(), ChildSessionError> {
+        // Non-adopting save: the caller just set the child's posture flags from
+        // the live parent (the #74 re-seed), so persist them as-is instead of
+        // reverting to the child's stale on-disk bypass. #540.
         self.persistence
             .save_runtime_authoritative_flags(child)
             .await

--- a/crates/app/bamboo-server/src/tools/child_session_adapter.rs
+++ b/crates/app/bamboo-server/src/tools/child_session_adapter.rs
@@ -111,6 +111,25 @@ fn write_runtime_state(session: &mut Session, runtime_state: &AgentRuntimeState)
 }
 
 impl ChildSessionAdapter {
+    /// Shared tail of the two child-save methods: map the persist error and
+    /// refresh the in-memory cache. The two public methods differ ONLY in which
+    /// persistence call they make (adopting vs authoritative); everything after
+    /// is identical, so it lives here to stay in lockstep. #540.
+    fn finish_child_save(
+        &self,
+        child: &Session,
+        saved: std::io::Result<()>,
+    ) -> Result<(), ChildSessionError> {
+        saved.map_err(|error| {
+            ChildSessionError::Execution(format!("failed to save child session: {error}"))
+        })?;
+        self.sessions_cache.insert(
+            child.id.clone(),
+            Arc::new(parking_lot::RwLock::new(child.clone())),
+        );
+        Ok(())
+    }
+
     /// Construct an adapter. Public so a self-orchestrating WORKER (Phase 6:
     /// direct nested execution) can build its OWN child-session machinery
     /// against its own store/scheduler — the struct fields are `pub(crate)`, so
@@ -489,19 +508,8 @@ impl ChildSessionPort for ChildSessionAdapter {
         // Adopting save: most child actions (update/run/send_message/cancel)
         // don't touch bypass_permissions, so a concurrent `PATCH` to a running
         // child must still win over this control write. #540.
-        self.persistence
-            .merge_save_runtime(child)
-            .await
-            .map_err(|error| {
-                ChildSessionError::Execution(format!("failed to save child session: {error}"))
-            })?;
-
-        self.sessions_cache.insert(
-            child.id.clone(),
-            Arc::new(parking_lot::RwLock::new(child.clone())),
-        );
-
-        Ok(())
+        let saved = self.persistence.merge_save_runtime(child).await;
+        self.finish_child_save(child, saved)
     }
 
     async fn save_child_session_authoritative_flags(
@@ -511,19 +519,11 @@ impl ChildSessionPort for ChildSessionAdapter {
         // Non-adopting save: the caller just set the child's posture flags from
         // the live parent (the #74 re-seed), so persist them as-is instead of
         // reverting to the child's stale on-disk bypass. #540.
-        self.persistence
+        let saved = self
+            .persistence
             .save_runtime_authoritative_flags(child)
-            .await
-            .map_err(|error| {
-                ChildSessionError::Execution(format!("failed to save child session: {error}"))
-            })?;
-
-        self.sessions_cache.insert(
-            child.id.clone(),
-            Arc::new(parking_lot::RwLock::new(child.clone())),
-        );
-
-        Ok(())
+            .await;
+        self.finish_child_save(child, saved)
     }
 
     async fn is_child_running(&self, child_session_id: &str) -> bool {

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -1306,13 +1306,26 @@ pub(super) async fn run_pipeline(
             })
             .await;
 
-        // --- Merge any queued injected messages from send_message ---
-        state_bridge::merge_pending_injected_messages(
+        // --- Turn-boundary refresh from disk: injected messages + live bypass ---
+        // A single load also picks up a mid-run `PATCH /sessions
+        // {bypass_permissions}`: the run owns a Session taken at spawn and never
+        // otherwise re-reads storage, so without this a bypass flip would not
+        // take effect until the next run. Adopt the disk value onto BOTH the
+        // live runtime state and the owned session so this round's per-tool-call
+        // `ToolExecutionSessionFlags::from_session` sees it. #540.
+        let turn_refresh = state_bridge::refresh_turn_boundary_from_disk(
             session,
             config.storage.as_ref(),
             config.persistence.as_ref(),
         )
         .await;
+        if let Some(disk_bypass) = turn_refresh.disk_bypass_permissions {
+            state.runtime_state.bypass_permissions = disk_bypass;
+            session
+                .agent_runtime_state
+                .get_or_insert_with(bamboo_domain::AgentRuntimeState::default)
+                .bypass_permissions = disk_bypass;
+        }
 
         // --- Cancellation check ---
         if cancel_token.is_cancelled() {

--- a/crates/engine/bamboo-engine/src/runtime/runner/state_bridge.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/state_bridge.rs
@@ -159,13 +159,15 @@ pub async fn refresh_turn_boundary_from_disk(
         session.clear_pending_injected_messages();
         session.updated_at = chrono::Utc::now();
 
+        let mut saved = false;
         if let Some(persistence) = persistence {
-            if let Err(error) = persistence.save_runtime_session(session).await {
-                tracing::warn!(
+            match persistence.save_runtime_session(session).await {
+                Ok(()) => saved = true,
+                Err(error) => tracing::warn!(
                     "[{}] Failed to persist pending injected message cleanup: {}",
                     session.id,
                     error
-                );
+                ),
             }
         }
 
@@ -175,24 +177,24 @@ pub async fn refresh_turn_boundary_from_disk(
             merged
         );
 
-        // The cleanup save above adopted the freshest on-disk bypass; re-read it
-        // so the value the caller stamps reflects a `PATCH` that may have landed
-        // DURING the merge, not the pre-merge snapshot. Only when we actually
-        // saved (injected messages present) — the no-injection fast path keeps
-        // its single load. #540.
-        let refreshed_bypass = storage
-            .load_session(&session.id)
-            .await
-            .ok()
-            .flatten()
-            .and_then(|s| {
-                s.agent_runtime_state
-                    .as_ref()
-                    .map(|rs| rs.bypass_permissions)
-            });
+        // When the cleanup save ran, the adopting `save_runtime_session` stamped
+        // the freshest on-disk bypass onto `session.agent_runtime_state` (so a
+        // `PATCH` that landed DURING the merge is already reflected there) — read
+        // it back from memory instead of a third full-session deserialization on
+        // this steering hot path. Without a save, `session` holds no disk-fresh
+        // value, so keep the pre-merge snapshot. #540.
+        let disk_bypass_permissions = if saved {
+            session
+                .agent_runtime_state
+                .as_ref()
+                .map(|rs| rs.bypass_permissions)
+                .or(disk_bypass_permissions)
+        } else {
+            disk_bypass_permissions
+        };
         return TurnBoundaryRefresh {
             merged,
-            disk_bypass_permissions: refreshed_bypass.or(disk_bypass_permissions),
+            disk_bypass_permissions,
         };
     }
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/state_bridge.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/state_bridge.rs
@@ -81,29 +81,68 @@ pub fn sync_from_metadata(session: &Session, state: &mut AgentRuntimeState) {
     }
 }
 
+/// Result of a turn-boundary disk refresh: how many injected messages were
+/// merged, and the live per-session `bypass_permissions` flag as it stands on
+/// disk (the authoritative writer is `PATCH /sessions`).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TurnBoundaryRefresh {
+    pub merged: usize,
+    /// `None` when there was no storage / no on-disk session to read.
+    pub disk_bypass_permissions: Option<bool>,
+}
+
 /// Merge any queued follow-up messages that were injected via `send_message`
 /// while a session is running.
 ///
-/// Loads the latest persisted session to check for `pending_injected_messages`
-/// metadata, appends them to the in-memory session as user messages, and
-/// clears the metadata flag.
-///
-/// Returns the number of messages merged.
+/// Thin wrapper over [`refresh_turn_boundary_from_disk`] kept for callers that
+/// only need the merge count. Returns the number of messages merged.
 pub async fn merge_pending_injected_messages(
     session: &mut Session,
     storage: Option<&Arc<dyn bamboo_agent_core::storage::Storage>>,
     persistence: Option<&Arc<dyn bamboo_domain::RuntimeSessionPersistence>>,
 ) -> usize {
-    let Some(storage) = storage else { return 0 };
+    refresh_turn_boundary_from_disk(session, storage, persistence)
+        .await
+        .merged
+}
+
+/// Turn-boundary refresh from the on-disk session: a SINGLE load that both
+/// merges queued `send_message` injections AND reads the live
+/// `bypass_permissions` flag.
+///
+/// The bypass read is what makes a mid-run `PATCH /sessions {bypass_permissions}`
+/// take effect on the CURRENT run: the run owns a `Session` value taken at spawn
+/// and never otherwise re-reads storage, so the caller applies the returned
+/// `disk_bypass_permissions` to the live runtime state at each round boundary.
+/// The flag is folded into the existing per-round load so large parent sessions
+/// aren't deserialized twice.
+pub async fn refresh_turn_boundary_from_disk(
+    session: &mut Session,
+    storage: Option<&Arc<dyn bamboo_agent_core::storage::Storage>>,
+    persistence: Option<&Arc<dyn bamboo_domain::RuntimeSessionPersistence>>,
+) -> TurnBoundaryRefresh {
+    let Some(storage) = storage else {
+        return TurnBoundaryRefresh::default();
+    };
 
     let Ok(Some(latest)) = storage.load_session(&session.id).await else {
-        return 0;
+        return TurnBoundaryRefresh::default();
     };
+
+    let disk_bypass_permissions = Some(
+        latest
+            .agent_runtime_state
+            .as_ref()
+            .is_some_and(|state| state.bypass_permissions),
+    );
 
     // Read via the typed accessor (prefers `runtime_metadata`, falls back to the
     // legacy `pending_injected_messages` JSON string; defensive on malformed).
     let Some(messages) = latest.pending_injected_messages() else {
-        return 0;
+        return TurnBoundaryRefresh {
+            merged: 0,
+            disk_bypass_permissions,
+        };
     };
 
     let mut merged = 0usize;
@@ -136,7 +175,10 @@ pub async fn merge_pending_injected_messages(
         );
     }
 
-    merged
+    TurnBoundaryRefresh {
+        merged,
+        disk_bypass_permissions,
+    }
 }
 
 #[cfg(test)]
@@ -327,5 +369,35 @@ mod tests {
         let mut session = test_session();
         let count = merge_pending_injected_messages(&mut session, None, None).await;
         assert_eq!(count, 0);
+    }
+
+    // #540: the turn-boundary refresh reports the live on-disk bypass flag so
+    // the pipeline can adopt a mid-run PATCH into the running loop's state.
+    #[tokio::test]
+    async fn refresh_turn_boundary_reports_disk_bypass_permissions() {
+        let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());
+
+        // Persist a session with bypass ON.
+        let mut persisted = Session::new("bypass-live", "model");
+        let mut state = AgentRuntimeState::new("run-x");
+        state.bypass_permissions = true;
+        persisted.agent_runtime_state = Some(state);
+        storage.save_session(&persisted).await.unwrap();
+
+        // A running loop holds a stale copy with bypass OFF.
+        let mut running = Session::new("bypass-live", "model");
+        running.agent_runtime_state = Some(AgentRuntimeState::new("run-x"));
+
+        let refresh = refresh_turn_boundary_from_disk(&mut running, Some(&storage), None).await;
+        assert_eq!(refresh.disk_bypass_permissions, Some(true));
+        assert_eq!(refresh.merged, 0);
+    }
+
+    #[tokio::test]
+    async fn refresh_turn_boundary_reports_none_without_storage() {
+        let mut session = test_session();
+        let refresh = refresh_turn_boundary_from_disk(&mut session, None, None).await;
+        assert_eq!(refresh.disk_bypass_permissions, None);
+        assert_eq!(refresh.merged, 0);
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/state_bridge.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/state_bridge.rs
@@ -129,12 +129,13 @@ pub async fn refresh_turn_boundary_from_disk(
         return TurnBoundaryRefresh::default();
     };
 
-    let disk_bypass_permissions = Some(
-        latest
-            .agent_runtime_state
-            .as_ref()
-            .is_some_and(|state| state.bypass_permissions),
-    );
+    // A disk copy with no runtime state carries no authoritative bypass value —
+    // report `None` (unknown) so the caller leaves the live flag untouched
+    // rather than force-disabling a legitimately bypassed run. #540.
+    let disk_bypass_permissions = latest
+        .agent_runtime_state
+        .as_ref()
+        .map(|state| state.bypass_permissions);
 
     // Read via the typed accessor (prefers `runtime_metadata`, falls back to the
     // legacy `pending_injected_messages` JSON string; defensive on malformed).
@@ -173,6 +174,26 @@ pub async fn refresh_turn_boundary_from_disk(
             session.id,
             merged
         );
+
+        // The cleanup save above adopted the freshest on-disk bypass; re-read it
+        // so the value the caller stamps reflects a `PATCH` that may have landed
+        // DURING the merge, not the pre-merge snapshot. Only when we actually
+        // saved (injected messages present) — the no-injection fast path keeps
+        // its single load. #540.
+        let refreshed_bypass = storage
+            .load_session(&session.id)
+            .await
+            .ok()
+            .flatten()
+            .and_then(|s| {
+                s.agent_runtime_state
+                    .as_ref()
+                    .map(|rs| rs.bypass_permissions)
+            });
+        return TurnBoundaryRefresh {
+            merged,
+            disk_bypass_permissions: refreshed_bypass.or(disk_bypass_permissions),
+        };
     }
 
     TurnBoundaryRefresh {
@@ -399,5 +420,20 @@ mod tests {
         let refresh = refresh_turn_boundary_from_disk(&mut session, None, None).await;
         assert_eq!(refresh.disk_bypass_permissions, None);
         assert_eq!(refresh.merged, 0);
+    }
+
+    // #540 review: a disk copy with no agent_runtime_state reports None
+    // (unknown), NOT Some(false) — so the pipeline won't force-disable a
+    // legitimately bypassed run.
+    #[tokio::test]
+    async fn refresh_turn_boundary_reports_none_when_disk_has_no_runtime_state() {
+        let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());
+        let persisted = Session::new("no-rs", "model");
+        assert!(persisted.agent_runtime_state.is_none());
+        storage.save_session(&persisted).await.unwrap();
+
+        let mut running = Session::new("no-rs", "model");
+        let refresh = refresh_turn_boundary_from_disk(&mut running, Some(&storage), None).await;
+        assert_eq!(refresh.disk_bypass_permissions, None);
     }
 }

--- a/crates/engine/bamboo-engine/src/session_app/child_session/mod.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_session/mod.rs
@@ -167,6 +167,16 @@ pub trait ChildSessionPort: Send + Sync {
         child_id: &str,
     ) -> Result<Session, ChildSessionError>;
     async fn save_child_session(&self, child: &mut Session) -> Result<(), ChildSessionError>;
+    /// Save a child session whose `agent_runtime_state` posture flags
+    /// (`bypass_permissions` / `no_human_approver`) the caller just set
+    /// authoritatively (the #74 resident-reuse re-seed) — persists them as-is
+    /// instead of adopting the child's stale on-disk value, unlike
+    /// [`Self::save_child_session`], which protects a concurrent `PATCH` to a
+    /// running child. Use ONLY right after deliberately writing those flags. #540.
+    async fn save_child_session_authoritative_flags(
+        &self,
+        child: &mut Session,
+    ) -> Result<(), ChildSessionError>;
     async fn is_child_running(&self, child_id: &str) -> bool;
     async fn list_children(&self, parent_id: &str) -> Vec<ChildSessionEntry>;
     async fn enqueue_child_run(

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -184,7 +184,37 @@ impl LockedSessionStore {
     ///
     /// This is the locked equivalent of [`merge_save_session`]; prefer it for
     /// server-side paths where an authoritative write may race with this save.
+    ///
+    /// Adopts the on-disk `bypass_permissions` so a running loop's save can't
+    /// revert a concurrent `PATCH /sessions` flip (#540). Callers that are
+    /// themselves the authoritative writer of that flag — the parent seeding a
+    /// child's posture (#74) — must use
+    /// [`Self::save_runtime_authoritative_flags`] instead, which persists the
+    /// in-memory flag as-is.
     pub async fn merge_save_runtime(&self, session: &mut Session) -> std::io::Result<()> {
+        self.merge_save_runtime_inner(session, true).await
+    }
+
+    /// Like [`Self::merge_save_runtime`] but does NOT adopt the on-disk
+    /// `bypass_permissions` — the caller's in-memory value is authoritative and
+    /// persists as-is.
+    ///
+    /// For parent-side control writes to a child session (e.g. the #74
+    /// resident-reuse posture re-seed), which set the flag deliberately and must
+    /// not be reverted by the disk-wins protection meant for a running loop's
+    /// own stale saves. Still merges the authoritative metadata group.
+    pub async fn save_runtime_authoritative_flags(
+        &self,
+        session: &mut Session,
+    ) -> std::io::Result<()> {
+        self.merge_save_runtime_inner(session, false).await
+    }
+
+    async fn merge_save_runtime_inner(
+        &self,
+        session: &mut Session,
+        adopt_bypass: bool,
+    ) -> std::io::Result<()> {
         let _guard = self.acquire_lock(&session.id).await;
 
         // Single disk read serves BOTH the SHRINK diagnostic and the
@@ -224,8 +254,11 @@ impl LockedSessionStore {
         if let Some(latest) = latest.as_ref() {
             apply_authoritative_metadata(session, latest);
             // Never let a running loop's save revert a concurrent mid-run
-            // `PATCH /sessions {bypass_permissions}` flip. #540.
-            adopt_disk_bypass_permissions(session, latest);
+            // `PATCH /sessions {bypass_permissions}` flip. #540. Skipped for
+            // authoritative flag writers (`save_runtime_authoritative_flags`).
+            if adopt_bypass {
+                adopt_disk_bypass_permissions(session, latest);
+            }
         }
         self.storage.save_session(session).await
     }
@@ -297,10 +330,17 @@ async fn merge_authoritative_metadata_into_stale(
 /// group this is NOT version-gated: the PATCH writes via `update_runtime_config`,
 /// which does not bump `metadata_version`. #540.
 fn adopt_disk_bypass_permissions(session: &mut Session, latest: &Session) {
-    let disk_bypass = latest
+    // A disk copy with NO runtime state at all carries no authoritative bypass
+    // value — treat it as "unknown" and leave the in-memory flag untouched,
+    // rather than forcing it OFF (which would silently disable a legitimately
+    // bypassed run on any backend/path that doesn't round-trip the field). #540.
+    let Some(disk_bypass) = latest
         .agent_runtime_state
         .as_ref()
-        .is_some_and(|state| state.bypass_permissions);
+        .map(|state| state.bypass_permissions)
+    else {
+        return;
+    };
     match session.agent_runtime_state.as_mut() {
         Some(state) => state.bypass_permissions = disk_bypass,
         // No runtime state in memory and disk says "off" → nothing to adopt;
@@ -610,6 +650,78 @@ mod tests {
                 .as_ref()
                 .is_some_and(|s| s.bypass_permissions),
             "disk bypass=OFF must survive a stale runtime save (#540)"
+        );
+    }
+
+    // #540 review: the authoritative flag writer (#74 child-reseed) must NOT be
+    // reverted by the disk-wins protection — its in-memory value persists as-is.
+    #[tokio::test]
+    async fn save_runtime_authoritative_flags_persists_in_memory_bypass() {
+        use bamboo_domain::AgentRuntimeState;
+
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let session_id = "child-reseed";
+
+        // Child on disk has bypass ON (created under a bypassed parent).
+        let mut baseline = fresh(session_id);
+        let mut on_state = AgentRuntimeState::default();
+        on_state.bypass_permissions = true;
+        baseline.agent_runtime_state = Some(on_state);
+        storage.save_session(&baseline).await.unwrap();
+
+        // Parent re-seeds the reused child to OFF (parent flipped bypass off),
+        // loading the child then setting the flag in memory.
+        let mut child = storage.load_session(session_id).await.unwrap().unwrap();
+        child
+            .agent_runtime_state
+            .get_or_insert_with(AgentRuntimeState::default)
+            .bypass_permissions = false;
+
+        // Authoritative write must persist OFF, not adopt the disk's stale ON.
+        store
+            .save_runtime_authoritative_flags(&mut child)
+            .await
+            .unwrap();
+
+        let after = storage.load_session(session_id).await.unwrap().unwrap();
+        assert!(
+            !after
+                .agent_runtime_state
+                .as_ref()
+                .is_some_and(|s| s.bypass_permissions),
+            "authoritative re-seed of bypass=OFF must persist, not be reverted (#540/#74)"
+        );
+    }
+
+    // A disk copy lacking runtime state must not force the in-memory bypass OFF.
+    #[tokio::test]
+    async fn merge_save_runtime_leaves_bypass_when_disk_has_no_runtime_state() {
+        use bamboo_domain::AgentRuntimeState;
+
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let session_id = "no-runtime-state";
+
+        // Disk copy with NO agent_runtime_state.
+        let baseline = fresh(session_id);
+        assert!(baseline.agent_runtime_state.is_none());
+        storage.save_session(&baseline).await.unwrap();
+
+        // A running loop legitimately carries bypass ON in memory.
+        let mut running = storage.load_session(session_id).await.unwrap().unwrap();
+        let mut on_state = AgentRuntimeState::default();
+        on_state.bypass_permissions = true;
+        running.agent_runtime_state = Some(on_state);
+
+        store.merge_save_runtime(&mut running).await.unwrap();
+
+        assert!(
+            running
+                .agent_runtime_state
+                .as_ref()
+                .is_some_and(|s| s.bypass_permissions),
+            "a runtime-state-less disk copy must not force bypass OFF (#540)"
         );
     }
 

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -154,6 +154,9 @@ impl LockedSessionStore {
         let _guard = self.acquire_lock(&session.id).await;
         if let Ok(Some(latest)) = self.storage.load_runtime_control_plane(&session.id).await {
             apply_authoritative_metadata(session, &latest);
+            // The control-plane sidecar carries `agent_runtime_state`, so a
+            // concurrent mid-run bypass flip is here too — don't revert it. #540.
+            adopt_disk_bypass_permissions(session, &latest);
         }
         self.storage.save_runtime_state(session).await
     }
@@ -220,6 +223,9 @@ impl LockedSessionStore {
 
         if let Some(latest) = latest.as_ref() {
             apply_authoritative_metadata(session, latest);
+            // Never let a running loop's save revert a concurrent mid-run
+            // `PATCH /sessions {bypass_permissions}` flip. #540.
+            adopt_disk_bypass_permissions(session, latest);
         }
         self.storage.save_session(session).await
     }
@@ -277,6 +283,35 @@ async fn merge_authoritative_metadata_into_stale(
 ) {
     if let Ok(Some(latest)) = storage.load_session(&session.id).await {
         apply_authoritative_metadata(session, &latest);
+        adopt_disk_bypass_permissions(session, &latest);
+    }
+}
+
+/// Adopt the on-disk `agent_runtime_state.bypass_permissions` into the session
+/// about to be saved.
+///
+/// `PATCH /sessions {bypass_permissions}` is the SOLE authoritative writer of
+/// this flag (a running loop only carries it forward from run start). Without
+/// this, a runtime save from an in-flight run — which holds the run-start value
+/// — silently reverts a concurrent mid-run flip on disk. Unlike the metadata
+/// group this is NOT version-gated: the PATCH writes via `update_runtime_config`,
+/// which does not bump `metadata_version`. #540.
+fn adopt_disk_bypass_permissions(session: &mut Session, latest: &Session) {
+    let disk_bypass = latest
+        .agent_runtime_state
+        .as_ref()
+        .is_some_and(|state| state.bypass_permissions);
+    match session.agent_runtime_state.as_mut() {
+        Some(state) => state.bypass_permissions = disk_bypass,
+        // No runtime state in memory and disk says "off" → nothing to adopt;
+        // avoid allocating a default state just to store `false`.
+        None if disk_bypass => {
+            session
+                .agent_runtime_state
+                .get_or_insert_with(bamboo_domain::AgentRuntimeState::default)
+                .bypass_permissions = true;
+        }
+        None => {}
     }
 }
 
@@ -484,6 +519,98 @@ mod tests {
         // And the in-memory copy was corrected by the merge too.
         assert_eq!(stale_snapshot.title, "User Renamed");
         assert_eq!(stale_snapshot.metadata_version, 1);
+    }
+
+    // #540: a running loop's `merge_save_runtime` (carrying the run-start bypass
+    // value) must NOT revert a concurrent mid-run `PATCH /sessions
+    // {bypass_permissions}` write on disk — disk is the authoritative writer.
+    #[tokio::test]
+    async fn merge_save_runtime_adopts_disk_bypass_permissions() {
+        use bamboo_domain::AgentRuntimeState;
+
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let session_id = "runtime-bypass";
+
+        // Baseline persisted with bypass OFF.
+        let baseline = fresh(session_id);
+        storage.save_session(&baseline).await.unwrap();
+
+        // The running loop holds a snapshot with bypass OFF (run-start value).
+        let mut loop_snapshot = storage.load_session(session_id).await.unwrap().unwrap();
+        loop_snapshot.agent_runtime_state = Some(AgentRuntimeState::default());
+
+        // A concurrent PATCH flips bypass ON on disk (via update_runtime_config).
+        store
+            .update_runtime_config(session_id, |s| {
+                s.agent_runtime_state
+                    .get_or_insert_with(AgentRuntimeState::default)
+                    .bypass_permissions = true;
+            })
+            .await
+            .unwrap()
+            .expect("session exists");
+
+        // The loop saves its stale snapshot: it must adopt disk's ON value, not
+        // revert to OFF.
+        store.merge_save_runtime(&mut loop_snapshot).await.unwrap();
+
+        let after = storage.load_session(session_id).await.unwrap().unwrap();
+        assert!(
+            after
+                .agent_runtime_state
+                .as_ref()
+                .is_some_and(|s| s.bypass_permissions),
+            "disk bypass=ON must survive a stale runtime save (#540)"
+        );
+        // The in-memory copy is corrected too.
+        assert!(loop_snapshot
+            .agent_runtime_state
+            .as_ref()
+            .is_some_and(|s| s.bypass_permissions));
+    }
+
+    // The reverse direction: a PATCH turning bypass OFF must also stick against
+    // a stale loop snapshot that still has it ON.
+    #[tokio::test]
+    async fn merge_save_runtime_adopts_disk_bypass_off() {
+        use bamboo_domain::AgentRuntimeState;
+
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let session_id = "runtime-bypass-off";
+
+        // Baseline persisted with bypass ON.
+        let mut baseline = fresh(session_id);
+        let mut on_state = AgentRuntimeState::default();
+        on_state.bypass_permissions = true;
+        baseline.agent_runtime_state = Some(on_state);
+        storage.save_session(&baseline).await.unwrap();
+
+        // Loop snapshot still ON.
+        let mut loop_snapshot = storage.load_session(session_id).await.unwrap().unwrap();
+
+        // PATCH flips OFF on disk.
+        store
+            .update_runtime_config(session_id, |s| {
+                s.agent_runtime_state
+                    .get_or_insert_with(AgentRuntimeState::default)
+                    .bypass_permissions = false;
+            })
+            .await
+            .unwrap()
+            .expect("session exists");
+
+        store.merge_save_runtime(&mut loop_snapshot).await.unwrap();
+
+        let after = storage.load_session(session_id).await.unwrap().unwrap();
+        assert!(
+            !after
+                .agent_runtime_state
+                .as_ref()
+                .is_some_and(|s| s.bypass_permissions),
+            "disk bypass=OFF must survive a stale runtime save (#540)"
+        );
     }
 
     // ── Free-function merge tests (updated for metadata-group) ──────


### PR DESCRIPTION
Closes #540. Makes the per-session bypass toggle effective AT ANY TIME, including while the agent is actively running (paired with lotus `feat/bypass-anytime`, which unlocks the ⚡ button during execution).

## Problem (traced + adversarially verified)

`PATCH /sessions/{id} {bypass_permissions}` writes the flag to disk + swaps the `AppState.sessions` cache Arc, but an in-flight run owns a `Session` **moved by value** into its tokio task and derives the flag per tool call from that run-start snapshot (`ToolExecutionSessionFlags::from_session`). So a mid-run flip was inert for the current run — and worse, silently REVERTED: the loop re-stamps `agent_runtime_state` from its snapshot every turn and `merge_save_runtime` preserves only title/pinned/gold_config from disk.

## Fix (two parts)

**A. Stop the clobber** — `adopt_disk_bypass_permissions` adopts the on-disk flag into the session before every runtime save: `merge_save_runtime`, `save_runtime_only` (control-plane sidecar carries `agent_runtime_state`), and the stateless `merge_save_session` path. PATCH is the sole authoritative writer and doesn't bump `metadata_version`, so this is not version-gated.

**B. Live read** — the loop already reloads the session from disk at each round boundary (for `send_message` injection). `refresh_turn_boundary_from_disk` folds the live `bypass_permissions` read into that single load (no double deserialize on large parent sessions), and the pipeline adopts it onto the live `runtime_state` + owned session so the round's per-tool-call `from_session` sees the flip. Granularity: takes effect on the next round's tool calls.

## Unchanged by design (maintainer-confirmed contract)
- "Always ask" rules still force a prompt under bypass.
- An already-displayed permission prompt is still resolved only via `/respond` Approve/Deny — the flag never auto-answers a pending question.

## Tests
- `merge_save_runtime_adopts_disk_bypass_permissions` / `..._off` — a stale runtime save must not revert a concurrent PATCH (both directions).
- `refresh_turn_boundary_reports_disk_bypass_permissions` / `..._none_without_storage` — the turn-boundary refresh surfaces the live flag.
- Full suites green: bamboo-storage 68, bamboo-engine 940; `cargo build --workspace` clean; fmt/clippy clean on touched crates.

https://claude.ai/code/session_013oUofGqYAwMfpR2s1CteY9