### PR TITLE
feat(cli): completions, stdin prompts, unified model parsing, binary consolidation

### DIFF
--- a/src/actor_cli.rs
+++ b/src/actor_cli.rs
@@ -451,26 +451,23 @@ fn print_event(event: &serde_json::Value, raw: bool) {
 }
 
 /// `--model provider:model` (or bare model on the default provider) >
-/// `defaults.sub_agent` > `defaults.chat`.
+/// `defaults.sub_agent` > `defaults.chat`. Shared grammar (#246): the
+/// `provider:model` / bare-model split lives in [`crate::model_spec`], same
+/// as `-p -m` and `broker-agent spawn --model`.
 fn resolve_model(
     explicit: &Option<String>,
     config: &Config,
 ) -> Result<Option<ModelRefSpec>, String> {
-    if let Some(spec) = explicit {
-        let spec = spec.trim();
-        if let Some((p, m)) = spec.split_once(':') {
-            if p.trim().is_empty() || m.trim().is_empty() {
-                return Err(format!("--model '{spec}' must be provider:model"));
-            }
+    if let Some(raw) = explicit {
+        if let Some(parsed) =
+            crate::model_spec::parse_model_spec(raw).map_err(|e| format!("--model {e}"))?
+        {
+            let provider = parsed.provider.unwrap_or_else(|| config.provider.clone());
             return Ok(Some(ModelRefSpec {
-                provider: p.trim().into(),
-                model: m.trim().into(),
+                provider,
+                model: parsed.model,
             }));
         }
-        return Ok(Some(ModelRefSpec {
-            provider: config.provider.clone(),
-            model: spec.into(),
-        }));
     }
     if let Some(defaults) = &config.defaults {
         let pick = defaults.sub_agent.as_ref().or(Some(&defaults.chat));
@@ -486,4 +483,106 @@ fn resolve_model(
 
 fn pick_credential(creds: &[ScopedCredential], provider: &str) -> Option<ScopedCredential> {
     creds.iter().find(|c| c.provider == provider).cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn some(s: &str) -> Option<String> {
+        Some(s.to_string())
+    }
+
+    /// `--model provider:model` resolves to that exact pair, independent of
+    /// the configured default provider.
+    #[test]
+    fn resolve_model_colon_form() {
+        let config = Config {
+            provider: "anthropic".into(),
+            ..Config::default()
+        };
+        let m = resolve_model(&some("openai:gpt-4o"), &config)
+            .unwrap()
+            .unwrap();
+        assert_eq!(m.provider, "openai");
+        assert_eq!(m.model, "gpt-4o");
+    }
+
+    /// A bare `--model <id>` binds to the config's default provider — same
+    /// grammar `bamboo -p -m` uses (#246).
+    #[test]
+    fn resolve_model_bare_uses_config_default_provider() {
+        let config = Config {
+            provider: "openai".into(),
+            ..Config::default()
+        };
+        let m = resolve_model(&some("gpt-4o"), &config).unwrap().unwrap();
+        assert_eq!(m.provider, "openai");
+        assert_eq!(m.model, "gpt-4o");
+    }
+
+    fn defaults_config(
+        chat: (&str, &str),
+        sub_agent: Option<(&str, &str)>,
+    ) -> bamboo_config::DefaultsConfig {
+        bamboo_config::DefaultsConfig {
+            chat: bamboo_domain::ProviderModelRef::new(chat.0, chat.1),
+            fast: None,
+            task_summary: None,
+            vision: None,
+            memory_background: None,
+            planning: None,
+            search: None,
+            code_review: None,
+            sub_agent: sub_agent.map(|(p, m)| bamboo_domain::ProviderModelRef::new(p, m)),
+            subagent_models: std::collections::HashMap::new(),
+        }
+    }
+
+    /// No `--model` falls back to `defaults.sub_agent`, then `defaults.chat`.
+    #[test]
+    fn resolve_model_falls_back_to_defaults_sub_agent() {
+        let config = Config {
+            defaults: Some(defaults_config(
+                ("anthropic", "claude-x"),
+                Some(("openai", "gpt-sub")),
+            )),
+            ..Config::default()
+        };
+        let m = resolve_model(&None, &config).unwrap().unwrap();
+        assert_eq!(m.provider, "openai");
+        assert_eq!(m.model, "gpt-sub");
+    }
+
+    /// No `--model` and no `defaults.sub_agent` falls back to `defaults.chat`.
+    #[test]
+    fn resolve_model_falls_back_to_defaults_chat() {
+        let config = Config {
+            defaults: Some(defaults_config(("anthropic", "claude-x"), None)),
+            ..Config::default()
+        };
+        let m = resolve_model(&None, &config).unwrap().unwrap();
+        assert_eq!(m.provider, "anthropic");
+        assert_eq!(m.model, "claude-x");
+    }
+
+    /// Neither `--model` nor `defaults` configured → `None` (caller decides
+    /// whether that's fatal).
+    #[test]
+    fn resolve_model_none_when_nothing_configured() {
+        let config = Config {
+            defaults: None,
+            ..Config::default()
+        };
+        assert_eq!(resolve_model(&None, &config).unwrap(), None);
+    }
+
+    /// A malformed `provider:` (empty half) is rejected — same grammar
+    /// `bamboo -p -m` enforces (#246), not silently treated as a bare model.
+    #[test]
+    fn resolve_model_malformed_colon_errors() {
+        let config = Config::default();
+        assert!(resolve_model(&some("openai:"), &config).is_err());
+        assert!(resolve_model(&some(":gpt-4o"), &config).is_err());
+    }
 }

--- a/src/broker_agent.rs
+++ b/src/broker_agent.rs
@@ -231,7 +231,11 @@ fn build_spec(args: &BrokerAgentArgs) -> Result<ProvisionSpec, String> {
     // Model precedence: explicit --model > config defaults.sub_agent > defaults.chat.
     // A deployed worker given no --model must still inherit the configured default,
     // otherwise its AgentLoopConfig has no model_name and every LLM call fails.
-    spec.model = args.model.as_deref().and_then(parse_model).or_else(|| {
+    let explicit_model = match args.model.as_deref() {
+        Some(raw) => parse_model(raw)?,
+        None => None,
+    };
+    spec.model = explicit_model.or_else(|| {
         config.defaults.as_ref().and_then(|defaults| {
             defaults
                 .sub_agent
@@ -308,23 +312,17 @@ fn portable_mcp(
     }
 }
 
-/// Parse `provider:model`; a bare value leaves the provider empty (resolved by
-/// the runtime against the configured default).
-fn parse_model(s: &str) -> Option<ModelRefSpec> {
-    let s = s.trim();
-    if s.is_empty() {
-        return None;
-    }
-    Some(match s.split_once(':') {
-        Some((p, m)) => ModelRefSpec {
-            provider: p.trim().to_string(),
-            model: m.trim().to_string(),
-        },
-        None => ModelRefSpec {
-            provider: String::new(),
-            model: s.to_string(),
-        },
-    })
+/// Parse `--model provider:model`; a bare value leaves the provider empty
+/// (resolved by the runtime against the configured default). Shared grammar
+/// (#246): the `provider:model` / bare-model split and malformed-colon
+/// validation live in [`crate::model_spec`], same as `-p -m` and
+/// `actor run|serve -m`.
+fn parse_model(s: &str) -> Result<Option<ModelRefSpec>, String> {
+    let parsed = crate::model_spec::parse_model_spec(s).map_err(|e| format!("--model {e}"))?;
+    Ok(parsed.map(|p| ModelRefSpec {
+        provider: p.provider.unwrap_or_default(),
+        model: p.model,
+    }))
 }
 
 #[cfg(test)]
@@ -334,20 +332,29 @@ mod tests {
     #[test]
     fn parse_model_handles_provider_pair_and_bare() {
         assert_eq!(
-            parse_model("anthropic:claude-sonnet-4-6"),
+            parse_model("anthropic:claude-sonnet-4-6").unwrap(),
             Some(ModelRefSpec {
                 provider: "anthropic".into(),
                 model: "claude-sonnet-4-6".into()
             })
         );
         assert_eq!(
-            parse_model("gpt-5"),
+            parse_model("gpt-5").unwrap(),
             Some(ModelRefSpec {
                 provider: String::new(),
                 model: "gpt-5".into()
             })
         );
-        assert_eq!(parse_model("   "), None);
+        assert_eq!(parse_model("   ").unwrap(), None);
+    }
+
+    /// A malformed `provider:` (empty half) is rejected — previously this
+    /// silently produced a bogus empty-provider or empty-model spec; now it
+    /// fails fast like `-p -m` / `actor run -m` already do (#246).
+    #[test]
+    fn parse_model_rejects_malformed_colon() {
+        assert!(parse_model("openai:").is_err());
+        assert!(parse_model(":gpt-4o").is_err());
     }
 
     #[test]

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -683,20 +683,15 @@ fn resolve_model_selection(
     default_provider: &str,
 ) -> Result<ModelSelection, String> {
     let cli_provider = provider.as_deref().map(str::trim).filter(|p| !p.is_empty());
-    let model = model.as_deref().map(str::trim).filter(|m| !m.is_empty());
 
-    // Split an explicit `provider:model` spec, if any.
-    let (spec_provider, bare_model) = match model {
-        Some(spec) => match spec.split_once(':') {
-            Some((p, m)) => {
-                let (p, m) = (p.trim(), m.trim());
-                if p.is_empty() || m.is_empty() {
-                    return Err(format!("-m '{spec}' must be 'provider:model'"));
-                }
-                (Some(p.to_string()), Some(m.to_string()))
+    // Split an explicit `provider:model` spec, if any — shared grammar (#246).
+    let (spec_provider, bare_model) = match model.as_deref() {
+        Some(raw) => {
+            match crate::model_spec::parse_model_spec(raw).map_err(|e| format!("-m {e}"))? {
+                Some(parsed) => (parsed.provider, Some(parsed.model)),
+                None => (None, None),
             }
-            None => (None, Some(spec.to_string())),
-        },
+        }
         None => (None, None),
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,11 @@ pub mod admin_cli;
 /// The `bamboo -p` headless server mode: full AppState, one-shot, resumable.
 pub mod headless;
 
+/// Shared `-m`/`--model` CLI-flag grammar (`provider:model` / bare model id),
+/// used by `-p -m`, `actor run|serve -m`, and `broker-agent spawn --model`
+/// so all three parse and validate the same string the same way (#246).
+pub mod model_spec;
+
 /// The `bamboo init` / `doctor` / `config set` onboarding CLI: configure a
 /// provider + API key and self-diagnose without the web UI (server-less).
 pub mod setup_cli;

--- a/src/model_spec.rs
+++ b/src/model_spec.rs
@@ -1,0 +1,123 @@
+//! Shared `-m`/`--model` CLI-flag grammar.
+//!
+//! Every model-selecting flag in the `bamboo` binary (`-p -m`, `actor run
+//! -m`/`actor serve -m`, `broker-agent spawn --model`) accepts the same two
+//! shapes: `provider:model`, or a bare `model` id whose provider is filled in
+//! by the caller's own default policy (local config default, an explicit
+//! `--provider` flag, or "resolved later by the runtime" for a remote
+//! worker). Before this module each call site re-implemented the
+//! trim/split/validate step by hand and drifted: `bamboo -p -m` used to
+//! *require* the colon while `actor run -m` already accepted a bare id, and
+//! `broker-agent spawn --model` silently accepted a malformed `provider:`
+//! (empty half) that the other two rejected (#246).
+//!
+//! [`parse_model_spec`] is the one place that grammar is decided. Callers
+//! still own defaulting (what a bare model or an absent flag falls back to)
+//! since that legitimately differs by context.
+
+/// A parsed `-m`/`--model` value.
+///
+/// `provider` is `None` for a bare `model` id (no colon) — the caller decides
+/// what that means (bind to a `--provider` flag, the configured default
+/// provider, or leave it for a remote runtime to resolve).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedModelSpec {
+    pub provider: Option<String>,
+    pub model: String,
+}
+
+/// Parse a `-m`/`--model` flag value against the one grammar shared by the
+/// whole `bamboo` binary:
+///
+/// - blank / whitespace-only    → `Ok(None)` — treated as "flag omitted".
+/// - `"provider:model"`         → `Ok(Some({provider: Some(provider), model}))`.
+/// - `"model"` (no colon)       → `Ok(Some({provider: None, model}))`.
+/// - `"provider:"` / `":model"` (an empty half around a colon) → `Err` — a
+///   typo'd colon should fail fast rather than silently produce an empty
+///   provider or model.
+///
+/// Both halves (and a colon-less bare value) are trimmed of surrounding
+/// whitespace, so `" openai : gpt-4o "` parses the same as `"openai:gpt-4o"`.
+pub fn parse_model_spec(raw: &str) -> Result<Option<ParsedModelSpec>, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    match trimmed.split_once(':') {
+        Some((p, m)) => {
+            let (p, m) = (p.trim(), m.trim());
+            if p.is_empty() || m.is_empty() {
+                return Err(format!("'{trimmed}' must be 'provider:model'"));
+            }
+            Ok(Some(ParsedModelSpec {
+                provider: Some(p.to_string()),
+                model: m.to_string(),
+            }))
+        }
+        None => Ok(Some(ParsedModelSpec {
+            provider: None,
+            model: trimmed.to_string(),
+        })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blank_is_none() {
+        assert_eq!(parse_model_spec("").unwrap(), None);
+        assert_eq!(parse_model_spec("   ").unwrap(), None);
+    }
+
+    #[test]
+    fn colon_form_splits_both_halves() {
+        assert_eq!(
+            parse_model_spec("openai:gpt-4o").unwrap(),
+            Some(ParsedModelSpec {
+                provider: Some("openai".into()),
+                model: "gpt-4o".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn bare_model_has_no_provider() {
+        assert_eq!(
+            parse_model_spec("gpt-4o").unwrap(),
+            Some(ParsedModelSpec {
+                provider: None,
+                model: "gpt-4o".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn surrounding_and_inner_whitespace_is_trimmed() {
+        assert_eq!(
+            parse_model_spec(" openai : gpt-4o ").unwrap(),
+            Some(ParsedModelSpec {
+                provider: Some("openai".into()),
+                model: "gpt-4o".into(),
+            })
+        );
+        assert_eq!(
+            parse_model_spec("  gpt-4o  ").unwrap(),
+            Some(ParsedModelSpec {
+                provider: None,
+                model: "gpt-4o".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn empty_provider_half_errors() {
+        assert!(parse_model_spec(":gpt-4o").is_err());
+    }
+
+    #[test]
+    fn empty_model_half_errors() {
+        assert!(parse_model_spec("openai:").is_err());
+    }
+}


### PR DESCRIPTION
Closes #246.

## Investigation finding

Went through #246's remaining checklist (shell completions, stdin input for `-p`, unify model parsing, consolidate the 3 client binaries) item by item against current `main`. Three of the four were already shipped by earlier PRs before #469 landed its own slice:

- **Shell completions** — `bamboo completions {bash,zsh,fish,powershell,elvish}` via `clap_complete`, live since 6a2bc44a. Documented in `README.md`.
- **stdin prompt** — `bamboo -p -` reads the prompt from stdin (`echo "..." | bamboo -p -`), live since 6a2bc44a. Documented in `README.md`.
- **Consolidate the 3 client binaries** — `bamboo-cli` was already retired in #327 (a061b2dc): its `history` verb folded into `bamboo history`; `chat`/`send`/`stream` were superseded by `bamboo tui` + `bamboo respond`/`session`/`sessions`. Only 2 `[[bin]]` targets exist workspace-wide today (`bamboo`, `bamboo-tui`) — verified by grepping every `Cargo.toml` for `[[bin]]`.
- **Unify model parsing** — genuinely still open. `resolve_model_selection` (`headless.rs`, `-p -m`), `resolve_model` (`actor_cli.rs`, `actor run|serve -m`), and `parse_model` (`broker_agent.rs`, `broker-agent spawn --model`) had each independently reimplemented the same `provider:model` / bare-model split and drifted: `broker-agent spawn --model openai:` silently produced a bogus empty-model spec that `-p -m` and `actor run -m` already rejected.

## Change

Add `src/model_spec.rs` with `parse_model_spec` — the one shared `-m`/`--model` grammar (trim → split on `:` → reject an empty provider/model half → blank counts as "flag omitted"). All three call sites now build their own defaulting policy on top of it (local config default provider for `-p`/`actor`, `defaults.sub_agent`/`defaults.chat` cascade for `actor`, "leave empty, resolved later by the runtime" for a remote broker-agent worker) — those legitimately differ by context, so they stay separate functions, just sharing the validated split.

`broker-agent spawn --model` now rejects a malformed colon spec (`openai:`, `:gpt-4o`) the same way `-p -m` and `actor run -m` already do.

## Tests

- `cargo test --lib -p bamboo-agent`: 118 passed (24 model-parsing tests: 6 new `model_spec` unit tests, 6 new `actor_cli::resolve_model` tests — that function had zero test coverage before — 1 new `broker_agent` malformed-colon regression test; all pre-existing `headless.rs` model-selection tests pass unchanged, confirming behavior parity).
- `cargo build --workspace --tests`: clean.
- `cargo fmt -p bamboo-agent -- --check`: clean.
- `cargo clippy -p bamboo-agent --bin bamboo --tests`: no new warnings (pre-existing warnings are all in untouched crates: bamboo-memory, bamboo-engine, bamboo-server).
- Manual: `bamboo completions zsh` (2394-line sane script), `echo "ping from stdin" | bamboo -p - --echo` (reads stdin correctly), and confirmed a malformed `-m`/`--model` spec now errors identically across `-p` (both echo and non-echo paths) and `actor run`.

## Notes for review

- No `ExecuteRequest`/docs changes needed — completions and stdin are already documented in `README.md`; there's no separate CLI-reference doc in `docs/` to update.
- Deliberately did NOT add a `--provider` flag to `actor run`/`actor serve` (only `-p` has one today) — that's a flag-surface addition beyond what #246 asked for ("unify... and allow `--provider` separately" was about `-p`); happy to add it in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ux4nHUqFjEEGV3rX1x3V9Y