### PR TITLE
tune(ws_v2): keepalive cadence 5s → 2s (~6s dead-socket detection)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -88,14 +88,14 @@ const OUTBOUND_BUFFER: usize = 64;
 /// write probe) and the app-level `sys` keepalive data frame (client-side
 /// liveness signal, #533).
 ///
-/// 5s (down from the v1 SSE 15s cadence, #543): the client watchdog cannot
-/// detect a dead socket faster than a few missed keepalives, and 3×15s ≈ 45s
-/// is far too long for a user actively watching a running session. At 5s the
-/// watchdog resolves in ~15s. The frames are tiny (a ping + a ~50-byte text
+/// 2s (15s → 5s in #543, then → 2s): the client watchdog cannot detect a dead
+/// socket faster than a few missed keepalives, and a user actively watching a
+/// running session should not stare at a dead screen for long — at 2s the
+/// watchdog resolves in ~6s. The frames are tiny (a ping + a ~50-byte text
 /// frame); the cost is negligible even for remote clients. The lotus watchdog
 /// ADAPTS its threshold to the observed cadence (3×, clamped), so old-server ×
 /// new-client pairings stay safe in both directions.
-const PING_INTERVAL: Duration = Duration::from_secs(5);
+const PING_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Env var the live integration test sets to SHORTEN the ping interval so the
 /// `sys` keepalive cadence is asserted in milliseconds, not 15s. Read once per


### PR DESCRIPTION
#543 follow-up, user request: lower the heartbeat period further.

- `PING_INTERVAL` 5s → 2s: with the lotus watchdog's adaptive 3× threshold (floor lowered to 6s in Lotus#92), a dead socket on an actively watched session is detected in ~6s instead of ~15s.
- Cost: one protocol ping + one ~50-byte data frame per 2s per connection — negligible locally and remotely.
- Compat unchanged: old clients ignore the `sys` channel; new clients LEARN the cadence per connection (never assume it), so every old/new pairing keeps its correct threshold.
- No test churn: the live suite already runs at a 200ms test-only override.

`ws_v2` unit 33 ✓ · `ws_v2_live` 12 ✓ · fmt ✓

https://claude.ai/code/session_014iw5PBsSzDFHus1GfkAK4y