### PR TITLE
fix(subagent): child errors/blocks always wake the parent — push-side hole closure + heartbeat watchdog (#546)

### DIFF
--- a/crates/app/bamboo-server-tools/src/sub_agent.rs
+++ b/crates/app/bamboo-server-tools/src/sub_agent.rs
@@ -220,17 +220,46 @@ fn waiting_for_children_tool_result(mut value: serde_json::Value) -> Result<Tool
 }
 
 /// Split an explicit `SubAgent.wait` id list into `(targets, dropped)`:
-/// `dropped` = ids the index positively reported terminal (waiting on them
-/// could never be satisfied — issue #546), `targets` = everything else,
-/// including unknown ids (kept: the watchdog rescues a bogus id at runtime;
-/// an index-less backend reports nothing terminal and filters nothing).
+/// `dropped` = `(id, status)` pairs the index positively reported terminal
+/// (waiting on them could never be satisfied — issue #546), `targets` =
+/// everything else, including unknown ids (kept: the watchdog rescues a bogus
+/// id at runtime; an index-less backend reports nothing terminal and filters
+/// nothing).
 fn partition_wait_targets(
     requested: Vec<String>,
-    known_terminal: &[String],
-) -> (Vec<String>, Vec<String>) {
-    requested
-        .into_iter()
-        .partition(|id| !known_terminal.contains(id))
+    known_terminal: &[(String, String)],
+) -> (Vec<String>, Vec<(String, String)>) {
+    let mut targets = Vec::new();
+    let mut dropped = Vec::new();
+    for id in requested {
+        match known_terminal
+            .iter()
+            .find(|(terminal_id, _)| *terminal_id == id)
+        {
+            Some((_, status)) => dropped.push((id, status.clone())),
+            None => targets.push(id),
+        }
+    }
+    (targets, dropped)
+}
+
+/// Whether the dropped (already-terminal) ids of an explicit wait ALREADY
+/// satisfy the requested policy, so the wait must short-circuit to a
+/// non-suspending result instead of arming over the remainder (issue #546):
+/// `any` is satisfied by any terminal child; `first_error` by any error-like
+/// terminal child. For `all`, waiting on the remainder is equivalent, so the
+/// residual wait proceeds.
+fn wait_already_satisfied_by_dropped(
+    policy: ChildWaitPolicy,
+    dropped: &[(String, String)],
+) -> bool {
+    match policy {
+        ChildWaitPolicy::All => false,
+        ChildWaitPolicy::Any => !dropped.is_empty(),
+        ChildWaitPolicy::FirstError => dropped
+            .iter()
+            .any(|(_, status)| matches!(status.as_str(), "error" | "timeout" | "cancelled")),
+    }
 }
 
 /// Map a `ChildSessionError` to a `ToolError`.
@@ -804,37 +833,63 @@ impl Tool for SubAgentTool {
                 // KEPT (an index-less backend or a not-yet-indexed child must
                 // not be mistaken for finished); if such an id turns out to be
                 // bogus, the child-wait watchdog rescues the parent at runtime.
-                let (targets, dropped): (Vec<String>, Vec<String>) = match child_session_ids {
-                    Some(ids) if !ids.is_empty() => {
-                        let terminal = self.sessions.terminal_child_ids(&parent.id, &ids).await;
-                        partition_wait_targets(ids, &terminal)
-                    }
-                    _ => (
-                        self.sessions.active_child_ids(&parent.id).await,
-                        Vec::new(),
-                    ),
-                };
+                let (targets, dropped): (Vec<String>, Vec<(String, String)>) =
+                    match child_session_ids {
+                        Some(ids) if !ids.is_empty() => {
+                            let terminal =
+                                self.sessions.terminal_child_ids(&parent.id, &ids).await;
+                            partition_wait_targets(ids, &terminal)
+                        }
+                        _ => (
+                            self.sessions.active_child_ids(&parent.id).await,
+                            Vec::new(),
+                        ),
+                    };
+                let dropped_ids: Vec<String> =
+                    dropped.iter().map(|(id, _)| id.clone()).collect();
+
+                // Policy short-circuit (issue #546): if the already-terminal
+                // ids satisfy the policy on their own (`any` — any terminal;
+                // `first_error` — any error-like terminal), suspending on the
+                // remainder would sleep past an answer the model already has.
+                if wait_already_satisfied_by_dropped(policy, &dropped) {
+                    return tool_result(json!({
+                        "status": "already_satisfied",
+                        "parent_session_id": parent_session_id,
+                        "satisfied_by": dropped
+                            .iter()
+                            .map(|(id, status)| json!({ "child_session_id": id, "status": status }))
+                            .collect::<Vec<_>>(),
+                        "still_active_child_ids": targets,
+                        "wait_for": policy.as_str(),
+                        "note": "The wait policy is already satisfied by finished child \
+                                 session(s) — the parent was NOT suspended. Use SubAgent.get \
+                                 to read their results; call wait again (without those ids) \
+                                 if you still need the remaining children.",
+                    }))
+                    .map(ToolOutcome::Completed);
+                }
 
                 if targets.is_empty() {
                     // Nothing left to wait on — never register an empty wait
                     // (that would suspend the parent with no child able to
                     // resume it). Any explicitly named children are already
-                    // terminal (or unknown): tell the model to read their
-                    // results instead of suspending.
-                    let note = if dropped.is_empty() {
+                    // terminal: tell the model to read their results instead
+                    // of suspending.
+                    let note = if dropped_ids.is_empty() {
                         "No active child sessions to wait for; the parent continues running."
                             .to_string()
                     } else {
                         format!(
                             "The requested child session(s) [{}] are already finished; nothing \
                              to wait for. Use SubAgent.get to read their results.",
-                            dropped.join(", ")
+                            dropped_ids.join(", ")
                         )
                     };
                     return tool_result(json!({
                         "status": "no_active_children",
                         "parent_session_id": parent_session_id,
-                        "already_terminal_child_ids": dropped,
+                        "already_terminal_child_ids": dropped_ids,
                         "note": note,
                     }))
                     .map(ToolOutcome::Completed);
@@ -850,7 +905,7 @@ impl Tool for SubAgentTool {
                     "status": "waiting",
                     "parent_session_id": parent_session_id,
                     "child_session_ids": targets,
-                    "already_terminal_child_ids": dropped,
+                    "already_terminal_child_ids": dropped_ids,
                     "wait_for": policy.as_str(),
                     "waiting_on": count,
                 }))
@@ -1017,10 +1072,10 @@ mod tests {
     fn partition_wait_targets_drops_only_known_terminal_ids() {
         let (targets, dropped) = partition_wait_targets(
             vec!["done".into(), "running".into(), "unknown".into()],
-            &["done".to_string()],
+            &[("done".to_string(), "completed".to_string())],
         );
         assert_eq!(targets, vec!["running".to_string(), "unknown".to_string()]);
-        assert_eq!(dropped, vec!["done".to_string()]);
+        assert_eq!(dropped, vec![("done".to_string(), "completed".to_string())]);
 
         // Index-less backend: nothing reported terminal → nothing filtered.
         let (targets, dropped) = partition_wait_targets(vec!["a".into(), "b".into()], &[]);
@@ -1030,10 +1085,50 @@ mod tests {
         // Everything already finished → nothing left to wait on.
         let (targets, dropped) = partition_wait_targets(
             vec!["a".into(), "b".into()],
-            &["a".to_string(), "b".to_string()],
+            &[
+                ("a".to_string(), "completed".to_string()),
+                ("b".to_string(), "error".to_string()),
+            ],
         );
         assert!(targets.is_empty());
-        assert_eq!(dropped, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(dropped.len(), 2);
+    }
+
+    #[test]
+    fn wait_short_circuits_when_dropped_ids_satisfy_the_policy() {
+        let completed = [("a".to_string(), "completed".to_string())];
+        let errored = [("a".to_string(), "timeout".to_string())];
+
+        // `all`: waiting on the remainder is equivalent — never short-circuit.
+        assert!(!wait_already_satisfied_by_dropped(
+            ChildWaitPolicy::All,
+            &completed
+        ));
+        assert!(!wait_already_satisfied_by_dropped(
+            ChildWaitPolicy::All,
+            &errored
+        ));
+
+        // `any`: ANY terminal child satisfies the wait before it is armed.
+        assert!(wait_already_satisfied_by_dropped(
+            ChildWaitPolicy::Any,
+            &completed
+        ));
+        assert!(!wait_already_satisfied_by_dropped(
+            ChildWaitPolicy::Any,
+            &[]
+        ));
+
+        // `first_error`: only an error-like terminal child short-circuits; a
+        // completed one still waits on the remainder (all-complete fallback).
+        assert!(wait_already_satisfied_by_dropped(
+            ChildWaitPolicy::FirstError,
+            &errored
+        ));
+        assert!(!wait_already_satisfied_by_dropped(
+            ChildWaitPolicy::FirstError,
+            &completed
+        ));
     }
 
     #[test]

--- a/crates/app/bamboo-server-tools/src/sub_agent.rs
+++ b/crates/app/bamboo-server-tools/src/sub_agent.rs
@@ -219,6 +219,20 @@ fn waiting_for_children_tool_result(mut value: serde_json::Value) -> Result<Tool
     })
 }
 
+/// Split an explicit `SubAgent.wait` id list into `(targets, dropped)`:
+/// `dropped` = ids the index positively reported terminal (waiting on them
+/// could never be satisfied — issue #546), `targets` = everything else,
+/// including unknown ids (kept: the watchdog rescues a bogus id at runtime;
+/// an index-less backend reports nothing terminal and filters nothing).
+fn partition_wait_targets(
+    requested: Vec<String>,
+    known_terminal: &[String],
+) -> (Vec<String>, Vec<String>) {
+    requested
+        .into_iter()
+        .partition(|id| !known_terminal.contains(id))
+}
+
 /// Map a `ChildSessionError` to a `ToolError`.
 fn tool_error_from_child_session(error: ChildSessionError) -> ToolError {
     match error {
@@ -783,19 +797,45 @@ impl Tool for SubAgentTool {
             } => {
                 let policy = wait_for.unwrap_or(ChildWaitPolicy::All);
                 // Default to every currently-active child; honor an explicit
-                // subset when provided.
-                let targets = match child_session_ids {
-                    Some(ids) if !ids.is_empty() => ids,
-                    _ => self.sessions.active_child_ids(&parent.id).await,
+                // subset when provided. Explicit ids the index POSITIVELY
+                // reports terminal are dropped (issue #546): a terminal child
+                // fires no further completion, so a wait registered over it
+                // previously suspended the parent forever. Unknown ids are
+                // KEPT (an index-less backend or a not-yet-indexed child must
+                // not be mistaken for finished); if such an id turns out to be
+                // bogus, the child-wait watchdog rescues the parent at runtime.
+                let (targets, dropped): (Vec<String>, Vec<String>) = match child_session_ids {
+                    Some(ids) if !ids.is_empty() => {
+                        let terminal = self.sessions.terminal_child_ids(&parent.id, &ids).await;
+                        partition_wait_targets(ids, &terminal)
+                    }
+                    _ => (
+                        self.sessions.active_child_ids(&parent.id).await,
+                        Vec::new(),
+                    ),
                 };
 
                 if targets.is_empty() {
-                    // Nothing to wait on — never register an empty wait (that
-                    // would suspend the parent with no child able to resume it).
+                    // Nothing left to wait on — never register an empty wait
+                    // (that would suspend the parent with no child able to
+                    // resume it). Any explicitly named children are already
+                    // terminal (or unknown): tell the model to read their
+                    // results instead of suspending.
+                    let note = if dropped.is_empty() {
+                        "No active child sessions to wait for; the parent continues running."
+                            .to_string()
+                    } else {
+                        format!(
+                            "The requested child session(s) [{}] are already finished; nothing \
+                             to wait for. Use SubAgent.get to read their results.",
+                            dropped.join(", ")
+                        )
+                    };
                     return tool_result(json!({
                         "status": "no_active_children",
                         "parent_session_id": parent_session_id,
-                        "note": "No active child sessions to wait for; the parent continues running.",
+                        "already_terminal_child_ids": dropped,
+                        "note": note,
                     }))
                     .map(ToolOutcome::Completed);
                 }
@@ -810,6 +850,7 @@ impl Tool for SubAgentTool {
                     "status": "waiting",
                     "parent_session_id": parent_session_id,
                     "child_session_ids": targets,
+                    "already_terminal_child_ids": dropped,
                     "wait_for": policy.as_str(),
                     "waiting_on": count,
                 }))
@@ -971,6 +1012,29 @@ impl Tool for SubAgentTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn partition_wait_targets_drops_only_known_terminal_ids() {
+        let (targets, dropped) = partition_wait_targets(
+            vec!["done".into(), "running".into(), "unknown".into()],
+            &["done".to_string()],
+        );
+        assert_eq!(targets, vec!["running".to_string(), "unknown".to_string()]);
+        assert_eq!(dropped, vec!["done".to_string()]);
+
+        // Index-less backend: nothing reported terminal → nothing filtered.
+        let (targets, dropped) = partition_wait_targets(vec!["a".into(), "b".into()], &[]);
+        assert_eq!(targets, vec!["a".to_string(), "b".to_string()]);
+        assert!(dropped.is_empty());
+
+        // Everything already finished → nothing left to wait on.
+        let (targets, dropped) = partition_wait_targets(
+            vec!["a".into(), "b".into()],
+            &["a".to_string(), "b".to_string()],
+        );
+        assert!(targets.is_empty());
+        assert_eq!(dropped, vec!["a".to_string(), "b".to_string()]);
+    }
 
     #[test]
     fn normalize_title_accepts_legacy_description() {

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -646,6 +646,13 @@ impl AppState {
         let bash_resume_hook: Arc<dyn bamboo_engine::BashResumeHook> =
             child_completion_coordinator.clone();
 
+        // Child-wait watchdog (issue #546): boot-time reconciliation of
+        // children orphaned by a restart, then a periodic heartbeat sweep that
+        // backstops every lost child→parent wake (panicked child task, dead
+        // spawn scheduler, clobbered resume, expired wait lease, ...). Spawned
+        // AFTER `set_root_tools` above so a boot-time parent resume can spawn.
+        child_completion_coordinator.spawn_child_wait_watchdog();
+
         // Cluster-fabric reconcile: session-bound workers died with the previous
         // bamboo process (kill-on-drop child / in-memory russh session), so any
         // persisted `Running`/`Deploying` node state is stale on boot. Flip it to

--- a/crates/app/bamboo-server/src/connect/approvals.rs
+++ b/crates/app/bamboo-server/src/connect/approvals.rs
@@ -568,6 +568,9 @@ impl ResumeExecutionPort for ConnectResumePort {
                 runners: self.ctx.agent_runners.clone(),
                 sessions_cache: self.ctx.session_repo.cache().clone(),
                 on_complete: None,
+                // Connect drives root sessions; a child finishing on this
+                // path is backstopped by the child-wait watchdog (#546).
+                child_completion_handler: None,
             });
             return;
         };
@@ -678,6 +681,9 @@ impl ResumeExecutionPort for ConnectResumePort {
                 runners: ctx.agent_runners.clone(),
                 sessions_cache: ctx.session_repo.cache().clone(),
                 on_complete: None,
+                // Connect drives root sessions; a child finishing on this
+                // path is backstopped by the child-wait watchdog (#546).
+                child_completion_handler: None,
             });
         });
     }

--- a/crates/app/bamboo-server/src/connect/bridge.rs
+++ b/crates/app/bamboo-server/src/connect/bridge.rs
@@ -846,6 +846,9 @@ impl ConnectBridge {
             runners: self.ctx.agent_runners.clone(),
             sessions_cache: self.ctx.session_repo.cache().clone(),
             on_complete: None,
+            // Connect drives root sessions; a child finishing on this path
+            // is backstopped by the child-wait watchdog (#546).
+            child_completion_handler: None,
         });
 
         self.render_until_settled(key, platform, reply_ctx.clone(), &session_id, rx)

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
@@ -217,6 +217,10 @@ pub(crate) fn spawn_agent_execution(args: SpawnAgentExecution) {
         runners: args.state.agent_runners.clone(),
         sessions_cache: args.state.sessions.clone(),
         on_complete: None,
+        // Resumed/child sessions finishing on this path wake their waiting
+        // parent through the completion coordinator (issue #546); the
+        // publish is gated on kind=Child inside `spawn_session_execution`.
+        child_completion_handler: Some(args.state.child_completion_coordinator.clone()),
     });
 }
 

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -601,6 +601,8 @@ async fn run_schedule_job(
         runners: ctx.agent_runners.clone(),
         sessions_cache: ctx.sessions_cache.clone(),
         on_complete: Some(on_complete),
+        // Scheduled runs are root sessions — no parent to wake.
+        child_completion_handler: None,
     });
 
     Ok(ScheduleRunLifecycleResult::BackgroundExecutionInProgress)

--- a/crates/app/bamboo-server/src/tools/child_session_adapter.rs
+++ b/crates/app/bamboo-server/src/tools/child_session_adapter.rs
@@ -299,14 +299,14 @@ impl ChildSessionAdapter {
     }
 
     /// The subset of `candidates` the session index POSITIVELY reports as
-    /// terminal children of this parent (issue #546). Unknown ids are not
-    /// reported — an index-less backend or a not-yet-indexed child must not be
-    /// mistaken for a finished one.
+    /// terminal children of this parent, as `(child_id, status)` pairs
+    /// (issue #546). Unknown ids are not reported — an index-less backend or
+    /// a not-yet-indexed child must not be mistaken for a finished one.
     pub async fn terminal_child_ids(
         &self,
         parent_session_id: &str,
         candidates: &[String],
-    ) -> Vec<String> {
+    ) -> Vec<(String, String)> {
         let statuses = self
             .storage
             .list_child_run_statuses(parent_session_id)
@@ -314,12 +314,13 @@ impl ChildSessionAdapter {
             .unwrap_or_default();
         candidates
             .iter()
-            .filter(|candidate| {
-                statuses.iter().any(|(id, status)| {
-                    id == *candidate && status.as_deref().is_some_and(is_terminal_child_status)
+            .filter_map(|candidate| {
+                statuses.iter().find_map(|(id, status)| {
+                    let status = status.as_deref()?;
+                    (id == candidate && is_terminal_child_status(status))
+                        .then(|| (candidate.clone(), status.to_string()))
                 })
             })
-            .cloned()
             .collect()
     }
 
@@ -800,7 +801,7 @@ impl ChildSessionPort for ChildSessionAdapter {
         &self,
         parent_session_id: &str,
         candidates: &[String],
-    ) -> Vec<String> {
+    ) -> Vec<(String, String)> {
         ChildSessionAdapter::terminal_child_ids(self, parent_session_id, candidates).await
     }
 

--- a/crates/app/bamboo-server/src/tools/child_session_adapter.rs
+++ b/crates/app/bamboo-server/src/tools/child_session_adapter.rs
@@ -298,6 +298,31 @@ impl ChildSessionAdapter {
             .collect()
     }
 
+    /// The subset of `candidates` the session index POSITIVELY reports as
+    /// terminal children of this parent (issue #546). Unknown ids are not
+    /// reported — an index-less backend or a not-yet-indexed child must not be
+    /// mistaken for a finished one.
+    pub async fn terminal_child_ids(
+        &self,
+        parent_session_id: &str,
+        candidates: &[String],
+    ) -> Vec<String> {
+        let statuses = self
+            .storage
+            .list_child_run_statuses(parent_session_id)
+            .await
+            .unwrap_or_default();
+        candidates
+            .iter()
+            .filter(|candidate| {
+                statuses.iter().any(|(id, status)| {
+                    id == *candidate && status.as_deref().is_some_and(is_terminal_child_status)
+                })
+            })
+            .cloned()
+            .collect()
+    }
+
     /// Persist a batch of parent-wait registrations in one runtime-only save.
     async fn flush_parent_waits(
         &self,
@@ -769,6 +794,14 @@ impl ChildSessionPort for ChildSessionAdapter {
 
     async fn active_child_ids(&self, parent_session_id: &str) -> Vec<String> {
         ChildSessionAdapter::active_child_ids(self, parent_session_id).await
+    }
+
+    async fn terminal_child_ids(
+        &self,
+        parent_session_id: &str,
+        candidates: &[String],
+    ) -> Vec<String> {
+        ChildSessionAdapter::terminal_child_ids(self, parent_session_id, candidates).await
     }
 
     async fn ensure_child_indexed(&self, child_session_id: &str) {

--- a/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
+++ b/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
@@ -495,6 +495,10 @@ async fn create_with_wait_true_suspends_and_registers_wait() {
 #[tokio::test]
 async fn wait_action_with_explicit_children_suspends_and_registers() {
     let harness = build_test_harness().await;
+    // The jsonl-backed harness has no child index, so nothing is positively
+    // reported terminal and every requested id must be KEPT (issue #546:
+    // unknown ≠ finished — only index-confirmed terminal ids are dropped; a
+    // truly bogus id is rescued by the child-wait watchdog at runtime).
     let result = invoke_completed(
         &harness.tool,
         json!({
@@ -515,6 +519,13 @@ async fn wait_action_with_explicit_children_suspends_and_registers() {
     let payload: serde_json::Value = serde_json::from_str(&result.result).unwrap();
     assert_eq!(payload["status"].as_str(), Some("waiting"));
     assert_eq!(payload["wait_for"].as_str(), Some("any"));
+    assert_eq!(
+        payload["already_terminal_child_ids"]
+            .as_array()
+            .map(Vec::len),
+        Some(0),
+        "nothing may be dropped when the index reports no terminal children: {payload}"
+    );
 
     let parent = harness
         .storage

--- a/crates/core/bamboo-domain/src/storage.rs
+++ b/crates/core/bamboo-domain/src/storage.rs
@@ -61,6 +61,22 @@ pub trait Storage: Send + Sync {
         Ok(Vec::new())
     }
 
+    /// List `(session_id, parent_session_id)` for every session whose
+    /// `last_run_status` equals `status`, sourced from the backend's index.
+    ///
+    /// The child-wait watchdog (issue #546) uses this to cheaply enumerate
+    /// candidates — sessions suspended on children (`status == "suspended"`)
+    /// and orphaned children left `"running"` by a process restart — without
+    /// loading every session. Backends without an index return an empty list
+    /// by default, which degrades the watchdog to a no-op (never an error).
+    async fn list_sessions_by_run_status(
+        &self,
+        status: &str,
+    ) -> std::io::Result<Vec<(String, Option<String>)>> {
+        let _ = status;
+        Ok(Vec::new())
+    }
+
     /// Append one analysis record — a single JSON line — to the session's
     /// dedicated, append-only token-usage log, stored alongside the session's
     /// other files in its per-session directory.

--- a/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
@@ -21,6 +21,7 @@ use crate::runtime::config::{
     AuxiliaryModelConfig, BashCompletionSink, BashResumeHook, GoldConfig, GuardianConfig,
     GuardianSpawner, ImageFallbackConfig,
 };
+use crate::runtime::execution::child_completion::ChildCompletion;
 use crate::runtime::execution::runner_lifecycle::finalize_runner;
 use crate::runtime::execution::runner_state::AgentRunner;
 use crate::runtime::model_roster::ModelRoster;
@@ -162,6 +163,19 @@ pub struct SessionExecutionArgs {
     /// Optional bespoke finalization, run after the runner is finalized and
     /// before the session is persisted. See [`SessionCompletionHook`].
     pub on_complete: Option<SessionCompletionHook>,
+
+    /// Child-completion publisher for CHILD sessions driven through this path
+    /// (issue #546). The canonical first run of a child goes through
+    /// `run_child_spawn`, which publishes its own terminal completion — but a
+    /// child RESUMED later (after an approval, a clarification answer, or a
+    /// nested child-parent woken by its own children) runs through
+    /// `spawn_session_execution` and previously published nothing, so the
+    /// waiting parent was never woken. When set and `session.kind == Child`
+    /// with a parent id, the terminal block invokes this handler after the
+    /// final persist + runner finalization. Non-terminal suspends publish the
+    /// non-terminal "suspended" status, which the coordinator's terminality
+    /// guard ignores.
+    pub child_completion_handler: Option<Arc<dyn super::ChildCompletionHandler>>,
 }
 
 /// The per-request parameter subset of [`SessionExecutionArgs`] — everything
@@ -319,6 +333,7 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
                 runners,
                 sessions_cache,
                 on_complete,
+                child_completion_handler,
             } = args;
 
             // The primary model is required for a spawn; the roster stores it as
@@ -453,11 +468,51 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
             // lingering in its optimistic-settle window.
             finalize_runner(&runners, &session_id, &result).await;
 
+            // A CHILD session finishing through this path (a resumed child, or
+            // a nested child-parent woken by its own children) must wake its
+            // waiting parent (issue #546). Publish AFTER the final persist and
+            // runner finalization so the coordinator reads the child's settled
+            // terminal state — the resume message folds in the child's final
+            // assistant content from storage. The status mirrors the
+            // `last_run_status` mapping above; a non-terminal "suspended" is
+            // published too and ignored by the coordinator's terminality guard.
+            let child_completion = child_completion_handler.filter(|_| {
+                session.kind == bamboo_agent_core::SessionKind::Child
+                    && session.parent_session_id.is_some()
+            });
+            let parent_session_id = session.parent_session_id.clone();
+            let child_status = session.last_run_status();
+            let child_error = session.last_run_error();
+
             // Update memory cache.
             sessions_cache.insert(
                 session_id.clone(),
                 Arc::new(parking_lot::RwLock::new(session)),
             );
+
+            if let (Some(handler), Some(parent_session_id), Some(status)) =
+                (child_completion, parent_session_id, child_status)
+            {
+                use futures::FutureExt;
+                let completion = ChildCompletion {
+                    parent_session_id: parent_session_id.clone(),
+                    child_session_id: session_id.clone(),
+                    status,
+                    error: child_error,
+                    completed_at: chrono::Utc::now(),
+                };
+                if std::panic::AssertUnwindSafe(handler.on_child_completed(completion))
+                    .catch_unwind()
+                    .await
+                    .is_err()
+                {
+                    tracing::error!(
+                        %parent_session_id,
+                        child_session_id = %session_id,
+                        "child completion handler panicked on resumed-child terminal"
+                    );
+                }
+            }
 
             tracing::info!("[{}] Agent execution completed", session_id);
         }

--- a/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
@@ -400,7 +400,36 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
                 },
             );
 
-            let result = agent.execute(&mut session, execute_request).await;
+            // Panic containment (issue #546): everything below — the terminal
+            // status persist, finalize_runner, and the child-completion
+            // publish — only runs if this task survives execution. An
+            // unwinding panic would leave a zombie Running runner entry (which
+            // blinds liveness checks) and, for a child session, strand its
+            // waiting parent. Map a panic to a terminal error instead.
+            let result = {
+                use futures::FutureExt;
+                match std::panic::AssertUnwindSafe(agent.execute(&mut session, execute_request))
+                    .catch_unwind()
+                    .await
+                {
+                    Ok(result) => result,
+                    Err(panic) => {
+                        let message = panic
+                            .downcast_ref::<&str>()
+                            .map(|s| (*s).to_string())
+                            .or_else(|| panic.downcast_ref::<String>().cloned())
+                            .unwrap_or_else(|| "non-string panic payload".to_string());
+                        tracing::error!(
+                            "[{}] agent execution panicked; finalizing as terminal error: {}",
+                            session_id,
+                            message
+                        );
+                        Err(AgentError::LLM(format!(
+                            "agent execution panicked: {message}"
+                        )))
+                    }
+                }
+            };
 
             // Send terminal event for all error cases (including cancellation).
             if let Some(error_event) = terminal_error_event_for_result(&result) {

--- a/crates/engine/bamboo-engine/src/runtime/execution/spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/spawn.rs
@@ -88,10 +88,43 @@ impl SpawnScheduler {
     pub fn new(ctx: SpawnContext) -> Self {
         let (tx, mut rx) = mpsc::channel::<SpawnJob>(128);
 
+        // The worker loop is a single point of failure for ALL child spawning:
+        // if it unwinds, queued jobs are dropped with no completion published
+        // and every later enqueue fails with "spawn scheduler is not running"
+        // for the rest of the process lifetime. Run each job on its own task
+        // and await the JoinHandle — a panicking job is isolated, keeps the
+        // worker alive, and still publishes a terminal error completion so the
+        // waiting parent is woken instead of stranded.
         tokio::spawn(async move {
             while let Some(job) = rx.recv().await {
-                if let Err(err) = run_spawn_job(ctx.clone(), job).await {
-                    tracing::warn!("spawn job failed: {}", err);
+                let job_ctx = ctx.clone();
+                let job_for_panic = job.clone();
+                let handle = tokio::spawn(async move {
+                    if let Err(err) = run_spawn_job(job_ctx, job).await {
+                        tracing::warn!("spawn job failed: {}", err);
+                    }
+                });
+                if let Err(join_error) = handle.await {
+                    tracing::error!(
+                        parent_session_id = %job_for_panic.parent_session_id,
+                        child_session_id = %job_for_panic.child_session_id,
+                        error = %join_error,
+                        "spawn job panicked; publishing terminal error completion"
+                    );
+                    let parent_tx = super::session_events::get_or_create_event_sender(
+                        &ctx.session_event_senders,
+                        &job_for_panic.parent_session_id,
+                    )
+                    .await;
+                    publish_child_completion_parts(
+                        &parent_tx,
+                        ctx.completion_handler.clone(),
+                        job_for_panic.parent_session_id.clone(),
+                        job_for_panic.child_session_id.clone(),
+                        "error".to_string(),
+                        Some(format!("child spawn panicked: {join_error}")),
+                    )
+                    .await;
                 }
             }
         });
@@ -110,8 +143,11 @@ impl SpawnScheduler {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ChildWatchdogPolicy {
     check_interval_secs: i64,
-    max_total_secs: i64,
-    max_idle_secs: i64,
+    // pub(crate): the child-wait watchdog (#546) reads these limits to decide
+    // when a Running runner entry whose task died (frozen last_event_at) is
+    // stale beyond what the per-child liveness watchdog could still act on.
+    pub(crate) max_total_secs: i64,
+    pub(crate) max_idle_secs: i64,
 }
 
 impl Default for ChildWatchdogPolicy {
@@ -163,7 +199,26 @@ async fn publish_child_completion(
     });
 
     if let Some(handler) = completion_handler {
-        handler.on_child_completed(completion).await;
+        // Contain a panicking handler: this call frequently runs on the caller's
+        // only liveness-critical task (the child's terminal block, or the spawn
+        // scheduler worker for early failures). Unwinding here would kill that
+        // task after the child already looks terminal everywhere — the classic
+        // stranded-parent signature. The child-wait watchdog backstops the wake
+        // that a panicked handler failed to deliver.
+        use futures::FutureExt;
+        let parent_session_id = completion.parent_session_id.clone();
+        let child_session_id = completion.child_session_id.clone();
+        if std::panic::AssertUnwindSafe(handler.on_child_completed(completion))
+            .catch_unwind()
+            .await
+            .is_err()
+        {
+            tracing::error!(
+                %parent_session_id,
+                %child_session_id,
+                "child completion handler panicked; child-wait watchdog will backstop the parent wake"
+            );
+        }
     }
 }
 

--- a/crates/engine/bamboo-engine/src/sdk/spawn.rs
+++ b/crates/engine/bamboo-engine/src/sdk/spawn.rs
@@ -100,6 +100,17 @@ pub async fn run_child_spawn(ctx: SpawnContext, job: SpawnJob) -> Result<(), Str
 
     if session.kind != SessionKind::Child {
         let error = "spawn job child session is not kind=child".to_string();
+        // Persist the terminal status so the session index never reports this
+        // child as pending/running — a wait registered over it later (or the
+        // orphan safety net) would otherwise hang on a status that no future
+        // completion can ever advance.
+        session.set_last_run_status("error");
+        session.set_last_run_error(error.clone());
+        let _ = ctx
+            .agent
+            .persistence()
+            .save_runtime_session(&mut session)
+            .await;
         publish_child_completion_parts(
             &parent_tx,
             ctx.completion_handler.clone(),
@@ -160,6 +171,17 @@ pub async fn run_child_spawn(ctx: SpawnContext, job: SpawnJob) -> Result<(), Str
     )
     .await
     else {
+        // A Running runner already exists for this child (duplicate enqueue, or
+        // a stale entry left by a dead task). Publish nothing: if the earlier
+        // run is alive its own completion will fire; if it is a stale entry the
+        // child-wait watchdog will detect the dead child and synthesize an
+        // error completion. Publishing "error" here would falsely satisfy the
+        // parent's wait while a genuine run is still in flight.
+        tracing::warn!(
+            parent_session_id = %job.parent_session_id,
+            child_session_id = %job.child_session_id,
+            "child spawn skipped: runner already registered for this child"
+        );
         return Ok(());
     };
 
@@ -273,11 +295,43 @@ pub async fn run_child_spawn(ctx: SpawnContext, job: SpawnJob) -> Result<(), Str
         // via BashOutput. No strand can occur because the gate refuses to
         // suspend without the hook. (The parent-resume path re-wires the hook,
         // so a RESUMED run is covered; only the initial child run is not.)
+        // Panic containment: this task's terminal block below is the ONLY thing
+        // that publishes the child's completion — if execution panics and the
+        // task unwinds, the parent waits forever on a wake that can never fire.
+        // Catch the unwind and map it to a terminal error instead. The session
+        // may have been partially mutated by the panicking run; that is
+        // acceptable — we persist what we have and surface the panic as the
+        // child's error so the parent can decide how to proceed.
         let result: crate::runtime::runner::Result<()> =
             if external_runner.should_handle(&session).await {
-                external_runner
-                    .execute_external_child(&mut session, &job, mpsc_tx, cancel_token.clone())
-                    .await
+                use futures::FutureExt;
+                match std::panic::AssertUnwindSafe(external_runner.execute_external_child(
+                    &mut session,
+                    &job,
+                    mpsc_tx,
+                    cancel_token.clone(),
+                ))
+                .catch_unwind()
+                .await
+                {
+                    Ok(result) => result,
+                    Err(panic) => {
+                        let message = panic
+                            .downcast_ref::<&str>()
+                            .map(|s| (*s).to_string())
+                            .or_else(|| panic.downcast_ref::<String>().cloned())
+                            .unwrap_or_else(|| "non-string panic payload".to_string());
+                        tracing::error!(
+                            parent_session_id = %job.parent_session_id,
+                            child_session_id = %job.child_session_id,
+                            panic = %message,
+                            "child execution panicked; publishing terminal error completion"
+                        );
+                        Err(bamboo_agent_core::AgentError::LLM(format!(
+                            "child execution panicked: {message}"
+                        )))
+                    }
+                }
             } else {
                 Err(bamboo_agent_core::AgentError::LLM(format!(
                 "No child runner matched session runtime metadata: agent_id={:?}, protocol={:?}",
@@ -297,16 +351,19 @@ pub async fn run_child_spawn(ctx: SpawnContext, job: SpawnJob) -> Result<(), Str
         // likewise NOT done — it must not publish a premature terminal
         // "completed" to its parent while a `run_in_background` shell is still
         // running for it.
-        let suspended_non_terminal = session
-            .metadata
-            .get("runtime.suspend_reason")
-            .map(|reason| {
-                matches!(
-                    reason.as_str(),
-                    "awaiting_parent_approval" | "waiting_for_bash"
-                )
-            })
-            .unwrap_or(false);
+        //
+        // Issue #546: the same holds for EVERY suspend reason — a child-parent
+        // suspending on its own grandchildren (waiting_for_children) or on a
+        // human clarification is not done either. Any non-empty suspend reason
+        // maps to the non-terminal "suspended" status (mirroring the top-level
+        // mapping in `agent_spawn`), which the completion coordinator's
+        // terminality guard leaves un-counted; the real terminal completion is
+        // published when the child later resumes and finishes.
+        let suspended_non_terminal = result.is_ok()
+            && session
+                .metadata
+                .get("runtime.suspend_reason")
+                .is_some_and(|reason| !reason.trim().is_empty());
         let (status, error) = if let Some(reason) = timeout_error {
             ("timeout".to_string(), Some(reason))
         } else if suspended_non_terminal && result.is_ok() {

--- a/crates/engine/bamboo-engine/src/sdk/spawn.rs
+++ b/crates/engine/bamboo-engine/src/sdk/spawn.rs
@@ -123,6 +123,17 @@ pub async fn run_child_spawn(ctx: SpawnContext, job: SpawnJob) -> Result<(), Str
         return Err(error);
     }
 
+    // Clear suspend leftovers from a PRIOR run (issue #546): a child that
+    // suspended (clarification/approval), was answered through the parent via
+    // `send_message`/`run`, and is now re-enqueued still carries the old
+    // `runtime.suspend_reason` + pending question — none of the re-run entry
+    // points perform respond.rs's clear. The terminal mapping below must only
+    // observe suspend state stamped by THIS run, otherwise a genuinely
+    // completed re-run is published as non-terminal "suspended" and the
+    // parent stalls until the wait lease expires.
+    session.metadata.remove("runtime.suspend_reason");
+    session.clear_pending_question();
+
     // Ensure last message is user (otherwise nothing to do).
     let last_is_user = session
         .messages

--- a/crates/engine/bamboo-engine/src/sdk/spawn.rs
+++ b/crates/engine/bamboo-engine/src/sdk/spawn.rs
@@ -377,7 +377,7 @@ pub async fn run_child_spawn(ctx: SpawnContext, job: SpawnJob) -> Result<(), Str
                 .is_some_and(|reason| !reason.trim().is_empty());
         let (status, error) = if let Some(reason) = timeout_error {
             ("timeout".to_string(), Some(reason))
-        } else if suspended_non_terminal && result.is_ok() {
+        } else if suspended_non_terminal {
             ("suspended".to_string(), None)
         } else {
             match &result {

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -164,6 +164,7 @@ fn wait_policy_satisfied(
     policy: ChildWaitPolicy,
     wait_child_ids: &[String],
     completed_child_ids: &[String],
+    latest_child_id: &str,
     latest_status: &str,
 ) -> bool {
     if wait_child_ids.is_empty() {
@@ -178,7 +179,12 @@ fn wait_policy_satisfied(
             .iter()
             .any(|id| wait_child_ids.iter().any(|wait_id| wait_id == id)),
         ChildWaitPolicy::FirstError => {
-            is_error_like(latest_status)
+            // The error short-circuit only counts a completion from a child
+            // this wait actually tracks (issue #546): a stray/duplicate
+            // completion from an untracked child — e.g. a frozen runner's
+            // task waking up after the watchdog already synthesized its
+            // timeout, in a later run's wait — must not resume the parent.
+            (is_error_like(latest_status) && wait_child_ids.iter().any(|id| id == latest_child_id))
                 || wait_child_ids
                     .iter()
                     .all(|id| completed_child_ids.iter().any(|completed| completed == id))
@@ -485,6 +491,7 @@ impl ChildCompletionHandler for ChildCompletionCoordinator {
                 wait.wait_for,
                 &wait.child_session_ids,
                 &completed_child_ids,
+                &completion.child_session_id,
                 &completion.status,
             );
             if should_resume {
@@ -1580,8 +1587,18 @@ impl ChildCompletionCoordinator {
             .into_iter()
             .collect();
 
+        struct DeadChild {
+            child_id: String,
+            status: String,
+            reason: String,
+            /// `false` = the id does not name a child of THIS parent (wait ids
+            /// are model-provided and unvalidated): publish the wake but never
+            /// persist onto / cancel / finalize the named session.
+            owned: bool,
+        }
+
         let mut terminal: Vec<(String, String)> = Vec::new();
-        let mut dead: Vec<(String, String, String)> = Vec::new();
+        let mut dead: Vec<DeadChild> = Vec::new();
         for child_id in &wait.child_session_ids {
             let status = statuses.get(child_id).and_then(|status| status.as_deref());
             if let Some(status) = status {
@@ -1591,6 +1608,32 @@ impl ChildCompletionCoordinator {
                 }
             }
             if !is_dead_child_candidate_status(status) {
+                continue;
+            }
+
+            // Ownership check BEFORE anything destructive: `SubAgent.wait` ids
+            // are model-provided and unvalidated, so an id absent from the
+            // parent-scoped status map may name a REAL session in another tree
+            // (a grandchild, a foreign root). Such a session must never be
+            // mutated, cancelled, or finalized here — but the parent's bogus
+            // wait entry still needs a synthetic completion to clear it.
+            let control_plane = self.load_control_plane(child_id).await;
+            let owned = control_plane
+                .as_ref()
+                .is_some_and(|cp| cp.parent_session_id.as_deref() == Some(parent_session_id));
+            if !owned {
+                dead.push(DeadChild {
+                    child_id: child_id.clone(),
+                    status: "error".to_string(),
+                    reason: if control_plane.is_some() {
+                        "waited-on session id is not a child of this session; clearing it \
+                         from the wait without touching that session"
+                            .to_string()
+                    } else {
+                        "waited-on child session does not exist".to_string()
+                    },
+                    owned: false,
+                });
                 continue;
             }
 
@@ -1605,9 +1648,9 @@ impl ChildCompletionCoordinator {
                     let last_activity = runner.last_event_at.unwrap_or(runner.started_at);
                     let idle_secs = now.signed_duration_since(last_activity).num_seconds();
                     let total_secs = now.signed_duration_since(runner.started_at).num_seconds();
-                    let policy = match self.load_control_plane(child_id).await {
+                    let policy = match &control_plane {
                         Some(child) => {
-                            crate::runtime::execution::spawn::watchdog_policy_for_session(&child)
+                            crate::runtime::execution::spawn::watchdog_policy_for_session(child)
                         }
                         None => Default::default(),
                     };
@@ -1617,57 +1660,70 @@ impl ChildCompletionCoordinator {
                         .saturating_add(STALE_RUNNER_SLACK_SECS);
                     if idle_secs >= idle_limit || total_secs >= total_limit {
                         runner.cancel_token.cancel();
-                        dead.push((
-                            child_id.clone(),
-                            "timeout".to_string(),
-                            format!(
+                        dead.push(DeadChild {
+                            child_id: child_id.clone(),
+                            status: "timeout".to_string(),
+                            reason: format!(
                                 "child runner stalled: no events for {idle_secs}s \
                                  (limit {idle_limit}s including watchdog slack); \
                                  force-finalized by the child-wait watchdog"
                             ),
-                        ));
+                            owned: true,
+                        });
                     }
                 }
                 _ => {
                     // Nothing is driving this child, yet its index status will
                     // never advance by itself. The grace covers the enqueue →
                     // running-marker window and slow spawn queues.
-                    let quiet_secs = match self.load_control_plane(child_id).await {
-                        Some(child) => now.signed_duration_since(child.updated_at).num_seconds(),
-                        // Session gone entirely (deleted mid-wait).
-                        None => i64::MAX,
-                    };
+                    let quiet_secs = control_plane
+                        .as_ref()
+                        .map(|child| now.signed_duration_since(child.updated_at).num_seconds())
+                        .unwrap_or(i64::MAX);
                     if quiet_secs >= DEAD_CHILD_GRACE_SECS {
-                        dead.push((
-                            child_id.clone(),
-                            "error".to_string(),
-                            format!(
+                        dead.push(DeadChild {
+                            child_id: child_id.clone(),
+                            status: "error".to_string(),
+                            reason: format!(
                                 "child runner lost (crashed task, dropped spawn job, or \
                                  process restart): index status {status:?} with no live \
                                  runner driving it"
                             ),
-                        ));
+                            owned: true,
+                        });
                     }
                 }
             }
         }
 
         if !dead.is_empty() {
-            for (child_id, status, reason) in dead {
+            for entry in dead {
                 tracing::warn!(
                     %parent_session_id,
-                    child_session_id = %child_id,
-                    %status,
-                    %reason,
+                    child_session_id = %entry.child_id,
+                    status = %entry.status,
+                    reason = %entry.reason,
+                    owned = entry.owned,
                     "child-wait watchdog: synthesizing terminal completion for dead child"
                 );
-                self.synthesize_child_completion(
-                    parent_session_id,
-                    &child_id,
-                    &status,
-                    Some(reason),
-                )
-                .await;
+                if entry.owned {
+                    self.synthesize_child_completion(
+                        parent_session_id,
+                        &entry.child_id,
+                        &entry.status,
+                        Some(entry.reason),
+                    )
+                    .await;
+                } else {
+                    // Foreign / nonexistent id: wake the parent only.
+                    self.publish_synthetic_completion(
+                        parent_session_id,
+                        &entry.child_id,
+                        &entry.status,
+                        Some(entry.reason),
+                    )
+                    .await;
+                }
             }
             // The publishes above re-evaluate the wait policy themselves.
             return;
@@ -1684,6 +1740,7 @@ impl ChildCompletionCoordinator {
                 wait.wait_for,
                 &wait.child_session_ids,
                 &terminal_ids,
+                child_id,
                 status,
             ) {
                 tracing::warn!(
@@ -1716,6 +1773,26 @@ impl ChildCompletionCoordinator {
     ) {
         match self.storage.load_session(child_session_id).await {
             Ok(Some(mut child)) => {
+                // Ownership guard (defense in depth — callers check too): only
+                // a session that IS a child of this parent may be mutated. An
+                // arbitrary session id named in a wait still wakes the parent
+                // via the publish below, but its own state stays untouched.
+                if child.parent_session_id.as_deref() != Some(parent_session_id) {
+                    tracing::warn!(
+                        %parent_session_id,
+                        child_session_id = %child.id,
+                        "child-wait watchdog: refusing to synthesize status onto a session \
+                         that is not a child of this parent"
+                    );
+                    self.publish_synthetic_completion(
+                        parent_session_id,
+                        child_session_id,
+                        status,
+                        error,
+                    )
+                    .await;
+                    return;
+                }
                 child.set_last_run_status(status);
                 match &error {
                     Some(message) => child.set_last_run_error(message.clone()),
@@ -2007,12 +2084,44 @@ mod tests {
             ChildWaitPolicy::All,
             &waited,
             &["a".to_string()],
+            "a",
             "completed"
         ));
         assert!(wait_policy_satisfied(
             ChildWaitPolicy::All,
             &waited,
             &["a".to_string(), "b".to_string()],
+            "b",
+            "completed"
+        ));
+    }
+
+    #[test]
+    fn wait_policy_first_error_requires_tracked_membership() {
+        let waited = vec!["a".to_string(), "b".to_string()];
+        // An error from a TRACKED child resumes immediately.
+        assert!(wait_policy_satisfied(
+            ChildWaitPolicy::FirstError,
+            &waited,
+            &["a".to_string()],
+            "a",
+            "error"
+        ));
+        // An error-like completion from an UNTRACKED child (e.g. a zombie
+        // task from an earlier run waking up late) must not resume the wait.
+        assert!(!wait_policy_satisfied(
+            ChildWaitPolicy::FirstError,
+            &waited,
+            &["a".to_string()],
+            "stray-child",
+            "timeout"
+        ));
+        // The all-complete fallback still applies regardless of the reporter.
+        assert!(wait_policy_satisfied(
+            ChildWaitPolicy::FirstError,
+            &waited,
+            &["a".to_string(), "b".to_string()],
+            "stray-child",
             "completed"
         ));
     }

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -503,24 +503,58 @@ impl ChildCompletionHandler for ChildCompletionCoordinator {
 
         if should_resume {
             parent.metadata.remove("runtime.suspend_reason");
-            // Load the completed child once. The guardian branch inspects its
-            // subagent_type + final verdict; the generic path folds its final
-            // assistant content into the hidden resume message (avoiding an extra
-            // `SubAgent.get` round trip after resume).
-            let loaded_child = match self
+
+            // READ-SIDE OWNERSHIP GUARD (issue #546): `SubAgent.wait` ids are
+            // model-provided and unvalidated, and the watchdog unstrands a wait
+            // over a FOREIGN/unknown id by publishing a synthetic completion
+            // here. We must resume the parent (so it is not stranded) but MUST
+            // NOT fold that foreign session's transcript into the parent — that
+            // would be a cross-session disclosure primitive. Decide ownership
+            // from the child's OWN parent linkage (control-plane only, no
+            // messages loaded), and only load its full content when it is truly
+            // this parent's child. An unowned id resumes with the neutral/error
+            // message (`runtime_resume_message` falls back to `completion.error`
+            // when no child content is supplied).
+            let reported_child_owned = match self
                 .storage
-                .load_session(&completion.child_session_id)
+                .load_runtime_control_plane(&completion.child_session_id)
                 .await
             {
-                Ok(child) => child,
-                Err(error) => {
-                    tracing::warn!(
-                        child_session_id = %completion.child_session_id,
-                        %error,
-                        "failed to load child session for runtime resume message"
-                    );
-                    None
+                Ok(Some(control_plane)) => completion_child_is_owned(
+                    &completion.parent_session_id,
+                    control_plane.parent_session_id.as_deref(),
+                ),
+                _ => false,
+            };
+
+            // Load the completed child once, ONLY when owned. The guardian
+            // branch inspects its subagent_type + final verdict; the generic
+            // path folds its final assistant content into the hidden resume
+            // message (avoiding an extra `SubAgent.get` round trip after resume).
+            let loaded_child = if reported_child_owned {
+                match self
+                    .storage
+                    .load_session(&completion.child_session_id)
+                    .await
+                {
+                    Ok(child) => child,
+                    Err(error) => {
+                        tracing::warn!(
+                            child_session_id = %completion.child_session_id,
+                            %error,
+                            "failed to load child session for runtime resume message"
+                        );
+                        None
+                    }
                 }
+            } else {
+                tracing::warn!(
+                    parent_session_id = %completion.parent_session_id,
+                    child_session_id = %completion.child_session_id,
+                    "completion child is not a child of this parent; resuming with a neutral \
+                     message and NOT folding its content"
+                );
+                None
             };
 
             // Guardian branch: a completing guardian reviewer that matches the
@@ -1297,6 +1331,17 @@ fn is_dead_child_candidate_status(status: Option<&str>) -> bool {
     }
 }
 
+/// Whether a reported completion's child id is genuinely a child of the parent
+/// it claims (issue #546 read-side disclosure guard). `SubAgent.wait` ids are
+/// model-provided, and the watchdog resolves an unowned id by publishing a
+/// synthetic completion so the parent is unstranded — but the parent must NEVER
+/// receive a FOREIGN session's content folded into its transcript.
+/// `child_parent_linkage` is that session's own `parent_session_id` (`None`
+/// when the session does not exist). Pure so the rule is unit-testable.
+fn completion_child_is_owned(reported_parent: &str, child_parent_linkage: Option<&str>) -> bool {
+    child_parent_linkage == Some(reported_parent)
+}
+
 /// Pick which terminal child's completion to replay when the wait is already
 /// satisfied but the parent is still suspended (lost wake). Prefer an
 /// error-like child so a `FirstError` policy re-evaluates truthfully.
@@ -1960,6 +2005,17 @@ mod tests {
         for status in ["completed", "error", "timeout", "cancelled", "skipped"] {
             assert!(!is_dead_child_candidate_status(Some(status)), "{status}");
         }
+    }
+
+    #[test]
+    fn completion_child_ownership_gates_content_fold() {
+        // Owned: the child's own parent linkage matches the reporting parent.
+        assert!(completion_child_is_owned("parent-1", Some("parent-1")));
+        // Foreign: a real session that belongs to a DIFFERENT parent — its
+        // content must never be folded into parent-1's transcript.
+        assert!(!completion_child_is_owned("parent-1", Some("parent-2")));
+        // Root/unparented session, or a nonexistent id (linkage None).
+        assert!(!completion_child_is_owned("parent-1", None));
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -11,8 +11,9 @@ use std::time::Duration;
 use bamboo_domain::poison::PoisonRecover;
 
 use crate::execution::{
-    create_event_forwarder, spawn_session_execution, try_reserve_runner, AgentRunner,
-    ChildCompletion, ChildCompletionHandler, RunnerReservation, SessionExecutionArgs,
+    create_event_forwarder, finalize_runner, spawn_session_execution, try_reserve_runner,
+    AgentRunner, AgentStatus, ChildCompletion, ChildCompletionHandler, RunnerReservation,
+    SessionExecutionArgs,
 };
 use crate::runtime::config::{BashResumeHook, GuardianSpawner, BASH_COMPLETION_RESUME_KIND};
 use crate::runtime::guardian_state::{
@@ -27,7 +28,7 @@ use bamboo_agent_core::{
     AgentEvent, BashCompletionInfo, BashCompletionSink, Message, Role, Session,
 };
 use bamboo_domain::session::runtime_state::{
-    AgentRuntimeState, AgentStatusState, ChildWaitPolicy, SuspensionState,
+    AgentRuntimeState, AgentStatusState, ChildWaitPolicy, SuspensionState, WaitingForChildrenState,
 };
 use bamboo_llm::{Config, ProviderModelRouter, ProviderRegistry};
 use bamboo_storage::LockedSessionStore;
@@ -394,6 +395,15 @@ impl ChildCompletionCoordinator {
             }
         }
         // Exhausted the AlreadyRunning retry budget; surface the final state.
+        // The wait state was already cleared and the resume message persisted,
+        // so nothing event-driven will retry — the child-wait watchdog is the
+        // backstop that picks this stranded parent up (it resumes suspended
+        // sessions that hold a pending runtime resume message but no runner).
+        tracing::error!(
+            %parent_session_id,
+            "parent resume gave up after AlreadyRunning retry budget; \
+             relying on the child-wait watchdog backstop"
+        );
         ResumeOutcome::AlreadyRunning {
             run_id: String::new(),
         }
@@ -413,6 +423,24 @@ impl ChildCompletionCoordinator {
 #[async_trait]
 impl ChildCompletionHandler for ChildCompletionCoordinator {
     async fn on_child_completed(&self, completion: ChildCompletion) {
+        // Terminality guard: a child that reports a NON-terminal status (e.g.
+        // "suspended" — awaiting parent approval, its own bash wait, or its own
+        // grandchildren) is not done. It must never satisfy the parent's wait:
+        // `derive_completed_child_ids` folds the just-reported child in
+        // unconditionally, so without this guard a suspending child would
+        // resume the parent with a premature "finished with status
+        // `suspended`" message. The child will publish a real terminal
+        // completion when it later resumes and finishes.
+        if !is_terminal_child_status(&completion.status) {
+            tracing::info!(
+                parent_session_id = %completion.parent_session_id,
+                child_session_id = %completion.child_session_id,
+                status = %completion.status,
+                "non-terminal child status; leaving the parent wait armed"
+            );
+            return;
+        }
+
         // Acquire the per-session async lock to eliminate the concurrent
         // double-resume race (see `parent_locks` for the full scenario). The
         // inner std::sync::Mutex is released immediately so no sync lock is
@@ -791,6 +819,10 @@ impl ResumeExecutionPort for ChildCompletionCoordinator {
             runners: self.agent_runners.clone(),
             sessions_cache: self.sessions.clone(),
             on_complete: None,
+            // A resumed session that is itself a CHILD (nested sub-agents)
+            // must publish its terminal completion so ITS parent is woken
+            // in turn (issue #546).
+            child_completion_handler: Some(Arc::new(self.clone())),
         });
     }
 }
@@ -1225,10 +1257,685 @@ impl BashCompletionSink for ChildCompletionCoordinator {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Child-wait watchdog (issue #546)
+// ---------------------------------------------------------------------------
+
+/// How often the child-wait watchdog sweeps suspended sessions.
+const CHILD_WAIT_SWEEP_INTERVAL_SECS: u64 = 30;
+/// Leave a freshly registered wait alone for this long so the event-driven
+/// completion push always gets the first shot (and just-enqueued spawn jobs
+/// have time to persist their running marker).
+const CHILD_WAIT_REGISTRATION_GRACE_SECS: i64 = 60;
+/// A waited child with NO live runner and a non-terminal index status is
+/// declared dead once its control-plane has been quiet for this long.
+const DEAD_CHILD_GRACE_SECS: i64 = 120;
+/// Slack on top of the per-child liveness policy before a Running-but-frozen
+/// runner entry (dead task) is force-finalized by the sweeper. The per-child
+/// watchdog cancels at `max_idle`/`max_total` and the child then publishes its
+/// own timeout; an entry frozen this far PAST those limits proves that
+/// machinery is dead.
+const STALE_RUNNER_SLACK_SECS: i64 = 600;
+
+/// Whether a waited child's index status means the sweeper must consider it
+/// DEAD when nothing is driving it: non-terminal and not legitimately
+/// suspended. `None` = never ran (created-but-never-started, or a spawn that
+/// was lost before its running marker persisted).
+fn is_dead_child_candidate_status(status: Option<&str>) -> bool {
+    match status {
+        // "suspended" children wait on a human / their own children / bash —
+        // their wake has its own driver; never declare them dead here.
+        Some(status) => !is_terminal_child_status(status) && status != "suspended",
+        None => true,
+    }
+}
+
+/// Pick which terminal child's completion to replay when the wait is already
+/// satisfied but the parent is still suspended (lost wake). Prefer an
+/// error-like child so a `FirstError` policy re-evaluates truthfully.
+fn select_replay_child(terminal: &[(String, String)]) -> Option<&(String, String)> {
+    terminal
+        .iter()
+        .find(|(_, status)| is_error_like(status))
+        .or_else(|| terminal.last())
+}
+
+fn child_wait_watchdog_resume_message(body: String) -> Message {
+    let mut message = Message::user(body);
+    message.metadata = Some(serde_json::json!({
+        RUNTIME_RESUME_MESSAGE_HIDDEN_KEY: true,
+        RUNTIME_RESUME_MESSAGE_KIND_KEY: "child_wait_watchdog_resume",
+    }));
+    message.never_compress = false;
+    message
+}
+
+fn empty_child_wait_message() -> Message {
+    child_wait_watchdog_resume_message(
+        "Runtime notification: this session was suspended waiting for child sessions, but the \
+         wait tracked no children (internal inconsistency). The session has been resumed; use \
+         SubAgent.list to inspect child state and continue the task."
+            .to_string(),
+    )
+}
+
+fn child_wait_lease_expired_message(child_ids: &[String]) -> Message {
+    child_wait_watchdog_resume_message(format!(
+        "Runtime notification: the wait lease for child session(s) [{}] expired before they all \
+         reported completion. They were NOT cancelled and may still be running or already \
+         finished — verify their actual status with SubAgent.list / SubAgent.get before assuming \
+         anything, then continue the task.",
+        child_ids.join(", ")
+    ))
+}
+
+/// Child-wait watchdog (issue #546): the heartbeat backstop for parents
+/// suspended on `waiting_for_children`.
+///
+/// The primary wake is the event-driven completion push (child terminal →
+/// [`ChildCompletionHandler::on_child_completed`] → resume). This sweeper
+/// exists because ANY break in that chain — a panicked child task, a dead
+/// spawn scheduler, a process restart, a clobbered/exhausted resume, a wait
+/// registered over an already-terminal child — previously stranded the parent
+/// forever. It mirrors the bash backstop's philosophy: coarse, cheap, yields
+/// to the push, and only acts when the durable state proves nothing else can.
+///
+/// All wake decisions funnel through the SAME machinery the push uses
+/// (synthetic/replayed completions → `on_child_completed`, per-parent
+/// serialization via [`session_resume_lock`]), so there is exactly one resume
+/// implementation.
+impl ChildCompletionCoordinator {
+    /// Spawn the watchdog: one boot-time reconciliation pass, then a sweep
+    /// every [`CHILD_WAIT_SWEEP_INTERVAL_SECS`]. Call once at server startup.
+    pub fn spawn_child_wait_watchdog(self: &Arc<Self>) {
+        let coordinator = Arc::clone(self);
+        tokio::spawn(async move {
+            use futures::FutureExt;
+            if std::panic::AssertUnwindSafe(coordinator.reconcile_orphans_at_boot())
+                .catch_unwind()
+                .await
+                .is_err()
+            {
+                tracing::error!("child-wait watchdog: boot reconciliation panicked");
+            }
+            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(
+                CHILD_WAIT_SWEEP_INTERVAL_SECS,
+            ));
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            // Skip the immediate tick (boot reconciliation just ran).
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                if std::panic::AssertUnwindSafe(coordinator.sweep_child_waits())
+                    .catch_unwind()
+                    .await
+                    .is_err()
+                {
+                    tracing::error!("child-wait watchdog: sweep panicked; continuing");
+                }
+            }
+        });
+    }
+
+    /// One-shot startup reconciliation: a process restart kills every in-flight
+    /// child task AND the in-memory bash backstop polls, but the durable state
+    /// (child index status `running`, parents suspended on bash) survives —
+    /// previously stranding those parents forever.
+    async fn reconcile_orphans_at_boot(&self) {
+        let cutoff = Utc::now();
+
+        // (1) Children left `running` by the previous process: no task in THIS
+        // process is driving them, so no completion will ever fire. Mark them
+        // terminal and wake their parents through the canonical path. (Root
+        // sessions left `running` are user-visible and user-recoverable; only
+        // children hold a suspended parent hostage.)
+        let running = self
+            .storage
+            .list_sessions_by_run_status("running")
+            .await
+            .unwrap_or_default();
+        for (child_id, parent_id) in running {
+            let Some(parent_id) = parent_id else { continue };
+            if self.runner_is_running(&child_id).await {
+                continue;
+            }
+            let Some(control_plane) = self.load_control_plane(&child_id).await else {
+                continue;
+            };
+            // A child that started AFTER boot is alive by definition — the
+            // cutoff guards the tiny window where a fresh spawn races this scan.
+            if control_plane.updated_at >= cutoff {
+                continue;
+            }
+            tracing::warn!(
+                child_session_id = %child_id,
+                parent_session_id = %parent_id,
+                "boot reconciliation: child was running when the process died; \
+                 marking it error and waking the parent"
+            );
+            self.synthesize_child_completion(
+                &parent_id,
+                &child_id,
+                "error",
+                Some(
+                    "orphaned by server restart: the process died while this child session \
+                     was running"
+                        .to_string(),
+                ),
+            )
+            .await;
+        }
+
+        // (2) Sessions suspended on `waiting_for_bash`: their backstop poll was
+        // an in-memory task that died with the process. Re-arm it — with the
+        // shell registry empty after a restart it resumes on its first check.
+        let suspended = self
+            .storage
+            .list_sessions_by_run_status("suspended")
+            .await
+            .unwrap_or_default();
+        for (session_id, _) in suspended {
+            let Some(control_plane) = self.load_control_plane(&session_id).await else {
+                continue;
+            };
+            if control_plane
+                .metadata
+                .get("runtime.suspend_reason")
+                .map(String::as_str)
+                != Some("waiting_for_bash")
+            {
+                continue;
+            }
+            if let Some(wait) = read_runtime_state(&control_plane).waiting_for_bash {
+                tracing::warn!(
+                    %session_id,
+                    "boot reconciliation: re-arming bash self-resume backstop lost in restart"
+                );
+                let coordinator = self.clone();
+                tokio::spawn(async move {
+                    coordinator
+                        .bash_self_resume(session_id, wait.bash_ids)
+                        .await;
+                });
+            }
+        }
+    }
+
+    async fn runner_is_running(&self, session_id: &str) -> bool {
+        let runners = self.agent_runners.read().await;
+        runners
+            .get(session_id)
+            .is_some_and(|runner| matches!(runner.status, AgentStatus::Running))
+    }
+
+    async fn load_control_plane(&self, session_id: &str) -> Option<Session> {
+        match self.storage.load_runtime_control_plane(session_id).await {
+            Ok(session) => session,
+            Err(error) => {
+                tracing::warn!(
+                    %session_id,
+                    %error,
+                    "child-wait watchdog: failed to load session control plane"
+                );
+                None
+            }
+        }
+    }
+
+    /// One sweep: inspect every session whose index status is `suspended`.
+    /// Cheap in the common case — the candidate list is small and each check is
+    /// a sidecar (control-plane) load.
+    async fn sweep_child_waits(&self) {
+        let suspended = match self.storage.list_sessions_by_run_status("suspended").await {
+            Ok(entries) => entries,
+            Err(error) => {
+                tracing::warn!(%error, "child-wait watchdog: failed to list suspended sessions");
+                return;
+            }
+        };
+        for (session_id, _) in suspended {
+            self.sweep_one_suspended_session(&session_id).await;
+        }
+    }
+
+    async fn sweep_one_suspended_session(&self, session_id: &str) {
+        // A live runner means the session already resumed (the index status
+        // only advances at its next terminal) — nothing to do.
+        if self.runner_is_running(session_id).await {
+            return;
+        }
+        let Some(session) = self.load_control_plane(session_id).await else {
+            return;
+        };
+        let runtime_state = read_runtime_state(&session);
+        let suspend_reason = session
+            .metadata
+            .get("runtime.suspend_reason")
+            .map(String::as_str)
+            .unwrap_or_default()
+            .to_string();
+        match (
+            suspend_reason.as_str(),
+            runtime_state.waiting_for_children.clone(),
+        ) {
+            // Human-gated or bash-owned waits: not ours to time out.
+            ("waiting_for_bash", _)
+            | ("awaiting_clarification", _)
+            | ("awaiting_parent_approval", _) => {}
+            (_, Some(wait)) => self.sweep_child_wait(session_id, wait).await,
+            // Suspended with NO armed wait: either the coordinator cleared the
+            // wait but its resume never spawned, or state is half-cleared.
+            ("waiting_for_children", None) | ("", None) => {
+                self.rescue_stranded_resume(session_id).await;
+            }
+            _ => {}
+        }
+    }
+
+    /// Evaluate one armed child wait against reality and act on what the
+    /// durable state proves: dead children are synthesized terminal, an
+    /// already-satisfied wait gets its lost wake replayed, an expired lease or
+    /// empty wait force-resumes the parent.
+    async fn sweep_child_wait(&self, parent_session_id: &str, wait: WaitingForChildrenState) {
+        let now = Utc::now();
+
+        if wait.child_session_ids.is_empty() {
+            tracing::warn!(
+                %parent_session_id,
+                "child-wait watchdog: wait armed over an empty child set; force-resuming"
+            );
+            self.force_resume_child_wait(parent_session_id, empty_child_wait_message())
+                .await;
+            return;
+        }
+
+        // The 6h lease (previously written but never read). Expiry does not
+        // kill children — child runners own child liveness; the parent is
+        // resumed with a verify-don't-assume note.
+        if wait.timeout_at.is_some_and(|deadline| now >= deadline) {
+            tracing::warn!(
+                %parent_session_id,
+                "child-wait watchdog: wait lease expired; force-resuming parent"
+            );
+            self.force_resume_child_wait(
+                parent_session_id,
+                child_wait_lease_expired_message(&wait.child_session_ids),
+            )
+            .await;
+            return;
+        }
+
+        // Yield to the event-driven push on fresh waits.
+        if now.signed_duration_since(wait.registered_at).num_seconds()
+            < CHILD_WAIT_REGISTRATION_GRACE_SECS
+        {
+            return;
+        }
+
+        let statuses: HashMap<String, Option<String>> = self
+            .storage
+            .list_child_run_statuses(parent_session_id)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+
+        let mut terminal: Vec<(String, String)> = Vec::new();
+        let mut dead: Vec<(String, String, String)> = Vec::new();
+        for child_id in &wait.child_session_ids {
+            let status = statuses.get(child_id).and_then(|status| status.as_deref());
+            if let Some(status) = status {
+                if is_terminal_child_status(status) {
+                    terminal.push((child_id.clone(), status.to_string()));
+                    continue;
+                }
+            }
+            if !is_dead_child_candidate_status(status) {
+                continue;
+            }
+
+            let runner = { self.agent_runners.read().await.get(child_id).cloned() };
+            match runner {
+                Some(runner) if matches!(runner.status, AgentStatus::Running) => {
+                    // A live-looking runner: only intervene when it is frozen
+                    // far PAST the per-child liveness limits — which proves the
+                    // per-child watchdog machinery itself is dead (task
+                    // panicked or lost), because it would have cancelled and
+                    // published a timeout long before.
+                    let last_activity = runner.last_event_at.unwrap_or(runner.started_at);
+                    let idle_secs = now.signed_duration_since(last_activity).num_seconds();
+                    let total_secs = now.signed_duration_since(runner.started_at).num_seconds();
+                    let policy = match self.load_control_plane(child_id).await {
+                        Some(child) => {
+                            crate::runtime::execution::spawn::watchdog_policy_for_session(&child)
+                        }
+                        None => Default::default(),
+                    };
+                    let idle_limit = policy.max_idle_secs.saturating_add(STALE_RUNNER_SLACK_SECS);
+                    let total_limit = policy
+                        .max_total_secs
+                        .saturating_add(STALE_RUNNER_SLACK_SECS);
+                    if idle_secs >= idle_limit || total_secs >= total_limit {
+                        runner.cancel_token.cancel();
+                        dead.push((
+                            child_id.clone(),
+                            "timeout".to_string(),
+                            format!(
+                                "child runner stalled: no events for {idle_secs}s \
+                                 (limit {idle_limit}s including watchdog slack); \
+                                 force-finalized by the child-wait watchdog"
+                            ),
+                        ));
+                    }
+                }
+                _ => {
+                    // Nothing is driving this child, yet its index status will
+                    // never advance by itself. The grace covers the enqueue →
+                    // running-marker window and slow spawn queues.
+                    let quiet_secs = match self.load_control_plane(child_id).await {
+                        Some(child) => now.signed_duration_since(child.updated_at).num_seconds(),
+                        // Session gone entirely (deleted mid-wait).
+                        None => i64::MAX,
+                    };
+                    if quiet_secs >= DEAD_CHILD_GRACE_SECS {
+                        dead.push((
+                            child_id.clone(),
+                            "error".to_string(),
+                            format!(
+                                "child runner lost (crashed task, dropped spawn job, or \
+                                 process restart): index status {status:?} with no live \
+                                 runner driving it"
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+
+        if !dead.is_empty() {
+            for (child_id, status, reason) in dead {
+                tracing::warn!(
+                    %parent_session_id,
+                    child_session_id = %child_id,
+                    %status,
+                    %reason,
+                    "child-wait watchdog: synthesizing terminal completion for dead child"
+                );
+                self.synthesize_child_completion(
+                    parent_session_id,
+                    &child_id,
+                    &status,
+                    Some(reason),
+                )
+                .await;
+            }
+            // The publishes above re-evaluate the wait policy themselves.
+            return;
+        }
+
+        // No dead children — but if the terminal set ALREADY satisfies the
+        // policy, the original wake was lost (clobbered resume / retry budget
+        // exhausted / completion raced the wait registration). Replay one real
+        // completion through the canonical path; `on_child_completed` is
+        // idempotent for an already-cleared wait.
+        let terminal_ids: Vec<String> = terminal.iter().map(|(id, _)| id.clone()).collect();
+        if let Some((child_id, status)) = select_replay_child(&terminal) {
+            if wait_policy_satisfied(
+                wait.wait_for,
+                &wait.child_session_ids,
+                &terminal_ids,
+                status,
+            ) {
+                tracing::warn!(
+                    %parent_session_id,
+                    child_session_id = %child_id,
+                    "child-wait watchdog: wait already satisfied but parent still suspended \
+                     (lost wake); replaying the completion"
+                );
+                let error = self
+                    .load_control_plane(child_id)
+                    .await
+                    .and_then(|child| child.last_run_error());
+                self.publish_synthetic_completion(parent_session_id, child_id, status, error)
+                    .await;
+            }
+        }
+    }
+
+    /// Persist a synthesized terminal status on the child (so the index flips
+    /// and nothing re-detects or re-suspends on it), finalize any lingering
+    /// runner entry (so a future re-run can reserve), then publish through the
+    /// canonical completion path — broadcast + `on_child_completed`, exactly
+    /// like a real child terminal.
+    async fn synthesize_child_completion(
+        &self,
+        parent_session_id: &str,
+        child_session_id: &str,
+        status: &str,
+        error: Option<String>,
+    ) {
+        match self.storage.load_session(child_session_id).await {
+            Ok(Some(mut child)) => {
+                child.set_last_run_status(status);
+                match &error {
+                    Some(message) => child.set_last_run_error(message.clone()),
+                    None => child.clear_last_run_error(),
+                }
+                child.updated_at = Utc::now();
+                if let Err(save_error) = self.persistence.merge_save_runtime(&mut child).await {
+                    tracing::warn!(
+                        child_session_id = %child.id,
+                        %save_error,
+                        "child-wait watchdog: failed to persist synthesized terminal status"
+                    );
+                }
+                self.sessions
+                    .insert(child.id.clone(), Arc::new(parking_lot::RwLock::new(child)));
+            }
+            Ok(None) => {}
+            Err(load_error) => {
+                tracing::warn!(
+                    %child_session_id,
+                    %load_error,
+                    "child-wait watchdog: failed to load child for synthesized terminal status"
+                );
+            }
+        }
+        finalize_runner(
+            &self.agent_runners,
+            child_session_id,
+            &Err(bamboo_agent_core::AgentError::LLM(
+                error
+                    .clone()
+                    .unwrap_or_else(|| format!("synthesized {status}")),
+            )),
+        )
+        .await;
+        self.publish_synthetic_completion(parent_session_id, child_session_id, status, error)
+            .await;
+    }
+
+    async fn publish_synthetic_completion(
+        &self,
+        parent_session_id: &str,
+        child_session_id: &str,
+        status: &str,
+        error: Option<String>,
+    ) {
+        let parent_tx = crate::execution::session_events::get_or_create_event_sender(
+            &self.session_event_senders,
+            parent_session_id,
+        )
+        .await;
+        let handler: Arc<dyn ChildCompletionHandler> = Arc::new(self.clone());
+        crate::runtime::execution::spawn::publish_child_completion_parts(
+            &parent_tx,
+            Some(handler),
+            parent_session_id.to_string(),
+            child_session_id.to_string(),
+            status.to_string(),
+            error,
+        )
+        .await;
+    }
+
+    /// A parent whose wait was already cleared (resume message appended) but
+    /// whose resume never spawned — retry-budget exhaustion, root-tools not
+    /// yet initialized, or a restart between clear and spawn. Detected by: no
+    /// live runner, no armed wait, and a pending hidden runtime resume message
+    /// as the LAST message. Resume is all that's left to do.
+    async fn rescue_stranded_resume(&self, session_id: &str) {
+        let Some(session) = self.load_session(session_id).await else {
+            return;
+        };
+        let pending_runtime_resume = session.messages.last().is_some_and(|message| {
+            matches!(message.role, Role::User)
+                && message
+                    .metadata
+                    .as_ref()
+                    .is_some_and(|meta| meta.get(RUNTIME_RESUME_MESSAGE_KIND_KEY).is_some())
+        });
+        if !pending_runtime_resume {
+            return;
+        }
+        tracing::warn!(
+            %session_id,
+            "child-wait watchdog: stranded resume detected (wait cleared, resume never \
+             spawned); resuming"
+        );
+        self.resume_parent(session_id.to_string()).await;
+    }
+
+    /// Clear the parent's child wait, append `resume_message`, and drive the
+    /// resume — with a bounded clobber-retry mirroring
+    /// [`Self::perform_bash_resume`]: a suspending runner's one-shot finalize
+    /// save can land after ours and revert the wait while dropping the
+    /// message; we detect the re-armed wait and re-clear.
+    async fn force_resume_child_wait(&self, session_id: &str, resume_message: Message) {
+        const MAX_ATTEMPTS: u8 = 5;
+        let lock = session_resume_lock(session_id);
+        for attempt in 0..MAX_ATTEMPTS {
+            if attempt > 0 {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+            {
+                let _held = lock.lock().await;
+                let Some(mut session) = self.load_session(session_id).await else {
+                    return;
+                };
+                let mut runtime_state = read_runtime_state(&session);
+                if runtime_state.waiting_for_children.is_none() {
+                    // Another source already resumed this parent.
+                    return;
+                }
+                runtime_state.waiting_for_children = None;
+                runtime_state.status = AgentStatusState::Idle;
+                runtime_state.suspension = None;
+                write_runtime_state(&mut session, &runtime_state);
+                session.metadata.remove("runtime.suspend_reason");
+                session.add_message(resume_message.clone());
+                session.updated_at = Utc::now();
+                self.save_and_cache(&mut session).await;
+            }
+            let outcome = self.resume_parent(session_id.to_string()).await;
+            match outcome {
+                ResumeOutcome::Started { .. } | ResumeOutcome::NotFound => return,
+                ResumeOutcome::Completed | ResumeOutcome::AlreadyRunning { .. } => {
+                    // Only retry when the persisted wait was clobbered back to
+                    // armed; if it stayed cleared with the message intact, the
+                    // next sweep's stranded-resume rescue finishes the job.
+                    let clobbered = self
+                        .load_session(session_id)
+                        .await
+                        .map(|session| read_runtime_state(&session).waiting_for_children.is_some())
+                        .unwrap_or(false);
+                    if !clobbered {
+                        return;
+                    }
+                }
+            }
+        }
+        tracing::error!(
+            %session_id,
+            "child-wait watchdog: force-resume exhausted its clobber-retry budget"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use bamboo_agent_core::Message;
+
+    // ── child-wait watchdog pure helpers (issue #546) ────────────────────
+
+    #[test]
+    fn dead_child_candidate_status_matrix() {
+        // Never ran / lost before the running marker: dead candidate.
+        assert!(is_dead_child_candidate_status(None));
+        // Actively-reported non-terminal statuses: dead candidates when nothing
+        // is driving them.
+        assert!(is_dead_child_candidate_status(Some("running")));
+        assert!(is_dead_child_candidate_status(Some("pending")));
+        // Legitimately quiescent: waiting on a human / own children / bash.
+        assert!(!is_dead_child_candidate_status(Some("suspended")));
+        // Terminal statuses can never be "dead" — they are already done.
+        for status in ["completed", "error", "timeout", "cancelled", "skipped"] {
+            assert!(!is_dead_child_candidate_status(Some(status)), "{status}");
+        }
+    }
+
+    #[test]
+    fn replay_child_prefers_error_like_for_first_error_policy() {
+        let terminal = vec![
+            ("c-ok".to_string(), "completed".to_string()),
+            ("c-err".to_string(), "timeout".to_string()),
+            ("c-late".to_string(), "completed".to_string()),
+        ];
+        let (id, status) = select_replay_child(&terminal).expect("non-empty");
+        assert_eq!(id, "c-err");
+        assert_eq!(status, "timeout");
+
+        let all_ok = vec![
+            ("c-1".to_string(), "completed".to_string()),
+            ("c-2".to_string(), "completed".to_string()),
+        ];
+        let (id, _) = select_replay_child(&all_ok).expect("non-empty");
+        assert_eq!(id, "c-2");
+
+        assert!(select_replay_child(&[]).is_none());
+    }
+
+    #[test]
+    fn watchdog_resume_messages_are_hidden_runtime_messages() {
+        for message in [
+            empty_child_wait_message(),
+            child_wait_lease_expired_message(&["c-1".to_string(), "c-2".to_string()]),
+        ] {
+            assert!(matches!(message.role, Role::User));
+            let meta = message.metadata.expect("hidden runtime metadata");
+            assert_eq!(meta[RUNTIME_RESUME_MESSAGE_HIDDEN_KEY], true);
+            assert_eq!(
+                meta[RUNTIME_RESUME_MESSAGE_KIND_KEY],
+                "child_wait_watchdog_resume"
+            );
+        }
+        let lease = child_wait_lease_expired_message(&["c-1".to_string()]);
+        // The lease message must never claim the children finished.
+        assert!(lease.content.contains("NOT cancelled"));
+        assert!(lease.content.contains("c-1"));
+    }
+
+    // ── on_child_completed terminality guard (issue #546) ────────────────
+
+    #[test]
+    fn non_terminal_statuses_never_satisfy_wait_policies() {
+        // The guard keys on `is_terminal_child_status`; "suspended" (and any
+        // unknown non-terminal string) must not count toward any policy.
+        assert!(!is_terminal_child_status("suspended"));
+        assert!(!is_terminal_child_status("running"));
+        assert!(!is_terminal_child_status("pending"));
+    }
 
     fn make_completion(status: &str) -> ChildCompletion {
         ChildCompletion {

--- a/crates/engine/bamboo-engine/src/session_app/child_session/mod.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_session/mod.rs
@@ -216,17 +216,18 @@ pub trait ChildSessionPort: Send + Sync {
     async fn active_child_ids(&self, parent_session_id: &str) -> Vec<String>;
 
     /// The subset of `candidates` the session index POSITIVELY reports as
-    /// terminal children of this parent (issue #546). `SubAgent.wait` drops
-    /// these from an explicit wait — a terminal child fires no further
-    /// completion, so a wait over it could hang the parent. Unknown ids are
-    /// NOT reported (index-less backends can't distinguish "terminal" from
-    /// "not yet indexed"); the child-wait watchdog rescues those at runtime.
-    /// Default: empty (no filtering).
+    /// terminal children of this parent, as `(child_id, status)` pairs
+    /// (issue #546). `SubAgent.wait` uses this to avoid arming a wait over a
+    /// child that fires no further completion — and, policy-permitting, to
+    /// short-circuit a wait the terminal statuses already satisfy. Unknown
+    /// ids are NOT reported (index-less backends can't distinguish "terminal"
+    /// from "not yet indexed"); the child-wait watchdog rescues those at
+    /// runtime. Default: empty (no filtering).
     async fn terminal_child_ids(
         &self,
         parent_session_id: &str,
         candidates: &[String],
-    ) -> Vec<String> {
+    ) -> Vec<(String, String)> {
         let _ = (parent_session_id, candidates);
         Vec::new()
     }

--- a/crates/engine/bamboo-engine/src/session_app/child_session/mod.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_session/mod.rs
@@ -215,6 +215,22 @@ pub trait ChildSessionPort: Send + Sync {
     /// The parent's currently-active (non-terminal) child session ids.
     async fn active_child_ids(&self, parent_session_id: &str) -> Vec<String>;
 
+    /// The subset of `candidates` the session index POSITIVELY reports as
+    /// terminal children of this parent (issue #546). `SubAgent.wait` drops
+    /// these from an explicit wait — a terminal child fires no further
+    /// completion, so a wait over it could hang the parent. Unknown ids are
+    /// NOT reported (index-less backends can't distinguish "terminal" from
+    /// "not yet indexed"); the child-wait watchdog rescues those at runtime.
+    /// Default: empty (no filtering).
+    async fn terminal_child_ids(
+        &self,
+        parent_session_id: &str,
+        candidates: &[String],
+    ) -> Vec<String> {
+        let _ = (parent_session_id, candidates);
+        Vec::new()
+    }
+
     /// Find an existing resident agent in the same root tree by its stable
     /// `resident_name`, returning its child session id if one exists. Used to
     /// reuse a resident agent for a new task instead of minting a new child.

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -1332,6 +1332,19 @@ impl Storage for SessionStoreV2 {
             .collect())
     }
 
+    async fn list_sessions_by_run_status(
+        &self,
+        status: &str,
+    ) -> io::Result<Vec<(String, Option<String>)>> {
+        let index = self.index.read().await;
+        Ok(index
+            .sessions
+            .values()
+            .filter(|entry| entry.last_run_status.as_deref() == Some(status))
+            .map(|entry| (entry.id.clone(), entry.parent_session_id.clone()))
+            .collect())
+    }
+
     async fn append_token_usage_record(&self, session_id: &str, json_line: &str) -> io::Result<()> {
         use tokio::io::AsyncWriteExt;
 
@@ -1872,6 +1885,42 @@ mod tests {
         assert_eq!(got[1].0, "ch-pending");
         // pending child has no terminal status mirrored yet.
         assert!(got[1].1.as_deref() != Some("completed"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_sessions_by_run_status_matches_index_and_reports_parent() -> io::Result<()> {
+        let (storage, _t) = create_temp_storage().await?;
+
+        let mut root = Session::new("r-susp".to_string(), "m".to_string());
+        root.metadata
+            .insert("last_run_status".to_string(), "suspended".to_string());
+        storage.save_session(&root).await?;
+
+        let mut child = Session::new_child("ch-run", "r-susp", "m", "c");
+        child
+            .metadata
+            .insert("last_run_status".to_string(), "running".to_string());
+        storage.save_session(&child).await?;
+
+        let mut done = Session::new("r-done".to_string(), "m".to_string());
+        done.metadata
+            .insert("last_run_status".to_string(), "completed".to_string());
+        storage.save_session(&done).await?;
+
+        let suspended = storage.list_sessions_by_run_status("suspended").await?;
+        assert_eq!(suspended, vec![("r-susp".to_string(), None)]);
+
+        let running = storage.list_sessions_by_run_status("running").await?;
+        assert_eq!(
+            running,
+            vec![("ch-run".to_string(), Some("r-susp".to_string()))]
+        );
+
+        assert!(storage
+            .list_sessions_by_run_status("timeout")
+            .await?
+            .is_empty());
         Ok(())
     }
 


### PR DESCRIPTION
Closes #546.

When a sub-agent errored or blocked, the parent could stay suspended on `waiting_for_children` forever. The wake was a single-shot event push with no durable backstop — any break in the chain (panicked child task, dead spawn scheduler, clobbered resume, restart, wait over an already-terminal child) stranded the parent permanently. This PR closes every mapped hole and adds a heartbeat watchdog so even an unforeseen lost wake self-heals.

## Push-side correctness

- **Terminality guard** in `on_child_completed`: a non-terminal `"suspended"` completion no longer falsely satisfies the wait (it used to fold in unconditionally and resume the parent prematurely with "finished with status `suspended`").
- **Non-terminal allowlist** in `sdk/spawn.rs` now covers every suspend reason (`awaiting_clarification`, `waiting_for_children`, …): a child-parent suspending on its own grandchildren publishes `"suspended"`, not a false `"completed"`.
- **Panic containment**: `catch_unwind` around child execution AND around `agent.execute` in `spawn_session_execution` — a panic now finalizes as a terminal error completion instead of leaving a zombie Running runner and a stranded parent.
- **SpawnScheduler per-job isolation**: a panicking spawn job no longer kills the single worker loop (which permanently broke ALL future child spawning and dropped queued jobs silently); it publishes an error completion for the affected child.
- **Resumed children publish completions**: new `SessionExecutionArgs.child_completion_handler` — a child resumed after an approval/clarification answer, or a nested child-parent woken by its own children, now wakes ITS parent on terminal. Previously `on_complete: None` meant the parent slept forever after the human answered the child's question.
- **`SubAgent.wait` hardening**: explicit ids the index positively reports terminal are dropped (a wait over them could never be satisfied); with policy `any`/`first_error`, an already-satisfying terminal id short-circuits to a non-suspending `already_satisfied` result instead of arming a residual wait. Unknown ids are kept (index-less backends / not-yet-indexed children) and rescued by the watchdog at runtime.
- **`wait_policy_satisfied` FirstError membership**: an error-like completion from an untracked child (e.g. a frozen runner's task waking after the watchdog already synthesized its timeout) can no longer prematurely resume a later wait.
- **Stale suspend-state clear** in `run_child_spawn`: a re-run of a previously-suspended child no longer inherits the old `runtime.suspend_reason` (which turned a genuine completion into a non-terminal `"suspended"`).

## Heartbeat watchdog (兜底)

`ChildCompletionCoordinator::spawn_child_wait_watchdog` — 30s sweep over index-`suspended` sessions (new index-backed `Storage::list_sessions_by_run_status`):

- synthesizes `error`/`timeout` completions for **dead children** (no live runner + 120s grace, or a runner frozen past its liveness limits + 10min slack) — with an **ownership guard**: an id that isn't actually a child of the waiting parent wakes the parent publish-only, never mutating/cancelling the named session (wait ids are model-provided);
- **replays lost completions** when the wait is already satisfied (clobbered resume, retry-budget exhaustion, completion racing the wait registration);
- enforces the previously **written-but-never-read 6h wait lease** with a verify-don't-assume resume message (children are NOT cancelled);
- force-resumes **empty waits** and rescues **cleared-but-never-resumed** parents (pending hidden resume message, no runner);
- **boot reconciliation**: children left `running` by a process restart are marked `error` and their parents woken; `waiting_for_bash` backstop polls (in-memory, lost on restart) are re-armed.

All watchdog wakes funnel through the same `on_child_completed` machinery as the event path (per-parent `session_resume_lock`), so there is exactly one resume implementation.

## Validation

- `cargo build --workspace --tests` clean; `cargo fmt --check` clean.
- Test suites: bamboo-engine 956 ✓, bamboo-server 1376 ✓, bamboo-server-tools 87 ✓, bamboo-storage 71 ✓ (new units: dead-child candidate matrix, replay selection, watchdog message contracts, FirstError membership, wait partition + policy short-circuit, index enumeration).
- Pre-PR adversarial review: 4-dimension multi-agent review + per-finding verification; all 6 confirmed majors fixed in the second commit (ownership guards, policy short-circuits, resume-path panic containment, stale suspend-reason clear, FirstError membership).

https://claude.ai/code/session_013oUofGqYAwMfpR2s1CteY9