### PR TITLE
fix(engine): close child->parent wake holes + watchdog backstop for stranded parents

### DIFF
--- a/crates/app/bamboo-server-tools/src/sub_agent.rs
+++ b/crates/app/bamboo-server-tools/src/sub_agent.rs
@@ -783,10 +783,16 @@ impl Tool for SubAgentTool {
             } => {
                 let policy = wait_for.unwrap_or(ChildWaitPolicy::All);
                 // Default to every currently-active child; honor an explicit
-                // subset when provided.
-                let targets = match child_session_ids {
-                    Some(ids) if !ids.is_empty() => ids,
-                    _ => self.sessions.active_child_ids(&parent.id).await,
+                // subset when provided. `active_child_ids` already excludes
+                // terminal AND never-started children (issue #546 row 9), but
+                // an EXPLICIT list is caller-supplied and may name a child
+                // that already finished (a race) or was never started — those
+                // ids are filtered out below (issue #546 row 8) since no
+                // future completion event will ever arrive for them.
+                let explicit_ids = child_session_ids.filter(|ids| !ids.is_empty());
+                let targets = match explicit_ids {
+                    Some(ids) => self.sessions.pending_child_ids(&parent.id, &ids).await,
+                    None => self.sessions.active_child_ids(&parent.id).await,
                 };
 
                 if targets.is_empty() {
@@ -795,7 +801,8 @@ impl Tool for SubAgentTool {
                     return tool_result(json!({
                         "status": "no_active_children",
                         "parent_session_id": parent_session_id,
-                        "note": "No active child sessions to wait for; the parent continues running.",
+                        "note": "No pending child sessions to wait for (already finished, never \
+                                  started, or not found); the parent continues running.",
                     }))
                     .map(ToolOutcome::Completed);
                 }

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -351,6 +351,14 @@ impl AppState {
                 Some(account_sink.inbox()),
             ));
 
+        // Child-wait heartbeat watchdog backstop (issue #546 Part B). Config-
+        // gated via `BAMBOO_CHILD_WAIT_WATCHDOG_INTERVAL_SECS` (default 60s;
+        // `0` disables). Must be started AFTER `set_root_tools` /
+        // `set_guardian_spawner` are wired below so a sweep firing early in
+        // boot doesn't race an uninitialized dependency — deferred to the end
+        // of this function, right after those two calls (search for
+        // "spawn_wait_watchdog" there).
+
         // Initialize sub-session spawn scheduler (async background jobs).
         let config_snapshot = config.read().await.clone();
 
@@ -639,6 +647,13 @@ impl AppState {
         child_completion_coordinator
             .set_guardian_spawner(guardian_spawner.clone())
             .await;
+
+        // Child-wait heartbeat watchdog (issue #546 Part B): started only now
+        // that `root_tools` and `guardian_spawner` are both wired, so an early
+        // sweep can never race `spawn_resume_execution`'s dependency checks.
+        // Config-gated via `BAMBOO_CHILD_WAIT_WATCHDOG_INTERVAL_SECS`.
+        child_completion_coordinator
+            .spawn_wait_watchdog(bamboo_engine::wait_watchdog_interval_from_env());
 
         // The completion coordinator doubles as the bash self-resume hook
         // (issue #84 Phase 2b): it polls the live shell registry and resumes a

--- a/crates/app/bamboo-server/src/app_state/init.rs
+++ b/crates/app/bamboo-server/src/app_state/init.rs
@@ -69,6 +69,29 @@ pub async fn init_storage(
         }
     }
 
+    // Boot reconciliation (issue #546 row 10): a session whose mirrored index
+    // status is still `"running"` at this point in boot is UNCONDITIONALLY
+    // orphaned — no in-memory runner can possibly exist yet (we are still
+    // constructing storage, before any spawn happens), so whatever process
+    // was running it is gone. Mark each one `"error"` so the child-wait
+    // heartbeat watchdog's very first sweep (started later, once the server
+    // is fully wired) finds them already terminal and wakes their parents on
+    // its first pass, rather than waiting out `DEAD_CHILD_GRACE_SECS`.
+    // Run inline (before the server starts serving) so it can't race a
+    // legitimate spawn that starts immediately after boot.
+    match reconcile_orphaned_running_sessions(session_store.as_ref()).await {
+        Ok(0) => {}
+        Ok(count) => tracing::warn!(
+            "Boot reconciliation marked {count} orphaned \"running\" session(s) as \"error\" \
+             (issue #546 row 10)"
+        ),
+        Err(error) => {
+            tracing::warn!(
+                "Boot reconciliation for orphaned running sessions failed (continuing): {error}"
+            );
+        }
+    }
+
     let session_store_for_rebuild = session_store.clone();
     tokio::spawn(async move {
         let purged_rows = match session_store_for_rebuild
@@ -109,6 +132,63 @@ pub async fn init_storage(
         session_store.sessions_root_dir()
     );
     Ok((session_store, storage))
+}
+
+/// Boot reconciliation (issue #546 row 10): mark every session whose mirrored
+/// `last_run_status == "running"` as `"error"`. Called once, synchronously,
+/// during [`init_storage`] — at that point in boot no in-memory runner has
+/// been created for anything yet, so a `"running"` mirror can only be a
+/// leftover from a process that no longer exists. Left untouched, a parent
+/// durably suspended on `waiting_for_children` over such a child would never
+/// see a completion (nothing will ever run to publish one), stranding it
+/// until an operator noticed.
+///
+/// Deliberately uses [`Storage::save_session`] (a full save), NOT the cheaper
+/// [`Storage::save_runtime_state`] sidecar-only path: only `save_session`
+/// calls `upsert_index_from_session`, which is what actually updates the
+/// in-memory index `list_sessions_by_run_status`/`list_child_run_statuses`
+/// read from. A sidecar-only save would leave the index (and therefore the
+/// watchdog sweep and the coordinator's `derive_completed_child_ids`) still
+/// reporting `"running"` forever, silently defeating this whole function. The
+/// extra write cost is a boot-time, once-per-orphan non-issue. Idempotent — a
+/// session already fixed by a previous boot's reconciliation no longer
+/// matches the `"running"` filter.
+async fn reconcile_orphaned_running_sessions(storage: &dyn Storage) -> Result<usize, String> {
+    const ORPHAN_ERROR_MESSAGE: &str =
+        "orphaned by a server restart (boot reconciliation, issue #546 row 10)";
+
+    let orphans = storage
+        .list_sessions_by_run_status("running")
+        .await
+        .map_err(|error| error.to_string())?;
+
+    let mut fixed = 0usize;
+    for orphan in orphans {
+        match storage.load_session(&orphan.id).await {
+            Ok(Some(mut session)) => {
+                session.set_last_run_status("error");
+                session.set_last_run_error(ORPHAN_ERROR_MESSAGE.to_string());
+                if let Err(error) = storage.save_session(&session).await {
+                    tracing::warn!(
+                        session_id = %orphan.id,
+                        %error,
+                        "boot reconciliation: failed to persist orphaned session"
+                    );
+                    continue;
+                }
+                fixed += 1;
+            }
+            Ok(None) => {} // vanished between the index list and the load; nothing to fix
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %orphan.id,
+                    %error,
+                    "boot reconciliation: failed to load orphaned session"
+                );
+            }
+        }
+    }
+    Ok(fixed)
 }
 
 /// Initialize the skill manager with workspace directory and active mode from environment.
@@ -619,5 +699,110 @@ mod eviction_tests {
             senders.contains_key("s1"),
             "sender with a live receiver must be retained even when the runner is dropped"
         );
+    }
+}
+
+#[cfg(test)]
+mod boot_reconciliation_tests {
+    use super::*;
+    use bamboo_agent_core::Session;
+
+    async fn temp_storage() -> (tempfile::TempDir, Arc<SessionStoreV2>) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = SessionStoreV2::new(temp.path().to_path_buf())
+            .await
+            .expect("storage init");
+        (temp, Arc::new(store))
+    }
+
+    // Issue #546 row 10: boot reconciliation marks orphaned "running" sessions
+    // as "error" so the child-wait watchdog's first sweep can wake their
+    // parents, instead of leaving them "running" forever with no process
+    // that will ever finish them.
+
+    #[tokio::test]
+    async fn reconcile_marks_orphaned_running_sessions_as_error() {
+        let (_temp, store) = temp_storage().await;
+
+        let mut orphan = Session::new("orphan-1".to_string(), "m".to_string());
+        orphan
+            .metadata
+            .insert("last_run_status".to_string(), "running".to_string());
+        store.save_session(&orphan).await.expect("save");
+
+        let mut healthy = Session::new("healthy-1".to_string(), "m".to_string());
+        healthy
+            .metadata
+            .insert("last_run_status".to_string(), "completed".to_string());
+        store.save_session(&healthy).await.expect("save");
+
+        let fixed = reconcile_orphaned_running_sessions(store.as_ref())
+            .await
+            .expect("reconciliation ok");
+        assert_eq!(fixed, 1, "only the orphaned running session is touched");
+
+        let reloaded_orphan = store
+            .load_session("orphan-1")
+            .await
+            .expect("load ok")
+            .expect("session present");
+        assert_eq!(
+            reloaded_orphan.last_run_status().as_deref(),
+            Some("error"),
+            "orphaned running session must be marked error"
+        );
+        assert!(
+            reloaded_orphan
+                .last_run_error()
+                .unwrap_or_default()
+                .contains("boot reconciliation"),
+            "error message should explain the cause: {:?}",
+            reloaded_orphan.last_run_error()
+        );
+
+        let reloaded_healthy = store
+            .load_session("healthy-1")
+            .await
+            .expect("load ok")
+            .expect("session present");
+        assert_eq!(
+            reloaded_healthy.last_run_status().as_deref(),
+            Some("completed"),
+            "an already-terminal session must be left untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_is_noop_when_nothing_is_orphaned() {
+        let (_temp, store) = temp_storage().await;
+        let session = Session::new("s-1".to_string(), "m".to_string());
+        store.save_session(&session).await.expect("save");
+
+        let fixed = reconcile_orphaned_running_sessions(store.as_ref())
+            .await
+            .expect("reconciliation ok");
+        assert_eq!(fixed, 0);
+    }
+
+    #[tokio::test]
+    async fn reconcile_is_idempotent_across_repeated_boots() {
+        let (_temp, store) = temp_storage().await;
+        let mut orphan = Session::new("orphan-2".to_string(), "m".to_string());
+        orphan
+            .metadata
+            .insert("last_run_status".to_string(), "running".to_string());
+        store.save_session(&orphan).await.expect("save");
+
+        let first = reconcile_orphaned_running_sessions(store.as_ref())
+            .await
+            .expect("first reconciliation ok");
+        assert_eq!(first, 1);
+
+        // A second "boot" finds nothing left to fix — the session is now
+        // "error", not "running", so it no longer matches the filter.
+        let second = reconcile_orphaned_running_sessions(store.as_ref())
+            .await
+            .expect("second reconciliation ok");
+        assert_eq!(second, 0);
     }
 }

--- a/crates/app/bamboo-server/src/app_state/resume_adapter.rs
+++ b/crates/app/bamboo-server/src/app_state/resume_adapter.rs
@@ -63,7 +63,15 @@ impl ResumeExecutionPort for AppStateResumeRef {
         get_or_create_event_sender(&self.0.session_event_senders, session_id).await
     }
 
-    async fn spawn_resume_execution(&self, request: ResumeSpawnRequest) {
+    async fn release_reservation(&self, session_id: &str) {
+        // Issue #546 row 7: this adapter's `spawn_resume_execution` always
+        // spawns something (there is no early-bail path today), so this is
+        // never exercised in production — implemented for trait completeness
+        // and so a future bail path here is automatically safe.
+        self.0.agent_runners.write().await.remove(session_id);
+    }
+
+    async fn spawn_resume_execution(&self, request: ResumeSpawnRequest) -> bool {
         let ResumeSpawnRequest {
             session_id,
             session,
@@ -189,7 +197,7 @@ impl ResumeExecutionPort for AppStateResumeRef {
                     // config-level default (issue #221) still applies.
                     run_budget: None,
                 });
-                return;
+                return true;
             }
             Some(id) => id,
         };
@@ -295,6 +303,7 @@ impl ResumeExecutionPort for AppStateResumeRef {
                 run_budget: None,
             });
         });
+        true
     }
 }
 

--- a/crates/app/bamboo-server/src/connect/approvals.rs
+++ b/crates/app/bamboo-server/src/connect/approvals.rs
@@ -491,7 +491,14 @@ impl ResumeExecutionPort for ConnectResumePort {
         get_or_create_event_sender(&self.ctx.session_event_senders, session_id).await
     }
 
-    async fn spawn_resume_execution(&self, request: ResumeSpawnRequest) {
+    async fn release_reservation(&self, session_id: &str) {
+        // Issue #546 row 7: this adapter's `spawn_resume_execution` always
+        // spawns something (there is no early-bail path today), so this is
+        // never exercised in production — implemented for trait completeness.
+        self.ctx.agent_runners.write().await.remove(session_id);
+    }
+
+    async fn spawn_resume_execution(&self, request: ResumeSpawnRequest) -> bool {
         let ResumeSpawnRequest {
             session_id,
             session,
@@ -568,8 +575,13 @@ impl ResumeExecutionPort for ConnectResumePort {
                 runners: self.ctx.agent_runners.clone(),
                 sessions_cache: self.ctx.session_repo.cache().clone(),
                 on_complete: None,
+                // connect-bridged sessions are always root sessions (never
+                // `SessionKind::Child`), so the child-completion publish this
+                // hook drives is always a no-op here — `None` is correct, not
+                // a gap.
+                child_completion_handler: None,
             });
-            return;
+            return true;
         };
 
         let ctx = self.ctx.clone();
@@ -678,8 +690,12 @@ impl ResumeExecutionPort for ConnectResumePort {
                 runners: ctx.agent_runners.clone(),
                 sessions_cache: ctx.session_repo.cache().clone(),
                 on_complete: None,
+                // connect-bridged sessions are always root sessions — see the
+                // comment on the other `SessionExecutionArgs` literal above.
+                child_completion_handler: None,
             });
         });
+        true
     }
 }
 

--- a/crates/app/bamboo-server/src/connect/bridge.rs
+++ b/crates/app/bamboo-server/src/connect/bridge.rs
@@ -846,6 +846,9 @@ impl ConnectBridge {
             runners: self.ctx.agent_runners.clone(),
             sessions_cache: self.ctx.session_repo.cache().clone(),
             on_complete: None,
+            // connect-bridged sessions are always root sessions (never
+            // `SessionKind::Child`), so `None` is correct, not a gap.
+            child_completion_handler: None,
         });
 
         self.render_until_settled(key, platform, reply_ctx.clone(), &session_id, rx)

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
@@ -217,6 +217,15 @@ pub(crate) fn spawn_agent_execution(args: SpawnAgentExecution) {
         runners: args.state.agent_runners.clone(),
         sessions_cache: args.state.sessions.clone(),
         on_complete: None,
+        // Issue #546 row 5: this is THE path `/execute` and `/respond` funnel
+        // through to resume a session — including a child session resumed
+        // after a human answers its approval/clarification gate. Wire the
+        // same coordinator used for the initial-spawn completion publish
+        // (`bash_completion_sink` above already reuses it too) so a resumed
+        // child that reaches a real terminal status still tells its parent.
+        // A no-op for root sessions (`spawn_session_execution` gates on
+        // `session.kind == SessionKind::Child`).
+        child_completion_handler: Some(args.state.child_completion_coordinator.clone()),
     });
 }
 

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -601,6 +601,8 @@ async fn run_schedule_job(
         runners: ctx.agent_runners.clone(),
         sessions_cache: ctx.sessions_cache.clone(),
         on_complete: Some(on_complete),
+        // Scheduled runs always target root sessions, never `SessionKind::Child`.
+        child_completion_handler: None,
     });
 
     Ok(ScheduleRunLifecycleResult::BackgroundExecutionInProgress)

--- a/crates/app/bamboo-server/src/tools/child_session_adapter.rs
+++ b/crates/app/bamboo-server/src/tools/child_session_adapter.rs
@@ -88,6 +88,50 @@ fn is_terminal_child_status(status: &str) -> bool {
     )
 }
 
+/// Pure filtering core for [`ChildSessionAdapter::active_child_ids`] (issue
+/// #546 row 9): only a genuinely started-but-not-yet-terminal entry —
+/// `Some(non-terminal-status)` — counts as active. `None` (created but never
+/// run) is excluded, since nothing will ever execute it to move it past
+/// `None`. Extracted as a pure function (no storage I/O) so the filtering
+/// logic is unit-testable in isolation.
+fn filter_active_child_ids(statuses: Vec<(String, Option<String>)>) -> Vec<String> {
+    statuses
+        .into_iter()
+        .filter(|(_, status)| {
+            status
+                .as_deref()
+                .is_some_and(|s| !is_terminal_child_status(s))
+        })
+        .map(|(id, _)| id)
+        .collect()
+}
+
+/// Pure filtering core for [`ChildSessionAdapter::pending_child_ids`] (issue
+/// #546 rows 8/9): keep only candidate ids that are known children of the
+/// parent AND genuinely started-but-not-yet-terminal. Drops already-terminal
+/// ids, never-started ids (`status == None`), and unknown ids (absent from
+/// `statuses` — not a child of this parent at all). Extracted as a pure
+/// function so the filtering logic is unit-testable in isolation.
+fn filter_pending_child_ids(
+    candidate_ids: &[String],
+    statuses: &std::collections::HashMap<String, Option<String>>,
+) -> Vec<String> {
+    candidate_ids
+        .iter()
+        .filter(|id| {
+            statuses
+                .get(id.as_str())
+                .map(|status| {
+                    status
+                        .as_deref()
+                        .is_some_and(|s| !is_terminal_child_status(s))
+                })
+                .unwrap_or(false)
+        })
+        .cloned()
+        .collect()
+}
+
 fn read_runtime_state(session: &Session) -> AgentRuntimeState {
     session
         .agent_runtime_state
@@ -287,15 +331,52 @@ impl ChildSessionAdapter {
 
     /// The parent's currently-active (non-terminal) children, derived from the
     /// session index (single source of truth).
+    ///
+    /// Issue #546 row 9: a child that was `create`d but never `run` has
+    /// `last_run_status == None` — it will NEVER transition to a terminal
+    /// state on its own (nothing is executing it), so it must NOT be
+    /// considered "active" for wait purposes. `SubAgent.wait`'s default
+    /// (no explicit `child_session_ids`) target list is exactly this method's
+    /// output, so before this fix a never-started child silently entered the
+    /// default wait set and the parent suspended on a wait that could never
+    /// resolve. Only `Some(non-terminal-status)` — i.e. genuinely
+    /// started-but-not-yet-finished — counts as active now.
     pub async fn active_child_ids(&self, parent_session_id: &str) -> Vec<String> {
-        self.storage
+        filter_active_child_ids(
+            self.storage
+                .list_child_run_statuses(parent_session_id)
+                .await
+                .unwrap_or_default(),
+        )
+    }
+
+    /// Filter `candidate_ids` down to the subset that are still pending
+    /// (started, not yet terminal) children of `parent_session_id` — i.e.
+    /// eligible to be registered on a NEW wait.
+    ///
+    /// Issue #546 row 8: an EXPLICIT `SubAgent.wait(child_session_ids=[...])`
+    /// call previously registered a durable wait over exactly the ids given,
+    /// with no terminality check at all — if the caller named a child that had
+    /// already finished (a race: the child completed before the wait tool call
+    /// landed), the coordinator's `on_child_completed` for that child had
+    /// ALREADY fired and consumed its one-shot completion event, so no future
+    /// event would ever satisfy the newly-registered wait, stranding the
+    /// parent. Also drops never-started ids (`status == None`, issue #546 row
+    /// 9) and unknown ids (not a child of this parent at all) for the same
+    /// reason — none of them will ever produce a future completion event.
+    pub async fn pending_child_ids(
+        &self,
+        parent_session_id: &str,
+        candidate_ids: &[String],
+    ) -> Vec<String> {
+        let statuses: std::collections::HashMap<String, Option<String>> = self
+            .storage
             .list_child_run_statuses(parent_session_id)
             .await
             .unwrap_or_default()
             .into_iter()
-            .filter(|(_, status)| !status.as_deref().is_some_and(is_terminal_child_status))
-            .map(|(id, _)| id)
-            .collect()
+            .collect();
+        filter_pending_child_ids(candidate_ids, &statuses)
     }
 
     /// Persist a batch of parent-wait registrations in one runtime-only save.
@@ -771,7 +852,103 @@ impl ChildSessionPort for ChildSessionAdapter {
         ChildSessionAdapter::active_child_ids(self, parent_session_id).await
     }
 
+    async fn pending_child_ids(
+        &self,
+        parent_session_id: &str,
+        candidate_ids: &[String],
+    ) -> Vec<String> {
+        ChildSessionAdapter::pending_child_ids(self, parent_session_id, candidate_ids).await
+    }
+
     async fn ensure_child_indexed(&self, child_session_id: &str) {
         let _ = self.session_store.get_index_entry(child_session_id).await;
+    }
+}
+
+#[cfg(test)]
+mod wait_target_filter_tests {
+    use super::*;
+
+    // ── issue #546 row 9: never-started children are never "active" ────────
+
+    #[test]
+    fn filter_active_child_ids_excludes_never_started() {
+        let statuses = vec![
+            ("running".to_string(), Some("running".to_string())),
+            ("never-started".to_string(), None),
+            ("done".to_string(), Some("completed".to_string())),
+        ];
+        let active = filter_active_child_ids(statuses);
+        assert_eq!(active, vec!["running".to_string()]);
+    }
+
+    #[test]
+    fn filter_active_child_ids_empty_when_all_terminal_or_unstarted() {
+        let statuses = vec![
+            ("done".to_string(), Some("completed".to_string())),
+            ("errored".to_string(), Some("error".to_string())),
+            ("never-started".to_string(), None),
+        ];
+        assert!(filter_active_child_ids(statuses).is_empty());
+    }
+
+    // ── issue #546 row 8: an explicit wait target that's already terminal
+    //    (or never started) must never be registered on a new wait ─────────
+
+    #[test]
+    fn filter_pending_child_ids_drops_already_terminal_explicit_target() {
+        let mut statuses = std::collections::HashMap::new();
+        statuses.insert("a".to_string(), Some("running".to_string()));
+        statuses.insert("b".to_string(), Some("completed".to_string()));
+
+        let candidates = vec!["a".to_string(), "b".to_string()];
+        let pending = filter_pending_child_ids(&candidates, &statuses);
+        assert_eq!(pending, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn filter_pending_child_ids_drops_never_started_explicit_target() {
+        let mut statuses = std::collections::HashMap::new();
+        statuses.insert("a".to_string(), Some("running".to_string()));
+        statuses.insert("never-started".to_string(), None);
+
+        let candidates = vec!["a".to_string(), "never-started".to_string()];
+        let pending = filter_pending_child_ids(&candidates, &statuses);
+        assert_eq!(pending, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn filter_pending_child_ids_drops_unknown_ids() {
+        // An id that isn't even a child of this parent (not in the statuses
+        // map at all) must never be registered on a wait.
+        let statuses = std::collections::HashMap::new();
+        let candidates = vec!["not-a-child".to_string()];
+        assert!(filter_pending_child_ids(&candidates, &statuses).is_empty());
+    }
+
+    #[test]
+    fn filter_pending_child_ids_empty_when_every_target_already_terminal() {
+        // The scenario that used to strand the parent forever: EVERY
+        // explicitly-named target had already finished before the wait tool
+        // call landed. Must resolve to an empty pending set (the caller then
+        // treats this as "nothing to wait on", not registering a dead wait).
+        let mut statuses = std::collections::HashMap::new();
+        statuses.insert("a".to_string(), Some("completed".to_string()));
+        statuses.insert("b".to_string(), Some("error".to_string()));
+
+        let candidates = vec!["a".to_string(), "b".to_string()];
+        assert!(filter_pending_child_ids(&candidates, &statuses).is_empty());
+    }
+
+    #[test]
+    fn filter_pending_child_ids_keeps_genuinely_active_targets() {
+        let mut statuses = std::collections::HashMap::new();
+        statuses.insert("a".to_string(), Some("running".to_string()));
+        statuses.insert("b".to_string(), Some("running".to_string()));
+
+        let candidates = vec!["a".to_string(), "b".to_string()];
+        let mut pending = filter_pending_child_ids(&candidates, &statuses);
+        pending.sort();
+        assert_eq!(pending, vec!["a".to_string(), "b".to_string()]);
     }
 }

--- a/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
+++ b/crates/app/bamboo-server/src/tools/sub_agent_tests.rs
@@ -10,7 +10,6 @@ use uuid::Uuid;
 use bamboo_agent_core::tools::{
     Tool, ToolCtx, ToolError, ToolExecutionContext, ToolOutcome, ToolResult,
 };
-use bamboo_domain::session::runtime_state::ChildWaitPolicy;
 use bamboo_engine::session_app::child_session;
 
 use crate::app_state::{AgentRunner, AgentStatus};
@@ -493,8 +492,29 @@ async fn create_with_wait_true_suspends_and_registers_wait() {
 }
 
 #[tokio::test]
-async fn wait_action_with_explicit_children_suspends_and_registers() {
+async fn wait_action_with_unknown_explicit_children_does_not_register_a_dead_wait() {
+    // Issue #546 rows 8/9: an explicit `child_session_ids` list is filtered
+    // through `ChildSessionPort::pending_child_ids`, which drops any id that
+    // is not a genuinely pending (started, non-terminal) child of THIS
+    // parent — an already-terminal child, a never-started one, or (as here)
+    // an id that isn't a real child at all. None of those will ever produce
+    // a future completion event, so registering a wait over them would
+    // strand the parent forever; this test pins the OLD (pre-#546)
+    // regression where "k1"/"k2"/"k3" — never actually created as children —
+    // were accepted verbatim and durably registered.
+    //
+    // This harness's `Storage` is the lightweight `JsonlStorage` test double,
+    // which has no parent→child index (`list_child_run_statuses` always
+    // returns empty — a test-fixture-only limitation; production always runs
+    // `SessionStoreV2`, exercised directly in `bamboo-storage`'s own
+    // `list_child_run_statuses_filters_by_parent_and_reports_status` /
+    // `list_sessions_by_run_status_*` tests, and the pure filtering logic
+    // itself in `child_session_adapter::wait_target_filter_tests`). So here
+    // every explicit id is "unknown" regardless of content, which still
+    // exercises the safety property this test cares about: unknown ids are
+    // NEVER registered on a wait.
     let harness = build_test_harness().await;
+
     let result = invoke_completed(
         &harness.tool,
         json!({
@@ -507,14 +527,13 @@ async fn wait_action_with_explicit_children_suspends_and_registers() {
     .await
     .expect("wait should succeed");
 
-    assert_eq!(
+    assert_ne!(
         result.display_preference.as_deref(),
         Some("runtime_control:waiting_for_children"),
-        "wait must suspend the parent"
+        "a wait over only unknown/unresolvable targets must not suspend the parent"
     );
     let payload: serde_json::Value = serde_json::from_str(&result.result).unwrap();
-    assert_eq!(payload["status"].as_str(), Some("waiting"));
-    assert_eq!(payload["wait_for"].as_str(), Some("any"));
+    assert_eq!(payload["status"].as_str(), Some("no_active_children"));
 
     let parent = harness
         .storage
@@ -522,16 +541,13 @@ async fn wait_action_with_explicit_children_suspends_and_registers() {
         .await
         .unwrap()
         .unwrap();
-    let wait = parent
-        .agent_runtime_state
-        .unwrap()
-        .waiting_for_children
-        .unwrap();
-    assert_eq!(
-        wait.child_session_ids,
-        vec!["k1".to_string(), "k2".to_string(), "k3".to_string()]
+    assert!(
+        parent
+            .agent_runtime_state
+            .and_then(|state| state.waiting_for_children)
+            .is_none(),
+        "no dead wait may be registered"
     );
-    assert_eq!(wait.wait_for, ChildWaitPolicy::Any);
 }
 
 #[tokio::test]

--- a/crates/core/bamboo-domain/src/storage.rs
+++ b/crates/core/bamboo-domain/src/storage.rs
@@ -3,7 +3,25 @@
 //! These traits define the boundary between the domain layer and storage
 //! implementations. Concrete implementations live in infrastructure crates.
 
+use chrono::{DateTime, Utc};
+
 use crate::session::types::Session;
+
+/// Lightweight snapshot of a session's index entry — id, parent, run status,
+/// and last-update timestamp — without paying to load the full `session.json`.
+///
+/// Used by the child-wait heartbeat watchdog (issue #546) to (a) sweep the
+/// index for parents durably suspended on `waiting_for_children`, and (b)
+/// check a single child's staleness (a "running" child whose index entry
+/// hasn't moved in a long time is presumed dead — its owning process is gone
+/// and no completion will ever arrive for it).
+#[derive(Debug, Clone)]
+pub struct SessionRunStatusEntry {
+    pub id: String,
+    pub parent_session_id: Option<String>,
+    pub last_run_status: Option<String>,
+    pub updated_at: DateTime<Utc>,
+}
 
 /// Trait for session storage backends.
 ///
@@ -59,6 +77,35 @@ pub trait Storage: Send + Sync {
     ) -> std::io::Result<Vec<(String, Option<String>)>> {
         let _ = parent_session_id;
         Ok(Vec::new())
+    }
+
+    /// List every session whose mirrored `last_run_status` equals `status`,
+    /// sourced from the in-memory index (cheap: no `session.json` reads).
+    ///
+    /// Used by the child-wait heartbeat watchdog (issue #546) to sweep for
+    /// parents durably suspended (`status == "suspended"`) and, at boot, for
+    /// orphaned children left `"running"` by a killed process. Backends
+    /// without a status-aware index return an empty list by default (the
+    /// watchdog degrades to a no-op sweep, never a hard failure).
+    async fn list_sessions_by_run_status(
+        &self,
+        status: &str,
+    ) -> std::io::Result<Vec<SessionRunStatusEntry>> {
+        let _ = status;
+        Ok(Vec::new())
+    }
+
+    /// Cheap single-session status snapshot (id, parent, run status, last
+    /// update), sourced from the in-memory index. Returns `None` when the
+    /// session is not indexed (never persisted, or vanished — e.g. after a
+    /// destructive delete). Used by the child-wait watchdog to check one
+    /// child's staleness without loading its full `session.json`.
+    async fn session_run_status_snapshot(
+        &self,
+        session_id: &str,
+    ) -> std::io::Result<Option<SessionRunStatusEntry>> {
+        let _ = session_id;
+        Ok(None)
     }
 
     /// Append one analysis record — a single JSON line — to the session's

--- a/crates/engine/bamboo-engine/src/lib.rs
+++ b/crates/engine/bamboo-engine/src/lib.rs
@@ -24,7 +24,9 @@ pub use token_usage_log::TokenUsageRecord;
 
 pub use app_context::AgentSessionContext;
 pub use runtime::execution::agent_spawn::{read_cached_session, SessionCache};
-pub use session_app::child_completion_coordinator::ChildCompletionCoordinator;
+pub use session_app::child_completion_coordinator::{
+    wait_watchdog_interval_from_env, ChildCompletionCoordinator,
+};
 
 // Re-export commonly used types from agent (via dependency)
 pub use bamboo_agent_core::{

--- a/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
@@ -8,12 +8,13 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use chrono::Utc;
 use tokio::sync::{mpsc, RwLock};
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
 use bamboo_agent_core::tools::ToolExecutor;
-use bamboo_agent_core::{AgentError, AgentEvent, Session};
+use bamboo_agent_core::{AgentError, AgentEvent, Session, SessionKind};
 use bamboo_domain::ReasoningEffort;
 use bamboo_llm::LLMProvider;
 
@@ -21,6 +22,7 @@ use crate::runtime::config::{
     AuxiliaryModelConfig, BashCompletionSink, BashResumeHook, GoldConfig, GuardianConfig,
     GuardianSpawner, ImageFallbackConfig,
 };
+use crate::runtime::execution::child_completion::{ChildCompletion, ChildCompletionHandler};
 use crate::runtime::execution::runner_lifecycle::finalize_runner;
 use crate::runtime::execution::runner_state::AgentRunner;
 use crate::runtime::model_roster::ModelRoster;
@@ -162,6 +164,19 @@ pub struct SessionExecutionArgs {
     /// Optional bespoke finalization, run after the runner is finalized and
     /// before the session is persisted. See [`SessionCompletionHook`].
     pub on_complete: Option<SessionCompletionHook>,
+
+    /// Optional child-completion notification hook (issue #546 row 5).
+    ///
+    /// The INITIAL child spawn (`sdk::spawn::run_child_spawn`) has its own
+    /// dedicated terminal-completion publish. This generic execution path is
+    /// also used to RESUME an existing session — including a child resumed
+    /// after a human answers its approval/clarification gate, or a nested
+    /// child-parent resumed by the coordinator — and those resumes previously
+    /// terminated silently with no publish, stranding the parent forever once
+    /// the child finally finished. When `session.kind == SessionKind::Child`
+    /// and the run reaches a genuine terminal status (not `"suspended"`), this
+    /// hook is invoked exactly like the initial-spawn path would.
+    pub child_completion_handler: Option<Arc<dyn ChildCompletionHandler>>,
 }
 
 /// The per-request parameter subset of [`SessionExecutionArgs`] — everything
@@ -319,6 +334,7 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
                 runners,
                 sessions_cache,
                 on_complete,
+                child_completion_handler,
             } = args;
 
             // The primary model is required for a spawn; the roster stores it as
@@ -429,6 +445,32 @@ pub fn spawn_session_execution(args: SessionExecutionArgs) {
                 Err(error) => {
                     session.set_last_run_status("error");
                     session.set_last_run_error(error.to_string());
+                }
+            }
+
+            // Issue #546 row 5: a resumed CHILD session that reaches a genuine
+            // terminal status must publish its completion to its parent, exactly
+            // like the initial spawn path (`sdk::spawn::run_child_spawn`) does.
+            // Gated on `!suspended_non_terminal` so a child that merely
+            // re-suspended (e.g. immediately re-hit another approval gate, or
+            // registered a NEW wait on its own grandchildren) does not publish a
+            // premature completion — mirrors the terminal/non-terminal split in
+            // `sdk::spawn`.
+            if session.kind == SessionKind::Child && !suspended_non_terminal {
+                if let (Some(handler), Some(parent_session_id)) = (
+                    child_completion_handler.as_ref(),
+                    session.parent_session_id.clone(),
+                ) {
+                    let completion = ChildCompletion {
+                        parent_session_id,
+                        child_session_id: session.id.clone(),
+                        status: session
+                            .last_run_status()
+                            .unwrap_or_else(|| "completed".to_string()),
+                        error: session.last_run_error(),
+                        completed_at: Utc::now(),
+                    };
+                    handler.on_child_completed(completion).await;
                 }
             }
 

--- a/crates/engine/bamboo-engine/src/runtime/execution/spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/spawn.rs
@@ -20,6 +20,7 @@ use crate::runtime::Agent;
 
 use super::child_completion::{ChildCompletion, ChildCompletionHandler};
 use super::runner_state::AgentRunner;
+use super::session_events::get_or_create_event_sender;
 
 #[derive(Debug, Clone)]
 pub struct SpawnJob {
@@ -88,11 +89,67 @@ impl SpawnScheduler {
     pub fn new(ctx: SpawnContext) -> Self {
         let (tx, mut rx) = mpsc::channel::<SpawnJob>(128);
 
+        // Issue #546 row 2: the ORIGINAL worker awaited `run_spawn_job` directly
+        // in this loop. A panic anywhere in its synchronous setup phase (before
+        // `run_child_spawn`'s own inner task takes over — see the row-1 fix in
+        // `sdk::spawn`) would unwind straight through this `while let` loop,
+        // permanently killing the single worker task: `rx` is dropped, so every
+        // future `enqueue()` fails with "spawn scheduler is not running" for the
+        // REST OF THE PROCESS LIFETIME, and any job already dequeued when the
+        // panic hit is silently lost with no completion ever published.
+        //
+        // Fix: give each job its OWN task, monitored via a nested `JoinHandle`
+        // (mirrors the row-1 pattern) so a panic can never reach this loop.
+        // `run_spawn_job`'s `Err(_)` branches already publish a completion
+        // before returning (see `sdk::spawn::run_child_spawn`), so only the
+        // panic path here needs a synthetic completion.
         tokio::spawn(async move {
             while let Some(job) = rx.recv().await {
-                if let Err(err) = run_spawn_job(ctx.clone(), job).await {
-                    tracing::warn!("spawn job failed: {}", err);
-                }
+                let ctx = ctx.clone();
+                tokio::spawn(async move {
+                    let parent_session_id = job.parent_session_id.clone();
+                    let child_session_id = job.child_session_id.clone();
+                    let session_event_senders = ctx.session_event_senders.clone();
+                    let completion_handler = ctx.completion_handler.clone();
+
+                    let inner = tokio::spawn(run_spawn_job(ctx, job));
+                    match inner.await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(err)) => {
+                            tracing::warn!("spawn job failed: {}", err);
+                        }
+                        Err(join_error) => {
+                            let message = if join_error.is_panic() {
+                                "spawn job task panicked before completion could be published \
+                                 (issue #546 row 2)"
+                                    .to_string()
+                            } else {
+                                format!("spawn job task did not complete: {join_error}")
+                            };
+                            tracing::error!(
+                                %parent_session_id,
+                                %child_session_id,
+                                %message,
+                                "run_spawn_job panicked; publishing synthetic error completion \
+                                 so the parent is not stranded"
+                            );
+                            let parent_tx = get_or_create_event_sender(
+                                &session_event_senders,
+                                &parent_session_id,
+                            )
+                            .await;
+                            publish_child_completion_parts(
+                                &parent_tx,
+                                completion_handler,
+                                parent_session_id,
+                                child_session_id,
+                                "error".to_string(),
+                                Some(message),
+                            )
+                            .await;
+                        }
+                    }
+                });
             }
         });
 
@@ -163,7 +220,31 @@ async fn publish_child_completion(
     });
 
     if let Some(handler) = completion_handler {
-        handler.on_child_completed(completion).await;
+        let parent_session_id = completion.parent_session_id.clone();
+        let child_session_id = completion.child_session_id.clone();
+        // Issue #546 row 3: isolate a panic inside the coordinator's own
+        // `on_child_completed` (e.g. an unexpected storage error path or a bug
+        // in guardian-verdict handling) behind a monitored `JoinHandle` so it
+        // can never unwind through this publish call and abort whatever task
+        // invoked it (the child's finalize task, or the scheduler's own
+        // panic-monitor task — rows 1/2). By this point the child's terminal
+        // status is ALREADY durably persisted (every caller of
+        // `publish_child_completion_parts` persists before publishing), so if
+        // the handler panics before clearing the parent's wait, the heartbeat
+        // watchdog (issue #546 Part B) will replay this exact completion from
+        // the index on its next sweep — `on_child_completed` is documented as
+        // idempotent for exactly this reason.
+        let join = tokio::spawn(async move { handler.on_child_completed(completion).await });
+        if let Err(join_error) = join.await {
+            tracing::error!(
+                %parent_session_id,
+                %child_session_id,
+                panicked = join_error.is_panic(),
+                "child-completion handler panicked; the child's terminal status is already \
+                 persisted, so the heartbeat watchdog will replay this completion on its next \
+                 sweep"
+            );
+        }
     }
 }
 

--- a/crates/engine/bamboo-engine/src/sdk/spawn.rs
+++ b/crates/engine/bamboo-engine/src/sdk/spawn.rs
@@ -151,7 +151,18 @@ pub async fn run_child_spawn(ctx: SpawnContext, job: SpawnJob) -> Result<(), Str
         .save_runtime_session(&mut session)
         .await;
 
-    // Insert runner status.
+    // Insert runner status. A `None` here means a runner is ALREADY marked
+    // `Running` for this exact child session id — almost always a genuine
+    // duplicate/racing spawn attempt, in which case that other invocation owns
+    // publishing the eventual completion (and, after the panic-isolation fix
+    // below, is now guaranteed to do so even if it panics). We deliberately do
+    // NOT publish a synthetic completion here — the real runner is still in
+    // flight and a synthetic one would race a genuine one. Upgraded from a
+    // silent `tracing::debug!` inside `try_reserve_runner` to a `warn!` here so
+    // a persistently-stuck registry entry (e.g. a stale entry that survives
+    // across restarts is a genuinely different bug) is observable; the child-
+    // wait heartbeat watchdog (issue #546 Part B) is the backstop for a parent
+    // stranded because the *other* invocation's runner never completes.
     let Some(RunnerReservation { cancel_token, .. }) = try_reserve_runner(
         &ctx.agent_runners,
         &ctx.session_event_senders,
@@ -160,6 +171,13 @@ pub async fn run_child_spawn(ctx: SpawnContext, job: SpawnJob) -> Result<(), Str
     )
     .await
     else {
+        tracing::warn!(
+            parent_session_id = %job.parent_session_id,
+            child_session_id = %job.child_session_id,
+            "run_child_spawn: a runner is already Running for this child session; skipping \
+             this duplicate spawn attempt without publishing (the in-flight runner owns the \
+             eventual completion)"
+        );
         return Ok(());
     };
 
@@ -250,123 +268,321 @@ pub async fn run_child_spawn(ctx: SpawnContext, job: SpawnJob) -> Result<(), Str
     let session_event_senders = ctx.session_event_senders.clone();
     let completion_handler = ctx.completion_handler.clone();
 
-    tokio::spawn(async move {
-        // Set the child model via the single authoritative pre-execution
-        // mutation point. The child session's system prompt is already in place
-        // (loaded from storage), so pass `None` for `system_prompt`.
-        crate::session_app::execution_prep::prepare_session_for_execution(
-            &mut session,
-            None,
-            Some(&model),
-        );
+    // Issue #546 row 1: the actual execution runs on an INNER task that this
+    // outer task monitors via its `JoinHandle`. `std::panic::catch_unwind`
+    // does not compose with `.await` (the future must be `UnwindSafe`, which
+    // an arbitrary agent-loop future is not), so panic isolation instead
+    // relies on tokio's own unwind boundary at the task level: a panic inside
+    // `inner` is caught by the runtime, turned into an `Err(JoinError)`, and
+    // `inner`'s own stack unwinds WITHOUT taking this outer task with it. Before
+    // this fix a panic here silently dropped the `JoinHandle`, so the child's
+    // `last_run_status` stayed "running" forever in storage, its runner entry
+    // stayed `Running` in the registry, and — critically — no completion was
+    // ever published, stranding the parent's `waiting_for_children` durably.
+    let panic_agent = ctx.agent.clone();
+    let panic_agent_runners = ctx.agent_runners.clone();
+    let panic_session_id = job.child_session_id.clone();
+    let panic_parent_tx = parent_tx.clone();
+    let panic_completion_handler = ctx.completion_handler.clone();
+    let panic_parent_id = job.parent_session_id.clone();
+    let panic_child_id = job.child_session_id.clone();
+    let panic_done = forwarder_done.clone();
 
-        // Sub-agents always run as actors (the in-process runtime was removed):
-        // dispatch to the composite child runner. The built-in local actor
-        // handles the default case; expert `externalAgents` profiles handle
-        // roles pinned to other agents. `should_handle` selects the right one.
-        //
-        // The child's `AgentLoopConfig` is assembled by the external runner, not
-        // here, and does not currently wire `bash_resume_hook`. The end-of-turn
-        // bash suspend gate is therefore inert for children — graceful
-        // degradation: a child that leaves a `run_in_background` shell running
-        // simply completes; the shell keeps running detached and stays readable
-        // via BashOutput. No strand can occur because the gate refuses to
-        // suspend without the hook. (The parent-resume path re-wires the hook,
-        // so a RESUMED run is covered; only the initial child run is not.)
-        let result: crate::runtime::runner::Result<()> =
-            if external_runner.should_handle(&session).await {
-                external_runner
-                    .execute_external_child(&mut session, &job, mpsc_tx, cancel_token.clone())
-                    .await
-            } else {
-                Err(bamboo_agent_core::AgentError::LLM(format!(
+    tokio::spawn(async move {
+        let inner = tokio::spawn(child_execution_body(
+            session,
+            model,
+            mpsc_tx,
+            cancel_token,
+            job,
+            external_runner,
+            timeout_reason,
+            agent,
+            session_id_clone,
+            agent_runners_for_status,
+            sessions_cache,
+            done,
+            parent_tx_for_done,
+            completion_handler,
+            parent_id_for_done,
+            child_id_for_done,
+            session_event_senders,
+        ));
+
+        if let Err(join_error) = inner.await {
+            let panic_message = panic_message_from_join_error(join_error);
+            tracing::error!(
+                parent_session_id = %panic_parent_id,
+                child_session_id = %panic_child_id,
+                error = %panic_message,
+                "run_child_spawn: child execution task panicked; publishing synthetic error \
+                 completion so the parent is not stranded (issue #546 row 1)"
+            );
+
+            // Best-effort: reflect the panic on the child's own storage record
+            // too, so it doesn't show as permanently "running" in the UI/index.
+            // The inner task owned `session` and never got to persist its own
+            // terminal snapshot, so we reload fresh here.
+            if let Ok(Some(mut child_session)) =
+                panic_agent.storage().load_session(&panic_child_id).await
+            {
+                child_session.set_last_run_status("error");
+                child_session.set_last_run_error(panic_message.clone());
+                let _ = panic_agent
+                    .persistence()
+                    .save_runtime_session(&mut child_session)
+                    .await;
+            }
+
+            let panicked_result: crate::runtime::runner::Result<()> =
+                Err(bamboo_agent_core::AgentError::LLM(panic_message.clone()));
+            finalize_runner(&panic_agent_runners, &panic_session_id, &panicked_result).await;
+
+            panic_done.cancel();
+            publish_child_completion_parts(
+                &panic_parent_tx,
+                panic_completion_handler,
+                panic_parent_id,
+                panic_child_id,
+                "error".to_string(),
+                Some(panic_message),
+            )
+            .await;
+        }
+    });
+
+    Ok(())
+}
+
+/// Extract a human-readable panic message from an owned [`tokio::task::JoinError`].
+///
+/// Handles the two payload shapes `std::panic!`/`.unwrap()` produce (`&'static
+/// str` and `String`); falls back to the `JoinError`'s own `Display` for a
+/// cancellation (`is_panic() == false`, which cannot happen for a task nobody
+/// aborts, but is handled defensively) or an exotic payload type.
+fn panic_message_from_join_error(error: tokio::task::JoinError) -> String {
+    if error.is_panic() {
+        let payload = error.into_panic();
+        if let Some(message) = payload.downcast_ref::<&str>() {
+            return (*message).to_string();
+        }
+        if let Some(message) = payload.downcast_ref::<String>() {
+            return message.clone();
+        }
+        return "child execution task panicked (non-string payload)".to_string();
+    }
+    format!("child execution task did not complete: {error}")
+}
+
+/// The body of the child execution task — extracted from [`run_child_spawn`]'s
+/// former inline closure ONLY so it can be spawned as its own monitored
+/// `JoinHandle` (see the panic-isolation comment at the call site, issue #546
+/// row 1). Behavior is byte-for-byte identical to before the extraction.
+#[allow(clippy::too_many_arguments)]
+async fn child_execution_body(
+    mut session: bamboo_agent_core::Session,
+    model: String,
+    mpsc_tx: tokio::sync::mpsc::Sender<AgentEvent>,
+    cancel_token: CancellationToken,
+    job: SpawnJob,
+    external_runner: Arc<dyn crate::runtime::execution::ExternalChildRunner>,
+    timeout_reason: Arc<RwLock<Option<String>>>,
+    agent: Arc<crate::runtime::Agent>,
+    session_id_clone: String,
+    agent_runners_for_status: Arc<
+        RwLock<std::collections::HashMap<String, crate::runtime::execution::AgentRunner>>,
+    >,
+    sessions_cache: crate::runtime::execution::agent_spawn::SessionCache,
+    done: CancellationToken,
+    parent_tx_for_done: broadcast::Sender<AgentEvent>,
+    completion_handler: Option<Arc<dyn crate::runtime::execution::ChildCompletionHandler>>,
+    parent_id_for_done: String,
+    child_id_for_done: String,
+    session_event_senders: Arc<
+        RwLock<std::collections::HashMap<String, broadcast::Sender<AgentEvent>>>,
+    >,
+) {
+    // Set the child model via the single authoritative pre-execution
+    // mutation point. The child session's system prompt is already in place
+    // (loaded from storage), so pass `None` for `system_prompt`.
+    crate::session_app::execution_prep::prepare_session_for_execution(
+        &mut session,
+        None,
+        Some(&model),
+    );
+
+    // Sub-agents always run as actors (the in-process runtime was removed):
+    // dispatch to the composite child runner. The built-in local actor
+    // handles the default case; expert `externalAgents` profiles handle
+    // roles pinned to other agents. `should_handle` selects the right one.
+    //
+    // The child's `AgentLoopConfig` is assembled by the external runner, not
+    // here, and does not currently wire `bash_resume_hook`. The end-of-turn
+    // bash suspend gate is therefore inert for children — graceful
+    // degradation: a child that leaves a `run_in_background` shell running
+    // simply completes; the shell keeps running detached and stays readable
+    // via BashOutput. No strand can occur because the gate refuses to
+    // suspend without the hook. (The parent-resume path re-wires the hook,
+    // so a RESUMED run is covered; only the initial child run is not.)
+    let result: crate::runtime::runner::Result<()> =
+        if external_runner.should_handle(&session).await {
+            external_runner
+                .execute_external_child(&mut session, &job, mpsc_tx, cancel_token.clone())
+                .await
+        } else {
+            Err(bamboo_agent_core::AgentError::LLM(format!(
                 "No child runner matched session runtime metadata: agent_id={:?}, protocol={:?}",
                 session.metadata.get("external.agent_id"),
                 session.metadata.get("external.protocol"),
             )))
-            };
-
-        let timeout_error = timeout_reason.read().await.clone();
-        // Phase 2: a child that suspended awaiting the PARENT's approval of a
-        // gated tool is NOT done — publish a NON-terminal "suspended" status so
-        // the parent's completion coordinator does not resume the parent
-        // prematurely. The child is resumed once the human decides, then runs to
-        // a real terminal completion that re-enters this path.
-        //
-        // Issue #84 Phase 2b: a child that suspended mid-background-Bash is
-        // likewise NOT done — it must not publish a premature terminal
-        // "completed" to its parent while a `run_in_background` shell is still
-        // running for it.
-        let suspended_non_terminal = session
-            .metadata
-            .get("runtime.suspend_reason")
-            .map(|reason| {
-                matches!(
-                    reason.as_str(),
-                    "awaiting_parent_approval" | "waiting_for_bash"
-                )
-            })
-            .unwrap_or(false);
-        let (status, error) = if let Some(reason) = timeout_error {
-            ("timeout".to_string(), Some(reason))
-        } else if suspended_non_terminal && result.is_ok() {
-            ("suspended".to_string(), None)
-        } else {
-            match &result {
-                Ok(_) => ("completed".to_string(), None),
-                Err(e @ bamboo_agent_core::AgentError::Cancelled) => {
-                    ("cancelled".to_string(), Some(e.to_string()))
-                }
-                Err(e) => ("error".to_string(), Some(e.to_string())),
-            }
         };
 
-        // Merge any queued injected messages that the pipeline didn't pick up
-        // (e.g. if the loop exited before the next turn boundary).
-        crate::runtime::runner::state_bridge::merge_pending_injected_messages(
-            &mut session,
-            Some(agent.storage()),
-            Some(agent.persistence()),
-        )
-        .await;
-
-        // Persist final session snapshot.
-        session.set_last_run_status(status.clone());
-        if let Some(err) = &error {
-            session.set_last_run_error(err.clone());
-        } else {
-            session.clear_last_run_error();
+    let timeout_error = timeout_reason.read().await.clone();
+    // Phase 2: a child that suspended awaiting the PARENT's approval of a
+    // gated tool is NOT done — publish a NON-terminal "suspended" status so
+    // the parent's completion coordinator does not resume the parent
+    // prematurely. The child is resumed once the human decides, then runs to
+    // a real terminal completion that re-enters this path.
+    //
+    // Issue #84 Phase 2b: a child that suspended mid-background-Bash is
+    // likewise NOT done — it must not publish a premature terminal
+    // "completed" to its parent while a `run_in_background` shell is still
+    // running for it.
+    //
+    // Issue #546 row 13: this allowlist previously covered only the two
+    // reasons above, so a child suspending on `awaiting_clarification` (its
+    // own pending-question gate) or `waiting_for_children` (it spawned its
+    // OWN grandchildren and is durably waiting on them) fell through to the
+    // terminal branch below and published a premature "completed" to ITS
+    // parent — even though the child was very much still working. Every
+    // known non-terminal `runtime.suspend_reason` value must be listed here;
+    // see `runtime/runner/tool_execution/clarification.rs`,
+    // `core/tools/result_handler.rs`, and
+    // `runtime/runner/loop_execution/pipeline.rs` for where each is set.
+    let suspended_non_terminal = session
+        .metadata
+        .get("runtime.suspend_reason")
+        .map(|reason| {
+            matches!(
+                reason.as_str(),
+                "awaiting_parent_approval"
+                    | "waiting_for_bash"
+                    | "awaiting_clarification"
+                    | "waiting_for_children"
+            )
+        })
+        .unwrap_or(false);
+    let (status, error) = if let Some(reason) = timeout_error {
+        ("timeout".to_string(), Some(reason))
+    } else if suspended_non_terminal && result.is_ok() {
+        ("suspended".to_string(), None)
+    } else {
+        match &result {
+            Ok(_) => ("completed".to_string(), None),
+            Err(e @ bamboo_agent_core::AgentError::Cancelled) => {
+                ("cancelled".to_string(), Some(e.to_string()))
+            }
+            Err(e) => ("error".to_string(), Some(e.to_string())),
         }
-        let _ = agent.persistence().save_runtime_session(&mut session).await;
-        // Flip the runner registry to a terminal status (which makes session
-        // summaries report `is_running: false`) ONLY AFTER the final
-        // `last_run_status` is persisted above. Doing it earlier opens a window
-        // where the summary reports `{is_running: false, last_run_status: null}`,
-        // which the frontend's optimistic-race window reads as "still settling",
-        // leaving a phantom "thinking" indicator for a few seconds after the
-        // reply has already completed (notably on a session's first turn).
-        finalize_runner(&agent_runners_for_status, &session_id_clone, &result).await;
-        sessions_cache.insert(
-            session_id_clone.clone(),
-            Arc::new(parking_lot::RwLock::new(session)),
-        );
+    };
 
-        // Stop forwarding/heartbeats and emit terminal child status through the
-        // same durable completion path used by success/error/cancel/timeout.
-        done.cancel();
-        publish_child_completion_parts(
-            &parent_tx_for_done,
-            completion_handler,
-            parent_id_for_done,
-            child_id_for_done,
-            status,
-            error,
-        )
-        .await;
+    // Merge any queued injected messages that the pipeline didn't pick up
+    // (e.g. if the loop exited before the next turn boundary).
+    crate::runtime::runner::state_bridge::merge_pending_injected_messages(
+        &mut session,
+        Some(agent.storage()),
+        Some(agent.persistence()),
+    )
+    .await;
 
-        // Allow dead code: session_event_senders keeps the sender alive during the task.
-        drop(session_event_senders);
-    });
+    // Persist final session snapshot.
+    session.set_last_run_status(status.clone());
+    if let Some(err) = &error {
+        session.set_last_run_error(err.clone());
+    } else {
+        session.clear_last_run_error();
+    }
+    let _ = agent.persistence().save_runtime_session(&mut session).await;
+    // Flip the runner registry to a terminal status (which makes session
+    // summaries report `is_running: false`) ONLY AFTER the final
+    // `last_run_status` is persisted above. Doing it earlier opens a window
+    // where the summary reports `{is_running: false, last_run_status: null}`,
+    // which the frontend's optimistic-race window reads as "still settling",
+    // leaving a phantom "thinking" indicator for a few seconds after the
+    // reply has already completed (notably on a session's first turn).
+    finalize_runner(&agent_runners_for_status, &session_id_clone, &result).await;
+    sessions_cache.insert(
+        session_id_clone.clone(),
+        Arc::new(parking_lot::RwLock::new(session)),
+    );
 
-    Ok(())
+    // Stop forwarding/heartbeats and emit terminal child status through the
+    // same durable completion path used by success/error/cancel/timeout.
+    done.cancel();
+    publish_child_completion_parts(
+        &parent_tx_for_done,
+        completion_handler,
+        parent_id_for_done,
+        child_id_for_done,
+        status,
+        error,
+    )
+    .await;
+
+    // Allow dead code: session_event_senders keeps the sender alive during the task.
+    drop(session_event_senders);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── issue #546 row 1: panic → synthetic error completion ────────────────
+
+    #[tokio::test]
+    async fn panic_message_from_join_error_extracts_str_payload() {
+        let handle = tokio::spawn(async { panic!("boom") });
+        let error = handle.await.expect_err("task must have panicked");
+        assert!(error.is_panic());
+        let message = panic_message_from_join_error(error);
+        assert_eq!(message, "boom");
+    }
+
+    #[tokio::test]
+    async fn panic_message_from_join_error_extracts_string_payload() {
+        let handle = tokio::spawn(async {
+            let detail = format!("child {} exploded", "abc123");
+            panic!("{detail}");
+        });
+        let error = handle.await.expect_err("task must have panicked");
+        let message = panic_message_from_join_error(error);
+        assert_eq!(message, "child abc123 exploded");
+    }
+
+    #[tokio::test]
+    async fn panic_message_from_join_error_survives_non_string_payload() {
+        // std::panic::panic_any with a non-string payload — must not panic
+        // the extractor itself, and must produce SOME non-empty message.
+        let handle = tokio::spawn(async { std::panic::panic_any(42i32) });
+        let error = handle.await.expect_err("task must have panicked");
+        let message = panic_message_from_join_error(error);
+        assert!(!message.is_empty());
+    }
+
+    #[test]
+    fn panic_message_from_join_error_handles_abort() {
+        // A JoinError from an aborted (not panicked) task must not be treated
+        // as a panic payload — falls back to the JoinError's own Display.
+        let runtime = tokio::runtime::Runtime::new().expect("runtime");
+        runtime.block_on(async {
+            let handle = tokio::spawn(async {
+                tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+            });
+            handle.abort();
+            let error = handle.await.expect_err("aborted task must error");
+            assert!(!error.is_panic());
+            let message = panic_message_from_join_error(error);
+            assert!(message.contains("did not complete"), "message: {message}");
+        });
+    }
 }

--- a/crates/engine/bamboo-engine/src/sdk/tests.rs
+++ b/crates/engine/bamboo-engine/src/sdk/tests.rs
@@ -17,6 +17,7 @@ use bamboo_agent_core::tools::{ToolCall, ToolError, ToolResult, ToolSchema};
 use bamboo_agent_core::{AgentEvent, Message, Session};
 use bamboo_llm::{LLMChunk, LLMError, LLMProvider, LLMStream};
 
+use crate::runtime::execution::child_completion::{ChildCompletion, ChildCompletionHandler};
 use crate::runtime::execution::spawn::{ExternalChildRunner, SpawnContext, SpawnJob};
 use crate::sdk::runner::{ChildRunner, RunChildInput};
 use crate::sdk::spawn::run_child_spawn;
@@ -493,6 +494,143 @@ async fn s_t2_5_watchdog_timeout_completes_with_timeout_status() {
     match events.last().unwrap() {
         AgentEvent::SubAgentCompleted { status, .. } => {
             assert_eq!(status, "timeout", "watchdog must yield timeout status");
+        }
+        other => panic!("expected SubAgentCompleted, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Issue #546 row 1 — a panic in the child's execution task must publish a
+// synthetic error completion instead of silently stranding the parent.
+// ---------------------------------------------------------------------------
+
+/// External runner double that panics instead of executing, simulating an
+/// unforeseen panic anywhere in the child's execution path.
+struct PanickingRunner;
+
+#[async_trait]
+impl ExternalChildRunner for PanickingRunner {
+    async fn should_handle(&self, _session: &Session) -> bool {
+        true
+    }
+
+    async fn execute_external_child(
+        &self,
+        _session: &mut Session,
+        _job: &SpawnJob,
+        _event_tx: tokio::sync::mpsc::Sender<AgentEvent>,
+        _cancel_token: tokio_util::sync::CancellationToken,
+    ) -> crate::runtime::runner::Result<()> {
+        panic!("simulated child execution panic (issue #546 row 1 test)");
+    }
+}
+
+#[tokio::test]
+async fn s_t546_1_child_execution_panic_publishes_synthetic_error_completion() {
+    let harness = build_harness(Arc::new(CompletedProvider), Vec::new(), &[]).await;
+    let mut parent_rx = harness.parent_rx.resubscribe();
+    // Swap in a runner that panics instead of executing — everything else
+    // (storage, sessions cache, runner registry) is the real harness.
+    let ctx = SpawnContext {
+        external_child_runner: Arc::new(PanickingRunner),
+        ..harness.ctx.clone()
+    };
+
+    run_child_spawn(
+        ctx,
+        SpawnJob {
+            parent_session_id: harness.parent_session_id.clone(),
+            child_session_id: harness.child_session_id.clone(),
+            model: "gpt-5".to_string(),
+            disabled_tools: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    // Before the fix this event never arrived — the panic silently dropped
+    // the `JoinHandle` and the parent waited forever.
+    let events = collect_until_completed(&mut parent_rx).await;
+    match events.last().unwrap() {
+        AgentEvent::SubAgentCompleted { status, error, .. } => {
+            assert_eq!(
+                status, "error",
+                "a panicked child execution task must publish a synthetic error completion"
+            );
+            assert!(
+                error.as_deref().unwrap_or_default().contains("panic"),
+                "error should reference the panic: {error:?}"
+            );
+        }
+        other => panic!("expected SubAgentCompleted, got {other:?}"),
+    }
+
+    // The child's own storage record must also reflect the panic — not stay
+    // "running" forever (which would also defeat the boot-reconciliation /
+    // watchdog dead-child staleness signal for issue #546 Part B).
+    let persisted = harness
+        .storage
+        .load_session(&harness.child_session_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        persisted
+            .metadata
+            .get("last_run_status")
+            .map(String::as_str),
+        Some("error")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #546 row 3 — a panic inside the coordinator's `on_child_completed`
+// must not propagate and must not prevent the broadcast `SubAgentCompleted`
+// event (which is sent before the handler runs).
+// ---------------------------------------------------------------------------
+
+struct PanickingCompletionHandler;
+
+#[async_trait]
+impl ChildCompletionHandler for PanickingCompletionHandler {
+    async fn on_child_completed(&self, _completion: ChildCompletion) {
+        panic!("simulated coordinator panic (issue #546 row 3 test)");
+    }
+}
+
+#[tokio::test]
+async fn s_t546_3_completion_handler_panic_does_not_block_broadcast_or_hang() {
+    let harness = build_harness(Arc::new(CompletedProvider), Vec::new(), &[]).await;
+    let mut parent_rx = harness.parent_rx.resubscribe();
+    let ctx = SpawnContext {
+        completion_handler: Some(Arc::new(PanickingCompletionHandler)),
+        ..harness.ctx.clone()
+    };
+
+    // Must complete without hanging or crashing the process — a panicking
+    // handler is isolated behind its own monitored `JoinHandle`
+    // (`publish_child_completion`). `collect_until_completed`'s own internal
+    // timeout would fail this test if the panic somehow blocked delivery.
+    run_child_spawn(
+        ctx,
+        SpawnJob {
+            parent_session_id: harness.parent_session_id.clone(),
+            child_session_id: harness.child_session_id.clone(),
+            model: "gpt-5".to_string(),
+            disabled_tools: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let events = collect_until_completed(&mut parent_rx).await;
+    match events.last().unwrap() {
+        AgentEvent::SubAgentCompleted { status, .. } => {
+            assert_eq!(
+                status, "completed",
+                "the child's own real completion status is unaffected by a downstream \
+                 handler panic"
+            );
         }
         other => panic!("expected SubAgentCompleted, got {other:?}"),
     }

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -17,7 +17,7 @@ use crate::execution::{
 use crate::runtime::config::{BashResumeHook, GuardianSpawner, BASH_COMPLETION_RESUME_KIND};
 use crate::runtime::guardian_state::{
     parse_guardian_verdict, read_guardian_config, read_guardian_state, write_guardian_state,
-    GuardianVerdict,
+    GuardianState, GuardianVerdict,
 };
 use crate::Agent;
 use async_trait::async_trait;
@@ -29,15 +29,17 @@ use bamboo_agent_core::{
 use bamboo_domain::session::runtime_state::{
     AgentRuntimeState, AgentStatusState, ChildWaitPolicy, SuspensionState,
 };
+use bamboo_domain::SessionRunStatusEntry;
 use bamboo_llm::{Config, ProviderModelRouter, ProviderRegistry};
 use bamboo_storage::LockedSessionStore;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use tokio::sync::{broadcast, RwLock};
 
 use crate::model_areas::resolve_global_area_models;
 use crate::model_config_helper::{
     resolve_fast_model, resolve_gold_config, GOLD_CONFIG_METADATA_KEY,
 };
+use crate::session_app::execute::has_pending_user_message;
 use crate::session_app::provider_model::session_effective_model_ref;
 use crate::session_app::resume::{
     resume_session_execution, ResumeExecutionPort, ResumeSpawnRequest,
@@ -408,19 +410,136 @@ impl ChildCompletionCoordinator {
             Arc::new(parking_lot::RwLock::new(session.clone())),
         );
     }
+
+    /// Drive the clear→append→resume for a satisfied child wait through a
+    /// **clobber-retry loop** (issue #546 rows 6+7), mirroring
+    /// [`Self::perform_bash_resume`]'s bounded retry exactly. `resume_message`
+    /// and `guardian_update` are computed ONCE by the caller against the
+    /// initial completion event; each attempt reloads the parent fresh and
+    /// re-applies the SAME transition via [`apply_child_completion_wait_clear`],
+    /// so a reverted parent file (clobber) or a bailed-without-spawning resume
+    /// (row 7) both simply retry the identical mutation against the latest
+    /// state — safe because the transition is a no-op once someone else has
+    /// already applied it (the `waiting_for_children.is_none()` bail in
+    /// [`apply_child_completion_wait_clear`]).
+    ///
+    /// **The caller MUST hold the [`session_resume_lock`] for
+    /// `parent_session_id`** for this call's ENTIRE duration — same
+    /// requirement as [`Self::perform_bash_resume`], and for the same reason:
+    /// the load-check-clear-resume critical section must be serialized against
+    /// every other resume source for this parent (another child completion,
+    /// the watchdog sweep, a bash push). The only caller today
+    /// (`on_child_completed`) already holds it across this whole call.
+    async fn resume_parent_after_child_completion(
+        &self,
+        parent_session_id: String,
+        resume_message: Message,
+        guardian_update: Option<GuardianState>,
+    ) {
+        const MAX_RESUME_ATTEMPTS: u8 = 5;
+        let retry_backoff = Duration::from_millis(200);
+
+        for attempt in 0..MAX_RESUME_ATTEMPTS {
+            if attempt > 0 {
+                tokio::time::sleep(retry_backoff * attempt as u32).await;
+            }
+
+            let Some(mut session) = self.load_session(&parent_session_id).await else {
+                tracing::warn!(
+                    %parent_session_id,
+                    "child-completion resume: parent session not found; nothing to resume"
+                );
+                return;
+            };
+
+            if !apply_child_completion_wait_clear(
+                &mut session,
+                &resume_message,
+                guardian_update.as_ref(),
+            ) {
+                // Double-resume guard: another source (a concurrent completion
+                // — impossible under the held per-parent lock, but also a
+                // previous attempt of THIS SAME retry loop, or the watchdog
+                // sweep — has already cleared this wait. No-op.
+                tracing::info!(
+                    %parent_session_id, attempt,
+                    "child-completion resume: wait already cleared; nothing to resume"
+                );
+                return;
+            }
+            session.updated_at = Utc::now();
+            self.save_and_cache(&mut session).await;
+
+            let outcome = self.resume_parent(parent_session_id.clone()).await;
+            match outcome {
+                ResumeOutcome::Started { .. } => {
+                    tracing::info!(%parent_session_id, attempt, "child-completion resume: resume fired");
+                    return;
+                }
+                ResumeOutcome::NotFound => {
+                    tracing::warn!(%parent_session_id, "child-completion resume: session vanished during resume");
+                    return;
+                }
+                ResumeOutcome::Completed | ResumeOutcome::AlreadyRunning { .. } => {
+                    // Did not spawn: either a finalize-clobber reverted our
+                    // clear+message before the runner could observe it (row 6),
+                    // or the adapter's `spawn_resume_execution` bailed without
+                    // ever calling it (row 7, now honestly reported instead of
+                    // a lying `Started`). Either way, retry the whole
+                    // clear→append→resume against the latest state.
+                    tracing::warn!(
+                        %parent_session_id, attempt,
+                        outcome = outcome.as_str(),
+                        "child-completion resume: did not spawn (clobber or adapter bail); retrying"
+                    );
+                    continue;
+                }
+            }
+        }
+
+        tracing::warn!(
+            %parent_session_id,
+            attempts = MAX_RESUME_ATTEMPTS,
+            "child-completion resume: exhausted clobber-retry budget without confirming resume; \
+             the heartbeat watchdog (issue #546 Part B) will rescue this parent on its next sweep"
+        );
+    }
 }
 
 #[async_trait]
 impl ChildCompletionHandler for ChildCompletionCoordinator {
     async fn on_child_completed(&self, completion: ChildCompletion) {
+        // Issue #546 row 12: a NON-terminal completion (status "suspended",
+        // published for a child that merely hit an approval/clarification/
+        // grandchild-wait gate — see `sdk::spawn`'s `suspended_non_terminal`
+        // split) must never satisfy a wait or be folded into the completed
+        // set. Before this guard, `derive_completed_child_ids` folded the
+        // just-reported child in UNCONDITIONALLY regardless of its status, so
+        // a merely-suspended child could prematurely resume the parent with
+        // "finished with status `suspended`". The real terminal completion
+        // arrives later when the child is resumed and actually finishes,
+        // re-entering this same path. Bailing here (before acquiring the
+        // per-parent lock or touching storage) also means a non-terminal
+        // completion is nearly free.
+        if !is_terminal_child_status(&completion.status) {
+            tracing::debug!(
+                parent_session_id = %completion.parent_session_id,
+                child_session_id = %completion.child_session_id,
+                status = %completion.status,
+                "non-terminal child completion; not evaluating parent wait policy"
+            );
+            return;
+        }
+
         // Acquire the per-session async lock to eliminate the concurrent
-        // double-resume race (see `parent_locks` for the full scenario). The
-        // inner std::sync::Mutex is released immediately so no sync lock is
-        // held across the await that follows.
+        // double-resume race (see `parent_locks` for the full scenario). Held
+        // for this call's ENTIRE remainder — including the retry-capable
+        // resume below — mirroring `perform_bash_resume`'s own lock discipline
+        // (its callers hold this same lock across their whole retry loop too).
         let per_parent = session_resume_lock(&completion.parent_session_id);
         let _per_parent_guard = per_parent.lock().await;
 
-        let Some(mut parent) = self.load_session(&completion.parent_session_id).await else {
+        let Some(parent) = self.load_session(&completion.parent_session_id).await else {
             tracing::warn!(
                 parent_session_id = %completion.parent_session_id,
                 child_session_id = %completion.child_session_id,
@@ -434,7 +553,7 @@ impl ChildCompletionHandler for ChildCompletionCoordinator {
         // inspects that session's own `waiting_for_children` runtime state, and
         // resumes it. (Previously this bailed unless the parent was Root, which
         // silently dropped grandchild completions.)
-        let mut runtime_state = read_runtime_state(&parent);
+        let runtime_state = read_runtime_state(&parent);
 
         // Single source of truth: reconstruct the completed-child set from the
         // session index rather than from a denormalized copy on the parent file.
@@ -459,15 +578,9 @@ impl ChildCompletionHandler for ChildCompletionCoordinator {
                 &completed_child_ids,
                 &completion.status,
             );
-            if should_resume {
-                runtime_state.waiting_for_children = None;
-                runtime_state.status = AgentStatusState::Idle;
-                runtime_state.suspension = None;
-            }
         }
 
         if should_resume {
-            parent.metadata.remove("runtime.suspend_reason");
             // Load the completed child once. The guardian branch inspects its
             // subagent_type + final verdict; the generic path folds its final
             // assistant content into the hidden resume message (avoiding an extra
@@ -492,8 +605,12 @@ impl ChildCompletionHandler for ChildCompletionCoordinator {
             // parent's recorded review advances GuardianState (phase → Reviewed)
             // and resumes with a verdict-tailored, findings-carrying message. Any
             // id mismatch or unparseable verdict falls through to the generic
-            // resume, so the parent is never stranded.
+            // resume, so the parent is never stranded. The updated GuardianState
+            // (if any) is threaded through to the retry-capable resume below
+            // instead of being written directly to `parent` here — see
+            // `resume_parent_after_child_completion` / `apply_child_completion_wait_clear`.
             let reviewed_round = runtime_state.round.current_round;
+            let mut guardian_update: Option<GuardianState> = None;
             let guardian_resume = loaded_child.as_ref().and_then(|child| {
                 if child.subagent_type().as_deref() != Some("guardian") {
                     return None;
@@ -542,7 +659,7 @@ impl ChildCompletionHandler for ChildCompletionCoordinator {
                 let approved = verdict.approve;
                 let message = guardian_resume_message(&completion, &verdict);
                 guardian_state.record_verdict(verdict, reviewed_round);
-                write_guardian_state(&mut parent, guardian_state);
+                guardian_update = Some(guardian_state);
                 tracing::info!(
                     parent_session_id = %completion.parent_session_id,
                     child_session_id = %completion.child_session_id,
@@ -562,8 +679,24 @@ impl ChildCompletionHandler for ChildCompletionCoordinator {
                         .as_deref(),
                 )
             });
-            parent.add_message(resume_message);
-        } else if runtime_state.waiting_for_children.is_some() {
+
+            // Issue #546 rows 6+7: drive the clear→append→resume through a
+            // clobber-retry loop (mirrors the bash push's
+            // `perform_bash_resume`) instead of a single mutate-once attempt
+            // followed by a resume call that only retried `AlreadyRunning`.
+            self.resume_parent_after_child_completion(
+                parent.id.clone(),
+                resume_message,
+                guardian_update,
+            )
+            .await;
+            return;
+        }
+
+        if runtime_state.waiting_for_children.is_some() {
+            // Still waiting on other children — record continued suspension.
+            let mut parent = parent;
+            let mut runtime_state = runtime_state;
             runtime_state.status = AgentStatusState::Suspended;
             runtime_state.suspension = Some(SuspensionState {
                 reason: "waiting_for_children".to_string(),
@@ -571,22 +704,12 @@ impl ChildCompletionHandler for ChildCompletionCoordinator {
                 resumable: true,
                 hook_point: Some("ChildCompletion".to_string()),
             });
+            parent.updated_at = Utc::now();
+            write_runtime_state(&mut parent, &runtime_state);
+            self.save_and_cache(&mut parent).await;
         }
-
-        parent.updated_at = Utc::now();
-        write_runtime_state(&mut parent, &runtime_state);
-        self.save_and_cache(&mut parent).await;
-
-        // Capture before releasing the per-parent lock so the borrow checker
-        // is satisfied; `resume_parent` has its own retry loop and should not
-        // hold the per-parent lock (it would block other completions for the
-        // same parent, and the state is already durably settled above).
-        let resume_parent_id = parent.id.clone();
-        drop(_per_parent_guard);
-
-        if should_resume {
-            self.resume_parent(resume_parent_id).await;
-        }
+        // else: the parent wasn't waiting on any children at all (a stray or
+        // already-handled completion) — nothing to do.
     }
 }
 
@@ -641,7 +764,16 @@ impl ResumeExecutionPort for ChildCompletionCoordinator {
         .await
     }
 
-    async fn spawn_resume_execution(&self, request: ResumeSpawnRequest) {
+    async fn release_reservation(&self, session_id: &str) {
+        // Issue #546 row 7: undo a runner reservation that was granted but
+        // never used (this adapter's `spawn_resume_execution` bailed before
+        // spawning). Removing the entry entirely (rather than flipping it to
+        // some terminal status) restores the exact pre-reservation state, so
+        // the next `try_reserve_runner` call for this session succeeds cleanly.
+        self.agent_runners.write().await.remove(session_id);
+    }
+
+    async fn spawn_resume_execution(&self, request: ResumeSpawnRequest) -> bool {
         let ResumeSpawnRequest {
             session_id,
             session,
@@ -653,7 +785,7 @@ impl ResumeExecutionPort for ChildCompletionCoordinator {
 
         let Some(root_tools) = self.root_tools.read().await.clone() else {
             tracing::error!(%session_id, "cannot resume parent after child completion: root tool surface is not initialized");
-            return;
+            return false;
         };
 
         let model = session.model.clone();
@@ -791,7 +923,17 @@ impl ResumeExecutionPort for ChildCompletionCoordinator {
             runners: self.agent_runners.clone(),
             sessions_cache: self.sessions.clone(),
             on_complete: None,
+            // Issue #546 row 5: this IS the resume path for a nested
+            // child-parent (a child that itself spawned grandchildren) — wire
+            // the same coordinator back in as the completion handler so a
+            // resumed child-parent that reaches a real terminal state still
+            // publishes to ITS OWN parent. Before this fix `on_complete`-style
+            // wiring was entirely absent from this path (unlike `on_complete`,
+            // which is a DIFFERENT, unrelated hook), so a resumed child-parent
+            // could finish and never tell its own parent.
+            child_completion_handler: Some(Arc::new(self.clone())),
         });
+        true
     }
 }
 
@@ -880,6 +1022,44 @@ fn apply_bash_resume_transition(session: &mut Session, resume_message: &Message)
     runtime_state.suspension = None;
     write_runtime_state(session, &runtime_state);
     session.metadata.remove("runtime.suspend_reason");
+    session.add_message(resume_message.clone());
+    true
+}
+
+/// Apply the child-wait resume transition to a loaded session **in place**:
+/// clear `waiting_for_children`, mark the runtime Idle, drop the suspension +
+/// `runtime.suspend_reason`, re-apply `guardian_update` if present (a
+/// completing guardian review's verdict), and append `resume_message`. Returns
+/// `false` (a no-op) when the session was not actually waiting on children —
+/// the double-resume guard shared across every retry attempt and every other
+/// resume source for this parent. Pure (no I/O) so both
+/// [`ChildCompletionCoordinator::resume_parent_after_child_completion`] and
+/// unit tests exercise the exact same transition. Mirrors
+/// [`apply_bash_resume_transition`]'s shape for the bash wait.
+///
+/// `guardian_update`, when present, is re-applied on EVERY attempt gated by
+/// the SAME `waiting_for_children.is_some()` check as the wait-clear itself —
+/// safe because a finalize-clobber that reverts the wait reverts the WHOLE
+/// session file (same `merge_save_runtime` full overwrite), so a reverted
+/// guardian write is reverted right alongside it, and re-applying both
+/// together on retry is a genuine re-application, never a duplicate.
+fn apply_child_completion_wait_clear(
+    session: &mut Session,
+    resume_message: &Message,
+    guardian_update: Option<&GuardianState>,
+) -> bool {
+    let mut runtime_state = read_runtime_state(session);
+    if runtime_state.waiting_for_children.is_none() {
+        return false;
+    }
+    runtime_state.waiting_for_children = None;
+    runtime_state.status = AgentStatusState::Idle;
+    runtime_state.suspension = None;
+    write_runtime_state(session, &runtime_state);
+    session.metadata.remove("runtime.suspend_reason");
+    if let Some(guardian_state) = guardian_update {
+        write_guardian_state(session, guardian_state.clone());
+    }
     session.add_message(resume_message.clone());
     true
 }
@@ -1222,6 +1402,316 @@ impl BashCompletionSink for ChildCompletionCoordinator {
         tokio::spawn(async move {
             coordinator.deliver_bash_completion(info).await;
         });
+    }
+}
+
+// ── Child-wait heartbeat watchdog (issue #546 Part B) ──────────────────────
+//
+// Every push-side hole in the failure-mode matrix (#546) is closed above, but
+// "every KNOWN hole" is not "every POSSIBLE hole" — an unforeseen panic, a
+// storage hiccup mid-retry, or a killed process can still strand a parent.
+// This is the last-resort backstop: a periodic sweep over every session the
+// index reports `last_run_status == "suspended"`, looking specifically at
+// those durably waiting on children (`waiting_for_children`), and:
+//
+//  1. Replays a lost completion for any wait-tracked child that is ALREADY
+//     terminal in the index but never reached `on_child_completed` (row 3: a
+//     panic inside the handler; a publish that landed in storage but whose
+//     coordinator call never completed).
+//  2. Synthesizes an `error` completion for a DEAD child — not terminal, but
+//     its index entry hasn't moved in `DEAD_CHILD_GRACE_SECS` (covers a
+//     process crash mid-run, including a full server restart wiping every
+//     in-memory runner — row 10's boot reconciliation feeds this same path by
+//     marking orphaned "running" sessions "error" so this step finds them
+//     already terminal on the very first sweep).
+//  3. Rescues a "stranded-after-clear" parent: the wait was already cleared
+//     (a push succeeded at the mutation but its resume-spawn never landed —
+//     the clobber-retry budget in `resume_parent_after_child_completion`
+//     exhausted, or the process died mid-retry) and a resume message is
+//     genuinely pending — just re-drive the resume.
+//  4. Enforces the 6h wait lease (`WaitingForChildrenState::timeout_at`,
+//     issue #546 row 11 — written but never read before this fix) as a hard
+//     backstop: force-resumes with a verify-don't-assume message even if some
+//     children are nominally still alive.
+//
+// Design invariant: steps 1 and 2 reuse `on_child_completed` as their ONLY
+// resume path — replayed/synthetic completions flow through the exact same
+// terminality guard, wait-policy check, and clobber-retry-capable resume as a
+// genuine push, so there is exactly one resume implementation. Step 3 reuses
+// `resume_parent`; step 4 reuses `resume_parent_after_child_completion`. All
+// four are naturally idempotent against a concurrent push because
+// `on_child_completed` and `resume_parent_after_child_completion` both
+// acquire the per-parent `session_resume_lock` for their full duration — the
+// sweep can never double-resume a parent the push is already handling.
+const DEFAULT_WAIT_WATCHDOG_INTERVAL_SECS: u64 = 60;
+
+/// Grace period a child's index entry may go without updating while still
+/// non-terminal before the sweep gives up on it and synthesizes an `error`
+/// completion. Generous margin over the per-child liveness watchdog's own
+/// defaults (`ChildWatchdogPolicy`: 15 min idle / 60 min total) so a healthy
+/// long-running child already inside those bounds is never mistaken for dead;
+/// this only fires once the CHILD's own watchdog should already have
+/// terminated it and something ELSE (a crash, a panic in the finalize path)
+/// kept that from being observed.
+const DEAD_CHILD_GRACE_SECS: i64 = 90 * 60;
+
+impl ChildCompletionCoordinator {
+    /// Spawn the heartbeat-watchdog backstop as a detached, process-lifetime
+    /// background task. A `None` interval disables the watchdog entirely
+    /// (config-gated by the caller — see `BAMBOO_CHILD_WAIT_WATCHDOG_INTERVAL_SECS`
+    /// / [`wait_watchdog_interval_from_env`]).
+    pub fn spawn_wait_watchdog(self: &Arc<Self>, interval: Option<Duration>) {
+        let Some(interval) = interval else {
+            tracing::info!("child-wait heartbeat watchdog disabled (interval=0)");
+            return;
+        };
+        tracing::info!(
+            interval_secs = interval.as_secs(),
+            "child-wait heartbeat watchdog starting (issue #546 Part B)"
+        );
+        let coordinator = self.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                coordinator.sweep_stranded_waits().await;
+            }
+        });
+    }
+
+    /// One sweep pass. Never propagates a hard error: every per-session step
+    /// is independently logged-and-skipped so one bad session can't block the
+    /// rest of the sweep or kill the watchdog task.
+    async fn sweep_stranded_waits(&self) {
+        let entries = match self.storage.list_sessions_by_run_status("suspended").await {
+            Ok(entries) => entries,
+            Err(error) => {
+                tracing::warn!(%error, "child-wait watchdog: failed to list suspended sessions");
+                return;
+            }
+        };
+
+        for entry in entries {
+            self.sweep_one_suspended_session(&entry.id).await;
+        }
+    }
+
+    async fn sweep_one_suspended_session(&self, session_id: &str) {
+        let Some(session) = self.load_session(session_id).await else {
+            return; // vanished; nothing to rescue
+        };
+        let runtime_state = read_runtime_state(&session);
+
+        let Some(wait) = runtime_state.waiting_for_children.clone() else {
+            // Step 3: wait already cleared but the index still shows
+            // "suspended" — the clear succeeded but the resume-spawn itself
+            // never landed. Re-drive it if there is genuinely something
+            // pending; a no-op otherwise (this session may simply be
+            // suspended for an unrelated reason, e.g. `waiting_for_bash`,
+            // which has its own dedicated backstop).
+            if has_pending_user_message(&session) {
+                tracing::warn!(
+                    %session_id,
+                    "child-wait watchdog: rescuing a stranded-after-clear parent"
+                );
+                self.resume_parent(session_id.to_string()).await;
+            }
+            return;
+        };
+
+        let now = Utc::now();
+        let completed_now =
+            derive_completed_child_ids(&self.storage, session_id, "__watchdog_sentinel__").await;
+
+        for child_id in &wait.child_session_ids {
+            if completed_now.iter().any(|id| id == child_id) {
+                continue;
+            }
+
+            let snapshot = self.storage.session_run_status_snapshot(child_id).await;
+            match snapshot {
+                Ok(Some(SessionRunStatusEntry {
+                    last_run_status: Some(status),
+                    updated_at,
+                    ..
+                })) if is_terminal_child_status(&status) => {
+                    // Step 1: already terminal in the index, but the
+                    // coordinator never got the memo — replay it.
+                    tracing::warn!(
+                        %session_id, child_id, %status,
+                        "child-wait watchdog: replaying lost completion for already-terminal child"
+                    );
+                    self.on_child_completed(ChildCompletion {
+                        parent_session_id: session_id.to_string(),
+                        child_session_id: child_id.clone(),
+                        status,
+                        error: None,
+                        completed_at: updated_at,
+                    })
+                    .await;
+                }
+                Ok(Some(SessionRunStatusEntry { updated_at, .. })) => {
+                    // Non-terminal (or unset) status: dead only if stale well
+                    // past the grace period.
+                    let stale_secs = now.signed_duration_since(updated_at).num_seconds();
+                    if stale_secs >= DEAD_CHILD_GRACE_SECS {
+                        self.synthesize_dead_child_completion(session_id, child_id, now)
+                            .await;
+                    }
+                }
+                Ok(None) => {
+                    // Step 2 (row 10 companion): vanished from the index
+                    // entirely — a destructive delete, or an index that was
+                    // rebuilt without this child (should be rare given boot
+                    // reconciliation, but never assume). Dead by definition:
+                    // nothing will ever report on it again.
+                    self.synthesize_dead_child_completion(session_id, child_id, now)
+                        .await;
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        %session_id, child_id, %error,
+                        "child-wait watchdog: failed to read child status snapshot; skipping this child this sweep"
+                    );
+                }
+            }
+        }
+
+        // Step 4: enforce the 6h wait lease as a hard backstop. Re-check
+        // AFTER the loop above — it may already have resolved/cleared the
+        // wait via a replayed or synthetic `on_child_completed` call.
+        if wait.timeout_at.is_some_and(|deadline| now >= deadline) {
+            if let Some(refreshed) = self.load_session(session_id).await {
+                if read_runtime_state(&refreshed)
+                    .waiting_for_children
+                    .is_some()
+                {
+                    tracing::warn!(
+                        %session_id,
+                        "child-wait watchdog: 6h wait lease expired; force-resuming"
+                    );
+                    self.force_resume_expired_wait(session_id).await;
+                }
+            }
+        }
+    }
+
+    /// Step 2 body: best-effort mark the dead child's OWN storage record as
+    /// errored (so it stops showing as permanently "running"/stale in the
+    /// UI), then synthesize and replay an `error` completion for it through
+    /// the normal `on_child_completed` path.
+    async fn synthesize_dead_child_completion(
+        &self,
+        parent_session_id: &str,
+        child_id: &str,
+        now: DateTime<Utc>,
+    ) {
+        const DEAD_CHILD_MESSAGE: &str =
+            "child session vanished or stopped reporting (heartbeat watchdog, issue #546 Part B)";
+        tracing::warn!(
+            parent_session_id,
+            child_id,
+            "child-wait watchdog: synthesizing error completion for dead/vanished child"
+        );
+        if let Some(mut child_session) = self.load_session(child_id).await {
+            if !child_session
+                .last_run_status()
+                .as_deref()
+                .is_some_and(is_terminal_child_status)
+            {
+                child_session.set_last_run_status("error");
+                child_session.set_last_run_error(DEAD_CHILD_MESSAGE.to_string());
+                child_session.updated_at = now;
+                self.save_and_cache(&mut child_session).await;
+            }
+        }
+        self.on_child_completed(ChildCompletion {
+            parent_session_id: parent_session_id.to_string(),
+            child_session_id: child_id.to_string(),
+            status: "error".to_string(),
+            error: Some(DEAD_CHILD_MESSAGE.to_string()),
+            completed_at: now,
+        })
+        .await;
+    }
+
+    /// Step 4 body: force-resume a parent whose 6h wait lease has expired,
+    /// via the SAME clobber-retry-capable path a genuine child completion
+    /// uses (`resume_parent_after_child_completion`), so the finalize-clobber
+    /// / adapter-bail retry logic covers this path too. Acquires the
+    /// per-parent lock itself (there is no completion event to piggyback the
+    /// lock off of, unlike the push path).
+    async fn force_resume_expired_wait(&self, session_id: &str) {
+        let guard = session_resume_lock(session_id);
+        let _held = guard.lock().await;
+        self.resume_parent_after_child_completion(
+            session_id.to_string(),
+            wait_lease_expired_resume_message(),
+            None,
+        )
+        .await;
+    }
+}
+
+/// Hidden resume message for the 6h wait-lease-expiry force-resume (issue
+/// #546 row 11 / Part B step 4). Deliberately does NOT claim any child
+/// finished — some may still be genuinely running past the lease — so the
+/// model verifies actual status via `SubAgent.get`/`SubAgent.list` instead of
+/// assuming success on a false premise (mirrors
+/// `bash_completion_resume_message`'s `timed_out` wording).
+fn wait_lease_expired_resume_message() -> Message {
+    let body = "Runtime notification: the 6-hour child-wait lease expired while one or more \
+                child sessions may still be running. The session is being resumed so it is not \
+                stranded; verify each child's actual status with SubAgent.list or SubAgent.get \
+                before assuming completion."
+        .to_string();
+    let mut message = Message::user(body);
+    message.metadata = Some(serde_json::json!({
+        RUNTIME_RESUME_MESSAGE_HIDDEN_KEY: true,
+        RUNTIME_RESUME_MESSAGE_KIND_KEY: "child_wait_lease_expired_resume",
+    }));
+    message.never_compress = false;
+    message
+}
+
+/// Resolve the heartbeat-watchdog sweep interval from
+/// `BAMBOO_CHILD_WAIT_WATCHDOG_INTERVAL_SECS` (issue #546 Part B). Unset falls
+/// back to [`DEFAULT_WAIT_WATCHDOG_INTERVAL_SECS`]; `0` (or an unparseable
+/// value) disables the watchdog — returning `None` for
+/// [`ChildCompletionCoordinator::spawn_wait_watchdog`] to treat as "disabled",
+/// mirroring the `BAMBOO_RATE_LIMIT_*` env-tunable precedent elsewhere in the
+/// server. A free function (not a method) so it's usable before a coordinator
+/// instance exists, at server startup wiring time.
+pub fn wait_watchdog_interval_from_env() -> Option<Duration> {
+    parse_wait_watchdog_interval_secs(
+        std::env::var("BAMBOO_CHILD_WAIT_WATCHDOG_INTERVAL_SECS").ok(),
+    )
+}
+
+/// Pure parsing core of [`wait_watchdog_interval_from_env`] — takes the raw
+/// env value (or its absence) directly instead of reading the environment, so
+/// the parsing/default/disable rules are unit-testable without mutating
+/// process-global env state (which would race other tests).
+fn parse_wait_watchdog_interval_secs(raw: Option<String>) -> Option<Duration> {
+    let secs = match raw {
+        Some(value) => match value.trim().parse::<u64>() {
+            Ok(secs) => secs,
+            Err(_) => {
+                tracing::warn!(
+                    value = %value,
+                    "BAMBOO_CHILD_WAIT_WATCHDOG_INTERVAL_SECS is not a valid non-negative integer; \
+                     using the default"
+                );
+                DEFAULT_WAIT_WATCHDOG_INTERVAL_SECS
+            }
+        },
+        None => DEFAULT_WAIT_WATCHDOG_INTERVAL_SECS,
+    };
+    if secs == 0 {
+        None
+    } else {
+        Some(Duration::from_secs(secs))
     }
 }
 
@@ -1758,6 +2248,139 @@ mod tests {
         assert!(
             meta.contains(BASH_COMPLETION_RESUME_KIND),
             "resume message must be tagged as a bash-completion resume: {meta}"
+        );
+    }
+
+    // ── issue #546 row 12: non-terminal completions never satisfy a wait ────
+
+    #[test]
+    fn wait_policy_never_satisfied_by_non_terminal_status() {
+        // Even if a "suspended" child id happened to appear in the completed
+        // set (it must not, per `on_child_completed`'s terminality guard —
+        // this test pins the policy-level half of that invariant), FirstError
+        // must not treat "suspended" as an error-like status.
+        assert!(!is_terminal_child_status("suspended"));
+        assert!(is_terminal_child_status("completed"));
+        assert!(is_terminal_child_status("error"));
+        assert!(is_terminal_child_status("timeout"));
+        assert!(is_terminal_child_status("cancelled"));
+        assert!(is_terminal_child_status("skipped"));
+    }
+
+    // ── issue #546 rows 6+7: the child-completion wait-clear transition ─────
+
+    #[test]
+    fn apply_child_completion_wait_clear_clears_wait_and_appends_message() {
+        use bamboo_domain::session::runtime_state::WaitingForChildrenState;
+
+        let mut session = Session::new("parent-1", "test-model");
+        session.add_message(Message::user("spawn some children"));
+        let mut rt = read_runtime_state(&session);
+        rt.status = AgentStatusState::Suspended;
+        rt.waiting_for_children = Some(WaitingForChildrenState::for_children(
+            vec!["child-1".to_string()],
+            ChildWaitPolicy::All,
+            Utc::now(),
+        ));
+        write_runtime_state(&mut session, &rt);
+        session.metadata.insert(
+            "runtime.suspend_reason".to_string(),
+            "waiting_for_children".to_string(),
+        );
+
+        let completion = make_completion("completed");
+        let resume_message = runtime_resume_message(&completion, 0, Some("done"));
+        let did = apply_child_completion_wait_clear(&mut session, &resume_message, None);
+
+        assert!(did, "a waiting session must transition");
+        let after = read_runtime_state(&session);
+        assert!(
+            after.waiting_for_children.is_none(),
+            "child wait must be cleared"
+        );
+        assert_eq!(after.status, AgentStatusState::Idle);
+        assert!(!session.metadata.contains_key("runtime.suspend_reason"));
+        assert_eq!(session.messages.len(), 2, "resume message must be appended");
+    }
+
+    #[test]
+    fn apply_child_completion_wait_clear_noops_when_not_waiting() {
+        // Double-resume guard: a session not currently waiting on children is
+        // a no-op — this is what makes a clobber-retry attempt (or the
+        // watchdog sweep) harmless once another source already resumed it.
+        let mut session = Session::new("parent-1", "test-model");
+        session.add_message(Message::user("hi"));
+
+        let completion = make_completion("completed");
+        let resume_message = runtime_resume_message(&completion, 0, None);
+        let did = apply_child_completion_wait_clear(&mut session, &resume_message, None);
+
+        assert!(!did);
+        assert_eq!(session.messages.len(), 1, "no message appended");
+    }
+
+    #[test]
+    fn apply_child_completion_wait_clear_reapplies_guardian_update() {
+        use crate::runtime::guardian_state::{
+            ensure_guardian_state, read_guardian_state, GuardianPhase,
+        };
+        use bamboo_domain::session::runtime_state::WaitingForChildrenState;
+
+        let mut session = Session::new("parent-1", "test-model");
+        let mut rt = read_runtime_state(&session);
+        rt.waiting_for_children = Some(WaitingForChildrenState::for_children(
+            vec!["guardian-1".to_string()],
+            ChildWaitPolicy::All,
+            Utc::now(),
+        ));
+        write_runtime_state(&mut session, &rt);
+
+        let mut guardian_state = ensure_guardian_state(&session);
+        guardian_state.phase = GuardianPhase::Reviewed;
+
+        let completion = make_completion("completed");
+        let resume_message = runtime_resume_message(&completion, 0, None);
+        let did =
+            apply_child_completion_wait_clear(&mut session, &resume_message, Some(&guardian_state));
+
+        assert!(did);
+        let stored = read_guardian_state(&session).expect("guardian state persisted");
+        assert_eq!(stored.phase, GuardianPhase::Reviewed);
+    }
+
+    // ── issue #546 Part B: watchdog interval config gate ─────────────────────
+
+    #[test]
+    fn wait_watchdog_interval_unset_uses_default() {
+        let interval = parse_wait_watchdog_interval_secs(None);
+        assert_eq!(
+            interval,
+            Some(Duration::from_secs(DEFAULT_WAIT_WATCHDOG_INTERVAL_SECS))
+        );
+    }
+
+    #[test]
+    fn wait_watchdog_interval_zero_disables() {
+        assert_eq!(
+            parse_wait_watchdog_interval_secs(Some("0".to_string())),
+            None
+        );
+    }
+
+    #[test]
+    fn wait_watchdog_interval_custom_value_used() {
+        assert_eq!(
+            parse_wait_watchdog_interval_secs(Some("30".to_string())),
+            Some(Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn wait_watchdog_interval_unparseable_falls_back_to_default() {
+        let interval = parse_wait_watchdog_interval_secs(Some("not-a-number".to_string()));
+        assert_eq!(
+            interval,
+            Some(Duration::from_secs(DEFAULT_WAIT_WATCHDOG_INTERVAL_SECS))
         );
     }
 }

--- a/crates/engine/bamboo-engine/src/session_app/child_session/mod.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_session/mod.rs
@@ -215,6 +215,17 @@ pub trait ChildSessionPort: Send + Sync {
     /// The parent's currently-active (non-terminal) child session ids.
     async fn active_child_ids(&self, parent_session_id: &str) -> Vec<String>;
 
+    /// Filter `candidate_ids` down to the subset that are still pending
+    /// (started, not yet terminal) children of `parent_session_id` — eligible
+    /// to be registered on a new wait. Drops already-terminal ids and
+    /// never-started ids (issue #546 rows 8/9): neither will ever produce a
+    /// future completion event, so waiting on them would hang forever.
+    async fn pending_child_ids(
+        &self,
+        parent_session_id: &str,
+        candidate_ids: &[String],
+    ) -> Vec<String>;
+
     /// Find an existing resident agent in the same root tree by its stable
     /// `resident_name`, returning its child session id if one exists. Used to
     /// reuse a resident agent for a new task instead of minting a new child.

--- a/crates/engine/bamboo-engine/src/session_app/resume.rs
+++ b/crates/engine/bamboo-engine/src/session_app/resume.rs
@@ -52,7 +52,22 @@ pub trait ResumeExecutionPort: Send + Sync {
     ///
     /// The adapter creates the mpsc channel, spawns the event forwarder,
     /// and calls the server's agent execution spawner.
-    async fn spawn_resume_execution(&self, request: ResumeSpawnRequest);
+    ///
+    /// Returns `true` if execution was actually (or will imminently be)
+    /// spawned, `false` if the adapter bailed out before spawning anything
+    /// (issue #546 row 7 — e.g. a required late-bound dependency was not yet
+    /// initialized). [`resume_session_execution`] uses this to avoid lying
+    /// about [`ResumeOutcome::Started`] and to release the runner reservation
+    /// via [`Self::release_reservation`] so the slot isn't leaked forever.
+    async fn spawn_resume_execution(&self, request: ResumeSpawnRequest) -> bool;
+
+    /// Release a runner reservation that [`Self::try_reserve_runner`] granted
+    /// but [`Self::spawn_resume_execution`] never actually used (returned
+    /// `false`). Without this the reserved `Running` runner entry is a
+    /// permanent leak: every subsequent resume attempt for this session hits
+    /// `AlreadyRunning` against a runner that will never transition out of
+    /// `Running` (issue #546 row 7).
+    async fn release_reservation(&self, session_id: &str);
 }
 
 // ---------------------------------------------------------------------------
@@ -110,15 +125,29 @@ pub async fn resume_session_execution(
     consume_pending_clarification_resume(&mut session);
     port.save_and_cache_session(&mut session).await;
 
-    port.spawn_resume_execution(ResumeSpawnRequest {
-        session_id: session_id.to_string(),
-        session,
-        cancel_token: reservation.cancel_token,
-        run_id: reservation.run_id.clone(),
-        event_sender,
-        config,
-    })
-    .await;
+    let spawned = port
+        .spawn_resume_execution(ResumeSpawnRequest {
+            session_id: session_id.to_string(),
+            session,
+            cancel_token: reservation.cancel_token,
+            run_id: reservation.run_id.clone(),
+            event_sender,
+            config,
+        })
+        .await;
+
+    if !spawned {
+        // Issue #546 row 7: the adapter reserved the runner slot but bailed
+        // before actually spawning execution. Release the reservation so the
+        // slot isn't leaked (every future resume attempt would otherwise hit
+        // `AlreadyRunning` against a runner that can never finish), and report
+        // `Completed` rather than `Started` — this is a lie-free outcome that
+        // callers ALREADY treat as "did not spawn, may be worth retrying"
+        // (mirrors the finalize-clobber `Completed` outcome the bash and
+        // child-completion clobber-retry loops already handle).
+        port.release_reservation(session_id).await;
+        return ResumeOutcome::Completed;
+    }
 
     ResumeOutcome::Started {
         run_id: reservation.run_id,

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -30,7 +30,7 @@ use uuid::Uuid;
 
 use bamboo_domain::ProviderModelRef;
 use bamboo_domain::ReasoningEffort;
-use bamboo_domain::{Role, Session, SessionKind, TokenBudgetUsage};
+use bamboo_domain::{Role, Session, SessionKind, SessionRunStatusEntry, TokenBudgetUsage};
 
 use crate::search_index::{should_index_session, SessionSearchIndex};
 use bamboo_domain::AttachmentReader;
@@ -1332,6 +1332,40 @@ impl Storage for SessionStoreV2 {
             .collect())
     }
 
+    async fn list_sessions_by_run_status(
+        &self,
+        status: &str,
+    ) -> io::Result<Vec<SessionRunStatusEntry>> {
+        let index = self.index.read().await;
+        Ok(index
+            .sessions
+            .values()
+            .filter(|entry| entry.last_run_status.as_deref() == Some(status))
+            .map(|entry| SessionRunStatusEntry {
+                id: entry.id.clone(),
+                parent_session_id: entry.parent_session_id.clone(),
+                last_run_status: entry.last_run_status.clone(),
+                updated_at: entry.updated_at,
+            })
+            .collect())
+    }
+
+    async fn session_run_status_snapshot(
+        &self,
+        session_id: &str,
+    ) -> io::Result<Option<SessionRunStatusEntry>> {
+        let index = self.index.read().await;
+        Ok(index
+            .sessions
+            .get(session_id)
+            .map(|entry| SessionRunStatusEntry {
+                id: entry.id.clone(),
+                parent_session_id: entry.parent_session_id.clone(),
+                last_run_status: entry.last_run_status.clone(),
+                updated_at: entry.updated_at,
+            }))
+    }
+
     async fn append_token_usage_record(&self, session_id: &str, json_line: &str) -> io::Result<()> {
         use tokio::io::AsyncWriteExt;
 
@@ -1872,6 +1906,79 @@ mod tests {
         assert_eq!(got[1].0, "ch-pending");
         // pending child has no terminal status mirrored yet.
         assert!(got[1].1.as_deref() != Some("completed"));
+        Ok(())
+    }
+
+    // ── issue #546 Part B: watchdog-support index queries ───────────────────
+
+    #[tokio::test]
+    async fn list_sessions_by_run_status_filters_by_status_across_parents() -> io::Result<()> {
+        let (storage, _t) = create_temp_storage().await?;
+
+        let mut suspended_a = Session::new("root-a".to_string(), "m".to_string());
+        suspended_a
+            .metadata
+            .insert("last_run_status".to_string(), "suspended".to_string());
+        storage.save_session(&suspended_a).await?;
+
+        let mut suspended_b = Session::new_child("child-b", "root-a", "m", "c1");
+        suspended_b
+            .metadata
+            .insert("last_run_status".to_string(), "suspended".to_string());
+        storage.save_session(&suspended_b).await?;
+
+        let mut running = Session::new("root-c".to_string(), "m".to_string());
+        running
+            .metadata
+            .insert("last_run_status".to_string(), "running".to_string());
+        storage.save_session(&running).await?;
+
+        let mut got = storage.list_sessions_by_run_status("suspended").await?;
+        got.sort_by(|a, b| a.id.cmp(&b.id));
+        assert_eq!(
+            got.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
+            vec!["child-b", "root-a"],
+            "only the two suspended sessions, regardless of kind: {got:?}"
+        );
+        assert_eq!(
+            got.iter()
+                .find(|e| e.id == "child-b")
+                .unwrap()
+                .parent_session_id
+                .as_deref(),
+            Some("root-a")
+        );
+
+        let running_only = storage.list_sessions_by_run_status("running").await?;
+        assert_eq!(running_only.len(), 1);
+        assert_eq!(running_only[0].id, "root-c");
+
+        let none_matching = storage.list_sessions_by_run_status("cancelled").await?;
+        assert!(none_matching.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn session_run_status_snapshot_returns_entry_or_none() -> io::Result<()> {
+        let (storage, _t) = create_temp_storage().await?;
+
+        let mut session = Session::new("s-1".to_string(), "m".to_string());
+        session
+            .metadata
+            .insert("last_run_status".to_string(), "running".to_string());
+        storage.save_session(&session).await?;
+
+        let snapshot = storage
+            .session_run_status_snapshot("s-1")
+            .await?
+            .expect("session is indexed");
+        assert_eq!(snapshot.id, "s-1");
+        assert_eq!(snapshot.last_run_status.as_deref(), Some("running"));
+
+        let missing = storage
+            .session_run_status_snapshot("does-not-exist")
+            .await?;
+        assert!(missing.is_none());
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Closes #546. A 7-agent audit mapped every failure mode in the child->parent
wake plane — a single-shot event-driven push (`run_child_spawn` ->
`publish_child_completion_parts` -> `ChildCompletionCoordinator::on_child_completed`
-> `resume_parent`) with **no durable backstop**. This PR closes every
push-side hole the matrix lists (Part A) and adds a heartbeat watchdog
backstop for whatever an unforeseen hole still slips through (Part B).

## Part A — matrix row -> fix

| # | Failure mode | Fix |
|---|---|---|
| 1 | Child execution task panics; `tokio::spawn` handle discarded | `sdk/spawn.rs::run_child_spawn` now spawns the body as an inner task and monitors its `JoinHandle` from an outer task; a panic publishes a synthetic `error` completion, marks the child's own storage record, and finalizes the runner. New `panic_message_from_join_error` helper. |
| 2 | `SpawnScheduler` worker-loop panic kills the single worker forever (`"spawn scheduler is not running"` for the rest of the process) | `SpawnScheduler::new`'s `while let Some(job) = rx.recv()` loop now gives each job its own monitored task (same JoinHandle pattern); a panic can never reach the loop that owns `rx`. |
| 3 | Coordinator panic inside `on_child_completed` (invoked bare) strands the parent silently | `publish_child_completion` isolates the `handler.on_child_completed(...)` call behind its own monitored `JoinHandle`; a panic there is logged, never propagates, and the heartbeat watchdog (Part B, row 1 of its own list) replays the completion from the index on its next sweep. |
| 4 | `try_reserve_runner` conflict -> silent `Ok(())`, no publish | Kept intentionally silent for the winning invocation's sake (the in-flight runner owns the eventual publish, and after rows 1+3 it's now guaranteed to fire even on panic) but upgraded to `tracing::warn!` for observability. Residual risk (a truly stale registry entry) is covered by the watchdog's "no runner" dead-child sweep. |
| 5 | Resumed children (approval/clarification answer, or a nested child-parent resume) terminate through `spawn_session_execution` with no completion publish | New `child_completion_handler: Option<Arc<dyn ChildCompletionHandler>>` field on `SessionExecutionArgs`; `spawn_session_execution` now publishes a completion for a terminal (non-suspended) `SessionKind::Child` run. Wired in the two paths that actually resume a child: the coordinator's own `spawn_resume_execution`, and the server's `/execute`+`/respond` spawner (`handlers/agent/execute/runtime/execution.rs`). Other `SessionExecutionArgs` call sites (connect, schedules) pass `None` — they only ever spawn root sessions, so it's a documented no-op there, not a gap. |
| 6 | `resume_parent` only retries `AlreadyRunning` (~3.75s); no clobber-retry for children (bash has one) | New `resume_parent_after_child_completion`, mirroring `perform_bash_resume`'s bounded clear->append->resume clobber-retry loop. `on_child_completed`'s should-resume branch now drives through it instead of a single mutate-once attempt. |
| 7 | `spawn_resume_execution` bails after reserving the runner when `root_tools` isn't initialized; reservation leaks, outcome lies `Started` | `ResumeExecutionPort::spawn_resume_execution` now returns `bool` (did it actually spawn); a new `release_reservation` trait method undoes a leaked reservation; `resume_session_execution` reports `Completed` (not `Started`) on a bail, which the new clobber-retry loop (row 6) treats identically to a finalize-clobber and retries. |
| 8 | Explicit `SubAgent.wait(child_session_ids=[...])` doesn't check terminality — a child that already finished before the wait registers hangs forever | New `ChildSessionPort::pending_child_ids` filters an explicit target list to genuinely pending (started, non-terminal) children before registering; an all-terminal/unknown list resolves immediately instead of suspending. |
| 9 | Wait on a created-but-never-started child (`active_child_ids` counted `status=None` as active) | `active_child_ids`'s filter now requires `Some(non-terminal-status)` — a never-started child (`None`) is excluded from the default wait target set. |
| 10 | Server restart: children die with the process, index keeps `running`, no boot reconciliation | New `reconcile_orphaned_running_sessions` runs synchronously in `init_storage`: any session still `"running"` at that point in boot is unconditionally orphaned (no runner could possibly exist yet) and is marked `"error"` via a full `save_session` (not the sidecar-only `save_runtime_state` — only the former updates the in-memory index the watchdog/coordinator read from; caught by a failing test during development). |
| 11 | The 6h wait lease (`timeout_at`) written but never read | Watchdog Part B step 4 enforces it: force-resumes with a "verify, don't assume" message once the lease expires, even if some children are nominally still alive. |
| 12 | Non-terminal status `"suspended"` satisfies the wait (`derive_completed_child_ids` folded it in unconditionally) | `on_child_completed` now bails immediately (before acquiring any lock or touching storage) when `!is_terminal_child_status(&completion.status)`. |
| 13 | `suspended_non_terminal` allowlist in `sdk/spawn.rs` covered only `awaiting_parent_approval` / `waiting_for_bash`, missing `waiting_for_children` (grandchild wait) and `awaiting_clarification` | Allowlist extended to all four known non-terminal `runtime.suspend_reason` values. |

## Part B — heartbeat watchdog (issue #546 design notes)

`ChildCompletionCoordinator::spawn_wait_watchdog(interval)` — a periodic sweep
(default 60s, `0` disables; `BAMBOO_CHILD_WAIT_WATCHDOG_INTERVAL_SECS`) over
every session the index reports `last_run_status == "suspended"`. For each:

1. **Replay** a lost completion for any wait-tracked child already terminal
   in the index (row 3's residual risk, and any other missed publish).
2. **Synthesize** an `error` completion for a child that's neither terminal
   nor updated in `DEAD_CHILD_GRACE_SECS` (90 min — generous margin over the
   per-child liveness watchdog's own 60 min total cap) or missing from the
   index entirely (row 10's companion at runtime).
3. **Rescue** a stranded-after-clear parent: wait already cleared, a resume
   message genuinely pending, but the spawn never landed (clobber-retry
   budget exhausted, or the process died mid-retry) — re-drives `resume_parent`.
4. **Enforce** the 6h wait lease (row 11) as a hard backstop.

**Design invariant**: steps 1-2 reuse `on_child_completed` as their only
resume path (replayed/synthetic completions go through the exact same
terminality guard, wait-policy check, and clobber-retry-capable resume as a
genuine push) — "exactly one resume implementation," per the issue's design
note. Step 3 reuses `resume_parent`; step 4 reuses
`resume_parent_after_child_completion`. **Idempotency vs the push**: every
resume path (push and sweep alike) acquires the per-parent
`session_resume_lock` for its full duration, so the sweep can never double-
resume a parent the push is concurrently handling — the lock, not a separate
"is this already handled" check, is what prevents the race.

Two new `Storage` trait methods, backed by the in-memory index (no
`session.json` reads): `list_sessions_by_run_status(status)` (the sweep's
outer loop + boot reconciliation) and `session_run_status_snapshot(id)`
(one child's status+timestamp for the dead-child staleness check).

## Tests

- `sdk::tests::s_t546_1_child_execution_panic_publishes_synthetic_error_completion`
  and `s_t546_3_completion_handler_panic_does_not_block_broadcast_or_hang` —
  REAL integration tests via the existing `run_child_spawn` harness (a
  `PanickingRunner`/`PanickingCompletionHandler` test double that genuinely
  panics inside a real tokio task), proving rows 1 and 3 end-to-end.
- `panic_message_from_join_error_*` — real-panic unit tests (both `&str` and
  `String` payloads, non-string payload, and an aborted-not-panicked task).
- `child_completion_coordinator::tests` — `apply_child_completion_wait_clear_*`
  (rows 6/7's mechanical transition + guardian-state re-application),
  `wait_policy_never_satisfied_by_non_terminal_status` (row 12),
  `wait_watchdog_interval_*` (Part B config parsing, via a pure function so it
  never mutates real env state).
- `child_session_adapter::wait_target_filter_tests` — `filter_active_child_ids`
  / `filter_pending_child_ids` (rows 8/9), including the exact "every
  explicitly-named target had already finished" scenario that used to strand
  the parent.
- `bamboo-storage::v2::tests` — `list_sessions_by_run_status_filters_by_status_across_parents`,
  `session_run_status_snapshot_returns_entry_or_none`.
- `app_state::init::boot_reconciliation_tests` — marks orphans, no-ops when
  nothing's orphaned, idempotent across repeated boots (this test caught a
  real bug during development: the first draft used `save_runtime_state`,
  which never updates the in-memory index the watchdog reads from).
- Updated a pre-existing `sub_agent_tests.rs` test whose premise (waiting on
  fictional, never-created child ids) is exactly what row 8/9's fix now
  correctly rejects.

`cargo fmt --check` clean. `cargo clippy` clean on every touched crate (only
pre-existing warnings elsewhere, unrelated files). `cargo build --workspace
--tests` clean. `cargo test -p bamboo-engine` (967 passed) and `cargo test -p
bamboo-server` (1386 + 12 passed) both fully green.

## Deferred (with reason)

- **Row 4's "conflict, no publish" scenario**: left as an observability
  upgrade (`warn!`) rather than a synthetic-completion publish, since the
  in-flight runner (now hardened by rows 1+3) is guaranteed to eventually
  publish; a genuinely-stale registry entry with no real owner is out of
  scope for this row and would need its own dedicated audit of the runner
  registry's lifecycle.
- **`Any`/`FirstError`-immediate-satisfaction optimization** for rows 8/9: if
  an explicit wait names a mix of already-terminal and still-pending targets
  under `wait_for=any` (or an error under `first_error`), the fix correctly
  filters out the dead targets and waits on the rest rather than
  short-circuiting immediately on the already-satisfied policy. Not a
  stranding risk (the remaining pending targets still resolve normally), just
  a minor UX/latency nicety left for a follow-up.
- **connect-bridged / scheduled child resumes**: `child_completion_handler`
  is `None` on those `SessionExecutionArgs` call sites — verified neither
  path ever spawns a `SessionKind::Child` session today, so this is a
  documented no-op, not a real gap. Flagged in code comments so it's
  impossible to miss if that ever changes.
- **Full config-surface plumbing for the watchdog interval**: gated via
  `BAMBOO_CHILD_WAIT_WATCHDOG_INTERVAL_SECS` (mirrors the existing
  `BAMBOO_RATE_LIMIT_*` env-tunable precedent) rather than a new
  `Config`/settings-loader/frontend-UI field, to keep this PR scoped to the
  bug fix.

Not merging — leaving open for review per instructions.
