### PR TITLE
fix(license): replace GPL actix-governor with in-repo middleware over governor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,18 +58,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-governor"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7ffa43d3e1e92518355ffbc82c146b5f0fe24fba87f19f405270da7a7b3c1e"
-dependencies = [
- "actix-http",
- "actix-web",
- "futures",
- "governor",
-]
-
-[[package]]
 name = "actix-http"
 version = "3.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,7 +1335,6 @@ dependencies = [
  "actix-codec",
  "actix-cors",
  "actix-files",
- "actix-governor",
  "actix-rt",
  "actix-web",
  "actix-ws",
@@ -1383,6 +1370,7 @@ dependencies = [
  "flate2",
  "futures",
  "globset",
+ "governor",
  "hex",
  "http 1.4.2",
  "mockall",

--- a/crates/app/bamboo-broker/Cargo.toml
+++ b/crates/app/bamboo-broker/Cargo.toml
@@ -41,10 +41,10 @@ rustls-pemfile = "2"
 russh = { version = "0.62", default-features = false, features = ["ring", "flate2", "rsa"] }
 russh-sftp = "2.3.0"
 sha2 = "0.11"
-# Per-connection message-rate limiting (#53). Raw `governor`, not
-# `actix-governor` (bamboo-server's HTTP dep) — the broker is a plain
-# WebSocket/tokio server, not actix. Pinned to the same major/minor already
-# resolved transitively via bamboo-server's actix-governor so the workspace
+# Per-connection message-rate limiting (#53). The broker is a plain
+# WebSocket/tokio server (no actix), so it drives `governor` directly rather
+# than through an actix middleware. Pinned to the same major/minor bamboo-server
+# also depends on directly (`src/rate_limit.rs`, #504) so the workspace
 # doesn't grow a second `governor` semver line in Cargo.lock.
 governor = "0.10"
 

--- a/crates/app/bamboo-server/Cargo.toml
+++ b/crates/app/bamboo-server/Cargo.toml
@@ -130,7 +130,12 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # must declare its own deps to use them directly.
 flate2 = "1"
 tar = "0.4"
-actix-governor = "0.10.0"
+# Per-IP rate limiting (`src/rate_limit.rs`, wired from `src/config.rs`): raw
+# `governor` (MIT/Apache-2.0), not `actix-governor` (GPL-3.0-or-later,
+# license-incompatible with this MIT-licensed crate — #504). `bamboo-broker`
+# already depends on the same "0.10" line for its own WS message-rate
+# limiting, so this adds no new crate to the dependency tree.
+governor = "0.10"
 notify-rust = "4.18"
 # Feishu/Lark connect adapter (`src/connect/platforms/feishu/`): the
 # `pbbp2.Frame`/`Header` wire types are hand-derived `prost::Message` impls

--- a/crates/app/bamboo-server/src/config.rs
+++ b/crates/app/bamboo-server/src/config.rs
@@ -20,10 +20,6 @@
 //! - **Custom**: Restrictive CORS for specific addresses
 
 use actix_cors::Cors;
-use actix_governor::governor::middleware::NoOpMiddleware;
-use actix_governor::{
-    Governor, GovernorConfig, GovernorConfigBuilder, KeyExtractor, SimpleKeyExtractionError,
-};
 use actix_web::body::MessageBody;
 use actix_web::dev::{ServiceFactory, ServiceRequest, ServiceResponse};
 use actix_web::http::header;
@@ -33,6 +29,8 @@ use std::collections::HashSet;
 use std::net::IpAddr;
 use tracing::info;
 use tracing::warn;
+
+use crate::rate_limit::{KeyExtractor, RateLimit, RateLimiterConfig, SimpleKeyExtractionError};
 
 /// Default sustained per-IP request rate (requests/second) for the production
 /// (network-exposed) server. Overridable via `BAMBOO_RATE_LIMIT_PER_SECOND`.
@@ -95,7 +93,7 @@ impl ClientIpKeyExtractor {
 
 impl KeyExtractor for ClientIpKeyExtractor {
     type Key = IpAddr;
-    type KeyExtractionError = SimpleKeyExtractionError<&'static str>;
+    type KeyExtractionError = SimpleKeyExtractionError;
 
     fn extract(&self, req: &ServiceRequest) -> Result<Self::Key, Self::KeyExtractionError> {
         if self.trust_xff {
@@ -143,21 +141,20 @@ fn rate_limiter_config(
     per_second: u64,
     burst: u32,
     key_extractor: ClientIpKeyExtractor,
-) -> GovernorConfig<ClientIpKeyExtractor, NoOpMiddleware> {
+) -> RateLimiterConfig<ClientIpKeyExtractor> {
     // One cell replenishes every `1000 / per_second` ms (>=1), allowing `per_second`
     // sustained req/s with a `burst` bucket. Clamp to >=1 so a bad env value can't
-    // produce a zero period/burst (which finish() would reject).
+    // produce a zero period/burst (which `RateLimiterConfig::new` would panic on).
     let ms_per_request = (1000 / per_second.max(1)).max(1);
-    GovernorConfigBuilder::default()
-        .milliseconds_per_request(ms_per_request)
-        .burst_size(burst.max(1))
-        .key_extractor(key_extractor)
-        .finish()
-        .expect("rate limiter config is valid (non-zero period and burst)")
+    RateLimiterConfig::new(
+        std::time::Duration::from_millis(ms_per_request),
+        burst.max(1),
+        key_extractor,
+    )
 }
 
 /// Build the per-IP rate-limiter config applied to the PRODUCTION (network-bound)
-/// server via the `actix-governor` middleware. Throttles each client IP to
+/// server via the [`crate::rate_limit`] middleware. Throttles each client IP to
 /// `BAMBOO_RATE_LIMIT_PER_SECOND` (default 10) req/s with a `BAMBOO_RATE_LIMIT_BURST`
 /// (default 20) burst, returning 429 Too Many Requests when exceeded. Desktop
 /// (localhost) mode does not apply it. #13.
@@ -168,7 +165,7 @@ fn rate_limiter_config(
 /// `BAMBOO_RATE_LIMIT_TRUSTED_HOPS`, default one hop). #169. XFF mode is OPT-IN
 /// because trusting the header when NOT behind a trusted proxy lets any client
 /// spoof its rate-limit key; see [`ClientIpKeyExtractor`].
-pub fn build_rate_limiter() -> GovernorConfig<ClientIpKeyExtractor, NoOpMiddleware> {
+pub fn build_rate_limiter() -> RateLimiterConfig<ClientIpKeyExtractor> {
     let per_second = std::env::var("BAMBOO_RATE_LIMIT_PER_SECOND")
         .ok()
         .and_then(|v| v.trim().parse::<u64>().ok())
@@ -789,7 +786,7 @@ pub fn build_cors(bind_addr: &str, port: u16) -> Cors {
 /// would NOT have failed them).
 pub fn wrap_governor_and_cors<T, B>(
     app: App<T>,
-    rate_limiter: &GovernorConfig<ClientIpKeyExtractor, NoOpMiddleware>,
+    rate_limiter: &RateLimiterConfig<ClientIpKeyExtractor>,
     apply_rate_limit: bool,
     bind_addr: &str,
     port: u16,
@@ -814,7 +811,7 @@ where
 {
     app.wrap(Condition::new(
         apply_rate_limit,
-        Governor::new(rate_limiter),
+        RateLimit::new(rate_limiter),
     ))
     .wrap(build_cors(bind_addr, port))
 }
@@ -899,7 +896,7 @@ mod tests {
 
     #[actix_web::test]
     async fn rate_limiter_throttles_with_429_after_burst() {
-        use actix_governor::Governor;
+        use crate::rate_limit::RateLimit;
         use actix_web::http::StatusCode;
         use actix_web::{test, web, App, HttpResponse};
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -908,7 +905,7 @@ mod tests {
         let conf = rate_limiter_config(1, 2, ClientIpKeyExtractor::peer_ip());
         let app = test::init_service(
             App::new()
-                .wrap(Governor::new(&conf))
+                .wrap(RateLimit::new(&conf))
                 .route("/", web::get().to(|| async { HttpResponse::Ok().finish() })),
         )
         .await;
@@ -1202,7 +1199,7 @@ mod tests {
     /// behavior that would result.
     #[actix_web::test]
     async fn governor_outside_cors_regression_drops_cors_and_throttles_preflight() {
-        use actix_governor::Governor;
+        use crate::rate_limit::RateLimit;
         use actix_web::http::StatusCode;
         use actix_web::{test, web, App, HttpResponse};
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -1211,7 +1208,7 @@ mod tests {
         let app = test::init_service(
             App::new()
                 .wrap(build_cors("0.0.0.0", 9562)) // inner (WRONG)
-                .wrap(Governor::new(&conf)) // outer (WRONG)
+                .wrap(RateLimit::new(&conf)) // outer (WRONG)
                 .route("/", web::get().to(|| async { HttpResponse::Ok().finish() })),
         )
         .await;

--- a/crates/app/bamboo-server/src/lib.rs
+++ b/crates/app/bamboo-server/src/lib.rs
@@ -115,6 +115,7 @@ pub mod logging;
 pub mod notify_sinks;
 pub mod plugin_installer;
 pub mod plugin_source;
+pub mod rate_limit;
 pub mod reloadable_provider;
 pub mod routes;
 pub mod schedule_app;

--- a/crates/app/bamboo-server/src/rate_limit.rs
+++ b/crates/app/bamboo-server/src/rate_limit.rs
@@ -1,0 +1,344 @@
+//! Thin actix-web rate-limiting middleware over the MIT/Apache-2.0-licensed
+//! `governor` crate.
+//!
+//! Replaces `actix-governor` (GPL-3.0-or-later — license-incompatible with
+//! this MIT-licensed crate, #504) with an in-repo `Transform`/`Service` pair
+//! that reproduces exactly the slice of actix-governor 0.10's behavior
+//! `config.rs` relied on:
+//!
+//! - per-key token-bucket throttling, backed by `governor`'s keyed rate
+//!   limiter (same GCRA algorithm, same `Quota::with_period(..).allow_burst(..)`
+//!   construction actix-governor's `GovernorConfigBuilder::finish()` used);
+//! - on throttle: `429 Too Many Requests` with `retry-after` and
+//!   `x-ratelimit-after` headers (seconds until the bucket admits again) and
+//!   a `text/plain` body — byte-for-byte what actix-governor's `NoOpMiddleware`
+//!   path produced;
+//! - on key-extraction failure: whatever response the extractor's error
+//!   produces (bamboo's `ClientIpKeyExtractor` mirrors actix-governor's
+//!   `SimpleKeyExtractionError` default: `500`, `text/plain`).
+//!
+//! actix-governor features bamboo never configured — per-method filtering,
+//! `permissive` mode, whitelisted keys, and the `x-ratelimit-limit` /
+//! `-remaining` / `-whitelisted` headers only added by its
+//! `StateInformationMiddleware` — are intentionally NOT reproduced; adding
+//! them back is a small extension to [`KeyExtractor`]/[`RateLimitMiddleware`]
+//! if ever needed, not a rewrite.
+
+use std::future::{ready, Ready};
+use std::num::NonZeroU32;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::time::Duration;
+
+use actix_web::body::{EitherBody, MessageBody};
+use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform};
+use actix_web::http::StatusCode;
+use actix_web::{Error, HttpResponse, HttpResponseBuilder, ResponseError};
+use futures::future::LocalBoxFuture;
+use governor::clock::{Clock, DefaultClock};
+use governor::state::keyed::DefaultKeyedStateStore;
+use governor::{Quota, RateLimiter as GovernorRateLimiter};
+
+/// Extracts the rate-limiting key from an incoming request.
+///
+/// Mirrors the one piece of `actix_governor::KeyExtractor`'s shape bamboo
+/// actually used, so `config::ClientIpKeyExtractor` ports over with no
+/// change to its extraction logic — only its error type moves to
+/// [`SimpleKeyExtractionError`] below.
+pub trait KeyExtractor: Clone + 'static {
+    /// The extracted key type — must be usable as a `governor` keyed-limiter key.
+    type Key: Clone + Eq + std::hash::Hash + Send + Sync + 'static;
+    /// The error returned when extraction fails; converts to the response a
+    /// caller sees (via `actix_web::Error`'s blanket `From<ResponseError>`).
+    type KeyExtractionError: ResponseError + 'static;
+
+    /// Extract the key, or fail with a response-producing error.
+    fn extract(&self, req: &ServiceRequest) -> Result<Self::Key, Self::KeyExtractionError>;
+}
+
+/// A minimal extraction-failure error: fixed status + `text/plain` body.
+///
+/// Matches `actix_governor::SimpleKeyExtractionError`'s default (status
+/// `500`, content-type `text/plain`) — the only shape bamboo ever used (it
+/// never called that type's `set_status_code`/`set_content_type`).
+#[derive(Debug, Clone, Copy)]
+pub struct SimpleKeyExtractionError(pub &'static str);
+
+impl SimpleKeyExtractionError {
+    pub const fn new(body: &'static str) -> Self {
+        Self(body)
+    }
+}
+
+impl std::fmt::Display for SimpleKeyExtractionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SimpleKeyExtractionError")
+    }
+}
+
+impl std::error::Error for SimpleKeyExtractionError {}
+
+impl ResponseError for SimpleKeyExtractionError {
+    fn status_code(&self) -> StatusCode {
+        StatusCode::INTERNAL_SERVER_ERROR
+    }
+
+    fn error_response(&self) -> HttpResponse {
+        HttpResponseBuilder::new(self.status_code())
+            .content_type("text/plain; charset=utf-8")
+            .body(self.0)
+    }
+}
+
+type KeyedLimiter<Key> = GovernorRateLimiter<Key, DefaultKeyedStateStore<Key>, DefaultClock>;
+
+/// Rate-limiter configuration: a shared quota + key extractor, cheap to
+/// clone (the limiter is behind an `Arc`) so the SAME bucket state is reused
+/// across every `App` factory invocation (actix spins up one `App` per
+/// worker thread) — mirrors `actix_governor::GovernorConfig`.
+pub struct RateLimiterConfig<K: KeyExtractor> {
+    limiter: Arc<KeyedLimiter<K::Key>>,
+    key_extractor: K,
+}
+
+impl<K: KeyExtractor> Clone for RateLimiterConfig<K> {
+    fn clone(&self) -> Self {
+        Self {
+            limiter: self.limiter.clone(),
+            key_extractor: self.key_extractor.clone(),
+        }
+    }
+}
+
+impl<K: KeyExtractor> RateLimiterConfig<K> {
+    /// Build a config allowing bursts up to `burst_size`, replenishing one
+    /// quota element every `period`. Mirrors
+    /// `GovernorConfigBuilder::{milliseconds_per_request,burst_size}.finish()`
+    /// (same `Quota::with_period(..).allow_burst(..)` construction).
+    ///
+    /// Panics if `period` is zero or `burst_size` is zero, same as
+    /// `finish()` returning `None` did — callers clamp beforehand (see
+    /// `config::rate_limiter_config`).
+    pub fn new(period: Duration, burst_size: u32, key_extractor: K) -> Self {
+        let burst = NonZeroU32::new(burst_size).expect("burst_size must be non-zero");
+        let quota = Quota::with_period(period)
+            .expect("period must be non-zero")
+            .allow_burst(burst);
+        Self {
+            limiter: Arc::new(GovernorRateLimiter::keyed(quota)),
+            key_extractor,
+        }
+    }
+}
+
+/// Rate-limiting middleware factory — mirrors `actix_governor::Governor`.
+pub struct RateLimit<K: KeyExtractor> {
+    limiter: Arc<KeyedLimiter<K::Key>>,
+    key_extractor: K,
+}
+
+impl<K: KeyExtractor> RateLimit<K> {
+    /// Create a new middleware factory from a shared [`RateLimiterConfig`].
+    pub fn new(config: &RateLimiterConfig<K>) -> Self {
+        Self {
+            limiter: config.limiter.clone(),
+            key_extractor: config.key_extractor.clone(),
+        }
+    }
+}
+
+impl<S, B, K> Transform<S, ServiceRequest> for RateLimit<K>
+where
+    K: KeyExtractor,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: MessageBody + 'static,
+{
+    type Response = ServiceResponse<EitherBody<B>>;
+    type Error = Error;
+    type Transform = RateLimitMiddleware<S, K>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(RateLimitMiddleware {
+            service: Rc::new(service),
+            limiter: self.limiter.clone(),
+            key_extractor: self.key_extractor.clone(),
+        }))
+    }
+}
+
+pub struct RateLimitMiddleware<S, K: KeyExtractor> {
+    service: Rc<S>,
+    limiter: Arc<KeyedLimiter<K::Key>>,
+    key_extractor: K,
+}
+
+impl<S, B, K> Service<ServiceRequest> for RateLimitMiddleware<S, K>
+where
+    K: KeyExtractor,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    B: MessageBody + 'static,
+{
+    type Response = ServiceResponse<EitherBody<B>>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let key = match self.key_extractor.extract(&req) {
+            Ok(key) => key,
+            Err(err) => {
+                // Matches actix-governor's non-permissive extraction-failure
+                // path: fail the request with the extractor's own error
+                // response; the inner service is never reached.
+                return Box::pin(async move { Err(err.into()) });
+            }
+        };
+
+        match self.limiter.check_key(&key) {
+            Ok(_) => {
+                let fut = self.service.call(req);
+                Box::pin(async move { fut.await.map(|res| res.map_into_left_body()) })
+            }
+            Err(negative) => {
+                let wait_time = negative
+                    .wait_time_from(DefaultClock::default().now())
+                    .as_secs();
+                let response = HttpResponse::build(StatusCode::TOO_MANY_REQUESTS)
+                    .insert_header(("retry-after", wait_time))
+                    .insert_header(("x-ratelimit-after", wait_time))
+                    .content_type("text/plain; charset=utf-8")
+                    .body(format!("Too many requests, retry in {wait_time}s"));
+                let response = req.into_response(response).map_into_right_body();
+                Box::pin(async move { Ok(response) })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::http::StatusCode as HttpStatusCode;
+    use actix_web::{test, web, App, HttpResponse as Resp};
+    use std::net::{IpAddr, Ipv4Addr};
+
+    /// A trivial always-succeeds key extractor keyed on a fixed IP, used to
+    /// unit-test the burst/refill behavior of [`RateLimitMiddleware`]
+    /// directly (independent of `config::ClientIpKeyExtractor`, which has
+    /// its own dedicated tests in `config.rs`).
+    #[derive(Clone)]
+    struct FixedKeyExtractor(IpAddr);
+
+    impl KeyExtractor for FixedKeyExtractor {
+        type Key = IpAddr;
+        type KeyExtractionError = SimpleKeyExtractionError;
+
+        fn extract(&self, _req: &ServiceRequest) -> Result<Self::Key, Self::KeyExtractionError> {
+            Ok(self.0)
+        }
+    }
+
+    #[actix_web::test]
+    async fn burst_then_429_with_retry_after_header() {
+        let key = IpAddr::V4(Ipv4Addr::new(10, 1, 1, 1));
+        let conf = RateLimiterConfig::new(Duration::from_millis(100), 3, FixedKeyExtractor(key));
+        let app = test::init_service(
+            App::new()
+                .wrap(RateLimit::new(&conf))
+                .route("/", web::get().to(|| async { Resp::Ok().finish() })),
+        )
+        .await;
+
+        // The first 3 requests (burst_size) pass.
+        for _ in 0..3 {
+            let res =
+                test::call_service(&app, test::TestRequest::get().uri("/").to_request()).await;
+            assert_eq!(res.status(), HttpStatusCode::OK);
+        }
+
+        // The 4th is throttled, with a Retry-After header.
+        let res = test::call_service(&app, test::TestRequest::get().uri("/").to_request()).await;
+        assert_eq!(res.status(), HttpStatusCode::TOO_MANY_REQUESTS);
+        assert!(
+            res.headers().contains_key("retry-after"),
+            "a 429 must carry Retry-After"
+        );
+        assert!(
+            res.headers().contains_key("x-ratelimit-after"),
+            "a 429 must carry x-ratelimit-after"
+        );
+    }
+
+    #[actix_web::test]
+    async fn refills_after_period_elapses() {
+        let key = IpAddr::V4(Ipv4Addr::new(10, 1, 1, 2));
+        // burst=1, one element every 20ms — small enough to sleep past in a test.
+        let conf = RateLimiterConfig::new(Duration::from_millis(20), 1, FixedKeyExtractor(key));
+        let app = test::init_service(
+            App::new()
+                .wrap(RateLimit::new(&conf))
+                .route("/", web::get().to(|| async { Resp::Ok().finish() })),
+        )
+        .await;
+
+        let res = test::call_service(&app, test::TestRequest::get().uri("/").to_request()).await;
+        assert_eq!(res.status(), HttpStatusCode::OK);
+
+        let res = test::call_service(&app, test::TestRequest::get().uri("/").to_request()).await;
+        assert_eq!(
+            res.status(),
+            HttpStatusCode::TOO_MANY_REQUESTS,
+            "bucket must be empty immediately after the burst"
+        );
+
+        tokio::time::sleep(Duration::from_millis(60)).await;
+
+        let res = test::call_service(&app, test::TestRequest::get().uri("/").to_request()).await;
+        assert_eq!(
+            res.status(),
+            HttpStatusCode::OK,
+            "the bucket must have refilled after the period elapses"
+        );
+    }
+
+    #[actix_web::test]
+    async fn extraction_failure_returns_extractors_error_response() {
+        #[derive(Clone)]
+        struct AlwaysFailsExtractor;
+
+        impl KeyExtractor for AlwaysFailsExtractor {
+            type Key = ();
+            type KeyExtractionError = SimpleKeyExtractionError;
+
+            fn extract(
+                &self,
+                _req: &ServiceRequest,
+            ) -> Result<Self::Key, Self::KeyExtractionError> {
+                Err(SimpleKeyExtractionError::new("no key for you"))
+            }
+        }
+
+        let conf = RateLimiterConfig::new(Duration::from_secs(1), 1, AlwaysFailsExtractor);
+        let app = test::init_service(
+            App::new()
+                .wrap(RateLimit::new(&conf))
+                .route("/", web::get().to(|| async { Resp::Ok().finish() })),
+        )
+        .await;
+
+        // The middleware returns `Err(err.into())` on extraction failure (matching
+        // actix-governor's non-permissive path) rather than an `Ok(response)` —
+        // real HTTP serving converts that via `ResponseError` further down the
+        // stack (in the H1/H2 dispatcher), so exercise that conversion directly
+        // here via `try_call_service` + `ResponseError::error_response()` instead
+        // of `call_service` (which panics on `Err`, since it bypasses that layer).
+        let err = test::try_call_service(&app, test::TestRequest::get().uri("/").to_request())
+            .await
+            .expect_err("extraction failure must reach the caller as an Err");
+        let response = err.error_response();
+        assert_eq!(response.status(), HttpStatusCode::INTERNAL_SERVER_ERROR);
+    }
+}

--- a/crates/app/bamboo-server/src/routes/mod.rs
+++ b/crates/app/bamboo-server/src/routes/mod.rs
@@ -27,7 +27,7 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
 /// Configure all routes for production mode.
 ///
 /// This registers the same route set as [`configure_routes`]; the actual per-IP
-/// rate limiting is applied as an `actix-governor` middleware (`.wrap(Governor)`)
+/// rate limiting is applied as a [`crate::rate_limit`] middleware (`.wrap(RateLimit)`)
 /// on the production App in `server::entrypoints` / `server::web_service`, since
 /// rate limiting is App-level middleware, not route configuration. See
 /// [`crate::config::build_rate_limiter`]. (Name kept for back-compat.) #13.

--- a/deny.toml
+++ b/deny.toml
@@ -111,16 +111,11 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list.
 #
-# actix-governor (the actix-web integration for the `governor` rate limiter,
-# used by bamboo-server's rate-limit middleware) is GPL-3.0-or-later — unlike
-# the MIT/Apache-2.0 `governor` crate it wraps. This is a real license-compat
-# question for a binary distribution (not a cargo-deny config problem to
-# paper over), so it's an explicit, narrowly-scoped exception rather than a
-# blanket GPL allowance, and is flagged for follow-up (new-issue candidate,
-# bamboo-agent#254 PR description) rather than silently resolved here.
-exceptions = [
-    { allow = ["GPL-3.0-or-later"], crate = "actix-governor" },
-]
+# No exceptions currently needed: `actix-governor` (GPL-3.0-or-later) was
+# replaced by an in-repo actix middleware over the MIT/Apache-2.0 `governor`
+# crate it used to wrap (bamboo-server's `src/rate_limit.rs`, #504), which
+# removed the GPL dependency entirely rather than requiring one.
+exceptions = []
 
 # Some crates don't have (easily) machine readable licensing information,
 # adding a clarification entry for it allows you to manually specify the


### PR DESCRIPTION
## Summary

- `actix-governor` is GPL-3.0-or-later — license-incompatible with this MIT-licensed crate, despite wrapping the MIT/Apache-2.0 `governor` crate it's actually built on. Implements recommendation option 1 from #504: replace it with a thin in-repo actix middleware over `governor` directly, removing the GPL dependency entirely.
- New `bamboo-server/src/rate_limit.rs` (~250 lines incl. doc comments + tests) implements a `Transform`/`Service` pair (`RateLimit`/`RateLimitMiddleware`) driving `governor`'s keyed rate limiter, reproducing byte-for-byte the slice of actix-governor 0.10 behavior `config.rs` relied on:
  - per-key token-bucket throttling (same `Quota::with_period(..).allow_burst(..)` construction actix-governor's `GovernorConfigBuilder::finish()` used)
  - `429 Too Many Requests` with `retry-after` / `x-ratelimit-after` headers and a `text/plain` body on throttle
  - `500 Internal Server Error` / `text/plain` on key-extraction failure (matches `SimpleKeyExtractionError`'s default)
  - actix-governor features bamboo never configured (per-method filtering, `permissive` mode, whitelisted keys, `x-ratelimit-limit`/`-remaining`/`-whitelisted` headers from `StateInformationMiddleware`) are intentionally not reproduced.
- `bamboo-server` now depends on `governor` directly instead of `actix-governor`. `bamboo-broker` already depended on `governor = "0.10"` for its own WS rate limiting, so this adds no new crate/semver-line to the dependency tree — `Cargo.lock` still has exactly one `governor` entry (0.10.4).
- Removed the now-unneeded `actix-governor` GPL exception from `deny.toml` (added by #503) — that was the whole point of #504.
- Config knobs, defaults, and env vars are unchanged: `BAMBOO_RATE_LIMIT_PER_SECOND`, `BAMBOO_RATE_LIMIT_BURST`, `BAMBOO_RATE_LIMIT_TRUST_XFF`, `BAMBOO_RATE_LIMIT_TRUSTED_HOPS`; loopback/`is_loopback_bind` skip + `Condition` gate; `wrap_governor_and_cors`'s Governor-inner/CORS-outer wrap order (#169/#428) is untouched.

Closes #504.

## Test plan

- All existing rate-limit regression tests (#427 XFF keying, #428 loopback-range/wrap-order, #461 CORS/preflight-safe 429) pass **unchanged** except a single import-line swap (`actix_governor::Governor` → `crate::rate_limit::RateLimit`) in two tests that constructed the middleware directly:
  - `rate_limiter_throttles_with_429_after_burst`
  - `governor_inside_cors_makes_429_cors_readable_and_exempts_preflight`
  - `governor_outside_cors_regression_drops_cors_and_throttles_preflight`
  - `loopback_binds_skip_rate_limiter`, `loopback_binds_recognizes_full_loopback_range_and_bracketed_ipv6`
  - `key_extractor_*` (XFF keying/fail-closed/multi-header) suite
  - `require_limiter_*` bind-aware guard suite
- Added 3 new unit tests directly against the new middleware in `rate_limit.rs`: burst-then-429 with `retry-after`/`x-ratelimit-after` headers, refill-after-period-elapses, and extraction-failure → 500 response.
- `cargo fmt -p bamboo-server -p bamboo-broker -- --check` — clean
- `cargo clippy -p bamboo-server -p bamboo-broker --all-targets` — zero warnings in touched files (pre-existing `too_many_arguments`/`type_complexity` warnings elsewhere in the workspace are unrelated to this change and untouched)
- `cargo build --workspace --tests` — green
- `cargo test -p bamboo-server` — **1379 passed, 0 failed** (lib) + 12/12 (`ws_v2_live`) + 9/9 doctests
- `cargo deny check` — green, `licenses ok`, no exceptions needed
- `cargo tree -i actix-governor` — empty (crate fully removed)
- `cargo tree -i aws-lc-sys` — empty (native-tls pin intact)