### PR TITLE
refactor(config): add independently persisted modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ version = "0.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "async-trait",
  "bamboo-domain",
  "base64",
  "chrono",

--- a/crates/infra/bamboo-config/Cargo.toml
+++ b/crates/infra/bamboo-config/Cargo.toml
@@ -15,6 +15,7 @@ chrono = { workspace = true }
 thiserror = { workspace = true }
 anyhow = "1"
 tracing = "0.1"
+async-trait = "0.1"
 regex = "1"
 dirs = "6"
 aes-gcm = "0.11"

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -2228,6 +2228,36 @@ impl Config {
             Self::create_default()
         };
 
+        // Phase-1 registrar migration: an existing sidecar is authoritative;
+        // when absent, retain the legacy inline value loaded from config.json.
+        // A malformed sidecar is never rewritten during load and the inline
+        // value remains available, preventing a bad independent edit from
+        // erasing the user's last usable configuration.
+        let mut memory_module = crate::MemoryConfigModule(config.memory.clone());
+        match memory_module.load_sync(&data_dir) {
+            Ok(true) => config.memory = memory_module.0,
+            Ok(false) => {}
+            Err(error) => tracing::warn!(
+                "Failed to load memory.json; using legacy config.json memory: {error}"
+            ),
+        }
+        let mut subagents_module = crate::SubagentsConfigModule(config.subagents.clone());
+        match subagents_module.load_sync(&data_dir) {
+            Ok(true) => config.subagents = subagents_module.0,
+            Ok(false) => {}
+            Err(error) => tracing::warn!(
+                "Failed to load subagents.json; using legacy config.json subagents: {error}"
+            ),
+        }
+        let mut providers_module = crate::ProviderConfigsModule(config.providers.clone());
+        match providers_module.load_sync(&data_dir) {
+            Ok(true) => config.providers = providers_module.0,
+            Ok(false) => {}
+            Err(error) => tracing::warn!(
+                "Failed to load providers.json; using legacy config.json providers: {error}"
+            ),
+        }
+
         // Decrypt encrypted proxy auth into in-memory plaintext form.
         config.hydrate_proxy_auth_from_encrypted();
         // Decrypt encrypted provider API keys into in-memory plaintext form.
@@ -3054,6 +3084,24 @@ impl Config {
         self.save_to_dir(default_data_dir())
     }
 
+    /// Persist only the memory module, leaving every other config file untouched.
+    pub fn save_memory_to_dir(&self, data_dir: &std::path::Path) -> Result<()> {
+        crate::MemoryConfigModule(self.memory.clone()).save_sync(data_dir)
+    }
+
+    /// Persist only the sub-agent module, leaving every other config file untouched.
+    pub fn save_subagents_to_dir(&self, data_dir: &std::path::Path) -> Result<()> {
+        crate::SubagentsConfigModule(self.subagents.clone()).save_sync(data_dir)
+    }
+
+    /// Persist only provider configuration. Provider plaintext keys are first
+    /// refreshed into their encrypted at-rest representation.
+    pub fn save_providers_to_dir(&self, data_dir: &std::path::Path) -> Result<()> {
+        let mut config = self.clone();
+        config.refresh_provider_api_keys_encrypted()?;
+        crate::ProviderConfigsModule(config.providers).save_sync(data_dir)
+    }
+
     /// The pending config-corruption recovery, if `config.json` failed to
     /// parse on load and the recovery hasn't been confirmed yet. `None` on
     /// every clean load. #153.
@@ -3167,6 +3215,9 @@ impl Config {
             serde_json::to_value(&to_save).context("Failed to serialize config to JSON")?;
         if let Some(obj) = config_value.as_object_mut() {
             obj.remove("connect");
+            obj.remove("memory");
+            obj.remove("subagents");
+            obj.remove("providers");
         }
         let content = serde_json::to_string_pretty(&config_value)
             .context("Failed to serialize config to JSON")?;
@@ -3195,6 +3246,9 @@ impl Config {
         write_atomic(&path, content.as_bytes())
             .with_context(|| format!("Failed to write config file: {:?}", path))?;
 
+        crate::MemoryConfigModule(to_save.memory.clone()).save_sync(&data_dir)?;
+        crate::SubagentsConfigModule(to_save.subagents.clone()).save_sync(&data_dir)?;
+        crate::ProviderConfigsModule(to_save.providers.clone()).save_sync(&data_dir)?;
         save_connect_config(&to_save.connect, &data_dir)?;
 
         Ok(())
@@ -3539,7 +3593,7 @@ fn rotate_backups(config_path: &std::path::Path, generations: usize) {
     }
 }
 
-fn write_atomic(path: &std::path::Path, content: &[u8]) -> std::io::Result<()> {
+pub(crate) fn write_atomic(path: &std::path::Path, content: &[u8]) -> std::io::Result<()> {
     let Some(parent) = path.parent() else {
         return std::fs::write(path, content);
     };
@@ -6366,15 +6420,15 @@ mod tests {
             .save_to_dir(temp_home.path.clone())
             .expect("save should encrypt provider api keys");
 
-        let content =
-            std::fs::read_to_string(temp_home.path.join("config.json")).expect("read config.json");
+        let content = std::fs::read_to_string(temp_home.path.join("providers.json"))
+            .expect("read providers.json");
         assert!(
             content.contains("\"api_key_encrypted\""),
-            "config.json should store encrypted provider keys"
+            "providers.json should store encrypted provider keys"
         );
         assert!(
             !content.contains("\"api_key\""),
-            "config.json should not store plaintext provider keys"
+            "providers.json should not store plaintext provider keys"
         );
 
         let loaded = Config::from_data_dir(Some(temp_home.path.clone()));

--- a/crates/infra/bamboo-config/src/config_module.rs
+++ b/crates/infra/bamboo-config/src/config_module.rs
@@ -1,0 +1,309 @@
+//! Independently persisted configuration modules and their registrar.
+//!
+//! A module owns one sidecar file in Bamboo's data directory.  Modules are
+//! deliberately object-safe so new configuration domains can be registered
+//! without adding another field to the root [`crate::Config`] DTO.
+
+use std::{any::Any, collections::HashMap, path::Path};
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use serde::{de::DeserializeOwned, Serialize};
+
+/// A named, independently loadable and flushable configuration domain.
+#[async_trait]
+pub trait ConfigModule: Send + Sync {
+    fn name(&self) -> &'static str;
+    async fn load(&mut self, data_dir: &Path) -> Result<()>;
+    async fn save(&self, data_dir: &Path) -> Result<()>;
+    async fn reload(&mut self, data_dir: &Path) -> Result<()> {
+        self.load(data_dir).await
+    }
+    fn validate(&self) -> Result<()>;
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+/// Registrar for configuration domains. Each module can be loaded or saved
+/// without serializing unrelated configuration.
+#[derive(Default)]
+pub struct ConfigRegistry {
+    modules: HashMap<String, Box<dyn ConfigModule>>,
+}
+
+impl ConfigRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register<M: ConfigModule + 'static>(
+        &mut self,
+        module: M,
+    ) -> Option<Box<dyn ConfigModule>> {
+        self.modules
+            .insert(module.name().to_owned(), Box::new(module))
+    }
+
+    pub fn module<T: 'static>(&self, name: &str) -> Option<&T> {
+        self.modules.get(name)?.as_any().downcast_ref()
+    }
+
+    pub fn module_mut<T: 'static>(&mut self, name: &str) -> Option<&mut T> {
+        self.modules.get_mut(name)?.as_any_mut().downcast_mut()
+    }
+
+    pub async fn load_all(&mut self, data_dir: &Path) -> Result<()> {
+        for module in self.modules.values_mut() {
+            module.load(data_dir).await?;
+            module.validate()?;
+        }
+        Ok(())
+    }
+
+    pub async fn reload_module(&mut self, name: &str, data_dir: &Path) -> Result<()> {
+        let module = self
+            .modules
+            .get_mut(name)
+            .ok_or_else(|| anyhow!("unknown config module: {name}"))?;
+        module.reload(data_dir).await?;
+        module.validate()
+    }
+
+    pub async fn save_module(&self, name: &str, data_dir: &Path) -> Result<()> {
+        let module = self
+            .modules
+            .get(name)
+            .ok_or_else(|| anyhow!("unknown config module: {name}"))?;
+        module.validate()?;
+        module.save(data_dir).await
+    }
+
+    pub async fn save_all(&self, data_dir: &Path) -> Result<()> {
+        for module in self.modules.values() {
+            module.validate()?;
+            module.save(data_dir).await?;
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn load_sidecar<T: DeserializeOwned>(path: &Path) -> Result<Option<T>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = std::fs::read(path)?;
+    match serde_json::from_slice(&bytes) {
+        Ok(value) => Ok(Some(value)),
+        Err(primary_error) => {
+            let backup = path.with_extension("json.bak");
+            if backup.exists() {
+                let backup_bytes = std::fs::read(&backup)?;
+                return serde_json::from_slice(&backup_bytes)
+                    .map(Some)
+                    .map_err(Into::into);
+            }
+            Err(primary_error.into())
+        }
+    }
+}
+
+pub(crate) fn save_sidecar<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let bytes = serde_json::to_vec_pretty(value)?;
+    // Retain one last-known-good generation. A malformed current sidecar is
+    // deliberately not promoted over the usable backup.
+    if path.exists() {
+        let current = std::fs::read(path)?;
+        if serde_json::from_slice::<serde_json::Value>(&current).is_ok() {
+            std::fs::copy(path, path.with_extension("json.bak"))?;
+        }
+    }
+    crate::config::write_atomic(path, &bytes)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::SystemTime;
+
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use crate::{Config, MemoryConfig, OpenAIConfig};
+
+    fn write_json(path: &Path, value: serde_json::Value) {
+        std::fs::write(path, serde_json::to_vec_pretty(&value).unwrap()).unwrap();
+    }
+
+    use std::path::Path;
+
+    #[test]
+    fn legacy_inline_sections_load_and_migrate_to_sidecars() {
+        let dir = TempDir::new().unwrap();
+        write_json(
+            &dir.path().join("config.json"),
+            json!({
+                "memory": { "background_model": "legacy-memory" },
+                "subagents": { "max_concurrent": 3 },
+                "providers": { "openai": { "model": "legacy-model" } }
+            }),
+        );
+
+        let config = Config::from_data_dir_without_env(Some(dir.path().to_path_buf()));
+        assert_eq!(
+            config.memory.as_ref().unwrap().background_model.as_deref(),
+            Some("legacy-memory")
+        );
+        assert_eq!(config.subagents.max_concurrent, Some(3));
+        assert_eq!(
+            config.providers.openai.as_ref().unwrap().model.as_deref(),
+            Some("legacy-model")
+        );
+
+        config.save_to_dir(dir.path().to_path_buf()).unwrap();
+        let root: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(dir.path().join("config.json")).unwrap())
+                .unwrap();
+        assert!(root.get("memory").is_none());
+        assert!(root.get("subagents").is_none());
+        assert!(root.get("providers").is_none());
+        assert!(dir.path().join("memory.json").exists());
+        assert!(dir.path().join("subagents.json").exists());
+        assert!(dir.path().join("providers.json").exists());
+
+        let reloaded = Config::from_data_dir_without_env(Some(dir.path().to_path_buf()));
+        assert_eq!(
+            reloaded
+                .memory
+                .as_ref()
+                .unwrap()
+                .background_model
+                .as_deref(),
+            Some("legacy-memory")
+        );
+        assert_eq!(reloaded.subagents.max_concurrent, Some(3));
+        assert_eq!(
+            reloaded.providers.openai.as_ref().unwrap().model.as_deref(),
+            Some("legacy-model")
+        );
+    }
+
+    #[test]
+    fn sidecars_override_legacy_inline_sections() {
+        let dir = TempDir::new().unwrap();
+        write_json(
+            &dir.path().join("config.json"),
+            json!({
+                "memory": { "background_model": "inline" },
+                "subagents": { "max_concurrent": 1 },
+                "providers": { "openai": { "model": "inline" } }
+            }),
+        );
+        write_json(
+            &dir.path().join("memory.json"),
+            json!({"background_model": "sidecar"}),
+        );
+        write_json(
+            &dir.path().join("subagents.json"),
+            json!({"max_concurrent": 9}),
+        );
+        write_json(
+            &dir.path().join("providers.json"),
+            json!({"openai": {"model": "sidecar"}}),
+        );
+
+        let config = Config::from_data_dir_without_env(Some(dir.path().to_path_buf()));
+        assert_eq!(
+            config.memory.unwrap().background_model.as_deref(),
+            Some("sidecar")
+        );
+        assert_eq!(config.subagents.max_concurrent, Some(9));
+        assert_eq!(
+            config.providers.openai.unwrap().model.as_deref(),
+            Some("sidecar")
+        );
+    }
+
+    #[test]
+    fn independent_memory_save_does_not_touch_other_documents() {
+        let dir = TempDir::new().unwrap();
+        let config = Config::default();
+        config.save_to_dir(dir.path().to_path_buf()).unwrap();
+        let paths = ["config.json", "providers.json", "subagents.json"];
+        let before: Vec<_> = paths
+            .iter()
+            .map(|name| {
+                let path = dir.path().join(name);
+                (
+                    std::fs::read(&path).unwrap(),
+                    std::fs::metadata(path)
+                        .unwrap()
+                        .modified()
+                        .unwrap_or(SystemTime::UNIX_EPOCH),
+                )
+            })
+            .collect();
+
+        let mut changed = config;
+        changed.memory = Some(MemoryConfig {
+            background_model: Some("new-memory".into()),
+            ..MemoryConfig::default()
+        });
+        changed.save_memory_to_dir(dir.path()).unwrap();
+
+        for (index, name) in paths.iter().enumerate() {
+            let path = dir.path().join(name);
+            assert_eq!(
+                std::fs::read(&path).unwrap(),
+                before[index].0,
+                "{name} bytes changed"
+            );
+            assert_eq!(
+                std::fs::metadata(path)
+                    .unwrap()
+                    .modified()
+                    .unwrap_or(SystemTime::UNIX_EPOCH),
+                before[index].1,
+                "{name} mtime changed"
+            );
+        }
+    }
+
+    #[test]
+    fn providers_sidecar_never_contains_plaintext_api_key() {
+        let _key = crate::encryption::set_test_encryption_key([23; 32]);
+        let dir = TempDir::new().unwrap();
+        let mut config = Config::default();
+        config.providers.openai = Some(OpenAIConfig {
+            api_key: "sk-plaintext-must-not-leak".into(),
+            ..OpenAIConfig::default()
+        });
+        config.save_providers_to_dir(dir.path()).unwrap();
+        let raw = std::fs::read_to_string(dir.path().join("providers.json")).unwrap();
+        assert!(!raw.contains("sk-plaintext-must-not-leak"));
+        assert!(raw.contains("api_key_encrypted"));
+    }
+
+    #[test]
+    fn malformed_sidecar_recovers_from_last_known_good_backup() {
+        let dir = TempDir::new().unwrap();
+        write_json(&dir.path().join("config.json"), json!({}));
+        write_json(
+            &dir.path().join("memory.json.bak"),
+            json!({"background_model": "recovered"}),
+        );
+        std::fs::write(dir.path().join("memory.json"), b"{broken").unwrap();
+
+        let config = Config::from_data_dir_without_env(Some(dir.path().to_path_buf()));
+        assert_eq!(
+            config.memory.unwrap().background_model.as_deref(),
+            Some("recovered")
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join("memory.json")).unwrap(),
+            b"{broken"
+        );
+    }
+}

--- a/crates/infra/bamboo-config/src/dot_path.rs
+++ b/crates/infra/bamboo-config/src/dot_path.rs
@@ -644,13 +644,13 @@ mod tests {
             Some(serde_json::from_value(json!({"api_key": "sk-ant-super-secret"})).unwrap());
         config.save_to_dir(data_dir.clone()).expect("seed save");
 
-        let on_disk = std::fs::read_to_string(data_dir.join("config.json")).unwrap();
+        let on_disk = std::fs::read_to_string(data_dir.join("providers.json")).unwrap();
         assert!(
             !on_disk.contains("sk-ant-super-secret"),
             "plaintext key must never be written to disk"
         );
-        let cipher_before = serde_json::from_str::<Value>(&on_disk).unwrap()["providers"]
-            ["anthropic"]["api_key_encrypted"]
+        let cipher_before = serde_json::from_str::<Value>(&on_disk).unwrap()["anthropic"]
+            ["api_key_encrypted"]
             .as_str()
             .expect("encrypted key present")
             .to_string();
@@ -666,12 +666,12 @@ mod tests {
             apply_dot_path_set(&loaded, "providers.anthropic.model", json!("claude-x")).unwrap();
         outcome.config.save_to_dir(data_dir.clone()).expect("save");
 
-        let on_disk = std::fs::read_to_string(data_dir.join("config.json")).unwrap();
+        let on_disk = std::fs::read_to_string(data_dir.join("providers.json")).unwrap();
         assert!(!on_disk.contains("sk-ant-super-secret"));
         let root: Value = serde_json::from_str(&on_disk).unwrap();
-        assert_eq!(root["providers"]["anthropic"]["model"], json!("claude-x"));
+        assert_eq!(root["anthropic"]["model"], json!("claude-x"));
         assert_eq!(
-            root["providers"]["anthropic"]["api_key_encrypted"]
+            root["anthropic"]["api_key_encrypted"]
                 .as_str()
                 .expect("encrypted key still present"),
             cipher_before,

--- a/crates/infra/bamboo-config/src/lib.rs
+++ b/crates/infra/bamboo-config/src/lib.rs
@@ -14,24 +14,32 @@ pub mod cluster_fabric;
 #[allow(clippy::module_inception)]
 pub mod config;
 pub mod config_crypto;
+pub mod config_module;
 pub mod dot_path;
 pub mod encryption;
 pub mod keyword_masking;
+pub mod memory_config;
 pub mod model_mapping;
 pub mod patch;
 pub mod paths;
+pub mod provider_configs;
 pub mod provider_instance;
 pub mod settings;
 pub mod settings_loader;
+pub mod subagents_config;
 
 pub use cluster_fabric::*;
 pub use config::*;
+pub use config_module::*;
 pub use encryption::*;
 pub use keyword_masking::*;
+pub use memory_config::MemoryConfigModule;
 pub use model_mapping::*;
 pub use paths::*;
+pub use provider_configs::ProviderConfigsModule;
 pub use provider_instance::synthesize_legacy_instances;
 pub use settings::PermissionMode;
+pub use subagents_config::SubagentsConfigModule;
 
 /// Test-only synchronization for tests that mutate process-global state
 /// (env vars, the encryption-key var, the env-vars snapshot). Tests across

--- a/crates/infra/bamboo-config/src/memory_config.rs
+++ b/crates/infra/bamboo-config/src/memory_config.rs
@@ -1,0 +1,51 @@
+//! Independently persisted memory configuration (`memory.json`).
+
+use crate::{
+    config_module::{load_sidecar, save_sidecar},
+    ConfigModule, MemoryConfig,
+};
+use anyhow::Result;
+use async_trait::async_trait;
+use std::{any::Any, path::Path};
+
+pub const FILE_NAME: &str = "memory.json";
+
+#[derive(Debug, Clone, Default)]
+pub struct MemoryConfigModule(pub Option<MemoryConfig>);
+
+impl MemoryConfigModule {
+    pub(crate) fn load_sync(&mut self, data_dir: &Path) -> Result<bool> {
+        if let Some(value) = load_sidecar(&data_dir.join(FILE_NAME))? {
+            self.0 = value;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+    pub(crate) fn save_sync(&self, data_dir: &Path) -> Result<()> {
+        save_sidecar(&data_dir.join(FILE_NAME), &self.0)
+    }
+}
+
+#[async_trait]
+impl ConfigModule for MemoryConfigModule {
+    fn name(&self) -> &'static str {
+        "memory"
+    }
+    async fn load(&mut self, data_dir: &Path) -> Result<()> {
+        self.load_sync(data_dir).map(|_| ())
+    }
+    async fn save(&self, data_dir: &Path) -> Result<()> {
+        self.save_sync(data_dir)
+    }
+    fn validate(&self) -> Result<()> {
+        serde_json::to_value(&self.0)
+            .map(|_| ())
+            .map_err(Into::into)
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/crates/infra/bamboo-config/src/provider_configs.rs
+++ b/crates/infra/bamboo-config/src/provider_configs.rs
@@ -1,0 +1,51 @@
+//! Independently persisted legacy provider configuration (`providers.json`).
+
+use crate::{
+    config_module::{load_sidecar, save_sidecar},
+    ConfigModule, ProviderConfigs,
+};
+use anyhow::Result;
+use async_trait::async_trait;
+use std::{any::Any, path::Path};
+
+pub const FILE_NAME: &str = "providers.json";
+
+#[derive(Debug, Clone, Default)]
+pub struct ProviderConfigsModule(pub ProviderConfigs);
+
+impl ProviderConfigsModule {
+    pub(crate) fn load_sync(&mut self, data_dir: &Path) -> Result<bool> {
+        if let Some(value) = load_sidecar(&data_dir.join(FILE_NAME))? {
+            self.0 = value;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+    pub(crate) fn save_sync(&self, data_dir: &Path) -> Result<()> {
+        save_sidecar(&data_dir.join(FILE_NAME), &self.0)
+    }
+}
+
+#[async_trait]
+impl ConfigModule for ProviderConfigsModule {
+    fn name(&self) -> &'static str {
+        "providers"
+    }
+    async fn load(&mut self, data_dir: &Path) -> Result<()> {
+        self.load_sync(data_dir).map(|_| ())
+    }
+    async fn save(&self, data_dir: &Path) -> Result<()> {
+        self.save_sync(data_dir)
+    }
+    fn validate(&self) -> Result<()> {
+        serde_json::to_value(&self.0)
+            .map(|_| ())
+            .map_err(Into::into)
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/crates/infra/bamboo-config/src/subagents_config.rs
+++ b/crates/infra/bamboo-config/src/subagents_config.rs
@@ -1,0 +1,51 @@
+//! Independently persisted sub-agent configuration (`subagents.json`).
+
+use crate::{
+    config_module::{load_sidecar, save_sidecar},
+    ConfigModule, SubagentsConfig,
+};
+use anyhow::Result;
+use async_trait::async_trait;
+use std::{any::Any, path::Path};
+
+pub const FILE_NAME: &str = "subagents.json";
+
+#[derive(Debug, Clone, Default)]
+pub struct SubagentsConfigModule(pub SubagentsConfig);
+
+impl SubagentsConfigModule {
+    pub(crate) fn load_sync(&mut self, data_dir: &Path) -> Result<bool> {
+        if let Some(value) = load_sidecar(&data_dir.join(FILE_NAME))? {
+            self.0 = value;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+    pub(crate) fn save_sync(&self, data_dir: &Path) -> Result<()> {
+        save_sidecar(&data_dir.join(FILE_NAME), &self.0)
+    }
+}
+
+#[async_trait]
+impl ConfigModule for SubagentsConfigModule {
+    fn name(&self) -> &'static str {
+        "subagents"
+    }
+    async fn load(&mut self, data_dir: &Path) -> Result<()> {
+        self.load_sync(data_dir).map(|_| ())
+    }
+    async fn save(&self, data_dir: &Path) -> Result<()> {
+        self.save_sync(data_dir)
+    }
+    fn validate(&self) -> Result<()> {
+        serde_json::to_value(&self.0)
+            .map(|_| ())
+            .map_err(Into::into)
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/src/setup_cli.rs
+++ b/src/setup_cli.rs
@@ -761,13 +761,13 @@ mod tests {
         )
         .unwrap();
 
-        let raw = std::fs::read_to_string(data_dir.join("config.json")).unwrap();
+        let raw = std::fs::read_to_string(data_dir.join("providers.json")).unwrap();
         assert!(
             !raw.contains("sk-ant-setupcli-secret"),
             "plaintext api_key must never reach disk"
         );
         let root: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert!(root["providers"]["anthropic"]["api_key_encrypted"]
+        assert!(root["anthropic"]["api_key_encrypted"]
             .as_str()
             .is_some_and(|s| !s.is_empty()));
 
@@ -779,11 +779,11 @@ mod tests {
             false,
         )
         .unwrap();
-        let raw = std::fs::read_to_string(data_dir.join("config.json")).unwrap();
+        let raw = std::fs::read_to_string(data_dir.join("providers.json")).unwrap();
         assert!(!raw.contains("sk-ant-setupcli-secret"));
         let root: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert_eq!(root["providers"]["anthropic"]["model"], "claude-x");
-        assert!(root["providers"]["anthropic"]["api_key_encrypted"]
+        assert_eq!(root["anthropic"]["model"], "claude-x");
+        assert!(root["anthropic"]["api_key_encrypted"]
             .as_str()
             .is_some_and(|s| !s.is_empty()));
 

--- a/tests/e2e/config_flow/flows.rs
+++ b/tests/e2e/config_flow/flows.rs
@@ -5,6 +5,7 @@ async fn test_full_setup_and_provider_flow_does_not_conflict() {
     let state = crate::e2e::common::create_test_app().await;
     let data_dir = state.app_data_dir.clone();
     let config_path = data_dir.join("config.json");
+    let providers_path = data_dir.join("providers.json");
 
     let app = test::init_service(
         App::new()
@@ -108,10 +109,9 @@ async fn test_full_setup_and_provider_flow_does_not_conflict() {
     let resp = test::call_service(&app, req).await;
     assert!(resp.status().is_success());
 
-    let cfg = read_config_json(&config_path);
-    let openai_encrypted_before = cfg
-        .get("providers")
-        .and_then(|p| p.get("openai"))
+    let providers = read_config_json(&providers_path);
+    let openai_encrypted_before = providers
+        .get("openai")
         .and_then(|o| o.get("api_key_encrypted"))
         .and_then(|v| v.as_str())
         .unwrap_or("")
@@ -131,10 +131,9 @@ async fn test_full_setup_and_provider_flow_does_not_conflict() {
     let resp = test::call_service(&app, req).await;
     assert!(resp.status().is_success());
 
-    let cfg = read_config_json(&config_path);
-    let openai_encrypted_after = cfg
-        .get("providers")
-        .and_then(|p| p.get("openai"))
+    let providers = read_config_json(&providers_path);
+    let openai_encrypted_after = providers
+        .get("openai")
         .and_then(|o| o.get("api_key_encrypted"))
         .and_then(|v| v.as_str())
         .unwrap_or("")


### PR DESCRIPTION
## Summary

- add an object-safe async `ConfigModule` contract and typed `ConfigRegistry`
- extract `MemoryConfig`, `SubagentsConfig`, and legacy `ProviderConfigs` persistence into independent `memory.json`, `subagents.json`, and `providers.json` sidecars
- preserve legacy inline `config.json` migration with sidecar-first precedence
- add module-specific save APIs so one section can flush without rewriting unrelated documents
- retain provider secret encryption, atomic writes, and one last-known-good sidecar backup
- harden registry provider save/load so plaintext keys are encrypted at rest and hydrated on independent load
- validate sidecar backups against the typed schema, sanitize provider backups, and persist migration sidecars before rewriting the root document

This delivers the safe Phase 1 persistence/registrar portion of #39. Public root fields remain as a compatibility bridge for 14+ crates; their migration and the 50% root-field reduction are tracked in #590.

Part of #39.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test -p bamboo-config` — 293 passed
- `cargo clippy -p bamboo-config --all-targets -- -D warnings`
- `cargo build --workspace --tests`
- `git diff --check`

New regression coverage verifies legacy migration, sidecar precedence, isolated memory saves, encrypted provider registry round-trips, sanitized/type-validated backups, and failure-safe migration ordering.

A local full `cargo test` run reached 1378 passing `bamboo-server` library tests but hit the existing macOS self-signed-certificate fixture failure (`UnsupportedCertVersion`); the affected config suite and workspace test build pass, and GitHub CI remains the merge gate.

## Screenshots

Not applicable — configuration infrastructure only.