### PR TITLE
fix(ws_v2): add application ping/pong ACK

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
@@ -45,6 +45,20 @@ pub(crate) async fn terminal_event_if_ready(
         );
     }
 
+    // `Pending` is the reservation window immediately before a runner becomes
+    // `Running`. Treat it as live just like `Running`: a reconnect in this gap
+    // must wait for the new run instead of closing on the previous history.
+    if matches!(
+        runner_status,
+        Some(AgentStatus::Pending | AgentStatus::Running)
+    ) {
+        tracing::debug!(
+            "[{}] terminal_event_if_ready -> None (runner is pending/running) -> LIVE stream",
+            session_id,
+        );
+        return None;
+    }
+
     // Absence of an in-memory runner is not itself proof that a run finished:
     // a newly-created session is persisted before its runner is reserved. In
     // that window a subscriber must stay live for the first token instead of
@@ -76,7 +90,7 @@ pub(crate) async fn terminal_event_if_ready(
         "[{}] terminal_event_if_ready -> Some(terminal): no pending user message, not suspended, no running child",
         session_id,
     );
-    Some(terminal_event_for_status(runner_status))
+    Some(terminal_event_for_sources(session.as_ref(), runner_status))
 }
 
 pub(super) fn session_has_terminal_evidence(
@@ -117,6 +131,30 @@ pub(super) fn terminal_event_for_status(runner_status: Option<AgentStatus>) -> A
                 total_tokens: 0,
             },
         },
+    }
+}
+
+pub(super) fn terminal_event_for_sources(
+    session: Option<&Session>,
+    runner_status: Option<AgentStatus>,
+) -> AgentEvent {
+    if runner_status.is_some() {
+        return terminal_event_for_status(runner_status);
+    }
+
+    match session
+        .and_then(|session| session.agent_runtime_state.as_ref())
+        .map(|runtime| runtime.status)
+    {
+        Some(AgentStatusState::Cancelled) => {
+            terminal_event_for_status(Some(AgentStatus::Cancelled))
+        }
+        Some(AgentStatusState::Failed) => AgentEvent::Error {
+            // The durable runtime state records the failure class but does not
+            // currently persist the runner's error string.
+            message: "Agent execution failed".to_string(),
+        },
+        _ => terminal_event_for_status(None),
     }
 }
 

--- a/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
@@ -45,6 +45,19 @@ pub(crate) async fn terminal_event_if_ready(
         );
     }
 
+    // Absence of an in-memory runner is not itself proof that a run finished:
+    // a newly-created session is persisted before its runner is reserved. In
+    // that window a subscriber must stay live for the first token instead of
+    // receiving a synthetic Complete. Require positive durable/in-memory
+    // evidence of a prior run before considering the one-shot terminal path.
+    if !session_has_terminal_evidence(session.as_ref(), runner_status.as_ref()) {
+        tracing::debug!(
+            "[{}] terminal_event_if_ready -> None (session has not started) -> LIVE stream",
+            session_id,
+        );
+        return None;
+    }
+
     if session_prevents_terminal_event(session.as_ref()) {
         tracing::debug!(
             "[{}] terminal_event_if_ready -> None (pending user message / pending question / suspended) -> LIVE stream",
@@ -64,6 +77,30 @@ pub(crate) async fn terminal_event_if_ready(
         session_id,
     );
     Some(terminal_event_for_status(runner_status))
+}
+
+pub(super) fn session_has_terminal_evidence(
+    session: Option<&Session>,
+    runner_status: Option<&AgentStatus>,
+) -> bool {
+    if matches!(
+        runner_status,
+        Some(AgentStatus::Completed | AgentStatus::Cancelled | AgentStatus::Error(_))
+    ) {
+        return true;
+    }
+    let Some(session) = session else {
+        return false;
+    };
+    if !session.messages.is_empty() {
+        return true;
+    }
+    session.agent_runtime_state.as_ref().is_some_and(|runtime| {
+        matches!(
+            runtime.status,
+            AgentStatusState::Completed | AgentStatusState::Cancelled | AgentStatusState::Failed
+        )
+    })
 }
 
 pub(super) fn terminal_event_for_status(runner_status: Option<AgentStatus>) -> AgentEvent {

--- a/crates/app/bamboo-server/src/handlers/agent/events/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/tests.rs
@@ -1,4 +1,6 @@
-use super::terminal::{session_prevents_terminal_event, terminal_event_for_status};
+use super::terminal::{
+    session_has_terminal_evidence, session_prevents_terminal_event, terminal_event_for_status,
+};
 use crate::app_state::AgentStatus;
 use bamboo_agent_core::{AgentEvent, Message, Session};
 use bamboo_domain::{AgentRuntimeState, AgentStatusState};
@@ -73,8 +75,23 @@ fn session_prevents_terminal_when_runtime_is_suspended() {
 
 #[test]
 fn session_allows_terminal_when_not_waiting_for_user() {
-    let session = Session::new("sess-4", "test-model");
+    let mut session = Session::new("sess-4", "test-model");
+    session.add_message(Message::assistant("done", None));
 
     assert!(!session_prevents_terminal_event(Some(&session)));
     assert!(!session_prevents_terminal_event(None));
+}
+
+#[test]
+fn terminal_evidence_rejects_unstarted_session_but_accepts_completed_history() {
+    let empty = Session::new("empty", "test-model");
+    assert!(!session_has_terminal_evidence(Some(&empty), None));
+
+    let mut with_history = Session::new("done", "test-model");
+    with_history.add_message(Message::assistant("done", None));
+    assert!(session_has_terminal_evidence(Some(&with_history), None));
+    assert!(session_has_terminal_evidence(
+        Some(&empty),
+        Some(&AgentStatus::Completed),
+    ));
 }

--- a/crates/app/bamboo-server/src/handlers/agent/events/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/tests.rs
@@ -1,5 +1,6 @@
 use super::terminal::{
-    session_has_terminal_evidence, session_prevents_terminal_event, terminal_event_for_status,
+    session_has_terminal_evidence, session_prevents_terminal_event, terminal_event_for_sources,
+    terminal_event_for_status,
 };
 use crate::app_state::AgentStatus;
 use bamboo_agent_core::{AgentEvent, Message, Session};
@@ -39,6 +40,32 @@ fn terminal_event_for_non_error_status_defaults_to_complete() {
         }
         other => panic!("expected complete event, got {other:?}"),
     }
+}
+
+#[test]
+fn persisted_cancelled_status_replays_cancelled_after_runner_is_gone() {
+    let mut session = Session::new("cancelled", "test-model");
+    let mut runtime = AgentRuntimeState::new("run-cancelled");
+    runtime.status = AgentStatusState::Cancelled;
+    session.agent_runtime_state = Some(runtime);
+
+    assert!(matches!(
+        terminal_event_for_sources(Some(&session), None),
+        AgentEvent::Cancelled { .. }
+    ));
+}
+
+#[test]
+fn persisted_failed_status_replays_error_after_runner_is_gone() {
+    let mut session = Session::new("failed", "test-model");
+    let mut runtime = AgentRuntimeState::new("run-failed");
+    runtime.status = AgentStatusState::Failed;
+    session.agent_runtime_state = Some(runtime);
+
+    assert!(matches!(
+        terminal_event_for_sources(Some(&session), None),
+        AgentEvent::Error { .. }
+    ));
 }
 
 #[test]

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/envelope.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/envelope.rs
@@ -43,6 +43,24 @@ pub(crate) enum OutFrame {
     Binary(Vec<u8>),
 }
 
+/// Encode the application-level heartbeat acknowledgement.
+///
+/// This deliberately is a top-level frame (`{"type":"pong"}`), not a
+/// channel envelope: clients use it to prove that a frame made a complete
+/// round trip through the application read loop.
+pub(crate) fn pong_frame(encoding: Encoding) -> Option<OutFrame> {
+    #[derive(Serialize)]
+    struct PongFrame {
+        r#type: &'static str,
+    }
+
+    let pong = PongFrame { r#type: "pong" };
+    match encoding {
+        Encoding::Json => serde_json::to_string(&pong).ok().map(OutFrame::Text),
+        Encoding::Msgpack => rmp_serde::to_vec_named(&pong).ok().map(OutFrame::Binary),
+    }
+}
+
 /// A server→client envelope.
 ///
 /// Serializes as one of two shapes sharing `{ch, seq}`:
@@ -217,6 +235,9 @@ pub(crate) enum ClientFrame {
     Unsubscribe { ch: String },
     /// Cancel a running session (the only `control` uplink in P1).
     Stop { session_id: String },
+    /// Application-level heartbeat probe. Unlike WebSocket protocol Ping/Pong,
+    /// this is visible to browser JavaScript and receives a top-level `pong`.
+    Ping,
     /// Any frame whose `type` is not recognized. The driver logs and ignores it
     /// rather than disconnecting.
     #[serde(other)]
@@ -362,6 +383,25 @@ mod tests {
     }
 
     #[test]
+    fn client_ping_and_json_pong_wire_shapes() {
+        let ping: ClientFrame = serde_json::from_str(r#"{"type":"ping"}"#).unwrap();
+        assert_eq!(ping, ClientFrame::Ping);
+        assert_eq!(
+            pong_frame(Encoding::Json),
+            Some(OutFrame::Text(r#"{"type":"pong"}"#.to_string()))
+        );
+    }
+
+    #[test]
+    fn msgpack_pong_is_a_top_level_named_map() {
+        let OutFrame::Binary(bytes) = pong_frame(Encoding::Msgpack).expect("encodes") else {
+            panic!("msgpack pong must be binary");
+        };
+        let value: Value = rmp_serde::from_slice(&bytes).expect("decodes");
+        assert_eq!(value, json!({ "type": "pong" }));
+    }
+
+    #[test]
     fn unknown_frame_type_maps_to_unknown_not_error() {
         // An unrecognized `type` must NOT fail the parse — it maps to Unknown so
         // the driver logs + continues instead of disconnecting.
@@ -469,6 +509,7 @@ mod tests {
             ClientFrame::Stop {
                 session_id: "s1".into(),
             },
+            ClientFrame::Ping,
         ] {
             // ClientFrame is Deserialize-only; encode the equivalent JSON Value to
             // msgpack (the same bytes a client would send) and decode it back.
@@ -483,6 +524,7 @@ mod tests {
                 ClientFrame::Stop { session_id } => {
                     json!({ "type": "stop", "session_id": session_id })
                 }
+                ClientFrame::Ping => json!({ "type": "ping" }),
                 ClientFrame::Unknown => unreachable!(),
             };
             let bytes = rmp_serde::to_vec_named(&as_json).expect("encode client frame as msgpack");
@@ -536,6 +578,7 @@ mod tests {
             Some(Channel::Agent("sess_abc".to_string()))
         );
         assert_eq!(Channel::parse("agent."), None);
+        assert_eq!(Channel::parse("sys"), None, "sys is connection-reserved");
         assert_eq!(Channel::parse("bogus"), None);
     }
 

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
@@ -411,6 +411,42 @@ pub(crate) fn spawn_agent_forwarder(
     })
 }
 
+/// Spawn a one-shot `agent.{sid}` replay for a session that was already
+/// terminal when the client subscribed. This mirrors the v1 SSE terminal
+/// response: cached critical state, budget state, synthesized terminal event,
+/// then exactly one terminal control before the per-channel queue closes.
+pub(crate) fn spawn_agent_terminal_forwarder(
+    out: OutboundTx,
+    encoding: Encoding,
+    ch: String,
+    budget_event_to_replay: Option<AgentEvent>,
+    critical_events_to_replay: Vec<AgentEvent>,
+    terminal_event: AgentEvent,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let seq = AgentSeq::default();
+        for event in critical_events_to_replay {
+            if !emit_agent_event(&out, encoding, &ch, &seq, event).await {
+                return;
+            }
+        }
+        if let Some(event) = budget_event_to_replay {
+            if !emit_agent_event(&out, encoding, &ch, &seq, event).await {
+                return;
+            }
+        }
+        if !emit_agent_event(&out, encoding, &ch, &seq, terminal_event).await {
+            return;
+        }
+        let _ = send_env(
+            &out,
+            encoding,
+            ServerEnvelope::control(&ch, seq.next(), terminal_control("complete")),
+        )
+        .await;
+    })
+}
+
 /// What the agent forwarder should do after a broadcast-lag recovery attempt.
 #[derive(Debug, PartialEq, Eq)]
 enum LagOutcome {
@@ -598,6 +634,38 @@ mod tests {
         assert!(!is_terminal_event(&AgentEvent::Token {
             content: "x".into()
         }));
+    }
+
+    #[tokio::test]
+    async fn completed_subscription_replays_state_then_one_terminal_control() {
+        let (out_tx, mut out_rx) = mpsc::channel::<OutFrame>(64);
+        let handle = spawn_agent_terminal_forwarder(
+            out_tx,
+            Encoding::Json,
+            "agent.done".to_string(),
+            None,
+            vec![AgentEvent::Token {
+                content: "critical-state".into(),
+            }],
+            AgentEvent::Complete {
+                usage: Default::default(),
+            },
+        );
+
+        let replay = next_json(&mut out_rx).await;
+        assert_eq!(replay["seq"], 1);
+        assert_eq!(replay["event"]["content"], "critical-state");
+        let terminal_event = next_json(&mut out_rx).await;
+        assert_eq!(terminal_event["seq"], 2);
+        assert_eq!(terminal_event["event"]["type"], "complete");
+        let terminal_control = next_json(&mut out_rx).await;
+        assert_eq!(terminal_control["seq"], 3);
+        assert_eq!(terminal_control["control"]["type"], "terminal");
+        handle.await.expect("one-shot forwarder completes");
+        assert!(
+            out_rx.recv().await.is_none(),
+            "terminal control is emitted once"
+        );
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -732,11 +732,20 @@ async fn subscribe(
                     )
                     .await
                 {
+                    // Storage and descendant checks above are asynchronous. A
+                    // new runner can be reserved while they run, before it has
+                    // emitted its first broadcast event. Re-read the runner so
+                    // that Pending/Running wins over the stale terminal
+                    // snapshot even while the receiver is still empty.
+                    let current_runner_status = {
+                        let runners = state.agent_runners.read().await;
+                        runners.get(&sid).map(|runner| runner.status.clone())
+                    };
                     // We subscribed before the async storage/child checks. If a
                     // live event arrived meanwhile, preserve its ordering by
                     // handing the still-buffered receiver to the live forwarder
                     // instead of sending a synthetic terminal ahead of it.
-                    if can_attempt_terminal_replay(runner_status.as_ref(), &receiver) {
+                    if can_attempt_terminal_replay(current_runner_status.as_ref(), &receiver) {
                         return finish_subscribe(
                             forwarders,
                             queues,
@@ -776,7 +785,12 @@ fn can_attempt_terminal_replay(
     runner_status: Option<&crate::app_state::AgentStatus>,
     receiver: &tokio::sync::broadcast::Receiver<bamboo_agent_core::AgentEvent>,
 ) -> bool {
-    !matches!(runner_status, Some(crate::app_state::AgentStatus::Running)) && receiver.is_empty()
+    matches!(
+        runner_status,
+        None | Some(crate::app_state::AgentStatus::Completed)
+            | Some(crate::app_state::AgentStatus::Cancelled)
+            | Some(crate::app_state::AgentStatus::Error(_))
+    ) && receiver.is_empty()
 }
 
 fn finish_subscribe(
@@ -1105,5 +1119,18 @@ mod tests {
             !can_attempt_terminal_replay(None, &rx),
             "a queued live frame must win the race with synthetic terminal replay"
         );
+    }
+
+    #[test]
+    fn pending_or_running_runner_blocks_synthetic_terminal_replay() {
+        let (_tx, rx) = tokio::sync::broadcast::channel(4);
+        assert!(!can_attempt_terminal_replay(
+            Some(&crate::app_state::AgentStatus::Pending),
+            &rx,
+        ));
+        assert!(!can_attempt_terminal_replay(
+            Some(&crate::app_state::AgentStatus::Running),
+            &rx,
+        ));
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -72,7 +72,9 @@ use self::envelope::{
     decode_client_frame, pong_frame, sys_keepalive_envelope, Channel, ClientFrame, Encoding,
     OutFrame, SUBPROTOCOL_JSON, SUBPROTOCOL_MSGPACK,
 };
-use self::forwarders::{spawn_agent_forwarder, spawn_feed_forwarder, OutboundTx};
+use self::forwarders::{
+    spawn_agent_forwarder, spawn_agent_terminal_forwarder, spawn_feed_forwarder, OutboundTx,
+};
 use crate::app_state::AppState;
 use crate::handlers::agent::events::MAX_BATCH_MS;
 use crate::handlers::agent::stop::cancel_session;
@@ -716,6 +718,38 @@ async fn subscribe(
                 .map(|runner| runner.last_critical_events.clone())
                 .unwrap_or_default();
 
+            // Match the v1 SSE late-subscribe contract. A session that
+            // completed while this socket was half-open must replay cached
+            // state and a synthesized terminal exactly once, rather than open
+            // a live receiver that will never publish another event.
+            let runner_status = runner_snapshot.as_ref().map(|runner| runner.status.clone());
+            if !matches!(runner_status, Some(crate::app_state::AgentStatus::Running)) {
+                if let Some(terminal_event) =
+                    crate::handlers::agent::events::terminal_event_if_ready(
+                        state,
+                        &sid,
+                        runner_status,
+                    )
+                    .await
+                {
+                    return finish_subscribe(
+                        forwarders,
+                        queues,
+                        ch,
+                        out_rx,
+                        spawn_agent_terminal_forwarder(
+                            out_tx,
+                            encoding,
+                            ch.to_string(),
+                            budget_event_to_replay,
+                            critical_events_to_replay,
+                            terminal_event,
+                        ),
+                        since,
+                    );
+                }
+            }
+
             spawn_agent_forwarder(
                 state.clone(),
                 sid.clone(),
@@ -729,7 +763,17 @@ async fn subscribe(
             )
         }
     };
+    finish_subscribe(forwarders, queues, ch, out_rx, handle, since);
+}
 
+fn finish_subscribe(
+    forwarders: &mut HashMap<String, tokio::task::JoinHandle<()>>,
+    queues: &mut StreamMap<String, ReceiverStream<OutFrame>>,
+    ch: &str,
+    out_rx: mpsc::Receiver<OutFrame>,
+    handle: tokio::task::JoinHandle<()>,
+    since: Option<u64>,
+) {
     forwarders.insert(ch.to_string(), handle);
     // Register this channel's queue receiver into the fair-merge drain. Keyed by
     // the SAME channel id as `forwarders`, so unsubscribe/teardown drops both.

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -723,30 +723,36 @@ async fn subscribe(
             // state and a synthesized terminal exactly once, rather than open
             // a live receiver that will never publish another event.
             let runner_status = runner_snapshot.as_ref().map(|runner| runner.status.clone());
-            if !matches!(runner_status, Some(crate::app_state::AgentStatus::Running)) {
+            if can_attempt_terminal_replay(runner_status.as_ref(), &receiver) {
                 if let Some(terminal_event) =
                     crate::handlers::agent::events::terminal_event_if_ready(
                         state,
                         &sid,
-                        runner_status,
+                        runner_status.clone(),
                     )
                     .await
                 {
-                    return finish_subscribe(
-                        forwarders,
-                        queues,
-                        ch,
-                        out_rx,
-                        spawn_agent_terminal_forwarder(
-                            out_tx,
-                            encoding,
-                            ch.to_string(),
-                            budget_event_to_replay,
-                            critical_events_to_replay,
-                            terminal_event,
-                        ),
-                        since,
-                    );
+                    // We subscribed before the async storage/child checks. If a
+                    // live event arrived meanwhile, preserve its ordering by
+                    // handing the still-buffered receiver to the live forwarder
+                    // instead of sending a synthetic terminal ahead of it.
+                    if can_attempt_terminal_replay(runner_status.as_ref(), &receiver) {
+                        return finish_subscribe(
+                            forwarders,
+                            queues,
+                            ch,
+                            out_rx,
+                            spawn_agent_terminal_forwarder(
+                                out_tx,
+                                encoding,
+                                ch.to_string(),
+                                budget_event_to_replay,
+                                critical_events_to_replay,
+                                terminal_event,
+                            ),
+                            since,
+                        );
+                    }
                 }
             }
 
@@ -764,6 +770,13 @@ async fn subscribe(
         }
     };
     finish_subscribe(forwarders, queues, ch, out_rx, handle, since);
+}
+
+fn can_attempt_terminal_replay(
+    runner_status: Option<&crate::app_state::AgentStatus>,
+    receiver: &tokio::sync::broadcast::Receiver<bamboo_agent_core::AgentEvent>,
+) -> bool {
+    !matches!(runner_status, Some(crate::app_state::AgentStatus::Running)) && receiver.is_empty()
 }
 
 fn finish_subscribe(
@@ -1078,5 +1091,19 @@ mod tests {
         let (channel, frame) = queues.next().await.expect("sys queue remains drainable");
         assert_eq!(channel, SYS_CHANNEL);
         assert_eq!(frame, OutFrame::Text(r#"{"type":"pong"}"#.into()));
+    }
+
+    #[test]
+    fn queued_agent_event_blocks_synthetic_terminal_replay() {
+        let (tx, rx) = tokio::sync::broadcast::channel(4);
+        assert!(can_attempt_terminal_replay(None, &rx));
+        tx.send(bamboo_agent_core::AgentEvent::Token {
+            content: "first-live-token".into(),
+        })
+        .expect("receiver is subscribed");
+        assert!(
+            !can_attempt_terminal_replay(None, &rx),
+            "a queued live frame must win the race with synthetic terminal replay"
+        );
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -69,8 +69,8 @@ use tokio_stream::StreamMap;
 use serde::Deserialize;
 
 use self::envelope::{
-    decode_client_frame, sys_keepalive_envelope, Channel, ClientFrame, Encoding, OutFrame,
-    SUBPROTOCOL_JSON, SUBPROTOCOL_MSGPACK,
+    decode_client_frame, pong_frame, sys_keepalive_envelope, Channel, ClientFrame, Encoding,
+    OutFrame, SUBPROTOCOL_JSON, SUBPROTOCOL_MSGPACK,
 };
 use self::forwarders::{spawn_agent_forwarder, spawn_feed_forwarder, OutboundTx};
 use crate::app_state::AppState;
@@ -83,6 +83,19 @@ use crate::handlers::agent::stop::cancel_session;
 /// queue of another, because each channel owns its own bounded buffer and the
 /// driver drains them with a fair merge.
 const OUTBOUND_BUFFER: usize = 64;
+
+/// Reserved connection-level queue for heartbeat/control frames. A capacity of
+/// one intentionally coalesces probes while the socket writer is busy.
+const SYS_CHANNEL: &str = "sys";
+const SYS_OUTBOUND_BUFFER: usize = 1;
+
+/// Best-effort enqueue for connection-level control traffic. Heartbeats are
+/// probes, so retaining an old one is never worth blocking the socket read loop.
+fn try_enqueue_sys(sys_tx: &mpsc::Sender<OutFrame>, frame: Option<OutFrame>) {
+    if let Some(frame) = frame {
+        let _ = sys_tx.try_send(frame);
+    }
+}
 
 /// WS ping interval. Each tick sends BOTH the protocol-level ping (server-side
 /// write probe) and the app-level `sys` keepalive data frame (client-side
@@ -364,6 +377,8 @@ async fn drive(
     // channel id and mutated together (see [`subscribe`] / unsubscribe / teardown).
     let mut forwarders: HashMap<String, tokio::task::JoinHandle<()>> = HashMap::new();
     let mut queues: StreamMap<String, ReceiverStream<OutFrame>> = StreamMap::new();
+    let (sys_tx, sys_rx) = mpsc::channel::<OutFrame>(SYS_OUTBOUND_BUFFER);
+    queues.insert(SYS_CHANNEL.to_string(), ReceiverStream::new(sys_rx));
     let mut ping = tokio::time::interval(ping_interval());
     ping.tick().await; // skip the immediate tick
 
@@ -448,7 +463,7 @@ async fn drive(
                     Some(Ok(Message::Text(text))) if encoding == Encoding::Json => {
                         let keep_open = handle_client_bytes(
                             &state, &mut forwarders, &mut queues,
-                            batch_ms, encoding, text.as_bytes(), &mut authorized,
+                            &sys_tx, batch_ms, encoding, text.as_bytes(), &mut authorized,
                         )
                         .await;
                         if !keep_open {
@@ -458,7 +473,7 @@ async fn drive(
                     Some(Ok(Message::Binary(bytes))) if encoding == Encoding::Msgpack => {
                         let keep_open = handle_client_bytes(
                             &state, &mut forwarders, &mut queues,
-                            batch_ms, encoding, &bytes, &mut authorized,
+                            &sys_tx, batch_ms, encoding, &bytes, &mut authorized,
                         )
                         .await;
                         if !keep_open {
@@ -515,6 +530,7 @@ async fn handle_client_bytes(
     state: &web::Data<AppState>,
     forwarders: &mut HashMap<String, tokio::task::JoinHandle<()>>,
     queues: &mut StreamMap<String, ReceiverStream<OutFrame>>,
+    sys_tx: &mpsc::Sender<OutFrame>,
     batch_ms: u64,
     encoding: Encoding,
     bytes: &[u8],
@@ -528,7 +544,7 @@ async fn handle_client_bytes(
         }
     };
     handle_client_frame(
-        state, forwarders, queues, batch_ms, encoding, frame, authorized,
+        state, forwarders, queues, sys_tx, batch_ms, encoding, frame, authorized,
     )
     .await
 }
@@ -549,6 +565,7 @@ async fn handle_client_frame(
     state: &web::Data<AppState>,
     forwarders: &mut HashMap<String, tokio::task::JoinHandle<()>>,
     queues: &mut StreamMap<String, ReceiverStream<OutFrame>>,
+    sys_tx: &mpsc::Sender<OutFrame>,
     batch_ms: u64,
     encoding: Encoding,
     frame: ClientFrame,
@@ -561,6 +578,16 @@ async fn handle_client_frame(
         GateOutcome::Handled => return true,
         GateOutcome::Close => return false,
         GateOutcome::Dispatch => {}
+    }
+
+    // Like all server data, heartbeat acknowledgements are emitted only after
+    // authorization. They carry no channel envelope but share the connection's
+    // reserved sys queue and single socket writer.
+    if frame == ClientFrame::Ping {
+        // Drop-on-full is deliberate. The next client heartbeat retries, and
+        // the read loop must never wait behind a slow socket writer.
+        try_enqueue_sys(sys_tx, pong_frame(encoding));
+        return true;
     }
 
     // Authorized path: full dispatch.
@@ -604,6 +631,7 @@ async fn handle_client_frame(
             let cancelled = cancel_session(state, &session_id).await;
             tracing::debug!("ws_v2: stop {session_id} -> cancelled={cancelled}");
         }
+        ClientFrame::Ping => unreachable!("authorized ping handled above"),
         ClientFrame::Unknown => {
             tracing::debug!("ws_v2: ignoring unknown client frame type");
         }
@@ -723,6 +751,17 @@ mod tests {
         }
     }
 
+    #[test]
+    fn sys_queue_is_best_effort_and_drops_when_full() {
+        let (tx, mut rx) = mpsc::channel(SYS_OUTBOUND_BUFFER);
+        let first = OutFrame::Text("first".into());
+        try_enqueue_sys(&tx, Some(first.clone()));
+        // Must return immediately and leave the already-queued frame intact.
+        try_enqueue_sys(&tx, Some(OutFrame::Text("newer".into())));
+        assert_eq!(rx.try_recv().unwrap(), first);
+        assert!(rx.try_recv().is_err());
+    }
+
     // ── Subprotocol negotiation (v2-P3) ───────────────────────────────────────
 
     fn negotiate_for(header: Option<&str>) -> (Encoding, Option<&'static str>) {
@@ -803,6 +842,10 @@ mod tests {
             UnauthorizedAction::classify(&ClientFrame::Stop {
                 session_id: "s".into()
             }),
+            UnauthorizedAction::Ignore
+        );
+        assert_eq!(
+            UnauthorizedAction::classify(&ClientFrame::Ping),
             UnauthorizedAction::Ignore
         );
         assert_eq!(
@@ -902,5 +945,94 @@ mod tests {
         let outcome = apply_auth_gate(&state, &frame, &mut authorized).await;
         assert_eq!(outcome, GateOutcome::Dispatch);
         assert!(authorized);
+    }
+
+    #[actix_web::test]
+    async fn ping_is_ignored_before_auth_and_enqueued_after_auth() {
+        let (state, _cred, _token) = app_state_with_device().await;
+        let mut forwarders = HashMap::new();
+        let mut queues = StreamMap::new();
+        let (sys_tx, mut sys_rx) = mpsc::channel(SYS_OUTBOUND_BUFFER);
+
+        let mut authorized = false;
+        assert!(
+            handle_client_frame(
+                &state,
+                &mut forwarders,
+                &mut queues,
+                &sys_tx,
+                0,
+                Encoding::Json,
+                ClientFrame::Ping,
+                &mut authorized,
+            )
+            .await
+        );
+        assert!(
+            sys_rx.try_recv().is_err(),
+            "unauthorized ping must be silent"
+        );
+
+        authorized = true;
+        assert!(
+            handle_client_frame(
+                &state,
+                &mut forwarders,
+                &mut queues,
+                &sys_tx,
+                0,
+                Encoding::Json,
+                ClientFrame::Ping,
+                &mut authorized,
+            )
+            .await
+        );
+        assert_eq!(
+            sys_rx.try_recv().unwrap(),
+            OutFrame::Text(r#"{"type":"pong"}"#.into())
+        );
+    }
+
+    #[actix_web::test]
+    async fn client_cannot_subscribe_or_unsubscribe_reserved_sys_queue() {
+        let (state, _cred, _token) = app_state_with_device().await;
+        let mut forwarders = HashMap::new();
+        let mut queues = StreamMap::new();
+        let (sys_tx, sys_rx) = mpsc::channel(SYS_OUTBOUND_BUFFER);
+        queues.insert(SYS_CHANNEL.to_string(), ReceiverStream::new(sys_rx));
+        let mut authorized = true;
+
+        for frame in [
+            ClientFrame::Subscribe {
+                ch: SYS_CHANNEL.into(),
+                since: None,
+            },
+            ClientFrame::Unsubscribe {
+                ch: SYS_CHANNEL.into(),
+            },
+        ] {
+            assert!(
+                handle_client_frame(
+                    &state,
+                    &mut forwarders,
+                    &mut queues,
+                    &sys_tx,
+                    0,
+                    Encoding::Json,
+                    frame,
+                    &mut authorized,
+                )
+                .await
+            );
+            assert!(
+                queues.contains_key(SYS_CHANNEL),
+                "client channel operations must not remove reserved sys queue"
+            );
+        }
+
+        try_enqueue_sys(&sys_tx, pong_frame(Encoding::Json));
+        let (channel, frame) = queues.next().await.expect("sys queue remains drainable");
+        assert_eq!(channel, SYS_CHANNEL);
+        assert_eq!(frame, OutFrame::Text(r#"{"type":"pong"}"#.into()));
     }
 }

--- a/crates/app/bamboo-server/tests/ws_v2_live.rs
+++ b/crates/app/bamboo-server/tests/ws_v2_live.rs
@@ -390,10 +390,6 @@ async fn subscribe_event_unsubscribe_roundtrip() {
 
     let mut root = bamboo_agent_core::Session::new(sid, "test-model");
     register_session(&server.state, &mut root).await;
-    // This scenario exercises live broadcast delivery, not completed-session
-    // replay. Keep the session explicitly running so the terminal forwarder
-    // cannot synthesize a `complete` frame before the token under test.
-    set_runner_status(&server.state, sid, AgentStatus::Running).await;
 
     let mut conn = connect_local(&server).await;
     let ch = format!("agent.{sid}");
@@ -828,10 +824,6 @@ async fn msgpack_subprotocol_subscribe_event_roundtrip() {
 
     let mut root = bamboo_agent_core::Session::new(sid, "test-model");
     register_session(&server.state, &mut root).await;
-    // This scenario exercises live msgpack delivery, not completed-session
-    // replay. Mark it running to avoid a synthesized terminal frame racing the
-    // token broadcast.
-    set_runner_status(&server.state, sid, AgentStatus::Running).await;
 
     let (mut conn, echoed) = connect_local_msgpack(&server).await;
     // The server MUST echo the selected subprotocol on the upgrade response.

--- a/crates/app/bamboo-server/tests/ws_v2_live.rs
+++ b/crates/app/bamboo-server/tests/ws_v2_live.rs
@@ -574,6 +574,40 @@ async fn agent_terminal_without_child_closes_channel() {
     server.stop().await;
 }
 
+/// #588 regression guard: a session that completed while the prior socket was
+/// half-open has durable assistant history but no in-memory runner after a
+/// restart. A late subscription must receive the synthesized completion and
+/// terminal control without waiting for another broadcast event.
+#[actix_web::test]
+async fn completed_session_late_subscribe_replays_terminal_once() {
+    let server = TestServer::start(|_| {}).await;
+    let sid = "sess_completed_offline";
+
+    let mut root = bamboo_agent_core::Session::new(sid, "test-model");
+    root.add_message(bamboo_agent_core::Message::assistant("finished", None));
+    register_session(&server.state, &mut root).await;
+
+    let mut conn = connect_local(&server).await;
+    let ch = format!("agent.{sid}");
+    send_json(&mut conn, json!({"type": "subscribe", "ch": ch})).await;
+
+    let terminal_event = next_envelope(&mut conn)
+        .await
+        .expect("late subscriber receives synthesized completion");
+    assert_eq!(terminal_event["ch"], ch);
+    assert_eq!(terminal_event["seq"], 1);
+    assert_eq!(terminal_event["event"]["type"], "complete");
+
+    let terminal_control = next_envelope(&mut conn)
+        .await
+        .expect("late subscriber receives terminal control");
+    assert_eq!(terminal_control["ch"], ch);
+    assert_eq!(terminal_control["seq"], 2);
+    assert_eq!(terminal_control["control"]["type"], "terminal");
+
+    server.stop().await;
+}
+
 // ── Scenario 3b: terminal WITH a running child holds the channel open ─────────
 
 /// #186 regression guard: an agent terminal while a child sub-agent is still

--- a/crates/app/bamboo-server/tests/ws_v2_live.rs
+++ b/crates/app/bamboo-server/tests/ws_v2_live.rs
@@ -264,6 +264,40 @@ async fn next_sys_keepalive(conn: &mut WsConn) -> Value {
     }
 }
 
+/// Receive an application-level pong and assert its negotiated WS frame kind.
+/// Interleaved protocol heartbeats and legacy `sys` keepalives are ignored.
+async fn next_app_pong(conn: &mut WsConn, msgpack: bool) -> Value {
+    let deadline = tokio::time::Instant::now() + RECV_TIMEOUT;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let frame = tokio::time::timeout(remaining, conn.next())
+            .await
+            .expect("application pong did not arrive before timeout")
+            .expect("connection closed while waiting for application pong")
+            .expect("ws protocol error");
+        let value: Value = match frame {
+            ws::Frame::Text(bytes) if !msgpack => {
+                serde_json::from_slice(&bytes).expect("pong is JSON")
+            }
+            ws::Frame::Binary(bytes) if msgpack => {
+                rmp_serde::from_slice(&bytes).expect("pong is msgpack")
+            }
+            ws::Frame::Text(bytes) => panic!(
+                "msgpack pong must be BINARY, got text: {}",
+                String::from_utf8_lossy(&bytes)
+            ),
+            ws::Frame::Binary(_) => panic!("JSON pong must be TEXT"),
+            ws::Frame::Ping(_) | ws::Frame::Pong(_) => continue,
+            ws::Frame::Close(_) => panic!("connection closed before application pong"),
+            other => panic!("unexpected ws frame: {other:?}"),
+        };
+        if value["ch"] == "sys" {
+            continue;
+        }
+        return value;
+    }
+}
+
 /// Assert the connection is closed (or yields no more data) within [`RECV_TIMEOUT`]
 /// — i.e. a Close frame or stream end, and never another text envelope.
 async fn expect_closed(conn: &mut WsConn) {
@@ -894,6 +928,37 @@ async fn sys_keepalive_not_sent_to_unauthorized_connection() {
     // no sys keepalive may be served before authorization, and the deadline
     // (1.5s here) spans several ping ticks (200ms), so a leak would surface.
     expect_closed(&mut conn).await;
+
+    server.stop().await;
+}
+
+// ── Scenario 7: application Ping/Pong ACK (#588) ───────────────────────────
+
+/// The default JSON transport accepts a browser-visible ping and returns the
+/// exact top-level pong as a TEXT frame (no channel envelope fields).
+#[actix_web::test]
+async fn json_ping_returns_top_level_text_pong() {
+    let server = TestServer::start(|_| {}).await;
+    let mut conn = connect_local(&server).await;
+
+    send_json(&mut conn, json!({"type": "ping"})).await;
+    let pong = next_app_pong(&mut conn, false).await;
+    assert_eq!(pong, json!({"type": "pong"}));
+
+    server.stop().await;
+}
+
+/// A negotiated MessagePack connection accepts a binary named-map ping and
+/// returns the same top-level pong as a BINARY named map.
+#[actix_web::test]
+async fn msgpack_ping_returns_top_level_binary_pong() {
+    let server = TestServer::start(|_| {}).await;
+    let (mut conn, subprotocol) = connect_local_msgpack(&server).await;
+    assert_eq!(subprotocol.as_deref(), Some("bamboo.v2.msgpack"));
+
+    send_msgpack(&mut conn, json!({"type": "ping"})).await;
+    let pong = next_app_pong(&mut conn, true).await;
+    assert_eq!(pong, json!({"type": "pong"}));
 
     server.stop().await;
 }

--- a/crates/app/bamboo-server/tests/ws_v2_live.rs
+++ b/crates/app/bamboo-server/tests/ws_v2_live.rs
@@ -390,6 +390,10 @@ async fn subscribe_event_unsubscribe_roundtrip() {
 
     let mut root = bamboo_agent_core::Session::new(sid, "test-model");
     register_session(&server.state, &mut root).await;
+    // This scenario exercises live broadcast delivery, not completed-session
+    // replay. Keep the session explicitly running so the terminal forwarder
+    // cannot synthesize a `complete` frame before the token under test.
+    set_runner_status(&server.state, sid, AgentStatus::Running).await;
 
     let mut conn = connect_local(&server).await;
     let ch = format!("agent.{sid}");
@@ -824,6 +828,10 @@ async fn msgpack_subprotocol_subscribe_event_roundtrip() {
 
     let mut root = bamboo_agent_core::Session::new(sid, "test-model");
     register_session(&server.state, &mut root).await;
+    // This scenario exercises live msgpack delivery, not completed-session
+    // replay. Mark it running to avoid a synthesized terminal frame racing the
+    // token broadcast.
+    set_runner_status(&server.state, sid, AgentStatus::Running).await;
 
     let (mut conn, echoed) = connect_local_msgpack(&server).await;
     // The server MUST echo the selected subprotocol on the upgrade response.


### PR DESCRIPTION
## Summary

- add an authorized client `{type:"ping"}` frame and exact top-level `{type:"pong"}` response for JSON and MessagePack
- route pong through a reserved connection-level `sys` queue and the existing single WebSocket writer
- keep heartbeat enqueue non-blocking and drop on saturation so the next probe self-heals
- replay cached critical/budget state plus a synthesized terminal event/control for sessions completed before a late subscription
- require positive terminal evidence so empty sessions in the runner-reservation window stay live
- preserve live-event FIFO ordering when terminal detection races a queued token
- preserve legacy protocol ping and server `sys keepalive` behavior

Closes #588 (Bamboo backend portion). The Lotus counterpart bigduu/Lotus#112 merged first.

## Test Plan

- `cargo fmt --check`
- `cargo clippy -p bamboo-server` (passes with pre-existing warnings)
- `cargo test -p bamboo-server handlers::agent::events --lib` (22 passed)
- `cargo test -p bamboo-server handlers::agent::ws_v2 --lib` (40 passed)
- `cargo test -p bamboo-server --test ws_v2_live` (15 passed)
- original JSON and MessagePack subscription-race tests repeated five times each by the main reviewer
- `cargo test -p bamboo-server`: 1386 passed; one unrelated local TLS/OpenSSL environment failure reproduced in isolation
- `git diff --check`

## Screenshots

Not applicable; backend transport change.