### PR TITLE
fix(config): harden independent module persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,7 @@ dependencies = [
  "base64",
  "chrono",
  "dirs",
+ "futures",
  "hex",
  "rand 0.10.2",
  "regex",

--- a/crates/infra/bamboo-config/Cargo.toml
+++ b/crates/infra/bamboo-config/Cargo.toml
@@ -28,6 +28,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+futures = "0.3"
 
 [features]
 test-utils = []

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -6,10 +6,13 @@
 //!
 //! # Configuration File
 //!
-//! Configuration is stored in `config.json` under the unified data directory
-//! (defaults to `${HOME}/.bamboo/`). Environment variables can override file values.
+//! Root configuration is stored in `config.json` under the unified data
+//! directory (defaults to `${HOME}/.bamboo/`). Memory, sub-agent, and legacy
+//! provider settings are independently persisted in `memory.json`,
+//! `subagents.json`, and `providers.json`. Environment variables can override
+//! file values.
 //!
-//! # Example (JSON)
+//! # Example `config.json`
 //!
 //! ```json
 //! {
@@ -17,16 +20,17 @@
 //!   "server": {
 //!     "port": 9562,
 //!     "bind": "127.0.0.1"
-//!   },
-//!   "providers": {
-//!     "anthropic": {
-//!       "api_key": "sk-ant-...",
-//!       "model": "claude-3-5-sonnet-20241022"
-//!     },
-//!     "openai": {
-//!       "api_key": "sk-...",
-//!       "base_url": "https://api.openai.com/v1"
-//!     }
+//!   }
+//! }
+//! ```
+//!
+//! # Example `providers.json`
+//!
+//! ```json
+//! {
+//!   "anthropic": {
+//!     "api_key_encrypted": "...",
+//!     "model": "claude-3-5-sonnet-20241022"
 //!   }
 //! }
 //! ```
@@ -36,8 +40,9 @@
 //! Configuration values are loaded in this order (later overrides earlier):
 //! 1. Code defaults (hardcoded default values)
 //! 2. Config file values (from `${HOME}/.bamboo/config.json`)
-//! 3. Environment variables (e.g., `BAMBOO_PORT`)
-//! 4. CLI arguments (e.g., `--port 9000`)
+//! 3. Independent sidecars (`memory.json`, `subagents.json`, `providers.json`)
+//! 4. Environment variables (e.g., `BAMBOO_PORT`)
+//! 5. CLI arguments (e.g., `--port 9000`)
 //!
 //! # Environment Variables
 //!
@@ -49,7 +54,7 @@
 //! - `BAMBOO_OPENAI_API_KEY` / `BAMBOO_ANTHROPIC_API_KEY` / `BAMBOO_GEMINI_API_KEY`:
 //!   Supply a provider's API key from the environment (in-memory only, never
 //!   persisted) — for 12-factor / secret-manager / CI deploys without a
-//!   plaintext key in config.json.
+//!   plaintext key in `providers.json`.
 
 use anyhow::{Context, Result};
 use bamboo_domain::poison::PoisonRecover;
@@ -3162,7 +3167,8 @@ impl Config {
 
     /// Save configuration to disk under the provided data directory.
     ///
-    /// Configuration is always stored as `{data_dir}/config.json`.
+    /// Root configuration is stored as `{data_dir}/config.json`; extracted
+    /// memory, sub-agent, and provider modules are stored in sibling sidecars.
     ///
     /// Refuses to write when this config carries an unconfirmed
     /// [`ConfigRecoveryStatus`] (#153) — i.e. it was recovered from a corrupt
@@ -3222,6 +3228,16 @@ impl Config {
         let content = serde_json::to_string_pretty(&config_value)
             .context("Failed to serialize config to JSON")?;
 
+        // Persist extracted modules before stripping their legacy inline
+        // representation from config.json. If the process crashes or the root
+        // rewrite fails during the first migration, the next load can still use
+        // either the new sidecars or the untouched inline values. Do this before
+        // rotating root backups so a sidecar error cannot consume backup history
+        // for a root document that was never rewritten.
+        crate::MemoryConfigModule(to_save.memory.clone()).save_sync(&data_dir)?;
+        crate::SubagentsConfigModule(to_save.subagents.clone()).save_sync(&data_dir)?;
+        crate::ProviderConfigsModule(to_save.providers.clone()).save_sync(&data_dir)?;
+
         // Back up the current on-disk config (last-known-good) before overwriting,
         // so corruption (a bad/partial write, external edit, disk issue) stays
         // recoverable via config.json.bak on the next load. Best-effort. Only
@@ -3246,9 +3262,6 @@ impl Config {
         write_atomic(&path, content.as_bytes())
             .with_context(|| format!("Failed to write config file: {:?}", path))?;
 
-        crate::MemoryConfigModule(to_save.memory.clone()).save_sync(&data_dir)?;
-        crate::SubagentsConfigModule(to_save.subagents.clone()).save_sync(&data_dir)?;
-        crate::ProviderConfigsModule(to_save.providers.clone()).save_sync(&data_dir)?;
         save_connect_config(&to_save.connect, &data_dir)?;
 
         Ok(())

--- a/crates/infra/bamboo-config/src/config_module.rs
+++ b/crates/infra/bamboo-config/src/config_module.rs
@@ -107,17 +107,42 @@ pub(crate) fn load_sidecar<T: DeserializeOwned>(path: &Path) -> Result<Option<T>
     }
 }
 
-pub(crate) fn save_sidecar<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+pub(crate) fn save_sidecar<T: Serialize + DeserializeOwned>(path: &Path, value: &T) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
     let bytes = serde_json::to_vec_pretty(value)?;
-    // Retain one last-known-good generation. A malformed current sidecar is
-    // deliberately not promoted over the usable backup.
+    // Retain one last-known-good generation. Validate the current document
+    // against the module's schema rather than merely checking that it is JSON:
+    // a syntactically valid but type-invalid document must not replace a usable
+    // backup.
     if path.exists() {
         let current = std::fs::read(path)?;
-        if serde_json::from_slice::<serde_json::Value>(&current).is_ok() {
-            std::fs::copy(path, path.with_extension("json.bak"))?;
+        if serde_json::from_slice::<T>(&current).is_ok() {
+            crate::config::write_atomic(&path.with_extension("json.bak"), &current)?;
+        }
+    }
+    crate::config::write_atomic(path, &bytes)?;
+    Ok(())
+}
+
+/// Save a sidecar whose deserializer intentionally drops in-memory-only
+/// fields (for example provider plaintext API keys). The previous generation
+/// is parsed and reserialized before becoming the backup so a hand-written
+/// plaintext secret is never copied verbatim into `*.json.bak`.
+pub(crate) fn save_sidecar_with_sanitized_backup<T: Serialize + DeserializeOwned>(
+    path: &Path,
+    value: &T,
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let bytes = serde_json::to_vec_pretty(value)?;
+    if path.exists() {
+        let current = std::fs::read(path)?;
+        if let Ok(previous) = serde_json::from_slice::<T>(&current) {
+            let sanitized = serde_json::to_vec_pretty(&previous)?;
+            crate::config::write_atomic(&path.with_extension("json.bak"), &sanitized)?;
         }
     }
     crate::config::write_atomic(path, &bytes)?;
@@ -131,7 +156,9 @@ mod tests {
     use serde_json::json;
     use tempfile::TempDir;
 
-    use crate::{Config, MemoryConfig, OpenAIConfig};
+    use crate::{
+        Config, ConfigRegistry, MemoryConfig, OpenAIConfig, ProviderConfigs, ProviderConfigsModule,
+    };
 
     fn write_json(path: &Path, value: serde_json::Value) {
         std::fs::write(path, serde_json::to_vec_pretty(&value).unwrap()).unwrap();
@@ -305,5 +332,104 @@ mod tests {
             std::fs::read(dir.path().join("memory.json")).unwrap(),
             b"{broken"
         );
+    }
+
+    #[test]
+    fn schema_invalid_sidecar_is_not_promoted_over_last_known_good_backup() {
+        let dir = TempDir::new().unwrap();
+        write_json(&dir.path().join("config.json"), json!({}));
+        write_json(
+            &dir.path().join("memory.json.bak"),
+            json!({"background_model": "recovered"}),
+        );
+        write_json(
+            &dir.path().join("memory.json"),
+            json!({"auto_dream_interval_secs": "not-a-number"}),
+        );
+
+        let config = Config::from_data_dir_without_env(Some(dir.path().to_path_buf()));
+        assert_eq!(
+            config.memory.as_ref().unwrap().background_model.as_deref(),
+            Some("recovered")
+        );
+        config.save_memory_to_dir(dir.path()).unwrap();
+
+        let backup: MemoryConfig =
+            serde_json::from_slice(&std::fs::read(dir.path().join("memory.json.bak")).unwrap())
+                .unwrap();
+        assert_eq!(backup.background_model.as_deref(), Some("recovered"));
+    }
+
+    #[test]
+    fn provider_registry_save_encrypts_keys_and_sanitizes_backup() {
+        let _key = crate::encryption::set_test_encryption_key([29; 32]);
+        let dir = TempDir::new().unwrap();
+        write_json(
+            &dir.path().join("providers.json"),
+            json!({"openai": {"api_key": "sk-old-plaintext", "model": "old"}}),
+        );
+
+        let providers = ProviderConfigs {
+            openai: Some(OpenAIConfig {
+                api_key: "sk-new-plaintext".into(),
+                model: Some("new".into()),
+                ..OpenAIConfig::default()
+            }),
+            ..ProviderConfigs::default()
+        };
+        let mut registry = ConfigRegistry::new();
+        registry.register(ProviderConfigsModule(providers));
+        futures::executor::block_on(registry.save_module("providers", dir.path())).unwrap();
+
+        let current = std::fs::read_to_string(dir.path().join("providers.json")).unwrap();
+        assert!(!current.contains("sk-new-plaintext"));
+        assert!(current.contains("api_key_encrypted"));
+        let backup = std::fs::read_to_string(dir.path().join("providers.json.bak")).unwrap();
+        assert!(!backup.contains("sk-old-plaintext"));
+
+        let mut loaded = ConfigRegistry::new();
+        loaded.register(ProviderConfigsModule::default());
+        futures::executor::block_on(loaded.load_all(dir.path())).unwrap();
+        let module = loaded.module::<ProviderConfigsModule>("providers").unwrap();
+        assert_eq!(
+            module.0.openai.as_ref().unwrap().api_key,
+            "sk-new-plaintext"
+        );
+
+        // Config's compatibility path performs its historical hydration pass
+        // after module load. The module-level hydration above must remain
+        // idempotent when reached through that path.
+        let config = Config::from_data_dir_without_env(Some(dir.path().to_path_buf()));
+        assert_eq!(
+            config.providers.openai.as_ref().unwrap().api_key,
+            "sk-new-plaintext"
+        );
+    }
+
+    #[test]
+    fn sidecars_are_durable_before_root_migration_rewrite() {
+        let dir = TempDir::new().unwrap();
+        // A directory at config.json forces the final atomic rename to fail.
+        // The independently persisted modules must already be durable so a
+        // failed root rewrite cannot discard the migration source of truth.
+        std::fs::create_dir(dir.path().join("config.json")).unwrap();
+        let config = Config {
+            memory: Some(MemoryConfig {
+                background_model: Some("durable-before-root".into()),
+                ..MemoryConfig::default()
+            }),
+            ..Config::default()
+        };
+
+        assert!(config.save_to_dir(dir.path().to_path_buf()).is_err());
+        let memory: MemoryConfig =
+            serde_json::from_slice(&std::fs::read(dir.path().join("memory.json")).unwrap())
+                .unwrap();
+        assert_eq!(
+            memory.background_model.as_deref(),
+            Some("durable-before-root")
+        );
+        assert!(dir.path().join("subagents.json").exists());
+        assert!(dir.path().join("providers.json").exists());
     }
 }

--- a/crates/infra/bamboo-config/src/provider_configs.rs
+++ b/crates/infra/bamboo-config/src/provider_configs.rs
@@ -1,8 +1,8 @@
 //! Independently persisted legacy provider configuration (`providers.json`).
 
 use crate::{
-    config_module::{load_sidecar, save_sidecar},
-    ConfigModule, ProviderConfigs,
+    config_module::{load_sidecar, save_sidecar_with_sanitized_backup},
+    Config, ConfigModule, ProviderConfigs,
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -16,13 +16,30 @@ pub struct ProviderConfigsModule(pub ProviderConfigs);
 impl ProviderConfigsModule {
     pub(crate) fn load_sync(&mut self, data_dir: &Path) -> Result<bool> {
         if let Some(value) = load_sidecar(&data_dir.join(FILE_NAME))? {
-            self.0 = value;
+            // A provider module loaded through ConfigRegistry must be just as
+            // usable as one loaded through Config::from_data_dir. Hydrate its
+            // at-rest ciphertext here; the later Config-wide hydration pass is
+            // intentionally idempotent for the compatibility path.
+            let mut config = Config {
+                providers: value,
+                ..Config::default()
+            };
+            config.hydrate_provider_api_keys_from_encrypted();
+            self.0 = config.providers;
             return Ok(true);
         }
         Ok(false)
     }
     pub(crate) fn save_sync(&self, data_dir: &Path) -> Result<()> {
-        save_sidecar(&data_dir.join(FILE_NAME), &self.0)
+        // Provider fields keep plaintext only in memory. Make the module safe
+        // to persist through ConfigRegistry directly, not only through
+        // Config::save_to_dir's broader secret-refresh pass.
+        let mut config = Config {
+            providers: self.0.clone(),
+            ..Config::default()
+        };
+        config.refresh_provider_api_keys_encrypted()?;
+        save_sidecar_with_sanitized_backup(&data_dir.join(FILE_NAME), &config.providers)
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up hardening for #39 after #591:

- validate existing sidecars against their module schema before rotating backups
- sanitize provider backup generations so plaintext API keys are never copied into `providers.json.bak`
- hydrate/encrypt provider modules consistently through `ConfigRegistry`
- persist extracted sidecars before rewriting the root config during migration
- document the new sidecar layout and add regression coverage

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test -p bamboo-config` (293 passed)
- `cargo clippy -p bamboo-config --all-targets -- -D warnings`

Part of #39. The remaining root `Config` field-count reduction is tracked by #590.