### PR TITLE
fix(engine): stop evaluation drains blocking finalization

### DIFF
--- a/crates/core/bamboo-agent-core/src/agent/events.rs
+++ b/crates/core/bamboo-agent-core/src/agent/events.rs
@@ -233,6 +233,9 @@ pub enum AgentEvent {
         session_id: String,
         /// Number of items to evaluate
         items_count: usize,
+        /// Task-list generation evaluated. Optional for older producers/frames.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        generation: Option<u64>,
     },
 
     /// Emitted when task evaluation completes.
@@ -243,6 +246,19 @@ pub enum AgentEvent {
         updates_count: usize,
         /// Evaluation reasoning
         reasoning: String,
+        /// Task-list generation evaluated. Optional for backward compatibility.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        generation: Option<u64>,
+    },
+
+    /// Emitted when an unfinished task evaluation is stopped because its owning
+    /// run completed, suspended, or was cancelled.
+    TaskEvaluationCancelled {
+        session_id: String,
+        reason: String,
+        /// Task-list generation whose evaluation was cancelled.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        generation: Option<u64>,
     },
 
     /// Emitted when gold observe-only evaluation starts.
@@ -270,6 +286,9 @@ pub enum AgentEvent {
         /// Short reasoning summary
         reasoning: String,
     },
+
+    /// Emitted when an unfinished Gold evaluation is stopped with its owning run.
+    GoldEvaluationCancelled { session_id: String, reason: String },
 
     /// Emitted whenever the runtime goal state changes — a new status
     /// (active/complete/blocked/…), an incremented continuation count, or a
@@ -629,8 +648,10 @@ impl AgentEvent {
             | AgentEvent::TaskListCompleted { session_id, .. }
             | AgentEvent::TaskEvaluationStarted { session_id, .. }
             | AgentEvent::TaskEvaluationCompleted { session_id, .. }
+            | AgentEvent::TaskEvaluationCancelled { session_id, .. }
             | AgentEvent::GoldEvaluationStarted { session_id, .. }
             | AgentEvent::GoldEvaluationCompleted { session_id, .. }
+            | AgentEvent::GoldEvaluationCancelled { session_id, .. }
             | AgentEvent::GoalStatusChanged { session_id, .. }
             | AgentEvent::PlanModeEntered { session_id, .. }
             | AgentEvent::PlanModeExited { session_id, .. }
@@ -684,6 +705,8 @@ impl AgentEvent {
                 | AgentEvent::TaskListItemProgress { .. }
                 | AgentEvent::TaskListCompleted { .. }
                 | AgentEvent::TaskEvaluationCompleted { .. }
+                | AgentEvent::TaskEvaluationCancelled { .. }
+                | AgentEvent::GoldEvaluationCancelled { .. }
                 | AgentEvent::PlanModeEntered { .. }
                 | AgentEvent::PlanModeExited { .. }
                 | AgentEvent::PlanFileUpdated { .. }
@@ -847,10 +870,52 @@ mod tests {
             session_id: "session-1".to_string(),
             updates_count: 2,
             reasoning: "Updated statuses".to_string(),
+            generation: Some(7),
         };
 
         let value = serde_json::to_value(event).expect("event should serialize");
         assert_eq!(value["type"], "task_evaluation_completed");
+        assert_eq!(value["generation"], 7);
+    }
+
+    #[test]
+    fn task_evaluation_event_without_generation_remains_deserializable() {
+        let event: AgentEvent = serde_json::from_value(serde_json::json!({
+            "type": "task_evaluation_started",
+            "session_id": "session-1",
+            "items_count": 2
+        }))
+        .expect("legacy task evaluation frame should remain compatible");
+
+        assert!(matches!(
+            event,
+            AgentEvent::TaskEvaluationStarted {
+                generation: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn evaluation_cancelled_events_serialize_as_terminal_lifecycle_events() {
+        let task = AgentEvent::TaskEvaluationCancelled {
+            session_id: "session-1".to_string(),
+            reason: "run_suspended".to_string(),
+            generation: Some(7),
+        };
+        let gold = AgentEvent::GoldEvaluationCancelled {
+            session_id: "session-1".to_string(),
+            reason: "run_completed".to_string(),
+        };
+
+        assert!(task.is_durable_change());
+        assert!(gold.is_durable_change());
+        let task_value = serde_json::to_value(task).unwrap();
+        let gold_value = serde_json::to_value(gold).unwrap();
+        assert_eq!(task_value["type"], "task_evaluation_cancelled");
+        assert_eq!(task_value["reason"], "run_suspended");
+        assert_eq!(gold_value["type"], "gold_evaluation_cancelled");
+        assert_eq!(gold_value["reason"], "run_completed");
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/gold.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/gold.rs
@@ -339,37 +339,6 @@ pub(super) async fn poll_completed_gold_evaluation(state: &mut LoopRunState) {
     }
 }
 
-pub(super) async fn drain_in_flight_gold_evaluation(state: &mut LoopRunState) {
-    if state.gold_evaluation.completed.is_some() {
-        return;
-    }
-
-    let Some(in_flight) = state.gold_evaluation.in_flight.take() else {
-        return;
-    };
-
-    match in_flight.join_handle.await {
-        Ok(Some(result)) => {
-            state.gold_evaluation.completed = Some(result);
-        }
-        Ok(None) => {
-            tracing::debug!(
-                "[{}] Async Gold evaluation cancelled while draining round {}",
-                state.session_id,
-                in_flight.request.round_number
-            );
-        }
-        Err(error) => {
-            tracing::warn!(
-                "[{}] Async Gold evaluation join failed while draining round {}: {}",
-                state.session_id,
-                in_flight.request.round_number,
-                error
-            );
-        }
-    }
-}
-
 pub(super) async fn apply_completed_gold_evaluation(
     session: &mut Session,
     config: &AgentLoopConfig,

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -38,9 +38,8 @@ use bamboo_metrics::{
 
 use super::super::to_event_token_usage;
 use super::gold::{
-    apply_completed_gold_evaluation, drain_in_flight_gold_evaluation, evaluate_gold_terminal,
-    poll_completed_gold_evaluation, spawn_gold_evaluation_if_needed,
-    start_queued_gold_evaluation_if_idle, GoldTerminalDecision,
+    apply_completed_gold_evaluation, evaluate_gold_terminal, poll_completed_gold_evaluation,
+    spawn_gold_evaluation_if_needed, start_queued_gold_evaluation_if_idle, GoldTerminalDecision,
 };
 use crate::runtime::runner::state_bridge;
 
@@ -715,37 +714,6 @@ async fn poll_completed_task_evaluation(state: &mut LoopRunState) {
     }
 }
 
-async fn drain_in_flight_task_evaluation(state: &mut LoopRunState) {
-    if state.task_evaluation.completed.is_some() {
-        return;
-    }
-
-    let Some(in_flight) = state.task_evaluation.in_flight.take() else {
-        return;
-    };
-
-    match in_flight.join_handle.await {
-        Ok(Some(result)) => {
-            state.task_evaluation.completed = Some(result);
-        }
-        Ok(None) => {
-            tracing::debug!(
-                "[{}] Async task evaluation cancelled while draining round {}",
-                state.session_id,
-                in_flight.request.round_number
-            );
-        }
-        Err(error) => {
-            tracing::warn!(
-                "[{}] Async task evaluation join failed while draining round {}: {}",
-                state.session_id,
-                in_flight.request.round_number,
-                error
-            );
-        }
-    }
-}
-
 async fn apply_completed_task_evaluation(
     session: &mut Session,
     event_tx: &mpsc::Sender<AgentEvent>,
@@ -868,20 +836,53 @@ fn spawn_task_evaluation_request(
 
 /// Abort any in-flight async Gold/Task evaluation and clear its slot.
 ///
-/// Called on EVERY early return from [`run_pipeline`] (cancellation,
-/// terminal-error, no-outcome, overflow-recovery failure). The happy path
-/// instead *drains* (awaits + applies) these handles after the loop; the early
-/// returns skip that drain, so without an explicit abort the `JoinHandle` would
-/// simply be dropped — which DETACHES (not aborts) the tokio task, letting a
-/// cancelled run keep executing a full LLM request to completion and fire a late
-/// event onto the ended stream (issue #347). `abort()` drops the eval future at
-/// its next await point, stopping the spend.
-fn abort_in_flight_evaluations(state: &mut LoopRunState) {
+/// Called whenever a run stops. Dropping a `JoinHandle` detaches the task, so we
+/// must abort unfinished evaluations even on normal completion/suspension. This
+/// keeps issue #347's no-detached-request guarantee without making finalization
+/// wait for an auxiliary LLM request (issue #593).
+async fn abort_in_flight_evaluations(
+    state: &mut LoopRunState,
+    event_tx: &mpsc::Sender<AgentEvent>,
+    reason: &'static str,
+) {
+    let task_was_running = state.task_evaluation.in_flight.is_some();
+    let task_generation = state
+        .task_evaluation
+        .in_flight
+        .as_ref()
+        .map(|in_flight| in_flight.request.based_on_task_context_version);
+    let gold_was_running = state.gold_evaluation.in_flight.is_some();
     if let Some(in_flight) = state.task_evaluation.in_flight.take() {
         in_flight.join_handle.abort();
     }
     if let Some(in_flight) = state.gold_evaluation.in_flight.take() {
         in_flight.join_handle.abort();
+    }
+    // Queued snapshots belong to this run. A later run rebuilds an evaluation
+    // request from the current task-list generation instead of replaying stale
+    // work captured before completion/suspension.
+    state.task_evaluation.queued_request = None;
+    state.gold_evaluation.queued_request = None;
+
+    // A Started event may already be visible to clients. Always close that
+    // lifecycle explicitly so a reconnecting/current UI never remains stuck in
+    // "evaluating" after the owning run has reached a terminal/suspended state.
+    if task_was_running {
+        let _ = event_tx
+            .send(AgentEvent::TaskEvaluationCancelled {
+                session_id: state.session_id.clone(),
+                reason: reason.to_string(),
+                generation: task_generation,
+            })
+            .await;
+    }
+    if gold_was_running {
+        let _ = event_tx
+            .send(AgentEvent::GoldEvaluationCancelled {
+                session_id: state.session_id.clone(),
+                reason: reason.to_string(),
+            })
+            .await;
     }
 }
 
@@ -1474,7 +1475,7 @@ pub(super) async fn run_pipeline(
             // dropped (detached, not aborted) and the eval would keep running its
             // LLM request to completion — wasted spend + a late event onto the
             // already-ended stream (issue #347).
-            abort_in_flight_evaluations(state);
+            abort_in_flight_evaluations(state, event_tx, "run_cancelled").await;
             return Err(AgentError::Cancelled);
         }
 
@@ -1559,7 +1560,12 @@ pub(super) async fn run_pipeline(
                                     // Early exit before the post-loop drain — abort
                                     // any in-flight eval so it does not detach and
                                     // keep spending (issue #347).
-                                    abort_in_flight_evaluations(state);
+                                    abort_in_flight_evaluations(
+                                        state,
+                                        event_tx,
+                                        "terminal_error",
+                                    )
+                                    .await;
                                     return Err(error);
                                 }
                             };
@@ -1783,7 +1789,7 @@ pub(super) async fn run_pipeline(
             );
             // Early exit before the post-loop drain — abort in-flight evals so a
             // terminal error does not leave an eval detached and spending (#347).
-            abort_in_flight_evaluations(state);
+            abort_in_flight_evaluations(state, event_tx, "terminal_error").await;
             return Err(error);
         }
 
@@ -1801,7 +1807,7 @@ pub(super) async fn run_pipeline(
                 &error,
             );
             // Early exit before the post-loop drain — abort in-flight evals (#347).
-            abort_in_flight_evaluations(state);
+            abort_in_flight_evaluations(state, event_tx, "run_stopped").await;
             return Err(error);
         };
 
@@ -2153,33 +2159,20 @@ pub(super) async fn run_pipeline(
         }
     }
 
-    drain_in_flight_task_evaluation(state).await;
+    // Harvest results that are already ready, but never turn run finalization
+    // into a barrier on an auxiliary evaluator. Unfinished and queued work is
+    // cancelled below; generation checks still reject any completed stale
+    // snapshot before it can mutate the task list.
+    poll_completed_task_evaluation(state).await;
     apply_completed_task_evaluation(session, event_tx, config, state).await;
-    // A task evaluation may have been queued during the final round but never
-    // spawned because the in-flight slot was still busy when the loop ended.
-    // Run it now (spawn + drain) so the last round's progress is actually
-    // evaluated instead of being silently dropped — this also makes the
-    // between-rounds refresh behavior deterministic regardless of scheduling.
-    if state.task_evaluation.in_flight.is_none() {
-        if let Some(request) = state.task_evaluation.queued_request.take() {
-            let eval_provider = state
-                .auxiliary_models
-                .fast_model_provider
-                .clone()
-                .unwrap_or_else(|| llm.clone());
-            spawn_task_evaluation_request(
-                state,
-                event_tx,
-                request,
-                eval_provider,
-                cancel_token.clone(),
-            );
-            drain_in_flight_task_evaluation(state).await;
-            apply_completed_task_evaluation(session, event_tx, config, state).await;
-        }
-    }
-    drain_in_flight_gold_evaluation(state).await;
+    poll_completed_gold_evaluation(state).await;
     apply_completed_gold_evaluation(session, config, state).await;
+    let evaluation_stop_reason = if session.metadata.contains_key("runtime.suspend_reason") {
+        "run_suspended"
+    } else {
+        "run_completed"
+    };
+    abort_in_flight_evaluations(state, event_tx, evaluation_stop_reason).await;
 
     Ok(sent_complete)
 }
@@ -5381,7 +5374,7 @@ mod tests {
         let config = eval_abort_config();
         let mut session = Session::new("session-eval-terminal", "model");
         let mut state = e2e_loop_state("session-eval-terminal");
-        let (tx, _rx) = tokio::sync::mpsc::channel(64);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
         // Never cancelled: the terminal error, not a cancel, drives the early exit.
         let cancel = CancellationToken::new();
 
@@ -5408,6 +5401,20 @@ mod tests {
             state.gold_evaluation.in_flight.is_none(),
             "the in-flight Gold eval slot must be aborted+cleared on the terminal early-exit"
         );
+        let mut saw_cancelled = false;
+        while let Ok(event) = rx.try_recv() {
+            if matches!(
+                event,
+                AgentEvent::GoldEvaluationCancelled { ref reason, .. }
+                    if reason == "terminal_error"
+            ) {
+                saw_cancelled = true;
+            }
+        }
+        assert!(
+            saw_cancelled,
+            "an observed evaluation start must receive an explicit terminal cancellation event"
+        );
 
         // Release the (aborted) eval and confirm it does NOT complete. Without the
         // abort, the detached eval would wake here and fire `finished`.
@@ -5422,6 +5429,74 @@ mod tests {
             !gold_completed.load(Ordering::SeqCst),
             "aborted Gold eval must not complete its LLM request"
         );
+    }
+
+    /// The normal-finalization seam is not an auxiliary-evaluation barrier. It
+    /// aborts a blocked evaluation, drops the coalesced queued snapshot, and
+    /// emits a terminal lifecycle event without polling the blocked future.
+    #[tokio::test]
+    async fn abort_helper_is_nonblocking_for_completion_and_suspension() {
+        let mut session = Session::new("session-eval-complete", "model");
+        let mut state = e2e_loop_state("session-eval-complete");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let request = crate::runtime::gold_evaluation::AsyncGoldEvaluationRequest {
+            session_id: session.id.clone(),
+            round_number: 1,
+            model_name: "fast".to_string(),
+            reasoning_effort: None,
+            checkpoint: bamboo_agent_core::GoldCheckpoint::PostRound,
+            session_snapshot: session.clone(),
+            task_context_snapshot: None,
+            gold_config: crate::runtime::config::GoldConfig::default(),
+        };
+        state.gold_evaluation.in_flight = Some(super::super::startup::InFlightGoldEvaluation {
+            request: request.clone(),
+            join_handle: tokio::spawn(std::future::pending()),
+        });
+        state.gold_evaluation.queued_request = Some(request.clone());
+
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            super::abort_in_flight_evaluations(&mut state, &tx, "run_completed"),
+        )
+        .await
+        .expect("normal finalization waited for the blocked Gold evaluation");
+
+        assert!(state.gold_evaluation.in_flight.is_none());
+        assert!(state.gold_evaluation.queued_request.is_none());
+        let mut saw_cancelled = false;
+        while let Ok(event) = rx.try_recv() {
+            if matches!(
+                event,
+                AgentEvent::GoldEvaluationCancelled { ref reason, .. }
+                    if reason == "run_completed"
+            ) {
+                saw_cancelled = true;
+            }
+        }
+        assert!(saw_cancelled);
+
+        // waiting_for_children / awaiting_clarification both converge on the
+        // same post-loop suspension finalizer (`runtime.suspend_reason` selects
+        // this reason). Exercise that seam with another blocked request.
+        state.gold_evaluation.in_flight = Some(super::super::startup::InFlightGoldEvaluation {
+            request: request.clone(),
+            join_handle: tokio::spawn(std::future::pending()),
+        });
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            super::abort_in_flight_evaluations(&mut state, &tx, "run_suspended"),
+        )
+        .await
+        .expect("suspension finalization waited for the blocked Gold evaluation");
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(AgentEvent::GoldEvaluationCancelled { reason, .. })
+                if reason == "run_suspended"
+        ));
+        // Keep the session alive through the assertion: the finalizer must not
+        // require or mutate it to stop auxiliary work.
+        session.metadata.insert("verified".into(), "true".into());
     }
 
     // ---- Guardian final-message review context (issue #400) ----

--- a/crates/engine/bamboo-engine/src/runtime/runner/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tests.rs
@@ -155,7 +155,7 @@ async fn agent_loop_passes_session_id_into_tool_execution_context() {
 }
 
 #[tokio::test]
-async fn agent_loop_refreshes_fast_model_between_rounds_for_task_evaluation() {
+async fn agent_loop_uses_refreshed_fast_model_for_between_round_task_evaluation() {
     struct RecordingRoundProvider {
         queue: Mutex<Vec<Vec<bamboo_llm::provider::Result<LLMChunk>>>>,
         fast_models: Mutex<Vec<String>>,
@@ -225,8 +225,9 @@ async fn agent_loop_refreshes_fast_model_between_rounds_for_task_evaluation() {
         .expect("register Task tool")
         .build();
 
-    // Task evaluation now fires only on Task-tool writes, so each round must issue
-    // a Task call to exercise the per-round auxiliary fast-model refresh.
+    // Task evaluation fires only on Task-tool writes. Two writes also exercise
+    // coalescing while the first auxiliary request is in flight; normal
+    // finalization intentionally cancels the queued final-round snapshot (#593).
     let tool_call = |id: &str| bamboo_agent_core::tools::ToolCall {
         id: id.to_string(),
         tool_type: "function".to_string(),
@@ -296,8 +297,19 @@ async fn agent_loop_refreshes_fast_model_between_rounds_for_task_evaluation() {
     .expect("agent loop should succeed");
 
     let fast_models = provider.fast_models.lock().await.clone();
-    assert_eq!(
-        fast_models,
-        vec!["fast-2".to_string(), "fast-3".to_string()]
+    // `fast-1` was resolved at startup; the between-round refresh must select
+    // `fast-2` for the first evaluation. Depending on scheduling, that request
+    // may finish before the next round polls it, allowing the second write to
+    // launch with `fast-3`; otherwise it remains queued and is cancelled at
+    // finalization. Both are valid, and neither requires a finalize-time drain.
+    assert!(
+        matches!(
+            fast_models.as_slice(),
+            [first] if first == "fast-2"
+        ) || matches!(
+            fast_models.as_slice(),
+            [first, second] if first == "fast-2" && second == "fast-3"
+        ),
+        "between-round evaluations must use refreshed fast models in order, got {fast_models:?}"
     );
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tests.rs
@@ -175,6 +175,21 @@ async fn agent_loop_uses_refreshed_fast_model_for_between_round_task_evaluation(
                 return Err(LLMError::Api("intentional fast-model failure".to_string()));
             }
 
+            // When the second chat round starts, the first task evaluator has
+            // already been spawned but may not have received executor time yet.
+            // Wait for that background request to enter the provider so this
+            // test observes the between-round refresh deterministically without
+            // relying on the finalize path to drain it.
+            if self.queue.lock().await.len() == 2 {
+                tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                    while self.fast_models.lock().await.is_empty() {
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await
+                .expect("first between-round task evaluation should start");
+            }
+
             let mut guard = self.queue.lock().await;
             if guard.is_empty() {
                 panic!("test provider queue exhausted");

--- a/crates/engine/bamboo-engine/src/runtime/task_evaluation/executor.rs
+++ b/crates/engine/bamboo-engine/src/runtime/task_evaluation/executor.rs
@@ -69,6 +69,7 @@ pub async fn evaluate_task_progress(
         .send(AgentEvent::TaskEvaluationStarted {
             session_id: session_id.to_string(),
             items_count: in_progress_count,
+            generation: Some(ctx.version),
         })
         .await;
 
@@ -110,10 +111,14 @@ pub async fn evaluate_task_progress(
             .await
             .map_err(|error| AgentError::LLM(error.to_string()))?;
 
-            Ok(
-                outcomes::build_success_result(stream_output, event_tx, session_id, prompt_tokens)
-                    .await,
+            Ok(outcomes::build_success_result(
+                stream_output,
+                event_tx,
+                session_id,
+                prompt_tokens,
+                ctx.version,
             )
+            .await)
         }
         Err(error) => {
             tracing::warn!("[{}] Task evaluation failed: {}", session_id, error);

--- a/crates/engine/bamboo-engine/src/runtime/task_evaluation/executor/outcomes.rs
+++ b/crates/engine/bamboo-engine/src/runtime/task_evaluation/executor/outcomes.rs
@@ -12,6 +12,7 @@ pub(super) async fn build_success_result(
     event_tx: &mpsc::Sender<AgentEvent>,
     session_id: &str,
     prompt_tokens: u64,
+    generation: u64,
 ) -> TaskEvaluationResult {
     tracing::info!(
         "[{}] Task evaluation completed: {} tokens, {} tool calls",
@@ -39,6 +40,7 @@ pub(super) async fn build_success_result(
             session_id: session_id.to_string(),
             updates_count: updates.len(),
             reasoning: reasoning.clone(),
+            generation: Some(generation),
         })
         .await;
 


### PR DESCRIPTION
## Summary

- stop awaiting in-flight Task and Gold evaluations at normal run finalization/suspension
- non-blockingly apply already-ready generation-checked results, abort unfinished work, and discard queued snapshots instead of issuing a second serialized request
- emit explicit task/gold evaluation cancellation lifecycle events before finalization
- add optional Task evaluation generation correlation to reject stale results and preserve legacy deserialization
- preserve #347 cancellation/no-detached-request guarantees

Closes #593 (Bamboo safe backend slice). Lotus counterpart is bigduu/Lotus#113.

## Semantic tradeoff

An unfinished final-round evaluation is intentionally cancelled rather than detached. Preserving it safely in the background requires a later session-scoped coordinator with generation/CAS persistence; detaching the current owned-Session task would race future runs and overwrite state.

## Test Plan

- `cargo fmt --check`
- `cargo check -p bamboo-engine`
- evaluation-focused Bamboo tests (40 passed in review)
- `abort_helper_is_nonblocking_for_completion_and_suspension`
- terminal-error/cancel/stale-generation/legacy-serde tests
- `git diff --check`
