### PR TITLE
feat(subagent): journal child approval lifecycle

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/mod.rs
+++ b/crates/app/bamboo-sdk/src/agent/mod.rs
@@ -1413,7 +1413,16 @@ mod reexecute_and_child_approval_tests {
         // `external_agents::actor_adapter::drive` would.
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let _live_guard = bamboo_engine::external_agents::live::register("child-x", tx);
-        bamboo_engine::external_agents::live::register_pending_approval("child-x", "req-1");
+        let (approval_event_tx, _approval_event_rx) = tokio::sync::mpsc::channel(4);
+        bamboo_engine::external_agents::live::register_pending_approval_observed(
+            "parent-x",
+            "child-x",
+            "req-1",
+            "shell",
+            "execute",
+            "cargo test",
+            approval_event_tx,
+        );
 
         assert!(agent.answer_child_approval("child-x", "req-1", true));
         match rx.try_recv() {

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/events.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/events.rs
@@ -17,6 +17,8 @@ fn is_critical_event(event: &AgentEvent) -> bool {
             | AgentEvent::TaskListCompleted { .. }
             | AgentEvent::SubAgentStarted { .. }
             | AgentEvent::SubAgentCompleted { .. }
+            | AgentEvent::ChildApprovalRequested { .. }
+            | AgentEvent::ChildApprovalChanged { .. }
             | AgentEvent::BashCompleted { .. }
             | AgentEvent::SessionTitleUpdated { .. }
             | AgentEvent::SessionPinnedUpdated { .. }
@@ -82,7 +84,12 @@ pub(crate) fn spawn_event_forwarder(
                 // sink filters ephemeral events (tokens, etc.) internally, so
                 // this is near-free for the hot path. `session_id` is passed
                 // explicitly so terminal events (which carry no id) still route.
-                state.account_sink.record(Some(&session_id), &event);
+                // Parent-scoped child lifecycle/approval events carry their
+                // canonical routing id. Prefer it over the forwarder's source
+                // session so a child stream journals the delta under the parent
+                // account-feed envelope and reconnecting parent UIs see it.
+                let route_session_id = event.session_id().unwrap_or(&session_id);
+                state.account_sink.record(Some(route_session_id), &event);
 
                 // Always forward to the broadcast channel regardless of subscriber count.
                 // The broadcast channel's internal capacity (1000 slots) buffers events so
@@ -619,14 +626,29 @@ mod tests {
             })
             .await
             .unwrap();
+        mpsc_tx
+            .send(AgentEvent::ChildApprovalChanged {
+                parent_session_id: "parent-session".into(),
+                child_session_id: session_id.into(),
+                request_id: "req-1".into(),
+                version: 2,
+                status: "approved".into(),
+                reason: None,
+                tool_name: "Bash".into(),
+                permission: "execute".into(),
+                resource: "/tmp/x".into(),
+                created_at: "2026-01-01T00:00:00Z".into(),
+                resolved_at: Some("2026-01-01T00:00:01Z".into()),
+            })
+            .await
+            .unwrap();
         drop(mpsc_tx);
 
         tokio::time::sleep(std::time::Duration::from_millis(80)).await;
 
         let journaled =
             bamboo_engine::events::journal::read_since(state.account_sink.events_dir(), 0).unwrap();
-        // Only the two durable events (TaskListUpdated, Complete) were journaled.
-        assert_eq!(journaled.len(), 2, "ephemeral Token must be excluded");
+        assert_eq!(journaled.len(), 3, "ephemeral Token must be excluded");
         assert!(matches!(
             journaled[0].event,
             AgentEvent::TaskListUpdated { .. }
@@ -634,9 +656,15 @@ mod tests {
         assert!(matches!(journaled[1].event, AgentEvent::Complete { .. }));
         // The terminal event routed to the right session via caller context.
         assert_eq!(journaled[1].session_id.as_deref(), Some(session_id));
+        assert_eq!(journaled[2].session_id.as_deref(), Some("parent-session"));
+        assert!(matches!(
+            journaled[2].event,
+            AgentEvent::ChildApprovalChanged { .. }
+        ));
         // Sequence numbers are monotonic and 1-based.
         assert_eq!(journaled[0].seq, 1);
         assert_eq!(journaled[1].seq, 2);
+        assert_eq!(journaled[2].seq, 3);
     }
 
     #[tokio::test]

--- a/crates/core/bamboo-agent-core/src/agent/events.rs
+++ b/crates/core/bamboo-agent-core/src/agent/events.rs
@@ -546,6 +546,24 @@ pub enum AgentEvent {
         resource: String,
     },
 
+    /// Durable, versioned approval lifecycle delta for a child agent.
+    ChildApprovalChanged {
+        parent_session_id: String,
+        child_session_id: String,
+        request_id: String,
+        version: u64,
+        /// `pending` | `approved` | `denied` | `expired` | `delivery_failed`.
+        status: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+        tool_name: String,
+        permission: String,
+        resource: String,
+        created_at: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        resolved_at: Option<String>,
+    },
+
     /// A per-run resource guardrail (token / tool-call / subagent budget)
     /// tripped and the run was gracefully stopped — issue #221.
     ///
@@ -656,6 +674,9 @@ impl AgentEvent {
             }
             | AgentEvent::SubAgentCompleted {
                 parent_session_id, ..
+            }
+            | AgentEvent::ChildApprovalChanged {
+                parent_session_id, ..
             } => Some(parent_session_id.as_str()),
             _ => None,
         }
@@ -689,6 +710,7 @@ impl AgentEvent {
                 | AgentEvent::PlanFileUpdated { .. }
                 | AgentEvent::SubAgentStarted { .. }
                 | AgentEvent::SubAgentCompleted { .. }
+                | AgentEvent::ChildApprovalChanged { .. }
                 | AgentEvent::NeedClarification { .. }
                 | AgentEvent::ToolApprovalRequested { .. }
                 | AgentEvent::ExecutionStarted { .. }
@@ -1061,6 +1083,28 @@ mod tests {
             value["parameters"],
             serde_json::json!({"file_path": "/tmp/test.txt"})
         );
+    }
+
+    #[test]
+    fn child_approval_changed_routes_to_parent_and_is_durable() {
+        let event = AgentEvent::ChildApprovalChanged {
+            parent_session_id: "parent-1".into(),
+            child_session_id: "child-1".into(),
+            request_id: "req-1".into(),
+            version: 2,
+            status: "approved".into(),
+            reason: None,
+            tool_name: "Bash".into(),
+            permission: "execute".into(),
+            resource: "/tmp/x".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            resolved_at: Some("2026-01-01T00:00:01Z".into()),
+        };
+        assert_eq!(event.session_id(), Some("parent-1"));
+        assert!(event.is_durable_change());
+        let value = serde_json::to_value(event).unwrap();
+        assert_eq!(value["type"], "child_approval_changed");
+        assert_eq!(value["status"], "approved");
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -894,6 +894,7 @@ impl ExternalChildRunner for ActorChildRunner {
 
             let result = drive(
                 &mut *client,
+                &job.parent_session_id,
                 &job.child_session_id,
                 self.approval_decider.as_ref(),
                 escalation.clone(),
@@ -1025,6 +1026,7 @@ fn host_of_endpoint(endpoint: &str) -> String {
 /// the correct (then-current) parent bridge rather than a stale/overwritten one.
 async fn drive(
     client: &mut dyn bamboo_subagent::ChildLink,
+    parent_session_id: &str,
     child_session_id: &str,
     approval_decider: Option<&Arc<dyn ChildApprovalDecider>>,
     escalation_bridge: Option<bamboo_subagent::executor::HostBridge>,
@@ -1157,7 +1159,29 @@ async fn drive(
                             // the external handler's `deliver_approval_checked` can
                             // correlate an out-of-band POST against a genuine
                             // human-loop request (and consume it one-shot).
-                            super::live::register_pending_approval(child_session_id, &id);
+                            let (approval_version, approval_created_at) =
+                                super::live::register_pending_approval_observed(
+                                parent_session_id,
+                                child_session_id,
+                                &id,
+                                &tool_name,
+                                &permission,
+                                &resource,
+                                event_tx.clone(),
+                            );
+                            let _ = event_tx.send(AgentEvent::ChildApprovalChanged {
+                                parent_session_id: parent_session_id.to_string(),
+                                child_session_id: child_session_id.to_string(),
+                                request_id: id.clone(),
+                                version: approval_version,
+                                status: "pending".to_string(),
+                                reason: None,
+                                tool_name: tool_name.clone(),
+                                permission: permission.clone(),
+                                resource: resource.clone(),
+                                created_at: approval_created_at,
+                                resolved_at: None,
+                            }).await;
                             let _ = event_tx
                                 .send(AgentEvent::ChildApprovalRequested {
                                     child_session_id: child_session_id.to_string(),
@@ -1174,7 +1198,7 @@ async fn drive(
                                 // we don't double-deliver if the human already
                                 // answered (the POST took it), and so a late POST
                                 // after this fires finds nothing pending.
-                                if super::live::take_pending_approval(&child, &id) {
+                                if super::live::expire_pending_approval(&child, &id) {
                                     super::live::deliver_approval(&child, &id, false);
                                 }
                             });
@@ -1448,6 +1472,7 @@ mod tests {
         let mut link = SilentLink;
         let r = drive(
             &mut link,
+            "parent-x",
             "child-x",
             None,
             None,
@@ -1473,6 +1498,7 @@ mod tests {
         // disarms the watchdog.
         let r = drive(
             &mut link,
+            "parent-y",
             "child-y",
             None,
             None,

--- a/crates/engine/bamboo-engine/src/external_agents/live.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/live.rs
@@ -8,9 +8,10 @@
 //! children use, extended across the process boundary. When the child is not
 //! live, callers fall back to the durable `pending_injected_messages` queue.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 
+use bamboo_agent_core::AgentEvent;
 use bamboo_domain::poison::PoisonRecover;
 use bamboo_subagent::proto::ParentFrame;
 use tokio::sync::mpsc;
@@ -27,41 +28,149 @@ fn map() -> &'static Mutex<HashMap<String, mpsc::UnboundedSender<ParentFrame>>> 
 /// paths (model-review, escalation-bridge) do NOT — so the external handler's
 /// [`deliver_approval_checked`] correctly rejects any stray external POST aimed
 /// at a request that isn't a genuinely-pending human-loop one.
-fn pending() -> &'static Mutex<HashMap<String, HashSet<String>>> {
-    static PENDING: OnceLock<Mutex<HashMap<String, HashSet<String>>>> = OnceLock::new();
+#[derive(Clone)]
+struct PendingApproval {
+    parent_session_id: String,
+    tool_name: String,
+    permission: String,
+    resource: String,
+    created_at: String,
+    version: u64,
+    event_tx: mpsc::Sender<AgentEvent>,
+}
+
+fn pending() -> &'static Mutex<HashMap<(String, String), PendingApproval>> {
+    static PENDING: OnceLock<Mutex<HashMap<(String, String), PendingApproval>>> = OnceLock::new();
     PENDING.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 /// Record a `(child_id, request_id)` as a pending human-loop approval. Called
 /// just before surfacing `ChildApprovalRequested` so an external POST can be
 /// correlated against a genuinely-pending request.
-pub fn register_pending_approval(child_id: &str, request_id: &str) {
-    pending()
-        .lock()
-        .recover_poison()
-        .entry(child_id.to_string())
-        .or_default()
-        .insert(request_id.to_string());
+pub fn register_pending_approval_observed(
+    parent_session_id: &str,
+    child_id: &str,
+    request_id: &str,
+    tool_name: &str,
+    permission: &str,
+    resource: &str,
+    event_tx: mpsc::Sender<AgentEvent>,
+) -> (u64, String) {
+    let now = chrono::Utc::now();
+    let version = now.timestamp_micros().max(0) as u64;
+    let created_at = now.to_rfc3339();
+    pending().lock().recover_poison().insert(
+        (child_id.to_string(), request_id.to_string()),
+        PendingApproval {
+            parent_session_id: parent_session_id.to_string(),
+            tool_name: tool_name.to_string(),
+            permission: permission.to_string(),
+            resource: resource.to_string(),
+            created_at: created_at.clone(),
+            version,
+            event_tx,
+        },
+    );
+    (version, created_at)
+}
+
+#[cfg(test)]
+fn register_pending_approval(child_id: &str, request_id: &str) {
+    let (event_tx, _rx) = mpsc::channel(1);
+    let _ = register_pending_approval_observed(
+        "test-parent",
+        child_id,
+        request_id,
+        "test-tool",
+        "test-permission",
+        "test-resource",
+        event_tx,
+    );
 }
 
 /// One-shot consume of a `(child_id, request_id)` pending pair: remove it and
 /// return whether it WAS present. A second call for the same pair returns
 /// `false`, so a request can't be answered (or replayed) twice.
 pub fn take_pending_approval(child_id: &str, request_id: &str) -> bool {
-    let mut guard = pending().lock().recover_poison();
-    let Some(set) = guard.get_mut(child_id) else {
-        return false;
-    };
-    let took = set.remove(request_id);
-    if set.is_empty() {
-        guard.remove(child_id);
-    }
-    took
+    pending()
+        .lock()
+        .recover_poison()
+        .remove(&(child_id.to_string(), request_id.to_string()))
+        .is_some()
 }
 
 /// Drop all pending approvals for a child (e.g. when its live connection ends).
 pub fn clear_pending_approvals_for(child_id: &str) {
-    pending().lock().recover_poison().remove(child_id);
+    let records: Vec<_> = {
+        let mut guard = pending().lock().recover_poison();
+        let keys: Vec<_> = guard
+            .keys()
+            .filter(|(child, _)| child == child_id)
+            .cloned()
+            .collect();
+        keys.into_iter()
+            .filter_map(|key| guard.remove(&key).map(|record| (key.1, record)))
+            .collect()
+    };
+    for (request_id, record) in records {
+        emit_resolution(
+            child_id,
+            &request_id,
+            record,
+            "delivery_failed",
+            Some("child_disconnected"),
+        );
+    }
+}
+
+pub fn expire_pending_approval(child_id: &str, request_id: &str) -> bool {
+    let record = pending()
+        .lock()
+        .recover_poison()
+        .remove(&(child_id.to_string(), request_id.to_string()));
+    let Some(record) = record else {
+        return false;
+    };
+    emit_resolution(
+        child_id,
+        request_id,
+        record,
+        "expired",
+        Some("approval_timeout"),
+    );
+    true
+}
+
+fn emit_resolution(
+    child_id: &str,
+    request_id: &str,
+    record: PendingApproval,
+    status: &str,
+    reason: Option<&str>,
+) {
+    let now = chrono::Utc::now();
+    let event = AgentEvent::ChildApprovalChanged {
+        parent_session_id: record.parent_session_id,
+        child_session_id: child_id.to_string(),
+        request_id: request_id.to_string(),
+        version: (now.timestamp_micros().max(0) as u64).max(record.version.saturating_add(1)),
+        status: status.to_string(),
+        reason: reason.map(str::to_string),
+        tool_name: record.tool_name,
+        permission: record.permission,
+        resource: record.resource,
+        created_at: record.created_at,
+        resolved_at: Some(now.to_rfc3339()),
+    };
+    match record.event_tx.try_send(event) {
+        Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
+        Err(mpsc::error::TrySendError::Full(event)) => {
+            let tx = record.event_tx;
+            tokio::spawn(async move {
+                let _ = tx.send(event).await;
+            });
+        }
+    }
 }
 
 /// Validated external entry point: deliver an approval decision ONLY if the
@@ -72,11 +181,31 @@ pub fn clear_pending_approvals_for(child_id: &str) {
 /// (model-review / escalation) that never registered. This is the entry the
 /// external HTTP handler must use.
 pub fn deliver_approval_checked(child_id: &str, request_id: &str, approved: bool) -> bool {
-    if take_pending_approval(child_id, request_id) {
-        deliver_approval(child_id, request_id, approved)
+    let record = pending()
+        .lock()
+        .recover_poison()
+        .remove(&(child_id.to_string(), request_id.to_string()));
+    let Some(record) = record else {
+        return false;
+    };
+    let delivered = deliver_approval(child_id, request_id, approved);
+    let status = if delivered {
+        if approved {
+            "approved"
+        } else {
+            "denied"
+        }
     } else {
-        false
-    }
+        "delivery_failed"
+    };
+    emit_resolution(
+        child_id,
+        request_id,
+        record,
+        status,
+        (!delivered).then_some("child_not_live"),
+    );
+    delivered
 }
 
 /// Unregisters the child on drop, so a panicking/returning runner can't leak
@@ -242,5 +371,64 @@ mod tests {
         clear_pending_approvals_for("c-clear");
         assert!(!take_pending_approval("c-clear", "req-a"));
         assert!(!take_pending_approval("c-clear", "req-b"));
+    }
+
+    #[tokio::test]
+    async fn observed_approval_emits_exactly_one_terminal_outcome() {
+        let (wire_tx, _wire_rx) = mpsc::unbounded_channel();
+        let _guard = register("c-audit", wire_tx);
+        let (event_tx, mut event_rx) = mpsc::channel(8);
+        register_pending_approval_observed(
+            "parent-audit",
+            "c-audit",
+            "req-audit",
+            "Bash",
+            "execute",
+            "/tmp/x",
+            event_tx,
+        );
+
+        assert!(deliver_approval_checked("c-audit", "req-audit", false));
+        assert!(!deliver_approval_checked("c-audit", "req-audit", true));
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(AgentEvent::ChildApprovalChanged { status, .. }) if status == "denied"
+        ));
+        assert!(event_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn timeout_and_disconnect_emit_terminal_outcomes() {
+        let (event_tx, mut event_rx) = mpsc::channel(8);
+        register_pending_approval_observed(
+            "parent-audit",
+            "c-expire",
+            "req-expire",
+            "Bash",
+            "execute",
+            "/tmp/x",
+            event_tx.clone(),
+        );
+        assert!(expire_pending_approval("c-expire", "req-expire"));
+        assert!(!expire_pending_approval("c-expire", "req-expire"));
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(AgentEvent::ChildApprovalChanged { status, .. }) if status == "expired"
+        ));
+
+        register_pending_approval_observed(
+            "parent-audit",
+            "c-disconnect",
+            "req-disconnect",
+            "Write",
+            "write",
+            "/tmp/y",
+            event_tx,
+        );
+        clear_pending_approvals_for("c-disconnect");
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(AgentEvent::ChildApprovalChanged { status, .. }) if status == "delivery_failed"
+        ));
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/execution/event_forwarder.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/event_forwarder.rs
@@ -28,8 +28,37 @@ pub type AccountFeedInbox = mpsc::Sender<(Option<String>, AgentEvent)>;
 fn mirror_to_account_feed(inbox: &Option<AccountFeedInbox>, session_id: &str, event: &AgentEvent) {
     if let Some(inbox) = inbox {
         if event.is_durable_change() {
-            let _ = inbox.try_send((Some(session_id.to_string()), event.clone()));
+            let route_session_id = event.session_id().unwrap_or(session_id);
+            let _ = inbox.try_send((Some(route_session_id.to_string()), event.clone()));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn child_approval_change_routes_to_parent_account_envelope() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let event = AgentEvent::ChildApprovalChanged {
+            parent_session_id: "parent-1".into(),
+            child_session_id: "child-1".into(),
+            request_id: "req-1".into(),
+            version: 2,
+            status: "approved".into(),
+            reason: None,
+            tool_name: "Bash".into(),
+            permission: "execute".into(),
+            resource: "/tmp/x".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            resolved_at: Some("2026-01-01T00:00:01Z".into()),
+        };
+
+        mirror_to_account_feed(&Some(tx), "child-1", &event);
+        let (session_id, mirrored) = rx.recv().await.unwrap();
+        assert_eq!(session_id.as_deref(), Some("parent-1"));
+        assert!(matches!(mirrored, AgentEvent::ChildApprovalChanged { .. }));
     }
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of #592:

- add durable `child_approval_changed` events for pending, approved, denied, expired, and delivery_failed
- correlate parent, child, request, tool/resource, timestamps, and monotonic per-request version
- guarantee pending-before-request and exactly one terminal outcome across decision, timeout, disconnect, and delivery failure paths
- parent-route approval events through both server and engine account-feed forwarders
- include request/change in critical replay while keeping heartbeat liveness-only

This PR intentionally does **not** close #592.

## Known Phase 2 Gap

The deliverable pending-approval registry remains process-memory. A server crash between pending and terminal cannot yet reconstruct the request or synthesize a terminal outcome. Authoritative pending snapshot/persistence and boot reconciliation remain in #592.

## Test Plan

- `cargo fmt --check`
- `cargo check -p bamboo-engine -p bamboo-server`
- registry one-shot/idempotency/approve-deny/timeout/disconnect tests
- core serde/durability/routing tests
- engine parent-envelope routing test
- server persisted journal-envelope test
