### PR TITLE
[bamboo] feat: discover agents skills and scoped instructions

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/system_prompt.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/system_prompt.rs
@@ -138,6 +138,7 @@ mod tests {
 
         let root = tempfile::tempdir().expect("temp dir");
         let workspace = root.path().join("workspace");
+        std::fs::create_dir_all(root.path().join(".git")).expect("git marker");
         std::fs::create_dir_all(&workspace).expect("workspace dir");
         std::fs::write(root.path().join("AGENTS.md"), "Snapshot instruction policy")
             .expect("agents file");

--- a/crates/engine/bamboo-engine/src/runtime/context/instruction.rs
+++ b/crates/engine/bamboo-engine/src/runtime/context/instruction.rs
@@ -1,5 +1,6 @@
 //! Instruction layer: loads instruction files (AGENTS.md, CLAUDE.md) from workspace.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use bamboo_config::paths;
@@ -18,7 +19,28 @@ pub struct InstructionFile {
 }
 
 fn read_trimmed_file(path: &Path) -> Option<String> {
-    let bytes = std::fs::read(path).ok()?;
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(error) => {
+            tracing::warn!("Failed to inspect instruction file {:?}: {}", path, error);
+            return None;
+        }
+    };
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        tracing::warn!(
+            "Ignoring non-regular or symlinked instruction file: {:?}",
+            path
+        );
+        return None;
+    }
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            tracing::warn!("Failed to read instruction file {:?}: {}", path, error);
+            return None;
+        }
+    };
     let truncated = if bytes.len() > MAX_INSTRUCTION_BYTES_PER_FILE {
         &bytes[..MAX_INSTRUCTION_BYTES_PER_FILE]
     } else {
@@ -37,14 +59,20 @@ fn canonical_dir_or_self(path: &Path) -> Option<PathBuf> {
     std::fs::canonicalize(candidate).ok()
 }
 
-fn ancestor_dirs(start: &Path) -> Vec<PathBuf> {
-    let mut dirs = Vec::new();
+fn scoped_dirs(start: &Path) -> Vec<PathBuf> {
+    let mut leaf_to_root = Vec::new();
     let Some(mut current) = canonical_dir_or_self(start) else {
-        return dirs;
+        return leaf_to_root;
     };
+    let canonical_start = current.clone();
+    let mut found_workspace_boundary = false;
 
     loop {
-        dirs.push(current.clone());
+        leaf_to_root.push(current.clone());
+        if current.join(".git").exists() {
+            found_workspace_boundary = true;
+            break;
+        }
         let Some(parent) = current.parent() else {
             break;
         };
@@ -53,16 +81,23 @@ fn ancestor_dirs(start: &Path) -> Vec<PathBuf> {
         }
         current = parent.to_path_buf();
     }
-
-    dirs
+    if !found_workspace_boundary {
+        return vec![canonical_start];
+    }
+    leaf_to_root.reverse();
+    leaf_to_root
 }
 
 pub fn collect_instruction_files(workspace_path: &Path) -> Vec<InstructionFile> {
     let mut files = Vec::new();
 
-    for dir in ancestor_dirs(workspace_path) {
+    let mut seen = HashSet::new();
+    for dir in scoped_dirs(workspace_path) {
         for file_name in INSTRUCTION_FILE_NAMES {
             let candidate = dir.join(file_name);
+            if !seen.insert(candidate.clone()) {
+                continue;
+            }
             let Some(content) = read_trimmed_file(&candidate) else {
                 continue;
             };
@@ -119,6 +154,7 @@ mod tests {
     fn build_instruction_prompt_context_collects_workspace_and_ancestor_files() {
         let root = tempfile::tempdir().expect("temp dir");
         let nested = root.path().join("nested/project");
+        std::fs::create_dir_all(root.path().join(".git")).expect("git marker");
         std::fs::create_dir_all(&nested).expect("nested dir");
         std::fs::write(root.path().join("AGENTS.md"), "root agents").expect("agents");
         std::fs::write(root.path().join("CLAUDE.md"), "root claude").expect("claude");
@@ -137,5 +173,49 @@ mod tests {
     fn build_instruction_prompt_context_returns_none_when_no_files_exist() {
         let root = tempfile::tempdir().expect("temp dir");
         assert!(build_instruction_prompt_context(root.path().to_string_lossy().as_ref()).is_none());
+    }
+
+    #[test]
+    fn instructions_are_root_to_leaf_and_stop_at_git_workspace_boundary() {
+        let outer = tempfile::tempdir().expect("temp dir");
+        std::fs::write(outer.path().join("AGENTS.md"), "outside").expect("outside");
+        let repo = outer.path().join("repo");
+        let nested = repo.join("src/feature");
+        std::fs::create_dir_all(repo.join(".git")).expect("git marker");
+        std::fs::create_dir_all(&nested).expect("nested");
+        std::fs::write(repo.join("AGENTS.md"), "root rule").expect("root");
+        std::fs::write(repo.join("src/AGENTS.md"), "nested rule").expect("nested rule");
+
+        let files = collect_instruction_files(&nested);
+        let contents: Vec<_> = files.iter().map(|file| file.content.as_str()).collect();
+        assert_eq!(contents, vec!["root rule", "nested rule"]);
+        assert!(files.iter().all(|file| !file.content.contains("outside")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_instruction_file_is_not_followed() {
+        use std::os::unix::fs::symlink;
+        let root = tempfile::tempdir().expect("temp dir");
+        std::fs::create_dir_all(root.path().join(".git")).expect("git marker");
+        let outside = tempfile::NamedTempFile::new().expect("outside");
+        std::fs::write(outside.path(), "outside policy").expect("write outside");
+        symlink(outside.path(), root.path().join("AGENTS.md")).expect("symlink");
+        assert!(collect_instruction_files(root.path()).is_empty());
+    }
+
+    #[test]
+    fn git_worktree_file_is_a_workspace_boundary() {
+        let outer = tempfile::tempdir().expect("outer");
+        std::fs::write(outer.path().join("AGENTS.md"), "outside").expect("outside");
+        let worktree = outer.path().join(".bamboo/worktree/task");
+        std::fs::create_dir_all(worktree.join("src")).expect("worktree");
+        std::fs::write(worktree.join(".git"), "gitdir: /repo/.git/worktrees/task")
+            .expect("git file");
+        std::fs::write(worktree.join("AGENTS.md"), "worktree root").expect("agents");
+
+        let files = collect_instruction_files(&worktree.join("src"));
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].content, "worktree root");
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
@@ -501,6 +501,7 @@ fn apply_system_prompt_contexts_persists_runtime_prompt_metadata() {
 
     let root = tempfile::tempdir().expect("temp dir");
     let workspace = root.path().join("project");
+    std::fs::create_dir_all(root.path().join(".git")).expect("git marker");
     std::fs::create_dir_all(&workspace).expect("workspace dir");
     std::fs::write(root.path().join("AGENTS.md"), "Workspace policy").expect("agents file");
 

--- a/crates/infra/bamboo-config/src/paths.rs
+++ b/crates/infra/bamboo-config/src/paths.rs
@@ -67,6 +67,11 @@ pub fn bamboo_dir_display() -> String {
     path_to_display_string(&bamboo_dir())
 }
 
+/// Conventional cross-agent skill directory (`~/.agents/skills`).
+pub fn agents_skills_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".agents").join("skills"))
+}
+
 /// Get config.json path (in data directory)
 pub fn config_json_path() -> PathBuf {
     bamboo_dir().join("config.json")

--- a/crates/infra/bamboo-skills/src/store/mod.rs
+++ b/crates/infra/bamboo-skills/src/store/mod.rs
@@ -165,6 +165,19 @@ impl SkillStore {
         let mut dirs = Vec::new();
         let active_mode = self.effective_mode(mode_override);
 
+        // Enable the conventional user-level source for the production store.
+        // Custom/test stores remain hermetic instead of reading the developer's
+        // real home directory unexpectedly.
+        if self.config.skills_dir == bamboo_config::paths::bamboo_dir().join("skills") {
+            if let Some(dir) = bamboo_config::paths::agents_skills_dir() {
+                dirs.push(SkillDiscoveryDir {
+                    dir,
+                    source: SkillDirectorySource::Agents,
+                    mode: None,
+                });
+            }
+        }
+
         dirs.push(SkillDiscoveryDir {
             dir: self.config.skills_dir.clone(),
             source: SkillDirectorySource::Global,
@@ -220,7 +233,7 @@ impl SkillStore {
                 // plugins, or two dirs at the same precedence, shipping the
                 // same skill id) — the winner is decided only by discovery
                 // order, so surface it at WARN. Legitimate precedence
-                // overrides (project > global > plugin, or mode-specific >
+                // overrides (project > Bamboo global > ~/.agents > plugin, or mode-specific >
                 // generic) are expected and stay at debug.
                 let existing_meta = resolved_meta.get(&skill_id);
                 let is_ambiguous_collision = existing_meta.is_some_and(|existing| {
@@ -275,7 +288,8 @@ impl SkillStore {
     }
 
     /// Precedence rank: higher wins when two discovery dirs provide the same
-    /// skill id. Plugin-provided skills sit BELOW both Global and Project so
+    /// skill id. `~/.agents` augments Bamboo without shadowing Bamboo-owned
+    /// global/project definitions; plugin skills remain the lowest tier.
     /// an installed plugin can never silently shadow a user's own global or
     /// project skill of the same id; within the same source tier, a
     /// mode-specific candidate still overrides a generic one (unchanged from
@@ -283,8 +297,9 @@ impl SkillStore {
     fn source_rank(source: SkillDirectorySource) -> u8 {
         match source {
             SkillDirectorySource::Plugin => 0,
-            SkillDirectorySource::Global => 1,
-            SkillDirectorySource::Project => 2,
+            SkillDirectorySource::Agents => 1,
+            SkillDirectorySource::Global => 2,
+            SkillDirectorySource::Project => 3,
         }
     }
 
@@ -918,8 +933,28 @@ mod tests {
 
     use tokio::fs;
 
-    use super::SkillStore;
+    use super::{SkillCandidateMeta, SkillStore};
+    use crate::store::storage::SkillDirectorySource;
     use crate::types::SkillStoreConfig;
+
+    #[test]
+    fn agents_skill_precedence_is_below_bamboo_global_and_above_plugin() {
+        let agents = SkillCandidateMeta {
+            source: SkillDirectorySource::Agents,
+            mode: None,
+        };
+        let global = SkillCandidateMeta {
+            source: SkillDirectorySource::Global,
+            mode: None,
+        };
+        let plugin = SkillCandidateMeta {
+            source: SkillDirectorySource::Plugin,
+            mode: None,
+        };
+        assert!(SkillStore::should_override_skill(&agents, &global));
+        assert!(SkillStore::should_override_skill(&plugin, &agents));
+        assert!(!SkillStore::should_override_skill(&global, &agents));
+    }
 
     async fn write_skill(
         skills_root: &Path,

--- a/crates/infra/bamboo-skills/src/store/storage.rs
+++ b/crates/infra/bamboo-skills/src/store/storage.rs
@@ -8,6 +8,8 @@ use crate::types::{SkillDefinition, SkillResult};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SkillDirectorySource {
+    /// Cross-agent user skills discovered from `~/.agents/skills`.
+    Agents,
     Global,
     Project,
     /// `~/.bamboo/plugins/<plugin-id>/skills` — an installed plugin's skills,
@@ -37,24 +39,57 @@ pub async fn ensure_skills_dir(skills_dir: &Path) -> SkillResult<()> {
 }
 
 /// Recursively find all SKILL.md files in the skills directory
-async fn find_skill_files(dir: &Path) -> SkillResult<Vec<PathBuf>> {
+async fn find_skill_files(dir: &Path) -> Vec<PathBuf> {
     let mut skill_files = Vec::new();
-    let mut entries = fs::read_dir(dir).await?;
+    let mut entries = match fs::read_dir(dir).await {
+        Ok(entries) => entries,
+        Err(error) => {
+            warn!("Failed to read skill directory {:?}: {}", dir, error);
+            return skill_files;
+        }
+    };
 
-    while let Some(entry) = entries.next_entry().await? {
+    loop {
+        let entry = match entries.next_entry().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(error) => {
+                warn!("Failed while scanning skill directory {:?}: {}", dir, error);
+                break;
+            }
+        };
         let path = entry.path();
-
-        if path.is_dir() {
+        // Never follow directory symlinks: an external tree must not become
+        // part of skill discovery merely because it is linked below a root.
+        let is_real_dir = entry
+            .file_type()
+            .await
+            .map(|kind| kind.is_dir() && !kind.is_symlink())
+            .unwrap_or(false);
+        if is_real_dir {
             // Check if this directory contains SKILL.md
             let skill_file = path.join("SKILL.md");
             match fs::try_exists(&skill_file).await {
                 Ok(true) => {
-                    skill_files.push(skill_file);
+                    let is_regular_file = fs::symlink_metadata(&skill_file)
+                        .await
+                        .map(|metadata| {
+                            metadata.file_type().is_file() && !metadata.file_type().is_symlink()
+                        })
+                        .unwrap_or(false);
+                    if is_regular_file {
+                        skill_files.push(skill_file);
+                    } else {
+                        warn!(
+                            "Ignoring symlinked or non-regular skill file: {:?}",
+                            skill_file
+                        );
+                    }
                     continue; // Don't recurse into skill directories
                 }
                 Ok(false) => {
                     // Not a skill directory, recurse into it
-                    let sub_skills = Box::pin(find_skill_files(&path)).await?;
+                    let sub_skills = Box::pin(find_skill_files(&path)).await;
                     skill_files.extend(sub_skills);
                 }
                 Err(_) => {
@@ -64,7 +99,7 @@ async fn find_skill_files(dir: &Path) -> SkillResult<Vec<PathBuf>> {
         }
     }
 
-    Ok(skill_files)
+    skill_files
 }
 
 pub async fn load_skills_from_discovery_dirs(
@@ -98,7 +133,7 @@ pub async fn load_skills_from_discovery_dirs(
             discovery.mode.as_deref().unwrap_or("generic")
         );
 
-        let skill_files = find_skill_files(&discovery.dir).await?;
+        let skill_files = find_skill_files(&discovery.dir).await;
         for skill_file in skill_files {
             match fs::read_to_string(&skill_file).await {
                 Ok(content) => match parse_markdown_skill(&skill_file, &content) {
@@ -203,4 +238,62 @@ pub async fn write_skill_file(skills_dir: &Path, skill: &SkillDefinition) -> Ski
     let content = render_skill_markdown(skill)?;
     fs::write(path, content).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_skill(name: &str) -> String {
+        format!("---\nname: {name}\ndescription: test skill\n---\n\nFollow this skill.")
+    }
+
+    #[tokio::test]
+    async fn agents_source_recurses_and_bad_skill_does_not_block_good_skill() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let good = root.path().join("vendor/good");
+        let bad = root.path().join("bad");
+        fs::create_dir_all(&good).await.expect("good dir");
+        fs::create_dir_all(&bad).await.expect("bad dir");
+        fs::write(good.join("SKILL.md"), valid_skill("good"))
+            .await
+            .expect("good skill");
+        fs::write(bad.join("SKILL.md"), "not valid frontmatter")
+            .await
+            .expect("bad skill");
+
+        let records = load_skills_from_discovery_dirs(&[SkillDiscoveryDir {
+            dir: root.path().to_path_buf(),
+            source: SkillDirectorySource::Agents,
+            mode: None,
+        }])
+        .await
+        .expect("discovery survives invalid skill");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].skill.id, "good");
+        assert_eq!(records[0].source, SkillDirectorySource::Agents);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn agents_source_does_not_follow_directory_symlinks() {
+        use std::os::unix::fs::symlink;
+        let root = tempfile::tempdir().expect("root");
+        let outside = tempfile::tempdir().expect("outside");
+        let skill = outside.path().join("escaped");
+        fs::create_dir_all(&skill).await.expect("skill dir");
+        fs::write(skill.join("SKILL.md"), valid_skill("escaped"))
+            .await
+            .expect("skill");
+        symlink(outside.path(), root.path().join("linked")).expect("symlink");
+
+        let records = load_skills_from_discovery_dirs(&[SkillDiscoveryDir {
+            dir: root.path().to_path_buf(),
+            source: SkillDirectorySource::Agents,
+            mode: None,
+        }])
+        .await
+        .expect("discovery");
+        assert!(records.is_empty());
+    }
 }

--- a/docs/skills-and-project-instructions.md
+++ b/docs/skills-and-project-instructions.md
@@ -1,0 +1,21 @@
+# Skills and project instructions
+
+Bamboo rescans skills when its skill store starts or is explicitly refreshed. Sources use this
+precedence when the same skill id appears more than once (highest first):
+
+1. `<workspace>/.bamboo/skills[-<mode>]`
+2. `~/.bamboo/skills[-<mode>]`
+3. `~/.agents/skills/**/SKILL.md`
+4. installed plugin skills
+
+Mode-specific Bamboo directories override their generic sibling. Same-tier collisions keep the
+first deterministic discovery result and emit a warning. Invalid, unreadable, or missing skills
+are logged and skipped without preventing other skills from loading. Discovery never follows
+directory symlinks.
+
+For repository instructions Bamboo finds the nearest Git workspace boundary and reads applicable
+`AGENTS.md` and `CLAUDE.md` files from that root down to the active workspace directory. Root rules
+are injected first and deeper rules later, so the most specific scope can refine the repository
+defaults. Files above the Git workspace and symlinked instruction files are ignored. A Git worktree
+has its own `.git` boundary and receives the same checked-out repository instructions. This context
+is assembled by the shared runtime prompt path used by both primary and child agents.


### PR DESCRIPTION
## Summary
- discover ~/.agents/skills/**/SKILL.md through the existing skill registry
- define deterministic precedence: project > Bamboo global > agents > plugins
- isolate malformed/unreadable sources and refuse skill/instruction symlinks
- scope AGENTS.md and CLAUDE.md from the nearest Git/worktree boundary root to leaf
- document refresh, precedence, boundaries, and primary/child prompt injection

Closes #587

## Test Plan
- cargo test -p bamboo-skills (64 passed)
- cargo test -p bamboo-engine runtime::context::instruction (5 passed)
- cargo check -p bamboo-engine
- cargo fmt --check
- git diff --check