### PR TITLE
[bamboo] fix: preserve workspace path in session index

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
@@ -208,6 +208,10 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::CREATED);
         let body: Value = test::read_body_json(resp).await;
+        assert_eq!(
+            body["session"]["workspace_path"].as_str(),
+            Some(workspace_path.as_str())
+        );
         let session_id = body["session"]["id"]
             .as_str()
             .expect("session id")
@@ -221,6 +225,34 @@ mod tests {
             .expect("session exists");
         assert_eq!(
             session.workspace_path_meta().as_deref(),
+            Some(workspace_path.as_str())
+        );
+
+        let list_resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/v1/sessions")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(list_resp.status(), StatusCode::OK);
+        let list_body: Value = test::read_body_json(list_resp).await;
+        assert_eq!(
+            list_body["sessions"][0]["workspace_path"].as_str(),
+            Some(workspace_path.as_str())
+        );
+
+        let detail_resp = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/api/v1/sessions/{session_id}"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(detail_resp.status(), StatusCode::OK);
+        let detail_body: Value = test::read_body_json(detail_resp).await;
+        assert_eq!(
+            detail_body["session"]["workspace_path"].as_str(),
             Some(workspace_path.as_str())
         );
     }

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/tests.rs
@@ -21,6 +21,7 @@ fn session_summary_from_entry_includes_last_run_fields() {
         model: "gpt-4o".to_string(),
         model_ref: None,
         reasoning_effort: Some(ReasoningEffort::High),
+        workspace_path: Some("/workspaces/zenith".to_string()),
         gold_config_json: None,
         created_by_schedule_id: None,
         schedule_run_id: Some("run-123".to_string()),
@@ -45,6 +46,10 @@ fn session_summary_from_entry_includes_last_run_fields() {
     assert_eq!(summary.last_run_status.as_deref(), Some("completed"));
     assert_eq!(summary.last_run_error, None);
     assert_eq!(summary.schedule_run_id.as_deref(), Some("run-123"));
+    assert_eq!(
+        summary.workspace_path.as_deref(),
+        Some("/workspaces/zenith")
+    );
     assert_eq!(summary.subagent_type, None);
     assert!(summary.has_pending_question);
     assert_eq!(summary.running_child_count, 0);
@@ -66,6 +71,7 @@ fn session_summary_from_entry_propagates_subagent_type() {
         model: "gpt-4o".to_string(),
         model_ref: None,
         reasoning_effort: None,
+        workspace_path: None,
         gold_config_json: None,
         created_by_schedule_id: None,
         schedule_run_id: None,

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/types.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/types.rs
@@ -25,6 +25,8 @@ pub struct SessionSummary {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<ReasoningEffort>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub created_by_schedule_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub schedule_run_id: Option<String>,
@@ -96,6 +98,7 @@ impl SessionSummary {
             model_ref: entry.model_ref,
             provider: None,
             reasoning_effort: entry.reasoning_effort,
+            workspace_path: entry.workspace_path,
             created_by_schedule_id: entry.created_by_schedule_id,
             schedule_run_id: entry.schedule_run_id,
             created_at: entry.created_at,
@@ -437,6 +440,7 @@ mod tests {
             model_ref: None,
             provider: None,
             reasoning_effort: Some(ReasoningEffort::Medium),
+            workspace_path: Some("/workspaces/zenith".to_string()),
             created_by_schedule_id: None,
             schedule_run_id: None,
             created_at: Utc::now(),
@@ -462,6 +466,7 @@ mod tests {
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("\"session\""));
         assert!(json.contains("\"test-id\""));
+        assert!(json.contains("\"workspace_path\":\"/workspaces/zenith\""));
     }
 
     #[test]
@@ -481,6 +486,7 @@ mod tests {
             model_ref: None,
             provider: None,
             reasoning_effort: None,
+            workspace_path: Some("/workspaces/zenith".to_string()),
             created_by_schedule_id: None,
             schedule_run_id: None,
             created_at: Utc::now(),
@@ -612,6 +618,7 @@ mod tests {
             model_ref: None,
             provider: None,
             reasoning_effort: Some(ReasoningEffort::Low),
+            workspace_path: None,
             created_by_schedule_id: None,
             schedule_run_id: None,
             created_at: Utc::now(),

--- a/crates/infra/bamboo-storage/src/v2.rs
+++ b/crates/infra/bamboo-storage/src/v2.rs
@@ -123,6 +123,9 @@ pub struct SessionIndexEntry {
     pub model_ref: Option<ProviderModelRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<ReasoningEffort>,
+    /// Workspace path mirrored from the session's typed runtime metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_path: Option<String>,
     /// Raw session-level Gold config JSON mirrored from `session.metadata["gold_config"]`.
     /// Kept as a string here to avoid making infrastructure depend on bamboo-engine.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -202,7 +205,7 @@ pub struct SessionsIndex {
 impl SessionsIndex {
     fn empty() -> Self {
         Self {
-            version: 2,
+            version: 3,
             updated_at: Utc::now(),
             sessions: HashMap::new(),
         }
@@ -246,7 +249,20 @@ impl SessionStoreV2 {
         let index = if index_path.exists() {
             let raw = fs::read_to_string(&index_path).await?;
             match serde_json::from_str::<SessionsIndex>(&raw) {
-                Ok(index) => index,
+                Ok(index) if index.version >= 3 => index,
+                Ok(index) => {
+                    tracing::info!(
+                        "migrating sessions index from version {} to version 3 by rebuilding from session.json",
+                        index.version
+                    );
+                    needs_rebuild = true;
+                    let mut rebuilding = SessionsIndex::empty();
+                    // Keep an old-version marker on every incremental rebuild
+                    // persist. If the process crashes mid-scan, the next boot
+                    // must resume instead of accepting a partial v3 index.
+                    rebuilding.version = index.version.min(2);
+                    rebuilding
+                }
                 Err(error) => {
                     // Best-effort backup so the corrupt bytes are preserved for
                     // forensics but no longer block the (about to be rebuilt)
@@ -270,7 +286,9 @@ impl SessionStoreV2 {
                         ),
                     }
                     needs_rebuild = true;
-                    SessionsIndex::empty()
+                    let mut rebuilding = SessionsIndex::empty();
+                    rebuilding.version = 0;
+                    rebuilding
                 }
             }
         } else {
@@ -418,7 +436,13 @@ impl SessionStoreV2 {
         // Re-materialize sessions.json even when nothing was recovered (we may
         // have renamed the only copy to sessions.json.bak), so the "index file
         // always exists after boot" invariant holds.
-        self.update_index(|_| Ok(())).await?;
+        self.update_index(|index| {
+            // Publishing version 3 is the commit point for a complete rebuild.
+            // `persist_index_locked` writes a temp file and atomically renames it.
+            index.version = 3;
+            Ok(())
+        })
+        .await?;
 
         tracing::info!("index rebuild from disk complete: recovered {recovered} session(s)");
 
@@ -790,6 +814,10 @@ impl SessionStoreV2 {
             .metadata
             .get("placement")
             .and_then(|v| serde_json::from_str::<SessionPlacement>(v).ok());
+        let workspace_path = session
+            .workspace_path_meta()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
         self.update_index(|index| {
             index.sessions.insert(
                 session.id.clone(),
@@ -806,6 +834,7 @@ impl SessionStoreV2 {
                     model: session.model.clone(),
                     model_ref: session.model_ref.clone(),
                     reasoning_effort: session.reasoning_effort,
+                    workspace_path,
                     gold_config_json,
                     created_by_schedule_id,
                     schedule_run_id,
@@ -1303,7 +1332,30 @@ impl Storage for SessionStoreV2 {
             return self.save_session(session).await;
         };
         let abs_dir = self.abs_path_from_rel(&rel);
-        self.write_runtime_sidecar(&abs_dir, session).await
+        self.write_runtime_sidecar(&abs_dir, session).await?;
+
+        // Workspace ownership is part of the list/index API contract. Runtime
+        // workspace updates must therefore be reflected without waiting for a
+        // later full session save. Avoid rewriting the global index when the
+        // normalized value did not change.
+        let workspace_path = session
+            .workspace_path_meta()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let workspace_changed = self
+            .get_index_entry(&session.id)
+            .await
+            .is_some_and(|entry| entry.workspace_path != workspace_path);
+        if workspace_changed {
+            self.update_index(|index| {
+                if let Some(entry) = index.sessions.get_mut(&session.id) {
+                    entry.workspace_path = workspace_path;
+                }
+                Ok(())
+            })
+            .await?;
+        }
+        Ok(())
     }
 
     async fn load_runtime_control_plane(&self, session_id: &str) -> io::Result<Option<Session>> {
@@ -1692,6 +1744,108 @@ mod tests {
             "a fresh sessions.json must be written after rebuild"
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn v2_index_migrates_workspace_paths_from_root_and_child_sessions() -> io::Result<()> {
+        let temp_dir = TempDir::new().map_err(io::Error::other)?;
+        let bamboo_home = temp_dir.path().to_path_buf();
+
+        {
+            let storage = SessionStoreV2::new(bamboo_home.clone()).await?;
+            let mut root = Session::new("workspace-root", "m");
+            root.set_workspace_path_meta("  /workspaces/root  ");
+            storage.save_session(&root).await?;
+
+            let mut child = Session::new_child_of("workspace-child", &root, "m", "child");
+            child.set_workspace_path_meta("/workspaces/child");
+            storage.save_session(&child).await?;
+
+            let legacy_without_workspace = Session::new("workspace-missing", "m");
+            storage.save_session(&legacy_without_workspace).await?;
+
+            // A malformed sibling must not prevent recovery of intact sessions.
+            let broken_dir = bamboo_home.join("sessions/broken");
+            tokio::fs::create_dir_all(&broken_dir).await?;
+            tokio::fs::write(broken_dir.join("session.json"), b"{ invalid json").await?;
+        }
+
+        let index_path = bamboo_home.join("sessions.json");
+        let mut legacy: serde_json::Value =
+            serde_json::from_slice(&tokio::fs::read(&index_path).await?)
+                .map_err(|error| other_io_error(error.to_string()))?;
+        legacy["version"] = serde_json::json!(2);
+        for entry in legacy["sessions"]
+            .as_object_mut()
+            .expect("sessions object")
+            .values_mut()
+        {
+            entry
+                .as_object_mut()
+                .expect("entry")
+                .remove("workspace_path");
+        }
+        tokio::fs::write(
+            &index_path,
+            serde_json::to_vec_pretty(&legacy)
+                .map_err(|error| other_io_error(error.to_string()))?,
+        )
+        .await?;
+
+        let migrated = SessionStoreV2::new(bamboo_home.clone()).await?;
+        assert_eq!(
+            migrated
+                .get_index_entry("workspace-root")
+                .await
+                .and_then(|entry| entry.workspace_path),
+            Some("/workspaces/root".to_string())
+        );
+        assert_eq!(
+            migrated
+                .get_index_entry("workspace-child")
+                .await
+                .and_then(|entry| entry.workspace_path),
+            Some("/workspaces/child".to_string())
+        );
+        assert!(migrated.get_index_entry("broken").await.is_none());
+        assert_eq!(
+            migrated
+                .get_index_entry("workspace-missing")
+                .await
+                .and_then(|entry| entry.workspace_path),
+            None
+        );
+
+        let persisted: SessionsIndex = serde_json::from_slice(&tokio::fs::read(index_path).await?)
+            .map_err(|error| other_io_error(error.to_string()))?;
+        assert_eq!(persisted.version, 3);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn workspace_path_updates_index_on_full_and_runtime_only_saves() -> io::Result<()> {
+        let (storage, _temp_dir) = create_temp_storage().await?;
+        let mut session = Session::new("workspace-update", "m");
+        session.set_workspace_path_meta("  /workspaces/first  ");
+        storage.save_session(&session).await?;
+        assert_eq!(
+            storage
+                .get_index_entry(&session.id)
+                .await
+                .and_then(|entry| entry.workspace_path),
+            Some("/workspaces/first".to_string())
+        );
+
+        session.set_workspace_path_meta(" /workspaces/latest ");
+        storage.save_runtime_state(&session).await?;
+        assert_eq!(
+            storage
+                .get_index_entry(&session.id)
+                .await
+                .and_then(|entry| entry.workspace_path),
+            Some("/workspaces/latest".to_string())
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- add normalized workspace_path to session index entries and API summaries
- migrate v2/legacy indexes by rebuilding root and child sessions from authoritative session.json
- keep incremental rebuilds on the old version and atomically promote to v3 only after a complete scan
- synchronize runtime-only workspace changes into the index
- expose workspace_path through create, list, and detail responses

Closes #599

## Test Plan
- cargo test -p bamboo-storage (73 passed)
- cargo test -p bamboo-server handlers::agent::sessions (37 passed)
- cargo check -p bamboo-storage -p bamboo-server
- cargo fmt --check
- git diff --check