### PR TITLE
[bamboo] feat: add project-scoped markdown commands

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/prompt_presets/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/prompt_presets/mod.rs
@@ -12,7 +12,9 @@ pub use handlers::{
 // load/save/rename-on-collision logic the HTTP handlers use for prompt
 // presets, without a second implementation that could drift (see
 // PLUGIN_PLAN.md § Installer-core agent).
-pub(crate) use storage::{ensure_unique_preset_id, load_store, save_store, store_file_path};
+pub(crate) use storage::{
+    ensure_unique_preset_id, load_store, load_stored_presets, save_store, store_file_path,
+};
 pub(crate) use types::StoredPromptPreset;
 
 #[cfg(test)]

--- a/crates/app/bamboo-server/src/handlers/agent/prompt_presets/storage.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/prompt_presets/storage.rs
@@ -30,6 +30,12 @@ pub(crate) async fn load_store(path: &Path) -> Result<PromptPresetStore, AppErro
     Ok(store)
 }
 
+pub(crate) async fn load_stored_presets(
+    app_data_dir: &Path,
+) -> Result<Vec<StoredPromptPreset>, AppError> {
+    Ok(load_store(&store_file_path(app_data_dir)).await?.prompts)
+}
+
 /// # Non-atomic write (known, deferred gap)
 ///
 /// This writes `path` in place (`fs::write`), so a hard kill mid-write can

--- a/crates/app/bamboo-server/src/handlers/command/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/command/handlers.rs
@@ -1,18 +1,75 @@
+use std::collections::HashSet;
+
 use actix_web::{web, HttpResponse};
 
 use crate::app_state::AppState;
 use crate::error::AppError;
 use crate::handlers::settings::is_safe_workflow_name;
 
-use super::sources::{list_mcp_tools_as_commands, list_workflows_as_commands, skill_to_command};
-use super::types::CommandListResponse;
+use super::sources::{
+    list_markdown_commands, list_mcp_tools_as_commands, list_prompt_presets_as_commands,
+    list_workflows_as_commands, safe_project_commands_dir, skill_to_command,
+};
+use super::types::{CommandItem, CommandListResponse, GetCommandQuery, ListCommandsQuery};
+
+pub(super) fn append_unique(
+    commands: &mut Vec<CommandItem>,
+    seen: &mut HashSet<String>,
+    items: Vec<CommandItem>,
+) {
+    for item in items {
+        if seen.insert(item.name.clone()) {
+            commands.push(item);
+        }
+    }
+}
+
+pub(super) fn expand_arguments(template: &str, arguments: &str) -> String {
+    template.replace("$ARGUMENTS", arguments)
+}
 
 /// Lists all available commands from workflows, skills, and MCP tools.
-pub async fn list_commands(app_state: web::Data<AppState>) -> Result<HttpResponse, AppError> {
+pub async fn list_commands(
+    app_state: web::Data<AppState>,
+    query: web::Query<ListCommandsQuery>,
+) -> Result<HttpResponse, AppError> {
     let mut commands = Vec::new();
+    let mut seen = HashSet::new();
+
+    // Conflict precedence is deliberately source-based and stable:
+    // project markdown > global markdown > global preset > workflow > skill > MCP.
+    if let Some(workspace_path) = query
+        .workspace_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if let Some(dir) = safe_project_commands_dir(workspace_path) {
+            let project = list_markdown_commands(&dir, "project")
+                .await
+                .into_iter()
+                .map(|command| command.item)
+                .collect();
+            append_unique(&mut commands, &mut seen, project);
+        }
+    }
+
+    let global_dir = bamboo_config::paths::commands_dir_in(&app_state.app_data_dir);
+    let global = list_markdown_commands(&global_dir, "global")
+        .await
+        .into_iter()
+        .map(|command| command.item)
+        .collect();
+    append_unique(&mut commands, &mut seen, global);
+
+    append_unique(
+        &mut commands,
+        &mut seen,
+        list_prompt_presets_as_commands(&app_state.app_data_dir).await,
+    );
 
     match list_workflows_as_commands(&app_state.app_data_dir).await {
-        Ok(workflows) => commands.extend(workflows),
+        Ok(workflows) => append_unique(&mut commands, &mut seen, workflows),
         Err(error) => {
             tracing::warn!("Failed to load workflows: {error}");
         }
@@ -23,11 +80,14 @@ pub async fn list_commands(app_state: web::Data<AppState>) -> Result<HttpRespons
         .store()
         .list_skills(None, false)
         .await;
-    let skill_commands = skills.into_iter().map(|skill| skill_to_command(&skill));
-    commands.extend(skill_commands);
+    let skill_commands = skills
+        .into_iter()
+        .map(|skill| skill_to_command(&skill))
+        .collect();
+    append_unique(&mut commands, &mut seen, skill_commands);
 
     match list_mcp_tools_as_commands(app_state.get_ref()).await {
-        Ok(mcp_tools) => commands.extend(mcp_tools),
+        Ok(mcp_tools) => append_unique(&mut commands, &mut seen, mcp_tools),
         Err(error) => {
             tracing::warn!("Failed to load MCP tools: {error}");
         }
@@ -44,10 +104,62 @@ pub async fn list_commands(app_state: web::Data<AppState>) -> Result<HttpRespons
 pub async fn get_command(
     app_state: web::Data<AppState>,
     path: web::Path<(String, String)>,
+    query: web::Query<GetCommandQuery>,
 ) -> Result<HttpResponse, AppError> {
     let (command_type, id) = path.into_inner();
 
     match command_type.as_str() {
+        "prompt" => {
+            let mut sources = Vec::new();
+            if let Some(workspace_path) = query
+                .workspace_path
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                if let Some(dir) = safe_project_commands_dir(workspace_path) {
+                    sources.push((dir, "project"));
+                }
+            }
+            sources.push((
+                bamboo_config::paths::commands_dir_in(&app_state.app_data_dir),
+                "global",
+            ));
+
+            for (dir, source) in sources {
+                if let Some(command) = list_markdown_commands(&dir, source)
+                    .await
+                    .into_iter()
+                    .find(|command| command.item.name == id)
+                {
+                    let arguments = query.arguments.as_deref().unwrap_or_default();
+                    let content = expand_arguments(&command.content, arguments);
+                    return Ok(HttpResponse::Ok().json(serde_json::json!({
+                        "id": command.item.id,
+                        "name": command.item.name,
+                        "content": content,
+                        "type": "prompt",
+                        "metadata": command.item.metadata,
+                    })));
+                }
+            }
+            if let Some(preset) = list_prompt_presets_as_commands(&app_state.app_data_dir)
+                .await
+                .into_iter()
+                .find(|command| command.name == id)
+            {
+                let arguments = query.arguments.as_deref().unwrap_or_default();
+                let content = preset.metadata["prompt"].as_str().unwrap_or_default();
+                return Ok(HttpResponse::Ok().json(serde_json::json!({
+                    "id": preset.id,
+                    "name": preset.name,
+                    "content": expand_arguments(content, arguments),
+                    "type": "prompt",
+                    "metadata": preset.metadata,
+                })));
+            }
+            Err(AppError::NotFound(format!("Prompt command {id} not found")))
+        }
         "workflow" => {
             if !is_safe_workflow_name(&id) {
                 return Err(AppError::BadRequest("Invalid workflow name".to_string()));
@@ -89,6 +201,8 @@ pub async fn get_command(
 
 /// Configures command-related routes.
 pub fn config(cfg: &mut web::ServiceConfig) {
-    cfg.route("/commands", web::get().to(list_commands))
-        .route("/commands/{command_type}/{id}", web::get().to(get_command));
+    cfg.route("/commands", web::get().to(list_commands)).route(
+        "/commands/{command_type}/{id:.*}",
+        web::get().to(get_command),
+    );
 }

--- a/crates/app/bamboo-server/src/handlers/command/sources.rs
+++ b/crates/app/bamboo-server/src/handlers/command/sources.rs
@@ -1,10 +1,221 @@
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use crate::app_state::AppState;
 use crate::error::AppError;
 use bamboo_skills::types::SkillDefinition;
+use serde::Deserialize;
 
 use super::types::CommandItem;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct CommandFrontmatter {
+    description: Option<String>,
+    argument_hint: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct MarkdownCommand {
+    pub item: CommandItem,
+    pub content: String,
+}
+
+fn command_name(root: &Path, path: &Path) -> Option<String> {
+    let relative = path.strip_prefix(root).ok()?.with_extension("");
+    let mut parts = Vec::new();
+    for component in relative.components() {
+        let Component::Normal(part) = component else {
+            return None;
+        };
+        let part = part.to_str()?.trim();
+        if part.is_empty() || part == "." || part == ".." {
+            return None;
+        }
+        parts.push(part);
+    }
+    (!parts.is_empty()).then(|| parts.join("/"))
+}
+
+fn parse_command_markdown(raw: &str) -> (CommandFrontmatter, String) {
+    let normalized = raw.strip_prefix('\u{feff}').unwrap_or(raw);
+    let normalized_storage;
+    let normalized = if normalized.contains("\r\n") {
+        normalized_storage = normalized.replace("\r\n", "\n");
+        normalized_storage.as_str()
+    } else {
+        normalized
+    };
+    if let Some(rest) = normalized.strip_prefix("---\n") {
+        if let Some((frontmatter, body)) = rest.split_once("\n---\n") {
+            match serde_yaml::from_str::<CommandFrontmatter>(frontmatter) {
+                Ok(metadata) => return (metadata, body.trim().to_string()),
+                Err(error) => {
+                    tracing::warn!("Ignoring invalid command frontmatter: {error}");
+                    return (CommandFrontmatter::default(), body.trim().to_string());
+                }
+            }
+        }
+    }
+    (CommandFrontmatter::default(), normalized.trim().to_string())
+}
+
+pub(super) fn safe_project_commands_dir(workspace_path: &str) -> Option<PathBuf> {
+    let workspace = Path::new(workspace_path);
+    if !workspace.is_absolute() {
+        tracing::warn!("Ignoring relative workspace_path for command discovery");
+        return None;
+    }
+    let workspace = std::fs::canonicalize(workspace).ok()?;
+    if !workspace.is_dir() {
+        return None;
+    }
+    // A session may work in a repository subdirectory. Resolve `<project>` as
+    // the nearest Git boundary; linked worktrees use a regular `.git` file.
+    let mut project = workspace.clone();
+    let mut cursor = workspace.as_path();
+    loop {
+        let marker = cursor.join(".git");
+        let is_git_boundary = std::fs::symlink_metadata(&marker)
+            .map(|metadata| {
+                !metadata.file_type().is_symlink()
+                    && (metadata.file_type().is_dir() || metadata.file_type().is_file())
+            })
+            .unwrap_or(false);
+        if is_git_boundary {
+            project = cursor.to_path_buf();
+            break;
+        }
+        let Some(parent) = cursor.parent() else {
+            break;
+        };
+        cursor = parent;
+    }
+    let commands = bamboo_config::paths::project_commands_dir(&project);
+    if !commands.exists() {
+        return Some(commands);
+    }
+    let canonical_commands = std::fs::canonicalize(&commands).ok()?;
+    canonical_commands
+        .starts_with(&project)
+        .then_some(canonical_commands)
+        .or_else(|| {
+            tracing::warn!(
+                "Ignoring project commands directory outside workspace boundary: {}",
+                commands.display()
+            );
+            None
+        })
+}
+
+async fn find_markdown_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut entries = match tokio::fs::read_dir(root).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return files,
+        Err(error) => {
+            tracing::warn!(
+                "Failed to read command directory {}: {error}",
+                root.display()
+            );
+            return files;
+        }
+    };
+    loop {
+        let entry = match entries.next_entry().await {
+            Ok(Some(entry)) => entry,
+            Ok(None) => break,
+            Err(error) => {
+                tracing::warn!("Failed while scanning command directory: {error}");
+                break;
+            }
+        };
+        let Ok(file_type) = entry.file_type().await else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        let path = entry.path();
+        if file_type.is_dir() {
+            files.extend(Box::pin(find_markdown_files(&path)).await);
+        } else if file_type.is_file()
+            && path.extension().and_then(|extension| extension.to_str()) == Some("md")
+        {
+            files.push(path);
+        }
+    }
+    files.sort();
+    files
+}
+
+pub(super) async fn list_markdown_commands(root: &Path, source: &str) -> Vec<MarkdownCommand> {
+    let mut commands = Vec::new();
+    for path in find_markdown_files(root).await {
+        let Some(name) = command_name(root, &path) else {
+            continue;
+        };
+        let raw = match tokio::fs::read_to_string(&path).await {
+            Ok(raw) => raw,
+            Err(error) => {
+                tracing::warn!("Failed to read command {}: {error}", path.display());
+                continue;
+            }
+        };
+        let (metadata, content) = parse_command_markdown(&raw);
+        if content.is_empty() {
+            continue;
+        }
+        let description = metadata
+            .description
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| format!("{source} command: {name}"));
+        let argument_hint = metadata
+            .argument_hint
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        let item = CommandItem {
+            id: format!("command-{source}-{}", name.replace('/', "-")),
+            name: name.clone(),
+            display_name: name,
+            description,
+            command_type: "prompt".to_string(),
+            category: Some("Commands".to_string()),
+            tags: None,
+            metadata: serde_json::json!({
+                "source": source,
+                "argumentHint": argument_hint,
+                "prompt": content,
+            }),
+        };
+        commands.push(MarkdownCommand { item, content });
+    }
+    commands
+}
+
+pub(super) async fn list_prompt_presets_as_commands(data_dir: &Path) -> Vec<CommandItem> {
+    match crate::handlers::agent::prompt_presets::load_stored_presets(data_dir).await {
+        Ok(presets) => presets
+            .into_iter()
+            .map(|preset| CommandItem {
+                id: format!("preset-{}", preset.id),
+                name: preset.id,
+                display_name: preset.name,
+                description: preset
+                    .description
+                    .unwrap_or_else(|| "Prompt preset".to_string()),
+                command_type: "prompt".to_string(),
+                category: Some("Prompt Presets".to_string()),
+                tags: None,
+                metadata: serde_json::json!({"source": "preset", "prompt": preset.content}),
+            })
+            .collect(),
+        Err(error) => {
+            tracing::warn!("Failed to load prompt presets as commands: {error}");
+            Vec::new()
+        }
+    }
+}
 
 pub(super) async fn list_workflows_as_commands(
     data_dir: &Path,

--- a/crates/app/bamboo-server/src/handlers/command/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/command/tests.rs
@@ -1,7 +1,11 @@
 use actix_web::{http::StatusCode, web};
 use bamboo_skills::types::SkillDefinition;
 
-use super::sources::skill_to_command;
+use std::collections::HashSet;
+
+use super::handlers::{append_unique, expand_arguments};
+use super::sources::{list_markdown_commands, skill_to_command};
+use super::types::CommandItem;
 
 #[test]
 fn skill_to_command_maps_core_fields() {
@@ -13,6 +17,135 @@ fn skill_to_command_maps_core_fields() {
     assert_eq!(command.name, "sample");
     assert_eq!(command.display_name, "Sample");
     assert_eq!(command.command_type, "skill");
+}
+
+#[tokio::test]
+async fn markdown_commands_support_namespace_frontmatter_and_arguments() {
+    let project = tempfile::tempdir().expect("project");
+    let commands_dir = bamboo_config::paths::project_commands_dir(project.path());
+    tokio::fs::create_dir_all(commands_dir.join("db"))
+        .await
+        .expect("commands dir");
+    tokio::fs::write(
+        commands_dir.join("db/migrate.md"),
+        "---\r\ndescription: Run a database migration\r\nargument-hint: <target>\r\n---\r\nMigrate $ARGUMENTS now.",
+    )
+    .await
+    .expect("command");
+
+    let commands = list_markdown_commands(&commands_dir, "project").await;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].item.name, "db/migrate");
+    assert_eq!(commands[0].item.description, "Run a database migration");
+    assert_eq!(
+        commands[0].item.metadata["argumentHint"],
+        serde_json::json!("<target>")
+    );
+    assert_eq!(
+        expand_arguments(&commands[0].content, "production"),
+        "Migrate production now."
+    );
+}
+
+#[actix_web::test]
+async fn prompt_preset_list_item_can_be_resolved_and_expanded() {
+    let data = tempfile::tempdir().expect("data dir");
+    std::fs::write(
+        data.path().join("prompt-presets.json"),
+        r#"{"prompts":[{"id":"review","name":"Review","content":"Review $ARGUMENTS"}]}"#,
+    )
+    .expect("preset store");
+    let app_state = web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let app = actix_web::test::init_service(
+        actix_web::App::new()
+            .app_data(app_state)
+            .configure(super::config),
+    )
+    .await;
+    let request = actix_web::test::TestRequest::get()
+        .uri("/commands/prompt/review?arguments=code")
+        .to_request();
+    let body: serde_json::Value = actix_web::test::call_and_read_body_json(&app, request).await;
+    assert_eq!(body["content"], "Review code");
+}
+
+#[cfg(unix)]
+#[test]
+fn project_command_root_cannot_escape_through_symlink() {
+    use std::os::unix::fs::symlink;
+    let workspace = tempfile::tempdir().expect("workspace");
+    let outside = tempfile::tempdir().expect("outside");
+    std::fs::create_dir_all(workspace.path().join(".bamboo")).expect("bamboo dir");
+    symlink(outside.path(), workspace.path().join(".bamboo/commands")).expect("symlink");
+    assert!(
+        super::sources::safe_project_commands_dir(workspace.path().to_string_lossy().as_ref())
+            .is_none()
+    );
+}
+
+#[test]
+fn nested_workspace_resolves_commands_from_nearest_git_project_root() {
+    let project = tempfile::tempdir().expect("project");
+    std::fs::create_dir_all(project.path().join(".git")).expect("git marker");
+    let commands = project.path().join(".bamboo/commands");
+    std::fs::create_dir_all(&commands).expect("commands");
+    let nested = project.path().join("src/feature");
+    std::fs::create_dir_all(&nested).expect("nested");
+
+    let resolved = super::sources::safe_project_commands_dir(nested.to_string_lossy().as_ref())
+        .expect("commands root");
+    assert_eq!(
+        resolved,
+        std::fs::canonicalize(commands).expect("canonical")
+    );
+}
+
+#[test]
+fn nested_linked_worktree_uses_git_file_as_project_boundary() {
+    let outer = tempfile::tempdir().expect("outer");
+    let worktree = outer.path().join(".bamboo/worktree/task");
+    let commands = worktree.join(".bamboo/commands");
+    let nested = worktree.join("src/feature");
+    std::fs::create_dir_all(&commands).expect("commands");
+    std::fs::create_dir_all(&nested).expect("nested");
+    std::fs::write(worktree.join(".git"), "gitdir: /repo/.git/worktrees/task").expect("git file");
+
+    let resolved = super::sources::safe_project_commands_dir(nested.to_string_lossy().as_ref())
+        .expect("commands root");
+    assert_eq!(
+        resolved,
+        std::fs::canonicalize(commands).expect("canonical")
+    );
+}
+
+fn command(name: &str, source: &str) -> CommandItem {
+    CommandItem {
+        id: format!("{source}-{name}"),
+        name: name.to_string(),
+        display_name: name.to_string(),
+        description: source.to_string(),
+        command_type: "prompt".to_string(),
+        category: None,
+        tags: None,
+        metadata: serde_json::json!({"source": source}),
+    }
+}
+
+#[test]
+fn command_conflicts_keep_first_source_by_documented_precedence() {
+    let mut merged = Vec::new();
+    let mut seen = HashSet::new();
+    append_unique(&mut merged, &mut seen, vec![command("review", "project")]);
+    append_unique(&mut merged, &mut seen, vec![command("review", "global")]);
+    append_unique(&mut merged, &mut seen, vec![command("review", "preset")]);
+    append_unique(&mut merged, &mut seen, vec![command("review", "workflow")]);
+
+    assert_eq!(merged.len(), 1);
+    assert_eq!(merged[0].metadata["source"], "project");
 }
 
 #[actix_web::test]
@@ -44,4 +177,48 @@ async fn get_command_rejects_path_traversal_in_workflow_id() {
     let resp = actix_web::test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[actix_web::test]
+async fn project_command_is_listed_and_namespace_route_expands_arguments() {
+    let data = tempfile::tempdir().expect("data dir");
+    let project = tempfile::tempdir().expect("project dir");
+    let commands_dir = bamboo_config::paths::project_commands_dir(project.path());
+    std::fs::create_dir_all(commands_dir.join("db")).expect("commands dir");
+    std::fs::write(
+        commands_dir.join("db/migrate.md"),
+        "Migrate $ARGUMENTS safely",
+    )
+    .expect("command");
+
+    let app_state = web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let app = actix_web::test::init_service(
+        actix_web::App::new()
+            .app_data(app_state)
+            .configure(super::config),
+    )
+    .await;
+    let workspace_path = project.path().to_string_lossy();
+
+    let list = actix_web::test::TestRequest::get()
+        .uri(&format!("/commands?workspace_path={workspace_path}"))
+        .to_request();
+    let list_body: serde_json::Value = actix_web::test::call_and_read_body_json(&app, list).await;
+    assert!(list_body["commands"]
+        .as_array()
+        .expect("commands")
+        .iter()
+        .any(|command| command["name"] == "db/migrate"));
+
+    let get = actix_web::test::TestRequest::get()
+        .uri(&format!(
+            "/commands/prompt/db/migrate?workspace_path={workspace_path}&arguments=production"
+        ))
+        .to_request();
+    let get_body: serde_json::Value = actix_web::test::call_and_read_body_json(&app, get).await;
+    assert_eq!(get_body["content"], "Migrate production safely");
 }

--- a/crates/app/bamboo-server/src/handlers/command/types.rs
+++ b/crates/app/bamboo-server/src/handlers/command/types.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum CommandType {
+    /// Markdown commands and stored prompt presets.
+    Prompt,
     /// Workflow commands from markdown files.
     Workflow,
     /// Skill commands defined in the skill system.
@@ -13,7 +15,7 @@ pub enum CommandType {
 }
 
 /// Represents a unified command item from workflows, skills, and MCP tools.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct CommandItem {
     pub id: String,
     pub name: String,
@@ -26,6 +28,20 @@ pub struct CommandItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
     pub metadata: serde_json::Value,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ListCommandsQuery {
+    #[serde(default)]
+    pub workspace_path: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct GetCommandQuery {
+    #[serde(default)]
+    pub workspace_path: Option<String>,
+    #[serde(default)]
+    pub arguments: Option<String>,
 }
 
 /// Response structure for listing all available commands.
@@ -43,6 +59,9 @@ mod tests {
     fn test_command_type_serialization() {
         let workflow = CommandType::Workflow;
         assert_eq!(serde_json::to_string(&workflow).unwrap(), "\"workflow\"");
+
+        let prompt = CommandType::Prompt;
+        assert_eq!(serde_json::to_string(&prompt).unwrap(), "\"prompt\"");
 
         let skill = CommandType::Skill;
         assert_eq!(serde_json::to_string(&skill).unwrap(), "\"skill\"");

--- a/crates/infra/bamboo-config/src/paths.rs
+++ b/crates/infra/bamboo-config/src/paths.rs
@@ -82,6 +82,26 @@ pub fn workflows_dir() -> PathBuf {
     bamboo_dir().join("workflows")
 }
 
+/// Get the global markdown slash-command directory (`{bamboo_dir}/commands`).
+pub fn commands_dir() -> PathBuf {
+    commands_dir_in(&bamboo_dir())
+}
+
+/// Resolve a commands directory below an explicit Bamboo data directory.
+pub fn commands_dir_in(bamboo_data_dir: &Path) -> PathBuf {
+    bamboo_data_dir.join("commands")
+}
+
+/// Get the project-local Bamboo configuration directory.
+pub fn project_bamboo_dir(project_dir: &Path) -> PathBuf {
+    project_dir.join(".bamboo")
+}
+
+/// Get the project-local markdown slash-command directory.
+pub fn project_commands_dir(project_dir: &Path) -> PathBuf {
+    project_bamboo_dir(project_dir).join("commands")
+}
+
 /// Get the local plugin bundles root (`~/.bamboo/plugins`).
 ///
 /// Each installed plugin lives at `plugins_dir()/<plugin_id>/`, keeping the
@@ -484,6 +504,20 @@ mod tests {
     fn test_workflows_dir() {
         let path = workflows_dir();
         assert!(path.ends_with("workflows"));
+    }
+
+    #[test]
+    fn project_command_paths_are_scoped_below_project_bamboo_dir() {
+        let project = Path::new("/workspace/project");
+        assert_eq!(project_bamboo_dir(project), project.join(".bamboo"));
+        assert_eq!(
+            project_commands_dir(project),
+            project.join(".bamboo/commands")
+        );
+        assert_eq!(
+            commands_dir_in(Path::new("/data/bamboo")),
+            PathBuf::from("/data/bamboo/commands")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- discover project and global `.bamboo/commands/**/*.md` sources
- resolve nested workspace and linked-worktree Git boundaries safely
- support namespace paths, YAML description/argument-hint, and `$ARGUMENTS` expansion
- integrate prompt presets and stable conflict precedence: project > global markdown > preset > workflow > skill > MCP
- reject relative/outside/symlinked roots and isolate unreadable or invalid files

Closes #562

## Test Plan
- command tests (19 passed), including HTTP list/get, namespace, preset, CRLF, nested/worktree boundary and symlink cases
- cargo check -p bamboo-server -p bamboo-config
- cargo fmt --check
- git diff --check