### PR TITLE
fix(ws_v2): replay pre-response terminal states

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/images.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/images.rs
@@ -49,5 +49,36 @@ pub(super) async fn append_user_message(
         session.add_message(bamboo_agent_core::Message::user(message.to_string()));
     }
 
+    // Persist a durable handoff marker with the new turn. A reconnect may occur
+    // before POST /execute reserves a Pending runner; without this marker, the
+    // previous run's Cancelled/Failed runtime snapshot can be mistaken for the
+    // terminal state of this new request.
+    session.set_last_run_status("pending");
+    session.clear_last_run_error();
+
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[actix_web::test]
+    async fn new_user_turn_replaces_stale_terminal_metadata_with_pending() {
+        let dir = tempfile::tempdir().expect("temporary app data");
+        let state = web::Data::new(
+            AppState::new(dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let mut session = Session::new("new-turn", "test-model");
+        session.set_last_run_status("error");
+        session.set_last_run_error("old failure");
+
+        assert!(append_user_message(&state, &mut session, "try again", None)
+            .await
+            .is_ok());
+        assert_eq!(session.last_run_status().as_deref(), Some("pending"));
+        assert!(session.last_run_error().is_none());
+    }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/images.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/images.rs
@@ -53,8 +53,7 @@ pub(super) async fn append_user_message(
     // before POST /execute reserves a Pending runner; without this marker, the
     // previous run's Cancelled/Failed runtime snapshot can be mistaken for the
     // terminal state of this new request.
-    session.set_last_run_status("pending");
-    session.clear_last_run_error();
+    crate::handlers::agent::events::mark_pending_turn(session);
 
     Ok(())
 }

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
@@ -313,8 +313,7 @@ async fn handle_goal_command(
                 "runtime_kind": "gold_goal_resume"
             }));
             session.add_message(resume_msg);
-            session.set_last_run_status("pending");
-            session.clear_last_run_error();
+            crate::handlers::agent::events::mark_pending_turn(&mut session);
         }
 
         state.save_and_cache_session(&mut session).await;

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
@@ -313,6 +313,8 @@ async fn handle_goal_command(
                 "runtime_kind": "gold_goal_resume"
             }));
             session.add_message(resume_msg);
+            session.set_last_run_status("pending");
+            session.clear_last_run_error();
         }
 
         state.save_and_cache_session(&mut session).await;

--- a/crates/app/bamboo-server/src/handlers/agent/events/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/mod.rs
@@ -16,6 +16,7 @@ pub(crate) use stream::Coalescer;
 // child sub-agents are still running (parity with the v1 SSE stream, which does
 // not close on the parent terminal while descendants survive).
 pub(crate) use terminal::{has_running_child, terminal_event_if_ready};
+pub(crate) use terminal::{mark_pending_turn, mark_startup_failed_if_owned};
 
 #[cfg(test)]
 mod tests;

--- a/crates/app/bamboo-server/src/handlers/agent/events/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/mod.rs
@@ -15,8 +15,10 @@ pub(crate) use stream::Coalescer;
 // Reused by the v2 WS `agent.{sid}` forwarder to keep the channel open while
 // child sub-agents are still running (parity with the v1 SSE stream, which does
 // not close on the parent terminal while descendants survive).
+pub(crate) use terminal::{
+    begin_execute_startup, mark_pending_turn, mark_startup_failed_if_owned, pending_turn_id,
+};
 pub(crate) use terminal::{has_running_child, terminal_event_if_ready};
-pub(crate) use terminal::{mark_pending_turn, mark_startup_failed_if_owned};
 
 #[cfg(test)]
 mod tests;

--- a/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
@@ -5,7 +5,9 @@ use bamboo_agent_core::agent::events::TokenUsage;
 use bamboo_agent_core::agent::Role;
 use bamboo_agent_core::{AgentEvent, Session, SessionKind};
 use bamboo_domain::AgentStatusState;
-use bamboo_engine::session_app::execute::has_pending_user_message;
+use bamboo_engine::session_app::execute::{
+    has_pending_clarification_resume, has_pending_retry_resume,
+};
 
 pub(crate) async fn terminal_event_if_ready(
     state: &web::Data<AppState>,
@@ -72,7 +74,7 @@ pub(crate) async fn terminal_event_if_ready(
         return None;
     }
 
-    if session_prevents_terminal_event(session.as_ref()) {
+    if session_prevents_terminal_event(session.as_ref(), runner_status.as_ref()) {
         tracing::debug!(
             "[{}] terminal_event_if_ready -> None (pending user message / pending question / suspended) -> LIVE stream",
             session_id,
@@ -158,16 +160,19 @@ pub(super) fn terminal_event_for_sources(
     }
 }
 
-pub(super) fn session_prevents_terminal_event(session: Option<&Session>) -> bool {
+pub(super) fn session_prevents_terminal_event(
+    session: Option<&Session>,
+    runner_status: Option<&AgentStatus>,
+) -> bool {
     let Some(session) = session else {
         return false;
     };
 
-    if session
-        .messages
-        .last()
-        .is_some_and(|message| matches!(message.role, Role::User))
-    {
+    // A newly queued run is newer than a terminal runner/runtime snapshot. Chat
+    // persistence writes this marker together with the new User message, so a
+    // reconnect between POST /chat and POST /execute remains live even if the
+    // previous run was cancelled or failed.
+    if matches!(session.last_run_status().as_deref(), Some("pending")) {
         return true;
     }
 
@@ -186,14 +191,50 @@ pub(super) fn session_prevents_terminal_event(session: Option<&Session>) -> bool
     // a broadcast with no live subscriber, leaving the UI stuck on "thinking".
     // Mirror the resume decision, which uses this same predicate, so the window
     // [markers set] and [runner Running] tile with no gap.
-    if has_pending_user_message(session) {
+    if has_pending_clarification_resume(session) || has_pending_retry_resume(session) {
         return true;
     }
 
-    session
+    if session
         .agent_runtime_state
         .as_ref()
         .is_some_and(|runtime| matches!(runtime.status, AgentStatusState::Suspended))
+    {
+        return true;
+    }
+
+    let last_message_is_user = session
+        .messages
+        .last()
+        .is_some_and(|message| matches!(message.role, Role::User));
+    if !last_message_is_user {
+        return false;
+    }
+
+    // Cancellation/failure can happen before the model appends an Assistant
+    // message, leaving User as the last role. Those terminal sources are more
+    // authoritative than the role heuristic and must be replayed to a late
+    // subscriber. A genuinely newer User turn is protected by the `pending`
+    // marker above.
+    !terminal_failure_is_authoritative(session, runner_status)
+}
+
+fn terminal_failure_is_authoritative(
+    session: &Session,
+    runner_status: Option<&AgentStatus>,
+) -> bool {
+    match runner_status {
+        Some(AgentStatus::Cancelled | AgentStatus::Error(_)) => true,
+        // Any extant non-failure runner is the current source of truth; do not
+        // fall back to a stale persisted failure from an older run.
+        Some(_) => false,
+        None => session.agent_runtime_state.as_ref().is_some_and(|runtime| {
+            matches!(
+                runtime.status,
+                AgentStatusState::Cancelled | AgentStatusState::Failed
+            )
+        }),
+    }
 }
 
 /// Whether the watched session still has any running **descendant** (transitive,
@@ -243,17 +284,19 @@ pub(crate) async fn has_running_child(state: &web::Data<AppState>, session_id: &
 mod tests {
     use super::*;
     use bamboo_agent_core::Message;
+    use bamboo_domain::AgentRuntimeState;
+    use tempfile::tempdir;
 
     #[test]
     fn no_session_does_not_prevent_terminal() {
-        assert!(!session_prevents_terminal_event(None));
+        assert!(!session_prevents_terminal_event(None, None));
     }
 
     #[test]
     fn last_user_message_prevents_terminal() {
         let mut session = Session::new("s-1", "test-model");
         session.add_message(Message::user("hello"));
-        assert!(session_prevents_terminal_event(Some(&session)));
+        assert!(session_prevents_terminal_event(Some(&session), None));
     }
 
     #[test]
@@ -261,7 +304,7 @@ mod tests {
         let mut session = Session::new("s-1", "test-model");
         session.add_message(Message::user("hello"));
         session.add_message(Message::assistant("done", None));
-        assert!(!session_prevents_terminal_event(Some(&session)));
+        assert!(!session_prevents_terminal_event(Some(&session), None));
     }
 
     /// Regression: after answering a `conclusion_with_options` question the answer
@@ -276,13 +319,106 @@ mod tests {
         session.add_message(Message::tool_result("ask-1", "Selected response: A"));
         // No pending question, last message is a tool result — looks "finished"...
         assert!(!session.has_pending_question());
-        assert!(!session_prevents_terminal_event(Some(&session)));
+        assert!(!session_prevents_terminal_event(Some(&session), None));
 
         // ...until the resume marker set by `submit_pending_response` is present.
         session.metadata.insert(
             "conclusion_with_options_resume_pending".to_string(),
             "true".to_string(),
         );
-        assert!(session_prevents_terminal_event(Some(&session)));
+        assert!(session_prevents_terminal_event(Some(&session), None));
+    }
+
+    async fn state_with_session(mut session: Session) -> (tempfile::TempDir, web::Data<AppState>) {
+        let dir = tempdir().expect("temporary app data");
+        let state = web::Data::new(
+            AppState::new(dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        state.save_session(&mut session).await;
+        (dir, state)
+    }
+
+    #[actix_web::test]
+    async fn terminal_helper_replays_in_memory_cancelled_after_last_user() {
+        let mut session = Session::new("cancelled-user", "test-model");
+        session.add_message(Message::user("cancel before first token"));
+        // The in-memory terminal is authoritative even if persistence still
+        // reflects the run's prior phase.
+        session.set_last_run_status("running");
+        let (_dir, state) = state_with_session(session).await;
+
+        let event = terminal_event_if_ready(&state, "cancelled-user", Some(AgentStatus::Cancelled))
+            .await
+            .expect("cancelled run is terminal");
+        assert!(matches!(event, AgentEvent::Cancelled { .. }));
+    }
+
+    #[actix_web::test]
+    async fn terminal_helper_replays_in_memory_error_after_last_user() {
+        let mut session = Session::new("failed-user", "test-model");
+        session.add_message(Message::user("fail before first token"));
+        session.set_last_run_status("running");
+        let (_dir, state) = state_with_session(session).await;
+
+        let event = terminal_event_if_ready(
+            &state,
+            "failed-user",
+            Some(AgentStatus::Error("provider failed".to_string())),
+        )
+        .await
+        .expect("failed run is terminal");
+        assert!(matches!(event, AgentEvent::Error { message } if message == "provider failed"));
+    }
+
+    #[actix_web::test]
+    async fn terminal_helper_replays_persisted_cancelled_after_last_user() {
+        let mut session = Session::new("persisted-cancelled-user", "test-model");
+        session.add_message(Message::user("cancel before first token"));
+        session.set_last_run_status("cancelled");
+        let mut runtime = AgentRuntimeState::new("cancelled-run");
+        runtime.status = AgentStatusState::Cancelled;
+        session.agent_runtime_state = Some(runtime);
+        let (_dir, state) = state_with_session(session).await;
+
+        let event = terminal_event_if_ready(&state, "persisted-cancelled-user", None)
+            .await
+            .expect("persisted cancellation is terminal");
+        assert!(matches!(event, AgentEvent::Cancelled { .. }));
+    }
+
+    #[actix_web::test]
+    async fn terminal_helper_replays_persisted_failure_after_last_user() {
+        let mut session = Session::new("persisted-failed-user", "test-model");
+        session.add_message(Message::user("fail before first token"));
+        session.set_last_run_status("error");
+        let mut runtime = AgentRuntimeState::new("failed-run");
+        runtime.status = AgentStatusState::Failed;
+        session.agent_runtime_state = Some(runtime);
+        let (_dir, state) = state_with_session(session).await;
+
+        let event = terminal_event_if_ready(&state, "persisted-failed-user", None)
+            .await
+            .expect("persisted failure is terminal");
+        assert!(matches!(event, AgentEvent::Error { .. }));
+    }
+
+    #[actix_web::test]
+    async fn terminal_helper_keeps_new_user_after_old_failure_live() {
+        let mut session = Session::new("new-user-after-failure", "test-model");
+        session.add_message(Message::user("new request"));
+        session.set_last_run_status("pending");
+        let mut runtime = AgentRuntimeState::new("old-failed-run");
+        runtime.status = AgentStatusState::Failed;
+        session.agent_runtime_state = Some(runtime);
+        let (_dir, state) = state_with_session(session).await;
+
+        assert!(
+            terminal_event_if_ready(&state, "new-user-after-failure", None)
+                .await
+                .is_none(),
+            "new pending work must win over the old persisted failure"
+        );
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
 use actix_web::web;
 
 use crate::app_state::{AgentStatus, AppState};
@@ -11,6 +14,50 @@ use bamboo_engine::session_app::execute::{
 
 const PENDING_TURN_ID_KEY: &str = "execute.pending_turn_message_id";
 const PENDING_TURN_GRACE_SECS: i64 = 60;
+
+type StartupKey = (usize, String);
+static EXECUTE_STARTUPS: OnceLock<Mutex<HashMap<StartupKey, usize>>> = OnceLock::new();
+
+fn execute_startups() -> &'static Mutex<HashMap<StartupKey, usize>> {
+    EXECUTE_STARTUPS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn startup_key(state: &AppState, session_id: &str) -> StartupKey {
+    (state as *const AppState as usize, session_id.to_string())
+}
+
+pub(crate) struct ExecuteStartupGuard {
+    key: StartupKey,
+}
+
+impl Drop for ExecuteStartupGuard {
+    fn drop(&mut self) {
+        let mut startups = execute_startups().lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(count) = startups.get_mut(&self.key) {
+            *count -= 1;
+            if *count == 0 {
+                startups.remove(&self.key);
+            }
+        }
+    }
+}
+
+pub(crate) fn begin_execute_startup(state: &AppState, session_id: &str) -> ExecuteStartupGuard {
+    let key = startup_key(state, session_id);
+    *execute_startups()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .entry(key.clone())
+        .or_default() += 1;
+    ExecuteStartupGuard { key }
+}
+
+fn execute_startup_is_in_flight(state: &AppState, session_id: &str) -> bool {
+    execute_startups()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .contains_key(&startup_key(state, session_id))
+}
 
 pub(crate) fn mark_pending_turn(session: &mut Session) {
     if let Some(message) = session.messages.last() {
@@ -26,8 +73,18 @@ pub(crate) fn clear_pending_turn(session: &mut Session) {
     session.metadata.remove(PENDING_TURN_ID_KEY);
 }
 
-pub(crate) fn mark_startup_failed_if_owned(session: &mut Session, detail: &str) -> bool {
-    if !pending_turn_is_owned(session) {
+pub(crate) fn pending_turn_id(session: &Session) -> Option<String> {
+    pending_turn_is_owned(session)
+        .then(|| session.metadata.get(PENDING_TURN_ID_KEY).cloned())
+        .flatten()
+}
+
+pub(crate) fn mark_startup_failed_if_owned(
+    session: &mut Session,
+    expected_turn_id: &str,
+    detail: &str,
+) -> bool {
+    if pending_turn_id(session).as_deref() != Some(expected_turn_id) {
         return false;
     }
     session.set_last_run_status("error");
@@ -58,6 +115,14 @@ pub(crate) async fn terminal_event_if_ready(
     session_id: &str,
     runner_status: Option<AgentStatus>,
 ) -> Option<AgentEvent> {
+    // `/execute` may legitimately spend longer than the durable handoff grace
+    // in provider/image/storage preparation before it can reserve a runner.
+    // Never synthesize an abandoned-startup terminal while an in-process
+    // execute handler still owns this session. The guard disappears on every
+    // return path and naturally vanishes if the process crashes.
+    if execute_startup_is_in_flight(state.get_ref(), session_id) {
+        return None;
+    }
     let session = match state.storage.load_session(session_id).await {
         Ok(Some(session)) => Some(session),
         _ => None,
@@ -498,13 +563,49 @@ mod tests {
         ));
     }
 
+    #[actix_web::test]
+    async fn expired_pending_turn_stays_live_while_execute_startup_is_in_flight() {
+        let mut session = Session::new("slow-startup", "test-model");
+        session.add_message(Message::user("slow image preparation"));
+        mark_pending_turn(&mut session);
+        session.messages.last_mut().unwrap().created_at =
+            chrono::Utc::now() - chrono::Duration::seconds(PENDING_TURN_GRACE_SECS + 1);
+        let mut runtime = AgentRuntimeState::new("old-failed-run");
+        runtime.status = AgentStatusState::Failed;
+        session.agent_runtime_state = Some(runtime);
+        let (_dir, state) = state_with_session(session).await;
+
+        let guard = begin_execute_startup(state.get_ref(), "slow-startup");
+        let old_failure = Some(AgentStatus::Error("old run failed".to_string()));
+        assert!(
+            terminal_event_if_ready(&state, "slow-startup", old_failure.clone())
+                .await
+                .is_none()
+        );
+        // Reference counting matters when two execute requests overlap: one
+        // returning must not expose the other still-running preparation.
+        let second = begin_execute_startup(state.get_ref(), "slow-startup");
+        drop(guard);
+        assert!(
+            terminal_event_if_ready(&state, "slow-startup", old_failure.clone())
+                .await
+                .is_none()
+        );
+        drop(second);
+        assert!(terminal_event_if_ready(&state, "slow-startup", old_failure)
+            .await
+            .is_some());
+    }
+
     #[test]
     fn startup_failure_only_rolls_back_the_owned_turn() {
         let mut owned = Session::new("owned", "test-model");
         owned.add_message(Message::user("start me"));
         mark_pending_turn(&mut owned);
+        let owned_id = pending_turn_id(&owned).expect("owned turn id");
         assert!(mark_startup_failed_if_owned(
             &mut owned,
+            &owned_id,
             "provider rejected"
         ));
         assert_eq!(owned.last_run_status().as_deref(), Some("error"));
@@ -515,8 +616,14 @@ mod tests {
         let mut stale = Session::new("stale", "test-model");
         stale.add_message(Message::user("first"));
         mark_pending_turn(&mut stale);
+        let stale_id = pending_turn_id(&stale).expect("first turn id");
         stale.add_message(Message::user("newer turn"));
-        assert!(!mark_startup_failed_if_owned(&mut stale, "late rejection"));
+        mark_pending_turn(&mut stale);
+        assert!(!mark_startup_failed_if_owned(
+            &mut stale,
+            &stale_id,
+            "late rejection"
+        ));
         assert_eq!(stale.last_run_status().as_deref(), Some("pending"));
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
@@ -9,6 +9,50 @@ use bamboo_engine::session_app::execute::{
     has_pending_clarification_resume, has_pending_retry_resume,
 };
 
+const PENDING_TURN_ID_KEY: &str = "execute.pending_turn_message_id";
+const PENDING_TURN_GRACE_SECS: i64 = 60;
+
+pub(crate) fn mark_pending_turn(session: &mut Session) {
+    if let Some(message) = session.messages.last() {
+        session
+            .metadata
+            .insert(PENDING_TURN_ID_KEY.to_string(), message.id.clone());
+    }
+    session.set_last_run_status("pending");
+    session.clear_last_run_error();
+}
+
+pub(crate) fn clear_pending_turn(session: &mut Session) {
+    session.metadata.remove(PENDING_TURN_ID_KEY);
+}
+
+pub(crate) fn mark_startup_failed_if_owned(session: &mut Session, detail: &str) -> bool {
+    if !pending_turn_is_owned(session) {
+        return false;
+    }
+    session.set_last_run_status("error");
+    session.set_last_run_error(format!("Agent startup failed: {detail}"));
+    clear_pending_turn(session);
+    true
+}
+
+pub(crate) fn pending_turn_is_owned(session: &Session) -> bool {
+    matches!(session.last_run_status().as_deref(), Some("pending"))
+        && session
+            .metadata
+            .get(PENDING_TURN_ID_KEY)
+            .zip(session.messages.last())
+            .is_some_and(|(owner, message)| owner == &message.id)
+}
+
+fn pending_turn_is_active(session: &Session) -> bool {
+    pending_turn_is_owned(session)
+        && session.messages.last().is_some_and(|message| {
+            chrono::Utc::now().signed_duration_since(message.created_at)
+                <= chrono::Duration::seconds(PENDING_TURN_GRACE_SECS)
+        })
+}
+
 pub(crate) async fn terminal_event_if_ready(
     state: &web::Data<AppState>,
     session_id: &str,
@@ -140,6 +184,13 @@ pub(super) fn terminal_event_for_sources(
     session: Option<&Session>,
     runner_status: Option<AgentStatus>,
 ) -> AgentEvent {
+    if session
+        .is_some_and(|session| pending_turn_is_owned(session) && !pending_turn_is_active(session))
+    {
+        return AgentEvent::Error {
+            message: "Agent execution was not started; please retry this turn".to_string(),
+        };
+    }
     if runner_status.is_some() {
         return terminal_event_for_status(runner_status);
     }
@@ -172,7 +223,7 @@ pub(super) fn session_prevents_terminal_event(
     // persistence writes this marker together with the new User message, so a
     // reconnect between POST /chat and POST /execute remains live even if the
     // previous run was cancelled or failed.
-    if matches!(session.last_run_status().as_deref(), Some("pending")) {
+    if pending_turn_is_active(session) {
         return true;
     }
 
@@ -408,7 +459,7 @@ mod tests {
     async fn terminal_helper_keeps_new_user_after_old_failure_live() {
         let mut session = Session::new("new-user-after-failure", "test-model");
         session.add_message(Message::user("new request"));
-        session.set_last_run_status("pending");
+        mark_pending_turn(&mut session);
         let mut runtime = AgentRuntimeState::new("old-failed-run");
         runtime.status = AgentStatusState::Failed;
         session.agent_runtime_state = Some(runtime);
@@ -420,5 +471,52 @@ mod tests {
                 .is_none(),
             "new pending work must win over the old persisted failure"
         );
+    }
+
+    #[actix_web::test]
+    async fn terminal_helper_recovers_abandoned_pending_turn() {
+        let mut session = Session::new("abandoned-turn", "test-model");
+        session.add_message(Message::user("never executed"));
+        mark_pending_turn(&mut session);
+        session.messages.last_mut().unwrap().created_at =
+            chrono::Utc::now() - chrono::Duration::seconds(PENDING_TURN_GRACE_SECS + 1);
+        let mut runtime = AgentRuntimeState::new("old-failed-run");
+        runtime.status = AgentStatusState::Failed;
+        session.agent_runtime_state = Some(runtime);
+        let (_dir, state) = state_with_session(session).await;
+
+        let event = terminal_event_if_ready(
+            &state,
+            "abandoned-turn",
+            Some(AgentStatus::Error("old run failed".to_string())),
+        )
+        .await
+        .expect("expired pending handoff must become recoverable terminal state");
+        assert!(matches!(
+            event,
+            AgentEvent::Error { message } if message.contains("was not started")
+        ));
+    }
+
+    #[test]
+    fn startup_failure_only_rolls_back_the_owned_turn() {
+        let mut owned = Session::new("owned", "test-model");
+        owned.add_message(Message::user("start me"));
+        mark_pending_turn(&mut owned);
+        assert!(mark_startup_failed_if_owned(
+            &mut owned,
+            "provider rejected"
+        ));
+        assert_eq!(owned.last_run_status().as_deref(), Some("error"));
+        assert!(owned
+            .last_run_error()
+            .is_some_and(|error| error.contains("provider rejected")));
+
+        let mut stale = Session::new("stale", "test-model");
+        stale.add_message(Message::user("first"));
+        mark_pending_turn(&mut stale);
+        stale.add_message(Message::user("newer turn"));
+        assert!(!mark_startup_failed_if_owned(&mut stale, "late rejection"));
+        assert_eq!(stale.last_run_status().as_deref(), Some("pending"));
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/events/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/tests.rs
@@ -73,7 +73,7 @@ fn session_prevents_terminal_when_last_message_is_user() {
     let mut session = Session::new("sess-1", "test-model");
     session.add_message(Message::user("Hi"));
 
-    assert!(session_prevents_terminal_event(Some(&session)));
+    assert!(session_prevents_terminal_event(Some(&session), None));
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn session_prevents_terminal_when_pending_question_exists() {
         true,
     );
 
-    assert!(session_prevents_terminal_event(Some(&session)));
+    assert!(session_prevents_terminal_event(Some(&session), None));
 }
 
 #[test]
@@ -97,7 +97,7 @@ fn session_prevents_terminal_when_runtime_is_suspended() {
     runtime.status = AgentStatusState::Suspended;
     session.agent_runtime_state = Some(runtime);
 
-    assert!(session_prevents_terminal_event(Some(&session)));
+    assert!(session_prevents_terminal_event(Some(&session), None));
 }
 
 #[test]
@@ -105,8 +105,8 @@ fn session_allows_terminal_when_not_waiting_for_user() {
     let mut session = Session::new("sess-4", "test-model");
     session.add_message(Message::assistant("done", None));
 
-    assert!(!session_prevents_terminal_event(Some(&session)));
-    assert!(!session_prevents_terminal_event(None));
+    assert!(!session_prevents_terminal_event(Some(&session), None));
+    assert!(!session_prevents_terminal_event(None, None));
 }
 
 #[test]

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
@@ -120,6 +120,12 @@ pub async fn handler(
     {
         Ok(outcome) => outcome,
         Err(error) => {
+            fail_pending_startup(
+                &state,
+                &session_id,
+                &format!("execute preparation failed: {error}"),
+            )
+            .await;
             return match error {
                 bamboo_engine::session_app::errors::ExecutePreparationError::NotFound(_) => {
                     tracing::warn!("[{session_id}] Execute session not found");
@@ -211,13 +217,34 @@ pub async fn handler(
         }
 
         bamboo_engine::session_app::types::ExecutePreparationOutcome::ModelRequired => {
+            fail_pending_startup(&state, &session_id, "no model configured").await;
             bad_request_error_response("no model configured for session or provider")
         }
 
         bamboo_engine::session_app::types::ExecutePreparationOutcome::ImageFallbackError(error) => {
+            fail_pending_startup(&state, &session_id, &error).await;
             bad_request_error_response(error)
         }
     }
+}
+
+async fn fail_pending_startup(state: &web::Data<AppState>, session_id: &str, detail: &str) {
+    let Ok(Some(mut session)) = state.storage.load_session(session_id).await else {
+        return;
+    };
+    // Ownership prevents a delayed/retried rejection from poisoning a later
+    // turn, and avoids treating an old runner Error as this turn's outcome.
+    if !crate::handlers::agent::events::mark_startup_failed_if_owned(&mut session, detail) {
+        return;
+    }
+    if let Err(error) = state.persistence.merge_save_runtime(&mut session).await {
+        tracing::error!("[{session_id}] failed to persist execute rejection: {error}");
+        return;
+    }
+    state.sessions.insert(
+        session_id.to_string(),
+        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+    );
 }
 
 /// Convert a crate's `ExecuteSyncReason` to the handler's `ExecuteSyncReason`.

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
@@ -27,6 +27,19 @@ pub async fn handler(
     req: web::Json<ExecuteRequest>,
 ) -> HttpResponse {
     let session_id = path.into_inner();
+    // Covers the preparation window before a Pending runner can be reserved.
+    // The RAII guard is released on every success/error return path.
+    let _startup_guard =
+        crate::handlers::agent::events::begin_execute_startup(state.get_ref(), &session_id);
+    // Bind every later rejection to the exact user turn this execute request
+    // observed. A delayed failure from turn A must never poison newer turn B.
+    let startup_turn_id = state
+        .storage
+        .load_session(&session_id)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|session| crate::handlers::agent::events::pending_turn_id(&session));
     tracing::debug!(
         "[{}] Execute requested: model={:?}, model_ref={:?}, reasoning_effort={:?}, has_client_sync={}",
         session_id,
@@ -42,7 +55,10 @@ pub async fn handler(
     let config_snapshot = state.config.read().await.clone();
     let image_fallback = match resolve_image_fallback(&config_snapshot) {
         Ok(value) => value,
-        Err(error) => return internal_server_error_response(error),
+        Err(error) => {
+            fail_pending_startup(&state, &session_id, startup_turn_id.as_deref(), &error).await;
+            return internal_server_error_response(error);
+        }
     };
 
     let disabled_tools_vec: Vec<String> =
@@ -123,6 +139,7 @@ pub async fn handler(
             fail_pending_startup(
                 &state,
                 &session_id,
+                startup_turn_id.as_deref(),
                 &format!("execute preparation failed: {error}"),
             )
             .await;
@@ -217,24 +234,42 @@ pub async fn handler(
         }
 
         bamboo_engine::session_app::types::ExecutePreparationOutcome::ModelRequired => {
-            fail_pending_startup(&state, &session_id, "no model configured").await;
+            fail_pending_startup(
+                &state,
+                &session_id,
+                startup_turn_id.as_deref(),
+                "no model configured",
+            )
+            .await;
             bad_request_error_response("no model configured for session or provider")
         }
 
         bamboo_engine::session_app::types::ExecutePreparationOutcome::ImageFallbackError(error) => {
-            fail_pending_startup(&state, &session_id, &error).await;
+            fail_pending_startup(&state, &session_id, startup_turn_id.as_deref(), &error).await;
             bad_request_error_response(error)
         }
     }
 }
 
-async fn fail_pending_startup(state: &web::Data<AppState>, session_id: &str, detail: &str) {
+async fn fail_pending_startup(
+    state: &web::Data<AppState>,
+    session_id: &str,
+    expected_turn_id: Option<&str>,
+    detail: &str,
+) {
+    let Some(expected_turn_id) = expected_turn_id else {
+        return;
+    };
     let Ok(Some(mut session)) = state.storage.load_session(session_id).await else {
         return;
     };
     // Ownership prevents a delayed/retried rejection from poisoning a later
     // turn, and avoids treating an old runner Error as this turn's outcome.
-    if !crate::handlers::agent::events::mark_startup_failed_if_owned(&mut session, detail) {
+    if !crate::handlers::agent::events::mark_startup_failed_if_owned(
+        &mut session,
+        expected_turn_id,
+        detail,
+    ) {
         return;
     }
     if let Err(error) = state.persistence.merge_save_runtime(&mut session).await {

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
@@ -87,12 +87,21 @@ pub(super) async fn handle_execute_ready(
     // The reservation owns this exact turn now. Moving the owned marker out of
     // `pending` before persistence prevents an old terminal runner from being
     // used to classify the newly-starting turn.
+    let startup_turn_id = crate::handlers::agent::events::pending_turn_id(&session);
     session.set_last_run_status("running");
     session.clear_last_run_error();
 
     // ---- Save session before spawn (metadata-group merge) ----
     if let Err(error) = state.persistence.merge_save_runtime(&mut session).await {
-        rollback_startup(state, session_id, &run_id, &mut session, &error.to_string()).await;
+        rollback_startup(
+            state,
+            session_id,
+            &run_id,
+            startup_turn_id.as_deref(),
+            &mut session,
+            &error.to_string(),
+        )
+        .await;
         return internal_server_error_response(format!(
             "Failed to persist session config before execute: {}",
             error
@@ -201,6 +210,7 @@ async fn rollback_startup(
     state: &web::Data<AppState>,
     session_id: &str,
     run_id: &str,
+    expected_turn_id: Option<&str>,
     session: &mut bamboo_agent_core::Session,
     detail: &str,
 ) {
@@ -218,8 +228,17 @@ async fn rollback_startup(
     // Route through the same owned-turn failure transition used by preparation
     // rejects. The marker still identifies this exact message; status is reset
     // only to satisfy the transition's pending precondition.
-    session.set_last_run_status("pending");
-    crate::handlers::agent::events::mark_startup_failed_if_owned(session, detail);
+    if let Some(expected_turn_id) = expected_turn_id {
+        session.set_last_run_status("pending");
+        crate::handlers::agent::events::mark_startup_failed_if_owned(
+            session,
+            expected_turn_id,
+            detail,
+        );
+    } else {
+        session.set_last_run_status("error");
+        session.set_last_run_error(format!("Agent startup failed: {detail}"));
+    }
     if state.persistence.merge_save_runtime(session).await.is_ok() {
         state.sessions.insert(
             session_id.to_string(),

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
@@ -84,8 +84,15 @@ pub(super) async fn handle_execute_ready(
             }
         };
 
+    // The reservation owns this exact turn now. Moving the owned marker out of
+    // `pending` before persistence prevents an old terminal runner from being
+    // used to classify the newly-starting turn.
+    session.set_last_run_status("running");
+    session.clear_last_run_error();
+
     // ---- Save session before spawn (metadata-group merge) ----
     if let Err(error) = state.persistence.merge_save_runtime(&mut session).await {
+        rollback_startup(state, session_id, &run_id, &mut session, &error.to_string()).await;
         return internal_server_error_response(format!(
             "Failed to persist session config before execute: {}",
             error
@@ -188,6 +195,39 @@ pub(super) async fn handle_execute_ready(
     });
 
     started_response(session_id, sync_info, run_id)
+}
+
+async fn rollback_startup(
+    state: &web::Data<AppState>,
+    session_id: &str,
+    run_id: &str,
+    session: &mut bamboo_agent_core::Session,
+    detail: &str,
+) {
+    // Remove only our reservation. A concurrent retry may already have replaced
+    // it, and must not be disturbed.
+    let mut runners = state.agent_runners.write().await;
+    if runners
+        .get(session_id)
+        .is_some_and(|runner| runner.run_id == run_id)
+    {
+        runners.remove(session_id);
+    }
+    drop(runners);
+
+    // Route through the same owned-turn failure transition used by preparation
+    // rejects. The marker still identifies this exact message; status is reset
+    // only to satisfy the transition's pending precondition.
+    session.set_last_run_status("pending");
+    crate::handlers::agent::events::mark_startup_failed_if_owned(session, detail);
+    if state.persistence.merge_save_runtime(session).await.is_ok() {
+        state.sessions.insert(
+            session_id.to_string(),
+            std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
+        );
+    } else {
+        tracing::error!("[{session_id}] failed to persist execute startup rollback");
+    }
 }
 
 /// #74: re-derive the "no interactive human approver" posture for a

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
@@ -228,8 +228,22 @@ pub(crate) fn spawn_agent_forwarder(
             // every later child event. Hold the channel open and emit the
             // `terminal` control only once no running child is left.
             let mut awaiting_children = false;
+            let startup_reconcile = tokio::time::sleep(Duration::from_secs(61));
+            tokio::pin!(startup_reconcile);
             loop {
-                match receiver.recv().await {
+                let received = tokio::select! {
+                    received = receiver.recv() => received,
+                    _ = &mut startup_reconcile => {
+                        if reconcile_abandoned_startup(&state, &session_id, &out, encoding, &ch, &seq).await {
+                            return;
+                        }
+                        // A real run won the race; this one-shot guard is no
+                        // longer needed for this forwarder.
+                        startup_reconcile.as_mut().reset(tokio::time::Instant::now() + Duration::from_secs(86_400));
+                        continue;
+                    }
+                };
+                match received {
                     Ok(event) => {
                         let is_terminal = is_terminal_event(&event);
                         let is_child_completed =
@@ -305,12 +319,20 @@ pub(crate) fn spawn_agent_forwarder(
         // See the fast-path comment: keep the channel open after the parent
         // terminal while child sub-agents still run.
         let mut awaiting_children = false;
+        let startup_reconcile = tokio::time::sleep(Duration::from_secs(61));
+        tokio::pin!(startup_reconcile);
 
         loop {
             let sleep_until = flush_deadline
                 .unwrap_or_else(|| tokio::time::Instant::now() + Duration::from_secs(86_400));
 
             tokio::select! {
+                _ = &mut startup_reconcile => {
+                    if reconcile_abandoned_startup(&state, &session_id, &out, encoding, &ch, &seq).await {
+                        return;
+                    }
+                    startup_reconcile.as_mut().reset(tokio::time::Instant::now() + Duration::from_secs(86_400));
+                }
                 _ = tokio::time::sleep_until(sleep_until), if flush_deadline.is_some() => {
                     if let Some(pending) = coalescer.take_pending() {
                         if !emit_agent_event(&out, encoding, &ch, &seq, pending).await {
@@ -409,6 +431,35 @@ pub(crate) fn spawn_agent_forwarder(
             }
         }
     })
+}
+
+async fn reconcile_abandoned_startup(
+    state: &web::Data<AppState>,
+    session_id: &str,
+    out: &OutboundTx,
+    encoding: Encoding,
+    ch: &str,
+    seq: &AgentSeq,
+) -> bool {
+    let runner_status = state
+        .agent_runners
+        .read()
+        .await
+        .get(session_id)
+        .map(|runner| runner.status.clone());
+    let Some(event) = terminal_event_if_ready(state, session_id, runner_status).await else {
+        return false;
+    };
+    if !emit_agent_event(out, encoding, ch, seq, event).await {
+        return true;
+    }
+    let _ = send_env(
+        out,
+        encoding,
+        ServerEnvelope::control(ch, seq.next(), terminal_control("complete")),
+    )
+    .await;
+    true
 }
 
 /// Spawn a one-shot `agent.{sid}` replay for a session that was already

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -737,15 +737,11 @@ async fn subscribe(
                     // emitted its first broadcast event. Re-read the runner so
                     // that Pending/Running wins over the stale terminal
                     // snapshot even while the receiver is still empty.
-                    let current_runner_status = {
-                        let runners = state.agent_runners.read().await;
-                        runners.get(&sid).map(|runner| runner.status.clone())
-                    };
                     // We subscribed before the async storage/child checks. If a
                     // live event arrived meanwhile, preserve its ordering by
                     // handing the still-buffered receiver to the live forwarder
                     // instead of sending a synthetic terminal ahead of it.
-                    if can_attempt_terminal_replay(current_runner_status.as_ref(), &receiver) {
+                    if current_runner_allows_terminal_replay(state, &sid, &receiver).await {
                         return finish_subscribe(
                             forwarders,
                             queues,
@@ -791,6 +787,22 @@ fn can_attempt_terminal_replay(
             | Some(crate::app_state::AgentStatus::Cancelled)
             | Some(crate::app_state::AgentStatus::Error(_))
     ) && receiver.is_empty()
+}
+
+/// Re-read the runner after asynchronous terminal checks. This is deliberately
+/// a separate helper so the subscribe race can be covered without relying on
+/// scheduler timing: a runner reserved during storage I/O must invalidate the
+/// stale terminal snapshot before the one-shot forwarder is installed.
+async fn current_runner_allows_terminal_replay(
+    state: &web::Data<AppState>,
+    session_id: &str,
+    receiver: &tokio::sync::broadcast::Receiver<bamboo_agent_core::AgentEvent>,
+) -> bool {
+    let current_runner_status = {
+        let runners = state.agent_runners.read().await;
+        runners.get(session_id).map(|runner| runner.status.clone())
+    };
+    can_attempt_terminal_replay(current_runner_status.as_ref(), receiver)
 }
 
 fn finish_subscribe(
@@ -1132,5 +1144,29 @@ mod tests {
             Some(&crate::app_state::AgentStatus::Running),
             &rx,
         ));
+    }
+
+    #[actix_web::test]
+    async fn current_runner_reread_blocks_stale_terminal_snapshot() {
+        let (state, _cred, _token) = app_state_with_device().await;
+        let (_tx, rx) = tokio::sync::broadcast::channel(4);
+        let session_id = "runner-reserved-during-terminal-check";
+
+        assert!(
+            current_runner_allows_terminal_replay(&state, session_id, &rx).await,
+            "the initial no-runner snapshot permits a terminal check"
+        );
+
+        {
+            let mut runners = state.agent_runners.write().await;
+            let mut runner = crate::app_state::AgentRunner::new();
+            runner.status = crate::app_state::AgentStatus::Running;
+            runners.insert(session_id.to_string(), runner);
+        }
+
+        assert!(
+            !current_runner_allows_terminal_replay(&state, session_id, &rx).await,
+            "the post-await re-read must observe the newly Running runner"
+        );
     }
 }

--- a/crates/app/bamboo-server/tests/ws_v2_live.rs
+++ b/crates/app/bamboo-server/tests/ws_v2_live.rs
@@ -23,7 +23,7 @@ use actix_web::{web, App, HttpServer};
 use awc::ws;
 use bamboo_agent_core::AgentEvent;
 use bamboo_config::{AccessControlConfig, DeviceCredential};
-use bamboo_domain::SessionKind;
+use bamboo_domain::{AgentRuntimeState, AgentStatusState, SessionKind};
 use bamboo_server::routes::configure_routes;
 use bamboo_server::{AgentRunner, AgentStatus, AppState};
 use futures::{SinkExt, StreamExt};
@@ -604,6 +604,49 @@ async fn completed_session_late_subscribe_replays_terminal_once() {
     assert_eq!(terminal_control["ch"], ch);
     assert_eq!(terminal_control["seq"], 2);
     assert_eq!(terminal_control["control"]["type"], "terminal");
+
+    server.stop().await;
+}
+
+/// #588 follow-up regression: cancellation may finish before any Assistant
+/// message is appended, so the durable transcript still ends in User. The
+/// persisted terminal runtime must beat that role heuristic and replay exactly
+/// one Cancelled event followed by exactly one terminal control.
+#[actix_web::test]
+async fn cancelled_last_user_late_subscribe_replays_terminal_once() {
+    let server = TestServer::start(|_| {}).await;
+    let sid = "sess_cancelled_before_assistant";
+
+    let mut root = bamboo_agent_core::Session::new(sid, "test-model");
+    root.add_message(bamboo_agent_core::Message::user("start then cancel"));
+    root.set_last_run_status("cancelled");
+    let mut runtime = AgentRuntimeState::new("cancelled-run");
+    runtime.status = AgentStatusState::Cancelled;
+    root.agent_runtime_state = Some(runtime);
+    register_session(&server.state, &mut root).await;
+
+    let mut conn = connect_local(&server).await;
+    let ch = format!("agent.{sid}");
+    send_json(&mut conn, json!({"type": "subscribe", "ch": ch})).await;
+
+    let terminal_event = next_envelope(&mut conn)
+        .await
+        .expect("late subscriber receives persisted cancellation");
+    assert_eq!(terminal_event["ch"], ch);
+    assert_eq!(terminal_event["seq"], 1);
+    assert_eq!(terminal_event["event"]["type"], "cancelled");
+
+    let terminal_control = next_envelope(&mut conn)
+        .await
+        .expect("late subscriber receives terminal control");
+    assert_eq!(terminal_control["ch"], ch);
+    assert_eq!(terminal_control["seq"], 2);
+    assert_eq!(terminal_control["control"]["type"], "terminal");
+
+    match tokio::time::timeout(Duration::from_millis(400), next_envelope(&mut conn)).await {
+        Err(_) | Ok(None) => {}
+        Ok(Some(extra)) => panic!("terminal replay must be one-shot, got extra envelope: {extra}"),
+    }
 
     server.stop().await;
 }


### PR DESCRIPTION
## Summary

- replay Cancelled/Error when a run terminates before producing an assistant message
- keep genuine new user work live by durably marking new chat/goal-resume turns as pending
- preserve Pending/Running, clarification/retry resume, pending-question, and suspended live paths
- re-read the current runner after asynchronous terminal checks to prevent stale one-shot replay
- add async helper, AppState race, and real JSON WebSocket one-shot cancellation regressions

Follow-up to #594. Closes #588.

## Test Plan

- `cargo fmt --check`
- `cargo test -p bamboo-server handlers::agent::events --lib` (29 passed)
- `cargo test -p bamboo-server handlers::agent::ws_v2 --lib` (42 passed)
- `cargo test -p bamboo-server handlers::agent::chat::handler --lib` (24 passed)
- `cargo test -p bamboo-server --test ws_v2_live` (16 passed)
- `cargo clippy -p bamboo-server --all-targets` (passes; existing warnings only)
- `git diff --check`

## Screenshots

Not applicable; backend transport/state recovery change.