### PR TITLE
[bamboo] feat: add project-scoped worktree conventions

### DIFF
--- a/crates/engine/bamboo-tools/src/tools/glob.rs
+++ b/crates/engine/bamboo-tools/src/tools/glob.rs
@@ -49,6 +49,15 @@ impl GlobTool {
     }
 
     fn should_skip_dir(path: &Path) -> bool {
+        if path.file_name().and_then(|name| name.to_str()) == Some("worktree")
+            && path
+                .parent()
+                .and_then(Path::file_name)
+                .and_then(|name| name.to_str())
+                == Some(".bamboo")
+        {
+            return true;
+        }
         path.file_name()
             .and_then(|name| name.to_str())
             .map(|name| SKIP_DIRS.contains(&name))
@@ -290,14 +299,22 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let kept = dir.path().join("src").join("keep.txt");
         let skipped = dir.path().join("node_modules").join("skip.txt");
+        let worktree = dir
+            .path()
+            .join(".bamboo/worktree/child")
+            .join("duplicate.txt");
         tokio::fs::create_dir_all(kept.parent().unwrap())
             .await
             .unwrap();
         tokio::fs::create_dir_all(skipped.parent().unwrap())
             .await
             .unwrap();
+        tokio::fs::create_dir_all(worktree.parent().unwrap())
+            .await
+            .unwrap();
         tokio::fs::write(&kept, "ok").await.unwrap();
         tokio::fs::write(&skipped, "skip").await.unwrap();
+        tokio::fs::write(&worktree, "duplicate").await.unwrap();
 
         let tool = GlobTool::new();
         let out = tool
@@ -317,5 +334,6 @@ mod tests {
 
         assert!(result.result.contains("keep.txt"));
         assert!(!result.result.contains("node_modules"));
+        assert!(!result.result.contains("duplicate.txt"));
     }
 }

--- a/crates/engine/bamboo-tools/src/tools/grep.rs
+++ b/crates/engine/bamboo-tools/src/tools/grep.rs
@@ -128,6 +128,15 @@ impl GrepTool {
     }
 
     fn should_skip_dir(path: &Path) -> bool {
+        if path.file_name().and_then(|name| name.to_str()) == Some("worktree")
+            && path
+                .parent()
+                .and_then(Path::file_name)
+                .and_then(|name| name.to_str())
+                == Some(".bamboo")
+        {
+            return true;
+        }
         path.file_name()
             .and_then(|name| name.to_str())
             .map(|name| SKIP_DIRS.contains(&name))
@@ -528,6 +537,30 @@ mod tests {
         let lines = result_lines(&result);
         assert_eq!(lines.len(), 1);
         assert!(lines[0].contains("match.rs"));
+    }
+
+    #[tokio::test]
+    async fn grep_skips_project_worktree_checkout() {
+        let dir = tempfile::tempdir().unwrap();
+        let kept = dir.path().join("src/kept.txt");
+        let duplicate = dir.path().join(".bamboo/worktree/child/duplicate.txt");
+        tokio::fs::create_dir_all(kept.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::create_dir_all(duplicate.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&kept, "needle").await.unwrap();
+        tokio::fs::write(&duplicate, "needle").await.unwrap();
+
+        let result = run(
+            &GrepTool::new(),
+            json!({"pattern": "needle", "path": dir.path()}),
+        )
+        .await
+        .unwrap();
+        assert!(result.result.contains("kept.txt"));
+        assert!(!result.result.contains("duplicate.txt"));
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-config/src/paths.rs
+++ b/crates/infra/bamboo-config/src/paths.rs
@@ -107,6 +107,16 @@ pub fn project_commands_dir(project_dir: &Path) -> PathBuf {
     project_bamboo_dir(project_dir).join("commands")
 }
 
+/// Root for Git worktrees owned by Bamboo for this project.
+pub fn project_worktree_dir(project_dir: &Path) -> PathBuf {
+    project_bamboo_dir(project_dir).join("worktree")
+}
+
+/// Root for project-bound scratch data.
+pub fn project_tmp_dir(project_dir: &Path) -> PathBuf {
+    project_bamboo_dir(project_dir).join("tmp")
+}
+
 /// Get the local plugin bundles root (`~/.bamboo/plugins`).
 ///
 /// Each installed plugin lives at `plugins_dir()/<plugin_id>/`, keeping the
@@ -280,9 +290,34 @@ pub fn user_settings_path() -> PathBuf {
     bamboo_dir().join("settings.json")
 }
 
-/// Get the project-level settings directory: `<project>/.bamboo`
+/// Ensure project runtime directories exist and incrementally maintain the
+/// local `.bamboo/.gitignore` without overwriting user-authored entries.
+pub fn ensure_project_runtime_dirs(project_dir: &Path) -> std::io::Result<()> {
+    let bamboo_dir = project_bamboo_dir(project_dir);
+    std::fs::create_dir_all(project_worktree_dir(project_dir))?;
+    std::fs::create_dir_all(project_tmp_dir(project_dir))?;
+
+    let ignore_path = bamboo_dir.join(".gitignore");
+    let existing = std::fs::read_to_string(&ignore_path).unwrap_or_default();
+    let mut content = existing.clone();
+    for entry in ["worktree/", "tmp/", "settings.local.json"] {
+        if !existing.lines().any(|line| line.trim() == entry) {
+            if !content.is_empty() && !content.ends_with('\n') {
+                content.push('\n');
+            }
+            content.push_str(entry);
+            content.push('\n');
+        }
+    }
+    if content != existing {
+        std::fs::write(ignore_path, content)?;
+    }
+    Ok(())
+}
+
+/// Backward-compatible settings name for [`project_bamboo_dir`].
 pub fn project_settings_dir(project_dir: &Path) -> PathBuf {
-    project_dir.join(".bamboo")
+    project_bamboo_dir(project_dir)
 }
 
 /// Get the project-level settings file: `<project>/.bamboo/settings.json`
@@ -523,6 +558,35 @@ mod tests {
             commands_dir_in(Path::new("/data/bamboo")),
             PathBuf::from("/data/bamboo/commands")
         );
+    }
+
+    #[test]
+    fn project_runtime_paths_and_gitignore_are_scoped_and_incremental() {
+        let temp = tempdir().expect("tempdir");
+        let project = temp.path().join("project");
+        std::fs::create_dir_all(project_bamboo_dir(&project)).expect("bamboo dir");
+        std::fs::write(
+            project_bamboo_dir(&project).join(".gitignore"),
+            "custom-cache/\n",
+        )
+        .expect("custom ignore");
+
+        ensure_project_runtime_dirs(&project).expect("runtime dirs");
+        ensure_project_runtime_dirs(&project).expect("idempotent");
+
+        assert_eq!(
+            project_worktree_dir(&project),
+            project.join(".bamboo/worktree")
+        );
+        assert_eq!(project_tmp_dir(&project), project.join(".bamboo/tmp"));
+        assert!(project_worktree_dir(&project).is_dir());
+        assert!(project_tmp_dir(&project).is_dir());
+        let ignore = std::fs::read_to_string(project_bamboo_dir(&project).join(".gitignore"))
+            .expect("ignore");
+        assert!(ignore.contains("custom-cache/"));
+        for entry in ["worktree/", "tmp/", "settings.local.json"] {
+            assert_eq!(ignore.lines().filter(|line| *line == entry).count(), 1);
+        }
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/paths.rs
+++ b/crates/infra/bamboo-config/src/paths.rs
@@ -298,7 +298,11 @@ pub fn ensure_project_runtime_dirs(project_dir: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(project_tmp_dir(project_dir))?;
 
     let ignore_path = bamboo_dir.join(".gitignore");
-    let existing = std::fs::read_to_string(&ignore_path).unwrap_or_default();
+    let existing = match std::fs::read_to_string(&ignore_path) {
+        Ok(existing) => existing,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error),
+    };
     let mut content = existing.clone();
     for entry in ["worktree/", "tmp/", "settings.local.json"] {
         if !existing.lines().any(|line| line.trim() == entry) {
@@ -587,6 +591,23 @@ mod tests {
         for entry in ["worktree/", "tmp/", "settings.local.json"] {
             assert_eq!(ignore.lines().filter(|line| *line == entry).count(), 1);
         }
+    }
+
+    #[test]
+    fn project_runtime_gitignore_does_not_overwrite_invalid_existing_content() {
+        let temp = tempdir().expect("tempdir");
+        let project = temp.path().join("project");
+        let bamboo = project_bamboo_dir(&project);
+        std::fs::create_dir_all(&bamboo).expect("bamboo dir");
+        let ignore_path = bamboo.join(".gitignore");
+        let original = [0xff, 0xfe, b'x'];
+        std::fs::write(&ignore_path, original).expect("invalid utf8 ignore");
+
+        assert!(ensure_project_runtime_dirs(&project).is_err());
+        assert_eq!(
+            std::fs::read(ignore_path).expect("preserved ignore"),
+            original
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/settings_loader.rs
+++ b/crates/infra/bamboo-config/src/settings_loader.rs
@@ -36,7 +36,7 @@ fn load_settings_from_dirs(
     let mut settings = user;
 
     if let Some(proj_dir) = project_dir {
-        let project_bamboo = proj_dir.join(".bamboo");
+        let project_bamboo = paths::project_bamboo_dir(proj_dir);
 
         // 3. Project settings (shared, committed to git)
         let project_path = project_bamboo.join("settings.json");
@@ -127,7 +127,7 @@ mod tests {
 
         // Project settings
         let project_dir = temp.path().join("my_project");
-        let project_bamboo = project_dir.join(".bamboo");
+        let project_bamboo = paths::project_bamboo_dir(&project_dir);
         std::fs::create_dir_all(&project_bamboo).unwrap();
         write_settings(
             &project_bamboo,
@@ -156,7 +156,7 @@ mod tests {
 
         // Project settings
         let project_dir = temp.path().join("my_project");
-        let project_bamboo = project_dir.join(".bamboo");
+        let project_bamboo = paths::project_bamboo_dir(&project_dir);
         std::fs::create_dir_all(&project_bamboo).unwrap();
         write_settings(
             &project_bamboo,
@@ -194,7 +194,7 @@ mod tests {
 
         // Simulated project settings
         let project_dir = temp.path().join("my_project");
-        let project_bamboo = project_dir.join(".bamboo");
+        let project_bamboo = paths::project_bamboo_dir(&project_dir);
         std::fs::create_dir_all(&project_bamboo).unwrap();
         write_settings(
             &project_bamboo,

--- a/docs/project-scoped-directories.md
+++ b/docs/project-scoped-directories.md
@@ -1,0 +1,28 @@
+# Project-scoped Bamboo directories
+
+Bamboo keeps repository-bound runtime files below the Git project root:
+
+```text
+<git-root>/.bamboo/
+├── settings.json
+├── settings.local.json
+├── worktree/<name>/
+└── tmp/subagents/<child-id>/
+```
+
+`settings.json` remains suitable for source control. When Bamboo creates project runtime
+directories it incrementally maintains `.bamboo/.gitignore` with `worktree/`, `tmp/`, and
+`settings.local.json`; existing ignore entries are preserved.
+
+Managed worktrees use a validated name containing only ASCII letters, digits, `-`, or `_`, and
+the branch `bamboo/<name>`. Creation fails before invoking Git if either the destination or branch
+already exists. The owner should call the remove API when the task ends; it runs
+`git worktree remove --force` followed by `git worktree prune`. A retention-based garbage collector
+recovers worktrees left behind after a process failure. It removes a checkout only when Bamboo's
+ownership marker and directory have both expired and the checkout still has the exact expected
+`bamboo/<name>` branch. Unowned, fresh, detached, or branch-mismatched directories are preserved.
+
+Sub-agents with an explicit `storage_dir` keep that directory. Without one, a worker whose
+workspace belongs to a Git project uses `.bamboo/tmp/subagents/<child-id>`. Workspace-less
+broker/fabric workers retain the OS temporary-directory fallback. Project search tools exclude
+`.bamboo/worktree/` so a checkout is not indexed recursively through its sibling worktrees.

--- a/src/broker_agent.rs
+++ b/src/broker_agent.rs
@@ -141,7 +141,18 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
     } else {
         None
     };
-    if let Some(spec) = piped_spec {
+    if let Some(mut spec) = piped_spec {
+        if spec.storage_dir.is_none() {
+            spec.storage_dir = Some(
+                crate::subagent_worker::default_worker_storage_dir(
+                    spec.workspace.as_deref(),
+                    &spec.identity.child_id,
+                )
+                .await
+                .to_string_lossy()
+                .to_string(),
+            );
+        }
         let me = AgentRef {
             session_id: spec.identity.child_id.clone(),
             role: Some(spec.identity.role.clone()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod error;
 
 pub mod commands;
 
+pub mod project_worktree;
 /// The `bamboo subagent-worker` actor worker (provision via stdin, serve over WS).
 pub mod subagent_worker;
 

--- a/src/project_worktree.rs
+++ b/src/project_worktree.rs
@@ -259,6 +259,23 @@ pub async fn gc_orphans(project_root: &Path, retention: Duration) -> Result<usiz
         ) {
             continue;
         }
+        // A heartbeat owned by this process is definitive liveness. Besides
+        // avoiding needless filesystem work, this closes the race where GC
+        // observes an old marker just as a delayed heartbeat is about to renew
+        // it (for example immediately after a machine resumes from sleep).
+        let heartbeat_is_live = {
+            let mut heartbeats = lease_heartbeats().lock().await;
+            if heartbeats
+                .get(&marker)
+                .is_some_and(tokio::task::JoinHandle::is_finished)
+            {
+                heartbeats.remove(&marker);
+            }
+            heartbeats.contains_key(&marker)
+        };
+        if heartbeat_is_live {
+            continue;
+        }
         let (Ok(metadata), Ok(marker_metadata)) =
             (entry.metadata().await, tokio::fs::metadata(&marker).await)
         else {

--- a/src/project_worktree.rs
+++ b/src/project_worktree.rs
@@ -1,12 +1,25 @@
 //! Project-scoped Git worktree lifecycle.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::{Duration, SystemTime};
 
+use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
 pub const WORKTREE_BRANCH_PREFIX: &str = "bamboo/";
 pub const WORKTREE_RETENTION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+const WORKTREE_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
+
+static LEASE_HEARTBEATS: OnceLock<
+    tokio::sync::Mutex<HashMap<PathBuf, tokio::task::JoinHandle<()>>>,
+> = OnceLock::new();
+
+fn lease_heartbeats() -> &'static tokio::sync::Mutex<HashMap<PathBuf, tokio::task::JoinHandle<()>>>
+{
+    LEASE_HEARTBEATS.get_or_init(|| tokio::sync::Mutex::new(HashMap::new()))
+}
 
 fn validate_name(name: &str) -> Result<&str, String> {
     let name = name.trim();
@@ -59,6 +72,41 @@ fn ownership_marker(project_root: &Path, name: &str) -> PathBuf {
         .join(name)
 }
 
+async fn start_lease_heartbeat(marker: PathBuf, branch: String, interval: Duration) {
+    stop_lease_heartbeat(&marker).await;
+    let task_marker = marker.clone();
+    let handle = tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval.max(Duration::from_millis(1)));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            // Open an existing marker only. If normal cleanup deleted it, the
+            // heartbeat exits and can never recreate ownership metadata.
+            let Ok(mut file) = tokio::fs::OpenOptions::new()
+                .write(true)
+                .open(&task_marker)
+                .await
+            else {
+                break;
+            };
+            if file.write_all(branch.as_bytes()).await.is_err()
+                || file.set_len(branch.len() as u64).await.is_err()
+                || file.flush().await.is_err()
+            {
+                break;
+            }
+        }
+    });
+    lease_heartbeats().lock().await.insert(marker, handle);
+}
+
+async fn stop_lease_heartbeat(marker: &Path) {
+    if let Some(handle) = lease_heartbeats().lock().await.remove(marker) {
+        handle.abort();
+        let _ = handle.await;
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectWorktree {
     pub project_root: PathBuf,
@@ -67,6 +115,14 @@ pub struct ProjectWorktree {
 }
 
 pub async fn create(workspace: &Path, name: &str) -> Result<ProjectWorktree, String> {
+    create_with_heartbeat_interval(workspace, name, WORKTREE_HEARTBEAT_INTERVAL).await
+}
+
+async fn create_with_heartbeat_interval(
+    workspace: &Path,
+    name: &str,
+    heartbeat_interval: Duration,
+) -> Result<ProjectWorktree, String> {
     let name = validate_name(name)?;
     let project_root = git_project_root(workspace).await?;
     bamboo_config::paths::ensure_project_runtime_dirs(&project_root)
@@ -121,6 +177,7 @@ pub async fn create(workspace: &Path, name: &str) -> Result<ProjectWorktree, Str
         let _ = git_output(&project_root, &["worktree", "remove", "--force", &path_arg]).await;
         return Err(format!("record worktree ownership: {error}"));
     }
+    start_lease_heartbeat(marker, branch.clone(), heartbeat_interval).await;
     Ok(ProjectWorktree {
         project_root,
         path,
@@ -160,6 +217,7 @@ pub async fn remove(workspace: &Path, name: &str) -> Result<(), String> {
             String::from_utf8_lossy(&output.stderr).trim()
         ));
     }
+    stop_lease_heartbeat(&marker).await;
     let _ = tokio::fs::remove_file(marker).await;
     prune(&project_root).await
 }
@@ -284,6 +342,7 @@ mod tests {
             0
         );
         assert!(stale.path.exists(), "fresh worktree must not be reaped");
+        stop_lease_heartbeat(&ownership_marker(&stale.project_root, "child_2")).await;
         tokio::time::sleep(Duration::from_millis(5)).await;
         assert_eq!(gc_orphans(&project, Duration::ZERO).await.expect("gc"), 1);
         assert!(!stale.path.exists(), "expired owned worktree is reaped");
@@ -306,6 +365,36 @@ mod tests {
         );
         let mismatch_arg = mismatch.path.to_string_lossy().to_string();
         git(&project, &["worktree", "remove", "--force", &mismatch_arg]).await;
+        stop_lease_heartbeat(&ownership_marker(&mismatch.project_root, "mismatch")).await;
+    }
+
+    #[tokio::test]
+    async fn live_lease_prevents_reaping_until_heartbeat_stops() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("repo");
+        tokio::fs::create_dir_all(&project).await.expect("repo");
+        git(&project, &["init"]).await;
+        git(&project, &["config", "user.email", "test@example.com"]).await;
+        git(&project, &["config", "user.name", "Test"]).await;
+        tokio::fs::write(project.join("README.md"), "test")
+            .await
+            .expect("readme");
+        git(&project, &["add", "README.md"]).await;
+        git(&project, &["commit", "-m", "initial"]).await;
+
+        let worktree = create_with_heartbeat_interval(&project, "leased", Duration::from_millis(5))
+            .await
+            .expect("create leased worktree");
+        let retention = Duration::from_millis(30);
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert_eq!(gc_orphans(&project, retention).await.expect("live gc"), 0);
+        assert!(worktree.path.exists(), "live lease must prevent reaping");
+
+        let marker = ownership_marker(&worktree.project_root, "leased");
+        stop_lease_heartbeat(&marker).await;
+        tokio::time::sleep(Duration::from_millis(45)).await;
+        assert_eq!(gc_orphans(&project, retention).await.expect("stale gc"), 1);
+        assert!(!worktree.path.exists(), "expired lease should be reaped");
     }
 
     #[tokio::test]

--- a/src/project_worktree.rs
+++ b/src/project_worktree.rs
@@ -1,0 +1,347 @@
+//! Project-scoped Git worktree lifecycle.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use tokio::process::Command;
+
+pub const WORKTREE_BRANCH_PREFIX: &str = "bamboo/";
+pub const WORKTREE_RETENTION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+fn validate_name(name: &str) -> Result<&str, String> {
+    let name = name.trim();
+    if name.is_empty()
+        || name.len() > 80
+        || !name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+    {
+        return Err("worktree name must be 1-80 ASCII letters, digits, '-' or '_'".to_string());
+    }
+    Ok(name)
+}
+
+async fn git_output(project: &Path, args: &[&str]) -> Result<std::process::Output, String> {
+    Command::new("git")
+        .arg("-C")
+        .arg(project)
+        .args(args)
+        .output()
+        .await
+        .map_err(|error| format!("run git: {error}"))
+}
+
+pub async fn git_project_root(workspace: &Path) -> Result<PathBuf, String> {
+    // `rev-parse --show-toplevel` returns the *linked worktree* root. Runtime
+    // directories must instead stay anchored at the repository's main
+    // worktree, otherwise spawning from a managed checkout recursively creates
+    // `<checkout>/.bamboo/worktree/...`.
+    let output = git_output(workspace, &["worktree", "list", "--porcelain", "-z"]).await?;
+    if !output.status.success() {
+        return Err(format!(
+            "workspace is not inside a Git project: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let listing = String::from_utf8(output.stdout)
+        .map_err(|_| "git project root is not valid UTF-8".to_string())?;
+    let root = listing
+        .split('\0')
+        .find_map(|line| line.strip_prefix("worktree "))
+        .filter(|root| !root.is_empty())
+        .ok_or_else(|| "Git returned no main worktree".to_string())?;
+    Ok(PathBuf::from(root))
+}
+
+fn ownership_marker(project_root: &Path, name: &str) -> PathBuf {
+    bamboo_config::paths::project_worktree_dir(project_root)
+        .join(".bamboo-owned")
+        .join(name)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectWorktree {
+    pub project_root: PathBuf,
+    pub path: PathBuf,
+    pub branch: String,
+}
+
+pub async fn create(workspace: &Path, name: &str) -> Result<ProjectWorktree, String> {
+    let name = validate_name(name)?;
+    let project_root = git_project_root(workspace).await?;
+    bamboo_config::paths::ensure_project_runtime_dirs(&project_root)
+        .map_err(|error| format!("prepare project .bamboo directory: {error}"))?;
+    // Best-effort startup housekeeping. A failure to inspect stale siblings
+    // must not prevent creating an unrelated fresh worktree.
+    if let Err(error) = gc_orphans(&project_root, WORKTREE_RETENTION).await {
+        tracing::warn!("failed to garbage-collect stale project worktrees: {error}");
+    }
+    let path = bamboo_config::paths::project_worktree_dir(&project_root).join(name);
+    let branch = format!("{WORKTREE_BRANCH_PREFIX}{name}");
+    if path.exists() {
+        return Err(format!("worktree path already exists: {}", path.display()));
+    }
+
+    let branch_ref = format!("refs/heads/{branch}");
+    let branch_check = git_output(
+        &project_root,
+        &["show-ref", "--verify", "--quiet", &branch_ref],
+    )
+    .await?;
+    if branch_check.status.success() {
+        return Err(format!("worktree branch already exists: {branch}"));
+    }
+    if branch_check.status.code() != Some(1) {
+        return Err(format!(
+            "failed to check worktree branch: {}",
+            String::from_utf8_lossy(&branch_check.stderr).trim()
+        ));
+    }
+
+    let path_arg = path.to_string_lossy().to_string();
+    let output = git_output(
+        &project_root,
+        &["worktree", "add", "-b", &branch, &path_arg, "HEAD"],
+    )
+    .await?;
+    if !output.status.success() {
+        return Err(format!(
+            "create Git worktree: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let marker = ownership_marker(&project_root, name);
+    if let Some(parent) = marker.parent() {
+        if let Err(error) = tokio::fs::create_dir_all(parent).await {
+            let _ = git_output(&project_root, &["worktree", "remove", "--force", &path_arg]).await;
+            return Err(format!("create worktree ownership directory: {error}"));
+        }
+    }
+    if let Err(error) = tokio::fs::write(&marker, branch.as_bytes()).await {
+        let _ = git_output(&project_root, &["worktree", "remove", "--force", &path_arg]).await;
+        return Err(format!("record worktree ownership: {error}"));
+    }
+    Ok(ProjectWorktree {
+        project_root,
+        path,
+        branch,
+    })
+}
+
+pub async fn remove(workspace: &Path, name: &str) -> Result<(), String> {
+    let name = validate_name(name)?;
+    let project_root = git_project_root(workspace).await?;
+    let path = bamboo_config::paths::project_worktree_dir(&project_root).join(name);
+    let marker = ownership_marker(&project_root, name);
+    let expected_branch = format!("{WORKTREE_BRANCH_PREFIX}{name}");
+    let marker_branch = tokio::fs::read_to_string(&marker).await.ok();
+    if marker_branch.as_deref() != Some(expected_branch.as_str()) {
+        return Err(format!(
+            "refusing to remove an unmanaged worktree: {}",
+            path.display()
+        ));
+    }
+    if path.exists() {
+        let branch = git_output(&path, &["symbolic-ref", "--quiet", "--short", "HEAD"]).await?;
+        if !branch.status.success()
+            || String::from_utf8_lossy(&branch.stdout).trim() != expected_branch
+        {
+            return Err(format!(
+                "refusing to remove worktree with unexpected branch: {}",
+                path.display()
+            ));
+        }
+    }
+    let path_arg = path.to_string_lossy().to_string();
+    let output = git_output(&project_root, &["worktree", "remove", "--force", &path_arg]).await?;
+    if !output.status.success() && path.exists() {
+        return Err(format!(
+            "remove Git worktree: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let _ = tokio::fs::remove_file(marker).await;
+    prune(&project_root).await
+}
+
+pub async fn prune(project_root: &Path) -> Result<(), String> {
+    let output = git_output(project_root, &["worktree", "prune"]).await?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "prune Git worktrees: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+    }
+}
+
+/// Remove expired Bamboo-owned worktrees, then prune Git's administrative
+/// records. Ownership, lease age, and the checked-out branch must all match;
+/// ambiguous directories are deliberately preserved for manual recovery.
+pub async fn gc_orphans(project_root: &Path, retention: Duration) -> Result<usize, String> {
+    let root = bamboo_config::paths::project_worktree_dir(project_root);
+    let mut entries = match tokio::fs::read_dir(&root).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(format!("read worktree directory: {error}")),
+    };
+    let now = SystemTime::now();
+    let mut removed = 0;
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if validate_name(&name).is_err() {
+            continue;
+        }
+        let marker = ownership_marker(project_root, &name);
+        let expected_branch = format!("{WORKTREE_BRANCH_PREFIX}{name}");
+        if !matches!(
+            tokio::fs::read_to_string(&marker).await.as_deref(),
+            Ok(branch) if branch == expected_branch
+        ) {
+            continue;
+        }
+        let (Ok(metadata), Ok(marker_metadata)) =
+            (entry.metadata().await, tokio::fs::metadata(&marker).await)
+        else {
+            continue;
+        };
+        let older_than_retention = |metadata: &std::fs::Metadata| {
+            metadata
+                .modified()
+                .ok()
+                .and_then(|modified| now.duration_since(modified).ok())
+                .is_some_and(|age| age > retention)
+        };
+        let stale = metadata.is_dir()
+            && older_than_retention(&metadata)
+            && older_than_retention(&marker_metadata);
+        if !stale {
+            continue;
+        }
+        let path = entry.path();
+        let branch = git_output(&path, &["symbolic-ref", "--quiet", "--short", "HEAD"]).await;
+        if !branch.is_ok_and(|output| {
+            output.status.success()
+                && String::from_utf8_lossy(&output.stdout).trim() == expected_branch
+        }) {
+            continue;
+        }
+        if remove(project_root, &name).await.is_ok() {
+            removed += 1;
+        }
+    }
+    prune(project_root).await?;
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn git(project: &Path, args: &[&str]) {
+        let output = git_output(project, args).await.expect("git command");
+        assert!(
+            output.status.success(),
+            "git failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[tokio::test]
+    async fn create_collision_remove_and_prune_use_project_convention() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("repo");
+        tokio::fs::create_dir_all(&project).await.expect("repo");
+        git(&project, &["init"]).await;
+        git(&project, &["config", "user.email", "test@example.com"]).await;
+        git(&project, &["config", "user.name", "Test"]).await;
+        tokio::fs::write(project.join("README.md"), "test")
+            .await
+            .expect("readme");
+        git(&project, &["add", "README.md"]).await;
+        git(&project, &["commit", "-m", "initial"]).await;
+
+        let created = create(&project, "child_1").await.expect("create");
+        assert_eq!(created.branch, "bamboo/child_1");
+        assert_eq!(
+            created.path,
+            std::fs::canonicalize(&project)
+                .expect("canonical project")
+                .join(".bamboo/worktree/child_1")
+        );
+        assert!(created.path.join(".git").is_file());
+        assert!(create(&project, "child_1").await.is_err());
+
+        remove(&project, "child_1").await.expect("remove");
+        assert!(!created.path.exists());
+
+        let stale = create(&project, "child_2").await.expect("stale create");
+        assert_eq!(
+            gc_orphans(&project, WORKTREE_RETENTION)
+                .await
+                .expect("fresh gc"),
+            0
+        );
+        assert!(stale.path.exists(), "fresh worktree must not be reaped");
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        assert_eq!(gc_orphans(&project, Duration::ZERO).await.expect("gc"), 1);
+        assert!(!stale.path.exists(), "expired owned worktree is reaped");
+
+        let unowned = project.join(".bamboo/worktree/unowned");
+        tokio::fs::create_dir_all(&unowned)
+            .await
+            .expect("unowned directory");
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        assert_eq!(gc_orphans(&project, Duration::ZERO).await.expect("gc"), 0);
+        assert!(unowned.exists(), "unowned directory must be preserved");
+
+        let mismatch = create(&project, "mismatch").await.expect("mismatch create");
+        git(&mismatch.path, &["checkout", "--detach"]).await;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        assert_eq!(gc_orphans(&project, Duration::ZERO).await.expect("gc"), 0);
+        assert!(
+            mismatch.path.exists(),
+            "worktree on an unexpected branch must be preserved"
+        );
+        let mismatch_arg = mismatch.path.to_string_lossy().to_string();
+        git(&project, &["worktree", "remove", "--force", &mismatch_arg]).await;
+    }
+
+    #[tokio::test]
+    async fn linked_worktree_resolves_to_main_project_root() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("repo");
+        let linked = temp.path().join("linked");
+        tokio::fs::create_dir_all(&project).await.expect("repo");
+        git(&project, &["init"]).await;
+        git(&project, &["config", "user.email", "test@example.com"]).await;
+        git(&project, &["config", "user.name", "Test"]).await;
+        tokio::fs::write(project.join("README.md"), "test")
+            .await
+            .expect("readme");
+        git(&project, &["add", "README.md"]).await;
+        git(&project, &["commit", "-m", "initial"]).await;
+        let linked_arg = linked.to_string_lossy().to_string();
+        git(&project, &["worktree", "add", "-b", "linked", &linked_arg]).await;
+
+        assert_eq!(
+            git_project_root(&linked).await.expect("project root"),
+            std::fs::canonicalize(&project).expect("canonical project")
+        );
+        let child = create(&linked, "nested_child").await.expect("child");
+        assert!(child.path.starts_with(
+            std::fs::canonicalize(&project)
+                .expect("canonical project")
+                .join(".bamboo/worktree")
+        ));
+        assert!(!linked.join(".bamboo").exists());
+    }
+
+    #[test]
+    fn rejects_names_that_can_escape_the_managed_root() {
+        for name in ["", "../escape", "a/b", "space name", "."] {
+            assert!(validate_name(name).is_err(), "accepted {name:?}");
+        }
+    }
+}

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -1017,7 +1017,15 @@ async fn gc_stale_storage(root: PathBuf, fabric_dir: PathBuf, retention: std::ti
     let live_ids: std::collections::HashSet<String> = Fabric::at(&fabric_dir)
         .discover()
         .await
-        .map(|records| records.into_iter().map(|r| r.agent_id).collect())
+        // Storage directory names use the same safe component mapping as
+        // provisioning. Comparing raw Fabric ids would fail for `../`, Unicode,
+        // or Windows-reserved ids and could reap a still-live actor.
+        .map(|records| {
+            records
+                .into_iter()
+                .map(|record| safe_child_storage_component(&record.agent_id))
+                .collect()
+        })
         .unwrap_or_default();
 
     let Ok(mut rd) = tokio::fs::read_dir(&root).await else {
@@ -1237,5 +1245,16 @@ mod tests {
             .join(".bamboo/tmp/subagents");
         assert!(escaped.starts_with(&storage_root));
         assert_eq!(escaped.parent(), Some(storage_root.as_path()));
+    }
+
+    #[test]
+    fn live_fabric_ids_map_to_the_same_safe_storage_component() {
+        for id in ["ordinary-child", "../outside", "子代理", "CON"] {
+            let storage = safe_child_storage_component(id);
+            let live_components: std::collections::HashSet<_> =
+                [id].into_iter().map(safe_child_storage_component).collect();
+            assert!(live_components.contains(&storage), "id={id:?}");
+            assert!(!storage.contains(std::path::MAIN_SEPARATOR));
+        }
     }
 }

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -13,7 +13,7 @@
 //! the WebSocket verbatim (zero mapping).
 
 use std::collections::BTreeSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -44,17 +44,41 @@ const STORAGE_RETENTION: std::time::Duration = std::time::Duration::from_secs(7 
 /// Worker entry point: provision from stdin, build the executor, serve one run, clean up.
 pub async fn run() -> std::result::Result<(), String> {
     // Stage 1: provision (one JSON document on stdin; the parent closes the pipe).
-    let spec = ProvisionSpec::read_from_stdin()
+    let mut spec = ProvisionSpec::read_from_stdin()
         .await
         .map_err(|e| format!("read ProvisionSpec from stdin: {e}"))?;
 
+    // Preserve an explicit parent-selected storage root. Otherwise bind
+    // project workers to `<git-root>/.bamboo/tmp/subagents/<child-id>` and
+    // leave workspace-less broker/fabric workers in OS temp.
+    let uses_default_storage = spec.storage_dir.is_none();
+    if uses_default_storage {
+        spec.storage_dir = Some(
+            default_worker_storage_dir(spec.workspace.as_deref(), &spec.identity.child_id)
+                .await
+                .to_string_lossy()
+                .to_string(),
+        );
+    }
+
     // Best-effort housekeeping while we boot: expire stale sibling storage
-    // dirs (default retention 7 days) and stale fabric records.
-    // #217: the persistent data-dir subagents home, not `env::temp_dir()`.
-    tokio::spawn(gc_stale_storage(
-        bamboo_config::paths::subagents_dir(),
-        STORAGE_RETENTION,
-    ));
+    // dirs (default retention 7 days) while consulting the actual fabric for
+    // live leases, regardless of whether storage is project-scoped or in temp.
+    // An explicit storage directory is operator-owned. Its parent may contain
+    // unrelated directories, so never run sibling GC there.
+    if uses_default_storage {
+        let storage_root = spec
+            .storage_dir
+            .as_deref()
+            .and_then(|path| Path::new(path).parent())
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| std::env::temp_dir().join("bamboo-subagents"));
+        tokio::spawn(gc_stale_storage(
+            storage_root,
+            PathBuf::from(&spec.fabric_dir),
+            STORAGE_RETENTION,
+        ));
+    }
     {
         let fab = Fabric::at(&spec.fabric_dir);
         tokio::spawn(async move {
@@ -200,14 +224,9 @@ impl BambooRuntimeExecutor {
     /// isolated storage/skills/metrics, builtin tools — never touching the user's
     /// `~/.bamboo` or persisting any secret.
     pub async fn build(spec: &ProvisionSpec) -> std::result::Result<Self, String> {
-        // #217: default under the persistent data-dir subagents home instead
-        // of `env::temp_dir()` (mirrors `resolve_claude_code_state_dir` in
-        // `claude_code_executor.rs`, which the doc comment there points at).
-        let storage_dir = spec
-            .storage_dir
-            .clone()
-            .map(PathBuf::from)
-            .unwrap_or_else(|| bamboo_config::paths::subagents_dir().join(&spec.identity.child_id));
+        let storage_dir = spec.storage_dir.clone().map(PathBuf::from).unwrap_or(
+            default_worker_storage_dir(spec.workspace.as_deref(), &spec.identity.child_id).await,
+        );
         tokio::fs::create_dir_all(&storage_dir)
             .await
             .map_err(|e| format!("create storage dir: {e}"))?;
@@ -552,6 +571,77 @@ impl BambooRuntimeExecutor {
             child_runner,
         })
     }
+}
+
+pub(crate) async fn default_worker_storage_dir(workspace: Option<&str>, child_id: &str) -> PathBuf {
+    let child_component = safe_child_storage_component(child_id);
+    if let Some(workspace) = workspace.map(str::trim).filter(|value| !value.is_empty()) {
+        if let Ok(project_root) =
+            crate::project_worktree::git_project_root(Path::new(workspace)).await
+        {
+            if bamboo_config::paths::ensure_project_runtime_dirs(&project_root).is_ok() {
+                return bamboo_config::paths::project_tmp_dir(&project_root)
+                    .join("subagents")
+                    .join(&child_component);
+            }
+        }
+    }
+    std::env::temp_dir()
+        .join("bamboo-subagents")
+        .join(child_component)
+}
+
+fn safe_child_storage_component(child_id: &str) -> String {
+    let safe = !child_id.is_empty()
+        && child_id.len() <= 80
+        && child_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_');
+    let windows_reserved = matches!(
+        child_id.to_ascii_uppercase().as_str(),
+        "CON"
+            | "PRN"
+            | "AUX"
+            | "NUL"
+            | "COM1"
+            | "COM2"
+            | "COM3"
+            | "COM4"
+            | "COM5"
+            | "COM6"
+            | "COM7"
+            | "COM8"
+            | "COM9"
+            | "LPT1"
+            | "LPT2"
+            | "LPT3"
+            | "LPT4"
+            | "LPT5"
+            | "LPT6"
+            | "LPT7"
+            | "LPT8"
+            | "LPT9"
+    );
+    if safe && !windows_reserved {
+        return child_id.to_string();
+    }
+
+    // Hex encoding is injective and contains no path separators. Provisioned
+    // identities are small in practice; cap pathological input while retaining
+    // a hash of the complete value to avoid prefix collisions.
+    use std::hash::{Hash, Hasher};
+    let mut encoded = String::from("id-");
+    for byte in child_id.as_bytes().iter().take(80) {
+        use std::fmt::Write as _;
+        let _ = write!(encoded, "{byte:02x}");
+    }
+    if child_id.len() > 80 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        child_id.hash(&mut hasher);
+        use std::fmt::Write as _;
+        let _ = write!(encoded, "-{:016x}", hasher.finish());
+    }
+    encoded
 }
 
 /// Bridges the engine's task-local [`bamboo_tools::ApprovalProxy`] to the host
@@ -923,8 +1013,8 @@ impl ChildExecutor for BambooRuntimeExecutor {
 /// not expired) is never removed — dir mtime alone would misjudge a long-running
 /// actor (>retention) as stale, because file writes inside subdirectories do
 /// not bump the top-level directory's mtime.
-async fn gc_stale_storage(root: PathBuf, retention: std::time::Duration) {
-    let live_ids: std::collections::HashSet<String> = Fabric::at(&root)
+async fn gc_stale_storage(root: PathBuf, fabric_dir: PathBuf, retention: std::time::Duration) {
+    let live_ids: std::collections::HashSet<String> = Fabric::at(&fabric_dir)
         .discover()
         .await
         .map(|records| records.into_iter().map(|r| r.agent_id).collect())
@@ -1112,5 +1202,40 @@ mod tests {
         assert_eq!(config.provider, "openai");
         let slot = config.providers.openai.expect("openai slot");
         assert_eq!(slot.api_key, "sk-oa");
+    }
+
+    #[tokio::test]
+    async fn default_storage_is_project_scoped_only_for_git_workspaces() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project = temp.path().join("project");
+        tokio::fs::create_dir_all(&project).await.expect("project");
+        let status = tokio::process::Command::new("git")
+            .arg("-C")
+            .arg(&project)
+            .arg("init")
+            .status()
+            .await
+            .expect("git init");
+        assert!(status.success());
+
+        let project_storage = default_worker_storage_dir(project.to_str(), "child-project").await;
+        assert_eq!(
+            project_storage,
+            std::fs::canonicalize(&project)
+                .expect("canonical project")
+                .join(".bamboo/tmp/subagents/child-project")
+        );
+        let temp_storage = default_worker_storage_dir(None, "child-global").await;
+        assert_eq!(
+            temp_storage,
+            std::env::temp_dir().join("bamboo-subagents/child-global")
+        );
+
+        let escaped = default_worker_storage_dir(project.to_str(), "../outside").await;
+        let storage_root = std::fs::canonicalize(&project)
+            .expect("canonical project")
+            .join(".bamboo/tmp/subagents");
+        assert!(escaped.starts_with(&storage_root));
+        assert_eq!(escaped.parent(), Some(storage_root.as_path()));
     }
 }


### PR DESCRIPTION
## Summary

- centralize project-scoped `.bamboo` paths and incrementally maintain runtime ignore entries
- create managed checkouts under `.bamboo/worktree/<name>` on `bamboo/<name>` branches
- migrate implicit worker storage to `.bamboo/tmp/subagents/<child-id>` while preserving explicit and non-Git fallbacks
- exclude managed sibling worktrees from Glob/Grep traversal
- safely recover expired registered worktrees only when the Bamboo ownership marker, retention lease, and exact checked-out branch all match; preserve unowned, fresh, detached, or mismatched directories

## Test Plan

- `cargo fmt --all -- --check`
- `cargo check -p bamboo-agent -p bamboo-config -p bamboo-tools -p bamboo-server`
- `cargo test -p bamboo-agent project_worktree --lib`
- focused config, worker-path, Glob, Grep, and command-handler tests were run after rebasing onto main

Closes #555