### PR TITLE
[bamboo] refactor: add typed permission migration envelope

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/mod.rs
+++ b/crates/app/bamboo-sdk/src/agent/mod.rs
@@ -548,8 +548,10 @@ impl Agent {
             submit_pending_response(self, input).await?;
 
         if let Some(checker) = &self.permission_checker {
-            for (perm_type, resource) in &permission_grants {
-                checker.grant_session_permission(*perm_type, resource.clone());
+            if let Some(request_id) = session.metadata.get(PERMISSION_REEXECUTE_METADATA_KEY) {
+                for (perm_type, resource) in &permission_grants {
+                    checker.grant_once(&session.id, request_id, *perm_type, resource.clone());
+                }
             }
         }
 
@@ -977,14 +979,14 @@ mod approval_and_session_tests {
             .is_none());
     }
 
-    /// A stub `PermissionChecker` that only records `grant_session_permission`
+    /// A stub `PermissionChecker` that records one-shot grants
     /// calls, so the test can assert `Agent::answer` applies the permission
     /// grants `submit_pending_response` extracts from an approved permission
     /// prompt — mirroring what the HTTP `/respond` handler does explicitly for
     /// `state.permission_checker`.
     #[derive(Default)]
     struct RecordingPermissionChecker {
-        grants: StdMutex<Vec<(PermissionType, String)>>,
+        grants: StdMutex<Vec<(String, String, PermissionType, String)>>,
     }
 
     #[async_trait]
@@ -1001,7 +1003,22 @@ mod approval_and_session_tests {
         }
 
         fn grant_session_permission(&self, perm_type: PermissionType, resource: String) {
-            self.grants.lock().unwrap().push((perm_type, resource));
+            panic!("legacy unscoped grant used: {perm_type:?} {resource}");
+        }
+
+        fn grant_once(
+            &self,
+            session_id: &str,
+            request_id: &str,
+            perm_type: PermissionType,
+            resource: String,
+        ) {
+            self.grants.lock().unwrap().push((
+                session_id.to_string(),
+                request_id.to_string(),
+                perm_type,
+                resource,
+            ));
         }
 
         fn set_permission_mode(&self, _mode: PermissionMode) {}
@@ -1070,7 +1087,12 @@ mod approval_and_session_tests {
         let recorded = checker.grants.lock().unwrap();
         assert_eq!(
             *recorded,
-            vec![(PermissionType::WriteFile, "/tmp/example.txt".to_string())]
+            vec![(
+                "sess-permission".to_string(),
+                "call-perm-1".to_string(),
+                PermissionType::WriteFile,
+                "/tmp/example.txt".to_string()
+            )]
         );
     }
 

--- a/crates/app/bamboo-server/src/connect/approvals.rs
+++ b/crates/app/bamboo-server/src/connect/approvals.rs
@@ -362,9 +362,14 @@ impl Responder for EngineResponder {
         // permission grant so the resumed re-execution of the gated tool
         // passes the check without re-prompting.
         for (perm_type, resource) in &permission_grants {
-            self.ctx
-                .permission_checker
-                .grant_session_permission(*perm_type, resource.clone());
+            if let Some(request_id) = session.metadata.get(PERMISSION_REEXECUTE_METADATA_KEY) {
+                self.ctx.permission_checker.grant_once(
+                    session_id,
+                    request_id,
+                    *perm_type,
+                    resource.clone(),
+                );
+            }
         }
 
         // Subscribe BEFORE triggering resume so the `ExecutionStarted` event

--- a/crates/app/bamboo-server/src/handlers/agent/respond/handlers/submit.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/respond/handlers/submit.rs
@@ -34,7 +34,7 @@ pub async fn submit_response(
         reasoning_effort: req.reasoning_effort,
     };
 
-    let (_session, user_response, plan_mode_transition, permission_grants) =
+    let (session, user_response, plan_mode_transition, permission_grants) =
         match bamboo_engine::session_app::respond::submit_pending_response(state.as_ref(), input)
             .await
         {
@@ -73,9 +73,17 @@ pub async fn submit_response(
     // prompting again. `state.permission_checker` shares the same PermissionConfig
     // the tool executor checks against.
     for (perm_type, resource) in &permission_grants {
-        state
-            .permission_checker
-            .grant_session_permission(*perm_type, resource.clone());
+        if let Some(request_id) = session
+            .metadata
+            .get(bamboo_engine::session_app::respond::PERMISSION_REEXECUTE_METADATA_KEY)
+        {
+            state.permission_checker.grant_once(
+                &session_id,
+                request_id,
+                *perm_type,
+                resource.clone(),
+            );
+        }
         tracing::info!(
             "[{}] Granted session permission {:?} for: {}",
             session_id,
@@ -128,7 +136,7 @@ pub async fn submit_response(
     let resume_config = bamboo_engine::session_app::resolution::resolve_resume_config_snapshot(
         &config_snapshot,
         &state.provider_registry,
-        &_session,
+        &session,
         None,
     );
 

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -1225,6 +1225,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_explicit_deny_overrides_bypass() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("explicit-deny.txt");
+        let path_str = path.to_str().unwrap();
+        let config = Arc::new(crate::permission::PermissionConfig::new());
+        config.add_rule(crate::permission::PermissionRule::new(
+            crate::permission::PermissionType::WriteFile,
+            path_str,
+            false,
+        ));
+        let checker = Arc::new(crate::permission::ConfigPermissionChecker::new(config));
+        let executor = make_executor(Some(checker));
+        let call = make_tool_call(
+            "Write",
+            json!({"file_path": path_str, "content": "blocked"}),
+        );
+        let ctx = ToolExecutionContext {
+            session_id: Some("s-explicit-deny"),
+            tool_call_id: &call.id,
+            event_tx: None,
+            available_tool_schemas: None,
+            bypass_permissions: true,
+            can_async_resume: false,
+            bash_completion_sink: None,
+            pre_parsed_args: None,
+        };
+
+        let result = executor.execute_with_context(&call, ctx).await;
+        assert!(
+            matches!(result, Err(ToolError::Execution(ref message)) if message.contains("explicit policy")),
+            "explicit deny must beat bypass: {result:?}"
+        );
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
     async fn interactive_gate_returns_synthesized_approval_pause() {
         // With an event sink present, a forced-ask rule that yields
         // `ConfirmationRequired` must resolve to the synthesized "awaiting

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -1261,6 +1261,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_explicit_delete_deny_overrides_bypass() {
+        let config = Arc::new(crate::permission::PermissionConfig::new());
+        config.add_rule(crate::permission::PermissionRule::new(
+            crate::permission::PermissionType::DeleteOperation,
+            "rm child-to-preserve",
+            false,
+        ));
+        let checker = Arc::new(crate::permission::ConfigPermissionChecker::new(config));
+        let executor = BuiltinToolExecutorBuilder::new()
+            .with_tool(BashTool::new())
+            .expect("register Bash tool")
+            .with_permission_checker(checker)
+            .build();
+        let call = make_tool_call("Bash", json!({"command": "rm child-to-preserve"}));
+        let ctx = ToolExecutionContext {
+            session_id: Some("s-explicit-delete-deny"),
+            tool_call_id: &call.id,
+            event_tx: None,
+            available_tool_schemas: None,
+            bypass_permissions: true,
+            can_async_resume: false,
+            bash_completion_sink: None,
+            pre_parsed_args: None,
+        };
+
+        let result = executor.execute_with_context(&call, ctx).await;
+        assert!(
+            matches!(result, Err(ToolError::Execution(ref message)) if message.contains("explicit policy")),
+            "explicit delete deny must beat bypass: {result:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn interactive_gate_returns_synthesized_approval_pause() {
         // With an event sink present, a forced-ask rule that yields
         // `ConfirmationRequired` must resolve to the synthesized "awaiting

--- a/crates/engine/bamboo-tools/src/executor.rs
+++ b/crates/engine/bamboo-tools/src/executor.rs
@@ -377,14 +377,44 @@ impl ToolExecutor for BuiltinToolExecutor {
             // mode (scoped per-session via its runtime state).
             let force_ask = permission_checker.requires_forced_confirmation(&tool_name, &args);
             for context in contexts {
+                // Explicit deny is a non-overridable policy outcome. Evaluate it
+                // before forced confirmation, remembered grants, and bypass.
+                if permission_checker
+                    .permission_config()
+                    .is_some_and(|config| {
+                        config.is_whitelist_allowed(context.permission_type, &context.resource)
+                            == Some(false)
+                    })
+                {
+                    return Err(ToolError::Execution(format!(
+                        "Permission denied by explicit policy for: {}",
+                        context.resource
+                    )));
+                }
+                if ctx.session_id.is_some_and(|session_id| {
+                    permission_checker.consume_once(
+                        session_id,
+                        &call.id,
+                        context.permission_type,
+                        &context.resource,
+                    )
+                }) {
+                    continue;
+                }
                 if ctx.bypass_permissions && !force_ask {
                     continue;
                 }
                 let resource = context.resource.clone();
+                let operation_summary = context.operation_description.clone();
+                let risk_level = context.risk_level();
                 // Forced confirmations route through `check_or_request_forced`
                 // so the active mode/bypass cannot suppress the prompt.
                 let decision = if force_ask {
                     permission_checker.check_or_request_forced(context).await
+                } else if let Some(session_id) = ctx.session_id {
+                    permission_checker
+                        .check_or_request_for_session(session_id, context)
+                        .await
                 } else {
                     permission_checker.check_or_request(context).await
                 };
@@ -451,6 +481,39 @@ impl ToolExecutor for BuiltinToolExecutor {
                                 permission_type.description(),
                                 resource
                             );
+                            let effective_mode = permission_checker
+                                .permission_config()
+                                .map(|config| config.mode())
+                                .unwrap_or(bamboo_config::settings::PermissionMode::Default);
+                            let permission_request = crate::permission::PermissionRequest {
+                                request_id: call.id.clone(),
+                                session_id: ctx.session_id.unwrap_or_default().to_string(),
+                                workspace_path: None,
+                                tool_name: tool_name.clone(),
+                                permission_type,
+                                resource: resource.clone(),
+                                operation_summary,
+                                risk_level,
+                                reason_code: if permission_checker.permission_config().is_some_and(
+                                    |config| config.is_hard_dangerous(&tool_name, &args),
+                                ) {
+                                    crate::permission::PermissionReasonCode::HardDangerous
+                                } else if force_ask {
+                                    crate::permission::PermissionReasonCode::ConfiguredAlwaysAsk
+                                } else {
+                                    crate::permission::PermissionReasonCode::RiskThreshold
+                                },
+                                effective_mode,
+                                bypass_requested: ctx.bypass_permissions,
+                                policy_revision: 0,
+                                allowed_decisions:
+                                    crate::permission::PermissionRequest::migration_decisions(),
+                                suggested_matchers: vec![crate::permission::PermissionMatcher {
+                                    id: "exact_resource".to_string(),
+                                    kind: crate::permission::PermissionMatcherKind::ExactResource,
+                                    value: resource.clone(),
+                                }],
+                            };
                             let payload = serde_json::json!({
                                 "status": "awaiting_permission_approval",
                                 "question": question,
@@ -458,6 +521,7 @@ impl ToolExecutor for BuiltinToolExecutor {
                                 "resource": resource,
                                 "options": ["Approve", "Deny"],
                                 "allow_custom": false,
+                                "permission_request": permission_request,
                             });
                             // Permission-gate synthesized question stays on
                             // the Completed→sniff path for now (a later Phase B
@@ -1201,6 +1265,16 @@ mod tests {
             "interactive gate must return the request_permissions pause result"
         );
         assert!(result.result.contains("awaiting_permission_approval"));
+        let payload: serde_json::Value = serde_json::from_str(&result.result).expect("payload");
+        let request = &payload["permission_request"];
+        assert_eq!(request["request_id"], call.id);
+        assert_eq!(request["session_id"], "s-interactive");
+        assert_eq!(request["reason_code"], "configured_always_ask");
+        assert_eq!(
+            request["allowed_decisions"],
+            json!(["allow_once", "deny_once"])
+        );
+        assert_eq!(payload["options"], json!(["Approve", "Deny"]));
         assert!(fs::metadata("/etc/gated.conf").await.is_err());
 
         let ev = rx.recv().await.expect("approval event should be emitted");

--- a/crates/infra/bamboo-permission/src/checker.rs
+++ b/crates/infra/bamboo-permission/src/checker.rs
@@ -111,6 +111,20 @@ pub trait PermissionChecker: Send + Sync {
     /// Returns `true` if the operation requires user confirmation before proceeding.
     async fn needs_confirmation(&self, perm_type: PermissionType, resource: &str) -> bool;
 
+    async fn needs_confirmation_for_session(
+        &self,
+        session_id: &str,
+        perm_type: PermissionType,
+        resource: &str,
+    ) -> bool {
+        if self.permission_config().is_some_and(|config| {
+            config.consume_scoped_session_grant(session_id, perm_type, resource)
+        }) {
+            return false;
+        }
+        self.needs_confirmation(perm_type, resource).await
+    }
+
     /// Check if a permission is granted (without requesting confirmation)
     ///
     /// This method checks the whitelist and session grants but does not
@@ -132,6 +146,42 @@ pub trait PermissionChecker: Send + Sync {
     /// After granting, subsequent calls to `needs_confirmation` for the same
     /// permission type and matching resources will return `false`.
     fn grant_session_permission(&self, perm_type: PermissionType, resource: String);
+
+    fn grant_scoped_session_permission(
+        &self,
+        session_id: &str,
+        perm_type: PermissionType,
+        resource: String,
+    ) {
+        if let Some(config) = self.permission_config() {
+            config.grant_scoped_session_permission(session_id, perm_type, resource);
+        } else {
+            self.grant_session_permission(perm_type, resource);
+        }
+    }
+
+    fn grant_once(
+        &self,
+        session_id: &str,
+        request_id: &str,
+        perm_type: PermissionType,
+        resource: String,
+    ) {
+        if let Some(config) = self.permission_config() {
+            config.grant_once(session_id, request_id, perm_type, resource);
+        }
+    }
+
+    fn consume_once(
+        &self,
+        session_id: &str,
+        request_id: &str,
+        perm_type: PermissionType,
+        resource: &str,
+    ) -> bool {
+        self.permission_config()
+            .is_some_and(|config| config.consume_once(session_id, request_id, perm_type, resource))
+    }
 
     /// Override the active permission mode at runtime.
     ///
@@ -183,6 +233,20 @@ pub trait PermissionChecker: Send + Sync {
         }
 
         // Request confirmation from user
+        self.request_confirmation(ctx).await
+    }
+
+    async fn check_or_request_for_session(
+        &self,
+        session_id: &str,
+        ctx: PermissionContext,
+    ) -> Result<bool, PermissionError> {
+        if !self
+            .needs_confirmation_for_session(session_id, ctx.permission_type, &ctx.resource)
+            .await
+        {
+            return Ok(true);
+        }
         self.request_confirmation(ctx).await
     }
 }

--- a/crates/infra/bamboo-permission/src/config.rs
+++ b/crates/infra/bamboo-permission/src/config.rs
@@ -265,7 +265,12 @@ pub(crate) fn canonicalize_path_pattern_for_matching(pattern: &str) -> Option<St
         return Some(normalized);
     }
     let canonical_prefix = canonicalize_path_for_matching(prefix)?;
-    Some(format!("{}{}", canonical_prefix, &normalized[separator..]))
+    let suffix = &normalized[separator..];
+    if canonical_prefix.ends_with('/') && suffix.starts_with('/') {
+        Some(format!("{}{}", canonical_prefix, &suffix[1..]))
+    } else {
+        Some(format!("{canonical_prefix}{suffix}"))
+    }
 }
 
 /// Canonicalize a resource path before permission matching.
@@ -2243,6 +2248,11 @@ mod integration_tests {
         assert!(
             !deny.matches(PermissionType::WriteFile, &alias),
             "a traversal matcher must fail closed rather than normalize broader"
+        );
+        #[cfg(unix)]
+        assert_eq!(
+            canonicalize_path_pattern_for_matching("/**").as_deref(),
+            Some("/**")
         );
     }
 }

--- a/crates/infra/bamboo-permission/src/config.rs
+++ b/crates/infra/bamboo-permission/src/config.rs
@@ -599,6 +599,10 @@ pub struct PermissionConfig {
     /// used to resolve a *match*, however, because matching is glob-based — see
     /// [`PermissionConfig::is_session_granted`].
     session_grants: DashMap<PermissionType, HashMap<String, SessionGrant>>,
+    /// Grants keyed by stable session id. New interactive approvals use this
+    /// map; the unscoped map above remains only for API compatibility.
+    scoped_session_grants: DashMap<String, DashMap<PermissionType, HashMap<String, SessionGrant>>>,
+    one_shot_grants: DashMap<(String, String), Vec<(PermissionType, String)>>,
     /// Default session grant duration (default: 30 minutes)
     session_grant_duration: Duration,
     /// Whether permission checks are enabled
@@ -630,6 +634,8 @@ impl PermissionConfig {
         Self {
             whitelist: DashMap::new(),
             session_grants: DashMap::new(),
+            scoped_session_grants: DashMap::new(),
+            one_shot_grants: DashMap::new(),
             session_grant_duration: Duration::from_secs(30 * 60), // 30 minutes
             enabled: AtomicBool::new(true),
             mode: RwLock::new(PermissionMode::Default),
@@ -643,6 +649,8 @@ impl PermissionConfig {
         Self {
             whitelist: DashMap::new(),
             session_grants: DashMap::new(),
+            scoped_session_grants: DashMap::new(),
+            one_shot_grants: DashMap::new(),
             session_grant_duration: session_duration,
             enabled: AtomicBool::new(enabled),
             mode: RwLock::new(PermissionMode::Default),
@@ -753,6 +761,23 @@ impl PermissionConfig {
             .any(|rule| rule.matches_tool_call(tool_name, args))
     }
 
+    /// Whether the forced confirmation came from Bamboo's non-configurable
+    /// hard-dangerous backstop rather than a user configured ask rule.
+    pub fn is_hard_dangerous(&self, tool_name: &str, args: &serde_json::Value) -> bool {
+        if tool_name.eq_ignore_ascii_case("js_repl") {
+            return true;
+        }
+        tool_name.eq_ignore_ascii_case("Bash")
+            && args
+                .get("command")
+                .and_then(|value| value.as_str())
+                .is_some_and(|command| {
+                    crate::bash_security::analyze_command(command).verdict
+                        == crate::bash_security::BashVerdict::Deny
+                        || crate::bash_security::super_dangerous_reason(command).is_some()
+                })
+    }
+
     /// Get the session grant duration
     pub fn session_grant_duration(&self) -> Duration {
         self.session_grant_duration
@@ -832,9 +857,110 @@ impl PermissionConfig {
         false
     }
 
+    pub fn grant_scoped_session_permission(
+        &self,
+        session_id: &str,
+        perm_type: PermissionType,
+        resource_pattern: impl Into<String>,
+    ) {
+        let grant = SessionGrant::new(resource_pattern, self.session_grant_duration);
+        let pattern = grant.resource_pattern.clone();
+        let session = self
+            .scoped_session_grants
+            .entry(session_id.to_string())
+            .or_default();
+        let mut grants = session.entry(perm_type).or_default();
+        grants.retain(|_, grant| !grant.is_expired());
+        grants.insert(pattern, grant);
+    }
+
+    pub fn is_scoped_session_granted(
+        &self,
+        session_id: &str,
+        perm_type: PermissionType,
+        resource: &str,
+    ) -> bool {
+        self.scoped_session_grants
+            .get(session_id)
+            .and_then(|session| session.get(&perm_type).map(|grants| grants.clone()))
+            .is_some_and(|grants| {
+                grants
+                    .values()
+                    .any(|grant| !grant.is_expired() && grant.matches(perm_type, resource))
+            })
+    }
+
+    /// Consume a one-shot grant bound to one session. Legacy `Approve` maps to
+    /// this path and therefore authorizes only the parked re-execution.
+    pub fn consume_scoped_session_grant(
+        &self,
+        session_id: &str,
+        perm_type: PermissionType,
+        resource: &str,
+    ) -> bool {
+        let Some(session) = self.scoped_session_grants.get(session_id) else {
+            return false;
+        };
+        let Some(mut grants) = session.get_mut(&perm_type) else {
+            return false;
+        };
+        let matched = grants.iter().find_map(|(pattern, grant)| {
+            (!grant.is_expired() && grant.matches(perm_type, resource)).then(|| pattern.clone())
+        });
+        matched.is_some_and(|pattern| grants.remove(&pattern).is_some())
+    }
+
+    pub fn grant_once(
+        &self,
+        session_id: &str,
+        request_id: &str,
+        perm_type: PermissionType,
+        resource: String,
+    ) {
+        let mut grants = self
+            .one_shot_grants
+            .entry((session_id.to_string(), request_id.to_string()))
+            .or_default();
+        if !grants
+            .iter()
+            .any(|grant| grant.0 == perm_type && grant.1 == resource)
+        {
+            grants.push((perm_type, resource));
+        }
+    }
+
+    pub fn consume_once(
+        &self,
+        session_id: &str,
+        request_id: &str,
+        perm_type: PermissionType,
+        resource: &str,
+    ) -> bool {
+        let key = (session_id.to_string(), request_id.to_string());
+        let Some(mut grants) = self.one_shot_grants.get_mut(&key) else {
+            return false;
+        };
+        let Some(index) = grants
+            .iter()
+            .position(|grant| grant.0 == perm_type && grant.1 == resource)
+        else {
+            return false;
+        };
+        grants.swap_remove(index);
+        let empty = grants.is_empty();
+        drop(grants);
+        if empty {
+            self.one_shot_grants
+                .remove_if(&key, |_, grants| grants.is_empty());
+        }
+        true
+    }
+
     /// Clear all session grants
     pub fn clear_session_grants(&self) {
         self.session_grants.clear();
+        self.scoped_session_grants.clear();
+        self.one_shot_grants.clear();
     }
 
     /// Clean up expired session grants.
@@ -922,6 +1048,8 @@ impl PermissionConfig {
         Self {
             whitelist,
             session_grants: DashMap::new(),
+            scoped_session_grants: DashMap::new(),
+            one_shot_grants: DashMap::new(),
             session_grant_duration: Duration::from_secs(config.session_grant_duration_secs),
             enabled: AtomicBool::new(config.enabled),
             mode: RwLock::new(mode),
@@ -1894,5 +2022,146 @@ mod integration_tests {
             restored.ask_rule_patterns(),
             vec!["Bash(rm -rf *)".to_string(), "Read".to_string()]
         );
+    }
+
+    #[test]
+    fn scoped_session_grants_do_not_leak_between_sessions() {
+        let config = PermissionConfig::new();
+        config.grant_scoped_session_permission(
+            "session-a",
+            PermissionType::ExecuteCommand,
+            "git status",
+        );
+        assert!(config.is_scoped_session_granted(
+            "session-a",
+            PermissionType::ExecuteCommand,
+            "git status"
+        ));
+        assert!(!config.is_scoped_session_granted(
+            "session-b",
+            PermissionType::ExecuteCommand,
+            "git status"
+        ));
+        assert!(config.consume_scoped_session_grant(
+            "session-a",
+            PermissionType::ExecuteCommand,
+            "git status"
+        ));
+        assert!(!config.consume_scoped_session_grant(
+            "session-a",
+            PermissionType::ExecuteCommand,
+            "git status"
+        ));
+
+        config.grant_once(
+            "session-a",
+            "call-1",
+            PermissionType::ExecuteCommand,
+            "git status".into(),
+        );
+        assert!(!config.consume_once(
+            "session-b",
+            "call-1",
+            PermissionType::ExecuteCommand,
+            "git status"
+        ));
+        assert!(!config.consume_once(
+            "session-a",
+            "call-2",
+            PermissionType::ExecuteCommand,
+            "git status"
+        ));
+
+        config.grant_once(
+            "session-a",
+            "multi",
+            PermissionType::WriteFile,
+            "/tmp/a".into(),
+        );
+        config.grant_once(
+            "session-a",
+            "multi",
+            PermissionType::ExecuteCommand,
+            "cargo test".into(),
+        );
+        assert!(!config.consume_once(
+            "session-a",
+            "multi",
+            PermissionType::WriteFile,
+            "/tmp/not-a"
+        ));
+        assert!(config.consume_once(
+            "session-a",
+            "multi",
+            PermissionType::ExecuteCommand,
+            "cargo test"
+        ));
+        assert!(config.consume_once("session-a", "multi", PermissionType::WriteFile, "/tmp/a"));
+
+        config.grant_once(
+            "session-a",
+            "duplicate",
+            PermissionType::ExecuteCommand,
+            "cargo test".into(),
+        );
+        config.grant_once(
+            "session-a",
+            "duplicate",
+            PermissionType::ExecuteCommand,
+            "cargo test".into(),
+        );
+        assert!(config.consume_once(
+            "session-a",
+            "duplicate",
+            PermissionType::ExecuteCommand,
+            "cargo test"
+        ));
+        assert!(!config.consume_once(
+            "session-a",
+            "duplicate",
+            PermissionType::ExecuteCommand,
+            "cargo test"
+        ));
+
+        let config = std::sync::Arc::new(config);
+        config.grant_once(
+            "session-a",
+            "concurrent",
+            PermissionType::ExecuteCommand,
+            "cargo test".into(),
+        );
+        let successes = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..8)
+                .map(|_| {
+                    let config = config.clone();
+                    scope.spawn(move || {
+                        config.consume_once(
+                            "session-a",
+                            "concurrent",
+                            PermissionType::ExecuteCommand,
+                            "cargo test",
+                        )
+                    })
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|handle| handle.join().expect("consumer"))
+                .filter(|consumed| *consumed)
+                .count()
+        });
+        assert_eq!(successes, 1, "a one-shot grant must be consumed once");
+        assert!(config.consume_once(
+            "session-a",
+            "call-1",
+            PermissionType::ExecuteCommand,
+            "git status"
+        ));
+        assert!(!config.consume_once(
+            "session-a",
+            "call-1",
+            PermissionType::ExecuteCommand,
+            "git status"
+        ));
     }
 }

--- a/crates/infra/bamboo-permission/src/config.rs
+++ b/crates/infra/bamboo-permission/src/config.rs
@@ -64,6 +64,18 @@ impl PermissionType {
     }
 }
 
+fn is_path_permission(perm_type: PermissionType) -> bool {
+    matches!(
+        perm_type,
+        PermissionType::WriteFile | PermissionType::DeleteOperation
+    )
+}
+
+fn should_normalize_path(perm_type: PermissionType, resource: &str) -> bool {
+    is_path_permission(perm_type)
+        && (perm_type == PermissionType::WriteFile || Path::new(resource).is_absolute())
+}
+
 /// Risk level for permission types
 ///
 /// Ordered `Low < Medium < High` (derived from declaration order), so a risk
@@ -140,9 +152,10 @@ impl PermissionRule {
 
         // For file-related permissions, normalize the path
         // For other permissions (HTTP, commands, etc.), match directly
-        let normalized_resource = match perm_type {
-            PermissionType::WriteFile => canonicalize_path_for_matching(resource),
-            _ => Some(resource.to_string()),
+        let normalized_resource = if should_normalize_path(perm_type, resource) {
+            canonicalize_path_for_matching(resource)
+        } else {
+            Some(resource.to_string())
         };
 
         let normalized_resource = match normalized_resource {
@@ -151,11 +164,10 @@ impl PermissionRule {
         };
 
         // Use globset for proper glob matching
-        let normalized_pattern = match perm_type {
-            PermissionType::WriteFile => {
-                canonicalize_path_pattern_for_matching(&self.resource_pattern)
-            }
-            _ => Some(self.resource_pattern.clone()),
+        let normalized_pattern = if should_normalize_path(perm_type, &self.resource_pattern) {
+            canonicalize_path_pattern_for_matching(&self.resource_pattern)
+        } else {
+            Some(self.resource_pattern.clone())
         };
         normalized_pattern
             .as_deref()
@@ -207,9 +219,10 @@ impl SessionGrant {
 
         // For file-related permissions, normalize the path
         // For other permissions (HTTP, commands, etc.), match directly
-        let normalized_resource = match perm_type {
-            PermissionType::WriteFile => canonicalize_path_for_matching(resource),
-            _ => Some(resource.to_string()),
+        let normalized_resource = if should_normalize_path(perm_type, resource) {
+            canonicalize_path_for_matching(resource)
+        } else {
+            Some(resource.to_string())
         };
 
         let normalized_resource = match normalized_resource {
@@ -217,11 +230,10 @@ impl SessionGrant {
             None => return false,
         };
 
-        let normalized_pattern = match perm_type {
-            PermissionType::WriteFile => {
-                canonicalize_path_pattern_for_matching(&self.resource_pattern)
-            }
-            _ => Some(self.resource_pattern.clone()),
+        let normalized_pattern = if should_normalize_path(perm_type, &self.resource_pattern) {
+            canonicalize_path_pattern_for_matching(&self.resource_pattern)
+        } else {
+            Some(self.resource_pattern.clone())
         };
         normalized_pattern
             .as_deref()
@@ -2238,6 +2250,17 @@ mod integration_tests {
         let config = PermissionConfig::new();
         config.grant_session_permission(PermissionType::WriteFile, alias.clone());
         assert!(config.is_session_granted(PermissionType::WriteFile, &canonical));
+
+        config.grant_session_permission(PermissionType::DeleteOperation, alias.clone());
+        assert!(config.is_session_granted(PermissionType::DeleteOperation, &canonical));
+
+        let delete_deny =
+            PermissionRule::new(PermissionType::DeleteOperation, alias.clone(), false);
+        assert!(delete_deny.matches(PermissionType::DeleteOperation, &canonical));
+
+        let command_deny =
+            PermissionRule::new(PermissionType::DeleteOperation, "rm ./relative-file", false);
+        assert!(command_deny.matches(PermissionType::DeleteOperation, "rm ./relative-file"));
 
         config.set_ask_rules([format!("Write({alias})")]);
         assert!(config

--- a/crates/infra/bamboo-permission/src/config.rs
+++ b/crates/infra/bamboo-permission/src/config.rs
@@ -151,7 +151,15 @@ impl PermissionRule {
         };
 
         // Use globset for proper glob matching
-        match_glob_pattern(&self.resource_pattern, &normalized_resource)
+        let normalized_pattern = match perm_type {
+            PermissionType::WriteFile => {
+                canonicalize_path_pattern_for_matching(&self.resource_pattern)
+            }
+            _ => Some(self.resource_pattern.clone()),
+        };
+        normalized_pattern
+            .as_deref()
+            .is_some_and(|pattern| match_glob_pattern(pattern, &normalized_resource))
     }
 }
 
@@ -209,8 +217,55 @@ impl SessionGrant {
             None => return false,
         };
 
-        match_glob_pattern(&self.resource_pattern, &normalized_resource)
+        let normalized_pattern = match perm_type {
+            PermissionType::WriteFile => {
+                canonicalize_path_pattern_for_matching(&self.resource_pattern)
+            }
+            _ => Some(self.resource_pattern.clone()),
+        };
+        normalized_pattern
+            .as_deref()
+            .is_some_and(|pattern| match_glob_pattern(pattern, &normalized_resource))
     }
+}
+
+/// Canonicalize the static prefix of a file matcher without changing its glob
+/// suffix. This makes `/tmp/**` and `/private/tmp/**` the same matcher on macOS
+/// while preserving component boundaries and never widening an invalid rule.
+pub(crate) fn canonicalize_path_pattern_for_matching(pattern: &str) -> Option<String> {
+    let normalized = normalize_path_separators(pattern.trim());
+    if normalized.is_empty() || has_path_traversal(&normalized) {
+        return None;
+    }
+
+    let first_glob = normalized.find(['*', '?', '[', '{']);
+    let Some(first_glob) = first_glob else {
+        // Keep legacy filename-only patterns such as `*.rs`; path-like exact
+        // matchers must be absolute and canonical.
+        return if Path::new(&normalized).is_absolute() {
+            canonicalize_path_for_matching(&normalized)
+        } else {
+            Some(normalized)
+        };
+    };
+
+    // A filename-only glob has no filesystem prefix to canonicalize.
+    let Some(separator) = normalized[..first_glob].rfind('/') else {
+        return Some(normalized);
+    };
+    let prefix = if separator == 0 {
+        "/"
+    } else {
+        &normalized[..separator]
+    };
+    if !Path::new(prefix).is_absolute() {
+        // Legacy relative rules have no workspace identity. Preserve their
+        // exact historical semantics (without widening); traversal was already
+        // rejected above.
+        return Some(normalized);
+    }
+    let canonical_prefix = canonicalize_path_for_matching(prefix)?;
+    Some(format!("{}{}", canonical_prefix, &normalized[separator..]))
 }
 
 /// Canonicalize a resource path before permission matching.
@@ -2163,5 +2218,31 @@ mod integration_tests {
             PermissionType::ExecuteCommand,
             "git status"
         ));
+    }
+
+    #[test]
+    fn file_matchers_canonicalize_static_prefixes_without_widening() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let alias_path = temp.path().join("future.txt");
+        let canonical_path = std::fs::canonicalize(temp.path())
+            .expect("canonical temp")
+            .join("future.txt");
+        let alias = alias_path.to_string_lossy().to_string();
+        let canonical = canonical_path.to_string_lossy().to_string();
+
+        let config = PermissionConfig::new();
+        config.grant_session_permission(PermissionType::WriteFile, alias.clone());
+        assert!(config.is_session_granted(PermissionType::WriteFile, &canonical));
+
+        config.set_ask_rules([format!("Write({alias})")]);
+        assert!(config
+            .requires_forced_confirmation("Write", &serde_json::json!({"file_path": canonical})));
+
+        let traversal = format!("{}/../escape.txt", temp.path().display());
+        let deny = PermissionRule::new(PermissionType::WriteFile, traversal, false);
+        assert!(
+            !deny.matches(PermissionType::WriteFile, &alias),
+            "a traversal matcher must fail closed rather than normalize broader"
+        );
     }
 }

--- a/crates/infra/bamboo-permission/src/lib.rs
+++ b/crates/infra/bamboo-permission/src/lib.rs
@@ -34,6 +34,7 @@ pub mod bash_security;
 pub mod checker;
 pub mod config;
 pub mod hierarchy;
+pub mod policy;
 pub mod rule_parser;
 pub mod storage;
 pub mod tool_permissions;
@@ -51,6 +52,10 @@ pub use config::{
     SerializablePermissionConfig, SessionGrant,
 };
 pub use hierarchy::PermissionRuleSet;
+pub use policy::{
+    PermissionDecision, PermissionDecisionKind, PermissionMatcher, PermissionMatcherKind,
+    PermissionReasonCode, PermissionRequest,
+};
 pub use rule_parser::ParsedRule;
 pub use storage::PermissionStorage;
 pub use tool_permissions::{check_permissions, check_tool_rules, is_delete_command};

--- a/crates/infra/bamboo-permission/src/policy.rs
+++ b/crates/infra/bamboo-permission/src/policy.rs
@@ -1,0 +1,112 @@
+//! Stable, machine-readable permission request and decision contract.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{PermissionMode, PermissionType, RiskLevel};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionDecisionKind {
+    AllowOnce,
+    AllowSession,
+    AllowWorkspace,
+    AllowGlobal,
+    DenyOnce,
+    DenySession,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionReasonCode {
+    HardDangerous,
+    ConfiguredAlwaysAsk,
+    ExplicitDeny,
+    RiskThreshold,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionMatcherKind {
+    ExactResource,
+    PathSubtree,
+    CommandPrefix,
+    HttpOrigin,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PermissionMatcher {
+    /// Opaque identifier echoed by clients when selecting this suggestion.
+    pub id: String,
+    pub kind: PermissionMatcherKind,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PermissionRequest {
+    pub request_id: String,
+    pub session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace_path: Option<String>,
+    pub tool_name: String,
+    pub permission_type: PermissionType,
+    pub resource: String,
+    pub operation_summary: String,
+    pub risk_level: RiskLevel,
+    pub reason_code: PermissionReasonCode,
+    pub effective_mode: PermissionMode,
+    pub bypass_requested: bool,
+    pub policy_revision: u64,
+    pub allowed_decisions: Vec<PermissionDecisionKind>,
+    pub suggested_matchers: Vec<PermissionMatcher>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PermissionDecision {
+    pub request_id: String,
+    pub decision: PermissionDecisionKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub matcher_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_policy_revision: Option<u64>,
+}
+
+impl PermissionRequest {
+    pub fn migration_decisions() -> Vec<PermissionDecisionKind> {
+        // Phase 1 only wires one-shot legacy-compatible responses. Remembered
+        // scopes are deliberately omitted until the typed decision endpoint can
+        // validate matcher ids and persist them atomically.
+        vec![
+            PermissionDecisionKind::AllowOnce,
+            PermissionDecisionKind::DenyOnce,
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forced_requests_never_offer_remembered_scopes() {
+        assert_eq!(
+            PermissionRequest::migration_decisions(),
+            vec![
+                PermissionDecisionKind::AllowOnce,
+                PermissionDecisionKind::DenyOnce
+            ]
+        );
+    }
+
+    #[test]
+    fn decision_wire_uses_typed_ids() {
+        let value = serde_json::to_value(PermissionDecision {
+            request_id: "req-1".into(),
+            decision: PermissionDecisionKind::AllowWorkspace,
+            matcher_id: Some("path-subtree-1".into()),
+            expected_policy_revision: Some(7),
+        })
+        .expect("serialize");
+        assert_eq!(value["decision"], "allow_workspace");
+        assert_eq!(value["matcher_id"], "path-subtree-1");
+    }
+}

--- a/crates/infra/bamboo-permission/src/rule_parser.rs
+++ b/crates/infra/bamboo-permission/src/rule_parser.rs
@@ -6,6 +6,8 @@
 
 use serde_json::Value;
 
+use crate::config::{canonicalize_path_for_matching, canonicalize_path_pattern_for_matching};
+
 use crate::config::match_glob_pattern;
 
 /// Match a pattern against a target string with support for prefix/suffix/infix wildcards.
@@ -200,7 +202,24 @@ impl ParsedRule {
             _ => None,
         };
 
+        let is_path_tool = matches!(
+            tool_name_lower.as_str(),
+            "write" | "edit" | "read" | "apply_patch" | "notebookedit"
+        );
         match target {
+            Some(target_str) if is_path_tool => {
+                let normalized_pattern = canonicalize_path_pattern_for_matching(pattern);
+                let normalized_target = if std::path::Path::new(target_str).is_absolute() {
+                    canonicalize_path_for_matching(target_str)
+                } else if !target_str.split(['/', '\\']).any(|part| part == "..") {
+                    Some(target_str.to_string())
+                } else {
+                    None
+                };
+                normalized_pattern
+                    .zip(normalized_target)
+                    .is_some_and(|(pattern, target)| match_tool_pattern(&pattern, &target))
+            }
             Some(target_str) => match_tool_pattern(pattern, target_str),
             None => {
                 // Fallback: match against stringified args

--- a/docs/typed-permission-migration.md
+++ b/docs/typed-permission-migration.md
@@ -1,0 +1,15 @@
+# Typed permission migration
+
+Permission pauses continue to expose the legacy `question`, `options: ["Approve", "Deny"]`, and
+`allow_custom` fields. New clients should additionally read the nested `permission_request` object.
+It carries stable snake-case values for risk, reason, effective mode and allowed decisions.
+
+Phase 1 intentionally advertises only `allow_once` and `deny_once`. A legacy `Approve` is converted
+to a one-shot grant keyed by the stable session id and consumed by the parked tool re-execution; it
+cannot authorize another session or a later invocation. Hard-dangerous and configured always-ask
+prompts are distinguished by `reason_code`. Explicit deny rules are evaluated before bypass and
+return a denial rather than an overridable prompt.
+
+Remembered session/workspace/global scopes, matcher-id validation, durable rule CRUD/CAS, and remote
+policy propagation remain tracked by #601. Clients must not display those choices until Bamboo
+includes them in `allowed_decisions`.


### PR DESCRIPTION
## Summary

Phase 1 of #601:

- emit a machine-readable `permission_request` alongside legacy `question` / `Approve` / `Deny` fields
- expose typed risk, effective mode, bypass state, reason codes, policy revision placeholder, and matcher suggestions
- advertise only the end-to-end supported `allow_once` / `deny_once` decisions
- distinguish hard-dangerous and configured always-ask prompts
- evaluate explicit deny before bypass and confirmation
- migrate legacy `Approve` to a one-shot grant bound to session id + exact parked tool-call/request id, consumed once

## Compatibility

Old clients continue using the unchanged legacy fields. New clients may consume the nested typed envelope. Unsupported remembered scopes are deliberately omitted.

## Remaining #601 scope

- complete `PermissionOutcome` evaluator and full precedence matrix
- authenticated typed decision endpoint with concurrency/idempotency ledger
- session/workspace/global remembered scopes and validated matcher ids
- durable rule CRUD, revision/CAS, atomic persistence and last-known-good recovery
- child/broker/remote/external-executor policy propagation

## Test Plan

- `cargo check -p bamboo-permission -p bamboo-tools -p bamboo-server`
- `cargo test -p bamboo-permission policy::`
- `cargo test -p bamboo-permission scoped_session_grants_do_not_leak_between_sessions`
- `cargo test -p bamboo-tools executor::tests --lib`
- `cargo test -p bamboo-server respond --lib`

Refs #601