### PR TITLE
fix(events): stabilize execute startup reconciliation

### DIFF
--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -720,6 +720,7 @@ impl AppState {
             )),
             metrics_service,
             agent_runners,
+            execute_startups: Arc::new(std::sync::Mutex::new(HashMap::new())),
             session_event_senders,
             account_sink,
             process_registry,

--- a/crates/app/bamboo-server/src/app_state/mod.rs
+++ b/crates/app/bamboo-server/src/app_state/mod.rs
@@ -339,6 +339,11 @@ pub struct AppState {
     /// for an active agent execution.
     pub agent_runners: Arc<RwLock<HashMap<String, AgentRunner>>>,
 
+    /// Reference-counted execute handlers still preparing a runner, keyed by
+    /// session. This server-scoped registry closes the durable pending-turn
+    /// expiry race without leaking state across AppState instances/tests.
+    pub(crate) execute_startups: Arc<std::sync::Mutex<HashMap<String, usize>>>,
+
     /// Session-scoped event streams (long-lived).
     ///
     /// Unlike `agent_runners`, these senders exist even when no agent execution is running.

--- a/crates/app/bamboo-server/src/handlers/agent/events/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/mod.rs
@@ -16,9 +16,10 @@ pub(crate) use stream::Coalescer;
 // child sub-agents are still running (parity with the v1 SSE stream, which does
 // not close on the parent terminal while descendants survive).
 pub(crate) use terminal::{
-    begin_execute_startup, mark_pending_turn, mark_startup_failed_if_owned, pending_turn_id,
+    begin_execute_startup, clear_pending_turn, has_running_child, mark_pending_turn,
+    reconcile_abandoned_startup, startup_reconcile_delay, startup_work_id, terminal_event_if_ready,
+    transition_startup_failure_if_owned, ExecuteStartupGuard, StartupFailureTarget,
 };
-pub(crate) use terminal::{has_running_child, terminal_event_if_ready};
 
 #[cfg(test)]
 mod tests;

--- a/crates/app/bamboo-server/src/handlers/agent/events/stream.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/stream.rs
@@ -7,7 +7,7 @@ use bamboo_agent_core::AgentEvent;
 
 use crate::app_state::AppState;
 
-use super::terminal::has_running_child;
+use super::terminal::{has_running_child, reconcile_abandoned_startup, startup_reconcile_delay};
 
 /// Identifies which token-class channel a coalescible event belongs to.
 ///
@@ -228,6 +228,14 @@ pub(super) fn live_stream_response(
             // the terminal open and close only once no running child is left.
             let mut awaiting_children = false;
 
+            // A stream opened before or during the chat→execute handoff must
+            // eventually re-evaluate abandoned pending work. Active handoffs
+            // sleep until their durable grace ends; idle streams keep a slow
+            // probe so work written after subscription is still discovered.
+            let initial_reconcile_delay = startup_reconcile_delay(&state, &session_id).await;
+            let startup_reconcile = tokio::time::sleep(initial_reconcile_delay);
+            tokio::pin!(startup_reconcile);
+
             // Token coalescing (v2-P0). When `batch_ms == 0` we take the legacy
             // fast path below — every event is emitted immediately, byte-for-byte
             // unchanged, with no buffering and no added latency (desktop default).
@@ -240,6 +248,23 @@ pub(super) fn live_stream_response(
             if batch_ms == 0 {
                 loop {
                     tokio::select! {
+                        _ = &mut startup_reconcile => {
+                            if reconcile_abandoned_startup(
+                                &state,
+                                &session_id,
+                                &receiver,
+                            )
+                            .await
+                            {
+                                // The durable CAS queued one broadcast Error;
+                                // receive it through the normal ordered path.
+                                let delay = startup_reconcile_delay(&state, &session_id).await;
+                                startup_reconcile.as_mut().reset(tokio::time::Instant::now() + delay);
+                                continue;
+                            }
+                            let delay = startup_reconcile_delay(&state, &session_id).await;
+                            startup_reconcile.as_mut().reset(tokio::time::Instant::now() + delay);
+                        }
                         _ = heartbeat.tick() => {
                             if awaiting_children && !has_running_child(&state, &session_id).await {
                                 yield Ok::<_, actix_web::Error>(web::Bytes::from(done_sse_data()));
@@ -308,6 +333,24 @@ pub(super) fn live_stream_response(
                         .unwrap_or_else(|| tokio::time::Instant::now() + Duration::from_secs(86_400));
 
                     tokio::select! {
+                        _ = &mut startup_reconcile => {
+                            if reconcile_abandoned_startup(
+                                &state,
+                                &session_id,
+                                &receiver,
+                            )
+                            .await
+                            {
+                                // The Error is now queued after any existing
+                                // broadcast frames; normal coalescing preserves
+                                // buffered-token ordering before terminal close.
+                                let delay = startup_reconcile_delay(&state, &session_id).await;
+                                startup_reconcile.as_mut().reset(tokio::time::Instant::now() + delay);
+                                continue;
+                            }
+                            let delay = startup_reconcile_delay(&state, &session_id).await;
+                            startup_reconcile.as_mut().reset(tokio::time::Instant::now() + delay);
+                        }
                         _ = tokio::time::sleep_until(sleep_until), if flush_deadline.is_some() => {
                             if let Some(pending) = coalescer.take_pending() {
                                 if let Some(sse_data) = event_sse_data(&pending) {
@@ -437,7 +480,7 @@ fn is_terminal_event(event: &AgentEvent) -> bool {
 #[cfg(test)]
 mod coalesce_tests {
     use super::*;
-    use bamboo_agent_core::TokenUsage;
+    use bamboo_agent_core::{Message, Session, TokenUsage};
 
     fn token(content: &str) -> AgentEvent {
         AgentEvent::Token {
@@ -661,5 +704,133 @@ mod coalesce_tests {
         let value = serde_json::to_value(&merged).unwrap();
         assert_eq!(value["type"], "token");
         assert_eq!(value["content"], "foobar");
+    }
+
+    async fn abandoned_startup_stream_body(batch_ms: u64) -> String {
+        let dir = tempfile::tempdir().expect("temporary app data");
+        let state = web::Data::new(
+            AppState::new(dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let session_id = format!("sse-abandoned-{batch_ms}");
+        let mut session = Session::new(&session_id, "test-model");
+        session.add_message(Message::user("slow startup"));
+        crate::handlers::agent::events::mark_pending_turn(&mut session);
+        session.metadata.insert(
+            "execute.startup_handoff_at".to_string(),
+            (chrono::Utc::now() - chrono::Duration::seconds(120)).to_rfc3339(),
+        );
+        state.save_session(&mut session).await;
+
+        let sender = state.get_session_event_sender(&session_id).await;
+        let receiver = sender.subscribe();
+        sender
+            .send(AgentEvent::Token {
+                content: "before-terminal".to_string(),
+            })
+            .expect("live receiver");
+        let startup_guard =
+            crate::handlers::agent::events::begin_execute_startup(state.get_ref(), &session_id);
+        let watcher_guard = crate::app_state::watchers::WatcherGuard::new(
+            state.session_watchers.clone(),
+            &session_id,
+        );
+        let response = live_stream_response(
+            None,
+            Vec::new(),
+            receiver,
+            state,
+            session_id,
+            batch_ms,
+            watcher_guard,
+        );
+
+        let release_slow_startup = async move {
+            // The first expired-turn reconcile fires while this guard is still
+            // held and must re-arm. Dropping it models a slow execute handler
+            // finally returning without reserving a runner.
+            tokio::time::sleep(Duration::from_millis(350)).await;
+            drop(startup_guard);
+        };
+        let collect_body = actix_web::body::to_bytes(response.into_body());
+        let (_, bytes) = tokio::time::timeout(Duration::from_secs(2), async {
+            tokio::join!(release_slow_startup, collect_body)
+        })
+        .await
+        .expect("SSE abandoned-startup reconcile must terminate");
+        String::from_utf8(bytes.expect("read SSE body").to_vec()).expect("UTF-8 SSE")
+    }
+
+    #[actix_web::test]
+    async fn live_sse_reconciles_abandoned_startup_in_both_batch_paths() {
+        for batch_ms in [0, 1_000] {
+            let body = abandoned_startup_stream_body(batch_ms).await;
+            let token = body.find("before-terminal").expect("token frame");
+            let terminal = body
+                .find("was not started")
+                .expect("synthetic startup terminal");
+            let done = body.find("[DONE]").expect("done frame");
+            assert!(
+                token < terminal && terminal < done,
+                "batch_ms={batch_ms} must preserve token → terminal → DONE ordering: {body}"
+            );
+            assert_eq!(body.matches("was not started").count(), 1);
+            assert_eq!(body.matches("[DONE]").count(), 1);
+        }
+    }
+
+    #[actix_web::test]
+    async fn live_sse_idle_probe_discovers_later_abandoned_turn() {
+        for batch_ms in [0, 1_000] {
+            let dir = tempfile::tempdir().expect("temporary app data");
+            let state = web::Data::new(
+                AppState::new(dir.path().to_path_buf())
+                    .await
+                    .expect("app state"),
+            );
+            let session_id = format!("sse-late-pending-{batch_ms}");
+            let mut session = Session::new(&session_id, "test-model");
+            state.save_session(&mut session).await;
+            let sender = state.get_session_event_sender(&session_id).await;
+            let receiver = sender.subscribe();
+            let watcher_guard = crate::app_state::watchers::WatcherGuard::new(
+                state.session_watchers.clone(),
+                &session_id,
+            );
+            let response = live_stream_response(
+                None,
+                Vec::new(),
+                receiver,
+                state.clone(),
+                session_id.clone(),
+                batch_ms,
+                watcher_guard,
+            );
+
+            let write_late_turn = async move {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                session.add_message(Message::user("never executed"));
+                crate::handlers::agent::events::mark_pending_turn(&mut session);
+                session.metadata.insert(
+                    "execute.startup_handoff_at".to_string(),
+                    (chrono::Utc::now() - chrono::Duration::seconds(120)).to_rfc3339(),
+                );
+                state.save_session(&mut session).await;
+            };
+            let collect_body = actix_web::body::to_bytes(response.into_body());
+            let (_, bytes) = tokio::time::timeout(Duration::from_secs(2), async {
+                tokio::join!(write_late_turn, collect_body)
+            })
+            .await
+            .expect("idle probe must discover late pending turn");
+            let body =
+                String::from_utf8(bytes.expect("read SSE body").to_vec()).expect("UTF-8 SSE");
+            assert!(
+                body.contains("was not started"),
+                "batch_ms={batch_ms}: {body}"
+            );
+            assert_eq!(body.matches("[DONE]").count(), 1);
+        }
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use actix_web::web;
+use tokio::sync::broadcast;
 
 use crate::app_state::{AgentStatus, AppState};
 use bamboo_agent_core::agent::events::TokenUsage;
@@ -9,54 +10,81 @@ use bamboo_agent_core::agent::Role;
 use bamboo_agent_core::{AgentEvent, Session, SessionKind};
 use bamboo_domain::AgentStatusState;
 use bamboo_engine::session_app::execute::{
-    has_pending_clarification_resume, has_pending_retry_resume,
+    clear_startup_handoff, consume_pending_clarification_resume, has_pending_clarification_resume,
+    has_pending_retry_resume, mark_startup_handoff, startup_handoff_at,
 };
 
 const PENDING_TURN_ID_KEY: &str = "execute.pending_turn_message_id";
 const PENDING_TURN_GRACE_SECS: i64 = 60;
+const STARTUP_FAILURE_PREFIX: &str = "Agent startup failed: ";
+const EXPIRED_STARTUP_RECHECK: Duration = Duration::from_millis(250);
+#[cfg(not(test))]
+const IDLE_STARTUP_PROBE: Duration = Duration::from_secs(15);
+#[cfg(test)]
+const IDLE_STARTUP_PROBE: Duration = Duration::from_millis(25);
 
-type StartupKey = (usize, String);
-static EXECUTE_STARTUPS: OnceLock<Mutex<HashMap<StartupKey, usize>>> = OnceLock::new();
-
-fn execute_startups() -> &'static Mutex<HashMap<StartupKey, usize>> {
-    EXECUTE_STARTUPS.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-fn startup_key(state: &AppState, session_id: &str) -> StartupKey {
-    (state as *const AppState as usize, session_id.to_string())
-}
-
+/// Owns one in-process `/execute` preparation for a session. The registry is
+/// AppState-scoped (not process-global), and reference counting keeps an
+/// overlapping request protected until its last handler returns.
 pub(crate) struct ExecuteStartupGuard {
-    key: StartupKey,
+    startups: Arc<Mutex<std::collections::HashMap<String, usize>>>,
+    session_id: String,
+    active: bool,
+}
+
+impl ExecuteStartupGuard {
+    /// Release this request's preparation ownership and return the number of
+    /// other startup owners still active for the session.
+    pub(crate) fn release(&mut self) -> usize {
+        if !self.active {
+            return self
+                .startups
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .get(&self.session_id)
+                .copied()
+                .unwrap_or(0);
+        }
+        self.active = false;
+        let mut startups = self.startups.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(count) = startups.get_mut(&self.session_id) {
+            *count -= 1;
+            if *count == 0 {
+                startups.remove(&self.session_id);
+                return 0;
+            }
+            return *count;
+        }
+        0
+    }
 }
 
 impl Drop for ExecuteStartupGuard {
     fn drop(&mut self) {
-        let mut startups = execute_startups().lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(count) = startups.get_mut(&self.key) {
-            *count -= 1;
-            if *count == 0 {
-                startups.remove(&self.key);
-            }
-        }
+        self.release();
     }
 }
 
 pub(crate) fn begin_execute_startup(state: &AppState, session_id: &str) -> ExecuteStartupGuard {
-    let key = startup_key(state, session_id);
-    *execute_startups()
+    let mut startups = state
+        .execute_startups
         .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .entry(key.clone())
-        .or_default() += 1;
-    ExecuteStartupGuard { key }
+        .unwrap_or_else(|e| e.into_inner());
+    *startups.entry(session_id.to_string()).or_default() += 1;
+    drop(startups);
+    ExecuteStartupGuard {
+        startups: state.execute_startups.clone(),
+        session_id: session_id.to_string(),
+        active: true,
+    }
 }
 
 fn execute_startup_is_in_flight(state: &AppState, session_id: &str) -> bool {
-    execute_startups()
+    state
+        .execute_startups
         .lock()
         .unwrap_or_else(|e| e.into_inner())
-        .contains_key(&startup_key(state, session_id))
+        .contains_key(session_id)
 }
 
 pub(crate) fn mark_pending_turn(session: &mut Session) {
@@ -67,16 +95,40 @@ pub(crate) fn mark_pending_turn(session: &mut Session) {
     }
     session.set_last_run_status("pending");
     session.clear_last_run_error();
+    mark_startup_handoff(session);
 }
 
 pub(crate) fn clear_pending_turn(session: &mut Session) {
     session.metadata.remove(PENDING_TURN_ID_KEY);
+    clear_startup_handoff(session);
 }
 
 pub(crate) fn pending_turn_id(session: &Session) -> Option<String> {
-    pending_turn_is_owned(session)
-        .then(|| session.metadata.get(PENDING_TURN_ID_KEY).cloned())
-        .flatten()
+    if !matches!(session.last_run_status().as_deref(), Some("pending")) {
+        return None;
+    }
+    let message = session
+        .messages
+        .last()
+        .filter(|message| matches!(message.role, Role::User))?;
+    match session.metadata.get(PENDING_TURN_ID_KEY) {
+        Some(owner) if owner == &message.id => Some(owner.clone()),
+        Some(_) => None,
+        // Backward compatibility for a pending turn persisted before the
+        // ownership marker shipped: last-User id is still an exact CAS token.
+        None => Some(message.id.clone()),
+    }
+}
+
+/// Exact durable message token for any work accepted by `/execute`: a normal
+/// pending User turn or a clarification/retry resume whose last message is a
+/// tool result. Used as a compare-and-set owner across async preparation.
+pub(crate) fn startup_work_id(session: &Session) -> Option<String> {
+    pending_turn_id(session).or_else(|| {
+        (has_pending_clarification_resume(session) || has_pending_retry_resume(session))
+            .then(|| session.messages.last().map(|message| message.id.clone()))
+            .flatten()
+    })
 }
 
 pub(crate) fn mark_startup_failed_if_owned(
@@ -84,30 +136,182 @@ pub(crate) fn mark_startup_failed_if_owned(
     expected_turn_id: &str,
     detail: &str,
 ) -> bool {
-    if pending_turn_id(session).as_deref() != Some(expected_turn_id) {
+    if startup_work_id(session).as_deref() != Some(expected_turn_id) {
         return false;
     }
     session.set_last_run_status("error");
-    session.set_last_run_error(format!("Agent startup failed: {detail}"));
+    session.set_last_run_error(format!("{STARTUP_FAILURE_PREFIX}{detail}"));
     clear_pending_turn(session);
+    consume_pending_clarification_resume(session);
     true
 }
 
-pub(crate) fn pending_turn_is_owned(session: &Session) -> bool {
-    matches!(session.last_run_status().as_deref(), Some("pending"))
-        && session
-            .metadata
-            .get(PENDING_TURN_ID_KEY)
-            .zip(session.messages.last())
-            .is_some_and(|(owner, message)| owner == &message.id)
+pub(crate) enum StartupFailureTarget<'a> {
+    WorkId {
+        work_id: &'a str,
+        startup_guard: &'a mut ExecuteStartupGuard,
+    },
+    Abandoned(&'a broadcast::Receiver<AgentEvent>),
 }
 
-fn pending_turn_is_active(session: &Session) -> bool {
-    pending_turn_is_owned(session)
-        && session.messages.last().is_some_and(|message| {
-            chrono::Utc::now().signed_duration_since(message.created_at)
-                <= chrono::Duration::seconds(PENDING_TURN_GRACE_SECS)
-        })
+/// Atomically reject startup work if the latest durable session still belongs
+/// to `target`.
+///
+/// The per-session persistence lock covers the latest load, ownership CAS, raw
+/// save, cache replacement, and broadcast. A stale preparation/rollback can
+/// therefore never overwrite or notify after a newer chat turn is persisted.
+pub(crate) async fn transition_startup_failure_if_owned(
+    state: &web::Data<AppState>,
+    session_id: &str,
+    target: StartupFailureTarget<'_>,
+    detail: &str,
+) -> bool {
+    let (mut expected_work_id, abandoned_receiver) = match target {
+        StartupFailureTarget::WorkId {
+            work_id,
+            startup_guard,
+        } => {
+            // Consume this failing request while holding the persistence lock.
+            // Only the last preparation failure may own the durable rollback;
+            // this prevents both premature failure and the dual-failure gap.
+            (Some((work_id, startup_guard)), None)
+        }
+        StartupFailureTarget::Abandoned(receiver) => (None, Some(receiver)),
+    };
+    if abandoned_receiver.is_some_and(|receiver| !receiver.is_empty()) {
+        return false;
+    }
+
+    let _session_guard = state.persistence.acquire_lock(session_id).await;
+    if let Some((_, startup_guard)) = expected_work_id.as_mut() {
+        if (*startup_guard).release() != 0 {
+            return false;
+        }
+    }
+    // An overlapping execute may already own this same durable work id but not
+    // yet have persisted the marker clear. Its live runner is authoritative.
+    if matches!(
+        state
+            .agent_runners
+            .read()
+            .await
+            .get(session_id)
+            .map(|runner| &runner.status),
+        Some(AgentStatus::Pending | AgentStatus::Running)
+    ) {
+        return false;
+    }
+    if let Some(receiver) = abandoned_receiver {
+        if !receiver.is_empty() || execute_startup_is_in_flight(state.get_ref(), session_id) {
+            return false;
+        }
+    }
+
+    let Ok(Some(mut session)) = state.storage.load_session(session_id).await else {
+        return false;
+    };
+    let expected_work_id = match expected_work_id {
+        Some((work_id, _)) => work_id.to_string(),
+        None => {
+            let Some(work_id) = startup_work_id(&session) else {
+                return false;
+            };
+            if startup_work_is_active(&session) {
+                return false;
+            }
+            work_id
+        }
+    };
+
+    // Execute registers its startup guard while holding this same persistence
+    // lock. Re-read all live ownership sources immediately before the CAS.
+    if matches!(
+        state
+            .agent_runners
+            .read()
+            .await
+            .get(session_id)
+            .map(|runner| &runner.status),
+        Some(AgentStatus::Pending | AgentStatus::Running)
+    ) {
+        return false;
+    }
+    if let Some(receiver) = abandoned_receiver {
+        if !receiver.is_empty() || execute_startup_is_in_flight(state.get_ref(), session_id) {
+            return false;
+        }
+    }
+
+    if !mark_startup_failed_if_owned(&mut session, &expected_work_id, detail) {
+        return false;
+    }
+    session.updated_at = chrono::Utc::now();
+    let message = session
+        .last_run_error()
+        .unwrap_or_else(|| format!("{STARTUP_FAILURE_PREFIX}{detail}"));
+    if let Err(error) = state.storage.save_session(&session).await {
+        tracing::error!("[{session_id}] failed to persist startup failure transition: {error}");
+        // A concrete execute request has already failed and released its last
+        // startup owner. Even if durable storage is unavailable, unblock its
+        // currently-connected client with the exact owned failure. An
+        // abandoned-startup probe must instead stay silent and retry: emitting
+        // without clearing its durable marker would create duplicate terminals.
+        if abandoned_receiver.is_none() {
+            let sender = state.get_session_event_sender(session_id).await;
+            let _ = sender.send(AgentEvent::Error { message });
+        }
+        return false;
+    }
+    state.sessions.insert(
+        session_id.to_string(),
+        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+    );
+    let sender = state.get_session_event_sender(session_id).await;
+    let _ = sender.send(AgentEvent::Error { message });
+    true
+}
+
+fn startup_work_is_active(session: &Session) -> bool {
+    let Some(started_at) = startup_work_started_at(session) else {
+        return false;
+    };
+    chrono::Utc::now().signed_duration_since(started_at)
+        <= chrono::Duration::seconds(PENDING_TURN_GRACE_SECS)
+}
+
+fn startup_work_started_at(session: &Session) -> Option<chrono::DateTime<chrono::Utc>> {
+    startup_work_id(session)?;
+    startup_handoff_at(session)
+        .or_else(|| session.messages.last().map(|message| message.created_at))
+}
+
+fn startup_failure_message(session: &Session) -> Option<String> {
+    matches!(session.last_run_status().as_deref(), Some("error"))
+        .then(|| session.last_run_error())
+        .flatten()
+        .filter(|message| message.starts_with(STARTUP_FAILURE_PREFIX))
+}
+
+/// Delay until the next live-transport startup probe. Active work sleeps until
+/// its exact durable grace expires; idle transports probe infrequently so a
+/// later chat/retry written after subscription still arms reconciliation.
+pub(crate) async fn startup_reconcile_delay(
+    state: &web::Data<AppState>,
+    session_id: &str,
+) -> Duration {
+    let Some(session) = state.storage.load_session(session_id).await.ok().flatten() else {
+        return IDLE_STARTUP_PROBE;
+    };
+    let Some(started_at) = startup_work_started_at(&session) else {
+        return IDLE_STARTUP_PROBE;
+    };
+    let remaining = chrono::Duration::seconds(PENDING_TURN_GRACE_SECS)
+        - chrono::Utc::now().signed_duration_since(started_at);
+    if remaining <= chrono::Duration::zero() {
+        return EXPIRED_STARTUP_RECHECK;
+    }
+    let millis = remaining.num_milliseconds().max(1) as u64;
+    Duration::from_millis(millis + 25)
 }
 
 pub(crate) async fn terminal_event_if_ready(
@@ -115,11 +319,9 @@ pub(crate) async fn terminal_event_if_ready(
     session_id: &str,
     runner_status: Option<AgentStatus>,
 ) -> Option<AgentEvent> {
-    // `/execute` may legitimately spend longer than the durable handoff grace
-    // in provider/image/storage preparation before it can reserve a runner.
-    // Never synthesize an abandoned-startup terminal while an in-process
-    // execute handler still owns this session. The guard disappears on every
-    // return path and naturally vanishes if the process crashes.
+    // A slow but legitimate execute may outlive the durable handoff grace
+    // before it can reserve a runner. Its RAII owner wins until every
+    // overlapping handler returns; a crash naturally drops the whole AppState.
     if execute_startup_is_in_flight(state.get_ref(), session_id) {
         return None;
     }
@@ -204,6 +406,23 @@ pub(crate) async fn terminal_event_if_ready(
     Some(terminal_event_for_sources(session.as_ref(), runner_status))
 }
 
+/// Atomically consume an abandoned startup and enqueue its terminal error on
+/// the session broadcast. Each transport consumes that broadcast through its
+/// normal ordered receive path.
+pub(crate) async fn reconcile_abandoned_startup(
+    state: &web::Data<AppState>,
+    session_id: &str,
+    receiver: &broadcast::Receiver<AgentEvent>,
+) -> bool {
+    transition_startup_failure_if_owned(
+        state,
+        session_id,
+        StartupFailureTarget::Abandoned(receiver),
+        "Agent execution was not started; please retry this turn",
+    )
+    .await
+}
+
 pub(super) fn session_has_terminal_evidence(
     session: Option<&Session>,
     runner_status: Option<&AgentStatus>,
@@ -249,12 +468,17 @@ pub(super) fn terminal_event_for_sources(
     session: Option<&Session>,
     runner_status: Option<AgentStatus>,
 ) -> AgentEvent {
-    if session
-        .is_some_and(|session| pending_turn_is_owned(session) && !pending_turn_is_active(session))
-    {
+    if session.is_some_and(|session| {
+        startup_work_id(session).is_some() && !startup_work_is_active(session)
+    }) {
         return AgentEvent::Error {
             message: "Agent execution was not started; please retry this turn".to_string(),
         };
+    }
+    // A startup rejection belongs to the newest durable handoff and must beat
+    // an old runner/runtime snapshot from the preceding run.
+    if let Some(message) = session.and_then(startup_failure_message) {
+        return AgentEvent::Error { message };
     }
     if runner_status.is_some() {
         return terminal_event_for_status(runner_status);
@@ -288,8 +512,21 @@ pub(super) fn session_prevents_terminal_event(
     // persistence writes this marker together with the new User message, so a
     // reconnect between POST /chat and POST /execute remains live even if the
     // previous run was cancelled or failed.
-    if pending_turn_is_active(session) {
+    if startup_work_is_active(session) {
         return true;
+    }
+
+    if startup_work_id(session).is_some() {
+        // The execute handoff (User turn or resume marker) outlived its grace
+        // without a runner. Old suspended/terminal state must not hide this
+        // abandoned work; an in-flight handler was already protected above.
+        return false;
+    }
+
+    // Durable startup rejection is terminal even when the previous run left a
+    // pending-question or Suspended runtime snapshot behind.
+    if startup_failure_message(session).is_some() {
+        return false;
     }
 
     if session.has_pending_question() {
@@ -344,12 +581,15 @@ fn terminal_failure_is_authoritative(
         // Any extant non-failure runner is the current source of truth; do not
         // fall back to a stale persisted failure from an older run.
         Some(_) => false,
-        None => session.agent_runtime_state.as_ref().is_some_and(|runtime| {
-            matches!(
-                runtime.status,
-                AgentStatusState::Cancelled | AgentStatusState::Failed
-            )
-        }),
+        None => {
+            startup_failure_message(session).is_some()
+                || session.agent_runtime_state.as_ref().is_some_and(|runtime| {
+                    matches!(
+                        runtime.status,
+                        AgentStatusState::Cancelled | AgentStatusState::Failed
+                    )
+                })
+        }
     }
 }
 
@@ -456,6 +696,14 @@ mod tests {
         (dir, state)
     }
 
+    fn expire_startup_handoff(session: &mut Session) {
+        session.metadata.insert(
+            "execute.startup_handoff_at".to_string(),
+            (chrono::Utc::now() - chrono::Duration::seconds(PENDING_TURN_GRACE_SECS + 1))
+                .to_rfc3339(),
+        );
+    }
+
     #[actix_web::test]
     async fn terminal_helper_replays_in_memory_cancelled_after_last_user() {
         let mut session = Session::new("cancelled-user", "test-model");
@@ -543,8 +791,7 @@ mod tests {
         let mut session = Session::new("abandoned-turn", "test-model");
         session.add_message(Message::user("never executed"));
         mark_pending_turn(&mut session);
-        session.messages.last_mut().unwrap().created_at =
-            chrono::Utc::now() - chrono::Duration::seconds(PENDING_TURN_GRACE_SECS + 1);
+        expire_startup_handoff(&mut session);
         let mut runtime = AgentRuntimeState::new("old-failed-run");
         runtime.status = AgentStatusState::Failed;
         session.agent_runtime_state = Some(runtime);
@@ -564,37 +811,214 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn expired_pending_turn_stays_live_while_execute_startup_is_in_flight() {
+    async fn abandoned_first_turn_needs_no_old_terminal_evidence() {
+        let mut session = Session::new("abandoned-first-turn", "test-model");
+        session.add_message(Message::user("never executed"));
+        mark_pending_turn(&mut session);
+        expire_startup_handoff(&mut session);
+        let (_dir, state) = state_with_session(session).await;
+
+        let event = terminal_event_if_ready(&state, "abandoned-first-turn", None)
+            .await
+            .expect("expired first turn is terminal");
+        assert!(matches!(
+            event,
+            AgentEvent::Error { message } if message.contains("was not started")
+        ));
+    }
+
+    #[actix_web::test]
+    async fn app_state_scoped_guard_refcounts_slow_overlapping_startups() {
         let mut session = Session::new("slow-startup", "test-model");
         session.add_message(Message::user("slow image preparation"));
         mark_pending_turn(&mut session);
-        session.messages.last_mut().unwrap().created_at =
-            chrono::Utc::now() - chrono::Duration::seconds(PENDING_TURN_GRACE_SECS + 1);
-        let mut runtime = AgentRuntimeState::new("old-failed-run");
-        runtime.status = AgentStatusState::Failed;
-        session.agent_runtime_state = Some(runtime);
+        expire_startup_handoff(&mut session);
         let (_dir, state) = state_with_session(session).await;
 
-        let guard = begin_execute_startup(state.get_ref(), "slow-startup");
-        let old_failure = Some(AgentStatus::Error("old run failed".to_string()));
-        assert!(
-            terminal_event_if_ready(&state, "slow-startup", old_failure.clone())
-                .await
-                .is_none()
-        );
-        // Reference counting matters when two execute requests overlap: one
-        // returning must not expose the other still-running preparation.
+        let first = begin_execute_startup(state.get_ref(), "slow-startup");
         let second = begin_execute_startup(state.get_ref(), "slow-startup");
-        drop(guard);
-        assert!(
-            terminal_event_if_ready(&state, "slow-startup", old_failure.clone())
-                .await
-                .is_none()
-        );
+        assert!(terminal_event_if_ready(&state, "slow-startup", None)
+            .await
+            .is_none());
+        drop(first);
+        assert!(terminal_event_if_ready(&state, "slow-startup", None)
+            .await
+            .is_none());
         drop(second);
-        assert!(terminal_event_if_ready(&state, "slow-startup", old_failure)
+        assert!(terminal_event_if_ready(&state, "slow-startup", None)
             .await
             .is_some());
+    }
+
+    #[actix_web::test]
+    async fn startup_failure_is_durable_terminal_without_runtime_state() {
+        let mut session = Session::new("startup-rejected", "test-model");
+        session.add_message(Message::user("start me"));
+        mark_pending_turn(&mut session);
+        let turn_id = pending_turn_id(&session).expect("owned turn");
+        assert!(mark_startup_failed_if_owned(
+            &mut session,
+            &turn_id,
+            "provider rejected"
+        ));
+        let (_dir, state) = state_with_session(session).await;
+
+        let event = terminal_event_if_ready(&state, "startup-rejected", None)
+            .await
+            .expect("startup rejection is terminal");
+        assert!(matches!(
+            event,
+            AgentEvent::Error { message } if message.contains("provider rejected")
+        ));
+    }
+
+    #[actix_web::test]
+    async fn startup_failure_after_suspended_resume_is_authoritative_terminal() {
+        let mut session = Session::new("suspended-resume-failed", "test-model");
+        session.add_message(Message::assistant("question", None));
+        session.add_message(Message::tool_result("ask-1", "answer"));
+        let mut runtime = AgentRuntimeState::new("old-suspended-run");
+        runtime.status = AgentStatusState::Suspended;
+        session.agent_runtime_state = Some(runtime);
+        session.metadata.insert(
+            "clarification_resume_pending".to_string(),
+            "true".to_string(),
+        );
+        mark_startup_handoff(&mut session);
+        let work_id = startup_work_id(&session).expect("resume work id");
+        assert!(mark_startup_failed_if_owned(
+            &mut session,
+            &work_id,
+            "resume provider rejected"
+        ));
+        let (_dir, state) = state_with_session(session).await;
+
+        let event = terminal_event_if_ready(&state, "suspended-resume-failed", None)
+            .await
+            .expect("durable startup rejection beats old Suspended state");
+        assert!(matches!(
+            event,
+            AgentEvent::Error { message } if message.contains("resume provider rejected")
+        ));
+    }
+
+    #[test]
+    fn newly_marked_retry_on_old_history_gets_a_fresh_grace_window() {
+        let mut session = Session::new("old-history-retry", "test-model");
+        session.add_message(Message::assistant("old failure", None));
+        session.messages.last_mut().unwrap().created_at =
+            chrono::Utc::now() - chrono::Duration::hours(6);
+        session
+            .metadata
+            .insert("retry_resume_pending".to_string(), "true".to_string());
+        mark_startup_handoff(&mut session);
+
+        assert!(startup_work_id(&session).is_some());
+        assert!(startup_work_is_active(&session));
+        assert!(session_prevents_terminal_event(Some(&session), None));
+    }
+
+    #[actix_web::test]
+    async fn concurrent_live_reconcilers_broadcast_abandoned_startup_once() {
+        let mut session = Session::new("multi-reconcile", "test-model");
+        session.add_message(Message::user("never executed"));
+        mark_pending_turn(&mut session);
+        session.metadata.insert(
+            "execute.startup_handoff_at".to_string(),
+            (chrono::Utc::now() - chrono::Duration::seconds(120)).to_rfc3339(),
+        );
+        let (_dir, state) = state_with_session(session).await;
+        let sender = state.get_session_event_sender("multi-reconcile").await;
+        let mut first_rx = sender.subscribe();
+        let mut second_rx = sender.subscribe();
+
+        let (first, second) = tokio::join!(
+            reconcile_abandoned_startup(&state, "multi-reconcile", &first_rx),
+            reconcile_abandoned_startup(&state, "multi-reconcile", &second_rx),
+        );
+        if first == second {
+            let debug = state
+                .storage
+                .load_session("multi-reconcile")
+                .await
+                .expect("debug load")
+                .expect("debug session");
+            panic!(
+                "only one durable CAS may broadcast: first={first}, second={second}, status={:?}, work={:?}, handoff={:?}, error={:?}",
+                debug.last_run_status(),
+                startup_work_id(&debug),
+                startup_handoff_at(&debug),
+                debug.last_run_error(),
+            );
+        }
+        assert!(matches!(first_rx.try_recv(), Ok(AgentEvent::Error { .. })));
+        assert!(matches!(second_rx.try_recv(), Ok(AgentEvent::Error { .. })));
+        assert!(first_rx.try_recv().is_err());
+        assert!(second_rx.try_recv().is_err());
+
+        let stored = state
+            .storage
+            .load_session("multi-reconcile")
+            .await
+            .expect("load session")
+            .expect("stored session");
+        assert!(startup_work_id(&stored).is_none());
+        assert!(startup_failure_message(&stored).is_some());
+    }
+
+    #[actix_web::test]
+    async fn newer_chat_waiting_on_session_lock_wins_before_reconcile() {
+        let mut session = Session::new("chat-reconcile-race", "test-model");
+        session.add_message(Message::user("abandoned first turn"));
+        mark_pending_turn(&mut session);
+        session.metadata.insert(
+            "execute.startup_handoff_at".to_string(),
+            (chrono::Utc::now() - chrono::Duration::seconds(120)).to_rfc3339(),
+        );
+        let mut newer = session.clone();
+        newer.add_message(Message::user("newer turn"));
+        mark_pending_turn(&mut newer);
+        let newer_id = startup_work_id(&newer).expect("newer work id");
+        let (_dir, state) = state_with_session(session).await;
+        let sender = state.get_session_event_sender("chat-reconcile-race").await;
+        let reconcile_receiver = sender.subscribe();
+        let mut observer = sender.subscribe();
+
+        // Queue the chat save first, then reconciliation, behind the same
+        // per-session guard. FIFO lock acquisition makes the new turn durable
+        // before reconciliation re-evaluates it.
+        let blocker = state.persistence.acquire_lock("chat-reconcile-race").await;
+        let persistence = state.persistence.clone();
+        let save = tokio::spawn(async move {
+            persistence
+                .merge_save_runtime(&mut newer)
+                .await
+                .expect("save newer turn");
+        });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let reconcile_state = state.clone();
+        let reconcile = tokio::spawn(async move {
+            reconcile_abandoned_startup(
+                &reconcile_state,
+                "chat-reconcile-race",
+                &reconcile_receiver,
+            )
+            .await
+        });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        drop(blocker);
+
+        save.await.expect("save task");
+        assert!(!reconcile.await.expect("reconcile task"));
+        let stored = state
+            .storage
+            .load_session("chat-reconcile-race")
+            .await
+            .expect("load session")
+            .expect("stored session");
+        assert_eq!(startup_work_id(&stored).as_deref(), Some(newer_id.as_str()));
+        assert_eq!(stored.last_run_status().as_deref(), Some("pending"));
+        assert!(observer.try_recv().is_err(), "new turn must not be closed");
     }
 
     #[test]
@@ -625,5 +1049,31 @@ mod tests {
             "late rejection"
         ));
         assert_eq!(stale.last_run_status().as_deref(), Some("pending"));
+
+        let mut legacy = Session::new("legacy", "test-model");
+        legacy.add_message(Message::user("persisted before owner marker"));
+        legacy.set_last_run_status("pending");
+        let legacy_id = pending_turn_id(&legacy).expect("legacy last-User ownership");
+        assert!(mark_startup_failed_if_owned(
+            &mut legacy,
+            &legacy_id,
+            "legacy startup rejected"
+        ));
+
+        let mut resume = Session::new("resume", "test-model");
+        resume.add_message(Message::assistant("question", None));
+        resume.add_message(Message::tool_result("ask-1", "answer"));
+        resume.metadata.insert(
+            "clarification_resume_pending".to_string(),
+            "true".to_string(),
+        );
+        let resume_id = startup_work_id(&resume).expect("resume work id");
+        assert!(mark_startup_failed_if_owned(
+            &mut resume,
+            &resume_id,
+            "resume persistence failed"
+        ));
+        assert!(!has_pending_clarification_resume(&resume));
+        assert_eq!(resume.last_run_status().as_deref(), Some("error"));
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
@@ -27,19 +27,25 @@ pub async fn handler(
     req: web::Json<ExecuteRequest>,
 ) -> HttpResponse {
     let session_id = path.into_inner();
-    // Covers the preparation window before a Pending runner can be reserved.
-    // The RAII guard is released on every success/error return path.
-    let _startup_guard =
+    // Linearize startup ownership against an abandoned-turn reconciliation.
+    // Reconciliation holds the same persistence lock through its durable CAS
+    // and broadcast; whichever acquires it first becomes the authoritative
+    // transition for this turn.
+    let startup_lock = state.persistence.acquire_lock(&session_id).await;
+    // Protect the preparation window before `reserve_runner` can publish a
+    // Pending runner. Reference-counted RAII releases on every return/panic.
+    let mut startup_guard =
         crate::handlers::agent::events::begin_execute_startup(state.get_ref(), &session_id);
-    // Bind every later rejection to the exact user turn this execute request
-    // observed. A delayed failure from turn A must never poison newer turn B.
+    // Bind rejection rollback to the exact turn observed by this request. A
+    // delayed failure from turn A must never poison a newer turn B.
     let startup_turn_id = state
         .storage
         .load_session(&session_id)
         .await
         .ok()
         .flatten()
-        .and_then(|session| crate::handlers::agent::events::pending_turn_id(&session));
+        .and_then(|session| crate::handlers::agent::events::startup_work_id(&session));
+    drop(startup_lock);
     tracing::debug!(
         "[{}] Execute requested: model={:?}, model_ref={:?}, reasoning_effort={:?}, has_client_sync={}",
         session_id,
@@ -56,7 +62,14 @@ pub async fn handler(
     let image_fallback = match resolve_image_fallback(&config_snapshot) {
         Ok(value) => value,
         Err(error) => {
-            fail_pending_startup(&state, &session_id, startup_turn_id.as_deref(), &error).await;
+            fail_pending_startup(
+                &state,
+                &session_id,
+                startup_turn_id.as_deref(),
+                &error,
+                &mut startup_guard,
+            )
+            .await;
             return internal_server_error_response(error);
         }
     };
@@ -141,6 +154,7 @@ pub async fn handler(
                 &session_id,
                 startup_turn_id.as_deref(),
                 &format!("execute preparation failed: {error}"),
+                &mut startup_guard,
             )
             .await;
             return match error {
@@ -176,11 +190,14 @@ pub async fn handler(
             reasoning_source,
             is_child_session,
         } => {
+            let session = *session;
             ready::handle_execute_ready(
                 &state,
                 &session_id,
                 ready::ReadyExecution {
-                    session: *session,
+                    session,
+                    startup_guard: &mut startup_guard,
+                    startup_turn_id: startup_turn_id.clone(),
                     effective_model,
                     effective_reasoning_effort,
                     model_source,
@@ -239,13 +256,21 @@ pub async fn handler(
                 &session_id,
                 startup_turn_id.as_deref(),
                 "no model configured",
+                &mut startup_guard,
             )
             .await;
             bad_request_error_response("no model configured for session or provider")
         }
 
         bamboo_engine::session_app::types::ExecutePreparationOutcome::ImageFallbackError(error) => {
-            fail_pending_startup(&state, &session_id, startup_turn_id.as_deref(), &error).await;
+            fail_pending_startup(
+                &state,
+                &session_id,
+                startup_turn_id.as_deref(),
+                &error,
+                &mut startup_guard,
+            )
+            .await;
             bad_request_error_response(error)
         }
     }
@@ -256,30 +281,21 @@ async fn fail_pending_startup(
     session_id: &str,
     expected_turn_id: Option<&str>,
     detail: &str,
+    startup_guard: &mut crate::handlers::agent::events::ExecuteStartupGuard,
 ) {
     let Some(expected_turn_id) = expected_turn_id else {
         return;
     };
-    let Ok(Some(mut session)) = state.storage.load_session(session_id).await else {
-        return;
-    };
-    // Ownership prevents a delayed/retried rejection from poisoning a later
-    // turn, and avoids treating an old runner Error as this turn's outcome.
-    if !crate::handlers::agent::events::mark_startup_failed_if_owned(
-        &mut session,
-        expected_turn_id,
+    crate::handlers::agent::events::transition_startup_failure_if_owned(
+        state,
+        session_id,
+        crate::handlers::agent::events::StartupFailureTarget::WorkId {
+            work_id: expected_turn_id,
+            startup_guard,
+        },
         detail,
-    ) {
-        return;
-    }
-    if let Err(error) = state.persistence.merge_save_runtime(&mut session).await {
-        tracing::error!("[{session_id}] failed to persist execute rejection: {error}");
-        return;
-    }
-    state.sessions.insert(
-        session_id.to_string(),
-        std::sync::Arc::new(parking_lot::RwLock::new(session)),
-    );
+    )
+    .await;
 }
 
 /// Convert a crate's `ExecuteSyncReason` to the handler's `ExecuteSyncReason`.

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
@@ -27,8 +27,11 @@ use bamboo_engine::ImageFallbackConfig;
 use bamboo_llm::Config;
 
 /// The fields the engine's `ExecutePreparationOutcome::Ready` carries.
-pub(super) struct ReadyExecution {
+pub(super) struct ReadyExecution<'a> {
     pub session: bamboo_agent_core::Session,
+    pub startup_guard: &'a mut crate::handlers::agent::events::ExecuteStartupGuard,
+    /// Durable message id owned by the pending execute handoff, if any.
+    pub startup_turn_id: Option<String>,
     pub effective_model: String,
     pub effective_reasoning_effort: Option<bamboo_domain::reasoning::ReasoningEffort>,
     pub model_source: &'static str,
@@ -46,7 +49,7 @@ pub(super) struct ReadyExecution {
 pub(super) async fn handle_execute_ready(
     state: &web::Data<AppState>,
     session_id: &str,
-    ready: ReadyExecution,
+    ready: ReadyExecution<'_>,
     config: &ExecutionConfigSnapshot,
     config_snapshot: &Config,
     image_fallback: Option<ImageFallbackConfig>,
@@ -87,9 +90,9 @@ pub(super) async fn handle_execute_ready(
     // The reservation owns this exact turn now. Moving the owned marker out of
     // `pending` before persistence prevents an old terminal runner from being
     // used to classify the newly-starting turn.
-    let startup_turn_id = crate::handlers::agent::events::pending_turn_id(&session);
     session.set_last_run_status("running");
     session.clear_last_run_error();
+    crate::handlers::agent::events::clear_pending_turn(&mut session);
 
     // ---- Save session before spawn (metadata-group merge) ----
     if let Err(error) = state.persistence.merge_save_runtime(&mut session).await {
@@ -97,9 +100,9 @@ pub(super) async fn handle_execute_ready(
             state,
             session_id,
             &run_id,
-            startup_turn_id.as_deref(),
-            &mut session,
+            ready.startup_turn_id.as_deref(),
             &error.to_string(),
+            ready.startup_guard,
         )
         .await;
         return internal_server_error_response(format!(
@@ -211,8 +214,8 @@ async fn rollback_startup(
     session_id: &str,
     run_id: &str,
     expected_turn_id: Option<&str>,
-    session: &mut bamboo_agent_core::Session,
     detail: &str,
+    startup_guard: &mut crate::handlers::agent::events::ExecuteStartupGuard,
 ) {
     // Remove only our reservation. A concurrent retry may already have replaced
     // it, and must not be disturbed.
@@ -225,28 +228,19 @@ async fn rollback_startup(
     }
     drop(runners);
 
-    // Route through the same owned-turn failure transition used by preparation
-    // rejects. The marker still identifies this exact message; status is reset
-    // only to satisfy the transition's pending precondition.
-    if let Some(expected_turn_id) = expected_turn_id {
-        session.set_last_run_status("pending");
-        crate::handlers::agent::events::mark_startup_failed_if_owned(
-            session,
-            expected_turn_id,
-            detail,
-        );
-    } else {
-        session.set_last_run_status("error");
-        session.set_last_run_error(format!("Agent startup failed: {detail}"));
-    }
-    if state.persistence.merge_save_runtime(session).await.is_ok() {
-        state.sessions.insert(
-            session_id.to_string(),
-            std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
-        );
-    } else {
-        tracing::error!("[{session_id}] failed to persist execute startup rollback");
-    }
+    let Some(expected_turn_id) = expected_turn_id else {
+        return;
+    };
+    crate::handlers::agent::events::transition_startup_failure_if_owned(
+        state,
+        session_id,
+        crate::handlers::agent::events::StartupFailureTarget::WorkId {
+            work_id: expected_turn_id,
+            startup_guard,
+        },
+        detail,
+    )
+    .await;
 }
 
 /// #74: re-derive the "no interactive human approver" posture for a

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/tests.rs
@@ -174,3 +174,295 @@ fn evaluate_client_sync_allows_missing_pending_question_tool_call_id() {
         None
     );
 }
+
+#[actix_web::test]
+async fn startup_failure_persists_and_broadcasts_for_owned_turn() {
+    use actix_web::web;
+    use bamboo_agent_core::{AgentEvent, Message, Session};
+
+    let dir = tempfile::tempdir().expect("temporary app data");
+    let state = web::Data::new(
+        crate::AppState::new(dir.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let session_id = "owned-startup-failure";
+    let mut session = Session::new(session_id, "test-model");
+    session.add_message(Message::user("start"));
+    crate::handlers::agent::events::mark_pending_turn(&mut session);
+    let turn_id = crate::handlers::agent::events::startup_work_id(&session).unwrap();
+    state.save_and_cache_session(&mut session).await;
+    let mut receiver = state.get_session_event_sender(session_id).await.subscribe();
+    let mut startup_guard =
+        crate::handlers::agent::events::begin_execute_startup(state.get_ref(), session_id);
+
+    super::fail_pending_startup(
+        &state,
+        session_id,
+        Some(&turn_id),
+        "provider rejected",
+        &mut startup_guard,
+    )
+    .await;
+
+    let stored = state
+        .storage
+        .load_session(session_id)
+        .await
+        .expect("load session")
+        .expect("stored session");
+    assert_eq!(stored.last_run_status().as_deref(), Some("error"));
+    assert!(stored
+        .last_run_error()
+        .is_some_and(|message| message.contains("provider rejected")));
+    assert!(matches!(
+        receiver.try_recv(),
+        Ok(AgentEvent::Error { message }) if message.contains("provider rejected")
+    ));
+}
+
+#[actix_web::test]
+async fn pending_or_running_runner_wins_over_same_work_id_failure() {
+    use actix_web::web;
+    use bamboo_agent_core::{Message, Session};
+
+    for (suffix, status) in [
+        ("pending", crate::app_state::AgentStatus::Pending),
+        ("running", crate::app_state::AgentStatus::Running),
+    ] {
+        let dir = tempfile::tempdir().expect("temporary app data");
+        let state = web::Data::new(
+            crate::AppState::new(dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let session_id = format!("runner-wins-{suffix}");
+        let mut session = Session::new(&session_id, "test-model");
+        session.add_message(Message::user("start"));
+        crate::handlers::agent::events::mark_pending_turn(&mut session);
+        let turn_id = crate::handlers::agent::events::startup_work_id(&session).unwrap();
+        state.save_and_cache_session(&mut session).await;
+        let mut receiver = state
+            .get_session_event_sender(&session_id)
+            .await
+            .subscribe();
+        let mut runner = crate::app_state::AgentRunner::new();
+        runner.status = status;
+        state
+            .agent_runners
+            .write()
+            .await
+            .insert(session_id.clone(), runner);
+        let mut startup_guard =
+            crate::handlers::agent::events::begin_execute_startup(state.get_ref(), &session_id);
+
+        super::fail_pending_startup(
+            &state,
+            &session_id,
+            Some(&turn_id),
+            "overlapping rejection",
+            &mut startup_guard,
+        )
+        .await;
+
+        let stored = state
+            .storage
+            .load_session(&session_id)
+            .await
+            .expect("load session")
+            .expect("stored session");
+        assert_eq!(stored.last_run_status().as_deref(), Some("pending"));
+        assert_eq!(
+            crate::handlers::agent::events::startup_work_id(&stored).as_deref(),
+            Some(turn_id.as_str())
+        );
+        assert!(receiver.try_recv().is_err(), "live runner must stay silent");
+    }
+}
+
+#[actix_web::test]
+async fn overlapping_preparation_failure_defers_to_other_owner_and_runner() {
+    use actix_web::web;
+    use bamboo_agent_core::{Message, Session};
+
+    let dir = tempfile::tempdir().expect("temporary app data");
+    let state = web::Data::new(
+        crate::AppState::new(dir.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let session_id = "overlap-prep-runner-wins";
+    let mut session = Session::new(session_id, "test-model");
+    session.add_message(Message::user("start"));
+    crate::handlers::agent::events::mark_pending_turn(&mut session);
+    let turn_id = crate::handlers::agent::events::startup_work_id(&session).unwrap();
+    state.save_and_cache_session(&mut session).await;
+    let mut receiver = state.get_session_event_sender(session_id).await.subscribe();
+    let mut first =
+        crate::handlers::agent::events::begin_execute_startup(state.get_ref(), session_id);
+    let second = crate::handlers::agent::events::begin_execute_startup(state.get_ref(), session_id);
+
+    super::fail_pending_startup(
+        &state,
+        session_id,
+        Some(&turn_id),
+        "first preparation rejected",
+        &mut first,
+    )
+    .await;
+    assert!(receiver.try_recv().is_err());
+
+    let mut runner = crate::app_state::AgentRunner::new();
+    runner.status = crate::app_state::AgentStatus::Pending;
+    state
+        .agent_runners
+        .write()
+        .await
+        .insert(session_id.to_string(), runner);
+    drop(second);
+
+    let stored = state
+        .storage
+        .load_session(session_id)
+        .await
+        .expect("load session")
+        .expect("stored session");
+    assert_eq!(stored.last_run_status().as_deref(), Some("pending"));
+    assert_eq!(
+        crate::handlers::agent::events::startup_work_id(&stored).as_deref(),
+        Some(turn_id.as_str())
+    );
+    assert!(
+        receiver.try_recv().is_err(),
+        "other preparation owns startup"
+    );
+}
+
+#[actix_web::test]
+async fn last_of_two_preparation_failures_broadcasts_exactly_once() {
+    use actix_web::web;
+    use bamboo_agent_core::{AgentEvent, Message, Session};
+
+    let dir = tempfile::tempdir().expect("temporary app data");
+    let state = web::Data::new(
+        crate::AppState::new(dir.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let session_id = "overlap-prep-both-fail";
+    let mut session = Session::new(session_id, "test-model");
+    session.add_message(Message::user("start"));
+    crate::handlers::agent::events::mark_pending_turn(&mut session);
+    let turn_id = crate::handlers::agent::events::startup_work_id(&session).unwrap();
+    state.save_and_cache_session(&mut session).await;
+    let mut receiver = state.get_session_event_sender(session_id).await.subscribe();
+    let mut first =
+        crate::handlers::agent::events::begin_execute_startup(state.get_ref(), session_id);
+    let mut second =
+        crate::handlers::agent::events::begin_execute_startup(state.get_ref(), session_id);
+
+    super::fail_pending_startup(
+        &state,
+        session_id,
+        Some(&turn_id),
+        "first preparation rejected",
+        &mut first,
+    )
+    .await;
+    assert!(receiver.try_recv().is_err(), "first owner must defer");
+    super::fail_pending_startup(
+        &state,
+        session_id,
+        Some(&turn_id),
+        "second preparation rejected",
+        &mut second,
+    )
+    .await;
+
+    assert!(matches!(
+        receiver.try_recv(),
+        Ok(AgentEvent::Error { message }) if message.contains("second preparation rejected")
+    ));
+    assert!(
+        receiver.try_recv().is_err(),
+        "only one failure is broadcast"
+    );
+    let stored = state
+        .storage
+        .load_session(session_id)
+        .await
+        .expect("load session")
+        .expect("stored session");
+    assert_eq!(stored.last_run_status().as_deref(), Some("error"));
+    assert!(crate::handlers::agent::events::startup_work_id(&stored).is_none());
+}
+
+#[actix_web::test]
+async fn startup_failure_waiting_on_lock_cannot_overwrite_newer_turn() {
+    use actix_web::web;
+    use bamboo_agent_core::{Message, Session};
+
+    let dir = tempfile::tempdir().expect("temporary app data");
+    let state = web::Data::new(
+        crate::AppState::new(dir.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let session_id = "stale-startup-failure";
+    let mut session = Session::new(session_id, "test-model");
+    session.add_message(Message::user("first"));
+    crate::handlers::agent::events::mark_pending_turn(&mut session);
+    let stale_turn_id = crate::handlers::agent::events::startup_work_id(&session).unwrap();
+    state.save_and_cache_session(&mut session).await;
+    let mut receiver = state.get_session_event_sender(session_id).await.subscribe();
+
+    // Model a newer chat writer already inside the canonical per-session lock.
+    // The stale preparation failure starts and blocks behind it.
+    let chat_guard = state.persistence.acquire_lock(session_id).await;
+    let failure_state = state.clone();
+    let mut failure_guard =
+        crate::handlers::agent::events::begin_execute_startup(state.get_ref(), session_id);
+    let failure = tokio::spawn(async move {
+        super::fail_pending_startup(
+            &failure_state,
+            session_id,
+            Some(&stale_turn_id),
+            "late rejection",
+            &mut failure_guard,
+        )
+        .await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert!(
+        !failure.is_finished(),
+        "stale failure must be waiting on the session lock"
+    );
+
+    session.add_message(Message::user("newer"));
+    crate::handlers::agent::events::mark_pending_turn(&mut session);
+    let current_turn_id = crate::handlers::agent::events::startup_work_id(&session).unwrap();
+    state
+        .storage
+        .save_session(&session)
+        .await
+        .expect("persist newer turn while owning session lock");
+    state.sessions.insert(
+        session_id.to_string(),
+        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+    );
+    drop(chat_guard);
+    failure.await.expect("failure task completes");
+
+    let stored = state
+        .storage
+        .load_session(session_id)
+        .await
+        .expect("load session")
+        .expect("stored session");
+    assert_eq!(
+        crate::handlers::agent::events::startup_work_id(&stored).as_deref(),
+        Some(current_turn_id.as_str())
+    );
+    assert_eq!(stored.last_run_status().as_deref(), Some("pending"));
+    assert!(receiver.try_recv().is_err(), "stale failure must be silent");
+}

--- a/crates/app/bamboo-server/src/handlers/agent/messages/truncate.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/messages/truncate.rs
@@ -6,6 +6,7 @@ use super::shared::{
 };
 use super::types::TruncateRequest;
 use crate::app_state::AppState;
+use bamboo_engine::session_app::execute::{clear_startup_handoff, mark_startup_handoff};
 use bamboo_engine::session_app::truncation::{
     sanitize_malformed_tool_chains, truncate_after_last_user, truncate_for_unresolved_tool_calls,
     unresolved_tool_call_ids,
@@ -45,6 +46,9 @@ pub async fn truncate_messages(
             let cleared_pending_flag = session.metadata.remove(RETRY_RESUME_PENDING_KEY).is_some();
             let cleared_reason_flag = session.metadata.remove(RETRY_RESUME_REASON_KEY).is_some();
             let cleared_retry_flags = cleared_pending_flag || cleared_reason_flag;
+            if cleared_retry_flags {
+                clear_startup_handoff(&mut session);
+            }
             (
                 removed,
                 session.messages.len(),
@@ -62,6 +66,7 @@ pub async fn truncate_messages(
                     RETRY_RESUME_REASON_KEY.to_string(),
                     "error_retry".to_string(),
                 );
+                mark_startup_handoff(&mut session);
                 (0, session.messages.len(), false, true)
             } else {
                 let removed_via_sanitization = sanitize_malformed_tool_chains(&mut session);
@@ -80,6 +85,7 @@ pub async fn truncate_messages(
                         RETRY_RESUME_REASON_KEY.to_string(),
                         "error_retry".to_string(),
                     );
+                    mark_startup_handoff(&mut session);
                     (
                         removed_via_sanitization,
                         session.messages.len(),
@@ -107,6 +113,9 @@ pub async fn truncate_messages(
                     let cleared_reason_flag =
                         session.metadata.remove(RETRY_RESUME_REASON_KEY).is_some();
                     let cleared_retry_flags = cleared_pending_flag || cleared_reason_flag;
+                    if cleared_retry_flags {
+                        clear_startup_handoff(&mut session);
+                    }
 
                     (
                         removed,

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
@@ -51,7 +51,10 @@ use super::envelope::{
     feed_reset_control, gap_control, terminal_control, Encoding, OutFrame, ServerEnvelope,
 };
 use crate::app_state::{AgentStatus, AppState};
-use crate::handlers::agent::events::{has_running_child, terminal_event_if_ready, Coalescer};
+use crate::handlers::agent::events::{
+    has_running_child, reconcile_abandoned_startup, startup_reconcile_delay,
+    terminal_event_if_ready, Coalescer,
+};
 use crate::handlers::agent::stream::{plan_replay, ReplayPlan};
 
 /// What the driver sends to the WS writer: an already-encoded frame (a JSON text
@@ -216,6 +219,10 @@ pub(crate) fn spawn_agent_forwarder(
             }
         }
 
+        let initial_reconcile_delay = startup_reconcile_delay(&state, &session_id).await;
+        let startup_reconcile = tokio::time::sleep(initial_reconcile_delay);
+        tokio::pin!(startup_reconcile);
+
         if batch_ms == 0 {
             // Fast path: every event emitted immediately, byte-for-byte (desktop
             // default), with no buffering.
@@ -228,18 +235,21 @@ pub(crate) fn spawn_agent_forwarder(
             // every later child event. Hold the channel open and emit the
             // `terminal` control only once no running child is left.
             let mut awaiting_children = false;
-            let startup_reconcile = tokio::time::sleep(Duration::from_secs(61));
-            tokio::pin!(startup_reconcile);
             loop {
                 let received = tokio::select! {
                     received = receiver.recv() => received,
                     _ = &mut startup_reconcile => {
-                        if reconcile_abandoned_startup(&state, &session_id, &out, encoding, &ch, &seq).await {
-                            return;
+                        if reconcile_abandoned_startup(
+                            &state,
+                            &session_id,
+                            &receiver,
+                        ).await {
+                            let delay = startup_reconcile_delay(&state, &session_id).await;
+                            startup_reconcile.as_mut().reset(tokio::time::Instant::now() + delay);
+                            continue;
                         }
-                        // A real run won the race; this one-shot guard is no
-                        // longer needed for this forwarder.
-                        startup_reconcile.as_mut().reset(tokio::time::Instant::now() + Duration::from_secs(86_400));
+                        let delay = startup_reconcile_delay(&state, &session_id).await;
+                        startup_reconcile.as_mut().reset(tokio::time::Instant::now() + delay);
                         continue;
                     }
                 };
@@ -319,8 +329,6 @@ pub(crate) fn spawn_agent_forwarder(
         // See the fast-path comment: keep the channel open after the parent
         // terminal while child sub-agents still run.
         let mut awaiting_children = false;
-        let startup_reconcile = tokio::time::sleep(Duration::from_secs(61));
-        tokio::pin!(startup_reconcile);
 
         loop {
             let sleep_until = flush_deadline
@@ -328,10 +336,17 @@ pub(crate) fn spawn_agent_forwarder(
 
             tokio::select! {
                 _ = &mut startup_reconcile => {
-                    if reconcile_abandoned_startup(&state, &session_id, &out, encoding, &ch, &seq).await {
-                        return;
+                    if reconcile_abandoned_startup(
+                        &state,
+                        &session_id,
+                        &receiver,
+                    ).await {
+                        let delay = startup_reconcile_delay(&state, &session_id).await;
+                        startup_reconcile.as_mut().reset(tokio::time::Instant::now() + delay);
+                        continue;
                     }
-                    startup_reconcile.as_mut().reset(tokio::time::Instant::now() + Duration::from_secs(86_400));
+                    let delay = startup_reconcile_delay(&state, &session_id).await;
+                    startup_reconcile.as_mut().reset(tokio::time::Instant::now() + delay);
                 }
                 _ = tokio::time::sleep_until(sleep_until), if flush_deadline.is_some() => {
                     if let Some(pending) = coalescer.take_pending() {
@@ -431,35 +446,6 @@ pub(crate) fn spawn_agent_forwarder(
             }
         }
     })
-}
-
-async fn reconcile_abandoned_startup(
-    state: &web::Data<AppState>,
-    session_id: &str,
-    out: &OutboundTx,
-    encoding: Encoding,
-    ch: &str,
-    seq: &AgentSeq,
-) -> bool {
-    let runner_status = state
-        .agent_runners
-        .read()
-        .await
-        .get(session_id)
-        .map(|runner| runner.status.clone());
-    let Some(event) = terminal_event_if_ready(state, session_id, runner_status).await else {
-        return false;
-    };
-    if !emit_agent_event(out, encoding, ch, seq, event).await {
-        return true;
-    }
-    let _ = send_env(
-        out,
-        encoding,
-        ServerEnvelope::control(ch, seq.next(), terminal_control("complete")),
-    )
-    .await;
-    true
 }
 
 /// Spawn a one-shot `agent.{sid}` replay for a session that was already
@@ -951,5 +937,109 @@ mod tests {
                 .is_none(),
             "channel must close after the terminal control"
         );
+    }
+
+    #[tokio::test]
+    async fn live_ws_reconciles_abandoned_startup_in_both_batch_paths() {
+        for batch_ms in [0, 1_000] {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = web::Data::new(AppState::new(tmp.path().to_path_buf()).await.unwrap());
+            let session_id = format!("ws-abandoned-{batch_ms}");
+            let mut session = bamboo_agent_core::Session::new(&session_id, "test-model");
+            session.add_message(bamboo_agent_core::Message::user("slow startup"));
+            crate::handlers::agent::events::mark_pending_turn(&mut session);
+            session.metadata.insert(
+                "execute.startup_handoff_at".to_string(),
+                (chrono::Utc::now() - chrono::Duration::seconds(120)).to_rfc3339(),
+            );
+            state.save_session(&mut session).await;
+
+            let tx = state.get_session_event_sender(&session_id).await;
+            let rx = tx.subscribe();
+            tx.send(AgentEvent::Token {
+                content: "before-terminal".to_string(),
+            })
+            .expect("live receiver");
+            let guard =
+                crate::handlers::agent::events::begin_execute_startup(state.get_ref(), &session_id);
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(350)).await;
+                drop(guard);
+            });
+
+            let (out_tx, mut out_rx) = mpsc::channel::<OutFrame>(64);
+            let handle = spawn_agent_forwarder(
+                state,
+                session_id.clone(),
+                out_tx,
+                Encoding::Json,
+                format!("agent.{session_id}"),
+                rx,
+                None,
+                Vec::new(),
+                batch_ms,
+            );
+
+            let token = next_json(&mut out_rx).await;
+            assert_eq!(token["event"]["content"], "before-terminal");
+            let terminal_event = next_json(&mut out_rx).await;
+            assert_eq!(terminal_event["event"]["type"], "error");
+            assert!(terminal_event["event"]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("was not started")));
+            let terminal_control = next_json(&mut out_rx).await;
+            assert_eq!(terminal_control["control"]["type"], "terminal");
+            tokio::time::timeout(Duration::from_secs(2), handle)
+                .await
+                .expect("forwarder terminates")
+                .expect("forwarder task succeeds");
+            assert!(out_rx.try_recv().is_err(), "replay must be one-shot");
+        }
+    }
+
+    #[tokio::test]
+    async fn live_ws_idle_probe_discovers_later_abandoned_turn() {
+        for batch_ms in [0, 1_000] {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let state = web::Data::new(AppState::new(tmp.path().to_path_buf()).await.unwrap());
+            let session_id = format!("ws-late-pending-{batch_ms}");
+            let mut session = bamboo_agent_core::Session::new(&session_id, "test-model");
+            state.save_session(&mut session).await;
+            let sender = state.get_session_event_sender(&session_id).await;
+            let receiver = sender.subscribe();
+            let (out_tx, mut out_rx) = mpsc::channel::<OutFrame>(64);
+            let handle = spawn_agent_forwarder(
+                state.clone(),
+                session_id.clone(),
+                out_tx,
+                Encoding::Json,
+                format!("agent.{session_id}"),
+                receiver,
+                None,
+                Vec::new(),
+                batch_ms,
+            );
+
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            session.add_message(bamboo_agent_core::Message::user("never executed"));
+            crate::handlers::agent::events::mark_pending_turn(&mut session);
+            session.metadata.insert(
+                "execute.startup_handoff_at".to_string(),
+                (chrono::Utc::now() - chrono::Duration::seconds(120)).to_rfc3339(),
+            );
+            state.save_session(&mut session).await;
+
+            let terminal_event = next_json(&mut out_rx).await;
+            assert_eq!(terminal_event["event"]["type"], "error");
+            assert!(terminal_event["event"]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("was not started")));
+            let terminal_control = next_json(&mut out_rx).await;
+            assert_eq!(terminal_control["control"]["type"], "terminal");
+            tokio::time::timeout(Duration::from_secs(2), handle)
+                .await
+                .expect("forwarder terminates")
+                .expect("forwarder task succeeds");
+        }
     }
 }

--- a/crates/engine/bamboo-engine/src/session_app/execute/mod.rs
+++ b/crates/engine/bamboo-engine/src/session_app/execute/mod.rs
@@ -22,9 +22,10 @@ mod tests;
 
 pub use billing::{billable_user_turn_count, is_billable_user_turn, is_system_resume_message};
 pub use resume_markers::{
-    consume_pending_clarification_resume, consume_pending_conclusion_with_options_resume,
-    has_pending_clarification_resume, has_pending_conclusion_with_options_resume,
-    has_pending_retry_resume, has_pending_user_message,
+    clear_startup_handoff, consume_pending_clarification_resume,
+    consume_pending_conclusion_with_options_resume, has_pending_clarification_resume,
+    has_pending_conclusion_with_options_resume, has_pending_retry_resume, has_pending_user_message,
+    mark_startup_handoff, startup_handoff_at,
 };
 pub use sync::evaluate_client_sync;
 

--- a/crates/engine/bamboo-engine/src/session_app/execute/resume_markers.rs
+++ b/crates/engine/bamboo-engine/src/session_app/execute/resume_markers.rs
@@ -2,10 +2,36 @@
 
 use bamboo_agent_core::Role;
 use bamboo_domain::Session;
+use chrono::{DateTime, SecondsFormat, Utc};
 
 pub(crate) const CLARIFICATION_RESUME_PENDING_KEY: &str = "clarification_resume_pending";
 pub(crate) const CONCLUSION_WITH_OPTIONS_RESUME_PENDING_KEY: &str =
     "conclusion_with_options_resume_pending";
+const STARTUP_HANDOFF_AT_KEY: &str = "execute.startup_handoff_at";
+
+/// Persist the start of a chat-to-execute or resume-to-run handoff.
+///
+/// Resume operations can reuse an old transcript message, so message creation
+/// time is not a safe grace-period origin. This marker records when the user
+/// actually requested the new handoff.
+pub fn mark_startup_handoff(session: &mut Session) {
+    session.metadata.insert(
+        STARTUP_HANDOFF_AT_KEY.to_string(),
+        Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+    );
+}
+
+pub fn clear_startup_handoff(session: &mut Session) {
+    session.metadata.remove(STARTUP_HANDOFF_AT_KEY);
+}
+
+pub fn startup_handoff_at(session: &Session) -> Option<DateTime<Utc>> {
+    session
+        .metadata
+        .get(STARTUP_HANDOFF_AT_KEY)
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&Utc))
+}
 
 /// Whether the session has resumable user work (pending tool response, retry, or last message is from user).
 pub fn has_pending_user_message(session: &Session) -> bool {
@@ -26,6 +52,7 @@ pub fn consume_pending_clarification_resume(session: &mut Session) {
         .remove(CONCLUSION_WITH_OPTIONS_RESUME_PENDING_KEY);
     session.metadata.remove("retry_resume_pending");
     session.metadata.remove("retry_resume_reason");
+    clear_startup_handoff(session);
 }
 
 pub fn has_pending_clarification_resume(session: &Session) -> bool {

--- a/crates/engine/bamboo-engine/src/session_app/respond.rs
+++ b/crates/engine/bamboo-engine/src/session_app/respond.rs
@@ -6,6 +6,7 @@ use bamboo_tools::permission::PermissionType;
 use chrono::Utc;
 
 use super::errors::RespondError;
+use super::execute::mark_startup_handoff;
 use super::provider_model::{derive_model_ref, persist_legacy_model_provider, persist_model_ref};
 use super::repository::SessionAccess;
 use super::types::RespondInput;
@@ -155,6 +156,7 @@ pub async fn submit_pending_response_with_source(
         CONCLUSION_WITH_OPTIONS_RESUME_PENDING_KEY.to_string(),
         "true".to_string(),
     );
+    mark_startup_handoff(&mut session);
 
     // ---- Merge model/reasoning from request ----
     let request_model_ref = derive_model_ref(


### PR DESCRIPTION
## Summary

- make execute-startup ownership AppState-scoped, reference-counted, and bound to the exact pending User or resume message
- atomically reconcile preparation rejection, Ready rollback, and abandoned startup under the per-session persistence lock
- prevent stale failures from overwriting newer turns; defer to overlapping preparation owners and Pending/Running runners
- give clarification/retry resumes a durable handoff timestamp and make startup failures authoritative over stale Suspended state
- keep idle SSE and WS subscriptions probing for later abandoned work, with ordered single-broadcast terminal delivery

Follow-up to #607. Closes #588.

## Test Plan

- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p bamboo-server handlers::agent::execute::handler::tests -- --nocapture` (13 passed)
- `cargo test -p bamboo-server handlers::agent::events -- --nocapture` (40 passed)
- `cargo test -p bamboo-server handlers::agent::ws_v2 -- --nocapture` (44 passed)
- `cargo test -p bamboo-engine session_app::execute -- --nocapture` (46 passed)
- `cargo test -p bamboo-server --test ws_v2_live` (16 passed)
- `cargo test -p bamboo-server handlers::agent::messages -- --nocapture` (14 passed)
- `cargo clippy --all-targets` (passes; existing warnings only)
- `cargo test` reached Bamboo server with 1421/1422 library tests passing; the sole failure is the unchanged macOS LibreSSL 3.3.6 self-signed-cert test (`UnsupportedCertVersion`), reproduced in isolation. GitHub CI is the platform-neutral full-suite gate.

## Screenshots

Not applicable; backend stream lifecycle change.