### PR TITLE
[bamboo] feat: persist child approval lifecycle

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/mod.rs
+++ b/crates/app/bamboo-sdk/src/agent/mod.rs
@@ -656,6 +656,7 @@ impl Agent {
         approved: bool,
     ) -> bool {
         bamboo_engine::external_agents::live::deliver_approval_checked(
+            None,
             child_session_id.as_ref(),
             request_id.as_ref(),
             approved,
@@ -1434,11 +1435,13 @@ mod reexecute_and_child_approval_tests {
         // process-global engine state, set up here exactly as
         // `external_agents::actor_adapter::drive` would.
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-        let _live_guard = bamboo_engine::external_agents::live::register("child-x", tx);
+        let _live_guard = bamboo_engine::external_agents::live::register("child-x", tx, 0, None);
         let (approval_event_tx, _approval_event_rx) = tokio::sync::mpsc::channel(4);
         bamboo_engine::external_agents::live::register_pending_approval_observed(
+            None,
             "parent-x",
             "child-x",
+            0,
             "req-1",
             "shell",
             "execute",

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -448,10 +448,11 @@ impl AppState {
                 });
             }
         }
-        let external_runner = bamboo_engine::external_agents::runtime::build_external_child_runner(
-            &config_snapshot,
-            Some(approval_registry.clone()),
-        );
+        let external_runner =
+            bamboo_engine::external_agents::runtime::build_external_child_runner_with_registry(
+                &config_snapshot,
+                Some(approval_registry.clone()),
+            );
         let spawn_scheduler = build_spawn_scheduler(
             agent.clone(),
             child_tools,

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -313,6 +313,18 @@ impl AppState {
                     "failed to initialize account change-feed journal: {e}"
                 ))
             })?;
+        let (approval_registry, restart_approval_events) =
+            bamboo_engine::external_agents::live::initialize_durable_approvals(
+                data_dir.join("approvals/child-approvals-v1.json"),
+            )
+            .map_err(|error| {
+                AppError::InternalError(anyhow::anyhow!(
+                    "failed to initialize durable child approvals: {error}"
+                ))
+            })?;
+        for event in restart_approval_events {
+            account_sink.record(event.session_id(), &event);
+        }
 
         // Sub-agents are full agents with the full toolset (no per-role tool
         // trimming): the child tool surface is the plain base tools.
@@ -436,8 +448,10 @@ impl AppState {
                 });
             }
         }
-        let external_runner =
-            bamboo_engine::external_agents::runtime::build_external_child_runner(&config_snapshot);
+        let external_runner = bamboo_engine::external_agents::runtime::build_external_child_runner(
+            &config_snapshot,
+            Some(approval_registry.clone()),
+        );
         let spawn_scheduler = build_spawn_scheduler(
             agent.clone(),
             child_tools,
@@ -708,6 +722,7 @@ impl AppState {
             connect_manager,
             tool_factory,
             permission_checker,
+            approval_registry,
             notification_service,
             session_watchers,
             cancel_tokens: Arc::new(RwLock::new(HashMap::new())),

--- a/crates/app/bamboo-server/src/app_state/mod.rs
+++ b/crates/app/bamboo-server/src/app_state/mod.rs
@@ -270,6 +270,8 @@ pub struct AppState {
     /// executors use. Retained so request handlers can record session grants
     /// when the user approves a permission prompt (see the respond handler).
     pub permission_checker: Arc<dyn bamboo_tools::permission::PermissionChecker>,
+    pub approval_registry:
+        bamboo_engine::external_agents::approval_registry::SharedApprovalRegistry,
 
     /// Backend notification policy service (preferences + dedup + per-session
     /// relays). Classifies agent events into `AgentEvent::Notification` for

--- a/crates/app/bamboo-server/src/handlers/agent/child_approval.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/child_approval.rs
@@ -11,6 +11,8 @@
 use actix_web::{web, HttpResponse, Responder};
 use serde::{Deserialize, Serialize};
 
+use crate::app_state::AppState;
+
 /// Body for `POST /api/v1/child-approval/{child_session_id}`.
 #[derive(Debug, Deserialize)]
 pub struct ChildApprovalDecision {
@@ -29,6 +31,7 @@ struct ChildApprovalResponse {
 ///
 /// `POST /api/v1/child-approval/{child_session_id}`
 pub async fn handler(
+    state: web::Data<AppState>,
     path: web::Path<String>,
     body: web::Json<ChildApprovalDecision>,
 ) -> impl Responder {
@@ -39,6 +42,7 @@ pub async fn handler(
     } = body.into_inner();
 
     let delivered = bamboo_engine::external_agents::live::deliver_approval_checked(
+        Some(&state.approval_registry),
         &child_session_id,
         &request_id,
         approved,

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/events.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/events.rs
@@ -630,6 +630,7 @@ mod tests {
             .send(AgentEvent::ChildApprovalChanged {
                 parent_session_id: "parent-session".into(),
                 child_session_id: session_id.into(),
+                child_attempt: 1,
                 request_id: "req-1".into(),
                 version: 2,
                 status: "approved".into(),

--- a/crates/core/bamboo-agent-core/src/agent/events.rs
+++ b/crates/core/bamboo-agent-core/src/agent/events.rs
@@ -569,6 +569,10 @@ pub enum AgentEvent {
     ChildApprovalChanged {
         parent_session_id: String,
         child_session_id: String,
+        /// Execution attempt that produced this approval. Older persisted
+        /// events predate attempt tracking and deserialize as attempt zero.
+        #[serde(default)]
+        child_attempt: u32,
         request_id: String,
         version: u64,
         /// `pending` | `approved` | `denied` | `expired` | `delivery_failed`.
@@ -1155,6 +1159,7 @@ mod tests {
         let event = AgentEvent::ChildApprovalChanged {
             parent_session_id: "parent-1".into(),
             child_session_id: "child-1".into(),
+            child_attempt: 3,
             request_id: "req-1".into(),
             version: 2,
             status: "approved".into(),
@@ -1170,6 +1175,18 @@ mod tests {
         let value = serde_json::to_value(event).unwrap();
         assert_eq!(value["type"], "child_approval_changed");
         assert_eq!(value["status"], "approved");
+        assert_eq!(value["child_attempt"], 3);
+
+        let mut legacy = value;
+        legacy.as_object_mut().unwrap().remove("child_attempt");
+        let restored: AgentEvent = serde_json::from_value(legacy).unwrap();
+        assert!(matches!(
+            restored,
+            AgentEvent::ChildApprovalChanged {
+                child_attempt: 0,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -1216,6 +1216,7 @@ async fn drive(
                                     .send(AgentEvent::ChildApprovalChanged {
                                         parent_session_id: parent_session_id.to_string(),
                                         child_session_id: child_session_id.to_string(),
+                                        child_attempt,
                                         request_id: id,
                                         version: 1,
                                         status: "delivery_failed".to_string(),
@@ -1232,6 +1233,7 @@ async fn drive(
                             let _ = event_tx.send(AgentEvent::ChildApprovalChanged {
                                 parent_session_id: parent_session_id.to_string(),
                                 child_session_id: child_session_id.to_string(),
+                                child_attempt,
                                 request_id: id.clone(),
                                 version: approval_version,
                                 status: "pending".to_string(),

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -110,6 +110,7 @@ enum PlacementKind {
 
 /// Spawns and drives a child session as an independent actor: a `bamboo-subagent` worker process.
 pub struct ActorChildRunner {
+    approval_registry: Option<super::approval_registry::SharedApprovalRegistry>,
     agent_id: String,
     worker_bin: PathBuf,
     worker_args: Vec<String>,
@@ -261,6 +262,7 @@ impl ActorChildRunner {
         max_concurrent: usize,
     ) -> Self {
         Self {
+            approval_registry: None,
             agent_id,
             worker_bin,
             worker_args,
@@ -278,6 +280,14 @@ impl ActorChildRunner {
             schedulable_placements: HashMap::new(),
             schedule_cursor: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
+    }
+
+    pub fn with_approval_registry(
+        mut self,
+        registry: super::approval_registry::SharedApprovalRegistry,
+    ) -> Self {
+        self.approval_registry = Some(registry);
+        self
     }
 
     /// Run children over the mailbox bus (the unified actor+mailbox transport).
@@ -890,12 +900,19 @@ impl ExternalChildRunner for ActorChildRunner {
             // steer this child in-band over the existing WS connection. The guard
             // unregisters on every exit path.
             let (live_tx, mut live_rx) = mpsc::unbounded_channel::<ParentFrame>();
-            let live_guard = super::live::register(&job.child_session_id, live_tx);
+            let live_guard = super::live::register(
+                &job.child_session_id,
+                live_tx,
+                attempt as u32,
+                self.approval_registry.clone(),
+            );
 
             let result = drive(
                 &mut *client,
                 &job.parent_session_id,
                 &job.child_session_id,
+                attempt as u32,
+                self.approval_registry.as_ref(),
                 self.approval_decider.as_ref(),
                 escalation.clone(),
                 &event_tx,
@@ -1028,6 +1045,8 @@ async fn drive(
     client: &mut dyn bamboo_subagent::ChildLink,
     parent_session_id: &str,
     child_session_id: &str,
+    child_attempt: u32,
+    approval_registry: Option<&super::approval_registry::SharedApprovalRegistry>,
     approval_decider: Option<&Arc<dyn ChildApprovalDecider>>,
     escalation_bridge: Option<bamboo_subagent::executor::HostBridge>,
     event_tx: &mpsc::Sender<AgentEvent>,
@@ -1095,6 +1114,7 @@ async fn drive(
                             let child = child_session_id.to_string();
                             let req_id = id.clone();
                             let body = body.clone();
+                            let registry = approval_registry.cloned();
                             tokio::spawn(async move {
                                 let approved = tokio::time::timeout(
                                     CHILD_APPROVAL_TIMEOUT,
@@ -1102,7 +1122,13 @@ async fn drive(
                                 )
                                 .await
                                 .unwrap_or(false);
-                                super::live::deliver_approval(&child, &req_id, approved);
+                                super::live::deliver_approval_scoped(
+                                    registry.as_ref(),
+                                    &child,
+                                    child_attempt,
+                                    &req_id,
+                                    approved,
+                                );
                             });
                         } else if approval_decider.is_some() {
                             // A decider is wired (policy / auto): decide promptly
@@ -1129,6 +1155,7 @@ async fn drive(
                             let child = child_session_id.to_string();
                             let req_id = id.clone();
                             let body = body.clone();
+                            let registry = approval_registry.cloned();
                             tokio::spawn(async move {
                                 let approved = match tokio::time::timeout(
                                     CHILD_APPROVAL_TIMEOUT,
@@ -1143,7 +1170,13 @@ async fn drive(
                                     // Transport error or timeout ⇒ fail closed.
                                     _ => false,
                                 };
-                                super::live::deliver_approval(&child, &req_id, approved);
+                                super::live::deliver_approval_scoped(
+                                    registry.as_ref(),
+                                    &child,
+                                    child_attempt,
+                                    &req_id,
+                                    approved,
+                                );
                             });
                         } else {
                             // Top orchestrator (no escalation bridge): human-in-the-
@@ -1161,14 +1194,41 @@ async fn drive(
                             // human-loop request (and consume it one-shot).
                             let (approval_version, approval_created_at) =
                                 super::live::register_pending_approval_observed(
+                                approval_registry,
                                 parent_session_id,
                                 child_session_id,
+                                child_attempt,
                                 &id,
                                 &tool_name,
                                 &permission,
                                 &resource,
                                 event_tx.clone(),
                             );
+                            if approval_version == 0 {
+                                super::live::deliver_approval_scoped(
+                                    approval_registry,
+                                    child_session_id,
+                                    child_attempt,
+                                    &id,
+                                    false,
+                                );
+                                let _ = event_tx
+                                    .send(AgentEvent::ChildApprovalChanged {
+                                        parent_session_id: parent_session_id.to_string(),
+                                        child_session_id: child_session_id.to_string(),
+                                        request_id: id,
+                                        version: 1,
+                                        status: "delivery_failed".to_string(),
+                                        reason: Some("persistence_failed".to_string()),
+                                        tool_name,
+                                        permission,
+                                        resource,
+                                        created_at: approval_created_at,
+                                        resolved_at: Some(chrono::Utc::now().to_rfc3339()),
+                                    })
+                                    .await;
+                                continue;
+                            }
                             let _ = event_tx.send(AgentEvent::ChildApprovalChanged {
                                 parent_session_id: parent_session_id.to_string(),
                                 child_session_id: child_session_id.to_string(),
@@ -1192,14 +1252,21 @@ async fn drive(
                                 })
                                 .await;
                             let child = child_session_id.to_string();
+                            let approval_registry = approval_registry.cloned();
                             tokio::spawn(async move {
                                 tokio::time::sleep(CHILD_APPROVAL_TIMEOUT).await;
                                 // Deny only if still pending: a one-shot consume so
                                 // we don't double-deliver if the human already
                                 // answered (the POST took it), and so a late POST
                                 // after this fires finds nothing pending.
-                                if super::live::expire_pending_approval(&child, &id) {
-                                    super::live::deliver_approval(&child, &id, false);
+                                if super::live::expire_pending_approval(approval_registry.as_ref(), &child, &id) {
+                                    super::live::deliver_approval_scoped(
+                                        approval_registry.as_ref(),
+                                        &child,
+                                        child_attempt,
+                                        &id,
+                                        false,
+                                    );
                                 }
                             });
                         }
@@ -1474,6 +1541,8 @@ mod tests {
             &mut link,
             "parent-x",
             "child-x",
+            0,
+            None,
             None,
             None,
             &event_tx,
@@ -1500,6 +1569,8 @@ mod tests {
             &mut link,
             "parent-y",
             "child-y",
+            0,
+            None,
             None,
             None,
             &event_tx,

--- a/crates/engine/bamboo-engine/src/external_agents/approval_registry.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/approval_registry.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use serde::{Deserialize, Serialize};
 
@@ -48,6 +49,7 @@ struct RegistryFile {
 
 #[derive(Debug)]
 pub struct ApprovalRegistry {
+    scope_id: usize,
     path: PathBuf,
     revision: u64,
     records: HashMap<(String, String, u32, String), DurableApproval>,
@@ -87,6 +89,7 @@ impl ApprovalRegistry {
                     ));
                 }
                 Ok(Self {
+                    scope_id: next_scope_id(),
                     path,
                     revision: file.revision,
                     records: file
@@ -107,6 +110,7 @@ impl ApprovalRegistry {
                 })
             }
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(Self {
+                scope_id: next_scope_id(),
                 path,
                 revision: 0,
                 records: HashMap::new(),
@@ -136,6 +140,11 @@ impl ApprovalRegistry {
             return Err(error);
         }
         Ok(())
+    }
+
+    /// Stable process-local identity used to isolate ephemeral live state.
+    pub fn scope_id(&self) -> usize {
+        self.scope_id
     }
 
     pub fn record_decision(
@@ -253,6 +262,11 @@ impl ApprovalRegistry {
     }
 }
 
+fn next_scope_id() -> usize {
+    static NEXT_SCOPE_ID: AtomicUsize = AtomicUsize::new(1);
+    NEXT_SCOPE_ID.fetch_add(1, Ordering::Relaxed)
+}
+
 fn approval_key(
     parent_id: &str,
     child_id: &str,
@@ -302,8 +316,8 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
         std::fs::copy(path, &backup)?;
         File::open(&backup)?.sync_all()?;
     }
-    std::fs::rename(&tmp, path)?;
-    File::open(parent)?.sync_all()?;
+    replace_file(&tmp, path)?;
+    sync_parent(parent)?;
     Ok(())
 }
 
@@ -322,8 +336,39 @@ fn replace_primary(path: &Path, bytes: &[u8]) -> io::Result<()> {
         file.write_all(bytes)?;
         file.sync_all()?;
     }
-    std::fs::rename(tmp, path)?;
+    replace_file(&tmp, path)?;
+    sync_parent(parent)
+}
+
+#[cfg(not(windows))]
+fn sync_parent(parent: &Path) -> io::Result<()> {
     File::open(parent)?.sync_all()
+}
+
+// Opening directories for fsync is not supported by std on Windows.
+#[cfg(windows)]
+fn sync_parent(_parent: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
+    std::fs::rename(source, destination)
+}
+
+// Windows rename does not replace an existing destination. The durable backup
+// is synced before this fallback, so a crash in the remove/rename window still
+// recovers fail-closed from the LKG file on the next boot.
+#[cfg(windows)]
+fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
+    match std::fs::rename(source, destination) {
+        Ok(()) => Ok(()),
+        Err(error) if destination.exists() => {
+            std::fs::remove_file(destination)?;
+            std::fs::rename(source, destination).map_err(|_| error)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/bamboo-engine/src/external_agents/approval_registry.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/approval_registry.rs
@@ -1,0 +1,522 @@
+//! Durable state machine for human-loop child approvals.
+
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalState {
+    Pending,
+    DecisionRecorded,
+    Delivered,
+    DeliveryFailed,
+    Expired,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DurableApproval {
+    pub parent_session_id: String,
+    pub child_session_id: String,
+    #[serde(default)]
+    pub child_attempt: u32,
+    pub request_id: String,
+    pub tool_name: String,
+    pub permission: String,
+    pub resource: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub version: u64,
+    pub state: ApprovalState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approved: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RegistryFile {
+    schema_version: u32,
+    revision: u64,
+    approvals: Vec<DurableApproval>,
+}
+
+#[derive(Debug)]
+pub struct ApprovalRegistry {
+    path: PathBuf,
+    revision: u64,
+    records: HashMap<(String, String, u32, String), DurableApproval>,
+}
+
+pub type SharedApprovalRegistry = std::sync::Arc<std::sync::Mutex<ApprovalRegistry>>;
+
+impl ApprovalRegistry {
+    pub fn open(path: PathBuf) -> io::Result<Self> {
+        let loaded = match load_file(&path) {
+            Ok(file) => Ok(file),
+            Err(primary) => match load_file(&backup_path(&path)) {
+                Ok(file) => {
+                    let bytes = serde_json::to_vec_pretty(&file).map_err(io::Error::other)?;
+                    replace_primary(&path, &bytes)?;
+                    Ok(file)
+                }
+                Err(backup)
+                    if primary.kind() == io::ErrorKind::NotFound
+                        && backup.kind() == io::ErrorKind::NotFound =>
+                {
+                    Err(primary)
+                }
+                Err(backup) if primary.kind() == io::ErrorKind::NotFound => Err(backup),
+                Err(_) => Err(primary),
+            },
+        };
+        match loaded {
+            Ok(file) => {
+                if file.schema_version != SCHEMA_VERSION {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "unsupported approval registry schema {}",
+                            file.schema_version
+                        ),
+                    ));
+                }
+                Ok(Self {
+                    path,
+                    revision: file.revision,
+                    records: file
+                        .approvals
+                        .into_iter()
+                        .map(|record| {
+                            (
+                                (
+                                    record.parent_session_id.clone(),
+                                    record.child_session_id.clone(),
+                                    record.child_attempt,
+                                    record.request_id.clone(),
+                                ),
+                                record,
+                            )
+                        })
+                        .collect(),
+                })
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(Self {
+                path,
+                revision: 0,
+                records: HashMap::new(),
+            }),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub fn register(&mut self, mut record: DurableApproval) -> io::Result<()> {
+        let key = (
+            record.parent_session_id.clone(),
+            record.child_session_id.clone(),
+            record.child_attempt,
+            record.request_id.clone(),
+        );
+        if self.records.contains_key(&key) {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "approval request already registered",
+            ));
+        }
+        record.state = ApprovalState::Pending;
+        record.approved = None;
+        self.records.insert(key.clone(), record);
+        if let Err(error) = self.persist() {
+            self.records.remove(&key);
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    pub fn record_decision(
+        &mut self,
+        parent_id: &str,
+        child_id: &str,
+        child_attempt: u32,
+        request_id: &str,
+        approved: bool,
+    ) -> io::Result<Option<DurableApproval>> {
+        let key = approval_key(parent_id, child_id, child_attempt, request_id);
+        let Some(record) = self.records.get_mut(&key) else {
+            return Ok(None);
+        };
+        if record.state != ApprovalState::Pending {
+            return Ok(None);
+        }
+        let previous = record.clone();
+        record.state = ApprovalState::DecisionRecorded;
+        record.approved = Some(approved);
+        bump(record);
+        let updated = record.clone();
+        if let Err(error) = self.persist() {
+            self.records.insert(key, previous);
+            return Err(error);
+        }
+        Ok(Some(updated))
+    }
+
+    pub fn finish(
+        &mut self,
+        parent_id: &str,
+        child_id: &str,
+        child_attempt: u32,
+        request_id: &str,
+        delivered: bool,
+        reason: Option<&str>,
+    ) -> io::Result<Option<DurableApproval>> {
+        let key = approval_key(parent_id, child_id, child_attempt, request_id);
+        let Some(record) = self.records.get_mut(&key) else {
+            return Ok(None);
+        };
+        if delivered && record.state != ApprovalState::DecisionRecorded {
+            return Ok(None);
+        }
+        if !delivered
+            && !matches!(
+                record.state,
+                ApprovalState::Pending | ApprovalState::DecisionRecorded
+            )
+        {
+            return Ok(None);
+        }
+        let previous = record.clone();
+        record.state = if reason == Some("approval_timeout") {
+            ApprovalState::Expired
+        } else if delivered {
+            ApprovalState::Delivered
+        } else {
+            ApprovalState::DeliveryFailed
+        };
+        record.reason = reason.map(str::to_string);
+        bump(record);
+        let updated = record.clone();
+        if let Err(error) = self.persist() {
+            self.records.insert(key, previous);
+            return Err(error);
+        }
+        Ok(Some(updated))
+    }
+
+    pub fn reconcile_restart(&mut self) -> io::Result<Vec<DurableApproval>> {
+        let previous = self.records.clone();
+        let mut changed = Vec::new();
+        for record in self.records.values_mut() {
+            if matches!(
+                record.state,
+                ApprovalState::Pending | ApprovalState::DecisionRecorded
+            ) {
+                record.state = ApprovalState::DeliveryFailed;
+                record.reason = Some("server_restart".to_string());
+                bump(record);
+                changed.push(record.clone());
+            }
+        }
+        if !changed.is_empty() {
+            if let Err(error) = self.persist() {
+                self.records = previous;
+                return Err(error);
+            }
+        }
+        Ok(changed)
+    }
+
+    #[cfg(test)]
+    fn get(&self, child: &str, request: &str) -> Option<&DurableApproval> {
+        self.records
+            .values()
+            .find(|record| record.child_session_id == child && record.request_id == request)
+    }
+
+    fn persist(&mut self) -> io::Result<()> {
+        let next_revision = self.revision.saturating_add(1);
+        let file = RegistryFile {
+            schema_version: SCHEMA_VERSION,
+            revision: next_revision,
+            approvals: self.records.values().cloned().collect(),
+        };
+        atomic_write(
+            &self.path,
+            &serde_json::to_vec_pretty(&file).map_err(io::Error::other)?,
+        )?;
+        self.revision = next_revision;
+        Ok(())
+    }
+}
+
+fn approval_key(
+    parent_id: &str,
+    child_id: &str,
+    child_attempt: u32,
+    request_id: &str,
+) -> (String, String, u32, String) {
+    (
+        parent_id.to_string(),
+        child_id.to_string(),
+        child_attempt,
+        request_id.to_string(),
+    )
+}
+
+fn bump(record: &mut DurableApproval) {
+    record.version = record.version.saturating_add(1);
+    record.updated_at = chrono::Utc::now().to_rfc3339();
+}
+
+fn load_file(path: &Path) -> io::Result<RegistryFile> {
+    let bytes = std::fs::read(path)?;
+    serde_json::from_slice(&bytes)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
+fn backup_path(path: &Path) -> PathBuf {
+    path.with_extension("json.bak")
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::other("registry path has no parent"))?;
+    std::fs::create_dir_all(parent)?;
+    let tmp = path.with_extension("json.tmp");
+    let backup = backup_path(path);
+    {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&tmp)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+    }
+    if path.exists() {
+        std::fs::copy(path, &backup)?;
+        File::open(&backup)?.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+fn replace_primary(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::other("registry path has no parent"))?;
+    std::fs::create_dir_all(parent)?;
+    let tmp = path.with_extension("json.recovery.tmp");
+    {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&tmp)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+    }
+    std::fs::rename(tmp, path)?;
+    File::open(parent)?.sync_all()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pending() -> DurableApproval {
+        DurableApproval {
+            parent_session_id: "parent".into(),
+            child_session_id: "child".into(),
+            child_attempt: 1,
+            request_id: "request".into(),
+            tool_name: "Bash".into(),
+            permission: "execute".into(),
+            resource: "git status".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            updated_at: "2026-01-01T00:00:00Z".into(),
+            version: 1,
+            state: ApprovalState::Pending,
+            approved: None,
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn decision_is_one_shot_and_survives_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("child-approvals-v1.json");
+        let mut registry = ApprovalRegistry::open(path.clone()).unwrap();
+        registry.register(pending()).unwrap();
+        assert!(registry
+            .record_decision("parent", "child", 1, "request", true)
+            .unwrap()
+            .is_some());
+        assert!(registry
+            .record_decision("parent", "child", 1, "request", false)
+            .unwrap()
+            .is_none());
+        let mut restored = ApprovalRegistry::open(path).unwrap();
+        assert_eq!(
+            restored.get("child", "request").unwrap().state,
+            ApprovalState::DecisionRecorded
+        );
+        let reconciled = restored.reconcile_restart().unwrap();
+        assert_eq!(reconciled.len(), 1);
+        assert_eq!(reconciled[0].state, ApprovalState::DeliveryFailed);
+    }
+
+    #[test]
+    fn corrupt_primary_falls_back_to_last_known_good() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("child-approvals-v1.json");
+        let mut registry = ApprovalRegistry::open(path.clone()).unwrap();
+        registry.register(pending()).unwrap();
+        registry
+            .record_decision("parent", "child", 1, "request", true)
+            .unwrap();
+        std::fs::write(&path, b"{").unwrap();
+        let restored = ApprovalRegistry::open(path).unwrap();
+        assert!(restored.get("child", "request").is_some());
+    }
+
+    #[test]
+    fn concurrent_decisions_record_exactly_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = std::sync::Arc::new(std::sync::Mutex::new(
+            ApprovalRegistry::open(dir.path().join("child-approvals-v1.json")).unwrap(),
+        ));
+        registry.lock().unwrap().register(pending()).unwrap();
+        let successes = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..8)
+                .map(|index| {
+                    let registry = registry.clone();
+                    scope.spawn(move || {
+                        registry
+                            .lock()
+                            .unwrap()
+                            .record_decision("parent", "child", 1, "request", index % 2 == 0)
+                            .unwrap()
+                            .is_some()
+                    })
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|handle| handle.join().unwrap())
+                .filter(|accepted| *accepted)
+                .count()
+        });
+        assert_eq!(successes, 1);
+    }
+
+    #[test]
+    fn corrupt_primary_and_backup_fail_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("child-approvals-v1.json");
+        std::fs::write(&path, b"{").unwrap();
+        std::fs::write(backup_path(&path), b"{").unwrap();
+        assert_eq!(
+            ApprovalRegistry::open(path).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn missing_primary_and_corrupt_backup_fail_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("child-approvals-v1.json");
+        std::fs::write(backup_path(&path), b"{").unwrap();
+        assert_eq!(
+            ApprovalRegistry::open(path).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn attempts_are_isolated_and_can_be_finished_independently() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut registry =
+            ApprovalRegistry::open(dir.path().join("child-approvals-v1.json")).unwrap();
+        let first = pending();
+        let mut retry = first.clone();
+        retry.child_attempt = 2;
+        registry.register(first).unwrap();
+        registry.register(retry).unwrap();
+        assert!(registry
+            .record_decision("parent", "child", 1, "request", true)
+            .unwrap()
+            .is_some());
+        assert!(registry
+            .finish("parent", "child", 1, "request", true, None)
+            .unwrap()
+            .is_some());
+        assert!(registry
+            .record_decision("parent", "child", 2, "request", false)
+            .unwrap()
+            .is_some());
+    }
+
+    #[test]
+    fn last_known_good_pending_is_failed_closed_after_crash() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("child-approvals-v1.json");
+        let mut registry = ApprovalRegistry::open(path.clone()).unwrap();
+        registry.register(pending()).unwrap();
+        registry
+            .record_decision("parent", "child", 1, "request", true)
+            .unwrap();
+
+        // Simulate a torn latest write. The backup contains the preceding
+        // Pending state, which must never become actionable after restart.
+        std::fs::write(&path, b"{").unwrap();
+        let mut restored = ApprovalRegistry::open(path).unwrap();
+        let reconciled = restored.reconcile_restart().unwrap();
+        assert_eq!(reconciled.len(), 1);
+        assert_eq!(reconciled[0].state, ApprovalState::DeliveryFailed);
+        assert_eq!(reconciled[0].reason.as_deref(), Some("server_restart"));
+        assert!(restored
+            .record_decision("parent", "child", 1, "request", false)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn failed_persist_rolls_back_in_memory_transition() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("store");
+        std::fs::create_dir(&store).unwrap();
+        let path = store.join("child-approvals-v1.json");
+        let mut registry = ApprovalRegistry::open(path).unwrap();
+        std::fs::remove_dir(&store).unwrap();
+        std::fs::write(&store, b"not a directory").unwrap();
+
+        assert!(registry.register(pending()).is_err());
+        assert!(registry.get("child", "request").is_none());
+    }
+
+    #[test]
+    fn registries_are_isolated_for_separate_app_states() {
+        let first_dir = tempfile::tempdir().unwrap();
+        let second_dir = tempfile::tempdir().unwrap();
+        let mut first = ApprovalRegistry::open(first_dir.path().join("registry.json")).unwrap();
+        let mut second = ApprovalRegistry::open(second_dir.path().join("registry.json")).unwrap();
+        first.register(pending()).unwrap();
+        second.register(pending()).unwrap();
+
+        assert!(first
+            .record_decision("parent", "child", 1, "request", true)
+            .unwrap()
+            .is_some());
+        assert_eq!(
+            second.get("child", "request").unwrap().state,
+            ApprovalState::Pending
+        );
+    }
+}

--- a/crates/engine/bamboo-engine/src/external_agents/live.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/live.rs
@@ -171,7 +171,7 @@ pub fn clear_pending_approvals_for(
             .collect()
     };
     for (request_id, record) in records {
-        finish_durable(
+        let durable = finish_durable(
             registry,
             &record.parent_session_id,
             child_id,
@@ -180,13 +180,16 @@ pub fn clear_pending_approvals_for(
             false,
             Some("child_disconnected"),
         );
-        emit_resolution(
-            child_id,
-            &request_id,
-            record,
-            "delivery_failed",
-            Some("child_disconnected"),
-        );
+        if registry.is_none() || durable.is_some() {
+            emit_resolution(
+                child_id,
+                &request_id,
+                record,
+                "delivery_failed",
+                Some("child_disconnected"),
+                durable.as_ref(),
+            );
+        }
     }
 }
 
@@ -199,7 +202,7 @@ pub fn expire_pending_approval(
     let Some(record) = record else {
         return false;
     };
-    finish_durable(
+    let durable = finish_durable(
         registry,
         &record.parent_session_id,
         child_id,
@@ -208,13 +211,16 @@ pub fn expire_pending_approval(
         false,
         Some("approval_timeout"),
     );
-    emit_resolution(
-        child_id,
-        request_id,
-        record,
-        "expired",
-        Some("approval_timeout"),
-    );
+    if registry.is_none() || durable.is_some() {
+        emit_resolution(
+            child_id,
+            request_id,
+            record,
+            "expired",
+            Some("approval_timeout"),
+            durable.as_ref(),
+        );
+    }
     true
 }
 
@@ -224,20 +230,29 @@ fn emit_resolution(
     record: PendingApproval,
     status: &str,
     reason: Option<&str>,
+    durable: Option<&DurableApproval>,
 ) {
     let now = chrono::Utc::now();
     let event = AgentEvent::ChildApprovalChanged {
         parent_session_id: record.parent_session_id,
         child_session_id: child_id.to_string(),
+        child_attempt: record.child_attempt,
         request_id: request_id.to_string(),
-        version: (now.timestamp_micros().max(0) as u64).max(record.version.saturating_add(1)),
+        version: durable.map_or_else(
+            || (now.timestamp_micros().max(0) as u64).max(record.version.saturating_add(1)),
+            |record| record.version,
+        ),
         status: status.to_string(),
         reason: reason.map(str::to_string),
         tool_name: record.tool_name,
         permission: record.permission,
         resource: record.resource,
         created_at: record.created_at,
-        resolved_at: Some(now.to_rfc3339()),
+        resolved_at: Some(
+            durable
+                .map(|record| record.updated_at.clone())
+                .unwrap_or_else(|| now.to_rfc3339()),
+        ),
     };
     match record.event_tx.try_send(event) {
         Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
@@ -285,7 +300,7 @@ pub fn deliver_approval_checked(
         }
     }
     let Some(record) = pending().lock().recover_poison().remove(&key) else {
-        finish_durable(
+        let _ = finish_durable(
             registry,
             &record.parent_session_id,
             child_id,
@@ -312,7 +327,7 @@ pub fn deliver_approval_checked(
     } else {
         "delivery_failed"
     };
-    finish_durable(
+    let durable = finish_durable(
         registry,
         &record.parent_session_id,
         child_id,
@@ -321,13 +336,16 @@ pub fn deliver_approval_checked(
         delivered,
         (!delivered).then_some("child_not_live"),
     );
-    emit_resolution(
-        child_id,
-        request_id,
-        record,
-        status,
-        (!delivered).then_some("child_not_live"),
-    );
+    if registry.is_none() || durable.is_some() {
+        emit_resolution(
+            child_id,
+            request_id,
+            record,
+            status,
+            (!delivered).then_some("child_not_live"),
+            durable.as_ref(),
+        );
+    }
     delivered
 }
 
@@ -339,9 +357,9 @@ fn finish_durable(
     request_id: &str,
     delivered: bool,
     reason: Option<&str>,
-) {
+) -> Option<DurableApproval> {
     if let Some(registry) = registry {
-        if let Err(error) = registry.lock().recover_poison().finish(
+        match registry.lock().recover_poison().finish(
             parent_id,
             child_id,
             child_attempt,
@@ -349,15 +367,20 @@ fn finish_durable(
             delivered,
             reason,
         ) {
-            tracing::error!("failed to persist child approval resolution: {error}");
+            Ok(record) => return record,
+            Err(error) => {
+                tracing::error!("failed to persist child approval resolution: {error}");
+            }
         }
     }
+    None
 }
 
 fn record_event(record: DurableApproval) -> AgentEvent {
     AgentEvent::ChildApprovalChanged {
         parent_session_id: record.parent_session_id,
         child_session_id: record.child_session_id,
+        child_attempt: record.child_attempt,
         request_id: record.request_id,
         version: record.version,
         status: match record.state {
@@ -705,6 +728,41 @@ mod tests {
             Some(AgentEvent::ChildApprovalChanged { status, .. }) if status == "denied"
         ));
         assert!(event_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn durable_resolution_uses_registry_version_and_attempt() {
+        let registry = registry();
+        let (wire_tx, _wire_rx) = mpsc::unbounded_channel();
+        let _guard = register("c-versioned", wire_tx, 7, Some(registry.clone()));
+        let (event_tx, mut event_rx) = mpsc::channel(4);
+        let (pending_version, _) = register_pending_approval_observed(
+            Some(&registry),
+            "parent-versioned",
+            "c-versioned",
+            7,
+            "req-versioned",
+            "Bash",
+            "execute",
+            "/tmp/versioned",
+            event_tx,
+        );
+
+        assert!(deliver_approval_checked(
+            Some(&registry),
+            "c-versioned",
+            "req-versioned",
+            true,
+        ));
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(AgentEvent::ChildApprovalChanged {
+                child_attempt: 7,
+                version,
+                status,
+                ..
+            }) if version == pending_version + 2 && status == "approved"
+        ));
     }
 
     #[tokio::test]

--- a/crates/engine/bamboo-engine/src/external_agents/live.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/live.rs
@@ -9,7 +9,7 @@
 //! live, callers fall back to the durable `pending_injected_messages` queue.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Mutex, OnceLock};
 
 use bamboo_agent_core::AgentEvent;
 use bamboo_domain::poison::PoisonRecover;
@@ -25,7 +25,7 @@ type LiveKey = (ScopeId, String, u32);
 type PendingKey = (ScopeId, String, String, u32, String);
 
 fn scope_id(registry: Option<&SharedApprovalRegistry>) -> ScopeId {
-    registry.map_or(0, |registry| Arc::as_ptr(registry) as usize)
+    registry.map_or(0, |registry| registry.lock().recover_poison().scope_id())
 }
 
 fn map() -> &'static Mutex<HashMap<LiveKey, mpsc::UnboundedSender<ParentFrame>>> {
@@ -551,7 +551,7 @@ mod tests {
     use super::*;
 
     fn registry() -> SharedApprovalRegistry {
-        Arc::new(Mutex::new(
+        std::sync::Arc::new(Mutex::new(
             ApprovalRegistry::open(tempfile::tempdir().unwrap().keep().join("registry.json"))
                 .unwrap(),
         ))

--- a/crates/engine/bamboo-engine/src/external_agents/live.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/live.rs
@@ -9,15 +9,27 @@
 //! live, callers fall back to the durable `pending_injected_messages` queue.
 
 use std::collections::HashMap;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use bamboo_agent_core::AgentEvent;
 use bamboo_domain::poison::PoisonRecover;
 use bamboo_subagent::proto::ParentFrame;
 use tokio::sync::mpsc;
 
-fn map() -> &'static Mutex<HashMap<String, mpsc::UnboundedSender<ParentFrame>>> {
-    static MAP: OnceLock<Mutex<HashMap<String, mpsc::UnboundedSender<ParentFrame>>>> =
+use super::approval_registry::{
+    ApprovalRegistry, ApprovalState, DurableApproval, SharedApprovalRegistry,
+};
+
+type ScopeId = usize;
+type LiveKey = (ScopeId, String, u32);
+type PendingKey = (ScopeId, String, String, u32, String);
+
+fn scope_id(registry: Option<&SharedApprovalRegistry>) -> ScopeId {
+    registry.map_or(0, |registry| Arc::as_ptr(registry) as usize)
+}
+
+fn map() -> &'static Mutex<HashMap<LiveKey, mpsc::UnboundedSender<ParentFrame>>> {
+    static MAP: OnceLock<Mutex<HashMap<LiveKey, mpsc::UnboundedSender<ParentFrame>>>> =
         OnceLock::new();
     MAP.get_or_init(|| Mutex::new(HashMap::new()))
 }
@@ -36,20 +48,34 @@ struct PendingApproval {
     resource: String,
     created_at: String,
     version: u64,
+    child_attempt: u32,
     event_tx: mpsc::Sender<AgentEvent>,
 }
 
-fn pending() -> &'static Mutex<HashMap<(String, String), PendingApproval>> {
-    static PENDING: OnceLock<Mutex<HashMap<(String, String), PendingApproval>>> = OnceLock::new();
+fn pending() -> &'static Mutex<HashMap<PendingKey, PendingApproval>> {
+    static PENDING: OnceLock<Mutex<HashMap<PendingKey, PendingApproval>>> = OnceLock::new();
     PENDING.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Configure durable approval storage and fail-close records whose live
+/// transport was lost across restart.
+pub fn initialize_durable_approvals(
+    path: std::path::PathBuf,
+) -> std::io::Result<(SharedApprovalRegistry, Vec<AgentEvent>)> {
+    let mut registry = ApprovalRegistry::open(path)?;
+    let reconciled = registry.reconcile_restart()?;
+    let events = reconciled.into_iter().map(record_event).collect();
+    Ok((std::sync::Arc::new(Mutex::new(registry)), events))
 }
 
 /// Record a `(child_id, request_id)` as a pending human-loop approval. Called
 /// just before surfacing `ChildApprovalRequested` so an external POST can be
 /// correlated against a genuinely-pending request.
 pub fn register_pending_approval_observed(
+    registry: Option<&SharedApprovalRegistry>,
     parent_session_id: &str,
     child_id: &str,
+    child_attempt: u32,
     request_id: &str,
     tool_name: &str,
     permission: &str,
@@ -59,8 +85,35 @@ pub fn register_pending_approval_observed(
     let now = chrono::Utc::now();
     let version = now.timestamp_micros().max(0) as u64;
     let created_at = now.to_rfc3339();
+    let durable_record = DurableApproval {
+        parent_session_id: parent_session_id.to_string(),
+        child_session_id: child_id.to_string(),
+        child_attempt,
+        request_id: request_id.to_string(),
+        tool_name: tool_name.to_string(),
+        permission: permission.to_string(),
+        resource: resource.to_string(),
+        created_at: created_at.clone(),
+        updated_at: created_at.clone(),
+        version,
+        state: ApprovalState::Pending,
+        approved: None,
+        reason: None,
+    };
+    if let Some(registry) = registry {
+        if let Err(error) = registry.lock().recover_poison().register(durable_record) {
+            tracing::error!("failed to persist pending child approval: {error}");
+            return (0, created_at);
+        }
+    }
     pending().lock().recover_poison().insert(
-        (child_id.to_string(), request_id.to_string()),
+        (
+            scope_id(registry),
+            parent_session_id.to_string(),
+            child_id.to_string(),
+            child_attempt,
+            request_id.to_string(),
+        ),
         PendingApproval {
             parent_session_id: parent_session_id.to_string(),
             tool_name: tool_name.to_string(),
@@ -68,6 +121,7 @@ pub fn register_pending_approval_observed(
             resource: resource.to_string(),
             created_at: created_at.clone(),
             version,
+            child_attempt,
             event_tx,
         },
     );
@@ -78,8 +132,10 @@ pub fn register_pending_approval_observed(
 fn register_pending_approval(child_id: &str, request_id: &str) {
     let (event_tx, _rx) = mpsc::channel(1);
     let _ = register_pending_approval_observed(
+        None,
         "test-parent",
         child_id,
+        0,
         request_id,
         "test-tool",
         "test-permission",
@@ -92,27 +148,38 @@ fn register_pending_approval(child_id: &str, request_id: &str) {
 /// return whether it WAS present. A second call for the same pair returns
 /// `false`, so a request can't be answered (or replayed) twice.
 pub fn take_pending_approval(child_id: &str, request_id: &str) -> bool {
-    pending()
-        .lock()
-        .recover_poison()
-        .remove(&(child_id.to_string(), request_id.to_string()))
-        .is_some()
+    remove_unique_pending(None, child_id, request_id).is_some()
 }
 
 /// Drop all pending approvals for a child (e.g. when its live connection ends).
-pub fn clear_pending_approvals_for(child_id: &str) {
+pub fn clear_pending_approvals_for(
+    registry: Option<&SharedApprovalRegistry>,
+    child_id: &str,
+    child_attempt: u32,
+) {
     let records: Vec<_> = {
         let mut guard = pending().lock().recover_poison();
         let keys: Vec<_> = guard
             .keys()
-            .filter(|(child, _)| child == child_id)
+            .filter(|(scope, _, child, attempt, _)| {
+                *scope == scope_id(registry) && child == child_id && *attempt == child_attempt
+            })
             .cloned()
             .collect();
         keys.into_iter()
-            .filter_map(|key| guard.remove(&key).map(|record| (key.1, record)))
+            .filter_map(|key| guard.remove(&key).map(|record| (key.4, record)))
             .collect()
     };
     for (request_id, record) in records {
+        finish_durable(
+            registry,
+            &record.parent_session_id,
+            child_id,
+            record.child_attempt,
+            &request_id,
+            false,
+            Some("child_disconnected"),
+        );
         emit_resolution(
             child_id,
             &request_id,
@@ -123,14 +190,24 @@ pub fn clear_pending_approvals_for(child_id: &str) {
     }
 }
 
-pub fn expire_pending_approval(child_id: &str, request_id: &str) -> bool {
-    let record = pending()
-        .lock()
-        .recover_poison()
-        .remove(&(child_id.to_string(), request_id.to_string()));
+pub fn expire_pending_approval(
+    registry: Option<&SharedApprovalRegistry>,
+    child_id: &str,
+    request_id: &str,
+) -> bool {
+    let record = remove_unique_pending(registry, child_id, request_id);
     let Some(record) = record else {
         return false;
     };
+    finish_durable(
+        registry,
+        &record.parent_session_id,
+        child_id,
+        record.child_attempt,
+        request_id,
+        false,
+        Some("approval_timeout"),
+    );
     emit_resolution(
         child_id,
         request_id,
@@ -180,15 +257,52 @@ fn emit_resolution(
 /// — unknown, already-answered/timed-out, or a non-human-loop path
 /// (model-review / escalation) that never registered. This is the entry the
 /// external HTTP handler must use.
-pub fn deliver_approval_checked(child_id: &str, request_id: &str, approved: bool) -> bool {
-    let record = pending()
-        .lock()
-        .recover_poison()
-        .remove(&(child_id.to_string(), request_id.to_string()));
-    let Some(record) = record else {
+pub fn deliver_approval_checked(
+    registry: Option<&SharedApprovalRegistry>,
+    child_id: &str,
+    request_id: &str,
+    approved: bool,
+) -> bool {
+    let Some((key, record)) = find_unique_pending(registry, child_id, request_id) else {
         return false;
     };
-    let delivered = deliver_approval(child_id, request_id, approved);
+    // Persist DecisionRecorded before touching the live transport. Duplicate or
+    // concurrent decisions fail this transition and cannot deliver twice.
+    if let Some(registry) = registry {
+        match registry.lock().recover_poison().record_decision(
+            &record.parent_session_id,
+            child_id,
+            record.child_attempt,
+            request_id,
+            approved,
+        ) {
+            Ok(Some(_)) => {}
+            Ok(None) => return false,
+            Err(error) => {
+                tracing::error!("failed to persist child approval decision: {error}");
+                return false;
+            }
+        }
+    }
+    let Some(record) = pending().lock().recover_poison().remove(&key) else {
+        finish_durable(
+            registry,
+            &record.parent_session_id,
+            child_id,
+            record.child_attempt,
+            request_id,
+            false,
+            Some("pending_state_lost"),
+        );
+        return false;
+    };
+    let delivered = deliver_approval_scoped(
+        registry,
+        child_id,
+        record.child_attempt,
+        request_id,
+        approved,
+    );
     let status = if delivered {
         if approved {
             "approved"
@@ -198,6 +312,15 @@ pub fn deliver_approval_checked(child_id: &str, request_id: &str, approved: bool
     } else {
         "delivery_failed"
     };
+    finish_durable(
+        registry,
+        &record.parent_session_id,
+        child_id,
+        record.child_attempt,
+        request_id,
+        delivered,
+        (!delivered).then_some("child_not_live"),
+    );
     emit_resolution(
         child_id,
         request_id,
@@ -208,44 +331,154 @@ pub fn deliver_approval_checked(child_id: &str, request_id: &str, approved: bool
     delivered
 }
 
+fn finish_durable(
+    registry: Option<&SharedApprovalRegistry>,
+    parent_id: &str,
+    child_id: &str,
+    child_attempt: u32,
+    request_id: &str,
+    delivered: bool,
+    reason: Option<&str>,
+) {
+    if let Some(registry) = registry {
+        if let Err(error) = registry.lock().recover_poison().finish(
+            parent_id,
+            child_id,
+            child_attempt,
+            request_id,
+            delivered,
+            reason,
+        ) {
+            tracing::error!("failed to persist child approval resolution: {error}");
+        }
+    }
+}
+
+fn record_event(record: DurableApproval) -> AgentEvent {
+    AgentEvent::ChildApprovalChanged {
+        parent_session_id: record.parent_session_id,
+        child_session_id: record.child_session_id,
+        request_id: record.request_id,
+        version: record.version,
+        status: match record.state {
+            ApprovalState::Pending => "pending",
+            ApprovalState::DecisionRecorded => "decision_recorded",
+            ApprovalState::Delivered if record.approved == Some(true) => "approved",
+            ApprovalState::Delivered => "denied",
+            ApprovalState::DeliveryFailed => "delivery_failed",
+            ApprovalState::Expired => "expired",
+        }
+        .to_string(),
+        reason: record.reason,
+        tool_name: record.tool_name,
+        permission: record.permission,
+        resource: record.resource,
+        created_at: record.created_at,
+        resolved_at: Some(record.updated_at),
+    }
+}
+
 /// Unregisters the child on drop, so a panicking/returning runner can't leak
 /// a stale sender.
 pub struct LiveActorGuard {
+    scope_id: ScopeId,
     child_id: String,
+    child_attempt: u32,
+    approval_registry: Option<SharedApprovalRegistry>,
 }
 
 impl Drop for LiveActorGuard {
     fn drop(&mut self) {
-        map().lock().recover_poison().remove(&self.child_id);
+        map().lock().recover_poison().remove(&(
+            self.scope_id,
+            self.child_id.clone(),
+            self.child_attempt,
+        ));
         // A disconnecting child can't answer any still-pending approval — drop
         // them so a late external POST finds nothing pending and is rejected.
-        clear_pending_approvals_for(&self.child_id);
+        clear_pending_approvals_for(
+            self.approval_registry.as_ref(),
+            &self.child_id,
+            self.child_attempt,
+        );
     }
 }
 
 /// Register a live child's frame sender for the duration of its run.
-pub fn register(child_id: &str, tx: mpsc::UnboundedSender<ParentFrame>) -> LiveActorGuard {
+pub fn register(
+    child_id: &str,
+    tx: mpsc::UnboundedSender<ParentFrame>,
+    child_attempt: u32,
+    approval_registry: Option<SharedApprovalRegistry>,
+) -> LiveActorGuard {
+    let scope_id = scope_id(approval_registry.as_ref());
     map()
         .lock()
         .recover_poison()
-        .insert(child_id.to_string(), tx);
+        .insert((scope_id, child_id.to_string(), child_attempt), tx);
     LiveActorGuard {
+        scope_id,
         child_id: child_id.to_string(),
+        child_attempt,
+        approval_registry,
     }
+}
+
+fn find_unique_pending(
+    registry: Option<&SharedApprovalRegistry>,
+    child_id: &str,
+    request_id: &str,
+) -> Option<(PendingKey, PendingApproval)> {
+    let guard = pending().lock().recover_poison();
+    let scope = scope_id(registry);
+    let mut matches = guard
+        .iter()
+        .filter(|(key, _)| key.0 == scope && key.2 == child_id && key.4 == request_id);
+    let (key, record) = matches.next()?;
+    if matches.next().is_some() {
+        return None;
+    }
+    Some((key.clone(), record.clone()))
+}
+
+fn remove_unique_pending(
+    registry: Option<&SharedApprovalRegistry>,
+    child_id: &str,
+    request_id: &str,
+) -> Option<PendingApproval> {
+    let mut guard = pending().lock().recover_poison();
+    let scope = scope_id(registry);
+    let mut keys = guard
+        .keys()
+        .filter(|(key_scope, _, child, _, request)| {
+            *key_scope == scope && child == child_id && request == request_id
+        })
+        .cloned();
+    let key = keys.next()?;
+    if keys.next().is_some() {
+        return None;
+    }
+    guard.remove(&key)
 }
 
 /// Deliver an in-band steering message to a live child. Returns `false` when
 /// the child is not live (caller should use the durable queue instead).
 pub fn deliver_message(child_id: &str, text: &str) -> bool {
     let guard = map().lock().recover_poison();
-    match guard.get(child_id) {
-        Some(tx) => tx
-            .send(ParentFrame::Message {
-                text: text.to_string(),
-            })
-            .is_ok(),
-        None => false,
+    let mut senders = guard
+        .iter()
+        .filter(|((_, child, _), _)| child == child_id)
+        .map(|(_, sender)| sender);
+    let Some(tx) = senders.next() else {
+        return false;
+    };
+    if senders.next().is_some() {
+        return false;
     }
+    tx.send(ParentFrame::Message {
+        text: text.to_string(),
+    })
+    .is_ok()
 }
 
 /// Deliver a host/human approval decision to a live child's pending gated-tool
@@ -259,8 +492,18 @@ pub fn deliver_message(child_id: &str, text: &str) -> bool {
 /// `false` when the child is not live (no connection to answer on — the caller
 /// should treat that as a denied/expired request).
 pub fn deliver_approval(child_id: &str, request_id: &str, approved: bool) -> bool {
+    deliver_approval_scoped(None, child_id, 0, request_id, approved)
+}
+
+pub fn deliver_approval_scoped(
+    registry: Option<&SharedApprovalRegistry>,
+    child_id: &str,
+    child_attempt: u32,
+    request_id: &str,
+    approved: bool,
+) -> bool {
     let guard = map().lock().recover_poison();
-    match guard.get(child_id) {
+    match guard.get(&(scope_id(registry), child_id.to_string(), child_attempt)) {
         Some(tx) => tx
             .send(ParentFrame::ApprovalReply {
                 id: request_id.to_string(),
@@ -273,17 +516,28 @@ pub fn deliver_approval(child_id: &str, request_id: &str, approved: bool) -> boo
 
 /// Whether a child currently has a live actor connection.
 pub fn is_live(child_id: &str) -> bool {
-    map().lock().recover_poison().contains_key(child_id)
+    map()
+        .lock()
+        .recover_poison()
+        .keys()
+        .any(|(_, child, _)| child == child_id)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn registry() -> SharedApprovalRegistry {
+        Arc::new(Mutex::new(
+            ApprovalRegistry::open(tempfile::tempdir().unwrap().keep().join("registry.json"))
+                .unwrap(),
+        ))
+    }
+
     #[test]
     fn register_deliver_unregister() {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let guard = register("c-live", tx);
+        let guard = register("c-live", tx, 0, None);
         assert!(is_live("c-live"));
         assert!(deliver_message("c-live", "hi"));
         match rx.try_recv() {
@@ -299,7 +553,7 @@ mod tests {
     #[test]
     fn deliver_fails_when_receiver_dropped() {
         let (tx, rx) = mpsc::unbounded_channel();
-        let _guard = register("c-dead", tx);
+        let _guard = register("c-dead", tx, 0, None);
         drop(rx);
         assert!(!deliver_message("c-dead", "hi"));
     }
@@ -307,7 +561,7 @@ mod tests {
     #[test]
     fn deliver_approval_routes_reply_frame() {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let guard = register("c-appr", tx);
+        let guard = register("c-appr", tx, 0, None);
         assert!(deliver_approval("c-appr", "req-7", true));
         match rx.try_recv() {
             Ok(ParentFrame::ApprovalReply { id, approved }) => {
@@ -319,6 +573,45 @@ mod tests {
         drop(guard);
         // Not-live child ⇒ false (no connection to answer on).
         assert!(!deliver_approval("c-appr", "req-8", false));
+    }
+
+    #[test]
+    fn app_scopes_and_attempt_guards_do_not_cross_talk() {
+        let first_registry = registry();
+        let second_registry = registry();
+        let (first_tx, mut first_rx) = mpsc::unbounded_channel();
+        let (retry_tx, mut retry_rx) = mpsc::unbounded_channel();
+        let (second_tx, mut second_rx) = mpsc::unbounded_channel();
+        let old_guard = register("shared-child", first_tx, 1, Some(first_registry.clone()));
+        let retry_guard = register("shared-child", retry_tx, 2, Some(first_registry.clone()));
+        let second_guard = register("shared-child", second_tx, 1, Some(second_registry.clone()));
+
+        drop(old_guard);
+        assert!(deliver_approval_scoped(
+            Some(&first_registry),
+            "shared-child",
+            2,
+            "retry-request",
+            true,
+        ));
+        assert!(matches!(
+            retry_rx.try_recv(),
+            Ok(ParentFrame::ApprovalReply { id, .. }) if id == "retry-request"
+        ));
+        assert!(deliver_approval_scoped(
+            Some(&second_registry),
+            "shared-child",
+            1,
+            "other-app-request",
+            false,
+        ));
+        assert!(matches!(
+            second_rx.try_recv(),
+            Ok(ParentFrame::ApprovalReply { id, .. }) if id == "other-app-request"
+        ));
+        assert!(first_rx.try_recv().is_err());
+        drop(retry_guard);
+        drop(second_guard);
     }
 
     #[test]
@@ -343,15 +636,20 @@ mod tests {
     #[test]
     fn deliver_approval_checked_only_delivers_for_registered_pair() {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let _guard = register("c-checked", tx);
+        let _guard = register("c-checked", tx, 0, None);
 
         // Not registered ⇒ rejected, nothing on the wire.
-        assert!(!deliver_approval_checked("c-checked", "req-stray", true));
+        assert!(!deliver_approval_checked(
+            None,
+            "c-checked",
+            "req-stray",
+            true
+        ));
         assert!(rx.try_recv().is_err());
 
         // Registered ⇒ delivered, frame rides the wire, and consumed.
         register_pending_approval("c-checked", "req-ok");
-        assert!(deliver_approval_checked("c-checked", "req-ok", true));
+        assert!(deliver_approval_checked(None, "c-checked", "req-ok", true));
         match rx.try_recv() {
             Ok(ParentFrame::ApprovalReply { id, approved }) => {
                 assert_eq!(id, "req-ok");
@@ -360,7 +658,7 @@ mod tests {
             other => panic!("expected approval reply, got {other:?}"),
         }
         // One-shot: a replay is rejected (and nothing further on the wire).
-        assert!(!deliver_approval_checked("c-checked", "req-ok", true));
+        assert!(!deliver_approval_checked(None, "c-checked", "req-ok", true));
         assert!(rx.try_recv().is_err());
     }
 
@@ -368,7 +666,7 @@ mod tests {
     fn clear_pending_approvals_for_drops_them() {
         register_pending_approval("c-clear", "req-a");
         register_pending_approval("c-clear", "req-b");
-        clear_pending_approvals_for("c-clear");
+        clear_pending_approvals_for(None, "c-clear", 0);
         assert!(!take_pending_approval("c-clear", "req-a"));
         assert!(!take_pending_approval("c-clear", "req-b"));
     }
@@ -376,11 +674,13 @@ mod tests {
     #[tokio::test]
     async fn observed_approval_emits_exactly_one_terminal_outcome() {
         let (wire_tx, _wire_rx) = mpsc::unbounded_channel();
-        let _guard = register("c-audit", wire_tx);
+        let _guard = register("c-audit", wire_tx, 0, None);
         let (event_tx, mut event_rx) = mpsc::channel(8);
         register_pending_approval_observed(
+            None,
             "parent-audit",
             "c-audit",
+            0,
             "req-audit",
             "Bash",
             "execute",
@@ -388,8 +688,18 @@ mod tests {
             event_tx,
         );
 
-        assert!(deliver_approval_checked("c-audit", "req-audit", false));
-        assert!(!deliver_approval_checked("c-audit", "req-audit", true));
+        assert!(deliver_approval_checked(
+            None,
+            "c-audit",
+            "req-audit",
+            false
+        ));
+        assert!(!deliver_approval_checked(
+            None,
+            "c-audit",
+            "req-audit",
+            true
+        ));
         assert!(matches!(
             event_rx.recv().await,
             Some(AgentEvent::ChildApprovalChanged { status, .. }) if status == "denied"
@@ -401,31 +711,35 @@ mod tests {
     async fn timeout_and_disconnect_emit_terminal_outcomes() {
         let (event_tx, mut event_rx) = mpsc::channel(8);
         register_pending_approval_observed(
+            None,
             "parent-audit",
             "c-expire",
+            0,
             "req-expire",
             "Bash",
             "execute",
             "/tmp/x",
             event_tx.clone(),
         );
-        assert!(expire_pending_approval("c-expire", "req-expire"));
-        assert!(!expire_pending_approval("c-expire", "req-expire"));
+        assert!(expire_pending_approval(None, "c-expire", "req-expire"));
+        assert!(!expire_pending_approval(None, "c-expire", "req-expire"));
         assert!(matches!(
             event_rx.recv().await,
             Some(AgentEvent::ChildApprovalChanged { status, .. }) if status == "expired"
         ));
 
         register_pending_approval_observed(
+            None,
             "parent-audit",
             "c-disconnect",
+            0,
             "req-disconnect",
             "Write",
             "write",
             "/tmp/y",
             event_tx,
         );
-        clear_pending_approvals_for("c-disconnect");
+        clear_pending_approvals_for(None, "c-disconnect", 0);
         assert!(matches!(
             event_rx.recv().await,
             Some(AgentEvent::ChildApprovalChanged { status, .. }) if status == "delivery_failed"

--- a/crates/engine/bamboo-engine/src/external_agents/mod.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/mod.rs
@@ -14,4 +14,4 @@ pub use config::{
     parse_external_agents, parse_subagent_routing, resolve_runtime_metadata, ExternalAgentProfile,
     ExternalAgentProtocol, SubagentRouting,
 };
-pub use runtime::build_external_child_runner;
+pub use runtime::{build_external_child_runner, build_external_child_runner_with_registry};

--- a/crates/engine/bamboo-engine/src/external_agents/mod.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/mod.rs
@@ -1,5 +1,6 @@
 pub mod a2a_adapter;
 pub mod actor_adapter;
+pub mod approval_registry;
 pub mod config;
 pub mod live;
 pub mod mapping;

--- a/crates/engine/bamboo-engine/src/external_agents/runtime.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/runtime.rs
@@ -72,7 +72,10 @@ impl ExternalChildRunner for CompositeExternalChildRunner {
 /// needed. Expert `externalAgents` profiles add extra routers so
 /// `external.agent_id` metadata can pin specific roles to other agents. Returns
 /// a composite router that delegates to the first matching runner.
-pub fn build_external_child_runner(config: &Config) -> Arc<dyn ExternalChildRunner> {
+pub fn build_external_child_runner(
+    config: &Config,
+    approval_registry: Option<super::approval_registry::SharedApprovalRegistry>,
+) -> Arc<dyn ExternalChildRunner> {
     let agents = parse_external_agents(config);
 
     let mut runners: Vec<Arc<dyn ExternalChildRunner>> = Vec::new();
@@ -80,7 +83,7 @@ pub fn build_external_child_runner(config: &Config) -> Arc<dyn ExternalChildRunn
     // The built-in local actor worker is the default runtime for every
     // sub-agent. Always build it; a build failure here is logged and leaves the
     // composite without a default handler (dispatch then errors clearly).
-    match build_local_actor_runner(config) {
+    match build_local_actor_runner(config, approval_registry.clone()) {
         Ok(runner) => runners.push(runner),
         Err(e) => tracing::error!("local actor sub-agent runner unavailable: {e}"),
     }
@@ -126,7 +129,7 @@ pub fn build_external_child_runner(config: &Config) -> Arc<dyn ExternalChildRunn
                     continue;
                 }
             };
-            runners.push(Arc::new(ActorChildRunner::new(
+            let mut runner = ActorChildRunner::new(
                 profile.agent_id.clone(),
                 std::path::PathBuf::from(worker_bin),
                 profile.worker_args.clone(),
@@ -138,7 +141,11 @@ pub fn build_external_child_runner(config: &Config) -> Arc<dyn ExternalChildRunn
                     .subagents
                     .max_concurrent
                     .unwrap_or(super::actor_adapter::DEFAULT_MAX_CONCURRENT_ACTORS),
-            )));
+            );
+            if let Some(registry) = approval_registry.clone() {
+                runner = runner.with_approval_registry(registry);
+            }
+            runners.push(Arc::new(runner));
             continue;
         }
 
@@ -201,7 +208,10 @@ pub fn build_external_child_runner(config: &Config) -> Arc<dyn ExternalChildRunn
 /// config. Everything is derived: worker = the current bamboo executable +
 /// `subagent-worker`, fabric = per-user temp dir — unless expert fields
 /// override them.
-fn build_local_actor_runner(config: &Config) -> Result<Arc<dyn ExternalChildRunner>, String> {
+fn build_local_actor_runner(
+    config: &Config,
+    approval_registry: Option<super::approval_registry::SharedApprovalRegistry>,
+) -> Result<Arc<dyn ExternalChildRunner>, String> {
     let sub = &config.subagents;
 
     let (worker_bin, worker_args) = match &sub.worker_bin {
@@ -241,31 +251,33 @@ fn build_local_actor_runner(config: &Config) -> Result<Arc<dyn ExternalChildRunn
         Some(other) => return Err(format!("unknown subagents.executor '{other}'")),
     };
 
-    Ok(Arc::new(
-        ActorChildRunner::new(
-            super::config::LOCAL_ACTOR_AGENT_ID.to_string(),
-            worker_bin,
-            worker_args,
-            fabric_dir,
-            executor,
-            extract_provider_credentials(config),
-            config.provider.clone(),
-            sub.max_concurrent
-                .unwrap_or(super::actor_adapter::DEFAULT_MAX_CONCURRENT_ACTORS),
-        )
-        .with_remote_placements(resolve_remote_placements(
-            &sub.remote_placements,
-            &config.cluster_fabric.nodes,
-        ))
-        .with_schedulable_placements(resolve_schedulable_placements(
-            &sub.schedulable_placements,
-            &config.cluster_fabric.nodes,
-        ))
-        .with_bus(sub.broker.as_ref().map(|b| bamboo_subagent::BusEndpoint {
-            endpoint: b.endpoint.clone(),
-            token: b.token.clone(),
-        })),
+    let mut runner = ActorChildRunner::new(
+        super::config::LOCAL_ACTOR_AGENT_ID.to_string(),
+        worker_bin,
+        worker_args,
+        fabric_dir,
+        executor,
+        extract_provider_credentials(config),
+        config.provider.clone(),
+        sub.max_concurrent
+            .unwrap_or(super::actor_adapter::DEFAULT_MAX_CONCURRENT_ACTORS),
+    )
+    .with_remote_placements(resolve_remote_placements(
+        &sub.remote_placements,
+        &config.cluster_fabric.nodes,
     ))
+    .with_schedulable_placements(resolve_schedulable_placements(
+        &sub.schedulable_placements,
+        &config.cluster_fabric.nodes,
+    ))
+    .with_bus(sub.broker.as_ref().map(|b| bamboo_subagent::BusEndpoint {
+        endpoint: b.endpoint.clone(),
+        token: b.token.clone(),
+    }));
+    if let Some(registry) = approval_registry {
+        runner = runner.with_approval_registry(registry);
+    }
+    Ok(Arc::new(runner))
 }
 
 /// Resolve config `schedulable_placements` into runner-ready handles (#181, P2b),

--- a/crates/engine/bamboo-engine/src/external_agents/runtime.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/runtime.rs
@@ -72,7 +72,12 @@ impl ExternalChildRunner for CompositeExternalChildRunner {
 /// needed. Expert `externalAgents` profiles add extra routers so
 /// `external.agent_id` metadata can pin specific roles to other agents. Returns
 /// a composite router that delegates to the first matching runner.
-pub fn build_external_child_runner(
+pub fn build_external_child_runner(config: &Config) -> Arc<dyn ExternalChildRunner> {
+    build_external_child_runner_with_registry(config, None)
+}
+
+/// Build the child runner with an AppState-scoped durable approval registry.
+pub fn build_external_child_runner_with_registry(
     config: &Config,
     approval_registry: Option<super::approval_registry::SharedApprovalRegistry>,
 ) -> Arc<dyn ExternalChildRunner> {

--- a/crates/engine/bamboo-engine/src/runtime/execution/event_forwarder.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/event_forwarder.rs
@@ -44,6 +44,7 @@ mod tests {
         let event = AgentEvent::ChildApprovalChanged {
             parent_session_id: "parent-1".into(),
             child_session_id: "child-1".into(),
+            child_attempt: 1,
             request_id: "req-1".into(),
             version: 2,
             status: "approved".into(),

--- a/docs/durable-child-approvals.md
+++ b/docs/durable-child-approvals.md
@@ -1,0 +1,21 @@
+# Durable child approval registry
+
+Human-loop approvals from actor children are persisted under
+`<data-dir>/approvals/child-approvals-v1.json` before they are exposed to clients. The versioned
+registry records the monotonic transition:
+
+```text
+pending -> decision_recorded -> delivered | delivery_failed
+pending -> expired | delivery_failed
+```
+
+The file is replaced atomically after flushing its temporary file. The previous complete file is
+kept as a last-known-good backup. Unsupported schemas or corruption of both copies fail server
+startup closed instead of silently dropping approvals.
+
+Approval decisions are one-shot by `(child_session_id, request_id)`. The decision is committed
+before delivery to the live worker, so duplicate and concurrent responses cannot execute twice.
+On server startup there is no surviving proof of the old actor transport; any persisted pending or
+decision-recorded request is therefore reconciled to `delivery_failed` with reason
+`server_restart` and emitted into the durable account change feed. Authoritative pending snapshot
+and browser reload hydration remain Phase 2 PR B of #592.


### PR DESCRIPTION
## Summary

- add a versioned, atomically replaced child-approval registry with last-known-good recovery
- commit one-shot decisions before live delivery and reconcile unresolved records fail-closed on restart
- isolate live senders and pending approvals by AppState scope and child attempt
- record restart reconciliation outcomes into the durable account change feed

## Why

A process restart or transport loss could previously erase pending human approval state, while process-global live maps could cross-talk between AppState instances or retry attempts.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test -p bamboo-engine external_agents::approval_registry --lib` (9 passed)
- `cargo test -p bamboo-engine external_agents::live::tests --lib` (10 passed)
- `cargo test -p bamboo-sdk --lib --no-run`
- `cargo test -p bamboo-server child_approval --lib` (1 passed)
- `cargo check -p bamboo-engine -p bamboo-server -p bamboo-sdk`

`cargo clippy -p bamboo-engine -p bamboo-server -p bamboo-sdk --all-targets -- -D warnings` is blocked by the pre-existing `clippy::too_many_arguments` warning in `crates/core/bamboo-agent-core/src/tools/context.rs:138`.

Refs #592

Phase 2 PR B (authoritative pending snapshot + Lotus hydration) remains separate; this PR intentionally keeps #592 open.