### PR TITLE
fix(events): serialize startup terminal admission

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/events/handler.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/handler.rs
@@ -139,3 +139,75 @@ pub async fn handler(
         watcher_guard,
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::Responder;
+    use bamboo_agent_core::{Message, Session};
+    use std::time::Duration;
+
+    #[actix_web::test]
+    async fn expired_startup_admission_waits_for_locked_live_reconcile() {
+        let dir = tempfile::tempdir().expect("temporary app data");
+        let state = web::Data::new(
+            AppState::new(dir.path().to_path_buf())
+                .await
+                .expect("app state"),
+        );
+        let session_id = "sse-admission-startup-race";
+        let mut session = Session::new(session_id, "test-model");
+        session.add_message(Message::user("slow startup"));
+        crate::handlers::agent::events::mark_pending_turn(&mut session);
+        session.metadata.insert(
+            "execute.startup_handoff_at".to_string(),
+            (chrono::Utc::now() - chrono::Duration::seconds(120)).to_rfc3339(),
+        );
+        state.save_session(&mut session).await;
+
+        // Models `/execute` registering after admission began but before an
+        // unlocked synthetic terminal could be emitted. The subscriber must
+        // remain live until the owner leaves and the locked reconciler wins.
+        let startup_guard =
+            crate::handlers::agent::events::begin_execute_startup(state.get_ref(), session_id);
+        let request = actix_web::test::TestRequest::get().to_http_request();
+        let response = handler(
+            state.clone(),
+            web::Path::from(session_id.to_string()),
+            web::Query(EventsQuery::default()),
+            request.clone(),
+        )
+        .await
+        .respond_to(&request);
+        let collect = actix_web::body::to_bytes(response.into_body());
+        tokio::pin!(collect);
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(350), &mut collect)
+                .await
+                .is_err(),
+            "an in-flight execute owner must prevent admission from closing"
+        );
+        drop(startup_guard);
+
+        let bytes = tokio::time::timeout(Duration::from_secs(2), &mut collect)
+            .await
+            .expect("locked reconcile closes the SSE stream");
+        let bytes = match bytes {
+            Ok(bytes) => bytes,
+            Err(_) => panic!("read SSE body"),
+        };
+        let body = String::from_utf8(bytes.to_vec()).expect("UTF-8 SSE");
+        assert!(body.contains("was not started"), "{body}");
+        assert_eq!(body.matches("[DONE]").count(), 1);
+
+        let stored = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load session")
+            .expect("stored session");
+        assert_eq!(stored.last_run_status().as_deref(), Some("error"));
+        assert!(crate::handlers::agent::events::startup_work_id(&stored).is_none());
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/events/terminal.rs
@@ -372,6 +372,20 @@ pub(crate) async fn terminal_event_if_ready(
         return None;
     }
 
+    // Admission must never synthesize an abandoned-startup terminal directly.
+    // The startup guard/runner/durable owner can change after the initial
+    // snapshots above, so a one-shot response here could close a subscriber
+    // while a concurrent `/execute` is legitimately starting the same work.
+    // Keep the transport live and let its periodic reconciler perform the
+    // per-session-lock exact-work CAS before broadcasting any Error.
+    if session.as_ref().and_then(startup_work_id).is_some() {
+        tracing::debug!(
+            "[{}] terminal_event_if_ready -> None (startup work requires locked reconcile) -> LIVE stream",
+            session_id,
+        );
+        return None;
+    }
+
     // Absence of an in-memory runner is not itself proof that a run finished:
     // a newly-created session is persisted before its runner is reserved. In
     // that window a subscriber must stay live for the first token instead of
@@ -468,13 +482,6 @@ pub(super) fn terminal_event_for_sources(
     session: Option<&Session>,
     runner_status: Option<AgentStatus>,
 ) -> AgentEvent {
-    if session.is_some_and(|session| {
-        startup_work_id(session).is_some() && !startup_work_is_active(session)
-    }) {
-        return AgentEvent::Error {
-            message: "Agent execution was not started; please retry this turn".to_string(),
-        };
-    }
     // A startup rejection belongs to the newest durable handoff and must beat
     // an old runner/runtime snapshot from the preceding run.
     if let Some(message) = session.and_then(startup_failure_message) {
@@ -512,15 +519,12 @@ pub(super) fn session_prevents_terminal_event(
     // persistence writes this marker together with the new User message, so a
     // reconnect between POST /chat and POST /execute remains live even if the
     // previous run was cancelled or failed.
-    if startup_work_is_active(session) {
-        return true;
-    }
-
     if startup_work_id(session).is_some() {
-        // The execute handoff (User turn or resume marker) outlived its grace
-        // without a runner. Old suspended/terminal state must not hide this
-        // abandoned work; an in-flight handler was already protected above.
-        return false;
+        // Admission never turns startup ownership into an unlocked synthetic
+        // terminal, even after the grace expires. The live transport's
+        // reconciler revalidates the exact durable work id under the canonical
+        // persistence lock and broadcasts the authoritative Error.
+        return true;
     }
 
     // Durable startup rejection is terminal even when the previous run left a
@@ -787,7 +791,7 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn terminal_helper_recovers_abandoned_pending_turn() {
+    async fn terminal_helper_defers_abandoned_pending_turn_to_locked_reconcile() {
         let mut session = Session::new("abandoned-turn", "test-model");
         session.add_message(Message::user("never executed"));
         mark_pending_turn(&mut session);
@@ -797,33 +801,46 @@ mod tests {
         session.agent_runtime_state = Some(runtime);
         let (_dir, state) = state_with_session(session).await;
 
-        let event = terminal_event_if_ready(
-            &state,
-            "abandoned-turn",
-            Some(AgentStatus::Error("old run failed".to_string())),
-        )
-        .await
-        .expect("expired pending handoff must become recoverable terminal state");
+        assert!(
+            terminal_event_if_ready(
+                &state,
+                "abandoned-turn",
+                Some(AgentStatus::Error("old run failed".to_string())),
+            )
+            .await
+            .is_none(),
+            "admission must stay live until the durable CAS"
+        );
+
+        let sender = state.get_session_event_sender("abandoned-turn").await;
+        let mut receiver = sender.subscribe();
+        assert!(reconcile_abandoned_startup(&state, "abandoned-turn", &receiver,).await);
         assert!(matches!(
-            event,
-            AgentEvent::Error { message } if message.contains("was not started")
+            receiver.try_recv(),
+            Ok(AgentEvent::Error { message }) if message.contains("was not started")
         ));
     }
 
     #[actix_web::test]
-    async fn abandoned_first_turn_needs_no_old_terminal_evidence() {
+    async fn abandoned_first_turn_waits_for_locked_reconcile() {
         let mut session = Session::new("abandoned-first-turn", "test-model");
         session.add_message(Message::user("never executed"));
         mark_pending_turn(&mut session);
         expire_startup_handoff(&mut session);
         let (_dir, state) = state_with_session(session).await;
 
-        let event = terminal_event_if_ready(&state, "abandoned-first-turn", None)
-            .await
-            .expect("expired first turn is terminal");
+        assert!(
+            terminal_event_if_ready(&state, "abandoned-first-turn", None)
+                .await
+                .is_none(),
+            "admission must not emit an unlocked synthetic terminal"
+        );
+        let sender = state.get_session_event_sender("abandoned-first-turn").await;
+        let mut receiver = sender.subscribe();
+        assert!(reconcile_abandoned_startup(&state, "abandoned-first-turn", &receiver,).await);
         assert!(matches!(
-            event,
-            AgentEvent::Error { message } if message.contains("was not started")
+            receiver.try_recv(),
+            Ok(AgentEvent::Error { message }) if message.contains("was not started")
         ));
     }
 
@@ -847,7 +864,10 @@ mod tests {
         drop(second);
         assert!(terminal_event_if_ready(&state, "slow-startup", None)
             .await
-            .is_some());
+            .is_none());
+        let sender = state.get_session_event_sender("slow-startup").await;
+        let receiver = sender.subscribe();
+        assert!(reconcile_abandoned_startup(&state, "slow-startup", &receiver,).await);
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -1169,4 +1169,80 @@ mod tests {
             "the post-await re-read must observe the newly Running runner"
         );
     }
+
+    #[actix_web::test]
+    async fn expired_startup_subscribe_waits_for_locked_live_reconcile() {
+        let dir = tempdir().expect("temporary app data");
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let session_id = "ws-admission-startup-race";
+        let channel = format!("agent.{session_id}");
+        let mut session = bamboo_agent_core::Session::new(session_id, "test-model");
+        session.add_message(bamboo_agent_core::Message::user("slow startup"));
+        crate::handlers::agent::events::mark_pending_turn(&mut session);
+        session.metadata.insert(
+            "execute.startup_handoff_at".to_string(),
+            (chrono::Utc::now() - chrono::Duration::seconds(120)).to_rfc3339(),
+        );
+        state.save_session(&mut session).await;
+
+        // Exercise the real WS admission function, not just the forwarder. An
+        // execute owner appearing around the async terminal checks must force a
+        // live subscription until the locked exact-work CAS can run.
+        let startup_guard =
+            crate::handlers::agent::events::begin_execute_startup(state.get_ref(), session_id);
+        let mut forwarders = HashMap::new();
+        let mut queues = StreamMap::new();
+        subscribe(
+            &state,
+            &mut forwarders,
+            &mut queues,
+            0,
+            Encoding::Json,
+            &channel,
+            None,
+        )
+        .await;
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(350), queues.next())
+                .await
+                .is_err(),
+            "an in-flight execute owner must prevent a one-shot terminal"
+        );
+        drop(startup_guard);
+
+        let (_, terminal_event) = tokio::time::timeout(Duration::from_secs(2), queues.next())
+            .await
+            .expect("locked reconcile emits startup failure")
+            .expect("agent queue remains installed");
+        let OutFrame::Text(terminal_event) = terminal_event else {
+            panic!("JSON subscription must emit text frames");
+        };
+        let terminal_event: serde_json::Value =
+            serde_json::from_str(&terminal_event).expect("terminal event JSON");
+        assert_eq!(terminal_event["event"]["type"], "error");
+        assert!(terminal_event["event"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("was not started")));
+
+        let (_, terminal_control) = tokio::time::timeout(Duration::from_secs(2), queues.next())
+            .await
+            .expect("terminal control follows failure")
+            .expect("agent queue drains terminal control");
+        let OutFrame::Text(terminal_control) = terminal_control else {
+            panic!("JSON subscription must emit text frames");
+        };
+        let terminal_control: serde_json::Value =
+            serde_json::from_str(&terminal_control).expect("terminal control JSON");
+        assert_eq!(terminal_control["control"]["type"], "terminal");
+
+        let stored = state
+            .storage
+            .load_session(session_id)
+            .await
+            .expect("load session")
+            .expect("stored session");
+        assert_eq!(stored.last_run_status().as_deref(), Some("error"));
+        assert!(crate::handlers::agent::events::startup_work_id(&stored).is_none());
+    }
 }


### PR DESCRIPTION
## Summary

- keep SSE and WS subscriptions live while any durable startup work is still pending
- route expired-startup failure exclusively through the persistence-lock exact-work CAS before broadcasting a terminal Error
- add real SSE handler and WS subscribe regression coverage for concurrent startup admission

Follow-up to #610. Closes #588.

## Root Cause

Subscription admission could synthesize an expired-startup Error from unlocked snapshots. A concurrent `/execute` could register or reserve the same work after the initial check, yet the subscriber would still receive a one-shot terminal and close.

## Test Plan

- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p bamboo-server expired_startup --lib` (2 passed)
- `cargo test -p bamboo-server handlers::agent::events --lib` (41 passed)
- `cargo test -p bamboo-server handlers::agent::ws_v2 --lib` (45 passed)
- `cargo test -p bamboo-server handlers::agent::execute --lib` (66 passed)
- `cargo test -p bamboo-server handlers::agent::chat --lib` (41 passed)
- `cargo test -p bamboo-engine session_app::execute` (46 passed)
- `cargo test -p bamboo-server --test ws_v2_live` (16 passed)
- `cargo clippy -p bamboo-server --all-targets` (passes; existing warnings only)

Full workspace `cargo test` passes except the pre-existing TLS self-signed certificate fixture failure (`UnsupportedCertVersion`), reproducible unchanged from this diff.

## Screenshots

Not applicable; backend stream admission fix.