### PR TITLE
refactor(config): modularize root facade

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/builder.rs
+++ b/crates/app/bamboo-sdk/src/agent/builder.rs
@@ -456,35 +456,37 @@ fn apply_api_key(config: &mut Config, api_key: &str) {
     // the assignment below (no `serde` trait import needed).
     let stanza = || serde_json::json!({ "api_key": api_key });
 
-    let applied = match config.provider.as_str() {
-        "openai" => match config.providers.openai.as_mut() {
+    let provider = config.provider.clone();
+    let providers = config.providers_mut();
+    let applied = match provider.as_str() {
+        "openai" => match providers.openai.as_mut() {
             Some(c) => {
                 c.api_key = api_key.to_string();
                 true
             }
             None => {
-                config.providers.openai = serde_json::from_value(stanza()).ok();
-                config.providers.openai.is_some()
+                providers.openai = serde_json::from_value(stanza()).ok();
+                providers.openai.is_some()
             }
         },
-        "anthropic" => match config.providers.anthropic.as_mut() {
+        "anthropic" => match providers.anthropic.as_mut() {
             Some(c) => {
                 c.api_key = api_key.to_string();
                 true
             }
             None => {
-                config.providers.anthropic = serde_json::from_value(stanza()).ok();
-                config.providers.anthropic.is_some()
+                providers.anthropic = serde_json::from_value(stanza()).ok();
+                providers.anthropic.is_some()
             }
         },
-        "gemini" => match config.providers.gemini.as_mut() {
+        "gemini" => match providers.gemini.as_mut() {
             Some(c) => {
                 c.api_key = api_key.to_string();
                 true
             }
             None => {
-                config.providers.gemini = serde_json::from_value(stanza()).ok();
-                config.providers.gemini.is_some()
+                providers.gemini = serde_json::from_value(stanza()).ok();
+                providers.gemini.is_some()
             }
         },
         _ => false,
@@ -515,20 +517,28 @@ mod tests {
             let mut config = Config::default();
             config.provider = provider.to_string();
             // Force the absent-stanza (fabricate) path.
-            config.providers.openai = None;
-            config.providers.anthropic = None;
-            config.providers.gemini = None;
+            config.providers_mut().openai = None;
+            config.providers_mut().anthropic = None;
+            config.providers_mut().gemini = None;
 
             apply_api_key(&mut config, "sk-test-123");
 
             let key = match provider {
-                "openai" => config.providers.openai.as_ref().map(|c| c.api_key.as_str()),
+                "openai" => config
+                    .providers()
+                    .openai
+                    .as_ref()
+                    .map(|c| c.api_key.as_str()),
                 "anthropic" => config
-                    .providers
+                    .providers()
                     .anthropic
                     .as_ref()
                     .map(|c| c.api_key.as_str()),
-                "gemini" => config.providers.gemini.as_ref().map(|c| c.api_key.as_str()),
+                "gemini" => config
+                    .providers()
+                    .gemini
+                    .as_ref()
+                    .map(|c| c.api_key.as_str()),
                 _ => unreachable!(),
             };
             assert_eq!(
@@ -547,20 +557,24 @@ mod tests {
     fn provider_selection_before_api_key_routes_key_to_chosen_provider() {
         let mut config = Config::default();
         config.provider = "anthropic".to_string(); // config.json default
-        config.providers.openai = None;
-        config.providers.anthropic = None;
+        config.providers_mut().openai = None;
+        config.providers_mut().anthropic = None;
 
         // Simulate `.provider_name("openai")` (set first), then `.api_key(...)`.
         config.provider = "openai".to_string();
         apply_api_key(&mut config, "sk-openai-xyz");
 
         assert_eq!(
-            config.providers.openai.as_ref().map(|c| c.api_key.as_str()),
+            config
+                .providers()
+                .openai
+                .as_ref()
+                .map(|c| c.api_key.as_str()),
             Some("sk-openai-xyz"),
             "api_key must land on the selected provider (openai), not the default"
         );
         assert!(
-            config.providers.anthropic.is_none(),
+            config.providers().anthropic.is_none(),
             "the default provider must not receive the key"
         );
     }

--- a/crates/app/bamboo-server-tools/src/cluster_tool.rs
+++ b/crates/app/bamboo-server-tools/src/cluster_tool.rs
@@ -426,7 +426,7 @@ mod tests {
         let (endpoint, _broker_dir) = start_broker().await;
         let mut config = Config::default();
         config.cluster_fabric.nodes = vec![local_node("n1")];
-        config.subagents.broker = Some(bamboo_config::BrokerClientConfig {
+        config.subagents_mut().broker = Some(bamboo_config::BrokerClientConfig {
             endpoint: endpoint.clone(),
             token: "t".into(),
             token_encrypted: None,

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -124,7 +124,7 @@ impl FabricDeployer {
             let cfg = self.config.read().await;
             (
                 self.node_snapshot(&cfg, node_id)?,
-                cfg.subagents.broker.clone(),
+                cfg.subagents().broker.clone(),
             )
         };
         if !node.enabled {
@@ -431,7 +431,7 @@ impl FabricDeployer {
             let cfg = self.config.read().await;
             (
                 self.node_snapshot(&cfg, node_id)?,
-                cfg.subagents.broker.clone(),
+                cfg.subagents().broker.clone(),
             )
         };
         let current = node.state.clone().unwrap_or_default();
@@ -1486,7 +1486,7 @@ mod health_check_tests {
     fn deployer_with(nodes: Vec<Node>, endpoint: &str) -> Arc<FabricDeployer> {
         let mut cfg = Config::default();
         cfg.cluster_fabric.nodes = nodes;
-        cfg.subagents.broker = Some(BrokerClientConfig {
+        cfg.subagents_mut().broker = Some(BrokerClientConfig {
             endpoint: endpoint.into(),
             token: "t".into(),
             token_encrypted: None,

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -373,7 +373,7 @@ impl AppState {
         // with bounded backoff after a transient WebSocket drop instead of
         // permanently disabling proxied tools for the worker's lifetime.
         let mcp_proxy_shutdown = tokio_util::sync::CancellationToken::new();
-        if let Some(broker) = config_snapshot.subagents.broker.clone() {
+        if let Some(broker) = config_snapshot.subagents().broker.clone() {
             if !broker.endpoint.trim().is_empty() {
                 let backend: std::sync::Arc<dyn bamboo_agent_core::tools::ToolExecutor> =
                     std::sync::Arc::new(bamboo_mcp::executor::McpToolExecutor::new(
@@ -391,7 +391,7 @@ impl AppState {
                 // set so a typo in `config.json` is surfaced at boot instead of
                 // silently granting nothing for the intended tool.
                 let role_entries: Vec<(String, Vec<String>)> = config_snapshot
-                    .subagents
+                    .subagents()
                     .mcp_role_allowlist
                     .iter()
                     .map(|e| (e.role.clone(), e.tools.clone()))
@@ -591,7 +591,7 @@ impl AppState {
             subagent_model_resolver,
             config.clone(),
             provider_registry.clone(),
-            config_snapshot.subagents.broker.clone(),
+            config_snapshot.subagents().broker.clone(),
             fabric_deployer.clone(),
             notification_relay_deps.clone(),
         );
@@ -802,7 +802,7 @@ async fn maybe_embed_broker(
         let endpoint = external.endpoint.trim().to_string();
         if broker_endpoint_reachable(&endpoint).await {
             tracing::info!(%endpoint, "using external broker from broker.json");
-            config.subagents.broker = Some(external);
+            config.subagents_mut().broker = Some(external);
             return None;
         }
         tracing::warn!(
@@ -843,7 +843,7 @@ async fn maybe_embed_broker(
 
     // Set the endpoint IN MEMORY ONLY — `subagents.broker` is `#[serde(skip)]`, so
     // this ephemeral loopback port is regenerated every boot and never touches disk.
-    config.subagents.broker = Some(bamboo_config::BrokerClientConfig {
+    config.subagents_mut().broker = Some(bamboo_config::BrokerClientConfig {
         endpoint: format!("ws://127.0.0.1:{port}"),
         token,
         token_encrypted: None,

--- a/crates/app/bamboo-server/src/config_manager.rs
+++ b/crates/app/bamboo-server/src/config_manager.rs
@@ -43,7 +43,7 @@ pub fn sync_provider_api_keys_encrypted_for_patch(
     for name in intents.providers.iter() {
         match name.as_str() {
             "openai" => {
-                if let Some(openai) = config.providers.openai.as_mut() {
+                if let Some(openai) = config.providers_mut().openai.as_mut() {
                     // Never encrypt/persist an env-sourced key — mirrors
                     // refresh_provider_api_keys_encrypted's guard (#253). Without
                     // it, an explicit `api_key: ""` clear of an env-sourced provider
@@ -66,7 +66,7 @@ pub fn sync_provider_api_keys_encrypted_for_patch(
                 }
             }
             "anthropic" => {
-                if let Some(anthropic) = config.providers.anthropic.as_mut() {
+                if let Some(anthropic) = config.providers_mut().anthropic.as_mut() {
                     // Skip env-sourced keys (see openai above). #373.
                     if !anthropic.api_key_from_env {
                         let api_key = anthropic.api_key.trim();
@@ -83,7 +83,7 @@ pub fn sync_provider_api_keys_encrypted_for_patch(
                 }
             }
             "gemini" => {
-                if let Some(gemini) = config.providers.gemini.as_mut() {
+                if let Some(gemini) = config.providers_mut().gemini.as_mut() {
                     // Skip env-sourced keys (see openai above). #373.
                     if !gemini.api_key_from_env {
                         let api_key = gemini.api_key.trim();
@@ -100,7 +100,7 @@ pub fn sync_provider_api_keys_encrypted_for_patch(
                 }
             }
             "bodhi" => {
-                if let Some(bodhi) = config.providers.bodhi.as_mut() {
+                if let Some(bodhi) = config.providers_mut().bodhi.as_mut() {
                     let api_key = bodhi.api_key.trim();
                     bodhi.api_key_encrypted = if api_key.is_empty() {
                         None
@@ -158,7 +158,8 @@ pub fn build_merged_config(
     let notification_intents = notification_secret_intents(&patch_obj);
     let connect_intents = connect_secret_intents(&patch_obj);
 
-    let mut merged = serde_json::to_value(current)
+    let mut merged = current
+        .to_compatibility_value()
         .map_err(|e| AppError::InternalError(anyhow::anyhow!("Failed to serialize config: {e}")))?;
 
     deep_merge_json(&mut merged, Value::Object(patch_obj));
@@ -205,7 +206,7 @@ mod tests {
 
     fn env_sourced_openai_config() -> Config {
         let mut config = Config::default();
-        config.providers.openai = Some(OpenAIConfig {
+        config.providers_mut().openai = Some(OpenAIConfig {
             api_key: "sk-env-secret".to_string(),
             api_key_from_env: true,
             ..Default::default()
@@ -231,7 +232,7 @@ mod tests {
         let mut merged = build_merged_config(&current, patch).expect("merge");
         sync_provider_api_keys_encrypted_for_patch(&mut merged, &intents).expect("sync");
 
-        let openai = merged.providers.openai.as_ref().unwrap();
+        let openai = merged.providers().openai.as_ref().unwrap();
         assert!(
             openai.api_key_encrypted.is_none(),
             "env secret must NOT be encrypted to disk on a clear"
@@ -252,7 +253,7 @@ mod tests {
         let mut merged = build_merged_config(&current, patch).expect("merge");
         sync_provider_api_keys_encrypted_for_patch(&mut merged, &intents).expect("sync");
 
-        let openai = merged.providers.openai.as_ref().unwrap();
+        let openai = merged.providers().openai.as_ref().unwrap();
         assert_eq!(openai.api_key, "sk-brand-new", "explicit override wins");
         assert!(!openai.api_key_from_env, "override clears the env flag");
         assert!(
@@ -276,7 +277,7 @@ mod tests {
         let mut merged = build_merged_config(&current, patch).expect("merge");
         sync_provider_api_keys_encrypted_for_patch(&mut merged, &intents).expect("sync");
 
-        let openai = merged.providers.openai.as_ref().unwrap();
+        let openai = merged.providers().openai.as_ref().unwrap();
         assert_eq!(
             openai.api_key, "sk-env-secret",
             "env key preserved across unrelated patch"
@@ -806,16 +807,16 @@ mod tests {
         // isolation): an `Option<String>` field written once must become
         // un-settable via a later PATCH.
         let mut current = Config::default();
-        current.subagents.claude_code_binary = Some("/usr/local/bin/claude".to_string());
-        current.subagents.executor = Some("claude_code".to_string());
+        current.subagents_mut().claude_code_binary = Some("/usr/local/bin/claude".to_string());
+        current.subagents_mut().executor = Some("claude_code".to_string());
 
         let patch: Map<String, Value> =
             serde_json::from_str(r#"{"subagents":{"claude_code_binary":null}}"#).unwrap();
         let merged = build_merged_config(&current, patch).expect("merge must not error");
 
-        assert_eq!(merged.subagents.claude_code_binary, None);
+        assert_eq!(merged.subagents().claude_code_binary, None);
         // Sibling field untouched by the patch survives — proves this was a
         // surgical field-level delete, not a whole-subtree reset.
-        assert_eq!(merged.subagents.executor, Some("claude_code".to_string()));
+        assert_eq!(merged.subagents().executor, Some("claude_code".to_string()));
     }
 }

--- a/crates/app/bamboo-server/src/connect/bridge.rs
+++ b/crates/app/bamboo-server/src/connect/bridge.rs
@@ -1178,7 +1178,7 @@ mod tests {
         {
             let mut cfg = state.config.write().await;
             cfg.provider = "openai".to_string();
-            cfg.providers.openai = Some(bamboo_config::OpenAIConfig {
+            cfg.providers_mut().openai = Some(bamboo_config::OpenAIConfig {
                 api_key: String::new(),
                 api_key_from_env: false,
                 api_key_encrypted: None,

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
@@ -352,7 +352,7 @@ mod optional_model_e2e {
         {
             let mut config = state.config.write().await;
             config.provider = "openai".to_string();
-            config.providers.openai = Some(bamboo_config::OpenAIConfig {
+            config.providers_mut().openai = Some(bamboo_config::OpenAIConfig {
                 model: Some("gpt-configured-default".to_string()),
                 ..Default::default()
             });
@@ -395,7 +395,7 @@ mod optional_model_e2e {
         {
             let mut config = state.config.write().await;
             config.provider = "openai".to_string();
-            config.providers.openai = Some(bamboo_config::OpenAIConfig {
+            config.providers_mut().openai = Some(bamboo_config::OpenAIConfig {
                 model: Some("gpt-configured-default".to_string()),
                 ..Default::default()
             });

--- a/crates/app/bamboo-server/src/handlers/agent/execute/defaults.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/defaults.rs
@@ -121,7 +121,7 @@ mod tests {
             // route each `ProviderModelRef` through the live provider registry
             // (`ProviderModelRouter::route`), which only succeeds for a provider
             // that's actually registered — an API key is what registers it.
-            config.providers.openai = Some(bamboo_config::OpenAIConfig {
+            config.providers_mut().openai = Some(bamboo_config::OpenAIConfig {
                 api_key: "test-key".to_string(),
                 ..Default::default()
             });
@@ -179,7 +179,7 @@ mod tests {
         {
             let mut config = state.config.write().await;
             config.provider = "openai".to_string();
-            config.providers.openai = Some(bamboo_config::OpenAIConfig {
+            config.providers_mut().openai = Some(bamboo_config::OpenAIConfig {
                 api_key: "sk-super-secret-value".to_string(),
                 model: Some("gpt-4o".to_string()),
                 ..Default::default()

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
@@ -254,10 +254,8 @@ mod tests {
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
 
         runtime.block_on(async {
-            let cached_snapshot = Config {
-                provider: "cached-provider".to_string(),
-                ..Default::default()
-            };
+            let mut cached_snapshot = Config::default();
+            cached_snapshot.provider = "cached-provider".to_string();
 
             let config = Arc::new(tokio::sync::RwLock::new(Config::default()));
             let cached_config = StdRwLock::new(cached_snapshot);

--- a/crates/app/bamboo-server/src/handlers/agent/mcp/server_handlers/query.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/mcp/server_handlers/query.rs
@@ -13,7 +13,8 @@ pub async fn list_servers(state: web::Data<AppState>) -> impl Responder {
     let servers: Vec<McpServerApiRecord> = config
         .mcp
         .servers
-        .into_iter()
+        .iter()
+        .cloned()
         .map(|server_cfg| {
             let runtime = state
                 .mcp_manager

--- a/crates/app/bamboo-server/src/handlers/agent/mcp/server_handlers/query.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/mcp/server_handlers/query.rs
@@ -14,7 +14,6 @@ pub async fn list_servers(state: web::Data<AppState>) -> impl Responder {
         .mcp
         .servers
         .iter()
-        .cloned()
         .map(|server_cfg| {
             let runtime = state
                 .mcp_manager
@@ -28,7 +27,7 @@ pub async fn list_servers(state: web::Data<AppState>) -> impl Responder {
                 tool_count: runtime.tool_count,
                 last_error: runtime.last_error.clone(),
                 restart_count: runtime.restart_count,
-                config: to_api_config(&server_cfg),
+                config: to_api_config(server_cfg),
                 runtime,
             }
         })

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/system_prompt.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/system_prompt.rs
@@ -70,16 +70,14 @@ mod tests {
     use bamboo_agent_core::{Message, Session};
 
     fn publish_test_env_context() {
-        let config = bamboo_llm::Config {
-            env_vars: vec![bamboo_config::EnvVarEntry {
-                name: "TEST_TOOL_TOKEN".to_string(),
-                value: "hidden-value".to_string(),
-                secret: true,
-                value_encrypted: None,
-                description: Some("Snapshot test token".to_string()),
-            }],
-            ..bamboo_llm::Config::default()
-        };
+        let mut config = bamboo_llm::Config::default();
+        config.env_vars = vec![bamboo_config::EnvVarEntry {
+            name: "TEST_TOOL_TOKEN".to_string(),
+            value: "hidden-value".to_string(),
+            secret: true,
+            value_encrypted: None,
+            description: Some("Snapshot test token".to_string()),
+        }];
         config.publish_env_vars();
     }
 

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/tests.rs
@@ -6,6 +6,18 @@ use bamboo_engine::session_app::session_create::{
 };
 use bamboo_llm::Config;
 
+macro_rules! test_config {
+    (@assign $config:ident, providers, $value:expr) => { *$config.providers_mut() = $value; };
+    (@assign $config:ident, memory, $value:expr) => { *$config.memory_mut() = $value; };
+    (@assign $config:ident, subagents, $value:expr) => { *$config.subagents_mut() = $value; };
+    (@assign $config:ident, $field:ident, $value:expr) => { $config.$field = $value; };
+    ($($field:ident: $value:expr),* $(,)?) => {{
+        let mut config = Config::default();
+        $(test_config!(@assign config, $field, $value);)*
+        config
+    }};
+}
+
 const BUILTIN_FALLBACK: &str = crate::app_state::DEFAULT_BASE_PROMPT;
 
 fn config_from_server(config: &Config) -> CreateSessionConfig {
@@ -19,9 +31,8 @@ fn config_from_server(config: &Config) -> CreateSessionConfig {
 
 #[test]
 fn model_from_request_uses_provider_default_when_absent_or_blank() {
-    let config = Config {
+    let config = test_config! {
         provider: "copilot".to_string(),
-        ..Config::default()
     };
     let expected = config
         .get_model()
@@ -83,10 +94,9 @@ fn build_new_session_applies_title_and_system_prompt_metadata() {
 
 #[test]
 fn build_new_session_uses_global_default_template_when_request_prompt_is_missing() {
-    let config = Config {
+    let config = test_config! {
         provider: "copilot".to_string(),
         providers: ProviderConfigs::default(),
-        ..Config::default()
     };
     let input = CreateSessionInput {
         id: "session-1".to_string(),
@@ -112,10 +122,9 @@ fn build_new_session_uses_global_default_template_when_request_prompt_is_missing
 
 #[test]
 fn reasoning_effort_from_request_falls_back_to_provider_default() {
-    let config = Config {
+    let config = test_config! {
         provider: "copilot".to_string(),
         providers: ProviderConfigs::default(),
-        ..Config::default()
     };
 
     assert_eq!(

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/maintenance.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/maintenance.rs
@@ -255,24 +255,22 @@ mod tests {
         data_dir: std::path::PathBuf,
         provider: Arc<dyn LLMProvider>,
     ) -> web::Data<AppState> {
-        let config = Config {
-            memory: Some(bamboo_config::MemoryConfig {
-                background_model: Some("fast-model".to_string()),
-                // Disable the background maintenance tickers in tests. L4 made them
-                // default-ON, so with a background_model set the AppState builder
-                // spawns real auto_dream/gardener tasks whose first tick fires
-                // immediately and calls the mock provider — racing the endpoint's
-                // own dream call and draining the finite `SequenceProvider` queue,
-                // which flakily panics on `remove(0)`. These endpoint tests drive
-                // dream generation explicitly (the endpoint runs regardless of the
-                // flag), so the background tickers must stay quiet.
-                auto_dream_enabled: false,
-                gardener_enabled: false,
-                dedup_gardener_enabled: false,
-                ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        };
+        let mut config = Config::default();
+        *config.memory_mut() = Some(bamboo_config::MemoryConfig {
+            background_model: Some("fast-model".to_string()),
+            // Disable the background maintenance tickers in tests. L4 made them
+            // default-ON, so with a background_model set the AppState builder
+            // spawns real auto_dream/gardener tasks whose first tick fires
+            // immediately and calls the mock provider — racing the endpoint's
+            // own dream call and draining the finite `SequenceProvider` queue,
+            // which flakily panics on `remove(0)`. These endpoint tests drive
+            // dream generation explicitly (the endpoint runs regardless of the
+            // flag), so the background tickers must stay quiet.
+            auto_dream_enabled: false,
+            gardener_enabled: false,
+            dedup_gardener_enabled: false,
+            ..bamboo_config::MemoryConfig::default()
+        });
         web::Data::new(
             AppState::new_with_provider(data_dir, config, provider)
                 .await

--- a/crates/app/bamboo-server/src/handlers/copilot_auth/client.rs
+++ b/crates/app/bamboo-server/src/handlers/copilot_auth/client.rs
@@ -9,7 +9,7 @@ use bamboo_llm::Config;
 
 pub(super) fn resolve_headless_auth(config: &Config) -> bool {
     config
-        .providers
+        .providers()
         .copilot
         .as_ref()
         .map(|copilot| copilot.headless_auth)

--- a/crates/app/bamboo-server/src/handlers/copilot_auth/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/copilot_auth/tests.rs
@@ -6,22 +6,20 @@ use super::{client::resolve_headless_auth, status_logout::auth_status_from_token
 
 #[test]
 fn resolve_headless_auth_prefers_provider_specific_value() {
-    let config = Config {
-        headless_auth: false,
-        providers: ProviderConfigs {
-            copilot: Some(CopilotConfig {
-                enabled: true,
-                headless_auth: true,
-                model: None,
-                fast_model: None,
-                vision_model: None,
-                reasoning_effort: None,
-                responses_only_models: Vec::new(),
-                request_overrides: None,
-                extra: Default::default(),
-            }),
-            ..Default::default()
-        },
+    let mut config = Config::default();
+    config.headless_auth = false;
+    *config.providers_mut() = ProviderConfigs {
+        copilot: Some(CopilotConfig {
+            enabled: true,
+            headless_auth: true,
+            model: None,
+            fast_model: None,
+            vision_model: None,
+            reasoning_effort: None,
+            responses_only_models: Vec::new(),
+            request_overrides: None,
+            extra: Default::default(),
+        }),
         ..Default::default()
     };
 
@@ -31,7 +29,7 @@ fn resolve_headless_auth_prefers_provider_specific_value() {
 #[test]
 fn resolve_headless_auth_falls_back_to_legacy_root_field() {
     let mut config = Config::default();
-    config.providers.copilot = None;
+    config.providers_mut().copilot = None;
     config.headless_auth = true;
 
     assert!(resolve_headless_auth(&config));

--- a/crates/app/bamboo-server/src/handlers/settings/access_control.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/access_control.rs
@@ -1315,6 +1315,17 @@ mod tests {
     use actix_web::test::TestRequest;
     use bamboo_config::AccessControlConfig;
 
+    macro_rules! test_config {
+        (@assign $config:ident, providers, $value:expr) => { *$config.providers_mut() = $value; };
+        (@assign $config:ident, memory, $value:expr) => { *$config.memory_mut() = $value; };
+        (@assign $config:ident, subagents, $value:expr) => { *$config.subagents_mut() = $value; };
+        (@assign $config:ident, $field:ident, $value:expr) => { $config.$field = $value; };
+        ($($field:ident: $value:expr),* $(,)?) => {{
+            let mut config = Config::default();
+            $(test_config!(@assign config, $field, $value);)*
+            config
+        }};
+    }
     #[test]
     fn loopback_request_is_local() {
         let req = TestRequest::default()
@@ -1379,7 +1390,7 @@ mod tests {
     fn password_hash_roundtrip_verifies() {
         let salt_hex = hex::encode([1_u8; 16]);
         let hash = compute_password_hash("secret", &salt_hex).unwrap();
-        let config = Config {
+        let config = test_config! {
             access_control: Some(AccessControlConfig {
                 password_enabled: true,
                 password_hash: Some(hash),
@@ -1387,7 +1398,6 @@ mod tests {
                 updated_at: None,
                 devices: Vec::new(),
             }),
-            ..Config::default()
         };
 
         assert!(verify_password(&config, "secret"));
@@ -1399,7 +1409,7 @@ mod tests {
     fn config_with_password() -> Config {
         let salt_hex = hex::encode([1_u8; 16]);
         let hash = compute_password_hash("secret", &salt_hex).unwrap();
-        Config {
+        test_config! {
             access_control: Some(AccessControlConfig {
                 password_enabled: true,
                 password_hash: Some(hash),
@@ -1407,7 +1417,6 @@ mod tests {
                 updated_at: None,
                 devices: Vec::new(),
             }),
-            ..Config::default()
         }
     }
 
@@ -1502,7 +1511,7 @@ mod tests {
     fn device_presence_requires_credential_even_without_password() {
         // A device paired but no root password still gates remote access.
         let (cred, _t) = issue_device_token("d");
-        let config = Config {
+        let config = test_config! {
             access_control: Some(AccessControlConfig {
                 password_enabled: false,
                 password_hash: None,
@@ -1510,7 +1519,6 @@ mod tests {
                 updated_at: None,
                 devices: vec![cred],
             }),
-            ..Config::default()
         };
         assert!(build_access_status(&config, &remote_req()).requires_password);
         // Local still bypasses.
@@ -1562,7 +1570,7 @@ mod tests {
     fn request_is_authorized_remote_with_devices_and_no_creds_is_denied() {
         // Remote + a credential mechanism configured + no presented credential.
         let (cred, _t) = issue_device_token("d");
-        let config = Config {
+        let config = test_config! {
             access_control: Some(AccessControlConfig {
                 password_enabled: false,
                 password_hash: None,
@@ -1570,7 +1578,6 @@ mod tests {
                 updated_at: None,
                 devices: vec![cred],
             }),
-            ..Config::default()
         };
         assert!(!request_is_authorized(&remote_req(), &config));
     }

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/common.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/common.rs
@@ -133,7 +133,10 @@ pub(super) async fn redacted_config_json(
     // "configured" (mirrors the provider-API-key refresh above).
     config_for_response.refresh_notifications_encrypted()?;
     config_for_response.refresh_connect_platform_tokens_encrypted()?;
-    let value = serde_json::to_value(&config_for_response)?;
+    // The settings API and public `Serialize for Config` both retain the full
+    // compatibility shape, including sidecar domains. Only `save_to_dir`
+    // persists the modular root DTO separately from those sidecars.
+    let value = config_for_response.to_compatibility_value()?;
     let mut redacted = redact_config_for_api(value, &config_for_response);
 
     if let Some(model_limits) = read_model_limits_file(app_data_dir).await? {

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
@@ -47,7 +47,7 @@ fn connect_backup_file_path_appends_connect_json_bak_filename() {
 #[actix_web::test]
 async fn redacted_config_json_masks_provider_api_key_and_hides_encrypted_proxy_auth() {
     let mut config = Config::default();
-    config.providers.openai = Some(OpenAIConfig {
+    config.providers_mut().openai = Some(OpenAIConfig {
         api_key: "sk-secret".to_string(),
         api_key_from_env: false,
         api_key_encrypted: None,

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/tests.rs
@@ -3,15 +3,26 @@ use std::collections::BTreeMap;
 use bamboo_config::{OpenAIConfig, ProviderConfigs};
 use bamboo_llm::Config;
 
+macro_rules! test_config {
+    (@assign $config:ident, providers, $value:expr) => { *$config.providers_mut() = $value; };
+    (@assign $config:ident, memory, $value:expr) => { *$config.memory_mut() = $value; };
+    (@assign $config:ident, subagents, $value:expr) => { *$config.subagents_mut() = $value; };
+    (@assign $config:ident, $field:ident, $value:expr) => { $config.$field = $value; };
+    ($($field:ident: $value:expr),* $(,)?) => {{
+        let mut config = Config::default();
+        $(test_config!(@assign config, $field, $value);)*
+        config
+    }};
+}
+
 use super::types::ProxyAuthPayload;
 use super::validation::provider_validation_issue;
 
 #[test]
 fn provider_validation_issue_returns_missing_key_path_for_unconfigured_openai() {
-    let config = Config {
+    let config = test_config! {
         provider: "openai".to_string(),
         providers: ProviderConfigs::default(),
-        ..Default::default()
     };
 
     let (path, message) = provider_validation_issue(&config, "invalid".to_string());
@@ -21,7 +32,7 @@ fn provider_validation_issue_returns_missing_key_path_for_unconfigured_openai() 
 
 #[test]
 fn provider_validation_issue_returns_provider_path_when_openai_key_present() {
-    let config = Config {
+    let config = test_config! {
         provider: "openai".to_string(),
         providers: ProviderConfigs {
             openai: Some(OpenAIConfig {
@@ -39,7 +50,6 @@ fn provider_validation_issue_returns_provider_path_when_openai_key_present() {
             }),
             ..Default::default()
         },
-        ..Default::default()
     };
 
     let (path, message) = provider_validation_issue(&config, "invalid provider setup".to_string());

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/validation.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/validation.rs
@@ -76,7 +76,7 @@ pub(super) fn provider_validation_issue(
     match config.provider.as_str() {
         "openai" => provider_issue(
             config
-                .providers
+                .providers()
                 .openai
                 .as_ref()
                 .map(|provider| {
@@ -94,7 +94,7 @@ pub(super) fn provider_validation_issue(
         ),
         "anthropic" => provider_issue(
             config
-                .providers
+                .providers()
                 .anthropic
                 .as_ref()
                 .map(|provider| {
@@ -112,7 +112,7 @@ pub(super) fn provider_validation_issue(
         ),
         "gemini" => provider_issue(
             config
-                .providers
+                .providers()
                 .gemini
                 .as_ref()
                 .map(|provider| {

--- a/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/get.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/endpoints/get.rs
@@ -12,7 +12,7 @@ pub(super) async fn handle_get_provider_config(
     let mut config = app_state.config.read().await.clone();
     let provider = config.provider.clone();
     config.refresh_provider_api_keys_encrypted()?;
-    let providers = serde_json::to_value(&config.providers)?;
+    let providers = serde_json::to_value(config.providers())?;
     let masked_providers = redact_providers_for_api(providers, &config);
 
     let response = ProviderConfigResponse {

--- a/crates/app/bamboo-server/src/handlers/settings/provider/models/dispatch.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/models/dispatch.rs
@@ -27,7 +27,7 @@ pub(super) async fn fetch_models_for_provider(
         "copilot" => fetch_copilot_models(app_state).await,
         "openai" => {
             let openai =
-                config.providers.openai.as_ref().ok_or_else(|| {
+                config.providers().openai.as_ref().ok_or_else(|| {
                     AppError::BadRequest("OpenAI configuration required".to_string())
                 })?;
             ensure_api_key(openai.api_key.as_str())?;
@@ -41,7 +41,7 @@ pub(super) async fn fetch_models_for_provider(
             .await
         }
         "anthropic" => {
-            let anthropic = config.providers.anthropic.as_ref().ok_or_else(|| {
+            let anthropic = config.providers().anthropic.as_ref().ok_or_else(|| {
                 AppError::BadRequest("Anthropic configuration required".to_string())
             })?;
             ensure_api_key(anthropic.api_key.as_str())?;
@@ -56,7 +56,7 @@ pub(super) async fn fetch_models_for_provider(
         }
         "gemini" => {
             let gemini =
-                config.providers.gemini.as_ref().ok_or_else(|| {
+                config.providers().gemini.as_ref().ok_or_else(|| {
                     AppError::BadRequest("Gemini configuration required".to_string())
                 })?;
             ensure_api_key(gemini.api_key.as_str())?;

--- a/crates/app/bamboo-server/src/handlers/settings/provider/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider/tests.rs
@@ -18,25 +18,23 @@ fn deep_merge_json(dst: &mut serde_json::Value, src: serde_json::Value) {
 }
 
 fn build_config_with_mcp_secrets(temp_dir: &std::path::Path) -> Config {
-    let mut cfg = Config {
-        provider: "openai".to_string(),
-        providers: ProviderConfigs {
-            openai: Some(OpenAIConfig {
-                api_key: "sk-test".to_string(),
-                api_key_from_env: false,
-                api_key_encrypted: None,
-                base_url: None,
-                model: Some("gpt-4o".to_string()),
-                fast_model: None,
-                vision_model: None,
-                reasoning_effort: None,
-                responses_only_models: vec![],
-                request_overrides: None,
-                extra: Default::default(),
-            }),
-            ..ProviderConfigs::default()
-        },
-        ..Config::default()
+    let mut cfg = Config::default();
+    cfg.provider = "openai".to_string();
+    *cfg.providers_mut() = ProviderConfigs {
+        openai: Some(OpenAIConfig {
+            api_key: "sk-test".to_string(),
+            api_key_from_env: false,
+            api_key_encrypted: None,
+            base_url: None,
+            model: Some("gpt-4o".to_string()),
+            fast_model: None,
+            vision_model: None,
+            reasoning_effort: None,
+            responses_only_models: vec![],
+            request_overrides: None,
+            extra: Default::default(),
+        }),
+        ..ProviderConfigs::default()
     };
 
     cfg.mcp.servers = vec![

--- a/crates/app/bamboo-server/src/handlers/settings/redaction/provider.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/redaction/provider.rs
@@ -20,19 +20,19 @@ pub(super) fn redact_provider_entry(name: &str, provider_cfg: &mut Value, config
 fn provider_is_configured(name: &str, config: &Config) -> bool {
     match name {
         "openai" => config
-            .providers
+            .providers()
             .openai
             .as_ref()
             .map(|c| !c.api_key.trim().is_empty() || c.api_key_encrypted.is_some())
             .unwrap_or(false),
         "anthropic" => config
-            .providers
+            .providers()
             .anthropic
             .as_ref()
             .map(|c| !c.api_key.trim().is_empty() || c.api_key_encrypted.is_some())
             .unwrap_or(false),
         "gemini" => config
-            .providers
+            .providers()
             .gemini
             .as_ref()
             .map(|c| !c.api_key.trim().is_empty() || c.api_key_encrypted.is_some())

--- a/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
@@ -6,10 +6,22 @@ use bamboo_config::{OpenAIConfig, ProviderConfigs};
 use bamboo_llm::Config;
 use bamboo_mcp::{McpServerConfig, StdioConfig, TransportConfig};
 
+macro_rules! test_config {
+    (@assign $config:ident, providers, $value:expr) => { *$config.providers_mut() = $value; };
+    (@assign $config:ident, memory, $value:expr) => { *$config.memory_mut() = $value; };
+    (@assign $config:ident, subagents, $value:expr) => { *$config.subagents_mut() = $value; };
+    (@assign $config:ident, $field:ident, $value:expr) => { $config.$field = $value; };
+    ($($field:ident: $value:expr),* $(,)?) => {{
+        let mut config = Config::default();
+        $(test_config!(@assign config, $field, $value);)*
+        config
+    }};
+}
+
 use super::{redact_config_for_api, redact_providers_for_api};
 
 fn config_with_openai_key() -> Config {
-    Config {
+    test_config! {
         providers: ProviderConfigs {
             openai: Some(OpenAIConfig {
                 api_key: String::new(),
@@ -26,7 +38,6 @@ fn config_with_openai_key() -> Config {
             }),
             ..ProviderConfigs::default()
         },
-        ..Default::default()
     }
 }
 
@@ -58,9 +69,8 @@ fn redact_config_masks_configured_provider_and_removes_proxy_encrypted_keys() {
 
 #[test]
 fn redact_providers_removes_unconfigured_api_key_fields() {
-    let config = Config {
+    let config = test_config! {
         providers: ProviderConfigs::default(),
-        ..Default::default()
     };
     let input = json!({
         "openai": {

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -744,6 +744,17 @@ mod build_context_tests {
     use std::sync::Arc;
     use tokio::sync::RwLock;
 
+    macro_rules! test_config {
+        (@assign $config:ident, providers, $value:expr) => { *$config.providers_mut() = $value; };
+        (@assign $config:ident, memory, $value:expr) => { *$config.memory_mut() = $value; };
+        (@assign $config:ident, subagents, $value:expr) => { *$config.subagents_mut() = $value; };
+        (@assign $config:ident, $field:ident, $value:expr) => { $config.$field = $value; };
+        ($($field:ident: $value:expr),* $(,)?) => {{
+            let mut config = Config::default();
+            $(test_config!(@assign config, $field, $value);)*
+            config
+        }};
+    }
     fn test_job() -> ScheduleRunJob {
         ScheduleRunJob {
             run_id: "run-1".to_string(),
@@ -758,7 +769,7 @@ mod build_context_tests {
 
     #[test]
     fn resolve_run_config_from_config_prefers_fast_model() {
-        let config = Config {
+        let config = test_config! {
             provider: "openai".to_string(),
             defaults: None,
             features: bamboo_config::FeatureFlags {
@@ -781,7 +792,6 @@ mod build_context_tests {
                 }),
                 ..ProviderConfigs::default()
             },
-            ..Config::default()
         };
 
         let registry = Arc::new(ProviderRegistry::new(
@@ -795,7 +805,7 @@ mod build_context_tests {
 
     #[test]
     fn resolve_run_config_from_config_falls_back_to_default_model_when_fast_missing() {
-        let config = Config {
+        let config = test_config! {
             provider: "openai".to_string(),
             defaults: Some(DefaultsConfig {
                 chat: ProviderModelRef::new("openai", "gpt-chat"),
@@ -814,7 +824,6 @@ mod build_context_tests {
                 ..Default::default()
             },
             providers: ProviderConfigs::default(),
-            ..Config::default()
         };
 
         let registry = Arc::new(ProviderRegistry::new(

--- a/crates/engine/bamboo-engine/src/auto_dream.rs
+++ b/crates/engine/bamboo-engine/src/auto_dream.rs
@@ -623,7 +623,7 @@ async fn run_auto_dream_once_for_scope(
     };
 
     let config_snapshot = ctx.config.read().await.clone();
-    let memory_cfg = config_snapshot.memory.clone().unwrap_or_default();
+    let memory_cfg = config_snapshot.memory().clone().unwrap_or_default();
     if require_auto_dream_enabled && !memory_cfg.auto_dream_enabled {
         tracing::info!(
             target: DREAM_TRACING_TARGET,
@@ -885,7 +885,7 @@ pub fn spawn_auto_dream_task(ctx: AutoDreamContext) {
             .config
             .read()
             .await
-            .memory
+            .memory()
             .as_ref()
             .map(|memory| memory.auto_dream_interval_secs)
             .filter(|secs| *secs > 0)
@@ -919,6 +919,12 @@ mod tests {
 
     use bamboo_agent_core::storage::Storage;
     use bamboo_llm::{LLMError, LLMStream};
+
+    fn config_with_memory(memory: bamboo_config::MemoryConfig) -> Config {
+        let mut config = Config::default();
+        *config.memory_mut() = Some(memory);
+        config
+    }
 
     #[test]
     fn full_rebuild_marker_bootstraps_on_first_grounded_rebuild() {
@@ -1047,14 +1053,13 @@ mod tests {
         let provider: Arc<dyn LLMProvider> = Arc::new(SequenceProvider::new(vec![
             "{\"candidates\":[{\"title\":\"User prefers terse responses\",\"type\":\"feedback\",\"scope\":\"project\",\"content\":\"The user prefers terse responses and no recap.\",\"tags\":[\"preference\",\"style\"],\"session_id\":\"session-auto\",\"confidence\":\"high\"}]}".to_string(),
         ]));
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 auto_dream_enabled: true,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
 
         let mut session = bamboo_agent_core::Session::new("session-auto", "model");
         session.title = "Auto memory test".to_string();
@@ -1152,14 +1157,13 @@ mod tests {
         let provider: Arc<dyn LLMProvider> = Arc::new(SequenceProvider::new(vec![
             "{\"candidates\":[]}".to_string(),
         ]));
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 auto_dream_enabled: true,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
 
         let mut session = bamboo_agent_core::Session::new("session-empty", "model");
         session.metadata.insert(
@@ -1222,14 +1226,13 @@ mod tests {
             "## Current durable context\n- Durable signal found\n\n## Cross-session patterns\n- Prefer concise answers\n\n## Active threads to remember\n- Memory extraction\n\n## Stable constraints and preferences\n- Terse replies\n\n## Open risks or questions\n- None".to_string(),
             "{\"candidates\":[{\"title\":\"User prefers concise answers\",\"type\":\"feedback\",\"scope\":\"project\",\"content\":\"The user prefers concise answers and minimal recap.\",\"tags\":[\"preference\"],\"session_id\":\"session-dream-run\"}],\"ledger_candidates\":[{\"title\":\"Renew passport\",\"kind\":\"todo\",\"due_at\":\"2026-08-01T00:00:00Z\",\"starts_at\":null,\"excerpt\":\"I need to renew my passport before August\",\"session_id\":\"session-dream-run\",\"confidence\":\"high\"}]}".to_string(),
         ]));
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 auto_dream_enabled: true,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
 
         let mut session = bamboo_agent_core::Session::new("session-dream-run", "model");
         session.title = "Dream run test".to_string();
@@ -1534,14 +1537,13 @@ mod tests {
             "## Current durable context\n- Project A signal only\n\n## Cross-session patterns\n- Focus on project A\n\n## Active threads to remember\n- Ship project A\n\n## Stable constraints and preferences\n- Keep scope isolated\n\n## Open risks or questions\n- None".to_string(),
             "{\"candidates\":[{\"title\":\"Project A prefers concise planning\",\"type\":\"project\",\"scope\":\"project\",\"content\":\"Project A plans should stay concise and scoped.\",\"tags\":[\"planning\"],\"session_id\":\"session-project-a\"}]}".to_string(),
         ]));
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 auto_dream_enabled: true,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
 
         let mut session_a = bamboo_agent_core::Session::new("session-project-a", "model");
         session_a.title = "Project A session".to_string();
@@ -1664,14 +1666,13 @@ mod tests {
         );
         let storage: Arc<dyn Storage> = session_store.clone();
         let provider: Arc<dyn LLMProvider> = Arc::new(SequenceProvider::new(vec![]));
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 auto_dream_enabled: true,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
 
         let mut other_session = bamboo_agent_core::Session::new("session-other-project", "model");
         other_session.title = "Other project session".to_string();
@@ -1738,13 +1739,12 @@ mod tests {
             "## Current durable context\n- Manual project dream worked\n\n## Cross-session patterns\n- None\n\n## Active threads to remember\n- None\n\n## Stable constraints and preferences\n- None\n\n## Open risks or questions\n- None".to_string(),
             "{\"candidates\":[]}".to_string(),
         ]));
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
 
         let mut session = bamboo_agent_core::Session::new("session-manual-project-dream", "model");
         session.title = "Manual project dream session".to_string();
@@ -1813,14 +1813,13 @@ mod tests {
             "{\"candidates\":[]}".to_string(),
         ]);
         let provider_handle: Arc<dyn LLMProvider> = Arc::new(provider.clone());
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 auto_dream_enabled: true,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
 
         let workspace = temp_dir.path().join("workspace-grounded-mode");
         std::fs::create_dir_all(&workspace).expect("workspace dir");
@@ -1923,14 +1922,13 @@ mod tests {
             "{\"candidates\":[]}".to_string(),
         ]);
         let provider_handle: Arc<dyn LLMProvider> = Arc::new(provider.clone());
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 auto_dream_enabled: true,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
 
         let workspace = temp_dir.path().join("workspace-rebuild-mode");
         std::fs::create_dir_all(&workspace).expect("workspace dir");
@@ -2056,14 +2054,13 @@ Model: gpt-5-mini
             "{\"candidates\":[]}".to_string(),
         ]);
         let provider_handle: Arc<dyn LLMProvider> = Arc::new(provider.clone());
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 auto_dream_enabled: true,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
 
         let workspace = temp_dir.path().join("workspace-refine-normalize");
         std::fs::create_dir_all(&workspace).expect("workspace dir");
@@ -2136,14 +2133,13 @@ Model: gpt-5-mini
         let provider: Arc<dyn LLMProvider> = Arc::new(SequenceProvider::new(vec![]));
         // auto_dream is ON by default (L4), so disable it explicitly to keep
         // covering the disabled gate (not merely "no candidate sessions").
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 auto_dream_enabled: false,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
 
         let context = AutoDreamContext {
             session_store,
@@ -2170,14 +2166,13 @@ Model: gpt-5-mini
         );
         let storage: Arc<dyn Storage> = session_store.clone();
         let provider: Arc<dyn LLMProvider> = Arc::new(SequenceProvider::new(vec![]));
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 auto_dream_enabled: true,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
 
         let context = AutoDreamContext {
             session_store,

--- a/crates/engine/bamboo-engine/src/external_agents/config.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/config.rs
@@ -277,7 +277,7 @@ mod tests {
         // Sub-agents always run as actors: a type with no expert routing
         // resolves to the built-in local actor worker.
         let mut config = Config::default();
-        config.subagents = Default::default();
+        *config.subagents_mut() = Default::default();
         let metadata = resolve_runtime_metadata(&config, "unknown");
         assert_eq!(metadata.get("runtime.kind"), Some(&"external".to_string()));
         assert_eq!(

--- a/crates/engine/bamboo-engine/src/external_agents/runtime.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/runtime.rs
@@ -143,7 +143,7 @@ pub fn build_external_child_runner_with_registry(
                 extract_provider_credentials(config),
                 config.provider.clone(),
                 config
-                    .subagents
+                    .subagents()
                     .max_concurrent
                     .unwrap_or(super::actor_adapter::DEFAULT_MAX_CONCURRENT_ACTORS),
             );
@@ -217,7 +217,7 @@ fn build_local_actor_runner(
     config: &Config,
     approval_registry: Option<super::approval_registry::SharedApprovalRegistry>,
 ) -> Result<Arc<dyn ExternalChildRunner>, String> {
-    let sub = &config.subagents;
+    let sub = config.subagents();
 
     let (worker_bin, worker_args) = match &sub.worker_bin {
         Some(custom) => (
@@ -464,16 +464,16 @@ pub fn extract_provider_credentials(
             provider_type: Some(name.to_string()),
         });
     };
-    if let Some(c) = &config.providers.openai {
+    if let Some(c) = &config.providers().openai {
         push_legacy("openai", &c.api_key, c.base_url.clone());
     }
-    if let Some(c) = &config.providers.anthropic {
+    if let Some(c) = &config.providers().anthropic {
         push_legacy("anthropic", &c.api_key, c.base_url.clone());
     }
-    if let Some(c) = &config.providers.gemini {
+    if let Some(c) = &config.providers().gemini {
         push_legacy("gemini", &c.api_key, c.base_url.clone());
     }
-    if let Some(c) = &config.providers.bodhi {
+    if let Some(c) = &config.providers().bodhi {
         push_legacy("bodhi", &c.api_key, c.base_url.clone());
     }
 
@@ -535,7 +535,7 @@ mod extract_provider_credentials_tests {
     #[test]
     fn legacy_only_config_yields_credential() {
         let mut config = Config::default();
-        config.providers.anthropic = Some(AnthropicConfig {
+        config.providers_mut().anthropic = Some(AnthropicConfig {
             api_key: "sk-ant-legacy".to_string(),
             base_url: Some("https://api.anthropic.com".to_string()),
             ..Default::default()
@@ -556,7 +556,7 @@ mod extract_provider_credentials_tests {
     #[test]
     fn legacy_bodhi_config_yields_credential() {
         let mut config = Config::default();
-        config.providers.bodhi = Some(BodhiConfig {
+        config.providers_mut().bodhi = Some(BodhiConfig {
             api_key: "bhi_sk_legacy".to_string(),
             api_key_encrypted: None,
             base_url: None,
@@ -576,7 +576,7 @@ mod extract_provider_credentials_tests {
     #[test]
     fn legacy_config_with_empty_api_key_is_skipped() {
         let mut config = Config::default();
-        config.providers.openai = Some(OpenAIConfig::default());
+        config.providers_mut().openai = Some(OpenAIConfig::default());
         assert!(extract_provider_credentials(&config).is_empty());
     }
 
@@ -585,7 +585,7 @@ mod extract_provider_credentials_tests {
     #[test]
     fn legacy_and_instances_both_present_no_duplicates() {
         let mut config = Config::default();
-        config.providers.anthropic = Some(AnthropicConfig {
+        config.providers_mut().anthropic = Some(AnthropicConfig {
             api_key: "sk-ant-legacy".to_string(),
             ..Default::default()
         });

--- a/crates/engine/bamboo-engine/src/gardener.rs
+++ b/crates/engine/bamboo-engine/src/gardener.rs
@@ -167,7 +167,7 @@ async fn run_gardener_once_with_store(
     memory: &MemoryStore,
 ) -> Result<Option<GardenerRunResult>, String> {
     let config_snapshot = ctx.config.read().await.clone();
-    let memory_cfg = config_snapshot.memory.clone().unwrap_or_default();
+    let memory_cfg = config_snapshot.memory().clone().unwrap_or_default();
     if !memory_cfg.gardener_enabled {
         return Ok(None);
     }
@@ -300,7 +300,7 @@ async fn run_dedup_gardener_once_with_store(
     memory: &MemoryStore,
 ) -> Result<Option<DedupGardenerRunResult>, String> {
     let config_snapshot = ctx.config.read().await.clone();
-    let memory_cfg = config_snapshot.memory.clone().unwrap_or_default();
+    let memory_cfg = config_snapshot.memory().clone().unwrap_or_default();
     if !memory_cfg.dedup_gardener_enabled {
         return Ok(None);
     }
@@ -466,7 +466,7 @@ async fn run_capacity_gardener_once_with_store(
     ctx: &AutoDreamContext,
     memory: &MemoryStore,
 ) -> Result<Option<CapacityGardenerRunResult>, String> {
-    let memory_cfg = ctx.config.read().await.memory.clone().unwrap_or_default();
+    let memory_cfg = ctx.config.read().await.memory().clone().unwrap_or_default();
     let capacity = memory_cfg.memory_active_capacity;
     if capacity == 0 {
         return Ok(None);
@@ -520,7 +520,7 @@ async fn run_freshness_gardener_once_with_store(
     ctx: &AutoDreamContext,
     memory: &MemoryStore,
 ) -> Result<Option<FreshnessGardenerRunResult>, String> {
-    let memory_cfg = ctx.config.read().await.memory.clone().unwrap_or_default();
+    let memory_cfg = ctx.config.read().await.memory().clone().unwrap_or_default();
     if !memory_cfg.granularity_freshness_gardener_enabled {
         return Ok(None);
     }
@@ -627,7 +627,7 @@ pub fn spawn_gardener_task(ctx: AutoDreamContext) {
     tokio::spawn(async move {
         let (interval_secs, volume_trigger) = {
             let guard = ctx.config.read().await;
-            let memory = guard.memory.as_ref();
+            let memory = guard.memory().as_ref();
             let interval_secs = memory
                 .map(|memory| memory.gardener_interval_secs)
                 .filter(|secs| *secs > 0)
@@ -694,6 +694,12 @@ mod tests {
     use bamboo_llm::{LLMError, LLMStream, ProviderRegistry};
     use bamboo_memory::memory_store::DurableMemoryType;
     use bamboo_storage::SessionStoreV2;
+
+    fn config_with_memory(memory: bamboo_config::MemoryConfig) -> Config {
+        let mut config = Config::default();
+        *config.memory_mut() = Some(memory);
+        config
+    }
 
     #[test]
     fn gardener_trigger_fires_on_time_or_volume() {
@@ -762,16 +768,15 @@ mod tests {
         let provider: Arc<dyn LLMProvider> = Arc::new(CannedProvider::new(vec![
             "{\"pieces\":[{\"title\":\"Fact one\",\"type\":\"user\",\"content\":\"Fact one body.\",\"tags\":[]},{\"title\":\"Fact two\",\"type\":\"reference\",\"content\":\"Fact two body.\",\"tags\":[]}]}".to_string(),
         ]));
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 gardener_enabled: true,
                 gardener_min_sections: 2,
                 gardener_max_splits_per_run: 8,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
         let provider_registry = Arc::new(ProviderRegistry::new(HashMap::new(), "test".to_string()));
 
         let ctx = AutoDreamContext {
@@ -833,13 +838,12 @@ mod tests {
         let provider: Arc<dyn LLMProvider> = Arc::new(CannedProvider::new(vec![]));
         // Gardener is ON by default (L4), so disable it explicitly to test the
         // disabled path.
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 gardener_enabled: false,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
         let provider_registry = Arc::new(ProviderRegistry::new(HashMap::new(), "test".to_string()));
         let ctx = AutoDreamContext {
             session_store,
@@ -865,16 +869,15 @@ mod tests {
         let provider: Arc<dyn LLMProvider> = Arc::new(CannedProvider::new(vec![
             "{\"same_fact\":true,\"merged\":{\"title\":\"Mobile release freeze is Tuesday\",\"type\":\"project\",\"content\":\"Mobile release freeze begins Tuesday for the release cut.\",\"tags\":[\"release\"]}}".to_string(),
         ]));
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 dedup_gardener_enabled: true,
                 dedup_gardener_min_score: 0.3,
                 dedup_gardener_max_merges_per_run: 8,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
         let provider_registry = Arc::new(ProviderRegistry::new(HashMap::new(), "test".to_string()));
 
         let ctx = AutoDreamContext {
@@ -942,13 +945,12 @@ mod tests {
         let storage: Arc<dyn Storage> = session_store.clone();
         let provider: Arc<dyn LLMProvider> = Arc::new(CannedProvider::new(vec![]));
         // Dedup gardener is ON by default (L4); disable it explicitly here.
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 dedup_gardener_enabled: false,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
         let provider_registry = Arc::new(ProviderRegistry::new(HashMap::new(), "test".to_string()));
         let ctx = AutoDreamContext {
             session_store,
@@ -1016,13 +1018,12 @@ mod tests {
         );
 
         // Capacity 2 → archive the 2 over-capacity memories.
-        let on_config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let on_config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 memory_active_capacity: 2,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
         let ctx_on = AutoDreamContext {
             session_store,
             storage,
@@ -1060,13 +1061,12 @@ mod tests {
         );
         let storage: Arc<dyn Storage> = session_store.clone();
         let provider: Arc<dyn LLMProvider> = Arc::new(CannedProvider::new(vec![]));
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 granularity_freshness_gardener_enabled: false,
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
         let provider_registry = Arc::new(ProviderRegistry::new(HashMap::new(), "test".to_string()));
         let ctx = AutoDreamContext {
             session_store,

--- a/crates/engine/bamboo-engine/src/ledger_gardener.rs
+++ b/crates/engine/bamboo-engine/src/ledger_gardener.rs
@@ -150,7 +150,7 @@ async fn run_ledger_gardener_once_with_store(
     ledger: &LedgerStore,
 ) -> Result<Option<LedgerGardenerRunResult>, String> {
     let config_snapshot = ctx.dream.config.read().await.clone();
-    let memory_cfg = config_snapshot.memory.clone().unwrap_or_default();
+    let memory_cfg = config_snapshot.memory().clone().unwrap_or_default();
     if !memory_cfg.ledger_gardener_enabled {
         return Ok(None);
     }
@@ -431,7 +431,7 @@ pub fn spawn_ledger_gardener_task(ctx: LedgerGardenerContext) {
         let interval_secs = {
             let guard = ctx.dream.config.read().await;
             guard
-                .memory
+                .memory()
                 .as_ref()
                 .map(|memory| memory.ledger_gardener_interval_secs)
                 .filter(|secs| *secs > 0)
@@ -480,6 +480,12 @@ mod tests {
     use chrono::Duration as ChronoDuration;
     use futures::stream;
     use tokio::sync::{Mutex as AsyncMutex, RwLock};
+
+    fn config_with_memory(memory: bamboo_config::MemoryConfig) -> Config {
+        let mut config = Config::default();
+        *config.memory_mut() = Some(memory);
+        config
+    }
 
     fn record(kind: RecordKind, status: RecordStatus) -> LedgerRecord {
         let mut record = LedgerRecord::new("rec_test", kind, "Test record");
@@ -648,13 +654,12 @@ mod tests {
                 "[{\"title\": \"Runs every morning\", \"content\": \"User keeps a morning run habit.\", \"type\": \"user\", \"tags\": [\"health\"]}]".to_string(),
             ])),
         });
-        let config = Arc::new(RwLock::new(Config {
-            memory: Some(bamboo_config::MemoryConfig {
+        let config = Arc::new(RwLock::new(config_with_memory(
+            bamboo_config::MemoryConfig {
                 background_model: Some("fast-model".to_string()),
                 ..bamboo_config::MemoryConfig::default()
-            }),
-            ..Config::default()
-        }));
+            },
+        )));
         let bridge = Arc::new(RecordingBridge::default());
         let ctx = LedgerGardenerContext {
             dream: AutoDreamContext {

--- a/crates/engine/bamboo-engine/src/model_areas.rs
+++ b/crates/engine/bamboo-engine/src/model_areas.rs
@@ -141,6 +141,18 @@ pub fn resolve_effective_reasoning_effort(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    macro_rules! test_config {
+        (@assign $config:ident, providers, $value:expr) => { *$config.providers_mut() = $value; };
+        (@assign $config:ident, memory, $value:expr) => { *$config.memory_mut() = $value; };
+        (@assign $config:ident, subagents, $value:expr) => { *$config.subagents_mut() = $value; };
+        (@assign $config:ident, $field:ident, $value:expr) => { $config.$field = $value; };
+        ($($field:ident: $value:expr),* $(,)?) => {{
+            let mut config = Config::default();
+            $(test_config!(@assign config, $field, $value);)*
+            config
+        }};
+    }
     use bamboo_agent_core::tools::ToolSchema;
     use bamboo_agent_core::Message;
     use bamboo_config::{DefaultsConfig, FeatureFlags};
@@ -186,14 +198,13 @@ mod tests {
     }
 
     fn config_with_defaults(defaults: DefaultsConfig) -> Config {
-        Config {
+        test_config! {
             provider: "openai".to_string(),
             features: FeatureFlags {
                 provider_model_ref: true,
                 ..Default::default()
             },
             defaults: Some(defaults),
-            ..Config::default()
         }
     }
 
@@ -306,7 +317,7 @@ mod tests {
     #[test]
     fn legacy_mode_resolves_fast_from_provider_config() {
         // Flag OFF: no `defaults`, fast comes from the provider's global config.
-        let config = Config {
+        let config = test_config! {
             provider: "openai".to_string(),
             features: FeatureFlags {
                 provider_model_ref: false,
@@ -329,7 +340,6 @@ mod tests {
                 }),
                 ..ProviderConfigs::default()
             },
-            ..Config::default()
         };
 
         let areas = resolve_global_area_models(&config, "openai", &test_registry());

--- a/crates/engine/bamboo-engine/src/model_config_helper.rs
+++ b/crates/engine/bamboo-engine/src/model_config_helper.rs
@@ -117,7 +117,7 @@ pub fn get_default_model_for_provider(
     match provider_name.trim() {
         "copilot" => {
             let provider_model = config
-                .providers
+                .providers()
                 .copilot
                 .as_ref()
                 .and_then(|c| c.model.clone());
@@ -126,7 +126,7 @@ pub fn get_default_model_for_provider(
         }
         "openai" => {
             let openai_config = config
-                .providers
+                .providers()
                 .openai
                 .as_ref()
                 .ok_or_else(|| LLMError::Auth("OpenAI configuration required".to_string()))?;
@@ -137,7 +137,7 @@ pub fn get_default_model_for_provider(
         }
         "anthropic" => {
             let anthropic_config =
-                config.providers.anthropic.as_ref().ok_or_else(|| {
+                config.providers().anthropic.as_ref().ok_or_else(|| {
                     LLMError::Auth("Anthropic configuration required".to_string())
                 })?;
 
@@ -147,7 +147,7 @@ pub fn get_default_model_for_provider(
         }
         "gemini" => {
             let gemini_config = config
-                .providers
+                .providers()
                 .gemini
                 .as_ref()
                 .ok_or_else(|| LLMError::Auth("Gemini configuration required".to_string()))?;
@@ -187,22 +187,22 @@ pub fn get_schedule_model_from_config(config: &Config) -> Result<String, LLMErro
 pub fn get_fast_model_for_provider(config: &Config, provider_name: &str) -> Option<String> {
     let fast = match provider_name.trim() {
         "openai" => config
-            .providers
+            .providers()
             .openai
             .as_ref()
             .and_then(|c| c.fast_model.clone()),
         "anthropic" => config
-            .providers
+            .providers()
             .anthropic
             .as_ref()
             .and_then(|c| c.fast_model.clone()),
         "gemini" => config
-            .providers
+            .providers()
             .gemini
             .as_ref()
             .and_then(|c| c.fast_model.clone()),
         "copilot" => config
-            .providers
+            .providers()
             .copilot
             .as_ref()
             .and_then(|c| c.fast_model.clone()),
@@ -221,7 +221,7 @@ pub fn get_memory_background_model_for_provider(
     provider_name: &str,
 ) -> Option<String> {
     let configured = config
-        .memory
+        .memory()
         .as_ref()
         .and_then(|memory| memory.background_model.as_ref())
         .map(|value| value.trim())
@@ -618,6 +618,26 @@ mod tests {
     use bamboo_llm::{LLMProvider, LLMStream};
     use std::collections::HashMap;
 
+    macro_rules! test_config {
+        (@assign $config:ident, providers, $value:expr) => {
+            *$config.providers_mut() = $value;
+        };
+        (@assign $config:ident, memory, $value:expr) => {
+            *$config.memory_mut() = $value;
+        };
+        (@assign $config:ident, subagents, $value:expr) => {
+            *$config.subagents_mut() = $value;
+        };
+        (@assign $config:ident, $field:ident, $value:expr) => {
+            $config.$field = $value;
+        };
+        ($($field:ident: $value:expr),* $(,)?) => {{
+            let mut config = Config::default();
+            $(test_config!(@assign config, $field, $value);)*
+            config
+        }};
+    }
+
     struct NoopProvider;
 
     #[async_trait::async_trait]
@@ -641,7 +661,7 @@ mod tests {
 
     #[test]
     fn test_get_model_from_openai_config() {
-        let config = Config {
+        let config = test_config! {
             provider: "openai".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
@@ -659,7 +679,6 @@ mod tests {
                 }),
                 ..ProviderConfigs::default()
             },
-            ..Config::default()
         };
 
         let result = get_default_model_from_config(&config);
@@ -669,7 +688,7 @@ mod tests {
 
     #[test]
     fn test_error_when_model_not_configured() {
-        let config = Config {
+        let config = test_config! {
             provider: "openai".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
@@ -687,7 +706,6 @@ mod tests {
                 }),
                 ..ProviderConfigs::default()
             },
-            ..Config::default()
         };
 
         let result = get_default_model_from_config(&config);
@@ -700,7 +718,7 @@ mod tests {
 
     #[test]
     fn test_get_model_from_copilot_provider_config() {
-        let config = Config {
+        let config = test_config! {
             provider: "copilot".to_string(),
             providers: ProviderConfigs {
                 copilot: Some(CopilotConfig {
@@ -716,7 +734,6 @@ mod tests {
                 }),
                 ..ProviderConfigs::default()
             },
-            ..Config::default()
         };
 
         let result = get_default_model_from_config(&config);
@@ -726,10 +743,9 @@ mod tests {
 
     #[test]
     fn test_get_model_from_copilot_default_fallback() {
-        let config = Config {
+        let config = test_config! {
             provider: "copilot".to_string(),
             providers: ProviderConfigs::default(),
-            ..Config::default()
         };
 
         let result = get_default_model_from_config(&config);
@@ -739,7 +755,7 @@ mod tests {
 
     #[test]
     fn test_get_default_model_for_specific_provider() {
-        let config = Config {
+        let config = test_config! {
             provider: "anthropic".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
@@ -757,7 +773,6 @@ mod tests {
                 }),
                 ..ProviderConfigs::default()
             },
-            ..Config::default()
         };
 
         let result = get_default_model_for_provider(&config, "openai").expect("openai config");
@@ -766,7 +781,7 @@ mod tests {
 
     #[test]
     fn test_get_fast_model_for_specific_provider() {
-        let config = Config {
+        let config = test_config! {
             provider: "anthropic".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
@@ -784,7 +799,6 @@ mod tests {
                 }),
                 ..ProviderConfigs::default()
             },
-            ..Config::default()
         };
 
         assert_eq!(
@@ -795,7 +809,7 @@ mod tests {
 
     #[test]
     fn test_get_schedule_model_from_config_prefers_fast_model() {
-        let config = Config {
+        let config = test_config! {
             provider: "openai".to_string(),
             defaults: None,
             features: bamboo_config::FeatureFlags {
@@ -818,7 +832,6 @@ mod tests {
                 }),
                 ..ProviderConfigs::default()
             },
-            ..Config::default()
         };
 
         let result = get_schedule_model_from_config(&config);
@@ -828,7 +841,7 @@ mod tests {
 
     #[test]
     fn test_get_schedule_model_from_config_falls_back_to_default_model() {
-        let config = Config {
+        let config = test_config! {
             provider: "openai".to_string(),
             defaults: None,
             features: bamboo_config::FeatureFlags {
@@ -851,7 +864,6 @@ mod tests {
                 }),
                 ..ProviderConfigs::default()
             },
-            ..Config::default()
         };
 
         let result = get_schedule_model_from_config(&config);
@@ -861,7 +873,7 @@ mod tests {
 
     #[test]
     fn test_get_schedule_model_from_config_prefers_defaults_fast_over_chat() {
-        let config = Config {
+        let config = test_config! {
             provider: "openai".to_string(),
             features: bamboo_config::FeatureFlags {
                 provider_model_ref: true,
@@ -879,7 +891,6 @@ mod tests {
                 sub_agent: None,
                 subagent_models: HashMap::new(),
             }),
-            ..Default::default()
         };
 
         let result = get_schedule_model_from_config(&config);
@@ -889,7 +900,7 @@ mod tests {
 
     #[test]
     fn test_get_reasoning_effort_for_specific_provider() {
-        let config = Config {
+        let config = test_config! {
             provider: "anthropic".to_string(),
             providers: ProviderConfigs {
                 openai: Some(OpenAIConfig {
@@ -907,7 +918,6 @@ mod tests {
                 }),
                 ..ProviderConfigs::default()
             },
-            ..Config::default()
         };
 
         assert_eq!(
@@ -917,7 +927,7 @@ mod tests {
     }
     #[test]
     fn resolve_subagent_model_ref_prefers_sub_agent_over_fast() {
-        let config = Config {
+        let config = test_config! {
             provider: "openai".to_string(),
             features: bamboo_config::FeatureFlags {
                 provider_model_ref: true,
@@ -935,7 +945,6 @@ mod tests {
                 sub_agent: Some(ProviderModelRef::new("openai", "gpt-sub-agent")),
                 subagent_models: HashMap::new(),
             }),
-            ..Default::default()
         };
 
         let resolved = resolve_subagent_model_ref(&config, "openai", &test_registry(), "coder")
@@ -946,7 +955,7 @@ mod tests {
 
     #[test]
     fn resolve_subagent_model_ref_falls_back_to_fast_when_sub_agent_unset() {
-        let config = Config {
+        let config = test_config! {
             provider: "openai".to_string(),
             features: bamboo_config::FeatureFlags {
                 provider_model_ref: true,
@@ -964,7 +973,6 @@ mod tests {
                 sub_agent: None,
                 subagent_models: HashMap::new(),
             }),
-            ..Default::default()
         };
 
         let resolved = resolve_subagent_model_ref(&config, "openai", &test_registry(), "coder")

--- a/crates/engine/bamboo-engine/src/resolved_defaults.rs
+++ b/crates/engine/bamboo-engine/src/resolved_defaults.rs
@@ -88,6 +88,18 @@ pub fn resolve_default_run_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    macro_rules! test_config {
+        (@assign $config:ident, providers, $value:expr) => { *$config.providers_mut() = $value; };
+        (@assign $config:ident, memory, $value:expr) => { *$config.memory_mut() = $value; };
+        (@assign $config:ident, subagents, $value:expr) => { *$config.subagents_mut() = $value; };
+        (@assign $config:ident, $field:ident, $value:expr) => { $config.$field = $value; };
+        ($($field:ident: $value:expr),* $(,)?) => {{
+            let mut config = Config::default();
+            $(test_config!(@assign config, $field, $value);)*
+            config
+        }};
+    }
     use bamboo_agent_core::tools::ToolSchema;
     use bamboo_agent_core::Message;
     use bamboo_config::{DefaultsConfig, FeatureFlags, OpenAIConfig, ProviderConfigs};
@@ -129,7 +141,7 @@ mod tests {
             sub_agent: None,
             subagent_models: HashMap::new(),
         };
-        Config {
+        test_config! {
             provider: "openai".to_string(),
             features: FeatureFlags {
                 provider_model_ref: true,
@@ -144,7 +156,6 @@ mod tests {
                 ..Default::default()
             },
             defaults: Some(defaults),
-            ..Config::default()
         }
     }
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
@@ -487,16 +487,14 @@ fn refresh_prompt_snapshot_from_session_ignores_topic_truncation_note_outside_co
 #[test]
 fn apply_system_prompt_contexts_persists_runtime_prompt_metadata() {
     let _lock = crate::runtime::tests::env_cache_lock_acquire();
-    let config_with_env = bamboo_llm::Config {
-        env_vars: vec![bamboo_config::EnvVarEntry {
-            name: "TEST_TOOL_TOKEN".to_string(),
-            value: "hidden-value".to_string(),
-            secret: true,
-            value_encrypted: None,
-            description: Some("Runtime test token".to_string()),
-        }],
-        ..bamboo_llm::Config::default()
-    };
+    let mut config_with_env = bamboo_llm::Config::default();
+    config_with_env.env_vars = vec![bamboo_config::EnvVarEntry {
+        name: "TEST_TOOL_TOKEN".to_string(),
+        value: "hidden-value".to_string(),
+        secret: true,
+        value_encrypted: None,
+        description: Some("Runtime test token".to_string()),
+    }];
     config_with_env.publish_env_vars();
 
     let root = tempfile::tempdir().expect("temp dir");
@@ -587,16 +585,14 @@ fn prompt_assembly_report_component_values_match_sections() {
     use super::prompt_setup::{PromptAssemblyReport, PromptLayer, PromptSection};
 
     let _lock = crate::runtime::tests::env_cache_lock_acquire();
-    let config_with_env = bamboo_llm::Config {
-        env_vars: vec![bamboo_config::EnvVarEntry {
-            name: "TEST_TOOL_TOKEN".to_string(),
-            value: "hidden-value".to_string(),
-            secret: true,
-            value_encrypted: None,
-            description: Some("Runtime test token".to_string()),
-        }],
-        ..bamboo_llm::Config::default()
-    };
+    let mut config_with_env = bamboo_llm::Config::default();
+    config_with_env.env_vars = vec![bamboo_config::EnvVarEntry {
+        name: "TEST_TOOL_TOKEN".to_string(),
+        value: "hidden-value".to_string(),
+        secret: true,
+        value_encrypted: None,
+        description: Some("Runtime test token".to_string()),
+    }];
     config_with_env.publish_env_vars();
 
     let base_prompt = "Base prompt";
@@ -687,16 +683,14 @@ fn prompt_assembly_report_component_values_match_sections() {
 #[test]
 fn build_stable_prompt_frame_includes_base_and_stable_contexts() {
     let _lock = crate::runtime::tests::env_cache_lock_acquire();
-    let config_with_env = bamboo_llm::Config {
-        env_vars: vec![bamboo_config::EnvVarEntry {
-            name: "TEST_PROMPT_ENVELOPE_TOKEN".to_string(),
-            value: "hidden-value".to_string(),
-            secret: true,
-            value_encrypted: None,
-            description: Some("Prompt envelope token".to_string()),
-        }],
-        ..bamboo_llm::Config::default()
-    };
+    let mut config_with_env = bamboo_llm::Config::default();
+    config_with_env.env_vars = vec![bamboo_config::EnvVarEntry {
+        name: "TEST_PROMPT_ENVELOPE_TOKEN".to_string(),
+        value: "hidden-value".to_string(),
+        secret: true,
+        value_encrypted: None,
+        description: Some("Prompt envelope token".to_string()),
+    }];
     config_with_env.publish_env_vars();
 
     let workspace = std::env::temp_dir().join("bamboo-prompt-envelope-workspace");

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -702,7 +702,7 @@ impl AgentRuntime {
             image_fallback,
             app_data_dir,
             prompt_memory_flags: config
-                .memory
+                .memory()
                 .as_ref()
                 .map(PromptMemoryFlags::from)
                 .unwrap_or_default(),

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -2304,10 +2304,8 @@ mod tests {
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
 
         runtime.block_on(async {
-            let cached_snapshot = Config {
-                provider: "cached-provider".to_string(),
-                ..Default::default()
-            };
+            let mut cached_snapshot = Config::default();
+            cached_snapshot.provider = "cached-provider".to_string();
 
             let config = Arc::new(RwLock::new(Config::default()));
             let cached_config = StdRwLock::new(cached_snapshot);

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -1144,7 +1144,8 @@ pub fn is_host_trusted(url: &str, trusted_hosts: &[String]) -> bool {
 /// Contains all settings needed to run the agent, including provider credentials,
 /// proxy settings, model selection, and server configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Config {
+#[doc(hidden)]
+pub struct ConfigValues {
     /// HTTP proxy URL (e.g., `http://proxy.example.com:8080`)
     #[serde(default)]
     pub http_proxy: String,
@@ -1173,10 +1174,6 @@ pub struct Config {
     /// Default model assignments (used when features.provider_model_ref is enabled).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub defaults: Option<DefaultsConfig>,
-
-    /// Provider-specific configurations (legacy, single-instance per type).
-    #[serde(default)]
-    pub providers: ProviderConfigs,
 
     /// Multi-instance provider configurations keyed by instance id.
     ///
@@ -1253,20 +1250,6 @@ pub struct Config {
     #[serde(default)]
     pub features: FeatureFlags,
 
-    /// Memory/background summarization settings.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub memory: Option<MemoryConfig>,
-
-    /// Sub-agent execution settings.
-    ///
-    /// Sub-agents ALWAYS run as independent actor subprocesses (crash isolation,
-    /// true parallelism) — the in-process runtime was removed, so there is no
-    /// `runtime` toggle (a stray `runtime`/`overrides` key in an old config is
-    /// silently ignored). Most users need nothing here; the fields below
-    /// (`max_concurrent`, `broker`, remote/schedulable placements) are advanced.
-    #[serde(default)]
-    pub subagents: SubagentsConfig,
-
     /// Config-level default per-run token/tool-call/subagent budget (issue
     /// #221). `None` fields are unlimited. A per-request `ExecuteRequest`
     /// override may only tighten these ceilings, never loosen them; see
@@ -1318,19 +1301,441 @@ pub struct Config {
     /// typed (de)serialization.
     #[serde(default, flatten)]
     pub extra: BTreeMap<String, Value>,
+}
 
-    /// In-memory-only marker set when this `Config` was recovered from a
-    /// corrupt `config.json` at load time (salvage / `.bak` / defaults) and
-    /// has not yet been confirmed. Never persisted (`#[serde(skip)]`), so
-    /// every clean load starts at `None` and a fresh process only ever sees
-    /// it populated right after `Config::from_data_dir` hit corruption.
+impl Default for ConfigValues {
+    fn default() -> Self {
+        Self {
+            http_proxy: String::new(),
+            https_proxy: String::new(),
+            proxy_auth: None,
+            proxy_auth_encrypted: None,
+            headless_auth: false,
+            run_budget: RunBudgetConfig::default(),
+            cluster_fabric: crate::cluster_fabric::ClusterFabricConfig::default(),
+            provider: default_provider(),
+            provider_instances: HashMap::new(),
+            default_provider_instance: None,
+            server: ServerConfig::default(),
+            keyword_masking: KeywordMaskingConfig::default(),
+            anthropic_model_mapping: AnthropicModelMapping::default(),
+            gemini_model_mapping: GeminiModelMapping::default(),
+            hooks: HooksConfig::default(),
+            tools: ToolsConfig::default(),
+            skills: SkillsConfig::default(),
+            env_vars: Vec::new(),
+            default_work_area: None,
+            access_control: None,
+            features: FeatureFlags::default(),
+            defaults: None,
+            mcp: bamboo_domain::mcp_config::McpConfig::default(),
+            notifications: NotificationsConfig::default(),
+            connect: ConnectConfig::default(),
+            plugin_trust: PluginTrustConfig::default(),
+            extra: BTreeMap::new(),
+        }
+    }
+}
+
+/// Network-facing root configuration. Flattening preserves the historical
+/// top-level JSON keys while making the persisted root structurally modular.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct NetworkConfigSection {
+    #[serde(default)]
+    http_proxy: String,
+    #[serde(default)]
+    https_proxy: String,
+    #[serde(skip_serializing)]
+    proxy_auth: Option<ProxyAuth>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    proxy_auth_encrypted: Option<String>,
+    #[serde(default)]
+    headless_auth: bool,
+    #[serde(default)]
+    server: ServerConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ProviderRoutingConfigSection {
+    #[serde(default = "default_provider")]
+    provider: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    defaults: Option<DefaultsConfig>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    provider_instances: HashMap<String, ProviderInstanceConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    default_provider_instance: Option<String>,
+}
+
+impl Default for ProviderRoutingConfigSection {
+    fn default() -> Self {
+        Self {
+            provider: default_provider(),
+            defaults: None,
+            provider_instances: HashMap::new(),
+            default_provider_instance: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct ModelBehaviorConfigSection {
+    #[serde(default)]
+    keyword_masking: KeywordMaskingConfig,
+    #[serde(default)]
+    anthropic_model_mapping: AnthropicModelMapping,
+    #[serde(default)]
+    gemini_model_mapping: GeminiModelMapping,
+    #[serde(default)]
+    hooks: HooksConfig,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct ToolingConfigSection {
+    #[serde(default, skip_serializing_if = "ToolsConfig::is_empty")]
+    tools: ToolsConfig,
+    #[serde(default, skip_serializing_if = "SkillsConfig::is_empty")]
+    skills: SkillsConfig,
+    #[serde(default, rename = "mcpServers", alias = "mcp")]
+    mcp: bamboo_domain::mcp_config::McpConfig,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct WorkspaceConfigSection {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    env_vars: Vec<EnvVarEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    default_work_area: Option<DefaultWorkAreaConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    access_control: Option<AccessControlConfig>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct ExecutionConfigSection {
+    #[serde(default)]
+    features: FeatureFlags,
+    #[serde(default)]
+    run_budget: RunBudgetConfig,
+    #[serde(
+        default,
+        skip_serializing_if = "crate::cluster_fabric::ClusterFabricConfig::is_empty"
+    )]
+    cluster_fabric: crate::cluster_fabric::ClusterFabricConfig,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct IntegrationConfigSection {
+    #[serde(default)]
+    notifications: NotificationsConfig,
+    #[serde(default, skip_serializing_if = "connect_config_is_empty")]
+    connect: ConnectConfig,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct PluginSecurityConfigSection {
+    #[serde(default)]
+    plugin_trust: PluginTrustConfig,
+}
+
+// Count declarations from the same field list that defines each structural
+// budgeted type, so the constants cannot drift from the actual structs.
+macro_rules! count_fields {
+    ($($field:ident),* $(,)?) => {
+        <[()]>::len(&[$(count_fields!(@one $field)),*])
+    };
+    (@one $field:ident) => { () };
+}
+
+macro_rules! define_counted_struct {
+    (
+        $(#[$struct_meta:meta])*
+        $visibility:vis struct $name:ident {
+            $(
+                $(#[$field_meta:meta])*
+                $field_visibility:vis $field:ident: $field_type:ty
+            ),* $(,)?
+        }
+        count $count_visibility:vis $count_name:ident;
+    ) => {
+        $(#[$struct_meta])*
+        $visibility struct $name {
+            $(
+                $(#[$field_meta])*
+                $field_visibility $field: $field_type,
+            )*
+        }
+
+        $count_visibility const $count_name: usize = count_fields!($($field),*);
+    };
+}
+
+define_counted_struct! {
+    /// The root-only persistence DTO written to `config.json`.
     ///
-    /// [`Config::save_to_dir`] refuses to overwrite `config.json` while this
-    /// is `Some` and not `confirmed` — the corrupt original stays exactly as
-    /// it was on disk until [`Config::confirm_recovery`] (or
-    /// [`Config::confirm_recovery_and_save_to_dir`]) is called. #153.
-    #[serde(skip)]
-    pub recovery_status: Option<ConfigRecoveryStatus>,
+    /// Every section is flattened so existing documents keep their historical
+    /// top-level shape. The structural field count is nevertheless nine rather
+    /// than the Phase-#39 baseline of 31.
+    #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+    struct ConfigRoot {
+        #[serde(flatten)]
+        network: NetworkConfigSection,
+        #[serde(flatten)]
+        provider_routing: ProviderRoutingConfigSection,
+        #[serde(flatten)]
+        model_behavior: ModelBehaviorConfigSection,
+        #[serde(flatten)]
+        tooling: ToolingConfigSection,
+        #[serde(flatten)]
+        workspace: WorkspaceConfigSection,
+        #[serde(flatten)]
+        execution: ExecutionConfigSection,
+        #[serde(flatten)]
+        integrations: IntegrationConfigSection,
+        #[serde(flatten)]
+        plugin_security: PluginSecurityConfigSection,
+        #[serde(default, flatten)]
+        extra: BTreeMap<String, Value>,
+    }
+    count pub PERSISTED_ROOT_FIELD_COUNT;
+}
+
+impl From<ConfigValues> for ConfigRoot {
+    fn from(values: ConfigValues) -> Self {
+        // Deliberately exhaustive: adding a runtime compatibility field must
+        // update its persisted section mapping or this conversion stops compiling.
+        let ConfigValues {
+            http_proxy,
+            https_proxy,
+            proxy_auth,
+            proxy_auth_encrypted,
+            headless_auth,
+            provider,
+            defaults,
+            provider_instances,
+            default_provider_instance,
+            server,
+            keyword_masking,
+            anthropic_model_mapping,
+            gemini_model_mapping,
+            hooks,
+            tools,
+            skills,
+            env_vars,
+            default_work_area,
+            access_control,
+            features,
+            run_budget,
+            cluster_fabric,
+            mcp,
+            notifications,
+            connect,
+            plugin_trust,
+            extra,
+        } = values;
+
+        Self {
+            network: NetworkConfigSection {
+                http_proxy,
+                https_proxy,
+                proxy_auth,
+                proxy_auth_encrypted,
+                headless_auth,
+                server,
+            },
+            provider_routing: ProviderRoutingConfigSection {
+                provider,
+                defaults,
+                provider_instances,
+                default_provider_instance,
+            },
+            model_behavior: ModelBehaviorConfigSection {
+                keyword_masking,
+                anthropic_model_mapping,
+                gemini_model_mapping,
+                hooks,
+            },
+            tooling: ToolingConfigSection { tools, skills, mcp },
+            workspace: WorkspaceConfigSection {
+                env_vars,
+                default_work_area,
+                access_control,
+            },
+            execution: ExecutionConfigSection {
+                features,
+                run_budget,
+                cluster_fabric,
+            },
+            integrations: IntegrationConfigSection {
+                notifications,
+                connect,
+            },
+            plugin_security: PluginSecurityConfigSection { plugin_trust },
+            extra,
+        }
+    }
+}
+
+impl From<ConfigRoot> for ConfigValues {
+    fn from(root: ConfigRoot) -> Self {
+        // Keep every root and section destructure exhaustive so a newly added
+        // persisted field cannot be silently omitted from the runtime view.
+        let ConfigRoot {
+            network,
+            provider_routing,
+            model_behavior,
+            tooling,
+            workspace,
+            execution,
+            integrations,
+            plugin_security,
+            extra,
+        } = root;
+        let NetworkConfigSection {
+            http_proxy,
+            https_proxy,
+            proxy_auth,
+            proxy_auth_encrypted,
+            headless_auth,
+            server,
+        } = network;
+        let ProviderRoutingConfigSection {
+            provider,
+            defaults,
+            provider_instances,
+            default_provider_instance,
+        } = provider_routing;
+        let ModelBehaviorConfigSection {
+            keyword_masking,
+            anthropic_model_mapping,
+            gemini_model_mapping,
+            hooks,
+        } = model_behavior;
+        let ToolingConfigSection { tools, skills, mcp } = tooling;
+        let WorkspaceConfigSection {
+            env_vars,
+            default_work_area,
+            access_control,
+        } = workspace;
+        let ExecutionConfigSection {
+            features,
+            run_budget,
+            cluster_fabric,
+        } = execution;
+        let IntegrationConfigSection {
+            notifications,
+            connect,
+        } = integrations;
+        let PluginSecurityConfigSection { plugin_trust } = plugin_security;
+
+        Self {
+            http_proxy,
+            https_proxy,
+            proxy_auth,
+            proxy_auth_encrypted,
+            headless_auth,
+            provider,
+            defaults,
+            provider_instances,
+            default_provider_instance,
+            server,
+            keyword_masking,
+            anthropic_model_mapping,
+            gemini_model_mapping,
+            hooks,
+            tools,
+            skills,
+            env_vars,
+            default_work_area,
+            access_control,
+            features,
+            run_budget,
+            cluster_fabric,
+            mcp,
+            notifications,
+            connect,
+            plugin_trust,
+            extra,
+        }
+    }
+}
+
+define_counted_struct! {
+    /// Runtime configuration facade. Phase-1 sidecar domains are typed modules;
+    /// the remaining values keep field-access compatibility through `Deref`.
+    #[derive(Debug, Clone)]
+    pub struct Config {
+        values: ConfigValues,
+        pub(crate) memory: crate::MemoryConfigModule,
+        pub(crate) subagents: crate::SubagentsConfigModule,
+        pub(crate) providers: crate::ProviderConfigsModule,
+        recovery_status: Option<ConfigRecoveryStatus>,
+    }
+    count pub CONFIG_FIELD_COUNT;
+}
+
+/// Auditable structural budgets from Issue #590.
+pub const PHASE_39_CONFIG_FIELD_BASELINE: usize = 31;
+const _: () = assert!(CONFIG_FIELD_COUNT * 2 <= PHASE_39_CONFIG_FIELD_BASELINE);
+const _: () = assert!(PERSISTED_ROOT_FIELD_COUNT * 2 <= PHASE_39_CONFIG_FIELD_BASELINE);
+
+impl std::ops::Deref for Config {
+    type Target = ConfigValues;
+
+    fn deref(&self) -> &Self::Target {
+        &self.values
+    }
+}
+
+impl std::ops::DerefMut for Config {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.values
+    }
+}
+
+impl Serialize for Config {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_compatibility_value()
+            .map_err(serde::ser::Error::custom)?
+            .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Config {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        let mut value = Value::deserialize(deserializer)?;
+        let object = value
+            .as_object_mut()
+            .ok_or_else(|| D::Error::custom("config must be a JSON object"))?;
+        let memory = object
+            .remove("memory")
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(D::Error::custom)?
+            .unwrap_or_default();
+        let subagents = object
+            .remove("subagents")
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(D::Error::custom)?
+            .unwrap_or_default();
+        let providers = object
+            .remove("providers")
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(D::Error::custom)?
+            .unwrap_or_default();
+        let root: ConfigRoot = serde_json::from_value(value).map_err(D::Error::custom)?;
+
+        Ok(Self::from_parts(root.into(), memory, subagents, providers))
+    }
 }
 
 /// Where a [`ConfigRecoveryStatus`]'s recovered values came from. #153.
@@ -2151,6 +2556,70 @@ fn prompt_safe_env_vars_cache() -> &'static RwLock<Vec<PromptSafeEnvVarEntry>> {
 }
 
 impl Config {
+    fn from_parts(
+        values: ConfigValues,
+        memory: Option<MemoryConfig>,
+        subagents: SubagentsConfig,
+        providers: ProviderConfigs,
+    ) -> Self {
+        Self {
+            values,
+            memory: crate::MemoryConfigModule(memory),
+            subagents: crate::SubagentsConfigModule(subagents),
+            providers: crate::ProviderConfigsModule(providers),
+            recovery_status: None,
+        }
+    }
+
+    /// Compatibility accessor for independently persisted memory settings.
+    pub fn memory(&self) -> &Option<MemoryConfig> {
+        &self.memory.0
+    }
+
+    pub fn memory_mut(&mut self) -> &mut Option<MemoryConfig> {
+        &mut self.memory.0
+    }
+
+    /// Compatibility accessor for independently persisted sub-agent settings.
+    pub fn subagents(&self) -> &SubagentsConfig {
+        &self.subagents.0
+    }
+
+    pub fn subagents_mut(&mut self) -> &mut SubagentsConfig {
+        &mut self.subagents.0
+    }
+
+    /// Compatibility accessor for independently persisted legacy providers.
+    pub fn providers(&self) -> &ProviderConfigs {
+        &self.providers.0
+    }
+
+    pub fn providers_mut(&mut self) -> &mut ProviderConfigs {
+        &mut self.providers.0
+    }
+
+    /// Build the legacy full-config JSON view used by in-memory patching APIs.
+    ///
+    /// Public serde and patch/dot-path callers retain the historical full
+    /// configuration shape. This value is never the persistence representation:
+    /// [`Config::save_to_dir`] explicitly writes a root-only DTO plus sidecars.
+    pub fn to_compatibility_value(&self) -> serde_json::Result<Value> {
+        let mut value = serde_json::to_value(ConfigRoot::from(self.values.clone()))?;
+        let object = value
+            .as_object_mut()
+            .expect("ConfigRoot always serializes as a JSON object");
+        object.insert("memory".to_string(), serde_json::to_value(self.memory())?);
+        object.insert(
+            "subagents".to_string(),
+            serde_json::to_value(self.subagents())?,
+        );
+        object.insert(
+            "providers".to_string(),
+            serde_json::to_value(self.providers())?,
+        );
+        Ok(value)
+    }
+
     /// Load configuration from file with environment variable overrides
     ///
     /// Configuration loading order:
@@ -2238,25 +2707,25 @@ impl Config {
         // A malformed sidecar is never rewritten during load and the inline
         // value remains available, preventing a bad independent edit from
         // erasing the user's last usable configuration.
-        let mut memory_module = crate::MemoryConfigModule(config.memory.clone());
+        let mut memory_module = config.memory.clone();
         match memory_module.load_sync(&data_dir) {
-            Ok(true) => config.memory = memory_module.0,
+            Ok(true) => config.memory = memory_module,
             Ok(false) => {}
             Err(error) => tracing::warn!(
                 "Failed to load memory.json; using legacy config.json memory: {error}"
             ),
         }
-        let mut subagents_module = crate::SubagentsConfigModule(config.subagents.clone());
+        let mut subagents_module = config.subagents.clone();
         match subagents_module.load_sync(&data_dir) {
-            Ok(true) => config.subagents = subagents_module.0,
+            Ok(true) => config.subagents = subagents_module,
             Ok(false) => {}
             Err(error) => tracing::warn!(
                 "Failed to load subagents.json; using legacy config.json subagents: {error}"
             ),
         }
-        let mut providers_module = crate::ProviderConfigsModule(config.providers.clone());
+        let mut providers_module = config.providers.clone();
         match providers_module.load_sync(&data_dir) {
-            Ok(true) => config.providers = providers_module.0,
+            Ok(true) => config.providers = providers_module,
             Ok(false) => {}
             Err(error) => tracing::warn!(
                 "Failed to load providers.json; using legacy config.json providers: {error}"
@@ -2614,8 +3083,8 @@ impl Config {
         // if it parses, else a fresh default. This makes salvage >= the plain .bak
         // fallback in every case.
         let mut base = Self::load_backup(data_dir)
-            .and_then(|(backup, _generation)| serde_json::to_value(backup).ok())
-            .or_else(|| serde_json::to_value(Self::create_default()).ok())?;
+            .and_then(|(backup, _generation)| backup.to_compatibility_value().ok())
+            .or_else(|| Self::create_default().to_compatibility_value().ok())?;
         let base_obj = base.as_object_mut()?;
 
         let mut salvaged: Vec<String> = Vec::new();
@@ -3044,39 +3513,40 @@ impl Config {
 
     /// Create a default configuration without loading from file
     fn create_default() -> Self {
-        Config {
-            http_proxy: String::new(),
-            https_proxy: String::new(),
-            proxy_auth: None,
-            proxy_auth_encrypted: None,
-            headless_auth: false,
-            subagents: SubagentsConfig::default(),
-            run_budget: RunBudgetConfig::default(),
-            cluster_fabric: crate::cluster_fabric::ClusterFabricConfig::default(),
-            provider: default_provider(),
-            providers: ProviderConfigs::default(),
-            provider_instances: HashMap::new(),
-            default_provider_instance: None,
-            server: ServerConfig::default(),
-            keyword_masking: KeywordMaskingConfig::default(),
-            anthropic_model_mapping: AnthropicModelMapping::default(),
-            gemini_model_mapping: GeminiModelMapping::default(),
-            hooks: HooksConfig::default(),
-            tools: ToolsConfig::default(),
-            skills: SkillsConfig::default(),
-            env_vars: Vec::new(),
-            default_work_area: None,
-            access_control: None,
-            features: FeatureFlags::default(),
-            defaults: None,
-            memory: None,
-            mcp: bamboo_domain::mcp_config::McpConfig::default(),
-            notifications: NotificationsConfig::default(),
-            connect: ConnectConfig::default(),
-            plugin_trust: PluginTrustConfig::default(),
-            extra: BTreeMap::new(),
-            recovery_status: None,
-        }
+        Self::from_parts(
+            ConfigValues {
+                http_proxy: String::new(),
+                https_proxy: String::new(),
+                proxy_auth: None,
+                proxy_auth_encrypted: None,
+                headless_auth: false,
+                run_budget: RunBudgetConfig::default(),
+                cluster_fabric: crate::cluster_fabric::ClusterFabricConfig::default(),
+                provider: default_provider(),
+                provider_instances: HashMap::new(),
+                default_provider_instance: None,
+                server: ServerConfig::default(),
+                keyword_masking: KeywordMaskingConfig::default(),
+                anthropic_model_mapping: AnthropicModelMapping::default(),
+                gemini_model_mapping: GeminiModelMapping::default(),
+                hooks: HooksConfig::default(),
+                tools: ToolsConfig::default(),
+                skills: SkillsConfig::default(),
+                env_vars: Vec::new(),
+                default_work_area: None,
+                access_control: None,
+                features: FeatureFlags::default(),
+                defaults: None,
+                mcp: bamboo_domain::mcp_config::McpConfig::default(),
+                notifications: NotificationsConfig::default(),
+                connect: ConnectConfig::default(),
+                plugin_trust: PluginTrustConfig::default(),
+                extra: BTreeMap::new(),
+            },
+            None,
+            SubagentsConfig::default(),
+            ProviderConfigs::default(),
+        )
     }
 
     /// Get the full server address (bind:port)
@@ -3091,12 +3561,12 @@ impl Config {
 
     /// Persist only the memory module, leaving every other config file untouched.
     pub fn save_memory_to_dir(&self, data_dir: &std::path::Path) -> Result<()> {
-        crate::MemoryConfigModule(self.memory.clone()).save_sync(data_dir)
+        self.memory.save_sync(data_dir)
     }
 
     /// Persist only the sub-agent module, leaving every other config file untouched.
     pub fn save_subagents_to_dir(&self, data_dir: &std::path::Path) -> Result<()> {
-        crate::SubagentsConfigModule(self.subagents.clone()).save_sync(data_dir)
+        self.subagents.save_sync(data_dir)
     }
 
     /// Persist only provider configuration. Provider plaintext keys are first
@@ -3104,7 +3574,7 @@ impl Config {
     pub fn save_providers_to_dir(&self, data_dir: &std::path::Path) -> Result<()> {
         let mut config = self.clone();
         config.refresh_provider_api_keys_encrypted()?;
-        crate::ProviderConfigsModule(config.providers).save_sync(data_dir)
+        config.providers.save_sync(data_dir)
     }
 
     /// The pending config-corruption recovery, if `config.json` failed to
@@ -3217,13 +3687,10 @@ impl Config {
         // in-memory struct) — only the serialized DOCUMENT that becomes
         // config.json's bytes has the key stripped, and that's done on the
         // `serde_json::Value` here, not via `#[serde(skip)]` on the field.
-        let mut config_value =
-            serde_json::to_value(&to_save).context("Failed to serialize config to JSON")?;
+        let mut config_value = serde_json::to_value(ConfigRoot::from(to_save.values.clone()))
+            .context("Failed to serialize root config DTO to JSON")?;
         if let Some(obj) = config_value.as_object_mut() {
             obj.remove("connect");
-            obj.remove("memory");
-            obj.remove("subagents");
-            obj.remove("providers");
         }
         let content = serde_json::to_string_pretty(&config_value)
             .context("Failed to serialize config to JSON")?;
@@ -3234,9 +3701,9 @@ impl Config {
         // either the new sidecars or the untouched inline values. Do this before
         // rotating root backups so a sidecar error cannot consume backup history
         // for a root document that was never rewritten.
-        crate::MemoryConfigModule(to_save.memory.clone()).save_sync(&data_dir)?;
-        crate::SubagentsConfigModule(to_save.subagents.clone()).save_sync(&data_dir)?;
-        crate::ProviderConfigsModule(to_save.providers.clone()).save_sync(&data_dir)?;
+        to_save.memory.save_sync(&data_dir)?;
+        to_save.subagents.save_sync(&data_dir)?;
+        to_save.providers.save_sync(&data_dir)?;
 
         // Back up the current on-disk config (last-known-good) before overwriting,
         // so corruption (a bad/partial write, external edit, disk issue) stays
@@ -4218,25 +4685,23 @@ mod tests {
     #[test]
     fn publish_env_vars_updates_prompt_safe_snapshot_without_secret_values() {
         let _lock = crate::test_support::env_cache_lock_acquire();
-        let config = Config {
-            env_vars: vec![
-                EnvVarEntry {
-                    name: "SECRET_TOKEN".to_string(),
-                    value: "top-secret".to_string(),
-                    secret: true,
-                    value_encrypted: None,
-                    description: Some("Service token".to_string()),
-                },
-                EnvVarEntry {
-                    name: "API_BASE".to_string(),
-                    value: "https://internal.example".to_string(),
-                    secret: false,
-                    value_encrypted: None,
-                    description: Some("Internal API base".to_string()),
-                },
-            ],
-            ..Default::default()
-        };
+        let mut config = Config::default();
+        config.env_vars.extend([
+            EnvVarEntry {
+                name: "SECRET_TOKEN".to_string(),
+                value: "top-secret".to_string(),
+                secret: true,
+                value_encrypted: None,
+                description: Some("Service token".to_string()),
+            },
+            EnvVarEntry {
+                name: "API_BASE".to_string(),
+                value: "https://internal.example".to_string(),
+                secret: false,
+                value_encrypted: None,
+                description: Some("Internal API base".to_string()),
+            },
+        ]);
 
         config.publish_env_vars();
 
@@ -4278,17 +4743,15 @@ mod tests {
         let _lock = crate::test_support::env_cache_lock_acquire();
 
         // Seed the global cache with a marker "owned" by the live config.
-        Config {
-            env_vars: vec![EnvVarEntry {
-                name: "BAMBOO_CACHE_OWNER_40".to_string(),
-                value: "live".to_string(),
-                secret: false,
-                value_encrypted: None,
-                description: None,
-            }],
-            ..Default::default()
-        }
-        .publish_env_vars();
+        let mut live = Config::default();
+        live.env_vars.extend([EnvVarEntry {
+            name: "BAMBOO_CACHE_OWNER_40".to_string(),
+            value: "live".to_string(),
+            secret: false,
+            value_encrypted: None,
+            description: None,
+        }]);
+        live.publish_env_vars();
         assert_eq!(
             Config::current_env_vars()
                 .get("BAMBOO_CACHE_OWNER_40")
@@ -4462,6 +4925,60 @@ mod tests {
         assert_eq!(
             config.https_proxy, "https://kept-from-backup",
             "the backup baseline is preserved for fields not in (or invalid in) the corrupt file"
+        );
+    }
+
+    #[test]
+    fn salvage_preserves_legacy_inline_sidecars_from_backup_baseline() {
+        let temp = TempHome::new();
+        std::fs::write(
+            temp.path.join("config.json.bak"),
+            serde_json::json!({
+                "providers": {
+                    "anthropic": { "model": "claude-backup" }
+                },
+                "memory": {
+                    "auto_dream_enabled": true
+                },
+                "subagents": {
+                    "claude_code_model": "claude-code-backup"
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        assert!(!temp.path.join("providers.json").exists());
+        assert!(!temp.path.join("memory.json").exists());
+        assert!(!temp.path.join("subagents.json").exists());
+
+        let (salvaged, recovered_fields) = Config::salvage_partial(
+            r#"{"providers":"schema-invalid-provider-section"}"#,
+            &temp.path,
+        )
+        .expect("object-shaped corrupt config should be salvageable");
+
+        assert!(
+            recovered_fields.is_empty(),
+            "the schema-invalid provider field must not replace the backup baseline"
+        );
+        assert_eq!(
+            salvaged
+                .providers()
+                .anthropic
+                .as_ref()
+                .and_then(|provider| provider.model.as_deref()),
+            Some("claude-backup")
+        );
+        assert!(
+            salvaged
+                .memory()
+                .as_ref()
+                .expect("backup memory config survives")
+                .auto_dream_enabled
+        );
+        assert_eq!(
+            salvaged.subagents().claude_code_model.as_deref(),
+            Some("claude-code-backup")
         );
     }
 
@@ -5714,7 +6231,7 @@ mod tests {
             extra: BTreeMap::new(),
             api_key_from_env: false,
         });
-        config.memory = Some(MemoryConfig {
+        config.memory.0 = Some(MemoryConfig {
             background_model: Some("memory-fast".to_string()),
             ..MemoryConfig::default()
         });
@@ -5939,8 +6456,8 @@ mod tests {
 
     #[test]
     fn memory_config_preserves_auto_dream_dream_refine_and_prompt_flags() {
-        let config = Config {
-            memory: Some(MemoryConfig {
+        let legacy = serde_json::json!({
+            "memory": MemoryConfig {
                 background_model: Some("dream-fast".to_string()),
                 auto_dream_enabled: true,
                 auto_dream_interval_secs: 900,
@@ -5964,14 +6481,18 @@ mod tests {
                 memory_active_capacity: 500,
                 capacity_max_archivals_per_run: 10,
                 granularity_freshness_gardener_enabled: false,
-            }),
-            ..Config::default()
-        };
+            }
+        });
+        let config: Config = serde_json::from_value(legacy).unwrap();
 
-        let serialized = serde_json::to_string(&config).expect("config should serialize");
-        let roundtrip: Config =
-            serde_json::from_str(&serialized).expect("config should deserialize");
-        let memory = roundtrip.memory.expect("memory config should exist");
+        let serialized = serde_json::to_value(&config).expect("config should serialize");
+        assert!(serialized.get("memory").is_some());
+        let round_tripped: Config = serde_json::from_value(serialized).unwrap();
+        assert!(round_tripped
+            .memory()
+            .as_ref()
+            .is_some_and(|memory| memory.dream_refine_mode));
+        let memory = config.memory.as_ref().expect("memory config should exist");
         assert!(memory.auto_dream_enabled);
         assert!(!memory.project_prompt_injection);
         assert!(!memory.relevant_recall);
@@ -5997,7 +6518,7 @@ mod tests {
         assert_eq!(MemoryConfig::default().memory_active_capacity, 0);
         assert_eq!(MemoryConfig::default().capacity_max_archivals_per_run, 50);
         let parsed: Config = serde_json::from_str(r#"{"memory":{}}"#).expect("parse");
-        let memory = parsed.memory.unwrap();
+        let memory = parsed.memory.as_ref().unwrap();
         assert_eq!(memory.memory_active_capacity, 0);
         assert_eq!(
             memory.capacity_max_archivals_per_run, 50,
@@ -6018,7 +6539,7 @@ mod tests {
 
         // A config that mentions `memory` but omits the flags must still be ON.
         let parsed: Config = serde_json::from_str(r#"{"memory":{}}"#).expect("parse");
-        let memory = parsed.memory.expect("memory present");
+        let memory = parsed.memory.as_ref().expect("memory present");
         assert!(
             memory.auto_dream_enabled,
             "auto_dream on when field omitted"
@@ -6031,7 +6552,7 @@ mod tests {
         // An explicit opt-out is still honored.
         let opted_out: Config =
             serde_json::from_str(r#"{"memory":{"gardener_enabled":false}}"#).expect("parse");
-        assert!(!opted_out.memory.unwrap().gardener_enabled);
+        assert!(!opted_out.memory.as_ref().unwrap().gardener_enabled);
     }
 
     #[test]
@@ -6048,6 +6569,7 @@ mod tests {
         let config = Config::from_data_dir(Some(temp_home.path.clone()));
         let memory = config
             .memory
+            .as_ref()
             .expect("memory config should be created by env overrides");
         assert!(!memory.project_prompt_injection);
         assert!(!memory.relevant_recall);
@@ -6136,12 +6658,10 @@ mod tests {
         let target = temp_home.path.join("workspace-default");
         std::fs::create_dir_all(&target).expect("default work area dir should exist");
 
-        let config = Config {
-            default_work_area: Some(DefaultWorkAreaConfig {
-                path: Some("~/workspace-default".to_string()),
-            }),
-            ..Default::default()
-        };
+        let mut config = Config::default();
+        config.default_work_area.replace(DefaultWorkAreaConfig {
+            path: Some("~/workspace-default".to_string()),
+        });
 
         assert_eq!(config.get_default_work_area_path(), Some(target));
     }
@@ -6152,12 +6672,10 @@ mod tests {
         let temp_home = TempHome::new();
         let _home = EnvVarGuard::set("HOME", temp_home.path.to_string_lossy().as_ref());
 
-        let config = Config {
-            default_work_area: Some(DefaultWorkAreaConfig {
-                path: Some("~/missing-default-work-area".to_string()),
-            }),
-            ..Default::default()
-        };
+        let mut config = Config::default();
+        config.default_work_area.replace(DefaultWorkAreaConfig {
+            path: Some("~/missing-default-work-area".to_string()),
+        });
 
         assert!(config.get_default_work_area_path().is_none());
     }
@@ -6296,6 +6814,77 @@ mod tests {
     }
 
     #[test]
+    fn modular_root_and_public_serde_preserve_legacy_shape() {
+        let _lock = env_lock_acquire();
+        let temp_home = TempHome::new();
+        let input = serde_json::json!({
+            "http_proxy": "http://proxy.example",
+            "provider": "openai",
+            "mcp": { "servers": [] },
+            "future_extension": { "enabled": true },
+            "memory": { "background_model": "memory-model" },
+            "subagents": { "max_concurrent": 7 },
+            "providers": { "openai": { "model": "chat-model" } }
+        });
+
+        let config: Config = serde_json::from_value(input).unwrap();
+        let public = serde_json::to_value(&config).unwrap();
+        assert_eq!(public["http_proxy"], "http://proxy.example");
+        assert!(public.get("mcp").is_none());
+        assert!(public.get("mcpServers").is_some());
+        assert_eq!(public["future_extension"]["enabled"], true);
+        assert_eq!(public["memory"]["background_model"], "memory-model");
+        assert_eq!(public["subagents"]["max_concurrent"], 7);
+        assert_eq!(public["providers"]["openai"]["model"], "chat-model");
+
+        let round_tripped: Config = serde_json::from_value(public).unwrap();
+        assert_eq!(
+            round_tripped
+                .memory()
+                .as_ref()
+                .unwrap()
+                .background_model
+                .as_deref(),
+            Some("memory-model")
+        );
+        assert_eq!(round_tripped.subagents().max_concurrent, Some(7));
+        assert_eq!(
+            round_tripped
+                .providers()
+                .openai
+                .as_ref()
+                .unwrap()
+                .model
+                .as_deref(),
+            Some("chat-model")
+        );
+        assert_eq!(round_tripped.extra["future_extension"]["enabled"], true);
+
+        round_tripped.save_to_dir(temp_home.path.clone()).unwrap();
+        let persisted: Value =
+            serde_json::from_slice(&std::fs::read(temp_home.path.join("config.json")).unwrap())
+                .unwrap();
+        assert_eq!(persisted["http_proxy"], "http://proxy.example");
+        assert!(persisted.get("mcpServers").is_some());
+        assert_eq!(persisted["future_extension"]["enabled"], true);
+        assert!(persisted.get("memory").is_none());
+        assert!(persisted.get("subagents").is_none());
+        assert!(persisted.get("providers").is_none());
+        for internal_section_name in [
+            "network",
+            "provider_routing",
+            "model_behavior",
+            "tooling",
+            "workspace",
+            "execution",
+            "integrations",
+            "plugin_security",
+        ] {
+            assert!(persisted.get(internal_section_name).is_none());
+        }
+    }
+
+    #[test]
     fn config_decrypts_proxy_auth_from_encrypted_field() {
         let _lock = env_lock_acquire();
         let temp_home = TempHome::new();
@@ -6321,7 +6910,10 @@ mod tests {
 }}"#
         ));
         let config = Config::from_data_dir(Some(temp_home.path.clone()));
-        let loaded_auth = config.proxy_auth.expect("proxy auth should be hydrated");
+        let loaded_auth = config
+            .proxy_auth
+            .as_ref()
+            .expect("proxy auth should be hydrated");
         assert_eq!(loaded_auth.username, "user");
         assert_eq!(loaded_auth.password, "pass");
         drop(key_guard);
@@ -6356,7 +6948,10 @@ mod tests {
         ));
 
         let config = Config::from_data_dir(Some(temp_home.path.clone()));
-        let loaded_auth = config.proxy_auth.expect("proxy auth should be hydrated");
+        let loaded_auth = config
+            .proxy_auth
+            .as_ref()
+            .expect("proxy auth should be hydrated");
         assert_eq!(loaded_auth.username, "user");
         assert_eq!(loaded_auth.password, "pass");
         drop(key_guard);
@@ -6395,7 +6990,10 @@ mod tests {
         );
 
         let loaded = Config::from_data_dir(Some(temp_home.path.clone()));
-        let loaded_auth = loaded.proxy_auth.expect("proxy auth should be hydrated");
+        let loaded_auth = loaded
+            .proxy_auth
+            .as_ref()
+            .expect("proxy auth should be hydrated");
         assert_eq!(loaded_auth.username, "user");
         assert_eq!(loaded_auth.password, "pass");
         drop(key_guard);
@@ -6448,6 +7046,7 @@ mod tests {
         let openai = loaded
             .providers
             .openai
+            .as_ref()
             .expect("openai config should be present");
         assert_eq!(openai.api_key, "sk-test-provider-key");
 
@@ -6570,39 +7169,37 @@ mod tests {
 
     #[test]
     fn env_vars_as_map_includes_only_non_empty_values() {
-        let config = Config {
-            env_vars: vec![
-                EnvVarEntry {
-                    name: "A".to_string(),
-                    value: "val_a".to_string(),
-                    secret: false,
-                    value_encrypted: None,
-                    description: None,
-                },
-                EnvVarEntry {
-                    name: "B".to_string(),
-                    value: "".to_string(), // empty → should be excluded
-                    secret: true,
-                    value_encrypted: None,
-                    description: None,
-                },
-                EnvVarEntry {
-                    name: "C".to_string(),
-                    value: "  ".to_string(), // whitespace-only → excluded
-                    secret: false,
-                    value_encrypted: None,
-                    description: None,
-                },
-                EnvVarEntry {
-                    name: "D".to_string(),
-                    value: "val_d".to_string(),
-                    secret: true,
-                    value_encrypted: Some("enc".to_string()),
-                    description: Some("desc".to_string()),
-                },
-            ],
-            ..Default::default()
-        };
+        let mut config = Config::default();
+        config.env_vars.extend([
+            EnvVarEntry {
+                name: "A".to_string(),
+                value: "val_a".to_string(),
+                secret: false,
+                value_encrypted: None,
+                description: None,
+            },
+            EnvVarEntry {
+                name: "B".to_string(),
+                value: "".to_string(), // empty → should be excluded
+                secret: true,
+                value_encrypted: None,
+                description: None,
+            },
+            EnvVarEntry {
+                name: "C".to_string(),
+                value: "  ".to_string(), // whitespace-only → excluded
+                secret: false,
+                value_encrypted: None,
+                description: None,
+            },
+            EnvVarEntry {
+                name: "D".to_string(),
+                value: "val_d".to_string(),
+                secret: true,
+                value_encrypted: Some("enc".to_string()),
+                description: Some("desc".to_string()),
+            },
+        ]);
 
         let map = config.env_vars_as_map();
         assert_eq!(map.len(), 2);
@@ -6614,25 +7211,23 @@ mod tests {
 
     #[test]
     fn sanitize_env_vars_for_disk_clears_secret_plaintext() {
-        let mut config = Config {
-            env_vars: vec![
-                EnvVarEntry {
-                    name: "PLAIN".to_string(),
-                    value: "visible".to_string(),
-                    secret: false,
-                    value_encrypted: None,
-                    description: None,
-                },
-                EnvVarEntry {
-                    name: "SECRET".to_string(),
-                    value: "hidden_value".to_string(),
-                    secret: true,
-                    value_encrypted: Some("enc_data".to_string()),
-                    description: None,
-                },
-            ],
-            ..Default::default()
-        };
+        let mut config = Config::default();
+        config.env_vars.extend([
+            EnvVarEntry {
+                name: "PLAIN".to_string(),
+                value: "visible".to_string(),
+                secret: false,
+                value_encrypted: None,
+                description: None,
+            },
+            EnvVarEntry {
+                name: "SECRET".to_string(),
+                value: "hidden_value".to_string(),
+                secret: true,
+                value_encrypted: Some("enc_data".to_string()),
+                description: None,
+            },
+        ]);
 
         config.sanitize_env_vars_for_disk();
 
@@ -6642,25 +7237,23 @@ mod tests {
 
     #[test]
     fn sanitize_env_vars_for_disk_preserves_encrypted() {
-        let mut config = Config {
-            env_vars: vec![
-                EnvVarEntry {
-                    name: "OPEN".to_string(),
-                    value: "val".to_string(),
-                    secret: false,
-                    value_encrypted: None,
-                    description: None,
-                },
-                EnvVarEntry {
-                    name: "HIDDEN".to_string(),
-                    value: "real_secret".to_string(),
-                    secret: true,
-                    value_encrypted: Some("enc".to_string()),
-                    description: None,
-                },
-            ],
-            ..Default::default()
-        };
+        let mut config = Config::default();
+        config.env_vars.extend([
+            EnvVarEntry {
+                name: "OPEN".to_string(),
+                value: "val".to_string(),
+                secret: false,
+                value_encrypted: None,
+                description: None,
+            },
+            EnvVarEntry {
+                name: "HIDDEN".to_string(),
+                value: "real_secret".to_string(),
+                secret: true,
+                value_encrypted: Some("enc".to_string()),
+                description: None,
+            },
+        ]);
 
         config.sanitize_env_vars_for_disk();
 
@@ -6673,25 +7266,23 @@ mod tests {
 
     #[test]
     fn refresh_env_vars_encrypted_round_trip() {
-        let mut config = Config {
-            env_vars: vec![
-                EnvVarEntry {
-                    name: "TOKEN".to_string(),
-                    value: "my-secret-token".to_string(),
-                    secret: true,
-                    value_encrypted: None,
-                    description: Some("A token".to_string()),
-                },
-                EnvVarEntry {
-                    name: "PLAIN_VAR".to_string(),
-                    value: "hello".to_string(),
-                    secret: false,
-                    value_encrypted: None,
-                    description: None,
-                },
-            ],
-            ..Default::default()
-        };
+        let mut config = Config::default();
+        config.env_vars.extend([
+            EnvVarEntry {
+                name: "TOKEN".to_string(),
+                value: "my-secret-token".to_string(),
+                secret: true,
+                value_encrypted: None,
+                description: Some("A token".to_string()),
+            },
+            EnvVarEntry {
+                name: "PLAIN_VAR".to_string(),
+                value: "hello".to_string(),
+                secret: false,
+                value_encrypted: None,
+                description: None,
+            },
+        ]);
 
         // Encrypt
         config
@@ -6729,16 +7320,14 @@ mod tests {
         // the same race in the other direction. With the lock held, one
         // publish is deterministic.
         let _lock = crate::test_support::env_cache_lock_acquire();
-        let config = Config {
-            env_vars: vec![EnvVarEntry {
-                name: "TEST_PUBLISH".to_string(),
-                value: "pub_value".to_string(),
-                secret: false,
-                value_encrypted: None,
-                description: None,
-            }],
-            ..Default::default()
-        };
+        let mut config = Config::default();
+        config.env_vars.extend([EnvVarEntry {
+            name: "TEST_PUBLISH".to_string(),
+            value: "pub_value".to_string(),
+            secret: false,
+            value_encrypted: None,
+            description: None,
+        }]);
 
         config.publish_env_vars();
         assert_eq!(
@@ -6906,16 +7495,14 @@ mod tests {
 
     #[test]
     fn hydrate_skips_non_secret_entries() {
-        let mut config = Config {
-            env_vars: vec![EnvVarEntry {
-                name: "PLAIN".to_string(),
-                value: "original".to_string(),
-                secret: false,
-                value_encrypted: Some("should-be-ignored".to_string()),
-                description: None,
-            }],
-            ..Default::default()
-        };
+        let mut config = Config::default();
+        config.env_vars.extend([EnvVarEntry {
+            name: "PLAIN".to_string(),
+            value: "original".to_string(),
+            secret: false,
+            value_encrypted: Some("should-be-ignored".to_string()),
+            description: None,
+        }]);
 
         config.hydrate_env_vars_from_encrypted();
         // Non-secret entry should keep its original value
@@ -6933,25 +7520,23 @@ mod tests {
 
     #[test]
     fn serde_round_trip_with_env_vars() {
-        let config = Config {
-            env_vars: vec![
-                EnvVarEntry {
-                    name: "KEY1".to_string(),
-                    value: "val1".to_string(),
-                    secret: false,
-                    value_encrypted: None,
-                    description: Some("First key".to_string()),
-                },
-                EnvVarEntry {
-                    name: "KEY2".to_string(),
-                    value: "".to_string(), // on-disk secret has no plaintext
-                    secret: true,
-                    value_encrypted: Some("enc123".to_string()),
-                    description: None,
-                },
-            ],
-            ..Default::default()
-        };
+        let mut config = Config::default();
+        config.env_vars.extend([
+            EnvVarEntry {
+                name: "KEY1".to_string(),
+                value: "val1".to_string(),
+                secret: false,
+                value_encrypted: None,
+                description: Some("First key".to_string()),
+            },
+            EnvVarEntry {
+                name: "KEY2".to_string(),
+                value: "".to_string(), // on-disk secret has no plaintext
+                secret: true,
+                value_encrypted: Some("enc123".to_string()),
+                description: None,
+            },
+        ]);
 
         let json = serde_json::to_string(&config).unwrap();
         let restored: Config = serde_json::from_str(&json).unwrap();

--- a/crates/infra/bamboo-config/src/config_module.rs
+++ b/crates/infra/bamboo-config/src/config_module.rs
@@ -243,12 +243,12 @@ mod tests {
 
         let config = Config::from_data_dir_without_env(Some(dir.path().to_path_buf()));
         assert_eq!(
-            config.memory.unwrap().background_model.as_deref(),
+            config.memory.as_ref().unwrap().background_model.as_deref(),
             Some("sidecar")
         );
         assert_eq!(config.subagents.max_concurrent, Some(9));
         assert_eq!(
-            config.providers.openai.unwrap().model.as_deref(),
+            config.providers.openai.as_ref().unwrap().model.as_deref(),
             Some("sidecar")
         );
     }
@@ -274,7 +274,7 @@ mod tests {
             .collect();
 
         let mut changed = config;
-        changed.memory = Some(MemoryConfig {
+        changed.memory.0 = Some(MemoryConfig {
             background_model: Some("new-memory".into()),
             ..MemoryConfig::default()
         });
@@ -325,7 +325,7 @@ mod tests {
 
         let config = Config::from_data_dir_without_env(Some(dir.path().to_path_buf()));
         assert_eq!(
-            config.memory.unwrap().background_model.as_deref(),
+            config.memory.as_ref().unwrap().background_model.as_deref(),
             Some("recovered")
         );
         assert_eq!(
@@ -413,13 +413,11 @@ mod tests {
         // The independently persisted modules must already be durable so a
         // failed root rewrite cannot discard the migration source of truth.
         std::fs::create_dir(dir.path().join("config.json")).unwrap();
-        let config = Config {
-            memory: Some(MemoryConfig {
-                background_model: Some("durable-before-root".into()),
-                ..MemoryConfig::default()
-            }),
-            ..Config::default()
-        };
+        let mut config = Config::default();
+        config.memory.0 = Some(MemoryConfig {
+            background_model: Some("durable-before-root".into()),
+            ..MemoryConfig::default()
+        });
 
         assert!(config.save_to_dir(dir.path().to_path_buf()).is_err());
         let memory: MemoryConfig =

--- a/crates/infra/bamboo-config/src/dot_path.rs
+++ b/crates/infra/bamboo-config/src/dot_path.rs
@@ -5,7 +5,8 @@
 //! The flow is deliberately conservative — it never writes a config file it
 //! cannot fully re-read:
 //!
-//! 1. Serialize the current (hydrated, in-memory) [`Config`] to JSON.
+//! 1. Project the current (hydrated, in-memory) [`Config`] into its explicit
+//!    compatibility JSON view, including independently persisted modules.
 //! 2. Apply the dot-path assignment onto that JSON tree.
 //! 3. Deserialize the patched JSON back into the typed [`Config`] — a type
 //!    mismatch fails here with the offending key in the error.
@@ -97,10 +98,12 @@ pub fn apply_dot_path_set(
     }
     guard_reserved_paths(&segments, key)?;
 
-    let before = serde_json::to_value(current).map_err(|e| DotPathError::InvalidValue {
-        key: key.to_string(),
-        message: format!("failed to serialize current config: {e}"),
-    })?;
+    let before = current
+        .to_compatibility_value()
+        .map_err(|e| DotPathError::InvalidValue {
+            key: key.to_string(),
+            message: format!("failed to serialize current config: {e}"),
+        })?;
     let old_value = resolve_path(&before, &segments).cloned();
 
     let mut patched = before;
@@ -129,10 +132,12 @@ pub fn apply_dot_path_set(
     // legitimately move (`enabled` ⇄ `disabled`, transport flattening).
     let mcp_subtree = matches!(segments[0], "mcpServers" | "mcp");
     if !mcp_subtree {
-        let after = serde_json::to_value(&config).map_err(|e| DotPathError::InvalidValue {
-            key: key.to_string(),
-            message: format!("failed to serialize updated config: {e}"),
-        })?;
+        let after = config
+            .to_compatibility_value()
+            .map_err(|e| DotPathError::InvalidValue {
+                key: key.to_string(),
+                message: format!("failed to serialize updated config: {e}"),
+            })?;
         match resolve_path(&after, &segments) {
             Some(round_tripped) if values_equivalent(round_tripped, &value) => {}
             Some(round_tripped) => {
@@ -677,6 +682,17 @@ mod tests {
             cipher_before,
             "an unrelated generic set must not churn or drop the stored ciphertext"
         );
+
+        let config_json: Value = serde_json::from_slice(
+            &std::fs::read(data_dir.join("config.json")).expect("root config exists"),
+        )
+        .expect("root config is valid JSON");
+        for sidecar_key in ["memory", "subagents", "providers"] {
+            assert!(
+                config_json.get(sidecar_key).is_none(),
+                "compatibility projection must not persist {sidecar_key} in config.json"
+            );
+        }
 
         // And the key still decrypts after the round-trip.
         let reloaded = Config::from_data_dir_without_env(Some(data_dir));

--- a/crates/infra/bamboo-config/src/memory_config.rs
+++ b/crates/infra/bamboo-config/src/memory_config.rs
@@ -13,6 +13,19 @@ pub const FILE_NAME: &str = "memory.json";
 #[derive(Debug, Clone, Default)]
 pub struct MemoryConfigModule(pub Option<MemoryConfig>);
 
+impl std::ops::Deref for MemoryConfigModule {
+    type Target = Option<MemoryConfig>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for MemoryConfigModule {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl MemoryConfigModule {
     pub(crate) fn load_sync(&mut self, data_dir: &Path) -> Result<bool> {
         if let Some(value) = load_sidecar(&data_dir.join(FILE_NAME))? {

--- a/crates/infra/bamboo-config/src/patch.rs
+++ b/crates/infra/bamboo-config/src/patch.rs
@@ -2034,7 +2034,7 @@ mod tests {
     // `config_manager::build_merged_config` does around `deep_merge_json`,
     // minus the secret-specific composition (covered separately below).
     fn merge_and_deserialize(current: &Config, patch: Value) -> Config {
-        let mut merged = serde_json::to_value(current).unwrap();
+        let mut merged = current.to_compatibility_value().unwrap();
         deep_merge_json(&mut merged, patch);
         serde_json::from_value(merged).expect("merged config should deserialize")
     }

--- a/crates/infra/bamboo-config/src/provider_configs.rs
+++ b/crates/infra/bamboo-config/src/provider_configs.rs
@@ -13,6 +13,19 @@ pub const FILE_NAME: &str = "providers.json";
 #[derive(Debug, Clone, Default)]
 pub struct ProviderConfigsModule(pub ProviderConfigs);
 
+impl std::ops::Deref for ProviderConfigsModule {
+    type Target = ProviderConfigs;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ProviderConfigsModule {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl ProviderConfigsModule {
     pub(crate) fn load_sync(&mut self, data_dir: &Path) -> Result<bool> {
         if let Some(value) = load_sidecar(&data_dir.join(FILE_NAME))? {
@@ -20,12 +33,10 @@ impl ProviderConfigsModule {
             // usable as one loaded through Config::from_data_dir. Hydrate its
             // at-rest ciphertext here; the later Config-wide hydration pass is
             // intentionally idempotent for the compatibility path.
-            let mut config = Config {
-                providers: value,
-                ..Config::default()
-            };
+            let mut config = Config::default();
+            config.providers.0 = value;
             config.hydrate_provider_api_keys_from_encrypted();
-            self.0 = config.providers;
+            self.0 = config.providers.0.clone();
             return Ok(true);
         }
         Ok(false)
@@ -34,12 +45,10 @@ impl ProviderConfigsModule {
         // Provider fields keep plaintext only in memory. Make the module safe
         // to persist through ConfigRegistry directly, not only through
         // Config::save_to_dir's broader secret-refresh pass.
-        let mut config = Config {
-            providers: self.0.clone(),
-            ..Config::default()
-        };
+        let mut config = Config::default();
+        config.providers.0 = self.0.clone();
         config.refresh_provider_api_keys_encrypted()?;
-        save_sidecar_with_sanitized_backup(&data_dir.join(FILE_NAME), &config.providers)
+        save_sidecar_with_sanitized_backup(&data_dir.join(FILE_NAME), &config.providers.0)
     }
 }
 

--- a/crates/infra/bamboo-config/src/provider_instance.rs
+++ b/crates/infra/bamboo-config/src/provider_instance.rs
@@ -170,12 +170,7 @@ mod tests {
     /// `Config::default()` is in-memory only — no filesystem/env bleed — so the
     /// remaining fields come from clean defaults.)
     fn clean_test_config() -> Config {
-        Config {
-            providers: crate::config::ProviderConfigs::default(),
-            provider_instances: std::collections::HashMap::new(),
-            default_provider_instance: None,
-            ..Config::default()
-        }
+        Config::default()
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/subagents_config.rs
+++ b/crates/infra/bamboo-config/src/subagents_config.rs
@@ -13,6 +13,19 @@ pub const FILE_NAME: &str = "subagents.json";
 #[derive(Debug, Clone, Default)]
 pub struct SubagentsConfigModule(pub SubagentsConfig);
 
+impl std::ops::Deref for SubagentsConfigModule {
+    type Target = SubagentsConfig;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for SubagentsConfigModule {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl SubagentsConfigModule {
     pub(crate) fn load_sync(&mut self, data_dir: &Path) -> Result<bool> {
         if let Some(value) = load_sidecar(&data_dir.join(FILE_NAME))? {

--- a/crates/infra/bamboo-llm/src/http_client.rs
+++ b/crates/infra/bamboo-llm/src/http_client.rs
@@ -57,10 +57,8 @@ mod tests {
 
     #[test]
     fn proxy_attaches_no_proxy_loopback_list() {
-        let cfg = Config {
-            http_proxy: "http://proxy.example.com:8080".to_string(),
-            ..Default::default()
-        };
+        let mut cfg = Config::default();
+        cfg.http_proxy = "http://proxy.example.com:8080".to_string();
 
         let proxy = build_proxy(&cfg).unwrap().expect("proxy");
         let dbg = format!("{proxy:?}");

--- a/crates/infra/bamboo-llm/src/provider_factory.rs
+++ b/crates/infra/bamboo-llm/src/provider_factory.rs
@@ -47,7 +47,7 @@ pub async fn create_provider_by_name(
         "copilot" => {
             // Get headless_auth from providers.copilot config, with fallback to deprecated root field
             let headless_auth = config
-                .providers
+                .providers()
                 .copilot
                 .as_ref()
                 .map(|c| c.headless_auth)
@@ -59,7 +59,7 @@ pub async fn create_provider_by_name(
                 headless_auth,
             );
 
-            if let Some(copilot_cfg) = config.providers.copilot.as_ref() {
+            if let Some(copilot_cfg) = config.providers().copilot.as_ref() {
                 if !copilot_cfg.responses_only_models.is_empty() {
                     provider = provider
                         .with_responses_only_models(copilot_cfg.responses_only_models.clone());
@@ -87,7 +87,7 @@ pub async fn create_provider_by_name(
 
         "openai" => {
             let openai_config = config
-                .providers
+                .providers()
                 .openai
                 .as_ref()
                 .ok_or_else(|| LLMError::Auth("OpenAI configuration required".to_string()))?;
@@ -118,7 +118,7 @@ pub async fn create_provider_by_name(
 
         "anthropic" => {
             let anthropic_config =
-                config.providers.anthropic.as_ref().ok_or_else(|| {
+                config.providers().anthropic.as_ref().ok_or_else(|| {
                     LLMError::Auth("Anthropic configuration required".to_string())
                 })?;
 
@@ -150,7 +150,7 @@ pub async fn create_provider_by_name(
 
         "gemini" => {
             let gemini_config = config
-                .providers
+                .providers()
                 .gemini
                 .as_ref()
                 .ok_or_else(|| LLMError::Auth("Gemini configuration required".to_string()))?;
@@ -176,7 +176,7 @@ pub async fn create_provider_by_name(
 
         "bodhi" => {
             let bodhi_config = config
-                .providers
+                .providers()
                 .bodhi
                 .as_ref()
                 .ok_or_else(|| LLMError::Auth("Bodhi configuration required".to_string()))?;
@@ -218,7 +218,7 @@ pub fn validate_provider_config(config: &Config) -> Result<(), LLMError> {
 
         "openai" => {
             let openai_config = config
-                .providers
+                .providers()
                 .openai
                 .as_ref()
                 .ok_or_else(|| LLMError::Auth("OpenAI configuration required".to_string()))?;
@@ -232,7 +232,7 @@ pub fn validate_provider_config(config: &Config) -> Result<(), LLMError> {
 
         "anthropic" => {
             let anthropic_config =
-                config.providers.anthropic.as_ref().ok_or_else(|| {
+                config.providers().anthropic.as_ref().ok_or_else(|| {
                     LLMError::Auth("Anthropic configuration required".to_string())
                 })?;
 
@@ -245,7 +245,7 @@ pub fn validate_provider_config(config: &Config) -> Result<(), LLMError> {
 
         "gemini" => {
             let gemini_config = config
-                .providers
+                .providers()
                 .gemini
                 .as_ref()
                 .ok_or_else(|| LLMError::Auth("Gemini configuration required".to_string()))?;
@@ -259,7 +259,7 @@ pub fn validate_provider_config(config: &Config) -> Result<(), LLMError> {
 
         "bodhi" => {
             let bodhi_config = config
-                .providers
+                .providers()
                 .bodhi
                 .as_ref()
                 .ok_or_else(|| LLMError::Auth("Bodhi configuration required".to_string()))?;
@@ -283,13 +283,16 @@ mod tests {
     use super::*;
     use bamboo_config::{AnthropicConfig, GeminiConfig, OpenAIConfig, ProviderConfigs};
 
+    fn config_with_provider(provider: &str, providers: ProviderConfigs) -> Config {
+        let mut config = Config::default();
+        config.provider = provider.to_string();
+        *config.providers_mut() = providers;
+        config
+    }
+
     #[tokio::test]
     async fn test_create_copilot_provider() {
-        let config = Config {
-            provider: "copilot".to_string(),
-            providers: ProviderConfigs::default(),
-            ..Config::default()
-        };
+        let config = config_with_provider("copilot", ProviderConfigs::default());
 
         let result = create_provider(&config).await;
         assert!(result.is_ok());
@@ -297,11 +300,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_openai_provider_without_config() {
-        let config = Config {
-            provider: "openai".to_string(),
-            providers: ProviderConfigs::default(),
-            ..Config::default()
-        };
+        let config = config_with_provider("openai", ProviderConfigs::default());
 
         let result = create_provider(&config).await;
         assert!(result.is_err());
@@ -315,9 +314,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_openai_provider_with_empty_key() {
-        let config = Config {
-            provider: "openai".to_string(),
-            providers: ProviderConfigs {
+        let config = config_with_provider(
+            "openai",
+            ProviderConfigs {
                 openai: Some(OpenAIConfig {
                     api_key: "".to_string(),
                     api_key_from_env: false,
@@ -333,8 +332,7 @@ mod tests {
                 }),
                 ..ProviderConfigs::default()
             },
-            ..Config::default()
-        };
+        );
 
         let result = create_provider(&config).await;
         assert!(result.is_err());
@@ -348,9 +346,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_openai_provider_success() {
-        let config = Config {
-            provider: "openai".to_string(),
-            providers: ProviderConfigs {
+        let config = config_with_provider(
+            "openai",
+            ProviderConfigs {
                 openai: Some(OpenAIConfig {
                     api_key: "sk-test123".to_string(),
                     api_key_from_env: false,
@@ -366,8 +364,7 @@ mod tests {
                 }),
                 ..ProviderConfigs::default()
             },
-            ..Config::default()
-        };
+        );
 
         let result = create_provider(&config).await;
         assert!(result.is_ok());
@@ -375,9 +372,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_anthropic_provider_success() {
-        let config = Config {
-            provider: "anthropic".to_string(),
-            providers: ProviderConfigs {
+        let config = config_with_provider(
+            "anthropic",
+            ProviderConfigs {
                 anthropic: Some(AnthropicConfig {
                     api_key: "sk-ant-test123".to_string(),
                     api_key_from_env: false,
@@ -394,8 +391,7 @@ mod tests {
                 }),
                 ..ProviderConfigs::default()
             },
-            ..Config::default()
-        };
+        );
 
         let result = create_provider(&config).await;
         assert!(result.is_ok());
@@ -403,9 +399,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_gemini_provider_success() {
-        let config = Config {
-            provider: "gemini".to_string(),
-            providers: ProviderConfigs {
+        let config = config_with_provider(
+            "gemini",
+            ProviderConfigs {
                 gemini: Some(GeminiConfig {
                     api_key: "AIza-test123".to_string(),
                     api_key_from_env: false,
@@ -420,8 +416,7 @@ mod tests {
                 }),
                 ..ProviderConfigs::default()
             },
-            ..Config::default()
-        };
+        );
 
         let result = create_provider(&config).await;
         assert!(result.is_ok());
@@ -429,11 +424,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_unknown_provider() {
-        let config = Config {
-            provider: "unknown".to_string(),
-            providers: ProviderConfigs::default(),
-            ..Config::default()
-        };
+        let config = config_with_provider("unknown", ProviderConfigs::default());
 
         let result = create_provider(&config).await;
         assert!(result.is_err());
@@ -447,22 +438,14 @@ mod tests {
 
     #[test]
     fn test_validate_copilot_config() {
-        let config = Config {
-            provider: "copilot".to_string(),
-            providers: ProviderConfigs::default(),
-            ..Config::default()
-        };
+        let config = config_with_provider("copilot", ProviderConfigs::default());
 
         assert!(validate_provider_config(&config).is_ok());
     }
 
     #[test]
     fn test_validate_openai_config_missing() {
-        let config = Config {
-            provider: "openai".to_string(),
-            providers: ProviderConfigs::default(),
-            ..Config::default()
-        };
+        let config = config_with_provider("openai", ProviderConfigs::default());
 
         let result = validate_provider_config(&config);
         assert!(result.is_err());

--- a/crates/infra/bamboo-llm/src/provider_registry.rs
+++ b/crates/infra/bamboo-llm/src/provider_registry.rs
@@ -353,9 +353,10 @@ impl ProviderRegistry {
 /// Project an instance's credentials into the legacy `Config` provider slots
 /// so that `create_provider_by_name` can consume them.
 fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConfig) {
+    let providers = config.providers_mut();
     match instance.provider_type.as_str() {
         "openai" => {
-            config.providers.openai = Some(bamboo_config::OpenAIConfig {
+            providers.openai = Some(bamboo_config::OpenAIConfig {
                 api_key: instance.api_key.clone(),
                 // Key comes from the provider instance, not a BAMBOO_*_API_KEY env
                 // override, so it may be persisted normally. #253.
@@ -372,7 +373,7 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
             });
         }
         "anthropic" => {
-            config.providers.anthropic = Some(bamboo_config::AnthropicConfig {
+            providers.anthropic = Some(bamboo_config::AnthropicConfig {
                 api_key: instance.api_key.clone(),
                 // Key comes from the provider instance, not a BAMBOO_*_API_KEY env
                 // override, so it may be persisted normally. #253.
@@ -397,7 +398,7 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
             });
         }
         "gemini" => {
-            config.providers.gemini = Some(bamboo_config::GeminiConfig {
+            providers.gemini = Some(bamboo_config::GeminiConfig {
                 api_key: instance.api_key.clone(),
                 // Key comes from the provider instance, not a BAMBOO_*_API_KEY env
                 // override, so it may be persisted normally. #253.
@@ -414,8 +415,8 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
         }
         "copilot" => {
             // Copilot uses device auth; just set the model overrides.
-            let existing = config.providers.copilot.take();
-            config.providers.copilot = Some(bamboo_config::CopilotConfig {
+            let existing = providers.copilot.take();
+            providers.copilot = Some(bamboo_config::CopilotConfig {
                 enabled: true,
                 headless_auth: existing.as_ref().map(|c| c.headless_auth).unwrap_or(false),
                 model: instance.model.clone(),
@@ -428,7 +429,7 @@ fn apply_instance_to_config(config: &mut Config, instance: &ProviderInstanceConf
             });
         }
         "bodhi" => {
-            config.providers.bodhi = Some(bamboo_config::BodhiConfig {
+            providers.bodhi = Some(bamboo_config::BodhiConfig {
                 api_key: instance.api_key.clone(),
                 api_key_encrypted: instance.api_key_encrypted.clone(),
                 base_url: instance.base_url.clone(),
@@ -463,25 +464,25 @@ fn provider_is_configured(config: &Config, name: &str) -> bool {
     match name {
         "copilot" => true, // Copilot can be attempted without explicit config
         "openai" => config
-            .providers
+            .providers()
             .openai
             .as_ref()
             .map(|c| !c.api_key.is_empty())
             .unwrap_or(false),
         "anthropic" => config
-            .providers
+            .providers()
             .anthropic
             .as_ref()
             .map(|c| !c.api_key.is_empty())
             .unwrap_or(false),
         "gemini" => config
-            .providers
+            .providers()
             .gemini
             .as_ref()
             .map(|c| !c.api_key.is_empty())
             .unwrap_or(false),
         "bodhi" => config
-            .providers
+            .providers()
             .bodhi
             .as_ref()
             .map(|c| !c.api_key.is_empty())
@@ -513,12 +514,10 @@ mod tests {
 
     #[test]
     fn test_provider_is_configured() {
-        let config = Config {
-            providers: bamboo_config::ProviderConfigs {
-                openai: Some(test_openai_config()),
-                ..bamboo_config::ProviderConfigs::default()
-            },
-            ..Config::default()
+        let mut config = Config::default();
+        *config.providers_mut() = bamboo_config::ProviderConfigs {
+            openai: Some(test_openai_config()),
+            ..bamboo_config::ProviderConfigs::default()
         };
 
         assert!(provider_is_configured(&config, "copilot"));
@@ -529,16 +528,14 @@ mod tests {
 
     #[test]
     fn test_provider_is_configured_empty_key() {
-        let config = Config {
-            providers: bamboo_config::ProviderConfigs {
-                openai: Some(OpenAIConfig {
-                    api_key: String::new(),
-                    api_key_from_env: false,
-                    ..test_openai_config()
-                }),
-                ..bamboo_config::ProviderConfigs::default()
-            },
-            ..Config::default()
+        let mut config = Config::default();
+        *config.providers_mut() = bamboo_config::ProviderConfigs {
+            openai: Some(OpenAIConfig {
+                api_key: String::new(),
+                api_key_from_env: false,
+                ..test_openai_config()
+            }),
+            ..bamboo_config::ProviderConfigs::default()
         };
 
         assert!(!provider_is_configured(&config, "openai"));
@@ -610,7 +607,7 @@ mod tests {
         apply_instance_to_config(&mut config, &instance);
 
         let openai = config
-            .providers
+            .providers()
             .openai
             .as_ref()
             .expect("openai should be set");
@@ -653,7 +650,7 @@ mod tests {
         apply_instance_to_config(&mut config, &instance);
 
         let anthropic = config
-            .providers
+            .providers()
             .anthropic
             .as_ref()
             .expect("anthropic should be set");
@@ -685,7 +682,7 @@ mod tests {
         apply_instance_to_config(&mut config, &instance);
 
         let anthropic = config
-            .providers
+            .providers()
             .anthropic
             .as_ref()
             .expect("anthropic should be set");

--- a/crates/infra/bamboo-mcp/src/manager/tests.rs
+++ b/crates/infra/bamboo-mcp/src/manager/tests.rs
@@ -313,10 +313,8 @@ fn test_proxy_fingerprint_changes_on_proxy_or_auth_change() {
 async fn test_sse_transport_respects_proxy_settings_when_available() {
     // If the manager has access to global config, SSE client creation should
     // fail early when proxy URL is invalid (proving it attempted to apply proxy).
-    let cfg = Config {
-        http_proxy: "http://".to_string(), // invalid URL
-        ..Config::default()
-    };
+    let mut cfg = Config::default();
+    cfg.http_proxy = "http://".to_string(); // invalid URL
     let manager = McpServerManager::new_with_config(Arc::new(tokio::sync::RwLock::new(cfg)));
 
     let server = McpServerConfig {

--- a/src/actor_cli.rs
+++ b/src/actor_cli.rs
@@ -497,10 +497,8 @@ mod tests {
     /// the configured default provider.
     #[test]
     fn resolve_model_colon_form() {
-        let config = Config {
-            provider: "anthropic".into(),
-            ..Config::default()
-        };
+        let mut config = Config::default();
+        config.provider = "anthropic".into();
         let m = resolve_model(&some("openai:gpt-4o"), &config)
             .unwrap()
             .unwrap();
@@ -512,10 +510,8 @@ mod tests {
     /// grammar `bamboo -p -m` uses (#246).
     #[test]
     fn resolve_model_bare_uses_config_default_provider() {
-        let config = Config {
-            provider: "openai".into(),
-            ..Config::default()
-        };
+        let mut config = Config::default();
+        config.provider = "openai".into();
         let m = resolve_model(&some("gpt-4o"), &config).unwrap().unwrap();
         assert_eq!(m.provider, "openai");
         assert_eq!(m.model, "gpt-4o");
@@ -542,13 +538,11 @@ mod tests {
     /// No `--model` falls back to `defaults.sub_agent`, then `defaults.chat`.
     #[test]
     fn resolve_model_falls_back_to_defaults_sub_agent() {
-        let config = Config {
-            defaults: Some(defaults_config(
-                ("anthropic", "claude-x"),
-                Some(("openai", "gpt-sub")),
-            )),
-            ..Config::default()
-        };
+        let mut config = Config::default();
+        config.defaults = Some(defaults_config(
+            ("anthropic", "claude-x"),
+            Some(("openai", "gpt-sub")),
+        ));
         let m = resolve_model(&None, &config).unwrap().unwrap();
         assert_eq!(m.provider, "openai");
         assert_eq!(m.model, "gpt-sub");
@@ -557,10 +551,8 @@ mod tests {
     /// No `--model` and no `defaults.sub_agent` falls back to `defaults.chat`.
     #[test]
     fn resolve_model_falls_back_to_defaults_chat() {
-        let config = Config {
-            defaults: Some(defaults_config(("anthropic", "claude-x"), None)),
-            ..Config::default()
-        };
+        let mut config = Config::default();
+        config.defaults = Some(defaults_config(("anthropic", "claude-x"), None));
         let m = resolve_model(&None, &config).unwrap().unwrap();
         assert_eq!(m.provider, "anthropic");
         assert_eq!(m.model, "claude-x");
@@ -570,10 +562,8 @@ mod tests {
     /// whether that's fatal).
     #[test]
     fn resolve_model_none_when_nothing_configured() {
-        let config = Config {
-            defaults: None,
-            ..Config::default()
-        };
+        let mut config = Config::default();
+        config.defaults = None;
         assert_eq!(resolve_model(&None, &config).unwrap(), None);
     }
 

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -2072,7 +2072,9 @@ fn serialize_config_for_cli(
     config.refresh_mcp_secrets_encrypted()?;
     config.normalize_tool_settings();
 
-    let mut value = serde_json::to_value(&config)?;
+    // CLI output and public Config serde retain the full compatibility view.
+    // Only save_to_dir persists a root DTO that excludes sidecar domains.
+    let mut value = config.to_compatibility_value()?;
     if !show_secrets {
         value = bamboo_agent::server::handlers::settings::redact_config_for_api(value, &config);
     }
@@ -2147,7 +2149,7 @@ mod tests {
             username: "alice".to_string(),
             password: "secret".to_string(),
         });
-        config.providers = ProviderConfigs {
+        *config.providers_mut() = ProviderConfigs {
             openai: Some(OpenAIConfig {
                 api_key: "sk-cli-secret".to_string(),
                 api_key_from_env: false,

--- a/src/commands/keyword_masking.rs
+++ b/src/commands/keyword_masking.rs
@@ -23,7 +23,7 @@ pub async fn get_keyword_masking_config() -> Result<KeywordMaskingResponse, Stri
     let config = Config::new();
 
     Ok(KeywordMaskingResponse {
-        entries: config.keyword_masking.entries,
+        entries: config.keyword_masking.entries.clone(),
     })
 }
 

--- a/src/setup_cli.rs
+++ b/src/setup_cli.rs
@@ -262,7 +262,7 @@ pub fn run_config_set(
                 bail!("api_key must not be empty");
             }
             config
-                .providers
+                .providers_mut()
                 .bodhi
                 .get_or_insert_with(empty_provider)
                 .api_key = v.to_string();
@@ -436,21 +436,21 @@ fn set_provider_api_key(config: &mut Config, provider: &str, key: &str) -> Resul
     match provider {
         "anthropic" => {
             config
-                .providers
+                .providers_mut()
                 .anthropic
                 .get_or_insert_with(empty_provider)
                 .api_key = key.to_string()
         }
         "openai" => {
             config
-                .providers
+                .providers_mut()
                 .openai
                 .get_or_insert_with(empty_provider)
                 .api_key = key.to_string()
         }
         "gemini" => {
             config
-                .providers
+                .providers_mut()
                 .gemini
                 .get_or_insert_with(empty_provider)
                 .api_key = key.to_string()
@@ -465,21 +465,21 @@ fn set_provider_model(config: &mut Config, provider: &str, model: &str) -> Resul
     match provider {
         "anthropic" => {
             config
-                .providers
+                .providers_mut()
                 .anthropic
                 .get_or_insert_with(empty_provider)
                 .model = model
         }
         "openai" => {
             config
-                .providers
+                .providers_mut()
                 .openai
                 .get_or_insert_with(empty_provider)
                 .model = model
         }
         "gemini" => {
             config
-                .providers
+                .providers_mut()
                 .gemini
                 .get_or_insert_with(empty_provider)
                 .model = model
@@ -500,28 +500,28 @@ fn provider_credential_status(config: &Config, provider: &str) -> CredentialStat
     match provider {
         "anthropic" => key_status(
             config
-                .providers
+                .providers()
                 .anthropic
                 .as_ref()
                 .map(|c| (c.api_key.as_str(), c.api_key_encrypted.as_deref())),
         ),
         "openai" => key_status(
             config
-                .providers
+                .providers()
                 .openai
                 .as_ref()
                 .map(|c| (c.api_key.as_str(), c.api_key_encrypted.as_deref())),
         ),
         "gemini" => key_status(
             config
-                .providers
+                .providers()
                 .gemini
                 .as_ref()
                 .map(|c| (c.api_key.as_str(), c.api_key_encrypted.as_deref())),
         ),
         "bodhi" => key_status(
             config
-                .providers
+                .providers()
                 .bodhi
                 .as_ref()
                 .map(|c| (c.api_key.as_str(), c.api_key_encrypted.as_deref())),
@@ -677,13 +677,13 @@ mod tests {
         let mut config = default_config();
         set_provider_api_key(&mut config, "anthropic", "sk-ant-xyz").unwrap();
         set_provider_model(&mut config, "anthropic", "claude-x").unwrap();
-        let a = config.providers.anthropic.as_ref().unwrap();
+        let a = config.providers().anthropic.as_ref().unwrap();
         assert_eq!(a.api_key, "sk-ant-xyz");
         assert_eq!(a.model.as_deref(), Some("claude-x"));
 
         // Setting the model again must not wipe the key.
         set_provider_model(&mut config, "anthropic", "claude-y").unwrap();
-        let a = config.providers.anthropic.as_ref().unwrap();
+        let a = config.providers().anthropic.as_ref().unwrap();
         assert_eq!(a.api_key, "sk-ant-xyz");
         assert_eq!(a.model.as_deref(), Some("claude-y"));
     }
@@ -789,7 +789,7 @@ mod tests {
 
         let reloaded = Config::from_data_dir_without_env(Some(data_dir));
         assert_eq!(
-            reloaded.providers.anthropic.as_ref().unwrap().api_key,
+            reloaded.providers().anthropic.as_ref().unwrap().api_key,
             "sk-ant-setupcli-secret",
             "the stored key must still decrypt after a generic set"
         );

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -475,8 +475,8 @@ impl BambooRuntimeExecutor {
                 // found via `current_exe()` inside build_local_actor_runner.
                 {
                     let mut cfg = config_for_stack.write().await;
-                    if cfg.subagents.fabric_dir.is_none() {
-                        cfg.subagents.fabric_dir = Some(spec.fabric_dir.clone());
+                    if cfg.subagents().fabric_dir.is_none() {
+                        cfg.subagents_mut().fabric_dir = Some(spec.fabric_dir.clone());
                     }
                 }
                 let external_runner = {
@@ -1196,7 +1196,11 @@ mod tests {
         )
         .unwrap();
         assert_eq!(config.provider, "anthropic");
-        let slot = config.providers.anthropic.expect("anthropic slot");
+        let slot = config
+            .providers()
+            .anthropic
+            .as_ref()
+            .expect("anthropic slot");
         assert_eq!(slot.api_key, "sk-test");
         assert_eq!(slot.model.as_deref(), Some("claude-test"));
     }
@@ -1208,7 +1212,7 @@ mod tests {
             build_isolated_config("openai", spec.secrets.provider_credentials.first(), &spec)
                 .unwrap();
         assert_eq!(config.provider, "openai");
-        let slot = config.providers.openai.expect("openai slot");
+        let slot = config.providers().openai.as_ref().expect("openai slot");
         assert_eq!(slot.api_key, "sk-oa");
     }
 

--- a/tests/config_comprehensive.rs
+++ b/tests/config_comprehensive.rs
@@ -251,9 +251,9 @@ mod comprehensive_config_tests {
         assert_eq!(config.http_proxy, "http://proxy:8080");
         assert_eq!(config.https_proxy, "https://proxy:8443");
         assert_eq!(config.provider, "openai");
-        assert!(config.providers.openai.is_some());
-        assert!(config.providers.anthropic.is_some());
-        assert!(config.providers.copilot.is_some());
+        assert!(config.providers().openai.is_some());
+        assert!(config.providers().anthropic.is_some());
+        assert!(config.providers().copilot.is_some());
         assert_eq!(config.server.port, 9999);
         assert_eq!(config.server.bind, "0.0.0.0");
         assert_eq!(config.server.workers, 16);
@@ -267,7 +267,7 @@ mod comprehensive_config_tests {
 
         let mut original = Config::from_data_dir(Some(temp.path.clone()));
         original.provider = "anthropic".to_string();
-        original.providers.anthropic = Some(bamboo_config::AnthropicConfig {
+        original.providers_mut().anthropic = Some(bamboo_config::AnthropicConfig {
             api_key: String::new(),
             api_key_from_env: false,
             api_key_encrypted: None,
@@ -291,7 +291,7 @@ mod comprehensive_config_tests {
         assert_eq!(loaded.provider, "anthropic");
         assert_eq!(
             loaded
-                .providers
+                .providers()
                 .anthropic
                 .as_ref()
                 .and_then(|c| c.model.as_deref()),
@@ -432,8 +432,8 @@ mod comprehensive_config_tests {
         let config = Config::new();
 
         // Provider config should be available
-        assert!(config.providers.copilot.is_some());
-        let copilot = config.providers.copilot.unwrap();
+        assert!(config.providers().copilot.is_some());
+        let copilot = config.providers().copilot.as_ref().unwrap();
         assert!(copilot.headless_auth);
     }
 }

--- a/tests/e2e/sessions/mod.rs
+++ b/tests/e2e/sessions/mod.rs
@@ -31,5 +31,5 @@ async fn configure_openai_defaults(
 ) {
     let mut config = state.config.write().await;
     config.provider = "openai".to_string();
-    config.providers.openai = Some(openai_config_with(model, reasoning_effort));
+    config.providers_mut().openai = Some(openai_config_with(model, reasoning_effort));
 }


### PR DESCRIPTION
## Summary

- migrate workspace consumers of `Config.memory`, `Config.subagents`, and `Config.providers` to typed accessors backed by independently persisted modules
- reduce runtime `Config` from the #39 baseline of 31 fields to 5 (83.9%)
- reduce the actual `config.json` persistence DTO to 9 fields (8 flattened sections plus `extra`, 71.0%) while preserving the historical top-level JSON shape
- keep public `Config` serde compatible with legacy inline `memory` / `subagents` / `providers`, while `save_to_dir` writes those domains only to their sidecars
- preserve sidecar-first migration, provider-secret encryption, sanitized backups, settings/CLI/patch compatibility, and the original public `ConfigModule` trait contract
- add exhaustive conversion and counted-struct guards so future fields cannot silently escape persistence or make the field budget drift

Closes #590

## Test Plan

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p bamboo-config --all-targets -- -D warnings`
- `cargo test -p bamboo-config -- --test-threads=1` — 298 passed
- `cargo test -p bamboo-server handlers::settings -- --test-threads=1` — 247 passed
- `cargo test --bin bamboo config_ -- --test-threads=1` — 7 passed
- `cargo build --workspace --tests`
- `cargo test --workspace -- --test-threads=1` — all affected/config suites passed; the existing macOS OpenSSL fixture `server::tls::tests::build_rustls_config_succeeds_on_valid_self_signed_cert` remains the sole failure (`UnsupportedCertVersion`, 1423/1424 bamboo-server lib tests passed)

## Screenshots

Not applicable — backend configuration architecture only.