### PR TITLE
refactor(skills): unify workflow catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,6 +1446,7 @@ dependencies = [
  "bamboo-config",
  "bamboo-domain",
  "bamboo-infrastructure",
+ "notify",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1454,6 +1455,7 @@ dependencies = [
  "tokio",
  "tracing",
  "walkdir",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2920,6 +2922,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3696,6 +3707,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags 2.13.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3807,6 +3838,26 @@ checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
 dependencies = [
  "crypto-common 0.2.2",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
 ]
 
 [[package]]
@@ -4255,6 +4306,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4266,6 +4335,15 @@ dependencies = [
  "serde",
  "tauri-winrt-notification",
  "zbus",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -7779,7 +7857,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7788,7 +7866,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -7809,11 +7896,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -7856,6 +7960,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7866,6 +7976,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7880,10 +7996,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7898,6 +8026,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7908,6 +8042,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7922,6 +8062,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7932,6 +8078,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/crates/app/bamboo-server-tools/src/skill_runtime/load_skill.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/load_skill.rs
@@ -78,19 +78,13 @@ impl Tool for LoadSkillTool {
             .map_err(skill_access_error_to_tool_error)?;
         let skill_mode = access_control::selected_skill_mode(&self.access, ctx.session_id()).await;
 
-        let skill = self
-            .access
-            .skill_manager
-            .store()
-            .get_skill_for_mode(skill_id, skill_mode.as_deref())
+        let store = self.access.skill_store(ctx.session_id()).await?;
+        let (skill, skill_root) = store
+            .get_skill_with_root_for_mode(skill_id, skill_mode.as_deref())
             .await
             .map_err(|err| {
                 ToolError::Execution(format!("Failed to load skill '{skill_id}': {err}"))
             })?;
-        let skill_root = self
-            .access
-            .skill_root(skill_id, skill_mode.as_deref())
-            .await?;
         let resources = list_skill_resource_paths(&skill_root).map_err(|err| {
             ToolError::Execution(format!("Failed to list skill resources: {err}"))
         })?;

--- a/crates/app/bamboo-server-tools/src/skill_runtime/mod.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/mod.rs
@@ -7,7 +7,7 @@ use tokio::sync::RwLock;
 
 use bamboo_llm::Config;
 use bamboo_skills::access_control::{SkillAccessError, SkillSessionPort};
-use bamboo_skills::SkillManager;
+use bamboo_skills::{SkillManager, SkillStore};
 
 use bamboo_agent_core::tools::ToolError;
 use bamboo_agent_core::Session;
@@ -51,12 +51,39 @@ impl SkillToolAccess {
         &self,
         skill_id: &str,
         skill_mode: Option<&str>,
+        session_id: Option<&str>,
     ) -> Result<PathBuf, ToolError> {
-        self.skill_manager
-            .store()
+        self.skill_store(session_id)
+            .await?
             .get_skill_root_for_mode(skill_id, skill_mode)
             .await
             .map_err(|err| ToolError::Execution(format!("Failed to resolve skill root: {err}")))
+    }
+
+    pub(super) async fn skill_store(
+        &self,
+        session_id: Option<&str>,
+    ) -> Result<Arc<SkillStore>, ToolError> {
+        let session_id = session_id.ok_or_else(|| {
+            ToolError::Execution(
+                "Skill runtime tools require a session_id in tool context".to_string(),
+            )
+        })?;
+        let session = self
+            .session_for_context(Some(session_id))
+            .await
+            .ok_or_else(|| {
+                ToolError::Execution(format!(
+                    "Session '{session_id}' not found while resolving skill workspace"
+                ))
+            })?;
+        let workspace = session.workspace_path_meta().map(PathBuf::from);
+        self.skill_manager
+            .store_for_workspace(workspace.as_deref())
+            .await
+            .map_err(|error| {
+                ToolError::Execution(format!("Failed to resolve session skill store: {error}"))
+            })
     }
 }
 

--- a/crates/app/bamboo-server-tools/src/skill_runtime/read_resource.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/read_resource.rs
@@ -113,7 +113,7 @@ impl Tool for ReadSkillResourceTool {
 
         let skill_root = self
             .access
-            .skill_root(skill_id, skill_mode.as_deref())
+            .skill_root(skill_id, skill_mode.as_deref(), ctx.session_id())
             .await?;
         let canonical_root = tokio::fs::canonicalize(&skill_root).await.map_err(|_| {
             ToolError::Execution(format!(

--- a/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use bamboo_agent_core::storage::Storage;
-use bamboo_agent_core::tools::{Tool, ToolExecutionContext};
+use bamboo_agent_core::tools::{Tool, ToolExecutionContext, ToolOutcome};
 use bamboo_agent_core::Session;
 use bamboo_llm::Config;
 use bamboo_skills::{SkillManager, SkillStoreConfig};
@@ -316,4 +316,254 @@ Use this demo skill."#,
     assert!(summary.contains("demo-skill"));
     assert!(summary.contains("references/policy.md"));
     assert!(summary.contains("\"offset\":1"));
+}
+
+#[tokio::test]
+async fn session_workspace_catalog_selection_and_runtime_roots_are_isolated() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let global_skills = temp_dir.path().join("data/skills");
+    let workspace_one = temp_dir.path().join("workspace-one");
+    let workspace_two = temp_dir.path().join("workspace-two");
+
+    for (workspace, description, instructions, resource, exclusive) in [
+        (
+            &workspace_one,
+            "alpha needle workflow",
+            "Alpha workspace instructions.",
+            "alpha resource",
+            "only-alpha",
+        ),
+        (
+            &workspace_two,
+            "beta needle workflow",
+            "Beta workspace instructions.",
+            "beta resource",
+            "only-beta",
+        ),
+    ] {
+        let shared = workspace.join(".bamboo/skills/shared-workflow");
+        std::fs::create_dir_all(shared.join("references")).expect("shared resource dir");
+        std::fs::write(
+            shared.join("SKILL.md"),
+            format!(
+                "---\nname: shared-workflow\ndescription: {description}\nallowed-tools:\n  - read_file\n---\n{instructions}\n"
+            ),
+        )
+        .expect("shared skill");
+        std::fs::write(shared.join("references/scope.txt"), resource).expect("shared resource");
+        let exclusive_root = workspace.join(".bamboo/skills").join(exclusive);
+        std::fs::create_dir_all(&exclusive_root).expect("exclusive skill dir");
+        std::fs::write(
+            exclusive_root.join("SKILL.md"),
+            format!(
+                "---\nname: {exclusive}\ndescription: {exclusive} project skill\n---\n{exclusive} instructions\n"
+            ),
+        )
+        .expect("exclusive skill");
+    }
+
+    let skill_manager = Arc::new(SkillManager::with_config(SkillStoreConfig {
+        skills_dir: global_skills,
+        project_dir: None,
+        active_mode: None,
+    }));
+    skill_manager
+        .initialize()
+        .await
+        .expect("initialize manager");
+
+    let catalog_one = skill_manager
+        .store()
+        .workflow_catalog_for_workspace(&workspace_one)
+        .await
+        .expect("workspace one catalog");
+    let catalog_two = skill_manager
+        .store()
+        .workflow_catalog_for_workspace(&workspace_two)
+        .await
+        .expect("workspace two catalog");
+    assert_eq!(
+        catalog_one
+            .entries
+            .iter()
+            .find(|entry| entry.id == "shared-workflow")
+            .expect("shared one")
+            .description,
+        "alpha needle workflow"
+    );
+    assert_eq!(
+        catalog_two
+            .entries
+            .iter()
+            .find(|entry| entry.id == "shared-workflow")
+            .expect("shared two")
+            .description,
+        "beta needle workflow"
+    );
+    assert!(catalog_one
+        .entries
+        .iter()
+        .any(|entry| entry.id == "only-alpha"));
+    assert!(!catalog_one
+        .entries
+        .iter()
+        .any(|entry| entry.id == "only-beta"));
+    assert!(catalog_two
+        .entries
+        .iter()
+        .any(|entry| entry.id == "only-beta"));
+    assert!(!catalog_two
+        .entries
+        .iter()
+        .any(|entry| entry.id == "only-alpha"));
+
+    let disabled = std::collections::BTreeSet::new();
+    let explicitly_selected = vec!["shared-workflow".to_string()];
+    let selected_one = skill_manager
+        .resolve_skills_for_request_in_workspace_with_mode(
+            &workspace_one,
+            &disabled,
+            Some(&explicitly_selected),
+            None,
+            None,
+        )
+        .await
+        .expect("explicit selection one");
+    let selected_two = skill_manager
+        .resolve_skills_for_request_in_workspace_with_mode(
+            &workspace_two,
+            &disabled,
+            Some(&explicitly_selected),
+            None,
+            None,
+        )
+        .await
+        .expect("explicit selection two");
+    assert_eq!(selected_one[0].prompt, "Alpha workspace instructions.");
+    assert_eq!(selected_two[0].prompt, "Beta workspace instructions.");
+
+    let auto_one = skill_manager
+        .resolve_skills_for_request_in_workspace_with_mode(
+            &workspace_one,
+            &disabled,
+            None,
+            None,
+            Some("alpha needle"),
+        )
+        .await
+        .expect("auto selection one");
+    let auto_two = skill_manager
+        .resolve_skills_for_request_in_workspace_with_mode(
+            &workspace_two,
+            &disabled,
+            None,
+            None,
+            Some("beta needle"),
+        )
+        .await
+        .expect("auto selection two");
+    assert!(auto_one.iter().any(|skill| skill.id == "only-alpha"));
+    assert!(!auto_one.iter().any(|skill| skill.id == "only-beta"));
+    assert!(auto_two.iter().any(|skill| skill.id == "only-beta"));
+    assert!(!auto_two.iter().any(|skill| skill.id == "only-alpha"));
+    assert_eq!(
+        auto_one
+            .iter()
+            .find(|skill| skill.id == "shared-workflow")
+            .expect("auto shared one")
+            .description,
+        "alpha needle workflow"
+    );
+    assert_eq!(
+        auto_two
+            .iter()
+            .find(|skill| skill.id == "shared-workflow")
+            .expect("auto shared two")
+            .description,
+        "beta needle workflow"
+    );
+
+    let mut session_one = Session::new("workspace-session-one", "model");
+    session_one.set_workspace_path_meta(workspace_one.to_string_lossy());
+    let mut session_two = Session::new("workspace-session-two", "model");
+    session_two.set_workspace_path_meta(workspace_two.to_string_lossy());
+    let sessions = Arc::new(dashmap::DashMap::new());
+    for session in [&session_one, &session_two] {
+        sessions.insert(
+            session.id.clone(),
+            Arc::new(parking_lot::RwLock::new(session.clone())),
+        );
+    }
+    let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());
+    storage.save_session(&session_one).await.expect("save one");
+    storage.save_session(&session_two).await.expect("save two");
+    let persistence = Arc::new(bamboo_storage::LockedSessionStore::new(storage.clone()));
+    let repo = bamboo_engine::SessionRepository::new(sessions, storage, persistence);
+    let config = Arc::new(RwLock::new(Config::default()));
+    let load_tool = LoadSkillTool::new(skill_manager.clone(), config.clone(), repo.clone());
+    let read_tool = ReadSkillResourceTool::new(skill_manager, config, repo);
+
+    for (session_id, expected_instructions, expected_resource, expected_workspace) in [
+        (
+            "workspace-session-one",
+            "Alpha workspace instructions.",
+            "alpha resource",
+            &workspace_one,
+        ),
+        (
+            "workspace-session-two",
+            "Beta workspace instructions.",
+            "beta resource",
+            &workspace_two,
+        ),
+    ] {
+        let context = ToolExecutionContext {
+            session_id: Some(session_id),
+            tool_call_id: "workspace-skill-call",
+            event_tx: None,
+            available_tool_schemas: None,
+            bypass_permissions: false,
+            can_async_resume: false,
+            bash_completion_sink: None,
+            pre_parsed_args: None,
+        };
+        let ToolOutcome::Completed(loaded) = load_tool
+            .invoke(
+                serde_json::json!({ "skill_id": "shared-workflow" }),
+                context.to_tool_ctx(),
+            )
+            .await
+            .expect("load workspace skill")
+        else {
+            panic!("load_skill should complete")
+        };
+        let loaded: serde_json::Value =
+            serde_json::from_str(&loaded.result).expect("load result json");
+        assert_eq!(loaded["instructions"], expected_instructions);
+        let expected_workspace =
+            std::fs::canonicalize(expected_workspace).expect("canonical workspace");
+        let skill_root = loaded["skill_base_dir"].as_str().expect("skill root");
+        assert!(
+            skill_root.starts_with(expected_workspace.to_string_lossy().as_ref()),
+            "runtime root {skill_root} must stay under {}",
+            expected_workspace.display()
+        );
+
+        let ToolOutcome::Completed(resource) = read_tool
+            .invoke(
+                serde_json::json!({
+                    "skill_id": "shared-workflow",
+                    "resource_path": "references/scope.txt"
+                }),
+                context.to_tool_ctx(),
+            )
+            .await
+            .expect("read workspace resource")
+        else {
+            panic!("read_skill_resource should complete")
+        };
+        let resource: serde_json::Value =
+            serde_json::from_str(&resource.result).expect("resource result json");
+        assert_eq!(resource["content"], expected_resource);
+    }
 }

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -313,6 +313,48 @@ impl AppState {
                     "failed to initialize account change-feed journal: {e}"
                 ))
             })?;
+        // Bridge global workflow catalog transitions onto the same durable account feed used by
+        // SSE and v2 WebSocket clients. Catalog events are account-scoped (no session id).
+        {
+            let mut workflow_events = skill_manager.store().subscribe_workflow_catalog();
+            let account_sink = account_sink.clone();
+            tokio::spawn(async move {
+                loop {
+                    let event = match workflow_events.recv().await {
+                        Ok(event) => event,
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                            tracing::warn!("Workflow catalog event bridge lagged by {skipped}");
+                            continue;
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    };
+                    let event = match event.kind {
+                        bamboo_skills::WorkflowCatalogEventKind::Changed => {
+                            AgentEvent::WorkflowChanged {
+                                workflow_id: event.workflow_id,
+                                revision: event.revision,
+                                scope: event.scope,
+                            }
+                        }
+                        bamboo_skills::WorkflowCatalogEventKind::Invalid => {
+                            AgentEvent::WorkflowInvalid {
+                                workflow_id: event.workflow_id,
+                                revision: event.revision,
+                                scope: event.scope,
+                            }
+                        }
+                        bamboo_skills::WorkflowCatalogEventKind::Recovered => {
+                            AgentEvent::WorkflowRecovered {
+                                workflow_id: event.workflow_id,
+                                revision: event.revision,
+                                scope: event.scope,
+                            }
+                        }
+                    };
+                    account_sink.record(None, &event);
+                }
+            });
+        }
         let (approval_registry, restart_approval_events) =
             bamboo_engine::external_agents::live::initialize_durable_approvals(
                 data_dir.join("approvals/child-approvals-v1.json"),

--- a/crates/app/bamboo-server/src/app_state/init.rs
+++ b/crates/app/bamboo-server/src/app_state/init.rs
@@ -113,9 +113,9 @@ pub async fn init_storage(
 
 /// Initialize the skill manager with workspace directory and active mode from environment.
 pub async fn init_skill_manager(data_dir: &Path) -> Arc<SkillManager> {
-    let project_dir = std::env::var_os("BAMBOO_WORKSPACE_DIR")
-        .map(PathBuf::from)
-        .or_else(|| std::env::current_dir().ok());
+    // A server process may serve several unrelated workspaces. Never treat its cwd as a
+    // project root; session-scoped catalog requests provide the workspace explicitly.
+    let project_dir = std::env::var_os("BAMBOO_WORKSPACE_DIR").map(PathBuf::from);
     let active_mode = std::env::var("BAMBOO_SKILL_MODE")
         .ok()
         .map(|value| value.trim().to_string())

--- a/crates/app/bamboo-server/src/handlers/command/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/command/handlers.rs
@@ -7,8 +7,8 @@ use crate::error::AppError;
 use crate::handlers::settings::is_safe_workflow_name;
 
 use super::sources::{
-    list_markdown_commands, list_mcp_tools_as_commands, list_prompt_presets_as_commands,
-    list_workflows_as_commands, safe_project_commands_dir, skill_to_command,
+    catalog_entry_to_command, list_markdown_commands, list_mcp_tools_as_commands,
+    list_prompt_presets_as_commands, safe_project_commands_dir,
 };
 use super::types::{CommandItem, CommandListResponse, GetCommandQuery, ListCommandsQuery};
 
@@ -28,6 +28,38 @@ pub(super) fn expand_arguments(template: &str, arguments: &str) -> String {
     template.replace("$ARGUMENTS", arguments)
 }
 
+async fn session_workspace(
+    app_state: &AppState,
+    session_id: Option<&str>,
+    legacy_workspace_path: Option<&str>,
+) -> Result<Option<std::path::PathBuf>, AppError> {
+    if legacy_workspace_path.is_some_and(|value| !value.trim().is_empty()) {
+        return Err(AppError::BadRequest(
+            "workspace_path is deprecated; provide session_id so workspace access is session-bound"
+                .to_string(),
+        ));
+    }
+    let Some(session_id) = session_id.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    let session = app_state
+        .load_session(session_id)
+        .await
+        .ok_or_else(|| AppError::NotFound(format!("Session '{session_id}'")))?;
+    let Some(workspace) = session.workspace_path_meta() else {
+        return Ok(None);
+    };
+    let workspace = tokio::fs::canonicalize(workspace)
+        .await
+        .map_err(|error| AppError::BadRequest(format!("Invalid session workspace: {error}")))?;
+    if !workspace.is_dir() {
+        return Err(AppError::BadRequest(
+            "Session workspace must be a directory".to_string(),
+        ));
+    }
+    Ok(Some(workspace))
+}
+
 /// Lists all available commands from workflows, skills, and MCP tools.
 pub async fn list_commands(
     app_state: web::Data<AppState>,
@@ -35,16 +67,17 @@ pub async fn list_commands(
 ) -> Result<HttpResponse, AppError> {
     let mut commands = Vec::new();
     let mut seen = HashSet::new();
+    let workspace = session_workspace(
+        app_state.get_ref(),
+        query.session_id.as_deref(),
+        query.workspace_path.as_deref(),
+    )
+    .await?;
 
     // Conflict precedence is deliberately source-based and stable:
     // project markdown > global markdown > global preset > workflow > skill > MCP.
-    if let Some(workspace_path) = query
-        .workspace_path
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        if let Some(dir) = safe_project_commands_dir(workspace_path) {
+    if let Some(workspace_path) = workspace.as_ref() {
+        if let Some(dir) = safe_project_commands_dir(workspace_path.to_string_lossy().as_ref()) {
             let project = list_markdown_commands(&dir, "project")
                 .await
                 .into_iter()
@@ -68,21 +101,24 @@ pub async fn list_commands(
         list_prompt_presets_as_commands(&app_state.app_data_dir).await,
     );
 
-    match list_workflows_as_commands(&app_state.app_data_dir).await {
-        Ok(workflows) => append_unique(&mut commands, &mut seen, workflows),
-        Err(error) => {
-            tracing::warn!("Failed to load workflows: {error}");
-        }
-    }
-
-    let skills = app_state
-        .skill_manager
-        .store()
-        .list_skills(None, false)
-        .await;
-    let skill_commands = skills
+    let catalog = if let Some(workspace) = workspace.as_ref() {
+        app_state
+            .skill_manager
+            .store()
+            .workflow_catalog_for_workspace(workspace)
+            .await
+            .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?
+    } else {
+        app_state
+            .skill_manager
+            .store()
+            .workflow_catalog_snapshot()
+            .await
+    };
+    let skill_commands = catalog
+        .entries
         .into_iter()
-        .map(|skill| skill_to_command(&skill))
+        .map(|entry| catalog_entry_to_command(&entry))
         .collect();
     append_unique(&mut commands, &mut seen, skill_commands);
 
@@ -107,17 +143,20 @@ pub async fn get_command(
     query: web::Query<GetCommandQuery>,
 ) -> Result<HttpResponse, AppError> {
     let (command_type, id) = path.into_inner();
+    let workspace = session_workspace(
+        app_state.get_ref(),
+        query.session_id.as_deref(),
+        query.workspace_path.as_deref(),
+    )
+    .await?;
 
     match command_type.as_str() {
         "prompt" => {
             let mut sources = Vec::new();
-            if let Some(workspace_path) = query
-                .workspace_path
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-            {
-                if let Some(dir) = safe_project_commands_dir(workspace_path) {
+            if let Some(workspace_path) = workspace.as_ref() {
+                if let Some(dir) =
+                    safe_project_commands_dir(workspace_path.to_string_lossy().as_ref())
+                {
                     sources.push((dir, "project"));
                 }
             }
@@ -186,10 +225,19 @@ pub async fn get_command(
                 "type": "workflow"
             })))
         }
-        "skill" => match app_state.skill_manager.store().get_skill(&id).await {
-            Ok(skill) => Ok(HttpResponse::Ok().json(skill)),
-            Err(error) => Err(AppError::NotFound(format!("Skill {id} not found: {error}"))),
-        },
+        "skill" => {
+            let store = app_state
+                .skill_manager
+                .store_for_workspace(workspace.as_deref())
+                .await
+                .map_err(|error| {
+                    AppError::BadRequest(format!("Invalid session workspace: {error}"))
+                })?;
+            match store.get_skill(&id).await {
+                Ok(skill) => Ok(HttpResponse::Ok().json(skill)),
+                Err(error) => Err(AppError::NotFound(format!("Skill {id} not found: {error}"))),
+            }
+        }
         "mcp" => Err(AppError::NotFound(
             "MCP tools do not support content retrieval".to_string(),
         )),

--- a/crates/app/bamboo-server/src/handlers/command/sources.rs
+++ b/crates/app/bamboo-server/src/handlers/command/sources.rs
@@ -2,7 +2,7 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::app_state::AppState;
 use crate::error::AppError;
-use bamboo_skills::types::SkillDefinition;
+use bamboo_skills::WorkflowCatalogEntry;
 use serde::Deserialize;
 
 use super::types::CommandItem;
@@ -217,79 +217,27 @@ pub(super) async fn list_prompt_presets_as_commands(data_dir: &Path) -> Vec<Comm
     }
 }
 
-pub(super) async fn list_workflows_as_commands(
-    data_dir: &Path,
-) -> Result<Vec<CommandItem>, AppError> {
-    let dir = data_dir.join("workflows");
-    tokio::fs::create_dir_all(&dir).await.map_err(|error| {
-        AppError::InternalError(anyhow::anyhow!("Failed to create workflows dir: {error}"))
-    })?;
-
-    let mut entries = tokio::fs::read_dir(&dir).await.map_err(|error| {
-        AppError::InternalError(anyhow::anyhow!("Failed to read workflows dir: {error}"))
-    })?;
-
-    let mut commands = Vec::new();
-    while let Some(entry) = entries.next_entry().await.map_err(|error| {
-        AppError::InternalError(anyhow::anyhow!("Failed to read entry: {error}"))
-    })? {
-        let path = entry.path();
-        if path.extension().and_then(|value| value.to_str()) != Some("md") {
-            continue;
-        }
-
-        let name = path
-            .file_stem()
-            .and_then(|value| value.to_str())
-            .unwrap_or_default()
-            .to_string();
-        if name.is_empty() {
-            continue;
-        }
-
-        let metadata = entry.metadata().await.map_err(|error| {
-            AppError::InternalError(anyhow::anyhow!("Failed to read metadata: {error}"))
-        })?;
-        let filename = path
-            .file_name()
-            .and_then(|value| value.to_str())
-            .unwrap_or_default()
-            .to_string();
-
-        commands.push(CommandItem {
-            id: format!("workflow-{name}"),
-            name: name.clone(),
-            display_name: name.clone(),
-            description: format!("Workflow: {name}"),
-            command_type: "workflow".to_string(),
-            category: None,
-            tags: None,
-            metadata: serde_json::json!({
-                "filename": filename,
-                "size": metadata.len(),
-                "source": "global"
-            }),
-        });
-    }
-
-    Ok(commands)
-}
-
-pub(super) fn skill_to_command(skill: &SkillDefinition) -> CommandItem {
+pub(super) fn catalog_entry_to_command(entry: &WorkflowCatalogEntry) -> CommandItem {
+    let (id_prefix, command_type) = match entry.kind {
+        bamboo_skills::WorkflowKind::Instruction => ("skill", "skill"),
+        bamboo_skills::WorkflowKind::Orchestration => ("workflow", "workflow"),
+    };
     CommandItem {
-        id: format!("skill-{}", skill.id),
-        name: skill.id.clone(),
-        display_name: skill.name.clone(),
-        description: skill.description.clone(),
-        command_type: "skill".to_string(),
+        id: format!("{id_prefix}-{}", entry.id),
+        name: entry.id.clone(),
+        display_name: entry.name.clone(),
+        description: entry.description.clone(),
+        command_type: command_type.to_string(),
         category: None,
         tags: None,
         metadata: serde_json::json!({
-            "prompt": skill.prompt,
-            "toolRefs": skill.tool_refs,
-            "license": skill.license,
-            "compatibility": skill.compatibility,
-            "metadata": skill.metadata,
+            "kind": entry.kind,
+            "source": entry.source,
+            "revision": entry.revision,
+            "version": entry.version,
+            "invocationPolicy": entry.invocation_policy,
+            "argumentSchema": entry.argument_schema,
+            "status": entry.status,
         }),
     }
 }

--- a/crates/app/bamboo-server/src/handlers/command/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/command/tests.rs
@@ -1,22 +1,36 @@
 use actix_web::{http::StatusCode, web};
-use bamboo_skills::types::SkillDefinition;
+use bamboo_skills::{WorkflowCatalogEntry, WorkflowKind, WorkflowSource, WorkflowStatus};
 
 use std::collections::HashSet;
 
 use super::handlers::{append_unique, expand_arguments};
-use super::sources::{list_markdown_commands, skill_to_command};
+use super::sources::{catalog_entry_to_command, list_markdown_commands};
 use super::types::CommandItem;
 
 #[test]
-fn skill_to_command_maps_core_fields() {
-    let skill =
-        SkillDefinition::new("sample", "Sample", "Demo skill", "Use me").with_tool_ref("read_file");
-    let command = skill_to_command(&skill);
+fn catalog_entry_to_command_maps_metadata_without_prompt() {
+    let entry = WorkflowCatalogEntry {
+        id: "sample".into(),
+        name: "Sample".into(),
+        description: "Demo skill".into(),
+        kind: WorkflowKind::Instruction,
+        source: WorkflowSource::Project,
+        revision: 7,
+        version: "1".into(),
+        invocation_policy: serde_json::json!({"explicit": true}),
+        argument_schema: serde_json::json!({"type": "object"}),
+        status: WorkflowStatus::Valid,
+        last_error: None,
+        winner: true,
+        shadowed_candidates: vec![],
+    };
+    let command = catalog_entry_to_command(&entry);
 
     assert_eq!(command.id, "skill-sample");
     assert_eq!(command.name, "sample");
     assert_eq!(command.display_name, "Sample");
     assert_eq!(command.command_type, "skill");
+    assert!(command.metadata.get("prompt").is_none());
 }
 
 #[tokio::test]
@@ -196,16 +210,20 @@ async fn project_command_is_listed_and_namespace_route_expands_arguments() {
             .await
             .expect("app state"),
     );
+    let mut session = bamboo_agent_core::Session::new("workspace-session", "test-model");
+    session.set_workspace_path_meta(project.path().to_string_lossy().to_string());
+    app_state.sessions.insert(
+        session.id.clone(),
+        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+    );
     let app = actix_web::test::init_service(
         actix_web::App::new()
             .app_data(app_state)
             .configure(super::config),
     )
     .await;
-    let workspace_path = project.path().to_string_lossy();
-
     let list = actix_web::test::TestRequest::get()
-        .uri(&format!("/commands?workspace_path={workspace_path}"))
+        .uri("/commands?session_id=workspace-session")
         .to_request();
     let list_body: serde_json::Value = actix_web::test::call_and_read_body_json(&app, list).await;
     assert!(list_body["commands"]
@@ -215,10 +233,39 @@ async fn project_command_is_listed_and_namespace_route_expands_arguments() {
         .any(|command| command["name"] == "db/migrate"));
 
     let get = actix_web::test::TestRequest::get()
-        .uri(&format!(
-            "/commands/prompt/db/migrate?workspace_path={workspace_path}&arguments=production"
-        ))
+        .uri("/commands/prompt/db/migrate?session_id=workspace-session&arguments=production")
         .to_request();
     let get_body: serde_json::Value = actix_web::test::call_and_read_body_json(&app, get).await;
     assert_eq!(get_body["content"], "Migrate production safely");
+}
+
+#[actix_web::test]
+async fn arbitrary_workspace_path_is_rejected_for_list_and_get() {
+    let data = tempfile::tempdir().expect("data dir");
+    let outside = tempfile::tempdir().expect("outside");
+    let app_state = web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let app = actix_web::test::init_service(
+        actix_web::App::new()
+            .app_data(app_state)
+            .configure(super::config),
+    )
+    .await;
+    for uri in [
+        format!("/commands?workspace_path={}", outside.path().display()),
+        format!(
+            "/commands/prompt/secret?workspace_path={}",
+            outside.path().display()
+        ),
+    ] {
+        let response = actix_web::test::call_service(
+            &app,
+            actix_web::test::TestRequest::get().uri(&uri).to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
 }

--- a/crates/app/bamboo-server/src/handlers/command/types.rs
+++ b/crates/app/bamboo-server/src/handlers/command/types.rs
@@ -34,12 +34,16 @@ pub struct CommandItem {
 pub struct ListCommandsQuery {
     #[serde(default)]
     pub workspace_path: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
 pub struct GetCommandQuery {
     #[serde(default)]
     pub workspace_path: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
     #[serde(default)]
     pub arguments: Option<String>,
 }

--- a/crates/app/bamboo-server/src/handlers/settings/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/mod.rs
@@ -49,7 +49,8 @@ pub use redaction::{redact_config_for_api, redact_providers_for_api};
 pub use setup::{get_setup_status, mark_setup_complete, mark_setup_incomplete};
 pub(crate) use workflows::is_safe_workflow_name;
 pub use workflows::{
-    delete_workflow, get_workflow, list_workflows, save_workflow, SaveWorkflowRequest,
+    delete_workflow, get_workflow, list_workflow_catalog, list_workflows, save_workflow,
+    SaveWorkflowRequest, WorkflowCatalogQuery,
 };
 
 // NOTE: the production `/bamboo/*` route map lives in `routes::bamboo_v1_routes`

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
@@ -1,10 +1,69 @@
 use actix_web::{web, HttpResponse};
+use bamboo_skills::legacy::LegacySyncOutcome;
+use bamboo_skills::types::SkillDefinition;
 use tokio::fs;
+use tokio::io::AsyncWriteExt;
 
 use crate::{app_state::AppState, error::AppError};
 
-use super::types::{SaveWorkflowRequest, WorkflowGetResponse, WorkflowListItem};
+use super::types::{
+    SaveWorkflowRequest, WorkflowCatalogQuery, WorkflowGetResponse, WorkflowListItem,
+};
 use super::validation::is_safe_workflow_name;
+
+fn legacy_workflow_io_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+/// Metadata-only catalog shared by Lotus palette, explicit selection and model matching.
+pub async fn list_workflow_catalog(
+    app_state: web::Data<AppState>,
+    query: web::Query<WorkflowCatalogQuery>,
+) -> Result<HttpResponse, AppError> {
+    let snapshot = if let Some(session_id) = query
+        .session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let session = app_state
+            .load_session(session_id)
+            .await
+            .ok_or_else(|| AppError::NotFound(format!("Session '{session_id}'")))?;
+        if let Some(workspace) = session.workspace_path_meta() {
+            let workspace = tokio::fs::canonicalize(workspace).await.map_err(|error| {
+                AppError::BadRequest(format!("Invalid session workspace: {error}"))
+            })?;
+            if !workspace.is_dir() {
+                return Err(AppError::BadRequest(
+                    "Session workspace must be a directory".to_string(),
+                ));
+            }
+            app_state
+                .skill_manager
+                .store()
+                .workflow_catalog_for_workspace(&workspace)
+                .await
+                .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?
+        } else {
+            app_state
+                .skill_manager
+                .store()
+                .workflow_catalog_snapshot()
+                .await
+        }
+    } else {
+        app_state
+            .skill_manager
+            .store()
+            .workflow_catalog_snapshot()
+            .await
+    };
+    Ok(HttpResponse::Ok()
+        .insert_header(("Cache-Control", "no-store"))
+        .json(snapshot))
+}
 
 /// Lists all workflow markdown files
 ///
@@ -27,46 +86,25 @@ use super::validation::is_safe_workflow_name;
 /// # Response Status
 /// - `200 OK`: Successfully retrieved workflow list
 pub async fn list_workflows(app_state: web::Data<AppState>) -> Result<HttpResponse, AppError> {
-    let dir = app_state.app_data_dir.join("workflows");
-
-    fs::create_dir_all(&dir).await?;
-
-    let mut entries = fs::read_dir(&dir).await?;
-    let mut workflows: Vec<WorkflowListItem> = Vec::new();
-
-    while let Some(entry) = entries.next_entry().await? {
-        let file_type = entry.file_type().await?;
-        if !file_type.is_file() {
-            continue;
-        }
-
-        let path = entry.path();
-        if path.extension().and_then(|value| value.to_str()) != Some("md") {
-            continue;
-        }
-
-        let Some(stem) = path.file_stem().and_then(|value| value.to_str()) else {
-            continue;
-        };
-
-        let filename = path
-            .file_name()
-            .and_then(|value| value.to_str())
-            .unwrap_or_default()
-            .to_string();
-
-        let metadata = entry.metadata().await?;
-        workflows.push(WorkflowListItem {
-            name: stem.to_string(),
-            filename,
-            size: metadata.len(),
+    let workflows_dir = app_state.app_data_dir.join("workflows");
+    let mut workflows: Vec<WorkflowListItem> = app_state
+        .skill_manager
+        .store()
+        .list_skills(None, false)
+        .await
+        .into_iter()
+        .filter(|skill| legacy_source(skill, &workflows_dir).is_some())
+        .map(|skill| WorkflowListItem {
+            name: legacy_name(&skill).to_string(),
+            filename: format!("{}.md", legacy_name(&skill)),
+            size: skill.prompt.len() as u64,
             modified_at: None,
-        });
-    }
+        })
+        .collect();
 
     workflows.sort_by(|left, right| left.name.cmp(&right.name));
 
-    Ok(HttpResponse::Ok().json(workflows))
+    Ok(legacy_response().json(workflows))
 }
 
 /// Gets a specific workflow by name.
@@ -85,26 +123,25 @@ pub async fn get_workflow(
     }
 
     let dir = app_state.app_data_dir.join("workflows");
-    fs::create_dir_all(&dir).await?;
-
     let filename = format!("{name}.md");
-    let file_path = dir.join(&filename);
+    let skill_id = bamboo_skills::legacy::legacy_workflow_skill_id(&name);
+    let skill = app_state
+        .skill_manager
+        .store()
+        .get_skill(&skill_id)
+        .await
+        .map_err(|_| AppError::NotFound(format!("Workflow '{name}'")))?;
+    if legacy_source(&skill, &dir).is_none() || legacy_name(&skill) != name {
+        return Err(AppError::NotFound(format!("Workflow '{name}'")));
+    }
+    let content = skill.prompt;
+    let size = content.len() as u64;
 
-    let metadata = match fs::metadata(&file_path).await {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Err(AppError::NotFound(format!("Workflow '{name}'")));
-        }
-        Err(error) => return Err(AppError::StorageError(error)),
-    };
-
-    let content = fs::read_to_string(&file_path).await?;
-
-    Ok(HttpResponse::Ok().json(WorkflowGetResponse {
+    Ok(legacy_response().json(WorkflowGetResponse {
         name,
         filename,
         content,
-        size: metadata.len(),
+        size,
         modified_at: None,
     }))
 }
@@ -117,6 +154,7 @@ pub async fn save_workflow(
     app_state: web::Data<AppState>,
     payload: web::Json<SaveWorkflowRequest>,
 ) -> Result<HttpResponse, AppError> {
+    let _io_guard = legacy_workflow_io_lock().lock().await;
     let name = payload.name.trim();
     if !is_safe_workflow_name(name) {
         return Err(AppError::BadRequest("Invalid workflow name".to_string()));
@@ -126,11 +164,70 @@ pub async fn save_workflow(
     fs::create_dir_all(&dir).await?;
 
     let file_path = dir.join(format!("{}.md", name));
-    fs::write(&file_path, &payload.content).await?;
+    let skill_id = bamboo_skills::legacy::legacy_workflow_skill_id(name);
+    let preflight = bamboo_skills::legacy::legacy_bundle_preflight(
+        &file_path,
+        &app_state.app_data_dir.join("skills"),
+        &skill_id,
+    )
+    .await;
+    match preflight {
+        Ok(true) => {}
+        Ok(false) => {
+            return Err(AppError::BadRequest(format!(
+                "Workflow '{name}' conflicts with a non-legacy skill bundle"
+            )))
+        }
+        Err(error) => {
+            return Err(AppError::InternalError(anyhow::anyhow!(error)));
+        }
+    }
 
-    Ok(HttpResponse::Ok().json(serde_json::json!({
+    let temporary = dir.join(format!(".{name}.{}.tmp", uuid::Uuid::new_v4()));
+    let mut staging = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)
+        .await?;
+    if let Err(error) = async {
+        staging.write_all(payload.content.as_bytes()).await?;
+        staging.flush().await?;
+        staging.sync_all().await?;
+        drop(staging);
+        bamboo_skills::legacy::atomic_replace_file(&temporary, &file_path).await
+    }
+    .await
+    {
+        let _ = fs::remove_file(&temporary).await;
+        return Err(error.into());
+    }
+
+    // Source is authoritative and durable first. If bundle sync fails, the watcher/import pass
+    // retries from this committed source instead of leaving an unrecoverable split-brain write.
+    let outcome = bamboo_skills::legacy::sync_legacy_markdown_bundle(
+        &file_path,
+        &app_state.app_data_dir.join("skills"),
+        &skill_id,
+        &payload.content,
+    )
+    .await
+    .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
+    if outcome == LegacySyncOutcome::Conflict {
+        return Err(AppError::BadRequest(format!(
+            "Workflow '{name}' ownership changed during update; source was committed and will not overwrite the bundle"
+        )));
+    }
+    app_state
+        .skill_manager
+        .store()
+        .reload()
+        .await
+        .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
+
+    Ok(legacy_response().json(serde_json::json!({
         "success": true,
-        "path": file_path.to_string_lossy()
+        "path": file_path.to_string_lossy(),
+        "catalog_revision": app_state.skill_manager.store().workflow_catalog_snapshot().await.revision,
     })))
 }
 
@@ -142,6 +239,7 @@ pub async fn delete_workflow(
     app_state: web::Data<AppState>,
     workflow_name: web::Path<String>,
 ) -> Result<HttpResponse, AppError> {
+    let _io_guard = legacy_workflow_io_lock().lock().await;
     let name = workflow_name.into_inner();
     if !is_safe_workflow_name(&name) {
         return Err(AppError::BadRequest("Invalid workflow name".to_string()));
@@ -149,12 +247,66 @@ pub async fn delete_workflow(
 
     let dir = app_state.app_data_dir.join("workflows");
     let file_path = dir.join(format!("{}.md", name));
+    let skill_id = bamboo_skills::legacy::legacy_workflow_skill_id(&name);
 
     if !file_path.exists() {
         return Err(AppError::NotFound(format!("Workflow '{}'", name)));
     }
 
+    let removed_bundle = bamboo_skills::legacy::remove_legacy_markdown_bundle(
+        &file_path,
+        &app_state.app_data_dir.join("skills"),
+        &skill_id,
+    )
+    .await
+    .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
+    if !removed_bundle {
+        return Err(AppError::BadRequest(format!(
+            "Workflow '{name}' is not owned by the legacy adapter"
+        )));
+    }
     fs::remove_file(&file_path).await?;
+    app_state
+        .skill_manager
+        .store()
+        .reload()
+        .await
+        .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
 
-    Ok(HttpResponse::Ok().json(serde_json::json!({ "success": true })))
+    Ok(legacy_response().json(serde_json::json!({ "success": true })))
+}
+
+fn legacy_source(skill: &SkillDefinition, workflows_dir: &std::path::Path) -> Option<String> {
+    let metadata = skill.metadata.as_ref()?;
+    if metadata
+        .get("legacy_import")
+        .and_then(|value| value.as_bool())
+        != Some(true)
+    {
+        return None;
+    }
+    let source = metadata.get("original_source")?.as_str()?;
+    let expected = workflows_dir.join(format!("{}.md", legacy_name(skill)));
+    (std::path::Path::new(source) == expected).then(|| source.to_string())
+}
+
+fn legacy_name(skill: &SkillDefinition) -> &str {
+    skill
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("legacy_name"))
+        .and_then(|value| value.as_str())
+        .unwrap_or(&skill.id)
+}
+
+fn legacy_response() -> actix_web::HttpResponseBuilder {
+    let mut response = HttpResponse::Ok();
+    response
+        .insert_header(("Deprecation", "true"))
+        .insert_header(("Sunset", "2026-12-01"))
+        .insert_header((
+            "Link",
+            "</api/v1/bamboo/workflow-catalog>; rel=\"successor-version\"",
+        ));
+    response
 }

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/mod.rs
@@ -4,7 +4,9 @@ mod tests;
 mod types;
 mod validation;
 
-pub use handlers::{delete_workflow, get_workflow, list_workflows, save_workflow};
-pub use types::SaveWorkflowRequest;
+pub use handlers::{
+    delete_workflow, get_workflow, list_workflow_catalog, list_workflows, save_workflow,
+};
+pub use types::{SaveWorkflowRequest, WorkflowCatalogQuery};
 
 pub(crate) use validation::is_safe_workflow_name;

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
@@ -1,5 +1,230 @@
 use super::validation::is_safe_workflow_name;
 
+#[actix_web::test]
+async fn workflow_catalog_api_returns_metadata_without_skill_body() {
+    let data = tempfile::tempdir().expect("data dir");
+    let skill = data.path().join("skills/review");
+    tokio::fs::create_dir_all(&skill).await.expect("skill dir");
+    tokio::fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: review\ndescription: Reviews changes\n---\nTOP SECRET INSTRUCTIONS\n",
+    )
+    .await
+    .expect("skill");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let app = actix_web::test::init_service(actix_web::App::new().app_data(state).route(
+        "/catalog",
+        actix_web::web::get().to(super::list_workflow_catalog),
+    ))
+    .await;
+    let request = actix_web::test::TestRequest::get()
+        .uri("/catalog")
+        .to_request();
+    let body = actix_web::test::call_and_read_body(&app, request).await;
+    let text = std::str::from_utf8(&body).expect("utf8 response");
+    assert!(text.contains("Reviews changes"));
+    assert!(text.contains("\"revision\""));
+    assert!(!text.contains("TOP SECRET INSTRUCTIONS"));
+    assert!(!text.contains("SKILL.md"));
+}
+
+#[actix_web::test]
+async fn workflow_catalog_session_without_workspace_uses_global_snapshot() {
+    let data = tempfile::tempdir().expect("data dir");
+    let skill = data.path().join("skills/global-review");
+    tokio::fs::create_dir_all(&skill).await.expect("skill dir");
+    tokio::fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: global-review\ndescription: Global review workflow\n---\nGlobal body\n",
+    )
+    .await
+    .expect("skill");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let session = bamboo_agent_core::Session::new("global-session", "test-model");
+    state.sessions.insert(
+        session.id.clone(),
+        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+    );
+    let app = actix_web::test::init_service(actix_web::App::new().app_data(state).route(
+        "/catalog",
+        actix_web::web::get().to(super::list_workflow_catalog),
+    ))
+    .await;
+    let request = actix_web::test::TestRequest::get()
+        .uri("/catalog?session_id=global-session")
+        .to_request();
+    let response = actix_web::test::call_service(&app, request).await;
+    assert!(response.status().is_success());
+    let body: serde_json::Value = actix_web::test::read_body_json(response).await;
+    assert!(body["entries"]
+        .as_array()
+        .expect("catalog entries")
+        .iter()
+        .any(|entry| entry["id"] == "global-review"));
+}
+
+#[actix_web::test]
+async fn legacy_api_writes_through_bundle_and_bridges_catalog_event() {
+    let data = tempfile::tempdir().expect("data dir");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let mut account_events = state.account_sink.subscribe();
+    let app = actix_web::test::init_service(
+        actix_web::App::new()
+            .app_data(state.clone())
+            .route(
+                "/workflows",
+                actix_web::web::post().to(super::save_workflow),
+            )
+            .route(
+                "/workflows/{name}",
+                actix_web::web::get().to(super::get_workflow),
+            ),
+    )
+    .await;
+    for content in ["First body", "Second body"] {
+        let request = actix_web::test::TestRequest::post()
+            .uri("/workflows")
+            .set_json(serde_json::json!({"name": "legacy", "content": content}))
+            .to_request();
+        let response = actix_web::test::call_service(&app, request).await;
+        assert!(response.status().is_success());
+    }
+    let request = actix_web::test::TestRequest::get()
+        .uri("/workflows/legacy")
+        .to_request();
+    let body: serde_json::Value = actix_web::test::call_and_read_body_json(&app, request).await;
+    assert_eq!(body["content"], "Second body");
+    assert!(
+        tokio::fs::read_to_string(data.path().join("skills/legacy/SKILL.md"))
+            .await
+            .expect("adapter bundle")
+            .contains("Second body")
+    );
+
+    let bridged = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        let mut workflow_changes = 0;
+        loop {
+            let event = account_events.recv().await.expect("account event");
+            if matches!(
+                event.event,
+                bamboo_agent_core::AgentEvent::WorkflowChanged { .. }
+            ) {
+                workflow_changes += 1;
+                if workflow_changes == 2 {
+                    break;
+                }
+            }
+        }
+    })
+    .await;
+    assert!(bridged.is_ok(), "workflow.changed must reach account feed");
+}
+
+#[actix_web::test]
+async fn concurrent_legacy_updates_leave_source_and_bundle_consistent() {
+    let data = tempfile::tempdir().expect("data dir");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let app = actix_web::test::init_service(actix_web::App::new().app_data(state).route(
+        "/workflows",
+        actix_web::web::post().to(super::save_workflow),
+    ))
+    .await;
+    let first = actix_web::test::TestRequest::post()
+        .uri("/workflows")
+        .set_json(serde_json::json!({"name": "race", "content": "body one"}))
+        .to_request();
+    let second = actix_web::test::TestRequest::post()
+        .uri("/workflows")
+        .set_json(serde_json::json!({"name": "race", "content": "body two"}))
+        .to_request();
+    let (first, second) = tokio::join!(
+        actix_web::test::call_service(&app, first),
+        actix_web::test::call_service(&app, second)
+    );
+    assert!(first.status().is_success());
+    assert!(second.status().is_success());
+    let source = tokio::fs::read_to_string(data.path().join("workflows/race.md"))
+        .await
+        .expect("source");
+    let bundle = tokio::fs::read_to_string(data.path().join("skills/race/SKILL.md"))
+        .await
+        .expect("bundle");
+    assert!(bundle.contains(&source));
+    let mut entries = tokio::fs::read_dir(data.path().join("workflows"))
+        .await
+        .expect("workflow dir");
+    while let Some(entry) = entries.next_entry().await.expect("entry") {
+        assert!(!entry.file_name().to_string_lossy().ends_with(".tmp"));
+    }
+}
+
+#[actix_web::test]
+async fn legacy_api_preserves_names_outside_skill_id_grammar() {
+    let data = tempfile::tempdir().expect("data dir");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let app = actix_web::test::init_service(
+        actix_web::App::new()
+            .app_data(state)
+            .route(
+                "/workflows",
+                actix_web::web::get().to(super::list_workflows),
+            )
+            .route(
+                "/workflows",
+                actix_web::web::post().to(super::save_workflow),
+            )
+            .route(
+                "/workflows/{name}",
+                actix_web::web::get().to(super::get_workflow),
+            ),
+    )
+    .await;
+    let name = "发布 Workflow_v2";
+    let request = actix_web::test::TestRequest::post()
+        .uri("/workflows")
+        .set_json(serde_json::json!({"name": name, "content": "Original body"}))
+        .to_request();
+    let response = actix_web::test::call_service(&app, request).await;
+    assert!(response.status().is_success());
+
+    let request = actix_web::test::TestRequest::get()
+        .uri("/workflows")
+        .to_request();
+    let listed: serde_json::Value = actix_web::test::call_and_read_body_json(&app, request).await;
+    assert!(listed
+        .as_array()
+        .expect("workflow list")
+        .iter()
+        .any(|item| item["name"] == name));
+
+    let request = actix_web::test::TestRequest::get()
+        .uri("/workflows/%E5%8F%91%E5%B8%83%20Workflow_v2")
+        .to_request();
+    let loaded: serde_json::Value = actix_web::test::call_and_read_body_json(&app, request).await;
+    assert_eq!(loaded["name"], name);
+    assert_eq!(loaded["content"], "Original body");
+}
+
 #[test]
 fn safe_workflow_name_accepts_normal_names() {
     assert!(is_safe_workflow_name("my-workflow_01"));

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/types.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/types.rs
@@ -1,5 +1,11 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Default, Deserialize)]
+pub struct WorkflowCatalogQuery {
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
 /// Workflow list item for API responses.
 #[derive(Serialize)]
 pub(super) struct WorkflowListItem {

--- a/crates/app/bamboo-server/src/handlers/skill/tools.rs
+++ b/crates/app/bamboo-server/src/handlers/skill/tools.rs
@@ -26,21 +26,56 @@ pub async fn get_filtered_tools(
     query: web::Query<FilteredToolsQuery>,
 ) -> Result<HttpResponse, AppError> {
     let session_id = resolve_session_identifier(&query);
-    let selected_skill_ids = selected_skill_ids_for_session(state.get_ref(), session_id).await;
-    let selected_skill_mode = selected_skill_mode_for_session(state.get_ref(), session_id).await;
+    let session = match session_id {
+        Some(session_id) => state.load_session(session_id).await,
+        None => None,
+    };
+    let selected_skill_ids = session.as_ref().and_then(|session| {
+        session
+            .metadata
+            .get("selected_skill_ids")
+            .and_then(|raw| bamboo_skills::selection::parse_selected_skill_ids_metadata(raw))
+    });
+    let selected_skill_mode = session.as_ref().and_then(|session| {
+        session
+            .metadata
+            .get("skill_mode")
+            .or_else(|| session.metadata.get("mode"))
+            .map(|mode| mode.trim())
+            .filter(|mode| !mode.is_empty())
+            .map(str::to_string)
+    });
+    let workspace = session
+        .as_ref()
+        .and_then(|session| session.workspace_path_meta())
+        .map(std::path::PathBuf::from);
     let disabled_skill_ids = {
         let config = state.config.read().await;
         config.disabled_skill_ids()
     };
-    let allowed_tools = state
-        .skill_manager
-        .as_ref()
-        .get_allowed_tools_for_selection_with_mode(
-            &disabled_skill_ids,
-            selected_skill_ids.as_deref(),
-            selected_skill_mode.as_deref(),
-        )
-        .await;
+    let allowed_tools = if let Some(workspace) = workspace.as_deref() {
+        state
+            .skill_manager
+            .as_ref()
+            .get_allowed_tools_for_workspace_selection_with_mode(
+                workspace,
+                &disabled_skill_ids,
+                selected_skill_ids.as_deref(),
+                selected_skill_mode.as_deref(),
+            )
+            .await
+            .map_err(|error| AppError::BadRequest(format!("Invalid session workspace: {error}")))?
+    } else {
+        state
+            .skill_manager
+            .as_ref()
+            .get_allowed_tools_for_selection_with_mode(
+                &disabled_skill_ids,
+                selected_skill_ids.as_deref(),
+                selected_skill_mode.as_deref(),
+            )
+            .await
+    };
     debug!("Skill filtered tools allowed list: {:?}", allowed_tools);
 
     let all_tools = BuiltinToolExecutor::tool_schemas();
@@ -56,50 +91,6 @@ pub async fn get_filtered_tools(
 
 pub(super) fn resolve_session_identifier(query: &FilteredToolsQuery) -> Option<&str> {
     query.session_id.as_deref().or(query.chat_id.as_deref())
-}
-
-async fn selected_skill_ids_for_session(
-    state: &AppState,
-    session_id: Option<&str>,
-) -> Option<Vec<String>> {
-    let session_id = session_id?;
-
-    let in_memory = { bamboo_engine::read_cached_session(&state.sessions, session_id) };
-
-    let session = match in_memory {
-        Some(session) => Some(session),
-        None => state.storage.load_session(session_id).await.ok().flatten(),
-    }?;
-
-    session
-        .metadata
-        .get("selected_skill_ids")
-        .and_then(|raw| bamboo_skills::selection::parse_selected_skill_ids_metadata(raw))
-}
-
-async fn selected_skill_mode_for_session(
-    state: &AppState,
-    session_id: Option<&str>,
-) -> Option<String> {
-    let session_id = session_id?;
-
-    let in_memory = { bamboo_engine::read_cached_session(&state.sessions, session_id) };
-
-    let session = match in_memory {
-        Some(session) => Some(session),
-        None => state.storage.load_session(session_id).await.ok().flatten(),
-    }?;
-
-    let mode = session
-        .metadata
-        .get("skill_mode")
-        .or_else(|| session.metadata.get("mode"))?;
-    let trimmed = mode.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
 }
 
 pub(super) fn select_tools_by_allowlist(

--- a/crates/app/bamboo-server/src/routes/bamboo_v1.rs
+++ b/crates/app/bamboo-server/src/routes/bamboo_v1.rs
@@ -34,6 +34,10 @@ pub(crate) fn bamboo_relative_routes() -> impl HttpServiceFactory {
             web::get().to(command::get_command),
         )
         // Settings routes
+        .route(
+            "/bamboo/workflow-catalog",
+            web::get().to(settings::list_workflow_catalog),
+        )
         .route("/bamboo/workflows", web::get().to(settings::list_workflows))
         .route(
             "/bamboo/workflows/{name}",

--- a/crates/core/bamboo-agent-core/src/agent/events.rs
+++ b/crates/core/bamboo-agent-core/src/agent/events.rs
@@ -627,6 +627,27 @@ pub enum AgentEvent {
         message: String,
     },
 
+    /// A workflow catalog definition was added, changed, shadowed, or removed.
+    WorkflowChanged {
+        workflow_id: String,
+        revision: u64,
+        scope: String,
+    },
+
+    /// A workflow bundle became invalid while its last-known-good definition stays active.
+    WorkflowInvalid {
+        workflow_id: String,
+        revision: u64,
+        scope: String,
+    },
+
+    /// A previously invalid workflow bundle parsed successfully again.
+    WorkflowRecovered {
+        workflow_id: String,
+        revision: u64,
+        scope: String,
+    },
+
     /// A user-facing notification derived from agent activity by the backend
     /// notification policy. Clients render this (e.g. an OS desktop notification)
     /// after applying their own presence checks (window focus). The decision of
@@ -745,6 +766,9 @@ impl AgentEvent {
                 | AgentEvent::Complete { .. }
                 | AgentEvent::Cancelled { .. }
                 | AgentEvent::Error { .. }
+                | AgentEvent::WorkflowChanged { .. }
+                | AgentEvent::WorkflowInvalid { .. }
+                | AgentEvent::WorkflowRecovered { .. }
         )
     }
 }
@@ -1260,6 +1284,32 @@ mod tests {
                 assert_eq!(plan_file_path, None);
             }
             other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn workflow_catalog_events_are_durable_and_account_scoped() {
+        for event in [
+            AgentEvent::WorkflowChanged {
+                workflow_id: "review".to_string(),
+                revision: 2,
+                scope: "global".to_string(),
+            },
+            AgentEvent::WorkflowInvalid {
+                workflow_id: "review".to_string(),
+                revision: 3,
+                scope: "workspace:1234".to_string(),
+            },
+            AgentEvent::WorkflowRecovered {
+                workflow_id: "review".to_string(),
+                revision: 4,
+                scope: "workspace:1234".to_string(),
+            },
+        ] {
+            assert!(event.is_durable_change());
+            assert_eq!(event.session_id(), None);
+            let encoded = serde_json::to_string(&event).expect("serialize");
+            let _: AgentEvent = serde_json::from_str(&encoded).expect("deserialize");
         }
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup.rs
@@ -39,7 +39,8 @@ pub(crate) async fn prepare_session_for_loop(
     session_id: &str,
     debug_logger: &DebugLogger,
 ) -> Option<TaskLoopContext> {
-    let skill_result = skill_context::load_skill_context(config, session_id, initial_message).await;
+    let skill_result =
+        skill_context::load_skill_context(config, session, session_id, initial_message).await;
     let skill_context = skill_result.context.clone();
 
     if let Some(source) = skill_result.selection_source.as_deref() {

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/skill_context.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/skill_context.rs
@@ -1,4 +1,5 @@
 use crate::runtime::config::AgentLoopConfig;
+use bamboo_agent_core::Session;
 
 #[derive(Debug, Clone, Default)]
 pub(super) struct SkillContextLoadResult {
@@ -11,18 +12,43 @@ pub(super) struct SkillContextLoadResult {
 
 pub(super) async fn load_skill_context(
     config: &AgentLoopConfig,
+    session: &Session,
     session_id: &str,
     request_hint: &str,
 ) -> SkillContextLoadResult {
     if let Some(skill_manager) = config.skill_manager.as_ref() {
-        let selected_skills: Vec<bamboo_skills::SkillDefinition> = skill_manager
-            .resolve_skills_for_request_with_mode(
-                &config.disabled_skill_ids,
-                config.selected_skill_ids.as_deref(),
-                config.selected_skill_mode.as_deref(),
-                Some(request_hint),
-            )
-            .await;
+        let selected_skills: Vec<bamboo_skills::SkillDefinition> =
+            if let Some(workspace) = session.workspace_path_meta() {
+                match skill_manager
+                    .resolve_skills_for_request_in_workspace_with_mode(
+                        std::path::Path::new(&workspace),
+                        &config.disabled_skill_ids,
+                        config.selected_skill_ids.as_deref(),
+                        config.selected_skill_mode.as_deref(),
+                        Some(request_hint),
+                    )
+                    .await
+                {
+                    Ok(skills) => skills,
+                    Err(error) => {
+                        tracing::warn!(
+                            "[{}] Failed to resolve session workspace skills: {}",
+                            session_id,
+                            error
+                        );
+                        Vec::new()
+                    }
+                }
+            } else {
+                skill_manager
+                    .resolve_skills_for_request_with_mode(
+                        &config.disabled_skill_ids,
+                        config.selected_skill_ids.as_deref(),
+                        config.selected_skill_mode.as_deref(),
+                        Some(request_hint),
+                    )
+                    .await
+            };
         let selected_ids = selected_skills
             .iter()
             .map(|skill| skill.id.clone())

--- a/crates/infra/bamboo-skills/Cargo.toml
+++ b/crates/infra/bamboo-skills/Cargo.toml
@@ -18,6 +18,10 @@ tracing = "0.1"
 thiserror = "2"
 async-trait = "0.1"
 walkdir = "2"
+notify = "8"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/infra/bamboo-skills/src/catalog.rs
+++ b/crates/infra/bamboo-skills/src/catalog.rs
@@ -1,0 +1,233 @@
+//! Metadata-only workflow catalog layered on the canonical SkillStore discovery.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::store::storage::SkillDirectorySource;
+use crate::types::SkillDefinition;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowKind {
+    Instruction,
+    Orchestration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowSource {
+    Builtin,
+    Project,
+    User,
+    Plugin,
+}
+
+impl From<SkillDirectorySource> for WorkflowSource {
+    fn from(value: SkillDirectorySource) -> Self {
+        match value {
+            SkillDirectorySource::Builtin => Self::Builtin,
+            SkillDirectorySource::Project => Self::Project,
+            SkillDirectorySource::Global => Self::User,
+            // `~/.agents/skills` is another user-level discovery root. Keep its lower
+            // internal precedence without leaking an implementation-specific fifth public
+            // source into the four-source catalog contract.
+            SkillDirectorySource::Agents => Self::User,
+            SkillDirectorySource::Plugin => Self::Plugin,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowStatus {
+    Valid,
+    Invalid,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ShadowedWorkflowCandidate {
+    pub source: WorkflowSource,
+    pub status: WorkflowStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
+/// Public catalog item. It intentionally contains no instructions or resource paths.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WorkflowCatalogEntry {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub kind: WorkflowKind,
+    pub source: WorkflowSource,
+    pub revision: u64,
+    pub version: String,
+    pub invocation_policy: serde_json::Value,
+    pub argument_schema: serde_json::Value,
+    pub status: WorkflowStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    pub winner: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub shadowed_candidates: Vec<ShadowedWorkflowCandidate>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct WorkflowCatalogSnapshot {
+    pub revision: u64,
+    pub entries: Vec<WorkflowCatalogEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowCatalogEventKind {
+    Changed,
+    Invalid,
+    Recovered,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowCatalogEvent {
+    pub workflow_id: String,
+    pub revision: u64,
+    pub kind: WorkflowCatalogEventKind,
+    /// `global` or an opaque `workspace:<hash>`; never an absolute filesystem path.
+    pub scope: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct BambooWorkflowMetadata {
+    #[serde(default)]
+    version: Option<serde_yaml::Value>,
+    #[serde(default)]
+    invocation_policy: Option<serde_json::Value>,
+    #[serde(default)]
+    argument_schema: Option<serde_json::Value>,
+    // A composition is sufficient to classify legacy WorkflowDefinition YAML.
+    #[serde(default)]
+    composition: Option<serde_yaml::Value>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BundleMetadata {
+    pub kind: WorkflowKind,
+    pub version: String,
+    pub invocation_policy: serde_json::Value,
+    pub argument_schema: serde_json::Value,
+}
+
+impl Default for BundleMetadata {
+    fn default() -> Self {
+        Self {
+            kind: WorkflowKind::Instruction,
+            version: "1".to_string(),
+            invocation_policy: serde_json::json!({"explicit": true, "automatic": true}),
+            argument_schema: serde_json::json!({"type": "object", "additionalProperties": true}),
+        }
+    }
+}
+
+fn yaml_scalar_to_string(value: serde_yaml::Value) -> Option<String> {
+    match value {
+        serde_yaml::Value::String(value) => Some(value),
+        serde_yaml::Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+pub(crate) async fn load_bundle_metadata(root: &Path) -> Result<BundleMetadata, String> {
+    let workflow_path = root.join("workflow.yaml");
+    let bamboo_path = root.join("agents").join("bamboo.yaml");
+    let path = if tokio::fs::try_exists(&workflow_path).await.unwrap_or(false) {
+        Some(workflow_path)
+    } else if tokio::fs::try_exists(&bamboo_path).await.unwrap_or(false) {
+        Some(bamboo_path)
+    } else {
+        None
+    };
+
+    let Some(path) = path else {
+        return Ok(BundleMetadata::default());
+    };
+    let display_name = if path.ends_with("workflow.yaml") {
+        "workflow.yaml"
+    } else {
+        "agents/bamboo.yaml"
+    };
+    let raw = tokio::fs::read_to_string(&path)
+        .await
+        .map_err(|error| format!("{display_name}: {error}"))?;
+    let metadata: BambooWorkflowMetadata =
+        serde_yaml::from_str(&raw).map_err(|error| format!("{display_name}: {error}"))?;
+    let is_workflow_definition = path.ends_with("workflow.yaml");
+    if is_workflow_definition {
+        let definition: bamboo_domain::WorkflowDefinition =
+            serde_yaml::from_str(&raw).map_err(|error| format!("{display_name}: {error}"))?;
+        definition
+            .validate()
+            .map_err(|error| format!("{display_name}: {error}"))?;
+    }
+    let mut result = BundleMetadata {
+        kind: if metadata.composition.is_some() || is_workflow_definition {
+            WorkflowKind::Orchestration
+        } else {
+            WorkflowKind::Instruction
+        },
+        ..Default::default()
+    };
+    if let Some(version) = metadata.version.and_then(yaml_scalar_to_string) {
+        result.version = version;
+    }
+    if let Some(policy) = metadata.invocation_policy {
+        result.invocation_policy = policy;
+    }
+    if let Some(schema) = metadata.argument_schema {
+        result.argument_schema = schema;
+    }
+    Ok(result)
+}
+
+pub(crate) fn entry_from_skill(
+    skill: &SkillDefinition,
+    source: SkillDirectorySource,
+    revision: u64,
+    metadata: BundleMetadata,
+) -> WorkflowCatalogEntry {
+    WorkflowCatalogEntry {
+        id: skill.id.clone(),
+        name: skill.name.clone(),
+        description: skill.description.clone(),
+        kind: metadata.kind,
+        source: source.into(),
+        revision,
+        version: metadata.version,
+        invocation_policy: metadata.invocation_policy,
+        argument_schema: metadata.argument_schema,
+        status: WorkflowStatus::Valid,
+        last_error: None,
+        winner: true,
+        shadowed_candidates: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_serialization_never_contains_instructions_or_resources() {
+        let skill = SkillDefinition::new("review", "review", "Reviews code", "SECRET BODY");
+        let entry = entry_from_skill(
+            &skill,
+            SkillDirectorySource::Project,
+            4,
+            BundleMetadata::default(),
+        );
+        let json = serde_json::to_string(&entry).expect("serialize catalog entry");
+        assert!(!json.contains("SECRET BODY"));
+        assert!(!json.contains("prompt"));
+        assert!(!json.contains("SKILL.md"));
+        assert!(!json.contains("references"));
+    }
+}

--- a/crates/infra/bamboo-skills/src/legacy.rs
+++ b/crates/infra/bamboo-skills/src/legacy.rs
@@ -1,0 +1,617 @@
+//! Non-destructive, idempotent adapters for pre-catalog workflow formats.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+
+use crate::store::parser::is_valid_skill_id;
+use crate::types::{SkillError, SkillResult};
+
+static STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+async fn unique_staging_file(
+    directory: &Path,
+    label: &str,
+) -> SkillResult<(PathBuf, tokio::fs::File)> {
+    loop {
+        let sequence = STAGING_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let path = directory.join(format!(".{label}.{}.{}.tmp", std::process::id(), sequence));
+        match tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .await
+        {
+            Ok(file) => return Ok((path, file)),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error.into()),
+        }
+    }
+}
+
+/// Atomically replace `target` with a fully-written same-directory staging file.
+pub async fn atomic_replace_file(staging: &Path, target: &Path) -> std::io::Result<()> {
+    #[cfg(not(windows))]
+    {
+        tokio::fs::rename(staging, target).await
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Storage::FileSystem::{
+            MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+        };
+        let source: Vec<u16> = staging.as_os_str().encode_wide().chain(Some(0)).collect();
+        let destination: Vec<u16> = target.as_os_str().encode_wide().chain(Some(0)).collect();
+        let result = unsafe {
+            MoveFileExW(
+                source.as_ptr(),
+                destination.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        };
+        if result == 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LegacyImportReport {
+    pub imported: Vec<String>,
+    pub updated: Vec<String>,
+    pub already_present: Vec<String>,
+    pub diagnostics: Vec<String>,
+}
+
+/// Map a legacy filename to a stable Agent Skills-compatible bundle id.
+///
+/// Existing kebab-case names retain their id. Names accepted by the legacy API but rejected by
+/// the Agent Skills grammar (spaces, underscores, Unicode, uppercase, and dots) receive a readable
+/// ASCII prefix plus a deterministic hash, avoiding lossy normalization collisions.
+pub fn legacy_workflow_skill_id(name: &str) -> String {
+    if is_valid_skill_id(name) {
+        return name.to_string();
+    }
+
+    const OFFSET: u64 = 0xcbf29ce484222325;
+    const PRIME: u64 = 0x100000001b3;
+    let hash = name.as_bytes().iter().fold(OFFSET, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(PRIME)
+    });
+    let mut slug = String::new();
+    let mut pending_separator = false;
+    for character in name.chars() {
+        if character.is_ascii_alphanumeric() {
+            if pending_separator && !slug.is_empty() {
+                slug.push('-');
+            }
+            pending_separator = false;
+            slug.push(character.to_ascii_lowercase());
+            if slug.len() >= 40 {
+                break;
+            }
+        } else {
+            pending_separator = true;
+        }
+    }
+    let slug = slug.trim_matches('-');
+    if slug.is_empty() {
+        format!("legacy-{hash:016x}")
+    } else {
+        format!("{slug}-legacy-{hash:016x}")
+    }
+}
+
+/// Import `${BAMBOO_DATA_DIR}/workflows/*.md` as Skill-compatible bundles.
+/// The source is never deleted and an existing target is never overwritten.
+pub async fn import_legacy_markdown_workflows(
+    workflows_dir: &Path,
+    skills_dir: &Path,
+) -> SkillResult<LegacyImportReport> {
+    let mut report = LegacyImportReport {
+        imported: Vec::new(),
+        updated: Vec::new(),
+        already_present: Vec::new(),
+        diagnostics: Vec::new(),
+    };
+    let mut entries = match tokio::fs::read_dir(workflows_dir).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(report),
+        Err(error) => return Err(error.into()),
+    };
+    let mut sources = Vec::new();
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        let file_type = entry.file_type().await?;
+        if file_type.is_file()
+            && !file_type.is_symlink()
+            && path.extension().and_then(|value| value.to_str()) == Some("md")
+        {
+            sources.push(path);
+        }
+    }
+    sources.sort();
+
+    for source in sources {
+        let Some(legacy_name) = source.file_stem().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        let id = legacy_workflow_skill_id(legacy_name);
+        let body = tokio::fs::read_to_string(&source).await?;
+        match sync_legacy_markdown_bundle(&source, skills_dir, &id, &body).await? {
+            LegacySyncOutcome::Imported => report.imported.push(id.clone()),
+            LegacySyncOutcome::Updated => report.updated.push(id.clone()),
+            LegacySyncOutcome::Unchanged => report.already_present.push(id.clone()),
+            LegacySyncOutcome::Conflict => report.diagnostics.push(format!(
+                "{} was not imported because {} is not owned by this legacy source",
+                source.display(),
+                skills_dir.join(&id).join("SKILL.md").display()
+            )),
+        }
+    }
+    Ok(report)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LegacySyncOutcome {
+    Imported,
+    Updated,
+    Unchanged,
+    Conflict,
+}
+
+fn is_owned_legacy_skill(raw: &str, target: &Path, source: &Path) -> bool {
+    crate::store::parser::parse_markdown_skill(target, raw)
+        .ok()
+        .and_then(|skill| skill.metadata)
+        .is_some_and(|metadata| {
+            metadata.get("legacy_import").and_then(|v| v.as_bool()) == Some(true)
+                && metadata.get("original_source").and_then(|v| v.as_str())
+                    == Some(source.to_string_lossy().as_ref())
+        })
+}
+
+/// Synchronize one legacy source into its adapter bundle. Existing non-legacy bundles are never
+/// overwritten; an existing bundle owned by the same source is updated atomically.
+pub async fn sync_legacy_markdown_bundle(
+    source: &Path,
+    skills_dir: &Path,
+    id: &str,
+    body: &str,
+) -> SkillResult<LegacySyncOutcome> {
+    if !is_valid_skill_id(id) {
+        return Err(SkillError::InvalidId(id.to_string()));
+    }
+    let target_dir = skills_dir.join(id);
+    let target = target_dir.join("SKILL.md");
+    let legacy_name = source
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or(id);
+    let frontmatter = serde_yaml::to_string(&serde_json::json!({
+        "name": id,
+        "description": format!("Imported legacy workflow '{legacy_name}'."),
+        "metadata": {
+            "legacy_import": true,
+            "legacy_name": legacy_name,
+            "original_source": source.to_string_lossy(),
+            "format": "workflow_markdown"
+        }
+    }))?;
+    let content = format!("---\n{frontmatter}---\n\n{}\n", body.trim_end());
+    let existing = match tokio::fs::read_to_string(&target).await {
+        Ok(existing) => Some(existing),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error.into()),
+    };
+    if let Some(existing) = existing {
+        if !is_owned_legacy_skill(&existing, &target, source) {
+            return Ok(LegacySyncOutcome::Conflict);
+        }
+        if existing == content {
+            return Ok(LegacySyncOutcome::Unchanged);
+        }
+        let (temporary, mut file) = unique_staging_file(&target_dir, "SKILL.md").await?;
+        if let Err(error) = async {
+            file.write_all(content.as_bytes()).await?;
+            file.flush().await?;
+            file.sync_all().await?;
+            drop(file);
+            atomic_replace_file(&temporary, &target).await
+        }
+        .await
+        {
+            let _ = tokio::fs::remove_file(&temporary).await;
+            return Err(error.into());
+        }
+        return Ok(LegacySyncOutcome::Updated);
+    }
+    tokio::fs::create_dir_all(&target_dir).await?;
+    let (temporary, mut file) = unique_staging_file(&target_dir, "SKILL.md").await?;
+    if let Err(error) = async {
+        file.write_all(content.as_bytes()).await?;
+        file.flush().await?;
+        file.sync_all().await?;
+        tokio::fs::hard_link(&temporary, &target).await
+    }
+    .await
+    {
+        let _ = tokio::fs::remove_file(&temporary).await;
+        if error.kind() == std::io::ErrorKind::AlreadyExists {
+            return Ok(LegacySyncOutcome::Conflict);
+        }
+        return Err(error.into());
+    }
+    let _ = tokio::fs::remove_file(&temporary).await;
+    Ok(LegacySyncOutcome::Imported)
+}
+
+pub async fn legacy_bundle_preflight(
+    source: &Path,
+    skills_dir: &Path,
+    id: &str,
+) -> SkillResult<bool> {
+    if !is_valid_skill_id(id) {
+        return Err(SkillError::InvalidId(id.to_string()));
+    }
+    let target = skills_dir.join(id).join("SKILL.md");
+    match tokio::fs::read_to_string(&target).await {
+        Ok(raw) => Ok(is_owned_legacy_skill(&raw, &target, source)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(true),
+        Err(error) => Err(error.into()),
+    }
+}
+
+/// Remove only an adapter bundle owned by this legacy source.
+pub async fn remove_legacy_markdown_bundle(
+    source: &Path,
+    skills_dir: &Path,
+    id: &str,
+) -> SkillResult<bool> {
+    let target = skills_dir.join(id).join("SKILL.md");
+    let raw = match tokio::fs::read_to_string(&target).await {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    if !is_owned_legacy_skill(&raw, &target, source) {
+        return Ok(false);
+    }
+    tokio::fs::remove_file(&target).await?;
+    let dir = target.parent().expect("SKILL.md has parent");
+    if tokio::fs::read_dir(dir)
+        .await?
+        .next_entry()
+        .await?
+        .is_none()
+    {
+        tokio::fs::remove_dir(dir).await?;
+    }
+    Ok(true)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct YamlMigrationDiagnostic {
+    pub source: PathBuf,
+    pub workflow_id: Option<String>,
+    pub can_map_to_bundle: bool,
+    pub message: String,
+}
+
+/// Inspect old WorkflowDefinition YAML without writing or changing execution semantics.
+pub async fn diagnose_legacy_yaml_workflows(dir: &Path) -> Vec<YamlMigrationDiagnostic> {
+    let mut diagnostics = Vec::new();
+    let mut entries = match tokio::fs::read_dir(dir).await {
+        Ok(entries) => entries,
+        Err(_) => return diagnostics,
+    };
+    let mut paths = Vec::new();
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        if path
+            .extension()
+            .and_then(|value| value.to_str())
+            .is_some_and(|value| matches!(value, "yaml" | "yml"))
+        {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    for path in paths {
+        let result = async {
+            let raw = tokio::fs::read_to_string(&path)
+                .await
+                .map_err(|e| e.to_string())?;
+            let definition: bamboo_domain::WorkflowDefinition =
+                serde_yaml::from_str(&raw).map_err(|e| e.to_string())?;
+            definition.validate()?;
+            Ok::<_, String>(definition.id)
+        }
+        .await;
+        match result {
+            Ok(id) => diagnostics.push(YamlMigrationDiagnostic {
+                source: path,
+                workflow_id: Some(id),
+                can_map_to_bundle: true,
+                message: "Can be copied verbatim to workflow.yaml; execution remains owned by the orchestration runtime".to_string(),
+            }),
+            Err(error) => diagnostics.push(YamlMigrationDiagnostic {
+                source: path,
+                workflow_id: None,
+                can_map_to_bundle: false,
+                message: error,
+            }),
+        }
+    }
+    diagnostics
+}
+
+/// Copy safely mappable legacy WorkflowDefinition files into existing Skill bundles. The source
+/// YAML is read-only, an existing workflow.yaml is never overwritten, and definitions without a
+/// matching instruction bundle remain diagnostics instead of acquiring invented instructions.
+pub async fn migrate_legacy_yaml_workflows(
+    dir: &Path,
+    skills_dir: &Path,
+) -> Vec<YamlMigrationDiagnostic> {
+    let mut diagnostics = diagnose_legacy_yaml_workflows(dir).await;
+    for diagnostic in &mut diagnostics {
+        if !diagnostic.can_map_to_bundle {
+            continue;
+        }
+        let Some(id) = diagnostic.workflow_id.as_deref() else {
+            diagnostic.can_map_to_bundle = false;
+            diagnostic.message = "Missing workflow id".to_string();
+            continue;
+        };
+        if !is_valid_skill_id(id) {
+            diagnostic.can_map_to_bundle = false;
+            diagnostic.message = "Workflow id is not a valid skill bundle id".to_string();
+            continue;
+        }
+        let bundle = skills_dir.join(id);
+        if !tokio::fs::try_exists(&bundle.join("SKILL.md"))
+            .await
+            .unwrap_or(false)
+        {
+            diagnostic.can_map_to_bundle = false;
+            diagnostic.message =
+                "No matching Skill bundle; refusing to invent instruction semantics".to_string();
+            continue;
+        }
+        let target = bundle.join("workflow.yaml");
+        if tokio::fs::try_exists(&target).await.unwrap_or(false) {
+            let valid = match tokio::fs::read_to_string(&target).await {
+                Ok(raw) => serde_yaml::from_str::<bamboo_domain::WorkflowDefinition>(&raw)
+                    .ok()
+                    .is_some_and(|definition| definition.validate().is_ok()),
+                Err(_) => false,
+            };
+            diagnostic.message = if valid {
+                "workflow.yaml already present; left unchanged".to_string()
+            } else {
+                "invalid workflow.yaml already present; left unchanged for user repair".to_string()
+            };
+            continue;
+        }
+        match tokio::fs::read(&diagnostic.source).await {
+            Ok(bytes) => match unique_staging_file(&bundle, "workflow.yaml").await {
+                Ok((staging, mut file)) => {
+                    let result = async {
+                        file.write_all(&bytes).await?;
+                        file.flush().await?;
+                        file.sync_all().await?;
+                        tokio::fs::hard_link(&staging, &target).await
+                    }
+                    .await;
+                    let _ = tokio::fs::remove_file(&staging).await;
+                    match result {
+                        Ok(()) => {
+                            diagnostic.message =
+                                "Copied to workflow.yaml; source left unchanged".to_string()
+                        }
+                        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                            diagnostic.message =
+                                "workflow.yaml already present; left unchanged".to_string()
+                        }
+                        Err(error) => {
+                            diagnostic.can_map_to_bundle = false;
+                            diagnostic.message = error.to_string();
+                        }
+                    }
+                }
+                Err(error) => {
+                    diagnostic.can_map_to_bundle = false;
+                    diagnostic.message = error.to_string();
+                }
+            },
+            Err(error) => {
+                diagnostic.can_map_to_bundle = false;
+                diagnostic.message = error.to_string();
+            }
+        }
+    }
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn markdown_import_is_lossless_idempotent_and_keeps_source() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workflows = temp.path().join("workflows");
+        let skills = temp.path().join("skills");
+        tokio::fs::create_dir_all(&workflows)
+            .await
+            .expect("workflows");
+        let source = workflows.join("release.md");
+        tokio::fs::write(&source, "Release $ARGUMENTS\n")
+            .await
+            .expect("legacy workflow");
+
+        let first = import_legacy_markdown_workflows(&workflows, &skills)
+            .await
+            .expect("first import");
+        let second = import_legacy_markdown_workflows(&workflows, &skills)
+            .await
+            .expect("second import");
+        assert_eq!(first.imported, vec!["release"]);
+        assert_eq!(second.already_present, vec!["release"]);
+        assert_eq!(
+            tokio::fs::read_to_string(&source)
+                .await
+                .expect("source kept"),
+            "Release $ARGUMENTS\n"
+        );
+        let imported = tokio::fs::read_to_string(skills.join("release/SKILL.md"))
+            .await
+            .expect("imported skill");
+        assert!(imported.contains("Release $ARGUMENTS"));
+        assert!(imported.contains("legacy_import: true"));
+        assert!(imported.contains(source.to_string_lossy().as_ref()));
+
+        tokio::fs::write(&source, "Release safely\n")
+            .await
+            .expect("external legacy update");
+        let updated = import_legacy_markdown_workflows(&workflows, &skills)
+            .await
+            .expect("sync update");
+        assert_eq!(updated.updated, vec!["release"]);
+        assert!(tokio::fs::read_to_string(skills.join("release/SKILL.md"))
+            .await
+            .expect("updated skill")
+            .contains("Release safely"));
+    }
+
+    #[tokio::test]
+    async fn markdown_import_preserves_legacy_names_outside_skill_id_grammar() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workflows = temp.path().join("workflows");
+        let skills = temp.path().join("skills");
+        tokio::fs::create_dir_all(&workflows)
+            .await
+            .expect("workflows");
+        let source = workflows.join("发布 Workflow_v2.md");
+        tokio::fs::write(&source, "Preserve this body exactly.\n")
+            .await
+            .expect("legacy workflow");
+
+        let expected_id = legacy_workflow_skill_id("发布 Workflow_v2");
+        assert!(is_valid_skill_id(&expected_id));
+        let first = import_legacy_markdown_workflows(&workflows, &skills)
+            .await
+            .expect("first import");
+        let second = import_legacy_markdown_workflows(&workflows, &skills)
+            .await
+            .expect("second import");
+        assert_eq!(first.imported, vec![expected_id.clone()]);
+        assert_eq!(second.already_present, vec![expected_id.clone()]);
+
+        let imported = tokio::fs::read_to_string(skills.join(expected_id).join("SKILL.md"))
+            .await
+            .expect("imported bundle");
+        assert!(imported.contains("legacy_name: 发布 Workflow_v2"));
+        assert!(imported.contains("Preserve this body exactly."));
+        assert!(source.exists(), "legacy source remains untouched");
+    }
+
+    #[tokio::test]
+    async fn yaml_diagnostics_refuse_to_infer_missing_composition() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        tokio::fs::write(
+            temp.path().join("safe.yaml"),
+            "id: safe\nname: Safe\ndescription: Safe migration\nversion: '1'\ncomposition:\n  type: call\n  tool: read_file\n  args: {}\n",
+        )
+            .await
+            .expect("safe yaml");
+        tokio::fs::write(temp.path().join("unsafe.yaml"), "id: unsafe\nsteps: []\n")
+            .await
+            .expect("unsafe yaml");
+        let diagnostics = diagnose_legacy_yaml_workflows(temp.path()).await;
+        assert_eq!(diagnostics.len(), 2);
+        assert!(diagnostics.iter().any(|item| item.can_map_to_bundle));
+        assert!(diagnostics.iter().any(|item| !item.can_map_to_bundle));
+    }
+
+    #[tokio::test]
+    async fn yaml_migration_copies_only_into_existing_skill_bundle() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workflows = temp.path().join("workflows");
+        let skills = temp.path().join("skills");
+        tokio::fs::create_dir_all(&workflows)
+            .await
+            .expect("workflows");
+        tokio::fs::create_dir_all(skills.join("safe"))
+            .await
+            .expect("bundle");
+        tokio::fs::write(
+            skills.join("safe/SKILL.md"),
+            "---\nname: safe\ndescription: Safe workflow\n---\nInstructions\n",
+        )
+        .await
+        .expect("skill");
+        let source = workflows.join("safe.yaml");
+        tokio::fs::write(
+            &source,
+            "id: safe\nname: Safe\ndescription: Safe migration\nversion: '1'\ncomposition:\n  type: call\n  tool: read_file\n  args: {}\n",
+        )
+        .await
+        .expect("yaml");
+        tokio::fs::write(skills.join("safe/.workflow.yaml.stale.tmp"), "partial: [")
+            .await
+            .expect("simulate stale staging file");
+        let diagnostics = migrate_legacy_yaml_workflows(&workflows, &skills).await;
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].can_map_to_bundle);
+        assert!(skills.join("safe/workflow.yaml").exists());
+        let recovered = tokio::fs::read_to_string(skills.join("safe/workflow.yaml"))
+            .await
+            .expect("recovered workflow");
+        let definition: bamboo_domain::WorkflowDefinition =
+            serde_yaml::from_str(&recovered).expect("complete definition");
+        assert_eq!(definition.id, "safe");
+        assert!(source.exists(), "source remains read-only");
+    }
+
+    #[tokio::test]
+    async fn yaml_migration_never_replaces_invalid_existing_target() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workflows = temp.path().join("workflows");
+        let bundle = temp.path().join("skills/safe");
+        tokio::fs::create_dir_all(&workflows)
+            .await
+            .expect("workflows");
+        tokio::fs::create_dir_all(&bundle).await.expect("bundle");
+        tokio::fs::write(
+            bundle.join("SKILL.md"),
+            "---\nname: safe\ndescription: Safe workflow\n---\nInstructions\n",
+        )
+        .await
+        .expect("skill");
+        tokio::fs::write(
+            workflows.join("safe.yaml"),
+            "id: safe\nname: Safe\ndescription: Safe migration\nversion: '1'\ncomposition:\n  type: call\n  tool: read_file\n  args: {}\n",
+        )
+        .await
+        .expect("source");
+        let invalid = b"partial: [";
+        tokio::fs::write(bundle.join("workflow.yaml"), invalid)
+            .await
+            .expect("invalid target");
+        let diagnostics =
+            migrate_legacy_yaml_workflows(&workflows, &temp.path().join("skills")).await;
+        assert!(diagnostics[0].message.contains("left unchanged"));
+        assert_eq!(
+            tokio::fs::read(bundle.join("workflow.yaml"))
+                .await
+                .expect("target preserved"),
+            invalid
+        );
+    }
+}

--- a/crates/infra/bamboo-skills/src/lib.rs
+++ b/crates/infra/bamboo-skills/src/lib.rs
@@ -1,7 +1,9 @@
 //! Agent skill management (re-exported from bamboo-agent-skill crate).
 
 pub mod access_control;
+pub mod catalog;
 pub mod context;
+pub mod legacy;
 pub mod resource_helpers;
 pub mod runtime_metadata;
 pub mod selection;
@@ -9,10 +11,16 @@ pub mod session_port;
 pub mod store;
 pub mod types;
 
+pub use catalog::{
+    ShadowedWorkflowCandidate, WorkflowCatalogEntry, WorkflowCatalogEvent,
+    WorkflowCatalogEventKind, WorkflowCatalogSnapshot, WorkflowKind, WorkflowSource,
+    WorkflowStatus,
+};
 pub use store::{SkillStore, SkillUpdate};
 pub use types::*;
 
 use std::collections::{BTreeSet, HashSet};
+use std::path::Path;
 use std::sync::Arc;
 
 const MAX_UNSELECTED_SKILLS_IN_CONTEXT: usize = 24;
@@ -164,7 +172,9 @@ impl SkillManager {
 
     /// Initialize the manager.
     pub async fn initialize(&self) -> SkillResult<()> {
-        self.store.initialize().await
+        self.store.initialize().await?;
+        self.store.start_live_reload();
+        Ok(())
     }
 
     /// Get the underlying store.
@@ -172,18 +182,29 @@ impl SkillManager {
         &self.store
     }
 
-    pub(crate) async fn list_skills_for_selection(
+    /// Resolve the shared global store or an isolated workspace store.
+    /// Callers at API/runtime boundaries must derive `workspace` from trusted
+    /// server-side session state rather than request/tool arguments.
+    pub async fn store_for_workspace(
         &self,
+        workspace: Option<&Path>,
+    ) -> SkillResult<Arc<SkillStore>> {
+        match workspace {
+            Some(workspace) => self.store.skill_store_for_workspace(workspace).await,
+            None => Ok(self.store.clone()),
+        }
+    }
+
+    async fn list_skills_for_selection_from_store(
+        store: &SkillStore,
         disabled_skill_ids: &BTreeSet<String>,
         selected_skill_ids: Option<&[String]>,
         selected_skill_mode: Option<&str>,
     ) -> Vec<SkillDefinition> {
         let skills = if selected_skill_mode.is_some() {
-            self.store
-                .list_skills_for_mode(None, selected_skill_mode)
-                .await
+            store.list_skills_for_mode(None, selected_skill_mode).await
         } else {
-            self.store.list_skills(None, true).await
+            store.list_skills(None, true).await
         };
         let skills = filter_disabled_skills(skills, disabled_skill_ids);
         let Some(selected_skill_ids) = selected_skill_ids else {
@@ -219,6 +240,21 @@ impl SkillManager {
         }
 
         filtered
+    }
+
+    pub(crate) async fn list_skills_for_selection(
+        &self,
+        disabled_skill_ids: &BTreeSet<String>,
+        selected_skill_ids: Option<&[String]>,
+        selected_skill_mode: Option<&str>,
+    ) -> Vec<SkillDefinition> {
+        Self::list_skills_for_selection_from_store(
+            self.store.as_ref(),
+            disabled_skill_ids,
+            selected_skill_ids,
+            selected_skill_mode,
+        )
+        .await
     }
 
     /// Build system prompt context from a selected subset of skills.
@@ -279,6 +315,31 @@ impl SkillManager {
         }
 
         skills
+    }
+
+    /// Resolve prompt-visible skills against the same isolated store used by a
+    /// session's workspace catalog.
+    pub async fn resolve_skills_for_request_in_workspace_with_mode(
+        &self,
+        workspace: &Path,
+        disabled_skill_ids: &BTreeSet<String>,
+        selected_skill_ids: Option<&[String]>,
+        selected_skill_mode: Option<&str>,
+        request_hint: Option<&str>,
+    ) -> SkillResult<Vec<SkillDefinition>> {
+        let store = self.store.skill_store_for_workspace(workspace).await?;
+        let mut skills = Self::list_skills_for_selection_from_store(
+            store.as_ref(),
+            disabled_skill_ids,
+            selected_skill_ids,
+            selected_skill_mode,
+        )
+        .await;
+
+        if selected_skill_ids.is_none() {
+            skills = shortlist_skills_for_context(skills, request_hint);
+        }
+        Ok(skills)
     }
 
     /// Build system prompt context from a selected subset of skills with mode and user request hint.
@@ -351,6 +412,32 @@ impl SkillManager {
 
         tools.sort();
         tools
+    }
+
+    /// Get allowed tools from the winner set of a server-resolved session workspace.
+    pub async fn get_allowed_tools_for_workspace_selection_with_mode(
+        &self,
+        workspace: &Path,
+        disabled_skill_ids: &BTreeSet<String>,
+        selected_skill_ids: Option<&[String]>,
+        selected_skill_mode: Option<&str>,
+    ) -> SkillResult<Vec<String>> {
+        let store = self.store.skill_store_for_workspace(workspace).await?;
+        let skills = Self::list_skills_for_selection_from_store(
+            store.as_ref(),
+            disabled_skill_ids,
+            selected_skill_ids,
+            selected_skill_mode,
+        )
+        .await;
+        let mut tools: Vec<String> = skills
+            .into_iter()
+            .flat_map(|skill| skill.tool_refs)
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+        tools.sort();
+        Ok(tools)
     }
 
     /// Get allowed tool refs from all skills.

--- a/crates/infra/bamboo-skills/src/store/builtin.rs
+++ b/crates/infra/bamboo-skills/src/store/builtin.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::store::parser::parse_markdown_skill;
+use crate::store::parser::{parse_markdown_skill, render_skill_markdown};
 use crate::types::{SkillError, SkillResult};
 
 include!(concat!(env!("OUT_DIR"), "/builtin_skills_embedded.rs"));
@@ -9,6 +10,72 @@ include!(concat!(env!("OUT_DIR"), "/builtin_skills_embedded.rs"));
 pub struct BuiltinSkillBundle {
     pub skill: crate::types::SkillDefinition,
     pub files: HashMap<String, Vec<u8>>,
+}
+
+/// Archive the pre-catalog global materialization only when every file proves
+/// byte-for-byte ownership by the embedded bundle. The atomic directory rename
+/// is recoverable and never recursively deletes files; any user-added, removed,
+/// or edited file makes the directory a user override and leaves it untouched.
+pub async fn archive_exact_legacy_materialization(
+    global_skills_dir: &Path,
+    bundle: &BuiltinSkillBundle,
+) -> SkillResult<bool> {
+    let legacy_root = global_skills_dir.join(&bundle.skill.id);
+    if !tokio::fs::try_exists(&legacy_root).await? {
+        return Ok(false);
+    }
+
+    let mut expected = bundle.files.clone();
+    expected.insert(
+        "SKILL.md".to_string(),
+        render_skill_markdown(&bundle.skill)?.into_bytes(),
+    );
+    let mut actual = HashMap::new();
+    for entry in walkdir::WalkDir::new(&legacy_root).follow_links(false) {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => return Ok(false),
+        };
+        if entry.path() == legacy_root {
+            continue;
+        }
+        if !entry.file_type().is_file() || entry.file_type().is_symlink() {
+            if entry.file_type().is_dir() {
+                continue;
+            }
+            return Ok(false);
+        }
+        let relative = match entry.path().strip_prefix(&legacy_root) {
+            Ok(relative) => relative.to_string_lossy().replace('\\', "/"),
+            Err(_) => return Ok(false),
+        };
+        actual.insert(relative, tokio::fs::read(entry.path()).await?);
+    }
+
+    if actual != expected {
+        return Ok(false);
+    }
+
+    static ARCHIVE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+    let archive_parent = global_skills_dir
+        .parent()
+        .unwrap_or(global_skills_dir)
+        .join("legacy-builtins-v1")
+        .join(&bundle.skill.id);
+    tokio::fs::create_dir_all(&archive_parent).await?;
+    for _ in 0..16 {
+        let sequence = ARCHIVE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let archive = archive_parent.join(format!("{}-{sequence}", std::process::id()));
+        match tokio::fs::rename(&legacy_root, &archive).await {
+            Ok(()) => return Ok(true),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            // Another initializer won the rename, or a competing writer changed
+            // the source path. Either way, do not remove or overwrite anything.
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(false)
 }
 
 fn discover_skill_roots() -> Vec<String> {

--- a/crates/infra/bamboo-skills/src/store/mod.rs
+++ b/crates/infra/bamboo-skills/src/store/mod.rs
@@ -51,26 +51,62 @@ pub mod builtin;
 pub mod parser;
 pub mod storage;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use tokio::sync::RwLock;
 use tracing::info;
 
-use crate::store::builtin::load_builtin_skill_bundles;
+use crate::catalog::{
+    entry_from_skill, load_bundle_metadata, ShadowedWorkflowCandidate, WorkflowCatalogEntry,
+    WorkflowCatalogEvent, WorkflowCatalogEventKind, WorkflowCatalogSnapshot, WorkflowKind,
+    WorkflowStatus,
+};
+use crate::store::builtin::{archive_exact_legacy_materialization, load_builtin_skill_bundles};
 use crate::store::parser::render_skill_markdown;
 use crate::store::storage::{
-    discover_plugin_skill_dirs, ensure_skills_dir, load_skills_from_discovery_dirs,
-    write_skill_file, SkillDirectorySource, SkillDiscoveryDir,
+    discover_plugin_skill_dirs, ensure_skills_dir, load_skills_from_discovery_dirs_detailed,
+    write_skill_file, FailedSkillRecord, LoadedSkillRecord, SkillDirectorySource,
+    SkillDiscoveryDir,
 };
 use crate::types::{
     SkillDefinition, SkillError, SkillFilter, SkillId, SkillResult, SkillStoreConfig,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct SkillCandidateMeta {
+fn invalid_placeholder(
+    id: &str,
     source: SkillDirectorySource,
-    mode: Option<String>,
+    revision: u64,
+    error: &str,
+) -> WorkflowCatalogEntry {
+    WorkflowCatalogEntry {
+        id: id.to_string(),
+        name: id.to_string(),
+        description: "Invalid workflow bundle".to_string(),
+        kind: WorkflowKind::Instruction,
+        source: source.into(),
+        revision,
+        version: "1".to_string(),
+        invocation_policy: serde_json::json!({"explicit": false, "automatic": false}),
+        argument_schema: serde_json::json!({"type": "object"}),
+        status: WorkflowStatus::Invalid,
+        last_error: Some(error.to_string()),
+        winner: true,
+        shadowed_candidates: Vec::new(),
+    }
+}
+
+fn stable_workspace_hash(path: &Path) -> u64 {
+    const OFFSET: u64 = 0xcbf29ce484222325;
+    const PRIME: u64 = 0x100000001b3;
+    path.as_os_str()
+        .to_string_lossy()
+        .as_bytes()
+        .iter()
+        .fold(OFFSET, |hash, byte| {
+            (hash ^ u64::from(*byte)).wrapping_mul(PRIME)
+        })
 }
 
 /// Persistent storage for skills with in-memory caching.
@@ -94,10 +130,19 @@ struct SkillCandidateMeta {
 /// println!("Skill: {}", skill.name);
 /// ```
 pub struct SkillStore {
+    /// Serializes publication and observation of the correlated snapshot maps below.
+    snapshot_publish_lock: RwLock<()>,
     /// In-memory cache of loaded skills, keyed by skill ID.
     skills: RwLock<HashMap<SkillId, SkillDefinition>>,
     /// Root directory of each loaded skill (keyed by skill ID).
     skill_roots: RwLock<HashMap<SkillId, PathBuf>>,
+    catalog: RwLock<WorkflowCatalogSnapshot>,
+    next_revision: AtomicU64,
+    watcher_started: AtomicBool,
+    catalog_events: tokio::sync::broadcast::Sender<WorkflowCatalogEvent>,
+    reload_lock: tokio::sync::Mutex<()>,
+    mode_stores: RwLock<HashMap<String, std::sync::Arc<SkillStore>>>,
+    workspace_stores: RwLock<HashMap<PathBuf, std::sync::Arc<SkillStore>>>,
 
     /// Configuration specifying the skills directory path.
     config: SkillStoreConfig,
@@ -145,6 +190,18 @@ impl SkillStore {
         project_dir.join(".bamboo").join(format!("skills-{mode}"))
     }
 
+    /// Embedded bundles live outside the user-editable global skills directory.
+    ///
+    /// Keeping the version in the directory name lets Bamboo replace its own
+    /// read-only materialization without mistaking a user clone with the same
+    /// id for a builtin.
+    fn builtin_skills_dir(base_skills_dir: &Path) -> PathBuf {
+        base_skills_dir
+            .parent()
+            .map(|parent| parent.join("skills-builtin-v1"))
+            .unwrap_or_else(|| PathBuf::from("skills-builtin-v1"))
+    }
+
     /// Root directory under which installed plugins live, derived as a
     /// sibling of `skills_dir` (same pattern as [`Self::sibling_skills_mode_dir`]),
     /// so tests that point `skills_dir` at a tempdir automatically get an
@@ -162,7 +219,11 @@ impl SkillStore {
     }
 
     fn discovery_dirs_for_mode(&self, mode_override: Option<&str>) -> Vec<SkillDiscoveryDir> {
-        let mut dirs = Vec::new();
+        let mut dirs = vec![SkillDiscoveryDir {
+            dir: Self::builtin_skills_dir(&self.config.skills_dir),
+            source: SkillDirectorySource::Builtin,
+            mode: None,
+        }];
         let active_mode = self.effective_mode(mode_override);
 
         // Enable the conventional user-level source for the production store.
@@ -209,82 +270,17 @@ impl SkillStore {
         dirs
     }
 
-    fn resolve_from_loaded_records(
-        loaded_records: Vec<crate::store::storage::LoadedSkillRecord>,
-    ) -> (HashMap<SkillId, SkillDefinition>, HashMap<SkillId, PathBuf>) {
-        let mut resolved_skills: HashMap<SkillId, SkillDefinition> = HashMap::new();
-        let mut resolved_roots: HashMap<SkillId, PathBuf> = HashMap::new();
-        let mut resolved_meta: HashMap<SkillId, SkillCandidateMeta> = HashMap::new();
-
-        for record in loaded_records {
-            let skill_id = record.skill.id.clone();
-            let candidate_meta = SkillCandidateMeta {
-                source: record.source,
-                mode: record.mode.clone(),
-            };
-
-            let should_replace = resolved_meta
-                .get(&skill_id)
-                .is_some_and(|existing| Self::should_override_skill(existing, &candidate_meta));
-            let should_keep_existing = resolved_meta.contains_key(&skill_id) && !should_replace;
-
-            if should_keep_existing {
-                // A same-tier, same-mode collision is a genuine AMBIGUITY (two
-                // plugins, or two dirs at the same precedence, shipping the
-                // same skill id) — the winner is decided only by discovery
-                // order, so surface it at WARN. Legitimate precedence
-                // overrides (project > Bamboo global > ~/.agents > plugin, or mode-specific >
-                // generic) are expected and stay at debug.
-                let existing_meta = resolved_meta.get(&skill_id);
-                let is_ambiguous_collision = existing_meta.is_some_and(|existing| {
-                    existing.source == candidate_meta.source && existing.mode == candidate_meta.mode
-                });
-                if is_ambiguous_collision {
-                    tracing::warn!(
-                        "Skill id '{}' is shipped by more than one source at the same precedence \
-                         ({:?}); keeping the first and shadowing this duplicate (mode={})",
-                        skill_id,
-                        candidate_meta.source,
-                        candidate_meta.mode.as_deref().unwrap_or("generic")
-                    );
-                } else {
-                    tracing::debug!(
-                        "Keeping existing skill '{}' over candidate from {:?} (mode={})",
-                        skill_id,
-                        candidate_meta.source,
-                        candidate_meta.mode.as_deref().unwrap_or("generic")
-                    );
-                }
-                continue;
-            }
-
-            if should_replace {
-                tracing::info!(
-                    "Skill '{}' overridden by {:?} (mode={})",
-                    skill_id,
-                    candidate_meta.source,
-                    candidate_meta.mode.as_deref().unwrap_or("generic")
-                );
-            }
-
-            resolved_skills.insert(skill_id.clone(), record.skill);
-            resolved_roots.insert(skill_id.clone(), record.skill_root);
-            resolved_meta.insert(skill_id, candidate_meta);
-        }
-
-        (resolved_skills, resolved_roots)
-    }
-
     async fn resolve_skills_maps_for_mode(
         &self,
         mode_override: Option<&str>,
     ) -> SkillResult<(HashMap<SkillId, SkillDefinition>, HashMap<SkillId, PathBuf>)> {
-        let mut dirs = self.discovery_dirs_for_mode(mode_override);
-        let plugins_root = Self::plugins_root_dir(&self.config.skills_dir);
-        dirs.extend(discover_plugin_skill_dirs(&plugins_root).await);
-
-        let loaded_records = load_skills_from_discovery_dirs(&dirs).await?;
-        Ok(Self::resolve_from_loaded_records(loaded_records))
+        let mode_store = self.skill_store_for_mode(mode_override).await?;
+        let store = mode_store.as_deref().unwrap_or(self);
+        store.reload().await?;
+        let _snapshot_guard = store.snapshot_publish_lock.read().await;
+        let skills = store.skills.read().await.clone();
+        let roots = store.skill_roots.read().await.clone();
+        Ok((skills, roots))
     }
 
     /// Precedence rank: higher wins when two discovery dirs provide the same
@@ -296,27 +292,11 @@ impl SkillStore {
     /// the pre-plugin behavior).
     fn source_rank(source: SkillDirectorySource) -> u8 {
         match source {
-            SkillDirectorySource::Plugin => 0,
-            SkillDirectorySource::Agents => 1,
-            SkillDirectorySource::Global => 2,
-            SkillDirectorySource::Project => 3,
-        }
-    }
-
-    fn should_override_skill(
-        existing: &SkillCandidateMeta,
-        candidate: &SkillCandidateMeta,
-    ) -> bool {
-        let existing_rank = Self::source_rank(existing.source);
-        let candidate_rank = Self::source_rank(candidate.source);
-        if existing_rank != candidate_rank {
-            return candidate_rank > existing_rank;
-        }
-
-        match (existing.mode.is_some(), candidate.mode.is_some()) {
-            (false, true) => true,
-            (true, false) => false,
-            _ => false,
+            SkillDirectorySource::Builtin => 0,
+            SkillDirectorySource::Plugin => 1,
+            SkillDirectorySource::Agents => 2,
+            SkillDirectorySource::Global => 3,
+            SkillDirectorySource::Project => 4,
         }
     }
 
@@ -342,9 +322,18 @@ impl SkillStore {
     /// let store = SkillStore::new(config);
     /// ```
     pub fn new(config: SkillStoreConfig) -> Self {
+        let (catalog_events, _) = tokio::sync::broadcast::channel(128);
         Self {
+            snapshot_publish_lock: RwLock::new(()),
             skills: RwLock::new(HashMap::new()),
             skill_roots: RwLock::new(HashMap::new()),
+            catalog: RwLock::new(WorkflowCatalogSnapshot::default()),
+            next_revision: AtomicU64::new(1),
+            watcher_started: AtomicBool::new(false),
+            catalog_events,
+            reload_lock: tokio::sync::Mutex::new(()),
+            mode_stores: RwLock::new(HashMap::new()),
+            workspace_stores: RwLock::new(HashMap::new()),
             config,
         }
     }
@@ -376,7 +365,32 @@ impl SkillStore {
     pub async fn initialize(&self) -> SkillResult<()> {
         info!("Initializing skill store...");
         ensure_skills_dir(&self.config.skills_dir).await?;
+        let workflows_dir = self
+            .config
+            .skills_dir
+            .parent()
+            .map(|parent| parent.join("workflows"))
+            .unwrap_or_else(|| PathBuf::from("workflows"));
+        let report = crate::legacy::import_legacy_markdown_workflows(
+            &workflows_dir,
+            &self.config.skills_dir,
+        )
+        .await?;
+        if !report.imported.is_empty() {
+            info!("Imported legacy workflows as skills: {:?}", report.imported);
+        }
+        for diagnostic in report.diagnostics {
+            tracing::warn!("Legacy workflow import: {diagnostic}");
+        }
         self.create_builtin_skills().await?;
+        for diagnostic in
+            crate::legacy::migrate_legacy_yaml_workflows(&workflows_dir, &self.config.skills_dir)
+                .await
+        {
+            if !diagnostic.can_map_to_bundle {
+                tracing::warn!("Legacy YAML migration: {}", diagnostic.message);
+            }
+        }
         self.load().await?;
 
         info!("Skill store initialized");
@@ -396,14 +410,512 @@ impl SkillStore {
     ///
     /// Returns `SkillError` if the skills directory cannot be read.
     async fn load(&self) -> SkillResult<usize> {
-        let (resolved_skills, resolved_roots) = self.resolve_skills_maps_for_mode(None).await?;
+        let _reload_guard = self.reload_lock.lock().await;
+        let dirs = self.discovery_dirs_for_mode(None);
+        let mut dirs = dirs;
+        let plugins_root = Self::plugins_root_dir(&self.config.skills_dir);
+        dirs.extend(discover_plugin_skill_dirs(&plugins_root).await);
+        let report = load_skills_from_discovery_dirs_detailed(&dirs).await?;
+
+        let (previous_skills, previous_roots, previous_catalog) = {
+            let _snapshot_guard = self.snapshot_publish_lock.read().await;
+            (
+                self.skills.read().await.clone(),
+                self.skill_roots.read().await.clone(),
+                self.catalog.read().await.clone(),
+            )
+        };
+        let revision = self.next_revision.load(Ordering::SeqCst);
+        let (resolved_skills, resolved_roots, mut entries) = self
+            .resolve_catalog(
+                report.loaded,
+                report.failed,
+                &previous_skills,
+                &previous_roots,
+                &previous_catalog,
+                revision,
+            )
+            .await;
         let count = resolved_skills.len();
-        let mut skills = self.skills.write().await;
-        let mut roots = self.skill_roots.write().await;
-        *skills = resolved_skills;
-        *roots = resolved_roots;
+        let definition_changed: HashSet<String> = resolved_skills
+            .iter()
+            .filter(|(id, skill)| {
+                previous_skills.get(*id) != Some(*skill)
+                    || previous_roots.get(*id) != resolved_roots.get(*id)
+            })
+            .map(|(id, _)| id.clone())
+            .collect();
+        // `WorkflowCatalogEntry::revision` identifies the revision of that workflow,
+        // not merely the revision of the containing snapshot. Preserve it across
+        // unrelated catalog updates so an activation can pin a meaningful definition
+        // revision. Prompt-only changes are covered by `definition_changed` even though
+        // the metadata-only public entry would otherwise compare equal.
+        for entry in &mut entries {
+            let Some(previous) = previous_catalog
+                .entries
+                .iter()
+                .find(|previous| previous.id == entry.id)
+            else {
+                continue;
+            };
+            let mut comparable = entry.clone();
+            comparable.revision = previous.revision;
+            if !definition_changed.contains(&entry.id) && comparable == *previous {
+                entry.revision = previous.revision;
+            }
+        }
+        let next_catalog = WorkflowCatalogSnapshot { revision, entries };
+        let mut comparable_previous = previous_catalog.clone();
+        comparable_previous.revision = revision;
+        if resolved_skills == previous_skills
+            && resolved_roots == previous_roots
+            && next_catalog == comparable_previous
+        {
+            return Ok(count);
+        }
+        self.next_revision.fetch_add(1, Ordering::SeqCst);
+        {
+            // Definition, root, and metadata become visible as one immutable generation.
+            let _snapshot_guard = self.snapshot_publish_lock.write().await;
+            *self.skills.write().await = resolved_skills;
+            *self.skill_roots.write().await = resolved_roots;
+            *self.catalog.write().await = next_catalog.clone();
+        }
+        self.publish_catalog_events(&previous_catalog, &next_catalog, &definition_changed);
 
         Ok(count)
+    }
+
+    async fn resolve_catalog(
+        &self,
+        loaded: Vec<LoadedSkillRecord>,
+        failed: Vec<FailedSkillRecord>,
+        previous_skills: &HashMap<SkillId, SkillDefinition>,
+        previous_roots: &HashMap<SkillId, PathBuf>,
+        previous_catalog: &WorkflowCatalogSnapshot,
+        revision: u64,
+    ) -> (
+        HashMap<SkillId, SkillDefinition>,
+        HashMap<SkillId, PathBuf>,
+        Vec<WorkflowCatalogEntry>,
+    ) {
+        #[derive(Debug)]
+        enum Candidate {
+            Valid(LoadedSkillRecord),
+            Invalid(FailedSkillRecord),
+        }
+        impl Candidate {
+            fn source(&self) -> SkillDirectorySource {
+                match self {
+                    Self::Valid(record) => record.source,
+                    Self::Invalid(record) => record.source,
+                }
+            }
+            fn mode(&self) -> Option<&str> {
+                match self {
+                    Self::Valid(record) => record.mode.as_deref(),
+                    Self::Invalid(record) => record.mode.as_deref(),
+                }
+            }
+            fn root(&self) -> &Path {
+                match self {
+                    Self::Valid(record) => &record.skill_root,
+                    Self::Invalid(record) => &record.skill_root,
+                }
+            }
+            fn status(&self) -> WorkflowStatus {
+                match self {
+                    Self::Valid(_) => WorkflowStatus::Valid,
+                    Self::Invalid(_) => WorkflowStatus::Invalid,
+                }
+            }
+            fn error(&self) -> Option<String> {
+                match self {
+                    Self::Valid(_) => None,
+                    Self::Invalid(record) => Some(record.error.clone()),
+                }
+            }
+        }
+
+        let mut grouped: HashMap<String, Vec<Candidate>> = HashMap::new();
+        for record in loaded {
+            grouped
+                .entry(record.skill.id.clone())
+                .or_default()
+                .push(Candidate::Valid(record));
+        }
+        for record in failed {
+            if let Some(id) = record.skill_id.clone() {
+                grouped
+                    .entry(id)
+                    .or_default()
+                    .push(Candidate::Invalid(record));
+            }
+        }
+
+        let mut ids: Vec<_> = grouped.keys().cloned().collect();
+        ids.sort();
+        let mut skills = HashMap::new();
+        let mut roots = HashMap::new();
+        let mut entries = Vec::new();
+        for id in ids {
+            let previous_entry = previous_catalog.entries.iter().find(|entry| entry.id == id);
+            let mut candidates = grouped.remove(&id).unwrap_or_default();
+            candidates.sort_by(|left, right| {
+                Self::source_rank(right.source())
+                    .cmp(&Self::source_rank(left.source()))
+                    .then_with(|| right.mode().is_some().cmp(&left.mode().is_some()))
+                    .then_with(|| left.root().cmp(right.root()))
+            });
+            let Some(winner) = candidates.first() else {
+                continue;
+            };
+            let shadowed_candidates = candidates
+                .iter()
+                .skip(1)
+                .map(|candidate| ShadowedWorkflowCandidate {
+                    source: candidate.source().into(),
+                    status: candidate.status(),
+                    last_error: candidate.error(),
+                })
+                .collect();
+
+            let mut entry = match winner {
+                Candidate::Valid(record) => match load_bundle_metadata(&record.skill_root).await {
+                    Ok(metadata) => {
+                        skills.insert(id.clone(), record.skill.clone());
+                        roots.insert(id.clone(), record.skill_root.clone());
+                        entry_from_skill(&record.skill, record.source, revision, metadata)
+                    }
+                    Err(error) => {
+                        if previous_roots.get(&id) == Some(&record.skill_root) {
+                            if let (Some(skill), Some(previous_entry)) =
+                                (previous_skills.get(&id), previous_entry)
+                            {
+                                skills.insert(id.clone(), skill.clone());
+                                roots.insert(id.clone(), record.skill_root.clone());
+                                let mut entry = previous_entry.clone();
+                                entry.revision = revision;
+                                entry.status = WorkflowStatus::Invalid;
+                                entry.last_error = Some(error);
+                                entry
+                            } else {
+                                invalid_placeholder(&id, record.source, revision, &error)
+                            }
+                        } else {
+                            invalid_placeholder(&id, record.source, revision, &error)
+                        }
+                    }
+                },
+                Candidate::Invalid(record) => {
+                    if previous_roots.get(&id) == Some(&record.skill_root) {
+                        if let Some(skill) = previous_skills.get(&id) {
+                            skills.insert(id.clone(), skill.clone());
+                            roots.insert(id.clone(), record.skill_root.clone());
+                            let mut entry = previous_entry.cloned().unwrap_or_else(|| {
+                                entry_from_skill(skill, record.source, revision, Default::default())
+                            });
+                            entry.revision = revision;
+                            entry.status = WorkflowStatus::Invalid;
+                            entry.last_error = Some(record.error.clone());
+                            entry
+                        } else {
+                            invalid_placeholder(&id, record.source, revision, &record.error)
+                        }
+                    } else {
+                        invalid_placeholder(&id, record.source, revision, &record.error)
+                    }
+                }
+            };
+            entry.shadowed_candidates = shadowed_candidates;
+            entries.push(entry);
+        }
+        (skills, roots, entries)
+    }
+
+    /// Return the current immutable metadata-only catalog snapshot.
+    pub async fn workflow_catalog_snapshot(&self) -> WorkflowCatalogSnapshot {
+        let _snapshot_guard = self.snapshot_publish_lock.read().await;
+        self.catalog.read().await.clone()
+    }
+
+    pub fn subscribe_workflow_catalog(
+        &self,
+    ) -> tokio::sync::broadcast::Receiver<WorkflowCatalogEvent> {
+        self.catalog_events.subscribe()
+    }
+
+    /// Resolve a cached catalog/store for a per-session mode override. This keeps mode-specific
+    /// selection on the same validated snapshot/LKG path as the default catalog instead of
+    /// bypassing workflow metadata through a parallel directory scan.
+    async fn skill_store_for_mode(
+        &self,
+        mode_override: Option<&str>,
+    ) -> SkillResult<Option<std::sync::Arc<SkillStore>>> {
+        let Some(mode) = self.effective_mode(mode_override) else {
+            return Ok(None);
+        };
+        if Self::normalize_mode(self.config.active_mode.as_deref()).as_deref() == Some(&mode) {
+            return Ok(None);
+        }
+        if let Some(store) = self.mode_stores.read().await.get(&mode).cloned() {
+            return Ok(Some(store));
+        }
+        let mut stores = self.mode_stores.write().await;
+        if let Some(store) = stores.get(&mode).cloned() {
+            return Ok(Some(store));
+        }
+        let store = std::sync::Arc::new(SkillStore::new(SkillStoreConfig {
+            skills_dir: self.config.skills_dir.clone(),
+            project_dir: self.config.project_dir.clone(),
+            active_mode: Some(mode.clone()),
+        }));
+        store.load().await?;
+        store.start_live_reload();
+
+        let mut events = store.subscribe_workflow_catalog();
+        let aggregate = self.catalog_events.clone();
+        tokio::spawn(async move {
+            loop {
+                match events.recv().await {
+                    Ok(event) => {
+                        let _ = aggregate.send(event);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+        stores.insert(mode, store.clone());
+        Ok(Some(store))
+    }
+
+    fn publish_catalog_events(
+        &self,
+        previous: &WorkflowCatalogSnapshot,
+        next: &WorkflowCatalogSnapshot,
+        definition_changed: &HashSet<String>,
+    ) {
+        if previous.revision == 0 {
+            return;
+        }
+        let previous_by_id: HashMap<_, _> = previous
+            .entries
+            .iter()
+            .map(|entry| (entry.id.as_str(), entry))
+            .collect();
+        for entry in &next.entries {
+            let old = previous_by_id.get(entry.id.as_str()).copied();
+            let kind = match (old.map(|item| item.status), entry.status) {
+                (Some(WorkflowStatus::Valid), WorkflowStatus::Invalid) => {
+                    WorkflowCatalogEventKind::Invalid
+                }
+                (Some(WorkflowStatus::Invalid), WorkflowStatus::Valid) => {
+                    WorkflowCatalogEventKind::Recovered
+                }
+                _ if definition_changed.contains(&entry.id)
+                    || old.is_none()
+                    || old.is_some_and(|item| item != entry) =>
+                {
+                    WorkflowCatalogEventKind::Changed
+                }
+                _ => continue,
+            };
+            let _ = self.catalog_events.send(WorkflowCatalogEvent {
+                workflow_id: entry.id.clone(),
+                revision: next.revision,
+                kind,
+                scope: "global".to_string(),
+            });
+        }
+        for removed in previous.entries.iter().filter(|entry| {
+            !next
+                .entries
+                .iter()
+                .any(|candidate| candidate.id == entry.id)
+        }) {
+            let _ = self.catalog_events.send(WorkflowCatalogEvent {
+                workflow_id: removed.id.clone(),
+                revision: next.revision,
+                kind: WorkflowCatalogEventKind::Changed,
+                scope: "global".to_string(),
+            });
+        }
+    }
+
+    /// Resolve the complete isolated store for a server-owned session workspace.
+    ///
+    /// Catalog advertisement, prompt selection, and runtime resource access must
+    /// all retain this same store so they observe the same winner and root.
+    pub async fn skill_store_for_workspace(
+        &self,
+        workspace: &Path,
+    ) -> SkillResult<std::sync::Arc<SkillStore>> {
+        let workspace = tokio::fs::canonicalize(workspace).await?;
+        if let Some(store) = self.workspace_stores.read().await.get(&workspace).cloned() {
+            return Ok(store);
+        }
+        let mut stores = self.workspace_stores.write().await;
+        if let Some(store) = stores.get(&workspace).cloned() {
+            return Ok(store);
+        }
+        let store = std::sync::Arc::new(SkillStore::new(SkillStoreConfig {
+            skills_dir: self.config.skills_dir.clone(),
+            project_dir: Some(workspace.clone()),
+            active_mode: self.config.active_mode.clone(),
+        }));
+        store.load().await?;
+        store.start_live_reload();
+
+        let scope = format!("workspace:{:016x}", stable_workspace_hash(&workspace));
+        let mut events = store.subscribe_workflow_catalog();
+        let aggregate = self.catalog_events.clone();
+        tokio::spawn(async move {
+            loop {
+                match events.recv().await {
+                    Ok(mut event) => {
+                        event.scope = scope.clone();
+                        let _ = aggregate.send(event);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+        stores.insert(workspace, store.clone());
+        Ok(store)
+    }
+
+    /// Resolve an isolated catalog view for a specific session workspace without changing the
+    /// server-wide snapshot or consulting the server process current directory.
+    pub async fn workflow_catalog_for_workspace(
+        &self,
+        workspace: &Path,
+    ) -> SkillResult<WorkflowCatalogSnapshot> {
+        Ok(self
+            .skill_store_for_workspace(workspace)
+            .await?
+            .workflow_catalog_snapshot()
+            .await)
+    }
+
+    /// Roots watched for skill, workflow metadata, project, and plugin changes.
+    pub(crate) fn watch_roots(&self) -> Vec<PathBuf> {
+        let mut roots = vec![self
+            .config
+            .skills_dir
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| self.config.skills_dir.clone())];
+        if let Some(project) = self.config.project_dir.as_ref() {
+            roots.push(project.clone());
+        }
+        roots
+    }
+
+    fn is_catalog_watch_path(&self, path: &Path) -> bool {
+        fn normalized(path: &Path) -> std::borrow::Cow<'_, Path> {
+            std::fs::canonicalize(path)
+                .map(std::borrow::Cow::Owned)
+                .unwrap_or_else(|_| std::borrow::Cow::Borrowed(path))
+        }
+        fn starts_with(path: &Path, root: &Path) -> bool {
+            path.starts_with(root) || normalized(path).starts_with(normalized(root).as_ref())
+        }
+
+        if starts_with(path, &self.config.skills_dir) {
+            return true;
+        }
+        if let Some(data_dir) = self.config.skills_dir.parent() {
+            if starts_with(path, &data_dir.join("workflows"))
+                || starts_with(path, &data_dir.join("plugins"))
+            {
+                return true;
+            }
+            let normalized_path = normalized(path);
+            let normalized_data = normalized(data_dir);
+            if normalized_path
+                .strip_prefix(normalized_data.as_ref())
+                .ok()
+                .is_some_and(|relative| {
+                    relative
+                        .components()
+                        .next()
+                        .and_then(|component| component.as_os_str().to_str())
+                        .is_some_and(|name| name.starts_with("skills-"))
+                })
+            {
+                return true;
+            }
+        }
+        self.config.project_dir.as_ref().is_some_and(|project| {
+            normalized(path)
+                .strip_prefix(normalized(&project.join(".bamboo")).as_ref())
+                .ok()
+                .and_then(|relative| relative.components().next())
+                .and_then(|component| component.as_os_str().to_str())
+                .is_some_and(|name| name == "skills" || name.starts_with("skills-"))
+        })
+    }
+
+    /// Start an OS-backed recursive watcher. Debouncing coalesces editor atomic-renames and
+    /// avoids reloading once per low-level self-write event.
+    pub fn start_live_reload(self: &std::sync::Arc<Self>) {
+        use notify::{RecursiveMode, Watcher};
+        if self.watcher_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let weak = std::sync::Arc::downgrade(self);
+        let roots = self.watch_roots();
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        let mut watcher = match notify::recommended_watcher(move |event| {
+            let _ = sender.send(event);
+        }) {
+            Ok(watcher) => watcher,
+            Err(error) => {
+                tracing::warn!("Failed to start skill catalog watcher: {error}");
+                self.watcher_started.store(false, Ordering::SeqCst);
+                return;
+            }
+        };
+        for root in roots {
+            if root.exists() {
+                if let Err(error) = watcher.watch(&root, RecursiveMode::Recursive) {
+                    tracing::warn!(
+                        "Failed to watch skill catalog root {}: {error}",
+                        root.display()
+                    );
+                }
+            }
+        }
+        tokio::spawn(async move {
+            // Keep the native watcher alive for exactly as long as the receiver loop.
+            let _watcher = watcher;
+            while let Some(event) = receiver.recv().await {
+                let event = match event {
+                    Ok(event) => event,
+                    Err(error) => {
+                        tracing::warn!("Skill catalog watcher error: {error}");
+                        continue;
+                    }
+                };
+                let Some(store) = weak.upgrade() else { break };
+                if !event
+                    .paths
+                    .iter()
+                    .any(|path| store.is_catalog_watch_path(path))
+                {
+                    continue;
+                }
+                // Editors commonly emit write + chmod + rename. Publish one snapshot after the
+                // filesystem has settled, while still reacting promptly to external changes.
+                tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+                while receiver.try_recv().is_ok() {}
+                if let Err(error) = store.reload().await {
+                    tracing::warn!("Live skill catalog reload failed: {error}");
+                }
+            }
+        });
     }
 
     /// Create built-in skills on disk.
@@ -423,12 +935,20 @@ impl SkillStore {
     ///
     /// Returns `SkillError` if file operations fail.
     async fn create_builtin_skills(&self) -> SkillResult<()> {
+        let builtin_skills_dir = Self::builtin_skills_dir(&self.config.skills_dir);
+        ensure_skills_dir(&builtin_skills_dir).await?;
         for bundle in load_builtin_skill_bundles()? {
+            if archive_exact_legacy_materialization(&self.config.skills_dir, &bundle).await? {
+                info!(
+                    "Archived exact legacy builtin materialization '{}' before using versioned storage",
+                    bundle.skill.id
+                );
+            }
             let skill_id = bundle.skill.id.clone();
-            write_skill_file(&self.config.skills_dir, &bundle.skill).await?;
+            write_skill_file(&builtin_skills_dir, &bundle.skill).await?;
 
             for (relative_path, content) in bundle.files {
-                let full_path = self.config.skills_dir.join(&skill_id).join(&relative_path);
+                let full_path = builtin_skills_dir.join(&skill_id).join(&relative_path);
                 if let Some(parent) = full_path.parent() {
                     tokio::fs::create_dir_all(parent).await?;
                 }
@@ -467,6 +987,28 @@ impl SkillStore {
     /// ```
     pub async fn reload(&self) -> SkillResult<usize> {
         info!("Reloading skills from disk...");
+        let workflows_dir = self
+            .config
+            .skills_dir
+            .parent()
+            .map(|parent| parent.join("workflows"))
+            .unwrap_or_else(|| PathBuf::from("workflows"));
+        let report = crate::legacy::import_legacy_markdown_workflows(
+            &workflows_dir,
+            &self.config.skills_dir,
+        )
+        .await?;
+        for diagnostic in report.diagnostics {
+            tracing::warn!("Legacy workflow import: {diagnostic}");
+        }
+        for diagnostic in
+            crate::legacy::migrate_legacy_yaml_workflows(&workflows_dir, &self.config.skills_dir)
+                .await
+        {
+            if !diagnostic.can_map_to_bundle {
+                tracing::warn!("Legacy YAML migration: {}", diagnostic.message);
+            }
+        }
         self.load().await
     }
 
@@ -503,6 +1045,7 @@ impl SkillStore {
             }
         }
 
+        let _snapshot_guard = self.snapshot_publish_lock.read().await;
         let skills = self.skills.read().await;
 
         let mut result: Vec<SkillDefinition> = skills
@@ -571,6 +1114,7 @@ impl SkillStore {
     /// println!("Description: {}", skill.description);
     /// ```
     pub async fn get_skill(&self, id: &str) -> SkillResult<SkillDefinition> {
+        let _snapshot_guard = self.snapshot_publish_lock.read().await;
         let skills = self.skills.read().await;
         skills
             .get(id)
@@ -595,8 +1139,46 @@ impl SkillStore {
             .ok_or_else(|| SkillError::NotFound(id.to_string()))
     }
 
+    /// Resolve the definition and resource root from one snapshot generation.
+    pub async fn get_skill_with_root_for_mode(
+        &self,
+        id: &str,
+        mode_override: Option<&str>,
+    ) -> SkillResult<(SkillDefinition, PathBuf)> {
+        if mode_override.is_some() {
+            let (skills, roots) = self.resolve_skills_maps_for_mode(mode_override).await?;
+            let skill = skills
+                .get(id)
+                .cloned()
+                .ok_or_else(|| SkillError::NotFound(id.to_string()))?;
+            let root = roots
+                .get(id)
+                .cloned()
+                .ok_or_else(|| SkillError::NotFound(id.to_string()))?;
+            return Ok((skill, root));
+        }
+
+        let _snapshot_guard = self.snapshot_publish_lock.read().await;
+        let skill = self
+            .skills
+            .read()
+            .await
+            .get(id)
+            .cloned()
+            .ok_or_else(|| SkillError::NotFound(id.to_string()))?;
+        let root = self
+            .skill_roots
+            .read()
+            .await
+            .get(id)
+            .cloned()
+            .ok_or_else(|| SkillError::NotFound(id.to_string()))?;
+        Ok((skill, root))
+    }
+
     /// Get the root directory path for a loaded skill.
     pub async fn get_skill_root(&self, id: &str) -> SkillResult<PathBuf> {
+        let _snapshot_guard = self.snapshot_publish_lock.read().await;
         let roots = self.skill_roots.read().await;
         roots
             .get(id)
@@ -739,6 +1321,7 @@ impl SkillStore {
     /// println!("Total skills: {}", skills.len());
     /// ```
     pub async fn get_all_skills(&self) -> Vec<SkillDefinition> {
+        let _snapshot_guard = self.snapshot_publish_lock.read().await;
         let mut skills: Vec<SkillDefinition> = self.skills.read().await.values().cloned().collect();
         skills.sort_by_key(|s| s.name.clone());
         skills
@@ -933,27 +1516,23 @@ mod tests {
 
     use tokio::fs;
 
-    use super::{SkillCandidateMeta, SkillStore};
+    use super::SkillStore;
+    use crate::store::builtin::{load_builtin_skill_bundles, BuiltinSkillBundle};
+    use crate::store::storage::write_skill_file;
     use crate::store::storage::SkillDirectorySource;
     use crate::types::SkillStoreConfig;
+    use crate::{SkillManager, WorkflowCatalogEventKind, WorkflowSource, WorkflowStatus};
 
     #[test]
     fn agents_skill_precedence_is_below_bamboo_global_and_above_plugin() {
-        let agents = SkillCandidateMeta {
-            source: SkillDirectorySource::Agents,
-            mode: None,
-        };
-        let global = SkillCandidateMeta {
-            source: SkillDirectorySource::Global,
-            mode: None,
-        };
-        let plugin = SkillCandidateMeta {
-            source: SkillDirectorySource::Plugin,
-            mode: None,
-        };
-        assert!(SkillStore::should_override_skill(&agents, &global));
-        assert!(SkillStore::should_override_skill(&plugin, &agents));
-        assert!(!SkillStore::should_override_skill(&global, &agents));
+        assert!(
+            SkillStore::source_rank(SkillDirectorySource::Global)
+                > SkillStore::source_rank(SkillDirectorySource::Agents)
+        );
+        assert!(
+            SkillStore::source_rank(SkillDirectorySource::Agents)
+                > SkillStore::source_rank(SkillDirectorySource::Plugin)
+        );
     }
 
     async fn write_skill(
@@ -973,6 +1552,19 @@ mod tests {
         );
         fs::write(&skill_file, content).await?;
         Ok(skill_dir)
+    }
+
+    async fn materialize_legacy_builtin(skills_dir: &Path, bundle: &BuiltinSkillBundle) {
+        write_skill_file(skills_dir, &bundle.skill)
+            .await
+            .expect("legacy SKILL.md");
+        for (relative, bytes) in &bundle.files {
+            let path = skills_dir.join(&bundle.skill.id).join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).await.expect("legacy parent");
+            }
+            fs::write(path, bytes).await.expect("legacy resource");
+        }
     }
 
     #[tokio::test]
@@ -1021,6 +1613,141 @@ Use this skill for testing.
 
         let skills = store.list_skills(None, false).await;
         assert!(skills.iter().any(|skill| skill.id == "skill-creator"));
+    }
+
+    #[tokio::test]
+    async fn exact_legacy_builtin_is_migrated_and_cannot_shadow_versioned_builtin() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("data/skills");
+        let bundle = load_builtin_skill_bundles()
+            .expect("builtin bundles")
+            .into_iter()
+            .find(|bundle| bundle.skill.id == "skill-creator")
+            .expect("skill creator");
+        materialize_legacy_builtin(&skills_dir, &bundle).await;
+
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir: skills_dir.clone(),
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+        assert!(
+            !skills_dir.join("skill-creator").exists(),
+            "only an exact legacy materialization may leave discovery"
+        );
+        let archive_parent = directory
+            .path()
+            .join("data/legacy-builtins-v1/skill-creator");
+        let mut archives = fs::read_dir(&archive_parent)
+            .await
+            .expect("recoverable legacy archive");
+        let archive = archives
+            .next_entry()
+            .await
+            .expect("archive entry")
+            .expect("one archived materialization")
+            .path();
+        assert!(archive.join("SKILL.md").exists());
+        assert!(archives
+            .next_entry()
+            .await
+            .expect("archive exhaustion")
+            .is_none());
+
+        let builtin_root = directory
+            .path()
+            .join("data/skills-builtin-v1/skill-creator");
+        let mut upgraded = fs::read_to_string(builtin_root.join("SKILL.md"))
+            .await
+            .expect("versioned builtin");
+        upgraded = upgraded.replacen(
+            &format!("description: {}", bundle.skill.description),
+            "description: upgraded embedded description",
+            1,
+        );
+        fs::write(builtin_root.join("SKILL.md"), upgraded)
+            .await
+            .expect("simulate upgraded embedded bundle");
+        store.reload().await.expect("reload upgraded builtin");
+
+        assert_eq!(
+            store
+                .get_skill("skill-creator")
+                .await
+                .expect("builtin winner")
+                .description,
+            "upgraded embedded description"
+        );
+        assert_eq!(
+            store
+                .workflow_catalog_snapshot()
+                .await
+                .entries
+                .into_iter()
+                .find(|entry| entry.id == "skill-creator")
+                .expect("catalog entry")
+                .source,
+            WorkflowSource::Builtin
+        );
+    }
+
+    #[tokio::test]
+    async fn modified_legacy_builtin_is_preserved_as_user_override() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("data/skills");
+        let bundle = load_builtin_skill_bundles()
+            .expect("builtin bundles")
+            .into_iter()
+            .find(|bundle| bundle.skill.id == "skill-creator")
+            .expect("skill creator");
+        materialize_legacy_builtin(&skills_dir, &bundle).await;
+        let legacy_skill = skills_dir.join("skill-creator/SKILL.md");
+        let mut customized = fs::read_to_string(&legacy_skill)
+            .await
+            .expect("legacy skill");
+        customized.push_str("\nUser customization must survive.\n");
+        fs::write(&legacy_skill, customized)
+            .await
+            .expect("customize legacy skill");
+
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir: skills_dir.clone(),
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+
+        assert!(legacy_skill.exists(), "customized user clone must remain");
+        assert!(
+            !directory
+                .path()
+                .join("data/legacy-builtins-v1/skill-creator")
+                .exists(),
+            "unproven user content must not be archived"
+        );
+        assert!(store
+            .get_skill("skill-creator")
+            .await
+            .expect("user override")
+            .prompt
+            .contains("User customization must survive"));
+        assert_eq!(
+            store
+                .workflow_catalog_snapshot()
+                .await
+                .entries
+                .into_iter()
+                .find(|entry| entry.id == "skill-creator")
+                .expect("catalog entry")
+                .source,
+            WorkflowSource::User
+        );
+        assert_eq!(
+            store
+                .get_skill_root("skill-creator")
+                .await
+                .expect("user root"),
+            skills_dir.join("skill-creator")
+        );
     }
 
     #[tokio::test]
@@ -1080,6 +1807,15 @@ Use this skill for testing.
             .await
             .expect("canonical expected root");
         assert_eq!(resolved_root, expected_root);
+        let catalog = store.workflow_catalog_snapshot().await;
+        let entry = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "override-skill")
+            .expect("catalog entry");
+        assert_eq!(entry.source, WorkflowSource::Project);
+        assert_eq!(entry.shadowed_candidates.len(), 1);
+        assert_eq!(entry.shadowed_candidates[0].source, WorkflowSource::User);
     }
 
     #[tokio::test]
@@ -1308,6 +2044,15 @@ Use this skill for testing.
             skill.description, "alpha version",
             "lowest-sorting plugin id must deterministically win a same-id collision"
         );
+        let catalog = store.workflow_catalog_snapshot().await;
+        let entry = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "shared-id")
+            .expect("catalog entry");
+        assert_eq!(entry.source, WorkflowSource::Plugin);
+        assert_eq!(entry.shadowed_candidates.len(), 1);
+        assert_eq!(entry.shadowed_candidates[0].source, WorkflowSource::Plugin);
     }
 
     #[tokio::test]
@@ -1402,5 +2147,421 @@ Use this skill for testing.
             .await
             .expect("mode-specific skill exists");
         assert_eq!(mode_specific.description, "mode version");
+    }
+
+    #[tokio::test]
+    async fn mode_override_uses_catalog_validation_and_retains_lkg() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let data_dir = directory.path().join("data");
+        let global_skills_dir = data_dir.join("skills");
+        let mode_skills_dir = data_dir.join("skills-code");
+        fs::create_dir_all(&global_skills_dir)
+            .await
+            .expect("global skills");
+        let mode_root = write_skill(
+            &mode_skills_dir,
+            "mode-catalog",
+            "mode v1",
+            "Mode prompt v1",
+        )
+        .await
+        .expect("mode skill");
+        fs::write(
+            mode_root.join("workflow.yaml"),
+            "id: mode-catalog\nname: Mode catalog\ndescription: Mode workflow\nversion: '1'\ncomposition:\n  type: call\n  tool: read_file\n  args: {}\n",
+        )
+        .await
+        .expect("valid workflow metadata");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir: global_skills_dir,
+            project_dir: None,
+            active_mode: None,
+        });
+        store.initialize().await.expect("initialize");
+        assert_eq!(
+            store
+                .get_skill_for_mode("mode-catalog", Some("code"))
+                .await
+                .expect("initial mode skill")
+                .prompt,
+            "Mode prompt v1"
+        );
+
+        fs::write(
+            mode_root.join("SKILL.md"),
+            "---\nname: mode-catalog\ndescription: mode v2\n---\nMode prompt v2\n",
+        )
+        .await
+        .expect("updated instructions");
+        fs::write(mode_root.join("workflow.yaml"), "version: 2\n")
+            .await
+            .expect("invalid workflow metadata");
+        assert_eq!(
+            store
+                .get_skill_for_mode("mode-catalog", Some("code"))
+                .await
+                .expect("mode LKG")
+                .prompt,
+            "Mode prompt v1",
+            "invalid mode metadata must not activate new instructions"
+        );
+
+        fs::write(
+            mode_root.join("workflow.yaml"),
+            "id: mode-catalog\nname: Mode catalog\ndescription: Mode workflow\nversion: '2'\ncomposition:\n  type: call\n  tool: read_file\n  args: {}\n",
+        )
+        .await
+        .expect("recovered metadata");
+        assert_eq!(
+            store
+                .get_skill_for_mode("mode-catalog", Some("code"))
+                .await
+                .expect("recovered mode skill")
+                .prompt,
+            "Mode prompt v2"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_reload_retains_lkg_and_emits_invalid_then_recovered() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("data/skills");
+        let root = write_skill(&skills_dir, "steady", "original", "Original prompt")
+            .await
+            .expect("skill");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir,
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+        let mut events = store.subscribe_workflow_catalog();
+
+        fs::write(root.join("SKILL.md"), "not valid frontmatter")
+            .await
+            .expect("break skill");
+        store.reload().await.expect("invalid reload is isolated");
+        let skill = store.get_skill("steady").await.expect("LKG retained");
+        assert_eq!(skill.description, "original");
+        let invalid = store
+            .workflow_catalog_snapshot()
+            .await
+            .entries
+            .into_iter()
+            .find(|entry| entry.id == "steady")
+            .expect("invalid entry");
+        assert_eq!(invalid.status, WorkflowStatus::Invalid);
+        assert!(invalid.last_error.is_some());
+        assert_eq!(
+            events.recv().await.expect("invalid event").kind,
+            WorkflowCatalogEventKind::Invalid
+        );
+
+        write_skill(
+            root.parent().expect("skills root"),
+            "steady",
+            "recovered",
+            "Recovered prompt",
+        )
+        .await
+        .expect("repair skill");
+        store.reload().await.expect("recovered reload");
+        assert_eq!(
+            store
+                .get_skill("steady")
+                .await
+                .expect("recovered skill")
+                .description,
+            "recovered"
+        );
+        assert_eq!(
+            events.recv().await.expect("recovered event").kind,
+            WorkflowCatalogEventKind::Recovered
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_workflow_yaml_retains_orchestration_lkg_metadata() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("data/skills");
+        let root = write_skill(&skills_dir, "orchestrate", "orchestrates", "Instructions")
+            .await
+            .expect("skill");
+        fs::write(
+            root.join("workflow.yaml"),
+            "id: orchestrate\nname: Orchestrate\ndescription: Runs tools\nversion: '2'\ncomposition:\n  type: call\n  tool: read_file\n  args: {}\n",
+        )
+        .await
+        .expect("workflow yaml");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir,
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+        let original = store
+            .workflow_catalog_snapshot()
+            .await
+            .entries
+            .into_iter()
+            .find(|entry| entry.id == "orchestrate")
+            .expect("orchestration entry");
+        assert_eq!(original.kind, crate::WorkflowKind::Orchestration);
+        assert_eq!(original.version, "2");
+
+        fs::write(
+            root.join("SKILL.md"),
+            "---\nname: orchestrate\ndescription: changed too early\n---\nNEW BODY MUST NOT ACTIVATE\n",
+        )
+        .await
+        .expect("change instructions");
+        fs::write(root.join("workflow.yaml"), "version: 3\n")
+            .await
+            .expect("break workflow yaml");
+        store.reload().await.expect("isolated invalid metadata");
+        let invalid = store
+            .workflow_catalog_snapshot()
+            .await
+            .entries
+            .into_iter()
+            .find(|entry| entry.id == "orchestrate")
+            .expect("invalid entry");
+        assert_eq!(invalid.status, WorkflowStatus::Invalid);
+        assert_eq!(invalid.kind, crate::WorkflowKind::Orchestration);
+        assert_eq!(invalid.version, "2");
+        let active = store.get_skill("orchestrate").await.expect("LKG active");
+        assert_eq!(active.description, "orchestrates");
+        assert_eq!(active.prompt, "Instructions");
+        assert!(!invalid
+            .last_error
+            .as_deref()
+            .unwrap_or_default()
+            .contains('/'));
+    }
+
+    #[tokio::test]
+    async fn first_invalid_bundle_never_enters_active_skill_store() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("data/skills");
+        let root = write_skill(&skills_dir, "never-active", "invalid bundle", "Secret body")
+            .await
+            .expect("skill");
+        fs::write(root.join("workflow.yaml"), "version: 1\n")
+            .await
+            .expect("invalid workflow metadata");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir,
+            ..Default::default()
+        });
+        store
+            .initialize()
+            .await
+            .expect("initialize isolates invalid");
+        assert!(store.get_skill("never-active").await.is_err());
+        let entry = store
+            .workflow_catalog_snapshot()
+            .await
+            .entries
+            .into_iter()
+            .find(|entry| entry.id == "never-active")
+            .expect("invalid diagnostic entry");
+        assert_eq!(entry.status, WorkflowStatus::Invalid);
+        assert!(!entry
+            .last_error
+            .unwrap_or_default()
+            .contains(directory.path().to_string_lossy().as_ref()));
+    }
+
+    #[tokio::test]
+    async fn unrelated_reload_preserves_each_definition_revision() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("data/skills");
+        let alpha_root = write_skill(&skills_dir, "alpha", "alpha", "Alpha prompt")
+            .await
+            .expect("alpha skill");
+        write_skill(&skills_dir, "beta", "beta", "Beta prompt")
+            .await
+            .expect("beta skill");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir,
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+        let before = store.workflow_catalog_snapshot().await;
+        let alpha_before = before
+            .entries
+            .iter()
+            .find(|entry| entry.id == "alpha")
+            .expect("alpha catalog entry")
+            .revision;
+        let beta_before = before
+            .entries
+            .iter()
+            .find(|entry| entry.id == "beta")
+            .expect("beta catalog entry")
+            .revision;
+
+        fs::write(
+            alpha_root.join("SKILL.md"),
+            "---\nname: alpha\ndescription: alpha changed\n---\nChanged prompt\n",
+        )
+        .await
+        .expect("update alpha");
+        store.reload().await.expect("reload");
+
+        let after = store.workflow_catalog_snapshot().await;
+        assert!(after.revision > before.revision);
+        assert!(
+            after
+                .entries
+                .iter()
+                .find(|entry| entry.id == "alpha")
+                .expect("updated alpha")
+                .revision
+                > alpha_before
+        );
+        assert_eq!(
+            after
+                .entries
+                .iter()
+                .find(|entry| entry.id == "beta")
+                .expect("unchanged beta")
+                .revision,
+            beta_before,
+            "an unrelated definition must keep its activation revision"
+        );
+    }
+
+    #[tokio::test]
+    async fn os_watcher_hot_discovers_plugin_installed_after_startup() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("data/skills");
+        fs::create_dir_all(&skills_dir).await.expect("skills dir");
+        let manager = SkillManager::with_config(SkillStoreConfig {
+            skills_dir: skills_dir.clone(),
+            ..Default::default()
+        });
+        manager.initialize().await.expect("initialize manager");
+        let initial_revision = manager.store().workflow_catalog_snapshot().await.revision;
+        let plugin_skills = directory.path().join("data/plugins/late/skills");
+        write_skill(&plugin_skills, "hot-plugin", "hot discovered", "Prompt")
+            .await
+            .expect("plugin skill");
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let snapshot = manager.store().workflow_catalog_snapshot().await;
+                if snapshot.revision > initial_revision
+                    && snapshot
+                        .entries
+                        .iter()
+                        .any(|entry| entry.id == "hot-plugin")
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+            }
+        })
+        .await
+        .expect("watcher should publish plugin without explicit refresh");
+
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        let stable_revision = manager.store().workflow_catalog_snapshot().await.revision;
+        fs::create_dir_all(directory.path().join("data/sessions"))
+            .await
+            .expect("sessions dir");
+        fs::write(directory.path().join("data/sessions/unrelated.json"), "{}")
+            .await
+            .expect("unrelated write");
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        assert_eq!(
+            manager.store().workflow_catalog_snapshot().await.revision,
+            stable_revision,
+            "unrelated data-dir writes must not publish a catalog revision"
+        );
+    }
+
+    #[tokio::test]
+    async fn workspace_catalog_views_are_isolated_per_session() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("data/skills");
+        let one = directory.path().join("one");
+        let two = directory.path().join("two");
+        fs::create_dir_all(one.join(".bamboo/skills"))
+            .await
+            .expect("workspace one");
+        fs::create_dir_all(two.join(".bamboo/skills"))
+            .await
+            .expect("workspace two");
+        write_skill(&one.join(".bamboo/skills"), "only-one", "one", "One")
+            .await
+            .expect("one skill");
+        write_skill(&two.join(".bamboo/skills"), "only-two", "two", "Two")
+            .await
+            .expect("two skill");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir,
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+        let mut events = store.subscribe_workflow_catalog();
+        let first = store
+            .workflow_catalog_for_workspace(&one)
+            .await
+            .expect("first view");
+        let second = store
+            .workflow_catalog_for_workspace(&two)
+            .await
+            .expect("second view");
+        assert!(first.entries.iter().any(|entry| entry.id == "only-one"));
+        assert!(!first.entries.iter().any(|entry| entry.id == "only-two"));
+        assert!(second.entries.iter().any(|entry| entry.id == "only-two"));
+        assert!(!second.entries.iter().any(|entry| entry.id == "only-one"));
+
+        let repeated = store
+            .workflow_catalog_for_workspace(&one)
+            .await
+            .expect("cached first view");
+        assert_eq!(repeated.revision, first.revision, "read must not bump");
+
+        let skill_file = one.join(".bamboo/skills/only-one/SKILL.md");
+        let staging = one.join(".bamboo/skills/only-one/.SKILL.md.atomic");
+        fs::write(
+            &staging,
+            "---\nname: only-one\ndescription: one changed\n---\nChanged\n",
+        )
+        .await
+        .expect("atomic staging");
+        fs::rename(&staging, &skill_file)
+            .await
+            .expect("atomic rename");
+        let event = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let event = events.recv().await.expect("workspace event");
+                if event.workflow_id == "only-one" {
+                    break event;
+                }
+            }
+        })
+        .await
+        .expect("workspace watcher event");
+        assert!(event.scope.starts_with("workspace:"));
+        let updated = store
+            .workflow_catalog_for_workspace(&one)
+            .await
+            .expect("updated first view");
+        let untouched = store
+            .workflow_catalog_for_workspace(&two)
+            .await
+            .expect("untouched second view");
+        assert!(updated.revision > first.revision);
+        assert_eq!(untouched.revision, second.revision);
+        assert_eq!(
+            updated
+                .entries
+                .iter()
+                .find(|entry| entry.id == "only-one")
+                .expect("updated entry")
+                .description,
+            "one changed"
+        );
     }
 }

--- a/crates/infra/bamboo-skills/src/store/storage.rs
+++ b/crates/infra/bamboo-skills/src/store/storage.rs
@@ -6,8 +6,10 @@ use tracing::{debug, info, warn};
 use crate::store::parser::{parse_markdown_skill, render_skill_markdown};
 use crate::types::{SkillDefinition, SkillResult};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SkillDirectorySource {
+    /// Compile-time embedded bundle materialized under the global skills dir.
+    Builtin,
     /// Cross-agent user skills discovered from `~/.agents/skills`.
     Agents,
     Global,
@@ -31,6 +33,23 @@ pub struct LoadedSkillRecord {
     pub skill_root: PathBuf,
     pub source: SkillDirectorySource,
     pub mode: Option<String>,
+    pub skill_file: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct FailedSkillRecord {
+    pub skill_id: Option<String>,
+    pub skill_root: PathBuf,
+    pub skill_file: PathBuf,
+    pub source: SkillDirectorySource,
+    pub mode: Option<String>,
+    pub error: String,
+}
+
+#[derive(Debug, Default)]
+pub struct SkillLoadReport {
+    pub loaded: Vec<LoadedSkillRecord>,
+    pub failed: Vec<FailedSkillRecord>,
 }
 
 pub async fn ensure_skills_dir(skills_dir: &Path) -> SkillResult<()> {
@@ -105,7 +124,16 @@ async fn find_skill_files(dir: &Path) -> Vec<PathBuf> {
 pub async fn load_skills_from_discovery_dirs(
     discovery_dirs: &[SkillDiscoveryDir],
 ) -> SkillResult<Vec<LoadedSkillRecord>> {
-    let mut loaded = Vec::new();
+    Ok(load_skills_from_discovery_dirs_detailed(discovery_dirs)
+        .await?
+        .loaded)
+}
+
+/// Discover every candidate and preserve per-bundle failures for catalog LKG handling.
+pub async fn load_skills_from_discovery_dirs_detailed(
+    discovery_dirs: &[SkillDiscoveryDir],
+) -> SkillResult<SkillLoadReport> {
+    let mut report = SkillLoadReport::default();
 
     for discovery in discovery_dirs {
         match fs::try_exists(&discovery.dir).await {
@@ -133,7 +161,8 @@ pub async fn load_skills_from_discovery_dirs(
             discovery.mode.as_deref().unwrap_or("generic")
         );
 
-        let skill_files = find_skill_files(&discovery.dir).await;
+        let mut skill_files = find_skill_files(&discovery.dir).await;
+        skill_files.sort();
         for skill_file in skill_files {
             match fs::read_to_string(&skill_file).await {
                 Ok(content) => match parse_markdown_skill(&skill_file, &content) {
@@ -142,26 +171,61 @@ pub async fn load_skills_from_discovery_dirs(
                             .parent()
                             .map(Path::to_path_buf)
                             .unwrap_or_else(|| discovery.dir.clone());
-                        loaded.push(LoadedSkillRecord {
+                        report.loaded.push(LoadedSkillRecord {
                             skill,
                             skill_root,
                             source: discovery.source,
                             mode: discovery.mode.clone(),
+                            skill_file,
                         });
                     }
                     Err(error) => {
                         warn!("Failed to parse skill file {:?}: {}", skill_file, error);
+                        let skill_root = skill_file
+                            .parent()
+                            .map(Path::to_path_buf)
+                            .unwrap_or_else(|| discovery.dir.clone());
+                        report.failed.push(FailedSkillRecord {
+                            skill_id: skill_root
+                                .file_name()
+                                .and_then(|name| name.to_str())
+                                .map(str::to_string),
+                            skill_root,
+                            skill_file,
+                            source: discovery.source,
+                            mode: discovery.mode.clone(),
+                            error: error.to_string(),
+                        });
                     }
                 },
                 Err(error) => {
                     warn!("Failed to read skill file {:?}: {}", skill_file, error);
+                    let skill_root = skill_file
+                        .parent()
+                        .map(Path::to_path_buf)
+                        .unwrap_or_else(|| discovery.dir.clone());
+                    report.failed.push(FailedSkillRecord {
+                        skill_id: skill_root
+                            .file_name()
+                            .and_then(|name| name.to_str())
+                            .map(str::to_string),
+                        skill_root,
+                        skill_file,
+                        source: discovery.source,
+                        mode: discovery.mode.clone(),
+                        error: error.to_string(),
+                    });
                 }
             }
         }
     }
 
-    info!("Loaded {} skill records from discovery dirs", loaded.len());
-    Ok(loaded)
+    info!(
+        "Loaded {} skill records from discovery dirs ({} invalid)",
+        report.loaded.len(),
+        report.failed.len()
+    );
+    Ok(report)
 }
 
 /// Discover additional skill-discovery dirs contributed by installed

--- a/crates/infra/bamboo-skills/src/types.rs
+++ b/crates/infra/bamboo-skills/src/types.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub type SkillId = String;
 
 /// Complete definition of a skill
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SkillDefinition {
     /// Unique identifier (kebab-case)
     pub id: SkillId,

--- a/deny.toml
+++ b/deny.toml
@@ -111,11 +111,12 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list.
 #
-# No exceptions currently needed: `actix-governor` (GPL-3.0-or-later) was
-# replaced by an in-repo actix middleware over the MIT/Apache-2.0 `governor`
-# crate it used to wrap (bamboo-server's `src/rate_limit.rs`, #504), which
-# removed the GPL dependency entirely rather than requiring one.
-exceptions = []
+# Keep exceptions pinned to an exact package version instead of widening the
+# workspace-wide allow list. `notify` uses CC0-1.0 for a small portion of its
+# cross-platform filesystem-watcher implementation.
+exceptions = [
+    { crate = "notify@8.2.0", allow = ["CC0-1.0"] },
+]
 
 # Some crates don't have (easily) machine readable licensing information,
 # adding a clarification entry for it allows you to manually specify the

--- a/tests/e2e/commands/list.rs
+++ b/tests/e2e/commands/list.rs
@@ -66,21 +66,32 @@ async fn test_list_commands_includes_workflows_and_skills() {
     )
     .await;
 
-    let req = test::TestRequest::get().uri("/v1/commands").to_request();
+    let command = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let req = test::TestRequest::get().uri("/v1/commands").to_request();
+            let resp = test::call_service(&app, req).await;
+            let body = test::read_body(resp).await;
+            let result: Value =
+                serde_json::from_slice(&body).expect("Response should be valid JSON");
+            if let Some(command) = result["commands"]
+                .as_array()
+                .expect("commands should be an array")
+                .iter()
+                .find(|command| command["name"] == "example")
+                .cloned()
+            {
+                break command;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+        }
+    })
+    .await
+    .expect("watcher should publish the imported workflow command");
 
-    let resp = test::call_service(&app, req).await;
-    let body = test::read_body(resp).await;
-    let result: Value = serde_json::from_slice(&body).expect("Response should be valid JSON");
-
-    // Should have at least one command (the workflow we created)
-    let commands = result["commands"]
-        .as_array()
-        .expect("commands should be an array");
-    assert!(!commands.is_empty());
-
-    // Should include our workflow
-    let has_workflow = commands
-        .iter()
-        .any(|cmd| cmd["type"] == "workflow" && cmd["name"] == "example");
-    assert!(has_workflow, "Should include the example workflow");
+    assert_eq!(command["id"], "skill-example");
+    assert_eq!(command["type"], "skill");
+    assert_eq!(
+        command["description"],
+        "Imported legacy workflow 'example'."
+    );
 }


### PR DESCRIPTION
## Summary

- add a metadata-only workflow catalog backed by the shared SkillStore discovery and resource roots
- centralize builtin, plugin, user, and session-workspace project precedence with deterministic shadowing and revisions
- add debounced live reload, last-known-good invalid handling, durable catalog events, and legacy Markdown/YAML adapters
- route palette, explicit selection, automatic matching, filtered tools, load_skill, and read_skill_resource through the same session workspace winner

## Test Plan

- cargo fmt --all -- --check
- git diff --check
- cargo build --workspace
- cargo clippy -p bamboo-skills --all-targets --message-format=short
- cargo test -p bamboo-agent --test e2e_tests (206 passed)
- cargo test -- --skip build_rustls_config_succeeds_on_valid_self_signed_cert

The skipped TLS test fails identically on clean origin/main in this macOS/OpenSSL environment with rustls UnsupportedCertVersion; all remaining workspace and doc tests pass.

## Screenshots

Not applicable; this is a backend catalog and API refactor.

Closes #577