### PR TITLE
fix(skills): keep orchestration catalog commands selectable

### DIFF
--- a/crates/app/bamboo-server/src/handlers/command/sources.rs
+++ b/crates/app/bamboo-server/src/handlers/command/sources.rs
@@ -218,16 +218,19 @@ pub(super) async fn list_prompt_presets_as_commands(data_dir: &Path) -> Vec<Comm
 }
 
 pub(super) fn catalog_entry_to_command(entry: &WorkflowCatalogEntry) -> CommandItem {
-    let (id_prefix, command_type) = match entry.kind {
-        bamboo_skills::WorkflowKind::Instruction => ("skill", "skill"),
-        bamboo_skills::WorkflowKind::Orchestration => ("workflow", "workflow"),
-    };
+    // Until the WorkflowRun engine owns orchestration activation (#578), every catalog bundle is
+    // selected through its canonical SKILL.md instruction entrypoint. Advertising an
+    // orchestration bundle as a legacy `workflow` makes Lotus fetch
+    // `/commands/workflow/{id}`, whose compatibility handler only serves
+    // `${BAMBOO_DATA_DIR}/workflows/{id}.md`; a bundle-local workflow.yaml therefore becomes a
+    // visible command that always fails on selection. Keep the future execution semantic in
+    // metadata.kind without pretending the legacy prompt-workflow adapter can execute it.
     CommandItem {
-        id: format!("{id_prefix}-{}", entry.id),
+        id: format!("skill-{}", entry.id),
         name: entry.id.clone(),
         display_name: entry.name.clone(),
         description: entry.description.clone(),
-        command_type: command_type.to_string(),
+        command_type: "skill".to_string(),
         category: None,
         tags: None,
         metadata: serde_json::json!({

--- a/crates/app/bamboo-server/src/handlers/command/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/command/tests.rs
@@ -33,6 +33,31 @@ fn catalog_entry_to_command_maps_metadata_without_prompt() {
     assert!(command.metadata.get("prompt").is_none());
 }
 
+#[test]
+fn orchestration_catalog_entry_stays_selectable_as_skill_until_workflow_run_exists() {
+    let entry = WorkflowCatalogEntry {
+        id: "review-run".into(),
+        name: "Review run".into(),
+        description: "Reviews changes through an orchestration".into(),
+        kind: WorkflowKind::Orchestration,
+        source: WorkflowSource::Project,
+        revision: 8,
+        version: "1".into(),
+        invocation_policy: serde_json::json!({"explicit": true}),
+        argument_schema: serde_json::json!({"type": "object"}),
+        status: WorkflowStatus::Valid,
+        last_error: None,
+        winner: true,
+        shadowed_candidates: vec![],
+    };
+
+    let command = catalog_entry_to_command(&entry);
+
+    assert_eq!(command.id, "skill-review-run");
+    assert_eq!(command.command_type, "skill");
+    assert_eq!(command.metadata["kind"], "orchestration");
+}
+
 #[tokio::test]
 async fn markdown_commands_support_namespace_frontmatter_and_arguments() {
     let project = tempfile::tempdir().expect("project");

--- a/crates/infra/bamboo-skills/src/catalog.rs
+++ b/crates/infra/bamboo-skills/src/catalog.rs
@@ -136,6 +136,23 @@ fn yaml_scalar_to_string(value: serde_yaml::Value) -> Option<String> {
     }
 }
 
+fn public_yaml_error(display_name: &str, error: serde_yaml::Error) -> String {
+    tracing::warn!("Invalid workflow bundle metadata in {display_name}: {error}");
+    match error.location() {
+        Some(location) => format!(
+            "{display_name}: invalid metadata at line {}, column {}",
+            location.line(),
+            location.column()
+        ),
+        None => format!("{display_name}: invalid metadata"),
+    }
+}
+
+fn public_validation_error(display_name: &str, error: impl std::fmt::Display) -> String {
+    tracing::warn!("Invalid workflow definition in {display_name}: {error}");
+    format!("{display_name}: invalid workflow definition")
+}
+
 pub(crate) async fn load_bundle_metadata(root: &Path) -> Result<BundleMetadata, String> {
     let workflow_path = root.join("workflow.yaml");
     let bamboo_path = root.join("agents").join("bamboo.yaml");
@@ -159,14 +176,14 @@ pub(crate) async fn load_bundle_metadata(root: &Path) -> Result<BundleMetadata, 
         .await
         .map_err(|error| format!("{display_name}: {error}"))?;
     let metadata: BambooWorkflowMetadata =
-        serde_yaml::from_str(&raw).map_err(|error| format!("{display_name}: {error}"))?;
+        serde_yaml::from_str(&raw).map_err(|error| public_yaml_error(display_name, error))?;
     let is_workflow_definition = path.ends_with("workflow.yaml");
     if is_workflow_definition {
         let definition: bamboo_domain::WorkflowDefinition =
-            serde_yaml::from_str(&raw).map_err(|error| format!("{display_name}: {error}"))?;
+            serde_yaml::from_str(&raw).map_err(|error| public_yaml_error(display_name, error))?;
         definition
             .validate()
-            .map_err(|error| format!("{display_name}: {error}"))?;
+            .map_err(|error| public_validation_error(display_name, error))?;
     }
     let mut result = BundleMetadata {
         kind: if metadata.composition.is_some() || is_workflow_definition {
@@ -229,5 +246,35 @@ mod tests {
         assert!(!json.contains("prompt"));
         assert!(!json.contains("SKILL.md"));
         assert!(!json.contains("references"));
+    }
+
+    #[tokio::test]
+    async fn invalid_bundle_error_does_not_echo_private_yaml_values() {
+        const PRIVATE_VALUE: &str = "private-catalog-metadata-value";
+        const PRIVATE_RESOURCE: &str = "/private/resources/catalog-reference.md";
+        let directory = tempfile::tempdir().expect("tempdir");
+        tokio::fs::write(
+            directory.path().join("workflow.yaml"),
+            format!(
+                "id: private\nname: Private\ndescription: {PRIVATE_VALUE}\nversion: '1'\ncomposition:\n  type: {PRIVATE_RESOURCE}\n"
+            ),
+        )
+        .await
+        .expect("workflow metadata");
+
+        let error = load_bundle_metadata(directory.path())
+            .await
+            .expect_err("invalid composition type");
+
+        assert!(
+            !error.contains(PRIVATE_VALUE),
+            "catalog error leaked: {error}"
+        );
+        assert!(
+            !error.contains(PRIVATE_RESOURCE),
+            "catalog error leaked: {error}"
+        );
+        assert!(error.starts_with("workflow.yaml:"));
+        assert!(!error.contains(directory.path().to_string_lossy().as_ref()));
     }
 }

--- a/crates/infra/bamboo-skills/src/store/mod.rs
+++ b/crates/infra/bamboo-skills/src/store/mod.rs
@@ -2224,6 +2224,8 @@ Use this skill for testing.
 
     #[tokio::test]
     async fn invalid_reload_retains_lkg_and_emits_invalid_then_recovered() {
+        const PRIVATE_FIELD: &str = "private-lkg-frontmatter-field";
+        const PRIVATE_INSTRUCTIONS: &str = "Private LKG replacement instructions";
         let directory = tempfile::tempdir().expect("tempdir");
         let skills_dir = directory.path().join("data/skills");
         let root = write_skill(&skills_dir, "steady", "original", "Original prompt")
@@ -2236,7 +2238,12 @@ Use this skill for testing.
         store.initialize().await.expect("initialize");
         let mut events = store.subscribe_workflow_catalog();
 
-        fs::write(root.join("SKILL.md"), "not valid frontmatter")
+        fs::write(
+            root.join("SKILL.md"),
+            format!(
+                "---\nname: steady\ndescription: changed too early\n{PRIVATE_FIELD}: secret\n---\n{PRIVATE_INSTRUCTIONS}\n"
+            ),
+        )
             .await
             .expect("break skill");
         store.reload().await.expect("invalid reload is isolated");
@@ -2250,7 +2257,11 @@ Use this skill for testing.
             .find(|entry| entry.id == "steady")
             .expect("invalid entry");
         assert_eq!(invalid.status, WorkflowStatus::Invalid);
-        assert!(invalid.last_error.is_some());
+        let public_error = invalid.last_error.as_deref().expect("public error");
+        assert!(public_error.starts_with("SKILL.md:"));
+        assert!(!public_error.contains(PRIVATE_FIELD));
+        assert!(!public_error.contains(PRIVATE_INSTRUCTIONS));
+        assert!(!public_error.contains(root.to_string_lossy().as_ref()));
         assert_eq!(
             events.recv().await.expect("invalid event").kind,
             WorkflowCatalogEventKind::Invalid
@@ -2281,6 +2292,8 @@ Use this skill for testing.
 
     #[tokio::test]
     async fn invalid_workflow_yaml_retains_orchestration_lkg_metadata() {
+        const PRIVATE_RESOURCE: &str = "/private/resources/lkg-reference.md";
+        const PRIVATE_INSTRUCTIONS: &str = "NEW BODY MUST NOT ACTIVATE";
         let directory = tempfile::tempdir().expect("tempdir");
         let skills_dir = directory.path().join("data/skills");
         let root = write_skill(&skills_dir, "orchestrate", "orchestrates", "Instructions")
@@ -2309,11 +2322,18 @@ Use this skill for testing.
 
         fs::write(
             root.join("SKILL.md"),
-            "---\nname: orchestrate\ndescription: changed too early\n---\nNEW BODY MUST NOT ACTIVATE\n",
+            format!(
+                "---\nname: orchestrate\ndescription: changed too early\n---\n{PRIVATE_INSTRUCTIONS}\n"
+            ),
         )
         .await
         .expect("change instructions");
-        fs::write(root.join("workflow.yaml"), "version: 3\n")
+        fs::write(
+            root.join("workflow.yaml"),
+            format!(
+                "id: orchestrate\nname: Orchestrate\ndescription: Runs tools\nversion: '3'\ncomposition:\n  type: {PRIVATE_RESOURCE}\n"
+            ),
+        )
             .await
             .expect("break workflow yaml");
         store.reload().await.expect("isolated invalid metadata");
@@ -2330,21 +2350,33 @@ Use this skill for testing.
         let active = store.get_skill("orchestrate").await.expect("LKG active");
         assert_eq!(active.description, "orchestrates");
         assert_eq!(active.prompt, "Instructions");
-        assert!(!invalid
-            .last_error
-            .as_deref()
-            .unwrap_or_default()
-            .contains('/'));
+        let public_error = invalid.last_error.as_deref().expect("public error");
+        assert!(public_error.starts_with("workflow.yaml:"));
+        assert!(!public_error.contains(PRIVATE_RESOURCE));
+        assert!(!public_error.contains(PRIVATE_INSTRUCTIONS));
+        assert!(!public_error.contains(root.to_string_lossy().as_ref()));
     }
 
     #[tokio::test]
     async fn first_invalid_bundle_never_enters_active_skill_store() {
+        const PRIVATE_RESOURCE: &str = "/private/resources/first-load-reference.md";
+        const PRIVATE_INSTRUCTIONS: &str = "Secret body";
         let directory = tempfile::tempdir().expect("tempdir");
         let skills_dir = directory.path().join("data/skills");
-        let root = write_skill(&skills_dir, "never-active", "invalid bundle", "Secret body")
-            .await
-            .expect("skill");
-        fs::write(root.join("workflow.yaml"), "version: 1\n")
+        let root = write_skill(
+            &skills_dir,
+            "never-active",
+            "invalid bundle",
+            PRIVATE_INSTRUCTIONS,
+        )
+        .await
+        .expect("skill");
+        fs::write(
+            root.join("workflow.yaml"),
+            format!(
+                "id: never-active\nname: Never active\ndescription: Invalid workflow\nversion: '1'\ncomposition:\n  type: {PRIVATE_RESOURCE}\n"
+            ),
+        )
             .await
             .expect("invalid workflow metadata");
         let store = SkillStore::new(SkillStoreConfig {
@@ -2356,18 +2388,98 @@ Use this skill for testing.
             .await
             .expect("initialize isolates invalid");
         assert!(store.get_skill("never-active").await.is_err());
-        let entry = store
-            .workflow_catalog_snapshot()
-            .await
+        let snapshot = store.workflow_catalog_snapshot().await;
+        let serialized = serde_json::to_string(&snapshot).expect("serialize catalog");
+        let entry = snapshot
             .entries
             .into_iter()
             .find(|entry| entry.id == "never-active")
             .expect("invalid diagnostic entry");
         assert_eq!(entry.status, WorkflowStatus::Invalid);
-        assert!(!entry
+        let public_error = entry.last_error.as_deref().expect("public error");
+        assert!(public_error.starts_with("workflow.yaml:"));
+        assert!(!public_error.contains(PRIVATE_RESOURCE));
+        assert!(!serialized.contains(PRIVATE_INSTRUCTIONS));
+        assert!(!serialized.contains(directory.path().to_string_lossy().as_ref()));
+    }
+
+    #[tokio::test]
+    async fn invalid_skill_catalog_error_does_not_echo_private_frontmatter() {
+        const PRIVATE_FIELD: &str = "private-catalog-frontmatter-field";
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("data/skills");
+        let root = skills_dir.join("private-skill");
+        fs::create_dir_all(&root).await.expect("skill root");
+        fs::write(
+            root.join("SKILL.md"),
+            format!(
+                "---\nname: private-skill\ndescription: Private skill\n{PRIVATE_FIELD}: secret\n---\nPrivate instructions\n"
+            ),
+        )
+        .await
+        .expect("invalid skill");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir,
+            ..Default::default()
+        });
+
+        store.initialize().await.expect("isolate invalid skill");
+        let serialized = serde_json::to_string(&store.workflow_catalog_snapshot().await)
+            .expect("serialize catalog");
+
+        assert!(
+            !serialized.contains(PRIVATE_FIELD),
+            "catalog leaked: {serialized}"
+        );
+        assert!(!serialized.contains("Private instructions"));
+        assert!(!serialized.contains(root.to_string_lossy().as_ref()));
+    }
+
+    #[tokio::test]
+    async fn shadowed_invalid_skill_error_is_also_sanitized() {
+        const PRIVATE_FIELD: &str = "private-shadowed-frontmatter-field";
+        const PRIVATE_INSTRUCTIONS: &str = "Private shadowed instructions";
+        let directory = tempfile::tempdir().expect("tempdir");
+        let data_dir = directory.path().join("data");
+        let skills_dir = data_dir.join("skills");
+        write_skill(&skills_dir, "shared-skill", "winner", "Winner instructions")
+            .await
+            .expect("winner skill");
+        let shadowed_root = data_dir.join("plugins/shadowed-plugin/skills/shared-skill");
+        fs::create_dir_all(&shadowed_root)
+            .await
+            .expect("shadowed skill root");
+        fs::write(
+            shadowed_root.join("SKILL.md"),
+            format!(
+                "---\nname: shared-skill\ndescription: shadowed\n{PRIVATE_FIELD}: secret\n---\n{PRIVATE_INSTRUCTIONS}\n"
+            ),
+        )
+        .await
+        .expect("invalid shadowed skill");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir,
+            ..Default::default()
+        });
+
+        store.initialize().await.expect("initialize");
+        let snapshot = store.workflow_catalog_snapshot().await;
+        let serialized = serde_json::to_string(&snapshot).expect("serialize catalog");
+        let entry = snapshot
+            .entries
+            .iter()
+            .find(|entry| entry.id == "shared-skill")
+            .expect("winner entry");
+
+        assert_eq!(entry.shadowed_candidates.len(), 1);
+        let public_error = entry.shadowed_candidates[0]
             .last_error
-            .unwrap_or_default()
-            .contains(directory.path().to_string_lossy().as_ref()));
+            .as_deref()
+            .expect("shadowed public error");
+        assert!(public_error.starts_with("SKILL.md:"));
+        assert!(!serialized.contains(PRIVATE_FIELD));
+        assert!(!serialized.contains(PRIVATE_INSTRUCTIONS));
+        assert!(!serialized.contains(shadowed_root.to_string_lossy().as_ref()));
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-skills/src/store/storage.rs
+++ b/crates/infra/bamboo-skills/src/store/storage.rs
@@ -4,7 +4,23 @@ use tokio::fs;
 use tracing::{debug, info, warn};
 
 use crate::store::parser::{parse_markdown_skill, render_skill_markdown};
-use crate::types::{SkillDefinition, SkillResult};
+use crate::types::{SkillDefinition, SkillError, SkillResult};
+
+fn public_skill_error(error: &SkillError) -> String {
+    match error {
+        SkillError::Yaml(error) => match error.location() {
+            Some(location) => format!(
+                "SKILL.md: invalid metadata at line {}, column {}",
+                location.line(),
+                location.column()
+            ),
+            None => "SKILL.md: invalid metadata".to_string(),
+        },
+        SkillError::InvalidId(_) => "SKILL.md: invalid skill id".to_string(),
+        SkillError::Validation(_) => "SKILL.md: invalid frontmatter or content".to_string(),
+        _ => "SKILL.md: failed to load bundle".to_string(),
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SkillDirectorySource {
@@ -194,7 +210,7 @@ pub async fn load_skills_from_discovery_dirs_detailed(
                             skill_file,
                             source: discovery.source,
                             mode: discovery.mode.clone(),
-                            error: error.to_string(),
+                            error: public_skill_error(&error),
                         });
                     }
                 },


### PR DESCRIPTION
## Summary

- keep orchestration catalog entries selectable through the canonical skill instruction endpoint until WorkflowRun activation ships
- preserve orchestration kind metadata for the future execution transition
- sanitize public workflow and skill catalog errors so user metadata, instructions, paths, and resources are not exposed
- add regression coverage for command routing plus first-load, last-known-good reload, and shadowed-candidate leakage paths

## Test Plan

- cargo test -p bamboo-skills (82 passed)
- cargo test -p bamboo-server handlers::command (21 passed)
- cargo clippy -p bamboo-skills --all-targets -- -D warnings
- cargo clippy -p bamboo-server --all-targets (passes with existing unrelated warnings)
- cargo fmt --all -- --check
- git diff --check
- cargo test -- --skip build_rustls_config_succeeds_on_valid_self_signed_cert (passed)

The excluded TLS test is unrelated to this patch and is unstable in the local macOS/OpenSSL environment: a clean origin/main run passed while patch runs reported rustls UnsupportedCertVersion. CI remains authoritative for this environment-sensitive check.

## Screenshots

Not applicable; backend catalog/API behavior only.

Closes #615