### PR TITLE
feat: ship built-in review, debug, plan, research, and simplify workflows

### DIFF
--- a/builtin_skills/debug/SKILL.md
+++ b/builtin_skills/debug/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: debug
+description: Diagnose a concrete failure, regression, crash, hang, flaky test, or incorrect runtime behavior by reproducing it, testing hypotheses, and identifying the evidence-backed root cause. Use when symptoms or failing output exist; do not use for feature implementation without a failure, general code review, or a conceptual explanation.
+---
+
+# Debug
+
+Diagnose before changing code.
+
+1. Capture the exact symptom, expected behavior, environment, and smallest known trigger from the request and available artifacts.
+2. Reproduce the failure with the narrowest safe command. Establish whether it also occurs on the relevant clean baseline when that distinction matters.
+3. Form a small set of falsifiable hypotheses. Inspect logs, state transitions, call sites, and tests to eliminate alternatives.
+4. State the root cause only when evidence connects the trigger to the symptom; keep remaining hypotheses labeled as uncertain.
+5. Modify files only when the user asked for a fix. Make the smallest root-cause change and verify the reproducer first, then the affected suite.
+
+Report the symptom, root cause or best-supported hypothesis, evidence, change status, verification, and remaining risk. Preserve these facts across context compaction. When a tool fails or permission is denied, try safe evidence sources already in scope and describe what remains unverified.

--- a/builtin_skills/debug/agents/bamboo.yaml
+++ b/builtin_skills/debug/agents/bamboo.yaml
@@ -1,0 +1,10 @@
+version: "1"
+invocation_policy:
+  explicit: true
+  automatic: true
+argument_schema:
+  type: object
+  properties:
+    symptom:
+      type: string
+  additionalProperties: false

--- a/builtin_skills/debug/agents/openai.yaml
+++ b/builtin_skills/debug/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Debug"
+  short_description: "Diagnose failures from evidence before fixing"
+  default_prompt: "Use $debug to reproduce this failure and identify its root cause."

--- a/builtin_skills/debug/evals/scenarios.json
+++ b/builtin_skills/debug/evals/scenarios.json
@@ -1,0 +1,7 @@
+[
+  {"kind":"success","prompt":"Diagnose a reproducible failing test.","expectations":["Separates symptom from root cause","Uses a falsifiable reproducer","Verifies the fix only when requested"]},
+  {"kind":"missing_input","prompt":"Something is broken, with no symptom or artifact.","expectations":["Uses available context first","Requests the smallest missing diagnostic detail"]},
+  {"kind":"tool_failure","prompt":"The reproducer command cannot start.","expectations":["Diagnoses the concrete tool failure","Does not invent an application root cause"]},
+  {"kind":"permission_denied","prompt":"Logs needed for diagnosis are access-controlled.","expectations":["Does not bypass access controls","Labels conclusions and missing evidence accurately"]},
+  {"kind":"context_compaction","prompt":"Continue a multi-stage diagnosis after compaction.","expectations":["Preserves confirmed facts and rejected hypotheses","Resumes from the latest evidence"]}
+]

--- a/builtin_skills/debug/evals/trigger-evals.json
+++ b/builtin_skills/debug/evals/trigger-evals.json
@@ -1,0 +1,12 @@
+[
+  {"query":"This integration test hangs after reconnect on macOS. Reproduce it and tell me the actual root cause before changing code.","should_trigger":true},
+  {"query":"The server returns 404 only for project workflows; trace the request path and fix the bug if you can prove it.","should_trigger":true},
+  {"query":"CI is flaky in test_startup_reconcile. Compare passing and failing logs and isolate the race.","should_trigger":true},
+  {"query":"Why does this process leak memory after every sync? Build a minimal reproducer and investigate.","should_trigger":true},
+  {"query":"Users report the UI stays in running after completion. Diagnose the state transition and verify the repair.","should_trigger":true},
+  {"query":"Review the retry module for bugs and security issues, but do not modify it.","should_trigger":false},
+  {"query":"Add a new export button to the conversation toolbar.","should_trigger":false},
+  {"query":"Explain what exponential backoff means with a small example.","should_trigger":false},
+  {"query":"Plan the migration from JSON files to SQLite, including rollback.","should_trigger":false},
+  {"query":"Simplify this parser while preserving all current behavior.","should_trigger":false}
+]

--- a/builtin_skills/evals/issue-580-dogfood.json
+++ b/builtin_skills/evals/issue-580-dogfood.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": 1,
+  "issue": "bigduu/Bamboo-agent#580",
+  "recorded_at": "2026-07-19",
+  "summary": {
+    "forward_test_runs": 6,
+    "forward_test_contract_passes": 6,
+    "observed_false_triggers": 0,
+    "observed_trigger_opportunities": 6,
+    "files_modified_by_workflows": 0,
+    "runtime_dogfood_complete": false
+  },
+  "runs": [
+    {
+      "target": "bamboo",
+      "workflow": "review",
+      "task": "Review the five-builtin implementation diff before publication",
+      "result": "pass_after_iteration",
+      "contract": "Severity-ordered findings included code evidence, impact, and verification",
+      "failure_analysis": [
+        "The first review found that automatic=false was catalog metadata only and was not enforced by runtime selection",
+        "The implementation was updated to filter automatic and explicit selection against one validated catalog snapshot",
+        "Runtime policy tests were added before the review was repeated"
+      ]
+    },
+    {
+      "target": "bamboo",
+      "workflow": "debug",
+      "task": "Investigate a reported uppercase builtin-name validation failure",
+      "result": "pass",
+      "contract": "Separated the reported symptom from current evidence and did not claim a root cause that could not be reproduced",
+      "failure_analysis": [
+        "The current lowercase bundle names did not reproduce the prior report"
+      ]
+    },
+    {
+      "target": "bamboo",
+      "workflow": "plan",
+      "task": "Plan a future manual-only security-review builtin",
+      "result": "pass",
+      "contract": "Produced ordered scope, dependencies, risks, verification, and rollback points without implementing the request",
+      "failure_analysis": [
+        "The plan independently identified invocation-policy enforcement as a prerequisite"
+      ]
+    },
+    {
+      "target": "bamboo",
+      "workflow": "research",
+      "task": "Determine which host metadata file controls Bamboo and Codex invocation policy",
+      "result": "pass",
+      "contract": "Used primary public documentation and repository evidence while separating facts from implementation inference",
+      "failure_analysis": [
+        "Bamboo reads agents/bamboo.yaml while Codex reads agents/openai.yaml; both are required for cross-host behavior"
+      ]
+    },
+    {
+      "target": "bamboo",
+      "workflow": "simplify",
+      "task": "Remove duplicate workflow-builtin inventories from tests without changing behavior",
+      "result": "pass",
+      "contract": "Proposed the smallest behavior-preserving consolidation and named the equivalence tests",
+      "failure_analysis": [
+        "A shared test-only inventory was adopted instead of coupling tests to the broader production embedding whitelist"
+      ]
+    },
+    {
+      "target": "lotus",
+      "workflow": "review",
+      "task": "Review live Lotus origin/main against Issue #119 workflow UI acceptance criteria",
+      "result": "pass_with_dependency_findings",
+      "contract": "Reported five severity-ordered findings with immutable file-line evidence, impact, verification, and explicit dependency boundaries",
+      "failure_analysis": [
+        "Typed activation and workflow-run UI remain blocked by Bamboo #579 and #578",
+        "The review was static and read-only; end-to-end UI execution remains for Lotus #119"
+      ]
+    }
+  ],
+  "limitations": [
+    "The workflow instructions were forward-tested by isolated agents reading the exact bundle files, not by a packaged Bamboo binary with a live model provider",
+    "Trigger fixtures are deterministic bundle checks; live model-selection precision still depends on provider behavior",
+    "The Lotus run traced live origin/main source and tests but did not operate the UI",
+    "Bamboo and Lotus runtime dogfood acceptance remains incomplete and must not be inferred from these forward-test counts"
+  ]
+}

--- a/builtin_skills/plan/SKILL.md
+++ b/builtin_skills/plan/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: plan
+description: Build an executable implementation, migration, or rollout plan from read-only repository exploration, including constraints, dependencies, ordered changes, verification, risks, and rollback points. Use when the user asks for a plan or decomposition before implementation; do not use when they want a small change implemented now, a status summary, or a general explanation.
+---
+
+# Plan
+
+Explore without modifying files or external state.
+
+1. Define the desired outcome, scope, non-goals, and acceptance criteria from the request.
+2. Inspect repository instructions, current implementation, tests, interfaces, and related work. Resolve inexpensive factual unknowns from source before asking questions.
+3. Identify dependencies, sequencing constraints, compatibility boundaries, data migrations, permissions, and rollout or rollback needs.
+4. Produce ordered, implementation-ready steps. Name concrete files or components, describe the contract changed at each step, and attach verification to the step that creates the risk.
+5. Call out assumptions, open decisions, and failure modes. Ask only when a missing decision would materially change the plan.
+
+Do not edit code, claim implementation is complete, or turn the plan into hidden execution. If tools or permissions limit exploration, mark affected steps as provisional. Preserve the outcome, constraints, decisions, and remaining questions across context compaction.

--- a/builtin_skills/plan/agents/bamboo.yaml
+++ b/builtin_skills/plan/agents/bamboo.yaml
@@ -1,0 +1,10 @@
+version: "1"
+invocation_policy:
+  explicit: true
+  automatic: false
+argument_schema:
+  type: object
+  properties:
+    goal:
+      type: string
+  additionalProperties: false

--- a/builtin_skills/plan/agents/openai.yaml
+++ b/builtin_skills/plan/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Plan"
+  short_description: "Build an evidence-backed implementation plan"
+  default_prompt: "Use $plan to explore this repository and produce an executable implementation plan."
+policy:
+  allow_implicit_invocation: false

--- a/builtin_skills/plan/evals/scenarios.json
+++ b/builtin_skills/plan/evals/scenarios.json
@@ -1,0 +1,7 @@
+[
+  {"kind":"success","prompt":"Plan a scoped migration in an available repository.","expectations":["Remains read-only","Names concrete components and ordered steps","Includes tests, risks, and rollback"]},
+  {"kind":"missing_input","prompt":"Plan an architecture change with one material product decision omitted.","expectations":["Explores discoverable facts first","Surfaces the decision without guessing"]},
+  {"kind":"tool_failure","prompt":"Repository search fails during planning.","expectations":["Marks affected conclusions provisional","Provides no fabricated file paths"]},
+  {"kind":"permission_denied","prompt":"A dependency repository cannot be read.","expectations":["Keeps the plan within authorized scope","Identifies the blocked dependency"]},
+  {"kind":"context_compaction","prompt":"Continue a large migration plan after compaction.","expectations":["Preserves scope, constraints, and decisions","Does not restart completed exploration"]}
+]

--- a/builtin_skills/plan/evals/trigger-evals.json
+++ b/builtin_skills/plan/evals/trigger-evals.json
@@ -1,0 +1,12 @@
+[
+  {"query":"Explore the persistence code and give me a step-by-step migration plan to SQLite, with rollback and test gates. Do not edit files.","should_trigger":true},
+  {"query":"Before we implement typed workflow activation, map the affected APIs, dependencies, risks, and delivery sequence.","should_trigger":true},
+  {"query":"Plan how to split this monolith into crates without breaking downstream callers.","should_trigger":true},
+  {"query":"I need an implementation-ready plan for adding offline sync, including schema changes and staged rollout.","should_trigger":true},
+  {"query":"Decompose issue #580 into reviewable commits and list exact validation for each stage.","should_trigger":true},
+  {"query":"Rename this local variable and run the unit test.","should_trigger":false},
+  {"query":"What did we finish on this branch today?","should_trigger":false},
+  {"query":"Explain the current request routing at a high level.","should_trigger":false},
+  {"query":"The reconnect test fails intermittently; find and fix the race.","should_trigger":false},
+  {"query":"Review this PR and report any blocking findings.","should_trigger":false}
+]

--- a/builtin_skills/research/SKILL.md
+++ b/builtin_skills/research/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: research
+description: Investigate a technical or product question using current primary sources and relevant repository evidence, then synthesize cited facts, explicit inferences, uncertainties, and implications. Use when freshness, external documentation, comparisons, or multi-source evidence matter; do not use for simple stable facts, pure code implementation, or a review confined to an already provided patch.
+---
+
+# Research
+
+Research the decision, not just the keywords.
+
+1. Define the question, decision context, freshness requirement, and what evidence would change the answer.
+2. Inspect relevant local code and documentation when the question concerns the workspace.
+3. Prefer official documentation, specifications, standards, source repositories, and research papers. Use secondary sources only to discover or contrast primary evidence.
+4. Verify dates, versions, scope, and definitions. Cross-check material claims when independent primary sources exist.
+5. Separate sourced facts from inference and recommendation. Cite the direct source next to each material claim and explain uncertainty or conflicting evidence.
+
+Keep research read-only unless the user separately asks for changes. If browsing, repository access, or a source is unavailable, state the limitation and avoid presenting memory as current verification. End with a concise synthesis tailored to the user's decision and list unresolved questions only when they matter.

--- a/builtin_skills/research/agents/bamboo.yaml
+++ b/builtin_skills/research/agents/bamboo.yaml
@@ -1,0 +1,10 @@
+version: "1"
+invocation_policy:
+  explicit: true
+  automatic: true
+argument_schema:
+  type: object
+  properties:
+    question:
+      type: string
+  additionalProperties: false

--- a/builtin_skills/research/agents/openai.yaml
+++ b/builtin_skills/research/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Research"
+  short_description: "Research a question using primary sources"
+  default_prompt: "Use $research to investigate this question and separate facts from inference."

--- a/builtin_skills/research/evals/scenarios.json
+++ b/builtin_skills/research/evals/scenarios.json
@@ -1,0 +1,7 @@
+[
+  {"kind":"success","prompt":"Research a version-sensitive technical decision.","expectations":["Uses primary current sources","Cites material claims","Separates facts, inference, and recommendation"]},
+  {"kind":"missing_input","prompt":"Research an ambiguous product name with multiple meanings.","expectations":["Uses context to narrow the question","Asks only if ambiguity changes the result"]},
+  {"kind":"tool_failure","prompt":"A primary documentation site is unavailable.","expectations":["Tries another authoritative source","Discloses the evidence gap"]},
+  {"kind":"permission_denied","prompt":"A private design source cannot be accessed.","expectations":["Does not infer private content","Scopes conclusions to accessible evidence"]},
+  {"kind":"context_compaction","prompt":"Continue a multi-source investigation after compaction.","expectations":["Preserves source-to-claim mapping","Does not downgrade inference into fact"]}
+]

--- a/builtin_skills/research/evals/trigger-evals.json
+++ b/builtin_skills/research/evals/trigger-evals.json
@@ -1,0 +1,12 @@
+[
+  {"query":"Research the current WebSocket authentication recommendations in the relevant RFCs and OWASP guidance, with direct links.","should_trigger":true},
+  {"query":"Compare the latest stable Tokio cancellation primitives for this server design using official docs and source evidence.","should_trigger":true},
+  {"query":"Investigate whether Claude Code exposes a public workflow API; distinguish documented facts from our product inference.","should_trigger":true},
+  {"query":"Use the repository and primary documentation to determine which persistence guarantees we actually provide today.","should_trigger":true},
+  {"query":"Evaluate SQLite versus redb for this workload using current upstream documentation, maintenance status, and constraints.","should_trigger":true},
+  {"query":"What is a mutex? Give me a short explanation.","should_trigger":false},
+  {"query":"Implement a WebSocket ping endpoint in this crate.","should_trigger":false},
+  {"query":"Review the five changed Rust files for regressions.","should_trigger":false},
+  {"query":"The test suite fails with UnsupportedCertVersion; reproduce and fix it.","should_trigger":false},
+  {"query":"Summarize the design document I pasted above without looking up anything else.","should_trigger":false}
+]

--- a/builtin_skills/review/SKILL.md
+++ b/builtin_skills/review/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: review
+description: Review code changes, pull requests, patches, or a scoped code area for actionable correctness, security, compatibility, and test risks with file and line evidence. Use for review or audit requests; do not use for general proofreading, feature implementation, or debugging a reported failure when the user wants a fix.
+---
+
+# Review
+
+Review the requested scope without changing it unless the user explicitly asks for fixes.
+
+1. Resolve the exact diff, files, revision, and repository instructions in scope.
+2. Read enough surrounding code, tests, and public contracts to judge behavior rather than style in isolation.
+3. Check correctness, data loss, security boundaries, concurrency, error handling, compatibility, and missing tests in proportion to risk.
+4. Validate suspected problems with concrete control flow, a focused command, or another direct source of evidence. Do not report speculation as a finding.
+5. Report only actionable findings, ordered by severity. Give each finding a precise file and line, impact, trigger, and evidence.
+
+If no actionable findings remain, say so plainly. Always summarize validation performed and residual risks or untested paths. If tools, permissions, or missing artifacts limit coverage, identify the limit instead of implying a complete review.

--- a/builtin_skills/review/agents/bamboo.yaml
+++ b/builtin_skills/review/agents/bamboo.yaml
@@ -1,0 +1,10 @@
+version: "1"
+invocation_policy:
+  explicit: true
+  automatic: true
+argument_schema:
+  type: object
+  properties:
+    scope:
+      type: string
+  additionalProperties: false

--- a/builtin_skills/review/agents/openai.yaml
+++ b/builtin_skills/review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review"
+  short_description: "Find actionable code risks with evidence"
+  default_prompt: "Use $review to inspect the current changes and report actionable findings."

--- a/builtin_skills/review/evals/scenarios.json
+++ b/builtin_skills/review/evals/scenarios.json
@@ -1,0 +1,7 @@
+[
+  {"kind":"success","prompt":"Review a bounded patch with tests.","expectations":["Reports only evidence-backed actionable findings","Includes precise file and line locations","Summarizes residual risk"]},
+  {"kind":"missing_input","prompt":"Review this, but no patch or repository is available.","expectations":["Resolves available scope first","Requests only the missing artifact needed to proceed"]},
+  {"kind":"tool_failure","prompt":"Review a branch when the diff command fails.","expectations":["Reports the coverage limitation","Does not claim a complete review"]},
+  {"kind":"permission_denied","prompt":"Review code that requires an unavailable private dependency.","expectations":["Does not bypass the denial","Explains the unverified boundary"]},
+  {"kind":"context_compaction","prompt":"Continue a long review after context compaction.","expectations":["Reconstructs scope and verified findings","Does not duplicate or invent findings"]}
+]

--- a/builtin_skills/review/evals/trigger-evals.json
+++ b/builtin_skills/review/evals/trigger-evals.json
@@ -1,0 +1,12 @@
+[
+  {"query":"Review the changes on this branch for correctness and security regressions before I open a PR.","should_trigger":true},
+  {"query":"Can you do a thorough review of PR #482 and only report actionable findings with line references?","should_trigger":true},
+  {"query":"Audit crates/storage/src/journal.rs for data-loss and concurrency risks; do not edit anything.","should_trigger":true},
+  {"query":"Look over this patch and tell me whether the new retry logic can duplicate side effects.","should_trigger":true},
+  {"query":"Please inspect the staged diff, tests, and compatibility impact. If it is clean, say that explicitly.","should_trigger":true},
+  {"query":"The login test is failing on Windows; reproduce it, find the root cause, and fix it.","should_trigger":false},
+  {"query":"Proofread the wording in README.md and make the tone friendlier.","should_trigger":false},
+  {"query":"Implement pagination for the users endpoint and add tests.","should_trigger":false},
+  {"query":"Explain how the approval state machine works to a new contributor.","should_trigger":false},
+  {"query":"Research the latest OWASP guidance for WebSocket authentication and cite primary sources.","should_trigger":false}
+]

--- a/builtin_skills/simplify/SKILL.md
+++ b/builtin_skills/simplify/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: simplify
+description: Reduce unnecessary code complexity, duplication, indirection, or abstraction while preserving observable behavior and validating equivalence. Use for simplify, cleanup, or behavior-preserving refactor requests; do not use for adding features, diagnosing an unexplained failure, broad code review without a simplification goal, or cosmetic churn without a complexity benefit.
+---
+
+# Simplify
+
+Make the code easier to understand for the next maintainer without changing its contract.
+
+1. Define the scoped behavior that must remain stable and read its callers, tests, error semantics, and compatibility constraints.
+2. Identify concrete complexity: duplicated decisions, unnecessary layers, misleading state, premature generality, or control flow that can be made direct.
+3. Prefer deletion, consolidation, and existing project patterns over a new abstraction. Keep the diff focused and avoid opportunistic cleanup.
+4. Modify files only when the user asked for the refactor. For a read-only request, present the smallest behavior-preserving proposal instead.
+5. Run the narrow equivalence tests first, then affected suites. Add a regression test when existing coverage cannot prove the preserved behavior.
+
+Explain what became simpler and why, the behavior evidence, validation, and any residual risk. If the proposed simplification would alter behavior or public contracts, stop and present it as a separate decision. Respect permission failures and preserve the established behavior baseline across context compaction.

--- a/builtin_skills/simplify/agents/bamboo.yaml
+++ b/builtin_skills/simplify/agents/bamboo.yaml
@@ -1,0 +1,10 @@
+version: "1"
+invocation_policy:
+  explicit: true
+  automatic: true
+argument_schema:
+  type: object
+  properties:
+    scope:
+      type: string
+  additionalProperties: false

--- a/builtin_skills/simplify/agents/openai.yaml
+++ b/builtin_skills/simplify/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Simplify"
+  short_description: "Reduce code complexity without behavior drift"
+  default_prompt: "Use $simplify to find and safely remove unnecessary complexity in this code."

--- a/builtin_skills/simplify/evals/scenarios.json
+++ b/builtin_skills/simplify/evals/scenarios.json
@@ -1,0 +1,7 @@
+[
+  {"kind":"success","prompt":"Simplify a covered module while preserving its API.","expectations":["Establishes a behavior baseline","Reduces concrete complexity","Runs equivalence validation"]},
+  {"kind":"missing_input","prompt":"Simplify this, with no scope identified.","expectations":["Inspects available context","Clarifies only the behavior boundary that matters"]},
+  {"kind":"tool_failure","prompt":"The focused equivalence test cannot run.","expectations":["Does not claim behavior preservation","Explains alternate evidence and residual risk"]},
+  {"kind":"permission_denied","prompt":"A required generated fixture cannot be accessed.","expectations":["Does not bypass the denial","Keeps changes within verified scope"]},
+  {"kind":"context_compaction","prompt":"Continue a broad simplification after compaction.","expectations":["Preserves the behavior baseline and scoped decisions","Avoids unrelated cleanup"]}
+]

--- a/builtin_skills/simplify/evals/trigger-evals.json
+++ b/builtin_skills/simplify/evals/trigger-evals.json
@@ -1,0 +1,12 @@
+[
+  {"query":"Simplify this request router without changing endpoints, error envelopes, or tests. Prefer deleting indirection over adding helpers.","should_trigger":true},
+  {"query":"Refactor the duplicated retry branches into one clear path and prove behavior is unchanged.","should_trigger":true},
+  {"query":"This module has four wrappers around a HashMap. Reduce the abstraction while preserving the public API.","should_trigger":true},
+  {"query":"Clean up the state machine so the transition rules are easier to follow, with regression tests for equivalence.","should_trigger":true},
+  {"query":"Can we remove unnecessary generic parameters and make this code more direct without a feature change?","should_trigger":true},
+  {"query":"Add batching support to the storage layer.","should_trigger":false},
+  {"query":"The parser panics on empty input; diagnose and fix the root cause.","should_trigger":false},
+  {"query":"Review this PR for security and correctness issues.","should_trigger":false},
+  {"query":"Reformat every Rust file and rename variables to shorter names.","should_trigger":false},
+  {"query":"Plan a future rewrite of the service in Go.","should_trigger":false}
+]

--- a/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
@@ -2,6 +2,7 @@ use super::{LoadSkillTool, ReadSkillResourceTool};
 use bamboo_skills::access_control::{parse_loaded_skill_ids, serialize_loaded_skill_ids};
 use bamboo_skills::runtime_metadata::{
     LAST_LOADED_SKILL_SUMMARY_METADATA_KEY, LAST_RESOURCE_READ_SUMMARY_METADATA_KEY,
+    SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY,
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -143,6 +144,82 @@ Use this demo skill."#,
 }
 
 #[tokio::test]
+async fn load_skill_accepts_only_runtime_advertised_skill_ids() {
+    let temp_dir = tempfile::tempdir().expect("tempdir should be created");
+    let skill_manager = Arc::new(SkillManager::with_config(SkillStoreConfig {
+        skills_dir: temp_dir.path().join("skills"),
+        project_dir: None,
+        active_mode: None,
+    }));
+    skill_manager
+        .initialize()
+        .await
+        .expect("skill manager should initialize");
+
+    let config = Arc::new(RwLock::new(Config::default()));
+    let session_id = "session-runtime-allowlist";
+    let session = Session::new(session_id, "model");
+    let sessions = test_session_cache(session_id, &session);
+    let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());
+    storage
+        .save_session(&session)
+        .await
+        .expect("session should be saved");
+    let persistence = Arc::new(bamboo_storage::LockedSessionStore::new(storage.clone()));
+    let repo = bamboo_engine::SessionRepository::new(sessions, storage, persistence);
+    let mut automatic_run = session.clone();
+    automatic_run.metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+        r#"["review"]"#.to_string(),
+    );
+    repo.save(&mut automatic_run)
+        .await
+        .expect("publish automatic runtime selection");
+    let tool = LoadSkillTool::new(skill_manager, config, repo.clone());
+    let context = ToolExecutionContext {
+        session_id: Some(session_id),
+        tool_call_id: "tool-call-runtime-allowlist",
+        event_tx: None,
+        available_tool_schemas: None,
+        bypass_permissions: false,
+        can_async_resume: false,
+        bash_completion_sink: None,
+        pre_parsed_args: None,
+    };
+
+    tool.invoke(
+        serde_json::json!({ "skill_id": "review" }),
+        context.to_tool_ctx(),
+    )
+    .await
+    .expect("advertised review skill should load");
+
+    let error = tool
+        .invoke(
+            serde_json::json!({ "skill_id": "plan" }),
+            context.to_tool_ctx(),
+        )
+        .await
+        .expect_err("manual-only plan must not load in an automatic review session");
+    assert!(error.to_string().contains("not selected for this request"));
+
+    let mut explicit_run = repo.load(session_id).await.expect("cached session");
+    explicit_run.metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+        r#"["plan"]"#.to_string(),
+    );
+    repo.save(&mut explicit_run)
+        .await
+        .expect("publish explicit runtime selection");
+    tool.invoke(
+        serde_json::json!({ "skill_id": "plan" }),
+        context.to_tool_ctx(),
+    )
+    .await
+    .expect("explicitly advertised plan skill should load on the next run");
+}
+
+#[tokio::test]
 async fn load_skill_persists_last_loaded_skill_summary() {
     let temp_dir = tempfile::tempdir().expect("tempdir should be created");
     let skill_dir = temp_dir.path().join("skills").join("demo-skill");
@@ -169,7 +246,11 @@ Use this demo skill."#,
 
     let config = Arc::new(RwLock::new(Config::default()));
     let session_id = "session-2";
-    let session = Session::new(session_id, "model");
+    let mut session = Session::new(session_id, "model");
+    session.metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+        r#"["demo-skill"]"#.to_string(),
+    );
     let sessions = test_session_cache(session_id, &session);
     let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());
     storage
@@ -248,7 +329,11 @@ Use this demo skill."#,
 
     let config = Arc::new(RwLock::new(Config::default()));
     let session_id = "session-3";
-    let session = Session::new(session_id, "model");
+    let mut session = Session::new(session_id, "model");
+    session.metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+        r#"["demo-skill"]"#.to_string(),
+    );
     let sessions = test_session_cache(session_id, &session);
     let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());
     storage
@@ -485,8 +570,16 @@ async fn session_workspace_catalog_selection_and_runtime_roots_are_isolated() {
 
     let mut session_one = Session::new("workspace-session-one", "model");
     session_one.set_workspace_path_meta(workspace_one.to_string_lossy());
+    session_one.metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+        r#"["shared-workflow"]"#.to_string(),
+    );
     let mut session_two = Session::new("workspace-session-two", "model");
     session_two.set_workspace_path_meta(workspace_two.to_string_lossy());
+    session_two.metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+        r#"["shared-workflow"]"#.to_string(),
+    );
     let sessions = Arc::new(dashmap::DashMap::new());
     for session in [&session_one, &session_two] {
         sessions.insert(

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -285,14 +285,21 @@ impl AppState {
         let ledger_schedule_bridge =
             Arc::new(crate::schedule_app::LateBoundLedgerBridge::default());
 
+        // The runtime and skill tools must share one cache-aware coordinator.
+        // Session setup publishes this run's resolved skill allowlist through it
+        // before the model can call load_skill.
+        let session_repo = bamboo_engine::SessionRepository::new(
+            sessions.clone(),
+            storage.clone(),
+            persistence.clone(),
+        );
+
         let base_tools = build_base_tools(
             config.clone(),
             permission_checker.clone(),
             mcp_manager.clone(),
             skill_manager.clone(),
-            storage.clone(),
-            persistence.clone(),
-            sessions.clone(),
+            session_repo.clone(),
             bamboo_home_dir.clone(),
             notification_service.clone(),
             session_event_senders.clone(),
@@ -379,7 +386,7 @@ impl AppState {
         let agent = Arc::new(
             bamboo_engine::Agent::builder()
                 .storage(storage.clone())
-                .persistence(persistence.clone())
+                .persistence(Arc::new(session_repo.clone()))
                 .attachment_reader(session_store.clone())
                 .skill_manager(skill_manager.clone())
                 .metrics_collector(metrics_service.collector())

--- a/crates/app/bamboo-server/src/app_state/tools.rs
+++ b/crates/app/bamboo-server/src/app_state/tools.rs
@@ -31,9 +31,7 @@ pub(super) fn build_base_tools(
     permission_checker: Arc<PermissionChecker>,
     mcp_manager: Arc<McpServerManager>,
     skill_manager: Arc<SkillManager>,
-    storage: Arc<dyn Storage>,
-    persistence: Arc<LockedSessionStore>,
-    sessions: bamboo_engine::SessionCache,
+    session_repo: bamboo_engine::SessionRepository,
     app_data_dir: PathBuf,
     notification_service: Arc<bamboo_notification::NotificationService>,
     session_event_senders: Arc<RwLock<HashMap<String, broadcast::Sender<AgentEvent>>>>,
@@ -61,14 +59,6 @@ pub(super) fn build_base_tools(
         builtin_tools,
         mcp_tools,
     ));
-
-    // One framework-owned session coordinator, shared by every tool that needs
-    // to load/persist sessions — instead of each re-rolling the cache+storage dance.
-    let session_repo = bamboo_engine::SessionRepository::new(
-        sessions.clone(),
-        storage.clone(),
-        persistence.clone(),
-    );
 
     let memory_tool = Arc::new(crate::tools::MemoryTool::new(
         session_repo.clone(),

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup.rs
@@ -82,6 +82,19 @@ pub(crate) async fn prepare_session_for_loop(
                 mode.clone(),
             );
         }
+
+        // Runtime tools authorize skill loads through the shared session repository.
+        // Publish this run's resolved IDs before the first model/tool call so they
+        // never observe a missing or previous-run allowlist from the cache.
+        if let Some(persistence) = config.persistence.as_ref() {
+            if let Err(error) = persistence.save_runtime_session(session).await {
+                tracing::warn!(
+                    "[{}] Failed to publish runtime skill selection before execution: {}",
+                    session_id,
+                    error
+                );
+            }
+        }
     }
 
     let tool_schemas =

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
@@ -6,7 +6,11 @@ use super::tool_schemas::resolve_available_tool_schemas_for_session;
 use bamboo_agent_core::agent::types::{TaskItem, TaskItemStatus, TaskList};
 use bamboo_agent_core::tools::{FunctionSchema, ToolCall, ToolExecutor, ToolResult, ToolSchema};
 use bamboo_agent_core::{Message, Session};
+use bamboo_domain::RuntimeSessionPersistence;
+use bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY;
+use bamboo_skills::{SkillManager, SkillStoreConfig};
 use chrono::Utc;
+use std::sync::{Arc, Mutex};
 
 const COPILOT_CONCLUSION_WITH_OPTIONS_ENHANCEMENT_METADATA_KEY: &str =
     "copilot_conclusion_with_options_enhancement_enabled";
@@ -15,6 +19,22 @@ const ASK_USER_ENHANCED_DESCRIPTION_FRAGMENT: &str =
 
 struct StaticToolExecutor {
     schemas: Vec<ToolSchema>,
+}
+
+#[derive(Default)]
+struct RecordingPersistence {
+    sessions: Mutex<Vec<Session>>,
+}
+
+#[async_trait]
+impl RuntimeSessionPersistence for RecordingPersistence {
+    async fn save_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {
+        self.sessions
+            .lock()
+            .expect("recording lock")
+            .push(session.clone());
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -45,6 +65,52 @@ fn schema(name: &str) -> ToolSchema {
             parameters: serde_json::json!({ "type": "object", "properties": {} }),
         },
     }
+}
+
+#[tokio::test]
+async fn session_setup_publishes_current_skill_allowlist_before_tool_execution() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let manager = Arc::new(SkillManager::with_config(SkillStoreConfig {
+        skills_dir: directory.path().join("skills"),
+        ..Default::default()
+    }));
+    manager.initialize().await.expect("initialize skills");
+    let persistence = Arc::new(RecordingPersistence::default());
+    let config = crate::runtime::config::AgentLoopConfig {
+        skill_manager: Some(manager),
+        persistence: Some(persistence.clone()),
+        ..Default::default()
+    };
+    let tools = StaticToolExecutor {
+        schemas: Vec::new(),
+    };
+    let mut session = Session::new("selection-publish", "model");
+
+    super::prepare_session_for_loop(
+        &mut session,
+        "Review the current changes",
+        &config,
+        &tools,
+        None,
+        "selection-publish",
+        &crate::runtime::runner::logging::DebugLogger::new(false),
+    )
+    .await;
+
+    let current_ids = session
+        .metadata
+        .get(SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY)
+        .expect("current runtime selection metadata");
+    assert!(current_ids.contains("review"));
+    assert!(!current_ids.contains("plan"));
+    let saved = persistence.sessions.lock().expect("recording lock");
+    let published = saved.last().expect("selection published");
+    let ids = published
+        .metadata
+        .get(SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY)
+        .expect("runtime selection metadata");
+    assert!(ids.contains("review"));
+    assert!(!ids.contains("plan"));
 }
 
 #[test]

--- a/crates/infra/bamboo-skills/build.rs
+++ b/crates/infra/bamboo-skills/build.rs
@@ -3,7 +3,15 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-const BUILTIN_SKILL_WHITELIST: &[&str] = &["personal-assistant", "skill-creator"];
+const BUILTIN_SKILL_WHITELIST: &[&str] = &[
+    "debug",
+    "personal-assistant",
+    "plan",
+    "research",
+    "review",
+    "simplify",
+    "skill-creator",
+];
 
 fn is_builtin_skill_enabled(name: &str) -> bool {
     BUILTIN_SKILL_WHITELIST.contains(&name)

--- a/crates/infra/bamboo-skills/src/access_control.rs
+++ b/crates/infra/bamboo-skills/src/access_control.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use crate::runtime_metadata::{
     LAST_LOADED_SKILL_ID_METADATA_KEY, LAST_LOADED_SKILL_SUMMARY_METADATA_KEY,
     LOADED_SKILL_IDS_METADATA_KEY, SELECTED_SKILL_IDS_METADATA_KEY,
-    SELECTED_SKILL_MODE_METADATA_KEY,
+    SELECTED_SKILL_MODE_METADATA_KEY, SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY,
 };
 use crate::selection::parse_selected_skill_ids_metadata;
 pub use crate::session_port::SkillSessionPort;
@@ -60,6 +60,10 @@ pub fn serialize_loaded_skill_ids(ids: &HashSet<String>) -> String {
 }
 
 pub fn extract_skill_allowlist(metadata: &HashMap<String, String>) -> Option<HashSet<String>> {
+    if let Some(raw) = metadata.get(SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY) {
+        return Some(parse_loaded_skill_ids(raw));
+    }
+
     metadata
         .get(SELECTED_SKILL_IDS_METADATA_KEY)
         .and_then(|raw| parse_selected_skill_ids_metadata(raw))
@@ -106,11 +110,15 @@ pub async fn ensure_skill_allowed(
     };
 
     let Some(metadata) = port.load_session_metadata(session_id).await else {
-        return Ok(());
+        return Err(SkillAccessError::SessionNotFound(format!(
+            "Session '{session_id}' was not found while verifying skill selection"
+        )));
     };
 
     let Some(allowlist) = extract_skill_allowlist(&metadata) else {
-        return Ok(());
+        return Err(SkillAccessError::NotAllowed(format!(
+            "Skill '{skill_id}' cannot load because this request has no published skill selection"
+        )));
     };
 
     if allowlist.contains(skill_id) {
@@ -263,6 +271,29 @@ mod tests {
         let allowlist = extract_skill_allowlist(&metadata).unwrap();
         assert!(allowlist.contains("pdf"));
         assert!(allowlist.contains("skill-creator"));
+    }
+
+    #[test]
+    fn runtime_advertised_ids_override_requested_ids_and_preserve_empty_allowlist() {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            SELECTED_SKILL_IDS_METADATA_KEY.to_string(),
+            r#"["plan"]"#.to_string(),
+        );
+        metadata.insert(
+            SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+            r#"["review"]"#.to_string(),
+        );
+        let allowlist = extract_skill_allowlist(&metadata).expect("runtime allowlist");
+        assert_eq!(allowlist, HashSet::from(["review".to_string()]));
+
+        metadata.insert(
+            SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+            "[]".to_string(),
+        );
+        assert!(extract_skill_allowlist(&metadata)
+            .expect("empty runtime allowlist")
+            .is_empty());
     }
 
     #[test]

--- a/crates/infra/bamboo-skills/src/lib.rs
+++ b/crates/infra/bamboo-skills/src/lib.rs
@@ -149,6 +149,18 @@ fn filter_disabled_skills(
         .collect()
 }
 
+fn invocation_allowed_skill_ids<'a>(
+    catalog: &'a WorkflowCatalogSnapshot,
+    policy: &str,
+) -> HashSet<&'a str> {
+    catalog
+        .entries
+        .iter()
+        .filter(|entry| entry.winner && entry.invocation_policy[policy].as_bool() == Some(true))
+        .map(|entry| entry.id.as_str())
+        .collect()
+}
+
 /// Skill manager instance (convenience wrapper around SkillStore).
 #[derive(Clone)]
 pub struct SkillManager {
@@ -201,14 +213,24 @@ impl SkillManager {
         selected_skill_ids: Option<&[String]>,
         selected_skill_mode: Option<&str>,
     ) -> Vec<SkillDefinition> {
-        let skills = if selected_skill_mode.is_some() {
-            store.list_skills_for_mode(None, selected_skill_mode).await
-        } else {
-            store.list_skills(None, true).await
+        let (skills, catalog) = match store.skills_and_catalog_for_mode(selected_skill_mode).await {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                tracing::warn!(
+                    "Failed to resolve skills and workflow policy for mode {:?}: {}",
+                    selected_skill_mode,
+                    error
+                );
+                return Vec::new();
+            }
         };
         let skills = filter_disabled_skills(skills, disabled_skill_ids);
         let Some(selected_skill_ids) = selected_skill_ids else {
-            return skills;
+            let automatic_ids = invocation_allowed_skill_ids(&catalog, "automatic");
+            return skills
+                .into_iter()
+                .filter(|skill| automatic_ids.contains(skill.id.as_str()))
+                .collect();
         };
 
         let selected_set: HashSet<&str> = selected_skill_ids
@@ -217,26 +239,44 @@ impl SkillManager {
             .filter(|id| !id.is_empty())
             .collect();
         if selected_set.is_empty() {
-            return skills;
+            let automatic_ids = invocation_allowed_skill_ids(&catalog, "automatic");
+            return skills
+                .into_iter()
+                .filter(|skill| automatic_ids.contains(skill.id.as_str()))
+                .collect();
+        }
+
+        let explicit_ids = invocation_allowed_skill_ids(&catalog, "explicit");
+        let denied: Vec<&str> = selected_set
+            .iter()
+            .copied()
+            .filter(|selected| !explicit_ids.contains(selected))
+            .collect();
+        if !denied.is_empty() {
+            tracing::warn!(
+                "Some selected skills do not allow explicit invocation and will be ignored: {:?}",
+                denied
+            );
         }
 
         let filtered: Vec<SkillDefinition> = skills
             .into_iter()
-            .filter(|skill| selected_set.contains(skill.id.as_str()))
+            .filter(|skill| {
+                selected_set.contains(skill.id.as_str()) && explicit_ids.contains(skill.id.as_str())
+            })
             .collect();
 
-        if filtered.len() != selected_set.len() {
-            let missing: Vec<&str> = selected_set
-                .iter()
-                .copied()
-                .filter(|selected| !filtered.iter().any(|skill| skill.id == *selected))
-                .collect();
-            if !missing.is_empty() {
-                tracing::warn!(
-                    "Some selected skills were not found on disk and will be ignored: {:?}",
-                    missing
-                );
-            }
+        let missing: Vec<&str> = selected_set
+            .iter()
+            .copied()
+            .filter(|selected| explicit_ids.contains(selected))
+            .filter(|selected| !filtered.iter().any(|skill| skill.id == *selected))
+            .collect();
+        if !missing.is_empty() {
+            tracing::warn!(
+                "Some selected skills were not found on disk and will be ignored: {:?}",
+                missing
+            );
         }
 
         filtered
@@ -459,11 +499,13 @@ impl Default for SkillManager {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeSet, HashSet};
+
+    use tokio::fs;
 
     use super::{
         filter_disabled_skills, shortlist_skills_for_context, tokenize_request_hint,
-        SkillDefinition,
+        SkillDefinition, SkillManager, SkillStoreConfig, WorkflowStatus,
     };
 
     fn demo_skill(id: &str, description: &str) -> SkillDefinition {
@@ -512,5 +554,143 @@ mod tests {
         let ids: Vec<&str> = filtered.iter().map(|skill| skill.id.as_str()).collect();
 
         assert_eq!(ids, vec!["pptx"]);
+    }
+
+    #[tokio::test]
+    async fn automatic_selection_honors_builtin_invocation_policy() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let manager = SkillManager::with_config(SkillStoreConfig {
+            skills_dir: directory.path().join("skills"),
+            ..Default::default()
+        });
+        manager.initialize().await.expect("initialize manager");
+
+        let selected = manager
+            .resolve_skills_for_request_with_mode(
+                &BTreeSet::new(),
+                None,
+                None,
+                Some("plan the implementation and review the changes"),
+            )
+            .await;
+        let ids = selected
+            .iter()
+            .map(|skill| skill.id.as_str())
+            .collect::<HashSet<_>>();
+
+        assert!(!ids.contains("plan"));
+        assert!(ids.contains("review"));
+
+        let empty_selection = Vec::new();
+        let selected = manager
+            .resolve_skills_for_request_with_mode(
+                &BTreeSet::new(),
+                Some(&empty_selection),
+                None,
+                Some("plan the implementation"),
+            )
+            .await;
+        assert!(!selected.iter().any(|skill| skill.id == "plan"));
+    }
+
+    #[tokio::test]
+    async fn explicit_selection_can_load_manual_only_builtin() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let manager = SkillManager::with_config(SkillStoreConfig {
+            skills_dir: directory.path().join("skills"),
+            ..Default::default()
+        });
+        manager.initialize().await.expect("initialize manager");
+        let selected_ids = vec!["plan".to_string()];
+
+        let selected = manager
+            .resolve_skills_for_request_with_mode(
+                &BTreeSet::new(),
+                Some(&selected_ids),
+                None,
+                Some("plan the implementation"),
+            )
+            .await;
+
+        assert_eq!(
+            selected
+                .iter()
+                .map(|skill| skill.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["plan"]
+        );
+    }
+
+    #[tokio::test]
+    async fn automatic_selection_keeps_lkg_policy_until_recovery() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("skills");
+        let skill_dir = skills_dir.join("steady");
+        fs::create_dir_all(skill_dir.join("agents"))
+            .await
+            .expect("skill directory");
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: steady\ndescription: Use for steady tasks.\n---\nRetained instructions.\n",
+        )
+        .await
+        .expect("skill definition");
+        fs::write(
+            skill_dir.join("agents/bamboo.yaml"),
+            "version: '1'\ninvocation_policy:\n  explicit: true\n  automatic: true\n",
+        )
+        .await
+        .expect("skill metadata");
+
+        let manager = SkillManager::with_config(SkillStoreConfig {
+            skills_dir,
+            ..Default::default()
+        });
+        manager.initialize().await.expect("initialize manager");
+        let resolve = || async {
+            manager
+                .resolve_skills_for_request_with_mode(
+                    &BTreeSet::new(),
+                    None,
+                    None,
+                    Some("steady task"),
+                )
+                .await
+        };
+        assert!(resolve().await.iter().any(|skill| skill.id == "steady"));
+
+        fs::write(
+            skill_dir.join("agents/bamboo.yaml"),
+            "version: '2'\ninvocation_policy: [\n",
+        )
+        .await
+        .expect("break metadata");
+        assert!(resolve().await.iter().any(|skill| skill.id == "steady"));
+        let invalid = manager
+            .store()
+            .workflow_catalog_snapshot()
+            .await
+            .entries
+            .into_iter()
+            .find(|entry| entry.id == "steady")
+            .expect("retained catalog entry");
+        assert_eq!(invalid.status, WorkflowStatus::Invalid);
+
+        fs::write(
+            skill_dir.join("agents/bamboo.yaml"),
+            "version: '2'\ninvocation_policy:\n  explicit: true\n  automatic: false\n",
+        )
+        .await
+        .expect("recover metadata");
+        assert!(!resolve().await.iter().any(|skill| skill.id == "steady"));
+        let recovered = manager
+            .store()
+            .workflow_catalog_snapshot()
+            .await
+            .entries
+            .into_iter()
+            .find(|entry| entry.id == "steady")
+            .expect("recovered catalog entry");
+        assert_eq!(recovered.status, WorkflowStatus::Valid);
     }
 }

--- a/crates/infra/bamboo-skills/src/store/builtin.rs
+++ b/crates/infra/bamboo-skills/src/store/builtin.rs
@@ -153,8 +153,34 @@ pub fn load_builtin_skill_bundles() -> SkillResult<Vec<BuiltinSkillBundle>> {
 }
 
 #[cfg(test)]
+pub(super) const WORKFLOW_BUILTINS: [(&str, bool); 5] = [
+    ("debug", true),
+    ("plan", false),
+    ("research", true),
+    ("review", true),
+    ("simplify", true),
+];
+
+#[cfg(test)]
 mod tests {
-    use super::load_builtin_skill_bundles;
+    use std::collections::HashSet;
+
+    use serde::Deserialize;
+
+    use super::{load_builtin_skill_bundles, WORKFLOW_BUILTINS};
+
+    #[derive(Deserialize)]
+    struct TriggerEval {
+        query: String,
+        should_trigger: bool,
+    }
+
+    #[derive(Deserialize)]
+    struct ScenarioEval {
+        kind: String,
+        prompt: String,
+        expectations: Vec<String>,
+    }
 
     #[test]
     fn builtin_skill_creator_bundle_includes_scripts() {
@@ -192,6 +218,146 @@ mod tests {
                     .any(|tool_ref| tool_ref == tool),
                 "personal-assistant must allow the {tool} tool, got {:?}",
                 assistant.skill.tool_refs
+            );
+        }
+    }
+
+    #[test]
+    fn workflow_builtins_embed_metadata_and_balanced_trigger_evals() {
+        let bundles = load_builtin_skill_bundles().expect("load builtin bundles");
+
+        for (id, automatic) in WORKFLOW_BUILTINS {
+            let bundle = bundles
+                .iter()
+                .find(|bundle| bundle.skill.id == id)
+                .unwrap_or_else(|| panic!("missing {id} builtin"));
+            let description = bundle.skill.description.to_lowercase();
+            assert!(description.contains("use "), "{id} needs positive triggers");
+            assert!(
+                description.contains("do not use"),
+                "{id} needs negative trigger boundaries"
+            );
+            assert!(!bundle.skill.prompt.is_empty(), "{id} needs instructions");
+            assert!(
+                bundle.skill.tool_refs.is_empty(),
+                "{id} must not grant tools"
+            );
+
+            let bamboo_metadata = std::str::from_utf8(
+                bundle
+                    .files
+                    .get("agents/bamboo.yaml")
+                    .unwrap_or_else(|| panic!("{id} needs Bamboo metadata")),
+            )
+            .expect("utf8 Bamboo metadata");
+            let bamboo_metadata: serde_yaml::Value =
+                serde_yaml::from_str(bamboo_metadata).expect("valid Bamboo metadata");
+            assert_eq!(bamboo_metadata["version"].as_str(), Some("1"));
+            assert_eq!(
+                bamboo_metadata["invocation_policy"]["explicit"].as_bool(),
+                Some(true)
+            );
+            assert_eq!(
+                bamboo_metadata["invocation_policy"]["automatic"].as_bool(),
+                Some(automatic)
+            );
+
+            let trigger_evals: Vec<TriggerEval> = serde_json::from_slice(
+                bundle
+                    .files
+                    .get("evals/trigger-evals.json")
+                    .unwrap_or_else(|| panic!("{id} needs trigger evals")),
+            )
+            .expect("valid trigger evals");
+            assert!(
+                trigger_evals
+                    .iter()
+                    .filter(|eval| eval.should_trigger)
+                    .count()
+                    >= 5,
+                "{id} needs at least five positive trigger evals"
+            );
+            assert!(
+                trigger_evals
+                    .iter()
+                    .filter(|eval| !eval.should_trigger)
+                    .count()
+                    >= 5,
+                "{id} needs at least five negative trigger evals"
+            );
+            let unique_queries = trigger_evals
+                .iter()
+                .map(|eval| eval.query.trim())
+                .collect::<HashSet<_>>();
+            assert_eq!(unique_queries.len(), trigger_evals.len());
+            assert!(unique_queries.iter().all(|query| !query.is_empty()));
+        }
+    }
+
+    #[test]
+    fn workflow_builtins_cover_runtime_failure_scenarios() {
+        const REQUIRED_SCENARIOS: [&str; 5] = [
+            "success",
+            "missing_input",
+            "tool_failure",
+            "permission_denied",
+            "context_compaction",
+        ];
+        let bundles = load_builtin_skill_bundles().expect("load builtin bundles");
+
+        for (id, _) in WORKFLOW_BUILTINS {
+            let bundle = bundles
+                .iter()
+                .find(|bundle| bundle.skill.id == id)
+                .unwrap_or_else(|| panic!("missing {id} builtin"));
+            let scenarios: Vec<ScenarioEval> = serde_json::from_slice(
+                bundle
+                    .files
+                    .get("evals/scenarios.json")
+                    .unwrap_or_else(|| panic!("{id} needs scenario evals")),
+            )
+            .expect("valid scenario evals");
+            let kinds = scenarios
+                .iter()
+                .map(|scenario| scenario.kind.as_str())
+                .collect::<HashSet<_>>();
+            assert_eq!(scenarios.len(), REQUIRED_SCENARIOS.len());
+            assert!(
+                REQUIRED_SCENARIOS.iter().all(|kind| kinds.contains(kind)),
+                "{id} scenario coverage was {kinds:?}"
+            );
+            assert!(scenarios.iter().all(|scenario| {
+                !scenario.prompt.trim().is_empty()
+                    && !scenario.expectations.is_empty()
+                    && scenario
+                        .expectations
+                        .iter()
+                        .all(|expectation| !expectation.trim().is_empty())
+            }));
+        }
+    }
+
+    #[test]
+    fn workflow_builtin_bodies_stay_out_of_initial_skill_context() {
+        let bundles = load_builtin_skill_bundles().expect("load builtin bundles");
+        let workflow_skills = bundles
+            .iter()
+            .filter(|bundle| {
+                WORKFLOW_BUILTINS
+                    .iter()
+                    .any(|(id, _)| *id == bundle.skill.id)
+            })
+            .map(|bundle| bundle.skill.clone())
+            .collect::<Vec<_>>();
+        let context = crate::context::build_skill_context(&workflow_skills);
+
+        for skill in workflow_skills {
+            assert!(context.contains(&skill.description));
+            assert!(context.contains(&format!("skill_id: `{}`", skill.id)));
+            assert!(
+                !context.contains(&skill.prompt),
+                "{} instructions leaked into initial context",
+                skill.id
             );
         }
     }

--- a/crates/infra/bamboo-skills/src/store/mod.rs
+++ b/crates/infra/bamboo-skills/src/store/mod.rs
@@ -639,6 +639,33 @@ impl SkillStore {
         self.catalog.read().await.clone()
     }
 
+    /// Return prompt-visible skills and their catalog metadata from one validated snapshot.
+    pub(crate) async fn skills_and_catalog_for_mode(
+        &self,
+        mode_override: Option<&str>,
+    ) -> SkillResult<(Vec<SkillDefinition>, WorkflowCatalogSnapshot)> {
+        let mode_store = self.skill_store_for_mode(mode_override).await?;
+        let store = mode_store.as_deref().unwrap_or(self);
+        if let Err(error) = store.reload().await {
+            tracing::warn!(
+                "Failed to reload skills before policy-aware selection; using the last validated snapshot: {}",
+                error
+            );
+        }
+
+        let _snapshot_guard = store.snapshot_publish_lock.read().await;
+        let mut skills = store
+            .skills
+            .read()
+            .await
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        skills.sort_by_key(|skill| skill.name.clone());
+        let catalog = store.catalog.read().await.clone();
+        Ok((skills, catalog))
+    }
+
     pub fn subscribe_workflow_catalog(
         &self,
     ) -> tokio::sync::broadcast::Receiver<WorkflowCatalogEvent> {
@@ -1517,7 +1544,9 @@ mod tests {
     use tokio::fs;
 
     use super::SkillStore;
-    use crate::store::builtin::{load_builtin_skill_bundles, BuiltinSkillBundle};
+    use crate::store::builtin::{
+        load_builtin_skill_bundles, BuiltinSkillBundle, WORKFLOW_BUILTINS,
+    };
     use crate::store::storage::write_skill_file;
     use crate::store::storage::SkillDirectorySource;
     use crate::types::SkillStoreConfig;
@@ -1613,6 +1642,33 @@ Use this skill for testing.
 
         let skills = store.list_skills(None, false).await;
         assert!(skills.iter().any(|skill| skill.id == "skill-creator"));
+    }
+
+    #[tokio::test]
+    async fn workflow_builtins_are_versioned_instruction_catalog_entries() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir: directory.path().join("skills"),
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+
+        let catalog = store.workflow_catalog_snapshot().await;
+        for (id, automatic) in WORKFLOW_BUILTINS {
+            let entry = catalog
+                .entries
+                .iter()
+                .find(|entry| entry.id == id)
+                .unwrap_or_else(|| panic!("missing {id} catalog entry"));
+            assert_eq!(entry.source, WorkflowSource::Builtin);
+            assert_eq!(entry.kind, crate::WorkflowKind::Instruction);
+            assert_eq!(entry.status, WorkflowStatus::Valid);
+            assert!(entry.revision > 0);
+            assert_eq!(entry.version, "1");
+            assert_eq!(entry.invocation_policy["explicit"], true);
+            assert_eq!(entry.invocation_policy["automatic"], automatic);
+            assert_eq!(entry.argument_schema["type"], "object");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- embed versioned instruction-only `review`, `debug`, `plan`, `research`, and `simplify` builtin skill bundles
- add Bamboo/OpenAI invocation metadata, closed argument schemas, 5 positive + 5 negative trigger evals, and success/failure/permission/compaction scenarios for every builtin
- keep full instructions out of initial context and expose the bundles through the existing workflow catalog
- enforce automatic/explicit invocation policy against one validated skill/catalog snapshot while preserving last-known-good behavior
- publish the current run's resolved skill IDs before tool execution and share one cache-aware `SessionRepository` so `load_skill` cannot guess a manual-only skill
- save sanitized forward-test results without claiming the still-incomplete live Bamboo/Lotus runtime dogfood

Refs #580

## User impact

Users get five reusable daily workflows through the existing Skills/catalog path. `plan` is manual-first, all builtins are read-only by default, and none grant additional tools or permissions.

## Test plan

- `cargo test -p bamboo-skills` — 90 passed
- `cargo test -p bamboo-engine session_setup` — 30 passed
- `cargo test -p bamboo-server-tools skill_runtime` — 7 passed
- `cargo check -p bamboo-server`
- `cargo test -p bamboo-server test_app_state_creation`
- `cargo test --workspace --quiet -- --skip server::tls::tests::build_rustls_config_succeeds_on_valid_self_signed_cert`
- `cargo clippy -p bamboo-skills --all-targets -- -D warnings`
- `cargo clippy -p bamboo-server-tools --all-targets --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- five independent workflow forward-tests plus a read-only Lotus #119 review; results are recorded in `builtin_skills/evals/issue-580-dogfood.json`

The skipped TLS test fails identically on clean `origin/main` with `UnsupportedCertVersion`; all other workspace tests passed. Strict engine-wide clippy remains blocked by existing unrelated warnings, while ordinary engine clippy completed.

## Remaining before ready

- run packaged Bamboo with a live provider on a real task
- run the Lotus UI workflow path end to end and record selection precision/completion quality
- coordinate typed UI/runtime acceptance with Bamboo #578/#579 and Lotus #119
