### PR TITLE
fix: harden explicit workflow activation (#620)

### DIFF
--- a/builtin_skills/evals/issue-620-dogfood.json
+++ b/builtin_skills/evals/issue-620-dogfood.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "issue": "bigduu/Bamboo-agent#620",
+  "recorded_at": "2026-07-19",
+  "environment": {
+    "client": "Lotus origin/main via Vite",
+    "server": "Bamboo feature branch built from source",
+    "provider": "Deepseek/deepseek-v4-flash",
+    "data": "isolated temporary Bamboo data directory"
+  },
+  "runs": [
+    {
+      "session": "22d36944-24a3-4a62-81bc-acd22542914e",
+      "implementation": "baseline",
+      "selection_source": "explicit",
+      "selected_skill_ids": ["review"],
+      "loaded_skill_ids": [],
+      "model_load_skill_calls": 0,
+      "result": "fail",
+      "failure_analysis": "Lotus submitted a structured explicit selection, but the model answered before loading the workflow body."
+    },
+    {
+      "session": "8f983dfb-262b-4e77-b0e6-60ca373e4100",
+      "implementation": "preload_without_schema_suppression",
+      "selection_source": "explicit",
+      "selected_skill_ids": ["review"],
+      "loaded_skill_ids": ["review"],
+      "model_load_skill_calls": 1,
+      "result": "partial",
+      "failure_analysis": "The runtime activated review before the first model round, but load_skill remained advertised and the model redundantly loaded it again."
+    },
+    {
+      "session": "0a4e2928-b8d0-41ab-820c-459005e28105",
+      "implementation": "final",
+      "selection_source": "explicit",
+      "selected_skill_ids": ["review"],
+      "loaded_skill_ids": ["review"],
+      "model_load_skill_calls": 0,
+      "review_builtin_version": "3",
+      "result": "activation_pass_output_quality_fail",
+      "failure_analysis": "The system prompt contained the complete preloaded review payload and load_skill was absent from the model-visible activation path. The provider still asserted an incorrect Rust release-mode division behavior despite the workflow's evidence hard gate; this is recorded as residual model compliance risk rather than an activation failure."
+    }
+  ],
+  "checks": {
+    "automatic_multi_candidate_selection_remains_lazy": true,
+    "explicit_selected_and_loaded_ids_match": true,
+    "redundant_model_load_suppressed": true,
+    "current_page_console_errors_after_clear": 0,
+    "workflow_workspace_writes": 0
+  },
+  "limitations": [
+    "The provider's final answer did not comply with the loaded review evidence rule, so activation success must not be reported as output-quality success.",
+    "Lotus fuzzy command ranking selected agent-browser first for the exact query /review; review required four ArrowDown presses before Enter.",
+    "Historical browser network errors came from intentional Bamboo restarts during local dogfood and were cleared before the final page check."
+  ]
+}

--- a/builtin_skills/review/SKILL.md
+++ b/builtin_skills/review/SKILL.md
@@ -10,7 +10,8 @@ Review the requested scope without changing it unless the user explicitly asks f
 1. Resolve the exact diff, files, revision, and repository instructions in scope.
 2. Read enough surrounding code, tests, and public contracts to judge behavior rather than style in isolation.
 3. Check correctness, data loss, security boundaries, concurrency, error handling, compatibility, and missing tests in proportion to risk.
-4. Validate suspected problems with concrete control flow, a focused command, or another direct source of evidence. Do not report speculation as a finding.
-5. Report only actionable findings, ordered by severity. Give each finding a precise file and line, impact, trigger, and evidence.
+4. Validate suspected problems with concrete control flow, a focused command, or another direct source of evidence. For language, library, or runtime semantics, run a minimal reproducer or consult authoritative documentation instead of relying on memory. This is a hard gate: if neither verification path is available, omit the claim or state it only as an unverified coverage limit, never as a finding. Do not report speculation as a finding.
+5. Distinguish defects from documented behavior and unspecified caller expectations. Do not report a language primitive's normal semantics, a hypothetical contract, or a style preference unless the reviewed code or its callers establish that the behavior is wrong.
+6. Report only actionable findings, ordered by severity. Give each finding a precise file and line, impact, trigger, and evidence. Calibrate severity to demonstrated reachability and impact; do not label a local panic or edge case critical without evidence of a critical boundary.
 
 If no actionable findings remain, say so plainly. Always summarize validation performed and residual risks or untested paths. If tools, permissions, or missing artifacts limit coverage, identify the limit instead of implying a complete review.

--- a/builtin_skills/review/agents/bamboo.yaml
+++ b/builtin_skills/review/agents/bamboo.yaml
@@ -1,4 +1,4 @@
-version: "1"
+version: "3"
 invocation_policy:
   explicit: true
   automatic: true

--- a/builtin_skills/review/evals/scenarios.json
+++ b/builtin_skills/review/evals/scenarios.json
@@ -1,5 +1,5 @@
 [
-  {"kind":"success","prompt":"Review a bounded patch with tests.","expectations":["Reports only evidence-backed actionable findings","Includes precise file and line locations","Summarizes residual risk"]},
+  {"kind":"success","prompt":"Review a bounded patch with tests.","expectations":["Reports only evidence-backed actionable findings","Verifies language and runtime semantics with a reproducer or authoritative source","Does not report documented behavior without an established violated contract","Includes precise file and line locations","Calibrates severity to demonstrated reachability and impact","Summarizes residual risk"]},
   {"kind":"missing_input","prompt":"Review this, but no patch or repository is available.","expectations":["Resolves available scope first","Requests only the missing artifact needed to proceed"]},
   {"kind":"tool_failure","prompt":"Review a branch when the diff command fails.","expectations":["Reports the coverage limitation","Does not claim a complete review"]},
   {"kind":"permission_denied","prompt":"Review code that requires an unavailable private dependency.","expectations":["Does not bypass the denial","Explains the unverified boundary"]},

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup.rs
@@ -41,7 +41,7 @@ pub(crate) async fn prepare_session_for_loop(
 ) -> Option<TaskLoopContext> {
     let skill_result =
         skill_context::load_skill_context(config, session, session_id, initial_message).await;
-    let skill_context = skill_result.context.clone();
+    let mut skill_context = skill_result.context.clone();
 
     if let Some(source) = skill_result.selection_source.as_deref() {
         debug_logger.log_event(
@@ -83,6 +83,8 @@ pub(crate) async fn prepare_session_for_loop(
             );
         }
 
+        skill_context::reset_explicit_activation_state(session, &skill_result);
+
         // Runtime tools authorize skill loads through the shared session repository.
         // Publish this run's resolved IDs before the first model/tool call so they
         // never observe a missing or previous-run allowlist from the cache.
@@ -93,6 +95,21 @@ pub(crate) async fn prepare_session_for_loop(
                     session_id,
                     error
                 );
+            }
+        }
+
+        if let Some(activated_context) =
+            skill_context::activate_explicit_skill(tools, session, session_id, &skill_result).await
+        {
+            skill_context = activated_context;
+            if let Some(persistence) = config.persistence.as_ref() {
+                if let Err(error) = persistence.save_runtime_session(session).await {
+                    tracing::warn!(
+                        "[{}] Failed to publish explicit skill activation before execution: {}",
+                        session_id,
+                        error
+                    );
+                }
             }
         }
     }

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/skill_context.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/skill_context.rs
@@ -1,5 +1,12 @@
 use crate::runtime::config::AgentLoopConfig;
+use bamboo_agent_core::tools::{
+    FunctionCall, ToolCall, ToolExecutionContext, ToolExecutionSessionFlags, ToolExecutor,
+};
 use bamboo_agent_core::Session;
+use bamboo_skills::runtime_metadata::{
+    LAST_LOADED_SKILL_ID_METADATA_KEY, LAST_LOADED_SKILL_SUMMARY_METADATA_KEY,
+    LOADED_SKILL_IDS_METADATA_KEY,
+};
 
 #[derive(Debug, Clone, Default)]
 pub(super) struct SkillContextLoadResult {
@@ -91,4 +98,121 @@ pub(super) async fn load_skill_context(
         tracing::info!("[{}] No skill manager configured", session_id);
         SkillContextLoadResult::default()
     }
+}
+
+/// A new explicit activation supersedes any workflow loaded on an earlier run.
+/// Clear the old activation before publishing the current selection so tool
+/// authorization cannot briefly observe a stale loaded workflow.
+pub(super) fn reset_explicit_activation_state(
+    session: &mut Session,
+    selection: &SkillContextLoadResult,
+) {
+    if selection.selection_source.as_deref() == Some("explicit")
+        && selection.selected_skill_ids.len() == 1
+    {
+        session.metadata.remove(LOADED_SKILL_IDS_METADATA_KEY);
+        session.metadata.remove(LAST_LOADED_SKILL_ID_METADATA_KEY);
+        session
+            .metadata
+            .remove(LAST_LOADED_SKILL_SUMMARY_METADATA_KEY);
+    }
+}
+
+/// Deterministically activate a single explicitly selected workflow before the
+/// first model round. Automatic selection remains metadata-only because it can
+/// advertise several candidates and the model still has to choose one.
+pub(super) async fn activate_explicit_skill(
+    tools: &dyn ToolExecutor,
+    session: &mut Session,
+    session_id: &str,
+    selection: &SkillContextLoadResult,
+) -> Option<String> {
+    if selection.selection_source.as_deref() != Some("explicit")
+        || selection.selected_skill_ids.len() != 1
+    {
+        return None;
+    }
+
+    let skill_id = selection.selected_skill_ids.first()?.as_str();
+    let available_tool_schemas = tools.list_tools();
+    if !available_tool_schemas
+        .iter()
+        .any(|schema| schema.function.name == "load_skill")
+    {
+        tracing::warn!(
+            "[{}] Explicit skill '{}' could not be preloaded because load_skill is unavailable",
+            session_id,
+            skill_id
+        );
+        return None;
+    }
+
+    let call_id = format!("runtime-explicit-skill-{session_id}");
+    let arguments = serde_json::json!({ "skill_id": skill_id });
+    let call = ToolCall {
+        id: call_id.clone(),
+        tool_type: "function".to_string(),
+        function: FunctionCall {
+            name: "load_skill".to_string(),
+            arguments: arguments.to_string(),
+        },
+    };
+    let (event_tx, _event_rx) = tokio::sync::mpsc::channel(1);
+    let context = ToolExecutionContext::for_dispatch(
+        session_id,
+        &call_id,
+        &event_tx,
+        &available_tool_schemas,
+        ToolExecutionSessionFlags::from_session(session),
+        false,
+        None,
+        Some(&arguments),
+    );
+
+    let result = match tools.execute_with_context(&call, context).await {
+        Ok(result) if result.success => result,
+        Ok(result) => {
+            tracing::warn!(
+                "[{}] Explicit skill '{}' preload returned an unsuccessful result: {}",
+                session_id,
+                skill_id,
+                result.result
+            );
+            return None;
+        }
+        Err(error) => {
+            tracing::warn!(
+                "[{}] Explicit skill '{}' preload failed: {}",
+                session_id,
+                skill_id,
+                error
+            );
+            return None;
+        }
+    };
+
+    session.metadata.insert(
+        LOADED_SKILL_IDS_METADATA_KEY.to_string(),
+        serde_json::json!([skill_id]).to_string(),
+    );
+    session.metadata.insert(
+        LAST_LOADED_SKILL_ID_METADATA_KEY.to_string(),
+        skill_id.to_string(),
+    );
+    session.metadata.insert(
+        LAST_LOADED_SKILL_SUMMARY_METADATA_KEY.to_string(),
+        serde_json::json!({
+            "skill_id": skill_id,
+            "loaded_ids": [skill_id],
+            "selected_skill_mode": selection.selected_skill_mode,
+            "loaded_count": 1
+        })
+        .to_string(),
+    );
+
+    Some(format!(
+        "\n\n## Explicit Workflow Activated\n\
+The user explicitly selected the `{skill_id}` workflow. Bamboo loaded its detailed instructions before model execution. Follow the payload below as the active workflow; do not call `load_skill` again for this activation.\n\n{payload}\n",
+        payload = result.result
+    ))
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
@@ -22,6 +22,12 @@ struct StaticToolExecutor {
 }
 
 #[derive(Default)]
+struct RecordingToolExecutor {
+    calls: Mutex<Vec<ToolCall>>,
+    schemas: Vec<ToolSchema>,
+}
+
+#[derive(Default)]
 struct RecordingPersistence {
     sessions: Mutex<Vec<Session>>,
 }
@@ -47,6 +53,33 @@ impl ToolExecutor for StaticToolExecutor {
             success: true,
             result: "ok".to_string(),
             display_preference: None,
+            images: Vec::new(),
+        })
+    }
+
+    fn list_tools(&self) -> Vec<ToolSchema> {
+        self.schemas.clone()
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for RecordingToolExecutor {
+    async fn execute(
+        &self,
+        call: &ToolCall,
+    ) -> bamboo_agent_core::tools::executor::Result<ToolResult> {
+        self.calls
+            .lock()
+            .expect("recording tool lock")
+            .push(call.clone());
+        Ok(ToolResult {
+            success: true,
+            result: serde_json::json!({
+                "skill_id": "review",
+                "instructions": "REPORT_ONLY_ACTIONABLE_FINDINGS"
+            })
+            .to_string(),
+            display_preference: Some("Collapsible".to_string()),
             images: Vec::new(),
         })
     }
@@ -113,6 +146,76 @@ async fn session_setup_publishes_current_skill_allowlist_before_tool_execution()
     assert!(!ids.contains("plan"));
 }
 
+#[tokio::test]
+async fn session_setup_preloads_one_explicit_skill_before_model_execution() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let manager = Arc::new(SkillManager::with_config(SkillStoreConfig {
+        skills_dir: directory.path().join("skills"),
+        ..Default::default()
+    }));
+    manager.initialize().await.expect("initialize skills");
+    let persistence = Arc::new(RecordingPersistence::default());
+    let config = crate::runtime::config::AgentLoopConfig {
+        skill_manager: Some(manager),
+        selected_skill_ids: Some(vec!["review".to_string()]),
+        persistence: Some(persistence.clone()),
+        ..Default::default()
+    };
+    let tools = RecordingToolExecutor {
+        calls: Mutex::new(Vec::new()),
+        schemas: vec![schema("load_skill")],
+    };
+    let mut session = Session::new("explicit-review", "model");
+
+    super::prepare_session_for_loop(
+        &mut session,
+        "Review this change",
+        &config,
+        &tools,
+        None,
+        "explicit-review",
+        &crate::runtime::runner::logging::DebugLogger::new(false),
+    )
+    .await;
+
+    let calls = tools.calls.lock().expect("recording tool lock");
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].function.name, "load_skill");
+    assert!(calls[0].function.arguments.contains("review"));
+    assert_eq!(
+        session
+            .metadata
+            .get("skill_runtime_loaded_skill_ids")
+            .map(String::as_str),
+        Some("[\"review\"]")
+    );
+    assert_eq!(
+        session
+            .metadata
+            .get("skill_runtime_last_loaded_skill_id")
+            .map(String::as_str),
+        Some("review")
+    );
+    let system_prompt = session
+        .messages
+        .iter()
+        .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
+        .expect("system prompt")
+        .content
+        .as_str();
+    assert!(system_prompt.contains("## Explicit Workflow Activated"));
+    assert!(system_prompt.contains("REPORT_ONLY_ACTIONABLE_FINDINGS"));
+    assert!(!system_prompt.contains("Select EXACTLY ONE skill"));
+
+    let saved = persistence.sessions.lock().expect("recording lock");
+    assert!(saved.iter().any(|saved_session| {
+        saved_session
+            .metadata
+            .get("skill_runtime_loaded_skill_ids")
+            .is_some_and(|ids| ids == "[\"review\"]")
+    }));
+}
+
 #[test]
 fn resolve_available_tool_schemas_uses_executor_when_registry_empty() {
     let config = crate::runtime::config::AgentLoopConfig::default();
@@ -171,6 +274,66 @@ fn resolve_available_tool_schemas_excludes_disabled_tools() {
         .collect();
 
     assert_eq!(names, vec!["z_tool"]);
+}
+
+#[test]
+fn resolve_available_tool_schemas_hides_load_skill_after_activation() {
+    let config = crate::runtime::config::AgentLoopConfig::default();
+    let tools = StaticToolExecutor {
+        schemas: vec![schema("load_skill"), schema("read_skill_resource")],
+    };
+    let mut session = Session::new("session-loaded-skill", "model");
+    session.metadata.insert(
+        "skill_runtime_loaded_skill_ids".to_string(),
+        "[\"review\"]".to_string(),
+    );
+    session.metadata.insert(
+        "skill_runtime_selected_skill_ids".to_string(),
+        "[\"review\"]".to_string(),
+    );
+    session.metadata.insert(
+        "skill_runtime_selection_source".to_string(),
+        "explicit".to_string(),
+    );
+
+    let resolved = resolve_available_tool_schemas_for_session(&config, &tools, &session);
+    let names = resolved
+        .iter()
+        .map(|schema| schema.function.name.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(!names.contains(&"load_skill"));
+    assert!(names.contains(&"read_skill_resource"));
+}
+
+#[test]
+fn resolve_available_tool_schemas_keeps_load_skill_for_new_automatic_selection() {
+    let config = crate::runtime::config::AgentLoopConfig::default();
+    let tools = StaticToolExecutor {
+        schemas: vec![schema("load_skill"), schema("read_skill_resource")],
+    };
+    let mut session = Session::new("session-auto-after-loaded-skill", "model");
+    session.metadata.insert(
+        "skill_runtime_loaded_skill_ids".to_string(),
+        "[\"review\"]".to_string(),
+    );
+    session.metadata.insert(
+        "skill_runtime_selected_skill_ids".to_string(),
+        "[\"debug\",\"review\"]".to_string(),
+    );
+    session.metadata.insert(
+        "skill_runtime_selection_source".to_string(),
+        "auto".to_string(),
+    );
+
+    let resolved = resolve_available_tool_schemas_for_session(&config, &tools, &session);
+    let names = resolved
+        .iter()
+        .map(|schema| schema.function.name.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(names.contains(&"load_skill"));
+    assert!(names.contains(&"read_skill_resource"));
 }
 
 #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tool_schemas.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tool_schemas.rs
@@ -1,6 +1,10 @@
 use crate::runtime::config::AgentLoopConfig;
 use bamboo_agent_core::tools::{ToolExecutor, ToolSchema};
 use bamboo_agent_core::Session;
+use bamboo_skills::runtime_metadata::{
+    LOADED_SKILL_IDS_METADATA_KEY, SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY,
+    SKILL_RUNTIME_SELECTION_SOURCE_KEY,
+};
 use bamboo_tools::exposure::{
     activated_discoverable_tools, canonical_tool_name, discoverable_tool_short_description,
     is_core_tool,
@@ -61,6 +65,30 @@ pub(crate) fn resolve_available_tool_schemas_for_session(
         tool_schemas.retain(|schema| {
             schema.function.name != bamboo_tools::tools::goal::UPDATE_GOAL_TOOL_NAME
         });
+    }
+
+    // One activation chooses one workflow. Once its detailed instructions have
+    // been loaded, stop offering load_skill so the model cannot redundantly
+    // reload the same workflow (or switch to another advertised candidate) on a
+    // later round. Resource reads remain available for the active workflow.
+    let loaded_skill_ids = session
+        .metadata
+        .get(LOADED_SKILL_IDS_METADATA_KEY)
+        .and_then(|raw| serde_json::from_str::<Vec<String>>(raw).ok())
+        .unwrap_or_default();
+    let selected_skill_ids = session
+        .metadata
+        .get(SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY)
+        .and_then(|raw| serde_json::from_str::<Vec<String>>(raw).ok())
+        .unwrap_or_default();
+    let explicit_activation_is_current = session
+        .metadata
+        .get(SKILL_RUNTIME_SELECTION_SOURCE_KEY)
+        .is_some_and(|source| source == "explicit")
+        && !loaded_skill_ids.is_empty()
+        && loaded_skill_ids == selected_skill_ids;
+    if explicit_activation_is_current {
+        tool_schemas.retain(|schema| schema.function.name != "load_skill");
     }
 
     let activated = activated_discoverable_tools(session);

--- a/crates/engine/bamboo-engine/src/session_repository.rs
+++ b/crates/engine/bamboo-engine/src/session_repository.rs
@@ -217,7 +217,16 @@ fn should_prefer_storage(memory_session: &Session, storage_session: &Session) ->
 #[async_trait::async_trait]
 impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
     async fn save_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {
-        self.save(session).await
+        // Runtime authorization reads through this same cache. Refresh it even
+        // when durable storage fails so a current activation can never observe
+        // a previous run's skill allowlist. The error is still returned to the
+        // caller and durable state remains unchanged.
+        let result = self.persistence.merge_save_runtime(session).await;
+        self.cache.insert(
+            session.id.clone(),
+            Arc::new(parking_lot::RwLock::new(session.clone())),
+        );
+        result
     }
 
     async fn append_token_usage_record(
@@ -244,6 +253,10 @@ mod tests {
         sessions: Mutex<HashMap<String, Session>>,
     }
 
+    struct FailingSaveStorage {
+        persisted: Mutex<Option<Session>>,
+    }
+
     #[async_trait::async_trait]
     impl Storage for MapStorage {
         async fn save_session(&self, session: &Session) -> std::io::Result<()> {
@@ -258,6 +271,21 @@ mod tests {
         }
         async fn delete_session(&self, session_id: &str) -> std::io::Result<bool> {
             Ok(self.sessions.lock().unwrap().remove(session_id).is_some())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Storage for FailingSaveStorage {
+        async fn save_session(&self, _session: &Session) -> std::io::Result<()> {
+            Err(std::io::Error::other("injected save failure"))
+        }
+
+        async fn load_session(&self, _session_id: &str) -> std::io::Result<Option<Session>> {
+            Ok(self.persisted.lock().unwrap().clone())
+        }
+
+        async fn delete_session(&self, _session_id: &str) -> std::io::Result<bool> {
+            Ok(false)
         }
     }
 
@@ -341,6 +369,58 @@ mod tests {
         assert!(
             merged.pending_question.is_some(),
             "same-age storage carrying a pending question must still be recovered"
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_publish_refreshes_cache_even_when_storage_fails() {
+        let id = "runtime-selection";
+        let mut previous = Session::new(id.to_string(), "m");
+        previous.metadata.insert(
+            "skill_runtime_selected_skill_ids".to_string(),
+            "[\"plan\"]".to_string(),
+        );
+        let storage: Arc<dyn Storage> = Arc::new(FailingSaveStorage {
+            persisted: Mutex::new(Some(previous.clone())),
+        });
+        let repo = test_repo(storage.clone());
+        cache_put(&repo, &previous);
+
+        let mut current = previous.clone();
+        current.metadata.insert(
+            "skill_runtime_selected_skill_ids".to_string(),
+            "[\"review\"]".to_string(),
+        );
+        current.updated_at = Utc::now();
+
+        let result =
+            bamboo_domain::RuntimeSessionPersistence::save_runtime_session(&repo, &mut current)
+                .await;
+        assert!(result.is_err(), "durable failure must still be surfaced");
+
+        let cached = repo.load(id).await.expect("cached current session");
+        assert_eq!(
+            cached
+                .metadata
+                .get("skill_runtime_selected_skill_ids")
+                .map(String::as_str),
+            Some("[\"review\"]")
+        );
+        let allowlist = bamboo_skills::access_control::extract_skill_allowlist(&cached.metadata)
+            .expect("runtime authorization allowlist");
+        assert!(allowlist.contains("review"));
+        assert!(!allowlist.contains("plan"));
+        let durable = storage
+            .load_session(id)
+            .await
+            .expect("load durable state")
+            .expect("previous durable session");
+        assert_eq!(
+            durable
+                .metadata
+                .get("skill_runtime_selected_skill_ids")
+                .map(String::as_str),
+            Some("[\"plan\"]")
         );
     }
 }

--- a/crates/infra/bamboo-skills/src/store/builtin.rs
+++ b/crates/infra/bamboo-skills/src/store/builtin.rs
@@ -252,7 +252,8 @@ mod tests {
             .expect("utf8 Bamboo metadata");
             let bamboo_metadata: serde_yaml::Value =
                 serde_yaml::from_str(bamboo_metadata).expect("valid Bamboo metadata");
-            assert_eq!(bamboo_metadata["version"].as_str(), Some("1"));
+            let expected_version = if id == "review" { "3" } else { "1" };
+            assert_eq!(bamboo_metadata["version"].as_str(), Some(expected_version));
             assert_eq!(
                 bamboo_metadata["invocation_policy"]["explicit"].as_bool(),
                 Some(true)

--- a/crates/infra/bamboo-skills/src/store/mod.rs
+++ b/crates/infra/bamboo-skills/src/store/mod.rs
@@ -1664,7 +1664,8 @@ Use this skill for testing.
             assert_eq!(entry.kind, crate::WorkflowKind::Instruction);
             assert_eq!(entry.status, WorkflowStatus::Valid);
             assert!(entry.revision > 0);
-            assert_eq!(entry.version, "1");
+            let expected_version = if id == "review" { "3" } else { "1" };
+            assert_eq!(entry.version, expected_version);
             assert_eq!(entry.invocation_policy["explicit"], true);
             assert_eq!(entry.invocation_policy["automatic"], automatic);
             assert_eq!(entry.argument_schema["type"], "object");


### PR DESCRIPTION
## Summary
- preload exactly one structured explicit workflow before the first model round and persist matching activation metadata
- refresh the shared runtime session cache even when durable persistence fails, preventing stale allowlist authorization
- suppress redundant load_skill exposure only for the matching current explicit activation while keeping automatic selection lazy
- strengthen the review workflow evidence gate and record sanitized live Lotus/Bamboo dogfood

Closes #620

## Test Plan
- cargo fmt -- --check
- cargo clippy --all-features -- -A deprecated -A clippy::module_inception -A clippy::incompatible_msrv -A clippy::needless_borrows_for_generic_args -A clippy::too-many-arguments -A clippy::while-let-loop -A clippy::type_complexity -A dead-code -D warnings
- cargo test --all-features --lib --tests (1430 passed; one macOS UnsupportedCertVersion baseline reproduced on clean origin/main)
- cargo test --tests (same single reproduced macOS baseline)
- cargo build --examples
- targeted explicit activation, automatic-selection fallback, and persistence-failure authorization tests
- live Lotus UI plus Bamboo source build with Deepseek/deepseek-v4-flash

## Dogfood
- baseline explicit review selection had selected=[review] and loaded=[]
- final runtime recorded selected=[review], loaded=[review], injected the full workflow payload before model execution, and exposed no redundant model load_skill call
- provider output still violated the review evidence rule; this is preserved as a residual model-compliance limitation, not reported as activation success
- no workflow-driven workspace writes; final page console/error buffers were clean after excluding intentional server restart noise

## Known baseline
The macOS self-signed TLS test fails with UnsupportedCertVersion on this branch and clean origin/main@d8b770c0. GitHub Linux CI remains authoritative.