### PR TITLE
fix: pin workflow activation revisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,6 +1446,7 @@ dependencies = [
  "bamboo-config",
  "bamboo-domain",
  "bamboo-infrastructure",
+ "libc",
  "notify",
  "serde",
  "serde_json",

--- a/crates/app/bamboo-server-tools/src/skill_runtime/load_skill.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/load_skill.rs
@@ -7,12 +7,14 @@ use tokio::sync::RwLock;
 
 use bamboo_llm::Config;
 use bamboo_skills::access_control;
-use bamboo_skills::resource_helpers::list_skill_resource_paths;
 use bamboo_skills::SkillManager;
 
 use bamboo_agent_core::tools::{Tool, ToolCtx, ToolError, ToolOutcome, ToolResult};
 
-use super::{skill_access_error_to_tool_error, SkillToolAccess};
+use super::{
+    skill_access_error_to_tool_error, validate_runtime_activation,
+    validate_runtime_activation_descriptor, SkillToolAccess,
+};
 
 #[derive(Debug, Deserialize)]
 struct LoadSkillArgs {
@@ -73,21 +75,61 @@ impl Tool for LoadSkillTool {
             ));
         }
 
-        access_control::ensure_skill_allowed(&self.access, skill_id, ctx.session_id())
-            .await
-            .map_err(skill_access_error_to_tool_error)?;
-        let skill_mode = access_control::selected_skill_mode(&self.access, ctx.session_id()).await;
-
+        let session_id = ctx.session_id().ok_or_else(|| {
+            ToolError::Execution("load_skill requires a session_id in tool context".to_string())
+        })?;
         let store = self.access.skill_store(ctx.session_id()).await?;
-        let (skill, skill_root) = store
-            .get_skill_with_root_for_mode(skill_id, skill_mode.as_deref())
+        if !validate_runtime_activation(&self.access, store.as_ref(), session_id, skill_id).await? {
+            access_control::ensure_skill_allowed(&self.access, skill_id, ctx.session_id())
+                .await
+                .map_err(skill_access_error_to_tool_error)?;
+            let skill_mode =
+                access_control::selected_skill_mode(&self.access, ctx.session_id()).await;
+            let selected_ids =
+                access_control::selected_skill_allowlist(&self.access, ctx.session_id())
+                    .await
+                    .ok_or_else(|| {
+                        ToolError::Execution(
+                            "load_skill cannot pin a request with no published skill selection"
+                                .to_string(),
+                        )
+                    })?
+                    .into_iter()
+                    .collect::<Vec<_>>();
+            let session = self
+                .access
+                .session_for_context(Some(session_id))
+                .await
+                .ok_or_else(|| ToolError::Execution(format!("Session '{session_id}' not found")))?;
+            let workspace = session.workspace_path_meta().map(std::path::PathBuf::from);
+            self.access
+                .skill_manager
+                .pin_current_activation_for_workspace(
+                    session_id,
+                    workspace.as_deref(),
+                    &selected_ids,
+                    skill_mode.as_deref(),
+                )
+                .await
+                .map_err(|err| {
+                    ToolError::Execution(format!(
+                        "Failed to pin workflow activation for '{skill_id}': {err}"
+                    ))
+                })?;
+        }
+        let (skill, skill_root, revision, resources, payload_descriptor) = store
+            .get_pinned_skill_with_root_and_descriptor(session_id, skill_id)
             .await
             .map_err(|err| {
                 ToolError::Execution(format!("Failed to load skill '{skill_id}': {err}"))
             })?;
-        let resources = list_skill_resource_paths(&skill_root).map_err(|err| {
-            ToolError::Execution(format!("Failed to list skill resources: {err}"))
-        })?;
+        validate_runtime_activation_descriptor(
+            &self.access,
+            &payload_descriptor,
+            session_id,
+            skill_id,
+        )
+        .await?;
         let canonical_skill_root = tokio::fs::canonicalize(&skill_root)
             .await
             .unwrap_or(skill_root);
@@ -99,6 +141,7 @@ impl Tool for LoadSkillTool {
             success: true,
             result: json!({
                 "skill_id": skill.id,
+                "revision": revision,
                 "name": skill.name,
                 "description": skill.description,
                 "license": skill.license,

--- a/crates/app/bamboo-server-tools/src/skill_runtime/mod.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/mod.rs
@@ -7,6 +7,7 @@ use tokio::sync::RwLock;
 
 use bamboo_llm::Config;
 use bamboo_skills::access_control::{SkillAccessError, SkillSessionPort};
+use bamboo_skills::runtime_metadata::validate_pinned_activation_metadata;
 use bamboo_skills::{SkillManager, SkillStore};
 
 use bamboo_agent_core::tools::ToolError;
@@ -47,19 +48,6 @@ impl SkillToolAccess {
         self.session_repo.load(session_id?).await
     }
 
-    pub(super) async fn skill_root(
-        &self,
-        skill_id: &str,
-        skill_mode: Option<&str>,
-        session_id: Option<&str>,
-    ) -> Result<PathBuf, ToolError> {
-        self.skill_store(session_id)
-            .await?
-            .get_skill_root_for_mode(skill_id, skill_mode)
-            .await
-            .map_err(|err| ToolError::Execution(format!("Failed to resolve skill root: {err}")))
-    }
-
     pub(super) async fn skill_store(
         &self,
         session_id: Option<&str>,
@@ -85,6 +73,45 @@ impl SkillToolAccess {
                 ToolError::Execution(format!("Failed to resolve session skill store: {error}"))
             })
     }
+}
+
+/// Validate Bamboo runner-owned immutable activation metadata. Returns `false`
+/// only for legacy/direct-tool callers that have no generation marker and may
+/// establish their pin lazily.
+pub(super) async fn validate_runtime_activation(
+    access: &SkillToolAccess,
+    store: &SkillStore,
+    session_id: &str,
+    skill_id: &str,
+) -> Result<bool, ToolError> {
+    let session = access
+        .session_for_context(Some(session_id))
+        .await
+        .ok_or_else(|| ToolError::Execution(format!("Session '{session_id}' not found")))?;
+    let descriptor = store.activation_descriptor(session_id).await;
+    let validated =
+        validate_pinned_activation_metadata(&session.metadata, descriptor.as_ref(), Some(skill_id))
+            .map_err(ToolError::Execution)?;
+    if validated {
+        bamboo_skills::access_control::ensure_skill_enabled(access, skill_id)
+            .await
+            .map_err(skill_access_error_to_tool_error)?;
+    }
+    Ok(validated)
+}
+
+pub(super) async fn validate_runtime_activation_descriptor(
+    access: &SkillToolAccess,
+    descriptor: &bamboo_skills::SkillActivationDescriptor,
+    session_id: &str,
+    skill_id: &str,
+) -> Result<bool, ToolError> {
+    let session = access
+        .session_for_context(Some(session_id))
+        .await
+        .ok_or_else(|| ToolError::Execution(format!("Session '{session_id}' not found")))?;
+    validate_pinned_activation_metadata(&session.metadata, Some(descriptor), Some(skill_id))
+        .map_err(ToolError::Execution)
 }
 
 #[async_trait]

--- a/crates/app/bamboo-server-tools/src/skill_runtime/read_resource.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/read_resource.rs
@@ -16,7 +16,10 @@ use bamboo_skills::SkillManager;
 
 use bamboo_agent_core::tools::{Tool, ToolCtx, ToolError, ToolOutcome, ToolResult};
 
-use super::{skill_access_error_to_tool_error, SkillToolAccess, MAX_RESOURCE_CONTENT_CHARS};
+use super::{
+    skill_access_error_to_tool_error, validate_runtime_activation,
+    validate_runtime_activation_descriptor, SkillToolAccess, MAX_RESOURCE_CONTENT_CHARS,
+};
 
 #[derive(Debug, Deserialize)]
 struct ReadSkillResourceArgs {
@@ -94,13 +97,20 @@ impl Tool for ReadSkillResourceTool {
             ));
         }
 
-        access_control::ensure_skill_allowed(&self.access, skill_id, ctx.session_id())
-            .await
-            .map_err(skill_access_error_to_tool_error)?;
+        let session_id = ctx.session_id().ok_or_else(|| {
+            ToolError::Execution(
+                "read_skill_resource requires a session_id in tool context".to_string(),
+            )
+        })?;
+        let store = self.access.skill_store(ctx.session_id()).await?;
+        if !validate_runtime_activation(&self.access, store.as_ref(), session_id, skill_id).await? {
+            access_control::ensure_skill_allowed(&self.access, skill_id, ctx.session_id())
+                .await
+                .map_err(skill_access_error_to_tool_error)?;
+        }
         access_control::ensure_skill_loaded(&self.access, skill_id, ctx.session_id())
             .await
             .map_err(skill_access_error_to_tool_error)?;
-        let skill_mode = access_control::selected_skill_mode(&self.access, ctx.session_id()).await;
 
         let resource_path = normalize_relative_resource_path(&parsed.resource_path)
             .map_err(ToolError::InvalidArguments)?;
@@ -111,16 +121,8 @@ impl Tool for ReadSkillResourceTool {
             ));
         }
 
-        let skill_root = self
-            .access
-            .skill_root(skill_id, skill_mode.as_deref(), ctx.session_id())
-            .await?;
-        let canonical_root = tokio::fs::canonicalize(&skill_root).await.map_err(|_| {
-            ToolError::Execution(format!(
-                "Skill directory not found for '{skill_id}'. Load the skill list first."
-            ))
-        })?;
-        let canonical_resource = tokio::fs::canonicalize(skill_root.join(&resource_path))
+        let (bytes, payload_descriptor) = store
+            .read_pinned_skill_resource_with_descriptor(session_id, skill_id, &resource_path)
             .await
             .map_err(|_| {
                 ToolError::Execution(format!(
@@ -129,26 +131,13 @@ impl Tool for ReadSkillResourceTool {
                     display_relative_path(&resource_path)
                 ))
             })?;
-
-        if !canonical_resource.starts_with(&canonical_root) {
-            return Err(ToolError::InvalidArguments(
-                "resource_path must stay inside the skill directory".to_string(),
-            ));
-        }
-
-        let metadata = tokio::fs::metadata(&canonical_resource)
-            .await
-            .map_err(|err| ToolError::Execution(format!("Failed to stat resource: {err}")))?;
-        if !metadata.is_file() {
-            return Err(ToolError::InvalidArguments(format!(
-                "resource_path must reference a file: {}",
-                display_relative_path(&resource_path)
-            )));
-        }
-
-        let bytes = tokio::fs::read(&canonical_resource)
-            .await
-            .map_err(|err| ToolError::Execution(format!("Failed to read skill resource: {err}")))?;
+        validate_runtime_activation_descriptor(
+            &self.access,
+            &payload_descriptor,
+            session_id,
+            skill_id,
+        )
+        .await?;
         let size_bytes = bytes.len();
 
         let result = match String::from_utf8(bytes) {

--- a/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
@@ -2,7 +2,8 @@ use super::{LoadSkillTool, ReadSkillResourceTool};
 use bamboo_skills::access_control::{parse_loaded_skill_ids, serialize_loaded_skill_ids};
 use bamboo_skills::runtime_metadata::{
     LAST_LOADED_SKILL_SUMMARY_METADATA_KEY, LAST_RESOURCE_READ_SUMMARY_METADATA_KEY,
-    SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY,
+    SKILL_RUNTIME_ACTIVATION_GENERATION_KEY, SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY,
+    SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY,
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -217,6 +218,135 @@ async fn load_skill_accepts_only_runtime_advertised_skill_ids() {
     )
     .await
     .expect("explicitly advertised plan skill should load on the next run");
+}
+
+#[tokio::test]
+async fn runtime_generation_marker_prevents_stale_metadata_from_repinning_live_catalog() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let skills_dir = temp_dir.path().join("skills");
+    for (id, prompt) in [("review-demo", "review N"), ("plan-demo", "plan N")] {
+        let root = skills_dir.join(id);
+        std::fs::create_dir_all(root.join("references")).expect("skill root");
+        std::fs::write(
+            root.join("SKILL.md"),
+            format!("---\nname: {id}\ndescription: {id}\n---\n{prompt}\n"),
+        )
+        .expect("skill definition");
+        std::fs::write(
+            root.join("references/value.txt"),
+            format!("{prompt} resource"),
+        )
+        .expect("skill resource");
+    }
+    let skill_manager = Arc::new(SkillManager::with_config(SkillStoreConfig {
+        skills_dir: skills_dir.clone(),
+        project_dir: None,
+        active_mode: None,
+    }));
+    skill_manager
+        .initialize()
+        .await
+        .expect("initialize manager");
+    let session_id = "runtime-pinned-generation";
+    let review_ids = vec!["review-demo".to_string()];
+    let descriptor = skill_manager
+        .store()
+        .pin_current_activation(session_id, &review_ids, None)
+        .await
+        .expect("pin review N");
+    let mut session = Session::new(session_id, "model");
+    session.metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+        serde_json::to_string(&review_ids).expect("review ids"),
+    );
+    session.metadata.insert(
+        SKILL_RUNTIME_ACTIVATION_GENERATION_KEY.to_string(),
+        descriptor.catalog_revision.to_string(),
+    );
+    session.metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY.to_string(),
+        serde_json::to_string(&descriptor.skill_revisions).expect("review revisions"),
+    );
+    let sessions = test_session_cache(session_id, &session);
+    let storage: Arc<dyn Storage> = Arc::new(TestStorage::default());
+    storage.save_session(&session).await.expect("save session");
+    let persistence = Arc::new(bamboo_storage::LockedSessionStore::new(storage.clone()));
+    let repo = bamboo_engine::SessionRepository::new(sessions, storage, persistence);
+    let tool = LoadSkillTool::new(
+        skill_manager.clone(),
+        Arc::new(RwLock::new(Config::default())),
+        repo.clone(),
+    );
+    let read_tool = ReadSkillResourceTool::new(
+        skill_manager.clone(),
+        Arc::new(RwLock::new(Config::default())),
+        repo.clone(),
+    );
+    let context = ToolExecutionContext {
+        session_id: Some(session_id),
+        tool_call_id: "runtime-pinned-load",
+        event_tx: None,
+        available_tool_schemas: None,
+        bypass_permissions: false,
+        can_async_resume: false,
+        bash_completion_sink: None,
+        pre_parsed_args: None,
+    };
+
+    std::fs::write(
+        skills_dir.join("review-demo/SKILL.md"),
+        "---\nname: review-demo\ndescription: review N+1\n---\nreview N+1\n",
+    )
+    .expect("publish review N+1");
+    std::fs::write(
+        skills_dir.join("review-demo/references/value.txt"),
+        "review N+1 resource",
+    )
+    .expect("publish resource N+1");
+    skill_manager.store().reload().await.expect("reload N+1");
+    let mut stale_edit = repo.load(session_id).await.expect("cached session");
+    stale_edit.metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+        r#"["plan-demo"]"#.to_string(),
+    );
+    repo.save(&mut stale_edit).await.expect("save stale edit");
+
+    let ToolOutcome::Completed(loaded) = tool
+        .invoke(
+            serde_json::json!({"skill_id": "review-demo"}),
+            context.to_tool_ctx(),
+        )
+        .await
+        .expect("pinned review remains authoritative")
+    else {
+        panic!("load_skill should complete")
+    };
+    let loaded: serde_json::Value = serde_json::from_str(&loaded.result).expect("load result");
+    assert_eq!(loaded["instructions"], "review N");
+    let ToolOutcome::Completed(resource) = read_tool
+        .invoke(
+            serde_json::json!({
+                "skill_id": "review-demo",
+                "resource_path": "references/value.txt"
+            }),
+            context.to_tool_ctx(),
+        )
+        .await
+        .expect("pinned resource ignores stale allowlist")
+    else {
+        panic!("read_skill_resource should complete")
+    };
+    let resource: serde_json::Value =
+        serde_json::from_str(&resource.result).expect("resource result");
+    assert_eq!(resource["content"], "review N resource");
+    let error = tool
+        .invoke(
+            serde_json::json!({"skill_id": "plan-demo"}),
+            context.to_tool_ctx(),
+        )
+        .await
+        .expect_err("stale allowlist must not switch the active generation");
+    assert!(error.to_string().contains("does not match"));
 }
 
 #[tokio::test]
@@ -641,6 +771,10 @@ async fn session_workspace_catalog_selection_and_runtime_roots_are_isolated() {
             "runtime root {skill_root} must stay under {}",
             expected_workspace.display()
         );
+        if session_id == "workspace-session-one" {
+            std::fs::remove_dir_all(&workspace_one)
+                .expect("delete workspace after immutable activation is loaded");
+        }
 
         let ToolOutcome::Completed(resource) = read_tool
             .invoke(

--- a/crates/app/bamboo-server/src/handlers/agent/delete.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/delete.rs
@@ -61,6 +61,23 @@ pub async fn handler(state: web::Data<AppState>, path: web::Path<String>) -> Res
         None => vec![session_id.clone()],
     };
 
+    // Deletion is terminal, unlike a resumable stop/suspension. Release every
+    // root/child activation before removing session state so immutable snapshot
+    // capacity cannot leak even if a runner never reaches its own finalizer.
+    for id in &ids_to_cancel {
+        if let Err(error) = state
+            .skill_manager
+            .release_activation_for_workspace(id, None)
+            .await
+        {
+            tracing::warn!(
+                "[{}] Failed to release deleted workflow activation snapshot: {}",
+                id,
+                error
+            );
+        }
+    }
+
     let cancelled_runner = {
         let mut runners = state.agent_runners.write().await;
         let mut cancelled = false;
@@ -139,4 +156,63 @@ pub async fn handler(state: web::Data<AppState>, path: web::Path<String>) -> Res
     Ok(HttpResponse::NotFound().json(serde_json::json!({
         "error": crate::error::error_value("Session not found")
     })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_agent_core::storage::Storage;
+    use bamboo_agent_core::Session;
+
+    #[tokio::test]
+    async fn deleting_root_releases_root_and_child_workflow_activations() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let state = AppState::new(directory.path().to_path_buf())
+            .await
+            .expect("app state");
+        let root = Session::new("delete-root", "model");
+        let child = Session::new_child_of("delete-child", &root, "model", "child");
+        state
+            .session_store
+            .save_session(&root)
+            .await
+            .expect("save root index");
+        state
+            .session_store
+            .save_session(&child)
+            .await
+            .expect("save child index");
+        state.sessions.insert(
+            root.id.clone(),
+            std::sync::Arc::new(parking_lot::RwLock::new(root.clone())),
+        );
+        state.sessions.insert(
+            child.id.clone(),
+            std::sync::Arc::new(parking_lot::RwLock::new(child.clone())),
+        );
+        let ids = vec!["review".to_string()];
+        for session_id in [&root.id, &child.id] {
+            state
+                .skill_manager
+                .store()
+                .pin_current_activation(session_id, &ids, None)
+                .await
+                .expect("pin workflow activation");
+        }
+        let state = web::Data::new(state);
+
+        let response = handler(state.clone(), web::Path::from(root.id.clone()))
+            .await
+            .expect("delete response");
+
+        assert_eq!(response.status(), actix_web::http::StatusCode::OK);
+        for session_id in [&root.id, &child.id] {
+            assert!(state
+                .skill_manager
+                .store()
+                .activation_descriptor(session_id)
+                .await
+                .is_none());
+        }
+    }
 }

--- a/crates/app/bamboo-server/src/handlers/skill/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/skill/tests.rs
@@ -155,3 +155,78 @@ async fn get_available_workflows_maps_listing_failures_to_internal_error() {
         other => panic!("expected internal error, got {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn filtered_tools_rejects_runner_marker_when_pinned_snapshot_is_missing() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let app_state = web::Data::new(
+        AppState::new(temp_dir.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let mut session = bamboo_agent_core::Session::new("missing-tools-pin", "model");
+    session.metadata.insert(
+        bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_GENERATION_KEY.to_string(),
+        "42".to_string(),
+    );
+    session.metadata.insert(
+        bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY.to_string(),
+        r#"{"review":9}"#.to_string(),
+    );
+    session.metadata.insert(
+        bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+        r#"["review"]"#.to_string(),
+    );
+    app_state.sessions.insert(
+        session.id.clone(),
+        std::sync::Arc::new(parking_lot::RwLock::new(session.clone())),
+    );
+    app_state.save_session(&mut session).await;
+
+    let error = super::get_filtered_tools(
+        app_state.clone(),
+        web::Query(FilteredToolsQuery {
+            session_id: Some("missing-tools-pin".to_string()),
+            chat_id: None,
+        }),
+    )
+    .await
+    .expect_err("runner marker must not fall back to live tools");
+    match error {
+        AppError::BadRequest(message) => assert!(message.contains("retry as a new activation")),
+        other => panic!("expected bad request, got {other:?}"),
+    }
+
+    let descriptor = app_state
+        .skill_manager
+        .store()
+        .pin_current_activation("mismatched-tools-pin", &["review".to_string()], None)
+        .await
+        .expect("real activation");
+    let mut mismatched = bamboo_agent_core::Session::new("mismatched-tools-pin", "model");
+    mismatched.metadata.insert(
+        bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_GENERATION_KEY.to_string(),
+        descriptor.catalog_revision.saturating_add(1).to_string(),
+    );
+    mismatched.metadata.insert(
+        bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY.to_string(),
+        serde_json::to_string(&descriptor.skill_revisions).expect("revisions"),
+    );
+    app_state.sessions.insert(
+        mismatched.id.clone(),
+        std::sync::Arc::new(parking_lot::RwLock::new(mismatched.clone())),
+    );
+    app_state.save_session(&mut mismatched).await;
+    let mismatch_error = super::get_filtered_tools(
+        app_state,
+        web::Query(FilteredToolsQuery {
+            session_id: Some("mismatched-tools-pin".to_string()),
+            chat_id: None,
+        }),
+    )
+    .await
+    .expect_err("mismatched marker must not fall back to live tools");
+    assert!(
+        matches!(mismatch_error, AppError::BadRequest(message) if message.contains("does not match"))
+    );
+}

--- a/crates/app/bamboo-server/src/handlers/skill/tools.rs
+++ b/crates/app/bamboo-server/src/handlers/skill/tools.rs
@@ -1,5 +1,6 @@
 use actix_web::{web, HttpResponse};
 use bamboo_agent_core::tools::ToolSchema;
+use bamboo_skills::runtime_metadata::validate_pinned_activation_metadata;
 use bamboo_tools::BuiltinToolExecutor;
 use tracing::{debug, info};
 
@@ -33,18 +34,13 @@ pub async fn get_filtered_tools(
     let selected_skill_ids = session.as_ref().and_then(|session| {
         session
             .metadata
-            .get("selected_skill_ids")
+            .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY)
+            .or_else(|| session.metadata.get("selected_skill_ids"))
             .and_then(|raw| bamboo_skills::selection::parse_selected_skill_ids_metadata(raw))
     });
-    let selected_skill_mode = session.as_ref().and_then(|session| {
-        session
-            .metadata
-            .get("skill_mode")
-            .or_else(|| session.metadata.get("mode"))
-            .map(|mode| mode.trim())
-            .filter(|mode| !mode.is_empty())
-            .map(str::to_string)
-    });
+    let selected_skill_mode = session
+        .as_ref()
+        .and_then(|session| bamboo_skills::access_control::extract_skill_mode(&session.metadata));
     let workspace = session
         .as_ref()
         .and_then(|session| session.workspace_path_meta())
@@ -53,7 +49,45 @@ pub async fn get_filtered_tools(
         let config = state.config.read().await;
         config.disabled_skill_ids()
     };
-    let allowed_tools = if let Some(workspace) = workspace.as_deref() {
+    let mut runner_owned_activation = false;
+    let pinned_allowed_tools = match (session_id, session.as_ref()) {
+        (Some(activation_id), Some(session)) => {
+            let store = state
+                .skill_manager
+                .as_ref()
+                .store_for_workspace(workspace.as_deref())
+                .await
+                .map_err(|error| {
+                    AppError::BadRequest(format!("Invalid session workspace: {error}"))
+                })?;
+            let pinned = store
+                .pinned_allowed_tools_with_descriptor(activation_id, &disabled_skill_ids)
+                .await;
+            runner_owned_activation = validate_pinned_activation_metadata(
+                &session.metadata,
+                pinned.as_ref().map(|(_, descriptor)| descriptor),
+                None,
+            )
+            .map_err(AppError::BadRequest)?;
+            let tools = pinned.map(|(tools, _)| tools);
+            if runner_owned_activation && tools.is_none() {
+                return Err(AppError::BadRequest(
+                    "Pinned workflow activation is unavailable; retry as a new activation"
+                        .to_string(),
+                ));
+            }
+            tools
+        }
+        _ => None,
+    };
+    let allowed_tools = if let Some(tools) = pinned_allowed_tools {
+        tools
+    } else if runner_owned_activation {
+        return Err(AppError::BadRequest(
+            "Pinned workflow activation tools are unavailable; retry as a new activation"
+                .to_string(),
+        ));
+    } else if let Some(workspace) = workspace.as_deref() {
         state
             .skill_manager
             .as_ref()

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution.rs
@@ -47,9 +47,10 @@ pub(crate) async fn run_agent_loop_with_config(
     let session_span = tracing::info_span!("agent_loop", session_id = %session.id);
     async {
         let mut state: LoopRunState =
-            initialize_loop_state(session, initial_message.as_str(), &config, tools.as_ref()).await;
+            initialize_loop_state(session, initial_message.as_str(), &config, tools.as_ref())
+                .await?;
 
-        let sent_complete = run_pipeline(
+        let pipeline_result = run_pipeline(
             session,
             &event_tx,
             llm,
@@ -58,7 +59,31 @@ pub(crate) async fn run_agent_loop_with_config(
             &config,
             &mut state,
         )
-        .await?;
+        .await;
+
+        let sent_complete = match pipeline_result {
+            Ok(sent_complete) => sent_complete,
+            Err(error) => {
+                // Errors and cancellation are terminal for this activation but must
+                // not flow through normal finalization: that would emit a false
+                // Complete event and stamp the runtime state Completed. Release only
+                // the immutable workflow snapshot, then preserve the original error.
+                if let Some(skill_manager) = config.skill_manager.as_ref() {
+                    let workspace = session.workspace_path_meta().map(std::path::PathBuf::from);
+                    if let Err(release_error) = skill_manager
+                        .release_activation_for_workspace(&state.session_id, workspace.as_deref())
+                        .await
+                    {
+                        tracing::warn!(
+                            "[{}] Failed to release errored workflow activation snapshot: {}",
+                            state.session_id,
+                            release_error
+                        );
+                    }
+                }
+                return Err(error);
+            }
+        };
 
         super::session_finalize::finalize_session(
             state.task_context,

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/startup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/startup.rs
@@ -103,7 +103,7 @@ pub(super) async fn initialize_loop_state(
     initial_message: &str,
     config: &AgentLoopConfig,
     tools: &dyn ToolExecutor,
-) -> LoopRunState {
+) -> super::super::Result<LoopRunState> {
     let debug_logger = DebugLogger::new(tracing::enabled!(tracing::Level::DEBUG));
     let session_id = session.id.clone();
     let metrics_collector = config.metrics_collector.clone();
@@ -137,6 +137,10 @@ pub(super) async fn initialize_loop_state(
 
     let auxiliary_models = resolve_auxiliary_models(config);
 
+    let must_resume_pinned_activation = session
+        .agent_runtime_state
+        .as_ref()
+        .is_some_and(|previous| matches!(previous.status, AgentStatusState::Suspended));
     let mut runtime_state = AgentRuntimeState::new(&session_id);
     // "Bypass permissions" is a per-session sticky toggle (set via PATCH /sessions
     // and persisted in runtime.json). Each run rebuilds a fresh runtime state, so
@@ -171,10 +175,11 @@ pub(super) async fn initialize_loop_state(
         metrics_collector.as_ref(),
         &session_id,
         &debug_logger,
+        must_resume_pinned_activation,
     )
-    .await;
+    .await?;
 
-    LoopRunState {
+    Ok(LoopRunState {
         session_id,
         model_name,
         metrics_collector,
@@ -185,14 +190,55 @@ pub(super) async fn initialize_loop_state(
         gold_evaluation: GoldEvaluationState::default(),
         auxiliary_models,
         runtime_state,
-    }
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_auxiliary_models, OverflowRecoveryState};
+    use super::{initialize_loop_state, resolve_auxiliary_models, OverflowRecoveryState};
     use crate::runtime::config::{AgentLoopConfig, AuxiliaryModelConfig};
+    use async_trait::async_trait;
+    use bamboo_agent_core::tools::{
+        FunctionSchema, ToolCall, ToolExecutor, ToolResult, ToolSchema,
+    };
+    use bamboo_agent_core::Session;
+    use bamboo_domain::{AgentRuntimeState, AgentStatusState};
+    use bamboo_skills::runtime_metadata::{
+        LOADED_SKILL_IDS_METADATA_KEY, SKILL_RUNTIME_ACTIVATION_GENERATION_KEY,
+        SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY, SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY,
+        SKILL_RUNTIME_SELECTION_SOURCE_KEY,
+    };
+    use bamboo_skills::{SkillManager, SkillStoreConfig};
+    use std::collections::BTreeSet;
     use std::sync::{Arc, Mutex};
+
+    struct SuccessfulLoadSkill;
+
+    #[async_trait]
+    impl ToolExecutor for SuccessfulLoadSkill {
+        async fn execute(
+            &self,
+            _call: &ToolCall,
+        ) -> bamboo_agent_core::tools::executor::Result<ToolResult> {
+            Ok(ToolResult {
+                success: true,
+                result: serde_json::json!({"instructions": "pinned"}).to_string(),
+                display_preference: None,
+                images: Vec::new(),
+            })
+        }
+
+        fn list_tools(&self) -> Vec<ToolSchema> {
+            vec![ToolSchema {
+                schema_type: "function".to_string(),
+                function: FunctionSchema {
+                    name: "load_skill".to_string(),
+                    description: "load".to_string(),
+                    parameters: serde_json::json!({"type": "object"}),
+                },
+            }]
+        }
+    }
 
     #[test]
     fn overflow_recovery_state_tracks_recoveries_and_resets() {
@@ -267,5 +313,148 @@ mod tests {
 
         assert_eq!(first.summarization_model_name.as_deref(), Some("sum-1"));
         assert_eq!(second.summarization_model_name.as_deref(), Some("sum-2"));
+    }
+
+    #[tokio::test]
+    async fn startup_reuses_retained_activation_and_explicit_selection_supersedes_it() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("skills");
+        for (id, prompt) in [("review-demo", "review N"), ("plan-demo", "plan N")] {
+            let root = skills_dir.join(id);
+            tokio::fs::create_dir_all(&root).await.expect("skill root");
+            tokio::fs::write(
+                root.join("SKILL.md"),
+                format!("---\nname: {id}\ndescription: {id}\n---\n{prompt}\n"),
+            )
+            .await
+            .expect("skill definition");
+        }
+        let manager = Arc::new(SkillManager::with_config(SkillStoreConfig {
+            skills_dir: skills_dir.clone(),
+            ..Default::default()
+        }));
+        manager.initialize().await.expect("initialize");
+        let tools = SuccessfulLoadSkill;
+        let review_config = AgentLoopConfig {
+            skill_manager: Some(manager.clone()),
+            selected_skill_ids: Some(vec!["review-demo".to_string()]),
+            disabled_skill_ids: BTreeSet::new(),
+            ..Default::default()
+        };
+        let mut session = Session::new("retained-session", "model");
+        initialize_loop_state(&mut session, "review", &review_config, &tools)
+            .await
+            .expect("initial activation");
+        let pinned_generation = session
+            .metadata
+            .get(SKILL_RUNTIME_ACTIVATION_GENERATION_KEY)
+            .cloned()
+            .expect("pinned generation metadata");
+        let pinned_revisions = session
+            .metadata
+            .get(SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY)
+            .cloned()
+            .expect("pinned revision metadata");
+        assert_eq!(
+            manager
+                .store()
+                .pinned_activation_skills("retained-session")
+                .await
+                .expect("review pin")
+                .0[0]
+                .prompt,
+            "review N"
+        );
+
+        tokio::fs::write(
+            skills_dir.join("review-demo/SKILL.md"),
+            "---\nname: review-demo\ndescription: review N+1\n---\nreview N+1\n",
+        )
+        .await
+        .expect("review N+1");
+        manager.store().reload().await.expect("reload N+1");
+        let mut suspended = AgentRuntimeState::new("retained-session");
+        suspended.status = AgentStatusState::Suspended;
+        session.agent_runtime_state = Some(suspended);
+        session.metadata.remove(LOADED_SKILL_IDS_METADATA_KEY);
+        let continuation_config = AgentLoopConfig {
+            skill_manager: Some(manager.clone()),
+            disabled_skill_ids: BTreeSet::new(),
+            ..Default::default()
+        };
+        initialize_loop_state(
+            &mut session,
+            "plain clarification reply",
+            &continuation_config,
+            &tools,
+        )
+        .await
+        .expect("suspended continuation");
+        assert_eq!(
+            manager
+                .store()
+                .pinned_activation_skills("retained-session")
+                .await
+                .expect("retained review pin")
+                .0[0]
+                .prompt,
+            "review N",
+            "startup overwrites Suspended with Initializing, but retained pin must still win"
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(SKILL_RUNTIME_SELECTION_SOURCE_KEY)
+                .map(String::as_str),
+            Some("explicit")
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(SKILL_RUNTIME_ACTIVATION_GENERATION_KEY),
+            Some(&pinned_generation)
+        );
+        assert_eq!(
+            session
+                .metadata
+                .get(SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY),
+            Some(&pinned_revisions)
+        );
+        assert!(!session
+            .metadata
+            .contains_key(SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY));
+        assert_eq!(
+            session
+                .metadata
+                .get(LOADED_SKILL_IDS_METADATA_KEY)
+                .map(String::as_str),
+            Some("[\"review-demo\"]"),
+            "retained explicit activation must deterministically preload again"
+        );
+
+        let plan_config = AgentLoopConfig {
+            skill_manager: Some(manager.clone()),
+            selected_skill_ids: Some(vec!["plan-demo".to_string()]),
+            disabled_skill_ids: BTreeSet::new(),
+            ..Default::default()
+        };
+        initialize_loop_state(&mut session, "plan instead", &plan_config, &tools)
+            .await
+            .expect("superseding activation");
+        let (skills, descriptor) = manager
+            .store()
+            .pinned_activation_skills("retained-session")
+            .await
+            .expect("superseding plan pin");
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].id, "plan-demo");
+        assert_eq!(
+            descriptor
+                .skill_revisions
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec!["plan-demo"]
+        );
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_finalize.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_finalize.rs
@@ -39,6 +39,19 @@ pub(crate) async fn finalize_session(
     record_session_resolution(metrics_collector, session_id, session, runtime_state);
 
     if !matches!(runtime_state.status, AgentStatusState::Suspended) {
+        if let Some(skill_manager) = config.skill_manager.as_ref() {
+            let workspace = session.workspace_path_meta().map(std::path::PathBuf::from);
+            if let Err(error) = skill_manager
+                .release_activation_for_workspace(session_id, workspace.as_deref())
+                .await
+            {
+                tracing::warn!(
+                    "[{}] Failed to release completed workflow activation snapshot: {}",
+                    session_id,
+                    error
+                );
+            }
+        }
         runtime_state.status = AgentStatusState::Completed;
     }
     super::state_bridge::write_runtime_state(session, runtime_state);

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_finalize/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_finalize/tests.rs
@@ -5,7 +5,9 @@ use super::finalize_session;
 use crate::runtime::config::AgentLoopConfig;
 use crate::runtime::task_context::TaskLoopContext;
 use bamboo_agent_core::{AgentEvent, Session};
-use bamboo_domain::{AgentRuntimeState, TaskItem, TaskItemStatus, TaskList};
+use bamboo_domain::{AgentRuntimeState, AgentStatusState, TaskItem, TaskItemStatus, TaskList};
+use bamboo_skills::{SkillManager, SkillStoreConfig};
+use std::sync::Arc;
 
 fn completed_task_list(session_id: &str) -> TaskList {
     TaskList {
@@ -119,4 +121,74 @@ async fn finalize_session_syncs_task_context_and_emits_task_completed() {
         Some("0")
     );
     assert!(event_rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn finalize_releases_completed_activation_but_retains_suspended_activation() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let skill_root = directory.path().join("skills/finalize-demo");
+    tokio::fs::create_dir_all(&skill_root)
+        .await
+        .expect("skill root");
+    tokio::fs::write(
+        skill_root.join("SKILL.md"),
+        "---\nname: finalize-demo\ndescription: finalize\n---\nfinalize\n",
+    )
+    .await
+    .expect("skill");
+    let manager = Arc::new(SkillManager::with_config(SkillStoreConfig {
+        skills_dir: directory.path().join("skills"),
+        ..Default::default()
+    }));
+    manager.initialize().await.expect("initialize");
+    let ids = vec!["finalize-demo".to_string()];
+    for session_id in ["completed-pin", "suspended-pin"] {
+        manager
+            .store()
+            .pin_current_activation(session_id, &ids, None)
+            .await
+            .expect("pin activation");
+    }
+    let config = AgentLoopConfig {
+        skill_manager: Some(manager.clone()),
+        ..Default::default()
+    };
+    let (event_tx, _event_rx) = mpsc::channel(8);
+    let mut completed_session = Session::new("completed-pin", "model");
+    finalize_session(
+        None,
+        &mut completed_session,
+        &event_tx,
+        "completed-pin",
+        &config,
+        None,
+        true,
+        &mut AgentRuntimeState::new("completed-pin"),
+    )
+    .await;
+    assert!(manager
+        .store()
+        .activation_descriptor("completed-pin")
+        .await
+        .is_none());
+
+    let mut suspended_session = Session::new("suspended-pin", "model");
+    let mut suspended_state = AgentRuntimeState::new("suspended-pin");
+    suspended_state.status = AgentStatusState::Suspended;
+    finalize_session(
+        None,
+        &mut suspended_session,
+        &event_tx,
+        "suspended-pin",
+        &config,
+        None,
+        true,
+        &mut suspended_state,
+    )
+    .await;
+    assert!(manager
+        .store()
+        .activation_descriptor("suspended-pin")
+        .await
+        .is_some());
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup.rs
@@ -5,12 +5,13 @@ use chrono::Utc;
 use crate::runtime::config::AgentLoopConfig;
 use crate::runtime::task_context::TaskLoopContext;
 use bamboo_agent_core::tools::ToolExecutor;
-use bamboo_agent_core::{Message, PromptSnapshot, Session};
+use bamboo_agent_core::{AgentError, Message, PromptSnapshot, Session};
 use bamboo_metrics::MetricsCollector;
 use bamboo_skills::runtime_metadata::{
+    SKILL_RUNTIME_ACTIVATION_ERROR_KEY, SKILL_RUNTIME_ACTIVATION_GENERATION_KEY,
     SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY, SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY,
-    SKILL_RUNTIME_SELECTION_COUNT_KEY, SKILL_RUNTIME_SELECTION_SOURCE_KEY,
-    SKILL_RUNTIME_SELECTION_TRACE_KEY,
+    SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY, SKILL_RUNTIME_SELECTION_COUNT_KEY,
+    SKILL_RUNTIME_SELECTION_SOURCE_KEY, SKILL_RUNTIME_SELECTION_TRACE_KEY,
 };
 use bamboo_tools::exposure::activated_discoverable_tools;
 
@@ -30,6 +31,7 @@ pub fn refresh_prompt_snapshot(session: &mut Session) {
     prompt_setup::refresh_prompt_snapshot_from_session(session)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn prepare_session_for_loop(
     session: &mut Session,
     initial_message: &str,
@@ -38,9 +40,38 @@ pub(crate) async fn prepare_session_for_loop(
     metrics_collector: Option<&MetricsCollector>,
     session_id: &str,
     debug_logger: &DebugLogger,
-) -> Option<TaskLoopContext> {
-    let skill_result =
-        skill_context::load_skill_context(config, session, session_id, initial_message).await;
+    must_resume_pinned_activation: bool,
+) -> super::Result<Option<TaskLoopContext>> {
+    let skill_result = match skill_context::load_skill_context(
+        config,
+        session,
+        session_id,
+        initial_message,
+        must_resume_pinned_activation,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(error) => {
+            session.metadata.insert(
+                SKILL_RUNTIME_ACTIVATION_ERROR_KEY.to_string(),
+                error.clone(),
+            );
+            if let Some(persistence) = config.persistence.as_ref() {
+                if let Err(save_error) = persistence.save_runtime_session(session).await {
+                    tracing::warn!(
+                        "[{}] Failed to persist workflow activation setup error: {}",
+                        session_id,
+                        save_error
+                    );
+                }
+            }
+            return Err(AgentError::Tool(format!(
+                "Workflow activation failed before model execution: {error}"
+            )));
+        }
+    };
+    session.metadata.remove(SKILL_RUNTIME_ACTIVATION_ERROR_KEY);
     let mut skill_context = skill_result.context.clone();
 
     if let Some(source) = skill_result.selection_source.as_deref() {
@@ -66,6 +97,20 @@ pub(crate) async fn prepare_session_for_loop(
             SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
             serde_json::to_string(&skill_result.selected_skill_ids).unwrap_or("[]".to_string()),
         );
+        if let Some(revision) = skill_result.catalog_revision {
+            session.metadata.insert(
+                SKILL_RUNTIME_ACTIVATION_GENERATION_KEY.to_string(),
+                revision.to_string(),
+            );
+        } else {
+            session
+                .metadata
+                .remove(SKILL_RUNTIME_ACTIVATION_GENERATION_KEY);
+        }
+        session.metadata.insert(
+            SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY.to_string(),
+            serde_json::to_string(&skill_result.skill_revisions).unwrap_or("{}".to_string()),
+        );
         session.metadata.insert(
             SKILL_RUNTIME_SELECTION_TRACE_KEY.to_string(),
             serde_json::json!({
@@ -81,6 +126,10 @@ pub(crate) async fn prepare_session_for_loop(
                 SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY.to_string(),
                 mode.clone(),
             );
+        } else {
+            session
+                .metadata
+                .remove(SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY);
         }
 
         skill_context::reset_explicit_activation_state(session, &skill_result);
@@ -90,25 +139,48 @@ pub(crate) async fn prepare_session_for_loop(
         // never observe a missing or previous-run allowlist from the cache.
         if let Some(persistence) = config.persistence.as_ref() {
             if let Err(error) = persistence.save_runtime_session(session).await {
-                tracing::warn!(
-                    "[{}] Failed to publish runtime skill selection before execution: {}",
-                    session_id,
-                    error
-                );
+                if let Some(skill_manager) = config.skill_manager.as_ref() {
+                    let workspace = session.workspace_path_meta().map(std::path::PathBuf::from);
+                    let _ = skill_manager
+                        .release_activation_for_workspace(session_id, workspace.as_deref())
+                        .await;
+                }
+                return Err(AgentError::Tool(format!(
+                    "Workflow activation metadata could not be published before tool/model execution: {error}"
+                )));
             }
         }
 
-        if let Some(activated_context) =
-            skill_context::activate_explicit_skill(tools, session, session_id, &skill_result).await
-        {
+        let explicit_activation =
+            match skill_context::activate_explicit_skill(tools, session, session_id, &skill_result)
+                .await
+            {
+                Ok(activation) => activation,
+                Err(error) => {
+                    if let Some(skill_manager) = config.skill_manager.as_ref() {
+                        let workspace = session.workspace_path_meta().map(std::path::PathBuf::from);
+                        let _ = skill_manager
+                            .release_activation_for_workspace(session_id, workspace.as_deref())
+                            .await;
+                    }
+                    return Err(AgentError::Tool(format!(
+                        "Explicit workflow activation failed before model execution: {error}"
+                    )));
+                }
+            };
+        if let Some(activated_context) = explicit_activation {
             skill_context = activated_context;
             if let Some(persistence) = config.persistence.as_ref() {
                 if let Err(error) = persistence.save_runtime_session(session).await {
-                    tracing::warn!(
-                        "[{}] Failed to publish explicit skill activation before execution: {}",
-                        session_id,
-                        error
-                    );
+                    if let Some(skill_manager) = config.skill_manager.as_ref() {
+                        let workspace = session.workspace_path_meta().map(std::path::PathBuf::from);
+                        let _ = skill_manager
+                            .release_activation_for_workspace(session_id, workspace.as_deref())
+                            .await;
+                    }
+                    return Err(AgentError::Tool(format!(
+                        "Explicit workflow loaded-state could not be published before model execution: {error}"
+                    )));
                 }
             }
         }
@@ -151,7 +223,7 @@ pub(crate) async fn prepare_session_for_loop(
     if task_context.is_some() {
         tracing::debug!("[{}] TaskLoopContext initialized", session_id);
     }
-    task_context
+    Ok(task_context)
 }
 
 #[cfg(test)]

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/skill_context.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/skill_context.rs
@@ -7,6 +7,7 @@ use bamboo_skills::runtime_metadata::{
     LAST_LOADED_SKILL_ID_METADATA_KEY, LAST_LOADED_SKILL_SUMMARY_METADATA_KEY,
     LOADED_SKILL_IDS_METADATA_KEY,
 };
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Debug, Clone, Default)]
 pub(super) struct SkillContextLoadResult {
@@ -15,6 +16,8 @@ pub(super) struct SkillContextLoadResult {
     pub(super) selection_source: Option<String>,
     pub(super) selected_skill_mode: Option<String>,
     pub(super) request_hint_present: bool,
+    pub(super) catalog_revision: Option<u64>,
+    pub(super) skill_revisions: BTreeMap<String, u64>,
 }
 
 pub(super) async fn load_skill_context(
@@ -22,59 +25,180 @@ pub(super) async fn load_skill_context(
     session: &Session,
     session_id: &str,
     request_hint: &str,
-) -> SkillContextLoadResult {
+    must_resume_pinned_activation: bool,
+) -> Result<SkillContextLoadResult, String> {
     if let Some(skill_manager) = config.skill_manager.as_ref() {
-        let selected_skills: Vec<bamboo_skills::SkillDefinition> =
-            if let Some(workspace) = session.workspace_path_meta() {
-                match skill_manager
-                    .resolve_skills_for_request_in_workspace_with_mode(
-                        std::path::Path::new(&workspace),
-                        &config.disabled_skill_ids,
-                        config.selected_skill_ids.as_deref(),
-                        config.selected_skill_mode.as_deref(),
-                        Some(request_hint),
-                    )
+        let retained_selection_source = session
+            .metadata
+            .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTION_SOURCE_KEY)
+            .filter(|source| matches!(source.as_str(), "explicit" | "auto"))
+            .cloned();
+        let workspace = session.workspace_path_meta().map(std::path::PathBuf::from);
+        // Completed activations are released by finalization. Therefore an existing
+        // pin identifies a suspended/in-flight continuation even though startup has
+        // already replaced the session's prior status with `Initializing`.
+        let mut retained_activation = skill_manager
+            .pinned_activation_for_workspace(session_id, workspace.as_deref())
+            .await
+            .map_err(|error| format!("Failed to inspect retained workflow activation: {error}"))?;
+        let persisted_selection_requires_snapshot = session
+            .metadata
+            .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY)
+            .and_then(|raw| serde_json::from_str::<BTreeMap<String, u64>>(raw).ok())
+            .is_some_and(|revisions| !revisions.is_empty());
+        if must_resume_pinned_activation
+            && persisted_selection_requires_snapshot
+            && retained_activation.is_none()
+        {
+            return Err(
+                "Suspended workflow snapshot is unavailable after restart; retry as a new activation"
+                    .to_string(),
+            );
+        }
+        if let Some(retained) = retained_activation.as_ref() {
+            let requested_mode = config
+                .selected_skill_mode
+                .as_deref()
+                .map(str::trim)
+                .filter(|mode| !mode.is_empty())
+                .map(str::to_ascii_lowercase);
+            let mode_matches = requested_mode.as_ref().is_none_or(|requested| {
+                retained.descriptor.selected_skill_mode.as_ref() == Some(requested)
+            });
+            let selection_matches = if let Some(requested_ids) = config.selected_skill_ids.as_ref()
+            {
+                let requested = requested_ids
+                    .iter()
+                    .map(|id| id.trim())
+                    .filter(|id| !id.is_empty())
+                    .collect::<BTreeSet<_>>();
+                let pinned = retained
+                    .descriptor
+                    .skill_revisions
+                    .keys()
+                    .map(String::as_str)
+                    .collect::<BTreeSet<_>>();
+                requested == pinned
+            } else {
+                true
+            };
+            if !mode_matches || !selection_matches {
+                if let Err(error) = skill_manager
+                    .release_activation_for_workspace(session_id, workspace.as_deref())
                     .await
                 {
-                    Ok(skills) => skills,
-                    Err(error) => {
-                        tracing::warn!(
-                            "[{}] Failed to resolve session workspace skills: {}",
-                            session_id,
-                            error
-                        );
-                        Vec::new()
-                    }
+                    tracing::warn!(
+                        "[{}] Failed to supersede retained workflow activation: {}",
+                        session_id,
+                        error
+                    );
                 }
-            } else {
-                skill_manager
-                    .resolve_skills_for_request_with_mode(
-                        &config.disabled_skill_ids,
-                        config.selected_skill_ids.as_deref(),
-                        config.selected_skill_mode.as_deref(),
-                        Some(request_hint),
-                    )
-                    .await
-            };
+                retained_activation = None;
+            }
+        }
+        let continues_retained_activation = retained_activation.is_some();
+        let activation = if let Some(activation) = retained_activation {
+            Some(activation)
+        } else if let Some(workspace_path) = workspace.as_deref() {
+            match skill_manager
+                .resolve_and_pin_activation_in_workspace_with_mode(
+                    workspace_path,
+                    session_id,
+                    &config.disabled_skill_ids,
+                    config.selected_skill_ids.as_deref(),
+                    config.selected_skill_mode.as_deref(),
+                    Some(request_hint),
+                )
+                .await
+            {
+                Ok(activation) => Some(activation),
+                Err(error) => {
+                    if let Err(release_error) = skill_manager
+                        .release_activation_for_workspace(session_id, Some(workspace_path))
+                        .await
+                    {
+                        tracing::warn!(
+                            "[{}] Failed to clear stale workflow activation: {}",
+                            session_id,
+                            release_error
+                        );
+                    }
+                    return Err(format!(
+                        "Failed to pin immutable workflow activation for this run: {error}. Retry as a new activation after releasing capacity or reducing workflow resources"
+                    ));
+                }
+            }
+        } else {
+            match skill_manager
+                .resolve_and_pin_activation_for_request_with_mode(
+                    session_id,
+                    &config.disabled_skill_ids,
+                    config.selected_skill_ids.as_deref(),
+                    config.selected_skill_mode.as_deref(),
+                    Some(request_hint),
+                )
+                .await
+            {
+                Ok(activation) => Some(activation),
+                Err(error) => {
+                    if let Err(release_error) = skill_manager
+                        .release_activation_for_workspace(session_id, None)
+                        .await
+                    {
+                        tracing::warn!(
+                            "[{}] Failed to clear stale workflow activation: {}",
+                            session_id,
+                            release_error
+                        );
+                    }
+                    return Err(format!(
+                        "Failed to pin immutable workflow activation for this run: {error}. Retry as a new activation after releasing capacity or reducing workflow resources"
+                    ));
+                }
+            }
+        };
+        if activation.is_none() && workspace.is_none() && !continues_retained_activation {
+            if let Err(error) = skill_manager
+                .release_activation_for_workspace(session_id, None)
+                .await
+            {
+                tracing::warn!(
+                    "[{}] Failed to clear stale workflow activation: {}",
+                    session_id,
+                    error
+                );
+            }
+        }
+        let selected_skills = activation
+            .as_ref()
+            .map(|activation| activation.skills.clone())
+            .unwrap_or_default();
         let selected_ids = selected_skills
             .iter()
             .map(|skill| skill.id.clone())
             .collect::<Vec<_>>();
+        let configured_selection_source = if config.selected_skill_ids.is_some() {
+            "explicit".to_string()
+        } else {
+            "auto".to_string()
+        };
+        let selection_source = Some(if continues_retained_activation {
+            retained_selection_source.unwrap_or(configured_selection_source)
+        } else {
+            configured_selection_source
+        });
+        let selected_skill_mode = activation
+            .as_ref()
+            .and_then(|activation| activation.descriptor.selected_skill_mode.clone());
         tracing::info!(
             "[{}] Skill selection trace: source={}, selected_count={}, selected_ids={:?}, skill_mode={}, request_hint_present={}",
             session_id,
-            if config.selected_skill_ids.is_some() { "explicit" } else { "auto" },
+            selection_source.as_deref().unwrap_or("none"),
             selected_ids.len(),
             selected_ids,
-            config.selected_skill_mode.as_deref().unwrap_or("default"),
+            selected_skill_mode.as_deref().unwrap_or("default"),
             !request_hint.trim().is_empty(),
         );
-
-        let selection_source = if config.selected_skill_ids.is_some() {
-            Some("explicit".to_string())
-        } else {
-            Some("auto".to_string())
-        };
 
         let context = bamboo_skills::context::build_skill_context(&selected_skills);
         if !context.is_empty() {
@@ -87,16 +211,23 @@ pub(super) async fn load_skill_context(
         } else {
             tracing::info!("[{}] No skill context loaded (empty)", session_id);
         }
-        SkillContextLoadResult {
+        Ok(SkillContextLoadResult {
             context,
             selected_skill_ids: selected_ids,
             selection_source,
-            selected_skill_mode: config.selected_skill_mode.clone(),
+            selected_skill_mode,
             request_hint_present: !request_hint.trim().is_empty(),
-        }
+            catalog_revision: activation
+                .as_ref()
+                .map(|activation| activation.descriptor.catalog_revision),
+            skill_revisions: activation
+                .as_ref()
+                .map(|activation| activation.descriptor.skill_revisions.clone())
+                .unwrap_or_default(),
+        })
     } else {
         tracing::info!("[{}] No skill manager configured", session_id);
-        SkillContextLoadResult::default()
+        Ok(SkillContextLoadResult::default())
     }
 }
 
@@ -126,25 +257,22 @@ pub(super) async fn activate_explicit_skill(
     session: &mut Session,
     session_id: &str,
     selection: &SkillContextLoadResult,
-) -> Option<String> {
+) -> Result<Option<String>, String> {
     if selection.selection_source.as_deref() != Some("explicit")
         || selection.selected_skill_ids.len() != 1
     {
-        return None;
+        return Ok(None);
     }
 
-    let skill_id = selection.selected_skill_ids.first()?.as_str();
+    let skill_id = selection.selected_skill_ids[0].as_str();
     let available_tool_schemas = tools.list_tools();
     if !available_tool_schemas
         .iter()
         .any(|schema| schema.function.name == "load_skill")
     {
-        tracing::warn!(
-            "[{}] Explicit skill '{}' could not be preloaded because load_skill is unavailable",
-            session_id,
-            skill_id
-        );
-        return None;
+        return Err(format!(
+            "Explicit workflow '{skill_id}' cannot start because load_skill is unavailable"
+        ));
     }
 
     let call_id = format!("runtime-explicit-skill-{session_id}");
@@ -172,22 +300,15 @@ pub(super) async fn activate_explicit_skill(
     let result = match tools.execute_with_context(&call, context).await {
         Ok(result) if result.success => result,
         Ok(result) => {
-            tracing::warn!(
-                "[{}] Explicit skill '{}' preload returned an unsuccessful result: {}",
-                session_id,
-                skill_id,
+            return Err(format!(
+                "Explicit workflow '{skill_id}' preload was unsuccessful: {}",
                 result.result
-            );
-            return None;
+            ));
         }
         Err(error) => {
-            tracing::warn!(
-                "[{}] Explicit skill '{}' preload failed: {}",
-                session_id,
-                skill_id,
-                error
-            );
-            return None;
+            return Err(format!(
+                "Explicit workflow '{skill_id}' preload failed: {error}"
+            ));
         }
     };
 
@@ -210,9 +331,9 @@ pub(super) async fn activate_explicit_skill(
         .to_string(),
     );
 
-    Some(format!(
+    Ok(Some(format!(
         "\n\n## Explicit Workflow Activated\n\
 The user explicitly selected the `{skill_id}` workflow. Bamboo loaded its detailed instructions before model execution. Follow the payload below as the active workflow; do not call `load_skill` again for this activation.\n\n{payload}\n",
         payload = result.result
-    ))
+    )))
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
@@ -7,7 +7,10 @@ use bamboo_agent_core::agent::types::{TaskItem, TaskItemStatus, TaskList};
 use bamboo_agent_core::tools::{FunctionSchema, ToolCall, ToolExecutor, ToolResult, ToolSchema};
 use bamboo_agent_core::{Message, Session};
 use bamboo_domain::RuntimeSessionPersistence;
-use bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY;
+use bamboo_skills::runtime_metadata::{
+    SKILL_RUNTIME_ACTIVATION_GENERATION_KEY, SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY,
+    SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY,
+};
 use bamboo_skills::{SkillManager, SkillStoreConfig};
 use chrono::Utc;
 use std::sync::{Arc, Mutex};
@@ -127,8 +130,10 @@ async fn session_setup_publishes_current_skill_allowlist_before_tool_execution()
         None,
         "selection-publish",
         &crate::runtime::runner::logging::DebugLogger::new(false),
+        false,
     )
-    .await;
+    .await
+    .expect("session setup");
 
     let current_ids = session
         .metadata
@@ -175,8 +180,10 @@ async fn session_setup_preloads_one_explicit_skill_before_model_execution() {
         None,
         "explicit-review",
         &crate::runtime::runner::logging::DebugLogger::new(false),
+        false,
     )
-    .await;
+    .await
+    .expect("session setup");
 
     let calls = tools.calls.lock().expect("recording tool lock");
     assert_eq!(calls.len(), 1);
@@ -213,6 +220,72 @@ async fn session_setup_preloads_one_explicit_skill_before_model_execution() {
             .metadata
             .get("skill_runtime_loaded_skill_ids")
             .is_some_and(|ids| ids == "[\"review\"]")
+    }));
+}
+
+#[tokio::test]
+async fn pin_failure_clears_stale_runtime_selection_and_revision_metadata() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let manager = Arc::new(SkillManager::with_config(SkillStoreConfig {
+        skills_dir: directory.path().join("skills"),
+        ..Default::default()
+    }));
+    manager.initialize().await.expect("initialize skills");
+    let review = vec!["review".to_string()];
+    for index in 0..256 {
+        manager
+            .store()
+            .pin_current_activation(&format!("capacity-{index}"), &review, None)
+            .await
+            .expect("fill active snapshot capacity");
+    }
+    let persistence = Arc::new(RecordingPersistence::default());
+    let config = crate::runtime::config::AgentLoopConfig {
+        skill_manager: Some(manager),
+        selected_skill_ids: Some(review),
+        persistence: Some(persistence.clone()),
+        ..Default::default()
+    };
+    let tools = StaticToolExecutor {
+        schemas: Vec::new(),
+    };
+    let mut session = Session::new("over-capacity", "model");
+    session.metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+        r#"["plan"]"#.to_string(),
+    );
+    session.metadata.insert(
+        SKILL_RUNTIME_ACTIVATION_GENERATION_KEY.to_string(),
+        "999".to_string(),
+    );
+    session.metadata.insert(
+        SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY.to_string(),
+        r#"{"plan":999}"#.to_string(),
+    );
+
+    super::prepare_session_for_loop(
+        &mut session,
+        "review",
+        &config,
+        &tools,
+        None,
+        "over-capacity",
+        &crate::runtime::runner::logging::DebugLogger::new(false),
+        false,
+    )
+    .await
+    .expect_err("capacity failure must reject the run before model execution");
+
+    assert!(session
+        .metadata
+        .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_ERROR_KEY)
+        .is_some_and(|message| message.contains("capacity")));
+    let saved = persistence.sessions.lock().expect("recording lock");
+    assert!(saved.iter().any(|published| {
+        published
+            .metadata
+            .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_ERROR_KEY)
+            .is_some_and(|message| message.contains("capacity"))
     }));
 }
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tests.rs
@@ -328,3 +328,460 @@ async fn agent_loop_uses_refreshed_fast_model_for_between_round_task_evaluation(
         "between-round evaluations must use refreshed fast models in order, got {fast_models:?}"
     );
 }
+
+#[tokio::test]
+async fn cancelled_pipeline_releases_activation_without_false_completion() {
+    struct NeverCalledProvider;
+
+    #[async_trait]
+    impl LLMProvider for NeverCalledProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[bamboo_agent_core::tools::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> bamboo_llm::provider::Result<LLMStream> {
+            panic!("pre-cancelled pipeline must not call the provider")
+        }
+    }
+
+    let directory = tempfile::tempdir().expect("tempdir");
+    let skill_root = directory.path().join("skills/cancel-demo");
+    tokio::fs::create_dir_all(&skill_root)
+        .await
+        .expect("skill root");
+    tokio::fs::write(
+        skill_root.join("SKILL.md"),
+        "---\nname: cancel-demo\ndescription: cancel\n---\ncancel\n",
+    )
+    .await
+    .expect("skill");
+    let manager = Arc::new(bamboo_skills::SkillManager::with_config(
+        bamboo_skills::SkillStoreConfig {
+            skills_dir: directory.path().join("skills"),
+            ..Default::default()
+        },
+    ));
+    manager.initialize().await.expect("initialize");
+    manager
+        .store()
+        .pin_current_activation("cancelled-activation", &["cancel-demo".to_string()], None)
+        .await
+        .expect("pin activation");
+    let mut session = Session::new("cancelled-activation", "model");
+    session.metadata.insert(
+        bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTION_SOURCE_KEY.to_string(),
+        "auto".to_string(),
+    );
+    let config = AgentLoopConfig {
+        skill_manager: Some(manager.clone()),
+        model_name: Some("model".to_string()),
+        ..Default::default()
+    };
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+    let (event_tx, mut event_rx) = mpsc::channel(16);
+    let result = super::run_agent_loop_with_config(
+        &mut session,
+        "cancel".to_string(),
+        event_tx,
+        Arc::new(NeverCalledProvider),
+        Arc::new(bamboo_tools::BuiltinToolExecutor::new()),
+        cancel,
+        config,
+    )
+    .await;
+
+    assert!(matches!(
+        result,
+        Err(bamboo_agent_core::AgentError::Cancelled)
+    ));
+    assert!(manager
+        .store()
+        .activation_descriptor("cancelled-activation")
+        .await
+        .is_none());
+    assert!(!session.agent_runtime_state.as_ref().is_some_and(|state| {
+        matches!(state.status, bamboo_domain::AgentStatusState::Completed)
+    }));
+    while let Ok(event) = event_rx.try_recv() {
+        assert!(
+            !matches!(event, bamboo_agent_core::AgentEvent::Complete { .. }),
+            "cancelled pipeline must not emit Complete"
+        );
+    }
+}
+
+#[tokio::test]
+async fn suspended_restart_without_retained_snapshot_fails_before_provider_call() {
+    struct NeverCalledProvider;
+
+    #[async_trait]
+    impl LLMProvider for NeverCalledProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[bamboo_agent_core::tools::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> bamboo_llm::provider::Result<LLMStream> {
+            panic!("missing suspended snapshot must fail before the provider is called")
+        }
+    }
+
+    let directory = tempfile::tempdir().expect("tempdir");
+    let skill_root = directory.path().join("skills/restart-demo");
+    tokio::fs::create_dir_all(&skill_root)
+        .await
+        .expect("skill root");
+    tokio::fs::write(
+        skill_root.join("SKILL.md"),
+        "---\nname: restart-demo\ndescription: restart\n---\nrestart N+1\n",
+    )
+    .await
+    .expect("skill");
+    let manager = Arc::new(bamboo_skills::SkillManager::with_config(
+        bamboo_skills::SkillStoreConfig {
+            skills_dir: directory.path().join("skills"),
+            ..Default::default()
+        },
+    ));
+    manager.initialize().await.expect("initialize");
+
+    let mut session = Session::new("restart-missing-pin", "model");
+    let mut suspended = bamboo_domain::AgentRuntimeState::new("restart-missing-pin");
+    suspended.status = bamboo_domain::AgentStatusState::Suspended;
+    session.agent_runtime_state = Some(suspended);
+    session.metadata.insert(
+        bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_GENERATION_KEY.to_string(),
+        "7".to_string(),
+    );
+    session.metadata.insert(
+        bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY.to_string(),
+        r#"{"restart-demo":3}"#.to_string(),
+    );
+    let config = AgentLoopConfig {
+        skill_manager: Some(manager.clone()),
+        selected_skill_ids: Some(vec!["restart-demo".to_string()]),
+        model_name: Some("model".to_string()),
+        ..Default::default()
+    };
+    let (event_tx, _event_rx) = mpsc::channel(4);
+    let result = super::run_agent_loop_with_config(
+        &mut session,
+        "continue".to_string(),
+        event_tx,
+        Arc::new(NeverCalledProvider),
+        Arc::new(bamboo_tools::BuiltinToolExecutor::new()),
+        CancellationToken::new(),
+        config,
+    )
+    .await;
+
+    let bamboo_agent_core::AgentError::Tool(message) = result.expect_err("restart must fail")
+    else {
+        panic!("expected workflow setup error")
+    };
+    assert!(message.contains("before model execution"));
+    assert!(message.contains("retry as a new activation"));
+    assert!(session
+        .metadata
+        .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_ERROR_KEY)
+        .is_some_and(|message| message.contains("Suspended workflow snapshot is unavailable")));
+    assert!(manager
+        .store()
+        .activation_descriptor("restart-missing-pin")
+        .await
+        .is_none());
+}
+
+#[tokio::test]
+async fn suspended_restart_with_empty_selection_does_not_require_snapshot() {
+    struct CalledProvider(std::sync::atomic::AtomicBool);
+
+    #[async_trait]
+    impl LLMProvider for CalledProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[bamboo_agent_core::tools::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> bamboo_llm::provider::Result<LLMStream> {
+            self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(Box::pin(stream::iter(vec![
+                Ok(LLMChunk::Token("continued".to_string())),
+                Ok(LLMChunk::Done),
+            ])))
+        }
+    }
+
+    let directory = tempfile::tempdir().expect("tempdir");
+    let manager = Arc::new(bamboo_skills::SkillManager::with_config(
+        bamboo_skills::SkillStoreConfig {
+            skills_dir: directory.path().join("skills"),
+            ..Default::default()
+        },
+    ));
+    manager.initialize().await.expect("initialize");
+    let mut session = Session::new("restart-empty-selection", "model");
+    let mut suspended = bamboo_domain::AgentRuntimeState::new("restart-empty-selection");
+    suspended.status = bamboo_domain::AgentStatusState::Suspended;
+    session.agent_runtime_state = Some(suspended);
+    session.metadata.insert(
+        bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_GENERATION_KEY.to_string(),
+        "7".to_string(),
+    );
+    session.metadata.insert(
+        bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY.to_string(),
+        "{}".to_string(),
+    );
+    let provider = Arc::new(CalledProvider(std::sync::atomic::AtomicBool::new(false)));
+    let (event_tx, _event_rx) = mpsc::channel(8);
+    super::run_agent_loop_with_config(
+        &mut session,
+        "continue".to_string(),
+        event_tx,
+        provider.clone(),
+        Arc::new(bamboo_tools::BuiltinToolExecutor::new()),
+        CancellationToken::new(),
+        AgentLoopConfig {
+            skill_manager: Some(manager),
+            selected_skill_ids: Some(Vec::new()),
+            model_name: Some("model".to_string()),
+            max_rounds: 1,
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("empty selection continuation");
+    assert!(provider.0.load(std::sync::atomic::Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn activation_metadata_persistence_failure_releases_pin_before_provider_call() {
+    struct FailingPersistence;
+    #[async_trait]
+    impl bamboo_domain::RuntimeSessionPersistence for FailingPersistence {
+        async fn save_runtime_session(&self, _session: &mut Session) -> std::io::Result<()> {
+            Err(std::io::Error::other("injected persistence failure"))
+        }
+    }
+    struct NeverCalledProvider;
+    #[async_trait]
+    impl LLMProvider for NeverCalledProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[bamboo_agent_core::tools::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> bamboo_llm::provider::Result<LLMStream> {
+            panic!("persistence failure must stop before provider execution")
+        }
+    }
+
+    let directory = tempfile::tempdir().expect("tempdir");
+    let manager = Arc::new(bamboo_skills::SkillManager::with_config(
+        bamboo_skills::SkillStoreConfig {
+            skills_dir: directory.path().join("skills"),
+            ..Default::default()
+        },
+    ));
+    manager.initialize().await.expect("initialize");
+    let mut session = Session::new("persistence-failure", "model");
+    let (event_tx, _event_rx) = mpsc::channel(4);
+    let result = super::run_agent_loop_with_config(
+        &mut session,
+        "review".to_string(),
+        event_tx,
+        Arc::new(NeverCalledProvider),
+        Arc::new(bamboo_tools::BuiltinToolExecutor::new()),
+        CancellationToken::new(),
+        AgentLoopConfig {
+            skill_manager: Some(manager.clone()),
+            selected_skill_ids: Some(vec!["review".to_string()]),
+            persistence: Some(Arc::new(FailingPersistence)),
+            model_name: Some("model".to_string()),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(result
+        .expect_err("setup must fail closed")
+        .to_string()
+        .contains("could not be published before tool/model execution"));
+    assert!(manager
+        .store()
+        .activation_descriptor("persistence-failure")
+        .await
+        .is_none());
+}
+
+#[tokio::test]
+async fn post_preload_persistence_failure_stops_before_provider_and_releases_pin() {
+    struct FailSecondSave(std::sync::atomic::AtomicUsize);
+    #[async_trait]
+    impl bamboo_domain::RuntimeSessionPersistence for FailSecondSave {
+        async fn save_runtime_session(&self, _session: &mut Session) -> std::io::Result<()> {
+            let call = self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if call == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::other("second save failed"))
+            }
+        }
+    }
+    struct SuccessfulLoad;
+    #[async_trait]
+    impl bamboo_agent_core::tools::ToolExecutor for SuccessfulLoad {
+        async fn execute(
+            &self,
+            _call: &bamboo_agent_core::tools::ToolCall,
+        ) -> bamboo_agent_core::tools::executor::Result<ToolResult> {
+            Ok(ToolResult {
+                success: true,
+                result: "pinned instructions".to_string(),
+                display_preference: None,
+                images: Vec::new(),
+            })
+        }
+        fn list_tools(&self) -> Vec<bamboo_agent_core::tools::ToolSchema> {
+            vec![bamboo_agent_core::tools::ToolSchema {
+                schema_type: "function".to_string(),
+                function: bamboo_agent_core::tools::FunctionSchema {
+                    name: "load_skill".to_string(),
+                    description: "load".to_string(),
+                    parameters: serde_json::json!({"type":"object"}),
+                },
+            }]
+        }
+    }
+    struct NeverCalled;
+    #[async_trait]
+    impl LLMProvider for NeverCalled {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[bamboo_agent_core::tools::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> bamboo_llm::provider::Result<LLMStream> {
+            panic!("second persistence failure must stop before provider")
+        }
+    }
+    let directory = tempfile::tempdir().expect("tempdir");
+    let manager = Arc::new(bamboo_skills::SkillManager::with_config(
+        bamboo_skills::SkillStoreConfig {
+            skills_dir: directory.path().join("skills"),
+            ..Default::default()
+        },
+    ));
+    manager.initialize().await.expect("initialize");
+    let mut session = Session::new("post-preload-save-failure", "model");
+    let (event_tx, _event_rx) = mpsc::channel(4);
+    let result = super::run_agent_loop_with_config(
+        &mut session,
+        "review".to_string(),
+        event_tx,
+        Arc::new(NeverCalled),
+        Arc::new(SuccessfulLoad),
+        CancellationToken::new(),
+        AgentLoopConfig {
+            skill_manager: Some(manager.clone()),
+            selected_skill_ids: Some(vec!["review".to_string()]),
+            persistence: Some(Arc::new(FailSecondSave(
+                std::sync::atomic::AtomicUsize::new(0),
+            ))),
+            model_name: Some("model".to_string()),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(result
+        .expect_err("post preload save must fail")
+        .to_string()
+        .contains("loaded-state could not be published"));
+    assert!(manager
+        .store()
+        .activation_descriptor("post-preload-save-failure")
+        .await
+        .is_none());
+}
+
+#[tokio::test]
+async fn unsuccessful_explicit_preload_stops_before_provider_and_releases_pin() {
+    struct UnsuccessfulLoad;
+    #[async_trait]
+    impl bamboo_agent_core::tools::ToolExecutor for UnsuccessfulLoad {
+        async fn execute(
+            &self,
+            _call: &bamboo_agent_core::tools::ToolCall,
+        ) -> bamboo_agent_core::tools::executor::Result<ToolResult> {
+            Ok(ToolResult {
+                success: false,
+                result: "injected preload failure".to_string(),
+                display_preference: None,
+                images: Vec::new(),
+            })
+        }
+        fn list_tools(&self) -> Vec<bamboo_agent_core::tools::ToolSchema> {
+            vec![bamboo_agent_core::tools::ToolSchema {
+                schema_type: "function".to_string(),
+                function: bamboo_agent_core::tools::FunctionSchema {
+                    name: "load_skill".to_string(),
+                    description: "load".to_string(),
+                    parameters: serde_json::json!({"type":"object"}),
+                },
+            }]
+        }
+    }
+    struct NeverCalled;
+    #[async_trait]
+    impl LLMProvider for NeverCalled {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[bamboo_agent_core::tools::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> bamboo_llm::provider::Result<LLMStream> {
+            panic!("unsuccessful explicit preload must stop before provider")
+        }
+    }
+    let directory = tempfile::tempdir().expect("tempdir");
+    let manager = Arc::new(bamboo_skills::SkillManager::with_config(
+        bamboo_skills::SkillStoreConfig {
+            skills_dir: directory.path().join("skills"),
+            ..Default::default()
+        },
+    ));
+    manager.initialize().await.expect("initialize");
+    let mut session = Session::new("unsuccessful-preload", "model");
+    let (event_tx, _event_rx) = mpsc::channel(4);
+    let result = super::run_agent_loop_with_config(
+        &mut session,
+        "review".to_string(),
+        event_tx,
+        Arc::new(NeverCalled),
+        Arc::new(UnsuccessfulLoad),
+        CancellationToken::new(),
+        AgentLoopConfig {
+            skill_manager: Some(manager.clone()),
+            selected_skill_ids: Some(vec!["review".to_string()]),
+            model_name: Some("model".to_string()),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(result
+        .expect_err("preload must fail closed")
+        .to_string()
+        .contains("preload was unsuccessful"));
+    assert!(manager
+        .store()
+        .activation_descriptor("unsuccessful-preload")
+        .await
+        .is_none());
+}

--- a/crates/infra/bamboo-skills/Cargo.toml
+++ b/crates/infra/bamboo-skills/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = "2"
 async-trait = "0.1"
 walkdir = "2"
 notify = "8"
+libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }

--- a/crates/infra/bamboo-skills/src/access_control.rs
+++ b/crates/infra/bamboo-skills/src/access_control.rs
@@ -6,6 +6,7 @@ use crate::runtime_metadata::{
     LAST_LOADED_SKILL_ID_METADATA_KEY, LAST_LOADED_SKILL_SUMMARY_METADATA_KEY,
     LOADED_SKILL_IDS_METADATA_KEY, SELECTED_SKILL_IDS_METADATA_KEY,
     SELECTED_SKILL_MODE_METADATA_KEY, SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY,
+    SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY,
 };
 use crate::selection::parse_selected_skill_ids_metadata;
 pub use crate::session_port::SkillSessionPort;
@@ -72,7 +73,8 @@ pub fn extract_skill_allowlist(metadata: &HashMap<String, String>) -> Option<Has
 
 pub fn extract_skill_mode(metadata: &HashMap<String, String>) -> Option<String> {
     let mode = metadata
-        .get(SELECTED_SKILL_MODE_METADATA_KEY)
+        .get(SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY)
+        .or_else(|| metadata.get(SELECTED_SKILL_MODE_METADATA_KEY))
         .or_else(|| metadata.get("mode"))?;
     let trimmed = mode.trim();
     if trimmed.is_empty() {
@@ -98,12 +100,7 @@ pub async fn ensure_skill_allowed(
     skill_id: &str,
     session_id: Option<&str>,
 ) -> Result<(), SkillAccessError> {
-    let disabled = port.disabled_skill_ids().await;
-    if disabled.contains(skill_id) {
-        return Err(SkillAccessError::NotAllowed(format!(
-            "Skill '{skill_id}' is globally disabled in Bamboo settings"
-        )));
-    }
+    ensure_skill_enabled(port, skill_id).await?;
 
     let Some(session_id) = session_id else {
         return Ok(());
@@ -128,6 +125,19 @@ pub async fn ensure_skill_allowed(
     Err(SkillAccessError::NotAllowed(format!(
         "Skill '{skill_id}' is not selected for this request"
     )))
+}
+
+pub async fn ensure_skill_enabled(
+    port: &dyn SkillSessionPort,
+    skill_id: &str,
+) -> Result<(), SkillAccessError> {
+    let disabled = port.disabled_skill_ids().await;
+    if disabled.contains(skill_id) {
+        return Err(SkillAccessError::NotAllowed(format!(
+            "Skill '{skill_id}' is globally disabled in Bamboo settings"
+        )));
+    }
+    Ok(())
 }
 
 pub async fn ensure_skill_loaded(
@@ -303,5 +313,21 @@ mod tests {
         metadata.insert("skill_mode".to_string(), "code".to_string());
 
         assert_eq!(extract_skill_mode(&metadata).as_deref(), Some("code"));
+    }
+
+    #[test]
+    fn extract_skill_mode_prefers_runtime_mode_over_requested_mode() {
+        let mut metadata = HashMap::new();
+        metadata.insert("mode".to_string(), "ask".to_string());
+        metadata.insert(
+            SELECTED_SKILL_MODE_METADATA_KEY.to_string(),
+            "code".to_string(),
+        );
+        metadata.insert(
+            SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY.to_string(),
+            "review".to_string(),
+        );
+
+        assert_eq!(extract_skill_mode(&metadata).as_deref(), Some("review"));
     }
 }

--- a/crates/infra/bamboo-skills/src/lib.rs
+++ b/crates/infra/bamboo-skills/src/lib.rs
@@ -16,7 +16,7 @@ pub use catalog::{
     WorkflowCatalogEventKind, WorkflowCatalogSnapshot, WorkflowKind, WorkflowSource,
     WorkflowStatus,
 };
-pub use store::{SkillStore, SkillUpdate};
+pub use store::{SkillActivationDescriptor, SkillStore, SkillUpdate};
 pub use types::*;
 
 use std::collections::{BTreeSet, HashSet};
@@ -165,6 +165,13 @@ fn invocation_allowed_skill_ids<'a>(
 #[derive(Clone)]
 pub struct SkillManager {
     store: Arc<SkillStore>,
+    activation_scope_coordinator: Arc<tokio::sync::Mutex<()>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillActivationSelection {
+    pub skills: Vec<SkillDefinition>,
+    pub descriptor: SkillActivationDescriptor,
 }
 
 impl SkillManager {
@@ -172,6 +179,7 @@ impl SkillManager {
     pub fn new() -> Self {
         Self {
             store: Arc::new(SkillStore::default()),
+            activation_scope_coordinator: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -179,6 +187,7 @@ impl SkillManager {
     pub fn with_config(config: SkillStoreConfig) -> Self {
         Self {
             store: Arc::new(SkillStore::new(config)),
+            activation_scope_coordinator: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -207,26 +216,15 @@ impl SkillManager {
         }
     }
 
-    async fn list_skills_for_selection_from_store(
-        store: &SkillStore,
+    fn filter_skills_for_selection(
+        skills: Vec<SkillDefinition>,
+        catalog: &WorkflowCatalogSnapshot,
         disabled_skill_ids: &BTreeSet<String>,
         selected_skill_ids: Option<&[String]>,
-        selected_skill_mode: Option<&str>,
     ) -> Vec<SkillDefinition> {
-        let (skills, catalog) = match store.skills_and_catalog_for_mode(selected_skill_mode).await {
-            Ok(snapshot) => snapshot,
-            Err(error) => {
-                tracing::warn!(
-                    "Failed to resolve skills and workflow policy for mode {:?}: {}",
-                    selected_skill_mode,
-                    error
-                );
-                return Vec::new();
-            }
-        };
         let skills = filter_disabled_skills(skills, disabled_skill_ids);
         let Some(selected_skill_ids) = selected_skill_ids else {
-            let automatic_ids = invocation_allowed_skill_ids(&catalog, "automatic");
+            let automatic_ids = invocation_allowed_skill_ids(catalog, "automatic");
             return skills
                 .into_iter()
                 .filter(|skill| automatic_ids.contains(skill.id.as_str()))
@@ -239,14 +237,14 @@ impl SkillManager {
             .filter(|id| !id.is_empty())
             .collect();
         if selected_set.is_empty() {
-            let automatic_ids = invocation_allowed_skill_ids(&catalog, "automatic");
+            let automatic_ids = invocation_allowed_skill_ids(catalog, "automatic");
             return skills
                 .into_iter()
                 .filter(|skill| automatic_ids.contains(skill.id.as_str()))
                 .collect();
         }
 
-        let explicit_ids = invocation_allowed_skill_ids(&catalog, "explicit");
+        let explicit_ids = invocation_allowed_skill_ids(catalog, "explicit");
         let denied: Vec<&str> = selected_set
             .iter()
             .copied()
@@ -280,6 +278,65 @@ impl SkillManager {
         }
 
         filtered
+    }
+
+    async fn list_skills_for_selection_from_store(
+        store: &SkillStore,
+        disabled_skill_ids: &BTreeSet<String>,
+        selected_skill_ids: Option<&[String]>,
+        selected_skill_mode: Option<&str>,
+    ) -> Vec<SkillDefinition> {
+        let (skills, catalog) = match store.skills_and_catalog_for_mode(selected_skill_mode).await {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                tracing::warn!(
+                    "Failed to resolve skills and workflow policy for mode {:?}: {}",
+                    selected_skill_mode,
+                    error
+                );
+                return Vec::new();
+            }
+        };
+        Self::filter_skills_for_selection(skills, &catalog, disabled_skill_ids, selected_skill_ids)
+    }
+
+    async fn resolve_and_pin_activation_from_store(
+        store: &SkillStore,
+        activation_id: &str,
+        disabled_skill_ids: &BTreeSet<String>,
+        selected_skill_ids: Option<&[String]>,
+        selected_skill_mode: Option<&str>,
+        request_hint: Option<&str>,
+    ) -> SkillResult<SkillActivationSelection> {
+        // All four values are cloned under the store's publication read lock.
+        // A watcher may publish after this await, but this activation only consumes
+        // these correlated generation-N clones and can never mix them with N+1.
+        let (skills, roots, resources, catalog) = store
+            .activation_source_for_mode(selected_skill_mode)
+            .await?;
+        let mut selected = Self::filter_skills_for_selection(
+            skills,
+            &catalog,
+            disabled_skill_ids,
+            selected_skill_ids,
+        );
+        if selected_skill_ids.is_none() {
+            selected = shortlist_skills_for_context(selected, request_hint);
+        }
+        let descriptor = store
+            .pin_activation_from_source(
+                activation_id,
+                selected_skill_mode,
+                &selected,
+                &roots,
+                &resources,
+                &catalog,
+            )
+            .await?;
+        Ok(SkillActivationSelection {
+            skills: selected,
+            descriptor,
+        })
     }
 
     pub(crate) async fn list_skills_for_selection(
@@ -357,6 +414,30 @@ impl SkillManager {
         skills
     }
 
+    /// Resolve policy-aware prompt candidates and pin their exact published
+    /// definition/resource generation for one runtime activation.
+    pub async fn resolve_and_pin_activation_for_request_with_mode(
+        &self,
+        activation_id: &str,
+        disabled_skill_ids: &BTreeSet<String>,
+        selected_skill_ids: Option<&[String]>,
+        selected_skill_mode: Option<&str>,
+        request_hint: Option<&str>,
+    ) -> SkillResult<SkillActivationSelection> {
+        let _scope_guard = self.activation_scope_coordinator.lock().await;
+        self.prepare_activation_scope(activation_id, &self.store)
+            .await;
+        Self::resolve_and_pin_activation_from_store(
+            self.store.as_ref(),
+            activation_id,
+            disabled_skill_ids,
+            selected_skill_ids,
+            selected_skill_mode,
+            request_hint,
+        )
+        .await
+    }
+
     /// Resolve prompt-visible skills against the same isolated store used by a
     /// session's workspace catalog.
     pub async fn resolve_skills_for_request_in_workspace_with_mode(
@@ -380,6 +461,102 @@ impl SkillManager {
             skills = shortlist_skills_for_context(skills, request_hint);
         }
         Ok(skills)
+    }
+
+    pub async fn resolve_and_pin_activation_in_workspace_with_mode(
+        &self,
+        workspace: &Path,
+        activation_id: &str,
+        disabled_skill_ids: &BTreeSet<String>,
+        selected_skill_ids: Option<&[String]>,
+        selected_skill_mode: Option<&str>,
+        request_hint: Option<&str>,
+    ) -> SkillResult<SkillActivationSelection> {
+        let store = self.store.skill_store_for_workspace(workspace).await?;
+        let _scope_guard = self.activation_scope_coordinator.lock().await;
+        self.prepare_activation_scope(activation_id, &store).await;
+        Self::resolve_and_pin_activation_from_store(
+            store.as_ref(),
+            activation_id,
+            disabled_skill_ids,
+            selected_skill_ids,
+            selected_skill_mode,
+            request_hint,
+        )
+        .await
+    }
+
+    async fn prepare_activation_scope(&self, activation_id: &str, target: &Arc<SkillStore>) {
+        let mut has_non_target_owner = self
+            .store
+            .activation_descriptor(activation_id)
+            .await
+            .is_some()
+            && !Arc::ptr_eq(&self.store, target);
+        for store in self.store.cached_workspace_stores().await {
+            if store.activation_descriptor(activation_id).await.is_some()
+                && !Arc::ptr_eq(&store, target)
+            {
+                has_non_target_owner = true;
+                break;
+            }
+        }
+        if has_non_target_owner {
+            self.store
+                .release_activation_across_cached_scopes(activation_id)
+                .await;
+        }
+    }
+
+    pub async fn pin_current_activation_for_workspace(
+        &self,
+        activation_id: &str,
+        workspace: Option<&Path>,
+        selected_skill_ids: &[String],
+        selected_skill_mode: Option<&str>,
+    ) -> SkillResult<SkillActivationDescriptor> {
+        let store = self.store_for_workspace(workspace).await?;
+        let _scope_guard = self.activation_scope_coordinator.lock().await;
+        self.prepare_activation_scope(activation_id, &store).await;
+        store
+            .pin_current_activation(activation_id, selected_skill_ids, selected_skill_mode)
+            .await
+    }
+
+    pub async fn pinned_allowed_tools_for_workspace(
+        &self,
+        activation_id: &str,
+        workspace: Option<&Path>,
+        disabled_skill_ids: &BTreeSet<String>,
+    ) -> SkillResult<Option<Vec<String>>> {
+        let store = self.store_for_workspace(workspace).await?;
+        Ok(store
+            .pinned_allowed_tools(activation_id, disabled_skill_ids)
+            .await)
+    }
+
+    pub async fn pinned_activation_for_workspace(
+        &self,
+        activation_id: &str,
+        workspace: Option<&Path>,
+    ) -> SkillResult<Option<SkillActivationSelection>> {
+        let store = self.store_for_workspace(workspace).await?;
+        Ok(store
+            .pinned_activation_skills(activation_id)
+            .await
+            .map(|(skills, descriptor)| SkillActivationSelection { skills, descriptor }))
+    }
+
+    pub async fn release_activation_for_workspace(
+        &self,
+        activation_id: &str,
+        _workspace: Option<&Path>,
+    ) -> SkillResult<()> {
+        let _scope_guard = self.activation_scope_coordinator.lock().await;
+        self.store
+            .release_activation_across_cached_scopes(activation_id)
+            .await;
+        Ok(())
     }
 
     /// Build system prompt context from a selected subset of skills with mode and user request hint.
@@ -692,5 +869,92 @@ mod tests {
             .find(|entry| entry.id == "steady")
             .expect("recovered catalog entry");
         assert_eq!(recovered.status, WorkflowStatus::Valid);
+    }
+
+    #[tokio::test]
+    async fn activation_scope_moves_atomically_between_workspaces_without_stale_revival() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let workspace_a = directory.path().join("a");
+        let workspace_b = directory.path().join("b");
+        for (workspace, prompt) in [(&workspace_a, "prompt A"), (&workspace_b, "prompt B")] {
+            let skill = workspace.join(".bamboo/skills/scope-demo");
+            fs::create_dir_all(&skill).await.expect("skill root");
+            fs::write(
+                skill.join("SKILL.md"),
+                format!("---\nname: scope-demo\ndescription: scope\n---\n{prompt}\n"),
+            )
+            .await
+            .expect("skill");
+        }
+        let manager = std::sync::Arc::new(SkillManager::with_config(SkillStoreConfig {
+            skills_dir: directory.path().join("data/skills"),
+            ..Default::default()
+        }));
+        manager.initialize().await.expect("initialize");
+        let ids = vec!["scope-demo".to_string()];
+        for (workspace, expected) in [
+            (&workspace_a, "prompt A"),
+            (&workspace_b, "prompt B"),
+            (&workspace_a, "prompt A"),
+        ] {
+            let selection = manager
+                .resolve_and_pin_activation_in_workspace_with_mode(
+                    workspace,
+                    "moving-session",
+                    &BTreeSet::new(),
+                    Some(&ids),
+                    None,
+                    None,
+                )
+                .await
+                .expect("move activation");
+            assert_eq!(selection.skills[0].prompt, expected);
+            let mut owners = 0;
+            for store in manager.store.cached_workspace_stores().await {
+                owners += usize::from(
+                    store
+                        .activation_descriptor("moving-session")
+                        .await
+                        .is_some(),
+                );
+            }
+            assert_eq!(owners, 1);
+        }
+
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(3));
+        let mut tasks = Vec::new();
+        for workspace in [workspace_a.clone(), workspace_b.clone()] {
+            let manager = manager.clone();
+            let ids = ids.clone();
+            let barrier = barrier.clone();
+            tasks.push(tokio::spawn(async move {
+                barrier.wait().await;
+                manager
+                    .resolve_and_pin_activation_in_workspace_with_mode(
+                        &workspace,
+                        "concurrent-session",
+                        &BTreeSet::new(),
+                        Some(&ids),
+                        None,
+                        None,
+                    )
+                    .await
+                    .expect("concurrent pin");
+            }));
+        }
+        barrier.wait().await;
+        for task in tasks {
+            task.await.expect("pin task");
+        }
+        let mut owners = 0;
+        for store in manager.store.cached_workspace_stores().await {
+            owners += usize::from(
+                store
+                    .activation_descriptor("concurrent-session")
+                    .await
+                    .is_some(),
+            );
+        }
+        assert_eq!(owners, 1, "coordinator must prevent duplicate scope owners");
     }
 }

--- a/crates/infra/bamboo-skills/src/resource_helpers.rs
+++ b/crates/infra/bamboo-skills/src/resource_helpers.rs
@@ -92,6 +92,14 @@ pub fn display_relative_path(path: &Path) -> String {
 /// Skips `SKILL.md` (the skill definition) and non-file entries.
 /// Returns sorted, deduplicated relative paths.
 pub fn list_skill_resource_paths(skill_root: &Path) -> std::io::Result<Vec<String>> {
+    list_skill_resource_paths_bounded(skill_root, usize::MAX, usize::MAX)
+}
+
+pub fn list_skill_resource_paths_bounded(
+    skill_root: &Path,
+    max_resources: usize,
+    max_relative_path_bytes: usize,
+) -> std::io::Result<Vec<String>> {
     if !skill_root.exists() {
         return Ok(Vec::new());
     }
@@ -113,7 +121,20 @@ pub fn list_skill_resource_paths(skill_root: &Path) -> std::io::Result<Vec<Strin
             continue;
         }
 
-        resources.push(display_relative_path(relative));
+        let displayed = display_relative_path(relative);
+        if displayed.len() > max_relative_path_bytes {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "workflow resource relative path exceeds limit",
+            ));
+        }
+        if resources.len() >= max_resources {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "workflow resource count exceeds limit",
+            ));
+        }
+        resources.push(displayed);
     }
 
     resources.sort();
@@ -161,5 +182,14 @@ mod tests {
         assert_eq!(start, 1);
         assert_eq!(end, 2);
         assert_eq!(total, 3);
+    }
+
+    #[test]
+    fn bounded_resource_listing_rejects_count_and_path_limits_while_streaming() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        std::fs::write(directory.path().join("one.txt"), "one").expect("one");
+        std::fs::write(directory.path().join("two.txt"), "two").expect("two");
+        assert!(list_skill_resource_paths_bounded(directory.path(), 1, 1024).is_err());
+        assert!(list_skill_resource_paths_bounded(directory.path(), 2, 3).is_err());
     }
 }

--- a/crates/infra/bamboo-skills/src/runtime_metadata.rs
+++ b/crates/infra/bamboo-skills/src/runtime_metadata.rs
@@ -1,8 +1,16 @@
+use std::collections::{BTreeMap, HashMap};
+
+use crate::store::SkillActivationDescriptor;
+
 pub const SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY: &str = "skill_runtime_selected_skill_ids";
 pub const SKILL_RUNTIME_SELECTION_SOURCE_KEY: &str = "skill_runtime_selection_source";
 pub const SKILL_RUNTIME_SELECTION_TRACE_KEY: &str = "skill_runtime_selection_trace";
 pub const SKILL_RUNTIME_SELECTION_COUNT_KEY: &str = "skill_runtime_selection_count";
 pub const SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY: &str = "skill_runtime_selected_skill_mode";
+pub const SKILL_RUNTIME_ACTIVATION_GENERATION_KEY: &str = "skill_runtime_activation_generation";
+pub const SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY: &str =
+    "skill_runtime_selected_skill_revisions";
+pub const SKILL_RUNTIME_ACTIVATION_ERROR_KEY: &str = "skill_runtime_activation_error";
 
 pub const SELECTED_SKILL_IDS_METADATA_KEY: &str = "selected_skill_ids";
 pub const SELECTED_SKILL_MODE_METADATA_KEY: &str = "skill_mode";
@@ -12,3 +20,42 @@ pub const LAST_LOADED_SKILL_ID_METADATA_KEY: &str = "skill_runtime_last_loaded_s
 pub const LAST_LOADED_SKILL_SUMMARY_METADATA_KEY: &str = "skill_runtime_last_load_summary";
 pub const LAST_RESOURCE_READ_SUMMARY_METADATA_KEY: &str =
     "skill_runtime_last_resource_read_summary";
+
+/// Validate runner-owned immutable activation metadata against the snapshot
+/// retained in memory. `Ok(false)` is reserved for legacy/direct callers that
+/// have no generation marker and may establish a pin lazily.
+pub fn validate_pinned_activation_metadata(
+    metadata: &HashMap<String, String>,
+    descriptor: Option<&SkillActivationDescriptor>,
+    required_skill_id: Option<&str>,
+) -> Result<bool, String> {
+    let Some(raw_generation) = metadata.get(SKILL_RUNTIME_ACTIVATION_GENERATION_KEY) else {
+        return Ok(false);
+    };
+    let expected_generation = raw_generation.parse::<u64>().map_err(|_| {
+        "Invalid pinned workflow activation generation; retry as a new activation".to_string()
+    })?;
+    let descriptor = descriptor.ok_or_else(|| {
+        "Pinned workflow activation is unavailable; retry as a new activation".to_string()
+    })?;
+    let expected_revisions = metadata
+        .get(SKILL_RUNTIME_SELECTED_SKILL_REVISIONS_KEY)
+        .and_then(|raw| serde_json::from_str::<BTreeMap<String, u64>>(raw).ok())
+        .ok_or_else(|| {
+            "Pinned workflow activation revisions are missing or invalid; retry as a new activation"
+                .to_string()
+        })?;
+    let required_skill_is_pinned = required_skill_id
+        .map(|skill_id| descriptor.skill_revisions.contains_key(skill_id))
+        .unwrap_or(true);
+    if descriptor.catalog_revision != expected_generation
+        || descriptor.skill_revisions != expected_revisions
+        || !required_skill_is_pinned
+    {
+        return Err(
+            "Pinned workflow activation metadata does not match the immutable snapshot; retry as a new activation"
+                .to_string(),
+        );
+    }
+    Ok(true)
+}

--- a/crates/infra/bamboo-skills/src/store/mod.rs
+++ b/crates/infra/bamboo-skills/src/store/mod.rs
@@ -51,10 +51,12 @@ pub mod builtin;
 pub mod parser;
 pub mod storage;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
+use tokio::io::AsyncReadExt;
 use tokio::sync::RwLock;
 use tracing::info;
 
@@ -66,13 +68,312 @@ use crate::catalog::{
 use crate::store::builtin::{archive_exact_legacy_materialization, load_builtin_skill_bundles};
 use crate::store::parser::render_skill_markdown;
 use crate::store::storage::{
-    discover_plugin_skill_dirs, ensure_skills_dir, load_skills_from_discovery_dirs_detailed,
+    discover_plugin_skill_dirs, ensure_skills_dir,
+    load_skills_from_discovery_dirs_detailed_with_limits, open_skill_file_no_follow,
     write_skill_file, FailedSkillRecord, LoadedSkillRecord, SkillDirectorySource,
     SkillDiscoveryDir,
 };
 use crate::types::{
     SkillDefinition, SkillError, SkillFilter, SkillId, SkillResult, SkillStoreConfig,
 };
+
+const MAX_PINNED_SKILL_ACTIVATIONS: usize = 256;
+const MAX_WORKFLOW_FILE_BYTES: usize = 8 * 1024 * 1024;
+const MAX_WORKFLOW_SKILL_BYTES: usize = 32 * 1024 * 1024;
+const MAX_WORKFLOW_PUBLICATION_BYTES: usize = 128 * 1024 * 1024;
+const MAX_RETAINED_WORKFLOW_BYTES: usize = 256 * 1024 * 1024;
+const MAX_WORKFLOW_RESOURCES_PER_SKILL: usize = 1024;
+const MAX_WORKFLOW_RESOURCES_PER_PUBLICATION: usize = 4096;
+const MAX_WORKFLOW_RESOURCE_PATH_BYTES: usize = 1024;
+const MAX_WORKFLOWS_PER_PUBLICATION: usize = 1024;
+const MAX_CACHED_WORKSPACE_STORES: usize = 64;
+const MAX_CACHED_WORKSPACE_ALIASES: usize = 256;
+const MAX_CACHED_MODE_STORES: usize = 16;
+static NEXT_SKILL_STORE_TOKEN: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SkillSnapshotLimits {
+    pub(crate) max_file_bytes: usize,
+    pub(crate) max_skill_bytes: usize,
+    pub(crate) max_publication_bytes: usize,
+    pub(crate) max_retained_bytes: usize,
+}
+
+impl Default for SkillSnapshotLimits {
+    fn default() -> Self {
+        Self {
+            max_file_bytes: MAX_WORKFLOW_FILE_BYTES,
+            max_skill_bytes: MAX_WORKFLOW_SKILL_BYTES,
+            max_publication_bytes: MAX_WORKFLOW_PUBLICATION_BYTES,
+            max_retained_bytes: MAX_RETAINED_WORKFLOW_BYTES,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ActivationBudgetCharge {
+    definition_bytes: usize,
+    resources: Vec<(usize, usize)>,
+}
+
+#[derive(Debug, Default)]
+struct RetainedResourceBudgetState {
+    total_bytes: usize,
+    activations: HashMap<String, ActivationBudgetCharge>,
+    publications: HashMap<u64, ActivationBudgetCharge>,
+    resources: HashMap<usize, (usize, usize)>,
+}
+
+#[derive(Debug, Default)]
+struct RetainedResourceBudget {
+    state: Mutex<RetainedResourceBudgetState>,
+}
+
+impl RetainedResourceBudget {
+    fn replace(
+        &self,
+        activation_id: &str,
+        definition_bytes: usize,
+        resources: Vec<(usize, usize)>,
+        limit: usize,
+    ) -> SkillResult<()> {
+        let mut state = self.state.lock().expect("workflow retained budget lock");
+        if !state.activations.contains_key(activation_id)
+            && state.activations.len() >= MAX_PINNED_SKILL_ACTIVATIONS
+        {
+            return Err(SkillError::Storage(format!(
+                "global active workflow snapshot capacity ({MAX_PINNED_SKILL_ACTIVATIONS}) reached"
+            )));
+        }
+        let old = state.activations.get(activation_id);
+        let old_definition_bytes = old.map(|charge| charge.definition_bytes).unwrap_or(0);
+        let old_resource_ids: HashSet<usize> = old
+            .map(|charge| charge.resources.iter().map(|(id, _)| *id).collect())
+            .unwrap_or_default();
+        let mut projected = state.total_bytes.saturating_sub(old_definition_bytes);
+        for resource_id in &old_resource_ids {
+            if state
+                .resources
+                .get(resource_id)
+                .is_some_and(|(_, references)| *references == 1)
+            {
+                projected = projected.saturating_sub(state.resources[resource_id].0);
+            }
+        }
+        projected = projected.saturating_add(definition_bytes);
+        for (resource_id, bytes) in &resources {
+            let remains_after_replace =
+                state
+                    .resources
+                    .get(resource_id)
+                    .is_some_and(|(_, references)| {
+                        *references > usize::from(old_resource_ids.contains(resource_id))
+                    });
+            if !remains_after_replace {
+                projected = projected.saturating_add(*bytes);
+            }
+        }
+        if projected > limit {
+            return Err(SkillError::Storage(format!(
+                "retained workflow snapshot budget exceeded ({projected} > {limit} bytes)"
+            )));
+        }
+
+        if let Some(old) = state.activations.remove(activation_id) {
+            state.total_bytes = state.total_bytes.saturating_sub(old.definition_bytes);
+            for (resource_id, _) in old.resources {
+                if let Some((bytes, references)) = state.resources.get_mut(&resource_id) {
+                    *references -= 1;
+                    if *references == 0 {
+                        let bytes = *bytes;
+                        state.resources.remove(&resource_id);
+                        state.total_bytes = state.total_bytes.saturating_sub(bytes);
+                    }
+                }
+            }
+        }
+        state.total_bytes = state.total_bytes.saturating_add(definition_bytes);
+        for (resource_id, bytes) in &resources {
+            if !state.resources.contains_key(resource_id) {
+                state.total_bytes = state.total_bytes.saturating_add(*bytes);
+                state.resources.insert(*resource_id, (*bytes, 0));
+            }
+            state
+                .resources
+                .get_mut(resource_id)
+                .expect("retained resource charge")
+                .1 += 1;
+        }
+        state.activations.insert(
+            activation_id.to_string(),
+            ActivationBudgetCharge {
+                definition_bytes,
+                resources,
+            },
+        );
+        Ok(())
+    }
+
+    fn release(&self, activation_id: &str) {
+        let mut state = self.state.lock().expect("workflow retained budget lock");
+        let Some(old) = state.activations.remove(activation_id) else {
+            return;
+        };
+        state.total_bytes = state.total_bytes.saturating_sub(old.definition_bytes);
+        for (resource_id, _) in old.resources {
+            if let Some((bytes, references)) = state.resources.get_mut(&resource_id) {
+                *references -= 1;
+                if *references == 0 {
+                    let bytes = *bytes;
+                    state.resources.remove(&resource_id);
+                    state.total_bytes = state.total_bytes.saturating_sub(bytes);
+                }
+            }
+        }
+    }
+
+    fn replace_publication(
+        &self,
+        store_token: u64,
+        definition_bytes: usize,
+        resources: Vec<(usize, usize)>,
+        limit: usize,
+    ) -> SkillResult<()> {
+        let mut state = self.state.lock().expect("workflow retained budget lock");
+        let old = state.publications.get(&store_token);
+        let old_definition_bytes = old.map(|charge| charge.definition_bytes).unwrap_or(0);
+        let old_resource_ids: HashSet<usize> = old
+            .map(|charge| charge.resources.iter().map(|(id, _)| *id).collect())
+            .unwrap_or_default();
+        let mut projected = state.total_bytes.saturating_sub(old_definition_bytes);
+        for resource_id in &old_resource_ids {
+            if state
+                .resources
+                .get(resource_id)
+                .is_some_and(|(_, refs)| *refs == 1)
+            {
+                projected = projected.saturating_sub(state.resources[resource_id].0);
+            }
+        }
+        projected = projected.saturating_add(definition_bytes);
+        for (resource_id, bytes) in &resources {
+            let remains = state.resources.get(resource_id).is_some_and(|(_, refs)| {
+                *refs > usize::from(old_resource_ids.contains(resource_id))
+            });
+            if !remains {
+                projected = projected.saturating_add(*bytes);
+            }
+        }
+        if projected > limit {
+            return Err(SkillError::Storage(format!(
+                "global workflow snapshot budget exceeded ({projected} > {limit} bytes)"
+            )));
+        }
+        if let Some(old) = state.publications.remove(&store_token) {
+            Self::remove_charge(&mut state, old);
+        }
+        Self::add_charge(&mut state, definition_bytes, &resources);
+        state.publications.insert(
+            store_token,
+            ActivationBudgetCharge {
+                definition_bytes,
+                resources,
+            },
+        );
+        Ok(())
+    }
+
+    fn release_publication(&self, store_token: u64) {
+        let mut state = self.state.lock().expect("workflow retained budget lock");
+        if let Some(old) = state.publications.remove(&store_token) {
+            Self::remove_charge(&mut state, old);
+        }
+    }
+
+    fn remove_charge(state: &mut RetainedResourceBudgetState, charge: ActivationBudgetCharge) {
+        state.total_bytes = state.total_bytes.saturating_sub(charge.definition_bytes);
+        for (resource_id, _) in charge.resources {
+            if let Some((bytes, references)) = state.resources.get_mut(&resource_id) {
+                *references -= 1;
+                if *references == 0 {
+                    let bytes = *bytes;
+                    state.resources.remove(&resource_id);
+                    state.total_bytes = state.total_bytes.saturating_sub(bytes);
+                }
+            }
+        }
+    }
+
+    fn add_charge(
+        state: &mut RetainedResourceBudgetState,
+        definition_bytes: usize,
+        resources: &[(usize, usize)],
+    ) {
+        state.total_bytes = state.total_bytes.saturating_add(definition_bytes);
+        for (resource_id, bytes) in resources {
+            if !state.resources.contains_key(resource_id) {
+                state.total_bytes = state.total_bytes.saturating_add(*bytes);
+                state.resources.insert(*resource_id, (*bytes, 0));
+            }
+            state
+                .resources
+                .get_mut(resource_id)
+                .expect("resource charge")
+                .1 += 1;
+        }
+    }
+}
+
+pub(crate) type SkillResourceSnapshot = std::sync::Arc<HashMap<String, std::sync::Arc<Vec<u8>>>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillActivationDescriptor {
+    pub catalog_revision: u64,
+    pub skill_revisions: BTreeMap<SkillId, u64>,
+    pub selected_skill_mode: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct PinnedSkillDefinition {
+    definition: Arc<SkillDefinition>,
+    root: PathBuf,
+    revision: u64,
+    resources: SkillResourceSnapshot,
+}
+
+#[derive(Debug, Clone)]
+struct PinnedSkillActivation {
+    catalog_revision: u64,
+    selected_skill_mode: Option<String>,
+    skills: HashMap<SkillId, PinnedSkillDefinition>,
+}
+
+#[derive(Debug, Default)]
+struct PinnedSkillActivations {
+    by_id: HashMap<String, PinnedSkillActivation>,
+}
+
+impl PinnedSkillActivations {
+    fn insert(
+        &mut self,
+        activation_id: String,
+        activation: PinnedSkillActivation,
+    ) -> SkillResult<()> {
+        if !self.by_id.contains_key(&activation_id)
+            && self.by_id.len() >= MAX_PINNED_SKILL_ACTIVATIONS
+        {
+            return Err(SkillError::Storage(format!(
+                "active workflow snapshot capacity ({MAX_PINNED_SKILL_ACTIVATIONS}) reached"
+            )));
+        }
+        self.by_id.insert(activation_id, activation);
+        Ok(())
+    }
+
+    fn remove(&mut self, activation_id: &str) -> Option<PinnedSkillActivation> {
+        self.by_id.remove(activation_id)
+    }
+}
 
 fn invalid_placeholder(
     id: &str,
@@ -109,6 +410,127 @@ fn stable_workspace_hash(path: &Path) -> u64 {
         })
 }
 
+async fn snapshot_skill_resources(
+    roots: &HashMap<SkillId, PathBuf>,
+    definitions: &HashMap<SkillId, SkillDefinition>,
+    catalog_entries: &[WorkflowCatalogEntry],
+    previous: &HashMap<SkillId, SkillResourceSnapshot>,
+    limits: SkillSnapshotLimits,
+) -> SkillResult<HashMap<SkillId, SkillResourceSnapshot>> {
+    let mut snapshots = HashMap::with_capacity(roots.len());
+    let mut publication_bytes = 0usize;
+    let mut publication_resource_count = 0usize;
+    for (skill_id, root) in roots {
+        let definition_bytes = definitions
+            .get(skill_id)
+            .and_then(|definition| serde_json::to_vec(definition).ok())
+            .map(|bytes| bytes.len())
+            .unwrap_or(0);
+        let reuses_last_known_good = catalog_entries
+            .iter()
+            .find(|entry| entry.id == *skill_id)
+            .is_some_and(|entry| entry.status == WorkflowStatus::Invalid);
+        if reuses_last_known_good {
+            if let Some(resources) = previous.get(skill_id) {
+                let resource_bytes = resources.values().map(|bytes| bytes.len()).sum::<usize>();
+                let skill_bytes = definition_bytes.saturating_add(resource_bytes);
+                if skill_bytes > limits.max_skill_bytes {
+                    return Err(SkillError::Storage(format!(
+                        "workflow '{skill_id}' snapshot exceeds per-skill limit ({skill_bytes} > {} bytes)",
+                        limits.max_skill_bytes
+                    )));
+                }
+                publication_bytes = publication_bytes.saturating_add(skill_bytes);
+                publication_resource_count =
+                    publication_resource_count.saturating_add(resources.len());
+                if publication_bytes > limits.max_publication_bytes
+                    || publication_resource_count > MAX_WORKFLOW_RESOURCES_PER_PUBLICATION
+                {
+                    return Err(SkillError::Storage(
+                        "workflow catalog publication exceeds snapshot limits".to_string(),
+                    ));
+                }
+                snapshots.insert(skill_id.clone(), resources.clone());
+                continue;
+            }
+        }
+        let skill_markdown_bytes = tokio::fs::metadata(root.join("SKILL.md"))
+            .await
+            .map(|metadata| metadata.len() as usize)
+            .unwrap_or(0);
+        if skill_markdown_bytes > limits.max_file_bytes {
+            return Err(SkillError::Storage(format!(
+                "workflow '{skill_id}' SKILL.md exceeds per-file limit ({skill_markdown_bytes} > {} bytes)",
+                limits.max_file_bytes
+            )));
+        }
+        let paths = crate::resource_helpers::list_skill_resource_paths_bounded(
+            root,
+            MAX_WORKFLOW_RESOURCES_PER_SKILL,
+            MAX_WORKFLOW_RESOURCE_PATH_BYTES,
+        )?;
+        let mut resources = HashMap::with_capacity(paths.len());
+        let mut resource_bytes = 0usize;
+        for relative_path in paths {
+            let resource = root.join(&relative_path);
+            let file_bytes = tokio::fs::metadata(&resource).await?.len() as usize;
+            if file_bytes > limits.max_file_bytes {
+                return Err(SkillError::Storage(format!(
+                    "workflow '{skill_id}' resource '{relative_path}' exceeds per-file limit ({file_bytes} > {} bytes)",
+                    limits.max_file_bytes
+                )));
+            }
+            let file = open_skill_file_no_follow(&resource).await?;
+            let mut bytes = Vec::with_capacity(file_bytes.min(limits.max_file_bytes));
+            file.take(limits.max_file_bytes.saturating_add(1) as u64)
+                .read_to_end(&mut bytes)
+                .await?;
+            if bytes.len() > limits.max_file_bytes {
+                return Err(SkillError::Storage(format!(
+                    "workflow '{skill_id}' resource '{relative_path}' exceeds per-file limit ({} > {} bytes)",
+                    bytes.len(),
+                    limits.max_file_bytes
+                )));
+            }
+            resource_bytes = resource_bytes.saturating_add(bytes.len());
+            let projected_skill_bytes = definition_bytes
+                .saturating_add(skill_markdown_bytes)
+                .saturating_add(resource_bytes);
+            if projected_skill_bytes > limits.max_skill_bytes {
+                return Err(SkillError::Storage(format!(
+                    "workflow '{skill_id}' snapshot exceeds per-skill limit ({projected_skill_bytes} > {} bytes)",
+                    limits.max_skill_bytes
+                )));
+            }
+            resources.insert(relative_path, std::sync::Arc::new(bytes));
+        }
+        let skill_bytes = definition_bytes
+            .saturating_add(skill_markdown_bytes)
+            .saturating_add(resource_bytes);
+        if skill_bytes > limits.max_skill_bytes {
+            return Err(SkillError::Storage(format!(
+                "workflow '{skill_id}' snapshot exceeds per-skill limit ({skill_bytes} > {} bytes)",
+                limits.max_skill_bytes
+            )));
+        }
+        publication_bytes = publication_bytes.saturating_add(skill_bytes);
+        if publication_bytes > limits.max_publication_bytes {
+            return Err(SkillError::Storage(format!(
+                "workflow catalog publication exceeds limit ({publication_bytes} > {} bytes)",
+                limits.max_publication_bytes
+            )));
+        }
+        publication_resource_count = publication_resource_count.saturating_add(resources.len());
+        if publication_resource_count > MAX_WORKFLOW_RESOURCES_PER_PUBLICATION {
+            return Err(SkillError::Storage(format!(
+                "workflow catalog resource count exceeds limit ({publication_resource_count} > {MAX_WORKFLOW_RESOURCES_PER_PUBLICATION})"
+            )));
+        }
+        snapshots.insert(skill_id.clone(), std::sync::Arc::new(resources));
+    }
+    Ok(snapshots)
+}
+
 /// Persistent storage for skills with in-memory caching.
 ///
 /// Manages a collection of skills loaded from Markdown files on disk.
@@ -130,19 +552,28 @@ fn stable_workspace_hash(path: &Path) -> u64 {
 /// println!("Skill: {}", skill.name);
 /// ```
 pub struct SkillStore {
+    store_token: u64,
     /// Serializes publication and observation of the correlated snapshot maps below.
     snapshot_publish_lock: RwLock<()>,
     /// In-memory cache of loaded skills, keyed by skill ID.
     skills: RwLock<HashMap<SkillId, SkillDefinition>>,
     /// Root directory of each loaded skill (keyed by skill ID).
     skill_roots: RwLock<HashMap<SkillId, PathBuf>>,
+    /// Immutable bytes for every resource in the currently published generation.
+    /// Activations retain these snapshots after a watcher publishes a newer bundle.
+    skill_resources: RwLock<HashMap<SkillId, SkillResourceSnapshot>>,
     catalog: RwLock<WorkflowCatalogSnapshot>,
+    /// Session/activation-scoped immutable workflow generations. The cache is bounded,
+    /// and normal runtime finalization explicitly removes completed activations.
+    pinned_activations: RwLock<PinnedSkillActivations>,
     next_revision: AtomicU64,
     watcher_started: AtomicBool,
     catalog_events: tokio::sync::broadcast::Sender<WorkflowCatalogEvent>,
     reload_lock: tokio::sync::Mutex<()>,
     mode_stores: RwLock<HashMap<String, std::sync::Arc<SkillStore>>>,
     workspace_stores: RwLock<HashMap<PathBuf, std::sync::Arc<SkillStore>>>,
+    retained_budget: Arc<RetainedResourceBudget>,
+    snapshot_limits: SkillSnapshotLimits,
 
     /// Configuration specifying the skills directory path.
     config: SkillStoreConfig,
@@ -322,20 +753,49 @@ impl SkillStore {
     /// let store = SkillStore::new(config);
     /// ```
     pub fn new(config: SkillStoreConfig) -> Self {
+        Self::new_with_shared_snapshot_state(
+            config,
+            Arc::new(RetainedResourceBudget::default()),
+            SkillSnapshotLimits::default(),
+        )
+    }
+
+    fn new_with_shared_snapshot_state(
+        config: SkillStoreConfig,
+        retained_budget: Arc<RetainedResourceBudget>,
+        snapshot_limits: SkillSnapshotLimits,
+    ) -> Self {
         let (catalog_events, _) = tokio::sync::broadcast::channel(128);
         Self {
+            store_token: NEXT_SKILL_STORE_TOKEN.fetch_add(1, Ordering::Relaxed),
             snapshot_publish_lock: RwLock::new(()),
             skills: RwLock::new(HashMap::new()),
             skill_roots: RwLock::new(HashMap::new()),
+            skill_resources: RwLock::new(HashMap::new()),
             catalog: RwLock::new(WorkflowCatalogSnapshot::default()),
+            pinned_activations: RwLock::new(PinnedSkillActivations::default()),
             next_revision: AtomicU64::new(1),
             watcher_started: AtomicBool::new(false),
             catalog_events,
             reload_lock: tokio::sync::Mutex::new(()),
             mode_stores: RwLock::new(HashMap::new()),
             workspace_stores: RwLock::new(HashMap::new()),
+            retained_budget,
+            snapshot_limits,
             config,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_snapshot_limits(
+        config: SkillStoreConfig,
+        snapshot_limits: SkillSnapshotLimits,
+    ) -> Self {
+        Self::new_with_shared_snapshot_state(
+            config,
+            Arc::new(RetainedResourceBudget::default()),
+            snapshot_limits,
+        )
     }
 
     /// Initialize the store, loading skills from disk.
@@ -415,13 +875,19 @@ impl SkillStore {
         let mut dirs = dirs;
         let plugins_root = Self::plugins_root_dir(&self.config.skills_dir);
         dirs.extend(discover_plugin_skill_dirs(&plugins_root).await);
-        let report = load_skills_from_discovery_dirs_detailed(&dirs).await?;
+        let report = load_skills_from_discovery_dirs_detailed_with_limits(
+            &dirs,
+            self.snapshot_limits.max_file_bytes,
+            MAX_WORKFLOWS_PER_PUBLICATION,
+        )
+        .await?;
 
-        let (previous_skills, previous_roots, previous_catalog) = {
+        let (previous_skills, previous_roots, previous_resources, previous_catalog) = {
             let _snapshot_guard = self.snapshot_publish_lock.read().await;
             (
                 self.skills.read().await.clone(),
                 self.skill_roots.read().await.clone(),
+                self.skill_resources.read().await.clone(),
                 self.catalog.read().await.clone(),
             )
         };
@@ -437,11 +903,20 @@ impl SkillStore {
             )
             .await;
         let count = resolved_skills.len();
+        let resolved_resources = snapshot_skill_resources(
+            &resolved_roots,
+            &resolved_skills,
+            &entries,
+            &previous_resources,
+            self.snapshot_limits,
+        )
+        .await?;
         let definition_changed: HashSet<String> = resolved_skills
             .iter()
             .filter(|(id, skill)| {
                 previous_skills.get(*id) != Some(*skill)
                     || previous_roots.get(*id) != resolved_roots.get(*id)
+                    || previous_resources.get(*id) != resolved_resources.get(*id)
             })
             .map(|(id, _)| id.clone())
             .collect();
@@ -469,18 +944,51 @@ impl SkillStore {
         comparable_previous.revision = revision;
         if resolved_skills == previous_skills
             && resolved_roots == previous_roots
+            && resolved_resources == previous_resources
             && next_catalog == comparable_previous
         {
             return Ok(count);
         }
-        self.next_revision.fetch_add(1, Ordering::SeqCst);
-        {
-            // Definition, root, and metadata become visible as one immutable generation.
-            let _snapshot_guard = self.snapshot_publish_lock.write().await;
-            *self.skills.write().await = resolved_skills;
-            *self.skill_roots.write().await = resolved_roots;
-            *self.catalog.write().await = next_catalog.clone();
+        let publication_definition_bytes = resolved_skills
+            .values()
+            .map(|skill| {
+                serde_json::to_vec(skill)
+                    .map(|bytes| bytes.len())
+                    .unwrap_or(0)
+            })
+            .sum::<usize>();
+        let mut publication_resources = HashMap::<usize, usize>::new();
+        for snapshot in resolved_resources.values() {
+            for bytes in snapshot.values() {
+                publication_resources
+                    .entry(Arc::as_ptr(bytes) as usize)
+                    .or_insert(bytes.len());
+            }
         }
+        // Acquire every async publication guard before changing the synchronous
+        // shared budget. After `replace_publication` succeeds there are no await
+        // points until all correlated maps and the revision are committed.
+        let _snapshot_guard = self.snapshot_publish_lock.write().await;
+        let mut skills_guard = self.skills.write().await;
+        let mut roots_guard = self.skill_roots.write().await;
+        let mut resources_guard = self.skill_resources.write().await;
+        let mut catalog_guard = self.catalog.write().await;
+        self.retained_budget.replace_publication(
+            self.store_token,
+            publication_definition_bytes,
+            publication_resources.into_iter().collect(),
+            self.snapshot_limits.max_retained_bytes,
+        )?;
+        self.next_revision.fetch_add(1, Ordering::SeqCst);
+        *skills_guard = resolved_skills;
+        *roots_guard = resolved_roots;
+        *resources_guard = resolved_resources;
+        *catalog_guard = next_catalog.clone();
+        drop(catalog_guard);
+        drop(resources_guard);
+        drop(roots_guard);
+        drop(skills_guard);
+        drop(_snapshot_guard);
         self.publish_catalog_events(&previous_catalog, &next_catalog, &definition_changed);
 
         Ok(count)
@@ -639,11 +1147,18 @@ impl SkillStore {
         self.catalog.read().await.clone()
     }
 
-    /// Return prompt-visible skills and their catalog metadata from one validated snapshot.
-    pub(crate) async fn skills_and_catalog_for_mode(
+    /// Return definitions, roots, immutable resource bytes, and metadata from one
+    /// validated publication. Callers that create an activation must pin directly
+    /// from this tuple rather than resolving any component from the live store again.
+    pub(crate) async fn activation_source_for_mode(
         &self,
         mode_override: Option<&str>,
-    ) -> SkillResult<(Vec<SkillDefinition>, WorkflowCatalogSnapshot)> {
+    ) -> SkillResult<(
+        Vec<SkillDefinition>,
+        HashMap<SkillId, PathBuf>,
+        HashMap<SkillId, SkillResourceSnapshot>,
+        WorkflowCatalogSnapshot,
+    )> {
         let mode_store = self.skill_store_for_mode(mode_override).await?;
         let store = mode_store.as_deref().unwrap_or(self);
         if let Err(error) = store.reload().await {
@@ -662,8 +1177,395 @@ impl SkillStore {
             .cloned()
             .collect::<Vec<_>>();
         skills.sort_by_key(|skill| skill.name.clone());
+        let roots = store.skill_roots.read().await.clone();
+        let resources = store.skill_resources.read().await.clone();
         let catalog = store.catalog.read().await.clone();
+        Ok((skills, roots, resources, catalog))
+    }
+
+    /// Return prompt-visible skills and their catalog metadata from one validated snapshot.
+    pub(crate) async fn skills_and_catalog_for_mode(
+        &self,
+        mode_override: Option<&str>,
+    ) -> SkillResult<(Vec<SkillDefinition>, WorkflowCatalogSnapshot)> {
+        let (skills, _, _, catalog) = self.activation_source_for_mode(mode_override).await?;
         Ok((skills, catalog))
+    }
+
+    pub(crate) async fn pin_activation_from_source(
+        &self,
+        activation_id: &str,
+        mode_override: Option<&str>,
+        selected_skills: &[SkillDefinition],
+        roots: &HashMap<SkillId, PathBuf>,
+        resources: &HashMap<SkillId, SkillResourceSnapshot>,
+        catalog: &WorkflowCatalogSnapshot,
+    ) -> SkillResult<SkillActivationDescriptor> {
+        let catalog_entries = catalog
+            .entries
+            .iter()
+            .map(|entry| (entry.id.as_str(), entry))
+            .collect::<HashMap<_, _>>();
+        let mut pinned_skills = HashMap::with_capacity(selected_skills.len());
+        let mut skill_revisions = BTreeMap::new();
+        let mut definition_bytes = 0usize;
+        let mut retained_resources = HashMap::<usize, usize>::new();
+        for skill in selected_skills {
+            let root = roots
+                .get(&skill.id)
+                .cloned()
+                .ok_or_else(|| SkillError::NotFound(skill.id.clone()))?;
+            let resource_snapshot = resources
+                .get(&skill.id)
+                .cloned()
+                .ok_or_else(|| SkillError::NotFound(skill.id.clone()))?;
+            let revision = catalog_entries
+                .get(skill.id.as_str())
+                .map(|entry| entry.revision)
+                .ok_or_else(|| SkillError::NotFound(skill.id.clone()))?;
+            skill_revisions.insert(skill.id.clone(), revision);
+            definition_bytes = definition_bytes.saturating_add(
+                serde_json::to_vec(skill)
+                    .map(|serialized| serialized.len())
+                    .unwrap_or(0),
+            );
+            for bytes in resource_snapshot.values() {
+                retained_resources
+                    .entry(Arc::as_ptr(bytes) as usize)
+                    .or_insert(bytes.len());
+            }
+            pinned_skills.insert(
+                skill.id.clone(),
+                PinnedSkillDefinition {
+                    definition: Arc::new(skill.clone()),
+                    root,
+                    revision,
+                    resources: resource_snapshot,
+                },
+            );
+        }
+
+        let mut activations = self.pinned_activations.write().await;
+        if !activations.by_id.contains_key(activation_id)
+            && activations.by_id.len() >= MAX_PINNED_SKILL_ACTIVATIONS
+        {
+            return Err(SkillError::Storage(format!(
+                "active workflow snapshot capacity ({MAX_PINNED_SKILL_ACTIVATIONS}) reached"
+            )));
+        }
+        self.retained_budget.replace(
+            activation_id,
+            definition_bytes,
+            retained_resources.into_iter().collect(),
+            self.snapshot_limits.max_retained_bytes,
+        )?;
+        activations.insert(
+            activation_id.to_string(),
+            PinnedSkillActivation {
+                catalog_revision: catalog.revision,
+                selected_skill_mode: self.effective_mode(mode_override),
+                skills: pinned_skills,
+            },
+        )?;
+        Ok(SkillActivationDescriptor {
+            catalog_revision: catalog.revision,
+            skill_revisions,
+            selected_skill_mode: self.effective_mode(mode_override),
+        })
+    }
+
+    /// Lazily establish an activation for non-runner callers. The agent runtime pins
+    /// during selection, before the first model/tool call; this fallback preserves the
+    /// same invariant for SDK and direct-tool integrations.
+    pub async fn pin_current_activation(
+        &self,
+        activation_id: &str,
+        selected_skill_ids: &[String],
+        mode_override: Option<&str>,
+    ) -> SkillResult<SkillActivationDescriptor> {
+        if let Some(descriptor) = self.activation_descriptor(activation_id).await {
+            let requested = selected_skill_ids
+                .iter()
+                .map(|id| id.trim())
+                .filter(|id| !id.is_empty())
+                .collect::<HashSet<_>>();
+            let pinned = descriptor
+                .skill_revisions
+                .keys()
+                .map(String::as_str)
+                .collect::<HashSet<_>>();
+            if requested == pinned
+                && descriptor.selected_skill_mode == self.effective_mode(mode_override)
+            {
+                return Ok(descriptor);
+            }
+        }
+        let (skills, roots, resources, catalog) =
+            self.activation_source_for_mode(mode_override).await?;
+        let selected = selected_skill_ids
+            .iter()
+            .map(|id| id.trim())
+            .filter(|id| !id.is_empty())
+            .collect::<HashSet<_>>();
+        let selected_skills = skills
+            .into_iter()
+            .filter(|skill| selected.contains(skill.id.as_str()))
+            .collect::<Vec<_>>();
+        if selected_skills.len() != selected.len() {
+            let missing = selected_skill_ids
+                .iter()
+                .find(|id| !selected_skills.iter().any(|skill| &skill.id == *id))
+                .cloned()
+                .unwrap_or_default();
+            return Err(SkillError::NotFound(missing));
+        }
+        self.pin_activation_from_source(
+            activation_id,
+            mode_override,
+            &selected_skills,
+            &roots,
+            &resources,
+            &catalog,
+        )
+        .await
+    }
+
+    pub async fn activation_descriptor(
+        &self,
+        activation_id: &str,
+    ) -> Option<SkillActivationDescriptor> {
+        let activations = self.pinned_activations.read().await;
+        let activation = activations.by_id.get(activation_id)?;
+        Some(SkillActivationDescriptor {
+            catalog_revision: activation.catalog_revision,
+            skill_revisions: activation
+                .skills
+                .iter()
+                .map(|(id, skill)| (id.clone(), skill.revision))
+                .collect(),
+            selected_skill_mode: activation.selected_skill_mode.clone(),
+        })
+    }
+
+    pub async fn pinned_activation_skills(
+        &self,
+        activation_id: &str,
+    ) -> Option<(Vec<SkillDefinition>, SkillActivationDescriptor)> {
+        let activations = self.pinned_activations.read().await;
+        let activation = activations.by_id.get(activation_id)?;
+        let mut skills = activation
+            .skills
+            .values()
+            .map(|skill| skill.definition.as_ref().clone())
+            .collect::<Vec<_>>();
+        skills.sort_by(|left, right| left.id.cmp(&right.id));
+        let descriptor = SkillActivationDescriptor {
+            catalog_revision: activation.catalog_revision,
+            skill_revisions: activation
+                .skills
+                .iter()
+                .map(|(id, skill)| (id.clone(), skill.revision))
+                .collect(),
+            selected_skill_mode: activation.selected_skill_mode.clone(),
+        };
+        Some((skills, descriptor))
+    }
+
+    pub async fn get_pinned_skill_with_root(
+        &self,
+        activation_id: &str,
+        skill_id: &str,
+    ) -> SkillResult<(SkillDefinition, PathBuf, u64, Vec<String>)> {
+        let activations = self.pinned_activations.read().await;
+        let activation = activations
+            .by_id
+            .get(activation_id)
+            .ok_or_else(|| SkillError::NotFound(skill_id.to_string()))?;
+        let pinned = activation
+            .skills
+            .get(skill_id)
+            .ok_or_else(|| SkillError::NotFound(skill_id.to_string()))?;
+        let mut resource_paths = pinned.resources.keys().cloned().collect::<Vec<_>>();
+        resource_paths.sort();
+        Ok((
+            pinned.definition.as_ref().clone(),
+            pinned.root.clone(),
+            pinned.revision,
+            resource_paths,
+        ))
+    }
+
+    pub async fn get_pinned_skill_with_root_and_descriptor(
+        &self,
+        activation_id: &str,
+        skill_id: &str,
+    ) -> SkillResult<(
+        SkillDefinition,
+        PathBuf,
+        u64,
+        Vec<String>,
+        SkillActivationDescriptor,
+    )> {
+        let activations = self.pinned_activations.read().await;
+        let activation = activations
+            .by_id
+            .get(activation_id)
+            .ok_or_else(|| SkillError::NotFound(skill_id.to_string()))?;
+        let pinned = activation
+            .skills
+            .get(skill_id)
+            .ok_or_else(|| SkillError::NotFound(skill_id.to_string()))?;
+        let mut resource_paths = pinned.resources.keys().cloned().collect::<Vec<_>>();
+        resource_paths.sort();
+        let descriptor = SkillActivationDescriptor {
+            catalog_revision: activation.catalog_revision,
+            skill_revisions: activation
+                .skills
+                .iter()
+                .map(|(id, skill)| (id.clone(), skill.revision))
+                .collect(),
+            selected_skill_mode: activation.selected_skill_mode.clone(),
+        };
+        Ok((
+            pinned.definition.as_ref().clone(),
+            pinned.root.clone(),
+            pinned.revision,
+            resource_paths,
+            descriptor,
+        ))
+    }
+
+    pub async fn read_pinned_skill_resource(
+        &self,
+        activation_id: &str,
+        skill_id: &str,
+        resource_path: &Path,
+    ) -> SkillResult<Vec<u8>> {
+        let activations = self.pinned_activations.read().await;
+        let activation = activations
+            .by_id
+            .get(activation_id)
+            .ok_or_else(|| SkillError::NotFound(skill_id.to_string()))?;
+        let pinned = activation
+            .skills
+            .get(skill_id)
+            .ok_or_else(|| SkillError::NotFound(skill_id.to_string()))?;
+        let key = crate::resource_helpers::display_relative_path(resource_path);
+        pinned
+            .resources
+            .get(&key)
+            .map(|bytes| bytes.as_ref().clone())
+            .ok_or_else(|| SkillError::NotFound(format!("{skill_id}/{key}")))
+    }
+
+    pub async fn read_pinned_skill_resource_with_descriptor(
+        &self,
+        activation_id: &str,
+        skill_id: &str,
+        resource_path: &Path,
+    ) -> SkillResult<(Vec<u8>, SkillActivationDescriptor)> {
+        let activations = self.pinned_activations.read().await;
+        let activation = activations
+            .by_id
+            .get(activation_id)
+            .ok_or_else(|| SkillError::NotFound(skill_id.to_string()))?;
+        let pinned = activation
+            .skills
+            .get(skill_id)
+            .ok_or_else(|| SkillError::NotFound(skill_id.to_string()))?;
+        let key = crate::resource_helpers::display_relative_path(resource_path);
+        let bytes = pinned
+            .resources
+            .get(&key)
+            .map(|bytes| bytes.as_ref().clone())
+            .ok_or_else(|| SkillError::NotFound(format!("{skill_id}/{key}")))?;
+        let descriptor = SkillActivationDescriptor {
+            catalog_revision: activation.catalog_revision,
+            skill_revisions: activation
+                .skills
+                .iter()
+                .map(|(id, skill)| (id.clone(), skill.revision))
+                .collect(),
+            selected_skill_mode: activation.selected_skill_mode.clone(),
+        };
+        Ok((bytes, descriptor))
+    }
+
+    pub async fn pinned_allowed_tools(
+        &self,
+        activation_id: &str,
+        disabled_skill_ids: &BTreeSet<String>,
+    ) -> Option<Vec<String>> {
+        let activations = self.pinned_activations.read().await;
+        let activation = activations.by_id.get(activation_id)?;
+        let mut tools = activation
+            .skills
+            .iter()
+            .filter(|(skill_id, _)| !disabled_skill_ids.contains(*skill_id))
+            .map(|(_, skill)| skill)
+            .flat_map(|skill| skill.definition.tool_refs.iter().cloned())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        tools.sort();
+        Some(tools)
+    }
+
+    pub async fn pinned_allowed_tools_with_descriptor(
+        &self,
+        activation_id: &str,
+        disabled_skill_ids: &BTreeSet<String>,
+    ) -> Option<(Vec<String>, SkillActivationDescriptor)> {
+        let activations = self.pinned_activations.read().await;
+        let activation = activations.by_id.get(activation_id)?;
+        let mut tools = activation
+            .skills
+            .iter()
+            .filter(|(skill_id, _)| !disabled_skill_ids.contains(*skill_id))
+            .flat_map(|(_, skill)| skill.definition.tool_refs.iter().cloned())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        tools.sort();
+        let descriptor = SkillActivationDescriptor {
+            catalog_revision: activation.catalog_revision,
+            skill_revisions: activation
+                .skills
+                .iter()
+                .map(|(id, skill)| (id.clone(), skill.revision))
+                .collect(),
+            selected_skill_mode: activation.selected_skill_mode.clone(),
+        };
+        Some((tools, descriptor))
+    }
+
+    pub async fn release_activation(&self, activation_id: &str) {
+        let mut activations = self.pinned_activations.write().await;
+        // Hold the removed activation (and therefore its last resource Arcs)
+        // through budget release. This prevents allocator address reuse from
+        // turning raw Arc-pointer identity accounting into an ABA collision.
+        let removed = activations.remove(activation_id);
+        if removed.is_some() {
+            self.retained_budget.release(activation_id);
+        }
+        drop(removed);
+    }
+
+    /// Release a session pin without depending on its workspace still existing.
+    /// Session IDs are unique across scopes, so clearing the root and every cached
+    /// workspace store is both safe and robust to deleted/unmounted projects.
+    pub async fn release_activation_across_cached_scopes(&self, activation_id: &str) {
+        self.release_activation(activation_id).await;
+        let workspace_stores = self
+            .workspace_stores
+            .read()
+            .await
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        for store in workspace_stores {
+            store.release_activation(activation_id).await;
+        }
     }
 
     pub fn subscribe_workflow_catalog(
@@ -692,11 +1594,20 @@ impl SkillStore {
         if let Some(store) = stores.get(&mode).cloned() {
             return Ok(Some(store));
         }
-        let store = std::sync::Arc::new(SkillStore::new(SkillStoreConfig {
-            skills_dir: self.config.skills_dir.clone(),
-            project_dir: self.config.project_dir.clone(),
-            active_mode: Some(mode.clone()),
-        }));
+        if stores.len() >= MAX_CACHED_MODE_STORES {
+            return Err(SkillError::Storage(format!(
+                "cached workflow mode store capacity ({MAX_CACHED_MODE_STORES}) reached"
+            )));
+        }
+        let store = std::sync::Arc::new(SkillStore::new_with_shared_snapshot_state(
+            SkillStoreConfig {
+                skills_dir: self.config.skills_dir.clone(),
+                project_dir: self.config.project_dir.clone(),
+                active_mode: Some(mode.clone()),
+            },
+            self.retained_budget.clone(),
+            self.snapshot_limits,
+        ));
         store.load().await?;
         store.start_live_reload();
 
@@ -778,19 +1689,70 @@ impl SkillStore {
         &self,
         workspace: &Path,
     ) -> SkillResult<std::sync::Arc<SkillStore>> {
+        let requested_workspace = workspace.to_path_buf();
+        // Keep the server-owned path as an alias. Once an activation has pinned
+        // immutable bytes, deleting the workspace must not make its store
+        // unreachable merely because canonicalization now fails.
+        if let Some(store) = self
+            .workspace_stores
+            .read()
+            .await
+            .get(&requested_workspace)
+            .cloned()
+        {
+            return Ok(store);
+        }
         let workspace = tokio::fs::canonicalize(workspace).await?;
-        if let Some(store) = self.workspace_stores.read().await.get(&workspace).cloned() {
+        let cached_canonical = self.workspace_stores.read().await.get(&workspace).cloned();
+        if let Some(store) = cached_canonical {
+            let mut stores = self.workspace_stores.write().await;
+            if !stores.contains_key(&requested_workspace)
+                && stores.len() >= MAX_CACHED_WORKSPACE_ALIASES
+            {
+                return Err(SkillError::Storage(format!(
+                    "cached workflow workspace alias capacity ({MAX_CACHED_WORKSPACE_ALIASES}) reached"
+                )));
+            }
+            stores.insert(requested_workspace, store.clone());
             return Ok(store);
         }
         let mut stores = self.workspace_stores.write().await;
         if let Some(store) = stores.get(&workspace).cloned() {
+            if !stores.contains_key(&requested_workspace)
+                && stores.len() >= MAX_CACHED_WORKSPACE_ALIASES
+            {
+                return Err(SkillError::Storage(format!(
+                    "cached workflow workspace alias capacity ({MAX_CACHED_WORKSPACE_ALIASES}) reached"
+                )));
+            }
+            stores.insert(requested_workspace, store.clone());
             return Ok(store);
         }
-        let store = std::sync::Arc::new(SkillStore::new(SkillStoreConfig {
-            skills_dir: self.config.skills_dir.clone(),
-            project_dir: Some(workspace.clone()),
-            active_mode: self.config.active_mode.clone(),
-        }));
+        let unique_store_count = stores
+            .values()
+            .map(Arc::as_ptr)
+            .collect::<HashSet<_>>()
+            .len();
+        if unique_store_count >= MAX_CACHED_WORKSPACE_STORES {
+            return Err(SkillError::Storage(format!(
+                "cached workflow workspace store capacity ({MAX_CACHED_WORKSPACE_STORES}) reached"
+            )));
+        }
+        let new_aliases = 1 + usize::from(requested_workspace != workspace);
+        if stores.len().saturating_add(new_aliases) > MAX_CACHED_WORKSPACE_ALIASES {
+            return Err(SkillError::Storage(format!(
+                "cached workflow workspace alias capacity ({MAX_CACHED_WORKSPACE_ALIASES}) reached"
+            )));
+        }
+        let store = std::sync::Arc::new(SkillStore::new_with_shared_snapshot_state(
+            SkillStoreConfig {
+                skills_dir: self.config.skills_dir.clone(),
+                project_dir: Some(workspace.clone()),
+                active_mode: self.config.active_mode.clone(),
+            },
+            self.retained_budget.clone(),
+            self.snapshot_limits,
+        ));
         store.load().await?;
         store.start_live_reload();
 
@@ -810,7 +1772,21 @@ impl SkillStore {
             }
         });
         stores.insert(workspace, store.clone());
+        stores.insert(requested_workspace, store.clone());
         Ok(store)
+    }
+
+    pub(crate) async fn cached_workspace_stores(&self) -> Vec<std::sync::Arc<SkillStore>> {
+        let mut unique = Vec::new();
+        for store in self.workspace_stores.read().await.values() {
+            if !unique
+                .iter()
+                .any(|existing| std::sync::Arc::ptr_eq(existing, store))
+            {
+                unique.push(store.clone());
+            }
+        }
+        unique
     }
 
     /// Resolve an isolated catalog view for a specific session workspace without changing the
@@ -1412,6 +2388,12 @@ impl SkillStore {
     }
 }
 
+impl Drop for SkillStore {
+    fn drop(&mut self) {
+        self.retained_budget.release_publication(self.store_token);
+    }
+}
+
 impl Default for SkillStore {
     fn default() -> Self {
         Self::new(SkillStoreConfig::default())
@@ -1540,6 +2522,7 @@ impl SkillUpdate {
 #[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
+    use std::sync::Arc;
 
     use tokio::fs;
 
@@ -2732,5 +3715,690 @@ Use this skill for testing.
                 .description,
             "one changed"
         );
+    }
+
+    #[tokio::test]
+    async fn activation_pins_definition_revision_and_resources_across_reload() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("skills");
+        let skill_dir = write_skill(&skills_dir, "revision-demo", "revision N", "prompt N")
+            .await
+            .expect("skill N");
+        fs::create_dir_all(skill_dir.join("references"))
+            .await
+            .expect("references");
+        fs::write(skill_dir.join("references/value.txt"), "resource N")
+            .await
+            .expect("resource N");
+        let store = Arc::new(SkillStore::new(SkillStoreConfig {
+            skills_dir,
+            ..Default::default()
+        }));
+        store.initialize().await.expect("initialize");
+        let ids = vec!["revision-demo".to_string()];
+
+        let revision_n = store
+            .pin_current_activation("session-n", &ids, None)
+            .await
+            .expect("pin N");
+        let (_, _, pinned_revision_n, _) = store
+            .get_pinned_skill_with_root("session-n", "revision-demo")
+            .await
+            .expect("pinned N");
+        assert_eq!(
+            revision_n.skill_revisions["revision-demo"],
+            pinned_revision_n
+        );
+
+        let start = Arc::new(tokio::sync::Barrier::new(2));
+        let reader_observed_n = Arc::new(tokio::sync::Notify::new());
+        let writer_published_n1 = Arc::new(tokio::sync::Notify::new());
+        let reader = {
+            let store = store.clone();
+            let start = start.clone();
+            let reader_observed_n = reader_observed_n.clone();
+            let writer_published_n1 = writer_published_n1.clone();
+            tokio::spawn(async move {
+                start.wait().await;
+                let before = store
+                    .get_pinned_skill_with_root("session-n", "revision-demo")
+                    .await
+                    .expect("reader observes N before replacement");
+                reader_observed_n.notify_one();
+                writer_published_n1.notified().await;
+                let after = store
+                    .get_pinned_skill_with_root("session-n", "revision-demo")
+                    .await
+                    .expect("reader retains N after replacement");
+                let resource = store
+                    .read_pinned_skill_resource(
+                        "session-n",
+                        "revision-demo",
+                        Path::new("references/value.txt"),
+                    )
+                    .await
+                    .expect("reader retains resource N");
+                (before, after, resource)
+            })
+        };
+        let writer = {
+            let store = store.clone();
+            let start = start.clone();
+            let reader_observed_n = reader_observed_n.clone();
+            let writer_published_n1 = writer_published_n1.clone();
+            let ids = ids.clone();
+            tokio::spawn(async move {
+                start.wait().await;
+                reader_observed_n.notified().await;
+                let staged_skill = skill_dir.join("SKILL.md.next");
+                fs::write(
+                    &staged_skill,
+                    "---\nname: revision-demo\ndescription: revision N+1\n---\nprompt N+1\n",
+                )
+                .await
+                .expect("stage N+1");
+                fs::rename(&staged_skill, skill_dir.join("SKILL.md"))
+                    .await
+                    .expect("publish skill N+1");
+                let staged_resource = skill_dir.join("references/value.txt.next");
+                fs::write(&staged_resource, "resource N+1")
+                    .await
+                    .expect("stage resource N+1");
+                fs::rename(&staged_resource, skill_dir.join("references/value.txt"))
+                    .await
+                    .expect("publish resource N+1");
+                store.reload().await.expect("reload N+1");
+                let revision = store
+                    .pin_current_activation("session-n1", &ids, None)
+                    .await
+                    .expect("pin N+1");
+                let new_activation = store
+                    .get_pinned_skill_with_root("session-n1", "revision-demo")
+                    .await
+                    .expect("new activation N+1");
+                let resource = store
+                    .read_pinned_skill_resource(
+                        "session-n1",
+                        "revision-demo",
+                        Path::new("references/value.txt"),
+                    )
+                    .await
+                    .expect("new resource N+1");
+                writer_published_n1.notify_one();
+                (revision, new_activation, resource)
+            })
+        };
+
+        let (before, after, active_resource) = reader.await.expect("reader task");
+        let (revision_n1, new_activation, new_resource) = writer.await.expect("writer task");
+        assert_eq!(before.0.prompt, "prompt N");
+        assert_eq!(after.0.prompt, "prompt N");
+        assert_eq!(before.2, pinned_revision_n);
+        assert_eq!(after.2, pinned_revision_n);
+        assert_eq!(active_resource, b"resource N");
+        assert_eq!(new_activation.0.prompt, "prompt N+1");
+        assert!(new_activation.2 > after.2);
+        assert_eq!(
+            revision_n1.skill_revisions["revision-demo"],
+            new_activation.2
+        );
+        assert_eq!(new_resource, b"resource N+1");
+    }
+
+    #[tokio::test]
+    async fn activation_capacity_does_not_evict_live_sessions() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("skills");
+        write_skill(&skills_dir, "bounded", "bounded", "bounded")
+            .await
+            .expect("skill");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir,
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+        let ids = vec!["bounded".to_string()];
+        for index in 0..super::MAX_PINNED_SKILL_ACTIVATIONS {
+            store
+                .pin_current_activation(&format!("active-{index}"), &ids, None)
+                .await
+                .expect("capacity slot");
+        }
+        let error = store
+            .pin_current_activation("over-capacity", &ids, None)
+            .await
+            .expect_err("must reject instead of evicting a live activation");
+        assert!(error.to_string().contains("capacity"));
+        assert!(store.activation_descriptor("active-0").await.is_some());
+
+        store.release_activation("active-0").await;
+        store
+            .pin_current_activation("after-release", &ids, None)
+            .await
+            .expect("released slot is reusable");
+    }
+
+    #[tokio::test]
+    async fn invalid_transition_preserves_lkg_definition_and_resources_until_recovery() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("skills");
+        let skill_dir = write_skill(&skills_dir, "lkg-demo", "valid N", "prompt N")
+            .await
+            .expect("skill N");
+        fs::create_dir_all(skill_dir.join("references"))
+            .await
+            .expect("references");
+        fs::write(skill_dir.join("references/value.txt"), "resource N")
+            .await
+            .expect("resource N");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir: skills_dir.clone(),
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+        let ids = vec!["lkg-demo".to_string()];
+        store
+            .pin_current_activation("active-n", &ids, None)
+            .await
+            .expect("active N");
+
+        fs::write(skill_dir.join("SKILL.md"), "---\nname: [\n")
+            .await
+            .expect("corrupt skill");
+        fs::write(skill_dir.join("references/value.txt"), "corrupt resource")
+            .await
+            .expect("corrupt resource");
+        store.reload().await.expect("publish invalid LKG");
+        store
+            .pin_current_activation("invalid-new", &ids, None)
+            .await
+            .expect("pin retained LKG");
+        assert_eq!(
+            store
+                .get_pinned_skill_with_root("invalid-new", "lkg-demo")
+                .await
+                .expect("retained definition")
+                .0
+                .prompt,
+            "prompt N"
+        );
+        assert_eq!(
+            store
+                .read_pinned_skill_resource(
+                    "invalid-new",
+                    "lkg-demo",
+                    Path::new("references/value.txt"),
+                )
+                .await
+                .expect("retained resource"),
+            b"resource N"
+        );
+
+        write_skill(&skills_dir, "lkg-demo", "valid N+1", "prompt N+1")
+            .await
+            .expect("recover skill");
+        fs::write(skill_dir.join("references/value.txt"), "resource N+1")
+            .await
+            .expect("recover resource");
+        store.reload().await.expect("recover N+1");
+        store
+            .pin_current_activation("recovered-new", &ids, None)
+            .await
+            .expect("pin recovered");
+        assert_eq!(
+            store
+                .get_pinned_skill_with_root("active-n", "lkg-demo")
+                .await
+                .expect("old active N")
+                .0
+                .prompt,
+            "prompt N"
+        );
+        assert_eq!(
+            store
+                .get_pinned_skill_with_root("recovered-new", "lkg-demo")
+                .await
+                .expect("new recovered N+1")
+                .0
+                .prompt,
+            "prompt N+1"
+        );
+    }
+
+    #[tokio::test]
+    async fn direct_activation_replaces_same_ids_when_mode_changes() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("skills");
+        write_skill(&skills_dir, "mode-demo", "default", "default prompt")
+            .await
+            .expect("default skill");
+        write_skill(
+            &directory.path().join("skills-fast"),
+            "mode-demo",
+            "fast",
+            "fast prompt",
+        )
+        .await
+        .expect("fast skill");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir,
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+        let ids = vec!["mode-demo".to_string()];
+        store
+            .pin_current_activation("mode-session", &ids, None)
+            .await
+            .expect("default pin");
+        let descriptor = store
+            .pin_current_activation("mode-session", &ids, Some("fast"))
+            .await
+            .expect("mode replacement");
+        assert_eq!(descriptor.selected_skill_mode.as_deref(), Some("fast"));
+        assert_eq!(
+            store
+                .get_pinned_skill_with_root("mode-session", "mode-demo")
+                .await
+                .expect("fast activation")
+                .0
+                .prompt,
+            "fast prompt"
+        );
+    }
+
+    #[tokio::test]
+    async fn pinned_allowed_tools_use_pinned_definition_and_honor_live_disabled_skills() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("skills");
+        let skill_dir = skills_dir.join("tools-demo");
+        fs::create_dir_all(&skill_dir).await.expect("skill root");
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: tools-demo\ndescription: tools N\nallowed-tools:\n  - read_file\n---\ntools N\n",
+        )
+        .await
+        .expect("tools N");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir,
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+        let ids = vec!["tools-demo".to_string()];
+        store
+            .pin_current_activation("tools-n", &ids, None)
+            .await
+            .expect("pin tools N");
+
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: tools-demo\ndescription: tools N+1\nallowed-tools:\n  - write_file\n---\ntools N+1\n",
+        )
+        .await
+        .expect("tools N+1");
+        store.reload().await.expect("reload tools N+1");
+        assert_eq!(
+            store
+                .pinned_allowed_tools("tools-n", &std::collections::BTreeSet::new())
+                .await
+                .expect("pinned tools"),
+            vec!["Read"]
+        );
+        assert_eq!(
+            store
+                .pinned_allowed_tools(
+                    "tools-n",
+                    &std::collections::BTreeSet::from(["tools-demo".to_string()]),
+                )
+                .await
+                .expect("disabled pinned tools"),
+            Vec::<String>::new()
+        );
+        store
+            .pin_current_activation("tools-n1", &ids, None)
+            .await
+            .expect("pin tools N+1");
+        assert_eq!(
+            store
+                .pinned_allowed_tools("tools-n1", &std::collections::BTreeSet::new())
+                .await
+                .expect("new tools"),
+            vec!["Write"]
+        );
+    }
+
+    #[tokio::test]
+    async fn release_does_not_require_cached_workspace_to_still_exist() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let workspace = directory.path().join("workspace");
+        let project_skills = workspace.join(".bamboo/skills");
+        write_skill(
+            &project_skills,
+            "workspace-release",
+            "workspace release",
+            "workspace release",
+        )
+        .await
+        .expect("workspace skill");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir: directory.path().join("data/skills"),
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+        let workspace_store = store
+            .skill_store_for_workspace(&workspace)
+            .await
+            .expect("workspace store");
+        workspace_store
+            .pin_current_activation(
+                "deleted-workspace-session",
+                &["workspace-release".to_string()],
+                None,
+            )
+            .await
+            .expect("workspace activation");
+        fs::remove_dir_all(&workspace)
+            .await
+            .expect("delete workspace");
+
+        let cached_after_delete = store
+            .skill_store_for_workspace(&workspace)
+            .await
+            .expect("deleted workspace must resolve cached immutable store");
+        assert!(Arc::ptr_eq(&workspace_store, &cached_after_delete));
+        assert_eq!(
+            cached_after_delete
+                .get_pinned_skill_with_root("deleted-workspace-session", "workspace-release")
+                .await
+                .expect("pinned definition after delete")
+                .0
+                .prompt,
+            "workspace release"
+        );
+
+        store
+            .release_activation_across_cached_scopes("deleted-workspace-session")
+            .await;
+        assert!(workspace_store
+            .activation_descriptor("deleted-workspace-session")
+            .await
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn oversized_reload_keeps_previous_publication_and_retained_budget_is_reusable() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("skills");
+        let skill_dir = write_skill(&skills_dir, "bounded-bytes", "bounded", "prompt N")
+            .await
+            .expect("skill");
+        fs::create_dir_all(skill_dir.join("references"))
+            .await
+            .expect("references");
+        fs::write(skill_dir.join("references/value.txt"), vec![b'a'; 32])
+            .await
+            .expect("resource N");
+        let store = SkillStore::new_with_snapshot_limits(
+            SkillStoreConfig {
+                skills_dir,
+                ..Default::default()
+            },
+            super::SkillSnapshotLimits {
+                max_file_bytes: 128,
+                max_skill_bytes: 512,
+                max_publication_bytes: 4096,
+                max_retained_bytes: 2048,
+            },
+        );
+        store.reload().await.expect("publish N");
+        let catalog_n = store.workflow_catalog_snapshot().await;
+        let ids = vec!["bounded-bytes".to_string()];
+        store
+            .pin_current_activation("bounded-active", &ids, None)
+            .await
+            .expect("pin N");
+        fs::write(skill_dir.join("references/value.txt"), vec![b'b'; 129])
+            .await
+            .expect("oversize resource");
+        let error = store.reload().await.expect_err("oversize reload rejected");
+        assert!(error.to_string().contains("per-file limit"));
+        assert_eq!(store.workflow_catalog_snapshot().await, catalog_n);
+        assert_eq!(
+            store
+                .get_pinned_skill_with_root("bounded-active", "bounded-bytes")
+                .await
+                .expect("old pin")
+                .0
+                .prompt,
+            "prompt N"
+        );
+
+        store.release_activation("bounded-active").await;
+        store
+            .pin_current_activation("bounded-lkg", &ids, None)
+            .await
+            .expect("new activation uses live LKG after failed reload");
+        assert_eq!(
+            store
+                .read_pinned_skill_resource(
+                    "bounded-lkg",
+                    "bounded-bytes",
+                    Path::new("references/value.txt"),
+                )
+                .await
+                .expect("LKG resource"),
+            vec![b'a'; 32]
+        );
+        store.release_activation("bounded-lkg").await;
+        fs::write(skill_dir.join("references/value.txt"), vec![b'c'; 32])
+            .await
+            .expect("bounded resource");
+        store.reload().await.expect("recovered publication");
+        store
+            .pin_current_activation("bounded-reused", &ids, None)
+            .await
+            .expect("released retained budget is reusable");
+    }
+
+    #[tokio::test]
+    async fn retained_distinct_generation_budget_rejects_new_pin_without_evicting_old() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("skills");
+        let skill_dir = write_skill(&skills_dir, "generation-budget", "budget", "prompt N")
+            .await
+            .expect("skill N");
+        fs::create_dir_all(skill_dir.join("references"))
+            .await
+            .expect("references");
+        fs::write(skill_dir.join("references/value.txt"), vec![b'n'; 32])
+            .await
+            .expect("resource N");
+        let definition_n = serde_json::to_vec(&crate::SkillDefinition::new(
+            "generation-budget",
+            "generation-budget",
+            "budget",
+            "prompt N",
+        ))
+        .expect("definition N")
+        .len();
+        let definition_n1 = serde_json::to_vec(&crate::SkillDefinition::new(
+            "generation-budget",
+            "generation-budget",
+            "budget",
+            "prompt N+1",
+        ))
+        .expect("definition N+1")
+        .len();
+        let store = SkillStore::new_with_snapshot_limits(
+            SkillStoreConfig {
+                skills_dir,
+                ..Default::default()
+            },
+            super::SkillSnapshotLimits {
+                max_file_bytes: 256,
+                max_skill_bytes: 1024,
+                max_publication_bytes: 2048,
+                max_retained_bytes: definition_n + definition_n1 + 65,
+            },
+        );
+        store.reload().await.expect("publish N");
+        let ids = vec!["generation-budget".to_string()];
+        store
+            .pin_current_activation("active-n", &ids, None)
+            .await
+            .expect("pin N");
+        write_skill(
+            skill_dir.parent().expect("skills root"),
+            "generation-budget",
+            "budget",
+            "prompt N+1",
+        )
+        .await
+        .expect("skill N+1");
+        fs::write(skill_dir.join("references/value.txt"), vec![b'1'; 32])
+            .await
+            .expect("resource N+1");
+        store.reload().await.expect("publish N+1");
+        let catalog_n1 = store.workflow_catalog_snapshot().await;
+        let error = store
+            .pin_current_activation("new-n1", &ids, None)
+            .await
+            .expect_err("N and current N+1 fit, but pinning retained N+1 must exceed budget");
+        assert!(error.to_string().contains("budget"));
+        assert_eq!(store.workflow_catalog_snapshot().await, catalog_n1);
+        assert_eq!(
+            store
+                .read_pinned_skill_resource(
+                    "active-n",
+                    "generation-budget",
+                    Path::new("references/value.txt"),
+                )
+                .await
+                .expect("active N retained"),
+            vec![b'n'; 32]
+        );
+        store.release_activation("active-n").await;
+        store
+            .pin_current_activation("new-n1", &ids, None)
+            .await
+            .expect("release frees N generation budget");
+        assert_eq!(
+            store
+                .get_pinned_skill_with_root("new-n1", "generation-budget")
+                .await
+                .expect("N+1 pin")
+                .0
+                .prompt,
+            "prompt N+1"
+        );
+    }
+
+    #[tokio::test]
+    async fn workspace_publications_share_one_global_retained_budget() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let workspace_a = directory.path().join("workspace-a");
+        let workspace_b = directory.path().join("workspace-b");
+        for workspace in [&workspace_a, &workspace_b] {
+            let root = write_skill(
+                &workspace.join(".bamboo/skills"),
+                "publication-demo",
+                "publication",
+                "publication",
+            )
+            .await
+            .expect("workspace skill");
+            fs::create_dir_all(root.join("references"))
+                .await
+                .expect("references");
+            fs::write(root.join("references/value.bin"), vec![b'x'; 128])
+                .await
+                .expect("resource");
+        }
+        let store = SkillStore::new_with_snapshot_limits(
+            SkillStoreConfig {
+                skills_dir: directory.path().join("data/skills"),
+                ..Default::default()
+            },
+            super::SkillSnapshotLimits {
+                max_file_bytes: 256,
+                max_skill_bytes: 1024,
+                max_publication_bytes: 1024,
+                max_retained_bytes: 400,
+            },
+        );
+        store.reload().await.expect("empty root publication");
+        store
+            .skill_store_for_workspace(&workspace_a)
+            .await
+            .expect("first workspace publication fits");
+        let error = store
+            .skill_store_for_workspace(&workspace_b)
+            .await
+            .err()
+            .expect("second workspace publication must share the same budget");
+        assert!(error
+            .to_string()
+            .contains("global workflow snapshot budget"));
+    }
+
+    #[tokio::test]
+    async fn empty_workspace_store_cache_is_globally_bounded() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir: directory.path().join("data/skills"),
+            ..Default::default()
+        });
+        for index in 0..super::MAX_CACHED_WORKSPACE_STORES {
+            let workspace = directory.path().join(format!("workspace-{index}"));
+            fs::create_dir_all(&workspace).await.expect("workspace");
+            store
+                .skill_store_for_workspace(&workspace)
+                .await
+                .expect("bounded workspace store slot");
+        }
+        let overflow = directory.path().join("workspace-overflow");
+        fs::create_dir_all(&overflow)
+            .await
+            .expect("overflow workspace");
+        let error = store
+            .skill_store_for_workspace(&overflow)
+            .await
+            .err()
+            .expect("empty workspace stores must be capped");
+        assert!(error.to_string().contains("workspace store capacity"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn workspace_alias_cache_is_bounded_for_one_canonical_store() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().expect("tempdir");
+        let target = directory.path().join("target");
+        fs::create_dir_all(&target).await.expect("target");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir: directory.path().join("data/skills"),
+            ..Default::default()
+        });
+        store
+            .skill_store_for_workspace(&target)
+            .await
+            .expect("canonical target");
+        let initial_aliases = store.workspace_stores.read().await.len();
+        for index in 0..(super::MAX_CACHED_WORKSPACE_ALIASES - initial_aliases) {
+            let alias = directory.path().join(format!("alias-{index}"));
+            symlink(&target, &alias).expect("alias");
+            store
+                .skill_store_for_workspace(&alias)
+                .await
+                .expect("bounded alias slot");
+        }
+        let overflow = directory.path().join("alias-overflow");
+        symlink(&target, &overflow).expect("overflow alias");
+        let error = store
+            .skill_store_for_workspace(&overflow)
+            .await
+            .err()
+            .expect("aliases must be capped");
+        assert!(error.to_string().contains("workspace alias capacity"));
     }
 }

--- a/crates/infra/bamboo-skills/src/store/storage.rs
+++ b/crates/infra/bamboo-skills/src/store/storage.rs
@@ -1,10 +1,72 @@
 use std::path::{Path, PathBuf};
 
 use tokio::fs;
+use tokio::io::AsyncReadExt;
 use tracing::{debug, info, warn};
 
 use crate::store::parser::{parse_markdown_skill, render_skill_markdown};
 use crate::types::{SkillDefinition, SkillError, SkillResult};
+
+fn open_file_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+            .open(path)?;
+        if !file.metadata()?.file_type().is_file() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "workflow resource is not a regular file",
+            ));
+        }
+        Ok(file)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x00200000;
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .attributes(FILE_FLAG_OPEN_REPARSE_POINT)
+            .open(path)?;
+        if !file.metadata()?.file_type().is_file() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "workflow resource is not a regular file",
+            ));
+        }
+        Ok(file)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        if std::fs::symlink_metadata(path)?.file_type().is_symlink() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "workflow file is a symbolic link",
+            ));
+        }
+        let file = std::fs::OpenOptions::new().read(true).open(path)?;
+        if !file.metadata()?.file_type().is_file() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "workflow resource is not a regular file",
+            ));
+        }
+        Ok(file)
+    }
+}
+
+pub(crate) async fn open_skill_file_no_follow(path: &Path) -> std::io::Result<tokio::fs::File> {
+    let owned = path.to_path_buf();
+    let file = tokio::task::spawn_blocking(move || open_file_no_follow(&owned))
+        .await
+        .map_err(|error| {
+            std::io::Error::other(format!("workflow file open task failed: {error}"))
+        })??;
+    Ok(tokio::fs::File::from_std(file))
+}
 
 fn public_skill_error(error: &SkillError) -> String {
     match error {
@@ -74,7 +136,7 @@ pub async fn ensure_skills_dir(skills_dir: &Path) -> SkillResult<()> {
 }
 
 /// Recursively find all SKILL.md files in the skills directory
-async fn find_skill_files(dir: &Path) -> Vec<PathBuf> {
+async fn find_skill_files(dir: &Path, max_candidates: usize) -> Vec<PathBuf> {
     let mut skill_files = Vec::new();
     let mut entries = match fs::read_dir(dir).await {
         Ok(entries) => entries,
@@ -114,6 +176,9 @@ async fn find_skill_files(dir: &Path) -> Vec<PathBuf> {
                         .unwrap_or(false);
                     if is_regular_file {
                         skill_files.push(skill_file);
+                        if skill_files.len() > max_candidates {
+                            break;
+                        }
                     } else {
                         warn!(
                             "Ignoring symlinked or non-regular skill file: {:?}",
@@ -124,8 +189,14 @@ async fn find_skill_files(dir: &Path) -> Vec<PathBuf> {
                 }
                 Ok(false) => {
                     // Not a skill directory, recurse into it
-                    let sub_skills = Box::pin(find_skill_files(&path)).await;
+                    let remaining = max_candidates
+                        .saturating_add(1)
+                        .saturating_sub(skill_files.len());
+                    let sub_skills = Box::pin(find_skill_files(&path, remaining)).await;
                     skill_files.extend(sub_skills);
+                    if skill_files.len() > max_candidates {
+                        break;
+                    }
                 }
                 Err(_) => {
                     debug!("Cannot check {:?}, skipping", path);
@@ -148,6 +219,15 @@ pub async fn load_skills_from_discovery_dirs(
 /// Discover every candidate and preserve per-bundle failures for catalog LKG handling.
 pub async fn load_skills_from_discovery_dirs_detailed(
     discovery_dirs: &[SkillDiscoveryDir],
+) -> SkillResult<SkillLoadReport> {
+    load_skills_from_discovery_dirs_detailed_with_limits(discovery_dirs, 8 * 1024 * 1024, 1024)
+        .await
+}
+
+pub async fn load_skills_from_discovery_dirs_detailed_with_limits(
+    discovery_dirs: &[SkillDiscoveryDir],
+    max_skill_file_bytes: usize,
+    max_skill_candidates: usize,
 ) -> SkillResult<SkillLoadReport> {
     let mut report = SkillLoadReport::default();
 
@@ -177,10 +257,58 @@ pub async fn load_skills_from_discovery_dirs_detailed(
             discovery.mode.as_deref().unwrap_or("generic")
         );
 
-        let mut skill_files = find_skill_files(&discovery.dir).await;
+        let mut skill_files = find_skill_files(&discovery.dir, max_skill_candidates).await;
+        if skill_files.len() > max_skill_candidates
+            || report
+                .loaded
+                .len()
+                .saturating_add(report.failed.len())
+                .saturating_add(skill_files.len())
+                > max_skill_candidates
+        {
+            return Err(SkillError::Storage(format!(
+                "workflow catalog candidate count exceeds limit ({max_skill_candidates})"
+            )));
+        }
         skill_files.sort();
         for skill_file in skill_files {
-            match fs::read_to_string(&skill_file).await {
+            let metadata_bytes = fs::metadata(&skill_file).await?.len() as usize;
+            if metadata_bytes > max_skill_file_bytes {
+                let skill_root = skill_file
+                    .parent()
+                    .map(Path::to_path_buf)
+                    .unwrap_or_default();
+                report.failed.push(FailedSkillRecord {
+                    skill_id: skill_root.file_name().and_then(|name| name.to_str()).map(str::to_string),
+                    skill_root,
+                    skill_file,
+                    source: discovery.source,
+                    mode: discovery.mode.clone(),
+                    error: format!("SKILL.md exceeds per-file limit ({metadata_bytes} > {max_skill_file_bytes} bytes)"),
+                });
+                continue;
+            }
+            let file = open_skill_file_no_follow(&skill_file).await?;
+            let mut bytes = Vec::with_capacity(metadata_bytes.min(max_skill_file_bytes));
+            file.take(max_skill_file_bytes.saturating_add(1) as u64)
+                .read_to_end(&mut bytes)
+                .await?;
+            if bytes.len() > max_skill_file_bytes {
+                let skill_root = skill_file
+                    .parent()
+                    .map(Path::to_path_buf)
+                    .unwrap_or_default();
+                report.failed.push(FailedSkillRecord {
+                    skill_id: skill_root.file_name().and_then(|name| name.to_str()).map(str::to_string),
+                    skill_root,
+                    skill_file,
+                    source: discovery.source,
+                    mode: discovery.mode.clone(),
+                    error: format!("SKILL.md exceeds per-file limit after read ({} > {max_skill_file_bytes} bytes)", bytes.len()),
+                });
+                continue;
+            }
+            match String::from_utf8(bytes) {
                 Ok(content) => match parse_markdown_skill(&skill_file, &content) {
                     Ok(skill) => {
                         let skill_root = skill_file


### PR DESCRIPTION
## Summary

- Publish immutable workflow skill definitions and resources with stable catalog and skill revisions.
- Pin each activation to the advertised generation so load, resource reads, allowed tools, suspend/resume, cancellation, and deletion use one consistent snapshot.
- Bound retained snapshot bytes, files, paths, active pins, workspace stores, mode stores, and aliases; reject symlink/reparse traversal and oversized publications.
- Preserve active generation N across watcher reloads while future activations observe N+1.

## Root Cause

The catalog advertised revisions, but runtime reads could independently re-resolve live skill state. A reload or workspace transition could therefore mix descriptor and payload generations inside one activation, and retained snapshots lacked complete lifecycle and memory bounds.

## User Impact

Running workflows now remain deterministic across live reloads and resume, fail closed when a required pinned generation is unavailable, and release bounded snapshot state on every terminal path.

## Test Plan

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets`
- `cargo test --workspace -- --skip build_rustls_config_succeeds_on_valid_self_signed_cert`
- Independently reproduced the skipped TLS fixture on clean `origin/main`; both fail with `UnsupportedCertVersion`.
- Independent agent review: APPROVED, no blockers.

Closes #616