### PR TITLE
feat(engine): add durable workflow run engine (#578)

### DIFF
--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -307,6 +307,18 @@ impl AppState {
             ledger_schedule_bridge.clone(),
         );
 
+        // The workflow engine executes against the base tool surface. The
+        // caller-facing workflow_run tool is overlaid onto the root surface
+        // later, preventing a workflow from recursively dispatching itself.
+        let workflow_runs = crate::workflow::WorkflowRunAccess::new(
+            &data_dir,
+            base_tools.clone(),
+            skill_manager.clone(),
+            session_repo.clone(),
+        )
+        .await
+        .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
+
         // Idle-evict completed runners together with their paired session event
         // senders (issue #346). Spawned here (not next to `agent_runners`) so it
         // owns handles to both maps.
@@ -644,6 +656,11 @@ impl AppState {
             fabric_deployer.clone(),
             notification_relay_deps.clone(),
         );
+        let workflow_run_tool =
+            Arc::new(crate::workflow::WorkflowRunTool::new(workflow_runs.clone()));
+        let tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor> = Arc::new(
+            crate::tools::OverlayToolExecutor::new(tools, workflow_run_tool),
+        );
 
         child_completion_coordinator
             .set_root_tools(tools.clone())
@@ -778,6 +795,7 @@ impl AppState {
             cancel_tokens: Arc::new(RwLock::new(HashMap::new())),
             mcp_proxy_shutdown,
             skill_manager,
+            workflow_runs,
             mcp_manager,
             service_manager,
             boot_reconcile_services_handle: tokio::sync::Mutex::new(Some(

--- a/crates/app/bamboo-server/src/app_state/mod.rs
+++ b/crates/app/bamboo-server/src/app_state/mod.rs
@@ -301,6 +301,10 @@ pub struct AppState {
     /// validation, and execution.
     pub skill_manager: Arc<SkillManager>,
 
+    /// Durable, recovered workflow-run boundary. It owns the production engine
+    /// plus server-derived session/catalog trust adapters.
+    pub workflow_runs: crate::workflow::WorkflowRunAccess,
+
     /// MCP server manager for external tool servers
     ///
     /// Handles lifecycle of Model Context Protocol servers,

--- a/crates/app/bamboo-server/src/app_state/provider_api.rs
+++ b/crates/app/bamboo-server/src/app_state/provider_api.rs
@@ -212,6 +212,22 @@ mod tests {
         assert!(!schemas.is_empty(), "Root tools should not be empty");
     }
 
+    #[tokio::test]
+    async fn workflow_run_tool_is_root_only_and_cannot_recursively_dispatch_itself() {
+        let (_temp, state) = make_state().await;
+        let names = |surface| {
+            state
+                .tools_for(surface)
+                .list_tools()
+                .into_iter()
+                .map(|schema| schema.function.name)
+                .collect::<std::collections::HashSet<_>>()
+        };
+        assert!(names(ToolSurface::Root).contains("workflow_run"));
+        assert!(!names(ToolSurface::Base).contains("workflow_run"));
+        assert!(!names(ToolSurface::Child).contains("workflow_run"));
+    }
+
     // ---- get_all_tool_schemas ----
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/handlers/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/mod.rs
@@ -43,4 +43,5 @@ pub mod openai;
 pub mod settings;
 pub mod skill;
 pub mod tools;
+pub mod workflow_runs;
 pub mod workspace;

--- a/crates/app/bamboo-server/src/handlers/workflow_runs.rs
+++ b/crates/app/bamboo-server/src/handlers/workflow_runs.rs
@@ -1,0 +1,144 @@
+//! Safe HTTP facade for durable catalog-pinned workflow runs.
+
+use actix_web::{web, HttpResponse};
+use bamboo_engine::WorkflowRunError;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::app_state::AppState;
+use crate::workflow::public_workflow_snapshot;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StartWorkflowRunRequest {
+    pub workflow_id: String,
+    pub revision: u64,
+    #[serde(default)]
+    pub args: Value,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowEventsQuery {
+    #[serde(default)]
+    pub since: u64,
+}
+
+pub async fn start(
+    state: web::Data<AppState>,
+    session_id: web::Path<String>,
+    body: web::Json<StartWorkflowRunRequest>,
+) -> HttpResponse {
+    match state
+        .workflow_runs
+        .start(
+            &session_id,
+            &body.workflow_id,
+            body.revision,
+            body.args.clone(),
+        )
+        .await
+    {
+        Ok(snapshot) => HttpResponse::Accepted().json(public_workflow_snapshot(snapshot)),
+        Err(error) => workflow_error(error),
+    }
+}
+
+pub async fn get(state: web::Data<AppState>, path: web::Path<(String, String)>) -> HttpResponse {
+    let (session_id, run_id) = path.into_inner();
+    match state
+        .workflow_runs
+        .progress_for_session(&session_id, &run_id, u64::MAX)
+        .await
+    {
+        Ok(progress) => HttpResponse::Ok().json(public_workflow_snapshot(progress.snapshot)),
+        Err(error) => workflow_error(error),
+    }
+}
+
+pub async fn events(
+    state: web::Data<AppState>,
+    path: web::Path<(String, String)>,
+    query: web::Query<WorkflowEventsQuery>,
+) -> HttpResponse {
+    let (session_id, run_id) = path.into_inner();
+    match state
+        .workflow_runs
+        .progress_for_session(&session_id, &run_id, query.since)
+        .await
+    {
+        Ok(progress) => HttpResponse::Ok().json(progress.events),
+        Err(error) => workflow_error(error),
+    }
+}
+
+pub async fn cancel(state: web::Data<AppState>, path: web::Path<(String, String)>) -> HttpResponse {
+    let (session_id, run_id) = path.into_inner();
+    match state
+        .workflow_runs
+        .cancel_for_session(&session_id, &run_id)
+        .await
+    {
+        Ok(snapshot) => HttpResponse::Ok().json(public_workflow_snapshot(snapshot)),
+        Err(error) => workflow_error(error),
+    }
+}
+
+pub async fn restart(
+    state: web::Data<AppState>,
+    path: web::Path<(String, String)>,
+) -> HttpResponse {
+    let (session_id, run_id) = path.into_inner();
+    match state
+        .workflow_runs
+        .restart_for_session(&session_id, &run_id)
+        .await
+    {
+        Ok(snapshot) => HttpResponse::Accepted().json(public_workflow_snapshot(snapshot)),
+        Err(error) => workflow_error(error),
+    }
+}
+
+fn workflow_error(error: WorkflowRunError) -> HttpResponse {
+    let message = error.to_string();
+    match error {
+        WorkflowRunError::NotFound => {
+            HttpResponse::NotFound().json(serde_json::json!({"error": message}))
+        }
+        WorkflowRunError::Terminal => {
+            HttpResponse::Conflict().json(serde_json::json!({"error": message}))
+        }
+        WorkflowRunError::Storage(_) => HttpResponse::InternalServerError()
+            .json(serde_json::json!({"error": "workflow storage unavailable"})),
+        WorkflowRunError::Compile(_)
+        | WorkflowRunError::InvalidInput(_)
+        | WorkflowRunError::Preflight(_) => {
+            HttpResponse::BadRequest().json(serde_json::json!({"error": message}))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn start_request_rejects_spoofed_trust_and_capabilities() {
+        for field in ["workspace_trusted", "allowed_capabilities"] {
+            let mut value = serde_json::json!({
+                "workflow_id": "safe",
+                "revision": 1
+            });
+            value[field] = serde_json::json!(true);
+            assert!(serde_json::from_value::<StartWorkflowRunRequest>(value).is_err());
+        }
+        assert!(
+            serde_json::from_value::<StartWorkflowRunRequest>(serde_json::json!({
+                "workflow_id": "safe",
+                "revision": 1,
+                "session_id": "caller-controlled"
+            }))
+            .is_err()
+        );
+    }
+}

--- a/crates/app/bamboo-server/src/routes/bamboo_v1.rs
+++ b/crates/app/bamboo-server/src/routes/bamboo_v1.rs
@@ -1,6 +1,6 @@
 use actix_web::{dev::HttpServiceFactory, web};
 
-use crate::handlers::{command, copilot_auth, settings, skill, tools, workspace};
+use crate::handlers::{command, copilot_auth, settings, skill, tools, workflow_runs, workspace};
 
 /// Builds the full Bamboo internal route table (commands / settings / skills /
 /// tools / workspace / copilot-auth / provider-catalog / provider-instances /
@@ -37,6 +37,26 @@ pub(crate) fn bamboo_relative_routes() -> impl HttpServiceFactory {
         .route(
             "/bamboo/workflow-catalog",
             web::get().to(settings::list_workflow_catalog),
+        )
+        .route(
+            "/sessions/{session_id}/workflow-runs",
+            web::post().to(workflow_runs::start),
+        )
+        .route(
+            "/sessions/{session_id}/workflow-runs/{run_id}",
+            web::get().to(workflow_runs::get),
+        )
+        .route(
+            "/sessions/{session_id}/workflow-runs/{run_id}/events",
+            web::get().to(workflow_runs::events),
+        )
+        .route(
+            "/sessions/{session_id}/workflow-runs/{run_id}/cancel",
+            web::post().to(workflow_runs::cancel),
+        )
+        .route(
+            "/sessions/{session_id}/workflow-runs/{run_id}/restart",
+            web::post().to(workflow_runs::restart),
         )
         .route("/bamboo/workflows", web::get().to(settings::list_workflows))
         .route(

--- a/crates/app/bamboo-server/src/routes/tests.rs
+++ b/crates/app/bamboo-server/src/routes/tests.rs
@@ -93,6 +93,7 @@ async fn bamboo_v1_routes_resolve_under_both_canonical_and_legacy_prefix() {
     let relative_paths = [
         "/commands",
         "/bamboo/workflows",
+        "/sessions/session/workflow-runs/example",
         "/bamboo/setup/status",
         "/bamboo/config",
         "/bamboo/access/status",
@@ -206,6 +207,40 @@ async fn remote_unverified_request_is_blocked_by_access_middleware() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[actix_web::test]
+async fn workflow_run_routes_are_blocked_by_the_same_access_middleware() {
+    let data_dir = tempdir().unwrap();
+    let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());
+    {
+        let mut config = app_state.config.write().await;
+        config.access_control = Some(AccessControlConfig {
+            password_enabled: true,
+            password_hash: Some(
+                "a65192f8d645bc4d19765b8ea61bfbb896dc999cb88a4be419518c5493f92c9d".to_string(),
+            ),
+            password_salt: Some("01010101010101010101010101010101".to_string()),
+            updated_at: None,
+            devices: Vec::new(),
+        });
+    }
+    let app = test::init_service(App::new().app_data(app_state).configure(configure_routes)).await;
+    for (method, uri) in [
+        ("POST", "/api/v1/sessions/session/workflow-runs"),
+        ("GET", "/api/v1/sessions/session/workflow-runs/example"),
+        ("POST", "/v1/sessions/session/workflow-runs/example/cancel"),
+    ] {
+        let req = match method {
+            "POST" => test::TestRequest::post(),
+            _ => test::TestRequest::get(),
+        }
+        .uri(uri)
+        .insert_header((header::HOST, "bamboo.example.com"))
+        .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED, "{method} {uri}");
+    }
 }
 
 /// `/api/v1/plugins` (Wave 2 § HTTP agent, `PLUGIN_PLAN.md`) added no new

--- a/crates/app/bamboo-server/src/workflow/mod.rs
+++ b/crates/app/bamboo-server/src/workflow/mod.rs
@@ -8,6 +8,10 @@
 //! and cache.
 
 mod loader;
+mod run;
+
+pub(crate) use run::public_workflow_snapshot;
+pub use run::{WorkflowRunAccess, WorkflowRunTool};
 
 #[cfg(test)]
 mod tests;

--- a/crates/app/bamboo-server/src/workflow/run.rs
+++ b/crates/app/bamboo-server/src/workflow/run.rs
@@ -1,0 +1,545 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bamboo_agent_core::tools::{Tool, ToolClass, ToolCtx, ToolError, ToolOutcome, ToolResult};
+use bamboo_domain::{
+    StartWorkflowRun, WorkflowBudgets, WorkflowDefinitionBundle, WorkflowProgress,
+    WorkflowRunDefinition, WorkflowRunSnapshot,
+};
+use bamboo_engine::{
+    AgentStepPort, AgentStepResult, FileWorkflowRunRepository, NamedAgentSpec, PermissionDecision,
+    WorkflowDefinitionPort, WorkflowPolicyPort, WorkflowPolicyTarget, WorkflowRunEngine,
+    WorkflowRunError, WorkflowSecretMaterial, WorkflowSecretResolverPort,
+};
+use bamboo_skills::SkillManager;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+const MAX_CONCURRENCY: usize = 8;
+const MAX_AGENTS: u32 = 16;
+const MAX_STEPS: u32 = 512;
+const MAX_RETRIES: u32 = 16;
+const MAX_NESTING_DEPTH: u32 = 8;
+const MAX_WALL_TIME_MS: u64 = 60 * 60 * 1000;
+const MAX_TOKENS: u64 = 2_000_000;
+const MAX_COST_MICROS: u64 = 100_000_000;
+const MAX_PINNED_DEFINITIONS_PER_RUN: usize = 32;
+const MAX_PINNED_BUNDLE_BYTES_PER_RUN: usize = 512 * 1024;
+const SAFE_UNTRUSTED_WORKFLOW_TOOLS: &[&str] = &[
+    "Read",
+    "read_file",
+    "GetFileInfo",
+    "Glob",
+    "list_directory",
+    "Grep",
+];
+
+/// Server-owned access boundary for workflow runs. Session, workspace trust and
+/// capabilities are derived here rather than accepted from HTTP/tool callers.
+#[derive(Clone)]
+pub struct WorkflowRunAccess {
+    engine: Arc<WorkflowRunEngine>,
+    skills: Arc<SkillManager>,
+    sessions: bamboo_engine::SessionRepository,
+}
+
+impl WorkflowRunAccess {
+    pub async fn new(
+        data_dir: &Path,
+        tools: Arc<dyn bamboo_agent_core::tools::ToolExecutor>,
+        skills: Arc<SkillManager>,
+        sessions: bamboo_engine::SessionRepository,
+    ) -> Result<Self, String> {
+        let repository = Arc::new(
+            FileWorkflowRunRepository::new(data_dir.join("workflow-runs"))
+                .map_err(|error| format!("failed to initialize workflow journal: {error}"))?,
+        );
+        let engine = WorkflowRunEngine::new(
+            repository,
+            tools,
+            Arc::new(UnavailableAgentPort),
+            Arc::new(ExternallyPinnedDefinitions),
+            Arc::new(ServerWorkflowPolicy),
+            Arc::new(UnavailableSecretResolver),
+            WorkflowBudgets {
+                max_concurrency: MAX_CONCURRENCY,
+                max_agents: MAX_AGENTS,
+                max_steps: MAX_STEPS,
+                max_retries: MAX_RETRIES,
+                max_nesting_depth: MAX_NESTING_DEPTH,
+                wall_time_ms: MAX_WALL_TIME_MS,
+                max_tokens: Some(MAX_TOKENS),
+                max_cost_micros: Some(MAX_COST_MICROS),
+            },
+        );
+        engine
+            .recover()
+            .await
+            .map_err(|error| format!("failed to recover workflow journal: {error}"))?;
+        Ok(Self {
+            engine,
+            skills,
+            sessions,
+        })
+    }
+
+    async fn session_context(
+        &self,
+        session_id: &str,
+    ) -> Result<(Option<PathBuf>, bool), WorkflowRunError> {
+        let session =
+            self.sessions.try_load(session_id).await.map_err(|_| {
+                WorkflowRunError::Preflight("session state is unavailable".to_string())
+            })?;
+        let session = session.ok_or_else(|| {
+            WorkflowRunError::Preflight("workflow session does not exist".to_string())
+        })?;
+        let preferred = session.workspace.map(PathBuf::from);
+        let workspace =
+            bamboo_agent_core::workspace_state::ensure_session_workspace(session_id, preferred)
+                .or_else(|| {
+                    // Server bootstrap registers the workspace-root provider, so this
+                    // yields a persistent session-scoped directory under data_dir when
+                    // the session has no explicit/configured workspace (#217).
+                    Some(
+                        bamboo_agent_core::workspace_state::workspace_or_process_cwd(Some(
+                            session_id,
+                        )),
+                    )
+                });
+        // Path resolution and workspace trust are separate authorities. Until
+        // #601 provides an explicit server-owned trust decision, never infer
+        // trust merely because the resolved path is absolute. Read-only runs
+        // remain available through `ServerWorkflowPolicy`; every stronger
+        // capability stays fail-closed.
+        Ok((workspace, false))
+    }
+
+    pub async fn start(
+        &self,
+        session_id: &str,
+        workflow_id: &str,
+        revision: u64,
+        args: Value,
+    ) -> Result<WorkflowRunSnapshot, WorkflowRunError> {
+        let (workspace, workspace_trusted) = self.session_context(session_id).await?;
+        let bundle = self
+            .skills
+            .pin_workflow_definition_bundle(workspace.as_deref(), workflow_id, revision)
+            .await
+            .map_err(|_| WorkflowRunError::Preflight("workflow catalog pin failed".to_string()))?;
+        let bundle_bytes = serde_json::to_vec(&bundle)
+            .map_err(|_| WorkflowRunError::Preflight("workflow bundle is invalid".to_string()))?
+            .len();
+        enforce_pinned_bundle_limits(bundle.definitions.len(), bundle_bytes)?;
+        let definition = bundle.root().cloned().ok_or_else(|| {
+            WorkflowRunError::Preflight("pinned workflow root is missing".to_string())
+        })?;
+        self.engine
+            .start_pinned(
+                StartWorkflowRun {
+                    definition,
+                    args,
+                    session_id: session_id.to_string(),
+                    workspace_trusted,
+                    // #601 is not a production capability authority yet. Grant
+                    // only the server-owned read-only class needed by the review
+                    // dogfood workflow; the concrete base ToolExecutor still
+                    // performs its normal per-tool/per-resource permission gate.
+                    allowed_capabilities: vec!["read".to_string()],
+                },
+                bundle,
+            )
+            .await
+    }
+
+    pub async fn progress_for_session(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        since: u64,
+    ) -> Result<WorkflowProgress, WorkflowRunError> {
+        let progress = self.engine.progress(run_id, since).await?;
+        if progress.snapshot.session_id != session_id {
+            return Err(WorkflowRunError::NotFound);
+        }
+        Ok(progress)
+    }
+
+    pub async fn cancel_for_session(
+        &self,
+        session_id: &str,
+        run_id: &str,
+    ) -> Result<WorkflowRunSnapshot, WorkflowRunError> {
+        self.progress_for_session(session_id, run_id, u64::MAX)
+            .await?;
+        self.engine.cancel(run_id).await
+    }
+
+    pub async fn restart_for_session(
+        &self,
+        session_id: &str,
+        run_id: &str,
+    ) -> Result<WorkflowRunSnapshot, WorkflowRunError> {
+        self.progress_for_session(session_id, run_id, u64::MAX)
+            .await?;
+        let (_, workspace_trusted) = self.session_context(session_id).await?;
+        self.engine
+            .restart(run_id, workspace_trusted, vec!["read".to_string()])
+            .await
+    }
+}
+
+fn enforce_pinned_bundle_limits(
+    definition_count: usize,
+    serialized_bytes: usize,
+) -> Result<(), WorkflowRunError> {
+    if definition_count > MAX_PINNED_DEFINITIONS_PER_RUN {
+        return Err(WorkflowRunError::Preflight(
+            "workflow dependency count exceeds the server limit".to_string(),
+        ));
+    }
+    if serialized_bytes > MAX_PINNED_BUNDLE_BYTES_PER_RUN {
+        return Err(WorkflowRunError::Preflight(
+            "workflow definition bundle exceeds the server size limit".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// The durable snapshot keeps the complete pinned bundle for deterministic
+/// restart, but clients need only the root definition, bundle identity/hash,
+/// step tree and events. Avoid echoing every nested definition over HTTP/tools.
+pub(crate) fn public_workflow_snapshot(mut snapshot: WorkflowRunSnapshot) -> WorkflowRunSnapshot {
+    snapshot.definition_bundle.definitions.clear();
+    snapshot
+}
+
+/// The catalog adapter above always calls `start_pinned`. Generic engine starts
+/// remain unavailable so no future server call site can accidentally re-read a
+/// live definition or mix publications.
+struct ExternallyPinnedDefinitions;
+
+#[async_trait]
+impl WorkflowDefinitionPort for ExternallyPinnedDefinitions {
+    async fn pin_bundle(
+        &self,
+        _root: &WorkflowRunDefinition,
+    ) -> Result<WorkflowDefinitionBundle, String> {
+        Err("server workflows must be pinned through SkillManager".to_string())
+    }
+}
+
+/// #563 named-agent registry integration is not complete. Unknown and named
+/// agents therefore fail preflight rather than falling back to a dynamic agent.
+struct UnavailableAgentPort;
+
+#[async_trait]
+impl AgentStepPort for UnavailableAgentPort {
+    async fn resolve(&self, _name: &str) -> Result<Option<NamedAgentSpec>, String> {
+        Ok(None)
+    }
+
+    async fn execute(
+        &self,
+        _spec: &NamedAgentSpec,
+        _prompt: Value,
+        _model: Option<&str>,
+        _effort: Option<&str>,
+        _capabilities: &BTreeSet<String>,
+        _session_id: &str,
+    ) -> Result<AgentStepResult, String> {
+        Err("named-agent execution is not available".to_string())
+    }
+}
+
+struct ServerWorkflowPolicy;
+
+#[async_trait]
+impl WorkflowPolicyPort for ServerWorkflowPolicy {
+    async fn authorize(
+        &self,
+        _session_id: &str,
+        target: &WorkflowPolicyTarget,
+        requested: &BTreeSet<String>,
+        _workspace_trusted: bool,
+    ) -> PermissionDecision {
+        // Definition-declared capabilities are descriptive input, not an
+        // authority. Until #601 provides a server-owned capability registry,
+        // bind authorization to this strict server-owned target allowlist too.
+        // Unknown/MCP/network/script/write targets therefore fail closed even
+        // when hostile YAML claims `capabilities: []` or `[read]`.
+        match target {
+            // The reference itself belongs to the same immutable, validated
+            // bundle. Every concrete step in the nested definition is still
+            // authorized independently during this preflight walk.
+            WorkflowPolicyTarget::Workflow { .. } if requested.is_empty() => {
+                PermissionDecision::Allow
+            }
+            WorkflowPolicyTarget::Tool(name) => {
+                let safe_target = SAFE_UNTRUSTED_WORKFLOW_TOOLS
+                    .iter()
+                    .any(|candidate| candidate.eq_ignore_ascii_case(name));
+                if safe_target && requested.iter().all(|capability| capability == "read") {
+                    PermissionDecision::Allow
+                } else {
+                    PermissionDecision::Deny(
+                        "workflow capability authority is not available".to_string(),
+                    )
+                }
+            }
+            WorkflowPolicyTarget::Agent(_) | WorkflowPolicyTarget::Workflow { .. } => {
+                PermissionDecision::Deny(
+                    "workflow capability authority is not available".to_string(),
+                )
+            }
+        }
+    }
+}
+
+struct UnavailableSecretResolver;
+
+#[async_trait]
+impl WorkflowSecretResolverPort for UnavailableSecretResolver {
+    async fn resolve(
+        &self,
+        _session_id: &str,
+        _capability: &str,
+    ) -> Result<WorkflowSecretMaterial, String> {
+        Err("workflow secret capability resolver is not available".to_string())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+enum WorkflowToolInput {
+    Start {
+        workflow_id: String,
+        revision: u64,
+        #[serde(default)]
+        args: Value,
+    },
+    Get {
+        run_id: String,
+    },
+    Events {
+        run_id: String,
+        #[serde(default)]
+        since: u64,
+    },
+    Cancel {
+        run_id: String,
+    },
+    Restart {
+        run_id: String,
+    },
+}
+
+pub struct WorkflowRunTool {
+    access: WorkflowRunAccess,
+}
+
+impl WorkflowRunTool {
+    pub fn new(access: WorkflowRunAccess) -> Self {
+        Self { access }
+    }
+}
+
+#[async_trait]
+impl Tool for WorkflowRunTool {
+    fn name(&self) -> &str {
+        "workflow_run"
+    }
+
+    fn description(&self) -> &str {
+        "Start, inspect, cancel, or safely restart a catalog-pinned workflow run"
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "oneOf": [
+                {"properties": {"action": {"const": "start"}, "workflow_id": {"type": "string"}, "revision": {"type": "integer", "minimum": 0}, "args": {}}, "required": ["action", "workflow_id", "revision"], "additionalProperties": false},
+                {"properties": {"action": {"const": "get"}, "run_id": {"type": "string"}}, "required": ["action", "run_id"], "additionalProperties": false},
+                {"properties": {"action": {"const": "events"}, "run_id": {"type": "string"}, "since": {"type": "integer", "minimum": 0}}, "required": ["action", "run_id"], "additionalProperties": false},
+                {"properties": {"action": {"const": "cancel"}, "run_id": {"type": "string"}}, "required": ["action", "run_id"], "additionalProperties": false},
+                {"properties": {"action": {"const": "restart"}, "run_id": {"type": "string"}}, "required": ["action", "run_id"], "additionalProperties": false}
+            ]
+        })
+    }
+
+    fn classify(&self, args: &Value) -> ToolClass {
+        match args.get("action").and_then(Value::as_str) {
+            Some("get" | "events") => ToolClass::READONLY_PARALLEL,
+            _ => ToolClass::MUTATING_SERIAL,
+        }
+    }
+
+    async fn invoke(&self, args: Value, ctx: ToolCtx) -> Result<ToolOutcome, ToolError> {
+        let input: WorkflowToolInput = serde_json::from_value(args)
+            .map_err(|error| ToolError::InvalidArguments(error.to_string()))?;
+        let session_id = ctx.session_id().ok_or_else(|| {
+            ToolError::InvalidArguments("workflow_run requires a session".to_string())
+        })?;
+        let result = match input {
+            WorkflowToolInput::Start {
+                workflow_id,
+                revision,
+                args,
+            } => serde_json::to_value(public_workflow_snapshot(
+                self.access
+                    .start(session_id, &workflow_id, revision, args)
+                    .await
+                    .map_err(workflow_tool_error)?,
+            )),
+            WorkflowToolInput::Get { run_id } => {
+                let progress = self
+                    .access
+                    .progress_for_session(session_id, &run_id, u64::MAX)
+                    .await
+                    .map_err(workflow_tool_error)?;
+                serde_json::to_value(public_workflow_snapshot(progress.snapshot))
+            }
+            WorkflowToolInput::Events { run_id, since } => {
+                let progress = self
+                    .access
+                    .progress_for_session(session_id, &run_id, since)
+                    .await
+                    .map_err(workflow_tool_error)?;
+                serde_json::to_value(progress.events)
+            }
+            WorkflowToolInput::Cancel { run_id } => serde_json::to_value(public_workflow_snapshot(
+                self.access
+                    .cancel_for_session(session_id, &run_id)
+                    .await
+                    .map_err(workflow_tool_error)?,
+            )),
+            WorkflowToolInput::Restart { run_id } => {
+                serde_json::to_value(public_workflow_snapshot(
+                    self.access
+                        .restart_for_session(session_id, &run_id)
+                        .await
+                        .map_err(workflow_tool_error)?,
+                ))
+            }
+        }
+        .map_err(|error| ToolError::Execution(error.to_string()))?;
+        Ok(ToolOutcome::Completed(ToolResult::text(
+            true,
+            serde_json::to_string(&result)
+                .map_err(|error| ToolError::Execution(error.to_string()))?,
+        )))
+    }
+}
+
+fn workflow_tool_error(error: WorkflowRunError) -> ToolError {
+    match error {
+        WorkflowRunError::InvalidInput(message) => ToolError::InvalidArguments(message),
+        WorkflowRunError::Compile(error) => ToolError::InvalidArguments(error.to_string()),
+        other => ToolError::Execution(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_input_rejects_security_context_spoofing() {
+        let error = serde_json::from_value::<WorkflowToolInput>(json!({
+            "action": "start",
+            "workflow_id": "safe",
+            "revision": 1,
+            "workspace_trusted": true
+        }))
+        .unwrap_err();
+        assert!(error.to_string().contains("unknown field"));
+    }
+
+    #[tokio::test]
+    async fn production_policy_allows_read_without_fabricating_workspace_trust() {
+        let read = BTreeSet::from(["read".to_string()]);
+        assert_eq!(
+            ServerWorkflowPolicy
+                .authorize(
+                    "session",
+                    &WorkflowPolicyTarget::Tool("read_file".to_string()),
+                    &read,
+                    false,
+                )
+                .await,
+            PermissionDecision::Allow
+        );
+
+        let write = BTreeSet::from(["write".to_string()]);
+        assert!(matches!(
+            ServerWorkflowPolicy
+                .authorize(
+                    "session",
+                    &WorkflowPolicyTarget::Tool("write_file".to_string()),
+                    &write,
+                    false,
+                )
+                .await,
+            PermissionDecision::Deny(_)
+        ));
+
+        for hostile_target in [
+            "Write",
+            "write_file",
+            "WebFetch",
+            "mcp::remote_tool",
+            "Bash",
+        ] {
+            for claimed in [BTreeSet::new(), read.clone()] {
+                assert!(matches!(
+                    ServerWorkflowPolicy
+                        .authorize(
+                            "session",
+                            &WorkflowPolicyTarget::Tool(hostile_target.to_string()),
+                            &claimed,
+                            false,
+                        )
+                        .await,
+                    PermissionDecision::Deny(_)
+                ));
+            }
+        }
+
+        assert_eq!(
+            ServerWorkflowPolicy
+                .authorize(
+                    "session",
+                    &WorkflowPolicyTarget::Workflow {
+                        id: "nested-review".to_string(),
+                        revision: 1,
+                    },
+                    &BTreeSet::new(),
+                    false,
+                )
+                .await,
+            PermissionDecision::Allow
+        );
+    }
+
+    #[test]
+    fn pinned_bundle_limits_reject_oversized_runs_before_engine_start() {
+        assert!(enforce_pinned_bundle_limits(
+            MAX_PINNED_DEFINITIONS_PER_RUN,
+            MAX_PINNED_BUNDLE_BYTES_PER_RUN
+        )
+        .is_ok());
+        assert!(enforce_pinned_bundle_limits(
+            MAX_PINNED_DEFINITIONS_PER_RUN + 1,
+            MAX_PINNED_BUNDLE_BYTES_PER_RUN
+        )
+        .is_err());
+        assert!(enforce_pinned_bundle_limits(
+            MAX_PINNED_DEFINITIONS_PER_RUN,
+            MAX_PINNED_BUNDLE_BYTES_PER_RUN + 1
+        )
+        .is_err());
+    }
+}

--- a/crates/core/bamboo-domain/src/workflow/compiler.rs
+++ b/crates/core/bamboo-domain/src/workflow/compiler.rs
@@ -1,0 +1,524 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::{
+    ValueRef, WorkflowPlan, WorkflowRunDefinition, WorkflowSecretHandle, WorkflowStepDefinition,
+    WorkflowStepKind,
+};
+use thiserror::Error;
+
+use super::schema::{validate_schema, validate_schema_shape as validate_shape};
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum WorkflowCompileError {
+    #[error("unsupported workflow_schema {0}")]
+    UnsupportedSchema(u32),
+    #[error("workflow id and revision are required")]
+    MissingIdentity,
+    #[error("invalid workflow budget: {0}")]
+    InvalidBudget(String),
+    #[error("duplicate or empty step id: {0}")]
+    DuplicateStep(String),
+    #[error("unknown step reference: {0}")]
+    UnknownStep(String),
+    #[error("invalid step {step}: {message}")]
+    InvalidStep { step: String, message: String },
+    #[error("cyclic step dependency: {0}")]
+    Cycle(String),
+    #[error("invalid schema: {0}")]
+    InvalidSchema(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct CompiledWorkflow {
+    pub definition: WorkflowRunDefinition,
+    pub steps: HashMap<String, WorkflowStepDefinition>,
+}
+
+impl CompiledWorkflow {
+    pub fn compile(definition: WorkflowRunDefinition) -> Result<Self, WorkflowCompileError> {
+        if definition.workflow_schema != 1 {
+            return Err(WorkflowCompileError::UnsupportedSchema(
+                definition.workflow_schema,
+            ));
+        }
+        if definition.id.trim().is_empty() || definition.revision == 0 {
+            return Err(WorkflowCompileError::MissingIdentity);
+        }
+        validate_budget(&definition)?;
+        validate_schema_shape(&definition.input_schema)?;
+        if let Some(schema) = &definition.output_schema {
+            validate_schema_shape(schema)?;
+        }
+        let mut steps = HashMap::new();
+        for step in &definition.steps {
+            if step.id.trim().is_empty() || steps.insert(step.id.clone(), step.clone()).is_some() {
+                return Err(WorkflowCompileError::DuplicateStep(step.id.clone()));
+            }
+            validate_step(step)?;
+        }
+        if steps.is_empty() {
+            return Err(WorkflowCompileError::InvalidStep {
+                step: "<definition>".to_string(),
+                message: "at least one step is required".to_string(),
+            });
+        }
+        validate_plan(&definition.plan, &steps)?;
+        validate_dependencies(&definition.plan, &steps)?;
+        validate_execution_bindings(&definition, &steps)?;
+        Ok(Self { definition, steps })
+    }
+
+    pub fn validate_input(&self, value: &serde_json::Value) -> Result<(), String> {
+        validate_schema(&self.definition.input_schema, value)
+    }
+}
+
+fn validate_schema_shape(schema: &serde_json::Value) -> Result<(), WorkflowCompileError> {
+    validate_shape(schema, "$").map_err(WorkflowCompileError::InvalidSchema)
+}
+
+fn validate_budget(definition: &WorkflowRunDefinition) -> Result<(), WorkflowCompileError> {
+    let budget = &definition.budgets;
+    if budget.max_concurrency == 0 || budget.max_concurrency > 64 {
+        return Err(WorkflowCompileError::InvalidBudget(
+            "max_concurrency must be 1..=64".to_string(),
+        ));
+    }
+    if budget.max_steps == 0
+        || budget.max_agents > budget.max_steps
+        || budget.max_nesting_depth == 0
+        || budget.wall_time_ms == 0
+    {
+        return Err(WorkflowCompileError::InvalidBudget(
+            "step/agent/depth/wall budgets must be bounded and coherent".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_step(step: &WorkflowStepDefinition) -> Result<(), WorkflowCompileError> {
+    let required = match &step.kind {
+        WorkflowStepKind::Tool { tool, .. } => tool,
+        WorkflowStepKind::Agent {
+            agent,
+            structured_output_attempts,
+            ..
+        } => {
+            if *structured_output_attempts == 0 || *structured_output_attempts > 8 {
+                return Err(WorkflowCompileError::InvalidStep {
+                    step: step.id.clone(),
+                    message: "structured_output_attempts must be 1..=8".to_string(),
+                });
+            }
+            agent
+        }
+        WorkflowStepKind::Workflow {
+            workflow_id,
+            revision,
+            ..
+        } => {
+            if *revision == 0 {
+                return Err(WorkflowCompileError::InvalidStep {
+                    step: step.id.clone(),
+                    message: "nested workflow revision must be fixed and non-zero".to_string(),
+                });
+            }
+            workflow_id
+        }
+    };
+    if required.trim().is_empty() {
+        return Err(WorkflowCompileError::InvalidStep {
+            step: step.id.clone(),
+            message: "target cannot be empty".to_string(),
+        });
+    }
+    if let Some(schema) = &step.output_schema {
+        validate_schema_shape(schema)?;
+    }
+    Ok(())
+}
+
+fn validate_plan(
+    plan: &WorkflowPlan,
+    steps: &HashMap<String, WorkflowStepDefinition>,
+) -> Result<(), WorkflowCompileError> {
+    let mut seen = HashSet::new();
+    validate_plan_inner(plan, steps, &mut seen)?;
+    let unreferenced = steps
+        .keys()
+        .filter(|step| !seen.contains(*step))
+        .cloned()
+        .collect::<Vec<_>>();
+    if !unreferenced.is_empty() {
+        return Err(WorkflowCompileError::InvalidStep {
+            step: "<plan>".to_string(),
+            message: format!("unreferenced steps: {}", unreferenced.join(", ")),
+        });
+    }
+    Ok(())
+}
+
+fn validate_plan_inner(
+    plan: &WorkflowPlan,
+    steps: &HashMap<String, WorkflowStepDefinition>,
+    seen: &mut HashSet<String>,
+) -> Result<(), WorkflowCompileError> {
+    match plan {
+        WorkflowPlan::Step { step } => {
+            if !steps.contains_key(step) {
+                return Err(WorkflowCompileError::UnknownStep(step.clone()));
+            }
+            if !seen.insert(step.clone()) {
+                return Err(WorkflowCompileError::InvalidStep {
+                    step: step.clone(),
+                    message: "step appears more than once in the execution plan".to_string(),
+                });
+            }
+        }
+        WorkflowPlan::Sequence { nodes } | WorkflowPlan::Parallel { nodes } => {
+            if nodes.is_empty() {
+                return Err(WorkflowCompileError::InvalidStep {
+                    step: "<plan>".to_string(),
+                    message: "sequence/parallel requires nodes".to_string(),
+                });
+            }
+            for node in nodes {
+                validate_plan_inner(node, steps, seen)?;
+            }
+        }
+        WorkflowPlan::Map { source, item, body } => {
+            if item.trim().is_empty() {
+                return Err(WorkflowCompileError::InvalidStep {
+                    step: "<map>".to_string(),
+                    message: "map item name cannot be empty".to_string(),
+                });
+            }
+            validate_ref(source, steps)?;
+            validate_plan_inner(body, steps, seen)?;
+        }
+        WorkflowPlan::Retry {
+            node, max_attempts, ..
+        } => {
+            if *max_attempts == 0 {
+                return Err(WorkflowCompileError::InvalidStep {
+                    step: "<retry>".to_string(),
+                    message: "max_attempts must be greater than zero".to_string(),
+                });
+            }
+            validate_plan_inner(node, steps, seen)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_execution_bindings(
+    definition: &WorkflowRunDefinition,
+    steps: &HashMap<String, WorkflowStepDefinition>,
+) -> Result<(), WorkflowCompileError> {
+    type ItemSchemas = HashMap<String, serde_json::Value>;
+
+    fn reference_schema(
+        owner: &str,
+        reference: &ValueRef,
+        definition: &WorkflowRunDefinition,
+        steps: &HashMap<String, WorkflowStepDefinition>,
+        available: &HashSet<String>,
+        items: &ItemSchemas,
+    ) -> Result<serde_json::Value, WorkflowCompileError> {
+        let invalid = |message: String| WorkflowCompileError::InvalidStep {
+            step: owner.to_string(),
+            message,
+        };
+        match reference {
+            ValueRef::Args { pointer } => schema_pointer(&definition.input_schema, pointer)
+                .cloned()
+                .ok_or_else(|| invalid("args reference has an invalid schema pointer".to_string())),
+            ValueRef::Step { step, pointer } => {
+                if !available.contains(step) {
+                    return Err(invalid(format!(
+                        "step reference '{step}' is not available before this step"
+                    )));
+                }
+                let schema = steps
+                    .get(step)
+                    .and_then(|step| step.output_schema.as_ref())
+                    .ok_or_else(|| {
+                        invalid(format!(
+                            "step reference '{step}' requires a declared output_schema"
+                        ))
+                    })?;
+                schema_pointer(schema, pointer).cloned().ok_or_else(|| {
+                    invalid(format!(
+                        "step reference '{step}' has an invalid schema pointer"
+                    ))
+                })
+            }
+            ValueRef::Item { name, pointer } => {
+                let schema = items.get(name).ok_or_else(|| {
+                    invalid(format!(
+                        "map item reference '{name}' is outside its map body"
+                    ))
+                })?;
+                schema_pointer(schema, pointer).cloned().ok_or_else(|| {
+                    invalid(format!(
+                        "map item reference '{name}' has an invalid schema pointer"
+                    ))
+                })
+            }
+            ValueRef::Literal { value } => Ok(schema_for_literal(value)),
+        }
+    }
+
+    fn walk_template(
+        owner: &str,
+        value: &serde_json::Value,
+        definition: &WorkflowRunDefinition,
+        steps: &HashMap<String, WorkflowStepDefinition>,
+        available: &HashSet<String>,
+        items: &ItemSchemas,
+    ) -> Result<(), WorkflowCompileError> {
+        match value {
+            serde_json::Value::Object(object) if object.contains_key("$secret") => {
+                let handle: WorkflowSecretHandle =
+                    serde_json::from_value(value.clone()).map_err(|error| {
+                        WorkflowCompileError::InvalidStep {
+                            step: owner.to_string(),
+                            message: format!("malformed secret capability handle: {error}"),
+                        }
+                    })?;
+                if handle.capability.trim().is_empty() {
+                    return Err(WorkflowCompileError::InvalidStep {
+                        step: owner.to_string(),
+                        message: "secret capability handle cannot be empty".to_string(),
+                    });
+                }
+                Ok(())
+            }
+            serde_json::Value::Object(object) if object.contains_key("from") => {
+                let reference: ValueRef =
+                    serde_json::from_value(value.clone()).map_err(|error| {
+                        WorkflowCompileError::InvalidStep {
+                            step: owner.to_string(),
+                            message: format!("malformed value reference: {error}"),
+                        }
+                    })?;
+                reference_schema(owner, &reference, definition, steps, available, items)?;
+                Ok(())
+            }
+            serde_json::Value::Object(object) => object.values().try_for_each(|child| {
+                walk_template(owner, child, definition, steps, available, items)
+            }),
+            serde_json::Value::Array(array) => array.iter().try_for_each(|child| {
+                walk_template(owner, child, definition, steps, available, items)
+            }),
+            _ => Ok(()),
+        }
+    }
+
+    fn walk_plan(
+        plan: &WorkflowPlan,
+        definition: &WorkflowRunDefinition,
+        steps: &HashMap<String, WorkflowStepDefinition>,
+        available: &HashSet<String>,
+        items: &ItemSchemas,
+    ) -> Result<HashSet<String>, WorkflowCompileError> {
+        match plan {
+            WorkflowPlan::Step { step } => {
+                let definition_step = &steps[step];
+                let template = match &definition_step.kind {
+                    WorkflowStepKind::Tool { args, .. }
+                    | WorkflowStepKind::Workflow { args, .. } => args,
+                    WorkflowStepKind::Agent { prompt, .. } => prompt,
+                };
+                walk_template(step, template, definition, steps, available, items)?;
+                let mut result = available.clone();
+                result.insert(step.clone());
+                Ok(result)
+            }
+            WorkflowPlan::Sequence { nodes } => {
+                nodes.iter().try_fold(available.clone(), |available, node| {
+                    walk_plan(node, definition, steps, &available, items)
+                })
+            }
+            WorkflowPlan::Parallel { nodes } => {
+                let mut result = available.clone();
+                for node in nodes {
+                    // Every sibling receives the same pre-parallel availability;
+                    // no sibling may consume another sibling's output.
+                    result.extend(walk_plan(node, definition, steps, available, items)?);
+                }
+                Ok(result)
+            }
+            WorkflowPlan::Map { source, item, body } => {
+                let item_schema =
+                    reference_schema("<map>", source, definition, steps, available, items)?
+                        .get("items")
+                        .cloned()
+                        .ok_or_else(|| WorkflowCompileError::InvalidStep {
+                            step: "<map>".to_string(),
+                            message: "map source schema must declare array items".to_string(),
+                        })?;
+                let mut nested_items = items.clone();
+                nested_items.insert(item.clone(), item_schema);
+                // Map body step outputs are materialized under per-item scoped
+                // runtime ids (`step@map[index]`), not as root-level step ids.
+                // Validate the body, but do not leak its availability to nodes
+                // that execute after the map.
+                walk_plan(body, definition, steps, available, &nested_items)?;
+                Ok(available.clone())
+            }
+            WorkflowPlan::Retry { node, .. } => {
+                walk_plan(node, definition, steps, available, items)
+            }
+        }
+    }
+
+    walk_plan(
+        &definition.plan,
+        definition,
+        steps,
+        &HashSet::new(),
+        &HashMap::new(),
+    )?;
+    Ok(())
+}
+
+fn schema_for_literal(value: &serde_json::Value) -> serde_json::Value {
+    let kind = match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(number) if number.is_i64() || number.is_u64() => "integer",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    };
+    serde_json::json!({"type": kind})
+}
+
+fn schema_pointer<'a>(
+    schema: &'a serde_json::Value,
+    pointer: &str,
+) -> Option<&'a serde_json::Value> {
+    if pointer.is_empty() {
+        return Some(schema);
+    }
+    let mut current = schema;
+    for token in pointer.strip_prefix('/')?.split('/') {
+        let token = token.replace("~1", "/").replace("~0", "~");
+        current = if token.parse::<usize>().is_ok() {
+            current.get("items")?
+        } else {
+            current.get("properties")?.get(&token)?
+        };
+    }
+    Some(current)
+}
+
+fn validate_ref(
+    value_ref: &ValueRef,
+    steps: &HashMap<String, WorkflowStepDefinition>,
+) -> Result<(), WorkflowCompileError> {
+    if let ValueRef::Step { step, .. } = value_ref {
+        if !steps.contains_key(step) {
+            return Err(WorkflowCompileError::UnknownStep(step.clone()));
+        }
+    }
+    Ok(())
+}
+
+fn validate_dependencies(
+    plan: &WorkflowPlan,
+    steps: &HashMap<String, WorkflowStepDefinition>,
+) -> Result<(), WorkflowCompileError> {
+    let mut edges: HashMap<String, HashSet<String>> = HashMap::new();
+    collect_plan_edges(plan, HashSet::new(), &mut edges);
+    for (id, step) in steps {
+        collect_value_step_refs(step, |dependency| {
+            edges
+                .entry(id.clone())
+                .or_default()
+                .insert(dependency.to_string());
+        });
+    }
+    fn visit(
+        node: &str,
+        edges: &HashMap<String, HashSet<String>>,
+        visiting: &mut HashSet<String>,
+        visited: &mut HashSet<String>,
+    ) -> Result<(), WorkflowCompileError> {
+        if visited.contains(node) {
+            return Ok(());
+        }
+        if !visiting.insert(node.to_string()) {
+            return Err(WorkflowCompileError::Cycle(node.to_string()));
+        }
+        if let Some(dependencies) = edges.get(node) {
+            for dependency in dependencies {
+                visit(dependency, edges, visiting, visited)?;
+            }
+        }
+        visiting.remove(node);
+        visited.insert(node.to_string());
+        Ok(())
+    }
+    let mut visited = HashSet::new();
+    for id in steps.keys() {
+        visit(id, &edges, &mut HashSet::new(), &mut visited)?;
+    }
+    Ok(())
+}
+
+fn collect_plan_edges(
+    plan: &WorkflowPlan,
+    previous: HashSet<String>,
+    edges: &mut HashMap<String, HashSet<String>>,
+) -> HashSet<String> {
+    match plan {
+        WorkflowPlan::Step { step } => {
+            edges.entry(step.clone()).or_default().extend(previous);
+            HashSet::from([step.clone()])
+        }
+        WorkflowPlan::Sequence { nodes } => nodes.iter().fold(previous, |prior, node| {
+            collect_plan_edges(node, prior, edges)
+        }),
+        WorkflowPlan::Parallel { nodes } => {
+            let mut tails = HashSet::new();
+            for node in nodes {
+                tails.extend(collect_plan_edges(node, previous.clone(), edges));
+            }
+            tails
+        }
+        WorkflowPlan::Map { body, .. } | WorkflowPlan::Retry { node: body, .. } => {
+            collect_plan_edges(body, previous, edges)
+        }
+    }
+}
+
+fn collect_value_step_refs(step: &WorkflowStepDefinition, mut found: impl FnMut(&str)) {
+    let value = match &step.kind {
+        WorkflowStepKind::Tool { args, .. } | WorkflowStepKind::Workflow { args, .. } => args,
+        WorkflowStepKind::Agent { prompt, .. } => prompt,
+    };
+    fn walk(value: &serde_json::Value, found: &mut impl FnMut(&str)) {
+        match value {
+            serde_json::Value::Object(object) => {
+                if object.get("from").and_then(serde_json::Value::as_str) == Some("step") {
+                    if let Some(step) = object.get("step").and_then(serde_json::Value::as_str) {
+                        found(step);
+                    }
+                }
+                for child in object.values() {
+                    walk(child, found);
+                }
+            }
+            serde_json::Value::Array(array) => {
+                for child in array {
+                    walk(child, found);
+                }
+            }
+            _ => {}
+        }
+    }
+    walk(value, &mut found);
+}

--- a/crates/core/bamboo-domain/src/workflow/mod.rs
+++ b/crates/core/bamboo-domain/src/workflow/mod.rs
@@ -3,6 +3,12 @@
 //! Defines the `WorkflowDefinition` entity and its validation rules,
 //! independent of filesystem loading and server infrastructure.
 
+pub mod compiler;
 pub mod definition;
+pub mod run;
+pub mod schema;
 
+pub use compiler::{CompiledWorkflow, WorkflowCompileError};
 pub use definition::{validate_expr, validate_required, WorkflowDefinition, WorkflowLoadError};
+pub use run::*;
+pub use schema::{validate_schema, validate_schema_shape};

--- a/crates/core/bamboo-domain/src/workflow/run.rs
+++ b/crates/core/bamboo-domain/src/workflow/run.rs
@@ -1,0 +1,365 @@
+//! Versioned, durable orchestration workflow domain types.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A catalog-pinned orchestration definition. `revision` is immutable for a run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowRunDefinition {
+    /// Unambiguous format discriminator. Phase 1 accepts only `1`.
+    pub workflow_schema: u32,
+    pub id: String,
+    pub revision: u64,
+    #[serde(default = "default_object_schema")]
+    pub input_schema: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<Value>,
+    pub steps: Vec<WorkflowStepDefinition>,
+    pub plan: WorkflowPlan,
+    #[serde(default)]
+    pub budgets: WorkflowBudgets,
+}
+
+/// Immutable set of every definition reachable from one catalog publication.
+/// A run persists this value before execution and never resolves the live
+/// catalog again, eliminating definition TOCTOU across nested dispatch/restart.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowDefinitionBundle {
+    pub publication_revision: u64,
+    pub root_id: String,
+    pub root_revision: u64,
+    pub definitions: BTreeMap<String, WorkflowRunDefinition>,
+}
+
+impl WorkflowDefinitionBundle {
+    pub fn key(id: &str, revision: u64) -> String {
+        format!("{id}@{revision}")
+    }
+
+    pub fn root(&self) -> Option<&WorkflowRunDefinition> {
+        self.get(&self.root_id, self.root_revision)
+    }
+
+    pub fn get(&self, id: &str, revision: u64) -> Option<&WorkflowRunDefinition> {
+        self.definitions.get(&Self::key(id, revision))
+    }
+}
+
+fn default_object_schema() -> Value {
+    serde_json::json!({"type": "object", "additionalProperties": true})
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowStepDefinition {
+    pub id: String,
+    #[serde(flatten)]
+    pub kind: WorkflowStepKind,
+    #[serde(default)]
+    pub failure: FailurePolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WorkflowStepKind {
+    Tool {
+        tool: String,
+        #[serde(default)]
+        args: Value,
+        #[serde(default)]
+        capabilities: Vec<String>,
+    },
+    Agent {
+        /// Named agent resolved through the injected #563-compatible port.
+        agent: String,
+        prompt: Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        effort: Option<String>,
+        #[serde(default)]
+        capabilities: Vec<String>,
+        #[serde(default = "default_structured_attempts")]
+        structured_output_attempts: u32,
+    },
+    Workflow {
+        workflow_id: String,
+        revision: u64,
+        #[serde(default)]
+        args: Value,
+    },
+}
+
+fn default_structured_attempts() -> u32 {
+    2
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WorkflowPlan {
+    Step {
+        step: String,
+    },
+    Sequence {
+        nodes: Vec<WorkflowPlan>,
+    },
+    Parallel {
+        nodes: Vec<WorkflowPlan>,
+    },
+    Map {
+        source: ValueRef,
+        item: String,
+        body: Box<WorkflowPlan>,
+    },
+    Retry {
+        node: Box<WorkflowPlan>,
+        max_attempts: u32,
+        #[serde(default)]
+        delay_ms: u64,
+    },
+}
+
+/// Safe data binding: no interpolation, shell expansion, or expression evaluator.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "from", rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+pub enum ValueRef {
+    Args {
+        #[serde(default)]
+        pointer: String,
+    },
+    Step {
+        step: String,
+        #[serde(default)]
+        pointer: String,
+    },
+    Item {
+        name: String,
+        #[serde(default)]
+        pointer: String,
+    },
+    Literal {
+        value: Value,
+    },
+}
+
+/// The only serializable representation of secret input. The handle is safe to
+/// persist; secret material is resolved ephemerally at tool dispatch.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowSecretHandle {
+    #[serde(rename = "$secret")]
+    pub capability: String,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FailurePolicy {
+    #[default]
+    FailFast,
+    ContinueWithError,
+    SkipDependents,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowBudgets {
+    pub max_concurrency: usize,
+    pub max_agents: u32,
+    pub max_steps: u32,
+    pub max_retries: u32,
+    pub max_nesting_depth: u32,
+    pub wall_time_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_cost_micros: Option<u64>,
+}
+
+impl Default for WorkflowBudgets {
+    fn default() -> Self {
+        Self {
+            max_concurrency: 4,
+            max_agents: 8,
+            max_steps: 256,
+            max_retries: 8,
+            max_nesting_depth: 4,
+            wall_time_ms: 15 * 60 * 1000,
+            max_tokens: None,
+            max_cost_micros: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowRunStatus {
+    Queued,
+    Running,
+    Suspended,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+impl WorkflowRunStatus {
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Succeeded | Self::Failed | Self::Cancelled)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowStepStatus {
+    Queued,
+    Running,
+    Suspended,
+    Succeeded,
+    Failed,
+    Cancelled,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowBudgetUsage {
+    pub steps: u32,
+    pub retries: u32,
+    pub agents: u32,
+    pub tokens: u64,
+    pub cost_micros: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowFailure {
+    pub code: WorkflowFailureCode,
+    pub message: String,
+    #[serde(default)]
+    pub retryable: bool,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowFailureCode {
+    InvalidDefinition,
+    InvalidInput,
+    InvalidOutput,
+    UnknownReference,
+    PermissionDenied,
+    UntrustedWorkspace,
+    BudgetExceeded,
+    RetryExhausted,
+    ExecutionFailed,
+    Cancelled,
+    RecoverySuspended,
+    Suspended,
+    DependencySkipped,
+    Storage,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowStepSnapshot {
+    pub id: String,
+    pub status: WorkflowStepStatus,
+    pub input_hash: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<WorkflowFailure>,
+    pub attempts: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowRunSnapshot {
+    pub run_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_step_id: Option<String>,
+    pub session_id: String,
+    pub definition: WorkflowRunDefinition,
+    pub definition_bundle: WorkflowDefinitionBundle,
+    pub definition_bundle_hash: String,
+    pub validated_args: Value,
+    pub status: WorkflowRunStatus,
+    pub steps: BTreeMap<String, WorkflowStepSnapshot>,
+    pub usage: WorkflowBudgetUsage,
+    pub last_sequence: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<WorkflowFailure>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suspension: Option<WorkflowSuspensionContext>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Durable, non-secret context explaining why a run cannot be blindly replayed.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WorkflowSuspensionContext {
+    ToolApproval {
+        step_id: String,
+        tool: String,
+        tool_call_id: String,
+    },
+    ToolRunning {
+        step_id: String,
+        tool: String,
+        tool_call_id: String,
+        killed: bool,
+    },
+    Recovery {
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowRunEvent {
+    pub run_id: String,
+    pub sequence: u64,
+    pub at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_id: Option<String>,
+    #[serde(flatten)]
+    pub kind: WorkflowRunEventKind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WorkflowRunEventKind {
+    RunQueued,
+    RunStarted,
+    Phase { name: String },
+    StepQueued,
+    StepStarted,
+    StepSuspended { reason: String },
+    StepCompleted { output: Value },
+    StepFailed { failure: WorkflowFailure },
+    StepCancelled,
+    StepSkipped { reason: String },
+    RunSuspended { reason: String },
+    RunSucceeded { output: Value },
+    RunFailed { failure: WorkflowFailure },
+    RunCancelled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StartWorkflowRun {
+    pub definition: WorkflowRunDefinition,
+    pub args: Value,
+    pub session_id: String,
+    #[serde(default)]
+    pub workspace_trusted: bool,
+    #[serde(default)]
+    pub allowed_capabilities: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowProgress {
+    pub snapshot: WorkflowRunSnapshot,
+    pub events: Vec<WorkflowRunEvent>,
+}

--- a/crates/core/bamboo-domain/src/workflow/schema.rs
+++ b/crates/core/bamboo-domain/src/workflow/schema.rs
@@ -1,0 +1,171 @@
+use serde_json::Value;
+
+pub fn validate_schema(schema: &Value, value: &Value) -> Result<(), String> {
+    validate_schema_shape(schema, "$")?;
+    validate_at(schema, value, "$")
+}
+
+pub fn validate_schema_shape(schema: &Value, path: &str) -> Result<(), String> {
+    let object = schema
+        .as_object()
+        .ok_or_else(|| format!("{path}: schema must be an object"))?;
+    const SUPPORTED: &[&str] = &[
+        "type",
+        "enum",
+        "required",
+        "properties",
+        "additionalProperties",
+        "items",
+        "minimum",
+        "maximum",
+        "x-bamboo-secret",
+    ];
+    for key in object.keys() {
+        if !SUPPORTED.contains(&key.as_str()) {
+            return Err(format!("{path}: unsupported schema keyword '{key}'"));
+        }
+    }
+    if object
+        .get("x-bamboo-secret")
+        .is_some_and(|value| !value.is_boolean())
+    {
+        return Err(format!("{path}: x-bamboo-secret must be boolean"));
+    }
+    if let Some(kind) = object.get("type") {
+        let valid_kind = |kind: &str| {
+            matches!(
+                kind,
+                "null" | "boolean" | "object" | "array" | "number" | "integer" | "string"
+            )
+        };
+        match kind {
+            Value::String(kind) if valid_kind(kind) => {}
+            Value::Array(kinds)
+                if !kinds.is_empty()
+                    && kinds
+                        .iter()
+                        .all(|kind| kind.as_str().is_some_and(valid_kind)) => {}
+            _ => return Err(format!("{path}: invalid or unsupported type")),
+        }
+    }
+    if object.get("enum").is_some_and(|value| !value.is_array()) {
+        return Err(format!("{path}: enum must be an array"));
+    }
+    if let Some(required) = object.get("required") {
+        if !required
+            .as_array()
+            .is_some_and(|values| values.iter().all(Value::is_string))
+        {
+            return Err(format!("{path}: required must be an array of strings"));
+        }
+    }
+    if let Some(properties) = object.get("properties") {
+        let properties = properties
+            .as_object()
+            .ok_or_else(|| format!("{path}: properties must be an object"))?;
+        for (key, child) in properties {
+            validate_schema_shape(child, &format!("{path}/properties/{key}"))?;
+        }
+    }
+    if object
+        .get("additionalProperties")
+        .is_some_and(|value| !value.is_boolean())
+    {
+        return Err(format!("{path}: additionalProperties must be boolean"));
+    }
+    if let Some(items) = object.get("items") {
+        validate_schema_shape(items, &format!("{path}/items"))?;
+    }
+    for keyword in ["minimum", "maximum"] {
+        if object.get(keyword).is_some_and(|value| !value.is_number()) {
+            return Err(format!("{path}: {keyword} must be numeric"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_at(schema: &Value, value: &Value, path: &str) -> Result<(), String> {
+    let object = schema
+        .as_object()
+        .ok_or_else(|| format!("{path}: schema must be an object"))?;
+    if object.get("x-bamboo-secret") == Some(&Value::Bool(true)) {
+        let handle = value
+            .as_object()
+            .filter(|handle| handle.len() == 1)
+            .and_then(|handle| handle.get("$secret"))
+            .and_then(Value::as_str)
+            .filter(|handle| !handle.trim().is_empty());
+        return handle
+            .map(|_| ())
+            .ok_or_else(|| format!("{path}: secret input must be a typed capability handle"));
+    }
+    if let Some(types) = object.get("type") {
+        let valid = match types {
+            Value::String(kind) => matches_type(kind, value),
+            Value::Array(kinds) => kinds
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|kind| matches_type(kind, value)),
+            _ => false,
+        };
+        if !valid {
+            return Err(format!("{path}: value does not match schema type"));
+        }
+    }
+    if let Some(values) = object.get("enum").and_then(Value::as_array) {
+        if !values.contains(value) {
+            return Err(format!("{path}: value is not in enum"));
+        }
+    }
+    if let Some(required) = object.get("required").and_then(Value::as_array) {
+        let value_object = value
+            .as_object()
+            .ok_or_else(|| format!("{path}: required applies to an object"))?;
+        for key in required.iter().filter_map(Value::as_str) {
+            if !value_object.contains_key(key) {
+                return Err(format!("{path}: required property '{key}' is missing"));
+            }
+        }
+    }
+    if let Some(value_object) = value.as_object() {
+        let properties = object.get("properties").and_then(Value::as_object);
+        for (key, child) in value_object {
+            if let Some(child_schema) = properties.and_then(|schemas| schemas.get(key)) {
+                validate_at(child_schema, child, &format!("{path}/{key}"))?;
+            } else if object.get("additionalProperties") == Some(&Value::Bool(false)) {
+                return Err(format!(
+                    "{path}: additional property '{key}' is not allowed"
+                ));
+            }
+        }
+    }
+    if let (Some(items), Some(values)) = (object.get("items"), value.as_array()) {
+        for (index, child) in values.iter().enumerate() {
+            validate_at(items, child, &format!("{path}/{index}"))?;
+        }
+    }
+    if let Some(minimum) = object.get("minimum").and_then(Value::as_f64) {
+        if value.as_f64().is_none_or(|number| number < minimum) {
+            return Err(format!("{path}: value is below minimum"));
+        }
+    }
+    if let Some(maximum) = object.get("maximum").and_then(Value::as_f64) {
+        if value.as_f64().is_none_or(|number| number > maximum) {
+            return Err(format!("{path}: value is above maximum"));
+        }
+    }
+    Ok(())
+}
+
+fn matches_type(kind: &str, value: &Value) -> bool {
+    match kind {
+        "null" => value.is_null(),
+        "boolean" => value.is_boolean(),
+        "object" => value.is_object(),
+        "array" => value.is_array(),
+        "number" => value.is_number(),
+        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+        "string" => value.is_string(),
+        _ => false,
+    }
+}

--- a/crates/engine/bamboo-engine/src/lib.rs
+++ b/crates/engine/bamboo-engine/src/lib.rs
@@ -20,7 +20,13 @@ pub mod session_repository;
 pub use session_repository::SessionRepository;
 pub mod title_gen;
 pub mod token_usage_log;
+pub mod workflow_run;
 pub use token_usage_log::TokenUsageRecord;
+pub use workflow_run::{
+    AgentStepPort, AgentStepResult, FileWorkflowRunRepository, NamedAgentSpec, PermissionDecision,
+    WorkflowDefinitionPort, WorkflowPolicyPort, WorkflowPolicyTarget, WorkflowRunEngine,
+    WorkflowRunError, WorkflowRunRepository, WorkflowSecretMaterial, WorkflowSecretResolverPort,
+};
 
 pub use app_context::AgentSessionContext;
 pub use runtime::execution::agent_spawn::{read_cached_session, SessionCache};

--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use bamboo_agent_core::composition::CompositionExecutor;
 use bamboo_agent_core::storage::AttachmentReader;
 use bamboo_agent_core::storage::Storage;
 use bamboo_agent_core::tools::ToolSchema;
@@ -343,7 +342,6 @@ pub struct AgentLoopConfig {
     pub(crate) selected_skill_mode: Option<String>,
     pub(crate) additional_tool_schemas: Vec<ToolSchema>,
     pub(crate) tool_registry: Arc<ToolRegistry>,
-    pub(crate) composition_executor: Option<Arc<CompositionExecutor>>,
     pub(crate) skill_manager: Option<Arc<SkillManager>>,
     /// If true, skip appending the initial user message (already present in session).
     pub(crate) skip_initial_user_message: bool,
@@ -510,7 +508,6 @@ impl Default for AgentLoopConfig {
             selected_skill_mode: None,
             additional_tool_schemas: Vec::new(),
             tool_registry: Arc::new(ToolRegistry::new()),
-            composition_executor: None,
             skill_manager: None,
             skip_initial_user_message: false,
             storage: None,

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/execution_paths/success_path.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/execution_paths/success_path.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use bamboo_agent_core::tools::{handle_tool_result_with_agentic_support, ToolHandlingOutcome};
 use bamboo_agent_core::AgentEvent;
 
@@ -99,7 +97,10 @@ pub(super) async fn handle_successful_tool_result(ctx: SuccessPathContext<'_>) -
         ctx.event_tx,
         ctx.session,
         ctx.tools.as_ref(),
-        ctx.config.composition_executor.as_ref().map(Arc::clone),
+        // Legacy ad-hoc CompositionExecutor dispatch is intentionally disabled
+        // in the agent runtime. Catalog-pinned workflow_run is the single
+        // production orchestration authority (#578).
+        None,
     )
     .await;
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
@@ -193,7 +193,9 @@ pub(super) async fn execute_tool_call_only(
         match bamboo_agent_core::tools::executor::execute_tool_call_with_context_outcome(
             ctx.tool_call,
             ctx.tools.as_ref(),
-            ctx.config.composition_executor.as_ref().map(Arc::clone),
+            // Agent execution does not route through the legacy composition
+            // runtime; catalog-pinned workflow_run is the sole orchestrator.
+            None,
             tool_ctx,
         )
         .await

--- a/crates/engine/bamboo-engine/src/runtime/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/tests.rs
@@ -38,7 +38,6 @@ fn agent_loop_config_default() {
     assert!(config.system_prompt.is_none());
     assert!(config.additional_tool_schemas.is_empty());
     assert!(config.tool_registry.is_empty());
-    assert!(config.composition_executor.is_none());
     assert!(config.skill_manager.is_none());
     assert!(config.selected_skill_ids.is_none());
     assert!(config.disabled_tools.is_empty());

--- a/crates/engine/bamboo-engine/src/workflow_run/executor.rs
+++ b/crates/engine/bamboo-engine/src/workflow_run/executor.rs
@@ -1,0 +1,2487 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bamboo_agent_core::tools::{
+    FunctionCall, ToolCall, ToolExecutionContext, ToolExecutor, ToolOutcome, ToolResult,
+};
+use bamboo_domain::{
+    validate_schema, CompiledWorkflow, FailurePolicy, StartWorkflowRun, ValueRef,
+    WorkflowBudgetUsage, WorkflowBudgets, WorkflowCompileError, WorkflowDefinitionBundle,
+    WorkflowFailure, WorkflowFailureCode, WorkflowPlan, WorkflowProgress, WorkflowRunDefinition,
+    WorkflowRunEvent, WorkflowRunEventKind, WorkflowRunSnapshot, WorkflowRunStatus,
+    WorkflowStepDefinition, WorkflowStepKind, WorkflowStepSnapshot, WorkflowStepStatus,
+    WorkflowSuspensionContext,
+};
+use chrono::Utc;
+use dashmap::DashMap;
+use futures::{future::join_all, stream::FuturesUnordered, StreamExt};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tokio::sync::{broadcast, Mutex, Semaphore};
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use super::repository::WorkflowRunRepository;
+
+type SecretResolutionFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<(Value, Vec<String>), WorkflowFailure>> + Send + 'a>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamedAgentSpec {
+    pub name: String,
+    pub allowed_capabilities: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentStepResult {
+    pub output: Value,
+    pub tokens: u64,
+    pub cost_micros: u64,
+}
+
+#[async_trait]
+pub trait AgentStepPort: Send + Sync {
+    /// #563 seam. Unknown names must return `Ok(None)` and fail preflight.
+    async fn resolve(&self, name: &str) -> Result<Option<NamedAgentSpec>, String>;
+    async fn execute(
+        &self,
+        spec: &NamedAgentSpec,
+        prompt: Value,
+        model: Option<&str>,
+        effort: Option<&str>,
+        capabilities: &BTreeSet<String>,
+        session_id: &str,
+    ) -> Result<AgentStepResult, String>;
+}
+
+#[async_trait]
+pub trait WorkflowDefinitionPort: Send + Sync {
+    /// Pin the root and every transitively referenced nested definition from one
+    /// immutable catalog publication. Implementations must never re-read a live
+    /// source while constructing the returned bundle.
+    async fn pin_bundle(
+        &self,
+        root: &WorkflowRunDefinition,
+    ) -> Result<WorkflowDefinitionBundle, String>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PermissionDecision {
+    Allow,
+    Deny(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkflowPolicyTarget {
+    Tool(String),
+    Agent(String),
+    Workflow { id: String, revision: u64 },
+}
+
+#[async_trait]
+pub trait WorkflowPolicyPort: Send + Sync {
+    async fn authorize(
+        &self,
+        session_id: &str,
+        target: &WorkflowPolicyTarget,
+        requested: &BTreeSet<String>,
+        workspace_trusted: bool,
+    ) -> PermissionDecision;
+}
+
+/// Resolves a typed, persisted-safe capability handle to ephemeral secret
+/// material. Implementations own access control; raw values are never returned
+/// in snapshots/events/errors.
+pub struct WorkflowSecretMaterial(String);
+
+impl WorkflowSecretMaterial {
+    pub fn new(value: String) -> Self {
+        Self(value)
+    }
+
+    fn into_exposed(self) -> String {
+        self.0
+    }
+}
+
+#[async_trait]
+pub trait WorkflowSecretResolverPort: Send + Sync {
+    async fn resolve(
+        &self,
+        session_id: &str,
+        capability: &str,
+    ) -> Result<WorkflowSecretMaterial, String>;
+}
+
+#[derive(Debug, Error)]
+pub enum WorkflowRunError {
+    #[error(transparent)]
+    Compile(#[from] WorkflowCompileError),
+    #[error("invalid workflow input: {0}")]
+    InvalidInput(String),
+    #[error("workflow preflight failed: {0}")]
+    Preflight(String),
+    #[error("workflow storage failed: {0}")]
+    Storage(String),
+    #[error("workflow run not found")]
+    NotFound,
+    #[error("workflow run is already terminal")]
+    Terminal,
+}
+
+pub struct WorkflowRunEngine {
+    repository: Arc<dyn WorkflowRunRepository>,
+    tools: Arc<dyn ToolExecutor>,
+    agents: Arc<dyn AgentStepPort>,
+    definitions: Arc<dyn WorkflowDefinitionPort>,
+    policy: Arc<dyn WorkflowPolicyPort>,
+    secrets: Arc<dyn WorkflowSecretResolverPort>,
+    ceilings: WorkflowBudgets,
+    active: DashMap<String, Arc<ActiveRun>>,
+    events: DashMap<String, broadcast::Sender<WorkflowRunEvent>>,
+}
+
+struct ActiveRun {
+    cancellation: CancellationToken,
+    snapshot: Arc<Mutex<WorkflowRunSnapshot>>,
+}
+
+struct RuntimeRegistration {
+    engine: Weak<WorkflowRunEngine>,
+    run_id: String,
+}
+
+impl Drop for RuntimeRegistration {
+    fn drop(&mut self) {
+        if let Some(engine) = self.engine.upgrade() {
+            engine.active.remove(&self.run_id);
+            engine.events.remove(&self.run_id);
+        }
+    }
+}
+
+struct RunContext {
+    engine: Arc<WorkflowRunEngine>,
+    compiled: Arc<CompiledWorkflow>,
+    bundle: Arc<WorkflowDefinitionBundle>,
+    pinned_agents: Arc<HashMap<String, NamedAgentSpec>>,
+    snapshot: Arc<Mutex<WorkflowRunSnapshot>>,
+    cancellation: CancellationToken,
+    branch_cancellation: CancellationToken,
+    allowed_capabilities: BTreeSet<String>,
+    workspace_trusted: bool,
+    semaphore: Arc<Semaphore>,
+    items: HashMap<String, Value>,
+    scope: String,
+    depth: u32,
+    ledger: Arc<Mutex<WorkflowBudgetUsage>>,
+    root_limits: WorkflowBudgets,
+}
+
+impl Clone for RunContext {
+    fn clone(&self) -> Self {
+        Self {
+            engine: self.engine.clone(),
+            compiled: self.compiled.clone(),
+            bundle: self.bundle.clone(),
+            pinned_agents: self.pinned_agents.clone(),
+            snapshot: self.snapshot.clone(),
+            cancellation: self.cancellation.clone(),
+            branch_cancellation: self.branch_cancellation.clone(),
+            allowed_capabilities: self.allowed_capabilities.clone(),
+            workspace_trusted: self.workspace_trusted,
+            semaphore: self.semaphore.clone(),
+            items: self.items.clone(),
+            scope: self.scope.clone(),
+            depth: self.depth,
+            ledger: self.ledger.clone(),
+            root_limits: self.root_limits.clone(),
+        }
+    }
+}
+
+type NodeFuture<'a> = Pin<Box<dyn Future<Output = Result<Value, WorkflowFailure>> + Send + 'a>>;
+type StartSignal =
+    Arc<Mutex<Option<tokio::sync::oneshot::Sender<Result<WorkflowRunSnapshot, WorkflowRunError>>>>>;
+
+impl WorkflowRunEngine {
+    pub fn new(
+        repository: Arc<dyn WorkflowRunRepository>,
+        tools: Arc<dyn ToolExecutor>,
+        agents: Arc<dyn AgentStepPort>,
+        definitions: Arc<dyn WorkflowDefinitionPort>,
+        policy: Arc<dyn WorkflowPolicyPort>,
+        secrets: Arc<dyn WorkflowSecretResolverPort>,
+        ceilings: WorkflowBudgets,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            repository,
+            tools,
+            agents,
+            definitions,
+            policy,
+            secrets,
+            ceilings,
+            active: DashMap::new(),
+            events: DashMap::new(),
+        })
+    }
+
+    pub async fn run(
+        self: &Arc<Self>,
+        request: StartWorkflowRun,
+    ) -> Result<WorkflowRunSnapshot, WorkflowRunError> {
+        let bundle = self.pin_and_validate_bundle(&request.definition).await?;
+        self.run_pinned(request, bundle).await
+    }
+
+    pub async fn run_pinned(
+        self: &Arc<Self>,
+        request: StartWorkflowRun,
+        bundle: WorkflowDefinitionBundle,
+    ) -> Result<WorkflowRunSnapshot, WorkflowRunError> {
+        self.validate_bundle(&request.definition, &bundle)?;
+        let cancellation = CancellationToken::new();
+        let ledger = Arc::new(Mutex::new(WorkflowBudgetUsage::default()));
+        let limits = effective_limits(&request.definition.budgets, &self.ceilings);
+        let semaphore = Arc::new(Semaphore::new(limits.max_concurrency));
+        let pinned_agents = Arc::new(
+            self.preflight_bundle(
+                &bundle,
+                &request.session_id,
+                &request.allowed_capabilities.iter().cloned().collect(),
+                request.workspace_trusted,
+                &limits,
+            )
+            .await?,
+        );
+        self.run_internal(
+            request,
+            Arc::new(bundle),
+            pinned_agents,
+            None,
+            None,
+            0,
+            cancellation,
+            ledger,
+            limits,
+            semaphore,
+            None,
+        )
+        .await
+    }
+
+    /// Start in the background and return only after the running snapshot is
+    /// durable. HTTP and tool adapters use this non-blocking entrypoint.
+    pub async fn start(
+        self: &Arc<Self>,
+        request: StartWorkflowRun,
+    ) -> Result<WorkflowRunSnapshot, WorkflowRunError> {
+        let bundle = self.pin_and_validate_bundle(&request.definition).await?;
+        self.start_pinned(request, bundle).await
+    }
+
+    pub async fn start_pinned(
+        self: &Arc<Self>,
+        request: StartWorkflowRun,
+        bundle: WorkflowDefinitionBundle,
+    ) -> Result<WorkflowRunSnapshot, WorkflowRunError> {
+        self.validate_bundle(&request.definition, &bundle)?;
+        let cancellation = CancellationToken::new();
+        let ledger = Arc::new(Mutex::new(WorkflowBudgetUsage::default()));
+        let limits = effective_limits(&request.definition.budgets, &self.ceilings);
+        let semaphore = Arc::new(Semaphore::new(limits.max_concurrency));
+        let pinned_agents = Arc::new(
+            self.preflight_bundle(
+                &bundle,
+                &request.session_id,
+                &request.allowed_capabilities.iter().cloned().collect(),
+                request.workspace_trusted,
+                &limits,
+            )
+            .await?,
+        );
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let signal = Arc::new(Mutex::new(Some(tx)));
+        let engine = self.clone();
+        tokio::spawn(async move {
+            let result = engine
+                .run_internal(
+                    request,
+                    Arc::new(bundle),
+                    pinned_agents,
+                    None,
+                    None,
+                    0,
+                    cancellation,
+                    ledger,
+                    limits,
+                    semaphore,
+                    Some(signal.clone()),
+                )
+                .await;
+            if let Err(error) = result {
+                if let Some(sender) = signal.lock().await.take() {
+                    let _ = sender.send(Err(error));
+                } else {
+                    tracing::error!("background workflow run failed after start");
+                }
+            } else if signal.lock().await.is_some() {
+                tracing::error!("workflow task completed without publishing a start snapshot");
+            }
+        });
+        rx.await.map_err(|_| {
+            WorkflowRunError::Storage("workflow task exited before durable start".to_string())
+        })?
+    }
+
+    /// Phase-1 safe restart starts a fresh run from the suspended run's pinned
+    /// definition snapshot. Prefix/script resume remains explicitly out of scope (#581).
+    pub async fn restart(
+        self: &Arc<Self>,
+        run_id: &str,
+        workspace_trusted: bool,
+        allowed_capabilities: Vec<String>,
+    ) -> Result<WorkflowRunSnapshot, WorkflowRunError> {
+        let previous = self
+            .repository
+            .load(run_id)
+            .await
+            .map_err(storage)?
+            .ok_or(WorkflowRunError::NotFound)?;
+        if previous.status != WorkflowRunStatus::Suspended {
+            return Err(if previous.status.is_terminal() {
+                WorkflowRunError::Terminal
+            } else {
+                WorkflowRunError::Preflight("only suspended workflows can restart".to_string())
+            });
+        }
+        if matches!(
+            previous.suspension,
+            Some(
+                WorkflowSuspensionContext::ToolApproval { .. }
+                    | WorkflowSuspensionContext::ToolRunning { .. }
+            )
+        ) {
+            return Err(WorkflowRunError::Preflight(
+                "workflow has durable suspension context and requires explicit resume handling"
+                    .to_string(),
+            ));
+        }
+        let bundle = previous.definition_bundle;
+        self.start_pinned(
+            StartWorkflowRun {
+                definition: previous.definition,
+                args: previous.validated_args,
+                session_id: previous.session_id,
+                workspace_trusted,
+                allowed_capabilities,
+            },
+            bundle,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn run_internal(
+        self: &Arc<Self>,
+        request: StartWorkflowRun,
+        bundle: Arc<WorkflowDefinitionBundle>,
+        pinned_agents: Arc<HashMap<String, NamedAgentSpec>>,
+        parent_run_id: Option<String>,
+        parent_step_id: Option<String>,
+        depth: u32,
+        cancellation: CancellationToken,
+        ledger: Arc<Mutex<WorkflowBudgetUsage>>,
+        root_limits: WorkflowBudgets,
+        semaphore: Arc<Semaphore>,
+        started: Option<StartSignal>,
+    ) -> Result<WorkflowRunSnapshot, WorkflowRunError> {
+        if request.definition.steps.len() > self.ceilings.max_steps as usize {
+            return Err(WorkflowRunError::Preflight(
+                "workflow definition exceeds server step-count ceiling".to_string(),
+            ));
+        }
+        let compiled = Arc::new(CompiledWorkflow::compile(request.definition)?);
+        self.enforce_ceilings(&compiled.definition.budgets)?;
+        let definition_value = serde_json::to_value(&compiled.definition)
+            .map_err(|error| WorkflowRunError::Preflight(error.to_string()))?;
+        reject_secret_material_in_definition(&definition_value)
+            .map_err(WorkflowRunError::Preflight)?;
+        compiled
+            .validate_input(&request.args)
+            .map_err(WorkflowRunError::InvalidInput)?;
+        reject_secret_material(&request.args).map_err(WorkflowRunError::InvalidInput)?;
+        let allowed_capabilities = request
+            .allowed_capabilities
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        enforce_budget_within(&compiled.definition.budgets, &root_limits).map_err(|message| {
+            WorkflowRunError::Preflight(format!("nested workflow budget expands root: {message}"))
+        })?;
+
+        let run_id = Uuid::new_v4().to_string();
+        let now = Utc::now();
+        let snapshot = WorkflowRunSnapshot {
+            run_id: run_id.clone(),
+            parent_run_id,
+            parent_step_id,
+            session_id: request.session_id,
+            definition: compiled.definition.clone(),
+            definition_bundle: bundle.as_ref().clone(),
+            definition_bundle_hash: definition_bundle_hash(&bundle)?,
+            validated_args: request.args,
+            status: WorkflowRunStatus::Queued,
+            steps: BTreeMap::new(),
+            usage: WorkflowBudgetUsage::default(),
+            last_sequence: 1,
+            output: None,
+            failure: None,
+            suspension: None,
+            created_at: now,
+            updated_at: now,
+        };
+        let queued = event(&snapshot, None, WorkflowRunEventKind::RunQueued);
+        self.repository
+            .create(&snapshot, &queued)
+            .await
+            .map_err(storage)?;
+        let (sender, _) = broadcast::channel(256);
+        self.events.insert(run_id.clone(), sender);
+        self.publish(&queued);
+        let snapshot = Arc::new(Mutex::new(snapshot));
+        self.active.insert(
+            run_id.clone(),
+            Arc::new(ActiveRun {
+                cancellation: cancellation.clone(),
+                snapshot: snapshot.clone(),
+            }),
+        );
+        let _registration = RuntimeRegistration {
+            engine: Arc::downgrade(self),
+            run_id: run_id.clone(),
+        };
+        {
+            let mut shared = snapshot.lock().await;
+            let start_result = if cancellation.is_cancelled() {
+                self.finish_cancelled(&mut shared).await
+            } else {
+                self.transition(
+                    &mut shared,
+                    None,
+                    WorkflowRunEventKind::RunStarted,
+                    |snapshot| {
+                        snapshot.status = WorkflowRunStatus::Running;
+                    },
+                )
+                .await
+            };
+            start_result?;
+            if let Some(started) = started {
+                if let Some(sender) = started.lock().await.take() {
+                    let _ = sender.send(Ok(shared.clone()));
+                }
+            }
+        }
+        let context = RunContext {
+            engine: self.clone(),
+            compiled: compiled.clone(),
+            bundle,
+            pinned_agents,
+            snapshot: snapshot.clone(),
+            cancellation: cancellation.clone(),
+            branch_cancellation: cancellation.child_token(),
+            allowed_capabilities,
+            workspace_trusted: request.workspace_trusted,
+            semaphore,
+            items: HashMap::new(),
+            scope: "root".to_string(),
+            depth,
+            ledger,
+            root_limits,
+        };
+        let result = tokio::time::timeout(
+            Duration::from_millis(compiled.definition.budgets.wall_time_ms),
+            context.execute_node(&compiled.definition.plan, "root"),
+        )
+        .await;
+        let mut final_snapshot = snapshot.lock().await;
+        if final_snapshot.status.is_terminal() {
+            return Ok(final_snapshot.clone());
+        }
+        match result {
+            Ok(Ok(output)) if cancellation.is_cancelled() => {
+                let _ = output;
+                self.finish_cancelled(&mut final_snapshot).await?;
+            }
+            Ok(Ok(output)) => {
+                if let Some(schema) = &compiled.definition.output_schema {
+                    if let Err(message) = validate_schema(schema, &output) {
+                        let failure = failure(WorkflowFailureCode::InvalidOutput, message, false);
+                        self.finish_failed(&mut final_snapshot, failure).await?;
+                    } else {
+                        self.finish_succeeded(&mut final_snapshot, output).await?;
+                    }
+                } else {
+                    self.finish_succeeded(&mut final_snapshot, output).await?;
+                }
+            }
+            Ok(Err(error)) if error.code == WorkflowFailureCode::Cancelled => {
+                self.finish_cancelled(&mut final_snapshot).await?;
+            }
+            Ok(Err(error)) if error.code == WorkflowFailureCode::Suspended => {
+                self.finish_suspended(&mut final_snapshot, error.message)
+                    .await?;
+            }
+            Ok(Err(error)) => self.finish_failed(&mut final_snapshot, error).await?,
+            Err(_) => {
+                cancellation.cancel();
+                // `timeout` cancels the node future at an arbitrary await,
+                // including a repository commit. Reconcile the in-memory copy
+                // from the journal/temp recovery protocol before allocating the
+                // next sequence, so a partially committed StepStarted cannot
+                // make the timeout terminal transition skip a sequence.
+                if let Some(durable) = self.repository.load(&run_id).await.map_err(storage)? {
+                    *final_snapshot = durable;
+                }
+                let step_failure = failure(
+                    WorkflowFailureCode::BudgetExceeded,
+                    "workflow wall-time budget exceeded",
+                    false,
+                );
+                self.fail_timeout_frontier(
+                    &mut final_snapshot,
+                    &compiled.definition.plan,
+                    step_failure.clone(),
+                )
+                .await?;
+                self.fail_active_steps(&mut final_snapshot, step_failure.clone())
+                    .await?;
+                self.finish_failed(&mut final_snapshot, step_failure)
+                    .await?;
+            }
+        }
+        Ok(final_snapshot.clone())
+    }
+
+    pub async fn progress(
+        &self,
+        run_id: &str,
+        since: u64,
+    ) -> Result<WorkflowProgress, WorkflowRunError> {
+        let snapshot = self
+            .repository
+            .load(run_id)
+            .await
+            .map_err(storage)?
+            .ok_or(WorkflowRunError::NotFound)?;
+        let events = self
+            .repository
+            .events_since(run_id, since)
+            .await
+            .map_err(storage)?;
+        Ok(WorkflowProgress { snapshot, events })
+    }
+
+    pub async fn list_run_ids(&self) -> Result<Vec<String>, WorkflowRunError> {
+        self.repository.list_run_ids().await.map_err(storage)
+    }
+
+    pub async fn cancel(&self, run_id: &str) -> Result<WorkflowRunSnapshot, WorkflowRunError> {
+        let mut snapshot = self
+            .repository
+            .load(run_id)
+            .await
+            .map_err(storage)?
+            .ok_or(WorkflowRunError::NotFound)?;
+        if snapshot.status == WorkflowRunStatus::Cancelled {
+            return Ok(snapshot);
+        }
+        if snapshot.status.is_terminal() {
+            return Err(WorkflowRunError::Terminal);
+        }
+        if let Some(active) = self.active.get(run_id).map(|active| active.clone()) {
+            active.cancellation.cancel();
+            let mut shared = active.snapshot.lock().await;
+            if !shared.status.is_terminal() {
+                self.finish_cancelled(&mut shared).await?;
+            }
+            return Ok(shared.clone());
+        }
+        self.finish_cancelled(&mut snapshot).await?;
+        Ok(snapshot)
+    }
+
+    pub async fn recover(&self) -> Result<Vec<WorkflowRunSnapshot>, WorkflowRunError> {
+        let mut recovered = Vec::new();
+        for run_id in self.repository.list_run_ids().await.map_err(storage)? {
+            let Some(mut snapshot) = self.repository.load(&run_id).await.map_err(storage)? else {
+                continue;
+            };
+            if matches!(
+                snapshot.status,
+                WorkflowRunStatus::Queued | WorkflowRunStatus::Running
+            ) {
+                let reason = "process restarted; explicit safe restart is required".to_string();
+                let active_steps = snapshot
+                    .steps
+                    .iter()
+                    .filter(|(_, step)| {
+                        matches!(
+                            step.status,
+                            WorkflowStepStatus::Queued | WorkflowStepStatus::Running
+                        )
+                    })
+                    .map(|(id, _)| id.clone())
+                    .collect::<Vec<_>>();
+                for step_id in active_steps {
+                    let state_id = step_id.clone();
+                    let step_reason = reason.clone();
+                    self.transition(
+                        &mut snapshot,
+                        Some(step_id),
+                        WorkflowRunEventKind::StepSuspended {
+                            reason: reason.clone(),
+                        },
+                        move |snapshot| {
+                            if let Some(step) = snapshot.steps.get_mut(&state_id) {
+                                step.status = WorkflowStepStatus::Suspended;
+                                step.failure = Some(failure(
+                                    WorkflowFailureCode::RecoverySuspended,
+                                    step_reason,
+                                    true,
+                                ));
+                            }
+                        },
+                    )
+                    .await?;
+                }
+                self.transition(
+                    &mut snapshot,
+                    None,
+                    WorkflowRunEventKind::RunSuspended {
+                        reason: reason.clone(),
+                    },
+                    move |snapshot| {
+                        snapshot.status = WorkflowRunStatus::Suspended;
+                        snapshot.suspension = Some(WorkflowSuspensionContext::Recovery {
+                            reason: reason.clone(),
+                        });
+                    },
+                )
+                .await?;
+                recovered.push(snapshot);
+            }
+        }
+        Ok(recovered)
+    }
+
+    pub fn subscribe(&self, run_id: &str) -> Option<broadcast::Receiver<WorkflowRunEvent>> {
+        self.events.get(run_id).map(|sender| sender.subscribe())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn runtime_resource_counts(&self) -> (usize, usize) {
+        (self.active.len(), self.events.len())
+    }
+
+    async fn pin_and_validate_bundle(
+        &self,
+        root: &WorkflowRunDefinition,
+    ) -> Result<WorkflowDefinitionBundle, WorkflowRunError> {
+        let bundle =
+            self.definitions.pin_bundle(root).await.map_err(|_| {
+                WorkflowRunError::Preflight("workflow bundle pin failed".to_string())
+            })?;
+        self.validate_bundle(root, &bundle)?;
+        Ok(bundle)
+    }
+
+    fn validate_bundle(
+        &self,
+        root: &WorkflowRunDefinition,
+        bundle: &WorkflowDefinitionBundle,
+    ) -> Result<(), WorkflowRunError> {
+        if bundle.root_id != root.id
+            || bundle.root_revision != root.revision
+            || bundle.root() != Some(root)
+        {
+            return Err(WorkflowRunError::Preflight(
+                "pinned bundle root identity/content mismatch".to_string(),
+            ));
+        }
+        let serialized = serde_json::to_value(bundle).map_err(|_| {
+            WorkflowRunError::Preflight("workflow bundle is not serializable".into())
+        })?;
+        reject_secret_material_in_definition(&serialized).map_err(WorkflowRunError::Preflight)?;
+        let mut stack = vec![(root.id.clone(), root.revision, Vec::<String>::new())];
+        let mut visited = BTreeSet::new();
+        while let Some((id, revision, path)) = stack.pop() {
+            let key = WorkflowDefinitionBundle::key(&id, revision);
+            if path.contains(&key) {
+                return Err(WorkflowRunError::Preflight(format!(
+                    "nested workflow cycle includes {key}"
+                )));
+            }
+            if !visited.insert(key.clone()) {
+                continue;
+            }
+            let definition = bundle.get(&id, revision).ok_or_else(|| {
+                WorkflowRunError::Preflight(format!("pinned bundle is missing {key}"))
+            })?;
+            if definition.id != id || definition.revision != revision {
+                return Err(WorkflowRunError::Preflight(
+                    "pinned bundle definition identity mismatch".to_string(),
+                ));
+            }
+            let compiled = CompiledWorkflow::compile(definition.clone())?;
+            let mut nested_path = path;
+            nested_path.push(key);
+            for step in compiled.steps.values() {
+                if let WorkflowStepKind::Workflow {
+                    workflow_id,
+                    revision,
+                    args,
+                } = &step.kind
+                {
+                    let nested = bundle.get(workflow_id, *revision).ok_or_else(|| {
+                        WorkflowRunError::Preflight(format!(
+                            "pinned bundle is missing {workflow_id}@{revision}"
+                        ))
+                    })?;
+                    validate_nested_input_contract(args, &nested.input_schema, &compiled)
+                        .map_err(WorkflowRunError::Preflight)?;
+                    stack.push((workflow_id.clone(), *revision, nested_path.clone()));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn preflight_bundle(
+        &self,
+        bundle: &WorkflowDefinitionBundle,
+        session_id: &str,
+        allowed: &BTreeSet<String>,
+        trusted: bool,
+        root_limits: &WorkflowBudgets,
+    ) -> Result<HashMap<String, NamedAgentSpec>, WorkflowRunError> {
+        let mut pinned_agents = HashMap::<String, NamedAgentSpec>::new();
+        let mut stack = vec![(bundle.root_id.clone(), bundle.root_revision, 0_u32)];
+        let mut visited = BTreeSet::new();
+        while let Some((id, revision, depth)) = stack.pop() {
+            if depth >= root_limits.max_nesting_depth {
+                return Err(WorkflowRunError::Preflight(
+                    "nested workflow depth exceeded shared root limit".to_string(),
+                ));
+            }
+            if !visited.insert(WorkflowDefinitionBundle::key(&id, revision)) {
+                continue;
+            }
+            let definition = bundle.get(&id, revision).ok_or_else(|| {
+                WorkflowRunError::Preflight("pinned workflow definition missing".to_string())
+            })?;
+            enforce_budget_within(&definition.budgets, root_limits).map_err(|message| {
+                WorkflowRunError::Preflight(format!(
+                    "nested workflow budget expands root: {message}"
+                ))
+            })?;
+            let compiled = CompiledWorkflow::compile(definition.clone())?;
+            for step in compiled.steps.values() {
+                let (target, capabilities) = match &step.kind {
+                    WorkflowStepKind::Tool {
+                        tool, capabilities, ..
+                    } => (WorkflowPolicyTarget::Tool(tool.clone()), capabilities),
+                    WorkflowStepKind::Agent {
+                        agent,
+                        capabilities,
+                        ..
+                    } => {
+                        let spec = if let Some(spec) = pinned_agents.get(agent) {
+                            spec.clone()
+                        } else {
+                            let spec = self
+                                .agents
+                                .resolve(agent)
+                                .await
+                                .map_err(|_| {
+                                    WorkflowRunError::Preflight(
+                                        "named agent resolution failed".to_string(),
+                                    )
+                                })?
+                                .ok_or_else(|| {
+                                    WorkflowRunError::Preflight(format!(
+                                        "unknown named agent '{agent}'"
+                                    ))
+                                })?;
+                            if spec.name != *agent {
+                                return Err(WorkflowRunError::Preflight(
+                                    "named agent resolver returned mismatched identity".to_string(),
+                                ));
+                            }
+                            pinned_agents.insert(agent.clone(), spec.clone());
+                            spec
+                        };
+                        if !capabilities
+                            .iter()
+                            .all(|capability| spec.allowed_capabilities.contains(capability))
+                        {
+                            return Err(WorkflowRunError::Preflight(format!(
+                                "agent '{agent}' capability expansion denied"
+                            )));
+                        }
+                        (WorkflowPolicyTarget::Agent(agent.clone()), capabilities)
+                    }
+                    WorkflowStepKind::Workflow {
+                        workflow_id,
+                        revision,
+                        args,
+                    } => {
+                        let nested = bundle.get(workflow_id, *revision).ok_or_else(|| {
+                            WorkflowRunError::Preflight(format!(
+                                "missing pinned workflow {workflow_id}@{revision}"
+                            ))
+                        })?;
+                        validate_nested_input_contract(args, &nested.input_schema, &compiled)
+                            .map_err(WorkflowRunError::Preflight)?;
+                        stack.push((workflow_id.clone(), *revision, depth + 1));
+                        (
+                            WorkflowPolicyTarget::Workflow {
+                                id: workflow_id.clone(),
+                                revision: *revision,
+                            },
+                            &Vec::new(),
+                        )
+                    }
+                };
+                let requested = capabilities.iter().cloned().collect::<BTreeSet<_>>();
+                if !requested.is_subset(allowed) {
+                    return Err(WorkflowRunError::Preflight(format!(
+                        "step '{}' exceeds root capabilities",
+                        step.id
+                    )));
+                }
+                if let PermissionDecision::Deny(_reason) = self
+                    .policy
+                    .authorize(session_id, &target, &requested, trusted)
+                    .await
+                {
+                    return Err(WorkflowRunError::Preflight(
+                        "workflow policy denied this step".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(pinned_agents)
+    }
+
+    fn enforce_ceilings(&self, budget: &WorkflowBudgets) -> Result<(), WorkflowRunError> {
+        if budget.max_concurrency > self.ceilings.max_concurrency
+            || budget.max_agents > self.ceilings.max_agents
+            || budget.max_steps > self.ceilings.max_steps
+            || budget.max_retries > self.ceilings.max_retries
+            || budget.max_nesting_depth > self.ceilings.max_nesting_depth
+            || budget.wall_time_ms > self.ceilings.wall_time_ms
+            || exceeds_optional(budget.max_tokens, self.ceilings.max_tokens)
+            || exceeds_optional(budget.max_cost_micros, self.ceilings.max_cost_micros)
+        {
+            return Err(WorkflowRunError::Preflight(
+                "definition exceeds server workflow budget ceilings".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn transition(
+        &self,
+        snapshot: &mut WorkflowRunSnapshot,
+        step_id: Option<String>,
+        kind: WorkflowRunEventKind,
+        mutate: impl FnOnce(&mut WorkflowRunSnapshot),
+    ) -> Result<(), WorkflowRunError> {
+        // Always derive a candidate from durable state. The commit itself runs
+        // in an owned task, so dropping this caller at a timeout/cancel boundary
+        // cannot interrupt rename/fsync halfway through. In-memory state advances
+        // only after that task confirms the durable commit.
+        let mut candidate = self
+            .repository
+            .load(&snapshot.run_id)
+            .await
+            .map_err(storage)?
+            .ok_or_else(|| WorkflowRunError::Storage("workflow snapshot missing".to_string()))?;
+        mutate(&mut candidate);
+        candidate.last_sequence += 1;
+        candidate.updated_at = Utc::now();
+        let event = event(&candidate, step_id, kind);
+        let repository = self.repository.clone();
+        let durable_candidate = candidate.clone();
+        let durable_event = event.clone();
+        let commit =
+            tokio::spawn(
+                async move { repository.commit(&durable_candidate, &durable_event).await },
+            );
+        commit
+            .await
+            .map_err(|error| {
+                WorkflowRunError::Storage(format!("workflow commit task failed: {error}"))
+            })?
+            .map_err(storage)?;
+        *snapshot = candidate;
+        self.publish(&event);
+        Ok(())
+    }
+
+    fn publish(&self, event: &WorkflowRunEvent) {
+        if let Some(sender) = self.events.get(&event.run_id) {
+            let _ = sender.send(event.clone());
+        }
+    }
+
+    async fn finish_succeeded(
+        &self,
+        snapshot: &mut WorkflowRunSnapshot,
+        output: Value,
+    ) -> Result<(), WorkflowRunError> {
+        if snapshot.status.is_terminal() {
+            return Ok(());
+        }
+        let copy = output.clone();
+        self.transition(
+            snapshot,
+            None,
+            WorkflowRunEventKind::RunSucceeded { output },
+            move |snapshot| {
+                snapshot.status = WorkflowRunStatus::Succeeded;
+                snapshot.output = Some(copy);
+            },
+        )
+        .await
+    }
+    async fn finish_failed(
+        &self,
+        snapshot: &mut WorkflowRunSnapshot,
+        error: WorkflowFailure,
+    ) -> Result<(), WorkflowRunError> {
+        if snapshot.status.is_terminal() {
+            return Ok(());
+        }
+        let copy = error.clone();
+        self.transition(
+            snapshot,
+            None,
+            WorkflowRunEventKind::RunFailed { failure: error },
+            move |snapshot| {
+                snapshot.status = WorkflowRunStatus::Failed;
+                snapshot.failure = Some(copy);
+            },
+        )
+        .await
+    }
+    async fn finish_cancelled(
+        &self,
+        snapshot: &mut WorkflowRunSnapshot,
+    ) -> Result<(), WorkflowRunError> {
+        if snapshot.status == WorkflowRunStatus::Cancelled {
+            return Ok(());
+        }
+        let active_steps = snapshot
+            .steps
+            .iter()
+            .filter(|(_, step)| {
+                matches!(
+                    step.status,
+                    WorkflowStepStatus::Queued | WorkflowStepStatus::Running
+                )
+            })
+            .map(|(id, _)| id.clone())
+            .collect::<Vec<_>>();
+        for step_id in active_steps {
+            let state_id = step_id.clone();
+            self.transition(
+                snapshot,
+                Some(step_id),
+                WorkflowRunEventKind::StepCancelled,
+                move |snapshot| {
+                    if let Some(step) = snapshot.steps.get_mut(&state_id) {
+                        step.status = WorkflowStepStatus::Cancelled;
+                        step.failure = Some(failure(
+                            WorkflowFailureCode::Cancelled,
+                            "workflow cancelled",
+                            false,
+                        ));
+                    }
+                },
+            )
+            .await?;
+        }
+        self.transition(
+            snapshot,
+            None,
+            WorkflowRunEventKind::RunCancelled,
+            |snapshot| {
+                snapshot.status = WorkflowRunStatus::Cancelled;
+                snapshot.failure = Some(failure(
+                    WorkflowFailureCode::Cancelled,
+                    "workflow cancelled",
+                    false,
+                ));
+            },
+        )
+        .await
+    }
+
+    async fn finish_suspended(
+        &self,
+        snapshot: &mut WorkflowRunSnapshot,
+        reason: String,
+    ) -> Result<(), WorkflowRunError> {
+        if snapshot.status.is_terminal() {
+            return Ok(());
+        }
+        self.transition(
+            snapshot,
+            None,
+            WorkflowRunEventKind::RunSuspended { reason },
+            |snapshot| {
+                snapshot.status = WorkflowRunStatus::Suspended;
+            },
+        )
+        .await
+    }
+
+    async fn fail_active_steps(
+        &self,
+        snapshot: &mut WorkflowRunSnapshot,
+        error: WorkflowFailure,
+    ) -> Result<(), WorkflowRunError> {
+        let active_steps = snapshot
+            .steps
+            .iter()
+            .filter(|(_, step)| {
+                matches!(
+                    step.status,
+                    WorkflowStepStatus::Queued | WorkflowStepStatus::Running
+                )
+            })
+            .map(|(id, _)| id.clone())
+            .collect::<Vec<_>>();
+        for step_id in active_steps {
+            let state_id = step_id.clone();
+            let copy = error.clone();
+            self.transition(
+                snapshot,
+                Some(step_id),
+                WorkflowRunEventKind::StepFailed {
+                    failure: error.clone(),
+                },
+                move |snapshot| {
+                    if let Some(step) = snapshot.steps.get_mut(&state_id) {
+                        step.status = WorkflowStepStatus::Failed;
+                        step.failure = Some(copy);
+                    }
+                },
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn fail_timeout_frontier(
+        &self,
+        snapshot: &mut WorkflowRunSnapshot,
+        plan: &WorkflowPlan,
+        error: WorkflowFailure,
+    ) -> Result<(), WorkflowRunError> {
+        if snapshot.steps.values().any(|step| {
+            matches!(
+                step.status,
+                WorkflowStepStatus::Queued | WorkflowStepStatus::Running
+            )
+        }) {
+            return Ok(());
+        }
+        for step_id in plan_frontier(plan) {
+            if snapshot.steps.contains_key(&step_id) {
+                continue;
+            }
+            let state_id = step_id.clone();
+            let state_error = error.clone();
+            self.transition(
+                snapshot,
+                Some(step_id),
+                WorkflowRunEventKind::StepFailed {
+                    failure: error.clone(),
+                },
+                move |snapshot| {
+                    snapshot.steps.insert(
+                        state_id.clone(),
+                        WorkflowStepSnapshot {
+                            id: state_id,
+                            status: WorkflowStepStatus::Failed,
+                            input_hash: String::new(),
+                            output: None,
+                            failure: Some(state_error),
+                            attempts: 0,
+                        },
+                    );
+                },
+            )
+            .await?;
+        }
+        Ok(())
+    }
+}
+
+impl RunContext {
+    fn execute_node<'a>(&'a self, plan: &'a WorkflowPlan, path: &'a str) -> NodeFuture<'a> {
+        Box::pin(async move {
+            self.check_cancelled()?;
+            match plan {
+                WorkflowPlan::Step { step } => self.execute_step(step, path).await,
+                WorkflowPlan::Sequence { nodes } => {
+                    let mut result = Value::Null;
+                    for (index, node) in nodes.iter().enumerate() {
+                        match self.execute_node(node, &format!("{path}.{index}")).await {
+                            Ok(value) => result = value,
+                            Err(error) => {
+                                if error.code == WorkflowFailureCode::DependencySkipped {
+                                    for remaining in &nodes[index + 1..] {
+                                        self.skip_plan(
+                                            remaining,
+                                            "dependency requested skip_dependents",
+                                        )
+                                        .await?;
+                                    }
+                                }
+                                return Err(error);
+                            }
+                        }
+                    }
+                    Ok(result)
+                }
+                WorkflowPlan::Parallel { nodes } => {
+                    let parallel_cancellation = self.branch_cancellation.child_token();
+                    let mut futures = FuturesUnordered::new();
+                    for (index, node) in nodes.iter().enumerate() {
+                        let mut child = self.clone();
+                        child.branch_cancellation = parallel_cancellation.clone();
+                        futures.push(async move {
+                            (
+                                index,
+                                child.execute_node(node, &format!("{path}.{index}")).await,
+                            )
+                        });
+                    }
+                    let mut output = vec![Value::Null; nodes.len()];
+                    while let Some((index, result)) = futures.next().await {
+                        match result {
+                            Ok(value) => output[index] = value,
+                            Err(mut error) => {
+                                parallel_cancellation.cancel();
+                                // Drop sibling futures before awaiting durable
+                                // cancellation transitions. A sibling may hold
+                                // the snapshot mutex across its shielded commit;
+                                // leaving it parked inside FuturesUnordered would
+                                // deadlock this reconciliation.
+                                drop(futures);
+                                self.cancel_active_parallel_steps(nodes).await?;
+                                error.message =
+                                    format!("parallel branch[{index}] failed: {}", error.message);
+                                return Err(error);
+                            }
+                        }
+                    }
+                    Ok(Value::Array(output))
+                }
+                WorkflowPlan::Map { source, item, body } => {
+                    let source = self.resolve_ref(source).await?;
+                    let values = source.as_array().ok_or_else(|| {
+                        failure(
+                            WorkflowFailureCode::InvalidInput,
+                            "map source must be an array",
+                            false,
+                        )
+                    })?;
+                    let used = self.ledger.lock().await.steps as usize;
+                    let remaining = (self.root_limits.max_steps as usize).saturating_sub(used);
+                    let per_item = plan_leaf_count(body).max(1);
+                    if values
+                        .len()
+                        .checked_mul(per_item)
+                        .is_none_or(|required| required > remaining)
+                    {
+                        return Err(failure(
+                            WorkflowFailureCode::BudgetExceeded,
+                            "map cardinality exceeds remaining workflow step budget",
+                            false,
+                        ));
+                    }
+                    let futures = values.iter().cloned().enumerate().map(|(index, value)| {
+                        let mut child = self.clone();
+                        child.items.insert(item.clone(), value);
+                        // Scope identifies the logical map item, not a retry
+                        // attempt's diagnostic path. This keeps durable attempts
+                        // cumulative when Retry wraps Map and gives nested
+                        // Parallel invocations an item-local cancellation domain.
+                        child.scope = format!("{}[{index}]", self.scope);
+                        async move { child.execute_node(body, &format!("{path}[{index}]")).await }
+                    });
+                    let results = join_all(futures).await;
+                    let mut values = Vec::with_capacity(results.len());
+                    let mut failures = Vec::new();
+                    for (index, result) in results.into_iter().enumerate() {
+                        match result {
+                            Ok(value) => values.push(value),
+                            Err(error) => failures.push((index, error)),
+                        }
+                    }
+                    if failures.is_empty() {
+                        Ok(Value::Array(values))
+                    } else {
+                        let retryable = failures.iter().any(|(_, error)| error.retryable);
+                        let first_code = failures[0].1.code;
+                        let code = if failures
+                            .iter()
+                            .any(|(_, error)| error.code == WorkflowFailureCode::DependencySkipped)
+                        {
+                            WorkflowFailureCode::DependencySkipped
+                        } else if failures.iter().all(|(_, error)| error.code == first_code) {
+                            first_code
+                        } else {
+                            WorkflowFailureCode::ExecutionFailed
+                        };
+                        let diagnostics = failures
+                            .into_iter()
+                            .map(|(index, error)| format!("item[{index}]: {}", error.message))
+                            .collect::<Vec<_>>()
+                            .join("; ");
+                        Err(failure(
+                            code,
+                            format!("map items failed: {diagnostics}"),
+                            retryable,
+                        ))
+                    }
+                }
+                WorkflowPlan::Retry {
+                    node,
+                    max_attempts,
+                    delay_ms,
+                } => {
+                    let limit =
+                        (*max_attempts).min(self.compiled.definition.budgets.max_retries + 1);
+                    let mut last = None;
+                    for attempt in 0..limit {
+                        match self
+                            .execute_node(node, &format!("{path}.retry{attempt}"))
+                            .await
+                        {
+                            Ok(value) => return Ok(value),
+                            Err(error) if error.retryable => {
+                                last = Some(error);
+                                if attempt + 1 < limit {
+                                    self.reserve_retry().await?;
+                                    self.checkpoint_usage("retry_reserved").await?;
+                                    tokio::select! {
+                                        _ = self.cancellation.cancelled() => return Err(failure(WorkflowFailureCode::Cancelled, "workflow cancelled", false)),
+                                        _ = self.branch_cancellation.cancelled() => return Err(failure(WorkflowFailureCode::Cancelled, "workflow branch cancelled", false)),
+                                        _ = tokio::time::sleep(Duration::from_millis(*delay_ms)) => {}
+                                    }
+                                } else {
+                                    break;
+                                }
+                            }
+                            Err(error) => return Err(error),
+                        }
+                    }
+                    Err(failure(
+                        WorkflowFailureCode::RetryExhausted,
+                        last.map_or_else(|| "retry exhausted".to_string(), |error| error.message),
+                        false,
+                    ))
+                }
+            }
+        })
+    }
+
+    async fn execute_step(&self, step_id: &str, _path: &str) -> Result<Value, WorkflowFailure> {
+        self.check_cancelled()?;
+        let step = self.compiled.steps.get(step_id).cloned().ok_or_else(|| {
+            failure(
+                WorkflowFailureCode::UnknownReference,
+                format!("unknown step {step_id}"),
+                false,
+            )
+        })?;
+        let instance_id = if self.scope == "root" {
+            step_id.to_string()
+        } else {
+            format!("{step_id}@{}", self.scope)
+        };
+        let input = match &step.kind {
+            WorkflowStepKind::Tool { args, .. } | WorkflowStepKind::Workflow { args, .. } => {
+                self.resolve_template(args).await?
+            }
+            WorkflowStepKind::Agent { prompt, .. } => self.resolve_template(prompt).await?,
+        };
+        let input_hash = hex::encode(Sha256::digest(
+            serde_json::to_vec(&input).unwrap_or_default(),
+        ));
+        self.reserve_step().await?;
+        self.checkpoint_usage("step_reserved").await?;
+        self.step_transition(&instance_id, WorkflowRunEventKind::StepQueued, |snapshot| {
+            let state = snapshot
+                .steps
+                .entry(instance_id.clone())
+                .or_insert_with(|| WorkflowStepSnapshot {
+                    id: instance_id.clone(),
+                    status: WorkflowStepStatus::Queued,
+                    input_hash: input_hash.clone(),
+                    output: None,
+                    failure: None,
+                    attempts: 0,
+                });
+            state.status = WorkflowStepStatus::Queued;
+            state.input_hash = input_hash;
+            state.output = None;
+            state.failure = None;
+        })
+        .await?;
+        let _permit = if matches!(&step.kind, WorkflowStepKind::Workflow { .. }) {
+            None
+        } else {
+            Some(tokio::select! {
+                _ = self.cancellation.cancelled() => {
+                    let cancelled_id = instance_id.clone();
+                    self.step_transition(&instance_id, WorkflowRunEventKind::StepCancelled, move |snapshot| {
+                        if let Some(state) = snapshot.steps.get_mut(&cancelled_id) { state.status = WorkflowStepStatus::Cancelled; }
+                    }).await?;
+                    return Err(failure(WorkflowFailureCode::Cancelled, "workflow cancelled", false));
+                }
+                _ = self.branch_cancellation.cancelled() => {
+                    let cancelled_id = instance_id.clone();
+                    self.step_transition(&instance_id, WorkflowRunEventKind::StepCancelled, move |snapshot| {
+                        if let Some(state) = snapshot.steps.get_mut(&cancelled_id) {
+                            state.status = WorkflowStepStatus::Cancelled;
+                        }
+                    }).await?;
+                    return Err(failure(WorkflowFailureCode::Cancelled, "workflow branch cancelled", false));
+                }
+                permit = self.semaphore.acquire() => permit.map_err(|_| failure(WorkflowFailureCode::ExecutionFailed, "workflow semaphore closed", false))?,
+            })
+        };
+        let started_id = instance_id.clone();
+        self.step_transition(
+            &instance_id,
+            WorkflowRunEventKind::StepStarted,
+            move |snapshot| {
+                if let Some(state) = snapshot.steps.get_mut(&started_id) {
+                    state.status = WorkflowStepStatus::Running;
+                    state.attempts += 1;
+                }
+            },
+        )
+        .await?;
+        let result = self.dispatch(&step, input, &instance_id).await;
+        let result = match result {
+            Ok(output) => {
+                if let Some(schema) = &step.output_schema {
+                    validate_schema(schema, &output)
+                        .map(|()| output)
+                        .map_err(|message| {
+                            failure(WorkflowFailureCode::InvalidOutput, message, false)
+                        })
+                } else {
+                    Ok(output)
+                }
+            }
+            Err(error) => Err(error),
+        };
+        let result = result.and_then(|output| {
+            reject_secret_material(&output)
+                .map(|()| output)
+                .map_err(|message| failure(WorkflowFailureCode::InvalidOutput, message, false))
+        });
+        match result {
+            Ok(output) => {
+                let copy = output.clone();
+                let completed_id = instance_id.clone();
+                self.step_transition(
+                    &instance_id,
+                    WorkflowRunEventKind::StepCompleted {
+                        output: output.clone(),
+                    },
+                    move |snapshot| {
+                        if let Some(state) = snapshot.steps.get_mut(&completed_id) {
+                            state.status = WorkflowStepStatus::Succeeded;
+                            state.output = Some(copy);
+                        }
+                    },
+                )
+                .await?;
+                Ok(output)
+            }
+            Err(error) => {
+                if error.code == WorkflowFailureCode::Cancelled {
+                    let cancelled_id = instance_id.clone();
+                    self.step_transition(
+                        &instance_id,
+                        WorkflowRunEventKind::StepCancelled,
+                        move |snapshot| {
+                            if let Some(state) = snapshot.steps.get_mut(&cancelled_id) {
+                                state.status = WorkflowStepStatus::Cancelled;
+                                state.failure = Some(failure(
+                                    WorkflowFailureCode::Cancelled,
+                                    "workflow branch cancelled",
+                                    false,
+                                ));
+                            }
+                        },
+                    )
+                    .await?;
+                    return Err(error);
+                }
+                if error.code == WorkflowFailureCode::Suspended {
+                    let reason = error.message.clone();
+                    let suspended_id = instance_id.clone();
+                    self.step_transition(
+                        &instance_id,
+                        WorkflowRunEventKind::StepSuspended {
+                            reason: reason.clone(),
+                        },
+                        move |snapshot| {
+                            if let Some(state) = snapshot.steps.get_mut(&suspended_id) {
+                                state.status = WorkflowStepStatus::Suspended;
+                                state.failure =
+                                    Some(failure(WorkflowFailureCode::Suspended, reason, true));
+                            }
+                        },
+                    )
+                    .await?;
+                    return Err(error);
+                }
+                let copy = error.clone();
+                let failed_id = instance_id.clone();
+                self.step_transition(
+                    &instance_id,
+                    WorkflowRunEventKind::StepFailed {
+                        failure: error.clone(),
+                    },
+                    move |snapshot| {
+                        if let Some(state) = snapshot.steps.get_mut(&failed_id) {
+                            state.status = WorkflowStepStatus::Failed;
+                            state.failure = Some(copy);
+                        }
+                    },
+                )
+                .await?;
+                match step.failure {
+                    FailurePolicy::ContinueWithError => Ok(serde_json::json!({"error": error})),
+                    FailurePolicy::SkipDependents => Err(failure(
+                        WorkflowFailureCode::DependencySkipped,
+                        format!("{} (dependents skipped)", error.message),
+                        false,
+                    )),
+                    FailurePolicy::FailFast => Err(error),
+                }
+            }
+        }
+    }
+
+    async fn dispatch(
+        &self,
+        step: &WorkflowStepDefinition,
+        input: Value,
+        instance_id: &str,
+    ) -> Result<Value, WorkflowFailure> {
+        let session_id = { self.snapshot.lock().await.session_id.clone() };
+        match &step.kind {
+            WorkflowStepKind::Tool {
+                tool, capabilities, ..
+            } => {
+                self.authorize(
+                    &session_id,
+                    WorkflowPolicyTarget::Tool(tool.clone()),
+                    capabilities,
+                )
+                .await?;
+                let (resolved_input, resolved_secrets) =
+                    self.resolve_secret_handles(&input, &session_id).await?;
+                let arguments = serde_json::to_string(&resolved_input).map_err(|error| {
+                    failure(WorkflowFailureCode::InvalidInput, error.to_string(), false)
+                })?;
+                let call = ToolCall {
+                    id: format!("workflow-{}", Uuid::new_v4()),
+                    tool_type: "function".to_string(),
+                    function: FunctionCall {
+                        name: tool.clone(),
+                        arguments,
+                    },
+                };
+                let context = ToolExecutionContext {
+                    session_id: Some(&session_id),
+                    tool_call_id: &call.id,
+                    event_tx: None,
+                    available_tool_schemas: None,
+                    bypass_permissions: false,
+                    can_async_resume: false,
+                    bash_completion_sink: None,
+                    pre_parsed_args: Some(&resolved_input),
+                };
+                let outcome = self
+                    .engine
+                    .tools
+                    .execute_with_context_outcome(&call, context)
+                    .await
+                    .map_err(|error| {
+                        let (code, message, retryable) = match error {
+                            bamboo_agent_core::tools::ToolError::NotFound(_) => (
+                                WorkflowFailureCode::UnknownReference,
+                                "workflow tool is not available",
+                                false,
+                            ),
+                            bamboo_agent_core::tools::ToolError::InvalidArguments(_) => (
+                                WorkflowFailureCode::InvalidInput,
+                                "workflow tool arguments were rejected",
+                                false,
+                            ),
+                            bamboo_agent_core::tools::ToolError::Execution(_) => (
+                                WorkflowFailureCode::ExecutionFailed,
+                                "workflow tool execution was denied or failed",
+                                true,
+                            ),
+                        };
+                        failure(code, message, retryable)
+                    })?;
+                match outcome {
+                    ToolOutcome::Completed(result) => {
+                        let output = parse_tool_result(result)?;
+                        if contains_any_secret_material(&output, &resolved_secrets) {
+                            return Err(failure(
+                                WorkflowFailureCode::InvalidOutput,
+                                "workflow tool output contained resolved secret material",
+                                false,
+                            ));
+                        }
+                        Ok(output)
+                    }
+                    ToolOutcome::NeedsHuman { question, .. } => {
+                        self.persist_suspension(WorkflowSuspensionContext::ToolApproval {
+                            step_id: instance_id.to_string(),
+                            tool: tool.clone(),
+                            tool_call_id: question.tool_call_id,
+                        })
+                        .await?;
+                        Err(failure(
+                            WorkflowFailureCode::Suspended,
+                            "workflow tool requires human approval",
+                            true,
+                        ))
+                    }
+                    ToolOutcome::Running(handle) => {
+                        let tool_call_id = handle.tool_call_id.clone();
+                        (handle.kill)();
+                        self.persist_suspension(WorkflowSuspensionContext::ToolRunning {
+                            step_id: instance_id.to_string(),
+                            tool: tool.clone(),
+                            tool_call_id,
+                            killed: true,
+                        })
+                        .await?;
+                        Err(failure(
+                            WorkflowFailureCode::Suspended,
+                            "workflow tool is running without a durable workflow resume handle",
+                            true,
+                        ))
+                    }
+                }
+            }
+            WorkflowStepKind::Agent {
+                agent,
+                model,
+                effort,
+                capabilities,
+                structured_output_attempts,
+                ..
+            } => {
+                if contains_secret_handle(&input) {
+                    return Err(failure(
+                        WorkflowFailureCode::PermissionDenied,
+                        "secret capability handles are supported only for tool arguments",
+                        false,
+                    ));
+                }
+                self.authorize(
+                    &session_id,
+                    WorkflowPolicyTarget::Agent(agent.clone()),
+                    capabilities,
+                )
+                .await?;
+                let spec = self.pinned_agents.get(agent).cloned().ok_or_else(|| {
+                    failure(
+                        WorkflowFailureCode::PermissionDenied,
+                        "named agent was not pinned during preflight",
+                        false,
+                    )
+                })?;
+                let requested = capabilities.iter().cloned().collect::<BTreeSet<_>>();
+                if !requested.is_subset(&spec.allowed_capabilities) {
+                    return Err(failure(
+                        WorkflowFailureCode::PermissionDenied,
+                        "named agent capability intersection changed",
+                        false,
+                    ));
+                }
+                let mut last_error = None;
+                for _ in 0..*structured_output_attempts {
+                    self.reserve_agent().await?;
+                    self.checkpoint_usage("agent_reserved").await?;
+                    match self
+                        .engine
+                        .agents
+                        .execute(
+                            &spec,
+                            input.clone(),
+                            model.as_deref(),
+                            effort.as_deref(),
+                            &requested,
+                            &session_id,
+                        )
+                        .await
+                    {
+                        Ok(result) => {
+                            let exceeded =
+                                self.record_usage(result.tokens, result.cost_micros).await;
+                            self.checkpoint_usage("agent_usage_recorded").await?;
+                            if let Some(error) = exceeded {
+                                return Err(error);
+                            }
+                            if let Some(schema) = &step.output_schema {
+                                if let Err(error) = validate_schema(schema, &result.output) {
+                                    last_error = Some(error);
+                                    continue;
+                                }
+                            }
+                            return Ok(result.output);
+                        }
+                        Err(_error) => {
+                            last_error = Some("named agent execution failed".to_string())
+                        }
+                    }
+                }
+                Err(failure(
+                    WorkflowFailureCode::InvalidOutput,
+                    last_error.unwrap_or_else(|| "agent structured output exhausted".to_string()),
+                    false,
+                ))
+            }
+            WorkflowStepKind::Workflow {
+                workflow_id,
+                revision,
+                ..
+            } => {
+                if self.depth + 1 >= self.root_limits.max_nesting_depth {
+                    return Err(failure(
+                        WorkflowFailureCode::BudgetExceeded,
+                        "nested workflow depth exceeded",
+                        false,
+                    ));
+                }
+                let definition = self
+                    .bundle
+                    .get(workflow_id, *revision)
+                    .cloned()
+                    .ok_or_else(|| {
+                        failure(
+                            WorkflowFailureCode::UnknownReference,
+                            format!("persisted bundle missing workflow {workflow_id}@{revision}"),
+                            false,
+                        )
+                    })?;
+                let nested = StartWorkflowRun {
+                    definition,
+                    args: input,
+                    session_id,
+                    workspace_trusted: self.workspace_trusted,
+                    allowed_capabilities: self.allowed_capabilities.iter().cloned().collect(),
+                };
+                let parent_run_id = self.snapshot.lock().await.run_id.clone();
+                let result = Box::pin(self.engine.run_internal(
+                    nested,
+                    self.bundle.clone(),
+                    self.pinned_agents.clone(),
+                    Some(parent_run_id),
+                    Some(instance_id.to_string()),
+                    self.depth + 1,
+                    self.branch_cancellation.clone(),
+                    self.ledger.clone(),
+                    self.root_limits.clone(),
+                    self.semaphore.clone(),
+                    None,
+                ))
+                .await
+                .map_err(|_error| {
+                    failure(
+                        WorkflowFailureCode::ExecutionFailed,
+                        "nested workflow execution failed",
+                        false,
+                    )
+                })?;
+                result.output.ok_or_else(|| {
+                    result.failure.unwrap_or_else(|| {
+                        failure(
+                            WorkflowFailureCode::ExecutionFailed,
+                            "nested workflow returned no output",
+                            false,
+                        )
+                    })
+                })
+            }
+        }
+    }
+
+    async fn authorize(
+        &self,
+        session_id: &str,
+        target: WorkflowPolicyTarget,
+        capabilities: &[String],
+    ) -> Result<(), WorkflowFailure> {
+        let requested = capabilities.iter().cloned().collect::<BTreeSet<_>>();
+        if !requested.is_subset(&self.allowed_capabilities) {
+            return Err(failure(
+                WorkflowFailureCode::PermissionDenied,
+                "step capability exceeds root policy",
+                false,
+            ));
+        }
+        match self
+            .engine
+            .policy
+            .authorize(session_id, &target, &requested, self.workspace_trusted)
+            .await
+        {
+            PermissionDecision::Allow => Ok(()),
+            PermissionDecision::Deny(_reason) => Err(failure(
+                if self.workspace_trusted {
+                    WorkflowFailureCode::PermissionDenied
+                } else {
+                    WorkflowFailureCode::UntrustedWorkspace
+                },
+                "workflow policy denied this step",
+                false,
+            )),
+        }
+    }
+
+    async fn step_transition(
+        &self,
+        step_id: &str,
+        kind: WorkflowRunEventKind,
+        mutate: impl FnOnce(&mut WorkflowRunSnapshot),
+    ) -> Result<(), WorkflowFailure> {
+        let usage = self.ledger.lock().await.clone();
+        let mut snapshot = self.snapshot.lock().await;
+        snapshot.usage = usage;
+        self.engine
+            .transition(&mut snapshot, Some(step_id.to_string()), kind, mutate)
+            .await
+            .map_err(|error| failure(WorkflowFailureCode::Storage, error.to_string(), false))
+    }
+
+    async fn reserve_step(&self) -> Result<(), WorkflowFailure> {
+        let mut usage = self.ledger.lock().await;
+        if usage.steps >= self.root_limits.max_steps {
+            return Err(failure(
+                WorkflowFailureCode::BudgetExceeded,
+                "workflow step budget exceeded",
+                false,
+            ));
+        }
+        usage.steps += 1;
+        Ok(())
+    }
+
+    async fn reserve_retry(&self) -> Result<(), WorkflowFailure> {
+        let mut usage = self.ledger.lock().await;
+        if usage.retries >= self.root_limits.max_retries {
+            return Err(failure(
+                WorkflowFailureCode::BudgetExceeded,
+                "workflow retry budget exceeded",
+                false,
+            ));
+        }
+        usage.retries += 1;
+        Ok(())
+    }
+
+    async fn reserve_agent(&self) -> Result<(), WorkflowFailure> {
+        let mut usage = self.ledger.lock().await;
+        if usage.agents >= self.root_limits.max_agents {
+            return Err(failure(
+                WorkflowFailureCode::BudgetExceeded,
+                "workflow agent budget exceeded",
+                false,
+            ));
+        }
+        usage.agents += 1;
+        Ok(())
+    }
+
+    async fn record_usage(&self, tokens: u64, cost_micros: u64) -> Option<WorkflowFailure> {
+        let mut usage = self.ledger.lock().await;
+        let next_tokens = usage.tokens.saturating_add(tokens);
+        let next_cost = usage.cost_micros.saturating_add(cost_micros);
+        usage.tokens = next_tokens;
+        usage.cost_micros = next_cost;
+        if self
+            .root_limits
+            .max_tokens
+            .is_some_and(|limit| next_tokens > limit)
+            || self
+                .root_limits
+                .max_cost_micros
+                .is_some_and(|limit| next_cost > limit)
+        {
+            return Some(failure(
+                WorkflowFailureCode::BudgetExceeded,
+                "workflow token/cost budget exceeded",
+                false,
+            ));
+        }
+        None
+    }
+
+    async fn checkpoint_usage(&self, name: &str) -> Result<(), WorkflowFailure> {
+        let usage = self.ledger.lock().await.clone();
+        let mut snapshot = self.snapshot.lock().await;
+        self.engine
+            .transition(
+                &mut snapshot,
+                None,
+                WorkflowRunEventKind::Phase {
+                    name: name.to_string(),
+                },
+                move |snapshot| snapshot.usage = usage,
+            )
+            .await
+            .map_err(|error| failure(WorkflowFailureCode::Storage, error.to_string(), false))
+    }
+
+    async fn persist_suspension(
+        &self,
+        context: WorkflowSuspensionContext,
+    ) -> Result<(), WorkflowFailure> {
+        let mut snapshot = self.snapshot.lock().await;
+        self.engine
+            .transition(
+                &mut snapshot,
+                None,
+                WorkflowRunEventKind::Phase {
+                    name: "suspension_context_persisted".to_string(),
+                },
+                move |snapshot| snapshot.suspension = Some(context),
+            )
+            .await
+            .map_err(|error| failure(WorkflowFailureCode::Storage, error.to_string(), false))
+    }
+
+    async fn cancel_active_parallel_steps(
+        &self,
+        nodes: &[WorkflowPlan],
+    ) -> Result<(), WorkflowFailure> {
+        let sibling_steps = nodes
+            .iter()
+            .flat_map(plan_step_ids)
+            .collect::<BTreeSet<_>>();
+        let active = {
+            let snapshot = self.snapshot.lock().await;
+            snapshot
+                .steps
+                .iter()
+                .filter(|(id, step)| {
+                    matches!(
+                        step.status,
+                        WorkflowStepStatus::Queued | WorkflowStepStatus::Running
+                    ) && sibling_steps
+                        .iter()
+                        .any(|step_id| instance_is_in_scope(id, step_id, &self.scope))
+                })
+                .map(|(id, _)| id.clone())
+                .collect::<Vec<_>>()
+        };
+        for step_id in active {
+            let state_id = step_id.clone();
+            self.step_transition(
+                &step_id,
+                WorkflowRunEventKind::StepCancelled,
+                move |snapshot| {
+                    if let Some(step) = snapshot.steps.get_mut(&state_id) {
+                        step.status = WorkflowStepStatus::Cancelled;
+                        step.failure = Some(failure(
+                            WorkflowFailureCode::Cancelled,
+                            "parallel sibling cancelled by fail_fast",
+                            false,
+                        ));
+                    }
+                },
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn resolve_secret_handles(
+        &self,
+        value: &Value,
+        session_id: &str,
+    ) -> Result<(Value, Vec<String>), WorkflowFailure> {
+        fn walk<'a>(
+            context: &'a RunContext,
+            value: &'a Value,
+            session_id: &'a str,
+        ) -> SecretResolutionFuture<'a> {
+            Box::pin(async move {
+                match value {
+                    Value::Object(object) if object.contains_key("$secret") => {
+                        let handle: bamboo_domain::WorkflowSecretHandle =
+                            serde_json::from_value(value.clone()).map_err(|_| {
+                                failure(
+                                    WorkflowFailureCode::InvalidInput,
+                                    "malformed secret capability handle",
+                                    false,
+                                )
+                            })?;
+                        let material = context
+                            .engine
+                            .secrets
+                            .resolve(session_id, &handle.capability)
+                            .await
+                            .map_err(|_| {
+                                failure(
+                                    WorkflowFailureCode::PermissionDenied,
+                                    "secret capability resolution denied",
+                                    false,
+                                )
+                            })?;
+                        let material = material.into_exposed();
+                        Ok((Value::String(material.clone()), vec![material]))
+                    }
+                    Value::Object(object) => {
+                        let mut resolved = serde_json::Map::new();
+                        let mut secrets = Vec::new();
+                        for (key, child) in object {
+                            let (child, mut child_secrets) =
+                                walk(context, child, session_id).await?;
+                            resolved.insert(key.clone(), child);
+                            secrets.append(&mut child_secrets);
+                        }
+                        Ok((Value::Object(resolved), secrets))
+                    }
+                    Value::Array(array) => {
+                        let mut resolved = Vec::with_capacity(array.len());
+                        let mut secrets = Vec::new();
+                        for child in array {
+                            let (child, mut child_secrets) =
+                                walk(context, child, session_id).await?;
+                            resolved.push(child);
+                            secrets.append(&mut child_secrets);
+                        }
+                        Ok((Value::Array(resolved), secrets))
+                    }
+                    value => Ok((value.clone(), Vec::new())),
+                }
+            })
+        }
+        walk(self, value, session_id).await
+    }
+
+    fn skip_plan<'a>(&'a self, plan: &'a WorkflowPlan, reason: &'a str) -> NodeFuture<'a> {
+        Box::pin(async move {
+            match plan {
+                WorkflowPlan::Step { step } => {
+                    let instance_id = if self.scope == "root" {
+                        step.clone()
+                    } else {
+                        format!("{step}@{}", self.scope)
+                    };
+                    let reason_owned = reason.to_string();
+                    let state_id = instance_id.clone();
+                    self.step_transition(
+                        &instance_id,
+                        WorkflowRunEventKind::StepSkipped {
+                            reason: reason.to_string(),
+                        },
+                        move |snapshot| {
+                            let state = snapshot.steps.entry(state_id.clone()).or_insert(
+                                WorkflowStepSnapshot {
+                                    id: state_id,
+                                    status: WorkflowStepStatus::Skipped,
+                                    input_hash: String::new(),
+                                    output: None,
+                                    failure: Some(failure(
+                                        WorkflowFailureCode::DependencySkipped,
+                                        reason_owned.clone(),
+                                        false,
+                                    )),
+                                    attempts: 0,
+                                },
+                            );
+                            state.status = WorkflowStepStatus::Skipped;
+                            state.failure = Some(failure(
+                                WorkflowFailureCode::DependencySkipped,
+                                reason_owned,
+                                false,
+                            ));
+                        },
+                    )
+                    .await?;
+                }
+                WorkflowPlan::Sequence { nodes } | WorkflowPlan::Parallel { nodes } => {
+                    for node in nodes {
+                        self.skip_plan(node, reason).await?;
+                    }
+                }
+                WorkflowPlan::Map { body, .. } | WorkflowPlan::Retry { node: body, .. } => {
+                    self.skip_plan(body, reason).await?;
+                }
+            }
+            Ok(Value::Null)
+        })
+    }
+
+    async fn resolve_template(&self, value: &Value) -> Result<Value, WorkflowFailure> {
+        Box::pin(self.resolve_template_inner(value)).await
+    }
+
+    fn resolve_template_inner<'a>(
+        &'a self,
+        value: &'a Value,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, WorkflowFailure>> + Send + 'a>> {
+        Box::pin(async move {
+            match value {
+                Value::Object(object) if object.get("from").is_some() => {
+                    let reference: ValueRef =
+                        serde_json::from_value(value.clone()).map_err(|error| {
+                            failure(
+                                WorkflowFailureCode::InvalidInput,
+                                format!("malformed value reference: {error}"),
+                                false,
+                            )
+                        })?;
+                    self.resolve_ref(&reference).await
+                }
+                Value::Object(object) => {
+                    let mut resolved = serde_json::Map::new();
+                    for (key, child) in object {
+                        resolved.insert(key.clone(), self.resolve_template_inner(child).await?);
+                    }
+                    Ok(Value::Object(resolved))
+                }
+                Value::Array(array) => {
+                    let mut resolved = Vec::with_capacity(array.len());
+                    for child in array {
+                        resolved.push(self.resolve_template_inner(child).await?);
+                    }
+                    Ok(Value::Array(resolved))
+                }
+                value => Ok(value.clone()),
+            }
+        })
+    }
+
+    async fn resolve_ref(&self, reference: &ValueRef) -> Result<Value, WorkflowFailure> {
+        let (root, pointer) = match reference {
+            ValueRef::Args { pointer } => (
+                self.snapshot.lock().await.validated_args.clone(),
+                pointer.as_str(),
+            ),
+            ValueRef::Step { step, pointer } => {
+                let snapshot = self.snapshot.lock().await;
+                let exact = format!("{step}@{}", self.scope);
+                let output = snapshot
+                    .steps
+                    .get(&exact)
+                    .or_else(|| snapshot.steps.get(step))
+                    .and_then(|state| state.output.clone())
+                    .ok_or_else(|| {
+                        failure(
+                            WorkflowFailureCode::UnknownReference,
+                            format!("step output '{step}' unavailable in execution scope"),
+                            false,
+                        )
+                    })?;
+                (output, pointer.as_str())
+            }
+            ValueRef::Item { name, pointer } => (
+                self.items.get(name).cloned().ok_or_else(|| {
+                    failure(
+                        WorkflowFailureCode::UnknownReference,
+                        format!("map item '{name}' unavailable"),
+                        false,
+                    )
+                })?,
+                pointer.as_str(),
+            ),
+            ValueRef::Literal { value } => return Ok(value.clone()),
+        };
+        if pointer.is_empty() {
+            Ok(root)
+        } else {
+            root.pointer(pointer).cloned().ok_or_else(|| {
+                failure(
+                    WorkflowFailureCode::UnknownReference,
+                    format!("JSON pointer '{pointer}' not found"),
+                    false,
+                )
+            })
+        }
+    }
+
+    fn check_cancelled(&self) -> Result<(), WorkflowFailure> {
+        if self.cancellation.is_cancelled() || self.branch_cancellation.is_cancelled() {
+            Err(failure(
+                WorkflowFailureCode::Cancelled,
+                "workflow cancelled",
+                false,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn event(
+    snapshot: &WorkflowRunSnapshot,
+    step_id: Option<String>,
+    kind: WorkflowRunEventKind,
+) -> WorkflowRunEvent {
+    WorkflowRunEvent {
+        run_id: snapshot.run_id.clone(),
+        sequence: snapshot.last_sequence,
+        at: Utc::now(),
+        step_id,
+        kind,
+    }
+}
+fn failure(
+    code: WorkflowFailureCode,
+    message: impl Into<String>,
+    retryable: bool,
+) -> WorkflowFailure {
+    WorkflowFailure {
+        code,
+        message: message.into(),
+        retryable,
+    }
+}
+fn storage(error: std::io::Error) -> WorkflowRunError {
+    WorkflowRunError::Storage(error.to_string())
+}
+fn exceeds_optional(requested: Option<u64>, ceiling: Option<u64>) -> bool {
+    match (requested, ceiling) {
+        (Some(requested), Some(ceiling)) => requested > ceiling,
+        _ => false,
+    }
+}
+
+fn enforce_budget_within(
+    requested: &WorkflowBudgets,
+    ceiling: &WorkflowBudgets,
+) -> Result<(), &'static str> {
+    if requested.max_concurrency > ceiling.max_concurrency {
+        Err("max_concurrency")
+    } else if requested.max_agents > ceiling.max_agents {
+        Err("max_agents")
+    } else if requested.max_steps > ceiling.max_steps {
+        Err("max_steps")
+    } else if requested.max_retries > ceiling.max_retries {
+        Err("max_retries")
+    } else if requested.max_nesting_depth > ceiling.max_nesting_depth {
+        Err("max_nesting_depth")
+    } else if requested.wall_time_ms > ceiling.wall_time_ms {
+        Err("wall_time_ms")
+    } else if exceeds_optional(requested.max_tokens, ceiling.max_tokens) {
+        Err("max_tokens")
+    } else if exceeds_optional(requested.max_cost_micros, ceiling.max_cost_micros) {
+        Err("max_cost_micros")
+    } else {
+        Ok(())
+    }
+}
+
+fn definition_bundle_hash(bundle: &WorkflowDefinitionBundle) -> Result<String, WorkflowRunError> {
+    let bytes = serde_json::to_vec(bundle)
+        .map_err(|_| WorkflowRunError::Preflight("workflow bundle hashing failed".to_string()))?;
+    Ok(hex::encode(Sha256::digest(bytes)))
+}
+fn parse_tool_result(result: ToolResult) -> Result<Value, WorkflowFailure> {
+    if !result.success {
+        return Err(failure(
+            WorkflowFailureCode::ExecutionFailed,
+            "workflow tool reported failure",
+            true,
+        ));
+    }
+    Ok(serde_json::from_str(&result.result).unwrap_or(Value::String(result.result)))
+}
+fn reject_secret_material(value: &Value) -> Result<(), String> {
+    reject_secret_material_inner(value, false)
+}
+
+fn reject_secret_material_in_definition(value: &Value) -> Result<(), String> {
+    reject_secret_material_inner(value, true)
+}
+
+fn reject_secret_material_inner(value: &Value, allow_bindings: bool) -> Result<(), String> {
+    fn walk(value: &Value, key: Option<&str>, allow_bindings: bool) -> Result<(), String> {
+        if value.as_object().is_some_and(|object| {
+            object.len() == 1
+                && object
+                    .get("$secret")
+                    .and_then(Value::as_str)
+                    .is_some_and(|handle| !handle.trim().is_empty())
+        }) {
+            return Ok(());
+        }
+        let safe_binding = allow_bindings
+            && serde_json::from_value::<ValueRef>(value.clone())
+                .is_ok_and(|reference| !matches!(reference, ValueRef::Literal { .. }));
+        if key.is_some_and(|key| {
+            let normalized = key
+                .chars()
+                .filter(|character| character.is_ascii_alphanumeric())
+                .flat_map(char::to_lowercase)
+                .collect::<String>();
+            matches!(
+                normalized.as_str(),
+                "secret"
+                    | "token"
+                    | "password"
+                    | "credential"
+                    | "credentials"
+                    | "apikey"
+                    | "accesskey"
+                    | "accesstoken"
+                    | "secretkey"
+                    | "privatekey"
+            )
+        }) && !safe_binding
+        {
+            return Err("secret-bearing fields are not accepted by workflow runs".to_string());
+        }
+        if value.as_str().is_some_and(|value| {
+            let trimmed = value.trim();
+            trimmed.starts_with("capability://")
+                || trimmed.starts_with("Bearer ")
+                || trimmed.starts_with("sk-")
+                || trimmed.starts_with("ghp_")
+                || trimmed.starts_with("github_pat_")
+        }) {
+            // No production capability resolver is part of #578. Treating an
+            // arbitrary caller string as an opaque handle would be an injection
+            // channel, so handles and common raw credential forms fail closed.
+            return Err("opaque credential handles are not enabled for workflows".to_string());
+        }
+        match value {
+            Value::Object(object) => {
+                for (key, value) in object {
+                    if key == "properties" {
+                        let properties = value.as_object().ok_or_else(|| {
+                            "workflow schema properties must be an object".to_string()
+                        })?;
+                        for schema in properties.values() {
+                            walk(schema, None, allow_bindings)?;
+                        }
+                    } else {
+                        walk(value, Some(key), allow_bindings)?;
+                    }
+                }
+            }
+            Value::Array(array) => {
+                for value in array {
+                    walk(value, None, allow_bindings)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+    walk(value, None, allow_bindings)
+}
+
+fn contains_secret_handle(value: &Value) -> bool {
+    match value {
+        Value::Object(object) => {
+            object.contains_key("$secret") || object.values().any(contains_secret_handle)
+        }
+        Value::Array(array) => array.iter().any(contains_secret_handle),
+        _ => false,
+    }
+}
+
+fn contains_any_secret_material(value: &Value, secrets: &[String]) -> bool {
+    let matches = |candidate: &str| {
+        secrets
+            .iter()
+            .any(|secret| !secret.is_empty() && candidate.contains(secret))
+    };
+    fn walk(value: &Value, matches: &impl Fn(&str) -> bool) -> bool {
+        match value {
+            Value::String(value) => matches(value),
+            Value::Object(object) => object
+                .iter()
+                .any(|(key, value)| matches(key) || walk(value, matches)),
+            Value::Array(array) => array.iter().any(|value| walk(value, matches)),
+            _ => false,
+        }
+    }
+    walk(value, &matches)
+}
+
+fn plan_leaf_count(plan: &WorkflowPlan) -> usize {
+    match plan {
+        WorkflowPlan::Step { .. } => 1,
+        WorkflowPlan::Sequence { nodes } | WorkflowPlan::Parallel { nodes } => {
+            nodes.iter().fold(0usize, |total, node| {
+                total.saturating_add(plan_leaf_count(node))
+            })
+        }
+        WorkflowPlan::Map { body, .. } | WorkflowPlan::Retry { node: body, .. } => {
+            plan_leaf_count(body)
+        }
+    }
+}
+
+fn plan_step_ids(plan: &WorkflowPlan) -> Vec<String> {
+    match plan {
+        WorkflowPlan::Step { step } => vec![step.clone()],
+        WorkflowPlan::Sequence { nodes } | WorkflowPlan::Parallel { nodes } => {
+            nodes.iter().flat_map(plan_step_ids).collect()
+        }
+        WorkflowPlan::Map { body, .. } | WorkflowPlan::Retry { node: body, .. } => {
+            plan_step_ids(body)
+        }
+    }
+}
+
+fn instance_is_in_scope(instance_id: &str, step_id: &str, scope: &str) -> bool {
+    if scope == "root" {
+        instance_id == step_id
+            || instance_id
+                .strip_prefix(&format!("{step_id}@root"))
+                .is_some_and(|suffix| suffix.starts_with('['))
+    } else {
+        let exact = format!("{step_id}@{scope}");
+        instance_id == exact
+            || instance_id
+                .strip_prefix(&exact)
+                .is_some_and(|suffix| suffix.starts_with('['))
+    }
+}
+
+fn plan_frontier(plan: &WorkflowPlan) -> Vec<String> {
+    match plan {
+        WorkflowPlan::Step { step } => vec![step.clone()],
+        WorkflowPlan::Sequence { nodes } => nodes.first().map_or_else(Vec::new, plan_frontier),
+        WorkflowPlan::Parallel { nodes } => nodes.iter().flat_map(plan_frontier).collect(),
+        WorkflowPlan::Map { body, .. } | WorkflowPlan::Retry { node: body, .. } => {
+            plan_frontier(body)
+        }
+    }
+}
+
+fn validate_nested_input_contract(
+    template: &Value,
+    target_schema: &Value,
+    compiled: &CompiledWorkflow,
+) -> Result<(), String> {
+    fn contains_ref(value: &Value) -> bool {
+        match value {
+            Value::Object(object) => {
+                object.contains_key("from") || object.values().any(contains_ref)
+            }
+            Value::Array(array) => array.iter().any(contains_ref),
+            _ => false,
+        }
+    }
+    if !contains_ref(template) {
+        return validate_schema(target_schema, template)
+            .map_err(|error| format!("nested workflow input is incompatible: {error}"));
+    }
+    let reference: ValueRef = serde_json::from_value(template.clone()).map_err(|_| {
+        "nested dynamic input schema cannot be proven compatible in phase 1".to_string()
+    })?;
+    let source_schema = match reference {
+        ValueRef::Args { pointer } => {
+            schema_at_pointer(&compiled.definition.input_schema, &pointer)
+        }
+        ValueRef::Step { step, pointer } => compiled
+            .steps
+            .get(&step)
+            .and_then(|step| step.output_schema.as_ref())
+            .and_then(|schema| schema_at_pointer(schema, &pointer)),
+        ValueRef::Literal { value } => {
+            return validate_schema(target_schema, &value)
+                .map_err(|error| format!("nested workflow input is incompatible: {error}"));
+        }
+        ValueRef::Item { .. } => None,
+    }
+    .ok_or_else(|| {
+        "nested dynamic input source schema is missing or pointer is invalid".to_string()
+    })?;
+    if schema_compatible(source_schema, target_schema) {
+        Ok(())
+    } else {
+        Err("nested workflow input schema is not compatible with its pinned target".to_string())
+    }
+}
+
+fn schema_at_pointer<'a>(schema: &'a Value, pointer: &str) -> Option<&'a Value> {
+    if pointer.is_empty() {
+        return Some(schema);
+    }
+    let mut current = schema;
+    for token in pointer.strip_prefix('/')?.split('/') {
+        let token = token.replace("~1", "/").replace("~0", "~");
+        current = if token.parse::<usize>().is_ok() {
+            current.get("items")?
+        } else {
+            current.get("properties")?.get(&token)?
+        };
+    }
+    Some(current)
+}
+
+fn schema_compatible(source: &Value, target: &Value) -> bool {
+    if source == target {
+        return true;
+    }
+    let source_type = source.get("type").and_then(Value::as_str);
+    let target_type = target.get("type").and_then(Value::as_str);
+    source_type.is_some() && source_type == target_type && target_type != Some("object")
+}
+
+fn effective_limits(requested: &WorkflowBudgets, ceilings: &WorkflowBudgets) -> WorkflowBudgets {
+    WorkflowBudgets {
+        max_concurrency: requested.max_concurrency.min(ceilings.max_concurrency),
+        max_agents: requested.max_agents.min(ceilings.max_agents),
+        max_steps: requested.max_steps.min(ceilings.max_steps),
+        max_retries: requested.max_retries.min(ceilings.max_retries),
+        max_nesting_depth: requested.max_nesting_depth.min(ceilings.max_nesting_depth),
+        wall_time_ms: requested.wall_time_ms.min(ceilings.wall_time_ms),
+        max_tokens: match (requested.max_tokens, ceilings.max_tokens) {
+            (Some(requested), Some(ceiling)) => Some(requested.min(ceiling)),
+            (Some(requested), None) => Some(requested),
+            (None, ceiling) => ceiling,
+        },
+        max_cost_micros: match (requested.max_cost_micros, ceilings.max_cost_micros) {
+            (Some(requested), Some(ceiling)) => Some(requested.min(ceiling)),
+            (Some(requested), None) => Some(requested),
+            (None, ceiling) => ceiling,
+        },
+    }
+}

--- a/crates/engine/bamboo-engine/src/workflow_run/mod.rs
+++ b/crates/engine/bamboo-engine/src/workflow_run/mod.rs
@@ -1,0 +1,15 @@
+//! Durable, catalog-revision-pinned workflow execution.
+
+mod executor;
+mod repository;
+
+pub use bamboo_domain::{CompiledWorkflow, WorkflowCompileError};
+pub use executor::{
+    AgentStepPort, AgentStepResult, NamedAgentSpec, PermissionDecision, WorkflowDefinitionPort,
+    WorkflowPolicyPort, WorkflowPolicyTarget, WorkflowRunEngine, WorkflowRunError,
+    WorkflowSecretMaterial, WorkflowSecretResolverPort,
+};
+pub use repository::{FileWorkflowRunRepository, WorkflowRunRepository};
+
+#[cfg(test)]
+mod tests;

--- a/crates/engine/bamboo-engine/src/workflow_run/repository.rs
+++ b/crates/engine/bamboo-engine/src/workflow_run/repository.rs
@@ -1,0 +1,365 @@
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Weak};
+
+use async_trait::async_trait;
+use bamboo_domain::{WorkflowRunEvent, WorkflowRunSnapshot};
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+
+#[async_trait]
+pub trait WorkflowRunRepository: Send + Sync {
+    async fn create(
+        &self,
+        snapshot: &WorkflowRunSnapshot,
+        event: &WorkflowRunEvent,
+    ) -> io::Result<()>;
+    async fn commit(
+        &self,
+        snapshot: &WorkflowRunSnapshot,
+        event: &WorkflowRunEvent,
+    ) -> io::Result<()>;
+    async fn load(&self, run_id: &str) -> io::Result<Option<WorkflowRunSnapshot>>;
+    async fn events_since(&self, run_id: &str, sequence: u64) -> io::Result<Vec<WorkflowRunEvent>>;
+    async fn list_run_ids(&self) -> io::Result<Vec<String>>;
+}
+
+/// One directory per run: a compact atomic snapshot plus an append-only JSONL
+/// event journal. Each event is synced before the corresponding snapshot is
+/// replaced, and callers publish only after `commit` returns.
+pub struct FileWorkflowRunRepository {
+    root: PathBuf,
+    locks: DashMap<String, Weak<Mutex<()>>>,
+}
+
+impl FileWorkflowRunRepository {
+    pub fn new(root: PathBuf) -> io::Result<Self> {
+        std::fs::create_dir_all(&root)?;
+        Ok(Self {
+            root,
+            locks: DashMap::new(),
+        })
+    }
+
+    fn validate_id(run_id: &str) -> io::Result<()> {
+        if run_id.is_empty()
+            || run_id.len() > 128
+            || !run_id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid run id",
+            ));
+        }
+        Ok(())
+    }
+
+    fn run_dir(&self, run_id: &str) -> io::Result<PathBuf> {
+        Self::validate_id(run_id)?;
+        Ok(self.root.join(run_id))
+    }
+
+    fn lock(&self, run_id: &str) -> Arc<Mutex<()>> {
+        self.locks.retain(|_, lock| lock.strong_count() > 0);
+        match self.locks.entry(run_id.to_owned()) {
+            Entry::Occupied(mut entry) => {
+                if let Some(lock) = entry.get().upgrade() {
+                    lock
+                } else {
+                    let lock = Arc::new(Mutex::new(()));
+                    entry.insert(Arc::downgrade(&lock));
+                    lock
+                }
+            }
+            Entry::Vacant(entry) => {
+                let lock = Arc::new(Mutex::new(()));
+                entry.insert(Arc::downgrade(&lock));
+                lock
+            }
+        }
+    }
+
+    async fn commit_locked(
+        &self,
+        snapshot: &WorkflowRunSnapshot,
+        event: &WorkflowRunEvent,
+        create: bool,
+    ) -> io::Result<()> {
+        if snapshot.run_id != event.run_id || snapshot.last_sequence != event.sequence {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "snapshot/event sequence mismatch",
+            ));
+        }
+        let dir = self.run_dir(&snapshot.run_id)?;
+        if create {
+            match tokio::fs::create_dir(&dir).await {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                    return Err(io::Error::new(io::ErrorKind::AlreadyExists, "run exists"));
+                }
+                Err(error) => return Err(error),
+            }
+        } else if !tokio::fs::try_exists(&dir).await? {
+            return Err(io::Error::new(io::ErrorKind::NotFound, "run missing"));
+        }
+
+        // Serialize both records before mutating durable state. The staged
+        // snapshot is fsynced first but remains invisible until the matching
+        // journal record is durable.
+        let event_bytes = serde_json::to_vec(event).map_err(io::Error::other)?;
+        let snapshot_bytes = serde_json::to_vec(snapshot).map_err(io::Error::other)?;
+        let temporary = dir.join(format!(".snapshot-{}.tmp", event.sequence));
+        let mut file = tokio::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temporary)
+            .await?;
+        if let Err(error) = async {
+            file.write_all(&snapshot_bytes).await?;
+            file.sync_all().await
+        }
+        .await
+        {
+            let _ = tokio::fs::remove_file(&temporary).await;
+            return Err(error);
+        }
+        drop(file);
+
+        let journal_path = dir.join("journal.jsonl");
+        let mut journal = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&journal_path)
+            .await?;
+        journal.write_all(&event_bytes).await?;
+        journal.write_all(b"\n").await?;
+        journal.sync_all().await?;
+        atomic_replace(&temporary, &dir.join("snapshot.json")).await?;
+        sync_directory(&dir).await?;
+        Ok(())
+    }
+
+    async fn recover_snapshot(&self, run_id: &str) -> io::Result<Option<WorkflowRunSnapshot>> {
+        let dir = self.run_dir(run_id)?;
+        repair_journal_tail(&dir.join("journal.jsonl")).await?;
+        let snapshot_path = dir.join("snapshot.json");
+        let current = match tokio::fs::read(&snapshot_path).await {
+            Ok(bytes) => Some(
+                serde_json::from_slice::<WorkflowRunSnapshot>(&bytes).map_err(io::Error::other)?,
+            ),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error),
+        };
+        let journal = self.events_since(run_id, 0).await?;
+        let journal_sequence = journal.last().map_or(0, |event| event.sequence);
+        let snapshot_sequence = current
+            .as_ref()
+            .map_or(0, |snapshot| snapshot.last_sequence);
+        if journal_sequence == snapshot_sequence {
+            // A staged snapshot without a journal record was never committed.
+            let stale = dir.join(format!(".snapshot-{}.tmp", journal_sequence + 1));
+            let _ = tokio::fs::remove_file(stale).await;
+            return Ok(current);
+        }
+        if journal_sequence < snapshot_sequence || journal_sequence != snapshot_sequence + 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "workflow journal/snapshot sequence divergence",
+            ));
+        }
+        let temporary = dir.join(format!(".snapshot-{journal_sequence}.tmp"));
+        let bytes = tokio::fs::read(&temporary).await.map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("journal is ahead but staged snapshot is missing: {error}"),
+            )
+        })?;
+        let recovered: WorkflowRunSnapshot =
+            serde_json::from_slice(&bytes).map_err(io::Error::other)?;
+        if recovered.run_id != run_id || recovered.last_sequence != journal_sequence {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "staged workflow snapshot does not match journal",
+            ));
+        }
+        atomic_replace(&temporary, &snapshot_path).await?;
+        sync_directory(&dir).await?;
+        Ok(Some(recovered))
+    }
+}
+
+#[async_trait]
+impl WorkflowRunRepository for FileWorkflowRunRepository {
+    async fn create(
+        &self,
+        snapshot: &WorkflowRunSnapshot,
+        event: &WorkflowRunEvent,
+    ) -> io::Result<()> {
+        let lock = self.lock(&snapshot.run_id);
+        let _guard = lock.lock().await;
+        match self.commit_locked(snapshot, event, true).await {
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                let current = self.recover_snapshot(&snapshot.run_id).await?;
+                if current.as_ref() == Some(snapshot) {
+                    Ok(())
+                } else if current.is_none() {
+                    let dir = self.run_dir(&snapshot.run_id)?;
+                    let mut entries = tokio::fs::read_dir(&dir).await?;
+                    let mut removable = true;
+                    let mut paths = Vec::new();
+                    while let Some(entry) = entries.next_entry().await? {
+                        let path = entry.path();
+                        if entry.file_name() != "journal.jsonl"
+                            || entry.metadata().await?.len() != 0
+                        {
+                            removable = false;
+                            break;
+                        }
+                        paths.push(path);
+                    }
+                    if removable {
+                        for path in paths {
+                            tokio::fs::remove_file(path).await?;
+                        }
+                        tokio::fs::remove_dir(&dir).await?;
+                        self.commit_locked(snapshot, event, true).await
+                    } else {
+                        Err(error)
+                    }
+                } else {
+                    Err(error)
+                }
+            }
+            result => result,
+        }
+    }
+
+    async fn commit(
+        &self,
+        snapshot: &WorkflowRunSnapshot,
+        event: &WorkflowRunEvent,
+    ) -> io::Result<()> {
+        let lock = self.lock(&snapshot.run_id);
+        let _guard = lock.lock().await;
+        let current = self
+            .recover_snapshot(&snapshot.run_id)
+            .await?
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "run snapshot missing"))?;
+        if current.last_sequence == event.sequence && current == *snapshot {
+            return Ok(());
+        }
+        if current.status.is_terminal() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "terminal workflow run is immutable",
+            ));
+        }
+        if event.sequence != current.last_sequence.saturating_add(1) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "workflow event sequence is not monotonic",
+            ));
+        }
+        self.commit_locked(snapshot, event, false).await
+    }
+
+    async fn load(&self, run_id: &str) -> io::Result<Option<WorkflowRunSnapshot>> {
+        let lock = self.lock(run_id);
+        let _guard = lock.lock().await;
+        self.recover_snapshot(run_id).await
+    }
+
+    async fn events_since(&self, run_id: &str, sequence: u64) -> io::Result<Vec<WorkflowRunEvent>> {
+        let path = self.run_dir(run_id)?.join("journal.jsonl");
+        let bytes = match tokio::fs::read(path).await {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(error),
+        };
+        // A process crash may leave only the final, unterminated JSON fragment.
+        // Discard that tail; every newline-terminated record is committed and
+        // therefore must parse and form one contiguous run-local sequence.
+        let committed = match bytes.iter().rposition(|byte| *byte == b'\n') {
+            Some(end) => &bytes[..=end],
+            None => &[][..],
+        };
+        let text = std::str::from_utf8(committed)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        let mut result = Vec::new();
+        for (expected, line) in (1_u64..).zip(text.lines().filter(|line| !line.trim().is_empty())) {
+            let event: WorkflowRunEvent = serde_json::from_str(line)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+            if event.run_id != run_id || event.sequence != expected {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "workflow journal identity or sequence divergence",
+                ));
+            }
+            if event.sequence > sequence {
+                result.push(event);
+            }
+        }
+        Ok(result)
+    }
+
+    async fn list_run_ids(&self) -> io::Result<Vec<String>> {
+        let mut entries = tokio::fs::read_dir(&self.root).await?;
+        let mut ids = Vec::new();
+        while let Some(entry) = entries.next_entry().await? {
+            if entry.file_type().await?.is_dir() {
+                if let Some(id) = entry.file_name().to_str() {
+                    if Self::validate_id(id).is_ok() {
+                        ids.push(id.to_owned());
+                    }
+                }
+            }
+        }
+        ids.sort();
+        Ok(ids)
+    }
+}
+
+#[cfg(unix)]
+async fn sync_directory(path: &Path) -> io::Result<()> {
+    let file = tokio::fs::File::open(path).await?;
+    file.sync_all().await
+}
+
+#[cfg(not(unix))]
+async fn sync_directory(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+async fn atomic_replace(from: &Path, to: &Path) -> io::Result<()> {
+    match tokio::fs::rename(from, to).await {
+        Ok(()) => Ok(()),
+        Err(_error) if cfg!(windows) && tokio::fs::try_exists(to).await? => {
+            tokio::fs::remove_file(to).await?;
+            tokio::fs::rename(from, to).await
+        }
+        Err(error) => Err(error),
+    }
+}
+
+async fn repair_journal_tail(path: &Path) -> io::Result<()> {
+    let bytes = match tokio::fs::read(path).await {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    let committed_len = bytes
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(0, |index| index + 1);
+    if committed_len < bytes.len() {
+        let file = tokio::fs::OpenOptions::new().write(true).open(path).await?;
+        file.set_len(committed_len as u64).await?;
+        file.sync_all().await?;
+    }
+    Ok(())
+}

--- a/crates/engine/bamboo-engine/src/workflow_run/tests.rs
+++ b/crates/engine/bamboo-engine/src/workflow_run/tests.rs
@@ -1,0 +1,2360 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bamboo_agent_core::tools::{
+    AsyncWaitKind, RunningCompletion, RunningHandle, ToolCall, ToolError, ToolExecutionContext,
+    ToolExecutor, ToolOutcome, ToolResult,
+};
+use bamboo_domain::*;
+use chrono::Utc;
+use serde_json::{json, Value};
+use tokio::io::AsyncWriteExt;
+
+use super::*;
+
+fn budgets() -> WorkflowBudgets {
+    WorkflowBudgets {
+        max_concurrency: 4,
+        max_agents: 4,
+        max_steps: 64,
+        max_retries: 4,
+        max_nesting_depth: 4,
+        wall_time_ms: 10_000,
+        max_tokens: Some(10_000),
+        max_cost_micros: Some(10_000),
+    }
+}
+
+fn tool_step(id: &str, tool: &str, args: Value) -> WorkflowStepDefinition {
+    WorkflowStepDefinition {
+        id: id.to_string(),
+        kind: WorkflowStepKind::Tool {
+            tool: tool.to_string(),
+            args,
+            capabilities: vec!["read".to_string()],
+        },
+        failure: FailurePolicy::FailFast,
+        output_schema: None,
+    }
+}
+
+fn definition(steps: Vec<WorkflowStepDefinition>, plan: WorkflowPlan) -> WorkflowRunDefinition {
+    WorkflowRunDefinition {
+        workflow_schema: 1,
+        id: "review".to_string(),
+        revision: 7,
+        input_schema: json!({"type":"object","properties":{"items":{"type":"array","items":{"type":"integer"}}},"additionalProperties":true}),
+        output_schema: None,
+        steps,
+        plan,
+        budgets: budgets(),
+    }
+}
+
+fn snapshot(run_id: &str, status: WorkflowRunStatus, sequence: u64) -> WorkflowRunSnapshot {
+    let now = Utc::now();
+    let definition = definition(
+        vec![tool_step("echo", "echo", json!({}))],
+        WorkflowPlan::Step {
+            step: "echo".to_string(),
+        },
+    );
+    let definition_bundle = WorkflowDefinitionBundle {
+        publication_revision: 1,
+        root_id: definition.id.clone(),
+        root_revision: definition.revision,
+        definitions: BTreeMap::from([(
+            WorkflowDefinitionBundle::key(&definition.id, definition.revision),
+            definition.clone(),
+        )]),
+    };
+    WorkflowRunSnapshot {
+        run_id: run_id.to_string(),
+        parent_run_id: None,
+        parent_step_id: None,
+        session_id: "session-1".to_string(),
+        definition,
+        definition_bundle,
+        definition_bundle_hash: "test-bundle-hash".to_string(),
+        validated_args: json!({}),
+        status,
+        steps: BTreeMap::new(),
+        usage: WorkflowBudgetUsage::default(),
+        last_sequence: sequence,
+        output: None,
+        failure: None,
+        suspension: None,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+fn run_event(run_id: &str, sequence: u64, kind: WorkflowRunEventKind) -> WorkflowRunEvent {
+    WorkflowRunEvent {
+        run_id: run_id.to_string(),
+        sequence,
+        at: Utc::now(),
+        step_id: None,
+        kind,
+    }
+}
+
+#[tokio::test]
+async fn repository_promotes_journal_committed_staged_snapshot() {
+    let directory = tempfile::tempdir().unwrap();
+    let repository = FileWorkflowRunRepository::new(directory.path().to_path_buf()).unwrap();
+    let first = snapshot("run-1", WorkflowRunStatus::Queued, 1);
+    repository
+        .create(
+            &first,
+            &run_event("run-1", 1, WorkflowRunEventKind::RunQueued),
+        )
+        .await
+        .unwrap();
+
+    let second = snapshot("run-1", WorkflowRunStatus::Running, 2);
+    let event = run_event("run-1", 2, WorkflowRunEventKind::RunStarted);
+    let run_dir = directory.path().join("run-1");
+    tokio::fs::write(
+        run_dir.join(".snapshot-2.tmp"),
+        serde_json::to_vec(&second).unwrap(),
+    )
+    .await
+    .unwrap();
+    let mut journal = tokio::fs::OpenOptions::new()
+        .append(true)
+        .open(run_dir.join("journal.jsonl"))
+        .await
+        .unwrap();
+    journal
+        .write_all(&serde_json::to_vec(&event).unwrap())
+        .await
+        .unwrap();
+    journal.write_all(b"\n").await.unwrap();
+    journal.sync_all().await.unwrap();
+
+    let recovered = repository.load("run-1").await.unwrap().unwrap();
+    assert_eq!(recovered.status, WorkflowRunStatus::Running);
+    assert_eq!(recovered.last_sequence, 2);
+    assert!(!run_dir.join(".snapshot-2.tmp").exists());
+}
+
+#[tokio::test]
+async fn repository_truncates_torn_tail_before_next_commit() {
+    let directory = tempfile::tempdir().unwrap();
+    let repository = FileWorkflowRunRepository::new(directory.path().to_path_buf()).unwrap();
+    let first = snapshot("run-2", WorkflowRunStatus::Queued, 1);
+    repository
+        .create(
+            &first,
+            &run_event("run-2", 1, WorkflowRunEventKind::RunQueued),
+        )
+        .await
+        .unwrap();
+    let journal_path = directory.path().join("run-2/journal.jsonl");
+    let mut journal = tokio::fs::OpenOptions::new()
+        .append(true)
+        .open(&journal_path)
+        .await
+        .unwrap();
+    journal.write_all(br#"{"partial":"#).await.unwrap();
+    journal.sync_all().await.unwrap();
+    repository.load("run-2").await.unwrap();
+
+    let second = snapshot("run-2", WorkflowRunStatus::Running, 2);
+    repository
+        .commit(
+            &second,
+            &run_event("run-2", 2, WorkflowRunEventKind::RunStarted),
+        )
+        .await
+        .unwrap();
+    let events = repository.events_since("run-2", 0).await.unwrap();
+    assert_eq!(
+        events
+            .iter()
+            .map(|event| event.sequence)
+            .collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+}
+
+#[tokio::test]
+async fn repository_retries_create_after_empty_torn_attempt_and_replaces_snapshot() {
+    let directory = tempfile::tempdir().unwrap();
+    let repository = FileWorkflowRunRepository::new(directory.path().to_path_buf()).unwrap();
+    let run_dir = directory.path().join("run-3");
+    tokio::fs::create_dir(&run_dir).await.unwrap();
+    tokio::fs::write(run_dir.join("journal.jsonl"), b"torn")
+        .await
+        .unwrap();
+    let first = snapshot("run-3", WorkflowRunStatus::Queued, 1);
+    repository
+        .create(
+            &first,
+            &run_event("run-3", 1, WorkflowRunEventKind::RunQueued),
+        )
+        .await
+        .unwrap();
+    let second = snapshot("run-3", WorkflowRunStatus::Running, 2);
+    repository
+        .commit(
+            &second,
+            &run_event("run-3", 2, WorkflowRunEventKind::RunStarted),
+        )
+        .await
+        .unwrap();
+    let third = snapshot("run-3", WorkflowRunStatus::Suspended, 3);
+    repository
+        .commit(
+            &third,
+            &run_event(
+                "run-3",
+                3,
+                WorkflowRunEventKind::RunSuspended {
+                    reason: "restart".to_string(),
+                },
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        repository
+            .load("run-3")
+            .await
+            .unwrap()
+            .unwrap()
+            .last_sequence,
+        3
+    );
+}
+
+#[tokio::test]
+async fn repository_same_run_commit_lock_is_atomic_for_100_races() {
+    let directory = tempfile::tempdir().unwrap();
+    let repository =
+        Arc::new(FileWorkflowRunRepository::new(directory.path().to_path_buf()).unwrap());
+    for round in 0..100 {
+        let run_id = format!("commit-race-{round}");
+        let queued = snapshot(&run_id, WorkflowRunStatus::Queued, 1);
+        repository
+            .create(
+                &queued,
+                &run_event(&run_id, 1, WorkflowRunEventKind::RunQueued),
+            )
+            .await
+            .unwrap();
+        let mut left_snapshot = snapshot(&run_id, WorkflowRunStatus::Running, 2);
+        left_snapshot.validated_args = json!({"winner": "left"});
+        let mut right_snapshot = snapshot(&run_id, WorkflowRunStatus::Running, 2);
+        right_snapshot.validated_args = json!({"winner": "right"});
+        let left = {
+            let repository = repository.clone();
+            let running = left_snapshot;
+            let run_id = run_id.clone();
+            tokio::spawn(async move {
+                repository
+                    .commit(
+                        &running,
+                        &run_event(&run_id, 2, WorkflowRunEventKind::RunStarted),
+                    )
+                    .await
+            })
+        };
+        let right = {
+            let repository = repository.clone();
+            let running = right_snapshot;
+            let run_id = run_id.clone();
+            tokio::spawn(async move {
+                repository
+                    .commit(
+                        &running,
+                        &run_event(&run_id, 2, WorkflowRunEventKind::RunStarted),
+                    )
+                    .await
+            })
+        };
+        let (left, right) = tokio::join!(left, right);
+        let successes = [left.unwrap(), right.unwrap()]
+            .into_iter()
+            .filter(Result::is_ok)
+            .count();
+        assert_eq!(successes, 1, "round {round}");
+        let loaded = repository.load(&run_id).await.unwrap().unwrap();
+        let events = repository.events_since(&run_id, 0).await.unwrap();
+        assert_eq!(loaded.last_sequence, 2);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[1].sequence, 2);
+    }
+}
+
+#[test]
+fn compiler_rejects_unknown_schema_keywords_duplicate_plan_and_parallel_cycle() {
+    let mut bad_schema = definition(
+        vec![tool_step("one", "echo", json!({}))],
+        WorkflowPlan::Step {
+            step: "one".to_string(),
+        },
+    );
+    bad_schema.input_schema = json!({"type":"object","patternProperties":{}});
+    assert!(matches!(
+        CompiledWorkflow::compile(bad_schema),
+        Err(WorkflowCompileError::InvalidSchema(_))
+    ));
+
+    let duplicate = definition(
+        vec![tool_step("one", "echo", json!({}))],
+        WorkflowPlan::Sequence {
+            nodes: vec![
+                WorkflowPlan::Step {
+                    step: "one".to_string(),
+                },
+                WorkflowPlan::Step {
+                    step: "one".to_string(),
+                },
+            ],
+        },
+    );
+    assert!(CompiledWorkflow::compile(duplicate).is_err());
+
+    let cycle = definition(
+        vec![
+            tool_step("a", "echo", json!({"from":"step","step":"c","pointer":""})),
+            tool_step("b", "echo", json!({})),
+            tool_step("c", "echo", json!({})),
+        ],
+        WorkflowPlan::Sequence {
+            nodes: vec![
+                WorkflowPlan::Parallel {
+                    nodes: vec![
+                        WorkflowPlan::Step {
+                            step: "a".to_string(),
+                        },
+                        WorkflowPlan::Step {
+                            step: "b".to_string(),
+                        },
+                    ],
+                },
+                WorkflowPlan::Step {
+                    step: "c".to_string(),
+                },
+            ],
+        },
+    );
+    assert!(matches!(
+        CompiledWorkflow::compile(cycle),
+        Err(WorkflowCompileError::Cycle(_))
+    ));
+}
+
+#[test]
+fn compiler_enforces_execution_order_and_typed_value_reference_scopes() {
+    let mut left = tool_step("left", "echo", json!({}));
+    left.output_schema = Some(json!({
+        "type":"object",
+        "properties":{"value":{"type":"string"}},
+        "required":["value"],
+        "additionalProperties":false
+    }));
+    let parallel_sibling = definition(
+        vec![
+            left.clone(),
+            tool_step(
+                "right",
+                "echo",
+                json!({"from":"step","step":"left","pointer":"/value"}),
+            ),
+        ],
+        WorkflowPlan::Parallel {
+            nodes: vec![
+                WorkflowPlan::Step {
+                    step: "left".to_string(),
+                },
+                WorkflowPlan::Step {
+                    step: "right".to_string(),
+                },
+            ],
+        },
+    );
+    assert!(matches!(
+        CompiledWorkflow::compile(parallel_sibling),
+        Err(WorkflowCompileError::InvalidStep { step, .. }) if step == "right"
+    ));
+
+    let bad_args_pointer = definition(
+        vec![tool_step(
+            "bad-args",
+            "echo",
+            json!({"from":"args","pointer":"/missing"}),
+        )],
+        WorkflowPlan::Step {
+            step: "bad-args".to_string(),
+        },
+    );
+    assert!(CompiledWorkflow::compile(bad_args_pointer).is_err());
+
+    let item_outside_map = definition(
+        vec![tool_step(
+            "bad-item",
+            "echo",
+            json!({"from":"item","name":"row","pointer":""}),
+        )],
+        WorkflowPlan::Step {
+            step: "bad-item".to_string(),
+        },
+    );
+    assert!(CompiledWorkflow::compile(item_outside_map).is_err());
+
+    let non_array_map = definition(
+        vec![tool_step("mapped", "echo", json!({}))],
+        WorkflowPlan::Map {
+            source: ValueRef::Args {
+                pointer: "/missing".to_string(),
+            },
+            item: "row".to_string(),
+            body: Box::new(WorkflowPlan::Step {
+                step: "mapped".to_string(),
+            }),
+        },
+    );
+    assert!(CompiledWorkflow::compile(non_array_map).is_err());
+
+    let mut future = tool_step("future", "echo", json!({}));
+    future.output_schema = Some(json!({
+        "type":"array",
+        "items":{"type":"integer"}
+    }));
+    let future_map_source = definition(
+        vec![
+            tool_step(
+                "mapped",
+                "echo",
+                json!({"from":"item","name":"row","pointer":""}),
+            ),
+            future,
+        ],
+        WorkflowPlan::Sequence {
+            nodes: vec![
+                WorkflowPlan::Map {
+                    source: ValueRef::Step {
+                        step: "future".to_string(),
+                        pointer: "".to_string(),
+                    },
+                    item: "row".to_string(),
+                    body: Box::new(WorkflowPlan::Step {
+                        step: "mapped".to_string(),
+                    }),
+                },
+                WorkflowPlan::Step {
+                    step: "future".to_string(),
+                },
+            ],
+        },
+    );
+    assert!(CompiledWorkflow::compile(future_map_source).is_err());
+
+    let valid_map = definition(
+        vec![tool_step(
+            "mapped",
+            "echo",
+            json!({"from":"item","name":"row","pointer":""}),
+        )],
+        WorkflowPlan::Map {
+            source: ValueRef::Args {
+                pointer: "/items".to_string(),
+            },
+            item: "row".to_string(),
+            body: Box::new(WorkflowPlan::Step {
+                step: "mapped".to_string(),
+            }),
+        },
+    );
+    CompiledWorkflow::compile(valid_map).expect("valid map item binding");
+
+    let map_body_output_outside_map = definition(
+        vec![
+            tool_step(
+                "mapped",
+                "echo",
+                json!({"from":"item","name":"row","pointer":""}),
+            ),
+            tool_step(
+                "after-map",
+                "echo",
+                json!({"from":"step","step":"mapped","pointer":""}),
+            ),
+        ],
+        WorkflowPlan::Sequence {
+            nodes: vec![
+                WorkflowPlan::Map {
+                    source: ValueRef::Args {
+                        pointer: "/items".to_string(),
+                    },
+                    item: "row".to_string(),
+                    body: Box::new(WorkflowPlan::Step {
+                        step: "mapped".to_string(),
+                    }),
+                },
+                WorkflowPlan::Step {
+                    step: "after-map".to_string(),
+                },
+            ],
+        },
+    );
+    assert!(matches!(
+        CompiledWorkflow::compile(map_body_output_outside_map),
+        Err(WorkflowCompileError::InvalidStep { step, .. }) if step == "after-map"
+    ));
+}
+
+struct MockTools;
+
+#[async_trait]
+impl ToolExecutor for MockTools {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+        let args: Value = serde_json::from_str(&call.function.arguments).unwrap();
+        match call.function.name.as_str() {
+            "echo" => Ok(ToolResult::text(
+                true,
+                serde_json::to_string(&args).unwrap(),
+            )),
+            "flaky" => Err(ToolError::Execution("retry me".to_string())),
+            "fail" => Ok(ToolResult::text(false, "expected failure")),
+            "slow" => {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                Ok(ToolResult::text(true, "{}"))
+            }
+            "secretout" => Ok(ToolResult::text(true, r#"{"token":"raw-secret"}"#)),
+            "baresecret" => Ok(ToolResult::text(true, r#""sk-raw-secret""#)),
+            "secretfail" => Ok(ToolResult::text(false, "api_key=raw-secret")),
+            _ => Err(ToolError::NotFound(call.function.name.clone())),
+        }
+    }
+
+    fn list_tools(&self) -> Vec<bamboo_agent_core::tools::ToolSchema> {
+        Vec::new()
+    }
+}
+
+struct CapturingTools(Arc<std::sync::Mutex<Option<Value>>>);
+
+#[async_trait]
+impl ToolExecutor for CapturingTools {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+        let args = serde_json::from_str(&call.function.arguments).unwrap();
+        *self.0.lock().unwrap() = Some(args);
+        if call.function.name == "echo-secret" {
+            Ok(ToolResult::text(true, r#""resolved-test-value""#))
+        } else {
+            Ok(ToolResult::text(true, r#"{"ok":true}"#))
+        }
+    }
+
+    fn list_tools(&self) -> Vec<bamboo_agent_core::tools::ToolSchema> {
+        Vec::new()
+    }
+}
+
+struct ApprovalTools;
+
+#[async_trait]
+impl ToolExecutor for ApprovalTools {
+    async fn execute(&self, _call: &ToolCall) -> Result<ToolResult, ToolError> {
+        unreachable!("outcome-aware path must be used")
+    }
+
+    async fn execute_with_context_outcome(
+        &self,
+        call: &ToolCall,
+        _ctx: ToolExecutionContext<'_>,
+    ) -> Result<ToolOutcome, ToolError> {
+        Ok(ToolOutcome::NeedsHuman {
+            question: bamboo_agent_core::PendingQuestion {
+                tool_call_id: call.id.clone(),
+                tool_name: call.function.name.clone(),
+                question: "Approve?".to_string(),
+                options: vec!["yes".to_string(), "no".to_string()],
+                allow_custom: false,
+                source: bamboo_agent_core::PendingQuestionSource::PauseTool,
+            },
+            result: ToolResult::text(false, "approval required"),
+        })
+    }
+
+    fn list_tools(&self) -> Vec<bamboo_agent_core::tools::ToolSchema> {
+        Vec::new()
+    }
+}
+
+struct RunningTools(Arc<AtomicBool>);
+
+#[async_trait]
+impl ToolExecutor for RunningTools {
+    async fn execute(&self, _call: &ToolCall) -> Result<ToolResult, ToolError> {
+        unreachable!("outcome-aware path must be used")
+    }
+
+    async fn execute_with_context_outcome(
+        &self,
+        call: &ToolCall,
+        _ctx: ToolExecutionContext<'_>,
+    ) -> Result<ToolOutcome, ToolError> {
+        let killed = self.0.clone();
+        Ok(ToolOutcome::Running(RunningHandle {
+            tool_call_id: call.id.clone(),
+            ack: ToolResult::text(true, "running"),
+            completion: RunningCompletion::Detached,
+            wait_kind: AsyncWaitKind::AsyncTools,
+            kill: Box::new(move || killed.store(true, Ordering::SeqCst)),
+        }))
+    }
+
+    fn list_tools(&self) -> Vec<bamboo_agent_core::tools::ToolSchema> {
+        Vec::new()
+    }
+}
+
+struct MockAgents;
+
+#[async_trait]
+impl AgentStepPort for MockAgents {
+    async fn resolve(&self, name: &str) -> Result<Option<NamedAgentSpec>, String> {
+        Ok((name == "reviewer").then(|| NamedAgentSpec {
+            name: name.to_string(),
+            allowed_capabilities: BTreeSet::from(["read".to_string()]),
+        }))
+    }
+
+    async fn execute(
+        &self,
+        _spec: &NamedAgentSpec,
+        prompt: Value,
+        _model: Option<&str>,
+        _effort: Option<&str>,
+        _capabilities: &BTreeSet<String>,
+        _session_id: &str,
+    ) -> Result<AgentStepResult, String> {
+        Ok(AgentStepResult {
+            output: json!({"reviewed": prompt}),
+            tokens: 10,
+            cost_micros: 2,
+        })
+    }
+}
+
+struct CountingAgents(AtomicUsize);
+
+#[async_trait]
+impl AgentStepPort for CountingAgents {
+    async fn resolve(&self, name: &str) -> Result<Option<NamedAgentSpec>, String> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(Some(NamedAgentSpec {
+            name: name.to_string(),
+            allowed_capabilities: BTreeSet::from(["read".to_string()]),
+        }))
+    }
+
+    async fn execute(
+        &self,
+        _spec: &NamedAgentSpec,
+        prompt: Value,
+        _model: Option<&str>,
+        _effort: Option<&str>,
+        _capabilities: &BTreeSet<String>,
+        _session_id: &str,
+    ) -> Result<AgentStepResult, String> {
+        Ok(AgentStepResult {
+            output: prompt,
+            tokens: 1,
+            cost_micros: 1,
+        })
+    }
+}
+
+struct FlakyOnceTools(AtomicUsize);
+
+#[async_trait]
+impl ToolExecutor for FlakyOnceTools {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+        match call.function.name.as_str() {
+            "flaky-once" if self.0.fetch_add(1, Ordering::SeqCst) == 0 => {
+                Err(ToolError::Execution("transient".to_string()))
+            }
+            "flaky-once" => Ok(ToolResult::text(true, r#"{"ok":true}"#)),
+            "sibling" => {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                Ok(ToolResult::text(true, r#"{"sibling":true}"#))
+            }
+            other => Err(ToolError::NotFound(other.to_string())),
+        }
+    }
+
+    fn list_tools(&self) -> Vec<bamboo_agent_core::tools::ToolSchema> {
+        Vec::new()
+    }
+}
+
+struct FlakyMapTools(AtomicUsize);
+
+#[async_trait]
+impl ToolExecutor for FlakyMapTools {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+        let item: Value = serde_json::from_str(&call.function.arguments).unwrap();
+        if item == json!(1) && self.0.fetch_add(1, Ordering::SeqCst) == 0 {
+            Err(ToolError::Execution("transient map item".to_string()))
+        } else {
+            Ok(ToolResult::text(
+                true,
+                serde_json::to_string(&item).unwrap(),
+            ))
+        }
+    }
+
+    fn list_tools(&self) -> Vec<bamboo_agent_core::tools::ToolSchema> {
+        Vec::new()
+    }
+}
+
+struct MapParallelTools;
+
+#[async_trait]
+impl ToolExecutor for MapParallelTools {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+        let item: Value = serde_json::from_str(&call.function.arguments).unwrap();
+        match call.function.name.as_str() {
+            "fail-zero" if item == json!(0) => Ok(ToolResult::text(false, "expected item failure")),
+            "fail-zero" => Ok(ToolResult::text(true, item.to_string())),
+            "slow-item" => {
+                let delay = if item == json!(0) { 50 } else { 10 };
+                tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                Ok(ToolResult::text(true, item.to_string()))
+            }
+            other => Err(ToolError::NotFound(other.to_string())),
+        }
+    }
+
+    fn list_tools(&self) -> Vec<bamboo_agent_core::tools::ToolSchema> {
+        Vec::new()
+    }
+}
+
+struct GatedTools {
+    started: Arc<tokio::sync::Semaphore>,
+    release: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait]
+impl ToolExecutor for GatedTools {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+        let args: Value = serde_json::from_str(&call.function.arguments).unwrap();
+        match call.function.name.as_str() {
+            "gate" => {
+                self.started.add_permits(1);
+                self.release.notified().await;
+                Ok(ToolResult::text(true, "null"))
+            }
+            "echo" => Ok(ToolResult::text(
+                true,
+                serde_json::to_string(&args).unwrap(),
+            )),
+            other => Err(ToolError::NotFound(other.to_string())),
+        }
+    }
+
+    fn list_tools(&self) -> Vec<bamboo_agent_core::tools::ToolSchema> {
+        Vec::new()
+    }
+}
+
+struct MutableDefinitions {
+    pins: AtomicUsize,
+    definitions: std::sync::Mutex<HashMap<(String, u64), WorkflowRunDefinition>>,
+}
+
+#[async_trait]
+impl WorkflowDefinitionPort for MutableDefinitions {
+    async fn pin_bundle(
+        &self,
+        root: &WorkflowRunDefinition,
+    ) -> Result<WorkflowDefinitionBundle, String> {
+        self.pins.fetch_add(1, Ordering::SeqCst);
+        let mut definitions = self
+            .definitions
+            .lock()
+            .unwrap()
+            .values()
+            .cloned()
+            .map(|definition| {
+                (
+                    WorkflowDefinitionBundle::key(&definition.id, definition.revision),
+                    definition,
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        definitions.insert(
+            WorkflowDefinitionBundle::key(&root.id, root.revision),
+            root.clone(),
+        );
+        Ok(WorkflowDefinitionBundle {
+            publication_revision: 10,
+            root_id: root.id.clone(),
+            root_revision: root.revision,
+            definitions,
+        })
+    }
+}
+
+#[derive(Default)]
+struct MockDefinitions(HashMap<(String, u64), WorkflowRunDefinition>);
+
+#[async_trait]
+impl WorkflowDefinitionPort for MockDefinitions {
+    async fn pin_bundle(
+        &self,
+        root: &WorkflowRunDefinition,
+    ) -> Result<WorkflowDefinitionBundle, String> {
+        let mut definitions = self
+            .0
+            .values()
+            .cloned()
+            .map(|definition| {
+                (
+                    WorkflowDefinitionBundle::key(&definition.id, definition.revision),
+                    definition,
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        definitions.insert(
+            WorkflowDefinitionBundle::key(&root.id, root.revision),
+            root.clone(),
+        );
+        Ok(WorkflowDefinitionBundle {
+            publication_revision: 1,
+            root_id: root.id.clone(),
+            root_revision: root.revision,
+            definitions,
+        })
+    }
+}
+
+struct MockPolicy;
+
+#[async_trait]
+impl WorkflowPolicyPort for MockPolicy {
+    async fn authorize(
+        &self,
+        _session_id: &str,
+        _target: &WorkflowPolicyTarget,
+        requested: &BTreeSet<String>,
+        workspace_trusted: bool,
+    ) -> PermissionDecision {
+        if !workspace_trusted || !requested.iter().all(|capability| capability == "read") {
+            PermissionDecision::Deny(
+                "workflow policy denied capability or untrusted workspace".to_string(),
+            )
+        } else {
+            PermissionDecision::Allow
+        }
+    }
+}
+
+struct MockSecrets;
+
+#[async_trait]
+impl WorkflowSecretResolverPort for MockSecrets {
+    async fn resolve(
+        &self,
+        _session_id: &str,
+        capability: &str,
+    ) -> Result<WorkflowSecretMaterial, String> {
+        if capability == "test/read-token" {
+            Ok(WorkflowSecretMaterial::new(
+                "resolved-test-value".to_string(),
+            ))
+        } else {
+            Err("unknown capability".to_string())
+        }
+    }
+}
+
+fn engine(directory: &std::path::Path, definitions: MockDefinitions) -> Arc<WorkflowRunEngine> {
+    WorkflowRunEngine::new(
+        Arc::new(FileWorkflowRunRepository::new(directory.to_path_buf()).unwrap()),
+        Arc::new(MockTools),
+        Arc::new(MockAgents),
+        Arc::new(definitions),
+        Arc::new(MockPolicy),
+        Arc::new(MockSecrets),
+        budgets(),
+    )
+}
+
+fn request(definition: WorkflowRunDefinition, args: Value) -> StartWorkflowRun {
+    StartWorkflowRun {
+        definition,
+        args,
+        session_id: "session-real".to_string(),
+        workspace_trusted: true,
+        allowed_capabilities: vec!["read".to_string()],
+    }
+}
+
+#[tokio::test]
+async fn engine_runs_sequence_parallel_map_and_rebuilds_progress_from_sequence() {
+    let directory = tempfile::tempdir().unwrap();
+    let workflow = definition(
+        vec![
+            tool_step("first", "echo", json!({"from":"args","pointer":"/items"})),
+            tool_step("left", "echo", json!({"side":"left"})),
+            tool_step("right", "echo", json!({"side":"right"})),
+            tool_step(
+                "mapped",
+                "echo",
+                json!({"from":"item","name":"item","pointer":""}),
+            ),
+        ],
+        WorkflowPlan::Sequence {
+            nodes: vec![
+                WorkflowPlan::Step {
+                    step: "first".to_string(),
+                },
+                WorkflowPlan::Parallel {
+                    nodes: vec![
+                        WorkflowPlan::Step {
+                            step: "left".to_string(),
+                        },
+                        WorkflowPlan::Step {
+                            step: "right".to_string(),
+                        },
+                    ],
+                },
+                WorkflowPlan::Map {
+                    source: ValueRef::Args {
+                        pointer: "/items".to_string(),
+                    },
+                    item: "item".to_string(),
+                    body: Box::new(WorkflowPlan::Step {
+                        step: "mapped".to_string(),
+                    }),
+                },
+            ],
+        },
+    );
+    let engine = engine(directory.path(), MockDefinitions::default());
+    let snapshot = engine
+        .run(request(workflow, json!({"items":[1,2,3]})))
+        .await
+        .unwrap();
+    assert_eq!(snapshot.status, WorkflowRunStatus::Succeeded);
+    assert_eq!(snapshot.output, Some(json!([1, 2, 3])));
+    assert_eq!(
+        snapshot
+            .steps
+            .values()
+            .filter(|step| step.status == WorkflowStepStatus::Succeeded)
+            .count(),
+        6
+    );
+    let progress = engine.progress(&snapshot.run_id, 0).await.unwrap();
+    assert_eq!(
+        progress.events.last().unwrap().sequence,
+        progress.snapshot.last_sequence
+    );
+    assert!(matches!(
+        progress.events.last().unwrap().kind,
+        WorkflowRunEventKind::RunSucceeded { .. }
+    ));
+}
+
+#[tokio::test]
+async fn engine_agent_output_budget_and_permission_are_server_enforced() {
+    let directory = tempfile::tempdir().unwrap();
+    let agent = WorkflowStepDefinition {
+        id: "review".to_string(),
+        kind: WorkflowStepKind::Agent {
+            agent: "reviewer".to_string(),
+            prompt: json!({"from":"args","pointer":""}),
+            model: Some("test:model".to_string()),
+            effort: Some("high".to_string()),
+            capabilities: vec!["read".to_string()],
+            structured_output_attempts: 2,
+        },
+        failure: FailurePolicy::FailFast,
+        output_schema: Some(
+            json!({"type":"object","required":["reviewed"],"additionalProperties":true}),
+        ),
+    };
+    let workflow = definition(
+        vec![agent],
+        WorkflowPlan::Step {
+            step: "review".to_string(),
+        },
+    );
+    let engine = engine(directory.path(), MockDefinitions::default());
+    let snapshot = engine
+        .run(request(workflow.clone(), json!({"x":1})))
+        .await
+        .unwrap();
+    assert_eq!(snapshot.status, WorkflowRunStatus::Succeeded);
+    assert_eq!(snapshot.usage.agents, 1);
+    assert_eq!(snapshot.usage.tokens, 10);
+
+    let mut untrusted = request(workflow, json!({"x":1}));
+    untrusted.workspace_trusted = false;
+    assert!(matches!(
+        engine.run(untrusted).await,
+        Err(WorkflowRunError::Preflight(_))
+    ));
+}
+
+#[tokio::test]
+async fn review_orchestration_dogfood_runs_pinned_tool_and_parallel_agent_pipeline() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut inspect = tool_step(
+        "inspect",
+        "echo",
+        json!({"patch":{"from":"args","pointer":"/patch"}}),
+    );
+    inspect.output_schema = Some(json!({
+        "type":"object",
+        "properties":{"patch":{"type":"string"}},
+        "required":["patch"],
+        "additionalProperties":false
+    }));
+    let review = |id: &str| WorkflowStepDefinition {
+        id: id.to_string(),
+        kind: WorkflowStepKind::Agent {
+            agent: "reviewer".to_string(),
+            prompt: json!({
+                "focus": id,
+                "patch":{"from":"step","step":"inspect","pointer":"/patch"}
+            }),
+            model: Some("test:review".to_string()),
+            effort: Some("high".to_string()),
+            capabilities: vec!["read".to_string()],
+            structured_output_attempts: 2,
+        },
+        failure: FailurePolicy::FailFast,
+        output_schema: Some(json!({
+            "type":"object",
+            "properties":{"reviewed":{"type":"object","additionalProperties":true}},
+            "required":["reviewed"],
+            "additionalProperties":false
+        })),
+    };
+    let mut report = tool_step(
+        "report",
+        "echo",
+        json!({
+            "correctness":{"from":"step","step":"correctness","pointer":"/reviewed"},
+            "security":{"from":"step","step":"security","pointer":"/reviewed"}
+        }),
+    );
+    report.output_schema = Some(json!({"type":"object","additionalProperties":true}));
+    let mut workflow = definition(
+        vec![inspect, review("correctness"), review("security"), report],
+        WorkflowPlan::Sequence {
+            nodes: vec![
+                WorkflowPlan::Step {
+                    step: "inspect".to_string(),
+                },
+                WorkflowPlan::Parallel {
+                    nodes: vec![
+                        WorkflowPlan::Step {
+                            step: "correctness".to_string(),
+                        },
+                        WorkflowPlan::Step {
+                            step: "security".to_string(),
+                        },
+                    ],
+                },
+                WorkflowPlan::Step {
+                    step: "report".to_string(),
+                },
+            ],
+        },
+    );
+    workflow.input_schema = json!({
+        "type":"object",
+        "properties":{"patch":{"type":"string"}},
+        "required":["patch"],
+        "additionalProperties":false
+    });
+    let engine = engine(directory.path(), MockDefinitions::default());
+    let succeeded = engine
+        .run(request(workflow, json!({"patch":"diff --git a/a b/a"})))
+        .await
+        .unwrap();
+    assert_eq!(succeeded.status, WorkflowRunStatus::Succeeded);
+    assert_eq!(succeeded.usage.agents, 2);
+    assert_eq!(
+        succeeded.steps["report"].status,
+        WorkflowStepStatus::Succeeded
+    );
+    assert_eq!(
+        engine
+            .progress(&succeeded.run_id, 0)
+            .await
+            .unwrap()
+            .snapshot,
+        succeeded
+    );
+}
+
+#[tokio::test]
+async fn named_agent_is_resolved_once_and_reused_from_the_pinned_preflight_snapshot() {
+    let directory = tempfile::tempdir().unwrap();
+    let agents = Arc::new(CountingAgents(AtomicUsize::new(0)));
+    let engine = WorkflowRunEngine::new(
+        Arc::new(FileWorkflowRunRepository::new(directory.path().to_path_buf()).unwrap()),
+        Arc::new(MockTools),
+        agents.clone(),
+        Arc::new(MockDefinitions::default()),
+        Arc::new(MockPolicy),
+        Arc::new(MockSecrets),
+        budgets(),
+    );
+    let agent_step = |id: &str| WorkflowStepDefinition {
+        id: id.to_string(),
+        kind: WorkflowStepKind::Agent {
+            agent: "reviewer".to_string(),
+            prompt: json!({"step": id}),
+            model: None,
+            effort: None,
+            capabilities: vec!["read".to_string()],
+            structured_output_attempts: 1,
+        },
+        failure: FailurePolicy::FailFast,
+        output_schema: None,
+    };
+    let workflow = definition(
+        vec![agent_step("first"), agent_step("second")],
+        WorkflowPlan::Sequence {
+            nodes: vec![
+                WorkflowPlan::Step {
+                    step: "first".to_string(),
+                },
+                WorkflowPlan::Step {
+                    step: "second".to_string(),
+                },
+            ],
+        },
+    );
+    let succeeded = engine.run(request(workflow, json!({}))).await.unwrap();
+    assert_eq!(succeeded.status, WorkflowRunStatus::Succeeded);
+    assert_eq!(agents.0.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn retry_wrapping_parallel_preserves_retryable_failure_and_cumulative_attempts() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = WorkflowRunEngine::new(
+        Arc::new(FileWorkflowRunRepository::new(directory.path().to_path_buf()).unwrap()),
+        Arc::new(FlakyOnceTools(AtomicUsize::new(0))),
+        Arc::new(MockAgents),
+        Arc::new(MockDefinitions::default()),
+        Arc::new(MockPolicy),
+        Arc::new(MockSecrets),
+        budgets(),
+    );
+    let workflow = definition(
+        vec![
+            tool_step("flaky", "flaky-once", json!({})),
+            tool_step("sibling", "sibling", json!({})),
+        ],
+        WorkflowPlan::Retry {
+            node: Box::new(WorkflowPlan::Parallel {
+                nodes: vec![
+                    WorkflowPlan::Step {
+                        step: "flaky".to_string(),
+                    },
+                    WorkflowPlan::Step {
+                        step: "sibling".to_string(),
+                    },
+                ],
+            }),
+            max_attempts: 2,
+            delay_ms: 0,
+        },
+    );
+    let succeeded = engine.run(request(workflow, json!({}))).await.unwrap();
+    assert_eq!(succeeded.status, WorkflowRunStatus::Succeeded);
+    assert_eq!(succeeded.usage.retries, 1);
+    assert_eq!(succeeded.steps["flaky"].attempts, 2);
+    assert_eq!(succeeded.steps["sibling"].attempts, 2);
+}
+
+#[tokio::test]
+async fn retry_wrapping_map_retries_transient_items_with_cumulative_attempts() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = WorkflowRunEngine::new(
+        Arc::new(FileWorkflowRunRepository::new(directory.path().to_path_buf()).unwrap()),
+        Arc::new(FlakyMapTools(AtomicUsize::new(0))),
+        Arc::new(MockAgents),
+        Arc::new(MockDefinitions::default()),
+        Arc::new(MockPolicy),
+        Arc::new(MockSecrets),
+        budgets(),
+    );
+    let workflow = definition(
+        vec![tool_step(
+            "mapped",
+            "flaky-map",
+            json!({"from":"item","name":"item","pointer":""}),
+        )],
+        WorkflowPlan::Retry {
+            node: Box::new(WorkflowPlan::Map {
+                source: ValueRef::Args {
+                    pointer: "/items".to_string(),
+                },
+                item: "item".to_string(),
+                body: Box::new(WorkflowPlan::Step {
+                    step: "mapped".to_string(),
+                }),
+            }),
+            max_attempts: 2,
+            delay_ms: 0,
+        },
+    );
+    let succeeded = engine
+        .run(request(workflow, json!({"items":[1,2]})))
+        .await
+        .unwrap();
+    assert_eq!(succeeded.status, WorkflowRunStatus::Succeeded);
+    assert_eq!(succeeded.output, Some(json!([1, 2])));
+    assert_eq!(succeeded.usage.retries, 1);
+    assert_eq!(succeeded.steps["mapped@root[0]"].attempts, 2);
+    assert_eq!(succeeded.steps["mapped@root[1]"].attempts, 2);
+    let events = engine.progress(&succeeded.run_id, 0).await.unwrap().events;
+    assert!(events.iter().any(|event| {
+        event.step_id.as_deref() == Some("mapped@root[0]")
+            && matches!(event.kind, WorkflowRunEventKind::StepFailed { .. })
+    }));
+}
+
+#[tokio::test]
+async fn map_of_parallel_fail_fast_cancellation_is_isolated_per_item_scope() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = WorkflowRunEngine::new(
+        Arc::new(FileWorkflowRunRepository::new(directory.path().to_path_buf()).unwrap()),
+        Arc::new(MapParallelTools),
+        Arc::new(MockAgents),
+        Arc::new(MockDefinitions::default()),
+        Arc::new(MockPolicy),
+        Arc::new(MockSecrets),
+        budgets(),
+    );
+    let item_ref = json!({"from":"item","name":"item","pointer":""});
+    let workflow = definition(
+        vec![
+            tool_step("maybe-fail", "fail-zero", item_ref.clone()),
+            tool_step("slow", "slow-item", item_ref),
+        ],
+        WorkflowPlan::Map {
+            source: ValueRef::Args {
+                pointer: "/items".to_string(),
+            },
+            item: "item".to_string(),
+            body: Box::new(WorkflowPlan::Parallel {
+                nodes: vec![
+                    WorkflowPlan::Step {
+                        step: "maybe-fail".to_string(),
+                    },
+                    WorkflowPlan::Step {
+                        step: "slow".to_string(),
+                    },
+                ],
+            }),
+        },
+    );
+    let failed = engine
+        .run(request(workflow, json!({"items":[0,1]})))
+        .await
+        .unwrap();
+    assert_eq!(failed.status, WorkflowRunStatus::Failed);
+    assert_eq!(
+        failed.steps["maybe-fail@root[0]"].status,
+        WorkflowStepStatus::Failed
+    );
+    assert_eq!(
+        failed.steps["slow@root[0]"].status,
+        WorkflowStepStatus::Cancelled
+    );
+    assert_eq!(
+        failed.steps["maybe-fail@root[1]"].status,
+        WorkflowStepStatus::Succeeded
+    );
+    assert_eq!(
+        failed.steps["slow@root[1]"].status,
+        WorkflowStepStatus::Succeeded
+    );
+    assert!(failed.failure.as_ref().unwrap().message.contains("item[0]"));
+
+    let events = engine.progress(&failed.run_id, 0).await.unwrap().events;
+    assert!(!events.iter().any(|event| {
+        event
+            .step_id
+            .as_deref()
+            .is_some_and(|id| id.ends_with("@root[1]"))
+            && matches!(event.kind, WorkflowRunEventKind::StepCancelled)
+    }));
+    let mut cancelled = BTreeSet::new();
+    for event in events {
+        let Some(step_id) = event.step_id else {
+            continue;
+        };
+        match event.kind {
+            WorkflowRunEventKind::StepCancelled => {
+                cancelled.insert(step_id);
+            }
+            WorkflowRunEventKind::StepCompleted { .. } => assert!(
+                !cancelled.contains(&step_id),
+                "step {step_id} completed after cancellation"
+            ),
+            _ => {}
+        }
+    }
+}
+
+#[tokio::test]
+async fn nested_workflow_is_exact_revision_and_progress_is_linked() {
+    let directory = tempfile::tempdir().unwrap();
+    let nested = WorkflowRunDefinition {
+        id: "child".to_string(),
+        revision: 2,
+        ..definition(
+            vec![tool_step(
+                "child-step",
+                "echo",
+                json!({"from":"args","pointer":""}),
+            )],
+            WorkflowPlan::Step {
+                step: "child-step".to_string(),
+            },
+        )
+    };
+    let parent_step = WorkflowStepDefinition {
+        id: "nested".to_string(),
+        kind: WorkflowStepKind::Workflow {
+            workflow_id: "child".to_string(),
+            revision: 2,
+            args: json!({"from":"args","pointer":""}),
+        },
+        failure: FailurePolicy::FailFast,
+        output_schema: None,
+    };
+    let parent = definition(
+        vec![parent_step],
+        WorkflowPlan::Step {
+            step: "nested".to_string(),
+        },
+    );
+    let definitions = MockDefinitions(HashMap::from([(("child".to_string(), 2), nested)]));
+    let engine = engine(directory.path(), definitions);
+    let result = engine
+        .run(request(parent, json!({"task":"review"})))
+        .await
+        .unwrap();
+    assert_eq!(result.status, WorkflowRunStatus::Succeeded);
+    let ids = engine.list_run_ids().await.unwrap();
+    assert_eq!(ids.len(), 2);
+    let mut child = None;
+    for id in ids {
+        let snapshot = engine.progress(&id, 0).await.unwrap().snapshot;
+        if snapshot.parent_run_id.is_some() {
+            child = Some(snapshot);
+            break;
+        }
+    }
+    let child = child.unwrap();
+    assert_eq!(child.parent_run_id.as_deref(), Some(result.run_id.as_str()));
+    assert_eq!(child.parent_step_id.as_deref(), Some("nested"));
+}
+
+#[tokio::test]
+async fn nested_dispatch_uses_one_pinned_bundle_despite_live_definition_mutation() {
+    let directory = tempfile::tempdir().unwrap();
+    let old_child = WorkflowRunDefinition {
+        id: "mutable-child".to_string(),
+        revision: 2,
+        ..definition(
+            vec![tool_step("child", "echo", json!({"version":"old"}))],
+            WorkflowPlan::Step {
+                step: "child".to_string(),
+            },
+        )
+    };
+    let mut new_child = old_child.clone();
+    if let WorkflowStepKind::Tool { args, .. } = &mut new_child.steps[0].kind {
+        *args = json!({"version":"new"});
+    }
+    let definitions = Arc::new(MutableDefinitions {
+        pins: AtomicUsize::new(0),
+        definitions: std::sync::Mutex::new(HashMap::from([(
+            (old_child.id.clone(), old_child.revision),
+            old_child,
+        )])),
+    });
+    let started = Arc::new(tokio::sync::Semaphore::new(0));
+    let release = Arc::new(tokio::sync::Notify::new());
+    let engine = WorkflowRunEngine::new(
+        Arc::new(FileWorkflowRunRepository::new(directory.path().to_path_buf()).unwrap()),
+        Arc::new(GatedTools {
+            started: started.clone(),
+            release: release.clone(),
+        }),
+        Arc::new(MockAgents),
+        definitions.clone(),
+        Arc::new(MockPolicy),
+        Arc::new(MockSecrets),
+        budgets(),
+    );
+    let nested = WorkflowStepDefinition {
+        id: "nested".to_string(),
+        kind: WorkflowStepKind::Workflow {
+            workflow_id: "mutable-child".to_string(),
+            revision: 2,
+            args: json!({}),
+        },
+        failure: FailurePolicy::FailFast,
+        output_schema: None,
+    };
+    let parent = definition(
+        vec![tool_step("gate", "gate", json!({})), nested],
+        WorkflowPlan::Sequence {
+            nodes: vec![
+                WorkflowPlan::Step {
+                    step: "gate".to_string(),
+                },
+                WorkflowPlan::Step {
+                    step: "nested".to_string(),
+                },
+            ],
+        },
+    );
+    let running = engine.start(request(parent, json!({}))).await.unwrap();
+    let permit = started.acquire().await.unwrap();
+    permit.forget();
+    definitions
+        .definitions
+        .lock()
+        .unwrap()
+        .insert((new_child.id.clone(), new_child.revision), new_child);
+    release.notify_waiters();
+
+    let finished = loop {
+        let snapshot = engine.progress(&running.run_id, 0).await.unwrap().snapshot;
+        if snapshot.status.is_terminal() {
+            break snapshot;
+        }
+        tokio::task::yield_now().await;
+    };
+    assert_eq!(finished.status, WorkflowRunStatus::Succeeded);
+    assert_eq!(finished.output, Some(json!({"version":"old"})));
+    assert_eq!(definitions.pins.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        finished
+            .definition_bundle
+            .get("mutable-child", 2)
+            .unwrap()
+            .steps[0]
+            .kind,
+        WorkflowStepKind::Tool {
+            tool: "echo".to_string(),
+            args: json!({"version":"old"}),
+            capabilities: vec!["read".to_string()],
+        }
+    );
+}
+
+#[tokio::test]
+async fn skip_dependents_retry_exhaustion_and_recovery_have_typed_events() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut failing = tool_step("fail", "fail", json!({}));
+    failing.failure = FailurePolicy::SkipDependents;
+    let workflow = definition(
+        vec![failing, tool_step("never", "echo", json!({}))],
+        WorkflowPlan::Sequence {
+            nodes: vec![
+                WorkflowPlan::Step {
+                    step: "fail".to_string(),
+                },
+                WorkflowPlan::Step {
+                    step: "never".to_string(),
+                },
+            ],
+        },
+    );
+    let engine = engine(directory.path(), MockDefinitions::default());
+    let failed = engine.run(request(workflow, json!({}))).await.unwrap();
+    assert_eq!(failed.status, WorkflowRunStatus::Failed);
+    assert_eq!(failed.steps["never"].status, WorkflowStepStatus::Skipped);
+
+    let recovery_dir = tempfile::tempdir().unwrap();
+    let repository =
+        Arc::new(FileWorkflowRunRepository::new(recovery_dir.path().to_path_buf()).unwrap());
+    let queued = snapshot("stale", WorkflowRunStatus::Queued, 1);
+    repository
+        .create(
+            &queued,
+            &run_event("stale", 1, WorkflowRunEventKind::RunQueued),
+        )
+        .await
+        .unwrap();
+    let recovery_engine = WorkflowRunEngine::new(
+        repository.clone(),
+        Arc::new(MockTools),
+        Arc::new(MockAgents),
+        Arc::new(MockDefinitions::default()),
+        Arc::new(MockPolicy),
+        Arc::new(MockSecrets),
+        budgets(),
+    );
+    let recovered = recovery_engine.recover().await.unwrap();
+    assert_eq!(recovered[0].status, WorkflowRunStatus::Suspended);
+    let events = repository.events_since("stale", 0).await.unwrap();
+    assert!(matches!(
+        events.last().unwrap().kind,
+        WorkflowRunEventKind::RunSuspended { .. }
+    ));
+}
+
+#[tokio::test]
+async fn retry_exhaustion_and_step_budget_are_typed_failures() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut workflow = definition(
+        vec![tool_step("flaky", "flaky", json!({}))],
+        WorkflowPlan::Retry {
+            node: Box::new(WorkflowPlan::Step {
+                step: "flaky".to_string(),
+            }),
+            max_attempts: 3,
+            delay_ms: 0,
+        },
+    );
+    workflow.budgets.max_retries = 2;
+    let engine = engine(directory.path(), MockDefinitions::default());
+    let failed = engine.run(request(workflow, json!({}))).await.unwrap();
+    assert_eq!(failed.status, WorkflowRunStatus::Failed);
+    assert_eq!(
+        failed.failure.as_ref().unwrap().code,
+        WorkflowFailureCode::RetryExhausted
+    );
+    assert_eq!(failed.usage.retries, 2);
+    assert_eq!(failed.steps["flaky"].attempts, 3);
+
+    let mut limited = definition(
+        vec![
+            tool_step("one", "echo", json!(1)),
+            tool_step("two", "echo", json!(2)),
+        ],
+        WorkflowPlan::Sequence {
+            nodes: vec![
+                WorkflowPlan::Step {
+                    step: "one".to_string(),
+                },
+                WorkflowPlan::Step {
+                    step: "two".to_string(),
+                },
+            ],
+        },
+    );
+    limited.budgets.max_steps = 1;
+    limited.budgets.max_agents = 0;
+    let failed = engine.run(request(limited, json!({}))).await.unwrap();
+    assert_eq!(
+        failed.failure.as_ref().unwrap().code,
+        WorkflowFailureCode::BudgetExceeded
+    );
+    assert_eq!(failed.usage.steps, 1);
+}
+
+#[tokio::test]
+async fn cancellation_is_idempotent_and_never_publishes_success() {
+    let directory = tempfile::tempdir().unwrap();
+    let workflow = definition(
+        vec![tool_step("slow", "slow", json!({}))],
+        WorkflowPlan::Step {
+            step: "slow".to_string(),
+        },
+    );
+    let engine = engine(directory.path(), MockDefinitions::default());
+    let runner = {
+        let engine = engine.clone();
+        tokio::spawn(async move { engine.run(request(workflow, json!({}))).await.unwrap() })
+    };
+    let run_id = loop {
+        if let Some(id) = engine.list_run_ids().await.unwrap().into_iter().next() {
+            break id;
+        }
+        tokio::task::yield_now().await;
+    };
+    loop {
+        if !engine
+            .progress(&run_id, 0)
+            .await
+            .unwrap()
+            .snapshot
+            .steps
+            .is_empty()
+        {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    let cancelled = engine.cancel(&run_id).await.unwrap();
+    assert_eq!(cancelled.status, WorkflowRunStatus::Cancelled);
+    assert_eq!(
+        engine.cancel(&run_id).await.unwrap().status,
+        WorkflowRunStatus::Cancelled
+    );
+    let final_snapshot = runner.await.unwrap();
+    assert_eq!(final_snapshot.status, WorkflowRunStatus::Cancelled);
+    let events = engine.progress(&run_id, 0).await.unwrap().events;
+    assert!(events
+        .iter()
+        .any(|event| matches!(event.kind, WorkflowRunEventKind::StepCancelled)));
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event.kind, WorkflowRunEventKind::RunCancelled))
+            .count(),
+        1
+    );
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event.kind, WorkflowRunEventKind::RunSucceeded { .. })));
+}
+
+#[tokio::test]
+async fn templates_do_not_interpolate_and_secret_material_never_reaches_terminal_event() {
+    let directory = tempfile::tempdir().unwrap();
+    let literal = "$(touch /tmp/workflow-injection) {{args.secret}}";
+    let workflow = definition(
+        vec![tool_step("literal", "echo", json!({"text": literal}))],
+        WorkflowPlan::Step {
+            step: "literal".to_string(),
+        },
+    );
+    let engine = engine(directory.path(), MockDefinitions::default());
+    let succeeded = engine.run(request(workflow, json!({}))).await.unwrap();
+    assert_eq!(succeeded.output, Some(json!({"text": literal})));
+
+    let secret_output = definition(
+        vec![tool_step("leak", "secretout", json!({}))],
+        WorkflowPlan::Step {
+            step: "leak".to_string(),
+        },
+    );
+    let failed = engine.run(request(secret_output, json!({}))).await.unwrap();
+    assert_eq!(failed.status, WorkflowRunStatus::Failed);
+    assert!(failed.steps["leak"].output.is_none());
+    let serialized =
+        serde_json::to_string(&engine.progress(&failed.run_id, 0).await.unwrap()).unwrap();
+    assert!(!serialized.contains("raw-secret"));
+
+    let secret_input = definition(
+        vec![tool_step("echo", "echo", json!({}))],
+        WorkflowPlan::Step {
+            step: "echo".to_string(),
+        },
+    );
+    assert!(matches!(
+        engine
+            .run(request(secret_input, json!({"password":"plaintext"})))
+            .await,
+        Err(WorkflowRunError::InvalidInput(_))
+    ));
+
+    let secret_definition = definition(
+        vec![tool_step(
+            "definition-leak",
+            "echo",
+            json!({"api_key":"raw-secret"}),
+        )],
+        WorkflowPlan::Step {
+            step: "definition-leak".to_string(),
+        },
+    );
+    assert!(matches!(
+        engine.run(request(secret_definition, json!({}))).await,
+        Err(WorkflowRunError::Preflight(_))
+    ));
+
+    let secret_error = definition(
+        vec![tool_step("error-leak", "secretfail", json!({}))],
+        WorkflowPlan::Step {
+            step: "error-leak".to_string(),
+        },
+    );
+    let failed = engine.run(request(secret_error, json!({}))).await.unwrap();
+    let serialized =
+        serde_json::to_string(&engine.progress(&failed.run_id, 0).await.unwrap()).unwrap();
+    assert!(!serialized.contains("raw-secret"));
+
+    for sensitive in ["credential", "access_token", "secret_key"] {
+        let mut args = serde_json::Map::new();
+        args.insert(sensitive.to_string(), json!("plaintext"));
+        let workflow = definition(
+            vec![tool_step("echo", "echo", json!({}))],
+            WorkflowPlan::Step {
+                step: "echo".to_string(),
+            },
+        );
+        assert!(matches!(
+            engine.run(request(workflow, Value::Object(args))).await,
+            Err(WorkflowRunError::InvalidInput(_))
+        ));
+    }
+
+    let bare_secret_output = definition(
+        vec![tool_step("bare", "baresecret", json!({}))],
+        WorkflowPlan::Step {
+            step: "bare".to_string(),
+        },
+    );
+    let failed = engine
+        .run(request(bare_secret_output, json!({})))
+        .await
+        .unwrap();
+    assert_eq!(failed.status, WorkflowRunStatus::Failed);
+    let serialized =
+        serde_json::to_string(&engine.progress(&failed.run_id, 0).await.unwrap()).unwrap();
+    assert!(!serialized.contains("sk-raw-secret"));
+}
+
+#[tokio::test]
+async fn typed_secret_handle_is_resolved_only_for_tool_dispatch_and_never_persisted_raw() {
+    let directory = tempfile::tempdir().unwrap();
+    let captured = Arc::new(std::sync::Mutex::new(None));
+    let engine = WorkflowRunEngine::new(
+        Arc::new(FileWorkflowRunRepository::new(directory.path().to_path_buf()).unwrap()),
+        Arc::new(CapturingTools(captured.clone())),
+        Arc::new(MockAgents),
+        Arc::new(MockDefinitions::default()),
+        Arc::new(MockPolicy),
+        Arc::new(MockSecrets),
+        budgets(),
+    );
+    let mut workflow = definition(
+        vec![tool_step(
+            "use-secret",
+            "capture",
+            json!({"credential":{"from":"args","pointer":"/credential"}}),
+        )],
+        WorkflowPlan::Step {
+            step: "use-secret".to_string(),
+        },
+    );
+    workflow.input_schema = json!({
+        "type":"object",
+        "properties":{
+            "credential":{
+                "type":"object",
+                "x-bamboo-secret":true,
+                "additionalProperties":false
+            }
+        },
+        "required":["credential"],
+        "additionalProperties":false
+    });
+    let succeeded = engine
+        .run(request(
+            workflow,
+            json!({"credential":{"$secret":"test/read-token"}}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(succeeded.status, WorkflowRunStatus::Succeeded);
+    assert_eq!(
+        captured.lock().unwrap().as_ref().unwrap()["credential"],
+        "resolved-test-value"
+    );
+    let progress = engine.progress(&succeeded.run_id, 0).await.unwrap();
+    let serialized = serde_json::to_string(&progress).unwrap();
+    assert!(serialized.contains("test/read-token"));
+    assert!(!serialized.contains("resolved-test-value"));
+
+    let journal = tokio::fs::read_to_string(
+        directory
+            .path()
+            .join(&succeeded.run_id)
+            .join("journal.jsonl"),
+    )
+    .await
+    .unwrap();
+    assert!(!journal.contains("resolved-test-value"));
+
+    let mut echo_workflow = definition(
+        vec![tool_step(
+            "echo-secret",
+            "echo-secret",
+            json!({"credential":{"from":"args","pointer":"/credential"}}),
+        )],
+        WorkflowPlan::Step {
+            step: "echo-secret".to_string(),
+        },
+    );
+    echo_workflow.input_schema = json!({
+        "type":"object",
+        "properties":{"credential":{"x-bamboo-secret":true}},
+        "required":["credential"],
+        "additionalProperties":false
+    });
+    let failed = engine
+        .run(request(
+            echo_workflow,
+            json!({"credential":{"$secret":"test/read-token"}}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(failed.status, WorkflowRunStatus::Failed);
+    let serialized =
+        serde_json::to_string(&engine.progress(&failed.run_id, 0).await.unwrap()).unwrap();
+    assert!(!serialized.contains("resolved-test-value"));
+}
+
+#[tokio::test]
+async fn structured_agent_output_retries_are_bounded() {
+    let directory = tempfile::tempdir().unwrap();
+    let agent = WorkflowStepDefinition {
+        id: "agent".to_string(),
+        kind: WorkflowStepKind::Agent {
+            agent: "reviewer".to_string(),
+            prompt: json!({}),
+            model: None,
+            effort: None,
+            capabilities: vec!["read".to_string()],
+            structured_output_attempts: 2,
+        },
+        failure: FailurePolicy::FailFast,
+        output_schema: Some(
+            json!({"type":"object","required":["impossible"],"additionalProperties":true}),
+        ),
+    };
+    let workflow = definition(
+        vec![agent],
+        WorkflowPlan::Step {
+            step: "agent".to_string(),
+        },
+    );
+    let engine = engine(directory.path(), MockDefinitions::default());
+    let failed = engine.run(request(workflow, json!({}))).await.unwrap();
+    assert_eq!(failed.status, WorkflowRunStatus::Failed);
+    assert_eq!(
+        failed.steps["agent"].failure.as_ref().unwrap().code,
+        WorkflowFailureCode::InvalidOutput
+    );
+    assert_eq!(failed.usage.agents, 2);
+}
+
+#[tokio::test]
+async fn parallel_and_map_partial_failures_preserve_branch_indices() {
+    let directory = tempfile::tempdir().unwrap();
+    let parallel = definition(
+        vec![
+            tool_step("bad", "fail", json!({})),
+            tool_step("good", "echo", json!({"ok":true})),
+        ],
+        WorkflowPlan::Parallel {
+            nodes: vec![
+                WorkflowPlan::Step {
+                    step: "bad".to_string(),
+                },
+                WorkflowPlan::Step {
+                    step: "good".to_string(),
+                },
+            ],
+        },
+    );
+    let engine = engine(directory.path(), MockDefinitions::default());
+    let failed = engine.run(request(parallel, json!({}))).await.unwrap();
+    assert_eq!(failed.steps["good"].status, WorkflowStepStatus::Cancelled);
+    assert!(failed
+        .failure
+        .as_ref()
+        .unwrap()
+        .message
+        .contains("branch[0]"));
+
+    let map = definition(
+        vec![tool_step(
+            "bad-item",
+            "fail",
+            json!({"from":"item","name":"item","pointer":""}),
+        )],
+        WorkflowPlan::Map {
+            source: ValueRef::Args {
+                pointer: "/items".to_string(),
+            },
+            item: "item".to_string(),
+            body: Box::new(WorkflowPlan::Step {
+                step: "bad-item".to_string(),
+            }),
+        },
+    );
+    let failed = engine
+        .run(request(map, json!({"items":[1,2]})))
+        .await
+        .unwrap();
+    let message = &failed.failure.as_ref().unwrap().message;
+    assert!(message.contains("item[0]") && message.contains("item[1]"));
+}
+
+#[tokio::test]
+async fn nested_depth_and_shared_step_budget_cannot_be_bypassed() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut child = WorkflowRunDefinition {
+        id: "child-budget".to_string(),
+        revision: 3,
+        ..definition(
+            vec![tool_step("child-work", "echo", json!({}))],
+            WorkflowPlan::Step {
+                step: "child-work".to_string(),
+            },
+        )
+    };
+    child.budgets.max_steps = 1;
+    child.budgets.max_agents = 0;
+    let parent_step = WorkflowStepDefinition {
+        id: "child-call".to_string(),
+        kind: WorkflowStepKind::Workflow {
+            workflow_id: "child-budget".to_string(),
+            revision: 3,
+            args: json!({}),
+        },
+        failure: FailurePolicy::FailFast,
+        output_schema: None,
+    };
+    let mut parent = definition(
+        vec![parent_step.clone()],
+        WorkflowPlan::Step {
+            step: "child-call".to_string(),
+        },
+    );
+    parent.budgets.max_steps = 1;
+    parent.budgets.max_agents = 0;
+    let definitions = MockDefinitions(HashMap::from([(
+        ("child-budget".to_string(), 3),
+        child.clone(),
+    )]));
+    let budget_engine = engine(directory.path(), definitions);
+    let failed = budget_engine.run(request(parent, json!({}))).await.unwrap();
+    assert_eq!(failed.status, WorkflowRunStatus::Failed);
+    assert!(failed
+        .failure
+        .as_ref()
+        .unwrap()
+        .message
+        .contains("step budget"));
+
+    let mut shallow = definition(
+        vec![parent_step],
+        WorkflowPlan::Step {
+            step: "child-call".to_string(),
+        },
+    );
+    shallow.budgets.max_nesting_depth = 1;
+    let definitions = MockDefinitions(HashMap::from([(("child-budget".to_string(), 3), child)]));
+    let rejected = engine(directory.path(), definitions)
+        .run(request(shallow, json!({})))
+        .await;
+    assert!(matches!(rejected, Err(WorkflowRunError::Preflight(_))));
+}
+
+#[tokio::test]
+async fn agent_and_actual_usage_limits_are_persisted_before_failure() {
+    let directory = tempfile::tempdir().unwrap();
+    let agent = WorkflowStepDefinition {
+        id: "agent".to_string(),
+        kind: WorkflowStepKind::Agent {
+            agent: "reviewer".to_string(),
+            prompt: json!({}),
+            model: None,
+            effort: None,
+            capabilities: vec!["read".to_string()],
+            structured_output_attempts: 2,
+        },
+        failure: FailurePolicy::FailFast,
+        output_schema: Some(
+            json!({"type":"object","required":["missing"],"additionalProperties":true}),
+        ),
+    };
+    let mut agent_limited = definition(
+        vec![agent.clone()],
+        WorkflowPlan::Step {
+            step: "agent".to_string(),
+        },
+    );
+    agent_limited.budgets.max_agents = 1;
+    let engine = engine(directory.path(), MockDefinitions::default());
+    let failed = engine.run(request(agent_limited, json!({}))).await.unwrap();
+    assert_eq!(
+        failed.failure.as_ref().unwrap().code,
+        WorkflowFailureCode::BudgetExceeded
+    );
+    assert_eq!(failed.usage.agents, 1);
+
+    let mut usage_limited = definition(
+        vec![agent],
+        WorkflowPlan::Step {
+            step: "agent".to_string(),
+        },
+    );
+    usage_limited.steps[0].output_schema = None;
+    usage_limited.budgets.max_tokens = Some(5);
+    usage_limited.budgets.max_cost_micros = Some(1);
+    let failed = engine.run(request(usage_limited, json!({}))).await.unwrap();
+    assert_eq!(
+        failed.failure.as_ref().unwrap().code,
+        WorkflowFailureCode::BudgetExceeded
+    );
+    assert_eq!(failed.usage.tokens, 10);
+    assert_eq!(failed.usage.cost_micros, 2);
+    let persisted = engine.progress(&failed.run_id, 0).await.unwrap().snapshot;
+    assert_eq!(persisted.usage, failed.usage);
+}
+
+#[tokio::test]
+async fn recovery_suspends_running_steps_without_false_completion() {
+    let directory = tempfile::tempdir().unwrap();
+    let repository =
+        Arc::new(FileWorkflowRunRepository::new(directory.path().to_path_buf()).unwrap());
+    let queued = snapshot("running-recovery", WorkflowRunStatus::Queued, 1);
+    repository
+        .create(
+            &queued,
+            &run_event("running-recovery", 1, WorkflowRunEventKind::RunQueued),
+        )
+        .await
+        .unwrap();
+    let mut running = snapshot("running-recovery", WorkflowRunStatus::Running, 2);
+    running.steps.insert(
+        "echo".to_string(),
+        WorkflowStepSnapshot {
+            id: "echo".to_string(),
+            status: WorkflowStepStatus::Running,
+            input_hash: "abc".to_string(),
+            output: None,
+            failure: None,
+            attempts: 1,
+        },
+    );
+    repository
+        .commit(
+            &running,
+            &run_event("running-recovery", 2, WorkflowRunEventKind::RunStarted),
+        )
+        .await
+        .unwrap();
+    let engine = WorkflowRunEngine::new(
+        repository.clone(),
+        Arc::new(MockTools),
+        Arc::new(MockAgents),
+        Arc::new(MockDefinitions::default()),
+        Arc::new(MockPolicy),
+        Arc::new(MockSecrets),
+        budgets(),
+    );
+    let recovered = engine.recover().await.unwrap().pop().unwrap();
+    assert_eq!(recovered.status, WorkflowRunStatus::Suspended);
+    assert_eq!(
+        recovered.steps["echo"].status,
+        WorkflowStepStatus::Suspended
+    );
+    let events = repository
+        .events_since("running-recovery", 0)
+        .await
+        .unwrap();
+    assert!(events
+        .iter()
+        .any(|event| matches!(event.kind, WorkflowRunEventKind::StepSuspended { .. })));
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event.kind, WorkflowRunEventKind::RunSucceeded { .. })));
+}
+
+#[tokio::test]
+async fn outcome_aware_tool_approval_suspends_step_and_run() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = WorkflowRunEngine::new(
+        Arc::new(FileWorkflowRunRepository::new(directory.path().to_path_buf()).unwrap()),
+        Arc::new(ApprovalTools),
+        Arc::new(MockAgents),
+        Arc::new(MockDefinitions::default()),
+        Arc::new(MockPolicy),
+        Arc::new(MockSecrets),
+        budgets(),
+    );
+    let workflow = definition(
+        vec![tool_step("approval", "approval", json!({}))],
+        WorkflowPlan::Step {
+            step: "approval".to_string(),
+        },
+    );
+    let suspended = engine.run(request(workflow, json!({}))).await.unwrap();
+    assert_eq!(suspended.status, WorkflowRunStatus::Suspended);
+    assert_eq!(
+        suspended.steps["approval"].status,
+        WorkflowStepStatus::Suspended
+    );
+    assert!(matches!(
+        suspended.suspension,
+        Some(WorkflowSuspensionContext::ToolApproval {
+            ref step_id,
+            ref tool,
+            ..
+        }) if step_id == "approval" && tool == "approval"
+    ));
+    assert!(matches!(
+        engine
+            .restart(&suspended.run_id, true, vec!["read".to_string()])
+            .await,
+        Err(WorkflowRunError::Preflight(_))
+    ));
+    let events = engine.progress(&suspended.run_id, 0).await.unwrap().events;
+    assert!(matches!(
+        events.last().unwrap().kind,
+        WorkflowRunEventKind::RunSuspended { .. }
+    ));
+    assert!(!events.iter().any(|event| matches!(
+        event.kind,
+        WorkflowRunEventKind::RunSucceeded { .. } | WorkflowRunEventKind::RunFailed { .. }
+    )));
+}
+
+#[tokio::test]
+async fn omitted_definition_usage_limits_inherit_server_ceilings() {
+    let directory = tempfile::tempdir().unwrap();
+    let agent = WorkflowStepDefinition {
+        id: "agent".to_string(),
+        kind: WorkflowStepKind::Agent {
+            agent: "reviewer".to_string(),
+            prompt: json!({}),
+            model: None,
+            effort: None,
+            capabilities: vec!["read".to_string()],
+            structured_output_attempts: 1,
+        },
+        failure: FailurePolicy::FailFast,
+        output_schema: None,
+    };
+    let mut workflow = definition(
+        vec![agent],
+        WorkflowPlan::Step {
+            step: "agent".to_string(),
+        },
+    );
+    workflow.budgets.max_tokens = None;
+    workflow.budgets.max_cost_micros = None;
+    let mut ceilings = budgets();
+    ceilings.max_tokens = Some(5);
+    ceilings.max_cost_micros = Some(1);
+    let engine = WorkflowRunEngine::new(
+        Arc::new(FileWorkflowRunRepository::new(directory.path().to_path_buf()).unwrap()),
+        Arc::new(MockTools),
+        Arc::new(MockAgents),
+        Arc::new(MockDefinitions::default()),
+        Arc::new(MockPolicy),
+        Arc::new(MockSecrets),
+        ceilings,
+    );
+    let failed = engine.run(request(workflow, json!({}))).await.unwrap();
+    assert_eq!(
+        failed.failure.as_ref().unwrap().code,
+        WorkflowFailureCode::BudgetExceeded
+    );
+    assert_eq!((failed.usage.tokens, failed.usage.cost_micros), (10, 2));
+}
+
+#[tokio::test]
+async fn map_cardinality_fails_before_item_futures_are_created() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut workflow = definition(
+        vec![tool_step(
+            "mapped",
+            "echo",
+            json!({"from":"item","name":"item","pointer":""}),
+        )],
+        WorkflowPlan::Map {
+            source: ValueRef::Args {
+                pointer: "/items".to_string(),
+            },
+            item: "item".to_string(),
+            body: Box::new(WorkflowPlan::Step {
+                step: "mapped".to_string(),
+            }),
+        },
+    );
+    workflow.budgets.max_steps = 2;
+    workflow.budgets.max_agents = 0;
+    let engine = engine(directory.path(), MockDefinitions::default());
+    let failed = engine
+        .run(request(workflow, json!({"items":[1,2,3]})))
+        .await
+        .unwrap();
+    assert_eq!(
+        failed.failure.as_ref().unwrap().code,
+        WorkflowFailureCode::BudgetExceeded
+    );
+    assert!(failed.steps.is_empty());
+}
+
+#[tokio::test]
+async fn wall_timeout_finalizes_step_before_terminal_run_event() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut workflow = definition(
+        vec![tool_step("slow", "slow", json!({}))],
+        WorkflowPlan::Step {
+            step: "slow".to_string(),
+        },
+    );
+    workflow.budgets.wall_time_ms = 50;
+    let engine = engine(directory.path(), MockDefinitions::default());
+    let failed = engine.run(request(workflow, json!({}))).await.unwrap();
+    assert_eq!(failed.steps["slow"].status, WorkflowStepStatus::Failed);
+    let events = engine.progress(&failed.run_id, 0).await.unwrap().events;
+    let step = events
+        .iter()
+        .position(|event| matches!(event.kind, WorkflowRunEventKind::StepFailed { .. }))
+        .unwrap();
+    let run = events
+        .iter()
+        .position(|event| matches!(event.kind, WorkflowRunEventKind::RunFailed { .. }))
+        .unwrap();
+    assert!(step < run);
+    assert_eq!(engine.runtime_resource_counts(), (0, 0));
+}
+
+#[tokio::test]
+async fn timeout_and_cancel_commit_boundaries_remain_consistent_for_100_rounds() {
+    let timeout_dir = tempfile::tempdir().unwrap();
+    let timeout_engine = engine(timeout_dir.path(), MockDefinitions::default());
+    for round in 0..100 {
+        let mut workflow = definition(
+            vec![tool_step("slow", "slow", json!({"round": round}))],
+            WorkflowPlan::Step {
+                step: "slow".to_string(),
+            },
+        );
+        workflow.budgets.wall_time_ms = 1;
+        let failed = timeout_engine
+            .run(request(workflow, json!({})))
+            .await
+            .unwrap();
+        assert_eq!(failed.status, WorkflowRunStatus::Failed, "round {round}");
+        assert_eq!(
+            failed.steps["slow"].status,
+            WorkflowStepStatus::Failed,
+            "round {round}"
+        );
+        let progress = timeout_engine.progress(&failed.run_id, 0).await.unwrap();
+        assert_eq!(
+            progress.snapshot.last_sequence,
+            progress.events.len() as u64
+        );
+        assert!(progress
+            .events
+            .windows(2)
+            .all(|pair| pair[1].sequence == pair[0].sequence + 1));
+    }
+    assert_eq!(timeout_engine.runtime_resource_counts(), (0, 0));
+
+    let cancel_dir = tempfile::tempdir().unwrap();
+    let cancel_engine = engine(cancel_dir.path(), MockDefinitions::default());
+    for round in 0..100 {
+        let workflow = definition(
+            vec![tool_step("slow", "slow", json!({"round": round}))],
+            WorkflowPlan::Step {
+                step: "slow".to_string(),
+            },
+        );
+        let started = cancel_engine
+            .start(request(workflow, json!({})))
+            .await
+            .unwrap();
+        let cancelled = cancel_engine.cancel(&started.run_id).await.unwrap();
+        assert_eq!(
+            cancelled.status,
+            WorkflowRunStatus::Cancelled,
+            "round {round}"
+        );
+        let progress = cancel_engine.progress(&started.run_id, 0).await.unwrap();
+        assert_eq!(
+            progress.snapshot.last_sequence,
+            progress.events.len() as u64
+        );
+        assert!(!progress
+            .events
+            .iter()
+            .any(|event| matches!(event.kind, WorkflowRunEventKind::RunSucceeded { .. })));
+    }
+    for _ in 0..1000 {
+        if cancel_engine.runtime_resource_counts() == (0, 0) {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(cancel_engine.runtime_resource_counts(), (0, 0));
+}
+
+#[tokio::test]
+async fn start_returns_typed_compile_error_without_run_residue() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = engine(directory.path(), MockDefinitions::default());
+    let mut invalid = definition(
+        vec![tool_step("echo", "echo", json!({}))],
+        WorkflowPlan::Step {
+            step: "echo".to_string(),
+        },
+    );
+    invalid.workflow_schema = 99;
+    assert!(matches!(
+        engine.start(request(invalid, json!({}))).await,
+        Err(WorkflowRunError::Compile(
+            WorkflowCompileError::UnsupportedSchema(99)
+        ))
+    ));
+    assert!(engine.list_run_ids().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn unowned_running_tool_is_killed_before_workflow_suspends() {
+    let directory = tempfile::tempdir().unwrap();
+    let killed = Arc::new(AtomicBool::new(false));
+    let engine = WorkflowRunEngine::new(
+        Arc::new(FileWorkflowRunRepository::new(directory.path().to_path_buf()).unwrap()),
+        Arc::new(RunningTools(killed.clone())),
+        Arc::new(MockAgents),
+        Arc::new(MockDefinitions::default()),
+        Arc::new(MockPolicy),
+        Arc::new(MockSecrets),
+        budgets(),
+    );
+    let workflow = definition(
+        vec![tool_step("detached", "detached", json!({}))],
+        WorkflowPlan::Step {
+            step: "detached".to_string(),
+        },
+    );
+    let suspended = engine.run(request(workflow, json!({}))).await.unwrap();
+    assert_eq!(suspended.status, WorkflowRunStatus::Suspended);
+    assert!(killed.load(Ordering::SeqCst));
+    assert!(matches!(
+        suspended.suspension,
+        Some(WorkflowSuspensionContext::ToolRunning {
+            ref step_id,
+            ref tool,
+            killed: true,
+            ..
+        }) if step_id == "detached" && tool == "detached"
+    ));
+    assert!(matches!(
+        engine
+            .restart(&suspended.run_id, true, vec!["read".to_string()])
+            .await,
+        Err(WorkflowRunError::Preflight(_))
+    ));
+}

--- a/crates/infra/bamboo-skills/src/catalog.rs
+++ b/crates/infra/bamboo-skills/src/catalog.rs
@@ -107,6 +107,8 @@ struct BambooWorkflowMetadata {
     // A composition is sufficient to classify legacy WorkflowDefinition YAML.
     #[serde(default)]
     composition: Option<serde_yaml::Value>,
+    #[serde(default)]
+    workflow_schema: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -115,6 +117,7 @@ pub(crate) struct BundleMetadata {
     pub version: String,
     pub invocation_policy: serde_json::Value,
     pub argument_schema: serde_json::Value,
+    pub definition_revision: Option<u64>,
 }
 
 impl Default for BundleMetadata {
@@ -124,6 +127,7 @@ impl Default for BundleMetadata {
             version: "1".to_string(),
             invocation_policy: serde_json::json!({"explicit": true, "automatic": true}),
             argument_schema: serde_json::json!({"type": "object", "additionalProperties": true}),
+            definition_revision: None,
         }
     }
 }
@@ -179,11 +183,18 @@ pub(crate) async fn load_bundle_metadata(root: &Path) -> Result<BundleMetadata, 
         serde_yaml::from_str(&raw).map_err(|error| public_yaml_error(display_name, error))?;
     let is_workflow_definition = path.ends_with("workflow.yaml");
     if is_workflow_definition {
-        let definition: bamboo_domain::WorkflowDefinition =
-            serde_yaml::from_str(&raw).map_err(|error| public_yaml_error(display_name, error))?;
-        definition
-            .validate()
-            .map_err(|error| public_validation_error(display_name, error))?;
+        if metadata.workflow_schema.is_some() {
+            let definition: bamboo_domain::WorkflowRunDefinition = serde_yaml::from_str(&raw)
+                .map_err(|error| public_yaml_error(display_name, error))?;
+            bamboo_domain::CompiledWorkflow::compile(definition.clone())
+                .map_err(|error| public_validation_error(display_name, error))?;
+        } else {
+            let definition: bamboo_domain::WorkflowDefinition = serde_yaml::from_str(&raw)
+                .map_err(|error| public_yaml_error(display_name, error))?;
+            definition
+                .validate()
+                .map_err(|error| public_validation_error(display_name, error))?;
+        }
     }
     let mut result = BundleMetadata {
         kind: if metadata.composition.is_some() || is_workflow_definition {
@@ -193,6 +204,13 @@ pub(crate) async fn load_bundle_metadata(root: &Path) -> Result<BundleMetadata, 
         },
         ..Default::default()
     };
+    if is_workflow_definition && metadata.workflow_schema.is_some() {
+        let definition: bamboo_domain::WorkflowRunDefinition =
+            serde_yaml::from_str(&raw).map_err(|error| public_yaml_error(display_name, error))?;
+        result.version = definition.workflow_schema.to_string();
+        result.argument_schema = definition.input_schema.clone();
+        result.definition_revision = Some(definition.revision);
+    }
     if let Some(version) = metadata.version.and_then(yaml_scalar_to_string) {
         result.version = version;
     }
@@ -217,7 +235,7 @@ pub(crate) fn entry_from_skill(
         description: skill.description.clone(),
         kind: metadata.kind,
         source: source.into(),
-        revision,
+        revision: metadata.definition_revision.unwrap_or(revision),
         version: metadata.version,
         invocation_policy: metadata.invocation_policy,
         argument_schema: metadata.argument_schema,

--- a/crates/infra/bamboo-skills/src/lib.rs
+++ b/crates/infra/bamboo-skills/src/lib.rs
@@ -216,6 +216,20 @@ impl SkillManager {
         }
     }
 
+    /// Build an immutable workflow bundle from one global/workspace publication.
+    /// The workspace argument must be derived from trusted server-side session state.
+    pub async fn pin_workflow_definition_bundle(
+        &self,
+        workspace: Option<&Path>,
+        root_id: &str,
+        root_revision: u64,
+    ) -> SkillResult<bamboo_domain::WorkflowDefinitionBundle> {
+        self.store_for_workspace(workspace)
+            .await?
+            .pin_workflow_definition_bundle(root_id, root_revision)
+            .await
+    }
+
     fn filter_skills_for_selection(
         skills: Vec<SkillDefinition>,
         catalog: &WorkflowCatalogSnapshot,

--- a/crates/infra/bamboo-skills/src/store/mod.rs
+++ b/crates/infra/bamboo-skills/src/store/mod.rs
@@ -1103,7 +1103,6 @@ impl SkillStore {
                                 skills.insert(id.clone(), skill.clone());
                                 roots.insert(id.clone(), record.skill_root.clone());
                                 let mut entry = previous_entry.clone();
-                                entry.revision = revision;
                                 entry.status = WorkflowStatus::Invalid;
                                 entry.last_error = Some(error);
                                 entry
@@ -1123,7 +1122,6 @@ impl SkillStore {
                             let mut entry = previous_entry.cloned().unwrap_or_else(|| {
                                 entry_from_skill(skill, record.source, revision, Default::default())
                             });
-                            entry.revision = revision;
                             entry.status = WorkflowStatus::Invalid;
                             entry.last_error = Some(record.error.clone());
                             entry
@@ -1145,6 +1143,96 @@ impl SkillStore {
     pub async fn workflow_catalog_snapshot(&self) -> WorkflowCatalogSnapshot {
         let _snapshot_guard = self.snapshot_publish_lock.read().await;
         self.catalog.read().await.clone()
+    }
+
+    /// Pin every new-format orchestration definition from one validated store
+    /// publication. `workflow.yaml` bytes come from the immutable resource
+    /// snapshot (including LKG recovery), never from a second filesystem read.
+    pub async fn pin_workflow_definition_bundle(
+        &self,
+        root_id: &str,
+        root_revision: u64,
+    ) -> SkillResult<bamboo_domain::WorkflowDefinitionBundle> {
+        if let Err(error) = self.reload().await {
+            tracing::warn!(
+                "Failed to reload workflows before bundle pin; using LKG publication: {error}"
+            );
+        }
+        let _snapshot_guard = self.snapshot_publish_lock.read().await;
+        let catalog = self.catalog.read().await;
+        let resources = self.skill_resources.read().await;
+        let mut definitions = BTreeMap::new();
+        for entry in catalog
+            .entries
+            .iter()
+            .filter(|entry| entry.winner && entry.kind == WorkflowKind::Orchestration)
+        {
+            let Some(bytes) = resources
+                .get(&entry.id)
+                .and_then(|resources| resources.get("workflow.yaml"))
+            else {
+                continue;
+            };
+            let value: serde_yaml::Value = serde_yaml::from_slice(bytes)
+                .map_err(|_| SkillError::Validation("invalid pinned workflow yaml".to_string()))?;
+            if value.get("workflow_schema").is_none() {
+                // Legacy definitions stay catalog-visible but are not executable
+                // by the versioned #578 runtime.
+                continue;
+            }
+            let definition: bamboo_domain::WorkflowRunDefinition = serde_yaml::from_slice(bytes)
+                .map_err(|_| SkillError::Validation("invalid pinned workflow definition".into()))?;
+            bamboo_domain::CompiledWorkflow::compile(definition.clone())
+                .map_err(|_| SkillError::Validation("invalid pinned workflow definition".into()))?;
+            if definition.id != entry.id || definition.revision != entry.revision {
+                return Err(SkillError::Validation(
+                    "workflow identity does not match its catalog entry".to_string(),
+                ));
+            }
+            definitions.insert(
+                bamboo_domain::WorkflowDefinitionBundle::key(&definition.id, definition.revision),
+                definition,
+            );
+        }
+        let root_key = bamboo_domain::WorkflowDefinitionBundle::key(root_id, root_revision);
+        if !definitions.contains_key(&root_key) {
+            return Err(SkillError::NotFound(format!("{root_id}@{root_revision}")));
+        }
+
+        // Persist only the transitive closure reachable from the selected root.
+        // Keeping every orchestration definition in the publication would copy
+        // unrelated workflow contents into each run snapshot and unnecessarily
+        // amplify its durable storage footprint.
+        let mut reachable = BTreeMap::new();
+        let mut pending = vec![root_key];
+        while let Some(key) = pending.pop() {
+            if reachable.contains_key(&key) {
+                continue;
+            }
+            let definition = definitions.get(&key).cloned().ok_or_else(|| {
+                SkillError::Validation(format!("pinned workflow dependency is missing: {key}"))
+            })?;
+            for step in &definition.steps {
+                if let bamboo_domain::WorkflowStepKind::Workflow {
+                    workflow_id,
+                    revision,
+                    ..
+                } = &step.kind
+                {
+                    pending.push(bamboo_domain::WorkflowDefinitionBundle::key(
+                        workflow_id,
+                        *revision,
+                    ));
+                }
+            }
+            reachable.insert(key, definition);
+        }
+        Ok(bamboo_domain::WorkflowDefinitionBundle {
+            publication_revision: catalog.revision,
+            root_id: root_id.to_string(),
+            root_revision,
+            definitions: reachable,
+        })
     }
 
     /// Return definitions, roots, immutable resource bytes, and metadata from one
@@ -2566,6 +2654,12 @@ mod tests {
         Ok(skill_dir)
     }
 
+    fn orchestration_yaml(id: &str, revision: u64) -> String {
+        format!(
+            "workflow_schema: 1\nid: {id}\nrevision: {revision}\ninput_schema:\n  type: object\n  properties:\n    path:\n      type: string\n  required: [path]\n  additionalProperties: false\nsteps:\n  - id: inspect\n    type: tool\n    tool: read_file\n    args:\n      path:\n        from: args\n        pointer: /path\n    capabilities: [read]\n    output_schema:\n      type: object\n      additionalProperties: true\nplan:\n  type: step\n  step: inspect\nbudgets:\n  max_concurrency: 1\n  max_agents: 0\n  max_steps: 4\n  max_retries: 1\n  max_nesting_depth: 2\n  wall_time_ms: 10000\n"
+        )
+    }
+
     async fn materialize_legacy_builtin(skills_dir: &Path, bundle: &BuiltinSkillBundle) {
         write_skill_file(skills_dir, &bundle.skill)
             .await
@@ -3395,6 +3489,107 @@ Use this skill for testing.
         assert!(!public_error.contains(PRIVATE_RESOURCE));
         assert!(!public_error.contains(PRIVATE_INSTRUCTIONS));
         assert!(!public_error.contains(root.to_string_lossy().as_ref()));
+    }
+
+    #[tokio::test]
+    async fn new_orchestration_definition_is_compiled_and_pinned_from_one_publication() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("data/skills");
+        let root = write_skill(&skills_dir, "review-flow", "review", "Instructions")
+            .await
+            .expect("skill");
+        fs::write(
+            root.join("workflow.yaml"),
+            orchestration_yaml("review-flow", 42),
+        )
+        .await
+        .expect("workflow yaml");
+        let unrelated = write_skill(&skills_dir, "unrelated-flow", "other", "Unrelated")
+            .await
+            .expect("unrelated skill");
+        fs::write(
+            unrelated.join("workflow.yaml"),
+            orchestration_yaml("unrelated-flow", 9),
+        )
+        .await
+        .expect("unrelated workflow yaml");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir,
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+
+        let catalog = store.workflow_catalog_snapshot().await;
+        let entry = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "review-flow")
+            .expect("catalog entry");
+        assert_eq!(entry.kind, crate::WorkflowKind::Orchestration);
+        assert_eq!(entry.revision, 42);
+        assert_eq!(
+            entry.argument_schema["properties"]["path"]["type"],
+            "string"
+        );
+
+        let bundle = store
+            .pin_workflow_definition_bundle("review-flow", 42)
+            .await
+            .expect("pinned definition");
+        assert_eq!(bundle.publication_revision, catalog.revision);
+        assert_eq!(bundle.root().expect("root").id, "review-flow");
+        assert_eq!(bundle.root().expect("root").revision, 42);
+        assert_eq!(
+            bundle.definitions.len(),
+            1,
+            "unrelated definitions must not be persisted in this run bundle"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_new_definition_keeps_exact_lkg_bytes_and_definition_revision() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let skills_dir = directory.path().join("data/skills");
+        let root = write_skill(&skills_dir, "steady-flow", "review", "Original")
+            .await
+            .expect("skill");
+        fs::write(
+            root.join("workflow.yaml"),
+            orchestration_yaml("steady-flow", 7),
+        )
+        .await
+        .expect("workflow yaml");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir,
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+        let original = store
+            .pin_workflow_definition_bundle("steady-flow", 7)
+            .await
+            .expect("original pin");
+
+        fs::write(
+            root.join("workflow.yaml"),
+            "workflow_schema: 1\nid: steady-flow\nrevision: 8\nsteps: []\n",
+        )
+        .await
+        .expect("invalid replacement");
+        store.reload().await.expect("invalid reload isolated");
+        let entry = store
+            .workflow_catalog_snapshot()
+            .await
+            .entries
+            .into_iter()
+            .find(|entry| entry.id == "steady-flow")
+            .expect("LKG entry");
+        assert_eq!(entry.status, WorkflowStatus::Invalid);
+        assert_eq!(entry.revision, 7, "invalid bytes cannot advance identity");
+        let pinned = store
+            .pin_workflow_definition_bundle("steady-flow", 7)
+            .await
+            .expect("LKG remains executable");
+        assert_eq!(pinned.root(), original.root());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add a version-pinned WorkflowRun schema/compiler for sequence, parallel, map, retry, agent, tool, and nested workflow steps
- add durable journal/snapshot/event execution with recovery, cancellation, budgets, typed failures, and deterministic concurrency handling
- load and pin only the root-reachable workflow bundle from the skill catalog
- add session-owned HTTP APIs plus the root workflow_run tool with strict server-owned authorization and public snapshot redaction
- remove the production AgentLoopConfig composition executor path so workflow execution has one production authority
- keep production named-agent and stronger capability/secret resolution fail-closed until #563 and #601 land

Closes #578

## Test Plan

- cargo fmt --all -- --check
- git diff --check
- cargo check -p bamboo-engine -p bamboo-skills -p bamboo-server
- cargo clippy -p bamboo-engine -p bamboo-skills -p bamboo-server --all-targets
- cargo test -p bamboo-engine workflow_run --no-fail-fast (32 passed)
- cargo test -p bamboo-skills definition_ --no-fail-fast (13 passed)
- cargo test -p bamboo-server workflow --no-fail-fast (52 passed)
- CARGO_INCREMENTAL=0 RUSTFLAGS="-C debuginfo=0" cargo test --workspace -- --skip build_rustls_config_succeeds_on_valid_self_signed_cert

The skipped rustls self-signed certificate fixture fails on a clean main checkout with UnsupportedCertVersion and is not introduced by this change. All other workspace tests and doc tests completed successfully.

## Security and recovery coverage

- untrusted workspaces deny scripts, network, and writes by default
- tool targets use a strict read-only allowlist and nested targets are independently authorized
- session ownership prevents caller spoofing
- secret values are represented by typed handles and are redacted from journals and public snapshots
- durable commits precede completion event publication
- restart uses the persisted reachable definition bundle and never drifts to a live catalog revision
- 100-round race tests cover same-run commits, timeout, and cancellation boundaries