### PR TITLE
fix: distinguish LLM stream transport and semantic liveness

### DIFF
--- a/crates/app/bamboo-server/src/handlers/anthropic/complete/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/anthropic/complete/non_stream.rs
@@ -90,7 +90,8 @@ pub(super) async fn handle_non_streaming_complete(
                 ));
             }
             Ok(bamboo_llm::types::LLMChunk::Done) => break,
-            Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. })
+            Ok(bamboo_llm::types::LLMChunk::TransportActivity)
+            | Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. })
             | Ok(bamboo_llm::types::LLMChunk::UsageSummary { .. })
             | Ok(bamboo_llm::types::LLMChunk::ReasoningSignature(_)) => {}
             Err(error) => {

--- a/crates/app/bamboo-server/src/handlers/anthropic/conversion.rs
+++ b/crates/app/bamboo-server/src/handlers/anthropic/conversion.rs
@@ -155,7 +155,8 @@ pub(super) fn convert_llm_chunk_to_openai(
             }],
             usage: None,
         }),
-        bamboo_llm::types::LLMChunk::CacheUsage { .. }
+        bamboo_llm::types::LLMChunk::TransportActivity
+        | bamboo_llm::types::LLMChunk::CacheUsage { .. }
         | bamboo_llm::types::LLMChunk::UsageSummary { .. }
         | bamboo_llm::types::LLMChunk::ReasoningSignature(_) => None,
     }

--- a/crates/app/bamboo-server/src/handlers/anthropic/messages/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/anthropic/messages/non_stream.rs
@@ -88,7 +88,8 @@ pub(super) async fn handle_non_streaming_messages(
                 ));
             }
             Ok(bamboo_llm::types::LLMChunk::Done) => break,
-            Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. })
+            Ok(bamboo_llm::types::LLMChunk::TransportActivity)
+            | Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. })
             | Ok(bamboo_llm::types::LLMChunk::UsageSummary { .. })
             | Ok(bamboo_llm::types::LLMChunk::ReasoningSignature(_)) => {}
             Err(error) => {

--- a/crates/app/bamboo-server/src/handlers/gemini/generate/collect.rs
+++ b/crates/app/bamboo-server/src/handlers/gemini/generate/collect.rs
@@ -27,7 +27,8 @@ where
             LLMChunk::ToolCallsIndexed(calls) => {
                 collected.tool_calls = Some(calls.into_iter().map(|(_, call)| call).collect())
             }
-            LLMChunk::CacheUsage { .. }
+            LLMChunk::TransportActivity
+            | LLMChunk::CacheUsage { .. }
             | LLMChunk::UsageSummary { .. }
             | LLMChunk::ReasoningSignature(_) => {}
         }

--- a/crates/app/bamboo-server/src/handlers/gemini/stream/runtime.rs
+++ b/crates/app/bamboo-server/src/handlers/gemini/stream/runtime.rs
@@ -64,7 +64,8 @@ pub(super) fn build_gemini_event_stream(
                     yield Ok::<_, ActixError>(sse::done_chunk_bytes());
                     break;
                 }
-                Ok(LLMChunk::CacheUsage { .. })
+                Ok(LLMChunk::TransportActivity)
+                | Ok(LLMChunk::CacheUsage { .. })
                 | Ok(LLMChunk::UsageSummary { .. })
                 | Ok(LLMChunk::ReasoningSignature(_)) => {}
                 Err(error) => {

--- a/crates/app/bamboo-server/src/handlers/openai/chat/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/chat/non_stream.rs
@@ -85,6 +85,7 @@ pub(super) async fn handle_non_streaming_chat(
                     calls.into_iter().map(|(_, call)| call).collect(),
                 ));
             }
+            Ok(bamboo_llm::types::LLMChunk::TransportActivity) => {}
             Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. }) => {}
             Ok(bamboo_llm::types::LLMChunk::ReasoningSignature(_)) => {}
             Ok(bamboo_llm::types::LLMChunk::UsageSummary { .. }) => {}

--- a/crates/app/bamboo-server/src/handlers/openai/chat/stream/worker.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/chat/stream/worker.rs
@@ -66,7 +66,8 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
                     }
                 }
             }
-            Ok(LLMChunk::CacheUsage { .. })
+            Ok(LLMChunk::TransportActivity)
+            | Ok(LLMChunk::CacheUsage { .. })
             | Ok(LLMChunk::UsageSummary { .. })
             | Ok(LLMChunk::ReasoningSignature(_)) => {}
             Err(error) => {

--- a/crates/app/bamboo-server/src/handlers/openai/helpers/stream_utils.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/helpers/stream_utils.rs
@@ -109,7 +109,8 @@ pub(super) fn convert_chunk_to_openai(
             }],
             usage: None,
         }),
-        bamboo_llm::types::LLMChunk::CacheUsage { .. }
+        bamboo_llm::types::LLMChunk::TransportActivity
+        | bamboo_llm::types::LLMChunk::CacheUsage { .. }
         | bamboo_llm::types::LLMChunk::UsageSummary { .. }
         | bamboo_llm::types::LLMChunk::ReasoningSignature(_) => None,
     }

--- a/crates/app/bamboo-server/src/handlers/openai/responses/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/non_stream.rs
@@ -75,7 +75,8 @@ pub(super) async fn handle_non_streaming_response(
                 tool_calls.extend_indexed(calls)
             }
             Ok(bamboo_llm::types::LLMChunk::Done) => break,
-            Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. })
+            Ok(bamboo_llm::types::LLMChunk::TransportActivity)
+            | Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. })
             | Ok(bamboo_llm::types::LLMChunk::UsageSummary { .. })
             | Ok(bamboo_llm::types::LLMChunk::ReasoningSignature(_)) => {}
             Err(error) => {

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/worker.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/worker.rs
@@ -130,7 +130,8 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
                 tool_calls.extend_indexed(indexed)
             }
             Ok(LLMChunk::Done) => break,
-            Ok(LLMChunk::CacheUsage { .. })
+            Ok(LLMChunk::TransportActivity)
+            | Ok(LLMChunk::CacheUsage { .. })
             | Ok(LLMChunk::UsageSummary { .. })
             | Ok(LLMChunk::ReasoningSignature(_)) => {}
             Err(error) => {

--- a/crates/core/bamboo-agent-core/src/agent/error.rs
+++ b/crates/core/bamboo-agent-core/src/agent/error.rs
@@ -20,11 +20,10 @@ pub enum AgentError {
     #[error("LLM overflow: {0}")]
     LLMOverflow(String),
 
-    /// The provider's stream stalled mid-response: no chunk was received within
-    /// the inter-chunk idle deadline (issue #28). This indicates a hung
-    /// connection rather than a slow-but-healthy stream — the consume loop
-    /// resets the deadline on every received chunk, so a legitimately long
-    /// stream that keeps producing data never trips it.
+    /// An LLM stream watchdog expired. The attached diagnostic identifies
+    /// whether transport liveness, first semantic output, or midstream semantic
+    /// progress stalled. Kept distinct from `LLM` so generic retry logic cannot
+    /// replay partial output or tool-call state (#618).
     #[error("Stream timed out: {0}")]
     StreamTimeout(String),
 

--- a/crates/engine/bamboo-engine/Cargo.toml
+++ b/crates/engine/bamboo-engine/Cargo.toml
@@ -28,7 +28,7 @@ serde = { workspace = true }
 serde_json = "1"
 anyhow = "1"
 thiserror = "2"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["full", "test-util"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 futures = "0.3"
 async-trait = "0.1"

--- a/crates/engine/bamboo-engine/src/gold_auto_answer/evaluation.rs
+++ b/crates/engine/bamboo-engine/src/gold_auto_answer/evaluation.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use crate::config::GoldConfig;
 use crate::runtime::gold_evaluation::{evaluate_gold, GoldEvaluationResult};
-use crate::runtime::stream::handler::consume_llm_stream_silent;
 use crate::TaskLoopContext;
 use bamboo_agent_core::{AgentEvent, Session};
 use bamboo_domain::reasoning::ReasoningEffort;
@@ -24,7 +23,8 @@ pub(crate) async fn evaluate_gold_state_for_pending_question(
     gold_config: &GoldConfig,
 ) -> Result<GoldEvaluationResult, String> {
     let task_context = TaskLoopContext::from_session(session);
-    let (provider, model) = resolve_gold_provider_and_model(state, session, gold_config).await?;
+    let (provider, model, provider_name, stream_timeout) =
+        resolve_gold_provider_and_model(state, session, gold_config).await?;
     let iteration = session
         .agent_runtime_state
         .as_ref()
@@ -48,6 +48,11 @@ pub(crate) async fn evaluate_gold_state_for_pending_question(
             event_tx: &event_tx,
             session_id,
             model: &model,
+            timeout_context: crate::runtime::stream::handler::StreamTimeoutContext::new(
+                stream_timeout,
+                Some(&provider_name),
+                Some(&model),
+            ),
             reasoning_effort: session.reasoning_effort,
             checkpoint: bamboo_agent_core::GoldCheckpoint::Terminal,
             iteration,
@@ -74,7 +79,8 @@ pub(crate) async fn evaluate_gold_auto_answer_question(
         ));
     };
 
-    let (provider, model) = resolve_gold_provider_and_model(state, session, gold_config).await?;
+    let (provider, model, provider_name, stream_timeout) =
+        resolve_gold_provider_and_model(state, session, gold_config).await?;
     let messages = build_gold_auto_answer_messages(session, pending, state_evaluation, gold_config);
     let tools = get_gold_auto_answer_tools();
     let request_options = LLMRequestOptions {
@@ -97,9 +103,19 @@ pub(crate) async fn evaluate_gold_auto_answer_question(
         .await
         .map_err(|error| format!("provider call failed: {error}"))?;
 
-    let stream_output = consume_llm_stream_silent(stream, &CancellationToken::new(), session_id)
-        .await
-        .map_err(|error| format!("stream handling failed: {error}"))?;
+    let timeout_context = crate::runtime::stream::handler::StreamTimeoutContext::new(
+        stream_timeout,
+        Some(&provider_name),
+        Some(&model),
+    );
+    let stream_output = crate::runtime::stream::handler::consume_llm_stream_silent_with_context(
+        stream,
+        &CancellationToken::new(),
+        session_id,
+        &timeout_context,
+    )
+    .await
+    .map_err(|error| format!("stream handling failed: {error}"))?;
 
     Ok(
         parse_gold_auto_answer_decision(&stream_output.tool_calls).unwrap_or_else(|| {
@@ -114,12 +130,21 @@ async fn resolve_gold_provider_and_model(
     state: &dyn AgentSessionContext,
     session: &Session,
     gold_config: &GoldConfig,
-) -> Result<(Arc<dyn LLMProvider>, String), String> {
+) -> Result<
+    (
+        Arc<dyn LLMProvider>,
+        String,
+        String,
+        bamboo_config::StreamTimeoutConfig,
+    ),
+    String,
+> {
     // Resolve fast model eagerly for the fallback chain.
     let config_snapshot = state.config().read().await.clone();
     let provider_name = session_effective_model_ref(session)
         .map(|r| r.provider.clone())
         .unwrap_or_else(|| config_snapshot.provider.clone());
+    let stream_timeout = config_snapshot.stream_timeout;
     let fast_model_name = crate::model_config_helper::resolve_fast_model(
         &config_snapshot,
         &provider_name,
@@ -148,36 +173,54 @@ async fn resolve_gold_provider_and_model(
     if let Some(model_ref) = session_effective_model_ref(session) {
         let target = ProviderModelRef::new(model_ref.provider.clone(), model.clone());
         if let Some(provider) = state.get_provider_for_model_ref(&target) {
-            return Ok((provider, model));
+            return Ok((provider, model, provider_name, stream_timeout));
         }
         if let Some(provider) = state.provider_registry().get(&model_ref.provider) {
-            return Ok((provider, model));
+            return Ok((provider, model, provider_name, stream_timeout));
         }
         if let Some(provider) = state.get_provider_for_endpoint(&model_ref.provider).await {
-            return Ok((provider, model));
+            return Ok((provider, model, provider_name, stream_timeout));
         }
     }
 
-    if let Some(provider_name) = session
+    if let Some(metadata_provider_name) = session
         .metadata
         .get("provider_name")
         .map(String::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
     {
-        if let Some(provider) = state.provider_registry().get(provider_name) {
-            return Ok((provider, model));
+        if let Some(provider) = state.provider_registry().get(metadata_provider_name) {
+            return Ok((
+                provider,
+                model,
+                metadata_provider_name.to_string(),
+                stream_timeout,
+            ));
         }
-        if let Some(provider) = state.get_provider_for_endpoint(provider_name).await {
-            return Ok((provider, model));
+        if let Some(provider) = state
+            .get_provider_for_endpoint(metadata_provider_name)
+            .await
+        {
+            return Ok((
+                provider,
+                model,
+                metadata_provider_name.to_string(),
+                stream_timeout,
+            ));
         }
     }
 
     if let Some(provider) = state.provider_registry().get_default() {
-        return Ok((provider, model));
+        return Ok((provider, model, provider_name, stream_timeout));
     }
 
-    Ok((state.get_provider().await, model))
+    Ok((
+        state.get_provider().await,
+        model,
+        provider_name,
+        stream_timeout,
+    ))
 }
 
 fn normalize_lightweight_reasoning_effort(

--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -432,6 +432,9 @@ pub struct AgentLoopConfig {
     pub(crate) per_tool_timeout_secs: u64,
     /// Parallel batch execution timeout in seconds (default: 300).
     pub(crate) parallel_batch_timeout_secs: u64,
+    /// Resolved LLM stream transport/semantic watchdog policy. The same value
+    /// is passed to main response streams and auxiliary silent streams.
+    pub(crate) stream_timeout: bamboo_config::StreamTimeoutConfig,
     /// Permission mode for this execution (default: None = use PermissionConfig's mode).
     pub(crate) permission_mode: Option<PermissionMode>,
     /// Optional Gold observe-only evaluator configuration.
@@ -537,6 +540,7 @@ impl Default for AgentLoopConfig {
             max_consecutive_failures_per_tool: 3,
             per_tool_timeout_secs: 120,
             parallel_batch_timeout_secs: 300,
+            stream_timeout: bamboo_config::StreamTimeoutConfig::default(),
             permission_mode: None,
             gold_config: None,
             guardian_config: None,

--- a/crates/engine/bamboo-engine/src/runtime/gold_evaluation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/gold_evaluation.rs
@@ -12,7 +12,9 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::runtime::config::GoldConfig;
-use crate::runtime::stream::handler::consume_llm_stream_silent;
+use crate::runtime::stream::handler::{
+    consume_llm_stream_silent_with_context, StreamTimeoutContext,
+};
 use crate::runtime::task_context::TaskLoopContext;
 use bamboo_metrics::TokenUsage as MetricsTokenUsage;
 
@@ -23,6 +25,7 @@ pub struct GoldEvalFrame<'a> {
     pub event_tx: &'a mpsc::Sender<AgentEvent>,
     pub session_id: &'a str,
     pub model: &'a str,
+    pub timeout_context: StreamTimeoutContext,
     pub reasoning_effort: Option<ReasoningEffort>,
     pub checkpoint: GoldCheckpoint,
     pub iteration: u32,
@@ -49,6 +52,7 @@ pub(crate) struct AsyncGoldEvaluationRequest {
     pub(crate) session_id: String,
     pub(crate) round_number: usize,
     pub(crate) model_name: String,
+    pub(crate) timeout_context: StreamTimeoutContext,
     pub(crate) reasoning_effort: Option<ReasoningEffort>,
     pub(crate) checkpoint: GoldCheckpoint,
     pub(crate) session_snapshot: Session,
@@ -103,6 +107,7 @@ pub(crate) fn build_async_gold_evaluation_request(
     reasoning_effort: Option<ReasoningEffort>,
     checkpoint: GoldCheckpoint,
     gold_config: &GoldConfig,
+    timeout_context: StreamTimeoutContext,
 ) -> Result<Option<AsyncGoldEvaluationRequest>, AgentError> {
     if !gold_config.enabled {
         return Ok(None);
@@ -118,6 +123,7 @@ pub(crate) fn build_async_gold_evaluation_request(
         session_id: session_id.to_string(),
         round_number,
         model_name: model_name.to_string(),
+        timeout_context,
         reasoning_effort,
         checkpoint,
         session_snapshot: session.clone(),
@@ -140,6 +146,7 @@ pub(crate) async fn execute_async_gold_evaluation(
             event_tx: &event_tx,
             session_id: &request.session_id,
             model: &request.model_name,
+            timeout_context: request.timeout_context.clone(),
             reasoning_effort: request.reasoning_effort,
             checkpoint: request.checkpoint,
             iteration: request.round_number as u32,
@@ -216,10 +223,13 @@ pub async fn evaluate_gold(
         .await
     {
         Ok(stream) => {
-            let stream_output =
-                consume_llm_stream_silent(stream, &CancellationToken::new(), session_id)
-                    .await
-                    .map_err(|error| AgentError::LLM(error.to_string()))?;
+            let stream_output = consume_llm_stream_silent_with_context(
+                stream,
+                &CancellationToken::new(),
+                session_id,
+                &frame.timeout_context,
+            )
+            .await?;
 
             let result = parse_gold_evaluation(
                 &stream_output.content,

--- a/crates/engine/bamboo-engine/src/runtime/managers/adapters/llm_mini_loop.rs
+++ b/crates/engine/bamboo-engine/src/runtime/managers/adapters/llm_mini_loop.rs
@@ -13,11 +13,34 @@ use crate::runtime::managers::mini_loop::{MiniLoopDecision, MiniLoopExecutor};
 pub struct LLMMiniLoopExecutor {
     provider: std::sync::Arc<dyn LLMProvider>,
     model: String,
+    timeout_context: crate::runtime::stream::handler::StreamTimeoutContext,
 }
 
 impl LLMMiniLoopExecutor {
     pub fn new(provider: std::sync::Arc<dyn LLMProvider>, model: String) -> Self {
-        Self { provider, model }
+        Self {
+            provider,
+            model,
+            timeout_context: crate::runtime::stream::handler::StreamTimeoutContext::default(),
+        }
+    }
+
+    pub fn with_timeout_policy(
+        provider: std::sync::Arc<dyn LLMProvider>,
+        model: String,
+        policy: bamboo_config::StreamTimeoutConfig,
+        provider_name: Option<&str>,
+    ) -> Self {
+        let timeout_context = crate::runtime::stream::handler::StreamTimeoutContext::new(
+            policy,
+            provider_name,
+            Some(&model),
+        );
+        Self {
+            provider,
+            model,
+            timeout_context,
+        }
     }
 }
 
@@ -91,13 +114,13 @@ impl MiniLoopExecutor for LLMMiniLoopExecutor {
             .await
             .map_err(|e| AgentError::LLM(e.to_string()))?;
 
-        let output = crate::runtime::stream::handler::consume_llm_stream_silent(
+        let output = crate::runtime::stream::handler::consume_llm_stream_silent_with_context(
             stream,
             &tokio_util::sync::CancellationToken::new(),
             "mini-loop",
+            &self.timeout_context,
         )
-        .await
-        .map_err(|e| AgentError::LLM(e.to_string()))?;
+        .await?;
 
         Ok(MiniLoopDecision {
             answer: output.content.trim().to_string(),

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/gold.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/gold.rs
@@ -119,6 +119,11 @@ pub(super) async fn evaluate_gold_terminal(
             event_tx,
             session_id,
             model: model_name,
+            timeout_context: crate::runtime::stream::handler::StreamTimeoutContext::new(
+                config.stream_timeout,
+                config.provider_name.as_deref(),
+                Some(model_name),
+            ),
             reasoning_effort,
             checkpoint: GoldCheckpoint::Terminal,
             iteration,
@@ -476,6 +481,11 @@ pub(super) fn spawn_gold_evaluation_if_needed(
         config.reasoning_effort,
         GoldCheckpoint::PostRound,
         gold_config,
+        crate::runtime::stream::handler::StreamTimeoutContext::new(
+            config.stream_timeout,
+            config.provider_name.as_deref(),
+            eval_model,
+        ),
     )?;
     let Some(request) = request else {
         return Ok(());

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -923,6 +923,11 @@ fn spawn_task_evaluation_if_needed(
         turn + 1,
         eval_model,
         config.reasoning_effort,
+        crate::runtime::stream::handler::StreamTimeoutContext::new(
+            config.stream_timeout,
+            config.provider_name.as_deref(),
+            eval_model,
+        ),
     )?;
     let Some(request) = request else {
         return Ok(());
@@ -3944,6 +3949,9 @@ mod tests {
         assert!(!should_retry_turn_error(&AgentError::Budget(
             "budget exceeded".to_string(),
         )));
+        assert!(!should_retry_turn_error(&AgentError::StreamTimeout(
+            "semantic_output_started=true, retry_safe=false".to_string(),
+        )));
     }
 
     #[test]
@@ -5445,6 +5453,7 @@ mod tests {
             model_name: "fast".to_string(),
             reasoning_effort: None,
             checkpoint: bamboo_agent_core::GoldCheckpoint::PostRound,
+            timeout_context: crate::runtime::stream::handler::StreamTimeoutContext::default(),
             session_snapshot: session.clone(),
             task_context_snapshot: None,
             gold_config: crate::runtime::config::GoldConfig::default(),

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
@@ -817,11 +817,17 @@ pub(super) async fn execute_llm_stream(
         );
     }
 
-    let stream_output = crate::runtime::stream::handler::consume_llm_stream(
+    let timeout_context = crate::runtime::stream::handler::StreamTimeoutContext::new(
+        config.stream_timeout,
+        provider_name,
+        Some(model),
+    );
+    let stream_output = crate::runtime::stream::handler::consume_llm_stream_with_context(
         stream,
         event_tx,
         cancel_token,
         session_id,
+        &timeout_context,
     )
     .await?;
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/task_lifecycle/evaluation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/task_lifecycle/evaluation.rs
@@ -110,6 +110,8 @@ pub(in crate::runtime::runner) struct AsyncTaskEvaluationRequest {
     pub(in crate::runtime::runner) based_on_task_context_version: u64,
     pub(in crate::runtime::runner) task_list_title: Option<String>,
     pub(in crate::runtime::runner) model_name: String,
+    pub(in crate::runtime::runner) timeout_context:
+        crate::runtime::stream::handler::StreamTimeoutContext,
     pub(in crate::runtime::runner) reasoning_effort: Option<ReasoningEffort>,
     pub(in crate::runtime::runner) task_context_snapshot: TaskLoopContext,
     pub(in crate::runtime::runner) session_snapshot: Session,
@@ -132,6 +134,7 @@ pub(in crate::runtime::runner) fn build_async_task_evaluation_request(
     round_number: usize,
     model_name: Option<&str>,
     reasoning_effort: Option<ReasoningEffort>,
+    timeout_context: crate::runtime::stream::handler::StreamTimeoutContext,
 ) -> Result<Option<AsyncTaskEvaluationRequest>, AgentError> {
     let Some(task_context_snapshot) = task_context.clone() else {
         return Ok(None);
@@ -155,6 +158,7 @@ pub(in crate::runtime::runner) fn build_async_task_evaluation_request(
             .as_ref()
             .map(|task_list| task_list.title.clone()),
         model_name: model_name.to_string(),
+        timeout_context,
         reasoning_effort,
         task_context_snapshot,
         session_snapshot: session.clone(),
@@ -170,10 +174,13 @@ pub(in crate::runtime::runner) async fn execute_async_task_evaluation(
         &request.task_context_snapshot,
         &request.session_snapshot,
         llm,
-        &event_tx,
-        &request.session_id,
-        &request.model_name,
-        request.reasoning_effort,
+        &crate::runtime::task_evaluation::TaskEvaluationFrame {
+            event_tx: &event_tx,
+            session_id: &request.session_id,
+            model: &request.model_name,
+            reasoning_effort: request.reasoning_effort,
+            timeout_context: &request.timeout_context,
+        },
     )
     .await
     {

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -727,6 +727,7 @@ impl AgentRuntime {
             // the HTTP layer) means every caller — HTTP, schedules, connect,
             // the in-proc SDK — gets the same clamped fallback for free.
             run_budget: config.run_budget.merged_with_override(run_budget.as_ref()),
+            stream_timeout: config.stream_timeout,
             ..Default::default()
         };
 

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
@@ -1,31 +1,66 @@
-use std::time::Duration;
-
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use bamboo_agent_core::tools::ToolCall;
 use bamboo_agent_core::{AgentError, AgentEvent};
+use bamboo_config::StreamTimeoutConfig;
 use bamboo_llm::LLMStream;
 
 mod chunk_handling;
 mod consume;
 mod stream_state;
 
-/// Default *inter-chunk* idle timeout for LLM streams (issue #28).
-///
-/// A provider connection that stops sending chunks for longer than this is
-/// treated as a hung stream. Because the deadline resets on every received
-/// chunk (see [`consume::consume_llm_stream_internal`]), a legitimately long
-/// stream that keeps producing data — e.g. a thinking model that streams for
-/// minutes — is never affected; only a true stall (no chunk at all) trips it.
-///
-/// This is a well-named const default rather than a threaded config field: the
-/// consume function is shared across the main stream path and several
-/// auxiliary (silent) callers, and wiring a new field through `AgentLoopConfig`
-/// plus every call site is invasive for a streaming hot path. The internal
-/// function still accepts an `idle_timeout` override so it remains configurable
-/// and testable; full config wiring is deferred.
-const DEFAULT_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(120);
+/// Resolved identifiers and deadlines for one stream. Identifiers are sanitized
+/// before they reach timeout diagnostics; prompts and provider payloads are
+/// never retained here.
+#[derive(Debug, Clone)]
+pub struct StreamTimeoutContext {
+    pub(crate) policy: StreamTimeoutConfig,
+    pub(crate) provider: Option<String>,
+    pub(crate) model: Option<String>,
+}
+
+impl StreamTimeoutContext {
+    pub fn new(policy: StreamTimeoutConfig, provider: Option<&str>, model: Option<&str>) -> Self {
+        let policy = match policy.validate() {
+            Ok(()) => policy,
+            Err(error) => {
+                tracing::warn!(
+                    "invalid programmatic stream timeout policy ({error}); using safe defaults"
+                );
+                StreamTimeoutConfig::default()
+            }
+        };
+        Self {
+            policy,
+            provider: provider.and_then(sanitize_identifier),
+            model: model.and_then(sanitize_identifier),
+        }
+    }
+}
+
+impl Default for StreamTimeoutContext {
+    fn default() -> Self {
+        Self::new(StreamTimeoutConfig::default(), None, None)
+    }
+}
+
+fn sanitize_identifier(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    let sanitized: String = value
+        .chars()
+        .take(120)
+        .map(|character| match character {
+            character if character.is_ascii_alphanumeric() => character,
+            '-' | '_' | '.' | ':' | '/' | '@' => character,
+            _ => '_',
+        })
+        .collect();
+    (!sanitized.is_empty()).then_some(sanitized)
+}
 
 pub struct StreamHandlingOutput {
     pub response_id: Option<String>,
@@ -50,12 +85,29 @@ pub async fn consume_llm_stream(
     cancel_token: &CancellationToken,
     session_id: &str,
 ) -> Result<StreamHandlingOutput, AgentError> {
+    consume_llm_stream_with_context(
+        stream,
+        event_tx,
+        cancel_token,
+        session_id,
+        &StreamTimeoutContext::default(),
+    )
+    .await
+}
+
+pub async fn consume_llm_stream_with_context(
+    stream: LLMStream,
+    event_tx: &mpsc::Sender<AgentEvent>,
+    cancel_token: &CancellationToken,
+    session_id: &str,
+    timeout_context: &StreamTimeoutContext,
+) -> Result<StreamHandlingOutput, AgentError> {
     consume::consume_llm_stream_internal(
         stream,
         Some(event_tx),
         cancel_token,
         session_id,
-        DEFAULT_STREAM_IDLE_TIMEOUT,
+        timeout_context,
     )
     .await
 }
@@ -65,14 +117,23 @@ pub async fn consume_llm_stream_silent(
     cancel_token: &CancellationToken,
     session_id: &str,
 ) -> Result<StreamHandlingOutput, AgentError> {
-    consume::consume_llm_stream_internal(
+    consume_llm_stream_silent_with_context(
         stream,
-        None,
         cancel_token,
         session_id,
-        DEFAULT_STREAM_IDLE_TIMEOUT,
+        &StreamTimeoutContext::default(),
     )
     .await
+}
+
+pub async fn consume_llm_stream_silent_with_context(
+    stream: LLMStream,
+    cancel_token: &CancellationToken,
+    session_id: &str,
+    timeout_context: &StreamTimeoutContext,
+) -> Result<StreamHandlingOutput, AgentError> {
+    consume::consume_llm_stream_internal(stream, None, cancel_token, session_id, timeout_context)
+        .await
 }
 
 #[cfg(test)]

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/chunk_handling.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/chunk_handling.rs
@@ -12,6 +12,7 @@ pub(super) async fn handle_chunk_result(
     session_id: &str,
 ) -> Result<(), AgentError> {
     match chunk_result {
+        Ok(LLMChunk::TransportActivity) => Ok(()),
         Ok(LLMChunk::ResponseId(response_id)) => {
             tracing::debug!(
                 "[{}] Received upstream response_id={}",

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/consume.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/consume.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::time::Duration;
 
 use futures::StreamExt;
@@ -5,11 +6,95 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use bamboo_agent_core::{AgentError, AgentEvent};
-use bamboo_llm::LLMStream;
+use bamboo_llm::{LLMChunk, LLMStream};
 
 use super::chunk_handling::handle_chunk_result;
 use super::stream_state::StreamAccumulationState;
-use super::StreamHandlingOutput;
+use super::{StreamHandlingOutput, StreamTimeoutContext};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamTimeoutPhase {
+    TransportIdle,
+    FirstSemantic,
+    SemanticIdle,
+}
+
+impl fmt::Display for StreamTimeoutPhase {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::TransportIdle => "transport_idle",
+            Self::FirstSemantic => "first_semantic",
+            Self::SemanticIdle => "semantic_idle",
+        })
+    }
+}
+
+struct StreamTimeoutDiagnostic<'a> {
+    phase: StreamTimeoutPhase,
+    deadline: Duration,
+    provider: Option<&'a str>,
+    model: Option<&'a str>,
+    transport_idle: Duration,
+    semantic_idle: Option<Duration>,
+    semantic_output_started: bool,
+}
+
+impl fmt::Display for StreamTimeoutDiagnostic<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let semantic_idle = self
+            .semantic_idle
+            .map(|duration| format!("{}ms", duration.as_millis()))
+            .unwrap_or_else(|| "never".to_string());
+        write!(
+            formatter,
+            "phase={}, deadline_ms={}, provider={}, model={}, last_transport_ms_ago={}, \
+             last_semantic_ms_ago={}, semantic_output_started={}, retry_safe={}",
+            self.phase,
+            self.deadline.as_millis(),
+            self.provider.unwrap_or("unknown"),
+            self.model.unwrap_or("unknown"),
+            self.transport_idle.as_millis(),
+            semantic_idle,
+            self.semantic_output_started,
+            !self.semantic_output_started,
+        )
+    }
+}
+
+fn timeout_duration(seconds: u64) -> Duration {
+    Duration::from_secs(seconds)
+}
+
+fn classify_semantic_progress(chunk: &LLMChunk) -> bool {
+    chunk.is_semantic_progress()
+}
+
+fn timeout_error(
+    timeout_context: &StreamTimeoutContext,
+    session_id: &str,
+    phase: StreamTimeoutPhase,
+    deadline: Duration,
+    now: tokio::time::Instant,
+    last_transport_at: tokio::time::Instant,
+    last_semantic_at: Option<tokio::time::Instant>,
+) -> AgentError {
+    let diagnostic = StreamTimeoutDiagnostic {
+        phase,
+        deadline,
+        provider: timeout_context.provider.as_deref(),
+        model: timeout_context.model.as_deref(),
+        transport_idle: now.saturating_duration_since(last_transport_at),
+        semantic_idle: last_semantic_at
+            .map(|last_semantic| now.saturating_duration_since(last_semantic)),
+        semantic_output_started: last_semantic_at.is_some(),
+    };
+    tracing::warn!(
+        "[{}] LLM stream watchdog expired: {}",
+        session_id,
+        diagnostic,
+    );
+    AgentError::StreamTimeout(diagnostic.to_string())
+}
 
 fn preview_for_log(value: &str, max_chars: usize) -> String {
     let mut iter = value.chars();
@@ -31,30 +116,34 @@ pub(super) async fn consume_llm_stream_internal(
     event_tx: Option<&mpsc::Sender<AgentEvent>>,
     cancel_token: &CancellationToken,
     session_id: &str,
-    // Inter-chunk idle deadline: the maximum gap allowed between two
-    // consecutive stream chunks. The sleep is created fresh every loop
-    // iteration, so this is a true *inter-chunk* deadline that resets on
-    // every received chunk — NOT an overall stream cap. A legitimately long
-    // stream that keeps producing chunks is never killed; only a stall with
-    // no chunk for `idle_timeout` trips it (issue #28).
-    idle_timeout: Duration,
+    timeout_context: &StreamTimeoutContext,
 ) -> Result<StreamHandlingOutput, AgentError> {
     let mut state = StreamAccumulationState::new();
+    let policy = timeout_context.policy;
+    let started_at = tokio::time::Instant::now();
+    let mut last_transport_at = started_at;
+    let mut last_semantic_at = None;
 
     loop {
-        // Select on cancellation, the next chunk, *and* an inter-chunk idle
-        // deadline so a stalled provider connection is bounded.
-        //
-        // `biased` checks branches top-to-bottom: cancellation first (so a
-        // ready-but-cancelled chunk is dropped), then the pending chunk, then
-        // the idle timer. The idle `sleep` is created fresh every iteration, so
-        // it is a true *inter-chunk* deadline that resets on every received
-        // chunk — NOT an overall stream cap. A legitimately long stream that
-        // keeps producing chunks is never killed; only a stall with no chunk
-        // for `idle_timeout` trips it. Without this branch,
-        // `stream.next().await` blocks forever when the provider's connection
-        // hangs mid-stream (issue #28). Listing `stream.next()` ahead of the
-        // timer means a ready chunk always wins over the timer.
+        let transport_timeout = timeout_duration(policy.transport_idle_timeout_secs);
+        let transport_deadline = last_transport_at + transport_timeout;
+        let (semantic_phase, semantic_origin, semantic_timeout) = match last_semantic_at {
+            Some(last_semantic) => (
+                StreamTimeoutPhase::SemanticIdle,
+                last_semantic,
+                timeout_duration(policy.semantic_idle_timeout_secs),
+            ),
+            None => (
+                StreamTimeoutPhase::FirstSemantic,
+                started_at,
+                timeout_duration(policy.first_semantic_timeout_secs),
+            ),
+        };
+        let semantic_deadline = semantic_origin + semantic_timeout;
+        let next_deadline = transport_deadline.min(semantic_deadline);
+
+        // Cancellation wins, then a simultaneously-ready provider frame, then
+        // the earliest independent watchdog deadline.
         let chunk_result = tokio::select! {
             biased;
             _ = cancel_token.cancelled() => return Err(AgentError::Cancelled),
@@ -62,18 +151,46 @@ pub(super) async fn consume_llm_stream_internal(
                 Some(chunk_result) => chunk_result,
                 None => break,
             },
-            _ = tokio::time::sleep(idle_timeout) => {
-                tracing::warn!(
-                    "[{}] LLM stream timed out: no chunk received within {:?}; \
-                     aborting stalled stream",
+            _ = tokio::time::sleep_until(next_deadline) => {
+                let now = tokio::time::Instant::now();
+                let (phase, deadline) = if transport_deadline <= semantic_deadline {
+                    (StreamTimeoutPhase::TransportIdle, transport_timeout)
+                } else {
+                    (semantic_phase, semantic_timeout)
+                };
+                return Err(timeout_error(
+                    timeout_context,
                     session_id,
-                    idle_timeout,
-                );
-                return Err(AgentError::StreamTimeout(format!(
-                    "the model stopped responding (no data received for over {idle_timeout:?})"
-                )));
+                    phase,
+                    deadline,
+                    now,
+                    last_transport_at,
+                    last_semantic_at,
+                ));
             }
         };
+
+        if let Ok(chunk) = &chunk_result {
+            let now = tokio::time::Instant::now();
+            last_transport_at = now;
+            if classify_semantic_progress(chunk) {
+                last_semantic_at = Some(now);
+            } else if now >= semantic_deadline {
+                // A synchronously-ready stream of keepalives must not starve the
+                // semantic timer merely because `stream.next()` is intentionally
+                // ordered before the timer in the biased select. A semantic
+                // chunk ready at the boundary is accepted above and resets it.
+                return Err(timeout_error(
+                    timeout_context,
+                    session_id,
+                    semantic_phase,
+                    semantic_timeout,
+                    now,
+                    last_transport_at,
+                    last_semantic_at,
+                ));
+            }
+        }
 
         handle_chunk_result(chunk_result, &mut state, event_tx, session_id).await?;
     }

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
@@ -7,14 +7,31 @@ use tokio_util::sync::CancellationToken;
 
 use bamboo_agent_core::tools::{FunctionCall, ToolCall};
 use bamboo_agent_core::{AgentError, AgentEvent};
+use bamboo_config::StreamTimeoutConfig;
 use bamboo_llm::provider::LLMError;
 use bamboo_llm::{LLMChunk, LLMStream};
 
 use super::consume::consume_llm_stream_internal;
-use super::{consume_llm_stream, consume_llm_stream_silent};
+use super::{consume_llm_stream, consume_llm_stream_silent, StreamTimeoutContext};
 
 fn build_stream(items: Vec<bamboo_llm::provider::Result<LLMChunk>>) -> LLMStream {
     Box::pin(stream::iter(items))
+}
+
+fn timeout_context(
+    transport_secs: u64,
+    first_semantic_secs: u64,
+    semantic_secs: u64,
+) -> StreamTimeoutContext {
+    StreamTimeoutContext::new(
+        StreamTimeoutConfig {
+            transport_idle_timeout_secs: transport_secs,
+            first_semantic_timeout_secs: first_semantic_secs,
+            semantic_idle_timeout_secs: semantic_secs,
+        },
+        Some("test-provider"),
+        Some("test-model"),
+    )
 }
 
 #[tokio::test]
@@ -195,95 +212,184 @@ async fn consume_llm_stream_interrupts_blocked_next_on_mid_stream_cancel() {
     assert!(matches!(result, Err(AgentError::Cancelled)));
 }
 
-#[tokio::test]
-async fn consume_llm_stream_times_out_when_stream_stalls_after_first_chunk() {
-    // Issue #28: a stream that yields one chunk, then never yields again and
-    // never closes, models a provider connection that stalls mid-stream. The
-    // inter-chunk idle deadline must trip and return a StreamTimeout error
-    // instead of hanging forever.
+#[tokio::test(start_paused = true)]
+async fn truly_silent_transport_times_out_with_actionable_diagnostic() {
+    let stream: LLMStream = Box::pin(stream::pending());
+    let context = timeout_context(2, 20, 20);
+
+    let result = consume_llm_stream_internal(
+        stream,
+        None,
+        &CancellationToken::new(),
+        "session-transport-timeout",
+        &context,
+    )
+    .await;
+
+    let message = match result {
+        Err(AgentError::StreamTimeout(message)) => message,
+        Err(other) => panic!("expected transport StreamTimeout, got {other:?}"),
+        Ok(_) => panic!("expected transport StreamTimeout, got success"),
+    };
+    assert!(message.contains("phase=transport_idle"));
+    assert!(message.contains("deadline_ms=2000"));
+    assert!(message.contains("provider=test-provider"));
+    assert!(message.contains("model=test-model"));
+    assert!(message.contains("last_transport_ms_ago=2000"));
+    assert!(message.contains("last_semantic_ms_ago=never"));
+    assert!(message.contains("semantic_output_started=false"));
+    assert!(message.contains("retry_safe=true"));
+    assert!(!message.contains("prompt"));
+}
+
+#[tokio::test(start_paused = true)]
+async fn stream_stall_after_semantic_output_is_not_retry_safe() {
     let stream: LLMStream = Box::pin(
         stream::once(async { Ok::<_, LLMError>(LLMChunk::Token("first".to_string())) })
             .chain(stream::pending()),
     );
+    let context = timeout_context(2, 20, 20);
 
-    let idle_timeout = Duration::from_millis(80);
-    let started = std::time::Instant::now();
-
-    let result = tokio::time::timeout(
-        // Generous outer bound; the idle timeout must trip well before this.
-        Duration::from_secs(2),
-        consume_llm_stream_internal(
-            stream,
-            None,
-            &CancellationToken::new(),
-            "session-timeout",
-            idle_timeout,
-        ),
+    let result = consume_llm_stream_internal(
+        stream,
+        None,
+        &CancellationToken::new(),
+        "session-timeout",
+        &context,
     )
-    .await
-    .expect("idle timeout must interrupt the stalled stream, not hang");
+    .await;
 
-    let elapsed = started.elapsed();
-    match result {
-        Err(AgentError::StreamTimeout(_)) => {}
-        Err(other) => panic!("expected AgentError::StreamTimeout, got Err({other:?})"),
-        Ok(_) => panic!("expected AgentError::StreamTimeout, got Ok(_)"),
-    }
-
-    // The first chunk arrives immediately, so the idle timer effectively starts
-    // after it. The timeout should fire ~80ms later. A mild lower bound guards
-    // against an "instant timeout" regression; the upper bound guards against
-    // the timeout being ignored.
-    assert!(
-        elapsed >= Duration::from_millis(50),
-        "timeout fired too early ({elapsed:?}): the first chunk should reset the idle timer"
-    );
-    assert!(
-        elapsed < Duration::from_millis(800),
-        "timeout fired too late ({elapsed:?}): the stalled stream was not interrupted in time"
-    );
+    let message = match result {
+        Err(AgentError::StreamTimeout(message)) => message,
+        Err(other) => panic!("expected transport StreamTimeout, got {other:?}"),
+        Ok(_) => panic!("expected transport StreamTimeout, got success"),
+    };
+    assert!(message.contains("phase=transport_idle"));
+    assert!(message.contains("semantic_output_started=true"));
+    assert!(message.contains("retry_safe=false"));
 }
 
-#[tokio::test]
-async fn consume_llm_stream_idle_timeout_does_not_affect_healthy_stream() {
-    // Issue #28: each chunk arrives well within the idle window (25ms << 80ms),
-    // but the *total* stream duration (~150ms) far exceeds the idle timeout.
-    // Because the deadline resets on every received chunk, a legitimately long
-    // stream that keeps producing data must complete normally — the idle
-    // timeout only fires on a true stall (no chunk at all).
-    let idle_timeout = Duration::from_millis(80);
-    let per_chunk_delay = Duration::from_millis(25);
-    let chunk_count: u32 = 6;
-
-    let stream: LLMStream = Box::pin(stream::unfold(0u32, move |i| async move {
-        if i >= chunk_count {
-            return None;
+#[tokio::test(start_paused = true)]
+async fn transport_keepalives_allow_first_semantic_output_after_120_seconds() {
+    let stream: LLMStream = Box::pin(stream::unfold(0u8, |step| async move {
+        match step {
+            0..=4 => {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                Some((Ok::<_, LLMError>(LLMChunk::TransportActivity), step + 1))
+            }
+            5 => {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                Some((Ok::<_, LLMError>(LLMChunk::Token("late".to_string())), 6))
+            }
+            6 => Some((Ok::<_, LLMError>(LLMChunk::Done), 7)),
+            _ => None,
         }
-        tokio::time::sleep(per_chunk_delay).await;
-        Some((
-            Ok::<_, LLMError>(LLMChunk::Token(format!("chunk-{i}"))),
-            i + 1,
-        ))
     }));
+    let context = timeout_context(60, 240, 60);
 
-    let output = tokio::time::timeout(
-        Duration::from_secs(3),
-        consume_llm_stream_internal(
-            stream,
-            None,
-            &CancellationToken::new(),
-            "session-healthy",
-            idle_timeout,
-        ),
+    let output = consume_llm_stream_internal(
+        stream,
+        None,
+        &CancellationToken::new(),
+        "session-keepalive",
+        &context,
     )
     .await
-    .expect("healthy stream must complete without timing out")
     .expect("stream should succeed");
 
-    assert_eq!(output.content, "chunk-0chunk-1chunk-2chunk-3chunk-4chunk-5");
-    // `token_count` is the total character count of the stream, not the chunk
-    // count: 6 chunks × 7 chars ("chunk-N") = 42.
-    assert_eq!(output.token_count, output.content.chars().count());
+    assert_eq!(output.content, "late");
+}
+
+#[tokio::test(start_paused = true)]
+async fn transport_keepalives_allow_midstream_semantic_gap_after_120_seconds() {
+    let stream: LLMStream = Box::pin(
+        stream::once(async { Ok::<_, LLMError>(LLMChunk::Token("first".to_string())) }).chain(
+            stream::unfold(0u8, |step| async move {
+                match step {
+                    0..=4 => {
+                        tokio::time::sleep(Duration::from_secs(30)).await;
+                        Some((Ok::<_, LLMError>(LLMChunk::TransportActivity), step + 1))
+                    }
+                    5 => {
+                        tokio::time::sleep(Duration::from_secs(30)).await;
+                        Some((Ok::<_, LLMError>(LLMChunk::Token("second".to_string())), 6))
+                    }
+                    6 => Some((Ok::<_, LLMError>(LLMChunk::Done), 7)),
+                    _ => None,
+                }
+            }),
+        ),
+    );
+    let context = timeout_context(60, 240, 240);
+
+    let output = consume_llm_stream_internal(
+        stream,
+        None,
+        &CancellationToken::new(),
+        "session-midstream-keepalive",
+        &context,
+    )
+    .await
+    .expect("live stream should survive a 180-second semantic gap");
+
+    assert_eq!(output.content, "firstsecond");
+}
+
+#[tokio::test(start_paused = true)]
+async fn keepalives_do_not_make_first_semantic_deadline_unbounded() {
+    let stream: LLMStream = Box::pin(stream::unfold((), |_| async {
+        tokio::time::sleep(Duration::from_secs(20)).await;
+        Some((Ok::<_, LLMError>(LLMChunk::TransportActivity), ()))
+    }));
+    let context = timeout_context(60, 120, 120);
+
+    let result = consume_llm_stream_internal(
+        stream,
+        None,
+        &CancellationToken::new(),
+        "session-first-semantic",
+        &context,
+    )
+    .await;
+
+    let message = match result {
+        Err(AgentError::StreamTimeout(message)) => message,
+        Err(other) => panic!("expected first-semantic StreamTimeout, got {other:?}"),
+        Ok(_) => panic!("expected first-semantic StreamTimeout, got success"),
+    };
+    assert!(message.contains("phase=first_semantic"));
+    assert!(message.contains("semantic_output_started=false"));
+}
+
+#[tokio::test(start_paused = true)]
+async fn keepalives_do_not_hide_midstream_semantic_stall() {
+    let stream: LLMStream = Box::pin(
+        stream::once(async { Ok::<_, LLMError>(LLMChunk::Token("first".to_string())) }).chain(
+            stream::unfold((), |_| async {
+                tokio::time::sleep(Duration::from_secs(20)).await;
+                Some((Ok::<_, LLMError>(LLMChunk::TransportActivity), ()))
+            }),
+        ),
+    );
+    let context = timeout_context(60, 120, 90);
+
+    let result = consume_llm_stream_internal(
+        stream,
+        None,
+        &CancellationToken::new(),
+        "session-semantic-stall",
+        &context,
+    )
+    .await;
+
+    let message = match result {
+        Err(AgentError::StreamTimeout(message)) => message,
+        Err(other) => panic!("expected semantic-idle StreamTimeout, got {other:?}"),
+        Ok(_) => panic!("expected semantic-idle StreamTimeout, got success"),
+    };
+    assert!(message.contains("phase=semantic_idle"));
+    assert!(message.contains("semantic_output_started=true"));
+    assert!(message.contains("retry_safe=false"));
 }
 
 #[tokio::test]

--- a/crates/engine/bamboo-engine/src/runtime/task_evaluation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/task_evaluation.rs
@@ -34,7 +34,7 @@ pub struct TaskItemUpdate {
     pub criteria_met: Option<Vec<String>>,
 }
 
-pub use executor::evaluate_task_progress;
+pub use executor::{evaluate_task_progress, TaskEvaluationFrame};
 pub use message_builder::build_task_evaluation_messages;
 pub use schema::get_task_evaluation_tools;
 

--- a/crates/engine/bamboo-engine/src/runtime/task_evaluation/executor.rs
+++ b/crates/engine/bamboo-engine/src/runtime/task_evaluation/executor.rs
@@ -15,6 +15,14 @@ use super::TaskEvaluationResult;
 
 mod outcomes;
 
+pub struct TaskEvaluationFrame<'a> {
+    pub event_tx: &'a mpsc::Sender<AgentEvent>,
+    pub session_id: &'a str,
+    pub model: &'a str,
+    pub reasoning_effort: Option<ReasoningEffort>,
+    pub timeout_context: &'a crate::runtime::stream::handler::StreamTimeoutContext,
+}
+
 fn skipped_evaluation(reasoning: &str) -> TaskEvaluationResult {
     TaskEvaluationResult {
         needs_evaluation: false,
@@ -39,12 +47,15 @@ pub async fn evaluate_task_progress(
     ctx: &TaskLoopContext,
     session: &Session,
     llm: Arc<dyn LLMProvider>,
-    event_tx: &mpsc::Sender<AgentEvent>,
-    session_id: &str,
-    model: &str,
-    reasoning_effort: Option<ReasoningEffort>,
+    frame: &TaskEvaluationFrame<'_>,
 ) -> Result<TaskEvaluationResult, AgentError> {
-    use crate::runtime::stream::handler::consume_llm_stream_silent;
+    use crate::runtime::stream::handler::consume_llm_stream_silent_with_context;
+
+    let event_tx = frame.event_tx;
+    let session_id = frame.session_id;
+    let model = frame.model;
+    let reasoning_effort = frame.reasoning_effort;
+    let timeout_context = frame.timeout_context;
 
     let in_progress_count = ctx
         .items
@@ -103,13 +114,13 @@ pub async fn evaluate_task_progress(
         .await
     {
         Ok(stream) => {
-            let stream_output = consume_llm_stream_silent(
+            let stream_output = consume_llm_stream_silent_with_context(
                 stream,
                 &tokio_util::sync::CancellationToken::new(),
                 session_id,
+                timeout_context,
             )
-            .await
-            .map_err(|error| AgentError::LLM(error.to_string()))?;
+            .await?;
 
             Ok(outcomes::build_success_result(
                 stream_output,

--- a/crates/engine/bamboo-engine/src/runtime/task_evaluation/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/task_evaluation/tests.rs
@@ -146,15 +146,19 @@ async fn task_evaluation_uses_explicit_model_parameter_for_provider_request() {
     let provider = Arc::new(RecordingFailingProvider::default());
     let llm: Arc<dyn LLMProvider> = provider.clone();
     let (event_tx, _event_rx) = mpsc::channel::<AgentEvent>(4);
+    let timeout_context = crate::runtime::stream::handler::StreamTimeoutContext::default();
 
     let result = evaluate_task_progress(
         &context,
         &session,
         llm,
-        &event_tx,
-        "test-session",
-        "evaluation-model",
-        None,
+        &super::TaskEvaluationFrame {
+            event_tx: &event_tx,
+            session_id: "test-session",
+            model: "evaluation-model",
+            reasoning_effort: None,
+            timeout_context: &timeout_context,
+        },
     )
     .await
     .expect("evaluation should gracefully handle provider failure");
@@ -227,15 +231,19 @@ async fn task_evaluation_caps_reasoning_effort_to_high_for_lightweight_request()
     let provider = Arc::new(RecordingRequestOptionsProvider::default());
     let llm: Arc<dyn LLMProvider> = provider.clone();
     let (event_tx, _event_rx) = mpsc::channel::<AgentEvent>(4);
+    let timeout_context = crate::runtime::stream::handler::StreamTimeoutContext::default();
 
     let _ = evaluate_task_progress(
         &context,
         &session,
         llm,
-        &event_tx,
-        "test-session",
-        "gpt-5-mini",
-        Some(ReasoningEffort::Xhigh),
+        &super::TaskEvaluationFrame {
+            event_tx: &event_tx,
+            session_id: "test-session",
+            model: "gpt-5-mini",
+            reasoning_effort: Some(ReasoningEffort::Xhigh),
+            timeout_context: &timeout_context,
+        },
     )
     .await
     .expect("evaluation request should succeed");
@@ -253,15 +261,19 @@ async fn task_evaluation_sufficient_max_tokens_for_high_reasoning() {
     let provider = Arc::new(RecordingRequestOptionsProvider::default());
     let llm: Arc<dyn LLMProvider> = provider.clone();
     let (event_tx, _event_rx) = mpsc::channel::<AgentEvent>(4);
+    let timeout_context = crate::runtime::stream::handler::StreamTimeoutContext::default();
 
     let _ = evaluate_task_progress(
         &context,
         &session,
         llm,
-        &event_tx,
-        "test-session",
-        "gpt-5-mini",
-        Some(ReasoningEffort::High),
+        &super::TaskEvaluationFrame {
+            event_tx: &event_tx,
+            session_id: "test-session",
+            model: "gpt-5-mini",
+            reasoning_effort: Some(ReasoningEffort::High),
+            timeout_context: &timeout_context,
+        },
     )
     .await
     .expect("evaluation request should succeed");

--- a/crates/engine/bamboo-engine/src/title_gen/mod.rs
+++ b/crates/engine/bamboo-engine/src/title_gen/mod.rs
@@ -251,6 +251,11 @@ async fn try_llm_title(
     let messages: Vec<Message> = build_title_messages(first_user_text);
     let model_name = resolved.model_name.clone();
     let provider = resolved.provider;
+    let timeout_context = crate::runtime::stream::handler::StreamTimeoutContext::new(
+        config_snapshot.stream_timeout,
+        Some(&provider_name),
+        Some(&model_name),
+    );
 
     let fut = async move {
         let options = bamboo_llm::provider::LLMRequestOptions {
@@ -261,10 +266,11 @@ async fn try_llm_title(
             .chat_stream_with_options(&messages, &[], Some(64), &model_name, Some(&options))
             .await
             .map_err(|e| format!("chat_stream: {e}"))?;
-        let output = crate::runtime::stream::handler::consume_llm_stream_silent(
+        let output = crate::runtime::stream::handler::consume_llm_stream_silent_with_context(
             stream,
             &CancellationToken::new(),
             "title-gen",
+            &timeout_context,
         )
         .await
         .map_err(|e| format!("consume_llm_stream_silent: {e}"))?;

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -70,6 +70,113 @@ use crate::model_mapping::{AnthropicModelMapping, GeminiModelMapping};
 use bamboo_domain::tool_names::normalize_tool_ref;
 use bamboo_domain::ReasoningEffort;
 
+/// Minimum accepted watchdog deadline. Zero would turn scheduling jitter into
+/// an immediate stream failure, so it is rejected at the configuration boundary.
+pub const MIN_STREAM_TIMEOUT_SECS: u64 = 1;
+/// Maximum accepted watchdog deadline. This keeps a typo from disabling hung
+/// stream detection for days while still allowing operators to accommodate
+/// exceptionally slow reasoning models.
+pub const MAX_STREAM_TIMEOUT_SECS: u64 = 86_400;
+
+fn default_transport_idle_timeout_secs() -> u64 {
+    120
+}
+
+fn default_first_semantic_timeout_secs() -> u64 {
+    600
+}
+
+fn default_semantic_idle_timeout_secs() -> u64 {
+    600
+}
+
+fn deserialize_stream_timeout_secs<'de, D>(deserializer: D) -> std::result::Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error as _;
+
+    let value = u64::deserialize(deserializer)?;
+    if (MIN_STREAM_TIMEOUT_SECS..=MAX_STREAM_TIMEOUT_SECS).contains(&value) {
+        Ok(value)
+    } else {
+        Err(D::Error::custom(format!(
+            "stream timeout must be between {MIN_STREAM_TIMEOUT_SECS} and \
+             {MAX_STREAM_TIMEOUT_SECS} seconds, got {value}"
+        )))
+    }
+}
+
+/// LLM stream watchdog policy shared by the main response path and auxiliary
+/// silent consumers.
+///
+/// Transport and semantic progress are deliberately separate. Valid SSE
+/// lifecycle/keepalive frames refresh `transport_idle_timeout_secs` without
+/// hiding a model that never produces semantic output. The first semantic
+/// deadline starts at request dispatch; after the first token/reasoning/tool
+/// delta, `semantic_idle_timeout_secs` becomes the semantic deadline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct StreamTimeoutConfig {
+    /// Maximum gap between valid transport frames, including SSE keepalives.
+    #[serde(
+        default = "default_transport_idle_timeout_secs",
+        deserialize_with = "deserialize_stream_timeout_secs"
+    )]
+    pub transport_idle_timeout_secs: u64,
+    /// Maximum time from request dispatch to the first semantic chunk.
+    #[serde(
+        default = "default_first_semantic_timeout_secs",
+        deserialize_with = "deserialize_stream_timeout_secs"
+    )]
+    pub first_semantic_timeout_secs: u64,
+    /// Maximum gap between semantic chunks after semantic output has started.
+    #[serde(
+        default = "default_semantic_idle_timeout_secs",
+        deserialize_with = "deserialize_stream_timeout_secs"
+    )]
+    pub semantic_idle_timeout_secs: u64,
+}
+
+impl Default for StreamTimeoutConfig {
+    fn default() -> Self {
+        Self {
+            transport_idle_timeout_secs: default_transport_idle_timeout_secs(),
+            first_semantic_timeout_secs: default_first_semantic_timeout_secs(),
+            semantic_idle_timeout_secs: default_semantic_idle_timeout_secs(),
+        }
+    }
+}
+
+impl StreamTimeoutConfig {
+    /// Validate values created programmatically (serde performs the same check
+    /// while loading `config.json`).
+    pub fn validate(&self) -> std::result::Result<(), String> {
+        for (name, value) in [
+            (
+                "transport_idle_timeout_secs",
+                self.transport_idle_timeout_secs,
+            ),
+            (
+                "first_semantic_timeout_secs",
+                self.first_semantic_timeout_secs,
+            ),
+            (
+                "semantic_idle_timeout_secs",
+                self.semantic_idle_timeout_secs,
+            ),
+        ] {
+            if !(MIN_STREAM_TIMEOUT_SECS..=MAX_STREAM_TIMEOUT_SECS).contains(&value) {
+                return Err(format!(
+                    "{name} must be between {MIN_STREAM_TIMEOUT_SECS} and \
+                     {MAX_STREAM_TIMEOUT_SECS} seconds, got {value}"
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
 /// A user-managed environment variable that is injected into Bash tool processes.
 ///
 /// Secret entries are encrypted at rest: `value` is empty on disk and populated
@@ -1257,6 +1364,10 @@ pub struct ConfigValues {
     #[serde(default)]
     pub run_budget: RunBudgetConfig,
 
+    /// LLM stream liveness and semantic-progress watchdog policy.
+    #[serde(default)]
+    pub stream_timeout: StreamTimeoutConfig,
+
     /// Remote Cluster Fabric: operator-managed nodes & clusters for deploying
     /// `broker-agent` workers locally or over SSH. Additive/back-compat: absent
     /// ⇒ empty. SSH secrets are encrypted at rest (see [`crate::cluster_fabric`]).
@@ -1312,6 +1423,7 @@ impl Default for ConfigValues {
             proxy_auth_encrypted: None,
             headless_auth: false,
             run_budget: RunBudgetConfig::default(),
+            stream_timeout: StreamTimeoutConfig::default(),
             cluster_fabric: crate::cluster_fabric::ClusterFabricConfig::default(),
             provider: default_provider(),
             provider_instances: HashMap::new(),
@@ -1416,6 +1528,8 @@ struct ExecutionConfigSection {
     features: FeatureFlags,
     #[serde(default)]
     run_budget: RunBudgetConfig,
+    #[serde(default)]
+    stream_timeout: StreamTimeoutConfig,
     #[serde(
         default,
         skip_serializing_if = "crate::cluster_fabric::ClusterFabricConfig::is_empty"
@@ -1525,6 +1639,7 @@ impl From<ConfigValues> for ConfigRoot {
             access_control,
             features,
             run_budget,
+            stream_timeout,
             cluster_fabric,
             mcp,
             notifications,
@@ -1563,6 +1678,7 @@ impl From<ConfigValues> for ConfigRoot {
             execution: ExecutionConfigSection {
                 features,
                 run_budget,
+                stream_timeout,
                 cluster_fabric,
             },
             integrations: IntegrationConfigSection {
@@ -1619,6 +1735,7 @@ impl From<ConfigRoot> for ConfigValues {
         let ExecutionConfigSection {
             features,
             run_budget,
+            stream_timeout,
             cluster_fabric,
         } = execution;
         let IntegrationConfigSection {
@@ -1649,6 +1766,7 @@ impl From<ConfigRoot> for ConfigValues {
             access_control,
             features,
             run_budget,
+            stream_timeout,
             cluster_fabric,
             mcp,
             notifications,
@@ -3521,6 +3639,7 @@ impl Config {
                 proxy_auth_encrypted: None,
                 headless_auth: false,
                 run_budget: RunBudgetConfig::default(),
+                stream_timeout: StreamTimeoutConfig::default(),
                 cluster_fabric: crate::cluster_fabric::ClusterFabricConfig::default(),
                 provider: default_provider(),
                 provider_instances: HashMap::new(),
@@ -4124,6 +4243,68 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Mutex;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn stream_timeout_defaults_are_safe_and_back_compatible() {
+        let root: ConfigRoot = serde_json::from_value(serde_json::json!({}))
+            .expect("legacy config without stream_timeout should load");
+        let values = ConfigValues::from(root);
+
+        assert_eq!(
+            values.stream_timeout,
+            StreamTimeoutConfig {
+                transport_idle_timeout_secs: 120,
+                first_semantic_timeout_secs: 600,
+                semantic_idle_timeout_secs: 600,
+            }
+        );
+        values
+            .stream_timeout
+            .validate()
+            .expect("defaults are valid");
+    }
+
+    #[test]
+    fn stream_timeout_round_trips_through_persistence_dto() {
+        let values = ConfigValues {
+            stream_timeout: StreamTimeoutConfig {
+                transport_idle_timeout_secs: 45,
+                first_semantic_timeout_secs: 900,
+                semantic_idle_timeout_secs: 300,
+            },
+            ..ConfigValues::default()
+        };
+
+        let json = serde_json::to_value(ConfigRoot::from(values)).expect("serialize config root");
+        assert_eq!(json["stream_timeout"]["transport_idle_timeout_secs"], 45);
+        assert_eq!(json["stream_timeout"]["first_semantic_timeout_secs"], 900);
+        assert_eq!(json["stream_timeout"]["semantic_idle_timeout_secs"], 300);
+
+        let root: ConfigRoot = serde_json::from_value(json).expect("deserialize config root");
+        assert_eq!(
+            ConfigValues::from(root).stream_timeout,
+            StreamTimeoutConfig {
+                transport_idle_timeout_secs: 45,
+                first_semantic_timeout_secs: 900,
+                semantic_idle_timeout_secs: 300,
+            }
+        );
+    }
+
+    #[test]
+    fn stream_timeout_rejects_zero_and_unbounded_values() {
+        for (field, invalid) in [
+            ("transport_idle_timeout_secs", 0),
+            ("first_semantic_timeout_secs", MAX_STREAM_TIMEOUT_SECS + 1),
+            ("semantic_idle_timeout_secs", 0),
+        ] {
+            let mut timeout = serde_json::json!({});
+            timeout[field] = serde_json::json!(invalid);
+            let error = serde_json::from_value::<StreamTimeoutConfig>(timeout)
+                .expect_err("invalid timeout must be rejected");
+            assert!(error.to_string().contains("stream timeout must be between"));
+        }
+    }
 
     struct EnvVarGuard {
         key: &'static str,

--- a/crates/infra/bamboo-llm/src/providers/common/sse.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/sse.rs
@@ -38,7 +38,8 @@ fn to_stream_error(err: LLMError) -> LLMError {
 ///
 /// `handler` receives the SSE event name and data payload for each event, and can either:
 /// - return `Ok(Some(chunk))` to emit a chunk
-/// - return `Ok(None)` to skip an event
+/// - return `Ok(None)` when an event has no semantic chunk; the adapter emits
+///   an internal [`LLMChunk::TransportActivity`] marker so liveness is retained
 /// - return `Err(_)` to emit a stream error (mapped to `LLMError::Stream`)
 ///
 /// This is the common case where each SSE event yields at most one chunk.
@@ -55,7 +56,9 @@ where
 }
 
 /// Like [`llm_stream_from_sse`], but the handler may emit **zero or more**
-/// chunks per SSE event; they are flattened into the stream in order.
+/// chunks per SSE event; they are flattened into the stream in order. A valid
+/// event producing zero chunks becomes one [`LLMChunk::TransportActivity`]
+/// marker rather than disappearing from the transport watchdog.
 ///
 /// This is required for providers where a single SSE event must surface
 /// multiple logical chunks. The motivating case is Gemini: a final
@@ -78,6 +81,7 @@ where
         })
         .flat_map(|result| {
             stream::iter(match result {
+                Ok(chunks) if chunks.is_empty() => vec![Ok(LLMChunk::TransportActivity)],
                 Ok(chunks) => chunks.into_iter().map(Ok).collect::<Vec<_>>(),
                 Err(err) => vec![Err(err)],
             })
@@ -89,6 +93,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::providers::anthropic::{parse_anthropic_sse_event, AnthropicStreamState};
+    use crate::providers::common::openai_responses::ResponsesSseParser;
     use futures::StreamExt;
     use serde_json::json;
     // use http; // TODO: add http crate if needed
@@ -113,7 +119,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn llm_stream_from_sse_filters_none_and_passes_event_name_and_data() {
+    async fn llm_stream_from_sse_preserves_filtered_event_as_transport_activity() {
         let sse_body = concat!(
             "event: token\n",
             "data: hello\n",
@@ -143,11 +149,58 @@ mod tests {
             out.push(item.expect("chunk"));
         }
 
-        assert_eq!(out.len(), 1);
+        assert_eq!(out.len(), 2);
         match &out[0] {
             LLMChunk::Token(token) => assert_eq!(token, "token:hello"),
             other => panic!("expected LLMChunk::Token, got {other:?}"),
         }
+        assert!(matches!(out[1], LLMChunk::TransportActivity));
+    }
+
+    #[tokio::test]
+    async fn anthropic_ping_is_preserved_as_transport_activity() {
+        let response = reqwest::Response::from(
+            http::Response::builder()
+                .status(200)
+                .header("content-type", "text/event-stream")
+                .body("event: ping\ndata: {\"type\":\"ping\"}\n\n".to_string())
+                .expect("http response"),
+        );
+        let mut state = AnthropicStreamState::default();
+        let mut stream = llm_stream_from_sse(response, move |event, data| {
+            parse_anthropic_sse_event(&mut state, event, data)
+        });
+
+        let chunk = stream
+            .next()
+            .await
+            .expect("ping should yield a liveness marker")
+            .expect("ping should not fail the stream");
+        assert!(matches!(chunk, LLMChunk::TransportActivity));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn openai_responses_keepalive_is_preserved_as_transport_activity() {
+        let response = reqwest::Response::from(
+            http::Response::builder()
+                .status(200)
+                .header("content-type", "text/event-stream")
+                .body("event: ping\ndata: keep-alive\n\n".to_string())
+                .expect("http response"),
+        );
+        let mut parser = ResponsesSseParser::new();
+        let mut stream = llm_stream_from_sse(response, move |event, data| {
+            parser.handle_event(event, data)
+        });
+
+        let chunk = stream
+            .next()
+            .await
+            .expect("keepalive should yield a liveness marker")
+            .expect("keepalive should not fail the stream");
+        assert!(matches!(chunk, LLMChunk::TransportActivity));
+        assert!(stream.next().await.is_none());
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-llm/src/types.rs
+++ b/crates/infra/bamboo-llm/src/types.rs
@@ -2,6 +2,13 @@ use bamboo_domain::ToolCall;
 
 #[derive(Debug, Clone)]
 pub enum LLMChunk {
+    /// A valid provider transport frame that intentionally carried no semantic
+    /// model output (for example an SSE ping or lifecycle event).
+    ///
+    /// Consumers must not expose or persist this marker. It exists so stream
+    /// watchdogs can distinguish a live connection from a silent socket even
+    /// when provider parsers filter the frame's payload (#618).
+    TransportActivity,
     ResponseId(String),
     Token(String),
     ReasoningToken(String),
@@ -44,6 +51,25 @@ pub enum LLMChunk {
     Done,
 }
 
+impl LLMChunk {
+    /// Whether this chunk advances model-authored content or tool state.
+    /// Protocol metadata, usage, completion, and transport-only markers are
+    /// deliberately excluded from semantic-progress deadlines.
+    pub fn is_semantic_progress(&self) -> bool {
+        match self {
+            Self::Token(value) | Self::ReasoningToken(value) => !value.is_empty(),
+            Self::ToolCalls(calls) => !calls.is_empty(),
+            Self::ToolCallsIndexed(calls) => !calls.is_empty(),
+            Self::TransportActivity
+            | Self::ResponseId(_)
+            | Self::ReasoningSignature(_)
+            | Self::CacheUsage { .. }
+            | Self::UsageSummary { .. }
+            | Self::Done => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -55,6 +81,13 @@ mod tests {
             LLMChunk::Token(s) => assert_eq!(s, "Hello"),
             _ => panic!("Expected Token variant"),
         }
+    }
+
+    #[test]
+    fn transport_activity_is_not_semantic_progress() {
+        assert!(!LLMChunk::TransportActivity.is_semantic_progress());
+        assert!(!LLMChunk::ResponseId("resp_123".to_string()).is_semantic_progress());
+        assert!(LLMChunk::ReasoningToken("thinking".to_string()).is_semantic_progress());
     }
 
     #[test]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -26,6 +26,7 @@ wins; please file an issue.
 - [Providers](#providers)
 - [Server](#server)
 - [Tools, skills, hooks](#tools-skills-hooks)
+- [LLM stream timeouts](#llm-stream-timeouts)
 - [Memory / auto-dream / gardener](#memory--auto-dream--gardener)
 - [Sub-agents + the `claude_code` executor](#sub-agents--the-claude_code-executor)
 - [MCP servers](#mcp-servers)
@@ -74,6 +75,7 @@ default. The full field list of `Config`:
 | `default_work_area` | `Option<DefaultWorkAreaConfig>` | `{ path: Option<String> }` — default workspace when a session has none set. |
 | `access_control` | `Option<AccessControlConfig>` | Password gate for the HTTP API/UI (`password_enabled`, hashed+salted). |
 | `features` | `FeatureFlags` | `{ provider_model_ref: bool, dynamic_model_routing: bool }` — incremental rollout toggles, both off by default. |
+| `stream_timeout` | `StreamTimeoutConfig` | Independent transport, first-semantic, and midstream-semantic watchdog deadlines. See below. |
 | `memory` | `Option<MemoryConfig>` | Memory/auto-dream/gardener settings. See below. |
 | `subagents` | `SubagentsConfig` | Sub-agent execution + the `claude_code` executor. See below. |
 | `cluster_fabric` | `ClusterFabricConfig` | Operator-managed remote nodes for deploying `broker-agent` workers over SSH; empty by default. SSH secrets encrypted at rest. |
@@ -153,6 +155,35 @@ TLS termination — no ACME/auto-cert). All overridable per-invocation with
 - `hooks.image_fallback` — how image parts are handled when the effective
   model/path is text-only (drop, OCR-replace, etc. — see
   `ImageFallbackHookConfig`).
+
+## LLM stream timeouts
+
+```json
+{
+  "stream_timeout": {
+    "transport_idle_timeout_secs": 120,
+    "first_semantic_timeout_secs": 600,
+    "semantic_idle_timeout_secs": 600
+  }
+}
+```
+
+The three watchdogs measure different signals and apply identically to the
+main response stream and auxiliary silent model calls:
+
+| Field | Default | Meaning |
+|---|---:|---|
+| `transport_idle_timeout_secs` | `120` | Maximum gap between valid provider transport frames. Parsed SSE ping/lifecycle frames count even when they contain no token. |
+| `first_semantic_timeout_secs` | `600` | Maximum time from request dispatch to the first text, reasoning, or tool-call delta. Transport keepalives do not extend it. |
+| `semantic_idle_timeout_secs` | `600` | Maximum semantic-progress gap after output starts. Transport keepalives do not extend it. |
+
+Every value must be between `1` and `86400` seconds. Invalid persisted values
+are rejected by config loading; invalid values constructed by an embedding are
+replaced with the safe defaults. Timeout errors report the expired phase,
+deadline, provider/model identifiers, and last transport/semantic activity,
+but never include prompts or raw provider payloads. A stream timeout is not
+automatically retried, because replay after partial output or tool-call deltas
+could duplicate externally visible state.
 
 ## Memory / auto-dream / gardener
 


### PR DESCRIPTION
## Summary

- separate LLM transport liveness from first-token and midstream semantic progress watchdogs
- preserve filtered SSE ping/lifecycle events as internal transport activity without exposing or persisting them
- add a validated, documented `stream_timeout` configuration shared by main and silent stream consumers
- emit sanitized phase/provider/model/activity diagnostics and keep stream timeouts non-retryable after partial state
- cover delayed first output, delayed midstream output, true transport stalls, semantic stalls, cancellation, and real Anthropic/OpenAI keepalives

## Root cause

The old 120-second watchdog reset only when a parsed `LLMChunk` reached the engine. The common SSE adapter flattened provider events that intentionally produced no semantic chunk, including Anthropic pings and OpenAI-compatible lifecycle/keepalive frames. A live transport could therefore look silent and be terminated during long reasoning.

## User impact

Healthy streams with valid transport activity can now reason for more than 120 seconds without false transport timeouts, while truly silent sockets remain bounded. Operators can configure independent transport, first-semantic, and semantic-idle deadlines. Timeout messages report accurate sanitized diagnostics and never include prompts or raw provider payloads.

## Test Plan

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --all-targets`
- `cargo clippy -p bamboo-config -p bamboo-llm -p bamboo-engine -p bamboo-server --all-targets` (passes; existing repository warnings remain)
- `cargo test -p bamboo-engine runtime::stream::handler::tests -- --nocapture` (14 passed)
- `cargo test -p bamboo-engine runtime::managers::adapters::llm_mini_loop::tests -- --nocapture` (2 passed)
- `cargo test -p bamboo-config stream_timeout -- --nocapture` (3 passed)
- `cargo test -p bamboo-llm providers::common::sse::tests -- --nocapture` (5 passed)
- `cargo test -p bamboo-engine runtime::task_evaluation::tests -- --nocapture` (6 passed)
- affected-package run reached 1,442 passing `bamboo-server` tests; its sole macOS TLS failure, `UnsupportedCertVersion`, was reproduced unchanged in an isolated clean `origin/main@befb0a7f` worktree
- workspace run's unrelated config path global-state race passed on immediate isolated rerun

Closes #618
