### PR TITLE
fix: require model-issued explicit workflow activation

### DIFF
--- a/builtin_skills/evals/issue-620-model-issued-dogfood.json
+++ b/builtin_skills/evals/issue-620-model-issued-dogfood.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "issue": "bigduu/Bamboo-agent#620",
+  "recorded_at": "2026-07-21",
+  "environment": {
+    "client": "Lotus origin/main via Vite",
+    "server": "Bamboo bamboo/fix/620-model-issued-activation built from source",
+    "provider": "Gemini/gemini-3.1-flash-lite",
+    "transport_observer": "transparent local proxy logging request and SSE structure only",
+    "data": "isolated temporary Bamboo data directory"
+  },
+  "explicit_runs": [
+    {
+      "session": "2b0dc2f1-558c-4cbd-a776-704d10a4389c",
+      "selection_source": "explicit",
+      "selected_skill_ids": ["review"],
+      "loaded_skill_ids": ["review"],
+      "model_tool_sequence": ["load_skill", "Read"],
+      "activation_assistant_text_chars": 0,
+      "final_answer_present": true,
+      "result": "pass"
+    },
+    {
+      "session": "a5d2dc94-5832-495c-aafe-9ddc07bbf589",
+      "selection_source": "explicit",
+      "selected_skill_ids": ["review"],
+      "loaded_skill_ids": ["review"],
+      "model_tool_sequence": ["load_skill", "Read"],
+      "activation_assistant_text_chars": 0,
+      "final_answer_present": true,
+      "result": "pass"
+    },
+    {
+      "session": "c636ca2c-0103-45ea-ad0b-51e8ef65b4d8",
+      "selection_source": "explicit",
+      "selected_skill_ids": ["review"],
+      "loaded_skill_ids": ["review"],
+      "model_tool_sequence": ["load_skill", "Read"],
+      "activation_assistant_text_chars": 0,
+      "final_answer_present": true,
+      "result": "pass"
+    }
+  ],
+  "automatic_run": {
+    "session": "3ab49dd5-5dfe-4007-a7fe-e955d0f9775b",
+    "selection_source": "auto",
+    "selected_skill_count": 10,
+    "first_request_required_tool": null,
+    "first_model_tool": "GetFileInfo",
+    "later_model_tool": "load_skill",
+    "result": "lazy_activation_pass"
+  },
+  "wire_evidence": {
+    "explicit_first_request_tools": ["load_skill"],
+    "explicit_first_request_function_calling_mode": "ANY",
+    "explicit_first_request_allowed_function_names": ["load_skill"],
+    "explicit_first_response_function_call": {
+      "name": "load_skill",
+      "args": {"skill_id": "review"}
+    },
+    "explicit_second_request_required_tool": null,
+    "stream_content_type": "text/event-stream",
+    "plain_text_tool_results_wrapped_as_object": true
+  },
+  "checks": {
+    "three_fresh_explicit_runs_passed": true,
+    "model_issued_load_skill_before_answer": true,
+    "explicit_selected_and_loaded_ids_match": true,
+    "automatic_multi_candidate_selection_remains_lazy": true,
+    "ordinary_bypass_and_parent_forced_ask_paths_preserved_by_regression_tests": true,
+    "workflow_workspace_writes": 0,
+    "browser_runtime_errors_after_final_run": 0
+  },
+  "local_artifacts_not_committed": [
+    "/tmp/zenith-620-model-issued.kTdzQ7/evidence/screenshots/run-8-explicit-model-issued-pass.png",
+    "/tmp/zenith-620-model-issued.kTdzQ7/evidence/screenshots/run-9-explicit-repeat-pass.png",
+    "/tmp/zenith-620-model-issued.kTdzQ7/evidence/videos/run-8-explicit-model-issued-pass.webm",
+    "/tmp/zenith-620-model-issued.kTdzQ7/evidence/videos/run-9-explicit-repeat-pass.webm"
+  ],
+  "notes": [
+    "The Gemini streamGenerateContent URL must include alt=sse; otherwise the API returns a JSON array that the SSE parser cannot consume.",
+    "Gemini functionResponse.response requires an object, so scalar, array, and plain-text tool outputs are wrapped under result.",
+    "Historical browser console fetch errors were caused by intentional local server restarts; the final browser error query was empty."
+  ]
+}

--- a/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
@@ -233,6 +233,7 @@ RUNNER_RUNTIME_INSTRUCTIONS"#,
 #[tokio::test]
 async fn explicit_fail_closed_dynamic_context_stop_matrix_keeps_main_runner_alive() {
     use bamboo_agent_core::storage::AttachmentReader;
+    use bamboo_agent_core::tools::FunctionCall;
     use bamboo_engine::{Agent, ExecuteRequestBuilder};
     use bamboo_llm::{LLMChunk, LLMProvider, LLMStream};
     use futures::stream;
@@ -252,6 +253,7 @@ async fn explicit_fail_closed_dynamic_context_stop_matrix_keeps_main_runner_aliv
     }
     struct CapturingProvider {
         requests: AsyncMutex<Vec<Vec<bamboo_agent_core::Message>>>,
+        queue: AsyncMutex<Vec<Vec<bamboo_llm::provider::Result<LLMChunk>>>>,
     }
     #[async_trait::async_trait]
     impl LLMProvider for CapturingProvider {
@@ -263,10 +265,8 @@ async fn explicit_fail_closed_dynamic_context_stop_matrix_keeps_main_runner_aliv
             _model: &str,
         ) -> bamboo_llm::provider::Result<LLMStream> {
             self.requests.lock().await.push(messages.to_vec());
-            Ok(Box::pin(stream::iter(vec![
-                Ok(LLMChunk::Token("main model continued".to_string())),
-                Ok(LLMChunk::Done),
-            ])))
+            let items = self.queue.lock().await.remove(0);
+            Ok(Box::pin(stream::iter(items)))
         }
     }
 
@@ -310,8 +310,40 @@ async fn explicit_fail_closed_dynamic_context_stop_matrix_keeps_main_runner_aliv
             .expect("load tool")
             .build(),
     );
+    let activation_call = |id: &str, skill_id: &str| ToolCall {
+        id: id.to_string(),
+        tool_type: "function".to_string(),
+        function: FunctionCall {
+            name: "load_skill".to_string(),
+            arguments: serde_json::json!({"skill_id": skill_id}).to_string(),
+        },
+    };
+    let answer = || {
+        vec![
+            Ok(LLMChunk::Token("main model continued".to_string())),
+            Ok(LLMChunk::Done),
+        ]
+    };
     let llm = Arc::new(CapturingProvider {
         requests: AsyncMutex::new(Vec::new()),
+        queue: AsyncMutex::new(vec![
+            vec![
+                Ok(LLMChunk::ToolCalls(vec![activation_call(
+                    "load-dynamic-continue",
+                    "dynamic-continue",
+                )])),
+                Ok(LLMChunk::Done),
+            ],
+            answer(),
+            vec![
+                Ok(LLMChunk::ToolCalls(vec![activation_call(
+                    "load-dynamic-stop",
+                    "dynamic-stop",
+                )])),
+                Ok(LLMChunk::Done),
+            ],
+            answer(),
+        ]),
     });
     let metrics = bamboo_metrics::MetricsCollector::spawn(
         Arc::new(bamboo_metrics::SqliteMetricsStorage::new(
@@ -368,7 +400,20 @@ async fn explicit_fail_closed_dynamic_context_stop_matrix_keeps_main_runner_aliv
                 .contains_key(bamboo_skills::ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY),
             !stop
         );
-        let request = serde_json::to_string(&llm.requests.lock().await[index]).expect("request");
+        assert_eq!(
+            session
+                .messages
+                .iter()
+                .filter_map(|message| message.tool_calls.as_ref())
+                .flatten()
+                .filter(|call| call.function.name == "load_skill")
+                .count(),
+            1,
+            "explicit workflow activation must be model-issued exactly once"
+        );
+        let request_index = index * 2 + 1;
+        let request =
+            serde_json::to_string(&llm.requests.lock().await[request_index]).expect("request");
         if stop {
             assert!(!request.contains("context_type: workflow_runtime"));
         } else {

--- a/crates/app/bamboo-server/src/handlers/anthropic/complete/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/anthropic/complete/non_stream.rs
@@ -45,6 +45,7 @@ pub(super) async fn handle_non_streaming_complete(
                 session_id: None,
                 reasoning_effort,
                 parallel_tool_calls: None,
+                required_tool: None,
                 responses: None,
                 request_purpose: Some("anthropic_compat".to_string()),
                 cache: None,

--- a/crates/app/bamboo-server/src/handlers/anthropic/complete/stream.rs
+++ b/crates/app/bamboo-server/src/handlers/anthropic/complete/stream.rs
@@ -49,6 +49,7 @@ pub(super) async fn handle_streaming_complete(
                 session_id: None,
                 reasoning_effort,
                 parallel_tool_calls: None,
+                required_tool: None,
                 responses: None,
                 request_purpose: Some("anthropic_compat".to_string()),
                 cache: None,

--- a/crates/app/bamboo-server/src/handlers/anthropic/messages/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/anthropic/messages/non_stream.rs
@@ -42,6 +42,7 @@ pub(super) async fn handle_non_streaming_messages(
                 session_id: None,
                 reasoning_effort: prepared.reasoning_effort,
                 parallel_tool_calls: None,
+                required_tool: None,
                 responses: None,
                 request_purpose: Some("anthropic_compat".to_string()),
                 cache: None,

--- a/crates/app/bamboo-server/src/handlers/anthropic/messages/stream.rs
+++ b/crates/app/bamboo-server/src/handlers/anthropic/messages/stream.rs
@@ -47,6 +47,7 @@ pub(super) async fn handle_streaming_messages(
                 session_id: None,
                 reasoning_effort: prepared.reasoning_effort,
                 parallel_tool_calls: None,
+                required_tool: None,
                 responses: None,
                 request_purpose: Some("anthropic_compat".to_string()),
                 cache: None,

--- a/crates/app/bamboo-server/src/handlers/openai/chat/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/chat/non_stream.rs
@@ -57,6 +57,7 @@ pub(super) async fn handle_non_streaming_chat(
                 session_id: None,
                 reasoning_effort,
                 parallel_tool_calls,
+                required_tool: None,
                 responses: None,
                 request_purpose: Some("openai_compat".to_string()),
                 cache: None,

--- a/crates/app/bamboo-server/src/handlers/openai/chat/stream/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/chat/stream/mod.rs
@@ -63,6 +63,7 @@ pub(super) async fn handle_streaming_chat(
                 session_id: None,
                 reasoning_effort,
                 parallel_tool_calls,
+                required_tool: None,
                 responses: None,
                 request_purpose: Some("openai_compat".to_string()),
                 cache: None,

--- a/crates/app/bamboo-server/src/handlers/openai/responses/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/non_stream.rs
@@ -40,6 +40,7 @@ pub(super) async fn handle_non_streaming_response(
         session_id: None,
         reasoning_effort: prepared.reasoning_effort,
         parallel_tool_calls: prepared.parallel_tool_calls,
+        required_tool: None,
         responses: Some(prepared.responses_options.clone()),
         request_purpose: Some("openai_compat".to_string()),
         cache: None,

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/mod.rs
@@ -46,6 +46,7 @@ pub(super) async fn handle_streaming_response(
         session_id: None,
         reasoning_effort: prepared.reasoning_effort,
         parallel_tool_calls: prepared.parallel_tool_calls,
+        required_tool: None,
         responses: Some(prepared.responses_options.clone()),
         request_purpose: Some("openai_compat".to_string()),
         cache: None,

--- a/crates/engine/bamboo-engine/src/auto_dream.rs
+++ b/crates/engine/bamboo-engine/src/auto_dream.rs
@@ -451,6 +451,7 @@ async fn collect_stream_text(
         session_id: Some(DREAM_RUNTIME_SESSION_ID.to_string()),
         reasoning_effort: Some(ReasoningEffort::High),
         parallel_tool_calls: None,
+        required_tool: None,
         responses: None,
         request_purpose: Some("auto_dream".to_string()),
         cache: None,

--- a/crates/engine/bamboo-engine/src/gardener.rs
+++ b/crates/engine/bamboo-engine/src/gardener.rs
@@ -83,6 +83,7 @@ pub(crate) async fn collect_model_json(
         session_id: Some(GARDENER_RUNTIME_SESSION_ID.to_string()),
         reasoning_effort: Some(ReasoningEffort::High),
         parallel_tool_calls: None,
+        required_tool: None,
         responses: None,
         request_purpose: Some("memory_gardener".to_string()),
         cache: None,

--- a/crates/engine/bamboo-engine/src/gold_auto_answer/evaluation.rs
+++ b/crates/engine/bamboo-engine/src/gold_auto_answer/evaluation.rs
@@ -87,6 +87,7 @@ pub(crate) async fn evaluate_gold_auto_answer_question(
         session_id: Some(session_id.to_string()),
         reasoning_effort: normalize_lightweight_reasoning_effort(session.reasoning_effort),
         parallel_tool_calls: None,
+        required_tool: None,
         responses: None,
         request_purpose: Some("gold_auto_answer".to_string()),
         cache: None,

--- a/crates/engine/bamboo-engine/src/llm_summarizer.rs
+++ b/crates/engine/bamboo-engine/src/llm_summarizer.rs
@@ -253,6 +253,7 @@ Guidelines:
             session_id: None,
             reasoning_effort: Some(ReasoningEffort::High),
             parallel_tool_calls: None,
+            required_tool: None,
             responses: None,
             request_purpose: Some("compression".to_string()),
             cache: None,

--- a/crates/engine/bamboo-engine/src/runtime/gold_evaluation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/gold_evaluation.rs
@@ -207,6 +207,7 @@ pub async fn evaluate_gold(
         session_id: Some(session_id.to_string()),
         reasoning_effort: request_reasoning_effort,
         parallel_tool_calls: None,
+        required_tool: None,
         responses: None,
         request_purpose: Some("gold_evaluation".to_string()),
         cache: None,

--- a/crates/engine/bamboo-engine/src/runtime/managers/adapters/llm_mini_loop.rs
+++ b/crates/engine/bamboo-engine/src/runtime/managers/adapters/llm_mini_loop.rs
@@ -104,6 +104,7 @@ impl MiniLoopExecutor for LLMMiniLoopExecutor {
             session_id: None,
             reasoning_effort: None,
             parallel_tool_calls: None,
+            required_tool: None,
             responses: None,
             request_purpose: Some("mini_loop".to_string()),
             cache: None,

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -1354,6 +1354,88 @@ async fn handle_tool_calls_path(
 
 // ---- Core pipeline ----
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ExplicitActivationAttempt {
+    call_id: String,
+    skill_id: String,
+}
+
+fn validate_explicit_activation_first_step(
+    session: &Session,
+    tool_calls: &[bamboo_agent_core::tools::ToolCall],
+) -> Result<Option<ExplicitActivationAttempt>, AgentError> {
+    if !crate::runtime::runner::session_setup::skill_context::explicit_activation_pending(session) {
+        return Ok(None);
+    }
+
+    let selected_skill_id = session
+        .metadata
+        .get(bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY)
+        .and_then(|raw| serde_json::from_str::<Vec<String>>(raw).ok())
+        .and_then(|ids| ids.into_iter().next())
+        .ok_or_else(|| {
+            AgentError::Tool(format!(
+                "[{}] explicit workflow activation is missing its selected skill",
+                session.id
+            ))
+        })?;
+    let valid_call = tool_calls.len() == 1
+        && bamboo_tools::normalize_tool_ref(&tool_calls[0].function.name)
+            .is_some_and(|name| name == "load_skill");
+    if !valid_call {
+        return Err(AgentError::Tool(format!(
+            "[{}] explicit workflow activation was not completed: the first model step must be exactly one load_skill call",
+            session.id
+        )));
+    }
+    let called_skill_id =
+        serde_json::from_str::<serde_json::Value>(&tool_calls[0].function.arguments)
+            .ok()
+            .and_then(|arguments| {
+                arguments
+                    .get("skill_id")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::trim)
+                    .map(str::to_string)
+            });
+    if called_skill_id.as_deref() != Some(selected_skill_id.as_str()) {
+        return Err(AgentError::Tool(format!(
+            "[{}] explicit workflow activation must load selected skill '{}'",
+            session.id, selected_skill_id
+        )));
+    }
+
+    Ok(Some(ExplicitActivationAttempt {
+        call_id: tool_calls[0].id.clone(),
+        skill_id: selected_skill_id,
+    }))
+}
+
+fn apply_successful_explicit_activation(
+    session: &mut Session,
+    attempt: &ExplicitActivationAttempt,
+) -> Result<(), AgentError> {
+    let tool_succeeded = session.messages.iter().rev().any(|message| {
+        message.tool_call_id.as_deref() == Some(attempt.call_id.as_str())
+            && message.tool_success == Some(true)
+    });
+    // The #579 success path refreshes the complete workflow activation namespace
+    // from SessionRepository into this runner-owned Session before returning.
+    // Require both the successful tool result and that durable active snapshot;
+    // a provider/degraded/save failure must never unlock the answer round.
+    if !tool_succeeded
+        || crate::runtime::runner::session_setup::skill_context::explicit_activation_pending(
+            session,
+        )
+    {
+        return Err(AgentError::Tool(format!(
+            "[{}] explicit workflow '{}' failed to activate; refusing to continue to a user-facing answer",
+            session.id, attempt.skill_id
+        )));
+    }
+    Ok(())
+}
+
 pub(super) async fn run_pipeline(
     session: &mut Session,
     event_tx: &mpsc::Sender<AgentEvent>,
@@ -1670,12 +1752,17 @@ pub(super) async fn run_pipeline(
 
             // --- Handle LLM output ---
             let stream_output = llm_output.stream_output;
-
-            // Absorb this attempt's ACTUAL usage/activity before
-            // `stream_output` is consumed below — every successful LLM call in
-            // this round was billed, even if its post-LLM handling then fails
-            // and triggers a retry (issue #221 — see `RoundActivity`).
+            // Every successful provider call is billed, including an explicit
+            // activation attempt that the fail-closed guard rejects below.
             round_activity.absorb_attempt(&stream_output);
+            let activation_attempt =
+                match validate_explicit_activation_first_step(session, &stream_output.tool_calls) {
+                    Ok(attempt) => attempt,
+                    Err(error) => {
+                        terminal_error = Some(error);
+                        break;
+                    }
+                };
 
             if stream_output.tool_calls.is_empty() {
                 // Safety net: if the model is about to finish but left background
@@ -1766,6 +1853,16 @@ pub(super) async fn run_pipeline(
             .await
             {
                 Ok(outcome) => {
+                    if let Some(attempt) = activation_attempt.as_ref() {
+                        if !outcome.should_break {
+                            if let Err(error) =
+                                apply_successful_explicit_activation(session, attempt)
+                            {
+                                terminal_error = Some(error);
+                                break;
+                            }
+                        }
+                    }
                     turn_outcome = Some(outcome);
                     break;
                 }
@@ -2230,10 +2327,11 @@ fn heuristic_complexity(
 mod tests {
     use super::super::startup::OverflowRecoveryState;
     use super::{
-        build_guardian_review_prompt, check_run_budget_exceeded, is_overflow_recoverable,
-        is_subagent_create_call, is_terminal_child_status, map_turn_error_status,
-        maybe_spawn_guardian_review, maybe_suspend_for_orphaned_children,
-        maybe_suspend_for_outstanding_bash, should_retry_turn_error, suspend_to_wait_for_bash,
+        apply_successful_explicit_activation, build_guardian_review_prompt,
+        check_run_budget_exceeded, is_overflow_recoverable, is_subagent_create_call,
+        is_terminal_child_status, map_turn_error_status, maybe_spawn_guardian_review,
+        maybe_suspend_for_orphaned_children, maybe_suspend_for_outstanding_bash,
+        should_retry_turn_error, suspend_to_wait_for_bash, validate_explicit_activation_first_step,
     };
     use crate::runtime::config::{AgentLoopConfig, GuardianConfig, GuardianSpawner};
     use crate::runtime::goal_state::{
@@ -2256,6 +2354,161 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::RwLock;
+
+    fn pending_explicit_session() -> Session {
+        let mut session = Session::new("explicit-gate", "model");
+        session.metadata.insert(
+            bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTION_SOURCE_KEY.to_string(),
+            "explicit".to_string(),
+        );
+        session.metadata.insert(
+            bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+            "[\"review\"]".to_string(),
+        );
+        session
+    }
+
+    fn activation_call(id: &str, name: &str, arguments: &str) -> ToolCall {
+        ToolCall {
+            id: id.to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: name.to_string(),
+                arguments: arguments.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn explicit_activation_first_step_gate_rejects_missing_wrong_and_multiple_calls() {
+        let session = pending_explicit_session();
+        assert!(validate_explicit_activation_first_step(&session, &[]).is_err());
+        assert!(validate_explicit_activation_first_step(
+            &session,
+            &[activation_call("wrong", "Read", r#"{"file_path":"x"}"#)],
+        )
+        .is_err());
+        assert!(validate_explicit_activation_first_step(
+            &session,
+            &[
+                activation_call("load", "load_skill", r#"{"skill_id":"review"}"#),
+                activation_call("other", "Read", r#"{"file_path":"x"}"#),
+            ],
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn explicit_activation_first_step_gate_accepts_only_matching_load_skill() {
+        let session = pending_explicit_session();
+        assert!(validate_explicit_activation_first_step(
+            &session,
+            &[activation_call(
+                "wrong-skill",
+                "load_skill",
+                r#"{"skill_id":"plan"}"#,
+            )],
+        )
+        .is_err());
+
+        let attempt = validate_explicit_activation_first_step(
+            &session,
+            &[activation_call(
+                "load-review",
+                "load_skill",
+                r#"{"skill_id":"review"}"#,
+            )],
+        )
+        .expect("matching load_skill should pass")
+        .expect("pending activation attempt");
+        assert_eq!(attempt.call_id, "load-review");
+        assert_eq!(attempt.skill_id, "review");
+    }
+
+    #[test]
+    fn explicit_activation_clears_pending_only_after_successful_tool_result() {
+        let call = activation_call("load-review", "load_skill", r#"{"skill_id":"review"}"#);
+
+        let mut failed = pending_explicit_session();
+        let attempt = validate_explicit_activation_first_step(&failed, std::slice::from_ref(&call))
+            .expect("valid first step")
+            .expect("activation attempt");
+        failed.add_message(Message::tool_result_with_status(
+            "load-review",
+            "durable save failed",
+            false,
+        ));
+        assert!(apply_successful_explicit_activation(&mut failed, &attempt).is_err());
+        assert!(
+            crate::runtime::runner::session_setup::skill_context::explicit_activation_pending(
+                &failed
+            )
+        );
+
+        let mut succeeded = pending_explicit_session();
+        let attempt = validate_explicit_activation_first_step(&succeeded, &[call])
+            .expect("valid first step")
+            .expect("activation attempt");
+        succeeded.add_message(Message::tool_result_with_status(
+            "load-review",
+            "loaded",
+            true,
+        ));
+        succeeded.metadata.insert(
+            bamboo_skills::runtime_metadata::LOADED_SKILL_IDS_METADATA_KEY.to_string(),
+            "[\"review\"]".to_string(),
+        );
+        succeeded.metadata.insert(
+            bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY.to_string(),
+            serde_json::json!({
+                "id": "review",
+                "source": "builtin",
+                "revision": 1,
+                "kind": "instruction",
+                "args": {},
+                "invoked_by": "user",
+                "activated_at": "2026-07-21T00:00:00Z",
+                "status": "active"
+            })
+            .to_string(),
+        );
+        succeeded.metadata.insert(
+            bamboo_skills::ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY.to_string(),
+            "{}".to_string(),
+        );
+        apply_successful_explicit_activation(&mut succeeded, &attempt)
+            .expect("successful tool result activates workflow");
+        assert!(
+            !crate::runtime::runner::session_setup::skill_context::explicit_activation_pending(
+                &succeeded
+            )
+        );
+
+        let mut degraded = pending_explicit_session();
+        let call = activation_call("load-review", "load_skill", r#"{"skill_id":"review"}"#);
+        let attempt = validate_explicit_activation_first_step(&degraded, &[call])
+            .expect("valid first step")
+            .expect("activation attempt");
+        degraded.add_message(Message::tool_result_with_status(
+            "load-review",
+            r#"{"activation_status":"degraded"}"#,
+            true,
+        ));
+        degraded.metadata.insert(
+            bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_ERROR_KEY.to_string(),
+            r#"{"code":"provider_failed"}"#.to_string(),
+        );
+        apply_successful_explicit_activation(&mut degraded, &attempt)
+            .expect("typed degraded activation lets the main session continue fail-closed");
+        assert!(!degraded
+            .metadata
+            .contains_key(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY));
+        assert!(
+            !crate::runtime::runner::session_setup::skill_context::explicit_activation_pending(
+                &degraded
+            )
+        );
+    }
 
     /// A guardian spawner stub that returns a canned child id without touching
     /// any real spawn machinery — lets the gate's state machine be unit-tested.

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/startup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/startup.rs
@@ -350,8 +350,17 @@ mod tests {
         let (event_tx, _event_rx) = tokio::sync::mpsc::channel(8);
         initialize_loop_state(&mut session, "review", &review_config, &tools, &event_tx)
             .await
-            .expect("initial activation");
-        assert_eq!(tools.0.load(Ordering::SeqCst), 1);
+            .expect("initial selection");
+        assert_eq!(
+            tools.0.load(Ordering::SeqCst),
+            0,
+            "session setup must not execute load_skill on the model's behalf"
+        );
+        assert!(
+            crate::runtime::runner::session_setup::skill_context::explicit_activation_pending(
+                &session
+            )
+        );
         let pinned_generation = session
             .metadata
             .get(SKILL_RUNTIME_ACTIVATION_GENERATION_KEY)
@@ -431,30 +440,18 @@ mod tests {
         assert!(!session
             .metadata
             .contains_key(SKILL_RUNTIME_SELECTED_SKILL_MODE_KEY));
+        assert!(!session.metadata.contains_key(LOADED_SKILL_IDS_METADATA_KEY));
         assert!(
-            !session.metadata.contains_key(LOADED_SKILL_IDS_METADATA_KEY),
-            "restored active workflow must not be loaded or evented twice"
+            crate::runtime::runner::session_setup::skill_context::explicit_activation_pending(
+                &session
+            ),
+            "resuming a pinned but not-yet-loaded selection must still require a model-issued activation"
         );
-        let retained_block = crate::runtime::runner::session_setup::prompt_envelope::build_active_workflow_context_block(&session)
-            .expect("fixed durable workflow context rebuilt without preload");
-        assert_eq!(
-            retained_block.block_type,
-            bamboo_agent_core::ContextBlockType::WorkflowRuntime
-        );
-        assert_eq!(
-            retained_block.priority,
-            bamboo_agent_core::ContextBlockPriority::Critical
-        );
-        assert_eq!(
-            retained_block.stability,
-            bamboo_agent_core::ContextBlockStability::SessionStable
-        );
-        assert!(retained_block.content.contains("review N"));
-        assert!(!retained_block.content.contains("review N+1"));
+        assert!(crate::runtime::runner::session_setup::prompt_envelope::build_active_workflow_context_block(&session).is_none());
         assert_eq!(
             tools.0.load(Ordering::SeqCst),
-            1,
-            "resume must not preload or activate twice"
+            0,
+            "resume must not preload or activate on the model's behalf"
         );
 
         let plan_config = AgentLoopConfig {
@@ -481,8 +478,8 @@ mod tests {
         assert_eq!(skills[0].id, "plan-demo");
         assert_eq!(
             tools.0.load(Ordering::SeqCst),
-            2,
-            "new explicit selection preloads exactly once"
+            0,
+            "a superseding explicit selection must also wait for the model-issued load_skill call"
         );
         assert_eq!(
             descriptor
@@ -492,9 +489,11 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["plan-demo"]
         );
-        let superseding_block = crate::runtime::runner::session_setup::prompt_envelope::build_active_workflow_context_block(&session)
-            .expect("superseding workflow context");
-        assert!(superseding_block.content.contains("plan N"));
-        assert!(!superseding_block.content.contains("review N"));
+        assert!(
+            crate::runtime::runner::session_setup::skill_context::explicit_activation_pending(
+                &session
+            )
+        );
+        assert!(crate::runtime::runner::session_setup::prompt_envelope::build_active_workflow_context_block(&session).is_none());
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
@@ -631,6 +631,7 @@ fn plan_llm_request(
     session_id: &str,
     reasoning_effort: Option<ReasoningEffort>,
     tool_count: usize,
+    required_tool: Option<&str>,
 ) -> LlmRequestPlan {
     let is_continuation = envelope.ir.continuation.is_some();
 
@@ -642,7 +643,8 @@ fn plan_llm_request(
     let request_options = LLMRequestOptions {
         session_id: Some(session_id.to_string()),
         reasoning_effort,
-        parallel_tool_calls: Some(true),
+        parallel_tool_calls: Some(required_tool.is_none()),
+        required_tool: required_tool.map(str::to_string),
         responses: Some(responses_options),
         request_purpose: Some("agent_loop".to_string()),
         cache: Some(envelope.ir.cache.clone()),
@@ -708,6 +710,20 @@ pub(super) async fn execute_llm_stream(
     let session_id = frame.session_id;
 
     let llm_started_at = std::time::Instant::now();
+    let required_tool =
+        crate::runtime::runner::session_setup::skill_context::explicit_activation_pending(session)
+            .then_some("load_skill");
+    let restricted_tool_schemas;
+    let tool_schemas = if let Some(required_tool) = required_tool {
+        restricted_tool_schemas = tool_schemas
+            .iter()
+            .filter(|schema| schema.function.name == required_tool)
+            .cloned()
+            .collect::<Vec<_>>();
+        restricted_tool_schemas.as_slice()
+    } else {
+        tool_schemas
+    };
     // Stateful chaining is gated on the request policy: a `store=false` turn is
     // never persisted upstream, so its id must not be sent back (it would 400
     // with `previous_response_not_found`) nor kept in session metadata.
@@ -759,6 +775,7 @@ pub(super) async fn execute_llm_stream(
         session_id,
         reasoning_effort,
         tool_schemas.len(),
+        required_tool,
     );
     if !continuation_enabled {
         tracing::debug!(
@@ -826,14 +843,32 @@ pub(super) async fn execute_llm_stream(
         provider_name,
         Some(model),
     );
-    let stream_output = crate::runtime::stream::handler::consume_llm_stream_with_context(
-        stream,
-        event_tx,
-        cancel_token,
-        session_id,
-        &timeout_context,
-    )
-    .await?;
+    // A single structured explicit workflow has a fail-closed first step: the
+    // model must call load_skill before any answer tokens become user-visible.
+    // Keep that first stream silent; the pipeline verifies and executes the
+    // model-issued call, then later rounds stream normally once activation is
+    // mirrored into the runner-owned Session.
+    let stream_output =
+        if crate::runtime::runner::session_setup::skill_context::explicit_activation_pending(
+            session,
+        ) {
+            crate::runtime::stream::handler::consume_llm_stream_silent_with_context(
+                stream,
+                cancel_token,
+                session_id,
+                &timeout_context,
+            )
+            .await?
+        } else {
+            crate::runtime::stream::handler::consume_llm_stream_with_context(
+                stream,
+                event_tx,
+                cancel_token,
+                session_id,
+                &timeout_context,
+            )
+            .await?
+        };
 
     // Update session token usage with actual output/thinking/cache stats from the LLM response.
     if let Some(ref mut usage) = session.token_usage {

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
@@ -33,6 +33,9 @@ struct MockLlmProvider {
     requested_include: Mutex<Option<Vec<String>>>,
     requested_text_verbosity: Mutex<Option<String>>,
     requested_instructions: Mutex<Option<String>>,
+    requested_required_tool: Mutex<Option<String>>,
+    requested_parallel_tool_calls: Mutex<Option<bool>>,
+    requested_tool_names: Mutex<Vec<String>>,
     /// Set when the engine routed this request through the canonical
     /// `chat_stream_ir` entry point.
     ir_invoked: Mutex<bool>,
@@ -84,7 +87,7 @@ impl LLMProvider for MockLlmProvider {
     async fn chat_stream_with_options(
         &self,
         messages: &[Message],
-        _tools: &[bamboo_agent_core::tools::ToolSchema],
+        tools: &[bamboo_agent_core::tools::ToolSchema],
         _max_output_tokens: Option<u32>,
         _model: &str,
         options: Option<&LLMRequestOptions>,
@@ -122,6 +125,19 @@ impl LLMProvider for MockLlmProvider {
             .expect("instructions lock") = options
             .and_then(|value| value.responses.as_ref())
             .and_then(|value| value.instructions.clone());
+        *self
+            .requested_required_tool
+            .lock()
+            .expect("required_tool lock") = options.and_then(|value| value.required_tool.clone());
+        *self
+            .requested_parallel_tool_calls
+            .lock()
+            .expect("parallel_tool_calls lock") =
+            options.and_then(|value| value.parallel_tool_calls);
+        *self.requested_tool_names.lock().expect("tool names lock") = tools
+            .iter()
+            .map(|schema| schema.function.name.clone())
+            .collect();
 
         let items = self
             .chunks
@@ -143,6 +159,9 @@ fn mock_llm(chunks: Vec<LLMChunk>) -> Arc<MockLlmProvider> {
         requested_include: Mutex::new(None),
         requested_text_verbosity: Mutex::new(None),
         requested_instructions: Mutex::new(None),
+        requested_required_tool: Mutex::new(None),
+        requested_parallel_tool_calls: Mutex::new(None),
+        requested_tool_names: Mutex::new(Vec::new()),
         ir_invoked: Mutex::new(false),
     })
 }
@@ -331,6 +350,92 @@ async fn execute_llm_stream_sets_session_usage_and_emits_budget_event() {
             .as_deref(),
         Some("session-stream-1")
     );
+}
+
+#[tokio::test]
+async fn explicit_activation_pending_suppresses_answer_tokens() {
+    let _env_lock = isolate_prompt_safe_env_cache();
+    let mut session = Session::new("session-explicit-guard", "test-model");
+    session.metadata.insert(
+        bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTION_SOURCE_KEY.to_string(),
+        "explicit".to_string(),
+    );
+    session.metadata.insert(
+        bamboo_skills::runtime_metadata::SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+        "[\"review\"]".to_string(),
+    );
+    let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(16);
+    let config = test_config("system");
+    let prepared_context = PreparedContext {
+        messages: vec![Message::system("system")],
+        token_usage: usage(0, 22),
+        truncation_occurred: false,
+        segments_removed: 0,
+        compressed_message_ids: Vec::new(),
+        prompt_cached_tool_outputs: 0,
+        prompt_cached_tool_tokens_saved: 0,
+    };
+    let llm = mock_llm(vec![
+        LLMChunk::Token("answer must remain hidden".to_string()),
+        LLMChunk::Done,
+    ]);
+    let llm_dyn: Arc<dyn LLMProvider> = llm.clone();
+    let tool_schemas = ["load_skill", "Read"]
+        .into_iter()
+        .map(|name| bamboo_agent_core::tools::ToolSchema {
+            schema_type: "function".to_string(),
+            function: bamboo_agent_core::tools::FunctionSchema {
+                name: name.to_string(),
+                description: String::new(),
+                parameters: serde_json::json!({"type": "object"}),
+            },
+        })
+        .collect::<Vec<_>>();
+
+    let (stream_output, _) = execute_llm_stream(
+        &mut session,
+        &config,
+        &llm_dyn,
+        &prepared_context,
+        &tool_schemas,
+        &LlmStreamFrame {
+            event_tx: &event_tx,
+            cancel_token: &CancellationToken::new(),
+            session_id: "session-explicit-guard",
+            model: "test-model",
+            provider_name: None,
+            provider_type: None,
+            reasoning_effort: None,
+            max_context_tokens: 400_000,
+            max_output_tokens: 128,
+        },
+    )
+    .await
+    .expect("execute guarded stream");
+
+    assert_eq!(stream_output.content, "answer must remain hidden");
+    assert_eq!(
+        llm.requested_required_tool
+            .lock()
+            .expect("required_tool lock")
+            .as_deref(),
+        Some("load_skill")
+    );
+    assert_eq!(
+        *llm.requested_parallel_tool_calls
+            .lock()
+            .expect("parallel_tool_calls lock"),
+        Some(false)
+    );
+    assert_eq!(
+        *llm.requested_tool_names.lock().expect("tool names lock"),
+        vec!["load_skill".to_string()]
+    );
+    drop(event_tx);
+    let events = std::iter::from_fn(|| event_rx.try_recv().ok()).collect::<Vec<_>>();
+    assert!(events
+        .iter()
+        .all(|event| matches!(event, AgentEvent::TokenBudgetUpdated { .. })));
 }
 
 #[tokio::test]
@@ -1037,7 +1142,7 @@ fn plan_llm_request_lanes_path_records_observability() {
     };
     let envelope = super::build_request_envelope(&session, &prepared_context, &config, &[]);
 
-    let planned = super::plan_llm_request(&envelope, "session-plan", None, 3);
+    let planned = super::plan_llm_request(&envelope, "session-plan", None, 3, None);
 
     // No continuation set on the IR → the canonical lanes wire.
     assert!(envelope.ir.continuation.is_none());
@@ -1078,7 +1183,7 @@ fn plan_llm_request_continuation_path_builds_delta() {
         "resp_prev",
     );
 
-    let planned = super::plan_llm_request(&envelope, "session-plan-cont", None, 0);
+    let planned = super::plan_llm_request(&envelope, "session-plan-cont", None, 0, None);
 
     assert_eq!(planned.render.wire, "responses_continuation");
     // Delta is the tool result after the last assistant turn — NOT the full convo.
@@ -1333,7 +1438,7 @@ fn responses_continuation_uses_full_input_not_the_delta() {
         super::build_request_envelope(&session, &prepared_context, &config, &[]),
         "resp_prev",
     );
-    let planned = super::plan_llm_request(&envelope, "session-resp-cont", None, 0);
+    let planned = super::plan_llm_request(&envelope, "session-resp-cont", None, 0, None);
 
     // The adapter derives the Responses wire view from the IR + the engine's request
     // POLICY (planned.request_options.responses).
@@ -1376,7 +1481,7 @@ fn ir_cache_matches_request_options_cache() {
     };
 
     let envelope = super::build_request_envelope(&session, &prepared_context, &config, &[]);
-    let planned = super::plan_llm_request(&envelope, "session-cache-dup", None, 0);
+    let planned = super::plan_llm_request(&envelope, "session-cache-dup", None, 0, None);
     let options_cache = planned
         .request_options
         .cache

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup.rs
@@ -158,7 +158,26 @@ pub(crate) async fn prepare_session_for_loop(
         }
     };
     session.metadata.remove(SKILL_RUNTIME_ACTIVATION_ERROR_KEY);
-    let mut skill_context = skill_result.context.clone();
+    let explicit_activation_loaded = skill_result.restored_active_context
+        || skill_context::selection_matches_loaded_activation(session, &skill_result);
+    let skill_context = if explicit_activation_loaded {
+        format!(
+            "\n\n## Explicit Workflow Already Activated\n\
+The `{skill_id}` workflow was loaded successfully earlier in this session. Continue following the existing `load_skill` result and its workflow instructions. Do not call `load_skill` again solely because execution resumed.\n",
+            skill_id = skill_result.selected_skill_ids[0],
+        )
+    } else if skill_result.selection_source.as_deref() == Some("explicit")
+        && skill_result.selected_skill_ids.len() == 1
+    {
+        format!(
+            "\n\n## Required Explicit Workflow Activation\n\
+The user explicitly selected `{skill_id}`. Your first response step MUST be exactly one `load_skill` call for `{skill_id}`. Do not emit commentary, an answer, or any other tool call before it completes. If the tool reports `activation_status: degraded`, do not retry it; continue without workflow instructions. Otherwise, follow the loaded workflow instructions.\n{context}",
+            skill_id = skill_result.selected_skill_ids[0],
+            context = skill_result.context.as_str(),
+        )
+    } else {
+        skill_result.context.clone()
+    };
 
     if let Some(diagnostic) = skill_result.activation_diagnostic.as_ref() {
         session.metadata.insert(
@@ -263,7 +282,7 @@ pub(crate) async fn prepare_session_for_loop(
         }
 
         if !skill_result.restored_active_context {
-            skill_context::reset_explicit_activation_state(session, &skill_result);
+            skill_context::reset_activation_state_for_new_selection(session, &skill_result);
         }
 
         // Runtime tools authorize skill loads through the shared session repository.
@@ -280,71 +299,6 @@ pub(crate) async fn prepare_session_for_loop(
                 return Err(AgentError::Tool(format!(
                     "Workflow activation metadata could not be published before tool/model execution: {error}"
                 )));
-            }
-        }
-
-        let explicit_activation = if skill_result.restored_active_context {
-            None
-        } else {
-            match skill_context::activate_explicit_skill(
-                tools,
-                session,
-                session_id,
-                &skill_result,
-                event_tx,
-            )
-            .await
-            {
-                Ok(activation) => activation,
-                Err(error) => {
-                    if let Some(skill_manager) = config.skill_manager.as_ref() {
-                        let workspace = session.workspace_path_meta().map(std::path::PathBuf::from);
-                        let _ = skill_manager
-                            .release_activation_for_workspace(session_id, workspace.as_deref())
-                            .await;
-                    }
-                    return Err(AgentError::Tool(format!(
-                        "Explicit workflow activation failed before model execution: {error}"
-                    )));
-                }
-            }
-        };
-        if let Some(activated_context) = explicit_activation {
-            skill_context = activated_context;
-            if let Some(persistence) = config.persistence.as_ref() {
-                if let Err(error) = persistence.save_runtime_session(session).await {
-                    if let Some(skill_manager) = config.skill_manager.as_ref() {
-                        let workspace = session.workspace_path_meta().map(std::path::PathBuf::from);
-                        let _ = skill_manager
-                            .release_activation_for_workspace(session_id, workspace.as_deref())
-                            .await;
-                    }
-                    // The activation was never durably committed. Keep the caller's
-                    // in-memory session fail-closed as well, so a retry cannot observe
-                    // an active workflow whose immutable pin has already been released.
-                    session
-                        .metadata
-                        .remove(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY);
-                    session
-                        .metadata
-                        .remove(bamboo_skills::ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY);
-                    session
-                        .metadata
-                        .remove(bamboo_skills::WORKFLOW_ACTIVATION_EVENT_METADATA_KEY);
-                    session.metadata.remove(SKILL_RUNTIME_PINNED_SNAPSHOT_KEY);
-                    session
-                        .metadata
-                        .remove(bamboo_skills::runtime_metadata::LOADED_SKILL_IDS_METADATA_KEY);
-                    session
-                        .metadata
-                        .remove(bamboo_skills::runtime_metadata::LAST_LOADED_SKILL_ID_METADATA_KEY);
-                    session.metadata.remove(
-                        bamboo_skills::runtime_metadata::LAST_LOADED_SKILL_SUMMARY_METADATA_KEY,
-                    );
-                    return Err(AgentError::Tool(format!(
-                        "Explicit workflow loaded-state could not be published before model execution: {error}"
-                    )));
-                }
             }
         }
     }

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/skill_context.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/skill_context.rs
@@ -1,13 +1,10 @@
 use crate::runtime::config::AgentLoopConfig;
-use bamboo_agent_core::tools::{
-    FunctionCall, ToolCall, ToolExecutionContext, ToolExecutionSessionFlags, ToolExecutor,
-};
 use bamboo_agent_core::Session;
 use bamboo_skills::runtime_metadata::{
     LAST_LOADED_SKILL_ID_METADATA_KEY, LAST_LOADED_SKILL_SUMMARY_METADATA_KEY,
-    LOADED_SKILL_IDS_METADATA_KEY,
+    LOADED_SKILL_IDS_METADATA_KEY, SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY,
+    SKILL_RUNTIME_SELECTION_SOURCE_KEY,
 };
-use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Debug, Clone, Default)]
@@ -395,9 +392,9 @@ pub(super) async fn load_skill_context(
         // Automatic selection only advertises metadata. Keep its immutable candidate
         // pin in process for load_skill, but do not serialize every candidate's
         // resource tree into the session. The tool exports and narrows the pin to the
-        // one workflow the model actually activates. Explicit preload needs the
-        // candidate snapshot before invoking load_skill, while an already-active LKG
-        // remains durable across restarts.
+        // one workflow the model actually activates. Explicit selection needs the
+        // candidate snapshot before the model invokes load_skill, while an
+        // already-active LKG remains durable across restarts.
         let durable_snapshot = if activation.is_some()
             && (selection_source.as_deref() == Some("explicit") || durable_active.is_some())
         {
@@ -454,144 +451,83 @@ pub(super) async fn load_skill_context(
     }
 }
 
-/// A new explicit activation supersedes any workflow loaded on an earlier run.
-/// Clear the old activation before publishing the current selection so tool
-/// authorization cannot briefly observe a stale loaded workflow.
-pub(super) fn reset_explicit_activation_state(
-    session: &mut Session,
+pub(super) fn selection_matches_loaded_activation(
+    session: &Session,
     selection: &SkillContextLoadResult,
-) {
-    if selection.selection_source.as_deref() == Some("explicit")
-        && selection.selected_skill_ids.len() == 1
-    {
-        session.metadata.remove(LOADED_SKILL_IDS_METADATA_KEY);
-        session.metadata.remove(LAST_LOADED_SKILL_ID_METADATA_KEY);
-        session
-            .metadata
-            .remove(LAST_LOADED_SKILL_SUMMARY_METADATA_KEY);
-    }
-}
-
-/// Deterministically activate a single explicitly selected workflow before the
-/// first model round. Automatic selection remains metadata-only because it can
-/// advertise several candidates and the model still has to choose one.
-pub(super) async fn activate_explicit_skill(
-    tools: &dyn ToolExecutor,
-    session: &mut Session,
-    session_id: &str,
-    selection: &SkillContextLoadResult,
-    event_tx: &tokio::sync::mpsc::Sender<bamboo_agent_core::AgentEvent>,
-) -> Result<Option<String>, String> {
+) -> bool {
     if selection.selection_source.as_deref() != Some("explicit")
         || selection.selected_skill_ids.len() != 1
     {
-        return Ok(None);
+        return false;
     }
-
     let skill_id = selection.selected_skill_ids[0].as_str();
-    let available_tool_schemas = tools.list_tools();
-    if !available_tool_schemas
-        .iter()
-        .any(|schema| schema.function.name == "load_skill")
-    {
-        return Err(format!(
-            "Explicit workflow '{skill_id}' cannot start because load_skill is unavailable"
-        ));
-    }
-
-    let call_id = format!("runtime-explicit-skill-{session_id}");
-    let arguments = serde_json::json!({ "skill_id": skill_id });
-    let call = ToolCall {
-        id: call_id.clone(),
-        tool_type: "function".to_string(),
-        function: FunctionCall {
-            name: "load_skill".to_string(),
-            arguments: arguments.to_string(),
-        },
-    };
-    let context = ToolExecutionContext::for_dispatch(
-        session_id,
-        &call_id,
-        event_tx,
-        &available_tool_schemas,
-        ToolExecutionSessionFlags::from_session(session),
-        false,
-        None,
-        Some(&arguments),
-    );
-
-    let result = match tools.execute_with_context(&call, context).await {
-        Ok(result) if result.success => result,
-        Ok(result) => {
-            return Err(format!(
-                "Explicit workflow '{skill_id}' preload was unsuccessful: {}",
-                result.result
-            ));
-        }
-        Err(error) => {
-            return Err(format!(
-                "Explicit workflow '{skill_id}' preload failed: {error}"
-            ));
-        }
-    };
-
-    session.metadata.insert(
-        LOADED_SKILL_IDS_METADATA_KEY.to_string(),
-        serde_json::json!([skill_id]).to_string(),
-    );
-    session.metadata.insert(
-        LAST_LOADED_SKILL_ID_METADATA_KEY.to_string(),
-        skill_id.to_string(),
-    );
-    session.metadata.insert(
-        LAST_LOADED_SKILL_SUMMARY_METADATA_KEY.to_string(),
-        serde_json::json!({
-            "skill_id": skill_id,
-            "loaded_ids": [skill_id],
-            "selected_skill_mode": selection.selected_skill_mode,
-            "loaded_count": 1
-        })
-        .to_string(),
-    );
-
-    let payload_value = serde_json::from_str::<serde_json::Value>(&result.result)
-        .map_err(|_| format!("Explicit workflow '{skill_id}' returned an invalid payload"))?;
-    if let Some(dynamic) = payload_value.get("dynamic_context") {
-        session.metadata.insert(
-            bamboo_skills::WORKFLOW_LAST_DYNAMIC_CONTEXT_METADATA_KEY.to_string(),
-            dynamic.to_string(),
-        );
-    }
-    if payload_value["activation_status"].as_str() == Some("degraded") {
-        session.metadata.insert(
-            bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_ERROR_KEY.to_string(),
-            payload_value["dynamic_context"].to_string(),
-        );
-        session
-            .metadata
-            .remove(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY);
-        session
-            .metadata
-            .remove(bamboo_skills::ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY);
-        return Ok(Some(String::new()));
-    }
-    let canonical_context = serde_json::json!({
-        "id": skill_id,
-        "revision": payload_value.get("revision"),
-        "selection": session.metadata.get(bamboo_skills::WORKFLOW_SELECTION_METADATA_KEY),
-        "instructions": payload_value.get("instructions"),
-        "dynamic_context": payload_value.get("dynamic_context"),
-    });
-    let fingerprint = hex::encode(Sha256::digest(canonical_context.to_string().as_bytes()));
-    bamboo_skills::record_loaded_workflow_activation(&mut session.metadata, skill_id, fingerprint)
-        .map_err(|diagnostic| diagnostic.message)?;
-    // The tool already published WorkflowActivated through this run's real
-    // event channel. Acknowledge the mirrored local pending marker before the
-    // setup save, and let the per-round dedicated WorkflowRuntime ContextBlock
-    // carry the exact durable instructions without duplicating system text.
-    session
+    let loaded_matches = session
         .metadata
-        .remove(bamboo_skills::WORKFLOW_ACTIVATION_EVENT_METADATA_KEY);
+        .get(LOADED_SKILL_IDS_METADATA_KEY)
+        .and_then(|raw| serde_json::from_str::<Vec<String>>(raw).ok())
+        .is_some_and(|loaded| loaded == selection.selected_skill_ids);
+    let active_matches = session
+        .metadata
+        .get(bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY)
+        .and_then(|raw| serde_json::from_str::<bamboo_skills::ActiveWorkflow>(raw).ok())
+        .is_some_and(|active| {
+            active.id == skill_id
+                && active.status == bamboo_skills::WorkflowActivationStatus::Active
+        });
+    loaded_matches
+        && active_matches
+        && session
+            .metadata
+            .contains_key(bamboo_skills::ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY)
+}
 
-    Ok(Some(String::new()))
+/// Clear a prior activation only when a newly resolved selection supersedes it.
+/// The new candidate pin is kept so the model-issued `load_skill` call can load
+/// the exact catalog revision selected during this setup pass.
+pub(super) fn reset_activation_state_for_new_selection(
+    session: &mut Session,
+    selection: &SkillContextLoadResult,
+) {
+    if selection.selection_source.is_none()
+        || selection_matches_loaded_activation(session, selection)
+    {
+        return;
+    }
+    for key in [
+        LOADED_SKILL_IDS_METADATA_KEY,
+        LAST_LOADED_SKILL_ID_METADATA_KEY,
+        LAST_LOADED_SKILL_SUMMARY_METADATA_KEY,
+        bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY,
+        bamboo_skills::ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY,
+        bamboo_skills::WORKFLOW_ACTIVATION_EVENT_METADATA_KEY,
+        bamboo_skills::WORKFLOW_LAST_DYNAMIC_CONTEXT_METADATA_KEY,
+        bamboo_skills::WORKFLOW_CONTEXT_CACHE_METADATA_KEY,
+    ] {
+        session.metadata.remove(key);
+    }
+}
+
+pub(crate) fn explicit_activation_pending(session: &Session) -> bool {
+    let selected_skill_ids = session
+        .metadata
+        .get(SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY)
+        .and_then(|raw| serde_json::from_str::<Vec<String>>(raw).ok())
+        .unwrap_or_default();
+    if session
+        .metadata
+        .get(SKILL_RUNTIME_SELECTION_SOURCE_KEY)
+        .is_none_or(|source| source != "explicit")
+        || selected_skill_ids.len() != 1
+        || session
+            .metadata
+            .contains_key(bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_ERROR_KEY)
+    {
+        return false;
+    }
+    let selection = SkillContextLoadResult {
+        selected_skill_ids,
+        selection_source: Some("explicit".to_string()),
+        ..Default::default()
+    };
+    !selection_matches_loaded_activation(session, &selection)
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tests.rs
@@ -122,6 +122,47 @@ fn schema(name: &str) -> ToolSchema {
     }
 }
 
+fn mark_test_activation_current(session: &mut Session, skill_id: &str) {
+    session.metadata.insert(
+        bamboo_skills::runtime_metadata::LOADED_SKILL_IDS_METADATA_KEY.to_string(),
+        serde_json::json!([skill_id]).to_string(),
+    );
+    session.metadata.insert(
+        bamboo_skills::ACTIVE_WORKFLOW_METADATA_KEY.to_string(),
+        serde_json::json!({
+            "id": skill_id,
+            "source": "builtin",
+            "revision": 1,
+            "kind": "instruction",
+            "args": {},
+            "invoked_by": "user",
+            "activated_at": "2026-07-21T00:00:00Z",
+            "status": "active"
+        })
+        .to_string(),
+    );
+    session.metadata.insert(
+        bamboo_skills::ACTIVE_WORKFLOW_SNAPSHOT_METADATA_KEY.to_string(),
+        "{}".to_string(),
+    );
+}
+
+fn record_test_activation_from_pinned_snapshot(session: &mut Session, skill_id: &str) {
+    session.metadata.insert(
+        bamboo_skills::runtime_metadata::LOADED_SKILL_IDS_METADATA_KEY.to_string(),
+        serde_json::json!([skill_id]).to_string(),
+    );
+    bamboo_skills::record_loaded_workflow_activation(
+        &mut session.metadata,
+        skill_id,
+        "test-context-fingerprint".to_string(),
+    )
+    .expect("record pinned test activation");
+    session
+        .metadata
+        .remove(bamboo_skills::WORKFLOW_ACTIVATION_EVENT_METADATA_KEY);
+}
+
 #[tokio::test]
 async fn pending_workflow_deactivation_is_published_and_acked_exactly_once() {
     let persistence = Arc::new(RecordingPersistence::default());
@@ -263,6 +304,10 @@ async fn session_setup_publishes_current_skill_allowlist_before_tool_execution()
     };
     let mut session = Session::new("selection-publish", "model");
     let (event_tx, _event_rx) = tokio::sync::mpsc::channel(8);
+    session.metadata.insert(
+        "skill_runtime_loaded_skill_ids".to_string(),
+        "[\"review\"]".to_string(),
+    );
 
     super::prepare_session_for_loop(
         &mut session,
@@ -315,6 +360,12 @@ async fn session_setup_publishes_current_skill_allowlist_before_tool_execution()
         .expect("metadata-only catalog publication");
     assert!(published_catalog.contains("review"));
     assert!(!published_catalog.contains("pinned instructions"));
+    assert!(
+        !session
+            .metadata
+            .contains_key("skill_runtime_loaded_skill_ids"),
+        "a new automatic selection must not inherit the previous run's activation"
+    );
     let saved = persistence.sessions.lock().expect("recording lock");
     let published = saved.last().expect("selection published");
     let ids = published
@@ -326,7 +377,7 @@ async fn session_setup_publishes_current_skill_allowlist_before_tool_execution()
 }
 
 #[tokio::test]
-async fn session_setup_preloads_one_explicit_skill_before_model_execution() {
+async fn session_setup_requires_model_issued_load_for_one_explicit_skill() {
     let directory = tempfile::tempdir().expect("tempdir");
     let manager = Arc::new(SkillManager::with_config(SkillStoreConfig {
         skills_dir: directory.path().join("skills"),
@@ -362,9 +413,98 @@ async fn session_setup_preloads_one_explicit_skill_before_model_execution() {
     .expect("session setup");
 
     let calls = tools.calls.lock().expect("recording tool lock");
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].function.name, "load_skill");
-    assert!(calls[0].function.arguments.contains("review"));
+    assert!(
+        calls.is_empty(),
+        "the runtime must not impersonate the model"
+    );
+    assert!(session.messages.iter().all(|message| {
+        !message.content.contains("## Explicit Workflow Activated")
+            && !message.content.contains("REPORT_ONLY_ACTIONABLE_FINDINGS")
+    }));
+    assert!(
+        super::prompt_envelope::build_active_workflow_context_block(&session).is_none(),
+        "the workflow is not active until the model-issued load_skill succeeds"
+    );
+    assert!(
+        event_rx.try_recv().is_err(),
+        "selection alone must not emit WorkflowActivated"
+    );
+    assert!(!session
+        .metadata
+        .contains_key("skill_runtime_loaded_skill_ids"));
+    let system_prompt = session
+        .messages
+        .iter()
+        .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
+        .expect("system prompt")
+        .content
+        .as_str();
+    assert!(system_prompt.contains("## Required Explicit Workflow Activation"));
+    assert!(system_prompt.contains("first response step MUST be exactly one `load_skill` call"));
+    assert!(system_prompt.contains("review"));
+
+    let saved = persistence.sessions.lock().expect("recording lock");
+    assert!(saved.iter().all(|saved_session| !saved_session
+        .metadata
+        .contains_key("skill_runtime_loaded_skill_ids")));
+}
+
+#[tokio::test]
+async fn permission_style_second_prepare_preserves_unchanged_explicit_activation() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let manager = Arc::new(SkillManager::with_config(SkillStoreConfig {
+        skills_dir: directory.path().join("skills"),
+        ..Default::default()
+    }));
+    manager.initialize().await.expect("initialize skills");
+    let persistence = Arc::new(RecordingPersistence::default());
+    let config = crate::runtime::config::AgentLoopConfig {
+        skill_manager: Some(manager),
+        selected_skill_ids: Some(vec!["review".to_string()]),
+        persistence: Some(persistence),
+        ..Default::default()
+    };
+    let tools = RecordingToolExecutor {
+        calls: Mutex::new(Vec::new()),
+        schemas: vec![schema("load_skill")],
+    };
+    let mut session = Session::new("explicit-review-resume", "model");
+    let logger = crate::runtime::runner::logging::DebugLogger::new(false);
+    let (event_tx, _event_rx) = tokio::sync::mpsc::channel(8);
+
+    super::prepare_session_for_loop(
+        &mut session,
+        "Review this change",
+        &config,
+        &tools,
+        None,
+        "explicit-review-resume",
+        &logger,
+        false,
+        &event_tx,
+    )
+    .await
+    .expect("initial explicit setup");
+    assert!(super::skill_context::explicit_activation_pending(&session));
+    record_test_activation_from_pinned_snapshot(&mut session, "review");
+    assert!(!super::skill_context::explicit_activation_pending(&session));
+
+    // Mirrors re-entry after a permission/tool suspension: same session, same
+    // explicit workflow, and a second prepare before the model continues.
+    super::prepare_session_for_loop(
+        &mut session,
+        "Review this change",
+        &config,
+        &tools,
+        None,
+        "explicit-review-resume",
+        &logger,
+        true,
+        &event_tx,
+    )
+    .await
+    .expect("resume explicit setup");
+
     assert_eq!(
         session
             .metadata
@@ -372,61 +512,61 @@ async fn session_setup_preloads_one_explicit_skill_before_model_execution() {
             .map(String::as_str),
         Some("[\"review\"]")
     );
-    assert_eq!(
-        session
-            .metadata
-            .get("skill_runtime_last_loaded_skill_id")
-            .map(String::as_str),
-        Some("review")
-    );
-    assert!(session.messages.iter().all(|message| {
-        !message.content.contains("## Explicit Workflow Activated")
-            && !message.content.contains("REPORT_ONLY_ACTIONABLE_FINDINGS")
-    }));
-    let workflow_block = super::prompt_envelope::build_active_workflow_context_block(&session)
-        .expect("dedicated active workflow context block");
-    assert_eq!(
-        workflow_block.block_type,
-        bamboo_agent_core::ContextBlockType::WorkflowRuntime
-    );
-    assert!(workflow_block.content.contains("workflow_id: review"));
-    assert!(workflow_block.content.contains("### Instructions"));
-    assert_eq!(
-        super::prompt_envelope::build_active_workflow_context_block(&session),
-        Some(workflow_block.clone()),
-        "each round must rebuild one deterministic workflow block"
-    );
-    let rendered = workflow_block.render_runtime_context_message();
-    assert!(rendered.never_compress);
-    assert_eq!(
-        session
-            .messages
-            .iter()
-            .filter(|message| message.content.contains("context_type: workflow_runtime"))
-            .count(),
-        0,
-        "runtime workflow context must not be appended to durable user history"
-    );
-    assert!(matches!(
-        event_rx.try_recv(),
-        Ok(bamboo_agent_core::AgentEvent::WorkflowActivated {
-            ref session_id,
-            ref workflow_id,
-            ..
-        }) if session_id == "explicit-review" && workflow_id == "review"
-    ));
+    assert!(!super::skill_context::explicit_activation_pending(&session));
+    let system_prompt = session
+        .messages
+        .iter()
+        .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
+        .expect("system prompt")
+        .content
+        .as_str();
+    assert!(!system_prompt.contains("## Required Explicit Workflow Activation"));
+    assert!(system_prompt.contains("## Explicit Workflow Already Activated"));
     assert!(
-        event_rx.try_recv().is_err(),
-        "activation must emit exactly once"
+        system_prompt.contains("Do not call `load_skill` again solely because execution resumed")
     );
+    assert!(tools.calls.lock().expect("recording tool lock").is_empty());
+}
 
-    let saved = persistence.sessions.lock().expect("recording lock");
-    assert!(saved.iter().any(|saved_session| {
-        saved_session
+#[test]
+fn activation_reset_preserves_same_explicit_and_clears_superseded_selection() {
+    let explicit_review = super::skill_context::SkillContextLoadResult {
+        selected_skill_ids: vec!["review".to_string()],
+        selection_source: Some("explicit".to_string()),
+        ..Default::default()
+    };
+    let mut session = Session::new("activation-reset", "model");
+    mark_test_activation_current(&mut session, "review");
+
+    super::skill_context::reset_activation_state_for_new_selection(&mut session, &explicit_review);
+    assert_eq!(
+        session
             .metadata
             .get("skill_runtime_loaded_skill_ids")
-            .is_some_and(|ids| ids == "[\"review\"]")
-    }));
+            .map(String::as_str),
+        Some("[\"review\"]")
+    );
+
+    let explicit_plan = super::skill_context::SkillContextLoadResult {
+        selected_skill_ids: vec!["plan".to_string()],
+        selection_source: Some("explicit".to_string()),
+        ..Default::default()
+    };
+    super::skill_context::reset_activation_state_for_new_selection(&mut session, &explicit_plan);
+    assert!(!session
+        .metadata
+        .contains_key("skill_runtime_loaded_skill_ids"));
+
+    mark_test_activation_current(&mut session, "review");
+    let automatic_review = super::skill_context::SkillContextLoadResult {
+        selected_skill_ids: vec!["review".to_string()],
+        selection_source: Some("auto".to_string()),
+        ..Default::default()
+    };
+    super::skill_context::reset_activation_state_for_new_selection(&mut session, &automatic_review);
+    assert!(!session
+        .metadata
+        .contains_key("skill_runtime_loaded_skill_ids"));
 }
 
 #[tokio::test]
@@ -615,6 +755,31 @@ fn resolve_available_tool_schemas_keeps_load_skill_for_new_automatic_selection()
 
     assert!(names.contains(&"load_skill"));
     assert!(names.contains(&"read_skill_resource"));
+}
+
+#[test]
+fn explicit_activation_state_becomes_current_only_after_successful_model_load() {
+    let mut session = Session::new("explicit-activation-state", "model");
+    session.metadata.insert(
+        "skill_runtime_selection_source".to_string(),
+        "explicit".to_string(),
+    );
+    session.metadata.insert(
+        "skill_runtime_selected_skill_ids".to_string(),
+        "[\"review\"]".to_string(),
+    );
+    assert!(super::skill_context::explicit_activation_pending(&session));
+
+    mark_test_activation_current(&mut session, "review");
+
+    assert!(!super::skill_context::explicit_activation_pending(&session));
+    assert_eq!(
+        session
+            .metadata
+            .get("skill_runtime_loaded_skill_ids")
+            .map(String::as_str),
+        Some("[\"review\"]")
+    );
 }
 
 #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tool_schemas.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/tool_schemas.rs
@@ -67,10 +67,12 @@ pub(crate) fn resolve_available_tool_schemas_for_session(
         });
     }
 
-    // One activation chooses one workflow. Once its detailed instructions have
-    // been loaded, stop offering load_skill so the model cannot redundantly
-    // reload the same workflow (or switch to another advertised candidate) on a
-    // later round. Resource reads remain available for the active workflow.
+    // Once a single explicitly selected workflow reaches a terminal activation
+    // result, stop advertising load_skill so the model-issued attempt occurs
+    // exactly once. A typed degraded result is terminal too: the main session
+    // continues without workflow instructions instead of retrying forever.
+    // Automatic catalogs keep the tool available until the model chooses a
+    // candidate.
     let loaded_skill_ids = session
         .metadata
         .get(LOADED_SKILL_IDS_METADATA_KEY)
@@ -81,13 +83,18 @@ pub(crate) fn resolve_available_tool_schemas_for_session(
         .get(SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY)
         .and_then(|raw| serde_json::from_str::<Vec<String>>(raw).ok())
         .unwrap_or_default();
-    let explicit_activation_is_current = session
+    let explicit_selection = session
         .metadata
         .get(SKILL_RUNTIME_SELECTION_SOURCE_KEY)
-        .is_some_and(|source| source == "explicit")
+        .is_some_and(|source| source == "explicit");
+    let explicit_activation_is_current = explicit_selection
         && !loaded_skill_ids.is_empty()
         && loaded_skill_ids == selected_skill_ids;
-    if explicit_activation_is_current {
+    let explicit_activation_degraded = explicit_selection
+        && session
+            .metadata
+            .contains_key(bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_ERROR_KEY);
+    if explicit_activation_is_current || explicit_activation_degraded {
         tool_schemas.retain(|schema| schema.function.name != "load_skill");
     }
 
@@ -135,7 +142,7 @@ mod live_disabled_tests {
             self.execute(call).await
         }
         fn list_tools(&self) -> Vec<ToolSchema> {
-            ["alpha_tool", "beta_tool"]
+            ["alpha_tool", "beta_tool", "load_skill"]
                 .into_iter()
                 .map(|name| ToolSchema {
                     schema_type: "function".into(),
@@ -183,5 +190,30 @@ mod live_disabled_tests {
         // alpha_tool still offered. Re-enable would restore it (list rebuilt fresh).
         assert!(!offered(&config, &tools, &session, "beta_tool"));
         assert!(offered(&config, &tools, &session, "alpha_tool"));
+    }
+
+    #[test]
+    fn explicit_degraded_activation_hides_load_skill_after_one_attempt() {
+        let config = AgentLoopConfig::default();
+        let tools = TwoTools;
+        let mut session = Session::new("degraded", "m");
+        session.metadata.insert(
+            SKILL_RUNTIME_SELECTION_SOURCE_KEY.to_string(),
+            "explicit".to_string(),
+        );
+        session.metadata.insert(
+            SKILL_RUNTIME_SELECTED_SKILL_IDS_KEY.to_string(),
+            r#"["review"]"#.to_string(),
+        );
+
+        assert!(offered(&config, &tools, &session, "load_skill"));
+        session.metadata.insert(
+            bamboo_skills::runtime_metadata::SKILL_RUNTIME_ACTIVATION_ERROR_KEY.to_string(),
+            r#"{"code":"provider_failed"}"#.to_string(),
+        );
+        assert!(!offered(&config, &tools, &session, "load_skill"));
+        assert!(!super::super::skill_context::explicit_activation_pending(
+            &session
+        ));
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tests.rs
@@ -660,7 +660,7 @@ async fn activation_metadata_persistence_failure_releases_pin_before_provider_ca
 }
 
 #[tokio::test]
-async fn post_preload_persistence_failure_stops_before_provider_and_releases_pin() {
+async fn activation_tool_call_checkpoint_failure_stops_before_tool_and_releases_pin() {
     struct FailSecondSave(Arc<std::sync::atomic::AtomicUsize>);
     #[async_trait]
     impl bamboo_domain::RuntimeSessionPersistence for FailSecondSave {
@@ -673,26 +673,14 @@ async fn post_preload_persistence_failure_stops_before_provider_and_releases_pin
             }
         }
     }
-    struct SuccessfulLoad;
+    struct NeverExecutedLoad;
     #[async_trait]
-    impl bamboo_agent_core::tools::ToolExecutor for SuccessfulLoad {
+    impl bamboo_agent_core::tools::ToolExecutor for NeverExecutedLoad {
         async fn execute(
             &self,
             _call: &bamboo_agent_core::tools::ToolCall,
         ) -> bamboo_agent_core::tools::executor::Result<ToolResult> {
-            Ok(ToolResult {
-                success: true,
-                result: serde_json::json!({
-                    "skill_id": "review",
-                    "revision": 1,
-                    "instructions": "pinned instructions",
-                    "dynamic_context": [],
-                    "activation_status": "active"
-                })
-                .to_string(),
-                display_preference: None,
-                images: Vec::new(),
-            })
+            panic!("assistant tool-call checkpoint must persist before load_skill executes")
         }
         fn list_tools(&self) -> Vec<bamboo_agent_core::tools::ToolSchema> {
             vec![bamboo_agent_core::tools::ToolSchema {
@@ -705,9 +693,9 @@ async fn post_preload_persistence_failure_stops_before_provider_and_releases_pin
             }]
         }
     }
-    struct NeverCalled;
+    struct ActivationProvider;
     #[async_trait]
-    impl LLMProvider for NeverCalled {
+    impl LLMProvider for ActivationProvider {
         async fn chat_stream(
             &self,
             _messages: &[Message],
@@ -715,7 +703,18 @@ async fn post_preload_persistence_failure_stops_before_provider_and_releases_pin
             _max_output_tokens: Option<u32>,
             _model: &str,
         ) -> bamboo_llm::provider::Result<LLMStream> {
-            panic!("second persistence failure must stop before provider")
+            let call = bamboo_agent_core::tools::ToolCall {
+                id: "load-review".to_string(),
+                tool_type: "function".to_string(),
+                function: FunctionCall {
+                    name: "load_skill".to_string(),
+                    arguments: r#"{"skill_id":"review"}"#.to_string(),
+                },
+            };
+            Ok(Box::pin(stream::iter(vec![
+                Ok(LLMChunk::ToolCalls(vec![call])),
+                Ok(LLMChunk::Done),
+            ])))
         }
     }
     let directory = tempfile::tempdir().expect("tempdir");
@@ -726,15 +725,15 @@ async fn post_preload_persistence_failure_stops_before_provider_and_releases_pin
         },
     ));
     manager.initialize().await.expect("initialize");
-    let mut session = Session::new("post-preload-save-failure", "model");
+    let mut session = Session::new("activation-checkpoint-failure", "model");
     let save_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let (event_tx, _event_rx) = mpsc::channel(4);
     let result = super::run_agent_loop_with_config(
         &mut session,
         "review".to_string(),
         event_tx,
-        Arc::new(NeverCalled),
-        Arc::new(SuccessfulLoad),
+        Arc::new(ActivationProvider),
+        Arc::new(NeverExecutedLoad),
         CancellationToken::new(),
         AgentLoopConfig {
             skill_manager: Some(manager.clone()),
@@ -746,13 +745,13 @@ async fn post_preload_persistence_failure_stops_before_provider_and_releases_pin
     )
     .await;
     assert!(result
-        .expect_err("post preload save must fail")
+        .expect_err("activation tool-call checkpoint must fail")
         .to_string()
-        .contains("loaded-state could not be published"));
+        .contains("assistant tool-call checkpoint could not be persisted"));
     assert_eq!(save_count.load(std::sync::atomic::Ordering::SeqCst), 2);
     assert!(manager
         .store()
-        .activation_descriptor("post-preload-save-failure")
+        .activation_descriptor("activation-checkpoint-failure")
         .await
         .is_none());
     assert!(!session
@@ -764,7 +763,7 @@ async fn post_preload_persistence_failure_stops_before_provider_and_releases_pin
 }
 
 #[tokio::test]
-async fn unsuccessful_explicit_preload_stops_before_provider_and_releases_pin() {
+async fn unsuccessful_model_issued_explicit_activation_stops_before_answer_and_releases_pin() {
     struct UnsuccessfulLoad;
     #[async_trait]
     impl bamboo_agent_core::tools::ToolExecutor for UnsuccessfulLoad {
@@ -774,7 +773,7 @@ async fn unsuccessful_explicit_preload_stops_before_provider_and_releases_pin() 
         ) -> bamboo_agent_core::tools::executor::Result<ToolResult> {
             Ok(ToolResult {
                 success: false,
-                result: "injected preload failure".to_string(),
+                result: "injected activation failure".to_string(),
                 display_preference: None,
                 images: Vec::new(),
             })
@@ -790,9 +789,9 @@ async fn unsuccessful_explicit_preload_stops_before_provider_and_releases_pin() 
             }]
         }
     }
-    struct NeverCalled;
+    struct ActivationProvider;
     #[async_trait]
-    impl LLMProvider for NeverCalled {
+    impl LLMProvider for ActivationProvider {
         async fn chat_stream(
             &self,
             _messages: &[Message],
@@ -800,7 +799,18 @@ async fn unsuccessful_explicit_preload_stops_before_provider_and_releases_pin() 
             _max_output_tokens: Option<u32>,
             _model: &str,
         ) -> bamboo_llm::provider::Result<LLMStream> {
-            panic!("unsuccessful explicit preload must stop before provider")
+            let call = bamboo_agent_core::tools::ToolCall {
+                id: "load-review".to_string(),
+                tool_type: "function".to_string(),
+                function: FunctionCall {
+                    name: "load_skill".to_string(),
+                    arguments: r#"{"skill_id":"review"}"#.to_string(),
+                },
+            };
+            Ok(Box::pin(stream::iter(vec![
+                Ok(LLMChunk::ToolCalls(vec![call])),
+                Ok(LLMChunk::Done),
+            ])))
         }
     }
     let directory = tempfile::tempdir().expect("tempdir");
@@ -811,13 +821,13 @@ async fn unsuccessful_explicit_preload_stops_before_provider_and_releases_pin() 
         },
     ));
     manager.initialize().await.expect("initialize");
-    let mut session = Session::new("unsuccessful-preload", "model");
-    let (event_tx, _event_rx) = mpsc::channel(4);
+    let mut session = Session::new("unsuccessful-model-activation", "model");
+    let (event_tx, _event_rx) = mpsc::channel(64);
     let result = super::run_agent_loop_with_config(
         &mut session,
         "review".to_string(),
         event_tx,
-        Arc::new(NeverCalled),
+        Arc::new(ActivationProvider),
         Arc::new(UnsuccessfulLoad),
         CancellationToken::new(),
         AgentLoopConfig {
@@ -829,12 +839,12 @@ async fn unsuccessful_explicit_preload_stops_before_provider_and_releases_pin() 
     )
     .await;
     assert!(result
-        .expect_err("preload must fail closed")
+        .expect_err("model-issued activation must fail closed")
         .to_string()
-        .contains("preload was unsuccessful"));
+        .contains("failed to activate; refusing to continue"));
     assert!(manager
         .store()
-        .activation_descriptor("unsuccessful-preload")
+        .activation_descriptor("unsuccessful-model-activation")
         .await
         .is_none());
 }

--- a/crates/engine/bamboo-engine/src/runtime/task_evaluation/executor.rs
+++ b/crates/engine/bamboo-engine/src/runtime/task_evaluation/executor.rs
@@ -105,6 +105,7 @@ pub async fn evaluate_task_progress(
         session_id: Some(session_id.to_string()),
         reasoning_effort: request_reasoning_effort,
         parallel_tool_calls: None,
+        required_tool: None,
         responses: None,
         request_purpose: Some("task_evaluation".to_string()),
         cache: None,

--- a/crates/infra/bamboo-llm/src/protocol/gemini.rs
+++ b/crates/infra/bamboo-llm/src/protocol/gemini.rs
@@ -140,6 +140,14 @@ pub struct GeminiFunctionResponse {
     pub response: Value,
 }
 
+fn normalize_function_response(content: &str) -> Value {
+    match serde_json::from_str(content) {
+        Ok(Value::Object(response)) => Value::Object(response),
+        Ok(response) => serde_json::json!({ "result": response }),
+        Err(_) => serde_json::json!({ "result": content }),
+    }
+}
+
 /// Gemini tool definition
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GeminiTool {
@@ -379,8 +387,10 @@ impl ToProvider<GeminiContent> for Message {
                     function_call: None,
                     function_response: Some(GeminiFunctionResponse {
                         name: tool_name,
-                        response: serde_json::from_str(&self.content)
-                            .unwrap_or_else(|_| Value::String(self.content.clone())),
+                        // Gemini's functionResponse.response field is a protobuf
+                        // Struct, so scalar, array, and plain-text tool results
+                        // must be wrapped in an object before serialization.
+                        response: normalize_function_response(&self.content),
                     }),
                 }],
             });
@@ -824,6 +834,33 @@ mod tests {
 
         let func_resp = gemini.parts[0].function_response.as_ref().unwrap();
         assert_eq!(func_resp.name, "search_tool");
+        assert_eq!(func_resp.response, serde_json::json!({ "result": "ok" }));
+    }
+
+    #[test]
+    fn test_plain_text_tool_response_is_wrapped_in_object() {
+        let internal = Message::tool_result("read_file", "plain text output");
+
+        let gemini: GeminiContent = internal.to_provider().unwrap();
+
+        let func_resp = gemini.parts[0].function_response.as_ref().unwrap();
+        assert_eq!(
+            func_resp.response,
+            serde_json::json!({ "result": "plain text output" })
+        );
+    }
+
+    #[test]
+    fn test_non_object_json_tool_response_is_wrapped_in_object() {
+        let internal = Message::tool_result("list_items", r#"["first", "second"]"#);
+
+        let gemini: GeminiContent = internal.to_provider().unwrap();
+
+        let func_resp = gemini.parts[0].function_response.as_ref().unwrap();
+        assert_eq!(
+            func_resp.response,
+            serde_json::json!({ "result": ["first", "second"] })
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/provider.rs
+++ b/crates/infra/bamboo-llm/src/provider.rs
@@ -111,6 +111,10 @@ pub struct LLMRequestOptions {
     /// - OpenAI/Copilot: maps to `parallel_tool_calls`
     /// - Anthropic: maps to `tool_choice.disable_parallel_tool_use` (inverse)
     pub parallel_tool_calls: Option<bool>,
+    /// Require the model to issue this specific tool call when the provider
+    /// supports request-level tool choice. Providers translate this to their
+    /// native forced-function form; `None` preserves normal automatic choice.
+    pub required_tool: Option<String>,
     /// Responses API specific overrides.
     pub responses: Option<ResponsesRequestOptions>,
     /// Purpose of this request for observability (e.g., "agent_loop", "task_evaluation").
@@ -120,6 +124,28 @@ pub struct LLMRequestOptions {
     /// (Anthropic `cache_control` breakpoints; OpenAI/Gemini rely on the stable
     /// prefix automatically). `None` means "no explicit cache hints".
     pub cache: Option<crate::cache::PromptCachePlan>,
+}
+
+/// Resolve a forced named-tool request and fail before network I/O when the
+/// requested schema is not actually offered to the provider.
+pub(crate) fn required_tool_from_options<'a>(
+    options: Option<&'a LLMRequestOptions>,
+    tools: &[ToolSchema],
+) -> Result<Option<&'a str>> {
+    let Some(name) = options
+        .and_then(|options| options.required_tool.as_deref())
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+    else {
+        return Ok(None);
+    };
+    if tools.iter().any(|tool| tool.function.name == name) {
+        Ok(Some(name))
+    } else {
+        Err(LLMError::Api(format!(
+            "required tool schema '{name}' was not offered"
+        )))
+    }
 }
 
 /// Trait for LLM provider implementations

--- a/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/anthropic/mod.rs
@@ -25,12 +25,62 @@ use serde_json::{json, Value};
 use crate::cache::{CacheTtl, PromptCachePlan, MAX_ANTHROPIC_CACHE_BREAKPOINTS};
 use crate::prompt_ir::PromptIR;
 use crate::provider::LLMRequestOptions;
-use crate::provider::{LLMError, LLMProvider, LLMStream, Result};
+use crate::provider::{required_tool_from_options, LLMError, LLMProvider, LLMStream, Result};
 use crate::providers::common::model_fetcher;
 use crate::providers::common::request_overrides;
 use crate::types::LLMChunk;
 use bamboo_config::{KeywordMaskingConfig, RequestOverridesConfig};
 use bamboo_domain::ReasoningEffort;
+
+pub(crate) fn reasoning_effort_for_required_tool(
+    configured: Option<ReasoningEffort>,
+    required_tool: Option<&str>,
+) -> Option<ReasoningEffort> {
+    if required_tool.is_some() {
+        None
+    } else {
+        configured
+    }
+}
+
+pub(crate) fn apply_required_tool_choice(body: &mut Value, required_tool: Option<&str>) {
+    if let Some(name) = required_tool {
+        // Anthropic-compatible reasoning models (including DeepSeek through an
+        // Anthropic endpoint) reject forced named-tool choice while thinking is
+        // enabled. This is a request-scoped activation turn, so remove thinking
+        // after all request overrides and restore normal behavior next round.
+        if let Some(object) = body.as_object_mut() {
+            object.remove("thinking");
+        }
+        body["tool_choice"] = json!({
+            "type": "tool",
+            "name": name,
+            "disable_parallel_tool_use": true
+        });
+    }
+}
+
+pub(crate) fn apply_required_tool_auto_fallback(body: &mut Value, required_tool: Option<&str>) {
+    if required_tool.is_some() {
+        if let Some(object) = body.as_object_mut() {
+            object.remove("thinking");
+        }
+        body["tool_choice"] = json!({
+            "type": "auto",
+            "disable_parallel_tool_use": true
+        });
+    }
+}
+
+pub(crate) fn looks_like_thinking_forced_tool_choice_error(
+    status: reqwest::StatusCode,
+    body: &str,
+) -> bool {
+    status == reqwest::StatusCode::BAD_REQUEST
+        && body
+            .to_ascii_lowercase()
+            .contains("thinking mode does not support this tool_choice")
+}
 
 /// Anthropic Messages API provider.
 pub struct AnthropicProvider {
@@ -226,16 +276,24 @@ impl AnthropicProvider {
         options: Option<&LLMRequestOptions>,
     ) -> Result<LLMStream> {
         let max_tokens = max_output_tokens.unwrap_or(self.max_tokens);
-        let reasoning_effort = options
+        let parallel_tool_calls = options.and_then(|o| o.parallel_tool_calls);
+        let required_tool = required_tool_from_options(options, tools)?;
+        let configured_reasoning_effort = options
             .and_then(|o| o.reasoning_effort)
             .or(self.default_reasoning_effort);
-        let request_reasoning_effort = options.and_then(|o| o.reasoning_effort);
-        let parallel_tool_calls = options.and_then(|o| o.parallel_tool_calls);
+        let reasoning_effort =
+            reasoning_effort_for_required_tool(configured_reasoning_effort, required_tool);
+        let request_reasoning_effort = reasoning_effort_for_required_tool(
+            options.and_then(|o| o.reasoning_effort),
+            required_tool,
+        );
         let cache_plan = options.and_then(|o| o.cache.as_ref());
         let extended_cache_ttl = cache_plan
             .map(|plan| plan.ttl == CacheTtl::Extended)
             .unwrap_or(false);
-        let reasoning_source = if request_reasoning_effort.is_some() {
+        let reasoning_source = if required_tool.is_some() {
+            "required_tool_disabled"
+        } else if request_reasoning_effort.is_some() {
             "request"
         } else if self.default_reasoning_effort.is_some() {
             "provider_default"
@@ -270,6 +328,7 @@ impl AnthropicProvider {
             request_overrides::ENDPOINT_MESSAGES,
             Some(model),
         );
+        apply_required_tool_choice(&mut body, required_tool);
         // Last-moment scan: mask every text value in the fully-assembled body.
         crate::masking::mask_outbound_body(&mut body, &self.masking_config);
         // DIAGNOSTIC: count image blocks actually present in the OUTGOING request
@@ -355,7 +414,59 @@ impl AnthropicProvider {
             let status = response.status();
             let text = response.text().await.map_err(LLMError::Http)?;
 
-            if reasoning_effort.is_some()
+            if required_tool.is_some()
+                && looks_like_thinking_forced_tool_choice_error(status, &text)
+            {
+                tracing::warn!(
+                    "[{}] Anthropic model '{}' rejected forced named tool_choice in thinking mode; retrying activation with tool_choice=auto and parallel tool use disabled",
+                    session_log_id,
+                    model
+                );
+                let mut fallback_body = build_anthropic_request_with_cache_blocks(
+                    messages,
+                    system_blocks,
+                    tools,
+                    model,
+                    max_tokens,
+                    true,
+                    None,
+                    Some(false),
+                    cache_plan,
+                    false,
+                );
+                request_overrides::apply_overrides_to_body(
+                    &mut fallback_body,
+                    self.request_overrides.as_ref(),
+                    request_overrides::ENDPOINT_MESSAGES,
+                    Some(model),
+                );
+                apply_required_tool_auto_fallback(&mut fallback_body, required_tool);
+                crate::masking::mask_outbound_body(&mut fallback_body, &self.masking_config);
+                response =
+                    crate::retry::send_with_retry(crate::retry::global(), "Anthropic", || {
+                        self.client
+                            .post(&messages_url)
+                            .headers(headers.clone())
+                            .json(&fallback_body)
+                    })
+                    .await
+                    .map_err(LLMError::Http)?;
+
+                if !response.status().is_success() {
+                    let fallback_status = response.status();
+                    let fallback_text = response.text().await.map_err(LLMError::Http)?;
+                    if fallback_status == 401 || fallback_status == 403 {
+                        return Err(LLMError::Auth(format!(
+                            "Anthropic authentication failed: {}. Please check your API key.",
+                            fallback_text
+                        )));
+                    }
+                    return Err(LLMError::Api(format!(
+                        "Anthropic API error after tool_choice=auto activation fallback: HTTP {}: {}",
+                        fallback_status, fallback_text
+                    )));
+                }
+            } else if reasoning_effort.is_some()
                 && Self::looks_like_reasoning_unsupported_error(status, &text)
             {
                 tracing::warn!(
@@ -381,6 +492,7 @@ impl AnthropicProvider {
                     request_overrides::ENDPOINT_MESSAGES,
                     Some(model),
                 );
+                apply_required_tool_choice(&mut fallback_body, required_tool);
                 crate::masking::mask_outbound_body(&mut fallback_body, &self.masking_config);
                 applied_reasoning_effort = None;
                 thinking_enabled = false;
@@ -2906,6 +3018,100 @@ mod anthropic_request_building {
     }
 
     #[test]
+    fn required_tool_choice_uses_anthropic_named_tool_shape() {
+        assert_eq!(
+            super::reasoning_effort_for_required_tool(
+                Some(bamboo_domain::ReasoningEffort::High),
+                Some("load_skill"),
+            ),
+            None
+        );
+        let messages = vec![Message::user("activate")];
+        let tools = sample_tools();
+        let mut body = super::build_anthropic_request(
+            &messages,
+            &tools,
+            "deepseek-v4-pro",
+            8192,
+            false,
+            Some(bamboo_domain::ReasoningEffort::High),
+            Some(false),
+        );
+        assert!(body.get("thinking").is_some(), "test precondition");
+        super::apply_required_tool_choice(&mut body, Some("load_skill"));
+        assert!(
+            body.get("thinking").is_none(),
+            "forced named-tool request must disable thinking"
+        );
+        assert_eq!(
+            body["tool_choice"],
+            serde_json::json!({
+                "type": "tool",
+                "name": "load_skill",
+                "disable_parallel_tool_use": true
+            })
+        );
+    }
+
+    #[test]
+    fn thinking_forced_tool_error_detector_is_exact() {
+        assert!(super::looks_like_thinking_forced_tool_choice_error(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"Thinking mode does not support this tool_choice"}}"#,
+        ));
+        assert!(!super::looks_like_thinking_forced_tool_choice_error(
+            reqwest::StatusCode::UNPROCESSABLE_ENTITY,
+            "Thinking mode does not support this tool_choice",
+        ));
+        assert!(!super::looks_like_thinking_forced_tool_choice_error(
+            reqwest::StatusCode::BAD_REQUEST,
+            "tool_choice is invalid for this request",
+        ));
+    }
+
+    #[test]
+    fn thinking_forced_tool_fallback_uses_auto_and_disables_parallel() {
+        let mut body = serde_json::json!({
+            "thinking": {"type": "enabled", "budget_tokens": 4096},
+            "tool_choice": {"type": "tool", "name": "overridden"}
+        });
+        super::apply_required_tool_auto_fallback(&mut body, Some("load_skill"));
+
+        assert!(body.get("thinking").is_none());
+        assert_eq!(
+            body["tool_choice"],
+            serde_json::json!({
+                "type": "auto",
+                "disable_parallel_tool_use": true
+            })
+        );
+    }
+
+    #[test]
+    fn normal_anthropic_request_keeps_configured_thinking() {
+        assert_eq!(
+            super::reasoning_effort_for_required_tool(
+                Some(bamboo_domain::ReasoningEffort::High),
+                None,
+            ),
+            Some(bamboo_domain::ReasoningEffort::High)
+        );
+        let body = super::build_anthropic_request(
+            &[Message::user("answer normally")],
+            &sample_tools(),
+            "deepseek-v4-pro",
+            8192,
+            false,
+            Some(bamboo_domain::ReasoningEffort::High),
+            Some(true),
+        );
+
+        assert!(body.get("thinking").is_some());
+        assert_eq!(body["tool_choice"]["type"], "auto");
+        assert_eq!(body["tool_choice"]["disable_parallel_tool_use"], false);
+    }
+
+    #[test]
     fn parallel_tool_calls_false_disables_parallel_tool_use() {
         let messages = vec![Message::user("Hello")];
         let tools = sample_tools();
@@ -3820,6 +4026,83 @@ mod anthropic_request_building_edge_cases {
 #[cfg(test)]
 mod anthropic_provider_tests {
     use super::*;
+    use bamboo_domain::{FunctionSchema, ToolSchema};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+    const THINKING_TOOL_CHOICE_ERROR: &str =
+        r#"{"error":{"message":"Thinking mode does not support this tool_choice"}}"#;
+    const ANTHROPIC_SSE_OK: &str = "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
+
+    struct ThinkingToolChoiceResponder;
+
+    impl Respond for ThinkingToolChoiceResponder {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            let body: Value = serde_json::from_slice(&request.body).expect("JSON request body");
+            if body["tool_choice"]["type"] == "tool" {
+                ResponseTemplate::new(400).set_body_string(THINKING_TOOL_CHOICE_ERROR)
+            } else {
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(ANTHROPIC_SSE_OK)
+            }
+        }
+    }
+
+    fn load_skill_tool() -> ToolSchema {
+        ToolSchema {
+            schema_type: "function".to_string(),
+            function: FunctionSchema {
+                name: "load_skill".to_string(),
+                description: "Load one skill".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn forced_named_tool_retries_exact_thinking_error_with_auto_choice() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages"))
+            .respond_with(ThinkingToolChoiceResponder)
+            .expect(2)
+            .mount(&server)
+            .await;
+        let provider = AnthropicProvider::new("test-key")
+            .with_base_url(server.uri())
+            .with_reasoning_effort(Some(ReasoningEffort::High));
+        let tools = vec![load_skill_tool()];
+        let options = LLMRequestOptions {
+            required_tool: Some("load_skill".to_string()),
+            parallel_tool_calls: Some(false),
+            ..Default::default()
+        };
+
+        let _stream = provider
+            .chat_stream_with_options(
+                &[Message::user("activate")],
+                &tools,
+                Some(8192),
+                "deepseek-v4-pro",
+                Some(&options),
+            )
+            .await
+            .expect("exact incompatibility should retry with auto choice");
+
+        let requests = server.received_requests().await.expect("requests recorded");
+        assert_eq!(requests.len(), 2);
+        let named: Value = serde_json::from_slice(&requests[0].body).unwrap();
+        let fallback: Value = serde_json::from_slice(&requests[1].body).unwrap();
+        assert!(named.get("thinking").is_none());
+        assert_eq!(named["tool_choice"]["type"], "tool");
+        assert_eq!(named["tool_choice"]["name"], "load_skill");
+        assert!(fallback.get("thinking").is_none());
+        assert_eq!(fallback["tool_choice"]["type"], "auto");
+        assert_eq!(fallback["tool_choice"]["disable_parallel_tool_use"], true);
+        assert_eq!(fallback["tools"].as_array().map(Vec::len), Some(1));
+        assert_eq!(fallback["tools"][0]["name"], "load_skill");
+    }
 
     #[test]
     fn test_new_provider() {

--- a/crates/infra/bamboo-llm/src/providers/bodhi/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/bodhi/mod.rs
@@ -392,7 +392,10 @@ impl BodhiProvider {
         crate::masking::mask_outbound_body(&mut request_json, &self.masking_config);
 
         let headers = self.build_headers()?;
-        let url = self.proxy_url(&format!("v1beta/models/{}:streamGenerateContent", model));
+        let url = self.proxy_url(&format!(
+            "v1beta/models/{}:streamGenerateContent?alt=sse",
+            model
+        ));
 
         // Retry the initial request on transient failures (issue #18); the
         // returned body is unread, so SSE streaming below is unaffected.

--- a/crates/infra/bamboo-llm/src/providers/bodhi/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/bodhi/mod.rs
@@ -116,6 +116,7 @@ impl LLMProvider for BodhiProvider {
             .and_then(|o| o.reasoning_effort)
             .or(self.default_reasoning_effort);
         let parallel_tool_calls = options.and_then(|o| o.parallel_tool_calls);
+        let required_tool = crate::provider::required_tool_from_options(options, tools)?;
         let request_purpose = options
             .and_then(|o| o.request_purpose.as_deref())
             .unwrap_or("unknown");
@@ -140,16 +141,31 @@ impl LLMProvider for BodhiProvider {
                     model,
                     reasoning_effort,
                     parallel_tool_calls,
+                    required_tool,
                 )
                 .await
             }
             "anthropic" => {
-                self.proxy_anthropic(messages, tools, max_output_tokens, model, reasoning_effort)
-                    .await
+                self.proxy_anthropic(
+                    messages,
+                    tools,
+                    max_output_tokens,
+                    model,
+                    reasoning_effort,
+                    required_tool,
+                )
+                .await
             }
             "gemini" => {
-                self.proxy_gemini(messages, tools, max_output_tokens, model, reasoning_effort)
-                    .await
+                self.proxy_gemini(
+                    messages,
+                    tools,
+                    max_output_tokens,
+                    model,
+                    reasoning_effort,
+                    required_tool,
+                )
+                .await
             }
             other => Err(LLMError::Auth(format!(
                 "Unknown bodhi target provider: {}",
@@ -179,6 +195,7 @@ impl LLMProvider for BodhiProvider {
 }
 
 impl BodhiProvider {
+    #[allow(clippy::too_many_arguments)]
     async fn proxy_openai(
         &self,
         messages: &[Message],
@@ -187,12 +204,13 @@ impl BodhiProvider {
         model: &str,
         reasoning_effort: Option<ReasoningEffort>,
         parallel_tool_calls: Option<bool>,
+        required_tool: Option<&str>,
     ) -> Result<LLMStream> {
         let mut body = build_openai_compat_body(
             model,
             messages,
             tools,
-            None,
+            required_tool.map(|name| json!({"type": "function", "function": {"name": name}})),
             max_output_tokens,
             reasoning_effort,
             parallel_tool_calls,
@@ -240,12 +258,16 @@ impl BodhiProvider {
         max_output_tokens: Option<u32>,
         model: &str,
         reasoning_effort: Option<ReasoningEffort>,
+        required_tool: Option<&str>,
     ) -> Result<LLMStream> {
         use crate::providers::anthropic::{
-            build_anthropic_request, parse_anthropic_sse_event, AnthropicStreamState,
+            apply_required_tool_auto_fallback, apply_required_tool_choice, build_anthropic_request,
+            looks_like_thinking_forced_tool_choice_error, parse_anthropic_sse_event,
+            reasoning_effort_for_required_tool, AnthropicStreamState,
         };
 
         let max_tokens = max_output_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
+        let reasoning_effort = reasoning_effort_for_required_tool(reasoning_effort, required_tool);
 
         let mut body = build_anthropic_request(
             messages,
@@ -256,6 +278,7 @@ impl BodhiProvider {
             reasoning_effort,
             None,
         );
+        apply_required_tool_choice(&mut body, required_tool);
         crate::masking::mask_outbound_body(&mut body, &self.masking_config);
 
         let headers = self.build_headers()?;
@@ -263,7 +286,7 @@ impl BodhiProvider {
 
         // Retry the initial request on transient failures (issue #18); the
         // returned body is unread, so SSE streaming below is unaffected.
-        let response = crate::retry::send_with_retry(crate::retry::global(), "Bodhi", || {
+        let mut response = crate::retry::send_with_retry(crate::retry::global(), "Bodhi", || {
             self.client.post(&url).headers(headers.clone()).json(&body)
         })
         .await?;
@@ -271,10 +294,45 @@ impl BodhiProvider {
         if !response.status().is_success() {
             let status = response.status();
             let text = response.text().await?;
-            return Err(LLMError::Api(format!(
-                "Bodhi/Anthropic proxy HTTP {}: {}",
-                status, text
-            )));
+            if required_tool.is_some()
+                && looks_like_thinking_forced_tool_choice_error(status, &text)
+            {
+                tracing::warn!(
+                    "Bodhi/Anthropic model '{}' rejected forced named tool_choice in thinking mode; retrying activation with tool_choice=auto and parallel tool use disabled",
+                    model
+                );
+                let mut fallback_body = build_anthropic_request(
+                    messages,
+                    tools,
+                    model,
+                    max_tokens,
+                    true,
+                    None,
+                    Some(false),
+                );
+                apply_required_tool_auto_fallback(&mut fallback_body, required_tool);
+                crate::masking::mask_outbound_body(&mut fallback_body, &self.masking_config);
+                response = crate::retry::send_with_retry(crate::retry::global(), "Bodhi", || {
+                    self.client
+                        .post(&url)
+                        .headers(headers.clone())
+                        .json(&fallback_body)
+                })
+                .await?;
+                if !response.status().is_success() {
+                    let fallback_status = response.status();
+                    let fallback_text = response.text().await?;
+                    return Err(LLMError::Api(format!(
+                        "Bodhi/Anthropic proxy after tool_choice=auto activation fallback HTTP {}: {}",
+                        fallback_status, fallback_text
+                    )));
+                }
+            } else {
+                return Err(LLMError::Api(format!(
+                    "Bodhi/Anthropic proxy HTTP {}: {}",
+                    status, text
+                )));
+            }
         }
 
         let mut state = AnthropicStreamState::default();
@@ -292,10 +350,13 @@ impl BodhiProvider {
         max_output_tokens: Option<u32>,
         model: &str,
         reasoning_effort: Option<ReasoningEffort>,
+        required_tool: Option<&str>,
     ) -> Result<LLMStream> {
         use crate::protocol::gemini::GeminiRequest;
         use crate::protocol::ToProvider;
-        use crate::providers::gemini::{parse_gemini_sse_event, GeminiStreamState};
+        use crate::providers::gemini::{
+            apply_required_tool_choice, parse_gemini_sse_event, GeminiStreamState,
+        };
 
         let messages_vec: Vec<Message> = messages.to_vec();
         let mut request: GeminiRequest = messages_vec.to_provider()?;
@@ -327,6 +388,7 @@ impl BodhiProvider {
 
         // Serialize then run the last-moment scan over the body Value before send.
         let mut request_json = serde_json::to_value(&request).map_err(LLMError::Json)?;
+        apply_required_tool_choice(&mut request_json, required_tool);
         crate::masking::mask_outbound_body(&mut request_json, &self.masking_config);
 
         let headers = self.build_headers()?;
@@ -370,5 +432,85 @@ impl BodhiProvider {
             ReasoningEffort::High => Some(4096),
             ReasoningEffort::Xhigh | ReasoningEffort::Max => Some(8192),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_domain::FunctionSchema;
+    use serde_json::Value;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+    struct ThinkingToolChoiceResponder;
+
+    impl Respond for ThinkingToolChoiceResponder {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            let body: Value = serde_json::from_slice(&request.body).expect("JSON request body");
+            if body["tool_choice"]["type"] == "tool" {
+                ResponseTemplate::new(400).set_body_string(
+                    r#"{"error":{"message":"Thinking mode does not support this tool_choice"}}"#,
+                )
+            } else {
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")
+            }
+        }
+    }
+
+    fn load_skill_tool() -> ToolSchema {
+        ToolSchema {
+            schema_type: "function".to_string(),
+            function: FunctionSchema {
+                name: "load_skill".to_string(),
+                description: "Load one skill".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn anthropic_proxy_retries_exact_thinking_error_with_auto_choice() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/proxy/anthropic/v1/messages"))
+            .respond_with(ThinkingToolChoiceResponder)
+            .expect(2)
+            .mount(&server)
+            .await;
+        let provider = BodhiProvider::new("test-key")
+            .with_base_url(server.uri())
+            .with_target_provider("anthropic")
+            .with_reasoning_effort(Some(ReasoningEffort::High));
+        let tools = vec![load_skill_tool()];
+        let options = LLMRequestOptions {
+            required_tool: Some("load_skill".to_string()),
+            parallel_tool_calls: Some(false),
+            ..Default::default()
+        };
+
+        let _stream = provider
+            .chat_stream_with_options(
+                &[Message::user("activate")],
+                &tools,
+                Some(8192),
+                "deepseek-v4-pro",
+                Some(&options),
+            )
+            .await
+            .expect("Bodhi Anthropic proxy should retry with auto choice");
+
+        let requests = server.received_requests().await.expect("requests recorded");
+        assert_eq!(requests.len(), 2);
+        let named: Value = serde_json::from_slice(&requests[0].body).unwrap();
+        let fallback: Value = serde_json::from_slice(&requests[1].body).unwrap();
+        assert_eq!(named["tool_choice"]["type"], "tool");
+        assert_eq!(named["tool_choice"]["name"], "load_skill");
+        assert_eq!(fallback["tool_choice"]["type"], "auto");
+        assert_eq!(fallback["tool_choice"]["disable_parallel_tool_use"], true);
+        assert_eq!(fallback["tools"].as_array().map(Vec::len), Some(1));
+        assert_eq!(fallback["tools"][0]["name"], "load_skill");
     }
 }

--- a/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
@@ -583,6 +583,7 @@ impl CopilotProvider {
         reasoning_effort: Option<ReasoningEffort>,
         responses_options: Option<&ResponsesRequestOptions>,
         parallel_tool_calls: Option<bool>,
+        required_tool: Option<&str>,
         reasoning_source: &str,
         session_log_id: &str,
         request_purpose: &str,
@@ -617,6 +618,9 @@ impl CopilotProvider {
             request_overrides::ENDPOINT_RESPONSES,
             Some(model),
         );
+        if let Some(name) = required_tool {
+            body["tool_choice"] = json!({"type": "function", "name": name});
+        }
         // Last-moment scan: mask every text value in the fully-assembled body.
         crate::masking::mask_outbound_body(&mut body, &self.masking_config);
 
@@ -746,6 +750,9 @@ impl CopilotProvider {
                         request_overrides::ENDPOINT_RESPONSES,
                         Some(model),
                     );
+                    if let Some(name) = required_tool {
+                        fallback_body["tool_choice"] = json!({"type": "function", "name": name});
+                    }
                     crate::masking::mask_outbound_body(&mut fallback_body, &self.masking_config);
                     let fallback_headers = self.build_llm_headers(
                         token,
@@ -1105,6 +1112,7 @@ impl LLMProvider for CopilotProvider {
         let session_log_id = options
             .and_then(|value| value.session_id.as_deref())
             .unwrap_or("unknown-session");
+        let required_tool = crate::provider::required_tool_from_options(options, tools)?;
         let token = self.get_token_for_request().await?;
         let reasoning_effort = options
             .and_then(|o| o.reasoning_effort)
@@ -1150,6 +1158,7 @@ impl LLMProvider for CopilotProvider {
                     reasoning_effort,
                     responses_options,
                     parallel_tool_calls,
+                    required_tool,
                     reasoning_source,
                     session_log_id,
                     request_purpose,
@@ -1166,7 +1175,10 @@ impl LLMProvider for CopilotProvider {
         // Only include tools and tool_choice if tools are provided
         if !tools.is_empty() {
             body["tools"] = json!(tools_to_openai_compat_json(tools));
-            body["tool_choice"] = json!("auto");
+            body["tool_choice"] = required_tool.map_or_else(
+                || json!("auto"),
+                |name| json!({"type": "function", "function": {"name": name}}),
+            );
         }
         if let Some(parallel_tool_calls) = parallel_tool_calls {
             body["parallel_tool_calls"] = json!(parallel_tool_calls);
@@ -1185,6 +1197,9 @@ impl LLMProvider for CopilotProvider {
             request_overrides::ENDPOINT_CHAT_COMPLETIONS,
             Some(upstream_model),
         );
+        if let Some(name) = required_tool {
+            body["tool_choice"] = json!({"type": "function", "function": {"name": name}});
+        }
         crate::masking::mask_outbound_body(&mut body, &self.masking_config);
         tracing::info!(
             "[{}] Copilot request protocol=chat_completions model='{}' reasoning_effort={} reasoning_source={} request_reasoning_enabled={} max_output_tokens={} [{}]",
@@ -1314,7 +1329,10 @@ impl LLMProvider for CopilotProvider {
                     });
                     if !tools.is_empty() {
                         body_no_reasoning["tools"] = json!(tools_to_openai_compat_json(tools));
-                        body_no_reasoning["tool_choice"] = json!("auto");
+                        body_no_reasoning["tool_choice"] = required_tool.map_or_else(
+                            || json!("auto"),
+                            |name| json!({"type": "function", "function": {"name": name}}),
+                        );
                     }
                     if let Some(parallel_tool_calls) = parallel_tool_calls {
                         body_no_reasoning["parallel_tool_calls"] = json!(parallel_tool_calls);
@@ -1328,6 +1346,10 @@ impl LLMProvider for CopilotProvider {
                         request_overrides::ENDPOINT_CHAT_COMPLETIONS,
                         Some(upstream_model),
                     );
+                    if let Some(name) = required_tool {
+                        body_no_reasoning["tool_choice"] =
+                            json!({"type": "function", "function": {"name": name}});
+                    }
                     crate::masking::mask_outbound_body(
                         &mut body_no_reasoning,
                         &self.masking_config,
@@ -1415,6 +1437,7 @@ impl LLMProvider for CopilotProvider {
                             reasoning_effort,
                             responses_options,
                             parallel_tool_calls,
+                            required_tool,
                             reasoning_source,
                             session_log_id,
                             request_purpose,
@@ -1548,6 +1571,32 @@ mod tests {
 
         let provider = CopilotProvider::new();
         assert!(!provider.is_authenticated());
+    }
+
+    #[tokio::test]
+    async fn required_tool_missing_schema_fails_before_auth_resolution() {
+        let provider = CopilotProvider::new();
+        let options = LLMRequestOptions {
+            required_tool: Some("load_skill".to_string()),
+            ..Default::default()
+        };
+
+        let result = provider
+            .chat_stream_with_options(
+                &[Message::user("activate")],
+                &[],
+                Some(128),
+                "gpt-5",
+                Some(&options),
+            )
+            .await;
+        let error = match result {
+            Ok(_) => panic!("missing required tool schema must fail before auth or network"),
+            Err(error) => error,
+        };
+        assert!(error
+            .to_string()
+            .contains("required tool schema 'load_skill' was not offered"));
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/gemini/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/gemini/mod.rs
@@ -9,7 +9,7 @@ use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},
     Client,
 };
-use serde_json::json;
+use serde_json::{json, Value};
 
 use crate::protocol::gemini::GeminiRequest;
 use crate::protocol::ToProvider;
@@ -20,6 +20,17 @@ use crate::types::LLMChunk;
 use bamboo_config::{KeywordMaskingConfig, RequestOverridesConfig};
 use bamboo_domain::Message;
 use bamboo_domain::ReasoningEffort;
+
+pub(crate) fn apply_required_tool_choice(body: &mut Value, required_tool: Option<&str>) {
+    if let Some(name) = required_tool {
+        body["toolConfig"] = json!({
+            "functionCallingConfig": {
+                "mode": "ANY",
+                "allowedFunctionNames": [name]
+            }
+        });
+    }
+}
 use bamboo_domain::ToolSchema;
 
 /// Google Gemini API provider.
@@ -156,6 +167,7 @@ impl LLMProvider for GeminiProvider {
             .and_then(|o| o.reasoning_effort)
             .or(self.default_reasoning_effort);
         let request_reasoning_effort = options.and_then(|o| o.reasoning_effort);
+        let required_tool = crate::provider::required_tool_from_options(options, tools)?;
         let reasoning_source = if request_reasoning_effort.is_some() {
             "request"
         } else if self.default_reasoning_effort.is_some() {
@@ -214,6 +226,7 @@ impl LLMProvider for GeminiProvider {
             request_overrides::ENDPOINT_STREAM_GENERATE_CONTENT,
             Some(model),
         );
+        apply_required_tool_choice(&mut request_json, required_tool);
         // Last-moment scan: mask every text value in the fully-assembled body.
         crate::masking::mask_outbound_body(&mut request_json, &self.masking_config);
         tracing::info!(
@@ -274,6 +287,7 @@ impl LLMProvider for GeminiProvider {
                     request_overrides::ENDPOINT_STREAM_GENERATE_CONTENT,
                     Some(model),
                 );
+                apply_required_tool_choice(&mut fallback_request_json, required_tool);
                 crate::masking::mask_outbound_body(
                     &mut fallback_request_json,
                     &self.masking_config,
@@ -390,6 +404,29 @@ impl LLMProvider for GeminiProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn required_tool_choice_uses_gemini_any_allowlist_shape() {
+        let mut body = json!({
+            "generationConfig": {
+                "thinkingConfig": {"thinkingBudget": 4096}
+            }
+        });
+        apply_required_tool_choice(&mut body, Some("load_skill"));
+        assert_eq!(
+            body["toolConfig"],
+            json!({
+                "functionCallingConfig": {
+                    "mode": "ANY",
+                    "allowedFunctionNames": ["load_skill"]
+                }
+            })
+        );
+        assert_eq!(
+            body["generationConfig"]["thinkingConfig"]["thinkingBudget"],
+            4096
+        );
+    }
 
     #[test]
     fn test_new_provider() {

--- a/crates/infra/bamboo-llm/src/providers/gemini/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/gemini/mod.rs
@@ -115,7 +115,14 @@ impl GeminiProvider {
     /// `x-goog-api-key` header (see [`GeminiProvider::build_headers`]), so the
     /// API key never appears in this URL.
     fn stream_url(&self, model: &str) -> String {
-        format!("{}/models/{}:streamGenerateContent", self.base_url, model)
+        // Gemini returns a JSON array when `alt=sse` is omitted even though the
+        // endpoint name is `streamGenerateContent`. The downstream adapter is
+        // intentionally an SSE parser, so request the SSE representation
+        // explicitly instead of silently producing an empty assistant turn.
+        format!(
+            "{}/models/{}:streamGenerateContent?alt=sse",
+            self.base_url, model
+        )
     }
 
     /// Build the `list_models` URL. Auth travels via the `x-goog-api-key`
@@ -466,7 +473,11 @@ mod tests {
         let stream_url = provider.stream_url("gemini-custom");
         assert_eq!(
             stream_url,
-            "https://test.api.com/v1beta/models/gemini-custom:streamGenerateContent"
+            "https://test.api.com/v1beta/models/gemini-custom:streamGenerateContent?alt=sse"
+        );
+        assert!(
+            stream_url.ends_with("?alt=sse"),
+            "streamGenerateContent must explicitly request SSE transport"
         );
         assert!(
             !stream_url.contains("key="),

--- a/crates/infra/bamboo-llm/src/providers/openai/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/openai/mod.rs
@@ -8,10 +8,11 @@ use reqwest::{
     header::{HeaderMap, HeaderValue, AUTHORIZATION},
     Client,
 };
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use crate::provider::{
-    LLMError, LLMProvider, LLMRequestOptions, LLMStream, ResponsesRequestOptions, Result,
+    required_tool_from_options, LLMError, LLMProvider, LLMRequestOptions, LLMStream,
+    ResponsesRequestOptions, Result,
 };
 use crate::types::LLMChunk;
 use bamboo_config::{KeywordMaskingConfig, RequestOverridesConfig};
@@ -158,6 +159,7 @@ impl OpenAIProvider {
         reasoning_effort: Option<ReasoningEffort>,
         responses_options: Option<&ResponsesRequestOptions>,
         parallel_tool_calls: Option<bool>,
+        required_tool: Option<&str>,
         reasoning_source: &str,
         request_purpose: &str,
         session_log_id: &str,
@@ -182,6 +184,9 @@ impl OpenAIProvider {
             request_overrides::ENDPOINT_RESPONSES,
             Some(model),
         );
+        if let Some(name) = required_tool {
+            body["tool_choice"] = json!({"type": "function", "name": name});
+        }
         // Last-moment scan: mask every text value in the fully-assembled body.
         crate::masking::mask_outbound_body(&mut body, &self.masking_config);
         tracing::info!(
@@ -256,6 +261,9 @@ impl OpenAIProvider {
                     request_overrides::ENDPOINT_RESPONSES,
                     Some(model),
                 );
+                if let Some(name) = required_tool {
+                    fallback_body["tool_choice"] = json!({"type": "function", "name": name});
+                }
                 crate::masking::mask_outbound_body(&mut fallback_body, &self.masking_config);
                 let fallback_headers =
                     self.build_headers(request_overrides::ENDPOINT_RESPONSES, Some(model))?;
@@ -313,6 +321,9 @@ impl OpenAIProvider {
                     request_overrides::ENDPOINT_RESPONSES,
                     Some(model),
                 );
+                if let Some(name) = required_tool {
+                    fallback_body["tool_choice"] = json!({"type": "function", "name": name});
+                }
                 crate::masking::mask_outbound_body(&mut fallback_body, &self.masking_config);
                 let fallback_headers =
                     self.build_headers(request_overrides::ENDPOINT_RESPONSES, Some(model))?;
@@ -391,6 +402,7 @@ impl LLMProvider for OpenAIProvider {
             .or(self.default_reasoning_effort);
         let request_reasoning_effort = options.and_then(|o| o.reasoning_effort);
         let parallel_tool_calls = options.and_then(|o| o.parallel_tool_calls);
+        let required_tool = required_tool_from_options(options, tools)?;
         let responses_options = options.and_then(|o| o.responses.as_ref());
         let request_purpose = options
             .and_then(|o| o.request_purpose.as_deref())
@@ -416,6 +428,7 @@ impl LLMProvider for OpenAIProvider {
                     reasoning_effort,
                     responses_options,
                     parallel_tool_calls,
+                    required_tool,
                     reasoning_source,
                     request_purpose,
                     session_log_id,
@@ -438,6 +451,9 @@ impl LLMProvider for OpenAIProvider {
             request_overrides::ENDPOINT_CHAT_COMPLETIONS,
             Some(model),
         );
+        if let Some(name) = required_tool {
+            body["tool_choice"] = json!({"type": "function", "function": {"name": name}});
+        }
         crate::masking::mask_outbound_body(&mut body, &self.masking_config);
         tracing::info!(
             "[{}] OpenAI request protocol=chat_completions model='{}' reasoning_effort={} reasoning_source={} request_reasoning_enabled={} max_output_tokens={} [{}]",
@@ -494,6 +510,10 @@ impl LLMProvider for OpenAIProvider {
                     request_overrides::ENDPOINT_CHAT_COMPLETIONS,
                     Some(model),
                 );
+                if let Some(name) = required_tool {
+                    fallback_body["tool_choice"] =
+                        json!({"type": "function", "function": {"name": name}});
+                }
                 crate::masking::mask_outbound_body(&mut fallback_body, &self.masking_config);
                 let fallback_headers =
                     self.build_headers(request_overrides::ENDPOINT_CHAT_COMPLETIONS, Some(model))?;
@@ -546,6 +566,7 @@ impl LLMProvider for OpenAIProvider {
                         reasoning_effort,
                         responses_options,
                         parallel_tool_calls,
+                        required_tool,
                         reasoning_source,
                         request_purpose,
                         session_log_id,
@@ -954,6 +975,28 @@ mod tests {
     const PREVIOUS_RESPONSE_NOT_FOUND_BODY: &str = r#"{"error":{"message":"Previous response with id 'resp_stale' not found.","type":"invalid_request_error","param":"previous_response_id","code":"previous_response_not_found"}}"#;
 
     const RESPONSES_SSE_OK: &str = "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\nevent: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_new\"}}\n\n";
+    const CHAT_SSE_OK: &str =
+        "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n";
+
+    fn load_skill_tool() -> ToolSchema {
+        ToolSchema {
+            schema_type: "function".to_string(),
+            function: FunctionSchema {
+                name: "load_skill".to_string(),
+                description: "Load one skill".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            },
+        }
+    }
+
+    fn require_load_skill_options() -> LLMRequestOptions {
+        LLMRequestOptions {
+            required_tool: Some("load_skill".to_string()),
+            parallel_tool_calls: Some(false),
+            reasoning_effort: Some(bamboo_domain::ReasoningEffort::High),
+            ..Default::default()
+        }
+    }
 
     /// Emulates the real OpenAI contract: a request chaining a stale (or never
     /// stored) `previous_response_id` fails with 400
@@ -978,6 +1021,106 @@ mod tests {
         OpenAIProvider::new("test-key")
             .with_base_url(server.uri())
             .with_responses_only_models(vec!["gpt-5*".to_string()])
+    }
+
+    #[tokio::test]
+    async fn chat_completions_forces_named_required_tool_on_wire() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(CHAT_SSE_OK),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let provider = OpenAIProvider::new("test-key").with_base_url(server.uri());
+        let tools = vec![load_skill_tool()];
+        let options = require_load_skill_options();
+
+        let _stream = provider
+            .chat_stream_with_options(
+                &[Message::user("activate")],
+                &tools,
+                None,
+                "deepseek-v4-pro",
+                Some(&options),
+            )
+            .await
+            .expect("forced chat request");
+
+        let requests = server.received_requests().await.expect("requests recorded");
+        let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert_eq!(
+            body["tool_choice"],
+            serde_json::json!({
+                "type": "function",
+                "function": {"name": "load_skill"}
+            })
+        );
+        assert_eq!(body["parallel_tool_calls"], false);
+        assert_eq!(body["reasoning_effort"], "high");
+    }
+
+    #[tokio::test]
+    async fn responses_forces_named_required_tool_on_wire() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/responses"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(RESPONSES_SSE_OK),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let provider = responses_provider(&server);
+        let tools = vec![load_skill_tool()];
+        let options = require_load_skill_options();
+
+        let _stream = provider
+            .chat_stream_with_options(
+                &[Message::user("activate")],
+                &tools,
+                None,
+                "gpt-5.2",
+                Some(&options),
+            )
+            .await
+            .expect("forced Responses request");
+
+        let requests = server.received_requests().await.expect("requests recorded");
+        let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert_eq!(
+            body["tool_choice"],
+            serde_json::json!({"type": "function", "name": "load_skill"})
+        );
+        assert_eq!(body["parallel_tool_calls"], false);
+        assert_eq!(body["reasoning"]["effort"], "high");
+    }
+
+    #[tokio::test]
+    async fn required_tool_missing_from_schemas_fails_before_network() {
+        let provider = OpenAIProvider::new("test-key");
+        let result = provider
+            .chat_stream_with_options(
+                &[Message::user("activate")],
+                &[],
+                None,
+                "deepseek-v4-pro",
+                Some(&require_load_skill_options()),
+            )
+            .await;
+        let error = match result {
+            Ok(_) => panic!("missing required schema must fail closed"),
+            Err(error) => error,
+        };
+        assert!(error
+            .to_string()
+            .contains("required tool schema 'load_skill' was not offered"));
     }
 
     fn options_with_previous_response_id(id: Option<&str>) -> LLMRequestOptions {

--- a/crates/infra/bamboo-memory/src/memory_store/recall.rs
+++ b/crates/infra/bamboo-memory/src/memory_store/recall.rs
@@ -316,6 +316,7 @@ async fn rerank_candidate_ids(
         session_id: context.session_id.clone(),
         reasoning_effort: Some(ReasoningEffort::High),
         parallel_tool_calls: None,
+        required_tool: None,
         responses: None,
         request_purpose: Some("memory_rerank".to_string()),
         cache: None,


### PR DESCRIPTION
## Summary

- require a real model-issued `load_skill` call before answering when exactly one workflow was selected explicitly
- force the provider-specific named `load_skill` tool across OpenAI Chat/Responses, Copilot, Anthropic, Gemini, and Bodhi routing
- fail closed for missing, wrong, duplicate, or unsuccessful activation calls while allowing the normal turn to continue without workflow instructions after a degraded activation
- keep automatic multi-candidate discovery lazy and avoid reloading an already-active workflow on resumed sessions
- request Gemini SSE explicitly and normalize Gemini function responses so a successful activation can continue through later tool calls
- add sanitized three-run live dogfood evidence

## Root cause

The previous implementation activated explicitly selected workflows inside the runtime before the first model round. That satisfied loaded-state bookkeeping but did not satisfy the contract that the model itself must issue `load_skill` before any answer. Provider requests also lacked a cross-provider way to require one named tool.

Live Gemini verification exposed two transport gaps after the activation gate itself worked: `streamGenerateContent` returned a JSON array unless `alt=sse` was requested, and Gemini rejects scalar/plain-text values in `functionResponse.response` because that field is a protobuf `Struct`.

## Behavior and approval boundaries

- Explicit single selection: first model step is exactly `load_skill(selected_id)` with no user-facing text, then normal tools and answering resume.
- Automatic multi-candidate selection: metadata-only until the model chooses a workflow.
- Ordinary command bypass is unchanged.
- Dangerous `forced-ask` commands still bypass neither policy nor review; they route to the parent-agent automatic reviewer and do not create a human approval event.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy -p bamboo-llm --all-targets`
- `cargo test -p bamboo-llm` (500 passed; doc tests clean/ignored as expected)
- `cargo test -p bamboo-engine model_issued` (2 passed)
- `cargo test -p bamboo-engine drive_routes_forced_ask_to_parent_reviewer_without_human_event` (1 passed)
- `cargo test -p bamboo-tools test_forced_ask_rule_overrides_bypass` (1 passed)
- `cargo test -p bamboo-server parent_approval_reviewer` (2 passed)
- Earlier on this branch: full `cargo test -p bamboo-engine` (1044 passed), full `cargo test -p bamboo-server-tools`, and workspace clippy passed
- Live Lotus + Bamboo + Gemini 3.1 dogfood: 3/3 fresh explicit sessions persisted `selected=[review]`, `loaded=[review]`, and recorded `load_skill -> Read -> final answer` with zero activation text
- Live automatic-selection dogfood: initial full tool set remained lazy; the model used another tool before choosing `load_skill`

Closes #620
