### PR TITLE
fix: preserve provider instance api_key across settings patches (#633)

### DIFF
--- a/crates/app/bamboo-server/src/config_manager.rs
+++ b/crates/app/bamboo-server/src/config_manager.rs
@@ -200,6 +200,10 @@ pub fn build_merged_config(
     // key would vanish from config.json on the next persist. Carry unpatched
     // keys forward from the live config. #515/#516.
     preserve_unpatched_provider_secrets(&mut new_config, current, &api_key_intents);
+    // Explicit instance preserve path for #633: carry untouched instance
+    // plaintext keys (including instances created before first persist) from
+    // current to merged when the merge consumed the merge-time plaintext.
+    new_config.preserve_provider_instance_plaintext_keys(current, &api_key_intents);
     new_config.normalize_tool_settings();
     new_config.normalize_skill_settings();
     new_config.normalize_plugin_trust_settings();
@@ -358,6 +362,48 @@ mod tests {
         assert_eq!(
             instance.api_key, "sk-instance-live",
             "an unrelated settings PATCH must not lose the instance key (#516)"
+        );
+    }
+
+    #[test]
+    fn unrelated_patch_preserves_fresh_instance_plaintext_key() {
+        let current = config_with_plaintext_only_instance("sk-instance-fresh");
+
+        let patch: Map<String, Value> = serde_json::from_str(
+            r#"{"defaults":{"chat":{"provider":"openai","model":"gpt-4o-mini","temperature":1}}}"#,
+        )
+        .unwrap();
+        let intents = provider_api_key_intents(&patch);
+        assert!(intents.provider_instances.is_empty());
+
+        let mut merged = build_merged_config(&current, patch).expect("merge");
+        sync_provider_api_keys_encrypted_for_patch(&mut merged, &intents).expect("sync");
+
+        let instance = merged.provider_instances.get("uuid-1").expect("instance");
+        assert_eq!(instance.api_key, "sk-instance-fresh");
+    }
+
+    #[test]
+    fn explicit_instance_key_in_patch_wins_over_preserved_key() {
+        let current = config_with_plaintext_only_instance("sk-instance-live");
+        let patch: Map<String, Value> = serde_json::from_str(
+            r#"{"provider_instances":{"uuid-1":{"api_key":"sk-instance-updated"}}}"#,
+        )
+        .unwrap();
+        let intents = provider_api_key_intents(&patch);
+        assert!(intents.provider_instances.contains("uuid-1"));
+
+        let mut merged = build_merged_config(&current, patch).expect("merge");
+        sync_provider_api_keys_encrypted_for_patch(&mut merged, &intents).expect("sync");
+
+        let instance = merged.provider_instances.get("uuid-1").expect("instance");
+        assert_eq!(instance.api_key, "sk-instance-updated");
+        assert!(
+            instance
+                .api_key_encrypted
+                .as_deref()
+                .is_some_and(|cipher| !cipher.is_empty()),
+            "explicit instance key must be encrypted after sync"
         );
     }
 

--- a/crates/infra/bamboo-config/src/config_crypto.rs
+++ b/crates/infra/bamboo-config/src/config_crypto.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use super::{Config, ProxyAuth};
+use crate::patch::ProviderApiKeyIntents;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct AccessVerifierRecord {
@@ -1161,6 +1162,36 @@ impl Config {
         restore_env_key!(openai);
         restore_env_key!(anthropic);
         restore_env_key!(gemini);
+    }
+
+    /// Preserve freshly-created provider-instance plaintext keys that are lost
+    /// during the compatibility JSON round-trip.
+    ///
+    /// Provider instance `api_key` fields are `#[serde(skip_serializing)]`, so a
+    /// round-trip through `to_compatibility_value()` / `from_value()` in
+    /// `config_manager::build_merged_config` drops them. If no ciphertext was
+    /// persisted yet (newly created instance), copy key material from the live
+    /// `previous` config for instances not explicitly touched by the patch so
+    /// the key is not silently cleared before the next save.
+    pub fn preserve_provider_instance_plaintext_keys(
+        &mut self,
+        previous: &Config,
+        intents: &ProviderApiKeyIntents,
+    ) {
+        for (id, instance) in self.provider_instances.iter_mut() {
+            if intents.provider_instances.contains(id) {
+                continue;
+            }
+            if !instance.api_key.trim().is_empty() || instance.api_key_encrypted.is_some() {
+                continue;
+            }
+            if let Some(previous) = previous.provider_instances.get(id) {
+                if !previous.api_key.trim().is_empty() || previous.api_key_encrypted.is_some() {
+                    instance.api_key = previous.api_key.clone();
+                    instance.api_key_encrypted = previous.api_key_encrypted.clone();
+                }
+            }
+        }
     }
 
     /// Re-encrypt every secret domain's `*_encrypted` field from current


### PR DESCRIPTION
## Summary
- Add Config::preserve_provider_instance_plaintext_keys in infra config_crypto.
- Call the preserve path from config_manager::build_merged_config to avoid provider-instance plaintext loss after settings PATCH merges.
- Add regression tests for #633: untouched instance key survives unrelated PATCH and explicit instance key in PATCH wins over preserved value.

## Test Plan
- Not run in this turn.

## Issue
- https://github.com/bigduu/Bamboo-agent/issues/633