### PR TITLE
hooks(engine): activate the dormant AgentHook/HookRunner framework

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/builder.rs
+++ b/crates/app/bamboo-sdk/src/agent/builder.rs
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 use tokio::sync::RwLock;
 
 use bamboo_agent_core::tools::{Tool, ToolExecutor};
-use bamboo_engine::AgentBuilder as EngineAgentBuilder;
+use bamboo_engine::{AgentBuilder as EngineAgentBuilder, HookRunner};
 use bamboo_llm::{create_provider_with_dir, Config, LLMProvider};
 use bamboo_mcp::executor::{CompositeToolExecutor, McpToolExecutor};
 use bamboo_mcp::manager::McpServerManager;
@@ -252,6 +252,14 @@ impl AgentBuilder {
     /// can say what they mean instead of relying on silent default behavior.
     pub fn bypass_permissions(mut self) -> Self {
         self.permission_checker = None;
+        self
+    }
+
+    /// Install the immutable lifecycle-hook registry used by every run of this
+    /// agent. The registry is snapshotted into the sealed loop configuration at
+    /// run start, so one execution cannot observe mid-run registration changes.
+    pub fn hook_runner(mut self, runner: Arc<HookRunner>) -> Self {
+        self.inner = self.inner.hook_runner(runner);
         self
     }
 

--- a/crates/app/bamboo-sdk/src/agent/mod.rs
+++ b/crates/app/bamboo-sdk/src/agent/mod.rs
@@ -67,12 +67,14 @@ pub use error::SdkError;
 // Convenience re-exports of commonly used types (single source of truth — these
 // supersede the old duplicate re-export chain, resolving TD-2).
 pub use bamboo_agent_core::{
-    AgentError, AgentEvent, Message, MessageContent, PendingQuestion, Role, Session,
+    AgentError, AgentEvent, AgentHook, Message, MessageContent, PendingQuestion, Role, Session,
     TokenBudgetUsage, TokenUsage,
 };
-pub use bamboo_domain::{TaskItem, TaskItemStatus, TaskList};
+pub use bamboo_domain::{
+    AgentHookPoint, HookPayload, HookResult, HookToolOutcome, TaskItem, TaskItemStatus, TaskList,
+};
 pub use bamboo_engine::session_app::respond::PlanModeTransition;
-pub use bamboo_engine::ExecuteRequest;
+pub use bamboo_engine::{ExecuteRequest, HookRunner};
 pub use bamboo_llm::LLMProvider;
 pub use bamboo_mcp::manager::McpServerManager;
 pub use bamboo_mcp::McpServerConfig;

--- a/crates/app/bamboo-sdk/src/lib.rs
+++ b/crates/app/bamboo-sdk/src/lib.rs
@@ -15,7 +15,10 @@ pub mod agent;
 
 // Mirror the public facade re-exports the root crate previously exposed.
 pub use agent::ExecuteRequestBuilder;
-pub use agent::{Agent, AgentBuilder};
+pub use agent::{
+    Agent, AgentBuilder, AgentHook, AgentHookPoint, HookPayload, HookResult, HookRunner,
+    HookToolOutcome,
+};
 
 // Tool catalog surfaced by `agent::mod`.
 pub use agent::{

--- a/crates/core/bamboo-agent-core/src/agent/error.rs
+++ b/crates/core/bamboo-agent-core/src/agent/error.rs
@@ -31,6 +31,11 @@ pub enum AgentError {
     #[error("Tool error: {0}")]
     Tool(String),
 
+    /// A lifecycle hook deliberately suspended this activation. The outer
+    /// runner converts this control signal into a normal persisted suspension.
+    #[error("Hook suspended: {0}")]
+    HookSuspended(String),
+
     /// Token budget exceeded error
     #[error("Budget error: {0}")]
     Budget(String),
@@ -55,5 +60,10 @@ impl AgentError {
     /// logic.
     pub fn is_cancelled(&self) -> bool {
         matches!(self, AgentError::Cancelled)
+    }
+
+    /// Returns `true` when a lifecycle hook intentionally suspended the run.
+    pub fn is_hook_suspended(&self) -> bool {
+        matches!(self, AgentError::HookSuspended(_))
     }
 }

--- a/crates/core/bamboo-agent-core/src/agent/events.rs
+++ b/crates/core/bamboo-agent-core/src/agent/events.rs
@@ -36,7 +36,7 @@
 //! ```
 
 use crate::tools::ToolResult;
-use bamboo_domain::{TaskItemStatus, TaskList};
+use bamboo_domain::{AgentHookPoint, HookResult, TaskItemStatus, TaskList};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -176,6 +176,21 @@ pub enum AgentEvent {
         /// Error message (if phase == "error")
         #[serde(skip_serializing_if = "Option::is_none")]
         error: Option<String>,
+    },
+
+    /// A registered lifecycle hook completed at an engine seam.
+    HookLifecycle {
+        /// Stable hook name supplied by the hook implementation.
+        hook_name: String,
+        /// Engine seam where the hook ran.
+        point: AgentHookPoint,
+        /// Lifecycle phase. Currently `completed`; kept explicit so future
+        /// start/error events remain schema-compatible.
+        phase: String,
+        /// Wall-clock time spent inside the hook.
+        duration_ms: u64,
+        /// Decision returned by the hook.
+        decision: HookResult,
     },
 
     /// Agent needs clarification from the user.

--- a/crates/core/bamboo-agent-core/src/agent/hooks.rs
+++ b/crates/core/bamboo-agent-core/src/agent/hooks.rs
@@ -6,7 +6,7 @@
 //! [`HookResult`](bamboo_domain::HookResult).
 
 use async_trait::async_trait;
-use bamboo_domain::{AgentHookPoint, HookResult};
+use bamboo_domain::{AgentHookPoint, HookPayload, HookResult};
 
 use super::types::Session;
 
@@ -21,9 +21,15 @@ pub trait AgentHook: Send + Sync {
 
     /// Execute the hook.
     ///
-    /// Receives immutable access to the session and the current hook point.
+    /// Receives immutable access to the session, the current hook point, and a
+    /// point-specific payload.
     /// Returns a [`HookResult`] to control flow.
-    async fn run(&self, point: AgentHookPoint, session: &Session) -> HookResult;
+    async fn run(
+        &self,
+        point: AgentHookPoint,
+        payload: &HookPayload,
+        session: &Session,
+    ) -> HookResult;
 
     /// Optional priority (lower runs first). Default is 100.
     fn priority(&self) -> u32 {

--- a/crates/core/bamboo-domain/src/session/hook_types.rs
+++ b/crates/core/bamboo-domain/src/session/hook_types.rs
@@ -6,6 +6,60 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Point-specific data supplied to an [`AgentHookPoint`] callback.
+///
+/// Payloads own their data deliberately.  Hooks are asynchronous and may be
+/// shared by concurrent runs, so keeping the public contract free of borrowed
+/// engine-only types makes it serializable, easy to test, and preserves the
+/// domain/engine dependency boundary.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum HookPayload {
+    /// A point currently has no additional structured data.
+    #[default]
+    None,
+    /// Session initialization completed for this user turn.
+    SessionSetup { initial_message: String },
+    /// A round is about to start or has just completed.
+    Round { round: u32 },
+    /// A prompt-oriented hook payload reserved for prompt/LLM seams.
+    Prompt { prompt: String },
+    /// A parsed tool call immediately before dispatch.
+    ToolExecution {
+        tool_name: String,
+        tool_call_id: String,
+        parsed_args: serde_json::Value,
+    },
+    /// A tool outcome immediately before it is applied to the session.
+    ToolResult {
+        tool_name: String,
+        tool_call_id: String,
+        outcome: HookToolOutcome,
+    },
+    /// Context compression is about to begin.
+    Compression {
+        estimated_tokens: u32,
+        usage_percent: f64,
+        phase: String,
+    },
+    /// The run is about to emit its terminal completion event.
+    Finalize,
+}
+
+/// Engine-independent view of a tool execution outcome.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HookToolOutcome {
+    pub success: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub needs_human: bool,
+    #[serde(default)]
+    pub duration_ms: u64,
+}
+
 /// Lifecycle phases where hooks can be attached.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -49,6 +103,18 @@ pub enum HookResult {
     Continue,
     /// State was mutated; downstream should re-read.
     Mutated,
+    /// Explicitly allow the operation represented by the payload.
+    Allow,
+    /// Deny the operation represented by the payload.
+    Deny { reason: String },
+    /// Ask the owning parent agent to review the operation.
+    ///
+    /// The engine never turns this into an unowned/manual approval.  Tool
+    /// seams route it through a parent approval delegate/proxy and fail closed
+    /// when no such route exists.
+    Ask,
+    /// Add durable context for the remaining run.
+    InjectContext { text: String },
     /// Pause execution; set suspension state.
     Suspend { reason: String },
     /// Abort the agent run.
@@ -95,6 +161,14 @@ mod tests {
         let variants = [
             HookResult::Continue,
             HookResult::Mutated,
+            HookResult::Allow,
+            HookResult::Deny {
+                reason: "blocked".to_string(),
+            },
+            HookResult::Ask,
+            HookResult::InjectContext {
+                text: "extra context".to_string(),
+            },
             HookResult::Suspend {
                 reason: "waiting".to_string(),
             },
@@ -107,5 +181,17 @@ mod tests {
             let restored: HookResult = serde_json::from_str(&json).unwrap();
             assert_eq!(variant, &restored);
         }
+    }
+
+    #[test]
+    fn hook_payload_round_trips_structured_tool_data() {
+        let payload = HookPayload::ToolExecution {
+            tool_name: "Bash".to_string(),
+            tool_call_id: "call-1".to_string(),
+            parsed_args: serde_json::json!({"command": "pwd"}),
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        let restored: HookPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, payload);
     }
 }

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -180,15 +180,13 @@ pub struct ActorChildRunner {
 
 /// Decides how the host answers a child worker's gated-tool approval request
 /// (Phase 2: child → parent approval delegation). Async so an implementation
-/// can consult a policy or defer to a human. With no decider wired the host
-/// replies with a fail-closed DENY.
+/// can consult a policy. With no decider wired the host replies with a
+/// fail-closed DENY.
 ///
 /// NOTE: `decide` is awaited inside the per-child frame pump, so an
-/// implementation must resolve promptly (e.g. a policy lookup). A human-in-the-
-/// loop decision that may block indefinitely should instead be delivered
-/// out-of-band as a `ParentFrame::ApprovalReply` via the live steering channel
-/// (`super::live`), which `drive()` already forwards to the worker without
-/// stalling the pump.
+/// implementation must resolve promptly (e.g. a policy lookup). Model-based
+/// review belongs in [`ChildApprovalReviewer`], which runs off-loop and returns
+/// through the live steering channel without stalling the frame pump.
 #[async_trait]
 pub trait ChildApprovalDecider: Send + Sync {
     /// Decide whether `child_session_id` may perform the gated action described
@@ -209,22 +207,10 @@ async fn decide_child_approval(
     }
 }
 
-/// How long the host waits for a human approval decision before failing the
-/// child's gated tool closed (DENY). Bounds an unanswered request so it can't
-/// hang the worker indefinitely.
+/// How long a chained parent-agent review may take before the child's gated
+/// tool fails closed (DENY). Bounds an unanswered request so it cannot hang the
+/// worker indefinitely.
 const CHILD_APPROVAL_TIMEOUT: Duration = Duration::from_secs(300);
-
-/// Extract `(tool_name, permission, resource)` from a worker's approval request
-/// body (`{tool_name, permission, resource}`); missing fields default to empty.
-fn approval_request_fields(body: &serde_json::Value) -> (String, String, String) {
-    let field = |k: &str| {
-        body.get(k)
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string()
-    };
-    (field("tool_name"), field("permission"), field("resource"))
-}
 
 /// Off-loop reviewer for a child's gated-tool approval request (Phase 6, Part B).
 ///
@@ -1202,8 +1188,9 @@ async fn drive(
                         } else if let Some(host) = escalation_bridge.clone() {
                             // Non-bypass WORKER: ESCALATE up our own actor link
                             // (re-proxy) so the request chains to our parent — and
-                            // up every level until a bypass level (model-review) or
-                            // the top orchestrator (human) decides. Off-loop so the
+                            // up every level until a bypass level or the top
+                            // orchestrator's model reviewer decides. With no such
+                            // reviewer the top level fails closed. Off-loop so the
                             // pump never blocks; relay the reply down to the child.
                             let child = child_session_id.to_string();
                             let req_id = id.clone();
@@ -1232,98 +1219,27 @@ async fn drive(
                                 );
                             });
                         } else {
-                            // Top orchestrator (no escalation bridge): human-in-the-
-                            // loop. Surface the request on the parent's event stream
-                            // and DEFER — the decision arrives out-of-band via
-                            // `live::deliver_approval(child, request_id, approved)`
-                            // (→ this child's `live_rx` → forwarded to the worker
-                            // above). A timeout denies a never-answered request so
-                            // it can't hang the child forever.
-                            let (tool_name, permission, resource) =
-                                approval_request_fields(&body);
-                            // Register the pending request BEFORE surfacing it so
-                            // the external handler's `deliver_approval_checked` can
-                            // correlate an out-of-band POST against a genuine
-                            // human-loop request (and consume it one-shot).
-                            let (approval_version, approval_created_at) =
-                                super::live::register_pending_approval_observed(
-                                approval_registry,
+                            // There is no parent-agent reviewer or upstream actor
+                            // to own this decision. Never open a manual/UI approval
+                            // path: forced-ask is parent-reviewed or fail-closed.
+                            tracing::warn!(
                                 parent_session_id,
                                 child_session_id,
-                                child_attempt,
-                                &id,
-                                &tool_name,
-                                &permission,
-                                &resource,
-                                event_tx.clone(),
+                                request_id = %id,
+                                "forced-ask request has no parent-agent reviewer; denying"
                             );
-                            if approval_version == 0 {
-                                super::live::deliver_approval_scoped(
-                                    approval_registry,
-                                    child_session_id,
-                                    child_attempt,
-                                    &id,
-                                    false,
-                                );
-                                let _ = event_tx
-                                    .send(AgentEvent::ChildApprovalChanged {
-                                        parent_session_id: parent_session_id.to_string(),
-                                        child_session_id: child_session_id.to_string(),
-                                        child_attempt,
-                                        request_id: id,
-                                        version: 1,
-                                        status: "delivery_failed".to_string(),
-                                        reason: Some("persistence_failed".to_string()),
-                                        tool_name,
-                                        permission,
-                                        resource,
-                                        created_at: approval_created_at,
-                                        resolved_at: Some(chrono::Utc::now().to_rfc3339()),
-                                    })
-                                    .await;
-                                continue;
-                            }
-                            let _ = event_tx.send(AgentEvent::ChildApprovalChanged {
-                                parent_session_id: parent_session_id.to_string(),
-                                child_session_id: child_session_id.to_string(),
-                                child_attempt,
-                                request_id: id.clone(),
-                                version: approval_version,
-                                status: "pending".to_string(),
-                                reason: None,
-                                tool_name: tool_name.clone(),
-                                permission: permission.clone(),
-                                resource: resource.clone(),
-                                created_at: approval_created_at,
-                                resolved_at: None,
-                            }).await;
-                            let _ = event_tx
-                                .send(AgentEvent::ChildApprovalRequested {
-                                    child_session_id: child_session_id.to_string(),
-                                    request_id: id.clone(),
-                                    tool_name,
-                                    permission,
-                                    resource,
+                            if client
+                                .send(ParentFrame::ApprovalReply {
+                                    id,
+                                    approved: false,
                                 })
-                                .await;
-                            let child = child_session_id.to_string();
-                            let approval_registry = approval_registry.cloned();
-                            tokio::spawn(async move {
-                                tokio::time::sleep(CHILD_APPROVAL_TIMEOUT).await;
-                                // Deny only if still pending: a one-shot consume so
-                                // we don't double-deliver if the human already
-                                // answered (the POST took it), and so a late POST
-                                // after this fires finds nothing pending.
-                                if super::live::expire_pending_approval(approval_registry.as_ref(), &child, &id) {
-                                    super::live::deliver_approval_scoped(
-                                        approval_registry.as_ref(),
-                                        &child,
-                                        child_attempt,
-                                        &id,
-                                        false,
-                                    );
-                                }
-                            });
+                                .await
+                                .is_err()
+                            {
+                                tracing::warn!(
+                                    "failed to send fail-closed approval reply; connection failing"
+                                );
+                            }
                         }
                     }
                     Ok(Some(ChildFrame::Terminal { status, result, error, .. })) => {
@@ -1683,6 +1599,44 @@ mod tests {
         );
         drop(live_guard);
     }
+
+    #[tokio::test]
+    async fn drive_denies_forced_ask_without_parent_reviewer_or_manual_event() {
+        let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(8);
+        let cancel = CancellationToken::new();
+        let (_live_tx, mut live_rx) = mpsc::unbounded_channel::<ParentFrame>();
+        let mut link = ApprovalRoundTripLink {
+            step: 0,
+            approval_reply: None,
+        };
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            drive(
+                &mut link,
+                "parent-no-reviewer",
+                "child-no-reviewer",
+                0,
+                None,
+                None,
+                None,
+                None,
+                &event_tx,
+                &cancel,
+                &mut live_rx,
+                None,
+            ),
+        )
+        .await
+        .expect("fail-closed reply must unblock the child immediately");
+
+        assert_eq!(result.ok().flatten().as_deref(), Some("done"));
+        assert_eq!(link.approval_reply, Some(("approval-1".to_string(), false)));
+        assert!(
+            event_rx.try_recv().is_err(),
+            "missing parent review must not surface a manual approval event"
+        );
+    }
     #[async_trait]
     impl bamboo_subagent::ChildLink for InstantTerminalLink {
         async fn send(&mut self, _: ParentFrame) -> bamboo_subagent::TransportResult<()> {
@@ -1771,21 +1725,6 @@ mod tests {
         let deny: Arc<dyn ChildApprovalDecider> = Arc::new(StaticDecider(false));
         assert!(decide_child_approval(Some(&approve), "child-1", &body).await);
         assert!(!decide_child_approval(Some(&deny), "child-1", &body).await);
-    }
-
-    #[test]
-    fn approval_request_fields_extracts_and_defaults() {
-        let full = serde_json::json!({"tool_name":"Bash","permission":"run","resource":"ls"});
-        assert_eq!(
-            approval_request_fields(&full),
-            ("Bash".to_string(), "run".to_string(), "ls".to_string())
-        );
-        // Missing fields default to empty strings.
-        let partial = serde_json::json!({"tool_name":"Write"});
-        assert_eq!(
-            approval_request_fields(&partial),
-            ("Write".to_string(), String::new(), String::new())
-        );
     }
 
     // ---- #193: remote placement routing -------------------------------------

--- a/crates/engine/bamboo-engine/src/lib.rs
+++ b/crates/engine/bamboo-engine/src/lib.rs
@@ -39,8 +39,11 @@ pub use bamboo_agent_core::{
     ToolError, ToolExecutionContext, ToolExecutor, ToolRegistry, ToolResult, ToolSchema,
 };
 
-// Re-export from runtime
-pub use bamboo_domain::RuntimeSessionPersistence;
+// Re-export hook contracts and runtime persistence so consumers can configure
+// lifecycle hooks without depending on the domain crate directly.
+pub use bamboo_domain::{
+    AgentHookPoint, HookPayload, HookResult, HookToolOutcome, RuntimeSessionPersistence,
+};
 pub use runtime::agent::AgentBuilder;
 // `AgentLoopConfig` is intentionally NOT re-exported: its fields are `pub(crate)`,
 // so it cannot be constructed outside the engine. Execution funnels solely through

--- a/crates/engine/bamboo-engine/src/runtime/agent.rs
+++ b/crates/engine/bamboo-engine/src/runtime/agent.rs
@@ -131,6 +131,12 @@ impl AgentBuilder {
         self
     }
 
+    /// Install an immutable lifecycle-hook registry for this agent runtime.
+    pub fn hook_runner(mut self, v: Arc<crate::runtime::HookRunner>) -> Self {
+        self.inner = self.inner.hook_runner(v);
+        self
+    }
+
     pub fn build(self) -> Result<Agent, &'static str> {
         let runtime = self.inner.build()?;
         Ok(Agent {

--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -17,6 +17,8 @@ use bamboo_skills::SkillManager;
 use bamboo_tools::ToolRegistry;
 use serde::{Deserialize, Serialize};
 
+use super::hooks::HookRunner;
+
 #[derive(Clone, Default)]
 pub struct AuxiliaryModelConfig {
     pub fast_model_name: Option<String>,
@@ -468,6 +470,9 @@ pub struct AgentLoopConfig {
     /// to its parent (Phase 2). `None` (the default) leaves child gating on its
     /// legacy path. Wired by the server.
     pub(crate) approval_delegate: Option<Arc<dyn ApprovalDelegate>>,
+    /// Frozen lifecycle-hook registry for this run. The default registry is
+    /// empty, and every seam checks `has_hooks_for` before constructing payloads.
+    pub(crate) hook_runner: Arc<HookRunner>,
     /// Enable dynamic per-round model routing based on task complexity.
     /// When true, the pipeline classifies complexity at each round end and
     /// stores the result in session metadata.
@@ -548,6 +553,7 @@ impl Default for AgentLoopConfig {
             bash_resume_hook: None,
             bash_completion_sink: None,
             approval_delegate: None,
+            hook_runner: Arc::new(HookRunner::new()),
             features_dynamic_model_routing: false,
             auxiliary_model_resolver: None,
             disabled_filter_resolver: None,

--- a/crates/engine/bamboo-engine/src/runtime/hooks/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/hooks/mod.rs
@@ -2,10 +2,29 @@
 
 use std::sync::Arc;
 
-use bamboo_agent_core::AgentHook;
-use bamboo_agent_core::Session;
-use bamboo_domain::{AgentHookPoint, AgentRuntimeState, HookCheckpoint, HookResult};
+use bamboo_agent_core::{AgentError, AgentEvent, AgentHook, Message, Session};
+use bamboo_domain::{
+    AgentHookPoint, AgentRuntimeState, AgentStatusState, HookCheckpoint, HookPayload, HookResult,
+    SuspensionState,
+};
 use chrono::Utc;
+use tokio::sync::mpsc;
+
+/// Aggregate output from every hook registered at one seam.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookRunOutcome {
+    pub decision: HookResult,
+    pub injected_contexts: Vec<String>,
+}
+
+impl Default for HookRunOutcome {
+    fn default() -> Self {
+        Self {
+            decision: HookResult::Continue,
+            injected_contexts: Vec::new(),
+        }
+    }
+}
 
 /// Runs registered hooks at a given hook point.
 #[derive(Clone)]
@@ -31,10 +50,12 @@ impl HookRunner {
     pub async fn run_hooks(
         &self,
         point: AgentHookPoint,
+        payload: &HookPayload,
         session: &Session,
         runtime_state: &mut AgentRuntimeState,
-    ) -> HookResult {
-        let mut final_result = HookResult::Continue;
+        event_tx: Option<&mpsc::Sender<AgentEvent>>,
+    ) -> HookRunOutcome {
+        let mut outcome = HookRunOutcome::default();
 
         for hook in &self.hooks {
             if hook.point() != point {
@@ -42,7 +63,7 @@ impl HookRunner {
             }
 
             let start = std::time::Instant::now();
-            let result = hook.run(point, session).await;
+            let result = hook.run(point, payload, session).await;
             let elapsed = start.elapsed();
 
             runtime_state.checkpoints.push(HookCheckpoint {
@@ -52,14 +73,41 @@ impl HookRunner {
                 duration_ms: elapsed.as_millis() as u64,
             });
 
+            if let Some(event_tx) = event_tx {
+                let _ = event_tx
+                    .send(AgentEvent::HookLifecycle {
+                        hook_name: hook.name().to_string(),
+                        point,
+                        phase: "completed".to_string(),
+                        duration_ms: elapsed.as_millis() as u64,
+                        decision: result.clone(),
+                    })
+                    .await;
+            }
+
             match &result {
-                HookResult::Abort { .. } | HookResult::Suspend { .. } => return result,
-                HookResult::Mutated => final_result = HookResult::Mutated,
+                HookResult::Abort { .. }
+                | HookResult::Suspend { .. }
+                | HookResult::Deny { .. }
+                | HookResult::Ask => {
+                    outcome.decision = result;
+                    return outcome;
+                }
+                HookResult::InjectContext { text } => {
+                    outcome.injected_contexts.push(text.clone());
+                    outcome.decision = result;
+                }
+                HookResult::Mutated => outcome.decision = HookResult::Mutated,
+                HookResult::Allow => {
+                    if matches!(outcome.decision, HookResult::Continue) {
+                        outcome.decision = HookResult::Allow;
+                    }
+                }
                 HookResult::Continue => {}
             }
         }
 
-        final_result
+        outcome
     }
 
     /// Check if any hooks are registered for the given point.
@@ -75,6 +123,99 @@ impl HookRunner {
     /// Whether any hooks are registered.
     pub fn is_empty(&self) -> bool {
         self.hooks.is_empty()
+    }
+}
+
+/// Apply context injections and non-tool control decisions consistently across
+/// lifecycle seams.
+pub(crate) fn apply_hook_outcome(
+    point: AgentHookPoint,
+    outcome: HookRunOutcome,
+    session: &mut Session,
+    runtime_state: &mut AgentRuntimeState,
+) -> Result<(), AgentError> {
+    inject_contexts(session, point, outcome.injected_contexts);
+
+    match outcome.decision {
+        HookResult::Continue
+        | HookResult::Mutated
+        | HookResult::Allow
+        | HookResult::InjectContext { .. } => Ok(()),
+        HookResult::Suspend { reason } => {
+            let hook_point = format!("{point:?}");
+            runtime_state.status = AgentStatusState::Suspended;
+            runtime_state.suspension = Some(SuspensionState {
+                reason: reason.clone(),
+                suspended_at: Utc::now(),
+                resumable: true,
+                hook_point: Some(hook_point.clone()),
+            });
+            session.metadata.insert(
+                "runtime.suspend_reason".to_string(),
+                "hook_suspended".to_string(),
+            );
+            Err(AgentError::HookSuspended(format!("{hook_point}: {reason}")))
+        }
+        HookResult::Abort { reason } => Err(AgentError::Tool(format!(
+            "hook aborted at {point:?}: {reason}"
+        ))),
+        HookResult::Deny { reason } => Err(AgentError::Tool(format!(
+            "hook denied lifecycle seam {point:?}: {reason}"
+        ))),
+        HookResult::Ask => Err(AgentError::Tool(format!(
+            "hook requested parent approval at non-tool seam {point:?}"
+        ))),
+    }
+}
+
+pub(crate) fn inject_contexts(
+    session: &mut Session,
+    point: AgentHookPoint,
+    injected_contexts: Vec<String>,
+) {
+    for text in injected_contexts {
+        if text.trim().is_empty() {
+            continue;
+        }
+        let block =
+            format!("\n\n<agent_hook_context point=\"{point:?}\">\n{text}\n</agent_hook_context>");
+        if let Some(system_message) = session
+            .messages
+            .iter_mut()
+            .find(|message| matches!(message.role, bamboo_agent_core::Role::System))
+        {
+            system_message.content.push_str(&block);
+            system_message.never_compress = true;
+        } else {
+            let mut message = Message::system(block.trim().to_string());
+            message.never_compress = true;
+            message.metadata = Some(serde_json::json!({
+                "runtime_kind": "hook_context",
+                "hook_point": point,
+            }));
+            session.add_message(message);
+        }
+    }
+}
+
+/// Merge hook checkpoints produced through a session-local seam (notably
+/// compression) into the runner-owned state without losing checkpoints written
+/// directly by tool/round seams.
+pub(crate) fn merge_session_hook_checkpoints(
+    session: &Session,
+    runtime_state: &mut AgentRuntimeState,
+) {
+    let Some(session_state) = session.agent_runtime_state.as_ref() else {
+        return;
+    };
+    for checkpoint in &session_state.checkpoints {
+        if !runtime_state.checkpoints.contains(checkpoint) {
+            runtime_state.checkpoints.push(checkpoint.clone());
+        }
+    }
+    if matches!(session_state.status, AgentStatusState::Suspended) {
+        runtime_state.status = AgentStatusState::Suspended;
+        runtime_state.suspension = session_state.suspension.clone();
     }
 }
 
@@ -101,7 +242,12 @@ mod tests {
             self.point
         }
 
-        async fn run(&self, _point: AgentHookPoint, _session: &Session) -> HookResult {
+        async fn run(
+            &self,
+            _point: AgentHookPoint,
+            _payload: &HookPayload,
+            _session: &Session,
+        ) -> HookResult {
             HookResult::Continue
         }
 
@@ -123,7 +269,12 @@ mod tests {
             AgentHookPoint::BeforeLlmCall
         }
 
-        async fn run(&self, _point: AgentHookPoint, _session: &Session) -> HookResult {
+        async fn run(
+            &self,
+            _point: AgentHookPoint,
+            _payload: &HookPayload,
+            _session: &Session,
+        ) -> HookResult {
             HookResult::Abort {
                 reason: "test abort".to_string(),
             }
@@ -143,12 +294,19 @@ mod tests {
         let runner = HookRunner::new();
         let mut state = AgentRuntimeState::new("run-1");
         let session = test_session();
+        let (tx, _rx) = mpsc::channel(4);
 
         let result = runner
-            .run_hooks(AgentHookPoint::BeforeRound, &session, &mut state)
+            .run_hooks(
+                AgentHookPoint::BeforeRound,
+                &HookPayload::Round { round: 1 },
+                &session,
+                &mut state,
+                Some(&tx),
+            )
             .await;
 
-        assert_eq!(result, HookResult::Continue);
+        assert_eq!(result.decision, HookResult::Continue);
         assert!(state.checkpoints.is_empty());
     }
 
@@ -168,15 +326,26 @@ mod tests {
 
         let mut state = AgentRuntimeState::new("run-2");
         let session = test_session();
+        let (tx, mut rx) = mpsc::channel(4);
 
         let result = runner
-            .run_hooks(AgentHookPoint::BeforeRound, &session, &mut state)
+            .run_hooks(
+                AgentHookPoint::BeforeRound,
+                &HookPayload::Round { round: 1 },
+                &session,
+                &mut state,
+                Some(&tx),
+            )
             .await;
 
-        assert_eq!(result, HookResult::Continue);
+        assert_eq!(result.decision, HookResult::Continue);
         assert_eq!(state.checkpoints.len(), 2);
         // Lower priority runs first
         assert!(state.checkpoints[0].result.contains("Continue"));
+        assert!(matches!(
+            rx.recv().await,
+            Some(AgentEvent::HookLifecycle { hook_name, .. }) if hook_name == "fast"
+        ));
     }
 
     #[tokio::test]
@@ -186,12 +355,19 @@ mod tests {
 
         let mut state = AgentRuntimeState::new("run-3");
         let session = test_session();
+        let (tx, _rx) = mpsc::channel(4);
 
         let result = runner
-            .run_hooks(AgentHookPoint::BeforeLlmCall, &session, &mut state)
+            .run_hooks(
+                AgentHookPoint::BeforeLlmCall,
+                &HookPayload::None,
+                &session,
+                &mut state,
+                Some(&tx),
+            )
             .await;
 
-        assert!(matches!(result, HookResult::Abort { .. }));
+        assert!(matches!(result.decision, HookResult::Abort { .. }));
         assert_eq!(state.checkpoints.len(), 1);
     }
 
@@ -202,12 +378,19 @@ mod tests {
 
         let mut state = AgentRuntimeState::new("run-4");
         let session = test_session();
+        let (tx, _rx) = mpsc::channel(4);
 
         let result = runner
-            .run_hooks(AgentHookPoint::AfterRound, &session, &mut state)
+            .run_hooks(
+                AgentHookPoint::AfterRound,
+                &HookPayload::Round { round: 1 },
+                &session,
+                &mut state,
+                Some(&tx),
+            )
             .await;
 
-        assert_eq!(result, HookResult::Continue);
+        assert_eq!(result.decision, HookResult::Continue);
         assert!(state.checkpoints.is_empty());
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/managers/adapters/tool.rs
+++ b/crates/engine/bamboo-engine/src/runtime/managers/adapters/tool.rs
@@ -60,6 +60,10 @@ impl ToolManager for DefaultToolManager {
             llm: &self.llm,
             tools: &self.tools,
         };
+        let mut runtime_state = session
+            .agent_runtime_state
+            .clone()
+            .unwrap_or_else(|| bamboo_domain::AgentRuntimeState::new(session_id));
 
         // Mirror the live pipeline's #30 biased-cancel wrap so a cancel issued
         // DURING tool execution (e.g. a long foreground Bash run) is honored on
@@ -75,6 +79,7 @@ impl ToolManager for DefaultToolManager {
                 tool_calls,
                 &frame,
                 session,
+                &mut runtime_state,
                 task_context,
                 config
                     .summarization_model_name
@@ -87,6 +92,9 @@ impl ToolManager for DefaultToolManager {
                 tool_schemas,
             ) => result?,
         };
+        if !config.hook_runner.is_empty() {
+            session.agent_runtime_state = Some(runtime_state);
+        }
 
         Ok(ToolRoundResult {
             awaiting_clarification: result.awaiting_clarification,

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution.rs
@@ -7,6 +7,7 @@ use tracing::Instrument;
 use crate::runtime::config::AgentLoopConfig;
 use bamboo_agent_core::tools::ToolExecutor;
 use bamboo_agent_core::{AgentEvent, Session};
+use bamboo_domain::{AgentHookPoint, HookPayload};
 use bamboo_llm::LLMProvider;
 
 mod gold;
@@ -55,6 +56,62 @@ pub(crate) async fn run_agent_loop_with_config(
         )
         .await?;
 
+        if config
+            .hook_runner
+            .has_hooks_for(AgentHookPoint::AfterSessionSetup)
+        {
+            let payload = HookPayload::SessionSetup {
+                initial_message: initial_message.clone(),
+            };
+            let outcome = config
+                .hook_runner
+                .run_hooks(
+                    AgentHookPoint::AfterSessionSetup,
+                    &payload,
+                    session,
+                    &mut state.runtime_state,
+                    Some(&event_tx),
+                )
+                .await;
+            let hook_result = crate::runtime::hooks::apply_hook_outcome(
+                AgentHookPoint::AfterSessionSetup,
+                outcome,
+                session,
+                &mut state.runtime_state,
+            );
+            super::state_bridge::write_runtime_state(session, &state.runtime_state);
+            if let Err(error) = hook_result {
+                if error.is_hook_suspended() {
+                    super::session_finalize::finalize_session(
+                        state.task_context.take(),
+                        session,
+                        &event_tx,
+                        &state.session_id,
+                        &config,
+                        state.metrics_collector.as_ref(),
+                        false,
+                        &mut state.runtime_state,
+                    )
+                    .await;
+                    return Ok(());
+                }
+                if let Some(skill_manager) = config.skill_manager.as_ref() {
+                    let workspace = session.workspace_path_meta().map(std::path::PathBuf::from);
+                    if let Err(release_error) = skill_manager
+                        .release_activation_for_workspace(&state.session_id, workspace.as_deref())
+                        .await
+                    {
+                        tracing::warn!(
+                            "[{}] Failed to release hook-aborted workflow activation snapshot: {}",
+                            state.session_id,
+                            release_error
+                        );
+                    }
+                }
+                return Err(error);
+            }
+        }
+
         let pipeline_result = run_pipeline(
             session,
             &event_tx,
@@ -68,7 +125,32 @@ pub(crate) async fn run_agent_loop_with_config(
 
         let sent_complete = match pipeline_result {
             Ok(sent_complete) => sent_complete,
+            Err(error) if error.is_hook_suspended() => {
+                crate::runtime::hooks::merge_session_hook_checkpoints(
+                    session,
+                    &mut state.runtime_state,
+                );
+                super::session_finalize::finalize_session(
+                    state.task_context.take(),
+                    session,
+                    &event_tx,
+                    &state.session_id,
+                    &config,
+                    state.metrics_collector.as_ref(),
+                    false,
+                    &mut state.runtime_state,
+                )
+                .await;
+                return Ok(());
+            }
             Err(error) => {
+                if !config.hook_runner.is_empty() {
+                    crate::runtime::hooks::merge_session_hook_checkpoints(
+                        session,
+                        &mut state.runtime_state,
+                    );
+                    super::state_bridge::write_runtime_state(session, &state.runtime_state);
+                }
                 // Errors and cancellation are terminal for this activation but must
                 // not flow through normal finalization: that would emit a false
                 // Complete event and stamp the runtime state Completed. Release only
@@ -106,4 +188,145 @@ pub(crate) async fn run_agent_loop_with_config(
     }
     .instrument(session_span)
     .await
+}
+
+#[cfg(test)]
+mod hook_tests {
+    use super::*;
+    use async_trait::async_trait;
+    use bamboo_agent_core::tools::{ToolCall, ToolError, ToolResult, ToolSchema};
+    use bamboo_agent_core::{AgentHook, Message};
+    use bamboo_domain::{HookResult, Role};
+    use bamboo_llm::provider::LLMStream;
+
+    struct PanicProvider;
+
+    #[async_trait]
+    impl LLMProvider for PanicProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> bamboo_llm::provider::Result<LLMStream> {
+            panic!("LLM must not run after a BeforeRound abort")
+        }
+    }
+
+    struct EmptyTools;
+
+    #[async_trait]
+    impl ToolExecutor for EmptyTools {
+        async fn execute(&self, _call: &ToolCall) -> Result<ToolResult, ToolError> {
+            panic!("tools must not run in lifecycle-hook tests")
+        }
+
+        fn list_tools(&self) -> Vec<ToolSchema> {
+            Vec::new()
+        }
+    }
+
+    struct AbortRoundHook;
+
+    #[async_trait]
+    impl AgentHook for AbortRoundHook {
+        fn point(&self) -> AgentHookPoint {
+            AgentHookPoint::BeforeRound
+        }
+
+        async fn run(
+            &self,
+            _point: AgentHookPoint,
+            payload: &HookPayload,
+            _session: &Session,
+        ) -> HookResult {
+            assert_eq!(payload, &HookPayload::Round { round: 1 });
+            HookResult::Abort {
+                reason: "round rejected".to_string(),
+            }
+        }
+    }
+
+    struct InjectSetupHook;
+
+    #[async_trait]
+    impl AgentHook for InjectSetupHook {
+        fn point(&self) -> AgentHookPoint {
+            AgentHookPoint::AfterSessionSetup
+        }
+
+        async fn run(
+            &self,
+            _point: AgentHookPoint,
+            payload: &HookPayload,
+            _session: &Session,
+        ) -> HookResult {
+            assert!(matches!(
+                payload,
+                HookPayload::SessionSetup { initial_message } if initial_message == "hello hooks"
+            ));
+            HookResult::InjectContext {
+                text: "injected setup context".to_string(),
+            }
+        }
+    }
+
+    fn config_with_hooks(hooks: Vec<Arc<dyn AgentHook>>) -> AgentLoopConfig {
+        let mut runner = crate::runtime::hooks::HookRunner::new();
+        for hook in hooks {
+            runner.register(hook);
+        }
+        AgentLoopConfig {
+            model_name: Some("model".to_string()),
+            hook_runner: Arc::new(runner),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn before_round_hook_aborts_before_llm_call() {
+        let mut session = Session::new("abort-round", "model");
+        let (event_tx, _event_rx) = mpsc::channel(32);
+        let error = run_agent_loop_with_config(
+            &mut session,
+            "hello hooks".to_string(),
+            event_tx,
+            Arc::new(PanicProvider),
+            Arc::new(EmptyTools),
+            CancellationToken::new(),
+            config_with_hooks(vec![Arc::new(AbortRoundHook)]),
+        )
+        .await
+        .expect_err("BeforeRound abort must terminate the run");
+        assert!(
+            matches!(error, bamboo_agent_core::AgentError::Tool(message) if message.contains("round rejected"))
+        );
+    }
+
+    #[tokio::test]
+    async fn after_session_setup_hook_injects_context_before_round() {
+        let mut session = Session::new("inject-setup", "model");
+        let (event_tx, _event_rx) = mpsc::channel(32);
+        let error = run_agent_loop_with_config(
+            &mut session,
+            "hello hooks".to_string(),
+            event_tx,
+            Arc::new(PanicProvider),
+            Arc::new(EmptyTools),
+            CancellationToken::new(),
+            config_with_hooks(vec![Arc::new(InjectSetupHook), Arc::new(AbortRoundHook)]),
+        )
+        .await
+        .expect_err("the test's BeforeRound hook stops after setup");
+        assert!(matches!(error, bamboo_agent_core::AgentError::Tool(_)));
+        let injected = session.messages.iter().find(|message| {
+            message.role == Role::System && message.content.contains("injected setup context")
+        });
+        assert!(
+            injected.is_some(),
+            "hook context must be stored in the session"
+        );
+        assert!(injected.is_some_and(|message| message.never_compress));
+    }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -30,6 +30,7 @@ use bamboo_domain::session::runtime_state::{
     AgentRuntimeState, AgentStatusState, ChildWaitPolicy, SuspensionState, WaitingForBashState,
     WaitingForChildrenState,
 };
+use bamboo_domain::{AgentHookPoint, HookPayload};
 use bamboo_llm::LLMProvider;
 use bamboo_metrics::{
     MetricsCollector, RoundStatus as MetricsRoundStatus, SessionStatus as MetricsSessionStatus,
@@ -1024,7 +1025,7 @@ async fn handle_no_tool_calls(
     eval_model: &str,
     iteration: u32,
     llm: Arc<dyn LLMProvider>,
-) -> TurnOutcome {
+) -> Result<TurnOutcome, AgentError> {
     // The Gold judge reads the recent transcript, so when the goal loop is active
     // the assistant's final turn must be in the session BEFORE the gate runs
     // (matching the pre-#343 add-before-gold order). When no goal loop is active
@@ -1077,10 +1078,10 @@ async fn handle_no_tool_calls(
             session,
             round_usage,
         );
-        return TurnOutcome {
+        return Ok(TurnOutcome {
             should_break: false,
             sent_complete: false,
-        };
+        });
     }
 
     // Gold decided STOP: the goal is met, or no goal loop is configured. Only now
@@ -1113,10 +1114,34 @@ async fn handle_no_tool_calls(
         // Suspended on the guardian verdict. In the no-goal case the assistant
         // message was intentionally not appended yet (the resumed turn re-emits
         // it), so nothing to roll back here.
-        return review;
+        return Ok(review);
     }
 
     // Guardian approved, inactive, or out of budget → complete the run.
+    if config
+        .hook_runner
+        .has_hooks_for(AgentHookPoint::BeforeFinalize)
+    {
+        let outcome = config
+            .hook_runner
+            .run_hooks(
+                AgentHookPoint::BeforeFinalize,
+                &HookPayload::Finalize,
+                session,
+                runtime_state,
+                Some(event_tx),
+            )
+            .await;
+        let hook_result = crate::runtime::hooks::apply_hook_outcome(
+            AgentHookPoint::BeforeFinalize,
+            outcome,
+            session,
+            runtime_state,
+        );
+        state_bridge::write_runtime_state(session, runtime_state);
+        hook_result?;
+    }
+
     if let Some(message) = deferred_assistant_message.take() {
         session.add_message(message);
     }
@@ -1132,10 +1157,10 @@ async fn handle_no_tool_calls(
         session,
         round_usage,
     );
-    TurnOutcome {
+    Ok(TurnOutcome {
         should_break: true,
         sent_complete: true,
-    }
+    })
 }
 
 // ---- Tool-calls path (from round_flow/tool_calls.rs) ----
@@ -1146,6 +1171,7 @@ async fn handle_tool_calls_path(
     stream_output: StreamHandlingOutput,
     mut round_usage: MetricsTokenUsage,
     session: &mut Session,
+    runtime_state: &mut AgentRuntimeState,
     auxiliary_models: &crate::runtime::config::AuxiliaryModelConfig,
     model_name: &str,
     task_context: &mut Option<TaskLoopContext>,
@@ -1215,6 +1241,7 @@ async fn handle_tool_calls_path(
             &stream_output.tool_calls,
             frame,
             session,
+            runtime_state,
             task_context,
             compression_model
                 .as_deref()
@@ -1501,6 +1528,32 @@ pub(super) async fn run_pipeline(
 
         let round_id = format!("{}-round-{}", state.session_id, turn_counter + 1);
         state.runtime_state.round.last_round_id = Some(round_id.clone());
+
+        if config
+            .hook_runner
+            .has_hooks_for(AgentHookPoint::BeforeRound)
+        {
+            let outcome = config
+                .hook_runner
+                .run_hooks(
+                    AgentHookPoint::BeforeRound,
+                    &HookPayload::Round {
+                        round: turn_counter + 1,
+                    },
+                    session,
+                    &mut state.runtime_state,
+                    Some(event_tx),
+                )
+                .await;
+            let hook_result = crate::runtime::hooks::apply_hook_outcome(
+                AgentHookPoint::BeforeRound,
+                outcome,
+                session,
+                &mut state.runtime_state,
+            );
+            state_bridge::write_runtime_state(session, &state.runtime_state);
+            hook_result?;
+        }
 
         // --- Prompt context refresh ---
         let runtime_context = PromptMemoryRuntimeContext {
@@ -1823,7 +1876,7 @@ pub(super) async fn run_pipeline(
                         turn_counter + 1,
                         llm.clone(),
                     )
-                    .await,
+                    .await?,
                 );
                 break;
             }
@@ -1845,6 +1898,7 @@ pub(super) async fn run_pipeline(
                 stream_output,
                 llm_output.round_usage,
                 session,
+                &mut state.runtime_state,
                 &state.auxiliary_models,
                 &state.model_name,
                 &mut state.task_context,
@@ -2117,6 +2171,36 @@ pub(super) async fn run_pipeline(
             .round
             .total_subagents_spawned
             .saturating_add(round_activity.subagent_spawn_count);
+
+        if !config.hook_runner.is_empty() {
+            crate::runtime::hooks::merge_session_hook_checkpoints(
+                session,
+                &mut state.runtime_state,
+            );
+        }
+
+        if config.hook_runner.has_hooks_for(AgentHookPoint::AfterRound) {
+            let hook_outcome = config
+                .hook_runner
+                .run_hooks(
+                    AgentHookPoint::AfterRound,
+                    &HookPayload::Round {
+                        round: turn_counter + 1,
+                    },
+                    session,
+                    &mut state.runtime_state,
+                    Some(event_tx),
+                )
+                .await;
+            let hook_result = crate::runtime::hooks::apply_hook_outcome(
+                AgentHookPoint::AfterRound,
+                hook_outcome,
+                session,
+                &mut state.runtime_state,
+            );
+            state_bridge::write_runtime_state(session, &state.runtime_state);
+            hook_result?;
+        }
 
         state_bridge::write_runtime_state(session, &state.runtime_state);
 
@@ -2783,7 +2867,8 @@ mod tests {
                 confidence: "high",
             }),
         )
-        .await;
+        .await
+        .unwrap();
 
         // The run keeps going: no break, no terminal Complete.
         assert!(!outcome.should_break);
@@ -2843,7 +2928,8 @@ mod tests {
                 confidence: "high",
             }),
         )
-        .await;
+        .await
+        .unwrap();
 
         assert!(outcome.should_break);
         assert!(outcome.sent_complete);
@@ -2903,7 +2989,8 @@ mod tests {
                 confidence: "high",
             }),
         )
-        .await;
+        .await
+        .unwrap();
         assert!(!r1.should_break, "undeclared + continue → keep working");
         assert!(!r1.sent_complete);
 
@@ -2946,7 +3033,8 @@ mod tests {
                 confidence: "high",
             }),
         )
-        .await;
+        .await
+        .unwrap();
         assert!(r2.should_break, "declared complete + achieved → stop");
         assert!(r2.sent_complete);
 
@@ -3004,7 +3092,8 @@ mod tests {
                 confidence: "high",
             }),
         )
-        .await;
+        .await
+        .unwrap();
 
         assert!(!outcome.should_break, "premature completion vetoed");
         assert!(!outcome.sent_complete);
@@ -3080,7 +3169,8 @@ mod tests {
                 confidence: "high",
             }),
         )
-        .await;
+        .await
+        .unwrap();
 
         // The run keeps working: no break, no terminal Complete.
         assert!(!outcome.should_break);
@@ -3146,7 +3236,8 @@ mod tests {
                 confidence: "high",
             }),
         )
-        .await;
+        .await
+        .unwrap();
 
         // The guardian engaged: the run suspended on the reviewer verdict instead
         // of emitting a terminal Complete.
@@ -4359,7 +4450,8 @@ mod tests {
             1,
             Arc::new(StubProvider),
         )
-        .await;
+        .await
+        .unwrap();
 
         assert!(outcome.should_break);
         assert!(outcome.sent_complete);
@@ -5004,6 +5096,7 @@ mod tests {
             tools: &tools,
         };
         let auxiliary_models = crate::runtime::config::AuxiliaryModelConfig::default();
+        let mut runtime_state = AgentRuntimeState::new("s-cancel");
         let mut task_context: Option<TaskLoopContext> = None;
         let cancel_token = CancellationToken::new();
 
@@ -5038,6 +5131,7 @@ mod tests {
                     total_tokens: 0,
                 },
                 &mut session,
+                &mut runtime_state,
                 &auxiliary_models,
                 "model",
                 &mut task_context,
@@ -5094,6 +5188,7 @@ mod tests {
             tools: &tools,
         };
         let tool_schemas = tools.list_tools();
+        let mut runtime_state = AgentRuntimeState::new("s-normal");
         let mut task_context: Option<TaskLoopContext> = None;
 
         let result = tokio::time::timeout(
@@ -5102,6 +5197,7 @@ mod tests {
                 std::slice::from_ref(&single_read_call()),
                 &frame,
                 &mut session,
+                &mut runtime_state,
                 &mut task_context,
                 // No compression model -> mid-turn compression short-circuits, so
                 // the healthy path is exercised without any auxiliary LLM call.
@@ -5294,6 +5390,7 @@ mod tests {
             tools: &tools,
         };
         let auxiliary_models = crate::runtime::config::AuxiliaryModelConfig::default();
+        let mut runtime_state = AgentRuntimeState::new("s-compress-fail");
         let mut task_context: Option<TaskLoopContext> = None;
         let cancel_token = CancellationToken::new();
 
@@ -5329,6 +5426,7 @@ mod tests {
                     total_tokens: 0,
                 },
                 &mut session,
+                &mut runtime_state,
                 &auxiliary_models,
                 "model",
                 &mut task_context,
@@ -5922,7 +6020,8 @@ mod tests {
             1,
             Arc::new(StubProvider),
         )
-        .await;
+        .await
+        .unwrap();
 
         // The guardian engaged: suspended on the reviewer verdict rather than
         // completing outright.
@@ -5996,7 +6095,8 @@ mod tests {
                 confidence: "high",
             }),
         )
-        .await;
+        .await
+        .unwrap();
 
         assert!(outcome.should_break);
         assert!(!outcome.sent_complete);
@@ -6052,7 +6152,8 @@ mod tests {
             1,
             Arc::new(StubProvider),
         )
-        .await;
+        .await
+        .unwrap();
 
         assert!(outcome.should_break);
         assert!(!outcome.sent_complete);

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation.rs
@@ -13,6 +13,7 @@ use bamboo_compression::{
     estimate_context_compression_exposure, prepare_hybrid_context, summary_source_messages,
     PreparedContext, Summarizer, TiktokenTokenCounter, TokenBudget, TokenCounter,
 };
+use bamboo_domain::{AgentHookPoint, AgentRuntimeState, HookPayload};
 use bamboo_llm::LLMProvider;
 use std::sync::Arc;
 use std::time::Instant;
@@ -278,6 +279,39 @@ async fn maybe_apply_host_context_compression_with_budget(
     } else {
         CompressionTriggerType::Auto
     };
+
+    if config
+        .hook_runner
+        .has_hooks_for(AgentHookPoint::BeforeCompression)
+    {
+        let payload = HookPayload::Compression {
+            estimated_tokens: exposure.active_tokens,
+            usage_percent,
+            phase: phase_label.to_string(),
+        };
+        let mut hook_runtime_state = session
+            .agent_runtime_state
+            .clone()
+            .unwrap_or_else(|| AgentRuntimeState::new(session_id));
+        let hook_outcome = config
+            .hook_runner
+            .run_hooks(
+                AgentHookPoint::BeforeCompression,
+                &payload,
+                session,
+                &mut hook_runtime_state,
+                event_tx,
+            )
+            .await;
+        let hook_result = crate::runtime::hooks::apply_hook_outcome(
+            AgentHookPoint::BeforeCompression,
+            hook_outcome,
+            session,
+            &mut hook_runtime_state,
+        );
+        session.agent_runtime_state = Some(hook_runtime_state);
+        hook_result?;
+    }
 
     let start = Instant::now();
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
@@ -10,6 +10,7 @@ use crate::runtime::task_context::TaskLoopContext;
 use bamboo_agent_core::tools::{ToolCall, ToolExecutor, ToolSchema};
 use bamboo_agent_core::{AgentError, AgentEvent, Session};
 use bamboo_config::PermissionMode;
+use bamboo_domain::{AgentHookPoint, AgentRuntimeState};
 use bamboo_llm::LLMProvider;
 use bamboo_metrics::{MetricsCollector, RoundStatus as MetricsRoundStatus};
 
@@ -121,11 +122,12 @@ async fn execute_and_apply_single_tool_call(
     // Pre-built per-round snapshot of the executor's full tool-schema list —
     // avoids re-cloning every schema on each tool call.
     available_tool_schemas: &[ToolSchema],
+    runtime_state: &mut AgentRuntimeState,
     task_context: &mut Option<TaskLoopContext>,
     state: &mut RoundExecutionState,
     policy_guard: &mut policy::ToolPolicyGuard,
     reserved_calls: usize,
-) -> SingleToolExecutionControl {
+) -> Result<SingleToolExecutionControl, AgentError> {
     // Plan mode gate: block mutating tools (except pause/clarification tools)
     if config.permission_mode == Some(PermissionMode::Plan) {
         let tool_name = tool_call.function.name.trim();
@@ -171,16 +173,17 @@ async fn execute_and_apply_single_tool_call(
                     session,
                     tools,
                     config,
+                    runtime_state,
                     task_context,
                     state,
                 },
                 outcome,
             )
-            .await;
-            return SingleToolExecutionControl {
+            .await?;
+            return Ok(SingleToolExecutionControl {
                 should_break,
                 stop_round: false,
-            };
+            });
         }
     }
 
@@ -202,6 +205,11 @@ async fn execute_and_apply_single_tool_call(
                     tool_duration: std::time::Duration::ZERO,
                 }
             } else {
+                let session_flags =
+                    bamboo_agent_core::tools::ToolExecutionSessionFlags::from_session(session);
+                let before_tool_hooks = config
+                    .hook_runner
+                    .has_hooks_for(AgentHookPoint::BeforeToolExecution);
                 per_call::execute_tool_call_only(per_call::ToolExecutionOnlyContext {
                     tool_call,
                     event_tx,
@@ -211,11 +219,12 @@ async fn execute_and_apply_single_tool_call(
                     round,
                     tools,
                     config,
-                    session_flags:
-                        bamboo_agent_core::tools::ToolExecutionSessionFlags::from_session(session),
+                    hook_session: before_tool_hooks.then_some(&mut *session),
+                    hook_runtime_state: before_tool_hooks.then_some(&mut *runtime_state),
+                    session_flags,
                     available_tool_schemas,
                 })
-                .await
+                .await?
             }
         }
         Err(violation) => {
@@ -266,17 +275,18 @@ async fn execute_and_apply_single_tool_call(
             session,
             tools,
             config,
+            runtime_state,
             task_context,
             state,
         },
         outcome,
     )
-    .await;
+    .await?;
 
-    SingleToolExecutionControl {
+    Ok(SingleToolExecutionControl {
         should_break,
         stop_round,
-    }
+    })
 }
 
 /// Check if the most recent tool result is from `compact_context` and set
@@ -401,6 +411,7 @@ pub(crate) async fn execute_round_tool_calls(
     tool_calls: &[ToolCall],
     frame: &crate::runtime::runner::round_frame::RoundFrame<'_>,
     session: &mut Session,
+    runtime_state: &mut AgentRuntimeState,
     task_context: &mut Option<TaskLoopContext>,
     compression_model_name: Option<&str>,
     compression_model_provider: Option<&Arc<dyn LLMProvider>>,
@@ -437,10 +448,17 @@ pub(crate) async fn execute_round_tool_calls(
     );
 
     // Pre-classify all tool calls to avoid repeated normalization.
-    let scheduling_modes: Vec<ToolSchedulingMode> = tool_calls
-        .iter()
-        .map(|tc| scheduling_mode_for_tool_call(tc, tools))
-        .collect();
+    let scheduling_modes: Vec<ToolSchedulingMode> = if config
+        .hook_runner
+        .has_hooks_for(AgentHookPoint::BeforeToolExecution)
+    {
+        vec![ToolSchedulingMode::Sequential; tool_calls.len()]
+    } else {
+        tool_calls
+            .iter()
+            .map(|tc| scheduling_mode_for_tool_call(tc, tools))
+            .collect()
+    };
 
     let mut next_index = 0usize;
     'tool_calls: while next_index < tool_calls.len() {
@@ -474,12 +492,13 @@ pub(crate) async fn execute_round_tool_calls(
                         tools,
                         config,
                         available_tool_schemas,
+                        runtime_state,
                         task_context,
                         &mut state,
                         &mut policy_guard,
                         0,
                     )
-                    .await;
+                    .await?;
 
                     maybe_apply_mid_turn_context_compression_after_tool(
                         session,
@@ -513,12 +532,13 @@ pub(crate) async fn execute_round_tool_calls(
                     tools,
                     config,
                     available_tool_schemas,
+                    runtime_state,
                     task_context,
                     &mut state,
                     &mut policy_guard,
                     0,
                 )
-                .await;
+                .await?;
 
                 maybe_apply_mid_turn_context_compression_after_tool(
                     session,
@@ -571,20 +591,22 @@ pub(crate) async fn execute_round_tool_calls(
                                 round,
                                 tools,
                                 config,
+                                hook_session: None,
+                                hook_runtime_state: None,
                                 session_flags,
                                 available_tool_schemas,
                             }),
                         )
                         .await
                         .unwrap_or_else(|_| {
-                            per_call::ToolExecutionOutcome {
+                            Ok(per_call::ToolExecutionOutcome {
                                 needs_human: None,
                                 result: Err(format!(
                                     "Tool '{}' timed out after {:?}",
                                     tool_call.function.name, timeout
                                 )),
                                 tool_duration: timeout,
-                            }
+                            })
                         })
                     }
                 })),
@@ -599,16 +621,21 @@ pub(crate) async fn execute_round_tool_calls(
                 );
                 batch
                     .iter()
-                    .map(|_batch_call| per_call::ToolExecutionOutcome {
-                        needs_human: None,
-                        result: Err(format!(
-                            "Parallel batch timed out after {:?}",
-                            batch_timeout
-                        )),
-                        tool_duration: batch_timeout,
+                    .map(|_batch_call| {
+                        Ok(per_call::ToolExecutionOutcome {
+                            needs_human: None,
+                            result: Err(format!(
+                                "Parallel batch timed out after {:?}",
+                                batch_timeout
+                            )),
+                            tool_duration: batch_timeout,
+                        })
                     })
                     .collect::<Vec<_>>()
             });
+            let outcomes = outcomes
+                .into_iter()
+                .collect::<Result<Vec<_>, AgentError>>()?;
             let parallel_elapsed = parallel_start.elapsed();
 
             // Log individual tool durations to confirm parallelism
@@ -681,12 +708,13 @@ pub(crate) async fn execute_round_tool_calls(
                         session,
                         tools,
                         config,
+                        runtime_state,
                         task_context,
                         state: &mut state,
                     },
                     outcome,
                 )
-                .await;
+                .await?;
 
                 maybe_apply_mid_turn_context_compression_after_tool(
                     session,
@@ -719,12 +747,13 @@ pub(crate) async fn execute_round_tool_calls(
             tools,
             config,
             available_tool_schemas,
+            runtime_state,
             task_context,
             &mut state,
             &mut policy_guard,
             0,
         )
-        .await;
+        .await?;
 
         next_index += 1;
 
@@ -752,6 +781,7 @@ pub(crate) async fn execute_round_tool_calls(
 mod tests {
     use super::{scheduling_mode_for_tool_call, ToolSchedulingMode};
     use bamboo_agent_core::tools::{FunctionCall, ToolCall, ToolExecutor};
+    use bamboo_domain::AgentRuntimeState;
     use bamboo_tools::BuiltinToolExecutor;
     use serde_json::json;
     use std::sync::Arc;
@@ -1001,6 +1031,7 @@ mod tests {
         };
 
         let mut state = RoundExecutionState::default();
+        let mut runtime_state = AgentRuntimeState::new("test-session");
         let mut policy_guard = policy::ToolPolicyGuard::new(80, 3);
 
         let tool_call = tool_call_with_args(
@@ -1019,12 +1050,14 @@ mod tests {
             &tools,
             &config,
             tools.list_tools().as_slice(),
+            &mut runtime_state,
             &mut None,
             &mut state,
             &mut policy_guard,
             0,
         )
-        .await;
+        .await
+        .unwrap();
 
         // Should not break the round, just block the tool
         assert!(!control.should_break);
@@ -1055,6 +1088,7 @@ mod tests {
         };
 
         let mut state = RoundExecutionState::default();
+        let mut runtime_state = AgentRuntimeState::new("test-session");
         let mut policy_guard = policy::ToolPolicyGuard::new(80, 3);
 
         let temp_dir = std::env::temp_dir().join("bamboo_plan_mode_read_test");
@@ -1076,12 +1110,14 @@ mod tests {
             &tools,
             &config,
             tools.list_tools().as_slice(),
+            &mut runtime_state,
             &mut None,
             &mut state,
             &mut policy_guard,
             0,
         )
-        .await;
+        .await
+        .unwrap();
 
         assert!(!control.should_break);
         assert!(!control.stop_round);
@@ -1112,6 +1148,7 @@ mod tests {
         };
 
         let mut state = RoundExecutionState::default();
+        let mut runtime_state = AgentRuntimeState::new("test-session");
         let mut policy_guard = policy::ToolPolicyGuard::new(80, 3);
 
         let tool_call = tool_call_with_args("ExitPlanMode", json!({"plan": "test plan"}));
@@ -1127,12 +1164,14 @@ mod tests {
             &tools,
             &config,
             tools.list_tools().as_slice(),
+            &mut runtime_state,
             &mut None,
             &mut state,
             &mut policy_guard,
             0,
         )
-        .await;
+        .await
+        .unwrap();
 
         assert!(!control.stop_round);
         let last_msg = session.messages.last().expect("should have a tool result");
@@ -1157,6 +1196,7 @@ mod tests {
         let config = crate::runtime::config::AgentLoopConfig::default();
 
         let mut state = RoundExecutionState::default();
+        let mut runtime_state = AgentRuntimeState::new("test-session");
         let mut policy_guard = policy::ToolPolicyGuard::new(80, 3);
 
         let temp_dir = std::env::temp_dir().join("bamboo_default_mode_test");
@@ -1179,12 +1219,14 @@ mod tests {
             &tools,
             &config,
             tools.list_tools().as_slice(),
+            &mut runtime_state,
             &mut None,
             &mut state,
             &mut policy_guard,
             0,
         )
-        .await;
+        .await
+        .unwrap();
 
         assert!(!control.stop_round);
         let last_msg = session.messages.last().expect("should have a tool result");

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
@@ -8,7 +8,8 @@ use bamboo_agent_core::tools::{
     parse_tool_args_best_effort, ToolCall, ToolExecutionContext, ToolExecutionSessionFlags,
     ToolExecutor, ToolOutcome, ToolResult, ToolSchema,
 };
-use bamboo_agent_core::{AgentEvent, Session};
+use bamboo_agent_core::{AgentError, AgentEvent, Session};
+use bamboo_domain::{AgentHookPoint, AgentRuntimeState, HookPayload, HookResult, HookToolOutcome};
 use bamboo_metrics::MetricsCollector;
 
 use super::execution_paths;
@@ -39,6 +40,11 @@ pub(super) struct ToolExecutionOnlyContext<'a> {
     pub round: usize,
     pub tools: &'a Arc<dyn ToolExecutor>,
     pub config: &'a AgentLoopConfig,
+    /// Present only on the sequential path when BeforeToolExecution hooks are
+    /// registered. Parallel-safe tools are forced through that path whenever
+    /// such hooks exist, preserving deterministic mutation/control semantics.
+    pub hook_session: Option<&'a mut Session>,
+    pub hook_runtime_state: Option<&'a mut AgentRuntimeState>,
     /// Per-session execution flags (e.g. bypass permissions), derived from the
     /// session via `ToolExecutionSessionFlags::from_session` at the call site
     /// and threaded through so this (parallel-safe) path can apply them without
@@ -68,6 +74,7 @@ pub(super) struct ToolExecutionApplyContext<'a> {
     pub session: &'a mut Session,
     pub tools: &'a Arc<dyn ToolExecutor>,
     pub config: &'a AgentLoopConfig,
+    pub runtime_state: &'a mut AgentRuntimeState,
     pub task_context: &'a mut Option<TaskLoopContext>,
     pub state: &'a mut RoundExecutionState,
 }
@@ -83,8 +90,8 @@ pub(super) struct ToolExecutionOutcome {
 }
 
 pub(super) async fn execute_tool_call_only(
-    ctx: ToolExecutionOnlyContext<'_>,
-) -> ToolExecutionOutcome {
+    mut ctx: ToolExecutionOnlyContext<'_>,
+) -> Result<ToolExecutionOutcome, AgentError> {
     if let Err(policy_error) = policy::validate_tool_call_arguments(ctx.tool_call) {
         tracing::warn!(
             "[{}][round:{}] Tool call blocked by strict argument policy before ToolStart: tool_call_id={}, tool_name={}, error={}",
@@ -94,11 +101,11 @@ pub(super) async fn execute_tool_call_only(
             ctx.tool_call.function.name,
             policy_error
         );
-        return ToolExecutionOutcome {
+        return Ok(ToolExecutionOutcome {
             needs_human: None,
             result: Err(policy_error),
             tool_duration: std::time::Duration::ZERO,
-        };
+        });
     }
 
     let raw_arguments = ctx.tool_call.function.arguments.trim();
@@ -156,6 +163,87 @@ pub(super) async fn execute_tool_call_only(
     }
 
     let tool_timer = std::time::Instant::now();
+
+    if ctx
+        .config
+        .hook_runner
+        .has_hooks_for(AgentHookPoint::BeforeToolExecution)
+    {
+        let session = ctx
+            .hook_session
+            .as_deref_mut()
+            .expect("hooked tool calls must run on the sequential path");
+        let runtime_state = ctx
+            .hook_runtime_state
+            .as_deref_mut()
+            .expect("hooked tool calls must carry runtime state");
+        let payload = HookPayload::ToolExecution {
+            tool_name: ctx.tool_call.function.name.clone(),
+            tool_call_id: ctx.tool_call.id.clone(),
+            parsed_args: args.clone(),
+        };
+        let hook_outcome = ctx
+            .config
+            .hook_runner
+            .run_hooks(
+                AgentHookPoint::BeforeToolExecution,
+                &payload,
+                session,
+                runtime_state,
+                Some(ctx.event_tx),
+            )
+            .await;
+
+        match hook_outcome.decision.clone() {
+            HookResult::Deny { reason } => {
+                crate::runtime::hooks::inject_contexts(
+                    session,
+                    AgentHookPoint::BeforeToolExecution,
+                    hook_outcome.injected_contexts,
+                );
+                let elapsed = tool_timer.elapsed();
+                let end_event = emitter.error(reason.clone()).clone();
+                let _ = ctx.event_tx.send(end_event.into_agent_event()).await;
+                return Ok(ToolExecutionOutcome {
+                    result: Err(format!("Tool execution denied by hook: {reason}")),
+                    needs_human: None,
+                    tool_duration: elapsed,
+                });
+            }
+            HookResult::Ask => {
+                crate::runtime::hooks::inject_contexts(
+                    session,
+                    AgentHookPoint::BeforeToolExecution,
+                    hook_outcome.injected_contexts,
+                );
+                if let Some(outcome) =
+                    hook_ask_outcome(ctx.tool_call, ctx.config, session, runtime_state, &args).await
+                {
+                    let end_event = match &outcome.result {
+                        Ok(_) => emitter
+                            .finish(Some("waiting for parent review".to_string()))
+                            .clone(),
+                        Err(error) => emitter.error(error.clone()).clone(),
+                    };
+                    let _ = ctx.event_tx.send(end_event.into_agent_event()).await;
+                    return Ok(outcome);
+                }
+            }
+            _ => {
+                if let Err(error) = crate::runtime::hooks::apply_hook_outcome(
+                    AgentHookPoint::BeforeToolExecution,
+                    hook_outcome,
+                    session,
+                    runtime_state,
+                ) {
+                    let end_event = emitter.error(error.to_string()).clone();
+                    let _ = ctx.event_tx.send(end_event.into_agent_event()).await;
+                    return Err(error);
+                }
+            }
+        }
+    }
+
     // THIS is the live server tool-dispatch path (engine runtime). Build via
     // `for_dispatch` so per-session flags stay in sync with the other loop
     // (bamboo-agent-core's `result_handler.rs`). The schema slice is the
@@ -231,17 +319,184 @@ pub(super) async fn execute_tool_call_only(
         emitter.events().len()
     );
 
-    ToolExecutionOutcome {
+    Ok(ToolExecutionOutcome {
         result: result.map_err(|error| error.to_string()),
         needs_human,
         tool_duration,
+    })
+}
+
+/// Resolve `HookResult::Ask` without ever opening an unowned/manual approval.
+/// External workers use their ambient parent proxy inline; in-process children
+/// reuse the existing ApprovalDelegate suspension path. Missing parent routes
+/// fail closed.
+async fn hook_ask_outcome(
+    tool_call: &ToolCall,
+    config: &AgentLoopConfig,
+    session: &Session,
+    runtime_state: &AgentRuntimeState,
+    args: &serde_json::Value,
+) -> Option<ToolExecutionOutcome> {
+    let tool_name = tool_call.function.name.trim().to_string();
+    let permission_context = bamboo_tools::permission::check_permissions(&tool_name, args)
+        .ok()
+        .flatten()
+        .and_then(|contexts| contexts.into_iter().next());
+    let (permission_type, resource, operation_summary, risk_level) =
+        if let Some(permission) = permission_context {
+            let risk_level = permission.risk_level();
+            (
+                permission.permission_type,
+                permission.resource,
+                permission.operation_description,
+                risk_level,
+            )
+        } else {
+            let permission_type = bamboo_tools::permission::PermissionType::ExecuteCommand;
+            (
+                permission_type,
+                args.to_string(),
+                format!("Hook-requested review for {tool_name}"),
+                permission_type.risk_level(),
+            )
+        };
+
+    let request = bamboo_tools::permission::PermissionRequest {
+        request_id: tool_call.id.clone(),
+        session_id: session.id.clone(),
+        workspace_path: session.workspace_path_meta(),
+        tool_name: tool_name.clone(),
+        permission_type,
+        resource: resource.clone(),
+        operation_summary,
+        risk_level,
+        reason_code: bamboo_tools::permission::PermissionReasonCode::ConfiguredAlwaysAsk,
+        effective_mode: config.permission_mode.unwrap_or_default(),
+        bypass_requested: runtime_state.bypass_permissions,
+        policy_revision: 0,
+        matched_rule: None,
+        allowed_decisions: bamboo_tools::permission::PermissionRequest::forced_decisions(),
+        suggested_matchers: bamboo_tools::permission::conservative_matchers(
+            permission_type,
+            &resource,
+        ),
+    };
+
+    if let Some(proxy) = bamboo_tools::current_approval_proxy() {
+        let approved = proxy
+            .request_approval(bamboo_tools::ApprovalAsk {
+                tool_name,
+                permission: permission_type.description().to_string(),
+                resource,
+                permission_request: Some(request),
+            })
+            .await;
+        return (!approved).then(|| ToolExecutionOutcome {
+            result: Err("Tool execution denied by parent agent review".to_string()),
+            needs_human: None,
+            tool_duration: std::time::Duration::ZERO,
+        });
     }
+
+    if session.parent_session_id.is_some() && config.approval_delegate.is_some() {
+        let question = format!(
+            "Parent-agent approval required for `{}` on `{}`",
+            tool_call.function.name, resource
+        );
+        let payload = serde_json::json!({
+            "status": "awaiting_permission_approval",
+            "question": question,
+            "permission_type": permission_type,
+            "resource": resource,
+            "options": ["Approve", "Deny"],
+            "allow_custom": false,
+            "permission_request": request,
+        });
+        return Some(ToolExecutionOutcome {
+            result: Ok(ToolResult {
+                success: true,
+                result: payload.to_string(),
+                display_preference: Some("request_permissions".to_string()),
+                images: Vec::new(),
+            }),
+            needs_human: None,
+            tool_duration: std::time::Duration::ZERO,
+        });
+    }
+
+    Some(ToolExecutionOutcome {
+        result: Err(
+            "Hook requested approval, but no parent-agent reviewer is available; denied"
+                .to_string(),
+        ),
+        needs_human: None,
+        tool_duration: std::time::Duration::ZERO,
+    })
 }
 
 pub(super) async fn apply_tool_execution_outcome(
     ctx: ToolExecutionApplyContext<'_>,
-    outcome: ToolExecutionOutcome,
-) -> bool {
+    mut outcome: ToolExecutionOutcome,
+) -> Result<bool, AgentError> {
+    let mut deferred_contexts = Vec::new();
+    let mut deferred_hook_control = None;
+    if ctx
+        .config
+        .hook_runner
+        .has_hooks_for(AgentHookPoint::AfterToolExecution)
+    {
+        let hook_payload = HookPayload::ToolResult {
+            tool_name: ctx.tool_call.function.name.clone(),
+            tool_call_id: ctx.tool_call.id.clone(),
+            outcome: match &outcome.result {
+                Ok(result) => HookToolOutcome {
+                    success: result.success,
+                    result: Some(result.result.clone()),
+                    error: None,
+                    needs_human: outcome.needs_human.is_some(),
+                    duration_ms: outcome.tool_duration.as_millis() as u64,
+                },
+                Err(error) => HookToolOutcome {
+                    success: false,
+                    result: None,
+                    error: Some(error.clone()),
+                    needs_human: false,
+                    duration_ms: outcome.tool_duration.as_millis() as u64,
+                },
+            },
+        };
+        let mut hook_outcome = ctx
+            .config
+            .hook_runner
+            .run_hooks(
+                AgentHookPoint::AfterToolExecution,
+                &hook_payload,
+                ctx.session,
+                ctx.runtime_state,
+                Some(ctx.event_tx),
+            )
+            .await;
+        deferred_contexts = std::mem::take(&mut hook_outcome.injected_contexts);
+        if let HookResult::Deny { reason } = hook_outcome.decision.clone() {
+            outcome.needs_human = None;
+            outcome.result = Err(format!("Tool result denied by hook: {reason}"));
+            hook_outcome.decision = HookResult::Continue;
+        }
+        if matches!(
+            hook_outcome.decision,
+            HookResult::Suspend { .. } | HookResult::Abort { .. } | HookResult::Ask
+        ) {
+            deferred_hook_control = Some(hook_outcome);
+        } else {
+            crate::runtime::hooks::apply_hook_outcome(
+                AgentHookPoint::AfterToolExecution,
+                hook_outcome,
+                ctx.session,
+                ctx.runtime_state,
+            )?;
+        }
+    }
+
     // Capture tool lifecycle metadata before the borrow-splitting match.
     let tool_name_for_meta = ctx.tool_call.function.name.clone();
     let tool_call_id_for_meta = ctx.tool_call.id.clone();
@@ -354,5 +609,274 @@ pub(super) async fn apply_tool_execution_outcome(
         msg.metadata = Some(metadata_value);
     }
 
-    result
+    crate::runtime::hooks::inject_contexts(
+        ctx.session,
+        AgentHookPoint::AfterToolExecution,
+        deferred_contexts,
+    );
+
+    if let Some(hook_outcome) = deferred_hook_control {
+        crate::runtime::hooks::apply_hook_outcome(
+            AgentHookPoint::AfterToolExecution,
+            hook_outcome,
+            ctx.session,
+            ctx.runtime_state,
+        )?;
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod hook_tests {
+    use super::*;
+    use async_trait::async_trait;
+    use bamboo_agent_core::tools::{FunctionCall, ToolError};
+    use bamboo_agent_core::AgentHook;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct DenyToolHook;
+
+    #[async_trait]
+    impl AgentHook for DenyToolHook {
+        fn point(&self) -> AgentHookPoint {
+            AgentHookPoint::BeforeToolExecution
+        }
+
+        async fn run(
+            &self,
+            _point: AgentHookPoint,
+            payload: &HookPayload,
+            _session: &Session,
+        ) -> HookResult {
+            assert!(matches!(
+                payload,
+                HookPayload::ToolExecution {
+                    tool_name,
+                    parsed_args,
+                    ..
+                } if tool_name == "probe" && parsed_args["value"] == 7
+            ));
+            HookResult::Deny {
+                reason: "policy hook blocked probe".to_string(),
+            }
+        }
+
+        fn name(&self) -> &str {
+            "deny_probe"
+        }
+    }
+
+    struct AskToolHook;
+
+    #[async_trait]
+    impl AgentHook for AskToolHook {
+        fn point(&self) -> AgentHookPoint {
+            AgentHookPoint::BeforeToolExecution
+        }
+
+        async fn run(
+            &self,
+            _point: AgentHookPoint,
+            _payload: &HookPayload,
+            _session: &Session,
+        ) -> HookResult {
+            HookResult::Ask
+        }
+    }
+
+    struct RecordingParentReviewer {
+        seen: AtomicBool,
+        approve: bool,
+    }
+
+    #[async_trait]
+    impl bamboo_tools::ApprovalProxy for RecordingParentReviewer {
+        async fn request_approval(&self, ask: bamboo_tools::ApprovalAsk) -> bool {
+            assert_eq!(ask.tool_name, "probe");
+            assert_eq!(
+                ask.permission_request
+                    .as_ref()
+                    .map(|request| request.reason_code),
+                Some(bamboo_tools::permission::PermissionReasonCode::ConfiguredAlwaysAsk)
+            );
+            self.seen.store(true, Ordering::SeqCst);
+            self.approve
+        }
+    }
+
+    struct RecordingExecutor(AtomicBool);
+
+    #[async_trait]
+    impl ToolExecutor for RecordingExecutor {
+        async fn execute(&self, _call: &ToolCall) -> Result<ToolResult, ToolError> {
+            self.0.store(true, Ordering::SeqCst);
+            Ok(ToolResult {
+                success: true,
+                result: "executed".to_string(),
+                display_preference: None,
+                images: Vec::new(),
+            })
+        }
+
+        fn list_tools(&self) -> Vec<ToolSchema> {
+            Vec::new()
+        }
+    }
+
+    #[tokio::test]
+    async fn before_tool_hook_denies_without_dispatching_executor() {
+        let mut runner = crate::runtime::hooks::HookRunner::new();
+        runner.register(Arc::new(DenyToolHook));
+        let config = AgentLoopConfig {
+            hook_runner: Arc::new(runner),
+            ..Default::default()
+        };
+        let tools = Arc::new(RecordingExecutor(AtomicBool::new(false)));
+        let (event_tx, mut event_rx) = mpsc::channel(16);
+        let tool_call = ToolCall {
+            id: "call-probe".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: "probe".to_string(),
+                arguments: serde_json::json!({"value": 7}).to_string(),
+            },
+        };
+        let mut session = Session::new("hook-deny-session", "model");
+        let session_flags = ToolExecutionSessionFlags::from_session(&session);
+        let mut runtime_state = AgentRuntimeState::new(&session.id);
+
+        let outcome = execute_tool_call_only(ToolExecutionOnlyContext {
+            tool_call: &tool_call,
+            event_tx: &event_tx,
+            metrics_collector: None,
+            session_id: "hook-deny-session",
+            round_id: "round-1",
+            round: 0,
+            tools: &(tools.clone() as Arc<dyn ToolExecutor>),
+            config: &config,
+            hook_session: Some(&mut session),
+            hook_runtime_state: Some(&mut runtime_state),
+            session_flags,
+            available_tool_schemas: &[],
+        })
+        .await
+        .expect("deny is a tool outcome, not a runner error");
+
+        assert!(matches!(outcome.result, Err(ref error) if error.contains("policy hook blocked")));
+        assert!(!tools.0.load(Ordering::SeqCst));
+        assert_eq!(runtime_state.checkpoints.len(), 1);
+        let events: Vec<_> = std::iter::from_fn(|| event_rx.try_recv().ok()).collect();
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::HookLifecycle { hook_name, decision: HookResult::Deny { .. }, .. }
+                if hook_name == "deny_probe"
+        )));
+    }
+
+    #[tokio::test]
+    async fn ask_hook_routes_to_parent_proxy_and_executes_only_after_approval() {
+        let mut runner = crate::runtime::hooks::HookRunner::new();
+        runner.register(Arc::new(AskToolHook));
+        let config = AgentLoopConfig {
+            hook_runner: Arc::new(runner),
+            ..Default::default()
+        };
+        let tools = Arc::new(RecordingExecutor(AtomicBool::new(false)));
+        let tool_executor: Arc<dyn ToolExecutor> = tools.clone();
+        let reviewer = Arc::new(RecordingParentReviewer {
+            seen: AtomicBool::new(false),
+            approve: true,
+        });
+        let reviewer_proxy: Arc<dyn bamboo_tools::ApprovalProxy> = reviewer.clone();
+        let (event_tx, _event_rx) = mpsc::channel(16);
+        let tool_call = ToolCall {
+            id: "call-probe".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: "probe".to_string(),
+                arguments: serde_json::json!({"value": 7}).to_string(),
+            },
+        };
+        let mut session = Session::new("hook-ask-session", "model");
+        let session_flags = ToolExecutionSessionFlags::from_session(&session);
+        let mut runtime_state = AgentRuntimeState::new(&session.id);
+
+        let outcome = bamboo_tools::with_approval_proxy(
+            Some(reviewer_proxy),
+            execute_tool_call_only(ToolExecutionOnlyContext {
+                tool_call: &tool_call,
+                event_tx: &event_tx,
+                metrics_collector: None,
+                session_id: "hook-ask-session",
+                round_id: "round-1",
+                round: 0,
+                tools: &tool_executor,
+                config: &config,
+                hook_session: Some(&mut session),
+                hook_runtime_state: Some(&mut runtime_state),
+                session_flags,
+                available_tool_schemas: &[],
+            }),
+        )
+        .await
+        .expect("approved parent review should continue dispatch");
+
+        assert!(outcome.result.is_ok());
+        assert!(reviewer.seen.load(Ordering::SeqCst));
+        assert!(tools.0.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn ask_hook_without_parent_route_fails_closed_without_manual_prompt() {
+        let mut runner = crate::runtime::hooks::HookRunner::new();
+        runner.register(Arc::new(AskToolHook));
+        let config = AgentLoopConfig {
+            hook_runner: Arc::new(runner),
+            ..Default::default()
+        };
+        let tools = Arc::new(RecordingExecutor(AtomicBool::new(false)));
+        let tool_executor: Arc<dyn ToolExecutor> = tools.clone();
+        let (event_tx, mut event_rx) = mpsc::channel(16);
+        let tool_call = ToolCall {
+            id: "call-probe".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: "probe".to_string(),
+                arguments: serde_json::json!({"value": 7}).to_string(),
+            },
+        };
+        let mut session = Session::new("hook-ask-no-parent", "model");
+        let session_flags = ToolExecutionSessionFlags::from_session(&session);
+        let mut runtime_state = AgentRuntimeState::new(&session.id);
+
+        let outcome = execute_tool_call_only(ToolExecutionOnlyContext {
+            tool_call: &tool_call,
+            event_tx: &event_tx,
+            metrics_collector: None,
+            session_id: "hook-ask-no-parent",
+            round_id: "round-1",
+            round: 0,
+            tools: &tool_executor,
+            config: &config,
+            hook_session: Some(&mut session),
+            hook_runtime_state: Some(&mut runtime_state),
+            session_flags,
+            available_tool_schemas: &[],
+        })
+        .await
+        .expect("missing parent is represented as a denied tool outcome");
+
+        assert!(matches!(
+            outcome.result,
+            Err(ref error) if error.contains("no parent-agent reviewer")
+        ));
+        assert!(!tools.0.load(Ordering::SeqCst));
+        assert!(
+            !std::iter::from_fn(|| event_rx.try_recv().ok()).any(|event| matches!(
+                event,
+                AgentEvent::NeedClarification { .. } | AgentEvent::ChildApprovalRequested { .. }
+            ))
+        );
+    }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
@@ -327,9 +327,9 @@ pub(super) async fn execute_tool_call_only(
 }
 
 /// Resolve `HookResult::Ask` without ever opening an unowned/manual approval.
-/// External workers use their ambient parent proxy inline; in-process children
-/// reuse the existing ApprovalDelegate suspension path. Missing parent routes
-/// fail closed.
+/// External workers use their ambient parent proxy inline. Missing or failed
+/// parent routes fail closed; this path never reuses the interactive
+/// clarification/approval flow.
 async fn hook_ask_outcome(
     tool_call: &ToolCall,
     config: &AgentLoopConfig,
@@ -393,32 +393,6 @@ async fn hook_ask_outcome(
             .await;
         return (!approved).then(|| ToolExecutionOutcome {
             result: Err("Tool execution denied by parent agent review".to_string()),
-            needs_human: None,
-            tool_duration: std::time::Duration::ZERO,
-        });
-    }
-
-    if session.parent_session_id.is_some() && config.approval_delegate.is_some() {
-        let question = format!(
-            "Parent-agent approval required for `{}` on `{}`",
-            tool_call.function.name, resource
-        );
-        let payload = serde_json::json!({
-            "status": "awaiting_permission_approval",
-            "question": question,
-            "permission_type": permission_type,
-            "resource": resource,
-            "options": ["Approve", "Deny"],
-            "allow_custom": false,
-            "permission_request": request,
-        });
-        return Some(ToolExecutionOutcome {
-            result: Ok(ToolResult {
-                success: true,
-                result: payload.to_string(),
-                display_preference: Some("request_permissions".to_string()),
-                images: Vec::new(),
-            }),
             needs_human: None,
             tool_duration: std::time::Duration::ZERO,
         });
@@ -724,6 +698,18 @@ mod hook_tests {
         }
     }
 
+    struct PanicLegacyApprovalDelegate;
+
+    #[async_trait]
+    impl crate::runtime::config::ApprovalDelegate for PanicLegacyApprovalDelegate {
+        async fn delegate_child_approval(
+            &self,
+            _request: crate::runtime::config::ChildApprovalRequest,
+        ) -> Result<crate::runtime::config::ChildApprovalOutcome, String> {
+            panic!("Hook Ask must not enter the legacy interactive approval path")
+        }
+    }
+
     #[tokio::test]
     async fn before_tool_hook_denies_without_dispatching_executor() {
         let mut runner = crate::runtime::hooks::HookRunner::new();
@@ -828,11 +814,12 @@ mod hook_tests {
     }
 
     #[tokio::test]
-    async fn ask_hook_without_parent_route_fails_closed_without_manual_prompt() {
+    async fn ask_hook_without_parent_proxy_fails_closed_without_manual_prompt() {
         let mut runner = crate::runtime::hooks::HookRunner::new();
         runner.register(Arc::new(AskToolHook));
         let config = AgentLoopConfig {
             hook_runner: Arc::new(runner),
+            approval_delegate: Some(Arc::new(PanicLegacyApprovalDelegate)),
             ..Default::default()
         };
         let tools = Arc::new(RecordingExecutor(AtomicBool::new(false)));
@@ -847,6 +834,7 @@ mod hook_tests {
             },
         };
         let mut session = Session::new("hook-ask-no-parent", "model");
+        session.parent_session_id = Some("parent-with-legacy-delegate".to_string());
         let session_flags = ToolExecutionSessionFlags::from_session(&session);
         let mut runtime_state = AgentRuntimeState::new(&session.id);
 

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -26,6 +26,7 @@ use crate::runtime::config::{
     AgentLoopConfig, AuxiliaryModelConfig, BashCompletionSink, BashResumeHook, GoldConfig,
     GuardianConfig, GuardianSpawner, ImageFallbackConfig, PromptMemoryFlags,
 };
+use crate::runtime::hooks::HookRunner;
 use crate::runtime::model_roster::{ModelRoster, RoleModel};
 use crate::runtime::runner::run_agent_loop_with_config;
 use bamboo_domain::RuntimeSessionPersistence;
@@ -54,6 +55,10 @@ pub struct AgentRuntime {
     /// Call sites that need a reduced tool set (child / schedule) pass their
     /// own via `ExecuteRequest::tools`.
     pub default_tools: Arc<dyn ToolExecutor>,
+
+    /// Immutable hook registry shared by runs. Each execute call snapshots the
+    /// `Arc` onto its sealed [`AgentLoopConfig`].
+    pub hook_runner: Arc<HookRunner>,
 }
 
 // ---------------------------------------------------------------------------
@@ -79,6 +84,7 @@ pub struct AgentRuntimeBuilder {
     config: Option<Arc<RwLock<Config>>>,
     provider: Option<Arc<dyn LLMProvider>>,
     default_tools: Option<Arc<dyn ToolExecutor>>,
+    hook_runner: Arc<HookRunner>,
 }
 
 impl AgentRuntimeBuilder {
@@ -92,6 +98,7 @@ impl AgentRuntimeBuilder {
             config: None,
             provider: None,
             default_tools: None,
+            hook_runner: Arc::new(HookRunner::new()),
         }
     }
 
@@ -135,6 +142,12 @@ impl AgentRuntimeBuilder {
         self
     }
 
+    /// Install the lifecycle hook registry used by all runs from this runtime.
+    pub fn hook_runner(mut self, v: Arc<HookRunner>) -> Self {
+        self.hook_runner = v;
+        self
+    }
+
     pub fn build(self) -> Result<AgentRuntime, &'static str> {
         Ok(AgentRuntime {
             storage: self.storage.ok_or_else(|| format_missing("storage"))?,
@@ -155,6 +168,7 @@ impl AgentRuntimeBuilder {
             default_tools: self
                 .default_tools
                 .ok_or_else(|| format_missing("default_tools"))?,
+            hook_runner: self.hook_runner,
         })
     }
 }
@@ -717,6 +731,7 @@ impl AgentRuntime {
             guardian_spawner,
             bash_resume_hook,
             bash_completion_sink,
+            hook_runner: self.hook_runner.clone(),
             // Capture the tool executor's server-level guidance (connected MCP
             // servers' `instructions`) once, so it lands in the system prompt only
             // while those servers are loaded for this run.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,10 @@ pub mod core {
 // (`bamboo_agent::agent::...`, `bamboo_agent::Agent`, ...) stable.
 pub use bamboo_infrastructure as infrastructure;
 pub use bamboo_sdk::agent;
-pub use bamboo_sdk::{Agent, AgentBuilder};
+pub use bamboo_sdk::{
+    Agent, AgentBuilder, AgentHook, AgentHookPoint, HookPayload, HookResult, HookRunner,
+    HookToolOutcome,
+};
 
 // Re-export the runtime config crate so consumers can reach config, paths,
 // proxy auth, encryption, etc. via `bamboo_agent::config::...`. These moved out


### PR DESCRIPTION
## Summary
- add structured hook payloads and allow/deny/ask/context-injection decisions
- freeze HookRunner per execution and wire tool, session, finalize, round, and compression lifecycle seams
- emit HookLifecycle events while retaining runtime checkpoints
- route forced-ask tool decisions to the parent agent reviewer and fail closed without one; remove the manual approval fallback
- expose hook registration through engine, SDK, and root crate builders

## Test Plan
- `cargo fmt --all -- --check`
- `cargo test -p bamboo-domain hook_`
- `cargo test -p bamboo-engine hook_tests`
- `cargo test -p bamboo-engine runtime::hooks::tests`
- `cargo test -p bamboo-engine` (1050 unit tests + doctest)
- `cargo test -p bamboo-sdk --lib`
- `CARGO_INCREMENTAL=0 cargo build --workspace --tests`

Closes #549