### PR TITLE
feat(hooks): add config-driven shell lifecycle runner (#550)

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/mod.rs
+++ b/crates/app/bamboo-sdk/src/agent/mod.rs
@@ -74,7 +74,7 @@ pub use bamboo_domain::{
     AgentHookPoint, HookPayload, HookResult, HookToolOutcome, TaskItem, TaskItemStatus, TaskList,
 };
 pub use bamboo_engine::session_app::respond::PlanModeTransition;
-pub use bamboo_engine::{ExecuteRequest, HookRunner};
+pub use bamboo_engine::{ExecuteRequest, HookRunner, ShellCommandHook, ShellHookEvent};
 pub use bamboo_llm::LLMProvider;
 pub use bamboo_mcp::manager::McpServerManager;
 pub use bamboo_mcp::McpServerConfig;

--- a/crates/app/bamboo-sdk/src/lib.rs
+++ b/crates/app/bamboo-sdk/src/lib.rs
@@ -17,7 +17,7 @@ pub mod agent;
 pub use agent::ExecuteRequestBuilder;
 pub use agent::{
     Agent, AgentBuilder, AgentHook, AgentHookPoint, HookPayload, HookResult, HookRunner,
-    HookToolOutcome,
+    HookToolOutcome, ShellCommandHook, ShellHookEvent,
 };
 
 // Tool catalog surfaced by `agent::mod`.

--- a/crates/core/bamboo-agent-core/src/agent/hooks.rs
+++ b/crates/core/bamboo-agent-core/src/agent/hooks.rs
@@ -31,6 +31,15 @@ pub trait AgentHook: Send + Sync {
         session: &Session,
     ) -> HookResult;
 
+    /// Whether this hook applies to the point-specific payload.
+    ///
+    /// The default accepts every payload. Configured tool hooks override this
+    /// to apply their tool-name matcher without spawning a process or emitting
+    /// a misleading execution checkpoint for non-matching calls.
+    fn matches(&self, _payload: &HookPayload) -> bool {
+        true
+    }
+
     /// Optional priority (lower runs first). Default is 100.
     fn priority(&self) -> u32 {
         100

--- a/crates/core/bamboo-domain/src/session/hook_types.rs
+++ b/crates/core/bamboo-domain/src/session/hook_types.rs
@@ -115,6 +115,15 @@ pub enum HookResult {
     Ask,
     /// Add durable context for the remaining run.
     InjectContext { text: String },
+    /// Apply a control result and inject context from the same hook response.
+    ///
+    /// Config-driven shell hooks use this when stdout includes both a
+    /// `decision` and `additional_context`. The runner unwraps the control
+    /// result before returning its aggregate outcome.
+    WithContext {
+        result: Box<HookResult>,
+        text: String,
+    },
     /// Pause execution; set suspension state.
     Suspend { reason: String },
     /// Abort the agent run.
@@ -168,6 +177,10 @@ mod tests {
             HookResult::Ask,
             HookResult::InjectContext {
                 text: "extra context".to_string(),
+            },
+            HookResult::WithContext {
+                result: Box::new(HookResult::Allow),
+                text: "allowed context".to_string(),
             },
             HookResult::Suspend {
                 reason: "waiting".to_string(),

--- a/crates/engine/bamboo-engine/src/lib.rs
+++ b/crates/engine/bamboo-engine/src/lib.rs
@@ -53,7 +53,7 @@ pub use runtime::config::{
     ChildApprovalRequest, GuardianConfig, GuardianSpawner, ImageFallbackConfig, ImageFallbackMode,
 };
 pub use runtime::execution::runner_state::{AgentRunner, AgentStatus};
-pub use runtime::hooks::HookRunner;
+pub use runtime::hooks::{HookRunner, ShellCommandHook, ShellHookEvent};
 pub use runtime::managers::{
     LifecycleManager, LlmManager, MemoryManager, MiniLoopExecutor, PromptManager, ToolManager,
 };

--- a/crates/engine/bamboo-engine/src/runtime/hooks/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/hooks/mod.rs
@@ -1,5 +1,7 @@
 //! Hook runner — dispatches registered hooks at lifecycle points.
 
+mod shell_command;
+
 use std::sync::Arc;
 
 use bamboo_agent_core::{AgentError, AgentEvent, AgentHook, Message, Session};
@@ -9,6 +11,8 @@ use bamboo_domain::{
 };
 use chrono::Utc;
 use tokio::sync::mpsc;
+
+pub use shell_command::{ShellCommandHook, ShellHookEvent};
 
 /// Aggregate output from every hook registered at one seam.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -43,6 +47,18 @@ impl HookRunner {
         self.hooks.sort_by_key(|h| h.priority());
     }
 
+    /// Clone this registry and append shell hooks from one frozen config
+    /// snapshot. The original registry remains reusable by future runs.
+    pub fn with_lifecycle_config(
+        &self,
+        config: &bamboo_config::LifecycleHooksConfig,
+        fallback_cwd: Option<std::path::PathBuf>,
+    ) -> Self {
+        let mut runner = self.clone();
+        shell_command::register_configured_shell_hooks(&mut runner, config, fallback_cwd);
+        runner
+    }
+
     /// Run all hooks matching the given point.
     ///
     /// Records checkpoints in `runtime_state`. Returns the first
@@ -58,7 +74,7 @@ impl HookRunner {
         let mut outcome = HookRunOutcome::default();
 
         for hook in &self.hooks {
-            if hook.point() != point {
+            if hook.point() != point || !hook.matches(payload) {
                 continue;
             }
 
@@ -85,6 +101,9 @@ impl HookRunner {
                     .await;
             }
 
+            let (result, mut contexts) = unwrap_context_result(result);
+            outcome.injected_contexts.append(&mut contexts);
+
             match &result {
                 HookResult::Abort { .. }
                 | HookResult::Suspend { .. }
@@ -95,15 +114,15 @@ impl HookRunner {
                 }
                 HookResult::InjectContext { text } => {
                     outcome.injected_contexts.push(text.clone());
-                    outcome.decision = result;
                 }
-                HookResult::Mutated => outcome.decision = HookResult::Mutated,
-                HookResult::Allow => {
+                HookResult::Mutated => {
                     if matches!(outcome.decision, HookResult::Continue) {
-                        outcome.decision = HookResult::Allow;
+                        outcome.decision = HookResult::Mutated;
                     }
                 }
+                HookResult::Allow => outcome.decision = HookResult::Allow,
                 HookResult::Continue => {}
+                HookResult::WithContext { .. } => unreachable!("context results are unwrapped"),
             }
         }
 
@@ -124,6 +143,21 @@ impl HookRunner {
     pub fn is_empty(&self) -> bool {
         self.hooks.is_empty()
     }
+}
+
+fn unwrap_context_result(mut result: HookResult) -> (HookResult, Vec<String>) {
+    let mut contexts = Vec::new();
+    while let HookResult::WithContext {
+        result: inner,
+        text,
+    } = result
+    {
+        if !text.trim().is_empty() {
+            contexts.push(text);
+        }
+        result = *inner;
+    }
+    (result, contexts)
 }
 
 /// Apply context injections and non-tool control decisions consistently across
@@ -165,6 +199,15 @@ pub(crate) fn apply_hook_outcome(
         HookResult::Ask => Err(AgentError::Tool(format!(
             "hook requested parent approval at non-tool seam {point:?}"
         ))),
+        HookResult::WithContext { result, text } => apply_hook_outcome(
+            point,
+            HookRunOutcome {
+                decision: *result,
+                injected_contexts: vec![text],
+            },
+            session,
+            runtime_state,
+        ),
     }
 }
 

--- a/crates/engine/bamboo-engine/src/runtime/hooks/shell_command.rs
+++ b/crates/engine/bamboo-engine/src/runtime/hooks/shell_command.rs
@@ -15,7 +15,7 @@ use chrono::Utc;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
-use tokio::process::Command;
+use tokio::process::{Child, Command};
 use tracing::warn;
 
 use super::HookRunner;
@@ -172,6 +172,14 @@ impl ShellCommandHook {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+        #[cfg(unix)]
+        {
+            // Put every hook in its own process group so a timeout kills the
+            // complete command tree. Killing only the shell can leave a child
+            // holding stdout/stderr open and make the nominal timeout wait for
+            // that child to exit.
+            command.process_group(0);
+        }
 
         let mut child = command
             .spawn()
@@ -201,8 +209,7 @@ impl ShellCommandHook {
             Ok(Ok(status)) => (Some(status), false),
             Ok(Err(error)) => return Err(format!("failed waiting for lifecycle hook: {error}")),
             Err(_) => {
-                let _ = child.kill().await;
-                let _ = child.wait().await;
+                kill_hook_process_tree(&mut child).await;
                 (None, true)
             }
         };
@@ -303,6 +310,36 @@ impl ShellCommandHook {
             None => result,
         }
     }
+}
+
+#[cfg(unix)]
+async fn kill_hook_process_tree(child: &mut Child) {
+    if let Some(pid) = child.id() {
+        // SAFETY: the child was spawned as the leader of its own process group,
+        // so the negative pid targets only that hook and its descendants.
+        unsafe {
+            libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
+        }
+    }
+    let _ = child.wait().await;
+}
+
+#[cfg(windows)]
+async fn kill_hook_process_tree(child: &mut Child) {
+    if let Some(pid) = child.id() {
+        let pid = pid.to_string();
+        let mut kill = Command::new("taskkill");
+        hide_window_for_tokio_command(&mut kill);
+        let _ = kill.args(["/F", "/T", "/PID", &pid]).status().await;
+    }
+    let _ = child.start_kill();
+    let _ = child.wait().await;
+}
+
+#[cfg(not(any(unix, windows)))]
+async fn kill_hook_process_tree(child: &mut Child) {
+    let _ = child.kill().await;
+    let _ = child.wait().await;
 }
 
 #[async_trait]

--- a/crates/engine/bamboo-engine/src/runtime/hooks/shell_command.rs
+++ b/crates/engine/bamboo-engine/src/runtime/hooks/shell_command.rs
@@ -1,0 +1,846 @@
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bamboo_agent_core::{AgentHook, Session};
+use bamboo_config::{
+    LifecycleHookCommand, LifecycleHookGroup, LifecycleHookType, LifecycleHooksConfig,
+};
+use bamboo_domain::{AgentHookPoint, HookPayload, HookResult};
+use bamboo_infrastructure::{
+    build_command_environment, hide_window_for_tokio_command, preferred_bash_shell,
+};
+use chrono::Utc;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command;
+use tracing::warn;
+
+use super::HookRunner;
+
+const HOOK_OUTPUT_LIMIT_BYTES: usize = 64 * 1024;
+
+/// User-facing lifecycle events that currently map to engine hook seams.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShellHookEvent {
+    SessionStart,
+    PreToolUse,
+    PostToolUse,
+    Stop,
+    PreCompact,
+}
+
+impl ShellHookEvent {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SessionStart => "SessionStart",
+            Self::PreToolUse => "PreToolUse",
+            Self::PostToolUse => "PostToolUse",
+            Self::Stop => "Stop",
+            Self::PreCompact => "PreCompact",
+        }
+    }
+
+    fn point(self) -> AgentHookPoint {
+        match self {
+            Self::SessionStart => AgentHookPoint::AfterSessionSetup,
+            Self::PreToolUse => AgentHookPoint::BeforeToolExecution,
+            Self::PostToolUse => AgentHookPoint::AfterToolExecution,
+            Self::Stop => AgentHookPoint::BeforeFinalize,
+            Self::PreCompact => AgentHookPoint::BeforeCompression,
+        }
+    }
+
+    fn supports_tool_matcher(self) -> bool {
+        matches!(self, Self::PreToolUse | Self::PostToolUse)
+    }
+}
+
+/// One config-driven lifecycle shell command.
+pub struct ShellCommandHook {
+    event: ShellHookEvent,
+    command: String,
+    timeout: Duration,
+    matcher: Option<Regex>,
+    fallback_cwd: Option<PathBuf>,
+    name: String,
+}
+
+impl ShellCommandHook {
+    pub fn new(
+        event: ShellHookEvent,
+        config: &LifecycleHookCommand,
+        matcher: Option<&str>,
+        fallback_cwd: Option<PathBuf>,
+        sequence: usize,
+    ) -> Result<Self, regex::Error> {
+        let matcher = matcher.map(Regex::new).transpose()?;
+        Ok(Self {
+            event,
+            command: config.command.clone(),
+            timeout: Duration::from_millis(config.timeout_ms.max(1)),
+            matcher,
+            fallback_cwd,
+            name: format!("lifecycle_shell:{}:{sequence}", event.as_str()),
+        })
+    }
+
+    fn effective_cwd(&self, session: &Session) -> Option<PathBuf> {
+        session
+            .workspace
+            .as_deref()
+            .filter(|workspace| !workspace.trim().is_empty())
+            .map(PathBuf::from)
+            .or_else(|| self.fallback_cwd.clone())
+            .or_else(|| std::env::current_dir().ok())
+    }
+
+    fn envelope(
+        &self,
+        payload: &HookPayload,
+        session: &Session,
+        cwd: Option<&PathBuf>,
+    ) -> HookEnvelope {
+        let (tool_name, tool_input, tool_response, prompt) = match payload {
+            HookPayload::SessionSetup { initial_message } => {
+                (None, None, None, Some(initial_message.clone()))
+            }
+            HookPayload::Prompt { prompt } => (None, None, None, Some(prompt.clone())),
+            HookPayload::ToolExecution {
+                tool_name,
+                parsed_args,
+                ..
+            } => (
+                Some(tool_name.clone()),
+                Some(parsed_args.clone()),
+                None,
+                None,
+            ),
+            HookPayload::ToolResult {
+                tool_name, outcome, ..
+            } => (
+                Some(tool_name.clone()),
+                None,
+                serde_json::to_value(outcome).ok(),
+                None,
+            ),
+            HookPayload::None
+            | HookPayload::Round { .. }
+            | HookPayload::Compression { .. }
+            | HookPayload::Finalize => (None, None, None, None),
+        };
+
+        HookEnvelope {
+            schema_version: 1,
+            hook_event_name: self.event.as_str(),
+            session_id: session.id.clone(),
+            workspace_path: cwd
+                .map(|path| path.to_string_lossy().into_owned())
+                .unwrap_or_default(),
+            model: session.model.clone(),
+            tool_name,
+            tool_input,
+            tool_response,
+            prompt,
+            timestamp: Utc::now().to_rfc3339(),
+        }
+    }
+
+    async fn execute(
+        &self,
+        input: Vec<u8>,
+        cwd: Option<&PathBuf>,
+        session: &Session,
+    ) -> Result<CommandOutput, String> {
+        let shell = preferred_bash_shell();
+        let overrides = bamboo_llm::Config::current_env_vars();
+        let prepared_env = build_command_environment(&overrides).await;
+        let mut command = Command::new(&shell.program);
+        hide_window_for_tokio_command(&mut command);
+        prepared_env.apply_to_tokio_command(&mut command);
+        if let Some(cwd) = cwd {
+            command.current_dir(cwd);
+        }
+        command
+            .arg(shell.arg)
+            .arg(&self.command)
+            .env("BAMBOO_SESSION_ID", &session.id)
+            .env("BAMBOO_HOOK_EVENT", self.event.as_str())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut child = command
+            .spawn()
+            .map_err(|error| format!("failed to spawn lifecycle hook: {error}"))?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "failed to open lifecycle hook stdin".to_string())?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "failed to capture lifecycle hook stdout".to_string())?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| "failed to capture lifecycle hook stderr".to_string())?;
+
+        let input_task = tokio::spawn(async move {
+            let result = stdin.write_all(&input).await;
+            let _ = stdin.shutdown().await;
+            result
+        });
+        let stdout_task = tokio::spawn(read_capped(stdout));
+        let stderr_task = tokio::spawn(read_capped(stderr));
+
+        let (status, timed_out) = match tokio::time::timeout(self.timeout, child.wait()).await {
+            Ok(Ok(status)) => (Some(status), false),
+            Ok(Err(error)) => return Err(format!("failed waiting for lifecycle hook: {error}")),
+            Err(_) => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+                (None, true)
+            }
+        };
+
+        if let Ok(Err(error)) = input_task.await {
+            warn!(hook = %self.name, error = %error, "failed writing lifecycle hook stdin");
+        }
+        let stdout = stdout_task
+            .await
+            .map_err(|error| format!("lifecycle hook stdout task failed: {error}"))?
+            .map_err(|error| format!("failed reading lifecycle hook stdout: {error}"))?;
+        let stderr = stderr_task
+            .await
+            .map_err(|error| format!("lifecycle hook stderr task failed: {error}"))?
+            .map_err(|error| format!("failed reading lifecycle hook stderr: {error}"))?;
+
+        Ok(CommandOutput {
+            exit_code: status.and_then(|status| status.code()),
+            stdout,
+            stderr,
+            timed_out,
+        })
+    }
+
+    fn interpret(&self, output: CommandOutput) -> HookResult {
+        if output.stdout.truncated || output.stderr.truncated {
+            warn!(
+                hook = %self.name,
+                stdout_truncated = output.stdout.truncated,
+                stderr_truncated = output.stderr.truncated,
+                "lifecycle hook output exceeded capture limit"
+            );
+        }
+        if output.timed_out {
+            warn!(hook = %self.name, "lifecycle hook timed out and was killed");
+            return HookResult::Continue;
+        }
+
+        match output.exit_code {
+            Some(0) => self.interpret_success(&output.stdout.bytes),
+            Some(2) => {
+                let reason = String::from_utf8_lossy(&output.stderr.bytes)
+                    .trim()
+                    .to_string();
+                HookResult::Deny {
+                    reason: if reason.is_empty() {
+                        "lifecycle hook exited with blocking status 2".to_string()
+                    } else {
+                        reason
+                    },
+                }
+            }
+            exit_code => {
+                warn!(hook = %self.name, ?exit_code, "lifecycle hook failed non-blocking");
+                HookResult::Continue
+            }
+        }
+    }
+
+    fn interpret_success(&self, stdout: &[u8]) -> HookResult {
+        let stdout = String::from_utf8_lossy(stdout);
+        let stdout = stdout.trim();
+        if stdout.is_empty() {
+            return HookResult::Continue;
+        }
+
+        let response: HookResponse = match serde_json::from_str(stdout) {
+            Ok(response) => response,
+            Err(error) => {
+                warn!(hook = %self.name, error = %error, "ignoring malformed lifecycle hook response");
+                return HookResult::Continue;
+            }
+        };
+        let HookResponse {
+            decision,
+            reason,
+            additional_context,
+            suppress_output: _suppress_output,
+        } = response;
+        let result = match decision {
+            Some(HookDecision::Block) => HookResult::Deny {
+                reason: reason
+                    .filter(|reason| !reason.trim().is_empty())
+                    .unwrap_or_else(|| "blocked by lifecycle hook".to_string()),
+            },
+            Some(HookDecision::Allow) => HookResult::Allow,
+            Some(HookDecision::Ask) => HookResult::Ask,
+            None => HookResult::Continue,
+        };
+        match additional_context.filter(|context| !context.trim().is_empty()) {
+            Some(text) if matches!(result, HookResult::Continue) => {
+                HookResult::InjectContext { text }
+            }
+            Some(text) => HookResult::WithContext {
+                result: Box::new(result),
+                text,
+            },
+            None => result,
+        }
+    }
+}
+
+#[async_trait]
+impl AgentHook for ShellCommandHook {
+    fn point(&self) -> AgentHookPoint {
+        self.event.point()
+    }
+
+    async fn run(
+        &self,
+        _point: AgentHookPoint,
+        payload: &HookPayload,
+        session: &Session,
+    ) -> HookResult {
+        let cwd = self.effective_cwd(session);
+        let input = match serde_json::to_vec(&self.envelope(payload, session, cwd.as_ref())) {
+            Ok(input) => input,
+            Err(error) => {
+                warn!(hook = %self.name, error = %error, "failed serializing lifecycle hook payload");
+                return HookResult::Continue;
+            }
+        };
+        match self.execute(input, cwd.as_ref(), session).await {
+            Ok(output) => self.interpret(output),
+            Err(error) => {
+                warn!(hook = %self.name, error = %error, "lifecycle hook execution failed non-blocking");
+                HookResult::Continue
+            }
+        }
+    }
+
+    fn matches(&self, payload: &HookPayload) -> bool {
+        let Some(matcher) = &self.matcher else {
+            return true;
+        };
+        match payload {
+            HookPayload::ToolExecution { tool_name, .. }
+            | HookPayload::ToolResult { tool_name, .. } => matcher.is_match(tool_name),
+            _ => false,
+        }
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct HookEnvelope {
+    schema_version: u8,
+    hook_event_name: &'static str,
+    session_id: String,
+    workspace_path: String,
+    model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_input: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_response: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt: Option<String>,
+    timestamp: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct HookResponse {
+    #[serde(default)]
+    decision: Option<HookDecision>,
+    #[serde(default)]
+    reason: Option<String>,
+    #[serde(default)]
+    additional_context: Option<String>,
+    #[serde(default)]
+    suppress_output: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum HookDecision {
+    Block,
+    Allow,
+    Ask,
+}
+
+#[derive(Debug)]
+struct CommandOutput {
+    exit_code: Option<i32>,
+    stdout: CapturedOutput,
+    stderr: CapturedOutput,
+    timed_out: bool,
+}
+
+#[derive(Debug, Default)]
+struct CapturedOutput {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+async fn read_capped(mut reader: impl AsyncRead + Unpin) -> Result<CapturedOutput, std::io::Error> {
+    let mut captured = CapturedOutput::default();
+    let mut chunk = [0_u8; 8192];
+    loop {
+        let read = reader.read(&mut chunk).await?;
+        if read == 0 {
+            break;
+        }
+        let remaining = HOOK_OUTPUT_LIMIT_BYTES.saturating_sub(captured.bytes.len());
+        let keep = remaining.min(read);
+        captured.bytes.extend_from_slice(&chunk[..keep]);
+        captured.truncated |= keep < read;
+    }
+    Ok(captured)
+}
+
+pub(super) fn register_configured_shell_hooks(
+    runner: &mut HookRunner,
+    config: &LifecycleHooksConfig,
+    fallback_cwd: Option<PathBuf>,
+) {
+    if !config.enabled {
+        return;
+    }
+
+    let events: [(ShellHookEvent, &[LifecycleHookGroup]); 5] = [
+        (ShellHookEvent::SessionStart, &config.session_start),
+        (ShellHookEvent::PreToolUse, &config.pre_tool_use),
+        (ShellHookEvent::PostToolUse, &config.post_tool_use),
+        (ShellHookEvent::Stop, &config.stop),
+        (ShellHookEvent::PreCompact, &config.pre_compact),
+    ];
+    let mut sequence = 0_usize;
+    for (event, groups) in events {
+        for group in groups {
+            let matcher = if event.supports_tool_matcher() {
+                group.matcher.as_deref()
+            } else {
+                if group.matcher.is_some() {
+                    warn!(
+                        event = event.as_str(),
+                        "ignoring matcher on non-tool lifecycle hook"
+                    );
+                }
+                None
+            };
+            for command in &group.hooks {
+                match command.hook_type {
+                    LifecycleHookType::Command => {
+                        match ShellCommandHook::new(
+                            event,
+                            command,
+                            matcher,
+                            fallback_cwd.clone(),
+                            sequence,
+                        ) {
+                            Ok(hook) => runner.register(std::sync::Arc::new(hook)),
+                            Err(error) => warn!(
+                                event = event.as_str(),
+                                error = %error,
+                                "skipping lifecycle hook with invalid matcher"
+                            ),
+                        }
+                    }
+                }
+                sequence += 1;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_config::DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS;
+    use serde_json::json;
+    use std::time::Instant;
+
+    fn command(command: impl Into<String>, timeout_ms: u64) -> LifecycleHookCommand {
+        LifecycleHookCommand {
+            hook_type: LifecycleHookType::Command,
+            command: command.into(),
+            timeout_ms,
+        }
+    }
+
+    fn session(workspace: &std::path::Path) -> Session {
+        let mut session = Session::new("session-1", "test-model");
+        session.workspace = Some(workspace.to_string_lossy().into_owned());
+        session
+    }
+
+    #[tokio::test]
+    async fn exit_zero_without_output_passes_through() {
+        let dir = tempfile::tempdir().unwrap();
+        let hook = ShellCommandHook::new(
+            ShellHookEvent::SessionStart,
+            &command("printf ''", DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS),
+            None,
+            None,
+            0,
+        )
+        .unwrap();
+        let result = hook
+            .run(
+                AgentHookPoint::AfterSessionSetup,
+                &HookPayload::SessionSetup {
+                    initial_message: "hello".to_string(),
+                },
+                &session(dir.path()),
+            )
+            .await;
+        assert_eq!(result, HookResult::Continue);
+    }
+
+    #[tokio::test]
+    async fn exit_two_blocks_with_stderr_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let hook = ShellCommandHook::new(
+            ShellHookEvent::PreToolUse,
+            &command("printf 'blocked by policy' >&2; exit 2", 1_000),
+            None,
+            None,
+            0,
+        )
+        .unwrap();
+        let result = hook
+            .run(
+                AgentHookPoint::BeforeToolExecution,
+                &HookPayload::ToolExecution {
+                    tool_name: "bash".to_string(),
+                    tool_call_id: "call-1".to_string(),
+                    parsed_args: json!({"command": "pwd"}),
+                },
+                &session(dir.path()),
+            )
+            .await;
+        assert_eq!(
+            result,
+            HookResult::Deny {
+                reason: "blocked by policy".to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn versioned_json_protocol_is_delivered_on_stdin() {
+        let dir = tempfile::tempdir().unwrap();
+        let shell = r#"payload=$(cat); case "$payload" in *'"hook_event_name":"PreToolUse"'*'"tool_name":"bash"'*) printf '%s' '{"decision":"allow"}' ;; *) printf 'bad payload' >&2; exit 2 ;; esac"#;
+        let hook = ShellCommandHook::new(
+            ShellHookEvent::PreToolUse,
+            &command(shell, 1_000),
+            None,
+            None,
+            0,
+        )
+        .unwrap();
+        let result = hook
+            .run(
+                AgentHookPoint::BeforeToolExecution,
+                &HookPayload::ToolExecution {
+                    tool_name: "bash".to_string(),
+                    tool_call_id: "call-1".to_string(),
+                    parsed_args: json!({"command": "pwd"}),
+                },
+                &session(dir.path()),
+            )
+            .await;
+        assert_eq!(result, HookResult::Allow);
+    }
+
+    #[tokio::test]
+    async fn stdout_decisions_and_context_are_parsed() {
+        let dir = tempfile::tempdir().unwrap();
+        for (body, expected) in [
+            (r#"{"decision":"allow"}"#, HookResult::Allow),
+            (r#"{"decision":"ask"}"#, HookResult::Ask),
+            (
+                r#"{"decision":"block","reason":"nope"}"#,
+                HookResult::Deny {
+                    reason: "nope".to_string(),
+                },
+            ),
+            (
+                r#"{"additional_context":"remember this"}"#,
+                HookResult::InjectContext {
+                    text: "remember this".to_string(),
+                },
+            ),
+            (
+                r#"{"decision":"allow","additional_context":"allowed context"}"#,
+                HookResult::WithContext {
+                    result: Box::new(HookResult::Allow),
+                    text: "allowed context".to_string(),
+                },
+            ),
+        ] {
+            let shell = format!("printf '%s' '{body}'");
+            let hook = ShellCommandHook::new(
+                ShellHookEvent::SessionStart,
+                &command(shell, 1_000),
+                None,
+                None,
+                0,
+            )
+            .unwrap();
+            assert_eq!(
+                hook.run(
+                    AgentHookPoint::AfterSessionSetup,
+                    &HookPayload::None,
+                    &session(dir.path()),
+                )
+                .await,
+                expected
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn runner_preserves_decision_and_context_from_one_response() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut runner = HookRunner::new();
+        runner.register(std::sync::Arc::new(
+            ShellCommandHook::new(
+                ShellHookEvent::SessionStart,
+                &command(
+                    r#"printf '%s' '{"decision":"allow","additional_context":"keep me"}'"#,
+                    1_000,
+                ),
+                None,
+                None,
+                0,
+            )
+            .unwrap(),
+        ));
+        let session = session(dir.path());
+        let mut state = bamboo_domain::AgentRuntimeState::new("run-1");
+        let outcome = runner
+            .run_hooks(
+                AgentHookPoint::AfterSessionSetup,
+                &HookPayload::None,
+                &session,
+                &mut state,
+                None,
+            )
+            .await;
+        assert_eq!(outcome.decision, HookResult::Allow);
+        assert_eq!(outcome.injected_contexts, vec!["keep me"]);
+    }
+
+    #[tokio::test]
+    async fn malformed_json_is_non_blocking() {
+        let dir = tempfile::tempdir().unwrap();
+        let hook = ShellCommandHook::new(
+            ShellHookEvent::SessionStart,
+            &command("printf 'not-json'", 1_000),
+            None,
+            None,
+            0,
+        )
+        .unwrap();
+        assert_eq!(
+            hook.run(
+                AgentHookPoint::AfterSessionSetup,
+                &HookPayload::None,
+                &session(dir.path()),
+            )
+            .await,
+            HookResult::Continue
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_kills_hook_and_continues() {
+        let dir = tempfile::tempdir().unwrap();
+        let hook = ShellCommandHook::new(
+            ShellHookEvent::SessionStart,
+            &command("sleep 5", 25),
+            None,
+            None,
+            0,
+        )
+        .unwrap();
+        let started = Instant::now();
+        let result = hook
+            .run(
+                AgentHookPoint::AfterSessionSetup,
+                &HookPayload::None,
+                &session(dir.path()),
+            )
+            .await;
+        assert_eq!(result, HookResult::Continue);
+        assert!(started.elapsed() < Duration::from_secs(2));
+    }
+
+    #[test]
+    fn matcher_filters_tool_names() {
+        let hook = ShellCommandHook::new(
+            ShellHookEvent::PreToolUse,
+            &command("exit 2", 1_000),
+            Some("^(bash|write_file)$"),
+            None,
+            0,
+        )
+        .unwrap();
+        let payload = |tool_name: &str| HookPayload::ToolExecution {
+            tool_name: tool_name.to_string(),
+            tool_call_id: "call-1".to_string(),
+            parsed_args: json!({}),
+        };
+        assert!(hook.matches(&payload("bash")));
+        assert!(!hook.matches(&payload("read_file")));
+    }
+
+    #[test]
+    fn envelope_contains_versioned_protocol_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let hook = ShellCommandHook::new(
+            ShellHookEvent::PreToolUse,
+            &command("true", 1_000),
+            None,
+            None,
+            0,
+        )
+        .unwrap();
+        let session = session(dir.path());
+        let payload = HookPayload::ToolExecution {
+            tool_name: "bash".to_string(),
+            tool_call_id: "call-1".to_string(),
+            parsed_args: json!({"command": "pwd"}),
+        };
+        let value = serde_json::to_value(hook.envelope(
+            &payload,
+            &session,
+            hook.effective_cwd(&session).as_ref(),
+        ))
+        .unwrap();
+        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["hook_event_name"], "PreToolUse");
+        assert_eq!(value["session_id"], "session-1");
+        assert_eq!(value["model"], "test-model");
+        assert_eq!(value["tool_name"], "bash");
+        assert_eq!(value["tool_input"]["command"], "pwd");
+        assert!(value["timestamp"].as_str().is_some());
+    }
+
+    #[test]
+    fn configured_runner_registers_only_enabled_engine_events() {
+        let hook = command("true", 1_000);
+        let config = LifecycleHooksConfig {
+            enabled: true,
+            pre_tool_use: vec![LifecycleHookGroup {
+                matcher: Some("bash".to_string()),
+                hooks: vec![hook.clone()],
+            }],
+            session_start: vec![LifecycleHookGroup {
+                matcher: None,
+                hooks: vec![hook.clone()],
+            }],
+            notification: vec![LifecycleHookGroup {
+                matcher: None,
+                hooks: vec![hook],
+            }],
+            ..LifecycleHooksConfig::default()
+        };
+
+        let base = HookRunner::new();
+        let configured = base.with_lifecycle_config(&config, None);
+        assert!(
+            base.is_empty(),
+            "per-run registration must not mutate the base"
+        );
+        assert_eq!(configured.len(), 2);
+        assert!(configured.has_hooks_for(AgentHookPoint::AfterSessionSetup));
+        assert!(configured.has_hooks_for(AgentHookPoint::BeforeToolExecution));
+    }
+
+    #[tokio::test]
+    async fn configured_commands_run_in_order_and_first_block_wins() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = LifecycleHooksConfig {
+            enabled: true,
+            pre_tool_use: vec![LifecycleHookGroup {
+                matcher: None,
+                hooks: vec![
+                    command("printf 'first' >&2; exit 2", 1_000),
+                    command("printf 'second' >&2; exit 2", 1_000),
+                ],
+            }],
+            ..LifecycleHooksConfig::default()
+        };
+        let runner = HookRunner::new().with_lifecycle_config(&config, None);
+        let mut state = bamboo_domain::AgentRuntimeState::new("run-ordered");
+        let outcome = runner
+            .run_hooks(
+                AgentHookPoint::BeforeToolExecution,
+                &HookPayload::ToolExecution {
+                    tool_name: "bash".to_string(),
+                    tool_call_id: "call-1".to_string(),
+                    parsed_args: json!({}),
+                },
+                &session(dir.path()),
+                &mut state,
+                None,
+            )
+            .await;
+        assert_eq!(
+            outcome.decision,
+            HookResult::Deny {
+                reason: "first".to_string()
+            }
+        );
+        assert_eq!(state.checkpoints.len(), 1);
+    }
+
+    #[test]
+    fn invalid_matcher_is_skipped_without_failing_registration() {
+        let config = LifecycleHooksConfig {
+            enabled: true,
+            pre_tool_use: vec![LifecycleHookGroup {
+                matcher: Some("[".to_string()),
+                hooks: vec![command("true", 1_000)],
+            }],
+            ..LifecycleHooksConfig::default()
+        };
+        let configured = HookRunner::new().with_lifecycle_config(&config, None);
+        assert!(configured.is_empty());
+    }
+
+    #[tokio::test]
+    async fn output_capture_is_capped_but_fully_drained() {
+        let (mut writer, reader) = tokio::io::duplex(1024);
+        let input = vec![b'x'; HOOK_OUTPUT_LIMIT_BYTES + 17];
+        let write_task = tokio::spawn(async move {
+            writer.write_all(&input).await.unwrap();
+        });
+        let captured = read_capped(reader).await.unwrap();
+        write_task.await.unwrap();
+        assert_eq!(captured.bytes.len(), HOOK_OUTPUT_LIMIT_BYTES);
+        assert!(captured.truncated);
+    }
+}

--- a/crates/engine/bamboo-engine/src/runtime/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/mod.rs
@@ -30,7 +30,7 @@ pub use config::{
 // `crate::runtime::config::AgentLoopConfig`. External code drives the loop only
 // through `AgentRuntime::execute`.
 pub use execution::runner_state::{AgentRunner, AgentStatus};
-pub use hooks::HookRunner;
+pub use hooks::{HookRunner, ShellCommandHook, ShellHookEvent};
 pub use managers::{
     LifecycleManager, LlmManager, MemoryManager, MiniLoopExecutor, PromptManager, ToolManager,
 };

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -665,6 +665,10 @@ impl AgentRuntime {
             provider_type,
             ..
         } = model_roster;
+        let hook_runner = Arc::new(
+            self.hook_runner
+                .with_lifecycle_config(&config.lifecycle_hooks, app_data_dir.clone()),
+        );
 
         let loop_config = AgentLoopConfig {
             max_rounds: 200,
@@ -731,7 +735,7 @@ impl AgentRuntime {
             guardian_spawner,
             bash_resume_hook,
             bash_completion_sink,
-            hook_runner: self.hook_runner.clone(),
+            hook_runner,
             // Capture the tool executor's server-level guidance (connected MCP
             // servers' `instructions`) once, so it lands in the system prompt only
             // while those servers are loaded for this run.

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -1394,6 +1394,14 @@ pub struct ConfigValues {
     #[serde(default)]
     pub hooks: HooksConfig,
 
+    /// User-configured agent lifecycle command hooks.
+    ///
+    /// This is intentionally separate from `hooks`, which is already the
+    /// provider HTTP request-hook namespace. Lifecycle hooks are snapshotted
+    /// when an agent run starts.
+    #[serde(default, skip_serializing_if = "LifecycleHooksConfig::is_empty")]
+    pub lifecycle_hooks: LifecycleHooksConfig,
+
     /// Global tool toggles.
     ///
     /// Any tool listed in `disabled` is omitted from the tool schemas sent to the LLM.
@@ -1501,6 +1509,7 @@ impl Default for ConfigValues {
             anthropic_model_mapping: AnthropicModelMapping::default(),
             gemini_model_mapping: GeminiModelMapping::default(),
             hooks: HooksConfig::default(),
+            lifecycle_hooks: LifecycleHooksConfig::default(),
             tools: ToolsConfig::default(),
             skills: SkillsConfig::default(),
             env_vars: Vec::new(),
@@ -1570,6 +1579,8 @@ struct ModelBehaviorConfigSection {
     gemini_model_mapping: GeminiModelMapping,
     #[serde(default)]
     hooks: HooksConfig,
+    #[serde(default, skip_serializing_if = "LifecycleHooksConfig::is_empty")]
+    lifecycle_hooks: LifecycleHooksConfig,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -1703,6 +1714,7 @@ impl From<ConfigValues> for ConfigRoot {
             anthropic_model_mapping,
             gemini_model_mapping,
             hooks,
+            lifecycle_hooks,
             tools,
             skills,
             env_vars,
@@ -1740,6 +1752,7 @@ impl From<ConfigValues> for ConfigRoot {
                 anthropic_model_mapping,
                 gemini_model_mapping,
                 hooks,
+                lifecycle_hooks,
             },
             tooling: ToolingConfigSection { tools, skills, mcp },
             workspace: WorkspaceConfigSection {
@@ -1798,6 +1811,7 @@ impl From<ConfigRoot> for ConfigValues {
             anthropic_model_mapping,
             gemini_model_mapping,
             hooks,
+            lifecycle_hooks,
         } = model_behavior;
         let ToolingConfigSection { tools, skills, mcp } = tooling;
         let WorkspaceConfigSection {
@@ -1833,6 +1847,7 @@ impl From<ConfigRoot> for ConfigValues {
             anthropic_model_mapping,
             gemini_model_mapping,
             hooks,
+            lifecycle_hooks,
             tools,
             skills,
             env_vars,
@@ -2056,6 +2071,99 @@ pub struct HooksConfig {
     /// Image fallback behavior for OpenAI-compatible requests (chat/responses).
     #[serde(default)]
     pub image_fallback: ImageFallbackHookConfig,
+}
+
+/// Default deadline for one lifecycle command hook.
+pub const DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS: u64 = 60_000;
+
+fn default_lifecycle_hook_timeout_ms() -> u64 {
+    DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS
+}
+
+fn lifecycle_hook_timeout_is_default(value: &u64) -> bool {
+    *value == DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS
+}
+
+/// Config-driven agent lifecycle hooks.
+///
+/// Event names deliberately preserve the user-facing PascalCase protocol.
+/// Server-owned events are represented here even though their invocation
+/// seams are added by follow-up issues; this keeps one stable config schema.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LifecycleHooksConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(
+        default,
+        rename = "SessionStart",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub session_start: Vec<LifecycleHookGroup>,
+    #[serde(
+        default,
+        rename = "UserPromptSubmit",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub user_prompt_submit: Vec<LifecycleHookGroup>,
+    #[serde(default, rename = "PreToolUse", skip_serializing_if = "Vec::is_empty")]
+    pub pre_tool_use: Vec<LifecycleHookGroup>,
+    #[serde(default, rename = "PostToolUse", skip_serializing_if = "Vec::is_empty")]
+    pub post_tool_use: Vec<LifecycleHookGroup>,
+    #[serde(default, rename = "Stop", skip_serializing_if = "Vec::is_empty")]
+    pub stop: Vec<LifecycleHookGroup>,
+    #[serde(default, rename = "SessionEnd", skip_serializing_if = "Vec::is_empty")]
+    pub session_end: Vec<LifecycleHookGroup>,
+    #[serde(default, rename = "PreCompact", skip_serializing_if = "Vec::is_empty")]
+    pub pre_compact: Vec<LifecycleHookGroup>,
+    #[serde(
+        default,
+        rename = "Notification",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub notification: Vec<LifecycleHookGroup>,
+}
+
+impl LifecycleHooksConfig {
+    pub fn is_empty(&self) -> bool {
+        !self.enabled
+            && self.session_start.is_empty()
+            && self.user_prompt_submit.is_empty()
+            && self.pre_tool_use.is_empty()
+            && self.post_tool_use.is_empty()
+            && self.stop.is_empty()
+            && self.session_end.is_empty()
+            && self.pre_compact.is_empty()
+            && self.notification.is_empty()
+    }
+}
+
+/// A matcher and its ordered command-hook list for one lifecycle event.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LifecycleHookGroup {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub matcher: Option<String>,
+    #[serde(default)]
+    pub hooks: Vec<LifecycleHookCommand>,
+}
+
+/// Supported lifecycle hook implementation kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LifecycleHookType {
+    Command,
+}
+
+/// One configured lifecycle shell command.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LifecycleHookCommand {
+    #[serde(rename = "type")]
+    pub hook_type: LifecycleHookType,
+    pub command: String,
+    #[serde(
+        default = "default_lifecycle_hook_timeout_ms",
+        skip_serializing_if = "lifecycle_hook_timeout_is_default"
+    )]
+    pub timeout_ms: u64,
 }
 
 /// Request override configuration for provider-specific HTTP behavior.
@@ -3852,6 +3960,7 @@ impl Config {
                 anthropic_model_mapping: AnthropicModelMapping::default(),
                 gemini_model_mapping: GeminiModelMapping::default(),
                 hooks: HooksConfig::default(),
+                lifecycle_hooks: LifecycleHooksConfig::default(),
                 tools: ToolsConfig::default(),
                 skills: SkillsConfig::default(),
                 env_vars: Vec::new(),
@@ -4684,6 +4793,60 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Mutex;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn lifecycle_hooks_round_trip_as_a_distinct_top_level_section() {
+        let config: Config = serde_json::from_value(serde_json::json!({
+            "hooks": {
+                "image_fallback": {"enabled": true, "mode": "placeholder"}
+            },
+            "lifecycle_hooks": {
+                "enabled": true,
+                "PreToolUse": [{
+                    "matcher": "bash|write_file",
+                    "hooks": [{"type": "command", "command": "guard.sh"}]
+                }],
+                "SessionStart": [{
+                    "hooks": [{"type": "command", "command": "setup.sh", "timeout_ms": 25}]
+                }]
+            }
+        }))
+        .expect("lifecycle hook config should deserialize");
+
+        assert!(config.lifecycle_hooks.enabled);
+        assert_eq!(config.lifecycle_hooks.pre_tool_use.len(), 1);
+        assert_eq!(
+            config.lifecycle_hooks.pre_tool_use[0].hooks[0].timeout_ms,
+            DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS
+        );
+        assert_eq!(
+            config.lifecycle_hooks.session_start[0].hooks[0].timeout_ms,
+            25
+        );
+
+        let json = serde_json::to_value(&config).expect("lifecycle hook config should serialize");
+        assert_eq!(json["lifecycle_hooks"]["enabled"], true);
+        assert_eq!(
+            json["lifecycle_hooks"]["PreToolUse"][0]["matcher"],
+            "bash|write_file"
+        );
+        assert_eq!(
+            json["lifecycle_hooks"]["PreToolUse"][0]["hooks"][0]["type"],
+            "command"
+        );
+        assert!(json["lifecycle_hooks"]["PreToolUse"][0]["hooks"][0]
+            .get("timeout_ms")
+            .is_none());
+        assert!(json.get("hooks").is_some());
+    }
+
+    #[test]
+    fn absent_lifecycle_hooks_remain_disabled_and_omitted() {
+        let config: Config = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(config.lifecycle_hooks, LifecycleHooksConfig::default());
+        let json = serde_json::to_value(&config).unwrap();
+        assert!(json.get("lifecycle_hooks").is_none());
+    }
 
     #[test]
     fn stream_timeout_defaults_are_safe_and_back_compatible() {

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -23,10 +23,10 @@ use crate::{
     ClusterFabricConfig, Config, ConfigSectionEvent, ConfigStoreResult, ConfigValues,
     ConnectConfig, CredentialRef, CredentialSource, CredentialStatus, CredentialStore,
     DefaultWorkAreaConfig, DefaultsConfig, EnvVarEntry, FeatureFlags, GeminiModelMapping,
-    HooksConfig, KeywordMaskingConfig, LiveSection, MemoryConfig, NotificationsConfig,
-    PluginTrustConfig, ProviderConfigs, ProviderInstanceConfig, RunBudgetConfig, SectionEnvelope,
-    SectionSourceKind, SectionStatus, ServerConfig, SkillsConfig, StreamTimeoutConfig,
-    SubagentsConfig, ToolsConfig,
+    HooksConfig, KeywordMaskingConfig, LifecycleHooksConfig, LiveSection, MemoryConfig,
+    NotificationsConfig, PluginTrustConfig, ProviderConfigs, ProviderInstanceConfig,
+    RunBudgetConfig, SectionEnvelope, SectionSourceKind, SectionStatus, ServerConfig, SkillsConfig,
+    StreamTimeoutConfig, SubagentsConfig, ToolsConfig,
 };
 
 const SECTION_SCHEMA_VERSION: u32 = 1;
@@ -186,7 +186,7 @@ impl SectionId {
 /// `proxy_auth` and `proxy_auth_encrypted` remain compatibility read fields,
 /// but their owner is still core; section serialization always drops them in
 /// favour of `proxy_auth_credential_ref`.
-pub const CONFIG_VALUE_FIELD_OWNERS: [(&str, SectionId); 29] = [
+pub const CONFIG_VALUE_FIELD_OWNERS: [(&str, SectionId); 30] = [
     ("http_proxy", SectionId::Core),
     ("https_proxy", SectionId::Core),
     ("proxy_auth", SectionId::Core),
@@ -202,6 +202,7 @@ pub const CONFIG_VALUE_FIELD_OWNERS: [(&str, SectionId); 29] = [
     ("anthropic_model_mapping", SectionId::ModelPolicy),
     ("gemini_model_mapping", SectionId::ModelPolicy),
     ("hooks", SectionId::Hooks),
+    ("lifecycle_hooks", SectionId::Hooks),
     ("tools", SectionId::ToolsSkills),
     ("skills", SectionId::ToolsSkills),
     ("env_vars", SectionId::Env),
@@ -327,8 +328,12 @@ pub struct EnvSection(pub Vec<EnvVarEntry>);
 pub struct AccessControlSection(pub Option<AccessControlConfig>);
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct HooksSection(pub HooksConfig);
+pub struct HooksSection {
+    #[serde(flatten)]
+    pub request_hooks: HooksConfig,
+    #[serde(default, skip_serializing_if = "LifecycleHooksConfig::is_empty")]
+    pub lifecycle_hooks: LifecycleHooksConfig,
+}
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ModelPolicySection {
@@ -482,6 +487,7 @@ impl SectionProjection {
             anthropic_model_mapping,
             gemini_model_mapping,
             hooks,
+            lifecycle_hooks,
             tools,
             skills,
             env_vars,
@@ -534,7 +540,10 @@ impl SectionProjection {
             cluster_fabric: ClusterFabricSection(cluster_fabric),
             env: EnvSection(env_vars),
             access_control: AccessControlSection(access_control),
-            hooks: HooksSection(hooks),
+            hooks: HooksSection {
+                request_hooks: hooks,
+                lifecycle_hooks,
+            },
             model_policy: ModelPolicySection {
                 keyword_masking,
                 anthropic_model_mapping,
@@ -613,7 +622,8 @@ impl SectionProjection {
                 keyword_masking,
                 anthropic_model_mapping,
                 gemini_model_mapping,
-                hooks: hooks.0,
+                hooks: hooks.request_hooks,
+                lifecycle_hooks: hooks.lifecycle_hooks,
                 tools,
                 skills,
                 env_vars: env.0,
@@ -1803,7 +1813,7 @@ fn validate_access_control(value: &AccessControlSection) -> Result<(), String> {
 
 fn validate_hooks(value: &HooksSection) -> Result<(), String> {
     if !matches!(
-        value.0.image_fallback.mode.as_str(),
+        value.request_hooks.image_fallback.mode.as_str(),
         "placeholder" | "error" | "ocr" | "vision"
     ) {
         return Err("image fallback mode is invalid".to_string());
@@ -2592,6 +2602,7 @@ fn project_legacy_raw_sections(
     let mut tools_skills = Map::new();
     let mut subagents = Map::new();
     let mut notifications = Map::new();
+    let mut hooks = Map::new();
     let mut model_policy = Map::new();
 
     for (key, value) in root {
@@ -2656,7 +2667,15 @@ fn project_legacy_raw_sections(
                 sections.insert(SectionId::AccessControl, value.clone());
             }
             "hooks" => {
-                sections.insert(SectionId::Hooks, value.clone());
+                let object = value.as_object().ok_or_else(|| {
+                    crate::ConfigStoreError::Validation(
+                        "legacy hooks configuration must be an object".to_string(),
+                    )
+                })?;
+                hooks.extend(object.clone());
+            }
+            "lifecycle_hooks" => {
+                hooks.insert(key.clone(), value.clone());
             }
             "keyword_masking" | "anthropic_model_mapping" | "gemini_model_mapping" => {
                 model_policy.insert(key.clone(), value.clone());
@@ -2680,6 +2699,7 @@ fn project_legacy_raw_sections(
         (SectionId::ToolsSkills, tools_skills),
         (SectionId::Subagents, subagents),
         (SectionId::Notifications, notifications),
+        (SectionId::Hooks, hooks),
         (SectionId::ModelPolicy, model_policy),
     ] {
         if !object.is_empty() {
@@ -4469,6 +4489,7 @@ mod tests {
             "default_work_area",
             "run_budget",
             "stream_timeout",
+            "lifecycle_hooks",
         ] {
             assert!(names.contains(required), "missing owner for {required}");
         }
@@ -4496,6 +4517,13 @@ mod tests {
             "notifications": {"desktop": {"enabled": true}},
             "connect": {"platforms": []},
             "plugin_trust": {"enforcement": "off"},
+            "lifecycle_hooks": {
+                "enabled": true,
+                "PreToolUse": [{
+                    "matcher": "bash",
+                    "hooks": [{"type": "command", "command": "guard.sh"}]
+                }]
+            },
             "memory": {"background_model": "memory-model"},
             "subagents": {"max_concurrent": 3},
             "providers": {"openai": {"model": "gpt-test"}},
@@ -4524,6 +4552,11 @@ mod tests {
         assert_eq!(value["default_work_area"]["path"], "/workspace");
         assert_eq!(value["run_budget"]["max_tool_calls"], 4);
         assert_eq!(value["plugin_trust"]["enforcement"], "off");
+        assert_eq!(value["lifecycle_hooks"]["enabled"], true);
+        assert_eq!(
+            value["lifecycle_hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+            "guard.sh"
+        );
         assert!(round_trip.connect.platforms.is_empty());
         assert_eq!(value["future_root_key"]["nested"], true);
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub use bamboo_infrastructure as infrastructure;
 pub use bamboo_sdk::agent;
 pub use bamboo_sdk::{
     Agent, AgentBuilder, AgentHook, AgentHookPoint, HookPayload, HookResult, HookRunner,
-    HookToolOutcome,
+    HookToolOutcome, ShellCommandHook, ShellHookEvent,
 };
 
 // Re-export the runtime config crate so consumers can reach config, paths,


### PR DESCRIPTION
## Summary

- add a distinct, frozen-per-run lifecycle_hooks config schema without reusing provider HTTP hooks
- run local shell hooks sequentially through a versioned stdin JSON protocol with matcher, timeout, cwd/env, capped output, and decision parsing
- preserve combined decisions plus injected context and register engine-owned lifecycle events at loop start
- keep hook failures non-blocking while block/ask decisions flow through the existing hook and parent-agent review paths

## Test Plan

- cargo fmt --all -- --check
- git diff --check
- cargo clippy -p bamboo-config -p bamboo-engine --all-targets
- cargo test -p bamboo-config
- cargo test -p bamboo-engine
- cargo test -p bamboo-engine runtime::hooks::
- cargo build --workspace --tests

Closes #550