### PR TITLE
feat(hooks): wire session lifecycle events (#552)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
@@ -45,10 +45,10 @@ pub async fn handler(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     // (an explicit model) pays none of that cost. #480: fall back to the SAME
     // resolved default the connect bridge and `GET /execute/defaults` use, so
     // there is one implementation of "what model does this server default to".
+    let config_snapshot = state.config.read().await.clone();
     let default_model = if request::optional_non_empty(req.model.as_deref()).is_some() {
         None
     } else {
-        let config_snapshot = state.config.read().await.clone();
         bamboo_engine::resolved_defaults::resolve_default_run_config(
             &config_snapshot,
             &state.provider_registry,
@@ -114,6 +114,25 @@ pub async fn handler(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
         }
     };
 
+    let effective_message = match crate::lifecycle_hooks::apply_user_prompt_submit_hooks(
+        &config_snapshot.lifecycle_hooks,
+        Some(state.app_data_dir.clone()),
+        &mut session,
+        &req.message,
+    )
+    .await
+    {
+        Ok(message) => message,
+        Err(reason) => {
+            // Persist the hook checkpoint but never the rejected user message.
+            state.save_and_cache_session(&mut session).await;
+            return HttpResponse::BadRequest().json(serde_json::json!({
+                "error": crate::error::error_value(reason),
+                "hook_event": "UserPromptSubmit"
+            }));
+        }
+    };
+
     // ---- Goal command interception ----
     if let Some(goal_cmd) = parse_goal_command(&req.message) {
         tracing::debug!(
@@ -125,8 +144,13 @@ pub async fn handler(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     }
 
     // Image handling stays in the handler layer (depends on AppState attachment reader).
-    if let Err(response) =
-        images::append_user_message(&state, &mut session, &req.message, req.images.as_deref()).await
+    if let Err(response) = images::append_user_message(
+        &state,
+        &mut session,
+        &effective_message,
+        req.images.as_deref(),
+    )
+    .await
     {
         return response;
     }

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
@@ -457,4 +457,66 @@ mod optional_model_e2e {
 
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
+
+    #[actix_web::test]
+    async fn user_prompt_submit_block_returns_reason_and_persists_no_user_message() {
+        let state = new_state().await;
+        {
+            let mut config = state.config.write().await;
+            config.lifecycle_hooks = bamboo_config::LifecycleHooksConfig {
+                enabled: true,
+                user_prompt_submit: vec![bamboo_config::LifecycleHookGroup {
+                    matcher: None,
+                    hooks: vec![bamboo_config::LifecycleHookCommand {
+                        hook_type: bamboo_config::LifecycleHookType::Command,
+                        command: "printf 'prompt rejected by policy' >&2; exit 2".to_string(),
+                        timeout_ms: bamboo_config::DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS,
+                    }],
+                }],
+                ..Default::default()
+            };
+        }
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .configure(configure_routes),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/v1/chat")
+                .set_json(serde_json::json!({
+                    "session_id": "blocked-user-prompt",
+                    "message": "must not persist",
+                    "model": "test-model"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body: Value = test::read_body_json(response).await;
+        assert!(body.to_string().contains("prompt rejected by policy"));
+        assert_eq!(body["hook_event"], "UserPromptSubmit");
+
+        let session = state
+            .storage
+            .load_session("blocked-user-prompt")
+            .await
+            .expect("load")
+            .expect("prepared session is persisted for hook observability");
+        assert!(session
+            .messages
+            .iter()
+            .all(|message| !matches!(message.role, bamboo_agent_core::Role::User)));
+        assert_eq!(
+            session
+                .agent_runtime_state
+                .as_ref()
+                .map(|state| state.checkpoints.len()),
+            Some(1)
+        );
+    }
 }

--- a/crates/app/bamboo-server/src/lib.rs
+++ b/crates/app/bamboo-server/src/lib.rs
@@ -111,6 +111,7 @@ pub mod connect;
 pub mod error;
 pub mod events;
 pub mod handlers;
+mod lifecycle_hooks;
 pub mod logging;
 pub mod notify_sinks;
 pub mod plugin_installer;

--- a/crates/app/bamboo-server/src/lifecycle_hooks.rs
+++ b/crates/app/bamboo-server/src/lifecycle_hooks.rs
@@ -1,0 +1,161 @@
+use std::path::PathBuf;
+
+use bamboo_agent_core::Session;
+use bamboo_config::LifecycleHooksConfig;
+use bamboo_domain::{AgentHookPoint, AgentRuntimeState, HookPayload, HookResult};
+use bamboo_engine::HookRunner;
+
+const USER_PROMPT_CONTEXT_START: &str = "<user_prompt_submit_context>";
+const USER_PROMPT_CONTEXT_END: &str = "</user_prompt_submit_context>";
+
+/// Run config-backed `UserPromptSubmit` hooks before the caller persists the
+/// user message. A blocked result is fail-closed and carries the hook reason;
+/// injected context is returned as a clearly-delimited extension of the user
+/// message without changing the raw prompt delivered to the hook.
+pub(crate) async fn apply_user_prompt_submit_hooks(
+    config: &LifecycleHooksConfig,
+    fallback_cwd: Option<PathBuf>,
+    session: &mut Session,
+    raw_prompt: &str,
+) -> Result<String, String> {
+    let runner = HookRunner::new().with_lifecycle_config(config, fallback_cwd);
+    let mut runtime_state = session
+        .agent_runtime_state
+        .clone()
+        .unwrap_or_else(|| AgentRuntimeState::new(&session.id));
+    // A submitted user prompt starts a new run. Preserve sticky control fields
+    // on the cloned state, but reset per-run hook observations before recording
+    // this prompt's checkpoints.
+    runtime_state.checkpoints.clear();
+    runtime_state.hook_contexts.clear();
+    runtime_state.stop_hook_forced_continuations = 0;
+    if !runner.has_hooks_for(AgentHookPoint::BeforeSessionSetup) {
+        session.agent_runtime_state = Some(runtime_state);
+        return Ok(raw_prompt.to_string());
+    }
+    let outcome = runner
+        .run_hooks(
+            AgentHookPoint::BeforeSessionSetup,
+            &HookPayload::Prompt {
+                prompt: raw_prompt.to_string(),
+            },
+            session,
+            &mut runtime_state,
+            None,
+        )
+        .await;
+    session.agent_runtime_state = Some(runtime_state);
+
+    let blocked_reason = match outcome.decision {
+        HookResult::Deny { reason } | HookResult::Abort { reason } => Some(reason),
+        HookResult::Suspend { reason } => Some(format!("hook suspended prompt submission: {reason}")),
+        HookResult::Ask => Some(
+            "UserPromptSubmit hook requested parent-agent review, but a user prompt has no owning parent agent"
+                .to_string(),
+        ),
+        HookResult::Continue
+        | HookResult::Mutated
+        | HookResult::Allow
+        | HookResult::InjectContext { .. } => None,
+        HookResult::WithContext { .. } => unreachable!("hook runner unwraps context results"),
+    };
+    if let Some(reason) = blocked_reason {
+        return Err(reason);
+    }
+
+    let contexts = outcome
+        .injected_contexts
+        .into_iter()
+        .map(|context| context.trim().to_string())
+        .filter(|context| !context.is_empty())
+        .collect::<Vec<_>>();
+    if contexts.is_empty() {
+        return Ok(raw_prompt.to_string());
+    }
+    Ok(format!(
+        "{raw_prompt}\n\n{USER_PROMPT_CONTEXT_START}\n{}\n{USER_PROMPT_CONTEXT_END}",
+        contexts.join("\n\n---\n\n")
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_config::{
+        LifecycleHookCommand, LifecycleHookGroup, LifecycleHookType,
+        DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS,
+    };
+
+    fn config(command: &str) -> LifecycleHooksConfig {
+        LifecycleHooksConfig {
+            enabled: true,
+            user_prompt_submit: vec![LifecycleHookGroup {
+                matcher: None,
+                hooks: vec![LifecycleHookCommand {
+                    hook_type: LifecycleHookType::Command,
+                    command: command.to_string(),
+                    timeout_ms: DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS,
+                }],
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn prompt_block_is_fail_closed_and_never_appends_a_message() {
+        let mut session = Session::new("blocked-prompt", "model");
+        let result = apply_user_prompt_submit_hooks(
+            &config("payload=$(cat); case \"$payload\" in *'\"prompt\":\"raw prompt\"'*) printf 'policy says no' >&2; exit 2 ;; *) exit 1 ;; esac"),
+            None,
+            &mut session,
+            "raw prompt",
+        )
+        .await;
+
+        assert_eq!(result, Err("policy says no".to_string()));
+        assert!(session.messages.is_empty());
+        assert_eq!(
+            session
+                .agent_runtime_state
+                .as_ref()
+                .map(|state| state.checkpoints.len()),
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn prompt_context_is_delimited_and_raw_prompt_is_unchanged_on_stdin() {
+        let mut session = Session::new("context-prompt", "model");
+        let prompt = apply_user_prompt_submit_hooks(
+            &config(
+                "payload=$(cat); case \"$payload\" in *'\"prompt\":\"raw prompt\"'*) printf '%s' '{\"additional_context\":\"workspace policy\"}' ;; *) exit 2 ;; esac",
+            ),
+            None,
+            &mut session,
+            "raw prompt",
+        )
+        .await
+        .expect("context hook should pass");
+
+        assert_eq!(
+            prompt,
+            "raw prompt\n\n<user_prompt_submit_context>\nworkspace policy\n</user_prompt_submit_context>"
+        );
+        assert!(session.messages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn prompt_ask_has_no_manual_fallback_and_fails_closed_without_parent() {
+        let mut session = Session::new("ask-prompt", "model");
+        let result = apply_user_prompt_submit_hooks(
+            &config("printf '%s' '{\"decision\":\"ask\"}'"),
+            None,
+            &mut session,
+            "raw prompt",
+        )
+        .await;
+
+        assert!(result.is_err_and(|reason| reason.contains("no owning parent agent")));
+        assert!(session.messages.is_empty());
+    }
+}

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -47,6 +47,7 @@ pub struct ResolvedRunConfig {
     pub system_prompt: String,
     pub base_system_prompt: String,
     pub workspace_path: Option<String>,
+    pub lifecycle_hooks: bamboo_config::LifecycleHooksConfig,
 }
 
 #[derive(Clone)]
@@ -363,6 +364,31 @@ async fn run_schedule_job(
         .get_or_insert_with(bamboo_domain::AgentRuntimeState::default)
         .no_human_approver = true;
 
+    let mut prompt_hook_block = None;
+    if let Some(user_index) = session
+        .messages
+        .iter()
+        .rposition(|message| matches!(message.role, Role::User))
+    {
+        let raw_prompt = session.messages[user_index].content.clone();
+        match crate::lifecycle_hooks::apply_user_prompt_submit_hooks(
+            &resolved.lifecycle_hooks,
+            ctx.app_data_dir.clone(),
+            &mut session,
+            &raw_prompt,
+        )
+        .await
+        {
+            Ok(prompt) => session.messages[user_index].content = prompt,
+            Err(reason) => {
+                session.messages.remove(user_index);
+                session.set_last_run_status("error");
+                session.set_last_run_error(reason.clone());
+                prompt_hook_block = Some(reason);
+            }
+        }
+    }
+
     // Persist session and index entry.
     ctx.persistence
         .merge_save_runtime(&mut session)
@@ -385,6 +411,12 @@ async fn run_schedule_job(
         session_id.clone(),
         Arc::new(parking_lot::RwLock::new(session.clone())),
     );
+
+    if let Some(reason) = prompt_hook_block {
+        return Err(format!(
+            "UserPromptSubmit hook blocked scheduled run: {reason}"
+        ));
+    }
 
     // If no task message (or not configured to execute), we're done.
     let should_execute = job.run_config.auto_execute
@@ -744,6 +776,7 @@ fn resolve_run_config_from_config(
         system_prompt,
         base_system_prompt: base_system_prompt.to_string(),
         workspace_path,
+        lifecycle_hooks: config_snapshot.lifecycle_hooks.clone(),
     }
 }
 
@@ -849,6 +882,34 @@ mod build_context_tests {
         let resolved =
             resolve_run_config_from_config(&test_job(), &Arc::new(RwLock::new(config)), &registry);
         assert_eq!(resolved.model_roster.model.as_deref(), Some("gpt-chat"));
+    }
+
+    #[test]
+    fn resolve_run_config_from_config_snapshots_lifecycle_hooks_for_scheduled_runs() {
+        let lifecycle_hooks = bamboo_config::LifecycleHooksConfig {
+            enabled: true,
+            session_start: vec![bamboo_config::LifecycleHookGroup {
+                matcher: None,
+                hooks: vec![bamboo_config::LifecycleHookCommand {
+                    hook_type: bamboo_config::LifecycleHookType::Command,
+                    command: "printf schedule-start".to_string(),
+                    timeout_ms: bamboo_config::DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS,
+                }],
+            }],
+            ..Default::default()
+        };
+        let config = test_config! {
+            lifecycle_hooks: lifecycle_hooks.clone(),
+        };
+        let registry = Arc::new(ProviderRegistry::new(
+            Default::default(),
+            "openai".to_string(),
+        ));
+
+        let resolved =
+            resolve_run_config_from_config(&test_job(), &Arc::new(RwLock::new(config)), &registry);
+
+        assert_eq!(resolved.lifecycle_hooks, lifecycle_hooks);
     }
 }
 

--- a/crates/app/bamboo-server/src/schedule_app/session_factory.rs
+++ b/crates/app/bamboo-server/src/schedule_app/session_factory.rs
@@ -25,6 +25,10 @@ pub fn create_schedule_session(
     );
 
     let mut session = Session::new(session_id.clone(), model.to_string());
+    session.metadata.insert(
+        bamboo_engine::session_app::chat::SESSION_START_SOURCE_METADATA_KEY.to_string(),
+        "startup".to_string(),
+    );
     session.title = title;
     session.metadata.insert(
         "created_by_schedule_id".to_string(),

--- a/crates/core/bamboo-domain/src/session/context_block.rs
+++ b/crates/core/bamboo-domain/src/session/context_block.rs
@@ -93,6 +93,8 @@ pub enum ContextBlockType {
     /// Per-round session-goal block (placed in the volatile tail so a goal
     /// change never invalidates the cached prefix).
     GoalState,
+    /// Context injected by session lifecycle hooks for the current run.
+    AgentHookContext,
     EnvSnapshot,
     RecoverySnapshot,
 }
@@ -114,6 +116,7 @@ impl ContextBlockType {
             Self::PlanModeState => "plan_mode_state",
             Self::PlanRuntimeState => "plan_runtime_state",
             Self::GoalState => "goal_state",
+            Self::AgentHookContext => "agent_hook_context",
             Self::EnvSnapshot => "env_snapshot",
             Self::RecoverySnapshot => "recovery_snapshot",
         }

--- a/crates/core/bamboo-domain/src/session/hook_types.rs
+++ b/crates/core/bamboo-domain/src/session/hook_types.rs
@@ -19,7 +19,10 @@ pub enum HookPayload {
     #[default]
     None,
     /// Session initialization completed for this user turn.
-    SessionSetup { initial_message: String },
+    SessionSetup {
+        initial_message: String,
+        source: SessionStartSource,
+    },
     /// A round is about to start or has just completed.
     Round { round: u32 },
     /// A prompt-oriented hook payload reserved for prompt/LLM seams.
@@ -43,7 +46,31 @@ pub enum HookPayload {
         phase: String,
     },
     /// The run is about to emit its terminal completion event.
-    Finalize,
+    Finalize { stop_hook_active: bool },
+    /// The run reached a terminal status and is about to be persisted.
+    SessionEnd {
+        status: SessionEndStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        completion_reason: Option<String>,
+    },
+}
+
+/// Why a `SessionStart` hook is running.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStartSource {
+    #[default]
+    Startup,
+    Resume,
+}
+
+/// Terminal status exposed to `SessionEnd` hooks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionEndStatus {
+    Completed,
+    Failed,
+    Cancelled,
 }
 
 /// Engine-independent view of a tool execution outcome.
@@ -68,6 +95,7 @@ pub enum AgentHookPoint {
     BeforeSessionSetup,
     AfterSessionSetup,
     BeforeFinalize,
+    AfterSessionEnd,
 
     // Round-level
     BeforeRound,
@@ -140,6 +168,7 @@ mod tests {
             AgentHookPoint::BeforeSessionSetup,
             AgentHookPoint::AfterSessionSetup,
             AgentHookPoint::BeforeFinalize,
+            AgentHookPoint::AfterSessionEnd,
             AgentHookPoint::BeforeRound,
             AgentHookPoint::AfterRound,
             AgentHookPoint::BeforePromptAssembly,

--- a/crates/core/bamboo-domain/src/session/runtime_state.rs
+++ b/crates/core/bamboo-domain/src/session/runtime_state.rs
@@ -320,6 +320,14 @@ pub struct AgentRuntimeState {
     pub waiting_for_bash: Option<WaitingForBashState>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub checkpoints: Vec<HookCheckpoint>,
+    /// Volatile context injected by lifecycle hooks for this run. Request
+    /// assembly renders it after conversation history, never into the cached
+    /// system prefix.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hook_contexts: Vec<String>,
+    /// Number of extra rounds forced by a blocking `Stop` hook in this run.
+    #[serde(default)]
+    pub stop_hook_forced_continuations: u8,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plan_mode: Option<PlanModeState>,
     /// When `true`, this session skips all tool permission checks (the
@@ -353,6 +361,8 @@ impl AgentRuntimeState {
             waiting_for_children: None,
             waiting_for_bash: None,
             checkpoints: Vec::new(),
+            hook_contexts: Vec::new(),
+            stop_hook_forced_continuations: 0,
             plan_mode: None,
             bypass_permissions: false,
             no_human_approver: false,
@@ -376,6 +386,8 @@ impl Default for AgentRuntimeState {
             waiting_for_children: None,
             waiting_for_bash: None,
             checkpoints: Vec::new(),
+            hook_contexts: Vec::new(),
+            stop_hook_forced_continuations: 0,
             plan_mode: None,
             bypass_permissions: false,
             no_human_approver: false,

--- a/crates/engine/bamboo-engine/src/runtime/hooks/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/hooks/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use bamboo_agent_core::{AgentError, AgentEvent, AgentHook, Message, Session};
 use bamboo_domain::{
     AgentHookPoint, AgentRuntimeState, AgentStatusState, HookCheckpoint, HookPayload, HookResult,
-    SuspensionState,
+    SessionEndStatus, SuspensionState,
 };
 use chrono::Utc;
 use tokio::sync::mpsc;
@@ -71,6 +71,35 @@ impl HookRunner {
         runtime_state: &mut AgentRuntimeState,
         event_tx: Option<&mpsc::Sender<AgentEvent>>,
     ) -> HookRunOutcome {
+        self.run_hooks_with_control(point, payload, session, runtime_state, event_tx, true)
+            .await
+    }
+
+    /// Run every matching hook while recording checkpoints/events, but never
+    /// short-circuit on a control decision. Terminal observer seams such as
+    /// `SessionEnd` use this so one cleanup hook cannot suppress later ones.
+    async fn run_observer_hooks(
+        &self,
+        point: AgentHookPoint,
+        payload: &HookPayload,
+        session: &Session,
+        runtime_state: &mut AgentRuntimeState,
+        event_tx: Option<&mpsc::Sender<AgentEvent>>,
+    ) {
+        let _ = self
+            .run_hooks_with_control(point, payload, session, runtime_state, event_tx, false)
+            .await;
+    }
+
+    async fn run_hooks_with_control(
+        &self,
+        point: AgentHookPoint,
+        payload: &HookPayload,
+        session: &Session,
+        runtime_state: &mut AgentRuntimeState,
+        event_tx: Option<&mpsc::Sender<AgentEvent>>,
+        honor_control_decisions: bool,
+    ) -> HookRunOutcome {
         let mut outcome = HookRunOutcome::default();
 
         for hook in &self.hooks {
@@ -109,8 +138,10 @@ impl HookRunner {
                 | HookResult::Suspend { .. }
                 | HookResult::Deny { .. }
                 | HookResult::Ask => {
-                    outcome.decision = result;
-                    return outcome;
+                    if honor_control_decisions {
+                        outcome.decision = result;
+                        return outcome;
+                    }
                 }
                 HookResult::InjectContext { text } => {
                     outcome.injected_contexts.push(text.clone());
@@ -145,6 +176,57 @@ impl HookRunner {
     }
 }
 
+/// Fire cleanup/notification hooks after a terminal run. Decisions and context
+/// are intentionally ignored: `SessionEnd` observes a settled outcome and may
+/// not reverse it. Suspended runs are non-terminal and do not fire this event.
+pub(crate) async fn run_session_end_hooks(
+    runner: &HookRunner,
+    result: &Result<(), AgentError>,
+    session: &mut Session,
+    event_tx: &mpsc::Sender<AgentEvent>,
+) {
+    let suspended_non_terminal = result.is_ok()
+        && session
+            .metadata
+            .get("runtime.suspend_reason")
+            .is_some_and(|reason| !reason.trim().is_empty());
+    if suspended_non_terminal || !runner.has_hooks_for(AgentHookPoint::AfterSessionEnd) {
+        return;
+    }
+
+    let (status, completion_reason) = match result {
+        Ok(()) => (
+            SessionEndStatus::Completed,
+            session
+                .metadata
+                .get("runtime.completion_reason")
+                .cloned()
+                .or_else(|| Some("completed".to_string())),
+        ),
+        Err(error) if error.is_cancelled() => {
+            (SessionEndStatus::Cancelled, Some(error.to_string()))
+        }
+        Err(error) => (SessionEndStatus::Failed, Some(error.to_string())),
+    };
+    let mut runtime_state = session
+        .agent_runtime_state
+        .clone()
+        .unwrap_or_else(|| AgentRuntimeState::new(&session.id));
+    runner
+        .run_observer_hooks(
+            AgentHookPoint::AfterSessionEnd,
+            &HookPayload::SessionEnd {
+                status,
+                completion_reason,
+            },
+            session,
+            &mut runtime_state,
+            Some(event_tx),
+        )
+        .await;
+    session.agent_runtime_state = Some(runtime_state);
+}
+
 fn unwrap_context_result(mut result: HookResult) -> (HookResult, Vec<String>) {
     let mut contexts = Vec::new();
     while let HookResult::WithContext {
@@ -168,7 +250,16 @@ pub(crate) fn apply_hook_outcome(
     session: &mut Session,
     runtime_state: &mut AgentRuntimeState,
 ) -> Result<(), AgentError> {
-    inject_contexts(session, point, outcome.injected_contexts);
+    if matches!(point, AgentHookPoint::AfterSessionSetup) {
+        runtime_state.hook_contexts.extend(
+            outcome
+                .injected_contexts
+                .into_iter()
+                .filter(|text| !text.trim().is_empty()),
+        );
+    } else {
+        inject_contexts(session, point, outcome.injected_contexts);
+    }
 
     match outcome.decision {
         HookResult::Continue
@@ -435,5 +526,93 @@ mod tests {
 
         assert_eq!(result.decision, HookResult::Continue);
         assert!(state.checkpoints.is_empty());
+    }
+
+    struct RecordingSessionEndHook {
+        payloads: Arc<std::sync::Mutex<Vec<HookPayload>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl AgentHook for RecordingSessionEndHook {
+        fn point(&self) -> AgentHookPoint {
+            AgentHookPoint::AfterSessionEnd
+        }
+
+        async fn run(
+            &self,
+            _point: AgentHookPoint,
+            payload: &HookPayload,
+            _session: &Session,
+        ) -> HookResult {
+            self.payloads.lock().unwrap().push(payload.clone());
+            // Decisions at SessionEnd are observability-only and must not
+            // change the already-settled terminal outcome.
+            HookResult::Deny {
+                reason: "ignored cleanup decision".to_string(),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn session_end_fires_for_completed_failed_and_cancelled_and_ignores_decisions() {
+        for (result, expected_status) in [
+            (Ok(()), SessionEndStatus::Completed),
+            (
+                Err(AgentError::Tool("terminal failure".to_string())),
+                SessionEndStatus::Failed,
+            ),
+            (Err(AgentError::Cancelled), SessionEndStatus::Cancelled),
+        ] {
+            let payloads = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let mut runner = HookRunner::new();
+            runner.register(Arc::new(RecordingSessionEndHook {
+                payloads: payloads.clone(),
+            }));
+            runner.register(Arc::new(RecordingSessionEndHook {
+                payloads: payloads.clone(),
+            }));
+            let mut session = test_session();
+            let (tx, _rx) = mpsc::channel(4);
+
+            run_session_end_hooks(&runner, &result, &mut session, &tx).await;
+
+            let recorded = payloads.lock().unwrap();
+            assert_eq!(
+                recorded.len(),
+                2,
+                "a denied observer must not suppress later cleanup hooks"
+            );
+            assert!(recorded.iter().all(|payload| matches!(
+                payload,
+                HookPayload::SessionEnd { status, .. } if *status == expected_status
+            )));
+            assert_eq!(
+                session
+                    .agent_runtime_state
+                    .as_ref()
+                    .map(|state| state.checkpoints.len()),
+                Some(2)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn session_end_skips_suspended_non_terminal_runs() {
+        let payloads = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut runner = HookRunner::new();
+        runner.register(Arc::new(RecordingSessionEndHook {
+            payloads: payloads.clone(),
+        }));
+        let mut session = test_session();
+        session.metadata.insert(
+            "runtime.suspend_reason".to_string(),
+            "waiting_for_children".to_string(),
+        );
+        let (tx, _rx) = mpsc::channel(4);
+
+        run_session_end_hooks(&runner, &Ok(()), &mut session, &tx).await;
+
+        assert!(payloads.lock().unwrap().is_empty());
+        assert!(session.agent_runtime_state.is_none());
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/hooks/shell_command.rs
+++ b/crates/engine/bamboo-engine/src/runtime/hooks/shell_command.rs
@@ -7,7 +7,9 @@ use bamboo_agent_core::{AgentHook, Session};
 use bamboo_config::{
     LifecycleHookCommand, LifecycleHookGroup, LifecycleHookType, LifecycleHooksConfig,
 };
-use bamboo_domain::{AgentHookPoint, HookPayload, HookResult};
+use bamboo_domain::{
+    AgentHookPoint, HookPayload, HookResult, SessionEndStatus, SessionStartSource,
+};
 use bamboo_infrastructure::{
     build_command_environment, hide_window_for_tokio_command, preferred_bash_shell,
 };
@@ -26,9 +28,11 @@ const HOOK_OUTPUT_LIMIT_BYTES: usize = 64 * 1024;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShellHookEvent {
     SessionStart,
+    UserPromptSubmit,
     PreToolUse,
     PostToolUse,
     Stop,
+    SessionEnd,
     PreCompact,
 }
 
@@ -36,9 +40,11 @@ impl ShellHookEvent {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::SessionStart => "SessionStart",
+            Self::UserPromptSubmit => "UserPromptSubmit",
             Self::PreToolUse => "PreToolUse",
             Self::PostToolUse => "PostToolUse",
             Self::Stop => "Stop",
+            Self::SessionEnd => "SessionEnd",
             Self::PreCompact => "PreCompact",
         }
     }
@@ -46,9 +52,11 @@ impl ShellHookEvent {
     fn point(self) -> AgentHookPoint {
         match self {
             Self::SessionStart => AgentHookPoint::AfterSessionSetup,
+            Self::UserPromptSubmit => AgentHookPoint::BeforeSessionSetup,
             Self::PreToolUse => AgentHookPoint::BeforeToolExecution,
             Self::PostToolUse => AgentHookPoint::AfterToolExecution,
             Self::Stop => AgentHookPoint::BeforeFinalize,
+            Self::SessionEnd => AgentHookPoint::AfterSessionEnd,
             Self::PreCompact => AgentHookPoint::BeforeCompression,
         }
     }
@@ -103,11 +111,39 @@ impl ShellCommandHook {
         session: &Session,
         cwd: Option<&PathBuf>,
     ) -> HookEnvelope {
-        let (tool_name, tool_input, tool_response, prompt) = match payload {
-            HookPayload::SessionSetup { initial_message } => {
-                (None, None, None, Some(initial_message.clone()))
-            }
-            HookPayload::Prompt { prompt } => (None, None, None, Some(prompt.clone())),
+        let (
+            tool_name,
+            tool_input,
+            tool_response,
+            prompt,
+            source,
+            stop_hook_active,
+            terminal_status,
+            completion_reason,
+        ) = match payload {
+            HookPayload::SessionSetup {
+                initial_message,
+                source,
+            } => (
+                None,
+                None,
+                None,
+                Some(initial_message.clone()),
+                Some(*source),
+                None,
+                None,
+                None,
+            ),
+            HookPayload::Prompt { prompt } => (
+                None,
+                None,
+                None,
+                Some(prompt.clone()),
+                None,
+                None,
+                None,
+                None,
+            ),
             HookPayload::ToolExecution {
                 tool_name,
                 parsed_args,
@@ -115,6 +151,10 @@ impl ShellCommandHook {
             } => (
                 Some(tool_name.clone()),
                 Some(parsed_args.clone()),
+                None,
+                None,
+                None,
+                None,
                 None,
                 None,
             ),
@@ -125,11 +165,37 @@ impl ShellCommandHook {
                 None,
                 serde_json::to_value(outcome).ok(),
                 None,
+                None,
+                None,
+                None,
+                None,
             ),
-            HookPayload::None
-            | HookPayload::Round { .. }
-            | HookPayload::Compression { .. }
-            | HookPayload::Finalize => (None, None, None, None),
+            HookPayload::Finalize { stop_hook_active } => (
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(*stop_hook_active),
+                None,
+                None,
+            ),
+            HookPayload::SessionEnd {
+                status,
+                completion_reason,
+            } => (
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(*status),
+                completion_reason.clone(),
+            ),
+            HookPayload::None | HookPayload::Round { .. } | HookPayload::Compression { .. } => {
+                (None, None, None, None, None, None, None, None)
+            }
         };
 
         HookEnvelope {
@@ -144,6 +210,10 @@ impl ShellCommandHook {
             tool_input,
             tool_response,
             prompt,
+            source,
+            stop_hook_active,
+            terminal_status,
+            completion_reason,
             timestamp: Utc::now().to_rfc3339(),
         }
     }
@@ -402,6 +472,14 @@ struct HookEnvelope {
     tool_response: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<SessionStartSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stop_hook_active: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    terminal_status: Option<SessionEndStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    completion_reason: Option<String>,
     timestamp: String,
 }
 
@@ -464,11 +542,13 @@ pub(super) fn register_configured_shell_hooks(
         return;
     }
 
-    let events: [(ShellHookEvent, &[LifecycleHookGroup]); 5] = [
+    let events: [(ShellHookEvent, &[LifecycleHookGroup]); 7] = [
         (ShellHookEvent::SessionStart, &config.session_start),
+        (ShellHookEvent::UserPromptSubmit, &config.user_prompt_submit),
         (ShellHookEvent::PreToolUse, &config.pre_tool_use),
         (ShellHookEvent::PostToolUse, &config.post_tool_use),
         (ShellHookEvent::Stop, &config.stop),
+        (ShellHookEvent::SessionEnd, &config.session_end),
         (ShellHookEvent::PreCompact, &config.pre_compact),
     ];
     let mut sequence = 0_usize;
@@ -547,6 +627,7 @@ mod tests {
                 AgentHookPoint::AfterSessionSetup,
                 &HookPayload::SessionSetup {
                     initial_message: "hello".to_string(),
+                    source: SessionStartSource::Startup,
                 },
                 &session(dir.path()),
             )
@@ -786,6 +867,51 @@ mod tests {
     }
 
     #[test]
+    fn session_envelopes_include_source_stop_and_terminal_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let session = session(dir.path());
+        for (event, payload, expected) in [
+            (
+                ShellHookEvent::SessionStart,
+                HookPayload::SessionSetup {
+                    initial_message: "hello".to_string(),
+                    source: SessionStartSource::Resume,
+                },
+                ("source", json!("resume")),
+            ),
+            (
+                ShellHookEvent::Stop,
+                HookPayload::Finalize {
+                    stop_hook_active: true,
+                },
+                ("stop_hook_active", json!(true)),
+            ),
+            (
+                ShellHookEvent::SessionEnd,
+                HookPayload::SessionEnd {
+                    status: SessionEndStatus::Cancelled,
+                    completion_reason: Some("cancelled by user".to_string()),
+                },
+                ("terminal_status", json!("cancelled")),
+            ),
+        ] {
+            let hook =
+                ShellCommandHook::new(event, &command("true", 1_000), None, None, 0).expect("hook");
+            let value = serde_json::to_value(hook.envelope(
+                &payload,
+                &session,
+                hook.effective_cwd(&session).as_ref(),
+            ))
+            .unwrap();
+            assert_eq!(value["hook_event_name"], event.as_str());
+            assert_eq!(value[expected.0], expected.1);
+            if matches!(event, ShellHookEvent::SessionEnd) {
+                assert_eq!(value["completion_reason"], "cancelled by user");
+            }
+        }
+    }
+
+    #[test]
     fn configured_runner_registers_only_enabled_engine_events() {
         let hook = command("true", 1_000);
         let config = LifecycleHooksConfig {
@@ -795,6 +921,14 @@ mod tests {
                 hooks: vec![hook.clone()],
             }],
             session_start: vec![LifecycleHookGroup {
+                matcher: None,
+                hooks: vec![hook.clone()],
+            }],
+            user_prompt_submit: vec![LifecycleHookGroup {
+                matcher: None,
+                hooks: vec![hook.clone()],
+            }],
+            session_end: vec![LifecycleHookGroup {
                 matcher: None,
                 hooks: vec![hook.clone()],
             }],
@@ -811,8 +945,10 @@ mod tests {
             base.is_empty(),
             "per-run registration must not mutate the base"
         );
-        assert_eq!(configured.len(), 2);
+        assert_eq!(configured.len(), 4);
         assert!(configured.has_hooks_for(AgentHookPoint::AfterSessionSetup));
+        assert!(configured.has_hooks_for(AgentHookPoint::BeforeSessionSetup));
+        assert!(configured.has_hooks_for(AgentHookPoint::AfterSessionEnd));
         assert!(configured.has_hooks_for(AgentHookPoint::BeforeToolExecution));
     }
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution.rs
@@ -7,7 +7,7 @@ use tracing::Instrument;
 use crate::runtime::config::AgentLoopConfig;
 use bamboo_agent_core::tools::ToolExecutor;
 use bamboo_agent_core::{AgentEvent, Session};
-use bamboo_domain::{AgentHookPoint, HookPayload};
+use bamboo_domain::{AgentHookPoint, HookPayload, SessionStartSource};
 use bamboo_llm::LLMProvider;
 
 mod gold;
@@ -47,6 +47,28 @@ pub(crate) async fn run_agent_loop_with_config(
 ) -> super::Result<()> {
     let session_span = tracing::info_span!("agent_loop", session_id = %session.id);
     async {
+        let session_start_source = session
+            .metadata
+            .remove(crate::session_app::chat::SESSION_START_SOURCE_METADATA_KEY)
+            .as_deref()
+            .map(|source| match source {
+                "resume" => SessionStartSource::Resume,
+                _ => SessionStartSource::Startup,
+            })
+            .unwrap_or_else(|| {
+                let has_prior_run = session.last_run_status().is_some()
+                    || session.messages.iter().any(|message| {
+                        matches!(
+                            message.role,
+                            bamboo_agent_core::Role::Assistant | bamboo_agent_core::Role::Tool
+                        )
+                    });
+                if has_prior_run {
+                    SessionStartSource::Resume
+                } else {
+                    SessionStartSource::Startup
+                }
+            });
         let mut state: LoopRunState = initialize_loop_state(
             session,
             initial_message.as_str(),
@@ -62,6 +84,7 @@ pub(crate) async fn run_agent_loop_with_config(
         {
             let payload = HookPayload::SessionSetup {
                 initial_message: initial_message.clone(),
+                source: session_start_source,
             };
             let outcome = config
                 .hook_runner
@@ -264,7 +287,10 @@ mod hook_tests {
         ) -> HookResult {
             assert!(matches!(
                 payload,
-                HookPayload::SessionSetup { initial_message } if initial_message == "hello hooks"
+                HookPayload::SessionSetup {
+                    initial_message,
+                    source: SessionStartSource::Startup,
+                } if initial_message == "hello hooks"
             ));
             HookResult::InjectContext {
                 text: "injected setup context".to_string(),
@@ -320,13 +346,16 @@ mod hook_tests {
         .await
         .expect_err("the test's BeforeRound hook stops after setup");
         assert!(matches!(error, bamboo_agent_core::AgentError::Tool(_)));
-        let injected = session.messages.iter().find(|message| {
-            message.role == Role::System && message.content.contains("injected setup context")
-        });
-        assert!(
-            injected.is_some(),
-            "hook context must be stored in the session"
+        assert!(session.messages.iter().all(|message| {
+            message.role != Role::System || !message.content.contains("injected setup context")
+        }));
+        assert_eq!(
+            session
+                .agent_runtime_state
+                .as_ref()
+                .map(|state| state.hook_contexts.as_slice()),
+            Some(["injected setup context".to_string()].as_slice()),
+            "session hook context must ride runtime state, not the cached system prompt"
         );
-        assert!(injected.is_some_and(|message| message.never_compress));
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -30,7 +30,7 @@ use bamboo_domain::session::runtime_state::{
     AgentRuntimeState, AgentStatusState, ChildWaitPolicy, SuspensionState, WaitingForBashState,
     WaitingForChildrenState,
 };
-use bamboo_domain::{AgentHookPoint, HookPayload};
+use bamboo_domain::{AgentHookPoint, HookPayload, HookResult};
 use bamboo_llm::LLMProvider;
 use bamboo_metrics::{
     MetricsCollector, RoundStatus as MetricsRoundStatus, SessionStatus as MetricsSessionStatus,
@@ -1118,6 +1118,8 @@ async fn handle_no_tool_calls(
     }
 
     // Guardian approved, inactive, or out of budget → complete the run.
+    const MAX_STOP_HOOK_CONTINUATIONS: u8 = 5;
+
     if config
         .hook_runner
         .has_hooks_for(AgentHookPoint::BeforeFinalize)
@@ -1126,20 +1128,71 @@ async fn handle_no_tool_calls(
             .hook_runner
             .run_hooks(
                 AgentHookPoint::BeforeFinalize,
-                &HookPayload::Finalize,
+                &HookPayload::Finalize {
+                    stop_hook_active: runtime_state.stop_hook_forced_continuations > 0,
+                },
                 session,
                 runtime_state,
                 Some(event_tx),
             )
             .await;
-        let hook_result = crate::runtime::hooks::apply_hook_outcome(
-            AgentHookPoint::BeforeFinalize,
-            outcome,
-            session,
-            runtime_state,
-        );
-        state_bridge::write_runtime_state(session, runtime_state);
-        hook_result?;
+        if let HookResult::Deny { reason } = &outcome.decision {
+            if runtime_state.stop_hook_forced_continuations < MAX_STOP_HOOK_CONTINUATIONS {
+                runtime_state.stop_hook_forced_continuations += 1;
+                if let Some(message) = deferred_assistant_message.take() {
+                    session.add_message(message);
+                }
+                let extra_context = outcome
+                    .injected_contexts
+                    .iter()
+                    .map(|context| context.trim())
+                    .filter(|context| !context.is_empty())
+                    .collect::<Vec<_>>()
+                    .join("\n\n");
+                let context_suffix = if extra_context.is_empty() {
+                    String::new()
+                } else {
+                    format!("\n\nAdditional hook context:\n{extra_context}")
+                };
+                session.add_message(Message::user(format!(
+                    "A Stop lifecycle hook requires another work round ({}/{}): {}{}\n\nContinue working and address this feedback before attempting to finish again.",
+                    runtime_state.stop_hook_forced_continuations,
+                    MAX_STOP_HOOK_CONTINUATIONS,
+                    reason.trim(),
+                    context_suffix,
+                )));
+                state_bridge::write_runtime_state(session, runtime_state);
+                record_no_tool_calls_round_completed(
+                    metrics_collector,
+                    round_id,
+                    session_id,
+                    session,
+                    round_usage,
+                );
+                return Ok(TurnOutcome {
+                    should_break: false,
+                    sent_complete: false,
+                });
+            }
+            tracing::warn!(
+                "[{}] Stop hook continuation cap ({}) reached; ignoring further block",
+                session_id,
+                MAX_STOP_HOOK_CONTINUATIONS
+            );
+            session.metadata.insert(
+                "runtime.completion_reason".to_string(),
+                "stop_hook_continuation_cap".to_string(),
+            );
+        } else {
+            let hook_result = crate::runtime::hooks::apply_hook_outcome(
+                AgentHookPoint::BeforeFinalize,
+                outcome,
+                session,
+                runtime_state,
+            );
+            state_bridge::write_runtime_state(session, runtime_state);
+            hook_result?;
+        }
     }
 
     if let Some(message) = deferred_assistant_message.take() {
@@ -2427,8 +2480,8 @@ mod tests {
     };
     use crate::runtime::runner::state_bridge;
     use bamboo_agent_core::storage::Storage;
-    use bamboo_agent_core::{AgentError, AgentEvent, Message, Session};
-    use bamboo_domain::AgentRuntimeState;
+    use bamboo_agent_core::{AgentError, AgentEvent, AgentHook, Message, Session};
+    use bamboo_domain::{AgentHookPoint, AgentRuntimeState, HookPayload, HookResult};
     use bamboo_llm::{LLMChunk, LLMError, LLMProvider, LLMStream};
     use bamboo_metrics::{
         RoundStatus as MetricsRoundStatus, SessionStatus as MetricsSessionStatus,
@@ -2833,6 +2886,178 @@ mod tests {
             completion_tokens: 1,
             total_tokens: 2,
         }
+    }
+
+    struct BlockFirstStopHook;
+
+    #[async_trait::async_trait]
+    impl AgentHook for BlockFirstStopHook {
+        fn point(&self) -> AgentHookPoint {
+            AgentHookPoint::BeforeFinalize
+        }
+
+        async fn run(
+            &self,
+            _point: AgentHookPoint,
+            payload: &HookPayload,
+            _session: &Session,
+        ) -> HookResult {
+            match payload {
+                HookPayload::Finalize {
+                    stop_hook_active: false,
+                } => HookResult::WithContext {
+                    result: Box::new(HookResult::Deny {
+                        reason: "verify the result".to_string(),
+                    }),
+                    text: "run the focused check".to_string(),
+                },
+                HookPayload::Finalize {
+                    stop_hook_active: true,
+                } => HookResult::Continue,
+                payload => panic!("unexpected stop payload: {payload:?}"),
+            }
+        }
+    }
+
+    struct AlwaysBlockStopHook;
+
+    #[async_trait::async_trait]
+    impl AgentHook for AlwaysBlockStopHook {
+        fn point(&self) -> AgentHookPoint {
+            AgentHookPoint::BeforeFinalize
+        }
+
+        async fn run(
+            &self,
+            _point: AgentHookPoint,
+            _payload: &HookPayload,
+            _session: &Session,
+        ) -> HookResult {
+            HookResult::Deny {
+                reason: "keep going".to_string(),
+            }
+        }
+    }
+
+    fn stop_hook_config(hook: Arc<dyn AgentHook>) -> AgentLoopConfig {
+        let mut runner = crate::runtime::hooks::HookRunner::new();
+        runner.register(hook);
+        AgentLoopConfig {
+            hook_runner: Arc::new(runner),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn stop_hook_block_continues_then_allows_completion_with_active_payload() {
+        let mut session = Session::new("stop-hook", "model");
+        let mut runtime_state = AgentRuntimeState::new("stop-hook");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let config = stop_hook_config(Arc::new(BlockFirstStopHook));
+
+        let first = super::handle_no_tool_calls(
+            "first final answer".to_string(),
+            None,
+            None,
+            5,
+            5,
+            round_usage(),
+            &mut session,
+            &mut runtime_state,
+            &tx,
+            None,
+            "round-1",
+            "stop-hook",
+            &config,
+            &None,
+            "model",
+            1,
+            Arc::new(StubProvider),
+        )
+        .await
+        .unwrap();
+        assert!(!first.should_break);
+        assert!(!first.sent_complete);
+        assert_eq!(runtime_state.stop_hook_forced_continuations, 1);
+        assert!(session.messages.last().is_some_and(|message| {
+            message.content.contains("verify the result")
+                && message.content.contains("run the focused check")
+        }));
+        while let Ok(event) = rx.try_recv() {
+            assert!(
+                !matches!(event, AgentEvent::Complete { .. }),
+                "blocked stop must not emit Complete"
+            );
+        }
+
+        let second = super::handle_no_tool_calls(
+            "verified final answer".to_string(),
+            None,
+            None,
+            5,
+            5,
+            round_usage(),
+            &mut session,
+            &mut runtime_state,
+            &tx,
+            None,
+            "round-2",
+            "stop-hook",
+            &config,
+            &None,
+            "model",
+            2,
+            Arc::new(StubProvider),
+        )
+        .await
+        .unwrap();
+        assert!(second.should_break);
+        assert!(second.sent_complete);
+        let mut saw_complete = false;
+        while let Ok(event) = rx.try_recv() {
+            saw_complete |= matches!(event, AgentEvent::Complete { .. });
+        }
+        assert!(saw_complete, "allowed stop must emit Complete");
+    }
+
+    #[tokio::test]
+    async fn stop_hook_continuation_cap_completes_despite_further_blocks() {
+        let mut session = Session::new("stop-hook-cap", "model");
+        let mut runtime_state = AgentRuntimeState::new("stop-hook-cap");
+        runtime_state.stop_hook_forced_continuations = 5;
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let config = stop_hook_config(Arc::new(AlwaysBlockStopHook));
+
+        let outcome = super::handle_no_tool_calls(
+            "forced final answer".to_string(),
+            None,
+            None,
+            5,
+            5,
+            round_usage(),
+            &mut session,
+            &mut runtime_state,
+            &tx,
+            None,
+            "round-cap",
+            "stop-hook-cap",
+            &config,
+            &None,
+            "model",
+            6,
+            Arc::new(StubProvider),
+        )
+        .await
+        .unwrap();
+        assert!(outcome.should_break);
+        assert!(outcome.sent_complete);
+        assert_eq!(
+            session
+                .metadata
+                .get("runtime.completion_reason")
+                .map(String::as_str),
+            Some("stop_hook_continuation_cap")
+        );
     }
 
     /// THE bug-fix invariant: when Gold decides to continue at the terminal

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/startup.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/startup.rs
@@ -158,6 +158,15 @@ pub(super) async fn initialize_loop_state(
         .agent_runtime_state
         .as_ref()
         .is_some_and(|prev| prev.no_human_approver);
+    // Server-owned UserPromptSubmit runs before the engine loop and records
+    // into the session state. Carry those current-turn checkpoints into the
+    // fresh runner-owned state. This also preserves hook context/checkpoints
+    // when a suspended run resumes without a new user prompt.
+    if let Some(previous) = session.agent_runtime_state.as_ref() {
+        runtime_state.checkpoints = previous.checkpoints.clone();
+        runtime_state.hook_contexts = previous.hook_contexts.clone();
+        runtime_state.stop_hook_forced_continuations = previous.stop_hook_forced_continuations;
+    }
     runtime_state.llm.model_name = Some(model_name.clone());
     runtime_state.llm.provider_name = config.provider_name.clone();
     runtime_state.llm.fast_model_name = auxiliary_models.fast_model_name.clone();

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
@@ -11,7 +11,7 @@ use crate::runtime::runner::prompt_context::{
     strip_existing_task_list,
 };
 use crate::runtime::runner::session_setup::prompt_envelope::{
-    assemble_prompt_envelope, build_active_workflow_context_block,
+    assemble_prompt_envelope, build_active_workflow_context_block, build_agent_hook_context_block,
     build_conversation_summary_context_block, build_external_memory_context_block,
     build_goal_context_block, build_plan_mode_context_block, build_plan_runtime_context_block,
     build_task_list_context_block,
@@ -302,6 +302,9 @@ fn build_request_envelope(
     // NOT injected into the system message — so a goal change never invalidates
     // the cached system prefix (goal-leak fix).
     if let Some(block) = build_goal_context_block(config.active_goal()) {
+        volatile_blocks.push(block);
+    }
+    if let Some(block) = build_agent_hook_context_block(session) {
         volatile_blocks.push(block);
     }
     // Plan runtime + plan mode blocks are built DIRECTLY from session state (the

--- a/crates/engine/bamboo-engine/src/runtime/runner/session_setup/prompt_envelope.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/session_setup/prompt_envelope.rs
@@ -157,6 +157,29 @@ pub(crate) fn build_goal_context_block(goal: Option<&str>) -> Option<ContextBloc
     ))
 }
 
+/// Build context injected by `SessionStart` hooks as a volatile block. The
+/// source strings live in the current run's structured runtime state, so they
+/// never mutate or invalidate the cached base system prompt.
+pub(crate) fn build_agent_hook_context_block(session: &Session) -> Option<ContextBlock> {
+    let contexts = &session.agent_runtime_state.as_ref()?.hook_contexts;
+    let content = contexts
+        .iter()
+        .map(|text| text.trim())
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n---\n\n");
+    if content.is_empty() {
+        return None;
+    }
+    Some(ContextBlock::new(
+        ContextBlockType::AgentHookContext,
+        ContextBlockPriority::High,
+        ContextBlockStability::RoundDynamic,
+        "Session Hook Context",
+        content,
+    ))
+}
+
 /// Build the per-round plan-mode block directly from session state (the active
 /// `PlanModeState`), replacing the legacy inject-into-system + reparse path.
 /// Returns `None` when plan mode is inactive.
@@ -323,6 +346,23 @@ mod tests {
         assert!(block.content.contains("Session note body"));
         // No external memory field → no block.
         assert!(build_external_memory_context_block(&Session::new("s2", "model")).is_none());
+    }
+
+    #[test]
+    fn build_agent_hook_context_block_reads_runtime_state_as_volatile_context() {
+        let mut session = Session::new("session-hook-block", "model");
+        let mut state = bamboo_domain::AgentRuntimeState::new("run-hook");
+        state.hook_contexts = vec!["first hook context".to_string(), "second".to_string()];
+        session.agent_runtime_state = Some(state);
+
+        let block = build_agent_hook_context_block(&session).expect("hook block should exist");
+
+        assert_eq!(block.block_type, ContextBlockType::AgentHookContext);
+        assert_eq!(block.priority, ContextBlockPriority::High);
+        assert_eq!(block.stability, ContextBlockStability::RoundDynamic);
+        assert!(block.content.contains("first hook context"));
+        assert!(block.content.contains("second"));
+        assert!(build_agent_hook_context_block(&Session::new("empty", "model")).is_none());
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -752,7 +752,9 @@ impl AgentRuntime {
 
         drop(config);
 
-        run_agent_loop_with_config(
+        let session_end_runner = loop_config.hook_runner.clone();
+        let session_end_event_tx = event_tx.clone();
+        let result = run_agent_loop_with_config(
             session,
             initial_message,
             event_tx,
@@ -761,6 +763,16 @@ impl AgentRuntime {
             cancel_token,
             loop_config,
         )
-        .await
+        .await;
+
+        crate::runtime::hooks::run_session_end_hooks(
+            &session_end_runner,
+            &result,
+            session,
+            &session_end_event_tx,
+        )
+        .await;
+
+        result
     }
 }

--- a/crates/engine/bamboo-engine/src/session_app/chat.rs
+++ b/crates/engine/bamboo-engine/src/session_app/chat.rs
@@ -30,6 +30,7 @@ const PROMPT_COMPONENT_FLAGS_KEY: &str = "prompt_component_flags";
 const PROMPT_COMPONENT_LENGTHS_KEY: &str = "prompt_component_lengths";
 
 const PROMPT_COMPOSER_VERSION: &str = "bamboo.prompt-composer.v2";
+pub const SESSION_START_SOURCE_METADATA_KEY: &str = "runtime.session_start_source";
 
 /// Prepare a chat turn: load/create session, resolve prompts, update metadata,
 /// append user message, persist.
@@ -44,7 +45,17 @@ pub async fn prepare_chat_turn(
     global_default_prompt: &str,
     builtin_fallback_prompt: &str,
 ) -> Result<Session, ChatError> {
-    let mut session = repo.load_or_create(&input.session_id, &input.model).await?;
+    let (mut session, session_start_source) = match repo.load_merged(&input.session_id).await? {
+        Some(session) => (session, "resume"),
+        None => (
+            repo.load_or_create(&input.session_id, &input.model).await?,
+            "startup",
+        ),
+    };
+    session.metadata.insert(
+        SESSION_START_SOURCE_METADATA_KEY.to_string(),
+        session_start_source.to_string(),
+    );
 
     // ---- Resolve base prompt ----
     let base_prompt = resolve_base_prompt(
@@ -565,6 +576,8 @@ mod tests {
 
     struct InMemorySessionAccess;
 
+    struct ExistingSessionAccess(Session);
+
     #[async_trait]
     impl SessionAccess for InMemorySessionAccess {
         async fn load_session(&self, _id: &str) -> Result<Option<Session>, SessionLoadError> {
@@ -577,6 +590,33 @@ mod tests {
 
         async fn load_merged(&self, _id: &str) -> Result<Option<Session>, SessionLoadError> {
             Ok(None)
+        }
+
+        async fn save_session(&self, _session: &mut Session) -> Result<(), SessionSaveError> {
+            Ok(())
+        }
+
+        async fn save_and_cache(&self, _session: &mut Session) -> Result<(), SessionSaveError> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl SessionAccess for ExistingSessionAccess {
+        async fn load_session(&self, _id: &str) -> Result<Option<Session>, SessionLoadError> {
+            Ok(Some(self.0.clone()))
+        }
+
+        async fn load_or_create(
+            &self,
+            _id: &str,
+            _model: &str,
+        ) -> Result<Session, SessionLoadError> {
+            panic!("existing chat session must not be recreated")
+        }
+
+        async fn load_merged(&self, _id: &str) -> Result<Option<Session>, SessionLoadError> {
+            Ok(Some(self.0.clone()))
         }
 
         async fn save_session(&self, _session: &mut Session) -> Result<(), SessionSaveError> {
@@ -629,6 +669,41 @@ mod tests {
             context_fingerprint: Some("fingerprint".to_string()),
             dynamic_context: Vec::new(),
         }
+    }
+
+    #[tokio::test]
+    async fn prepare_chat_turn_classifies_new_and_existing_sessions() {
+        let startup = prepare_chat_turn(
+            &InMemorySessionAccess,
+            chat_turn_input(None),
+            "global",
+            "builtin",
+        )
+        .await
+        .expect("new turn");
+        assert_eq!(
+            startup
+                .metadata
+                .get(SESSION_START_SOURCE_METADATA_KEY)
+                .map(String::as_str),
+            Some("startup")
+        );
+
+        let existing = prepare_chat_turn(
+            &ExistingSessionAccess(Session::new("session-enhance", "gpt-5")),
+            chat_turn_input(None),
+            "global",
+            "builtin",
+        )
+        .await
+        .expect("existing turn");
+        assert_eq!(
+            existing
+                .metadata
+                .get(SESSION_START_SOURCE_METADATA_KEY)
+                .map(String::as_str),
+            Some("resume")
+        );
     }
 
     #[test]

--- a/tests/schedule_tasks_tool.rs
+++ b/tests/schedule_tasks_tool.rs
@@ -170,6 +170,7 @@ fn build_manager(
             system_prompt: String::new(),
             base_system_prompt: String::new(),
             workspace_path: None,
+            lifecycle_hooks: bamboo_config::LifecycleHooksConfig::default(),
         }
     });
 


### PR DESCRIPTION
## Summary

- run UserPromptSubmit before server persistence with structured fail-closed errors and delimited context
- classify SessionStart startup/resume and inject hook context through volatile prompt blocks
- make blocking Stop hooks continue with feedback under an independent five-round cap
- fire all SessionEnd cleanup hooks for completed, failed, and cancelled runs without honoring decisions
- apply the same frozen lifecycle hook snapshot to scheduled runs

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test -p bamboo-domain --lib` (162 passed)
- `cargo test -p bamboo-engine --lib` (1075 passed)
- `cargo test -p bamboo-server --lib` (1512 passed; one pre-existing macOS/OpenSSL TLS fixture failure reproduced on detached `origin/main`: `UnsupportedCertVersion`)
- focused hook, HTTP, Stop, SessionEnd, prompt-lane, source-classification, and schedule snapshot tests
- `cargo clippy -p bamboo-domain -p bamboo-engine -p bamboo-server --all-targets` (passes with existing repository warnings)

Closes #552