### PR TITLE
feat(hooks): add lifecycle settings API (#553)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
@@ -466,6 +466,7 @@ mod optional_model_e2e {
             config.lifecycle_hooks = bamboo_config::LifecycleHooksConfig {
                 enabled: true,
                 user_prompt_submit: vec![bamboo_config::LifecycleHookGroup {
+                    enabled: true,
                     matcher: None,
                     hooks: vec![bamboo_config::LifecycleHookCommand {
                         hook_type: bamboo_config::LifecycleHookType::Command,

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/validation.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/validation.rs
@@ -1,6 +1,11 @@
 use std::collections::BTreeMap;
 
 use actix_web::{web, HttpResponse};
+use bamboo_config::{
+    LifecycleHookGroup, LifecycleHooksConfig, LIFECYCLE_HOOK_EVENT_NAMES,
+    MAX_LIFECYCLE_HOOK_TIMEOUT_MS, MIN_LIFECYCLE_HOOK_TIMEOUT_MS,
+};
+use regex::Regex;
 use serde_json::Value;
 
 use crate::config_manager;
@@ -28,6 +33,19 @@ pub async fn validate_bamboo_config_patch(
         ));
     }
     config_manager::sanitize_root_patch(&mut patch_obj);
+
+    let lifecycle_schema_issues = patch_obj
+        .get("lifecycle_hooks")
+        .map(validate_lifecycle_hooks_shape)
+        .unwrap_or_default();
+    if !lifecycle_schema_issues.is_empty() {
+        let mut errors = BTreeMap::new();
+        errors.insert("lifecycle_hooks".to_string(), lifecycle_schema_issues);
+        return Ok(HttpResponse::Ok().json(ValidateConfigResponse {
+            valid: false,
+            errors,
+        }));
+    }
 
     let current = app_state.config.read().await.clone();
     let merged = config_manager::build_merged_config(&current, patch_obj.clone())?;
@@ -70,8 +88,185 @@ pub async fn validate_bamboo_config_patch(
         }
     }
 
+    if domains.lifecycle_hooks {
+        for issue in validate_lifecycle_hooks_config(&merged.lifecycle_hooks) {
+            errors
+                .entry("lifecycle_hooks".to_string())
+                .or_default()
+                .push(issue);
+        }
+    }
+
     let valid = errors.values().all(|items| items.is_empty());
     Ok(HttpResponse::Ok().json(ValidateConfigResponse { valid, errors }))
+}
+
+fn issue(path: impl Into<String>, message: impl Into<String>) -> ValidationIssue {
+    ValidationIssue {
+        path: path.into(),
+        message: message.into(),
+    }
+}
+
+/// Validate the JSON shape before deserializing the merged config so serde
+/// failures (notably negative timeouts and missing command fields) are returned
+/// through the endpoint's structured field-error contract instead of a generic
+/// 400 response. Semantic checks run against the typed merged config below.
+fn validate_lifecycle_hooks_shape(value: &Value) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+    let Some(root) = value.as_object() else {
+        issues.push(issue(
+            "lifecycle_hooks",
+            "lifecycle_hooks must be a JSON object",
+        ));
+        return issues;
+    };
+
+    if let Some(enabled) = root.get("enabled") {
+        if !enabled.is_boolean() {
+            issues.push(issue(
+                "lifecycle_hooks.enabled",
+                "enabled must be a boolean",
+            ));
+        }
+    }
+
+    for (event, groups) in root {
+        if event == "enabled" {
+            continue;
+        }
+        if !LIFECYCLE_HOOK_EVENT_NAMES.contains(&event.as_str()) {
+            issues.push(issue(
+                format!("lifecycle_hooks.{event}"),
+                format!("unknown lifecycle hook event '{event}'"),
+            ));
+            continue;
+        }
+        let Some(groups) = groups.as_array() else {
+            issues.push(issue(
+                format!("lifecycle_hooks.{event}"),
+                "event hooks must be an array",
+            ));
+            continue;
+        };
+        for (group_index, group) in groups.iter().enumerate() {
+            let group_path = format!("lifecycle_hooks.{event}[{group_index}]");
+            let Some(group) = group.as_object() else {
+                issues.push(issue(&group_path, "hook group must be an object"));
+                continue;
+            };
+            if group
+                .get("enabled")
+                .is_some_and(|value| !value.is_boolean())
+            {
+                issues.push(issue(
+                    format!("{group_path}.enabled"),
+                    "enabled must be a boolean",
+                ));
+            }
+            if group
+                .get("matcher")
+                .is_some_and(|value| !value.is_null() && !value.is_string())
+            {
+                issues.push(issue(
+                    format!("{group_path}.matcher"),
+                    "matcher must be a string or null",
+                ));
+            }
+            let Some(hooks) = group.get("hooks") else {
+                continue;
+            };
+            let Some(hooks) = hooks.as_array() else {
+                issues.push(issue(
+                    format!("{group_path}.hooks"),
+                    "hooks must be an array",
+                ));
+                continue;
+            };
+            for (hook_index, hook) in hooks.iter().enumerate() {
+                let hook_path = format!("{group_path}.hooks[{hook_index}]");
+                let Some(hook) = hook.as_object() else {
+                    issues.push(issue(&hook_path, "hook must be an object"));
+                    continue;
+                };
+                match hook.get("type").and_then(Value::as_str) {
+                    Some("command") => {}
+                    Some(other) => issues.push(issue(
+                        format!("{hook_path}.type"),
+                        format!("unsupported lifecycle hook type '{other}'"),
+                    )),
+                    None => issues.push(issue(
+                        format!("{hook_path}.type"),
+                        "hook type must be 'command'",
+                    )),
+                }
+                if !hook.get("command").is_some_and(Value::is_string) {
+                    issues.push(issue(
+                        format!("{hook_path}.command"),
+                        "command must be a string",
+                    ));
+                }
+                if hook
+                    .get("timeout_ms")
+                    .is_some_and(|value| value.as_u64().is_none())
+                {
+                    issues.push(issue(
+                        format!("{hook_path}.timeout_ms"),
+                        "timeout_ms must be a non-negative integer",
+                    ));
+                }
+            }
+        }
+    }
+
+    issues
+}
+
+fn validate_lifecycle_hooks_config(config: &LifecycleHooksConfig) -> Vec<ValidationIssue> {
+    let events: [(&str, &[LifecycleHookGroup]); 8] = [
+        ("SessionStart", &config.session_start),
+        ("UserPromptSubmit", &config.user_prompt_submit),
+        ("PreToolUse", &config.pre_tool_use),
+        ("PostToolUse", &config.post_tool_use),
+        ("Stop", &config.stop),
+        ("SessionEnd", &config.session_end),
+        ("PreCompact", &config.pre_compact),
+        ("Notification", &config.notification),
+    ];
+    let mut issues = Vec::new();
+    for (event, groups) in events {
+        for (group_index, group) in groups.iter().enumerate() {
+            let group_path = format!("lifecycle_hooks.{event}[{group_index}]");
+            if let Some(matcher) = group.matcher.as_deref() {
+                if let Err(error) = Regex::new(matcher) {
+                    issues.push(issue(
+                        format!("{group_path}.matcher"),
+                        format!("invalid matcher regex: {error}"),
+                    ));
+                }
+            }
+            for (hook_index, hook) in group.hooks.iter().enumerate() {
+                let hook_path = format!("{group_path}.hooks[{hook_index}]");
+                if hook.command.trim().is_empty() {
+                    issues.push(issue(
+                        format!("{hook_path}.command"),
+                        "command must not be empty",
+                    ));
+                }
+                if !(MIN_LIFECYCLE_HOOK_TIMEOUT_MS..=MAX_LIFECYCLE_HOOK_TIMEOUT_MS)
+                    .contains(&hook.timeout_ms)
+                {
+                    issues.push(issue(
+                        format!("{hook_path}.timeout_ms"),
+                        format!(
+                            "timeout_ms must be between {MIN_LIFECYCLE_HOOK_TIMEOUT_MS} and {MAX_LIFECYCLE_HOOK_TIMEOUT_MS}"
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+    issues
 }
 
 pub(super) fn provider_validation_issue(

--- a/crates/app/bamboo-server/src/handlers/settings/lifecycle_hooks.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/lifecycle_hooks.rs
@@ -1,0 +1,144 @@
+use actix_web::{web, HttpResponse};
+use bamboo_config::{
+    LifecycleHookCommand, LifecycleHookType, DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS,
+    LIFECYCLE_HOOK_EVENT_NAMES, MAX_LIFECYCLE_HOOK_TIMEOUT_MS, MIN_LIFECYCLE_HOOK_TIMEOUT_MS,
+};
+use regex::Regex;
+use serde::Deserialize;
+
+use crate::{app_state::AppState, error::AppError};
+
+fn default_timeout_ms() -> u64 {
+    DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS
+}
+
+/// One lifecycle command selected in the settings editor for a dry run.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LifecycleHookTestRequest {
+    event: String,
+    #[serde(default)]
+    matcher: Option<String>,
+    command: String,
+    #[serde(default = "default_timeout_ms")]
+    timeout_ms: u64,
+}
+
+/// Execute one command against Bamboo's deterministic synthetic lifecycle
+/// payload and return raw output. The route is mounted inside the same access-
+/// password middleware as config writes; it deliberately never persists the
+/// submitted command.
+pub async fn test_lifecycle_hook(
+    app_state: web::Data<AppState>,
+    payload: web::Json<LifecycleHookTestRequest>,
+) -> Result<HttpResponse, AppError> {
+    let payload = payload.into_inner();
+    if !LIFECYCLE_HOOK_EVENT_NAMES.contains(&payload.event.as_str()) {
+        return Err(AppError::BadRequest(format!(
+            "unknown lifecycle hook event '{}'",
+            payload.event
+        )));
+    }
+    if payload.command.trim().is_empty() {
+        return Err(AppError::BadRequest(
+            "lifecycle hook command must not be empty".to_string(),
+        ));
+    }
+    if !(MIN_LIFECYCLE_HOOK_TIMEOUT_MS..=MAX_LIFECYCLE_HOOK_TIMEOUT_MS)
+        .contains(&payload.timeout_ms)
+    {
+        return Err(AppError::BadRequest(format!(
+            "timeout_ms must be between {MIN_LIFECYCLE_HOOK_TIMEOUT_MS} and {MAX_LIFECYCLE_HOOK_TIMEOUT_MS}"
+        )));
+    }
+    if let Some(matcher) = payload.matcher.as_deref() {
+        Regex::new(matcher).map_err(|error| {
+            AppError::BadRequest(format!("invalid lifecycle hook matcher regex: {error}"))
+        })?;
+    }
+
+    let fallback_cwd = app_state
+        .config
+        .read()
+        .await
+        .get_default_work_area_path()
+        .or_else(|| Some(app_state.app_data_dir.clone()));
+    let command = LifecycleHookCommand {
+        hook_type: LifecycleHookType::Command,
+        command: payload.command,
+        timeout_ms: payload.timeout_ms,
+    };
+    let output =
+        bamboo_engine::test_lifecycle_shell_command(&payload.event, &command, fallback_cwd)
+            .await
+            .map_err(|error| {
+                AppError::InternalError(anyhow::anyhow!("lifecycle hook dry run failed: {error}"))
+            })?;
+
+    Ok(HttpResponse::Ok().json(output))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{http::StatusCode, test, App};
+
+    #[actix_web::test]
+    async fn dry_run_returns_raw_exit_and_captured_streams() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/hooks/test", web::post().to(test_lifecycle_hook)),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/hooks/test")
+                .set_json(serde_json::json!({
+                    "event": "PreToolUse",
+                    "matcher": "^Bash$",
+                    "command": "printf '%s' \"$BAMBOO_HOOK_EVENT\"; printf 'diagnostic' >&2; exit 7",
+                    "timeout_ms": 2_000
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = test::read_body_json(response).await;
+        assert_eq!(body["exit_code"], 7);
+        assert_eq!(body["stdout"], "PreToolUse");
+        assert_eq!(body["stderr"], "diagnostic");
+        assert_eq!(body["timed_out"], false);
+    }
+
+    #[actix_web::test]
+    async fn dry_run_rejects_unknown_event_before_execution() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/hooks/test", web::post().to(test_lifecycle_hook)),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/hooks/test")
+                .set_json(serde_json::json!({
+                    "event": "Unknown",
+                    "command": "exit 99"
+                }))
+                .to_request(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/settings/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/mod.rs
@@ -8,6 +8,7 @@ mod bamboo_config;
 mod cluster_fabric;
 mod env_vars;
 mod keyword_masking;
+mod lifecycle_hooks;
 mod permission;
 mod provider;
 mod provider_instances;
@@ -39,6 +40,7 @@ pub use env_vars::{delete_env_var, list_env_vars, replace_env_vars, upsert_env_v
 pub use keyword_masking::{
     get_keyword_masking_config, update_keyword_masking_config, validate_keyword_entries,
 };
+pub use lifecycle_hooks::{test_lifecycle_hook, LifecycleHookTestRequest};
 pub use permission::{
     create_permission_rule, delete_permission_rule, diagnose_permission, get_permission_ask_rules,
     get_permission_policy, update_permission_ask_rules, update_permission_rule,

--- a/crates/app/bamboo-server/src/lifecycle_hooks.rs
+++ b/crates/app/bamboo-server/src/lifecycle_hooks.rs
@@ -90,6 +90,7 @@ mod tests {
         LifecycleHooksConfig {
             enabled: true,
             user_prompt_submit: vec![LifecycleHookGroup {
+                enabled: true,
                 matcher: None,
                 hooks: vec![LifecycleHookCommand {
                     hook_type: LifecycleHookType::Command,

--- a/crates/app/bamboo-server/src/routes/bamboo_v1.rs
+++ b/crates/app/bamboo-server/src/routes/bamboo_v1.rs
@@ -110,6 +110,10 @@ pub(crate) fn bamboo_relative_routes() -> impl HttpServiceFactory {
             web::post().to(settings::validate_bamboo_config_patch),
         )
         .route(
+            "/bamboo/hooks/test",
+            web::post().to(settings::test_lifecycle_hook),
+        )
+        .route(
             "/bamboo/config/reset",
             web::post().to(settings::reset_bamboo_config),
         )

--- a/crates/app/bamboo-server/src/routes/tests.rs
+++ b/crates/app/bamboo-server/src/routes/tests.rs
@@ -213,6 +213,43 @@ async fn remote_unverified_request_is_blocked_by_access_middleware() {
 }
 
 #[actix_web::test]
+async fn lifecycle_hook_dry_run_is_blocked_by_access_middleware() {
+    let data_dir = tempdir().unwrap();
+    let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());
+    {
+        let mut config = app_state.config.write().await;
+        config.access_control = Some(AccessControlConfig {
+            password_enabled: true,
+            password_hash: Some(
+                "a65192f8d645bc4d19765b8ea61bfbb896dc999cb88a4be419518c5493f92c9d".to_string(),
+            ),
+            password_salt: Some("01010101010101010101010101010101".to_string()),
+            password_credential_ref: None,
+            password_configured: false,
+            updated_at: None,
+            devices: Vec::new(),
+        });
+    }
+    let app = test::init_service(App::new().app_data(app_state).configure(configure_routes)).await;
+
+    for uri in ["/api/v1/bamboo/hooks/test", "/v1/bamboo/hooks/test"] {
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(uri)
+                .insert_header((header::HOST, "bamboo.example.com"))
+                .set_json(serde_json::json!({
+                    "event": "SessionStart",
+                    "command": "exit 99"
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{uri}");
+    }
+}
+
+#[actix_web::test]
 async fn workflow_run_routes_are_blocked_by_the_same_access_middleware() {
     let data_dir = tempdir().unwrap();
     let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());

--- a/crates/app/bamboo-server/src/schedule_app/manager.rs
+++ b/crates/app/bamboo-server/src/schedule_app/manager.rs
@@ -889,6 +889,7 @@ mod build_context_tests {
         let lifecycle_hooks = bamboo_config::LifecycleHooksConfig {
             enabled: true,
             session_start: vec![bamboo_config::LifecycleHookGroup {
+                enabled: true,
                 matcher: None,
                 hooks: vec![bamboo_config::LifecycleHookCommand {
                     hook_type: bamboo_config::LifecycleHookType::Command,

--- a/crates/engine/bamboo-engine/src/lib.rs
+++ b/crates/engine/bamboo-engine/src/lib.rs
@@ -53,7 +53,9 @@ pub use runtime::config::{
     ChildApprovalRequest, GuardianConfig, GuardianSpawner, ImageFallbackConfig, ImageFallbackMode,
 };
 pub use runtime::execution::runner_state::{AgentRunner, AgentStatus};
-pub use runtime::hooks::{HookRunner, ShellCommandHook, ShellHookEvent};
+pub use runtime::hooks::{
+    test_lifecycle_shell_command, HookRunner, ShellCommandHook, ShellHookEvent, ShellHookTestOutput,
+};
 pub use runtime::managers::{
     LifecycleManager, LlmManager, MemoryManager, MiniLoopExecutor, PromptManager, ToolManager,
 };

--- a/crates/engine/bamboo-engine/src/runtime/hooks/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/hooks/mod.rs
@@ -12,7 +12,9 @@ use bamboo_domain::{
 use chrono::Utc;
 use tokio::sync::mpsc;
 
-pub use shell_command::{ShellCommandHook, ShellHookEvent};
+pub use shell_command::{
+    test_lifecycle_shell_command, ShellCommandHook, ShellHookEvent, ShellHookTestOutput,
+};
 
 /// Aggregate output from every hook registered at one seam.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/engine/bamboo-engine/src/runtime/hooks/shell_command.rs
+++ b/crates/engine/bamboo-engine/src/runtime/hooks/shell_command.rs
@@ -36,6 +36,19 @@ pub enum ShellHookEvent {
     PreCompact,
 }
 
+/// Raw process result returned by the settings dry-run endpoint. Unlike the
+/// normal hook path, this deliberately exposes captured streams so users can
+/// diagnose a command before enabling it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ShellHookTestOutput {
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub timed_out: bool,
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
+}
+
 impl ShellHookEvent {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -69,6 +82,7 @@ impl ShellHookEvent {
 /// One config-driven lifecycle shell command.
 pub struct ShellCommandHook {
     event: ShellHookEvent,
+    event_name_override: Option<&'static str>,
     command: String,
     timeout: Duration,
     matcher: Option<Regex>,
@@ -87,12 +101,18 @@ impl ShellCommandHook {
         let matcher = matcher.map(Regex::new).transpose()?;
         Ok(Self {
             event,
+            event_name_override: None,
             command: config.command.clone(),
             timeout: Duration::from_millis(config.timeout_ms.max(1)),
             matcher,
             fallback_cwd,
             name: format!("lifecycle_shell:{}:{sequence}", event.as_str()),
         })
+    }
+
+    fn event_name(&self) -> &'static str {
+        self.event_name_override
+            .unwrap_or_else(|| self.event.as_str())
     }
 
     fn effective_cwd(&self, session: &Session) -> Option<PathBuf> {
@@ -200,7 +220,7 @@ impl ShellCommandHook {
 
         HookEnvelope {
             schema_version: 1,
-            hook_event_name: self.event.as_str(),
+            hook_event_name: self.event_name().to_string(),
             session_id: session.id.clone(),
             workspace_path: cwd
                 .map(|path| path.to_string_lossy().into_owned())
@@ -237,7 +257,7 @@ impl ShellCommandHook {
             .arg(shell.arg)
             .arg(&self.command)
             .env("BAMBOO_SESSION_ID", &session.id)
-            .env("BAMBOO_HOOK_EVENT", self.event.as_str())
+            .env("BAMBOO_HOOK_EVENT", self.event_name())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -380,6 +400,116 @@ impl ShellCommandHook {
             None => result,
         }
     }
+
+    async fn test(
+        &self,
+        payload: &HookPayload,
+        session: &Session,
+    ) -> Result<ShellHookTestOutput, String> {
+        let cwd = self.effective_cwd(session);
+        let input = serde_json::to_vec(&self.envelope(payload, session, cwd.as_ref()))
+            .map_err(|error| format!("failed serializing lifecycle hook test payload: {error}"))?;
+        let output = self.execute(input, cwd.as_ref(), session).await?;
+        Ok(ShellHookTestOutput {
+            exit_code: output.exit_code,
+            stdout: String::from_utf8_lossy(&output.stdout.bytes).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr.bytes).into_owned(),
+            timed_out: output.timed_out,
+            stdout_truncated: output.stdout.truncated,
+            stderr_truncated: output.stderr.truncated,
+        })
+    }
+}
+
+/// Execute one lifecycle command against a deterministic synthetic payload.
+/// This shares the production shell/environment/timeout/output-capping path;
+/// only hook-result interpretation is skipped so callers receive raw output.
+pub async fn test_lifecycle_shell_command(
+    event_name: &str,
+    config: &LifecycleHookCommand,
+    fallback_cwd: Option<PathBuf>,
+) -> Result<ShellHookTestOutput, String> {
+    let (event, event_name_override, payload) = match event_name {
+        "SessionStart" => (
+            ShellHookEvent::SessionStart,
+            None,
+            HookPayload::SessionSetup {
+                initial_message: "Lifecycle hook test".to_string(),
+                source: SessionStartSource::Startup,
+            },
+        ),
+        "UserPromptSubmit" => (
+            ShellHookEvent::UserPromptSubmit,
+            None,
+            HookPayload::Prompt {
+                prompt: "Lifecycle hook test".to_string(),
+            },
+        ),
+        "PreToolUse" => (
+            ShellHookEvent::PreToolUse,
+            None,
+            HookPayload::ToolExecution {
+                tool_name: "Bash".to_string(),
+                tool_call_id: "hook-test-call".to_string(),
+                parsed_args: serde_json::json!({"command": "echo lifecycle-hook-test"}),
+            },
+        ),
+        "PostToolUse" => (
+            ShellHookEvent::PostToolUse,
+            None,
+            HookPayload::ToolResult {
+                tool_name: "Bash".to_string(),
+                tool_call_id: "hook-test-call".to_string(),
+                outcome: bamboo_domain::HookToolOutcome {
+                    success: true,
+                    result: Some("lifecycle-hook-test".to_string()),
+                    error: None,
+                    needs_human: false,
+                    duration_ms: 1,
+                },
+            },
+        ),
+        "Stop" => (
+            ShellHookEvent::Stop,
+            None,
+            HookPayload::Finalize {
+                stop_hook_active: false,
+            },
+        ),
+        "SessionEnd" => (
+            ShellHookEvent::SessionEnd,
+            None,
+            HookPayload::SessionEnd {
+                status: SessionEndStatus::Completed,
+                completion_reason: Some("lifecycle hook test".to_string()),
+            },
+        ),
+        "PreCompact" => (
+            ShellHookEvent::PreCompact,
+            None,
+            HookPayload::Compression {
+                estimated_tokens: 1_000,
+                usage_percent: 50.0,
+                phase: "test".to_string(),
+            },
+        ),
+        // Notification is a reserved config event whose runtime seam is owned
+        // by a follow-up issue. It can still be dry-run safely with a generic
+        // payload and the correct event name/environment.
+        "Notification" => (
+            ShellHookEvent::SessionStart,
+            Some("Notification"),
+            HookPayload::None,
+        ),
+        other => return Err(format!("unknown lifecycle hook event '{other}'")),
+    };
+
+    let mut hook = ShellCommandHook::new(event, config, None, fallback_cwd, 0)
+        .map_err(|error| format!("invalid lifecycle hook matcher: {error}"))?;
+    hook.event_name_override = event_name_override;
+    hook.name = format!("lifecycle_shell_test:{event_name}");
+    let session = Session::new("lifecycle-hook-test", "hook-test");
+    hook.test(&payload, &session).await
 }
 
 #[cfg(unix)]
@@ -460,7 +590,7 @@ impl AgentHook for ShellCommandHook {
 #[derive(Debug, Serialize)]
 struct HookEnvelope {
     schema_version: u8,
-    hook_event_name: &'static str,
+    hook_event_name: String,
     session_id: String,
     workspace_path: String,
     model: String,
@@ -554,6 +684,10 @@ pub(super) fn register_configured_shell_hooks(
     let mut sequence = 0_usize;
     for (event, groups) in events {
         for group in groups {
+            if !group.enabled {
+                sequence += group.hooks.len();
+                continue;
+            }
             let matcher = if event.supports_tool_matcher() {
                 group.matcher.as_deref()
             } else {
@@ -917,22 +1051,27 @@ mod tests {
         let config = LifecycleHooksConfig {
             enabled: true,
             pre_tool_use: vec![LifecycleHookGroup {
+                enabled: true,
                 matcher: Some("bash".to_string()),
                 hooks: vec![hook.clone()],
             }],
             session_start: vec![LifecycleHookGroup {
+                enabled: true,
                 matcher: None,
                 hooks: vec![hook.clone()],
             }],
             user_prompt_submit: vec![LifecycleHookGroup {
+                enabled: true,
                 matcher: None,
                 hooks: vec![hook.clone()],
             }],
             session_end: vec![LifecycleHookGroup {
+                enabled: true,
                 matcher: None,
                 hooks: vec![hook.clone()],
             }],
             notification: vec![LifecycleHookGroup {
+                enabled: true,
                 matcher: None,
                 hooks: vec![hook],
             }],
@@ -952,12 +1091,30 @@ mod tests {
         assert!(configured.has_hooks_for(AgentHookPoint::BeforeToolExecution));
     }
 
+    #[test]
+    fn disabled_group_is_preserved_but_not_registered() {
+        let config = LifecycleHooksConfig {
+            enabled: true,
+            pre_tool_use: vec![LifecycleHookGroup {
+                enabled: false,
+                matcher: None,
+                hooks: vec![command("exit 2", 1_000)],
+            }],
+            ..LifecycleHooksConfig::default()
+        };
+
+        let configured = HookRunner::new().with_lifecycle_config(&config, None);
+
+        assert!(configured.is_empty());
+    }
+
     #[tokio::test]
     async fn configured_commands_run_in_order_and_first_block_wins() {
         let dir = tempfile::tempdir().unwrap();
         let config = LifecycleHooksConfig {
             enabled: true,
             pre_tool_use: vec![LifecycleHookGroup {
+                enabled: true,
                 matcher: None,
                 hooks: vec![
                     command("printf 'first' >&2; exit 2", 1_000),
@@ -995,6 +1152,7 @@ mod tests {
         let config = LifecycleHooksConfig {
             enabled: true,
             pre_tool_use: vec![LifecycleHookGroup {
+                enabled: true,
                 matcher: Some("[".to_string()),
                 hooks: vec![command("true", 1_000)],
             }],

--- a/crates/engine/bamboo-engine/src/runtime/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/mod.rs
@@ -30,7 +30,9 @@ pub use config::{
 // `crate::runtime::config::AgentLoopConfig`. External code drives the loop only
 // through `AgentRuntime::execute`.
 pub use execution::runner_state::{AgentRunner, AgentStatus};
-pub use hooks::{HookRunner, ShellCommandHook, ShellHookEvent};
+pub use hooks::{
+    test_lifecycle_shell_command, HookRunner, ShellCommandHook, ShellHookEvent, ShellHookTestOutput,
+};
 pub use managers::{
     LifecycleManager, LlmManager, MemoryManager, MiniLoopExecutor, PromptManager, ToolManager,
 };

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/per_call.rs
@@ -1006,6 +1006,7 @@ mod hook_tests {
         let lifecycle_config = LifecycleHooksConfig {
             enabled: true,
             pre_tool_use: vec![LifecycleHookGroup {
+                enabled: true,
                 matcher: Some("^bash$".to_string()),
                 hooks: vec![LifecycleHookCommand {
                     hook_type: LifecycleHookType::Command,

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -2075,6 +2075,24 @@ pub struct HooksConfig {
 
 /// Default deadline for one lifecycle command hook.
 pub const DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS: u64 = 60_000;
+/// Smallest accepted lifecycle hook deadline at the config API boundary.
+pub const MIN_LIFECYCLE_HOOK_TIMEOUT_MS: u64 = 1;
+/// Largest accepted lifecycle hook deadline (10 minutes). Lifecycle hooks run
+/// inline with agent progress, so they share the same upper bound as Bamboo's
+/// interactive shell tool instead of allowing an accidental hours-long stall.
+pub const MAX_LIFECYCLE_HOOK_TIMEOUT_MS: u64 = 600_000;
+
+/// Stable user-facing event keys accepted by `lifecycle_hooks`.
+pub const LIFECYCLE_HOOK_EVENT_NAMES: [&str; 8] = [
+    "SessionStart",
+    "UserPromptSubmit",
+    "PreToolUse",
+    "PostToolUse",
+    "Stop",
+    "SessionEnd",
+    "PreCompact",
+    "Notification",
+];
 
 fn default_lifecycle_hook_timeout_ms() -> u64 {
     DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS
@@ -2082,6 +2100,14 @@ fn default_lifecycle_hook_timeout_ms() -> u64 {
 
 fn lifecycle_hook_timeout_is_default(value: &u64) -> bool {
     *value == DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS
+}
+
+fn lifecycle_hook_enabled_default() -> bool {
+    true
+}
+
+fn lifecycle_hook_enabled_is_default(value: &bool) -> bool {
+    *value
 }
 
 /// Config-driven agent lifecycle hooks.
@@ -2138,12 +2164,29 @@ impl LifecycleHooksConfig {
 }
 
 /// A matcher and its ordered command-hook list for one lifecycle event.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LifecycleHookGroup {
+    /// A disabled group remains persisted and editable but is not registered
+    /// for execution. Missing values default to true for old config files.
+    #[serde(
+        default = "lifecycle_hook_enabled_default",
+        skip_serializing_if = "lifecycle_hook_enabled_is_default"
+    )]
+    pub enabled: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub matcher: Option<String>,
     #[serde(default)]
     pub hooks: Vec<LifecycleHookCommand>,
+}
+
+impl Default for LifecycleHookGroup {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            matcher: None,
+            hooks: Vec::new(),
+        }
+    }
 }
 
 /// Supported lifecycle hook implementation kinds.
@@ -4815,6 +4858,10 @@ mod tests {
 
         assert!(config.lifecycle_hooks.enabled);
         assert_eq!(config.lifecycle_hooks.pre_tool_use.len(), 1);
+        assert!(
+            config.lifecycle_hooks.pre_tool_use[0].enabled,
+            "legacy groups without an enabled flag remain active"
+        );
         assert_eq!(
             config.lifecycle_hooks.pre_tool_use[0].hooks[0].timeout_ms,
             DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS
@@ -4834,6 +4881,9 @@ mod tests {
             json["lifecycle_hooks"]["PreToolUse"][0]["hooks"][0]["type"],
             "command"
         );
+        assert!(json["lifecycle_hooks"]["PreToolUse"][0]
+            .get("enabled")
+            .is_none());
         assert!(json["lifecycle_hooks"]["PreToolUse"][0]["hooks"][0]
             .get("timeout_ms")
             .is_none());

--- a/crates/infra/bamboo-config/src/patch.rs
+++ b/crates/infra/bamboo-config/src/patch.rs
@@ -124,6 +124,7 @@ pub struct DomainChanges {
     pub mcp: bool,
     pub keyword_masking: bool,
     pub hooks: bool,
+    pub lifecycle_hooks: bool,
     pub model_mapping: bool,
 }
 
@@ -159,6 +160,7 @@ pub fn domains_for_root_patch(patch_obj: &Map<String, Value>) -> DomainChanges {
             // Other known config domains
             "keyword_masking" => changes.keyword_masking = true,
             "hooks" => changes.hooks = true,
+            "lifecycle_hooks" => changes.lifecycle_hooks = true,
             "anthropic_model_mapping" | "gemini_model_mapping" => changes.model_mapping = true,
 
             _ => {}
@@ -1031,6 +1033,19 @@ mod tests {
 
         let domains = domains_for_root_patch(patch.as_object().unwrap());
         assert!(domains.provider);
+    }
+
+    #[test]
+    fn domains_for_root_patch_detects_lifecycle_hooks() {
+        let patch = json!({"lifecycle_hooks": {"enabled": true}});
+
+        let domains = domains_for_root_patch(patch.as_object().unwrap());
+
+        assert!(domains.lifecycle_hooks);
+        assert!(
+            !domains.hooks,
+            "request hooks and lifecycle hooks are distinct"
+        );
     }
 
     #[test]

--- a/tests/e2e/config_flow/validation.rs
+++ b/tests/e2e/config_flow/validation.rs
@@ -33,3 +33,90 @@ async fn test_validate_config_patch_reports_domain_errors() {
     assert_eq!(result["valid"], false);
     assert!(!result["errors"]["setup"].as_array().unwrap().is_empty());
 }
+
+#[actix_web::test]
+async fn test_validate_lifecycle_hooks_reports_structured_field_errors() {
+    let state = crate::e2e::common::create_test_app().await;
+    let app = test::init_service(App::new().app_data(state).configure(configure_routes)).await;
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/bamboo/config/validate")
+            .set_json(json!({
+                "lifecycle_hooks": {
+                    "enabled": true,
+                    "PreToolUse": [{
+                        "matcher": "[",
+                        "hooks": [{"type": "command", "command": "   ", "timeout_ms": 0}]
+                    }],
+                    "SessionEnd": [{
+                        "hooks": [{
+                            "type": "command",
+                            "command": "echo done",
+                            "timeout_ms": bamboo_config::MAX_LIFECYCLE_HOOK_TIMEOUT_MS + 1
+                        }]
+                    }]
+                }
+            }))
+            .to_request(),
+    )
+    .await;
+
+    assert!(response.status().is_success());
+    let body: serde_json::Value = test::read_body_json(response).await;
+    assert_eq!(body["valid"], false);
+    let paths = body["errors"]["lifecycle_hooks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|issue| issue["path"].as_str())
+        .collect::<Vec<_>>();
+    assert!(paths.contains(&"lifecycle_hooks.PreToolUse[0].matcher"));
+    assert!(paths.contains(&"lifecycle_hooks.PreToolUse[0].hooks[0].command"));
+    assert!(paths.contains(&"lifecycle_hooks.PreToolUse[0].hooks[0].timeout_ms"));
+    assert!(paths.contains(&"lifecycle_hooks.SessionEnd[0].hooks[0].timeout_ms"));
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/bamboo/config/validate")
+            .set_json(json!({
+                "lifecycle_hooks": {"BeforeEverything": []}
+            }))
+            .to_request(),
+    )
+    .await;
+    assert!(response.status().is_success());
+    let body: serde_json::Value = test::read_body_json(response).await;
+    assert_eq!(body["valid"], false);
+    assert_eq!(
+        body["errors"]["lifecycle_hooks"][0]["path"],
+        "lifecycle_hooks.BeforeEverything"
+    );
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/bamboo/config/validate")
+            .set_json(json!({
+                "lifecycle_hooks": {
+                    "PreToolUse": [{
+                        "hooks": [{"type": "command", "command": "echo ok", "timeout_ms": -1}]
+                    }]
+                }
+            }))
+            .to_request(),
+    )
+    .await;
+    assert!(
+        response.status().is_success(),
+        "shape errors use the structured response"
+    );
+    let body: serde_json::Value = test::read_body_json(response).await;
+    assert_eq!(body["valid"], false);
+    assert_eq!(
+        body["errors"]["lifecycle_hooks"][0]["path"],
+        "lifecycle_hooks.PreToolUse[0].hooks[0].timeout_ms"
+    );
+}

--- a/tests/e2e/settings/config.rs
+++ b/tests/e2e/settings/config.rs
@@ -105,6 +105,83 @@ async fn test_set_bamboo_config() {
 }
 
 #[actix_web::test]
+async fn test_lifecycle_hooks_round_trip_persists_and_reloads() {
+    let state = crate::e2e::common::create_test_app().await;
+    let data_dir = state.app_data_dir.clone();
+    let app = test::init_service(
+        App::new()
+            .app_data(state.clone())
+            .route(
+                "/v1/bamboo/config",
+                web::post().to(settings::set_bamboo_config),
+            )
+            .route(
+                "/v1/bamboo/config",
+                web::get().to(settings::get_bamboo_config),
+            ),
+    )
+    .await;
+    let lifecycle_hooks = json!({
+        "enabled": true,
+        "PreToolUse": [{
+            "enabled": false,
+            "matcher": "^Bash$",
+            "hooks": [{"type": "command", "command": "echo checked", "timeout_ms": 2500}]
+        }],
+        "SessionEnd": [{
+            "hooks": [{"type": "command", "command": "echo complete"}]
+        }]
+    });
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/v1/bamboo/config")
+            .set_json(json!({"lifecycle_hooks": lifecycle_hooks}))
+            .to_request(),
+    )
+    .await;
+    assert!(response.status().is_success());
+
+    let persisted: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(data_dir.join("hooks.json")).expect("hooks.json persisted"),
+    )
+    .unwrap();
+    let persisted = persisted.get("data").unwrap_or(&persisted);
+    assert_eq!(persisted["lifecycle_hooks"]["enabled"], true);
+    assert_eq!(
+        persisted["lifecycle_hooks"]["PreToolUse"][0]["enabled"],
+        false
+    );
+    assert_eq!(
+        persisted["lifecycle_hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+        "echo checked"
+    );
+
+    let reloaded = state.reload_config().await;
+    assert!(reloaded.lifecycle_hooks.enabled);
+    assert!(!reloaded.lifecycle_hooks.pre_tool_use[0].enabled);
+    assert_eq!(
+        reloaded.lifecycle_hooks.pre_tool_use[0].hooks[0].timeout_ms,
+        2_500
+    );
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/v1/bamboo/config")
+            .to_request(),
+    )
+    .await;
+    let body: serde_json::Value = test::read_body_json(response).await;
+    assert_eq!(body["lifecycle_hooks"]["PreToolUse"][0]["enabled"], false);
+    assert_eq!(
+        body["lifecycle_hooks"]["SessionEnd"][0]["hooks"][0]["command"],
+        "echo complete"
+    );
+}
+
+#[actix_web::test]
 async fn test_set_bamboo_config_allows_incomplete_provider_config() {
     let state = crate::e2e::common::create_test_app().await;
 


### PR DESCRIPTION
## Summary

- validate lifecycle hook event names, command shape, timeout bounds, and Rust matcher regex with structured lifecycle_hooks paths
- add permission-gated POST /v1/bamboo/hooks/test dry-run using the same shell execution, environment, timeout, and output caps as runtime hooks
- preserve disabled hook groups through config loading while skipping their runtime registration
- cover route access, structured validation, and modular hooks.json persistence/reload

Refs #553

## Test Plan

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets
- cargo test --workspace (1518/1519 server tests passed; the sole UnsupportedCertVersion TLS failure reproduces unchanged in a detached clean origin/main worktree)
- targeted lifecycle hook config, server route, structured validation, and persistence tests
- live Lotus/Bamboo browser dogfood on fresh data: invalid Rust regex inline error, Rust named-group save/reload, dry-run exit/stdout/stderr

## Security

- dry-run requires settings write access
- command output is capped and reports truncation
- timeout is constrained to 1..600000 ms
- fallback working directory is the Bamboo app data directory