### PR TITLE
feat: complete phase 2 lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Zenith is a monorepo, and bamboo is the execution-engine submodule within it.
 **In-module docs:** start at [`docs/README.md`](./docs/README.md) for the full index. Highlights:
 - Getting started: [`docs/guides/GETTING_STARTED.md`](./docs/guides/GETTING_STARTED.md)
 - Configuration reference (every `config.json` key + env vars): [`docs/config-reference.md`](./docs/config-reference.md)
+- Lifecycle command hooks (events, payloads, decisions, examples): [`docs/lifecycle-hooks.md`](./docs/lifecycle-hooks.md)
 - How-to guides: [Connect/IM bridge](./docs/guides/CONNECT.md) · [Plugins](./docs/guides/PLUGINS.md) · [Deploy](./docs/guides/DEPLOY.md)
 - API reference: [`docs/guides/API.md`](./docs/guides/API.md)
 - Migration: [`docs/guides/MIGRATION_GUIDE.md`](./docs/guides/MIGRATION_GUIDE.md)

--- a/crates/app/bamboo-server/src/app_state/session_events.rs
+++ b/crates/app/bamboo-server/src/app_state/session_events.rs
@@ -38,7 +38,7 @@ pub struct NotificationRelayDeps {
 /// notification policy on each event, and:
 /// - re-broadcasts any resulting `AgentEvent::Notification` onto the same
 ///   channel so connected SSE/WS clients receive it, and
-/// - fans it out to the configured delivery sinks (desktop/ntfy/bark — see
+/// - fans it out to the configured delivery sinks (command/desktop/ntfy/bark — see
 ///   [`crate::notify_sinks::dispatch_to_sinks`]), reading the CURRENT config
 ///   on every notification so a hot-reloaded topic/token/toggle takes effect
 ///   immediately.
@@ -131,7 +131,7 @@ impl super::AppState {
     }
 
     /// Fans a classified notification out to configured delivery sinks
-    /// (desktop/ntfy/bark). Free of `&self` — the relay task started by
+    /// (command/desktop/ntfy/bark). Free of `&self` — the relay task started by
     /// [`ensure_notification_relay`] only holds cloned `Arc`s (not a full
     /// `AppState`), so this is a plain associated function over the values
     /// it needs; see [`crate::notify_sinks::dispatch_to_sinks`].

--- a/crates/app/bamboo-server/src/handlers/agent/notifications.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/notifications.rs
@@ -52,11 +52,14 @@ pub async fn send_test_notification(state: web::Data<AppState>) -> impl Responde
         format!("Enabled channels: {}.", attempted.join(", "))
     };
     let notification = crate::notify_sinks::SinkNotification {
+        id: None,
         title: "Bamboo test notification".to_string(),
         body,
         category: "custom".to_string(),
         priority: "normal".to_string(),
         session_id: "test".to_string(),
+        dedup_key: None,
+        created_at: None,
         click_url: None,
     };
     crate::notify_sinks::dispatch_to_sinks(&config_snapshot, false, &notification);

--- a/crates/app/bamboo-server/src/notify_sinks/bark.rs
+++ b/crates/app/bamboo-server/src/notify_sinks/bark.rs
@@ -110,11 +110,14 @@ mod tests {
 
     fn sample_notification() -> SinkNotification {
         SinkNotification {
+            id: None,
             title: "Approval needed".to_string(),
             body: "please approve".to_string(),
             category: "needs_approval".to_string(),
             priority: "high".to_string(),
             session_id: "sess-1".to_string(),
+            dedup_key: None,
+            created_at: None,
             click_url: Some("bamboo://session/sess-1".to_string()),
         }
     }

--- a/crates/app/bamboo-server/src/notify_sinks/command.rs
+++ b/crates/app/bamboo-server/src/notify_sinks/command.rs
@@ -1,0 +1,147 @@
+//! Config-driven command sink for classified notifications.
+//!
+//! This is invoked only from the shared post-classification sink fan-out, so
+//! commands never see policy-rejected or deduplicated notification attempts.
+
+use bamboo_agent_core::Session;
+use bamboo_config::LifecycleHooksConfig;
+use bamboo_domain::{AgentHookPoint, AgentRuntimeState, HookPayload};
+use bamboo_engine::HookRunner;
+
+use super::{NotificationSink, SinkNotification};
+
+pub(super) struct CommandSink {
+    hooks: LifecycleHooksConfig,
+    fallback_cwd: Option<std::path::PathBuf>,
+}
+
+impl CommandSink {
+    pub(super) fn from_config(config: &bamboo_llm::Config) -> Self {
+        Self {
+            hooks: config.lifecycle_hooks.clone(),
+            fallback_cwd: config.get_default_work_area_path(),
+        }
+    }
+}
+
+impl NotificationSink for CommandSink {
+    fn name(&self) -> &'static str {
+        "command"
+    }
+
+    fn deliver(&self, notification: &SinkNotification) {
+        let hooks = self.hooks.clone();
+        let fallback_cwd = self.fallback_cwd.clone();
+        let notification = notification.clone();
+        tokio::spawn(async move {
+            let runner = HookRunner::new().with_lifecycle_config(&hooks, fallback_cwd);
+            if !runner.has_hooks_for(AgentHookPoint::AfterNotification) {
+                return;
+            }
+
+            let session = Session::new(&notification.session_id, "");
+            let mut runtime_state = AgentRuntimeState::new(&notification.session_id);
+            let payload = HookPayload::Notification {
+                id: notification.id,
+                category: notification.category,
+                priority: notification.priority,
+                title: notification.title,
+                body: notification.body,
+                dedup_key: notification.dedup_key,
+                created_at: notification.created_at,
+                click_url: notification.click_url,
+            };
+
+            // Notifications are observers: decision-shaped stdout and exit 2
+            // are recorded but cannot undo an already-delivered notification or
+            // prevent later configured commands from running.
+            let _ = runner
+                .run_observer_hooks(
+                    AgentHookPoint::AfterNotification,
+                    &payload,
+                    &session,
+                    &mut runtime_state,
+                    None,
+                )
+                .await;
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bamboo_config::{
+        LifecycleHookCommand, LifecycleHookGroup, LifecycleHookType,
+        DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS,
+    };
+
+    fn sample_notification() -> SinkNotification {
+        SinkNotification {
+            id: Some("notification-1".to_string()),
+            title: "Build finished".to_string(),
+            body: "All checks passed".to_string(),
+            category: "background_task_completed".to_string(),
+            priority: "normal".to_string(),
+            session_id: "session-1".to_string(),
+            dedup_key: Some("background:session-1:build".to_string()),
+            created_at: Some("2026-07-22T09:00:00Z".to_string()),
+            click_url: Some("bamboo://session/session-1".to_string()),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn command_sink_receives_the_classified_notification_payload() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("notification.json");
+        let command = format!("cat > '{}'", output.display());
+        let hooks = LifecycleHooksConfig {
+            enabled: true,
+            notification: vec![LifecycleHookGroup {
+                enabled: true,
+                matcher: None,
+                hooks: vec![LifecycleHookCommand {
+                    hook_type: LifecycleHookType::Command,
+                    command,
+                    timeout_ms: DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS,
+                }],
+            }],
+            ..Default::default()
+        };
+
+        let mut config = bamboo_llm::Config::default();
+        config.lifecycle_hooks = hooks;
+        CommandSink::from_config(&config).deliver(&sample_notification());
+
+        let written = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if let Ok(contents) = std::fs::read_to_string(&output) {
+                    break contents;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("notification hook should complete within its test deadline");
+        let envelope: serde_json::Value = serde_json::from_str(&written).unwrap();
+
+        assert_eq!(envelope["hook_event_name"], "Notification");
+        assert_eq!(envelope["session_id"], "session-1");
+        assert_eq!(envelope["payload"]["type"], "notification");
+        assert_eq!(envelope["payload"]["id"], "notification-1");
+        assert_eq!(envelope["payload"]["category"], "background_task_completed");
+        assert_eq!(envelope["payload"]["priority"], "normal");
+        assert_eq!(envelope["payload"]["title"], "Build finished");
+        assert_eq!(envelope["payload"]["body"], "All checks passed");
+        assert_eq!(
+            envelope["payload"]["dedup_key"],
+            "background:session-1:build"
+        );
+        assert_eq!(envelope["payload"]["created_at"], "2026-07-22T09:00:00Z");
+        assert_eq!(
+            envelope["payload"]["click_url"],
+            "bamboo://session/session-1"
+        );
+    }
+}

--- a/crates/app/bamboo-server/src/notify_sinks/mod.rs
+++ b/crates/app/bamboo-server/src/notify_sinks/mod.rs
@@ -15,6 +15,7 @@
 //! notification must never break an agent run.
 
 mod bark;
+mod command;
 mod desktop;
 mod ntfy;
 
@@ -24,11 +25,12 @@ use bamboo_llm::Config;
 
 /// An owned, sink-agnostic notification payload.
 ///
-/// Deliberately decoupled from `AgentEvent::Notification` (whose fields are
-/// wire-shaped for the SSE/WS client, e.g. carrying a dedup key and a
-/// timestamp sinks have no use for) — see [`SinkNotification::from_event`].
+/// Decoupled from `AgentEvent::Notification` so producers can attach a sink-only
+/// click URL. Delivery metadata is retained because command hooks receive the
+/// complete classified notification — see [`SinkNotification::from_event`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct SinkNotification {
+    pub id: Option<String>,
     pub title: String,
     pub body: String,
     /// Stable wire category, e.g. `"needs_approval"`, `"run_completed"` (see
@@ -38,8 +40,10 @@ pub struct SinkNotification {
     /// `bamboo_notification::policy::NotificationPriority::as_str`).
     pub priority: String,
     pub session_id: String,
-    /// Deep link to surface in a click-through push notification. Not yet
-    /// populated by any producer — reserved for a future frontend route.
+    pub dedup_key: Option<String>,
+    pub created_at: Option<String>,
+    /// Deep link to surface in a click-through push notification. The explicit
+    /// `Notify` tool populates this when its caller supplies a URL.
     pub click_url: Option<String>,
 }
 
@@ -50,18 +54,24 @@ impl SinkNotification {
     pub fn from_event(event: &bamboo_agent_core::AgentEvent) -> Option<Self> {
         match event {
             bamboo_agent_core::AgentEvent::Notification {
+                id,
                 session_id,
                 category,
                 priority,
                 title,
                 body,
+                dedup_key,
+                created_at,
                 ..
             } => Some(Self {
+                id: Some(id.clone()),
                 title: title.clone(),
                 body: body.clone(),
                 category: category.clone(),
                 priority: priority.clone(),
                 session_id: session_id.clone(),
+                dedup_key: dedup_key.clone(),
+                created_at: Some(created_at.clone()),
                 click_url: None,
             }),
             _ => None,
@@ -95,6 +105,15 @@ pub trait NotificationSink: Send + Sync {
 /// actually exercised.
 pub fn attempted_channels(config: &Config, has_watcher: bool, category: &str) -> Vec<&'static str> {
     let mut channels = Vec::new();
+    if config.lifecycle_hooks.enabled
+        && config
+            .lifecycle_hooks
+            .notification
+            .iter()
+            .any(|group| group.enabled && !group.hooks.is_empty())
+    {
+        channels.push("command");
+    }
     if desktop::desktop_enabled(
         config.notifications.desktop.enabled,
         desktop::is_sidecar_mode(),
@@ -125,6 +144,7 @@ pub fn attempted_channels(config: &Config, has_watcher: bool, category: &str) ->
 pub fn dispatch_to_sinks(config: &Config, has_watcher: bool, notification: &SinkNotification) {
     for channel in attempted_channels(config, has_watcher, &notification.category) {
         match channel {
+            "command" => command::CommandSink::from_config(config).deliver(notification),
             "desktop" => desktop::DesktopSink.deliver(notification),
             "ntfy" => ntfy::NtfySink::from_config(&config.notifications.ntfy).deliver(notification),
             "bark" => bark::BarkSink::from_config(&config.notifications.bark).deliver(notification),
@@ -158,6 +178,9 @@ mod tests {
         assert_eq!(sink.category, "needs_approval");
         assert_eq!(sink.priority, "high");
         assert_eq!(sink.session_id, "sess-1");
+        assert_eq!(sink.id.as_deref(), Some("n1"));
+        assert_eq!(sink.dedup_key.as_deref(), Some("dk"));
+        assert_eq!(sink.created_at.as_deref(), Some("2026-01-01T00:00:00Z"));
         assert_eq!(sink.click_url, None);
     }
 
@@ -184,6 +207,30 @@ mod tests {
         let mut config = Config::default();
         config.notifications.desktop.enabled = Some(false);
         assert!(attempted_channels(&config, false, "custom").is_empty());
+    }
+
+    #[test]
+    fn attempted_channels_reports_enabled_notification_command_hook() {
+        let mut config = Config::default();
+        config.notifications.desktop.enabled = Some(false);
+        config.lifecycle_hooks = bamboo_config::LifecycleHooksConfig {
+            enabled: true,
+            notification: vec![bamboo_config::LifecycleHookGroup {
+                enabled: true,
+                matcher: None,
+                hooks: vec![bamboo_config::LifecycleHookCommand {
+                    hook_type: bamboo_config::LifecycleHookType::Command,
+                    command: "true".to_string(),
+                    timeout_ms: bamboo_config::DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS,
+                }],
+            }],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            attempted_channels(&config, false, "custom"),
+            vec!["command"]
+        );
     }
 
     #[test]
@@ -228,7 +275,7 @@ mod tests {
             let names = attempted_channels(&config, false, "custom");
             assert!(names
                 .iter()
-                .all(|c| ["desktop", "ntfy", "bark"].contains(c)));
+                .all(|c| ["command", "desktop", "ntfy", "bark"].contains(c)));
         }
     }
 }

--- a/crates/app/bamboo-server/src/notify_sinks/ntfy.rs
+++ b/crates/app/bamboo-server/src/notify_sinks/ntfy.rs
@@ -106,11 +106,14 @@ mod tests {
 
     fn sample_notification() -> SinkNotification {
         SinkNotification {
+            id: None,
             title: "Approval needed".to_string(),
             body: "please approve".to_string(),
             category: "needs_approval".to_string(),
             priority: "high".to_string(),
             session_id: "sess-1".to_string(),
+            dedup_key: None,
+            created_at: None,
             click_url: None,
         }
     }

--- a/crates/app/bamboo-server/src/tools/notify_dispatcher.rs
+++ b/crates/app/bamboo-server/src/tools/notify_dispatcher.rs
@@ -8,7 +8,7 @@
 //! - re-broadcasts the resulting `AgentEvent::Notification` on the session's
 //!   event channel so connected SSE/WS clients see it, same as the always-on
 //!   relay (`app_state::session_events::ensure_notification_relay`); and
-//! - fans it out to configured delivery sinks (desktop/ntfy/bark) via
+//! - fans it out to configured delivery sinks (command/desktop/ntfy/bark) via
 //!   [`crate::notify_sinks::dispatch_to_sinks`] (WP3), reading the CURRENT
 //!   config so a hot-reloaded topic/token/toggle takes effect immediately.
 //!

--- a/crates/core/bamboo-domain/src/session/hook_types.rs
+++ b/crates/core/bamboo-domain/src/session/hook_types.rs
@@ -43,7 +43,25 @@ pub enum HookPayload {
     Compression {
         estimated_tokens: u32,
         usage_percent: f64,
+        max_context_tokens: u32,
+        trigger_context_tokens: u32,
+        trigger: String,
         phase: String,
+    },
+    /// A classified, deduplicated notification is being delivered to sinks.
+    Notification {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+        category: String,
+        priority: String,
+        title: String,
+        body: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        dedup_key: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        created_at: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        click_url: Option<String>,
     },
     /// The run is about to emit its terminal completion event.
     Finalize { stop_hook_active: bool },
@@ -120,6 +138,9 @@ pub enum AgentHookPoint {
     // Context compression
     BeforeCompression,
     AfterCompression,
+
+    // Classified notification delivery
+    AfterNotification,
 }
 
 /// Result of running a hook.
@@ -181,6 +202,7 @@ mod tests {
             AgentHookPoint::AfterMemoryRecall,
             AgentHookPoint::BeforeCompression,
             AgentHookPoint::AfterCompression,
+            AgentHookPoint::AfterNotification,
         ];
         for point in &points {
             let json = serde_json::to_string(point).unwrap();

--- a/crates/engine/bamboo-engine/src/runtime/hooks/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/hooks/mod.rs
@@ -78,19 +78,20 @@ impl HookRunner {
     }
 
     /// Run every matching hook while recording checkpoints/events, but never
-    /// short-circuit on a control decision. Terminal observer seams such as
-    /// `SessionEnd` use this so one cleanup hook cannot suppress later ones.
-    async fn run_observer_hooks(
+    /// short-circuit on a control decision. Observer/advisory seams such as
+    /// `SessionEnd`, `PreCompact`, and `Notification` use this so a command's
+    /// control-shaped output cannot suppress later hooks or reverse an
+    /// operation that must proceed for correctness.
+    pub async fn run_observer_hooks(
         &self,
         point: AgentHookPoint,
         payload: &HookPayload,
         session: &Session,
         runtime_state: &mut AgentRuntimeState,
         event_tx: Option<&mpsc::Sender<AgentEvent>>,
-    ) {
-        let _ = self
-            .run_hooks_with_control(point, payload, session, runtime_state, event_tx, false)
-            .await;
+    ) -> HookRunOutcome {
+        self.run_hooks_with_control(point, payload, session, runtime_state, event_tx, false)
+            .await
     }
 
     async fn run_hooks_with_control(

--- a/crates/engine/bamboo-engine/src/runtime/hooks/shell_command.rs
+++ b/crates/engine/bamboo-engine/src/runtime/hooks/shell_command.rs
@@ -34,6 +34,7 @@ pub enum ShellHookEvent {
     Stop,
     SessionEnd,
     PreCompact,
+    Notification,
 }
 
 /// Raw process result returned by the settings dry-run endpoint. Unlike the
@@ -59,6 +60,7 @@ impl ShellHookEvent {
             Self::Stop => "Stop",
             Self::SessionEnd => "SessionEnd",
             Self::PreCompact => "PreCompact",
+            Self::Notification => "Notification",
         }
     }
 
@@ -71,6 +73,7 @@ impl ShellHookEvent {
             Self::Stop => AgentHookPoint::BeforeFinalize,
             Self::SessionEnd => AgentHookPoint::AfterSessionEnd,
             Self::PreCompact => AgentHookPoint::BeforeCompression,
+            Self::Notification => AgentHookPoint::AfterNotification,
         }
     }
 
@@ -213,9 +216,10 @@ impl ShellCommandHook {
                 Some(*status),
                 completion_reason.clone(),
             ),
-            HookPayload::None | HookPayload::Round { .. } | HookPayload::Compression { .. } => {
-                (None, None, None, None, None, None, None, None)
-            }
+            HookPayload::None
+            | HookPayload::Round { .. }
+            | HookPayload::Compression { .. }
+            | HookPayload::Notification { .. } => (None, None, None, None, None, None, None, None),
         };
 
         HookEnvelope {
@@ -226,6 +230,7 @@ impl ShellCommandHook {
                 .map(|path| path.to_string_lossy().into_owned())
                 .unwrap_or_default(),
             model: session.model.clone(),
+            payload: payload.clone(),
             tool_name,
             tool_input,
             tool_response,
@@ -490,16 +495,25 @@ pub async fn test_lifecycle_shell_command(
             HookPayload::Compression {
                 estimated_tokens: 1_000,
                 usage_percent: 50.0,
+                max_context_tokens: 2_000,
+                trigger_context_tokens: 1_600,
+                trigger: "threshold".to_string(),
                 phase: "test".to_string(),
             },
         ),
-        // Notification is a reserved config event whose runtime seam is owned
-        // by a follow-up issue. It can still be dry-run safely with a generic
-        // payload and the correct event name/environment.
         "Notification" => (
-            ShellHookEvent::SessionStart,
-            Some("Notification"),
-            HookPayload::None,
+            ShellHookEvent::Notification,
+            None,
+            HookPayload::Notification {
+                id: Some("notification-test".to_string()),
+                category: "custom".to_string(),
+                priority: "normal".to_string(),
+                title: "Lifecycle hook test".to_string(),
+                body: "Synthetic notification delivery".to_string(),
+                dedup_key: Some("lifecycle-hook-test".to_string()),
+                created_at: Some(Utc::now().to_rfc3339()),
+                click_url: None,
+            },
         ),
         other => return Err(format!("unknown lifecycle hook event '{other}'")),
     };
@@ -594,6 +608,9 @@ struct HookEnvelope {
     session_id: String,
     workspace_path: String,
     model: String,
+    /// Complete, event-specific payload. Legacy convenience fields below stay
+    /// populated for existing tool/prompt/session hook commands.
+    payload: HookPayload,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -672,7 +689,7 @@ pub(super) fn register_configured_shell_hooks(
         return;
     }
 
-    let events: [(ShellHookEvent, &[LifecycleHookGroup]); 7] = [
+    let events: [(ShellHookEvent, &[LifecycleHookGroup]); 8] = [
         (ShellHookEvent::SessionStart, &config.session_start),
         (ShellHookEvent::UserPromptSubmit, &config.user_prompt_submit),
         (ShellHookEvent::PreToolUse, &config.pre_tool_use),
@@ -680,6 +697,7 @@ pub(super) fn register_configured_shell_hooks(
         (ShellHookEvent::Stop, &config.stop),
         (ShellHookEvent::SessionEnd, &config.session_end),
         (ShellHookEvent::PreCompact, &config.pre_compact),
+        (ShellHookEvent::Notification, &config.notification),
     ];
     let mut sequence = 0_usize;
     for (event, groups) in events {
@@ -997,6 +1015,8 @@ mod tests {
         assert_eq!(value["model"], "test-model");
         assert_eq!(value["tool_name"], "bash");
         assert_eq!(value["tool_input"]["command"], "pwd");
+        assert_eq!(value["payload"]["type"], "tool_execution");
+        assert_eq!(value["payload"]["tool_call_id"], "call-1");
         assert!(value["timestamp"].as_str().is_some());
     }
 
@@ -1046,7 +1066,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_runner_registers_only_enabled_engine_events() {
+    fn configured_runner_registers_all_enabled_events() {
         let hook = command("true", 1_000);
         let config = LifecycleHooksConfig {
             enabled: true,
@@ -1084,11 +1104,12 @@ mod tests {
             base.is_empty(),
             "per-run registration must not mutate the base"
         );
-        assert_eq!(configured.len(), 4);
+        assert_eq!(configured.len(), 5);
         assert!(configured.has_hooks_for(AgentHookPoint::AfterSessionSetup));
         assert!(configured.has_hooks_for(AgentHookPoint::BeforeSessionSetup));
         assert!(configured.has_hooks_for(AgentHookPoint::AfterSessionEnd));
         assert!(configured.has_hooks_for(AgentHookPoint::BeforeToolExecution));
+        assert!(configured.has_hooks_for(AgentHookPoint::AfterNotification));
     }
 
     #[test]
@@ -1145,6 +1166,50 @@ mod tests {
             }
         );
         assert_eq!(state.checkpoints.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn precompact_observer_ignores_block_and_collects_later_instructions() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = LifecycleHooksConfig {
+            enabled: true,
+            pre_compact: vec![LifecycleHookGroup {
+                enabled: true,
+                matcher: None,
+                hooks: vec![
+                    command("printf 'cannot block compaction' >&2; exit 2", 1_000),
+                    command(
+                        r#"printf '%s' '{"additional_context":"preserve the failing assertion"}'"#,
+                        1_000,
+                    ),
+                ],
+            }],
+            ..LifecycleHooksConfig::default()
+        };
+        let runner = HookRunner::new().with_lifecycle_config(&config, None);
+        let mut state = bamboo_domain::AgentRuntimeState::new("run-precompact");
+        let outcome = runner
+            .run_observer_hooks(
+                AgentHookPoint::BeforeCompression,
+                &HookPayload::Compression {
+                    estimated_tokens: 1_700,
+                    usage_percent: 85.0,
+                    max_context_tokens: 2_000,
+                    trigger_context_tokens: 1_600,
+                    trigger: "threshold".to_string(),
+                    phase: "pre-turn".to_string(),
+                },
+                &session(dir.path()),
+                &mut state,
+                None,
+            )
+            .await;
+
+        assert_eq!(state.checkpoints.len(), 2);
+        assert_eq!(
+            outcome.injected_contexts,
+            vec!["preserve the failing assertion".to_string()]
+        );
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation.rs
@@ -173,6 +173,29 @@ fn build_compression_context_blocks(
     blocks
 }
 
+fn merge_compression_instructions(
+    base: Option<String>,
+    hook_contexts: Vec<String>,
+) -> Option<String> {
+    let hook_contexts = hook_contexts
+        .into_iter()
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>();
+    if hook_contexts.is_empty() {
+        return base;
+    }
+
+    let hook_section = format!(
+        "## PreCompact Hook Instructions\n\n{}",
+        hook_contexts.join("\n\n---\n\n")
+    );
+    Some(match base {
+        Some(base) if !base.trim().is_empty() => format!("{}\n\n{}", base.trim(), hook_section),
+        _ => hook_section,
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn maybe_apply_host_context_compression_with_budget(
     session: &mut Session,
@@ -280,41 +303,6 @@ async fn maybe_apply_host_context_compression_with_budget(
         CompressionTriggerType::Auto
     };
 
-    if config
-        .hook_runner
-        .has_hooks_for(AgentHookPoint::BeforeCompression)
-    {
-        let payload = HookPayload::Compression {
-            estimated_tokens: exposure.active_tokens,
-            usage_percent,
-            phase: phase_label.to_string(),
-        };
-        let mut hook_runtime_state = session
-            .agent_runtime_state
-            .clone()
-            .unwrap_or_else(|| AgentRuntimeState::new(session_id));
-        let hook_outcome = config
-            .hook_runner
-            .run_hooks(
-                AgentHookPoint::BeforeCompression,
-                &payload,
-                session,
-                &mut hook_runtime_state,
-                event_tx,
-            )
-            .await;
-        let hook_result = crate::runtime::hooks::apply_hook_outcome(
-            AgentHookPoint::BeforeCompression,
-            hook_outcome,
-            session,
-            &mut hook_runtime_state,
-        );
-        session.agent_runtime_state = Some(hook_runtime_state);
-        hook_result?;
-    }
-
-    let start = Instant::now();
-
     let trigger_type_clone = trigger_type.clone();
 
     let messages = summary_source_messages(session);
@@ -347,6 +335,44 @@ async fn maybe_apply_host_context_compression_with_budget(
         return Ok(false);
     };
 
+    let mut hook_compression_instructions = Vec::new();
+    if config
+        .hook_runner
+        .has_hooks_for(AgentHookPoint::BeforeCompression)
+    {
+        let trigger = match &trigger_type {
+            CompressionTriggerType::Manual => "manual",
+            CompressionTriggerType::CriticalOverflow => "forced_overflow_recovery",
+            CompressionTriggerType::Auto => "threshold",
+        };
+        let payload = HookPayload::Compression {
+            estimated_tokens: exposure.active_tokens,
+            usage_percent,
+            max_context_tokens: budget.max_context_tokens,
+            trigger_context_tokens,
+            trigger: trigger.to_string(),
+            phase: phase_label.to_string(),
+        };
+        let mut hook_runtime_state = session
+            .agent_runtime_state
+            .clone()
+            .unwrap_or_else(|| AgentRuntimeState::new(session_id));
+        let hook_outcome = config
+            .hook_runner
+            .run_observer_hooks(
+                AgentHookPoint::BeforeCompression,
+                &payload,
+                session,
+                &mut hook_runtime_state,
+                event_tx,
+            )
+            .await;
+        hook_compression_instructions = hook_outcome.injected_contexts;
+        session.agent_runtime_state = Some(hook_runtime_state);
+    }
+
+    let start = Instant::now();
+
     let existing_summary = session
         .conversation_summary
         .as_ref()
@@ -369,6 +395,8 @@ async fn maybe_apply_host_context_compression_with_budget(
         .filter(|v| !v.trim().is_empty())
         .map(String::from)
         .or(base_instructions);
+    let compression_instructions =
+        merge_compression_instructions(compression_instructions, hook_compression_instructions);
 
     let summary_provider = config
         .summarization_model_provider

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation/tests.rs
@@ -7,10 +7,10 @@ use super::{
 use crate::runtime::config::{AgentLoopConfig, ImageFallbackConfig, ImageFallbackMode};
 use bamboo_agent_core::tools::{FunctionCall, ToolCall};
 use bamboo_agent_core::{
-    AgentEvent, CompressionTriggerType, Message, Role, Session, TokenBudgetUsage,
+    AgentEvent, AgentHook, CompressionTriggerType, Message, Role, Session, TokenBudgetUsage,
 };
 use bamboo_compression::{BudgetStrategy, TokenBudget};
-use bamboo_domain::{TaskItem, TaskItemStatus, TaskList};
+use bamboo_domain::{AgentHookPoint, HookPayload, HookResult, TaskItem, TaskItemStatus, TaskList};
 use bamboo_llm::models::{ContentPart, ImageUrl};
 use bamboo_llm::provider::{LLMProvider, LLMRequestOptions, LLMStream};
 use bamboo_llm::{LLMChunk, LLMError};
@@ -139,6 +139,44 @@ fn prompt_capture_llm() -> (Arc<dyn LLMProvider>, Arc<Mutex<Vec<Vec<Message>>>>)
         requests: Arc::clone(&requests),
     });
     (llm, requests)
+}
+
+struct CompressionInstructionHook;
+
+#[async_trait::async_trait]
+impl AgentHook for CompressionInstructionHook {
+    fn point(&self) -> AgentHookPoint {
+        AgentHookPoint::BeforeCompression
+    }
+
+    async fn run(
+        &self,
+        _point: AgentHookPoint,
+        payload: &HookPayload,
+        _session: &Session,
+    ) -> HookResult {
+        assert!(matches!(
+            payload,
+            HookPayload::Compression {
+                estimated_tokens,
+                usage_percent,
+                max_context_tokens: 1_200,
+                trigger_context_tokens: 960,
+                trigger,
+                phase,
+            } if *estimated_tokens > 0
+                && *usage_percent > 0.0
+                && trigger == "manual"
+                && phase == "mid-turn"
+        ));
+        HookResult::InjectContext {
+            text: "Preserve the exact build failure and its file path".to_string(),
+        }
+    }
+
+    fn name(&self) -> &str {
+        "compression_instructions"
+    }
 }
 
 #[tokio::test]
@@ -815,6 +853,12 @@ async fn mid_turn_host_context_compression_includes_unified_context_blocks_in_su
         background_model_name: Some("test-model".to_string()),
         ..Default::default()
     };
+    let mut hook_runner = crate::HookRunner::new();
+    hook_runner.register(Arc::new(CompressionInstructionHook));
+    let config = AgentLoopConfig {
+        hook_runner: Arc::new(hook_runner),
+        ..config
+    };
     let (llm, requests) = prompt_capture_llm();
 
     let applied = maybe_apply_host_context_compression(
@@ -850,6 +894,9 @@ async fn mid_turn_host_context_compression_includes_unified_context_blocks_in_su
     assert!(prompt.contains("External Memory (Persistent)"));
     assert!(prompt.contains("Plan Mode State"));
     assert!(prompt.contains("Durable Plan Execution Context"));
+    assert!(prompt.contains("## Custom Compression Instructions"));
+    assert!(prompt.contains("## PreCompact Hook Instructions"));
+    assert!(prompt.contains("Preserve the exact build failure and its file path"));
 }
 
 #[tokio::test]

--- a/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
+++ b/crates/engine/bamboo-engine/src/session_app/child_completion_coordinator.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, OnceLock, RwLock as StdRwLock};
 use std::time::Duration;
 
 use bamboo_domain::poison::PoisonRecover;
+use bamboo_domain::{AgentHookPoint, HookPayload, HookToolOutcome};
 
 use crate::execution::{
     create_event_forwarder, finalize_runner, spawn_session_execution, try_reserve_runner,
@@ -936,6 +937,73 @@ fn bash_completion_should_resume(
     loop_suspended_on_bash && all_waited_shells_done
 }
 
+fn background_bash_post_tool_payload(info: &BashCompletionInfo) -> HookPayload {
+    let success = info.status == "completed" && info.exit_code == Some(0);
+    let response = serde_json::json!({
+        "bash_id": info.bash_id,
+        "command": info.command,
+        "exit_code": info.exit_code,
+        "status": info.status,
+        "output_tail": info.output_tail,
+    });
+    HookPayload::ToolResult {
+        tool_name: "Bash".to_string(),
+        tool_call_id: info.bash_id.clone(),
+        outcome: HookToolOutcome {
+            success,
+            result: success.then(|| response.to_string()),
+            error: (!success).then(|| response.to_string()),
+            needs_human: false,
+            duration_ms: 0,
+        },
+    }
+}
+
+fn append_background_bash_hook_feedback(info: &mut BashCompletionInfo, feedback: Vec<String>) {
+    let feedback = feedback
+        .into_iter()
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+        .collect::<Vec<_>>();
+    if feedback.is_empty() {
+        return;
+    }
+    if !info.output_tail.is_empty() {
+        info.output_tail.push_str("\n\n");
+    }
+    info.output_tail.push_str("<post_tool_use_feedback>\n");
+    info.output_tail.push_str(&feedback.join("\n"));
+    info.output_tail.push_str("\n</post_tool_use_feedback>");
+}
+
+async fn run_background_bash_post_tool_hooks(
+    config: &bamboo_config::LifecycleHooksConfig,
+    fallback_cwd: Option<std::path::PathBuf>,
+    session: &Session,
+    info: &mut BashCompletionInfo,
+) -> bool {
+    let runner = crate::HookRunner::new().with_lifecycle_config(config, fallback_cwd);
+    if !runner.has_hooks_for(AgentHookPoint::AfterToolExecution) {
+        return false;
+    }
+
+    let mut runtime_state = session
+        .agent_runtime_state
+        .clone()
+        .unwrap_or_else(|| AgentRuntimeState::new(&session.id));
+    let outcome = runner
+        .run_observer_hooks(
+            AgentHookPoint::AfterToolExecution,
+            &background_bash_post_tool_payload(info),
+            session,
+            &mut runtime_state,
+            None,
+        )
+        .await;
+    append_background_bash_hook_feedback(info, outcome.injected_contexts);
+    true
+}
+
 /// Apply the bash-resume state transition to a loaded session **in place**: clear
 /// the `waiting_for_bash` wait, mark the runtime Idle, drop the suspension +
 /// `runtime.suspend_reason`, and append `resume_message`. Returns `false` (a
@@ -1228,7 +1296,23 @@ impl ChildCompletionCoordinator {
     ///   shells) → **enqueue** the notice as a pending injected message, drained at
     ///   the next round boundary (a live loop) or folded into the eventual resume
     ///   when the last shell finishes.
-    async fn deliver_bash_completion(&self, info: BashCompletionInfo) {
+    async fn deliver_bash_completion(&self, mut info: BashCompletionInfo) {
+        // A background shell completes outside the originating tool call, so
+        // fire its PostToolUse seam here before routing the completion into the
+        // next round/resume message. Do not hold the resume lock while an
+        // arbitrary command hook runs: its configured timeout must never block
+        // the independent liveness backstop.
+        if let Some(hook_session) = self.load_session(&info.session_id).await {
+            let config_snapshot = self.config.read().await.clone();
+            let _ = run_background_bash_post_tool_hooks(
+                &config_snapshot.lifecycle_hooks,
+                Some(self.app_data_dir.clone()),
+                &hook_session,
+                &mut info,
+            )
+            .await;
+        }
+
         let guard = session_resume_lock(&info.session_id);
         let _held = guard.lock().await;
 
@@ -2457,6 +2541,102 @@ mod tests {
         assert!(body.contains("no captured output"), "body: {body}");
         // No output tail section when there is nothing to show.
         assert!(!body.contains("Output tail:"), "body: {body}");
+    }
+
+    #[test]
+    fn background_completion_builds_post_tool_use_payload_and_feedback() {
+        let mut info = BashCompletionInfo {
+            session_id: "s".into(),
+            bash_id: "bg-7".into(),
+            command: "cargo test".into(),
+            exit_code: Some(0),
+            status: "completed".into(),
+            output_tail: "test result: ok".into(),
+        };
+
+        let payload = background_bash_post_tool_payload(&info);
+        match payload {
+            HookPayload::ToolResult {
+                tool_name,
+                tool_call_id,
+                outcome,
+            } => {
+                assert_eq!(tool_name, "Bash");
+                assert_eq!(tool_call_id, "bg-7");
+                assert!(outcome.success);
+                let response: serde_json::Value =
+                    serde_json::from_str(outcome.result.as_deref().unwrap()).unwrap();
+                assert_eq!(response["command"], "cargo test");
+                assert_eq!(response["exit_code"], 0);
+                assert_eq!(response["status"], "completed");
+                assert_eq!(response["output_tail"], "test result: ok");
+            }
+            other => panic!("expected PostToolUse payload, got {other:?}"),
+        }
+
+        append_background_bash_hook_feedback(
+            &mut info,
+            vec!["Run the formatter before continuing".to_string()],
+        );
+        assert!(info.output_tail.contains("<post_tool_use_feedback>"));
+        assert!(info
+            .output_tail
+            .contains("Run the formatter before continuing"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn background_completion_fires_configured_post_tool_use_command() {
+        use bamboo_config::{
+            LifecycleHookCommand, LifecycleHookGroup, LifecycleHookType, LifecycleHooksConfig,
+            DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("background-post-tool.json");
+        let command = format!(
+            "cat > '{}'; printf '%s' '{{\"additional_context\":\"inspect the completed build log\"}}'",
+            output.display()
+        );
+        let config = LifecycleHooksConfig {
+            enabled: true,
+            post_tool_use: vec![LifecycleHookGroup {
+                enabled: true,
+                matcher: Some("^Bash$".to_string()),
+                hooks: vec![LifecycleHookCommand {
+                    hook_type: LifecycleHookType::Command,
+                    command,
+                    timeout_ms: DEFAULT_LIFECYCLE_HOOK_TIMEOUT_MS,
+                }],
+            }],
+            ..Default::default()
+        };
+        let mut session = Session::new("session-bg-hook", "test-model");
+        session.workspace = Some(dir.path().to_string_lossy().into_owned());
+        let mut info = BashCompletionInfo {
+            session_id: session.id.clone(),
+            bash_id: "bg-9".into(),
+            command: "cargo test".into(),
+            exit_code: Some(0),
+            status: "completed".into(),
+            output_tail: "test result: ok".into(),
+        };
+
+        assert!(run_background_bash_post_tool_hooks(&config, None, &session, &mut info).await);
+        let envelope: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(output).unwrap()).unwrap();
+        assert_eq!(envelope["hook_event_name"], "PostToolUse");
+        assert_eq!(envelope["tool_name"], "Bash");
+        assert_eq!(envelope["payload"]["tool_call_id"], "bg-9");
+        let response = envelope["tool_response"]["result"]
+            .as_str()
+            .map(serde_json::from_str::<serde_json::Value>)
+            .transpose()
+            .unwrap()
+            .unwrap();
+        assert_eq!(response["command"], "cargo test");
+        assert_eq!(response["status"], "completed");
+        assert!(info.output_tail.contains("inspect the completed build log"));
     }
 
     async fn temp_store() -> (tempfile::TempDir, Arc<dyn Storage>, LockedSessionStore) {

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -2113,8 +2113,7 @@ fn lifecycle_hook_enabled_is_default(value: &bool) -> bool {
 /// Config-driven agent lifecycle hooks.
 ///
 /// Event names deliberately preserve the user-facing PascalCase protocol.
-/// Server-owned events are represented here even though their invocation
-/// seams are added by follow-up issues; this keeps one stable config schema.
+/// Server-owned events use the same stable schema as engine-owned events.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LifecycleHooksConfig {
     #[serde(default)]

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Task-oriented, kept current with the shipped codebase.
 |---|---|
 | [`guides/GETTING_STARTED.md`](guides/GETTING_STARTED.md) | Install, configure a provider, run your first turn three ways (CLI/HTTP/SDK). |
 | [`config-reference.md`](config-reference.md) | Every `config.json` key, the sibling config files (`connect.json`, `schedules.json`, `model_limits.json`), every `BAMBOO_*` env var, the secret-masking contract, encryption at rest, and corrupt-config recovery. |
+| [`lifecycle-hooks.md`](lifecycle-hooks.md) | Configure lifecycle shell commands, event payloads, decisions, timeouts, and practical examples. |
 | [`guides/CONNECT.md`](guides/CONNECT.md) | Drive Bamboo from Telegram or Feishu/Lark. |
 | [`guides/PLUGINS.md`](guides/PLUGINS.md) | Install/update/remove plugins, and the three-layer URL trust model. |
 | [`guides/DEPLOY.md`](guides/DEPLOY.md) | Run `bamboo serve` long-lived: bare binary, systemd, Docker, reverse proxy, backups. |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -168,6 +168,10 @@ TLS termination — no ACME/auto-cert). All overridable per-invocation with
 - `hooks.image_fallback` — how image parts are handled when the effective
   model/path is text-only (drop, OCR-replace, etc. — see
   `ImageFallbackHookConfig`).
+- `lifecycle_hooks` — config-driven shell commands for session, prompt, tool,
+  compaction, and notification events. It lives in `hooks.json`; see the
+  [lifecycle hooks guide](lifecycle-hooks.md) for the complete schema and
+  stdin/stdout contract.
 
 ## LLM stream timeouts
 

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -1,0 +1,146 @@
+# Lifecycle command hooks
+
+Bamboo can run user-configured shell commands at agent lifecycle events. Use
+the Hooks settings page, or edit the `lifecycle_hooks` object in
+`$BAMBOO_DATA_DIR/hooks.json` (normally `~/.bamboo/hooks.json`). Changes are
+validated and hot-reloaded. Engine-owned hooks are snapshotted when an
+execution starts. Notification hooks read the current configuration, and a
+background Bash completion reads the configuration available when it arrives.
+
+## Configuration
+
+```json
+{
+  "lifecycle_hooks": {
+    "enabled": true,
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".bamboo/hooks/block-dangerous-bash.sh",
+            "timeout_ms": 5000
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Each event contains ordered groups. A group and the whole section can be
+disabled without deleting them. `matcher` is a Rust regular expression over
+the tool name and is supported only for `PreToolUse` and `PostToolUse`. A
+command runs through Bamboo's preferred Bash-compatible shell. Agent events use
+the session workspace; server-owned notification hooks fall back to the
+configured default work area and then the server process directory. `timeout_ms`
+defaults to 60000 and must be between 1 and 600000.
+
+Supported events:
+
+| Event | When it runs | Control behavior |
+|---|---|---|
+| `SessionStart` | A run is initialized or resumed | May inject context or stop the run. |
+| `UserPromptSubmit` | Before a submitted prompt is persisted | May block or extend the effective prompt. |
+| `PreToolUse` | After arguments are parsed, before permission and dispatch | `allow`, `block`, and `ask` participate in the parent-agent permission path. |
+| `PostToolUse` | After a foreground or background tool completes | May attach feedback; background Bash completion uses `tool_name: "Bash"`. |
+| `Stop` | Before the run emits its terminal completion | May force a bounded continuation. |
+| `SessionEnd` | After a terminal status is known | Observer only; decisions cannot change the settled result. |
+| `PreCompact` | Immediately before LLM context summarization | `additional_context` becomes custom summarizer instructions. Decisions are ignored because blocking compaction risks context overflow. |
+| `Notification` | After notification policy and dedup, alongside desktop/ntfy/Bark delivery | Fire-and-forget observer; decisions and output are ignored. |
+
+## Command protocol
+
+The command receives one JSON object on stdin and these environment variables:
+
+- `BAMBOO_HOOK_EVENT`: the event name from the table above.
+- `BAMBOO_SESSION_ID`: the owning session id.
+
+Every stdin envelope has stable common fields and an event-specific `payload`:
+
+```json
+{
+  "schema_version": 1,
+  "hook_event_name": "PreCompact",
+  "session_id": "session-123",
+  "workspace_path": "/work/project",
+  "model": "claude-sonnet-4",
+  "payload": {
+    "type": "compression",
+    "estimated_tokens": 170000,
+    "usage_percent": 85.0,
+    "max_context_tokens": 200000,
+    "trigger_context_tokens": 160000,
+    "trigger": "threshold",
+    "phase": "pre-turn"
+  },
+  "timestamp": "2026-07-22T09:00:00Z"
+}
+```
+
+Compression `trigger` is `threshold`, `forced_overflow_recovery`, or `manual`.
+A delivered notification payload contains `id`, `category`, `priority`,
+`title`, `body`, `dedup_key`, `created_at`, and an optional `click_url`.
+Tool-oriented envelopes also keep the convenience fields `tool_name`,
+`tool_input`, and `tool_response` for compatibility.
+
+For decision-capable events, exit 0 with no stdout means continue. Exit 0 may
+instead print exactly one JSON response:
+
+```json
+{
+  "decision": "block",
+  "reason": "production deletion is forbidden",
+  "additional_context": "Use the staging workspace instead."
+}
+```
+
+`decision` is `allow`, `block`, or `ask`. `additional_context` can be returned
+with or without a decision. Exit 2 blocks with stderr as the reason. Other
+non-zero exits, malformed stdout, and timeouts are logged and treated as
+non-blocking failures. Stdout and stderr are each capped at 64 KiB.
+
+Observer events (`SessionEnd`, `Notification`) never change control flow.
+`PreCompact` consumes only `additional_context`; its decision and exit-2 block
+signal are deliberately ignored.
+
+## Examples
+
+Block dangerous Bash commands (`.bamboo/hooks/block-dangerous-bash.sh`):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+payload=$(cat)
+command=$(printf '%s' "$payload" | jq -r '.tool_input.command // ""')
+if printf '%s' "$command" | grep -Eq '(^|[;&|[:space:]])rm[[:space:]]+-rf[[:space:]]+(/|~)'; then
+  printf '%s\n' 'dangerous recursive deletion is blocked' >&2
+  exit 2
+fi
+```
+
+Auto-format after an edit:
+
+```json
+{
+  "PostToolUse": [{
+    "matcher": "^(Write|Edit)$",
+    "hooks": [{"type": "command", "command": "cargo fmt", "timeout_ms": 30000}]
+  }]
+}
+```
+
+Send a desktop notification when a run stops:
+
+```json
+{
+  "Stop": [{
+    "hooks": [{"type": "command", "command": "notify-send 'Bamboo' 'Agent run stopped'"}]
+  }]
+}
+```
+
+Use the Hooks settings page's dry-run action before enabling a command. The
+test uses the production shell, environment, timeout, output cap, and a
+deterministic synthetic payload for the selected event.


### PR DESCRIPTION
## Summary

- add `PreCompact` payload fields and pass hook `additional_context` into the real LLM summarizer prompt without allowing compaction to be blocked
- deliver classified, deduplicated notifications to fire-and-forget command hooks through the shared sink fan-out
- fire `PostToolUse` when background Bash completes and surface hook feedback in the completion/resume message
- add the user-facing lifecycle hooks guide and link it from the README/docs index

Closes #554

## Test Plan

- `cargo fmt --check`
- `cargo clippy --all-features -- -A deprecated -A clippy::module_inception -A clippy::incompatible_msrv -A clippy::needless_borrows_for_generic_args -A clippy::too-many-arguments -A clippy::while-let-loop -A clippy::type_complexity -A dead-code -D warnings`
- `cargo doc --no-deps --all-features --document-private-items`
- focused domain, shell-hook, compression prompt, background Bash, notification sink, and settings lifecycle-hook tests
- `cargo test --workspace --exclude bamboo-server`
- `cargo test`: all executed tests passed except `server::tls::tests::build_rustls_config_succeeds_on_valid_self_signed_cert`; the identical `UnsupportedCertVersion` failure was reproduced on a clean detached `origin/main@39034d57` worktree with an isolated target directory

## Review Notes

Two independent gates are required before merge: GitHub CI/checks and a parent-agent exact-head review of the pushed commit.
