### PR TITLE
feat(codex): enforce spawn-time permission profiles (#571)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/validation.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/validation.rs
@@ -115,6 +115,14 @@ pub async fn validate_bamboo_config_patch(
                 "subagents.codex_provider_key_ref"
             } else if message.contains("forward_env") || message.contains("OPENAI_API_KEY") {
                 "subagents.codex_forward_env"
+            } else if message.contains("network_access") || message.contains("workspace-write") {
+                "subagents.codex_network_access"
+            } else if message.contains("allow_danger_bypass") {
+                "subagents.codex_allow_danger_bypass"
+            } else if message.contains("approval") {
+                "subagents.codex_approval_policy"
+            } else if message.contains("sandbox") || message.contains("danger-full-access") {
+                "subagents.codex_sandbox"
             } else {
                 "subagents.codex_auth_mode"
             };
@@ -157,6 +165,44 @@ fn validate_codex_subagents_shape(value: &Value) -> Vec<ValidationIssue> {
             issues.push(issue(
                 "subagents.codex_wire_api",
                 "codex_wire_api must be responses for Codex CLI >= 0.144",
+            ));
+        }
+    }
+    if let Some(sandbox) = object.get("codex_sandbox") {
+        let valid = sandbox.is_null()
+            || sandbox.as_str().is_some_and(|sandbox| {
+                matches!(
+                    sandbox,
+                    "read-only" | "workspace-write" | "danger-full-access"
+                )
+            });
+        if !valid {
+            issues.push(issue(
+                "subagents.codex_sandbox",
+                "codex_sandbox must be read-only, workspace-write, or danger-full-access",
+            ));
+        }
+    }
+    if let Some(policy) = object.get("codex_approval_policy") {
+        let valid = policy.is_null()
+            || policy
+                .as_str()
+                .is_some_and(|policy| matches!(policy, "never" | "on-failure"));
+        if !valid {
+            issues.push(issue(
+                "subagents.codex_approval_policy",
+                "codex_approval_policy must be never or on-failure in non-interactive exec mode",
+            ));
+        }
+    }
+    for field in ["codex_network_access", "codex_allow_danger_bypass"] {
+        if object
+            .get(field)
+            .is_some_and(|value| !value.is_null() && !value.is_boolean())
+        {
+            issues.push(issue(
+                format!("subagents.{field}"),
+                format!("{field} must be a boolean or null"),
             ));
         }
     }
@@ -442,7 +488,11 @@ mod tests {
             "codex_wire_api": "chat",
             "codex_base_url": 42,
             "codex_provider_key_ref": "not a credential ref",
-            "codex_forward_env": ["OPENAI_API_KEY", 1]
+            "codex_forward_env": ["OPENAI_API_KEY", 1],
+            "codex_sandbox": "host-write",
+            "codex_approval_policy": "on-request",
+            "codex_network_access": "yes",
+            "codex_allow_danger_bypass": 1
         }));
         let paths = issues
             .iter()
@@ -455,6 +505,10 @@ mod tests {
             "subagents.codex_base_url",
             "subagents.codex_provider_key_ref",
             "subagents.codex_forward_env",
+            "subagents.codex_sandbox",
+            "subagents.codex_approval_policy",
+            "subagents.codex_network_access",
+            "subagents.codex_allow_danger_bypass",
         ] {
             assert!(
                 paths.contains(expected),
@@ -470,7 +524,11 @@ mod tests {
             "codex_wire_api": "responses",
             "codex_base_url": "https://provider.example/v1",
             "codex_provider_key_ref": "provider.openai.api_key",
-            "codex_forward_env": ["LANG"]
+            "codex_forward_env": ["LANG"],
+            "codex_sandbox": "workspace-write",
+            "codex_approval_policy": "never",
+            "codex_network_access": true,
+            "codex_allow_danger_bypass": false
         }))
         .is_empty());
     }

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -11,7 +11,7 @@
 //! tables can additionally route specific roles to other actor/a2a agents.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -97,6 +97,36 @@ fn executor_uses_bamboo_codex(executor: &ExecutorSpec) -> bool {
             ..
         } if !inherit_user_config.unwrap_or(false)
     )
+}
+
+fn workspace_is_bamboo_owned(raw: &str) -> bool {
+    let workspace = std::fs::canonicalize(raw).unwrap_or_else(|_| PathBuf::from(raw));
+    let configured_root = bamboo_config::paths::resolve_workspace_root();
+    let configured_root = std::fs::canonicalize(&configured_root).unwrap_or(configured_root);
+    if workspace.starts_with(&configured_root) {
+        return true;
+    }
+
+    // Project worktrees created by Bamboo live under
+    // `<project>/.bamboo/worktree/<name>` and carry the ownership marker used
+    // by the project-worktree lifecycle. A path that merely imitates the
+    // directory shape is not sufficient to bypass Codex's git guard.
+    workspace.ancestors().any(|candidate| {
+        let Some(name) = candidate.file_name().and_then(|name| name.to_str()) else {
+            return false;
+        };
+        let Some(worktree_root) = candidate.parent() else {
+            return false;
+        };
+        if worktree_root.file_name() != Some(std::ffi::OsStr::new("worktree"))
+            || worktree_root.parent().and_then(Path::file_name)
+                != Some(std::ffi::OsStr::new(".bamboo"))
+        {
+            return false;
+        }
+        let marker = worktree_root.join(".bamboo-owned").join(name);
+        std::fs::read_to_string(marker).is_ok_and(|branch| branch == format!("bamboo/{name}"))
+    })
 }
 
 fn build_codex_run_secrets(
@@ -558,6 +588,16 @@ impl ActorChildRunner {
             self.fabric_dir.to_string_lossy().into_owned(),
         );
         spec.workspace = session.workspace.clone();
+        if let ExecutorSpec::Codex {
+            workspace_owned, ..
+        } = &mut spec.executor
+        {
+            *workspace_owned = Some(
+                spec.workspace
+                    .as_deref()
+                    .is_some_and(workspace_is_bamboo_owned),
+            );
+        }
         // Unified transport: when a bus is configured, the child dials it (no
         // listen socket / file discovery) and the parent drives it by mailbox id.
         spec.bus = self.bus.clone();
@@ -675,6 +715,14 @@ impl ActorChildRunner {
         // still `rm -rf` / `git push` / `curl | sh`, defeating "read-only".
         spec.capabilities.guardian_read_only =
             session.metadata.get("subagent_type").map(String::as_str) == Some("guardian");
+        if spec.capabilities.guardian_read_only {
+            if let ExecutorSpec::Codex {
+                permission_profile, ..
+            } = &mut spec.executor
+            {
+                *permission_profile = Some("read-only".to_string());
+            }
+        }
         // #193: route this role to a REMOTE resident worker when one is pinned.
         // `spec.identity.role` was just computed from `subagent_type` above; a
         // match flips the placement to Remote and rides the worker's bearer on the
@@ -1490,7 +1538,34 @@ mod tests {
             wire_api: Some("responses".to_string()),
             provider_key_ref: None,
             forward_env: None,
+            approval_policy: None,
+            network_access: None,
+            allow_danger_bypass: None,
+            permission_profile: None,
+            workspace_owned: None,
         }
+    }
+
+    #[test]
+    fn only_bamboo_managed_non_git_workspaces_are_marked_owned() {
+        let project = tempfile::tempdir().unwrap();
+        let managed = project.path().join(".bamboo/worktree/child-571");
+        std::fs::create_dir_all(&managed).unwrap();
+        assert!(!workspace_is_bamboo_owned(managed.to_str().unwrap()));
+        let marker = project
+            .path()
+            .join(".bamboo/worktree/.bamboo-owned/child-571");
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        std::fs::write(&marker, "bamboo/child-571").unwrap();
+        assert!(workspace_is_bamboo_owned(managed.to_str().unwrap()));
+        let nested = managed.join("nested/path");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert!(workspace_is_bamboo_owned(nested.to_str().unwrap()));
+
+        let arbitrary = tempfile::tempdir().unwrap();
+        assert!(!workspace_is_bamboo_owned(
+            arbitrary.path().to_str().unwrap()
+        ));
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/external_agents/config.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/config.rs
@@ -82,6 +82,14 @@ pub struct ExternalAgentProfile {
     pub codex_provider_key_ref: Option<bamboo_config::CredentialRef>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_forward_env: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_sandbox: Option<bamboo_config::CodexSandbox>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_approval_policy: Option<bamboo_config::CodexApprovalPolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_network_access: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_allow_danger_bypass: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -233,6 +241,40 @@ mod tests {
             Some("https://example.com/agent-card.json".to_string())
         );
         assert_eq!(profile.auth_ref, Some("REMOTE_IMPL_TOKEN".to_string()));
+    }
+
+    #[test]
+    fn parse_external_codex_permission_fields() {
+        let mut config = Config::default();
+        config.extra.insert(
+            "externalAgents".to_string(),
+            serde_json::json!({
+                "codex_research": {
+                    "agent_id": "codex_research",
+                    "protocol": "actor",
+                    "permission_profile": "research",
+                    "executor": "codex",
+                    "codex_sandbox": "read-only",
+                    "codex_approval_policy": "never",
+                    "codex_network_access": false,
+                    "codex_allow_danger_bypass": false
+                }
+            }),
+        );
+
+        let profile = parse_external_agents(&config)
+            .remove("codex_research")
+            .expect("typed Codex profile");
+        assert_eq!(
+            profile.codex_sandbox,
+            Some(bamboo_config::CodexSandbox::ReadOnly)
+        );
+        assert_eq!(
+            profile.codex_approval_policy,
+            Some(bamboo_config::CodexApprovalPolicy::Never)
+        );
+        assert_eq!(profile.codex_network_access, Some(false));
+        assert_eq!(profile.codex_allow_danger_bypass, Some(false));
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/external_agents/runtime.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/runtime.rs
@@ -29,6 +29,23 @@ fn codex_wire_api_name(wire_api: bamboo_config::CodexWireApi) -> String {
     .to_string()
 }
 
+fn codex_sandbox_name(sandbox: bamboo_config::CodexSandbox) -> String {
+    match sandbox {
+        bamboo_config::CodexSandbox::ReadOnly => "read-only",
+        bamboo_config::CodexSandbox::WorkspaceWrite => "workspace-write",
+        bamboo_config::CodexSandbox::DangerFullAccess => "danger-full-access",
+    }
+    .to_string()
+}
+
+fn codex_approval_policy_name(policy: bamboo_config::CodexApprovalPolicy) -> String {
+    match policy {
+        bamboo_config::CodexApprovalPolicy::Never => "never",
+        bamboo_config::CodexApprovalPolicy::OnFailure => "on-failure",
+    }
+    .to_string()
+}
+
 fn codex_base_url(
     config: &Config,
     mode: bamboo_config::CodexAuthMode,
@@ -202,7 +219,7 @@ pub fn build_external_child_runner_with_codex_tokens(
                 Some("codex") => bamboo_subagent::provision::ExecutorSpec::Codex {
                     binary: profile.codex_binary.clone(),
                     model: profile.codex_model.clone(),
-                    sandbox: None,
+                    sandbox: profile.codex_sandbox.map(codex_sandbox_name),
                     inherit_user_config: None,
                     auth_mode: Some(codex_auth_mode_name(
                         profile.codex_auth_mode.unwrap_or_default(),
@@ -218,6 +235,13 @@ pub fn build_external_child_runner_with_codex_tokens(
                         .as_ref()
                         .map(|reference| reference.as_str().to_string()),
                     forward_env: profile.codex_forward_env.clone(),
+                    approval_policy: profile
+                        .codex_approval_policy
+                        .map(codex_approval_policy_name),
+                    network_access: profile.codex_network_access,
+                    allow_danger_bypass: profile.codex_allow_danger_bypass,
+                    permission_profile: Some(profile.permission_profile.clone()),
+                    workspace_owned: None,
                 },
                 Some(other) => {
                     tracing::error!(
@@ -360,7 +384,7 @@ fn build_local_actor_runner(
         Some("codex") => bamboo_subagent::provision::ExecutorSpec::Codex {
             binary: sub.codex_binary.clone(),
             model: sub.codex_model.clone(),
-            sandbox: None,
+            sandbox: sub.codex_sandbox.map(codex_sandbox_name),
             inherit_user_config: None,
             auth_mode: Some(codex_auth_mode_name(
                 sub.codex_auth_mode.unwrap_or_default(),
@@ -376,6 +400,11 @@ fn build_local_actor_runner(
                 .as_ref()
                 .map(|reference| reference.as_str().to_string()),
             forward_env: sub.codex_forward_env.clone(),
+            approval_policy: sub.codex_approval_policy.map(codex_approval_policy_name),
+            network_access: sub.codex_network_access,
+            allow_danger_bypass: sub.codex_allow_danger_bypass,
+            permission_profile: None,
+            workspace_owned: None,
         },
         Some(other) => return Err(format!("unknown subagents.executor '{other}'")),
     };
@@ -664,8 +693,11 @@ pub fn extract_provider_credentials(
 
 #[cfg(test)]
 mod codex_runtime_config_tests {
-    use super::{codex_auth_mode_name, codex_base_url, codex_wire_api_name};
-    use bamboo_config::{CodexAuthMode, CodexWireApi};
+    use super::{
+        codex_approval_policy_name, codex_auth_mode_name, codex_base_url, codex_sandbox_name,
+        codex_wire_api_name,
+    };
+    use bamboo_config::{CodexApprovalPolicy, CodexAuthMode, CodexSandbox, CodexWireApi};
     use bamboo_llm::Config;
 
     #[test]
@@ -675,6 +707,15 @@ mod codex_runtime_config_tests {
 
         assert_eq!(codex_auth_mode_name(CodexAuthMode::Bamboo), "bamboo");
         assert_eq!(codex_wire_api_name(CodexWireApi::Responses), "responses");
+        assert_eq!(codex_sandbox_name(CodexSandbox::ReadOnly), "read-only");
+        assert_eq!(
+            codex_sandbox_name(CodexSandbox::WorkspaceWrite),
+            "workspace-write"
+        );
+        assert_eq!(
+            codex_approval_policy_name(CodexApprovalPolicy::OnFailure),
+            "on-failure"
+        );
         assert_eq!(
             codex_base_url(&config, CodexAuthMode::Bamboo, None).as_deref(),
             Some("http://127.0.0.1:5700/openai/v1")

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -629,6 +629,27 @@ pub enum CodexWireApi {
     Responses,
 }
 
+/// OS sandbox selected for non-interactive `codex exec` children.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CodexSandbox {
+    ReadOnly,
+    WorkspaceWrite,
+    DangerFullAccess,
+}
+
+/// Spawn-time approval policy for non-interactive `codex exec` children.
+///
+/// Interactive policies (`untrusted` / `on-request`) are intentionally not
+/// representable: exec mode has no approval relay, so either policy would
+/// eventually wait for a human that cannot answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CodexApprovalPolicy {
+    Never,
+    OnFailure,
+}
+
 /// Sub-agent execution settings.
 ///
 /// Sub-agents always run as independent **actor** processes — an isolated OS
@@ -714,6 +735,21 @@ pub struct SubagentsConfig {
     /// requires an explicit `OPENAI_API_KEY` entry; it is never implicit.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_forward_env: Option<Vec<String>>,
+    /// Explicit Codex sandbox override. Unset derives the sandbox from the
+    /// child permission profile and the parent session's bypass posture.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_sandbox: Option<CodexSandbox>,
+    /// Explicit non-interactive approval policy. Unset always resolves to an
+    /// explicit safe value; Bamboo never trusts the CLI's implicit default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_approval_policy: Option<CodexApprovalPolicy>,
+    /// Permit network access from a workspace-write sandbox.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_network_access: Option<bool>,
+    /// Opt in to disabling the Codex OS sandbox, but only when the parent run
+    /// is itself in bypass mode. False/unset keeps bypass runs sandboxed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_allow_danger_bypass: Option<bool>,
     /// The active message-broker endpoint the `ask_agent` tool / sub-agent bus
     /// dials. RUNTIME-ONLY (`#[serde(skip)]`): never read from nor written to
     /// `config.json`. It is populated in memory each boot by `maybe_embed_broker`

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -1594,7 +1594,11 @@ pub fn validate_codex_subagents_config(value: &SubagentsConfig) -> Result<(), St
         || value.codex_base_url.is_some()
         || value.codex_wire_api.is_some()
         || value.codex_provider_key_ref.is_some()
-        || value.codex_forward_env.is_some();
+        || value.codex_forward_env.is_some()
+        || value.codex_sandbox.is_some()
+        || value.codex_approval_policy.is_some()
+        || value.codex_network_access.is_some()
+        || value.codex_allow_danger_bypass.is_some();
     if value.executor.as_deref() != Some("codex") && !codex_fields_present {
         return Ok(());
     }
@@ -1623,6 +1627,23 @@ pub fn validate_codex_subagents_config(value: &SubagentsConfig) -> Result<(), St
     }
     if mode != crate::CodexAuthMode::ApiKey && forwards_openai {
         return Err("OPENAI_API_KEY may only be forwarded in api_key auth mode".to_string());
+    }
+
+    if value.codex_network_access == Some(true)
+        && value.codex_sandbox == Some(crate::CodexSandbox::ReadOnly)
+    {
+        return Err(
+            "codex_network_access requires the workspace-write sandbox (or an unset sandbox)"
+                .to_string(),
+        );
+    }
+    if value.codex_sandbox == Some(crate::CodexSandbox::DangerFullAccess)
+        && value.codex_allow_danger_bypass != Some(true)
+    {
+        return Err(
+            "danger-full-access sandbox requires codex_allow_danger_bypass = true; parent bypass is still required at run time"
+                .to_string(),
+        );
     }
 
     match mode {
@@ -4533,6 +4554,21 @@ mod tests {
         assert!(validate_codex_subagents_config(&config)
             .unwrap_err()
             .contains("must not contain credentials"));
+
+        config.codex_base_url = Some("https://provider.example/v1".to_string());
+        config.codex_sandbox = Some(crate::CodexSandbox::ReadOnly);
+        config.codex_network_access = Some(true);
+        assert!(validate_codex_subagents_config(&config)
+            .unwrap_err()
+            .contains("workspace-write"));
+
+        config.codex_network_access = None;
+        config.codex_sandbox = Some(crate::CodexSandbox::DangerFullAccess);
+        assert!(validate_codex_subagents_config(&config)
+            .unwrap_err()
+            .contains("codex_allow_danger_bypass"));
+        config.codex_allow_danger_bypass = Some(true);
+        assert!(validate_codex_subagents_config(&config).is_ok());
     }
 
     fn directory_snapshot(root: &Path) -> BTreeMap<PathBuf, Option<Vec<u8>>> {

--- a/crates/infra/bamboo-subagent/src/provision.rs
+++ b/crates/infra/bamboo-subagent/src/provision.rs
@@ -251,8 +251,8 @@ pub enum ExecutorSpec {
         forward_env: Option<Vec<String>>,
     },
     /// Drive the official Codex CLI as a one-process-per-activation engine
-    /// over `codex exec --json`. Authentication, permission-profile mapping,
-    /// and resume state are layered on by the dependent issues in epic #568.
+    /// over `codex exec --json`. Authentication and spawn-time permission
+    /// posture are explicit because exec mode has no runtime approval relay.
     Codex {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         binary: Option<String>,
@@ -279,6 +279,20 @@ pub enum ExecutorSpec {
         provider_key_ref: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         forward_env: Option<Vec<String>>,
+        /// `never | on-failure`; interactive approval policies are rejected.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        approval_policy: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        network_access: Option<bool>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        allow_danger_bypass: Option<bool>,
+        /// External-agent permission profile used for default sandbox mapping.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        permission_profile: Option<String>,
+        /// Whether Bamboo created/owns the workspace. Only owned non-git
+        /// workspaces may receive `--skip-git-repo-check`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        workspace_owned: Option<bool>,
     },
 }
 
@@ -633,12 +647,20 @@ mod tests {
             wire_api: None,
             provider_key_ref: None,
             forward_env: Some(vec!["OPENAI_API_KEY".into()]),
+            approval_policy: Some("never".into()),
+            network_access: Some(true),
+            allow_danger_bypass: Some(false),
+            permission_profile: Some("restricted".into()),
+            workspace_owned: Some(true),
         };
         let vc = serde_json::to_value(&codex).unwrap();
         assert_eq!(vc["kind"], "codex");
         assert_eq!(vc["binary"], "/usr/local/bin/codex");
         assert_eq!(vc["sandbox"], "workspace-write");
         assert_eq!(vc["forward_env"][0], "OPENAI_API_KEY");
+        assert_eq!(vc["approval_policy"], "never");
+        assert_eq!(vc["network_access"], true);
+        assert_eq!(vc["permission_profile"], "restricted");
         assert_eq!(serde_json::from_value::<ExecutorSpec>(vc).unwrap(), codex);
         let minimal_codex = ExecutorSpec::Codex {
             binary: None,
@@ -650,6 +672,11 @@ mod tests {
             wire_api: None,
             provider_key_ref: None,
             forward_env: None,
+            approval_policy: None,
+            network_access: None,
+            allow_danger_bypass: None,
+            permission_profile: None,
+            workspace_owned: None,
         };
         assert_eq!(
             serde_json::to_value(&minimal_codex).unwrap(),

--- a/docs/codex-executor.md
+++ b/docs/codex-executor.md
@@ -7,10 +7,11 @@ with `--output-last-message`.
 
 The minimum supported version is **Codex CLI 0.144.0**. Bamboo verifies the
 installed version and the required `exec --json`, stdin prompt,
-`--output-last-message`, and `exec resume --json` surfaces before a worker
-starts. The implementation and live Bamboo-provider test are verified against
-0.144.5. Codex 0.144 removed the custom-provider Chat Completions wire, so
-`codex_wire_api` only accepts `"responses"`.
+`--output-last-message`, `--config`, sandbox/danger flags, and
+`exec resume --json` surfaces before a worker starts. The implementation and
+live Bamboo-provider test are verified against 0.144.5. Codex 0.144 removed the
+custom-provider Chat Completions wire, so `codex_wire_api` only accepts
+`"responses"`.
 
 ## Authentication and billing modes
 
@@ -85,6 +86,36 @@ query parameters, or a fragment. It and `codex_provider_key_ref` are valid only
 in `custom` mode. `OPENAI_API_KEY` is valid in `codex_forward_env` only in
 `api_key` mode. Unknown modes and wire protocols fail settings validation.
 
+## Sandbox and approval policy
+
+`codex exec` has no interactive approval relay. Bamboo therefore resolves both
+permission knobs before spawn and never relies on the CLI's implicit defaults:
+
+| Child posture | Effective Codex invocation |
+|---|---|
+| default / restricted | `--sandbox workspace-write --config approval_policy="never"` |
+| read-only / research / guardian | `--sandbox read-only --config approval_policy="never"` |
+| bypass parent | `--full-auto`, which remains workspace-sandboxed |
+| workspace network enabled | the workspace-write flags plus `--config sandbox_workspace_write.network_access=true` |
+
+`codex_sandbox` can explicitly select `read-only`, `workspace-write`, or
+`danger-full-access`; `codex_approval_policy` accepts only the non-interactive
+`never` and `on-failure` values. `codex_network_access` applies only to
+workspace-write. The same fields are available globally under `subagents` and
+per named `ExternalAgentProfile`.
+
+Disabling the OS sandbox is double-gated. A `danger-full-access` request becomes
+`--dangerously-bypass-approvals-and-sandbox` only when the child session's
+parent is currently in bypass mode and `codex_allow_danger_bypass` is true.
+Otherwise it is downgraded to `--full-auto` with an audit warning. Root workers
+are always downgraded. A successful danger bypass emits a separate, loud
+warning event as well as the bootstrap policy metadata.
+
+For a non-Git workspace, Bamboo adds `--skip-git-repo-check` only when the
+directory is under Bamboo's configured workspace root or a
+`<project>/.bamboo/worktree/...` directory. An arbitrary user-selected
+directory keeps Codex's repository check.
+
 ## Isolation and environment policy
 
 Every child starts after `env_clear()`. Bamboo restores only `HOME`, `PATH`,
@@ -122,11 +153,11 @@ record the request and outcome in the parent.
 ## Verification
 
 Run the deterministic executor and security tests normally with `cargo test`.
-Two real-machine tests are ignored in routine CI because they require an
+Real-machine tests are ignored in routine CI because they require an
 installed external binary:
 
 ```sh
-# User-login/inherit smoke test
+# User-login/inherit smoke and workspace sandbox tests
 cargo test --test e2e_codex_cli_manual -- --ignored --nocapture
 
 # Live Codex -> Bamboo Responses path, metrics, and post-run revocation

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -262,6 +262,10 @@ in-process runtime toggle.
 | `codex_wire_api` | `"responses"` (the only protocol accepted by supported Codex CLI versions). |
 | `codex_provider_key_ref` | Existing Bamboo provider credential reference used only by `custom` mode; the key is injected through an environment variable and is not written to the generated Codex config. |
 | `codex_forward_env` | Extra environment names after `env_clear()`; `api_key` mode requires an explicit `OPENAI_API_KEY`, and other modes reject it. `CODEX_*` and Bamboo's managed provider-key variable are reserved. |
+| `codex_sandbox` | Optional explicit `"read-only"` \| `"workspace-write"` \| `"danger-full-access"`. Unset derives a safe value from the child profile and live parent bypass posture. |
+| `codex_approval_policy` | Optional explicit `"never"` \| `"on-failure"`. Interactive policies are rejected because `codex exec` has no approval relay. |
+| `codex_network_access` | Enables network access inside `workspace-write`; incompatible with an explicit `read-only` sandbox. |
+| `codex_allow_danger_bypass` | Second gate for disabling the OS sandbox. The live parent must also be in bypass mode; root workers always downgrade and warn. |
 | `remote_placements` / `schedulable_placements` | Where a sub-agent may run (local / a named Cluster Fabric node) and whether schedules may target it. |
 | `mcp_role_allowlist` | Restrict which MCP servers a sub-agent role may see. |
 
@@ -276,11 +280,11 @@ in-process runtime toggle.
 }
 ```
 
-The same `claude_code_*` field set is duplicated per-agent under
+The same `claude_code_*` and `codex_*` field sets are duplicated per-agent under
 `ExternalAgentProfile` (`Config.extra["externalAgents"]`,
 `bamboo-engine/src/external_agents/config.rs`) when you need different
-`claude` executor settings for different named external agents rather than
-one global default.
+external CLI executor settings for different named agents rather than one
+global default.
 
 The concrete spawn implementation is `src/claude_code_executor.rs`
 (`ClaudeCodeExecutor`): it runs `claude --output-format stream-json

--- a/src/broker_agent.rs
+++ b/src/broker_agent.rs
@@ -193,6 +193,11 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
                 ref wire_api,
                 ref provider_key_ref,
                 ref forward_env,
+                ref approval_policy,
+                ref network_access,
+                ref allow_danger_bypass,
+                ref permission_profile,
+                ref workspace_owned,
             } => {
                 let forward_env = forward_env.clone().unwrap_or_default();
                 let auth = crate::codex_cli_executor::resolve_codex_auth_config(
@@ -204,11 +209,19 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
                     &spec.secrets.provider_credentials,
                     &forward_env,
                 )?;
+                let permissions = crate::codex_cli_executor::resolve_codex_permission_config(
+                    sandbox.as_deref(),
+                    approval_policy.as_deref(),
+                    network_access.unwrap_or(false),
+                    allow_danger_bypass.unwrap_or(false),
+                    permission_profile.clone(),
+                    spec.capabilities.bypass,
+                    workspace_owned.unwrap_or(false),
+                )?;
                 Arc::new(
                     crate::codex_cli_executor::CodexExecutor::new(
                         binary.clone(),
                         model.clone(),
-                        sandbox.clone(),
                         spec.workspace.clone(),
                         Some(crate::codex_cli_executor::resolve_codex_state_dir(
                             &spec.storage_dir,
@@ -216,6 +229,7 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
                         )),
                         forward_env,
                         auth,
+                        permissions,
                     )
                     .await?,
                 )

--- a/src/codex_cli_executor.rs
+++ b/src/codex_cli_executor.rs
@@ -4,8 +4,8 @@
 //! The CLI is one process per activation. Prompts are written on stdin (never
 //! argv), stdout is consumed as bounded JSONL, and the process owns a process
 //! group so cancellation tears down any descendants as well as the leader.
-//! Session resume, provider/auth selection, and bamboo permission-profile
-//! mapping are intentionally handled by the dependent issues in epic #568.
+//! Provider/auth selection and Bamboo permission-profile mapping are resolved
+//! before every spawn; session resume is handled by a dependent epic issue.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -190,12 +190,257 @@ pub fn resolve_codex_state_dir(storage_dir: &Option<String>, child_id: &str) -> 
         .unwrap_or_else(|| bamboo_config::paths::subagents_dir().join(child_id))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexSandbox {
+    ReadOnly,
+    WorkspaceWrite,
+    DangerFullAccess,
+}
+
+impl CodexSandbox {
+    fn parse(raw: &str) -> Result<Self, String> {
+        match raw {
+            "read-only" => Ok(Self::ReadOnly),
+            "workspace-write" => Ok(Self::WorkspaceWrite),
+            "danger-full-access" => Ok(Self::DangerFullAccess),
+            other => Err(format!(
+                "unknown Codex sandbox '{other}'; expected read-only, workspace-write, or danger-full-access"
+            )),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read-only",
+            Self::WorkspaceWrite => "workspace-write",
+            Self::DangerFullAccess => "danger-full-access",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexApprovalPolicy {
+    Never,
+    OnFailure,
+}
+
+impl CodexApprovalPolicy {
+    fn parse(raw: &str) -> Result<Self, String> {
+        match raw {
+            "never" => Ok(Self::Never),
+            "on-failure" => Ok(Self::OnFailure),
+            "untrusted" | "on-request" => Err(format!(
+                "Codex approval policy '{raw}' is interactive and unsupported by non-interactive exec mode"
+            )),
+            other => Err(format!(
+                "unknown Codex approval policy '{other}'; expected never or on-failure"
+            )),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Never => "never",
+            Self::OnFailure => "on-failure",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexPolicyInvocation {
+    Explicit,
+    FullAuto,
+    DangerBypass,
+}
+
+impl CodexPolicyInvocation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Explicit => "explicit",
+            Self::FullAuto => "full-auto",
+            Self::DangerBypass => "danger-bypass",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CodexPermissionConfig {
+    sandbox: Option<CodexSandbox>,
+    approval_policy: Option<CodexApprovalPolicy>,
+    network_access: bool,
+    allow_danger_bypass: bool,
+    permission_profile: Option<String>,
+    provisioned_bypass: bool,
+    workspace_owned: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EffectiveCodexPolicy {
+    sandbox: CodexSandbox,
+    approval_policy: CodexApprovalPolicy,
+    invocation: CodexPolicyInvocation,
+    network_access: bool,
+    warnings: Vec<String>,
+}
+
+impl CodexPermissionConfig {
+    fn effective(&self, bypass: bool, is_root: bool) -> EffectiveCodexPolicy {
+        let read_only_profile = self
+            .permission_profile
+            .as_deref()
+            .is_some_and(profile_is_read_only);
+        let mut warnings = Vec::new();
+
+        let (sandbox, approval_policy, invocation) = match self.sandbox {
+            Some(CodexSandbox::ReadOnly) => (
+                CodexSandbox::ReadOnly,
+                self.approval_policy.unwrap_or(CodexApprovalPolicy::Never),
+                CodexPolicyInvocation::Explicit,
+            ),
+            Some(CodexSandbox::WorkspaceWrite) => (
+                CodexSandbox::WorkspaceWrite,
+                self.approval_policy.unwrap_or(CodexApprovalPolicy::Never),
+                CodexPolicyInvocation::Explicit,
+            ),
+            Some(CodexSandbox::DangerFullAccess) => {
+                resolve_danger_request(bypass, self.allow_danger_bypass, is_root, &mut warnings)
+            }
+            None if self.allow_danger_bypass => {
+                resolve_danger_request(bypass, true, is_root, &mut warnings)
+            }
+            None if bypass => (
+                CodexSandbox::WorkspaceWrite,
+                CodexApprovalPolicy::Never,
+                CodexPolicyInvocation::FullAuto,
+            ),
+            None if read_only_profile => (
+                CodexSandbox::ReadOnly,
+                self.approval_policy.unwrap_or(CodexApprovalPolicy::Never),
+                CodexPolicyInvocation::Explicit,
+            ),
+            None => (
+                CodexSandbox::WorkspaceWrite,
+                self.approval_policy.unwrap_or(CodexApprovalPolicy::Never),
+                CodexPolicyInvocation::Explicit,
+            ),
+        };
+
+        let network_access = match sandbox {
+            CodexSandbox::ReadOnly => false,
+            CodexSandbox::WorkspaceWrite => self.network_access,
+            CodexSandbox::DangerFullAccess => true,
+        };
+        if invocation == CodexPolicyInvocation::DangerBypass {
+            warnings.push(
+                "DANGER: Codex is running with approvals and the OS sandbox disabled for this parent-bypass run"
+                    .to_string(),
+            );
+        }
+
+        EffectiveCodexPolicy {
+            sandbox,
+            approval_policy,
+            invocation,
+            network_access,
+            warnings,
+        }
+    }
+}
+
+fn resolve_danger_request(
+    bypass: bool,
+    allow_danger_bypass: bool,
+    is_root: bool,
+    warnings: &mut Vec<String>,
+) -> (CodexSandbox, CodexApprovalPolicy, CodexPolicyInvocation) {
+    if bypass && allow_danger_bypass && !is_root {
+        return (
+            CodexSandbox::DangerFullAccess,
+            CodexApprovalPolicy::Never,
+            CodexPolicyInvocation::DangerBypass,
+        );
+    }
+
+    let reason = if !bypass {
+        "the parent run is not in bypass mode"
+    } else if !allow_danger_bypass {
+        "codex_allow_danger_bypass is false"
+    } else {
+        "the worker is running as root"
+    };
+    warnings.push(format!(
+        "Codex danger-full-access request was downgraded to a sandboxed policy because {reason}"
+    ));
+    // A requested danger posture first falls back to Codex's sandboxed
+    // convenience mode. This keeps the two gates independent: neither a
+    // config-only request nor a root process can silently become unsandboxed.
+    (
+        CodexSandbox::WorkspaceWrite,
+        CodexApprovalPolicy::Never,
+        CodexPolicyInvocation::FullAuto,
+    )
+}
+
+fn profile_is_read_only(raw: &str) -> bool {
+    let normalized = raw.trim().to_ascii_lowercase().replace(['_', ' '], "-");
+    matches!(
+        normalized.as_str(),
+        "read-only" | "readonly" | "research" | "researcher" | "guardian" | "plan"
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn resolve_codex_permission_config(
+    sandbox: Option<&str>,
+    approval_policy: Option<&str>,
+    network_access: bool,
+    allow_danger_bypass: bool,
+    permission_profile: Option<String>,
+    provisioned_bypass: bool,
+    workspace_owned: bool,
+) -> Result<CodexPermissionConfig, String> {
+    let sandbox = sandbox.map(CodexSandbox::parse).transpose()?;
+    let approval_policy = approval_policy
+        .map(CodexApprovalPolicy::parse)
+        .transpose()?;
+    let profile_read_only = permission_profile
+        .as_deref()
+        .is_some_and(profile_is_read_only);
+    if network_access
+        && (sandbox == Some(CodexSandbox::ReadOnly) || (sandbox.is_none() && profile_read_only))
+    {
+        return Err(
+            "Codex network access requires an effective workspace-write sandbox".to_string(),
+        );
+    }
+    Ok(CodexPermissionConfig {
+        sandbox,
+        approval_policy,
+        network_access,
+        allow_danger_bypass,
+        permission_profile,
+        provisioned_bypass,
+        workspace_owned,
+    })
+}
+
+#[cfg(unix)]
+fn running_as_root() -> bool {
+    // SAFETY: geteuid has no preconditions and does not dereference memory.
+    unsafe { libc::geteuid() == 0 }
+}
+
+#[cfg(not(unix))]
+fn running_as_root() -> bool {
+    false
+}
+
 /// One-process-per-activation Codex CLI executor.
 pub struct CodexExecutor {
     binary: PathBuf,
     version: String,
     model: Option<String>,
-    sandbox: Option<String>,
+    permissions: CodexPermissionConfig,
     workspace: Option<String>,
     state_dir: Option<PathBuf>,
     forward_env: Vec<String>,
@@ -210,11 +455,11 @@ impl CodexExecutor {
     pub async fn new(
         binary: Option<String>,
         model: Option<String>,
-        sandbox: Option<String>,
         workspace: Option<String>,
         state_dir: Option<PathBuf>,
         forward_env: Vec<String>,
         auth: CodexAuthConfig,
+        permissions: CodexPermissionConfig,
     ) -> Result<Self, String> {
         let requested = binary.unwrap_or_else(|| "codex".to_string());
         let resolved =
@@ -251,7 +496,14 @@ impl CodexExecutor {
         verify_help_surface(
             &resolved,
             &["exec", "--help"],
-            &["--json", "--output-last-message", "stdin"],
+            &[
+                "--json",
+                "--output-last-message",
+                "--config",
+                "--sandbox",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "stdin",
+            ],
         )
         .await?;
         verify_help_surface(&resolved, &["exec", "resume", "--help"], &["--json"]).await?;
@@ -260,7 +512,7 @@ impl CodexExecutor {
             binary: resolved,
             version: version_text,
             model,
-            sandbox,
+            permissions,
             workspace,
             state_dir,
             forward_env,
@@ -276,7 +528,11 @@ impl CodexExecutor {
             .map(|directory| directory.join("codex-last-message.txt"))
     }
 
-    fn build_command(&self, run_provider_token: Option<&str>) -> Result<Command, String> {
+    fn build_command(
+        &self,
+        run_provider_token: Option<&str>,
+        policy: &EffectiveCodexPolicy,
+    ) -> Result<Command, String> {
         let mut command = Command::new(&self.binary);
         command
             .arg("exec")
@@ -290,20 +546,36 @@ impl CodexExecutor {
         } else {
             std::env::current_dir().ok()
         };
-        if workspace_path
-            .as_deref()
-            .is_some_and(|path| !has_git_metadata(path))
+        if self.permissions.workspace_owned
+            && workspace_path
+                .as_deref()
+                .is_some_and(|path| !has_git_metadata(path))
         {
             command.arg("--skip-git-repo-check");
         }
         if let Some(model) = &self.model {
             command.arg("--model").arg(model);
         }
-        // Safe foundation default until #571 maps Bamboo permission profiles
-        // onto Codex's sandbox and approval-policy pair.
-        command
-            .arg("--sandbox")
-            .arg(self.sandbox.as_deref().unwrap_or("read-only"));
+        match policy.invocation {
+            CodexPolicyInvocation::Explicit => {
+                command.arg("--sandbox").arg(policy.sandbox.as_str());
+                command.arg("--config").arg(format!(
+                    "approval_policy=\"{}\"",
+                    policy.approval_policy.as_str()
+                ));
+            }
+            CodexPolicyInvocation::FullAuto => {
+                command.arg("--full-auto");
+            }
+            CodexPolicyInvocation::DangerBypass => {
+                command.arg("--dangerously-bypass-approvals-and-sandbox");
+            }
+        }
+        if policy.sandbox == CodexSandbox::WorkspaceWrite && policy.network_access {
+            command
+                .arg("--config")
+                .arg("sandbox_workspace_write.network_access=true");
+        }
         if self.auth.isolated() {
             command.arg("--ignore-rules");
         }
@@ -431,7 +703,13 @@ impl CodexExecutor {
         }
     }
 
-    fn handle_event(&self, value: Value, events: &EventSink, state: &mut RunState) {
+    fn handle_event(
+        &self,
+        value: Value,
+        policy: &EffectiveCodexPolicy,
+        events: &EventSink,
+        state: &mut RunState,
+    ) {
         let event_type = value.get("type").and_then(Value::as_str).unwrap_or("");
         match event_type {
             "thread.started" => {
@@ -447,7 +725,11 @@ impl CodexExecutor {
                     "executor": "codex",
                     "binary": self.binary,
                     "version": self.version,
-                    "sandbox": self.sandbox.as_deref().unwrap_or("read-only"),
+                    "sandbox": policy.sandbox.as_str(),
+                    "approval_policy": policy.approval_policy.as_str(),
+                    "network_access": policy.network_access,
+                    "policy_invocation": policy.invocation.as_str(),
+                    "permission_profile": self.permissions.permission_profile.as_deref(),
                 }));
             }
             "turn.started" => {
@@ -461,6 +743,33 @@ impl CodexExecutor {
                 let phase = event_type.trim_start_matches("item.");
                 if let Some(item) = value.get("item") {
                     handle_item(phase, item, events, state);
+                    // Codex CLI 0.144 can omit the command_execution item when
+                    // the OS sandbox itself rejects the command, even though
+                    // it reports the exit status and errno to the model. Keep
+                    // that safety failure visible instead of reducing the JSONL
+                    // stream to an apparently successful agent message.
+                    if phase == "completed"
+                        && policy.sandbox != CodexSandbox::DangerFullAccess
+                        && !state.tool_error_emitted
+                        && item.get("type").and_then(Value::as_str) == Some("agent_message")
+                        && item
+                            .get("text")
+                            .and_then(Value::as_str)
+                            .is_some_and(looks_like_sandbox_denial)
+                    {
+                        let item_id = item
+                            .get("id")
+                            .and_then(Value::as_str)
+                            .unwrap_or("codex-sandbox-denial");
+                        let error = item.get("text").and_then(Value::as_str).unwrap_or(
+                            "Codex reported that the OS sandbox denied a tool operation",
+                        );
+                        events.emit(event_json(AgentEvent::ToolError {
+                            tool_call_id: format!("{item_id}-sandbox-denial"),
+                            error: truncate_chars(error, TOOL_RESULT_TRUNCATE_CHARS),
+                        }));
+                        state.tool_error_emitted = true;
+                    }
                 }
             }
             "turn.completed" => {
@@ -498,9 +807,12 @@ impl CodexExecutor {
         &self,
         prompt: &str,
         run_provider_token: Option<&str>,
+        parent_bypass: bool,
         events: &EventSink,
         cancel: &CancellationToken,
     ) -> ChildOutcome {
+        let policy = self.permissions.effective(parent_bypass, running_as_root());
+        self.emit_policy_bootstrap(&policy, events);
         // Warm workers reuse this executor across activations. Reassert the
         // isolated-home invariant at every run boundary so a prior Codex
         // process cannot leave an auth artifact or mutate provider routing for
@@ -512,8 +824,10 @@ impl CodexExecutor {
             return ChildOutcome::error(error);
         }
 
-        let mut child = match spawn_with_etxtbsy_retry(|| self.build_command(run_provider_token))
-            .await
+        let mut child = match spawn_with_etxtbsy_retry(|| {
+            self.build_command(run_provider_token, &policy)
+        })
+        .await
         {
             Ok(child) => child,
             Err(error) => {
@@ -577,7 +891,7 @@ impl CodexExecutor {
                                 continue;
                             }
                             match serde_json::from_slice::<Value>(&bytes) {
-                                Ok(value) => self.handle_event(value, events, &mut state),
+                                Ok(value) => self.handle_event(value, &policy, events, &mut state),
                                 Err(error) => tracing::debug!(%error, "codex: skipping unparsable stdout line"),
                             }
                         }
@@ -652,6 +966,37 @@ impl CodexExecutor {
             ),
         }
     }
+
+    fn emit_policy_bootstrap(&self, policy: &EffectiveCodexPolicy, events: &EventSink) {
+        events.emit(json!({
+            "type": "runner_progress",
+            "session_id": "codex",
+            "round_count": 0,
+            "executor": "codex",
+            "phase": "bootstrap",
+            "sandbox": policy.sandbox.as_str(),
+            "approval_policy": policy.approval_policy.as_str(),
+            "network_access": policy.network_access,
+            "policy_invocation": policy.invocation.as_str(),
+            "permission_profile": self.permissions.permission_profile.as_deref(),
+        }));
+        for warning in &policy.warnings {
+            tracing::warn!(message = %warning, "Codex spawn policy warning");
+            events.emit(json!({
+                "type": "runner_progress",
+                "session_id": "codex",
+                "round_count": 0,
+                "executor": "codex",
+                "phase": "policy_warning",
+                "level": "warning",
+                "message": warning,
+                "sandbox": policy.sandbox.as_str(),
+                "approval_policy": policy.approval_policy.as_str(),
+                "network_access": policy.network_access,
+                "policy_invocation": policy.invocation.as_str(),
+            }));
+        }
+    }
 }
 
 #[async_trait]
@@ -666,6 +1011,11 @@ impl ChildExecutor for CodexExecutor {
         // `codex exec` v1 has no mid-turn steering channel. Drain the inbox so
         // transport senders cannot build an unbounded backlog.
         let steer_drain = tokio::spawn(async move { while steer.recv().await.is_some() {} });
+        let parent_bypass = spec
+            .permission_policy
+            .as_ref()
+            .map(|policy| policy.bypass_permissions)
+            .unwrap_or(self.permissions.provisioned_bypass);
         let outcome = self
             .run_process(
                 &spec.assignment,
@@ -673,6 +1023,7 @@ impl ChildExecutor for CodexExecutor {
                     .codex_provider_token
                     .as_ref()
                     .map(bamboo_subagent::proto::SecretValue::expose),
+                parent_bypass,
                 &events,
                 &cancel,
             )
@@ -690,6 +1041,7 @@ struct RunState {
     failure: Option<String>,
     last_agent_message: String,
     usage: TokenUsage,
+    tool_error_emitted: bool,
     started_items: HashSet<String>,
     item_text: HashMap<String, String>,
     item_output: HashMap<String, String>,
@@ -773,6 +1125,7 @@ fn handle_item(phase: &str, item: &Value, events: &EventSink, state: &mut RunSta
                         tool_call_id: item_id,
                         error,
                     }));
+                    state.tool_error_emitted = true;
                 }
             }
         }
@@ -790,7 +1143,7 @@ fn handle_item(phase: &str, item: &Value, events: &EventSink, state: &mut RunSta
                 state,
             );
             if phase == "completed" {
-                complete_structured_tool(&item_id, item, events);
+                complete_structured_tool(&item_id, item, events, state);
             }
         }
         "mcp_tool_call" => {
@@ -808,7 +1161,7 @@ fn handle_item(phase: &str, item: &Value, events: &EventSink, state: &mut RunSta
                 .unwrap_or_else(|| json!({}));
             ensure_tool_started(&item_id, &tool_name, arguments, events, state);
             if phase == "completed" {
-                complete_structured_tool(&item_id, item, events);
+                complete_structured_tool(&item_id, item, events, state);
             }
         }
         "web_search" => {
@@ -821,7 +1174,7 @@ fn handle_item(phase: &str, item: &Value, events: &EventSink, state: &mut RunSta
                 state,
             );
             if phase == "completed" {
-                complete_structured_tool(&item_id, item, events);
+                complete_structured_tool(&item_id, item, events, state);
             }
         }
         "todo_list" => {
@@ -871,12 +1224,13 @@ fn emit_tool_output_delta(item_id: &str, output: &str, events: &EventSink, state
     *previous = output.to_string();
 }
 
-fn complete_structured_tool(item_id: &str, item: &Value, events: &EventSink) {
+fn complete_structured_tool(item_id: &str, item: &Value, events: &EventSink, state: &mut RunState) {
     if let Some(error) = item.get("error").filter(|value| !value.is_null()) {
         events.emit(event_json(AgentEvent::ToolError {
             tool_call_id: item_id.to_string(),
             error: value_text(error),
         }));
+        state.tool_error_emitted = true;
         return;
     }
     let result = item
@@ -891,6 +1245,18 @@ fn complete_structured_tool(item_id: &str, item: &Value, events: &EventSink) {
             truncate_chars(&value_text(&result), TOOL_RESULT_TRUNCATE_CHARS),
         ),
     }));
+}
+
+fn looks_like_sandbox_denial(text: &str) -> bool {
+    let normalized = text.to_ascii_lowercase();
+    let denied = normalized.contains("operation not permitted")
+        || normalized.contains("permission denied")
+        || normalized.contains("read-only file system");
+    let operation = normalized.contains("sandbox")
+        || normalized.contains("command")
+        || normalized.contains("write")
+        || normalized.contains("exit status");
+    denied && operation
 }
 
 fn emit_text_delta<F>(
@@ -1350,6 +1716,14 @@ mod tests {
             .map(|value| value.to_string_lossy().into_owned())
     }
 
+    fn command_args(command: &Command) -> Vec<String> {
+        command
+            .as_std()
+            .get_args()
+            .map(|argument| argument.to_string_lossy().into_owned())
+            .collect()
+    }
+
     fn auth_error(result: Result<CodexAuthConfig, String>) -> String {
         match result {
             Err(error) => error,
@@ -1357,12 +1731,41 @@ mod tests {
         }
     }
 
+    fn permissions(
+        sandbox: Option<&str>,
+        approval_policy: Option<&str>,
+        network_access: bool,
+        allow_danger_bypass: bool,
+        permission_profile: Option<&str>,
+        provisioned_bypass: bool,
+        workspace_owned: bool,
+    ) -> CodexPermissionConfig {
+        resolve_codex_permission_config(
+            sandbox,
+            approval_policy,
+            network_access,
+            allow_danger_bypass,
+            permission_profile.map(str::to_string),
+            provisioned_bypass,
+            workspace_owned,
+        )
+        .unwrap()
+    }
+
+    fn default_permissions() -> CodexPermissionConfig {
+        permissions(None, None, false, false, None, false, false)
+    }
+
+    fn default_policy(executor: &CodexExecutor) -> EffectiveCodexPolicy {
+        executor.permissions.effective(false, false)
+    }
+
     fn fixture_executor() -> CodexExecutor {
         CodexExecutor {
             binary: PathBuf::from("/usr/local/bin/codex"),
             version: "codex-cli 0.144.5".to_string(),
             model: None,
-            sandbox: None,
+            permissions: default_permissions(),
             workspace: None,
             state_dir: None,
             forward_env: Vec::new(),
@@ -1374,8 +1777,14 @@ mod tests {
         let executor = fixture_executor();
         let (sink, mut rx) = EventSink::channel();
         let mut state = RunState::default();
+        let policy = default_policy(&executor);
         for line in input.lines().filter(|line| !line.trim().is_empty()) {
-            executor.handle_event(serde_json::from_str(line).unwrap(), &sink, &mut state);
+            executor.handle_event(
+                serde_json::from_str(line).unwrap(),
+                &policy,
+                &sink,
+                &mut state,
+            );
         }
         let mut events = Vec::new();
         while let Ok(event) = rx.try_recv() {
@@ -1392,6 +1801,295 @@ mod tests {
     }
 
     #[test]
+    fn permission_profile_mapping_table_is_explicit_and_double_gated() {
+        struct Case {
+            name: &'static str,
+            permissions: CodexPermissionConfig,
+            parent_bypass: bool,
+            is_root: bool,
+            sandbox: CodexSandbox,
+            approval: CodexApprovalPolicy,
+            invocation: CodexPolicyInvocation,
+            network: bool,
+            warning: bool,
+        }
+
+        let cases = [
+            Case {
+                name: "default",
+                permissions: permissions(None, None, false, false, None, false, false),
+                parent_bypass: false,
+                is_root: false,
+                sandbox: CodexSandbox::WorkspaceWrite,
+                approval: CodexApprovalPolicy::Never,
+                invocation: CodexPolicyInvocation::Explicit,
+                network: false,
+                warning: false,
+            },
+            Case {
+                name: "restricted",
+                permissions: permissions(
+                    None,
+                    None,
+                    false,
+                    false,
+                    Some("restricted"),
+                    false,
+                    false,
+                ),
+                parent_bypass: false,
+                is_root: false,
+                sandbox: CodexSandbox::WorkspaceWrite,
+                approval: CodexApprovalPolicy::Never,
+                invocation: CodexPolicyInvocation::Explicit,
+                network: false,
+                warning: false,
+            },
+            Case {
+                name: "research",
+                permissions: permissions(None, None, false, false, Some("research"), false, false),
+                parent_bypass: false,
+                is_root: false,
+                sandbox: CodexSandbox::ReadOnly,
+                approval: CodexApprovalPolicy::Never,
+                invocation: CodexPolicyInvocation::Explicit,
+                network: false,
+                warning: false,
+            },
+            Case {
+                name: "network workspace",
+                permissions: permissions(None, None, true, false, None, false, false),
+                parent_bypass: false,
+                is_root: false,
+                sandbox: CodexSandbox::WorkspaceWrite,
+                approval: CodexApprovalPolicy::Never,
+                invocation: CodexPolicyInvocation::Explicit,
+                network: true,
+                warning: false,
+            },
+            Case {
+                name: "ordinary bypass stays sandboxed",
+                permissions: permissions(None, None, false, false, None, false, false),
+                parent_bypass: true,
+                is_root: false,
+                sandbox: CodexSandbox::WorkspaceWrite,
+                approval: CodexApprovalPolicy::Never,
+                invocation: CodexPolicyInvocation::FullAuto,
+                network: false,
+                warning: false,
+            },
+            Case {
+                name: "config-only danger opt-in downgrades",
+                permissions: permissions(None, None, false, true, None, false, false),
+                parent_bypass: false,
+                is_root: false,
+                sandbox: CodexSandbox::WorkspaceWrite,
+                approval: CodexApprovalPolicy::Never,
+                invocation: CodexPolicyInvocation::FullAuto,
+                network: false,
+                warning: true,
+            },
+            Case {
+                name: "both danger gates",
+                permissions: permissions(None, None, false, true, None, false, false),
+                parent_bypass: true,
+                is_root: false,
+                sandbox: CodexSandbox::DangerFullAccess,
+                approval: CodexApprovalPolicy::Never,
+                invocation: CodexPolicyInvocation::DangerBypass,
+                network: true,
+                warning: true,
+            },
+            Case {
+                name: "root danger request downgrades",
+                permissions: permissions(
+                    Some("danger-full-access"),
+                    None,
+                    false,
+                    true,
+                    None,
+                    false,
+                    false,
+                ),
+                parent_bypass: true,
+                is_root: true,
+                sandbox: CodexSandbox::WorkspaceWrite,
+                approval: CodexApprovalPolicy::Never,
+                invocation: CodexPolicyInvocation::FullAuto,
+                network: false,
+                warning: true,
+            },
+            Case {
+                name: "explicit safe override",
+                permissions: permissions(
+                    Some("workspace-write"),
+                    Some("on-failure"),
+                    false,
+                    false,
+                    Some("read-only"),
+                    false,
+                    false,
+                ),
+                parent_bypass: false,
+                is_root: false,
+                sandbox: CodexSandbox::WorkspaceWrite,
+                approval: CodexApprovalPolicy::OnFailure,
+                invocation: CodexPolicyInvocation::Explicit,
+                network: false,
+                warning: false,
+            },
+        ];
+
+        for case in cases {
+            let actual = case.permissions.effective(case.parent_bypass, case.is_root);
+            assert_eq!(actual.sandbox, case.sandbox, "{} sandbox", case.name);
+            assert_eq!(
+                actual.approval_policy, case.approval,
+                "{} approval",
+                case.name
+            );
+            assert_eq!(
+                actual.invocation, case.invocation,
+                "{} invocation",
+                case.name
+            );
+            assert_eq!(actual.network_access, case.network, "{} network", case.name);
+            assert_eq!(
+                !actual.warnings.is_empty(),
+                case.warning,
+                "{} warning",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn permission_configuration_rejects_interactive_and_incoherent_values() {
+        assert!(resolve_codex_permission_config(
+            None,
+            Some("on-request"),
+            false,
+            false,
+            None,
+            false,
+            false,
+        )
+        .unwrap_err()
+        .contains("non-interactive"));
+        assert!(resolve_codex_permission_config(
+            Some("read-only"),
+            None,
+            true,
+            false,
+            None,
+            false,
+            false,
+        )
+        .unwrap_err()
+        .contains("effective workspace-write"));
+        assert!(resolve_codex_permission_config(
+            None,
+            None,
+            true,
+            false,
+            Some("research".to_string()),
+            false,
+            false,
+        )
+        .unwrap_err()
+        .contains("effective workspace-write"));
+    }
+
+    #[test]
+    fn command_flags_match_effective_policy_and_workspace_ownership() {
+        let workspace = tempfile::tempdir().unwrap();
+        let mut executor = fixture_executor();
+        executor.workspace = Some(workspace.path().to_string_lossy().into_owned());
+
+        let policy = executor.permissions.effective(false, false);
+        let args = command_args(&executor.build_command(None, &policy).unwrap());
+        assert!(args
+            .windows(2)
+            .any(|pair| pair == ["--sandbox", "workspace-write"]));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair == ["--config", "approval_policy=\"never\""]));
+        assert!(!args
+            .iter()
+            .any(|argument| argument == "--skip-git-repo-check"));
+
+        executor.permissions = permissions(None, None, false, false, None, false, true);
+        let policy = executor.permissions.effective(false, false);
+        let args = command_args(&executor.build_command(None, &policy).unwrap());
+        assert!(args
+            .iter()
+            .any(|argument| argument == "--skip-git-repo-check"));
+
+        executor.permissions = permissions(None, None, true, false, None, false, true);
+        let policy = executor.permissions.effective(false, false);
+        let args = command_args(&executor.build_command(None, &policy).unwrap());
+        assert!(args
+            .windows(2)
+            .any(|pair| { pair == ["--config", "sandbox_workspace_write.network_access=true"] }));
+
+        executor.permissions = permissions(None, None, false, false, None, false, true);
+        let policy = executor.permissions.effective(true, false);
+        let args = command_args(&executor.build_command(None, &policy).unwrap());
+        assert!(args.iter().any(|argument| argument == "--full-auto"));
+        assert!(!args
+            .iter()
+            .any(|argument| argument == "--dangerously-bypass-approvals-and-sandbox"));
+
+        executor.permissions = permissions(
+            Some("danger-full-access"),
+            None,
+            false,
+            true,
+            None,
+            false,
+            true,
+        );
+        let policy = executor.permissions.effective(true, false);
+        let args = command_args(&executor.build_command(None, &policy).unwrap());
+        assert!(args
+            .iter()
+            .any(|argument| argument == "--dangerously-bypass-approvals-and-sandbox"));
+        assert!(!args.iter().any(|argument| argument == "--full-auto"));
+    }
+
+    #[test]
+    fn danger_bypass_emits_loud_audit_warning() {
+        let mut executor = fixture_executor();
+        executor.permissions = permissions(
+            Some("danger-full-access"),
+            None,
+            false,
+            true,
+            Some("bypass"),
+            false,
+            false,
+        );
+        let policy = executor.permissions.effective(true, false);
+        let (sink, mut receiver) = EventSink::channel();
+        executor.emit_policy_bootstrap(&policy, &sink);
+
+        let events = std::iter::from_fn(|| receiver.try_recv().ok()).collect::<Vec<_>>();
+        assert!(events.iter().any(|event| {
+            event["phase"] == "bootstrap"
+                && event["sandbox"] == "danger-full-access"
+                && event["approval_policy"] == "never"
+                && event["policy_invocation"] == "danger-bypass"
+        }));
+        assert!(events.iter().any(|event| {
+            event["phase"] == "policy_warning"
+                && event["level"] == "warning"
+                && event["message"]
+                    .as_str()
+                    .is_some_and(|message| message.contains("DANGER"))
+        }));
+    }
+
+    #[test]
     fn auth_mode_matrix_is_explicit_isolated_and_secret_safe() {
         let credential = ScopedCredential {
             provider: "custom-provider".to_string(),
@@ -1405,7 +2103,8 @@ mod tests {
         assert_eq!(inherit.mode(), CodexAuthMode::Inherit);
         let mut inherit_executor = fixture_executor();
         inherit_executor.auth = inherit;
-        let inherit_command = inherit_executor.build_command(None).unwrap();
+        let policy = default_policy(&inherit_executor);
+        let inherit_command = inherit_executor.build_command(None, &policy).unwrap();
         assert!(command_env(&inherit_command, "CODEX_HOME").is_none());
         let inherit_args = inherit_command
             .as_std()
@@ -1441,7 +2140,8 @@ mod tests {
         let mut custom_executor = fixture_executor();
         custom_executor.state_dir = Some(state.path().to_path_buf());
         custom_executor.auth = custom;
-        let custom_command = custom_executor.build_command(None).unwrap();
+        let policy = default_policy(&custom_executor);
+        let custom_command = custom_executor.build_command(None, &policy).unwrap();
         assert_eq!(
             command_env(&custom_command, CODEX_PROVIDER_ENV).as_deref(),
             Some("custom-secret-570")
@@ -1477,12 +2177,13 @@ mod tests {
         let mut bamboo_executor = fixture_executor();
         bamboo_executor.state_dir = Some(state.path().to_path_buf());
         bamboo_executor.auth = bamboo;
+        let policy = default_policy(&bamboo_executor);
         assert!(bamboo_executor
-            .build_command(None)
+            .build_command(None, &policy)
             .unwrap_err()
             .contains("per-run provider token"));
         let bamboo_command = bamboo_executor
-            .build_command(Some("bcx1_per_run_570"))
+            .build_command(Some("bcx1_per_run_570"), &policy)
             .unwrap();
         assert_eq!(
             command_env(&bamboo_command, CODEX_PROVIDER_ENV).as_deref(),
@@ -1718,19 +2419,53 @@ mod tests {
         let executor = fixture_executor();
         let (sink, mut rx) = EventSink::channel();
         let mut state = RunState::default();
+        let policy = default_policy(&executor);
         executor.handle_event(
             json!({"type":"future.event","payload":{"schema":2}}),
+            &policy,
             &sink,
             &mut state,
         );
         executor.handle_event(
             json!({"type":"item.completed","item":{"id":"x","type":"future_item"}}),
+            &policy,
             &sink,
             &mut state,
         );
         assert!(rx.try_recv().is_err());
         assert!(!state.completed);
         assert!(state.failure.is_none());
+    }
+
+    #[test]
+    fn sandbox_denial_report_without_cli_tool_item_becomes_tool_error() {
+        let executor = fixture_executor();
+        let policy = executor.permissions.effective(false, false);
+        let (sink, mut receiver) = EventSink::channel();
+        let mut state = RunState::default();
+        executor.handle_event(
+            json!({
+                "type": "item.completed",
+                "item": {
+                    "id": "denied-report",
+                    "type": "agent_message",
+                    "text": "Command exited with status 1. Sandbox failure: outside write: Operation not permitted"
+                }
+            }),
+            &policy,
+            &sink,
+            &mut state,
+        );
+
+        let events = std::iter::from_fn(|| receiver.try_recv().ok()).collect::<Vec<_>>();
+        assert!(events.iter().any(|event| event["type"] == "token"));
+        assert!(events.iter().any(|event| {
+            event["type"] == "tool_error"
+                && event["tool_call_id"] == "denied-report-sandbox-denial"
+                && event["error"]
+                    .as_str()
+                    .is_some_and(|error| error.contains("Operation not permitted"))
+        }));
     }
 
     #[cfg(unix)]
@@ -1755,7 +2490,7 @@ mod tests {
                 binary,
                 version: "codex-cli 0.144.5".to_string(),
                 model: None,
-                sandbox: None,
+                permissions: permissions(None, None, false, false, None, false, true),
                 workspace: Some(workspace.to_string_lossy().into_owned()),
                 state_dir: None,
                 forward_env: Vec::new(),
@@ -1781,7 +2516,7 @@ mod tests {
                 r#"
 case "$*" in
   "--version") echo 'codex-cli 0.144.5' ;;
-  "exec --help") echo '--json --output-last-message prompt from stdin' ;;
+  "exec --help") echo '--json --output-last-message --config --sandbox --dangerously-bypass-approvals-and-sandbox prompt from stdin' ;;
   "exec resume --help") echo '--json' ;;
   *) exit 2 ;;
 esac
@@ -1792,9 +2527,9 @@ esac
                 None,
                 None,
                 None,
-                None,
                 Vec::new(),
                 CodexAuthConfig::inherit(),
+                default_permissions(),
             )
             .await
             .unwrap();
@@ -1812,9 +2547,9 @@ if [ "$1" = "--version" ]; then echo 'codex-cli 0.143.9'; else exit 2; fi
                 None,
                 None,
                 None,
-                None,
                 Vec::new(),
                 CodexAuthConfig::inherit(),
+                default_permissions(),
             )
             .await
             .err()
@@ -1827,9 +2562,9 @@ if [ "$1" = "--version" ]; then echo 'codex-cli 0.143.9'; else exit 2; fi
                 None,
                 None,
                 None,
-                None,
                 Vec::new(),
                 CodexAuthConfig::inherit(),
+                default_permissions(),
             )
             .await
             .err()
@@ -1948,7 +2683,9 @@ echo '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
                 "--cd",
                 "--skip-git-repo-check",
                 "--sandbox",
-                "read-only",
+                "workspace-write",
+                "--config",
+                "approval_policy=\"never\"",
                 "--output-last-message",
                 "-",
             ] {

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -119,6 +119,11 @@ pub async fn run() -> std::result::Result<(), String> {
             wire_api,
             provider_key_ref,
             forward_env,
+            approval_policy,
+            network_access,
+            allow_danger_bypass,
+            permission_profile,
+            workspace_owned,
         } => {
             let forward_env = forward_env.clone().unwrap_or_default();
             let auth = crate::codex_cli_executor::resolve_codex_auth_config(
@@ -130,11 +135,19 @@ pub async fn run() -> std::result::Result<(), String> {
                 &spec.secrets.provider_credentials,
                 &forward_env,
             )?;
+            let permissions = crate::codex_cli_executor::resolve_codex_permission_config(
+                sandbox.as_deref(),
+                approval_policy.as_deref(),
+                network_access.unwrap_or(false),
+                allow_danger_bypass.unwrap_or(false),
+                permission_profile.clone(),
+                spec.capabilities.bypass,
+                workspace_owned.unwrap_or(false),
+            )?;
             Arc::new(
                 CodexExecutor::new(
                     binary.clone(),
                     model.clone(),
-                    sandbox.clone(),
                     spec.workspace.clone(),
                     Some(crate::codex_cli_executor::resolve_codex_state_dir(
                         &spec.storage_dir,
@@ -142,6 +155,7 @@ pub async fn run() -> std::result::Result<(), String> {
                     )),
                     forward_env,
                     auth,
+                    permissions,
                 )
                 .await?,
             )

--- a/tests/e2e_codex_cli_manual.rs
+++ b/tests/e2e_codex_cli_manual.rs
@@ -6,7 +6,9 @@
 use std::process::Command;
 use std::time::Duration;
 
-use bamboo_agent::codex_cli_executor::{CodexAuthConfig, CodexExecutor};
+use bamboo_agent::codex_cli_executor::{
+    resolve_codex_permission_config, CodexAuthConfig, CodexExecutor,
+};
 use bamboo_subagent::executor::{ChildExecutor, EventSink, SteerInbox};
 use bamboo_subagent::proto::{RunSpec, TerminalStatus};
 use tokio_util::sync::CancellationToken;
@@ -26,11 +28,20 @@ async fn real_codex_completes_trivial_turn_and_reports_bootstrap_metadata() {
     let executor = CodexExecutor::new(
         None,
         None,
-        Some("read-only".to_string()),
         Some(workspace.path().to_string_lossy().into_owned()),
         Some(state.path().to_path_buf()),
         Vec::new(),
         CodexAuthConfig::inherit(),
+        resolve_codex_permission_config(
+            Some("read-only"),
+            Some("never"),
+            false,
+            false,
+            Some("read-only".to_string()),
+            false,
+            false,
+        )
+        .unwrap(),
     )
     .await
     .expect("Codex preflight succeeds");
@@ -69,4 +80,96 @@ async fn real_codex_completes_trivial_turn_and_reports_bootstrap_metadata() {
     assert!(bootstrap["version"]
         .as_str()
         .is_some_and(|version| version.contains("codex-cli")));
+    assert_eq!(bootstrap["sandbox"], "read-only");
+    assert_eq!(bootstrap["approval_policy"], "never");
+    assert_eq!(bootstrap["policy_invocation"], "explicit");
+}
+
+#[tokio::test]
+#[ignore = "requires a logged-in Codex CLI >= 0.144 on PATH"]
+async fn real_workspace_write_denies_outside_write_and_emits_tool_error() {
+    let workspace = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let status = Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(workspace.path())
+        .status()
+        .expect("git is installed");
+    assert!(status.success());
+
+    let outside = std::env::var_os("HOME")
+        .map(std::path::PathBuf::from)
+        .expect("HOME is set")
+        .join(format!(
+            ".bamboo-codex-sandbox-e2e-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+    let _ = std::fs::remove_file(&outside);
+    let inside = workspace.path().join("inside-marker.txt");
+    let command = format!(
+        "printf inside > ./inside-marker.txt && printf outside > {}",
+        outside.display()
+    );
+
+    let executor = CodexExecutor::new(
+        None,
+        None,
+        Some(workspace.path().to_string_lossy().into_owned()),
+        Some(state.path().to_path_buf()),
+        Vec::new(),
+        CodexAuthConfig::inherit(),
+        resolve_codex_permission_config(
+            Some("workspace-write"),
+            Some("never"),
+            false,
+            false,
+            None,
+            false,
+            false,
+        )
+        .unwrap(),
+    )
+    .await
+    .expect("Codex preflight succeeds");
+    let (sink, mut receiver) = EventSink::channel();
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(180),
+        executor.run(
+            RunSpec {
+                assignment: format!(
+                    "Run this exact shell command now: /bin/sh -c '{command}'\nThen report the sandbox failure, including its exit status and exact stderr."
+                ),
+                reasoning_effort: None,
+                permission_policy: None,
+                messages: Vec::new(),
+                secrets: Default::default(),
+            },
+            sink,
+            SteerInbox::disconnected(),
+            CancellationToken::new(),
+        ),
+    )
+    .await
+    .expect("real Codex sandbox turn timed out");
+
+    let outside_written = outside.exists();
+    if outside_written {
+        let _ = std::fs::remove_file(&outside);
+    }
+    assert_eq!(outcome.status, TerminalStatus::Completed, "{outcome:?}");
+    assert!(inside.exists(), "workspace write did not succeed");
+    assert!(
+        !outside_written,
+        "sandbox allowed an outside-workspace write"
+    );
+
+    let events = std::iter::from_fn(|| receiver.try_recv().ok()).collect::<Vec<_>>();
+    assert!(
+        events.iter().any(|event| event["type"] == "tool_error"),
+        "outside denial was not surfaced as a tool error: {events:?}"
+    );
 }


### PR DESCRIPTION
## Summary
- map default, restricted, read-only, research, and bypass child postures to explicit Codex sandbox/approval flags
- double-gate danger bypass on live parent bypass plus config opt-in, downgrade root/config-only requests, and emit auditable warnings
- expose typed settings on both Codex config surfaces and restrict non-Git skip checks to Bamboo-owned workspaces
- surface sandbox denials as tool errors, including Codex 0.144 JSONL omission behavior

## Test Plan
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets`
- `cargo test -p bamboo-config -p bamboo-subagent -p bamboo-engine -p bamboo-agent --lib`
- `cargo test -p bamboo-server codex_shape_validation --lib`
- `cargo test --test e2e_codex_cli_manual -- --ignored --nocapture --test-threads=1`

## Screenshots
- Not applicable (backend/config behavior only)

Closes #571