### PR TITLE
feat(codex): persist and resume Codex threads (#572)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,7 @@ dependencies = [
  "tokio-tungstenite 0.24.0",
  "tokio-util",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/infra/bamboo-subagent/Cargo.toml
+++ b/crates/infra/bamboo-subagent/Cargo.toml
@@ -27,6 +27,9 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
 rustls-pemfile = "2"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
 tempfile = "3"

--- a/crates/infra/bamboo-subagent/src/executor_util.rs
+++ b/crates/infra/bamboo-subagent/src/executor_util.rs
@@ -1,0 +1,260 @@
+//! Shared persistence and fallback-rehydration helpers for external CLI
+//! executors. Provider adapters keep their session-id/state-machine logic, but
+//! use these helpers so transcript rendering and atomic state writes do not
+//! drift between Claude Code and Codex.
+
+use std::path::Path;
+
+use serde::Serialize;
+use serde_json::Value;
+use tokio::io::AsyncWriteExt;
+
+/// Fallback history cap shared by external CLI executors: retain the newest
+/// roughly 40 messages and no more than roughly 24k characters.
+const HISTORY_PREAMBLE_MAX_CHARS: usize = 24_000;
+const HISTORY_PREAMBLE_MAX_MESSAGES: usize = 40;
+
+/// Render a bounded, role-tagged history preamble for a provider whose native
+/// session id is unavailable.
+///
+/// `messages` are oldest-first and may include the current assignment as their
+/// trailing user message. That duplicate is removed before rendering. Unknown
+/// or malformed entries are skipped defensively.
+pub fn render_history_preamble(messages: &[Value], assignment: &str) -> Option<String> {
+    let mut entries: Vec<(String, String)> = messages
+        .iter()
+        .filter_map(|message| {
+            let role = message.get("role").and_then(Value::as_str)?.to_string();
+            let content = message.get("content").and_then(Value::as_str)?;
+            if content.is_empty() {
+                return None;
+            }
+            Some((role, content.to_string()))
+        })
+        .collect();
+
+    if let Some((role, content)) = entries.last() {
+        if role == "user" && content == assignment {
+            entries.pop();
+        }
+    }
+    if entries.is_empty() {
+        return None;
+    }
+
+    let dropped_by_count = entries.len().saturating_sub(HISTORY_PREAMBLE_MAX_MESSAGES);
+    if dropped_by_count > 0 {
+        entries.drain(0..dropped_by_count);
+    }
+
+    let mut rendered: Vec<String> = entries
+        .iter()
+        .map(|(role, content)| format!("**{role}**: {content}"))
+        .collect();
+    let mut dropped_by_chars = 0usize;
+    while rendered.len() > 1
+        && rendered
+            .iter()
+            .map(|entry| entry.chars().count() + 2)
+            .sum::<usize>()
+            > HISTORY_PREAMBLE_MAX_CHARS
+    {
+        rendered.remove(0);
+        dropped_by_chars += 1;
+    }
+    if let [only] = rendered.as_mut_slice() {
+        if only.chars().count() > HISTORY_PREAMBLE_MAX_CHARS {
+            *only = truncate_chars(only, HISTORY_PREAMBLE_MAX_CHARS);
+        }
+    }
+
+    let mut out = String::from("## Prior conversation (rehydrated)\n\n");
+    if dropped_by_count > 0 || dropped_by_chars > 0 {
+        out.push_str(&format!(
+            "_[truncated: {} earlier message(s) omitted]_\n\n",
+            dropped_by_count + dropped_by_chars
+        ));
+    }
+    out.push_str(&rendered.join("\n\n"));
+    Some(out)
+}
+
+/// Build a current-turn prompt with fallback history when native resume is not
+/// available. The current assignment remains in its own explicit section.
+pub fn build_rehydrated_turn(messages: &[Value], assignment: &str) -> String {
+    match render_history_preamble(messages, assignment) {
+        Some(preamble) => format!("{preamble}\n\n## Current task\n\n{assignment}"),
+        None => assignment.to_string(),
+    }
+}
+
+/// Serialize JSON and replace `path` atomically using a unique temporary file
+/// in the same directory. Readers see either the old complete document or the
+/// new complete document, never a partially written state file.
+pub async fn write_json_atomic<T: Serialize + ?Sized>(
+    path: &Path,
+    value: &T,
+) -> Result<(), String> {
+    let bytes = serde_json::to_vec_pretty(value)
+        .map_err(|error| format!("serialize executor state '{}': {error}", path.display()))?;
+    let directory = path
+        .parent()
+        .ok_or_else(|| format!("executor state path '{}' has no parent", path.display()))?;
+    tokio::fs::create_dir_all(directory)
+        .await
+        .map_err(|error| {
+            format!(
+                "create executor state directory '{}': {error}",
+                directory.display()
+            )
+        })?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("executor-state.json");
+    let temporary = directory.join(format!(".{file_name}.tmp.{}", uuid::Uuid::new_v4()));
+
+    let write_result = async {
+        let mut file = tokio::fs::File::create(&temporary).await.map_err(|error| {
+            format!(
+                "create executor state temp file '{}': {error}",
+                temporary.display()
+            )
+        })?;
+        file.write_all(&bytes).await.map_err(|error| {
+            format!(
+                "write executor state temp file '{}': {error}",
+                temporary.display()
+            )
+        })?;
+        file.sync_all().await.map_err(|error| {
+            format!(
+                "sync executor state temp file '{}': {error}",
+                temporary.display()
+            )
+        })?;
+        drop(file);
+        replace_path(&temporary, path).map_err(|error| {
+            format!(
+                "replace executor state '{}' from '{}': {error}",
+                path.display(),
+                temporary.display()
+            )
+        })
+    }
+    .await;
+
+    if write_result.is_err() {
+        let _ = tokio::fs::remove_file(&temporary).await;
+    }
+    write_result
+}
+
+fn replace_path(from: &Path, to: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::fs::rename(from, to)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Storage::FileSystem::{
+            MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+        };
+
+        let from = from
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect::<Vec<_>>();
+        let to = to
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect::<Vec<_>>();
+        // SAFETY: both vectors are stable NUL-terminated UTF-16 strings for
+        // the call duration, and MoveFileExW does not retain their pointers.
+        let result = unsafe {
+            MoveFileExW(
+                from.as_ptr(),
+                to.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        };
+        if result == 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        std::fs::rename(from, to)
+    }
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let head: String = text.chars().take(max_chars).collect();
+    let dropped = text.chars().count() - max_chars;
+    format!("{head}\n… [truncated, {dropped} more chars]")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, Value};
+
+    use super::{build_rehydrated_turn, render_history_preamble, write_json_atomic};
+
+    #[test]
+    fn rehydration_is_bounded_oldest_first_and_excludes_current_assignment() {
+        let mut messages: Vec<Value> = (0..45)
+            .map(|index| {
+                json!({
+                    "role": if index % 2 == 0 { "user" } else { "assistant" },
+                    "content": format!("message {index}")
+                })
+            })
+            .collect();
+        messages.push(json!({"role": "user", "content": "continue"}));
+
+        let body = build_rehydrated_turn(&messages, "continue");
+        assert!(body.contains("## Prior conversation (rehydrated)"));
+        assert!(body.contains("## Current task"));
+        assert!(body.contains("truncated"));
+        assert!(!body.contains("message 0"));
+        assert!(body.contains("message 44"));
+        assert_eq!(body.matches("continue").count(), 1);
+    }
+
+    #[test]
+    fn malformed_or_current_only_history_has_no_preamble() {
+        let messages = vec![
+            json!({"role": "user", "content": 42}),
+            json!({"role": "user", "content": "current"}),
+        ];
+        assert_eq!(render_history_preamble(&messages, "current"), None);
+        assert_eq!(build_rehydrated_turn(&messages, "current"), "current");
+    }
+
+    #[tokio::test]
+    async fn json_state_write_is_atomic_and_leaves_no_temp_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("session.json");
+        write_json_atomic(&path, &json!({"thread_id": "first"}))
+            .await
+            .unwrap();
+        write_json_atomic(&path, &json!({"thread_id": "second"}))
+            .await
+            .unwrap();
+
+        let parsed: Value = serde_json::from_slice(&tokio::fs::read(&path).await.unwrap()).unwrap();
+        assert_eq!(parsed["thread_id"], "second");
+        assert!(!std::fs::read_dir(directory.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|entry| entry.file_name().to_string_lossy().contains(".tmp.")));
+    }
+}

--- a/crates/infra/bamboo-subagent/src/lib.rs
+++ b/crates/infra/bamboo-subagent/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod discovery;
 pub mod error;
 pub mod executor;
+pub mod executor_util;
 pub mod fleet;
 pub mod mailbox;
 pub(crate) mod poison;

--- a/docs/codex-executor.md
+++ b/docs/codex-executor.md
@@ -113,8 +113,49 @@ warning event as well as the bootstrap policy metadata.
 
 For a non-Git workspace, Bamboo adds `--skip-git-repo-check` only when the
 directory is under Bamboo's configured workspace root or a
-`<project>/.bamboo/worktree/...` directory. An arbitrary user-selected
-directory keeps Codex's repository check.
+`<project>/.bamboo/worktree/...` directory carrying the matching Bamboo
+lifecycle ownership marker. Merely imitating that directory shape is not
+enough. An arbitrary user-selected directory keeps Codex's repository check.
+
+## Session identity and resume
+
+Codex transcripts are machine-local. On every `thread.started`, Bamboo writes
+the newest thread id atomically to `<child-state>/codex-session.json`:
+
+```json
+{
+  "thread_id": "...",
+  "workspace": "...",
+  "codex_home_mode": "isolated",
+  "updated_at": "2026-..."
+}
+```
+
+`codex_home_mode` is `inherit` when Codex uses the invoking user's home and
+`isolated` when it uses `<child-state>/codex-home`. A persisted id is usable
+only from the same workspace and home mode; changing either falls back safely
+instead of trying to resume a transcript Codex cannot see.
+
+Activation follows four bounded branches:
+
+1. Empty `RunSpec.messages` means a fresh activation. Bamboo deletes stale
+   state before spawning, so rerun never resumes accidentally.
+2. Non-empty messages plus a usable id invokes
+   `codex exec ... resume <thread_id> -` and sends only the live assignment.
+   Any new id from the resumed process replaces the prior state atomically.
+3. Without a usable id, Bamboo prepends a shared, role-tagged history preamble.
+   The newest ~40 messages are kept within ~24k characters, older entries are
+   dropped with an explicit truncation note, and the trailing current user
+   message is excluded to avoid duplication under `## Current task`.
+4. If a resume process exits before either `turn.started` or `turn.completed`,
+   Bamboo clears the bad id and retries exactly once as a fresh process with
+   that fallback history. Failures after turn progress and failures of the
+   fallback attempt are not retried.
+
+The history renderer and atomic JSON replacement live in `bamboo-subagent` and
+are shared with `ClaudeCodeExecutor`, keeping both adapters' fallback behavior
+identical. Mid-turn steering, multimodal input, and cross-machine resume remain
+out of scope.
 
 ## Isolation and environment policy
 

--- a/src/claude_code_executor.rs
+++ b/src/claude_code_executor.rs
@@ -36,6 +36,7 @@ use tokio_util::sync::CancellationToken;
 
 use bamboo_agent_core::{AgentEvent, TokenUsage, ToolResult};
 use bamboo_subagent::executor::{ChildExecutor, ChildOutcome, EventSink, HostBridge, SteerInbox};
+use bamboo_subagent::executor_util::{render_history_preamble, write_json_atomic};
 use bamboo_subagent::proto::RunSpec;
 
 /// Upper bound on a single stdout NDJSON line. Tool results can be huge (the
@@ -99,11 +100,6 @@ pub fn resolve_claude_code_state_dir(storage_dir: &Option<String>, child_id: &st
 /// agent-assigned Claude Code session id this actor last saw, so the NEXT
 /// activation of the SAME child can `--resume` it instead of losing context.
 const STATE_FILE_NAME: &str = "claude-code-session.json";
-
-/// Fallback history preamble cap (issue #444 test plan: "~24k chars / last
-/// ~40 messages, oldest dropped first").
-const HISTORY_PREAMBLE_MAX_CHARS: usize = 24_000;
-const HISTORY_PREAMBLE_MAX_MESSAGES: usize = 40;
 
 /// On-disk shape of [`STATE_FILE_NAME`]. `workspace` is recorded so a later
 /// activation on a DIFFERENT workspace (or a different machine — Claude Code
@@ -219,19 +215,9 @@ impl ClaudeCodeExecutor {
             workspace: self.workspace.clone(),
             updated_at: Utc::now(),
         };
-        let Ok(bytes) = serde_json::to_vec_pretty(&state) else {
-            return;
-        };
-        if tokio::fs::create_dir_all(dir).await.is_err() {
-            return;
+        if let Err(error) = write_json_atomic(&path, &state).await {
+            tracing::warn!(%error, "claude code: persist session state");
         }
-        // Unique tmp name (pid + session id) so concurrent activations of
-        // different children never collide on the same tmp path.
-        let tmp_path = dir.join(format!("{STATE_FILE_NAME}.{}.tmp", std::process::id()));
-        if tokio::fs::write(&tmp_path, &bytes).await.is_err() {
-            return;
-        }
-        let _ = tokio::fs::rename(&tmp_path, &path).await;
     }
 
     /// Step 2 of the activation logic (issue #444): a usable persisted id
@@ -981,72 +967,6 @@ fn build_turn_body(spec: &RunSpec, resume_id: Option<&str>) -> String {
 /// skipped defensively rather than failing the run. Returns `None` when
 /// there is nothing left to render (e.g. the only shipped message IS the
 /// current assignment, already excluded below to avoid duplicating it).
-fn render_history_preamble(messages: &[Value], assignment: &str) -> Option<String> {
-    let mut entries: Vec<(String, String)> = messages
-        .iter()
-        .filter_map(|m| {
-            let role = m.get("role").and_then(Value::as_str)?.to_string();
-            let content = m.get("content").and_then(Value::as_str)?;
-            if content.is_empty() {
-                return None;
-            }
-            Some((role, content.to_string()))
-        })
-        .collect();
-
-    // The assignment's own user message rides in `messages` too (contract) —
-    // drop it here so the preamble doesn't duplicate the live task below it.
-    if let Some((role, content)) = entries.last() {
-        if role == "user" && content == assignment {
-            entries.pop();
-        }
-    }
-    if entries.is_empty() {
-        return None;
-    }
-
-    // Cap by message count, oldest dropped first.
-    let dropped_by_count = entries.len().saturating_sub(HISTORY_PREAMBLE_MAX_MESSAGES);
-    if dropped_by_count > 0 {
-        entries.drain(0..dropped_by_count);
-    }
-
-    let mut rendered: Vec<String> = entries
-        .iter()
-        .map(|(role, content)| format!("**{role}**: {content}"))
-        .collect();
-
-    // Cap by char budget, oldest rendered entry dropped first; if even the
-    // single most-recent entry alone exceeds the budget, truncate it in place
-    // (never silently drop the entire preamble).
-    let mut dropped_by_chars = 0usize;
-    while rendered.len() > 1
-        && rendered
-            .iter()
-            .map(|s| s.chars().count() + 2)
-            .sum::<usize>()
-            > HISTORY_PREAMBLE_MAX_CHARS
-    {
-        rendered.remove(0);
-        dropped_by_chars += 1;
-    }
-    if let [only] = rendered.as_mut_slice() {
-        if only.chars().count() > HISTORY_PREAMBLE_MAX_CHARS {
-            *only = truncate_chars(only, HISTORY_PREAMBLE_MAX_CHARS);
-        }
-    }
-
-    let mut out = String::from("## Prior conversation (rehydrated)\n\n");
-    if dropped_by_count > 0 || dropped_by_chars > 0 {
-        out.push_str(&format!(
-            "_[truncated: {} earlier message(s) omitted]_\n\n",
-            dropped_by_count + dropped_by_chars
-        ));
-    }
-    out.push_str(&rendered.join("\n\n"));
-    Some(out)
-}
-
 fn truncate_chars(s: &str, max_chars: usize) -> String {
     if s.chars().count() <= max_chars {
         return s.to_string();

--- a/src/codex_cli_executor.rs
+++ b/src/codex_cli_executor.rs
@@ -5,7 +5,9 @@
 //! argv), stdout is consumed as bounded JSONL, and the process owns a process
 //! group so cancellation tears down any descendants as well as the leader.
 //! Provider/auth selection and Bamboo permission-profile mapping are resolved
-//! before every spawn; session resume is handled by a dependent epic issue.
+//! before every spawn. Thread ids are persisted per child so later activations
+//! can use `codex exec resume`, with bounded history rehydration when the local
+//! Codex transcript is unavailable.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -14,6 +16,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
@@ -22,6 +26,7 @@ use tokio_util::sync::CancellationToken;
 
 use bamboo_agent_core::{AgentEvent, TokenUsage, ToolResult};
 use bamboo_subagent::executor::{ChildExecutor, ChildOutcome, EventSink, SteerInbox};
+use bamboo_subagent::executor_util::{build_rehydrated_turn, write_json_atomic};
 use bamboo_subagent::proto::RunSpec;
 
 /// The oldest Codex CLI schema this executor intentionally supports. The
@@ -41,6 +46,15 @@ const ENV_ALLOWLIST: &[&str] = &[
 ];
 
 const CODEX_PROVIDER_ENV: &str = "BAMBOO_CODEX_PROVIDER_KEY";
+const CODEX_SESSION_STATE_FILE: &str = "codex-session.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CodexSessionState {
+    thread_id: String,
+    workspace: Option<String>,
+    codex_home_mode: String,
+    updated_at: DateTime<Utc>,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CodexAuthMode {
@@ -528,10 +542,83 @@ impl CodexExecutor {
             .map(|directory| directory.join("codex-last-message.txt"))
     }
 
+    fn session_state_path(&self) -> Option<PathBuf> {
+        self.state_dir
+            .as_ref()
+            .map(|directory| directory.join(CODEX_SESSION_STATE_FILE))
+    }
+
+    fn codex_home_mode(&self) -> &'static str {
+        if self.auth.isolated() {
+            "isolated"
+        } else {
+            "inherit"
+        }
+    }
+
+    async fn read_session_state(&self) -> Option<CodexSessionState> {
+        let path = self.session_state_path()?;
+        let bytes = tokio::fs::read(path).await.ok()?;
+        serde_json::from_slice(&bytes).ok()
+    }
+
+    async fn delete_session_state(&self) {
+        let Some(path) = self.session_state_path() else {
+            return;
+        };
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => tracing::warn!(
+                path = %path.display(),
+                %error,
+                "codex: remove stale session state"
+            ),
+        }
+    }
+
+    async fn write_session_state(&self, thread_id: &str) {
+        let Some(path) = self.session_state_path() else {
+            return;
+        };
+        let state = CodexSessionState {
+            thread_id: thread_id.to_string(),
+            workspace: self.workspace.clone(),
+            codex_home_mode: self.codex_home_mode().to_string(),
+            updated_at: Utc::now(),
+        };
+        if let Err(error) = write_json_atomic(&path, &state).await {
+            tracing::warn!(%error, "codex: persist thread state");
+        }
+    }
+
+    async fn resolve_resume_id(&self) -> Option<String> {
+        let state = self.read_session_state().await?;
+        if state.workspace != self.workspace {
+            tracing::warn!(
+                recorded = ?state.workspace,
+                current = ?self.workspace,
+                "codex: session state workspace mismatch; using history rehydration"
+            );
+            return None;
+        }
+        let current_mode = self.codex_home_mode();
+        if state.codex_home_mode != current_mode {
+            tracing::warn!(
+                recorded = %state.codex_home_mode,
+                current = current_mode,
+                "codex: session state CODEX_HOME mode mismatch; using history rehydration"
+            );
+            return None;
+        }
+        (!state.thread_id.trim().is_empty()).then_some(state.thread_id)
+    }
+
     fn build_command(
         &self,
         run_provider_token: Option<&str>,
         policy: &EffectiveCodexPolicy,
+        resume_id: Option<&str>,
     ) -> Result<Command, String> {
         let mut command = Command::new(&self.binary);
         command
@@ -581,6 +668,10 @@ impl CodexExecutor {
         }
         if let Some(path) = self.last_message_path() {
             command.arg("--output-last-message").arg(path);
+        }
+
+        if let Some(thread_id) = resume_id {
+            command.arg("resume").arg(thread_id);
         }
 
         // `-` is the documented stdin prompt sentinel. It avoids both argv
@@ -709,8 +800,9 @@ impl CodexExecutor {
         policy: &EffectiveCodexPolicy,
         events: &EventSink,
         state: &mut RunState,
-    ) {
+    ) -> Option<String> {
         let event_type = value.get("type").and_then(Value::as_str).unwrap_or("");
+        let mut captured_thread_id = None;
         match event_type {
             "thread.started" => {
                 state.thread_id = value
@@ -718,6 +810,9 @@ impl CodexExecutor {
                     .and_then(Value::as_str)
                     .unwrap_or("")
                     .to_string();
+                if !state.thread_id.is_empty() {
+                    captured_thread_id = Some(state.thread_id.clone());
+                }
                 events.emit(json!({
                     "type": "runner_progress",
                     "session_id": state.thread_id,
@@ -794,6 +889,7 @@ impl CodexExecutor {
                 tracing::debug!(event_type = other, "codex: unrecognized JSONL event");
             }
         }
+        captured_thread_id
     }
 
     async fn read_last_message(&self) -> Option<String> {
@@ -806,11 +902,12 @@ impl CodexExecutor {
     async fn run_process(
         &self,
         prompt: &str,
+        resume_id: Option<&str>,
         run_provider_token: Option<&str>,
         parent_bypass: bool,
         events: &EventSink,
         cancel: &CancellationToken,
-    ) -> ChildOutcome {
+    ) -> (ChildOutcome, bool) {
         let policy = self.permissions.effective(parent_bypass, running_as_root());
         self.emit_policy_bootstrap(&policy, events);
         // Warm workers reuse this executor across activations. Reassert the
@@ -818,32 +915,35 @@ impl CodexExecutor {
         // process cannot leave an auth artifact or mutate provider routing for
         // the next child session.
         if let Err(error) = self.prepare_auth_home().await {
-            return ChildOutcome::error(error);
+            return (ChildOutcome::error(error), false);
         }
         if let Err(error) = self.prepare_output_file().await {
-            return ChildOutcome::error(error);
+            return (ChildOutcome::error(error), false);
         }
 
         let mut child = match spawn_with_etxtbsy_retry(|| {
-            self.build_command(run_provider_token, &policy)
+            self.build_command(run_provider_token, &policy, resume_id)
         })
         .await
         {
             Ok(child) => child,
             Err(error) => {
-                return ChildOutcome::error(format!(
-                    "spawn Codex CLI '{}': {error}; install with `npm i -g @openai/codex`, `brew install codex`, or an official GitHub release",
-                    self.binary.display()
-                ));
+                return (
+                    ChildOutcome::error(format!(
+                        "spawn Codex CLI '{}': {error}; install with `npm i -g @openai/codex`, `brew install codex`, or an official GitHub release",
+                        self.binary.display()
+                    )),
+                    false,
+                );
             }
         };
         let Some(mut stdin) = child.stdin.take() else {
             terminate_child(&mut child).await;
-            return ChildOutcome::error("Codex child has no stdin pipe");
+            return (ChildOutcome::error("Codex child has no stdin pipe"), false);
         };
         let Some(stdout) = child.stdout.take() else {
             terminate_child(&mut child).await;
-            return ChildOutcome::error("Codex child has no stdout pipe");
+            return (ChildOutcome::error("Codex child has no stdout pipe"), false);
         };
         let stderr = child.stderr.take();
 
@@ -858,12 +958,15 @@ impl CodexExecutor {
                 events.emit(event_json(AgentEvent::Cancelled {
                     message: Some("Codex child cancelled".to_string()),
                 }));
-                return ChildOutcome::cancelled();
+                return (ChildOutcome::cancelled(), false);
             }
         };
         if let Err(error) = write_result {
             terminate_child(&mut child).await;
-            return ChildOutcome::error(format!("write Codex prompt to stdin: {error}"));
+            return (
+                ChildOutcome::error(format!("write Codex prompt to stdin: {error}")),
+                false,
+            );
         }
         drop(stdin);
 
@@ -891,7 +994,16 @@ impl CodexExecutor {
                                 continue;
                             }
                             match serde_json::from_slice::<Value>(&bytes) {
-                                Ok(value) => self.handle_event(value, &policy, events, &mut state),
+                                Ok(value) => {
+                                    if let Some(thread_id) = self.handle_event(
+                                        value,
+                                        &policy,
+                                        events,
+                                        &mut state,
+                                    ) {
+                                        self.write_session_state(&thread_id).await;
+                                    }
+                                }
                                 Err(error) => tracing::debug!(%error, "codex: skipping unparsable stdout line"),
                             }
                         }
@@ -926,45 +1038,45 @@ impl CodexExecutor {
             events.emit(event_json(AgentEvent::Cancelled {
                 message: Some("Codex child cancelled".to_string()),
             }));
-            return ChildOutcome::cancelled();
+            return (ChildOutcome::cancelled(), false);
         }
-        if let Some(error) = read_error {
-            return ChildOutcome::error(error);
-        }
-        if status.as_ref().is_some_and(|status| !status.success()) {
-            return ChildOutcome::error(format!(
+
+        let exited_without_turn = !state.turn_started && !state.completed;
+        let outcome = if let Some(error) = read_error {
+            ChildOutcome::error(error)
+        } else if status.as_ref().is_some_and(|status| !status.success()) {
+            ChildOutcome::error(format!(
                 "Codex CLI exited with status {}; stderr tail: {}",
                 status
                     .as_ref()
                     .map(ToString::to_string)
                     .unwrap_or_else(|| "<unknown>".to_string()),
                 display_stderr_tail(&stderr)
-            ));
-        }
-        if let Some(error) = state.failure {
-            return ChildOutcome::error(format!(
+            ))
+        } else if let Some(error) = state.failure {
+            ChildOutcome::error(format!(
                 "{error}; stderr tail: {}",
                 display_stderr_tail(&stderr)
-            ));
-        }
-        if !state.completed {
-            return ChildOutcome::error(format!(
+            ))
+        } else if !state.completed {
+            ChildOutcome::error(format!(
                 "Codex CLI exited without a turn.completed event; stderr tail: {}",
                 display_stderr_tail(&stderr)
-            ));
-        }
-
-        let final_text = if state.last_agent_message.trim().is_empty() {
-            self.read_last_message().await
+            ))
         } else {
-            Some(state.last_agent_message)
+            let final_text = if state.last_agent_message.trim().is_empty() {
+                self.read_last_message().await
+            } else {
+                Some(state.last_agent_message)
+            };
+            match final_text {
+                Some(text) => ChildOutcome::completed(text),
+                None => ChildOutcome::error(
+                    "Codex CLI completed without a final agent message or output-last-message file",
+                ),
+            }
         };
-        match final_text {
-            Some(text) => ChildOutcome::completed(text),
-            None => ChildOutcome::error(
-                "Codex CLI completed without a final agent message or output-last-message file",
-            ),
-        }
+        (outcome, exited_without_turn)
     }
 
     fn emit_policy_bootstrap(&self, policy: &EffectiveCodexPolicy, events: &EventSink) {
@@ -1016,18 +1128,61 @@ impl ChildExecutor for CodexExecutor {
             .as_ref()
             .map(|policy| policy.bypass_permissions)
             .unwrap_or(self.permissions.provisioned_bypass);
-        let outcome = self
+        if spec.messages.is_empty() {
+            self.delete_session_state().await;
+        }
+        let resume_id = if spec.messages.is_empty() {
+            None
+        } else {
+            self.resolve_resume_id().await
+        };
+        let body = if resume_id.is_some() || spec.messages.is_empty() {
+            spec.assignment.clone()
+        } else {
+            build_rehydrated_turn(&spec.messages, &spec.assignment)
+        };
+        let run_provider_token = spec
+            .secrets
+            .codex_provider_token
+            .as_ref()
+            .map(bamboo_subagent::proto::SecretValue::expose);
+        let (outcome, exited_without_turn) = self
             .run_process(
-                &spec.assignment,
-                spec.secrets
-                    .codex_provider_token
-                    .as_ref()
-                    .map(bamboo_subagent::proto::SecretValue::expose),
+                &body,
+                resume_id.as_deref(),
+                run_provider_token,
                 parent_bypass,
                 &events,
                 &cancel,
             )
             .await;
+        let outcome = if resume_id.is_some() && exited_without_turn {
+            tracing::warn!(
+                "codex: resume exited before turn progress; retrying once with rehydrated history"
+            );
+            events.emit(json!({
+                "type": "runner_progress",
+                "session_id": "codex",
+                "round_count": 0,
+                "executor": "codex",
+                "phase": "resume_fallback",
+                "message": "resume failed before turn progress; retrying once with rehydrated history",
+            }));
+            self.delete_session_state().await;
+            let fallback_body = build_rehydrated_turn(&spec.messages, &spec.assignment);
+            self.run_process(
+                &fallback_body,
+                None,
+                run_provider_token,
+                parent_bypass,
+                &events,
+                &cancel,
+            )
+            .await
+            .0
+        } else {
+            outcome
+        };
         steer_drain.abort();
         outcome
     }
@@ -2007,7 +2162,7 @@ mod tests {
         executor.workspace = Some(workspace.path().to_string_lossy().into_owned());
 
         let policy = executor.permissions.effective(false, false);
-        let args = command_args(&executor.build_command(None, &policy).unwrap());
+        let args = command_args(&executor.build_command(None, &policy, None).unwrap());
         assert!(args
             .windows(2)
             .any(|pair| pair == ["--sandbox", "workspace-write"]));
@@ -2020,21 +2175,21 @@ mod tests {
 
         executor.permissions = permissions(None, None, false, false, None, false, true);
         let policy = executor.permissions.effective(false, false);
-        let args = command_args(&executor.build_command(None, &policy).unwrap());
+        let args = command_args(&executor.build_command(None, &policy, None).unwrap());
         assert!(args
             .iter()
             .any(|argument| argument == "--skip-git-repo-check"));
 
         executor.permissions = permissions(None, None, true, false, None, false, true);
         let policy = executor.permissions.effective(false, false);
-        let args = command_args(&executor.build_command(None, &policy).unwrap());
+        let args = command_args(&executor.build_command(None, &policy, None).unwrap());
         assert!(args
             .windows(2)
             .any(|pair| { pair == ["--config", "sandbox_workspace_write.network_access=true"] }));
 
         executor.permissions = permissions(None, None, false, false, None, false, true);
         let policy = executor.permissions.effective(true, false);
-        let args = command_args(&executor.build_command(None, &policy).unwrap());
+        let args = command_args(&executor.build_command(None, &policy, None).unwrap());
         assert!(args.iter().any(|argument| argument == "--full-auto"));
         assert!(!args
             .iter()
@@ -2050,7 +2205,7 @@ mod tests {
             true,
         );
         let policy = executor.permissions.effective(true, false);
-        let args = command_args(&executor.build_command(None, &policy).unwrap());
+        let args = command_args(&executor.build_command(None, &policy, None).unwrap());
         assert!(args
             .iter()
             .any(|argument| argument == "--dangerously-bypass-approvals-and-sandbox"));
@@ -2104,7 +2259,7 @@ mod tests {
         let mut inherit_executor = fixture_executor();
         inherit_executor.auth = inherit;
         let policy = default_policy(&inherit_executor);
-        let inherit_command = inherit_executor.build_command(None, &policy).unwrap();
+        let inherit_command = inherit_executor.build_command(None, &policy, None).unwrap();
         assert!(command_env(&inherit_command, "CODEX_HOME").is_none());
         let inherit_args = inherit_command
             .as_std()
@@ -2141,7 +2296,7 @@ mod tests {
         custom_executor.state_dir = Some(state.path().to_path_buf());
         custom_executor.auth = custom;
         let policy = default_policy(&custom_executor);
-        let custom_command = custom_executor.build_command(None, &policy).unwrap();
+        let custom_command = custom_executor.build_command(None, &policy, None).unwrap();
         assert_eq!(
             command_env(&custom_command, CODEX_PROVIDER_ENV).as_deref(),
             Some("custom-secret-570")
@@ -2179,11 +2334,11 @@ mod tests {
         bamboo_executor.auth = bamboo;
         let policy = default_policy(&bamboo_executor);
         assert!(bamboo_executor
-            .build_command(None, &policy)
+            .build_command(None, &policy, None)
             .unwrap_err()
             .contains("per-run provider token"));
         let bamboo_command = bamboo_executor
-            .build_command(Some("bcx1_per_run_570"), &policy)
+            .build_command(Some("bcx1_per_run_570"), &policy, None)
             .unwrap();
         assert_eq!(
             command_env(&bamboo_command, CODEX_PROVIDER_ENV).as_deref(),
@@ -2508,6 +2663,20 @@ mod tests {
             }
         }
 
+        fn run_spec_with_messages(assignment: &str, messages: Vec<Value>) -> RunSpec {
+            RunSpec {
+                assignment: assignment.to_string(),
+                reasoning_effort: None,
+                permission_policy: None,
+                messages,
+                secrets: Default::default(),
+            }
+        }
+
+        fn message(role: &str, content: &str) -> Value {
+            json!({"role": role, "content": content})
+        }
+
         #[tokio::test]
         async fn preflight_accepts_current_surface_and_rejects_old_or_missing_binary() {
             let dir = tempfile::tempdir().unwrap();
@@ -2696,6 +2865,399 @@ echo '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
             }
             assert!(!argv.lines().any(|arg| arg == "--ignore-rules"));
             assert!(!argv.lines().any(|arg| arg == "--ignore-user-config"));
+        }
+
+        #[tokio::test]
+        async fn thread_state_is_captured_resumed_recaptured_and_cleared_for_fresh_run() {
+            let workspace = tempfile::tempdir().unwrap();
+            let bin_dir = tempfile::tempdir().unwrap();
+            let state_dir = tempfile::tempdir().unwrap();
+            let bin = write_stub(
+                bin_dir.path(),
+                r#"
+DIR=$(cd "$(dirname "$0")" && pwd)
+N=$(cat "$DIR/count" 2>/dev/null || echo 0)
+N=$((N+1))
+echo "$N" > "$DIR/count"
+printf '%s\n' "$@" > "$DIR/argv-$N.txt"
+IFS= read -r prompt
+printf '%s\n' "$prompt" > "$DIR/stdin-$N.txt"
+case "$N" in
+  1) THREAD='thread-one'; ANSWER='first' ;;
+  2) THREAD='thread-two'; ANSWER='second' ;;
+  *) THREAD=''; ANSWER='third' ;;
+esac
+if [ -n "$THREAD" ]; then
+  printf '{"type":"thread.started","thread_id":"%s"}\n' "$THREAD"
+fi
+echo '{"type":"turn.started"}'
+printf '{"type":"item.completed","item":{"id":"answer","type":"agent_message","text":"%s"}}\n' "$ANSWER"
+echo '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
+"#,
+            );
+            let mut exec = executor(bin, workspace.path());
+            exec.state_dir = Some(state_dir.path().to_path_buf());
+            let state_path = state_dir.path().join(CODEX_SESSION_STATE_FILE);
+
+            let (sink, _rx) = EventSink::channel();
+            let first = exec
+                .run(
+                    run_spec("remember amber-572"),
+                    sink,
+                    SteerInbox::disconnected(),
+                    CancellationToken::new(),
+                )
+                .await;
+            assert_eq!(first.status, TerminalStatus::Completed);
+            assert!(!std::fs::read_to_string(bin_dir.path().join("argv-1.txt"))
+                .unwrap()
+                .lines()
+                .any(|argument| argument == "resume"));
+            let state: CodexSessionState =
+                serde_json::from_slice(&std::fs::read(&state_path).unwrap()).unwrap();
+            assert_eq!(state.thread_id, "thread-one");
+            assert_eq!(state.workspace, exec.workspace);
+            assert_eq!(state.codex_home_mode, "inherit");
+
+            let (sink, _rx) = EventSink::channel();
+            let second = exec
+                .run(
+                    run_spec_with_messages(
+                        "what nonce?",
+                        vec![
+                            message("user", "remember amber-572"),
+                            message("assistant", "stored"),
+                            message("user", "what nonce?"),
+                        ],
+                    ),
+                    sink,
+                    SteerInbox::disconnected(),
+                    CancellationToken::new(),
+                )
+                .await;
+            assert_eq!(second.status, TerminalStatus::Completed);
+            let argv = std::fs::read_to_string(bin_dir.path().join("argv-2.txt")).unwrap();
+            let arguments = argv.lines().collect::<Vec<_>>();
+            let resume_index = arguments
+                .iter()
+                .position(|argument| *argument == "resume")
+                .expect("resume subcommand");
+            assert_eq!(arguments.get(resume_index + 1), Some(&"thread-one"));
+            assert_eq!(arguments.last(), Some(&"-"));
+            assert_eq!(
+                std::fs::read_to_string(bin_dir.path().join("stdin-2.txt"))
+                    .unwrap()
+                    .trim(),
+                "what nonce?"
+            );
+            let state: CodexSessionState =
+                serde_json::from_slice(&std::fs::read(&state_path).unwrap()).unwrap();
+            assert_eq!(state.thread_id, "thread-two");
+
+            let (sink, _rx) = EventSink::channel();
+            let third = exec
+                .run(
+                    run_spec("fresh rerun"),
+                    sink,
+                    SteerInbox::disconnected(),
+                    CancellationToken::new(),
+                )
+                .await;
+            assert_eq!(third.status, TerminalStatus::Completed);
+            assert!(!state_path.exists());
+            assert!(!std::fs::read_to_string(bin_dir.path().join("argv-3.txt"))
+                .unwrap()
+                .lines()
+                .any(|argument| argument == "resume"));
+        }
+
+        #[tokio::test]
+        async fn missing_or_mismatched_state_uses_bounded_history_rehydration() {
+            let workspace = tempfile::tempdir().unwrap();
+            let bin_dir = tempfile::tempdir().unwrap();
+            let state_dir = tempfile::tempdir().unwrap();
+            let bin = write_stub(
+                bin_dir.path(),
+                r#"
+DIR=$(cd "$(dirname "$0")" && pwd)
+printf '%s\n' "$@" > "$DIR/argv.txt"
+cat > "$DIR/stdin.txt"
+echo '{"type":"thread.started","thread_id":"fallback-thread"}'
+echo '{"type":"turn.started"}'
+echo '{"type":"item.completed","item":{"id":"answer","type":"agent_message","text":"ok"}}'
+echo '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
+"#,
+            );
+            let mut exec = executor(bin, workspace.path());
+            exec.state_dir = Some(state_dir.path().to_path_buf());
+            write_json_atomic(
+                &state_dir.path().join(CODEX_SESSION_STATE_FILE),
+                &CodexSessionState {
+                    thread_id: "unusable-thread".to_string(),
+                    workspace: exec.workspace.clone(),
+                    codex_home_mode: "isolated".to_string(),
+                    updated_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+            let (sink, _rx) = EventSink::channel();
+            let outcome = exec
+                .run(
+                    run_spec_with_messages(
+                        "continue",
+                        vec![
+                            message("user", "old question"),
+                            message("assistant", "old answer"),
+                            message("user", "continue"),
+                        ],
+                    ),
+                    sink,
+                    SteerInbox::disconnected(),
+                    CancellationToken::new(),
+                )
+                .await;
+            assert_eq!(outcome.status, TerminalStatus::Completed);
+            let argv = std::fs::read_to_string(bin_dir.path().join("argv.txt")).unwrap();
+            assert!(!argv.lines().any(|argument| argument == "resume"));
+            assert!(!argv.contains("unusable-thread"));
+            let body = std::fs::read_to_string(bin_dir.path().join("stdin.txt")).unwrap();
+            assert!(body.contains("## Prior conversation (rehydrated)"));
+            assert!(body.contains("old question"));
+            assert!(body.contains("old answer"));
+            assert!(body.contains("## Current task"));
+            assert_eq!(body.matches("continue").count(), 1);
+
+            let state: CodexSessionState = serde_json::from_slice(
+                &std::fs::read(state_dir.path().join(CODEX_SESSION_STATE_FILE)).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(state.thread_id, "fallback-thread");
+
+            let workspace_mismatch = CodexSessionState {
+                thread_id: "wrong-workspace".to_string(),
+                workspace: Some("/different/workspace".to_string()),
+                codex_home_mode: "inherit".to_string(),
+                updated_at: Utc::now(),
+            };
+            write_json_atomic(
+                &state_dir.path().join(CODEX_SESSION_STATE_FILE),
+                &workspace_mismatch,
+            )
+            .await
+            .unwrap();
+            assert_eq!(exec.resolve_resume_id().await, None);
+        }
+
+        #[tokio::test]
+        async fn invalid_resume_retries_once_fresh_with_rehydrated_history() {
+            let workspace = tempfile::tempdir().unwrap();
+            let bin_dir = tempfile::tempdir().unwrap();
+            let state_dir = tempfile::tempdir().unwrap();
+            let bin = write_stub(
+                bin_dir.path(),
+                r#"
+DIR=$(cd "$(dirname "$0")" && pwd)
+N=$(cat "$DIR/count" 2>/dev/null || echo 0)
+N=$((N+1))
+echo "$N" > "$DIR/count"
+printf '%s\n' "$@" > "$DIR/argv-$N.txt"
+cat > "$DIR/stdin-$N.txt"
+case " $* " in
+  *' resume dead-thread '*)
+    echo 'thread not found' >&2
+    exit 1
+    ;;
+  *)
+    echo '{"type":"thread.started","thread_id":"recovered-thread"}'
+    echo '{"type":"turn.started"}'
+    echo '{"type":"item.completed","item":{"id":"answer","type":"agent_message","text":"recovered"}}'
+    echo '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
+    ;;
+esac
+"#,
+            );
+            let mut exec = executor(bin, workspace.path());
+            exec.state_dir = Some(state_dir.path().to_path_buf());
+            write_json_atomic(
+                &state_dir.path().join(CODEX_SESSION_STATE_FILE),
+                &CodexSessionState {
+                    thread_id: "dead-thread".to_string(),
+                    workspace: exec.workspace.clone(),
+                    codex_home_mode: "inherit".to_string(),
+                    updated_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+            let (sink, mut events) = EventSink::channel();
+            let outcome = exec
+                .run(
+                    run_spec_with_messages(
+                        "please continue",
+                        vec![
+                            message("user", "prior nonce amber-572"),
+                            message("assistant", "stored"),
+                            message("user", "please continue"),
+                        ],
+                    ),
+                    sink,
+                    SteerInbox::disconnected(),
+                    CancellationToken::new(),
+                )
+                .await;
+            assert_eq!(outcome.status, TerminalStatus::Completed);
+            assert_eq!(outcome.result.as_deref(), Some("recovered"));
+            assert_eq!(
+                std::fs::read_to_string(bin_dir.path().join("count"))
+                    .unwrap()
+                    .trim(),
+                "2"
+            );
+            let first_argv = std::fs::read_to_string(bin_dir.path().join("argv-1.txt")).unwrap();
+            assert!(first_argv.lines().any(|argument| argument == "resume"));
+            assert!(first_argv.lines().any(|argument| argument == "dead-thread"));
+            let second_argv = std::fs::read_to_string(bin_dir.path().join("argv-2.txt")).unwrap();
+            assert!(!second_argv.lines().any(|argument| argument == "resume"));
+            let fallback = std::fs::read_to_string(bin_dir.path().join("stdin-2.txt")).unwrap();
+            assert!(fallback.contains("## Prior conversation (rehydrated)"));
+            assert!(fallback.contains("prior nonce amber-572"));
+            assert!(std::iter::from_fn(|| events.try_recv().ok()).any(|event| {
+                event["type"] == "runner_progress" && event["phase"] == "resume_fallback"
+            }));
+
+            let state: CodexSessionState = serde_json::from_slice(
+                &std::fs::read(state_dir.path().join(CODEX_SESSION_STATE_FILE)).unwrap(),
+            )
+            .unwrap();
+            assert_eq!(state.thread_id, "recovered-thread");
+            assert!(!std::fs::read_dir(state_dir.path())
+                .unwrap()
+                .filter_map(Result::ok)
+                .any(|entry| entry.file_name().to_string_lossy().contains(".tmp.")));
+        }
+
+        #[tokio::test]
+        async fn resume_failure_after_turn_progress_is_not_retried() {
+            let workspace = tempfile::tempdir().unwrap();
+            let bin_dir = tempfile::tempdir().unwrap();
+            let state_dir = tempfile::tempdir().unwrap();
+            let bin = write_stub(
+                bin_dir.path(),
+                r#"
+DIR=$(cd "$(dirname "$0")" && pwd)
+N=$(cat "$DIR/count" 2>/dev/null || echo 0)
+N=$((N+1))
+echo "$N" > "$DIR/count"
+cat >/dev/null
+echo '{"type":"thread.started","thread_id":"progressed-thread"}'
+echo '{"type":"turn.started"}'
+echo '{"type":"turn.failed","error":{"message":"model failed"}}'
+exit 1
+"#,
+            );
+            let mut exec = executor(bin, workspace.path());
+            exec.state_dir = Some(state_dir.path().to_path_buf());
+            write_json_atomic(
+                &state_dir.path().join(CODEX_SESSION_STATE_FILE),
+                &CodexSessionState {
+                    thread_id: "resumable-thread".to_string(),
+                    workspace: exec.workspace.clone(),
+                    codex_home_mode: "inherit".to_string(),
+                    updated_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+            let (sink, mut events) = EventSink::channel();
+            let outcome = exec
+                .run(
+                    run_spec_with_messages(
+                        "continue",
+                        vec![message("user", "earlier"), message("user", "continue")],
+                    ),
+                    sink,
+                    SteerInbox::disconnected(),
+                    CancellationToken::new(),
+                )
+                .await;
+
+            assert_eq!(outcome.status, TerminalStatus::Error);
+            assert_eq!(
+                std::fs::read_to_string(bin_dir.path().join("count"))
+                    .unwrap()
+                    .trim(),
+                "1"
+            );
+            assert!(!std::iter::from_fn(|| events.try_recv().ok()).any(|event| {
+                event["type"] == "runner_progress" && event["phase"] == "resume_fallback"
+            }));
+        }
+
+        #[tokio::test]
+        async fn failed_fallback_is_not_retried_a_second_time() {
+            let workspace = tempfile::tempdir().unwrap();
+            let bin_dir = tempfile::tempdir().unwrap();
+            let state_dir = tempfile::tempdir().unwrap();
+            let bin = write_stub(
+                bin_dir.path(),
+                r#"
+DIR=$(cd "$(dirname "$0")" && pwd)
+N=$(cat "$DIR/count" 2>/dev/null || echo 0)
+N=$((N+1))
+echo "$N" > "$DIR/count"
+cat >/dev/null
+echo "attempt $N failed" >&2
+exit 1
+"#,
+            );
+            let mut exec = executor(bin, workspace.path());
+            exec.state_dir = Some(state_dir.path().to_path_buf());
+            let state_path = state_dir.path().join(CODEX_SESSION_STATE_FILE);
+            write_json_atomic(
+                &state_path,
+                &CodexSessionState {
+                    thread_id: "dead-thread".to_string(),
+                    workspace: exec.workspace.clone(),
+                    codex_home_mode: "inherit".to_string(),
+                    updated_at: Utc::now(),
+                },
+            )
+            .await
+            .unwrap();
+
+            let (sink, mut events) = EventSink::channel();
+            let outcome = exec
+                .run(
+                    run_spec_with_messages(
+                        "continue",
+                        vec![message("user", "earlier"), message("user", "continue")],
+                    ),
+                    sink,
+                    SteerInbox::disconnected(),
+                    CancellationToken::new(),
+                )
+                .await;
+
+            assert_eq!(outcome.status, TerminalStatus::Error);
+            assert_eq!(
+                std::fs::read_to_string(bin_dir.path().join("count"))
+                    .unwrap()
+                    .trim(),
+                "2"
+            );
+            assert_eq!(
+                std::iter::from_fn(|| events.try_recv().ok())
+                    .filter(|event| {
+                        event["type"] == "runner_progress" && event["phase"] == "resume_fallback"
+                    })
+                    .count(),
+                1
+            );
+            assert!(!state_path.exists());
         }
 
         #[tokio::test]

--- a/tests/e2e_codex_cli_manual.rs
+++ b/tests/e2e_codex_cli_manual.rs
@@ -11,6 +11,7 @@ use bamboo_agent::codex_cli_executor::{
 };
 use bamboo_subagent::executor::{ChildExecutor, EventSink, SteerInbox};
 use bamboo_subagent::proto::{RunSpec, TerminalStatus};
+use serde_json::json;
 use tokio_util::sync::CancellationToken;
 
 #[tokio::test]
@@ -172,4 +173,108 @@ async fn real_workspace_write_denies_outside_write_and_emits_tool_error() {
         events.iter().any(|event| event["type"] == "tool_error"),
         "outside denial was not surfaced as a tool error: {events:?}"
     );
+}
+
+#[tokio::test]
+#[ignore = "requires a logged-in Codex CLI >= 0.144 on PATH"]
+async fn real_codex_second_activation_resumes_and_recalls_native_context() {
+    const NONCE: &str = "BAMBOO_RESUME_572_NONCE_9F3A";
+
+    let workspace = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let status = Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(workspace.path())
+        .status()
+        .expect("git is installed");
+    assert!(status.success());
+
+    let executor = CodexExecutor::new(
+        None,
+        None,
+        Some(workspace.path().to_string_lossy().into_owned()),
+        Some(state.path().to_path_buf()),
+        Vec::new(),
+        CodexAuthConfig::inherit(),
+        resolve_codex_permission_config(
+            Some("read-only"),
+            Some("never"),
+            false,
+            false,
+            Some("read-only".to_string()),
+            false,
+            false,
+        )
+        .unwrap(),
+    )
+    .await
+    .expect("Codex preflight succeeds");
+
+    let (sink, _events) = EventSink::channel();
+    let first = tokio::time::timeout(
+        Duration::from_secs(180),
+        executor.run(
+            RunSpec {
+                assignment: format!(
+                    "Remember this nonce for the next turn: {NONCE}. Reply with exactly STORED."
+                ),
+                reasoning_effort: None,
+                permission_policy: None,
+                messages: Vec::new(),
+                secrets: Default::default(),
+            },
+            sink,
+            SteerInbox::disconnected(),
+            CancellationToken::new(),
+        ),
+    )
+    .await
+    .expect("first real Codex turn timed out");
+    assert_eq!(first.status, TerminalStatus::Completed, "{first:?}");
+    assert_eq!(first.result.as_deref().map(str::trim), Some("STORED"));
+
+    let state_path = state.path().join("codex-session.json");
+    let first_state: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&state_path).unwrap()).unwrap();
+    assert!(first_state["thread_id"]
+        .as_str()
+        .is_some_and(|thread_id| !thread_id.is_empty()));
+
+    let current_task = "What exact nonce did I ask you to remember? Reply with that nonce only.";
+    let (sink, mut events) = EventSink::channel();
+    let second = tokio::time::timeout(
+        Duration::from_secs(180),
+        executor.run(
+            RunSpec {
+                assignment: current_task.to_string(),
+                reasoning_effort: None,
+                permission_policy: None,
+                // Deliberately ship only the current message. This keeps the
+                // activation discriminant non-empty but gives fallback
+                // rehydration no copy of NONCE, so only native resume can pass.
+                messages: vec![json!({"role": "user", "content": current_task})],
+                secrets: Default::default(),
+            },
+            sink,
+            SteerInbox::disconnected(),
+            CancellationToken::new(),
+        ),
+    )
+    .await
+    .expect("resumed real Codex turn timed out");
+    assert_eq!(second.status, TerminalStatus::Completed, "{second:?}");
+    assert_eq!(second.result.as_deref().map(str::trim), Some(NONCE));
+
+    let emitted = std::iter::from_fn(|| events.try_recv().ok()).collect::<Vec<_>>();
+    assert!(
+        !emitted
+            .iter()
+            .any(|event| event["phase"] == "resume_fallback"),
+        "real resume unexpectedly used fallback: {emitted:?}"
+    );
+    let second_state: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&state_path).unwrap()).unwrap();
+    assert!(second_state["thread_id"]
+        .as_str()
+        .is_some_and(|thread_id| !thread_id.is_empty()));
 }


### PR DESCRIPTION
## Summary
- persist Codex thread identity per child and resume native local transcripts across activations
- invalidate unusable workspace or CODEX_HOME modes and retry invalid resume ids exactly once with bounded history rehydration
- extract shared rehydration and atomic JSON helpers for both Codex and Claude executors, including Windows replacement support
- document the four activation branches and add a real nonce-recall resume regression

## Test Plan
- cargo fmt --all -- --check
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets
- cargo test -p bamboo-subagent
- cargo test -p bamboo-agent --lib
- cargo test --test e2e_codex_cli_manual -- --ignored --nocapture
- cargo test -p bamboo-agent --lib codex_cli_executor::tests
- cargo test -p bamboo-agent --lib claude_code_executor::tests

Real-machine acceptance passed with Codex CLI 0.144.5: turn one stored a nonce; turn two received only the current user message, resumed the persisted thread, recalled the nonce exactly, and emitted no resume_fallback event.

Closes #572