### PR TITLE
feat(codex): complete config and real-machine gate (#573)

### DIFF
--- a/crates/app/bamboo-server/src/codex_run_tokens.rs
+++ b/crates/app/bamboo-server/src/codex_run_tokens.rs
@@ -357,6 +357,12 @@ wire_api = "responses"
             }),
             "parent metrics must record the Codex Responses request: {recorded:?}"
         );
+        assert!(
+            !format!("{recorded:?}").contains(&issued.token)
+                && !stdout.contains(&issued.token)
+                && !stderr.contains(&issued.token),
+            "the scoped run token must remain masked from metrics and process output"
+        );
 
         registry.revoke(&issued.token_id);
         let revoked = live_client

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/codex.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/codex.rs
@@ -1,0 +1,87 @@
+use actix_web::{web, HttpResponse};
+use bamboo_subagent::codex_discovery::discover_codex_cli;
+use serde::Deserialize;
+
+use crate::error::AppError;
+
+#[derive(Debug, Deserialize)]
+pub struct DetectCodexRequest {
+    #[serde(default)]
+    binary: Option<String>,
+}
+
+/// Resolve and capability-check the configured Codex CLI without persisting
+/// settings. The worker executor uses the same shared discovery function.
+///
+/// # HTTP Route
+/// `POST /bamboo/config/codex/detect`
+pub async fn detect_codex_cli(
+    payload: web::Json<DetectCodexRequest>,
+) -> Result<HttpResponse, AppError> {
+    let binary = payload
+        .binary
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let discovery = discover_codex_cli(binary)
+        .await
+        .map_err(AppError::BadRequest)?;
+    Ok(HttpResponse::Ok().json(discovery))
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::io::Write as _;
+    use std::os::unix::fs::PermissionsExt as _;
+
+    use actix_web::{body::to_bytes, http::StatusCode};
+
+    use super::*;
+
+    fn write_codex_stub() -> (tempfile::TempDir, String) {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("codex");
+        let mut file = std::fs::File::create(&path).unwrap();
+        writeln!(file, "#!/bin/sh").unwrap();
+        writeln!(
+            file,
+            r#"case "$*" in
+  "--version") echo 'codex-cli 0.144.5' ;;
+  "exec --help") echo '--json --output-last-message --config --sandbox --dangerously-bypass-approvals-and-sandbox prompt from stdin' ;;
+  "exec resume --help") echo '--json' ;;
+  *) exit 2 ;;
+esac"#
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&path, permissions).unwrap();
+        (directory, path.to_string_lossy().into_owned())
+    }
+
+    #[actix_web::test]
+    async fn detect_returns_the_shared_preflight_path_and_version() {
+        let (_directory, binary) = write_codex_stub();
+        let response = detect_codex_cli(web::Json(DetectCodexRequest {
+            binary: Some(binary.clone()),
+        }))
+        .await
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body()).await.unwrap()).unwrap();
+        assert_eq!(body["path"], binary);
+        assert_eq!(body["version"], "codex-cli 0.144.5");
+    }
+
+    #[actix_web::test]
+    async fn detect_rejects_a_missing_override_with_install_guidance() {
+        let error = detect_codex_cli(web::Json(DetectCodexRequest {
+            binary: Some("/definitely/missing/codex".to_string()),
+        }))
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("npm i -g @openai/codex"));
+        assert!(error.to_string().contains("codex_binary"));
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
@@ -912,6 +912,103 @@ async fn provider_credential_full_payload_allows_unchanged_sidecars() {
     );
 }
 
+/// #573: the Codex custom-provider field is a stable credential reference,
+/// never a second copy of the provider secret. A subagents-only settings patch
+/// may round-trip that reference and update unrelated Codex fields without
+/// replacing, clearing, or exposing the provider-instance key.
+#[actix_web::test]
+async fn codex_provider_reference_round_trip_preserves_masked_provider_secret() {
+    use crate::app_state::AppState;
+    use actix_web::{test, web, App};
+
+    let temp_dir = tempdir().expect("temp dir should be created");
+    let state = AppState::new(temp_dir.path().to_path_buf())
+        .await
+        .expect("app state should initialize");
+    let app_state = web::Data::new(state);
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .route("/bamboo/config", web::get().to(super::get_bamboo_config))
+            .route("/bamboo/config", web::post().to(super::set_bamboo_config)),
+    )
+    .await;
+
+    let provider = test::TestRequest::post()
+        .uri("/bamboo/config")
+        .set_json(serde_json::json!({
+            "provider_instances": {
+                "codex-work": {
+                    "provider_type": "openai",
+                    "enabled": true,
+                    "api_key": "sk-codex-provider-secret"
+                }
+            }
+        }))
+        .to_request();
+    assert!(test::call_service(&app, provider)
+        .await
+        .status()
+        .is_success());
+
+    let reference = app_state.config.read().await.provider_instances["codex-work"]
+        .credential_ref
+        .clone()
+        .expect("provider instance has a stable credential reference");
+    let codex = test::TestRequest::post()
+        .uri("/bamboo/config")
+        .set_json(serde_json::json!({
+            "subagents": {
+                "executor": "codex",
+                "codex_auth_mode": "custom",
+                "codex_base_url": "https://provider.example/v1",
+                "codex_wire_api": "responses",
+                "codex_provider_key_ref": reference.as_str(),
+                "codex_sandbox": "workspace-write",
+                "codex_approval_policy": "never"
+            }
+        }))
+        .to_request();
+    assert!(test::call_service(&app, codex).await.status().is_success());
+
+    let body: serde_json::Value = test::call_and_read_body_json(
+        &app,
+        test::TestRequest::get().uri("/bamboo/config").to_request(),
+    )
+    .await;
+    assert_eq!(
+        body["provider_instances"]["codex-work"]["api_key"],
+        "****...****"
+    );
+    assert_eq!(
+        body["subagents"]["codex_provider_key_ref"],
+        reference.as_str(),
+        "the non-secret reference remains visible and editable"
+    );
+
+    let update = test::TestRequest::post()
+        .uri("/bamboo/config")
+        .set_json(serde_json::json!({
+            "subagents": {"codex_model": "gpt-5.4-mini"}
+        }))
+        .to_request();
+    assert!(test::call_service(&app, update).await.status().is_success());
+
+    assert_eq!(
+        app_state
+            .credential_store
+            .resolve(&reference)
+            .unwrap()
+            .unwrap()
+            .expose(),
+        "sk-codex-provider-secret"
+    );
+    let subagents = std::fs::read_to_string(temp_dir.path().join("subagents.json")).unwrap();
+    assert!(subagents.contains(reference.as_str()));
+    assert!(!subagents.contains("sk-codex-provider-secret"));
+    assert!(!subagents.contains("****...****"));
+}
+
 #[actix_web::test]
 async fn redacted_full_payload_provider_update_preserves_notification_credential() {
     use crate::app_state::AppState;

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/mod.rs
@@ -1,3 +1,4 @@
+mod codex;
 mod config_endpoints;
 mod credentials;
 mod notifications;
@@ -10,6 +11,7 @@ mod validation;
 #[cfg(test)]
 mod tests;
 
+pub use codex::detect_codex_cli;
 pub use config_endpoints::{
     confirm_config_recovery, get_bamboo_config, get_config_recovery_status,
     get_model_limit_defaults, reset_bamboo_config, set_bamboo_config,

--- a/crates/app/bamboo-server/src/handlers/settings/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/mod.rs
@@ -25,12 +25,12 @@ pub use access_control::{
 };
 pub(crate) use access_control::{request_is_authorized, verify_device_token};
 pub use bamboo_config::{
-    clear_credential, confirm_config_recovery, get_bamboo_config, get_bamboo_tools,
-    get_config_recovery_status, get_credential_status, get_live_config_health, get_mcp_section,
-    get_model_limit_defaults, get_notification_config, get_provider_section, get_proxy_auth_status,
-    get_typed_section, list_credentials, put_mcp_section, put_provider_section, put_typed_section,
-    replace_credential, reset_bamboo_config, set_bamboo_config, set_proxy_auth,
-    validate_bamboo_config_patch, ProxyAuthPayload,
+    clear_credential, confirm_config_recovery, detect_codex_cli, get_bamboo_config,
+    get_bamboo_tools, get_config_recovery_status, get_credential_status, get_live_config_health,
+    get_mcp_section, get_model_limit_defaults, get_notification_config, get_provider_section,
+    get_proxy_auth_status, get_typed_section, list_credentials, put_mcp_section,
+    put_provider_section, put_typed_section, replace_credential, reset_bamboo_config,
+    set_bamboo_config, set_proxy_auth, validate_bamboo_config_patch, ProxyAuthPayload,
 };
 pub use cluster_fabric::{
     create_cluster, create_node, delete_cluster, delete_node, get_node, list_nodes, node_deploy,

--- a/crates/app/bamboo-server/src/routes/bamboo_v1.rs
+++ b/crates/app/bamboo-server/src/routes/bamboo_v1.rs
@@ -110,6 +110,10 @@ pub(crate) fn bamboo_relative_routes() -> impl HttpServiceFactory {
             web::post().to(settings::validate_bamboo_config_patch),
         )
         .route(
+            "/bamboo/config/codex/detect",
+            web::post().to(settings::detect_codex_cli),
+        )
+        .route(
             "/bamboo/hooks/test",
             web::post().to(settings::test_lifecycle_hook),
         )

--- a/crates/engine/bamboo-engine/src/external_agents/runtime.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/runtime.rs
@@ -368,46 +368,7 @@ fn build_local_actor_runner(
         .map(std::path::PathBuf::from)
         .unwrap_or_else(bamboo_config::paths::subagents_dir);
 
-    let executor = match sub.executor.as_deref() {
-        Some("echo") => bamboo_subagent::provision::ExecutorSpec::Echo,
-        Some("bamboo_runtime") | None => bamboo_subagent::provision::ExecutorSpec::BambooRuntime,
-        // #443: binary/model/permission_mode/isolation/env-forward are
-        // plumbed from `subagents.claude_code_*` — mirrors the matching arm
-        // in `build_external_child_runner` above.
-        Some("claude_code") => bamboo_subagent::provision::ExecutorSpec::ClaudeCode {
-            binary: sub.claude_code_binary.clone(),
-            model: sub.claude_code_model.clone(),
-            permission_mode: sub.claude_code_permission_mode.clone(),
-            inherit_user_config: sub.claude_code_inherit_user_config,
-            forward_env: sub.claude_code_forward_env.clone(),
-        },
-        Some("codex") => bamboo_subagent::provision::ExecutorSpec::Codex {
-            binary: sub.codex_binary.clone(),
-            model: sub.codex_model.clone(),
-            sandbox: sub.codex_sandbox.map(codex_sandbox_name),
-            inherit_user_config: None,
-            auth_mode: Some(codex_auth_mode_name(
-                sub.codex_auth_mode.unwrap_or_default(),
-            )),
-            base_url: codex_base_url(
-                config,
-                sub.codex_auth_mode.unwrap_or_default(),
-                sub.codex_base_url.clone(),
-            ),
-            wire_api: sub.codex_wire_api.map(codex_wire_api_name),
-            provider_key_ref: sub
-                .codex_provider_key_ref
-                .as_ref()
-                .map(|reference| reference.as_str().to_string()),
-            forward_env: sub.codex_forward_env.clone(),
-            approval_policy: sub.codex_approval_policy.map(codex_approval_policy_name),
-            network_access: sub.codex_network_access,
-            allow_danger_bypass: sub.codex_allow_danger_bypass,
-            permission_profile: None,
-            workspace_owned: None,
-        },
-        Some(other) => return Err(format!("unknown subagents.executor '{other}'")),
-    };
+    let executor = subagent_executor_spec(config)?;
 
     let mut runner = ActorChildRunner::new(
         super::config::LOCAL_ACTOR_AGENT_ID.to_string(),
@@ -443,6 +404,52 @@ fn build_local_actor_runner(
         runner = runner.with_permission_config(config);
     }
     Ok(Arc::new(runner))
+}
+
+/// Convert the durable typed `subagents` section into the exact worker
+/// provisioning executor. This is deliberately independent of actor launch so
+/// the settings-to-spawn contract can be tested directly.
+fn subagent_executor_spec(
+    config: &Config,
+) -> Result<bamboo_subagent::provision::ExecutorSpec, String> {
+    let sub = config.subagents();
+    Ok(match sub.executor.as_deref() {
+        Some("echo") => bamboo_subagent::provision::ExecutorSpec::Echo,
+        Some("bamboo_runtime") | None => bamboo_subagent::provision::ExecutorSpec::BambooRuntime,
+        Some("claude_code") => bamboo_subagent::provision::ExecutorSpec::ClaudeCode {
+            binary: sub.claude_code_binary.clone(),
+            model: sub.claude_code_model.clone(),
+            permission_mode: sub.claude_code_permission_mode.clone(),
+            inherit_user_config: sub.claude_code_inherit_user_config,
+            forward_env: sub.claude_code_forward_env.clone(),
+        },
+        Some("codex") => bamboo_subagent::provision::ExecutorSpec::Codex {
+            binary: sub.codex_binary.clone(),
+            model: sub.codex_model.clone(),
+            sandbox: sub.codex_sandbox.map(codex_sandbox_name),
+            inherit_user_config: None,
+            auth_mode: Some(codex_auth_mode_name(
+                sub.codex_auth_mode.unwrap_or_default(),
+            )),
+            base_url: codex_base_url(
+                config,
+                sub.codex_auth_mode.unwrap_or_default(),
+                sub.codex_base_url.clone(),
+            ),
+            wire_api: sub.codex_wire_api.map(codex_wire_api_name),
+            provider_key_ref: sub
+                .codex_provider_key_ref
+                .as_ref()
+                .map(|reference| reference.as_str().to_string()),
+            forward_env: sub.codex_forward_env.clone(),
+            approval_policy: sub.codex_approval_policy.map(codex_approval_policy_name),
+            network_access: sub.codex_network_access,
+            allow_danger_bypass: sub.codex_allow_danger_bypass,
+            permission_profile: None,
+            workspace_owned: None,
+        },
+        Some(other) => return Err(format!("unknown subagents.executor '{other}'")),
+    })
 }
 
 /// Resolve config `schedulable_placements` into runner-ready handles (#181, P2b),
@@ -695,10 +702,13 @@ pub fn extract_provider_credentials(
 mod codex_runtime_config_tests {
     use super::{
         codex_approval_policy_name, codex_auth_mode_name, codex_base_url, codex_sandbox_name,
-        codex_wire_api_name,
+        codex_wire_api_name, subagent_executor_spec,
     };
-    use bamboo_config::{CodexApprovalPolicy, CodexAuthMode, CodexSandbox, CodexWireApi};
+    use bamboo_config::{
+        CodexApprovalPolicy, CodexAuthMode, CodexSandbox, CodexWireApi, CredentialRef,
+    };
     use bamboo_llm::Config;
+    use bamboo_subagent::provision::ExecutorSpec;
 
     #[test]
     fn codex_runtime_mapping_keeps_parent_loopback_and_custom_url_unambiguous() {
@@ -731,6 +741,59 @@ mod codex_runtime_config_tests {
         );
         assert_eq!(codex_base_url(&config, CodexAuthMode::Inherit, None), None);
         assert_eq!(codex_base_url(&config, CodexAuthMode::ApiKey, None), None);
+    }
+
+    #[test]
+    fn durable_codex_fields_map_without_loss_to_worker_spawn_spec() {
+        let mut config = Config::default();
+        let subagents = config.subagents_mut();
+        subagents.executor = Some("codex".to_string());
+        subagents.codex_binary = Some("/opt/codex/bin/codex".to_string());
+        subagents.codex_model = Some("gpt-5.4".to_string());
+        subagents.codex_auth_mode = Some(CodexAuthMode::Custom);
+        subagents.codex_base_url = Some("https://provider.example/v1".to_string());
+        subagents.codex_wire_api = Some(CodexWireApi::Responses);
+        subagents.codex_provider_key_ref = Some(
+            CredentialRef::parse("provider.codex-work.api_key").expect("valid credential ref"),
+        );
+        subagents.codex_forward_env = Some(vec!["HTTPS_PROXY".to_string()]);
+        subagents.codex_sandbox = Some(CodexSandbox::WorkspaceWrite);
+        subagents.codex_approval_policy = Some(CodexApprovalPolicy::OnFailure);
+        subagents.codex_network_access = Some(true);
+        subagents.codex_allow_danger_bypass = Some(false);
+
+        let spec = subagent_executor_spec(&config).expect("Codex config maps to executor spec");
+        let ExecutorSpec::Codex {
+            binary,
+            model,
+            sandbox,
+            auth_mode,
+            base_url,
+            wire_api,
+            provider_key_ref,
+            forward_env,
+            approval_policy,
+            network_access,
+            allow_danger_bypass,
+            ..
+        } = spec
+        else {
+            panic!("expected Codex executor spec");
+        };
+        assert_eq!(binary.as_deref(), Some("/opt/codex/bin/codex"));
+        assert_eq!(model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(sandbox.as_deref(), Some("workspace-write"));
+        assert_eq!(auth_mode.as_deref(), Some("custom"));
+        assert_eq!(base_url.as_deref(), Some("https://provider.example/v1"));
+        assert_eq!(wire_api.as_deref(), Some("responses"));
+        assert_eq!(
+            provider_key_ref.as_deref(),
+            Some("provider.codex-work.api_key")
+        );
+        assert_eq!(forward_env, Some(vec!["HTTPS_PROXY".to_string()]));
+        assert_eq!(approval_policy.as_deref(), Some("on-failure"));
+        assert_eq!(network_access, Some(true));
+        assert_eq!(allow_danger_bypass, Some(false));
     }
 }
 

--- a/crates/infra/bamboo-subagent/src/codex_discovery.rs
+++ b/crates/infra/bamboo-subagent/src/codex_discovery.rs
@@ -1,0 +1,204 @@
+//! Shared Codex CLI discovery and capability preflight.
+//!
+//! Both the worker executor and the settings HTTP endpoint call this module so
+//! a successful UI "Detect" result is exactly the binary the worker can use.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+
+/// The oldest Codex CLI schema Bamboo intentionally supports.
+pub const MIN_CODEX_VERSION: (u64, u64, u64) = (0, 144, 0);
+
+/// A discovery request must not leave a settings request or worker spawn
+/// waiting forever on a broken wrapper executable.
+const PREFLIGHT_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A resolved Codex executable that passed version and capability checks.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CodexCliDiscovery {
+    pub path: String,
+    pub version: String,
+}
+
+/// Resolve `binary` (or `codex` from `PATH`) and verify the exact CLI surface
+/// required by the executor.
+pub async fn discover_codex_cli(binary: Option<&str>) -> Result<CodexCliDiscovery, String> {
+    let requested = binary
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("codex");
+    let resolved = resolve_binary(requested).ok_or_else(|| missing_binary_error(requested))?;
+    ensure_executable(&resolved)?;
+
+    let version_output = command_output(&resolved, &["--version"]).await?;
+    if !version_output.status.success() {
+        return Err(format!(
+            "'{} --version' failed with status {}; reinstall or upgrade Codex CLI",
+            resolved.display(),
+            version_output.status
+        ));
+    }
+    let version = String::from_utf8_lossy(&version_output.stdout)
+        .trim()
+        .to_string();
+    let parsed_version = parse_codex_version(&version).ok_or_else(|| {
+        format!("could not parse Codex CLI version from {version:?}; expected `codex-cli X.Y.Z`")
+    })?;
+    if parsed_version < MIN_CODEX_VERSION {
+        return Err(format!(
+            "Codex CLI {version} is too old; Bamboo requires >= {}.{}.{} with `exec --json` and `exec resume`",
+            MIN_CODEX_VERSION.0, MIN_CODEX_VERSION.1, MIN_CODEX_VERSION.2
+        ));
+    }
+
+    verify_help_surface(
+        &resolved,
+        &["exec", "--help"],
+        &[
+            "--json",
+            "--output-last-message",
+            "--config",
+            "--sandbox",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "stdin",
+        ],
+    )
+    .await?;
+    verify_help_surface(&resolved, &["exec", "resume", "--help"], &["--json"]).await?;
+
+    Ok(CodexCliDiscovery {
+        path: resolved.to_string_lossy().into_owned(),
+        version,
+    })
+}
+
+/// Parse `codex-cli X.Y.Z` while tolerating vendor prefixes and a missing
+/// patch component.
+pub fn parse_codex_version(text: &str) -> Option<(u64, u64, u64)> {
+    let token = text
+        .split_whitespace()
+        .map(|token| token.trim_start_matches('v'))
+        .find(|token| token.chars().next().is_some_and(|ch| ch.is_ascii_digit()))?;
+    let clean = token.split(['-', '+']).next()?;
+    let mut parts = clean.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next().unwrap_or("0").parse().ok()?;
+    Some((major, minor, patch))
+}
+
+fn missing_binary_error(requested: &str) -> String {
+    format!(
+        "Codex CLI binary {requested:?} was not found or is not executable; install it with `npm i -g @openai/codex`, `brew install codex`, or an official GitHub release, or set codex_binary"
+    )
+}
+
+fn resolve_binary(requested: &str) -> Option<PathBuf> {
+    let requested_path = Path::new(requested);
+    if requested_path.components().count() > 1 || requested_path.is_absolute() {
+        return requested_path
+            .exists()
+            .then(|| requested_path.to_path_buf());
+    }
+    let path = std::env::var_os("PATH")?;
+    for directory in std::env::split_paths(&path) {
+        let candidate = directory.join(requested);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        #[cfg(windows)]
+        for extension in ["exe", "cmd", "bat"] {
+            let candidate = directory.join(format!("{requested}.{extension}"));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+fn ensure_executable(path: &Path) -> Result<(), String> {
+    let metadata = std::fs::metadata(path)
+        .map_err(|error| format!("inspect Codex binary '{}': {error}", path.display()))?;
+    if !metadata.is_file() {
+        return Err(missing_binary_error(&path.display().to_string()));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o111 == 0 {
+            return Err(missing_binary_error(&path.display().to_string()));
+        }
+    }
+    Ok(())
+}
+
+async fn verify_help_surface(
+    binary: &Path,
+    args: &[&str],
+    required: &[&str],
+) -> Result<(), String> {
+    let output = command_output(binary, args).await?;
+    if !output.status.success() {
+        return Err(format!(
+            "'{} {}' failed with status {}; upgrade Codex CLI",
+            binary.display(),
+            args.join(" "),
+            output.status
+        ));
+    }
+    let help = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let missing: Vec<_> = required
+        .iter()
+        .copied()
+        .filter(|flag| !help.contains(flag))
+        .collect();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Codex CLI '{}' lacks required `{}` capability flag(s): {}; upgrade to >= {}.{}.{}",
+            binary.display(),
+            args.join(" "),
+            missing.join(", "),
+            MIN_CODEX_VERSION.0,
+            MIN_CODEX_VERSION.1,
+            MIN_CODEX_VERSION.2
+        ))
+    }
+}
+
+async fn command_output(binary: &Path, args: &[&str]) -> Result<std::process::Output, String> {
+    let command_label = format!("'{} {}'", binary.display(), args.join(" "));
+    let mut command = Command::new(binary);
+    command.args(args).kill_on_drop(true);
+    tokio::time::timeout(PREFLIGHT_COMMAND_TIMEOUT, command.output())
+        .await
+        .map_err(|_| {
+            format!(
+                "{command_label} timed out after {} seconds; verify the Codex CLI installation or wrapper",
+                PREFLIGHT_COMMAND_TIMEOUT.as_secs()
+            )
+        })?
+        .map_err(|error| format!("run {command_label}: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_codex_version;
+
+    #[test]
+    fn version_parser_accepts_current_and_rejects_noise() {
+        assert_eq!(parse_codex_version("codex-cli 0.144.5"), Some((0, 144, 5)));
+        assert_eq!(parse_codex_version("vendor v0.144.5"), Some((0, 144, 5)));
+        assert_eq!(parse_codex_version("codex 1.2"), Some((1, 2, 0)));
+        assert_eq!(parse_codex_version("not-a-version"), None);
+    }
+}

--- a/crates/infra/bamboo-subagent/src/lib.rs
+++ b/crates/infra/bamboo-subagent/src/lib.rs
@@ -12,6 +12,7 @@
 //! crate stays a leaf and is fully unit-testable with a tempdir; higher layers pass the
 //! domain `Session`. Index rebuild is decoupled via the [`store::MetaExtractor`] seam.
 
+pub mod codex_discovery;
 pub mod discovery;
 pub mod error;
 pub mod executor;

--- a/docs/codex-executor.md
+++ b/docs/codex-executor.md
@@ -13,6 +13,40 @@ live Bamboo-provider test are verified against 0.144.5. Codex 0.144 removed the
 custom-provider Chat Completions wire, so `codex_wire_api` only accepts
 `"responses"`.
 
+The Lotus Sub-agents settings card exposes the same fields and validates the
+pending patch through `POST /bamboo/config/validate` before saving. Its Detect
+button calls `POST /bamboo/config/codex/detect` with an optional
+`{"binary":"..."}` override. The response is the resolved `path` and
+`version`; the endpoint and worker share one discovery implementation, so a
+successful detection cannot bypass the worker's version/capability preflight.
+
+## Spawn contract
+
+| Concern | Codex executor behavior |
+|---|---|
+| Process lifetime | One `codex exec` process group per activation; a warm Bamboo worker may run many activations but never reuses a Codex process. |
+| Prompt transport | The assignment is written to stdin (`-`), never placed in argv. |
+| Output | `--json --color never` JSONL plus a bounded `--output-last-message` fallback file. |
+| Model | `codex_model`, when set, becomes an explicit `--model`; otherwise the flag is omitted. |
+| Repository guard | A real Git workspace needs no override. `--skip-git-repo-check` is allowed only for a Bamboo-owned non-Git workspace. |
+| Cancellation | Bamboo snapshots the full descendant tree, sends SIGTERM deepest-first plus to the Codex process group, then escalates every survivor to SIGKILL after a bounded grace period. This also covers tool commands that create a new process group. |
+
+## Event mapping
+
+| Codex JSONL event | Bamboo output |
+|---|---|
+| `thread.started` | Persists the native thread id and emits runner metadata including binary, version, model, auth/home mode, sandbox, approval policy, and forwarded environment names. |
+| `turn.started` | `runner_progress` for round 1. |
+| `item.started/updated/completed` | Agent text becomes token deltas; reasoning becomes reasoning deltas; command/MCP/web items become Bamboo tool start/output/complete/error events. |
+| `turn.completed` | Captures input/output token usage and emits Bamboo `complete`. |
+| `turn.failed` / `error` | A bounded error outcome with the Codex message and stderr tail. |
+
+Unknown top-level or item event types are ignored rather than failing the run,
+so additive Codex schemas are tolerated. Bamboo raises the minimum version or
+changes the capability checks only when a required flag or event contract
+changes; CI fixtures cover known events and the ignored real-machine suite is
+the version-drift merge gate.
+
 ## Authentication and billing modes
 
 `codex_auth_mode` has four values. Unset defaults to `"bamboo"`; inheriting a
@@ -173,9 +207,21 @@ the environment variable but never includes a key or run token. The executor
 also passes `--ignore-rules`; `inherit` intentionally does neither and leaves
 `CODEX_HOME` unset.
 
-The process owns its own process group. Cancellation sends SIGTERM to the
-whole group, waits five seconds, then escalates to SIGKILL, so the npm launcher
-and its native Codex child cannot be orphaned independently.
+The process owns its own process group. Cancellation snapshots its descendant
+tree, sends SIGTERM deepest-first and to the whole group, waits five seconds,
+then escalates every survivor to SIGKILL. Tracking descendants separately is
+required because a Codex tool shell may create its own process group; a
+group-only signal would otherwise let that tool survive after Codex exits.
+
+## Differences from the Claude Code executor
+
+| Area | Codex | Claude Code |
+|---|---|---|
+| Activation | New `codex exec` process each turn; resume uses a persisted thread id. | Stream-JSON process per activation with Claude's session id and `--resume`. |
+| Runtime approvals | No interactive approval relay in v1; only `never` and `on-failure` are accepted. | Permission prompts can be relayed over stdio. |
+| Safety boundary | OS sandbox is the primary guard and unsandboxed mode is double-gated. | Claude permission mode plus Bamboo's permission relay is primary. |
+| Personal config | Explicit `inherit` auth mode; isolated modes create a minimal `CODEX_HOME`. | Controlled by `claude_code_inherit_user_config`. |
+| Parent provider | Scoped per-run Bamboo token can route Codex through `/openai/v1`. | Provider auth is controlled by Claude CLI login or explicitly forwarded environment names. |
 
 ## Bamboo-as-provider token and observability
 
@@ -206,3 +252,12 @@ cargo test -p bamboo-server \
   live_bamboo_codex_completes_records_metrics_and_rejects_revoked_token \
   --lib -- --ignored --nocapture
 ```
+
+The consolidated checklist covered by those commands is:
+
+1. Shared discovery reports the resolved path/version and an actionable missing-binary error.
+2. A fresh temporary Git-repository run completes with final text, token usage, and bootstrap metadata.
+3. A second activation resumes the native thread and recalls a nonce absent from fallback history.
+4. `workspace-write` permits an in-workspace write and blocks an out-of-workspace write with a tool error.
+5. `bamboo` auth completes through the parent `/openai/v1`, records parent metrics/session masking, and rejects the revoked scoped token.
+6. Cancellation removes a live descendant process group, returns `Cancelled`, and the same session subsequently resumes successfully.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -296,6 +296,10 @@ via a small `claude-code-session.json` state file per sub-agent workspace.
 
 For Codex configuration, billing implications, isolation details, and the
 per-run Bamboo token contract, see [`codex-executor.md`](codex-executor.md).
+Lotus validates this section with `POST /bamboo/config/validate`; its binary
+Detect action calls `POST /bamboo/config/codex/detect`, which returns the
+resolved `path` and `version` only after the same preflight used at worker
+spawn.
 
 ## MCP servers
 

--- a/src/codex_cli_executor.rs
+++ b/src/codex_cli_executor.rs
@@ -25,6 +25,7 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use bamboo_agent_core::{AgentEvent, TokenUsage, ToolResult};
+use bamboo_subagent::codex_discovery::discover_codex_cli;
 use bamboo_subagent::executor::{ChildExecutor, ChildOutcome, EventSink, SteerInbox};
 use bamboo_subagent::executor_util::{build_rehydrated_turn, write_json_atomic};
 use bamboo_subagent::proto::RunSpec;
@@ -33,7 +34,7 @@ use bamboo_subagent::proto::RunSpec;
 /// executor additionally capability-checks `exec --help` and `exec resume
 /// --help`, so a backported or vendor build must still expose the required
 /// flags. Version 0.144 is the schema verified by issue #569.
-pub const MIN_CODEX_VERSION: (u64, u64, u64) = (0, 144, 0);
+pub use bamboo_subagent::codex_discovery::MIN_CODEX_VERSION;
 
 const MAX_STDOUT_LINE_BYTES: usize = 10 * 1024 * 1024;
 const STDERR_TAIL_BYTES: usize = 16 * 1024;
@@ -62,6 +63,17 @@ pub enum CodexAuthMode {
     ApiKey,
     Custom,
     Bamboo,
+}
+
+impl CodexAuthMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Inherit => "inherit",
+            Self::ApiKey => "api_key",
+            Self::Custom => "custom",
+            Self::Bamboo => "bamboo",
+        }
+    }
 }
 
 /// Fully resolved auth posture. The custom-provider key is deliberately
@@ -475,56 +487,11 @@ impl CodexExecutor {
         auth: CodexAuthConfig,
         permissions: CodexPermissionConfig,
     ) -> Result<Self, String> {
-        let requested = binary.unwrap_or_else(|| "codex".to_string());
-        let resolved =
-            resolve_binary(&requested).ok_or_else(|| missing_binary_error(&requested))?;
-        ensure_executable(&resolved)?;
-
-        let version_output = Command::new(&resolved)
-            .arg("--version")
-            .output()
-            .await
-            .map_err(|error| format!("run '{} --version': {error}", resolved.display()))?;
-        if !version_output.status.success() {
-            return Err(format!(
-                "'{} --version' failed with status {}; reinstall or upgrade Codex CLI",
-                resolved.display(),
-                version_output.status
-            ));
-        }
-        let version_text = String::from_utf8_lossy(&version_output.stdout)
-            .trim()
-            .to_string();
-        let parsed_version = parse_codex_version(&version_text).ok_or_else(|| {
-            format!(
-                "could not parse Codex CLI version from {version_text:?}; expected `codex-cli X.Y.Z`"
-            )
-        })?;
-        if parsed_version < MIN_CODEX_VERSION {
-            return Err(format!(
-                "Codex CLI {version_text} is too old; Bamboo requires >= {}.{}.{} with `exec --json` and `exec resume`",
-                MIN_CODEX_VERSION.0, MIN_CODEX_VERSION.1, MIN_CODEX_VERSION.2
-            ));
-        }
-
-        verify_help_surface(
-            &resolved,
-            &["exec", "--help"],
-            &[
-                "--json",
-                "--output-last-message",
-                "--config",
-                "--sandbox",
-                "--dangerously-bypass-approvals-and-sandbox",
-                "stdin",
-            ],
-        )
-        .await?;
-        verify_help_surface(&resolved, &["exec", "resume", "--help"], &["--json"]).await?;
+        let discovery = discover_codex_cli(binary.as_deref()).await?;
 
         let executor = Self {
-            binary: resolved,
-            version: version_text,
+            binary: PathBuf::from(discovery.path),
+            version: discovery.version,
             model,
             permissions,
             workspace,
@@ -820,6 +787,10 @@ impl CodexExecutor {
                     "executor": "codex",
                     "binary": self.binary,
                     "version": self.version,
+                    "model": self.model,
+                    "auth_mode": self.auth.mode().as_str(),
+                    "codex_home_mode": self.codex_home_mode(),
+                    "forward_env": self.forward_env,
                     "sandbox": policy.sandbox.as_str(),
                     "approval_policy": policy.approval_policy.as_str(),
                     "network_access": policy.network_access,
@@ -1086,6 +1057,12 @@ impl CodexExecutor {
             "round_count": 0,
             "executor": "codex",
             "phase": "bootstrap",
+            "binary": self.binary,
+            "version": self.version,
+            "model": self.model,
+            "auth_mode": self.auth.mode().as_str(),
+            "codex_home_mode": self.codex_home_mode(),
+            "forward_env": self.forward_env,
             "sandbox": policy.sandbox.as_str(),
             "approval_policy": policy.approval_policy.as_str(),
             "network_access": policy.network_access,
@@ -1514,107 +1491,6 @@ fn truncate_chars(text: &str, max_chars: usize) -> String {
     format!("{head}\n… [truncated, {dropped} more chars]")
 }
 
-fn missing_binary_error(requested: &str) -> String {
-    format!(
-        "Codex CLI binary {requested:?} was not found or is not executable; install it with `npm i -g @openai/codex`, `brew install codex`, or an official GitHub release, or set codex_binary"
-    )
-}
-
-fn resolve_binary(requested: &str) -> Option<PathBuf> {
-    let requested_path = Path::new(requested);
-    if requested_path.components().count() > 1 || requested_path.is_absolute() {
-        return requested_path
-            .exists()
-            .then(|| requested_path.to_path_buf());
-    }
-    let path = std::env::var_os("PATH")?;
-    for directory in std::env::split_paths(&path) {
-        let candidate = directory.join(requested);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        #[cfg(windows)]
-        for extension in ["exe", "cmd", "bat"] {
-            let candidate = directory.join(format!("{requested}.{extension}"));
-            if candidate.is_file() {
-                return Some(candidate);
-            }
-        }
-    }
-    None
-}
-
-fn ensure_executable(path: &Path) -> Result<(), String> {
-    let metadata = std::fs::metadata(path)
-        .map_err(|error| format!("inspect Codex binary '{}': {error}", path.display()))?;
-    if !metadata.is_file() {
-        return Err(missing_binary_error(&path.display().to_string()));
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        if metadata.permissions().mode() & 0o111 == 0 {
-            return Err(missing_binary_error(&path.display().to_string()));
-        }
-    }
-    Ok(())
-}
-
-fn parse_codex_version(text: &str) -> Option<(u64, u64, u64)> {
-    let token = text
-        .split_whitespace()
-        .find(|token| token.chars().next().is_some_and(|ch| ch.is_ascii_digit()))?;
-    let clean = token.trim_start_matches('v').split(['-', '+']).next()?;
-    let mut parts = clean.split('.');
-    let major = parts.next()?.parse().ok()?;
-    let minor = parts.next()?.parse().ok()?;
-    let patch = parts.next().unwrap_or("0").parse().ok()?;
-    Some((major, minor, patch))
-}
-
-async fn verify_help_surface(
-    binary: &Path,
-    args: &[&str],
-    required: &[&str],
-) -> Result<(), String> {
-    let output = Command::new(binary)
-        .args(args)
-        .output()
-        .await
-        .map_err(|error| format!("run '{} {}': {error}", binary.display(), args.join(" ")))?;
-    if !output.status.success() {
-        return Err(format!(
-            "'{} {}' failed with status {}; upgrade Codex CLI",
-            binary.display(),
-            args.join(" "),
-            output.status
-        ));
-    }
-    let help = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let missing: Vec<_> = required
-        .iter()
-        .copied()
-        .filter(|flag| !help.contains(flag))
-        .collect();
-    if missing.is_empty() {
-        Ok(())
-    } else {
-        Err(format!(
-            "Codex CLI '{}' lacks required `{}` capability flag(s): {}; upgrade to >= {}.{}.{}",
-            binary.display(),
-            args.join(" "),
-            missing.join(", "),
-            MIN_CODEX_VERSION.0,
-            MIN_CODEX_VERSION.1,
-            MIN_CODEX_VERSION.2
-        ))
-    }
-}
-
 fn has_git_metadata(path: &Path) -> bool {
     path.ancestors()
         .any(|ancestor| ancestor.join(".git").exists())
@@ -1727,6 +1603,55 @@ fn signal_process_group(pgid: libc::pid_t, signal: ProcessSignal) {
 }
 
 #[cfg(unix)]
+fn signal_process(pid: libc::pid_t, signal: ProcessSignal) {
+    let signal = match signal {
+        ProcessSignal::Term => libc::SIGTERM,
+        ProcessSignal::Kill => libc::SIGKILL,
+    };
+    // SAFETY: the pid comes from the OS process table. ESRCH is harmless.
+    unsafe {
+        libc::kill(pid, signal);
+    }
+}
+
+#[cfg(unix)]
+fn descendant_processes(root: libc::pid_t) -> Vec<libc::pid_t> {
+    use sysinfo::{ProcessesToUpdate, System};
+
+    let mut system = System::new();
+    system.refresh_processes(ProcessesToUpdate::All, true);
+    let mut known = HashSet::from([root]);
+    let mut descendants = Vec::new();
+    loop {
+        let mut added = false;
+        for (pid, process) in system.processes() {
+            let pid = pid.as_u32() as libc::pid_t;
+            let parent = process
+                .parent()
+                .map(|parent| parent.as_u32() as libc::pid_t);
+            if !known.contains(&pid) && parent.is_some_and(|parent| known.contains(&parent)) {
+                known.insert(pid);
+                descendants.push(pid);
+                added = true;
+            }
+        }
+        if !added {
+            break;
+        }
+    }
+    descendants
+}
+
+#[cfg(unix)]
+fn process_exists(pid: libc::pid_t) -> bool {
+    // SAFETY: signal 0 only probes whether the process exists.
+    if unsafe { libc::kill(pid, 0) } == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+
+#[cfg(unix)]
 fn process_group_exists(pgid: libc::pid_t) -> bool {
     // SAFETY: signal 0 only probes whether the process group exists.
     if unsafe { libc::kill(-pgid, 0) } == 0 {
@@ -1740,13 +1665,20 @@ async fn terminate_child(child: &mut Child) {
     let Some(pgid) = child.id().map(|pid| pid as libc::pid_t) else {
         return;
     };
+    // Codex may launch a sandbox/tool command in a NEW process group. Capture
+    // the full descendant tree before terminating the Codex leader; otherwise
+    // those commands are reparented to init and escape a group-only signal.
+    let descendants = descendant_processes(pgid);
+    for &pid in descendants.iter().rev() {
+        signal_process(pid, ProcessSignal::Term);
+    }
     signal_process_group(pgid, ProcessSignal::Term);
     let deadline = tokio::time::Instant::now() + SIGTERM_WAIT;
     loop {
-        // Reap the leader when it exits, but keep tracking the process group:
-        // a descendant may have ignored SIGTERM and outlived that leader.
+        // Reap the leader when it exits, but keep tracking its process group
+        // and any descendants Codex placed in independent groups.
         let _ = child.try_wait();
-        if !process_group_exists(pgid) {
+        if !process_group_exists(pgid) && !descendants.iter().copied().any(process_exists) {
             let _ = child.wait().await;
             return;
         }
@@ -1754,6 +1686,9 @@ async fn terminate_child(child: &mut Child) {
             break;
         }
         tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    for &pid in descendants.iter().rev() {
+        signal_process(pid, ProcessSignal::Kill);
     }
     signal_process_group(pgid, ProcessSignal::Kill);
     let _ = child.start_kill();
@@ -1946,13 +1881,6 @@ mod tests {
             events.push(event);
         }
         (state, events)
-    }
-
-    #[test]
-    fn version_parser_accepts_current_and_rejects_noise() {
-        assert_eq!(parse_codex_version("codex-cli 0.144.5"), Some((0, 144, 5)));
-        assert_eq!(parse_codex_version("codex 1.2"), Some((1, 2, 0)));
-        assert_eq!(parse_codex_version("not-a-version"), None);
     }
 
     #[test]

--- a/tests/e2e_codex_cli_manual.rs
+++ b/tests/e2e_codex_cli_manual.rs
@@ -9,10 +9,31 @@ use std::time::Duration;
 use bamboo_agent::codex_cli_executor::{
     resolve_codex_permission_config, CodexAuthConfig, CodexExecutor,
 };
+use bamboo_subagent::codex_discovery::discover_codex_cli;
 use bamboo_subagent::executor::{ChildExecutor, EventSink, SteerInbox};
 use bamboo_subagent::proto::{RunSpec, TerminalStatus};
 use serde_json::json;
 use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+#[ignore = "requires an installed Codex CLI >= 0.144 on PATH"]
+async fn real_codex_discovery_reports_path_version_and_actionable_missing_error() {
+    let discovered = discover_codex_cli(None)
+        .await
+        .expect("installed Codex passes the shared discovery preflight");
+    println!(
+        "CODEX_DISCOVERY path={} version={}",
+        discovered.path, discovered.version
+    );
+    assert!(!discovered.path.is_empty());
+    assert!(discovered.version.contains("codex-cli"));
+
+    let missing = discover_codex_cli(Some("/definitely/missing/codex"))
+        .await
+        .expect_err("missing override must be rejected");
+    assert!(missing.contains("npm i -g @openai/codex"));
+    assert!(missing.contains("codex_binary"));
+}
 
 #[tokio::test]
 #[ignore = "requires a logged-in Codex CLI >= 0.144 on PATH"]
@@ -68,10 +89,13 @@ async fn real_codex_completes_trivial_turn_and_reports_bootstrap_metadata() {
     assert_eq!(outcome.status, TerminalStatus::Completed);
     assert_eq!(outcome.result.as_deref().map(str::trim), Some("PONG"));
     let mut bootstrap = None;
+    let mut usage = None;
     while let Ok(event) = rx.try_recv() {
         println!("EVENT: {event}");
         if event["executor"] == "codex" {
             bootstrap = Some(event);
+        } else if event["type"] == "complete" {
+            usage = Some(event["usage"].clone());
         }
     }
     let bootstrap = bootstrap.expect("thread.started emitted bootstrap metadata");
@@ -84,6 +108,13 @@ async fn real_codex_completes_trivial_turn_and_reports_bootstrap_metadata() {
     assert_eq!(bootstrap["sandbox"], "read-only");
     assert_eq!(bootstrap["approval_policy"], "never");
     assert_eq!(bootstrap["policy_invocation"], "explicit");
+    assert_eq!(bootstrap["auth_mode"], "inherit");
+    assert_eq!(bootstrap["codex_home_mode"], "inherit");
+    assert_eq!(bootstrap["forward_env"], json!([]));
+    assert!(usage
+        .as_ref()
+        .and_then(|value| value["total_tokens"].as_u64())
+        .is_some_and(|total| total > 0));
 }
 
 #[tokio::test]
@@ -277,4 +308,120 @@ async fn real_codex_second_activation_resumes_and_recalls_native_context() {
     assert!(second_state["thread_id"]
         .as_str()
         .is_some_and(|thread_id| !thread_id.is_empty()));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[ignore = "requires a logged-in Codex CLI >= 0.144 on PATH"]
+async fn real_cancellation_kills_the_process_group_and_the_session_can_resume() {
+    let workspace = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let status = Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(workspace.path())
+        .status()
+        .expect("git is installed");
+    assert!(status.success());
+
+    let executor = CodexExecutor::new(
+        None,
+        None,
+        Some(workspace.path().to_string_lossy().into_owned()),
+        Some(state.path().to_path_buf()),
+        Vec::new(),
+        CodexAuthConfig::inherit(),
+        resolve_codex_permission_config(
+            Some("workspace-write"),
+            Some("never"),
+            false,
+            false,
+            None,
+            false,
+            false,
+        )
+        .unwrap(),
+    )
+    .await
+    .expect("Codex preflight succeeds");
+
+    let pid_file = workspace.path().join("cancel-child.pid");
+    let cancel = CancellationToken::new();
+    let cancel_for_run = cancel.clone();
+    let (sink, _events) = EventSink::channel();
+    let first = executor.run(
+        RunSpec {
+            assignment: "Run this exact command now and wait for it to finish: /bin/sh -c 'echo $$ > ./cancel-child.pid; sleep 120'".to_string(),
+            reasoning_effort: None,
+            permission_policy: None,
+            messages: Vec::new(),
+            secrets: Default::default(),
+        },
+        sink,
+        SteerInbox::disconnected(),
+        cancel_for_run,
+    );
+    tokio::pin!(first);
+
+    let shell_pid = tokio::time::timeout(Duration::from_secs(90), async {
+        tokio::select! {
+            pid = async {
+                loop {
+                    if let Ok(raw) = tokio::fs::read_to_string(&pid_file).await {
+                        if let Ok(pid) = raw.trim().parse::<i32>() {
+                            break pid;
+                        }
+                    }
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            } => pid,
+            outcome = &mut first => {
+                panic!("Codex ended before starting the long-running descendant: {outcome:?}")
+            }
+        }
+    })
+    .await
+    .expect("Codex did not start the long-running descendant in time");
+    cancel.cancel();
+    let cancelled = tokio::time::timeout(Duration::from_secs(15), &mut first)
+        .await
+        .expect("cancelled Codex process did not exit in time");
+    assert_eq!(cancelled.status, TerminalStatus::Cancelled, "{cancelled:?}");
+
+    let descendant_gone = tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            // SAFETY: signal 0 performs an existence/permission probe and does
+            // not deliver a signal or dereference memory.
+            if unsafe { libc::kill(shell_pid, 0) } != 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+    assert!(
+        descendant_gone.is_ok(),
+        "cancelled Codex descendant process {shell_pid} is still alive"
+    );
+
+    let assignment = "Reply with exactly RECOVERED and nothing else.";
+    let (sink, _events) = EventSink::channel();
+    let resumed = tokio::time::timeout(
+        Duration::from_secs(180),
+        executor.run(
+            RunSpec {
+                assignment: assignment.to_string(),
+                reasoning_effort: None,
+                permission_policy: None,
+                messages: vec![json!({"role": "user", "content": assignment})],
+                secrets: Default::default(),
+            },
+            sink,
+            SteerInbox::disconnected(),
+            CancellationToken::new(),
+        ),
+    )
+    .await
+    .expect("Codex did not resume after cancellation");
+    assert_eq!(resumed.status, TerminalStatus::Completed, "{resumed:?}");
+    assert_eq!(resumed.result.as_deref().map(str::trim), Some("RECOVERED"));
 }


### PR DESCRIPTION
## Summary
- share Codex CLI discovery and capability preflight between worker startup and the settings Detect endpoint
- map every durable codex_* field into the child spawn spec and emit secret-safe bootstrap metadata
- prove provider credential references round-trip without copying plaintext into subagent config
- harden cancellation to terminate descendants that Codex moves into independent process groups
- document configuration, auth and billing boundaries, sandbox policy, resume behavior, cancellation, observability, and Claude Code differences
- add the consolidated real-machine Codex gate

Lotus UI: bigduu/Lotus#132

Closes #573.

## Test Plan
- cargo fmt --check
- cargo clippy --workspace --all-targets
- cargo build --workspace --tests
- cargo doc --workspace --no-deps
- cargo test -p bamboo-subagent -p bamboo-server -p bamboo-engine codex
- cargo test -p bamboo-agent --lib codex
- cargo test -p bamboo-agent --test e2e_codex_cli_manual -- --ignored --nocapture --test-threads=1: 5 passed using codex-cli 0.144.5
- cargo test -p bamboo-server live_bamboo_codex_completes_records_metrics_and_rejects_revoked_token --lib -- --ignored --nocapture: 1 passed
- cargo test --workspace: all affected tests passed; one unrelated baseline TLS test failed with UnsupportedCertVersion, reproduced identically on detached origin/main@558a4b30

## Real-machine evidence
- discovery returned the resolved path and codex-cli 0.144.5
- fresh execution returned PONG, usage, and bootstrap metadata
- native resume retained prior context
- workspace-write denied an outside write and emitted a tool error
- cancellation removed the full descendant tree and the same session resumed successfully
- Bamboo parent auth recorded metrics, kept the per-run token out of metrics/stdout/stderr, and rejected it after revocation

## Review gates
- GitHub automated checks must pass
- parent-agent review must approve the exact PR head SHA independently of checks
- no human-review gate