### PR TITLE
feat: add Codex app-server approval relay

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/codex.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/codex.rs
@@ -1,5 +1,5 @@
 use actix_web::{web, HttpResponse};
-use bamboo_subagent::codex_discovery::discover_codex_cli;
+use bamboo_subagent::codex_discovery::{discover_codex_app_server, discover_codex_cli};
 use serde::Deserialize;
 
 use crate::error::AppError;
@@ -8,6 +8,8 @@ use crate::error::AppError;
 pub struct DetectCodexRequest {
     #[serde(default)]
     binary: Option<String>,
+    #[serde(default)]
+    mode: Option<String>,
 }
 
 /// Resolve and capability-check the configured Codex CLI without persisting
@@ -23,9 +25,14 @@ pub async fn detect_codex_cli(
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty());
-    let discovery = discover_codex_cli(binary)
-        .await
-        .map_err(AppError::BadRequest)?;
+    let discovery = match payload.mode.as_deref().unwrap_or("exec") {
+        "exec" => discover_codex_cli(binary).await,
+        "app_server" => discover_codex_app_server(binary).await,
+        other => Err(format!(
+            "unknown Codex mode '{other}'; expected exec or app_server"
+        )),
+    }
+    .map_err(AppError::BadRequest)?;
     Ok(HttpResponse::Ok().json(discovery))
 }
 
@@ -49,6 +56,7 @@ mod tests {
   "--version") echo 'codex-cli 0.144.5' ;;
   "exec --help") echo '--json --output-last-message --config --sandbox --dangerously-bypass-approvals-and-sandbox prompt from stdin' ;;
   "exec resume --help") echo '--json' ;;
+  "app-server --help") echo '--listen stdio:// --stdio' ;;
   *) exit 2 ;;
 esac"#
         )
@@ -64,6 +72,7 @@ esac"#
         let (_directory, binary) = write_codex_stub();
         let response = detect_codex_cli(web::Json(DetectCodexRequest {
             binary: Some(binary.clone()),
+            mode: None,
         }))
         .await
         .unwrap();
@@ -78,10 +87,23 @@ esac"#
     async fn detect_rejects_a_missing_override_with_install_guidance() {
         let error = detect_codex_cli(web::Json(DetectCodexRequest {
             binary: Some("/definitely/missing/codex".to_string()),
+            mode: Some("app_server".to_string()),
         }))
         .await
         .unwrap_err();
         assert!(error.to_string().contains("npm i -g @openai/codex"));
         assert!(error.to_string().contains("codex_binary"));
+    }
+
+    #[actix_web::test]
+    async fn app_server_detection_uses_the_extra_capability_gate() {
+        let (_directory, binary) = write_codex_stub();
+        let response = detect_codex_cli(web::Json(DetectCodexRequest {
+            binary: Some(binary),
+            mode: Some("app_server".to_string()),
+        }))
+        .await
+        .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/validation.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/validation.rs
@@ -121,6 +121,8 @@ pub async fn validate_bamboo_config_patch(
                 "subagents.codex_allow_danger_bypass"
             } else if message.contains("approval") {
                 "subagents.codex_approval_policy"
+            } else if message.contains("codex_mode") || message.contains("app_server") {
+                "subagents.codex_mode"
             } else if message.contains("sandbox") || message.contains("danger-full-access") {
                 "subagents.codex_sandbox"
             } else {
@@ -148,6 +150,18 @@ fn validate_codex_subagents_shape(value: &Value) -> Vec<ValidationIssue> {
         return issues;
     };
 
+    if let Some(mode) = object.get("codex_mode") {
+        let valid = mode.is_null()
+            || mode
+                .as_str()
+                .is_some_and(|mode| matches!(mode, "exec" | "app_server"));
+        if !valid {
+            issues.push(issue(
+                "subagents.codex_mode",
+                "codex_mode must be exec or app_server",
+            ));
+        }
+    }
     if let Some(mode) = object.get("codex_auth_mode") {
         let valid = mode.is_null()
             || mode
@@ -187,11 +201,11 @@ fn validate_codex_subagents_shape(value: &Value) -> Vec<ValidationIssue> {
         let valid = policy.is_null()
             || policy
                 .as_str()
-                .is_some_and(|policy| matches!(policy, "never" | "on-failure"));
+                .is_some_and(|policy| matches!(policy, "never" | "on-failure" | "on-request"));
         if !valid {
             issues.push(issue(
                 "subagents.codex_approval_policy",
-                "codex_approval_policy must be never or on-failure in non-interactive exec mode",
+                "codex_approval_policy must be never, on-failure, or on-request",
             ));
         }
     }
@@ -484,13 +498,14 @@ mod tests {
     #[test]
     fn codex_shape_validation_reports_precise_fields() {
         let issues = validate_codex_subagents_shape(&serde_json::json!({
+            "codex_mode": "future",
             "codex_auth_mode": "future",
             "codex_wire_api": "chat",
             "codex_base_url": 42,
             "codex_provider_key_ref": "not a credential ref",
             "codex_forward_env": ["OPENAI_API_KEY", 1],
             "codex_sandbox": "host-write",
-            "codex_approval_policy": "on-request",
+            "codex_approval_policy": "auto",
             "codex_network_access": "yes",
             "codex_allow_danger_bypass": 1
         }));
@@ -500,6 +515,7 @@ mod tests {
             .collect::<std::collections::BTreeSet<_>>();
 
         for expected in [
+            "subagents.codex_mode",
             "subagents.codex_auth_mode",
             "subagents.codex_wire_api",
             "subagents.codex_base_url",
@@ -520,6 +536,7 @@ mod tests {
     #[test]
     fn codex_shape_validation_accepts_the_documented_surface() {
         assert!(validate_codex_subagents_shape(&serde_json::json!({
+            "codex_mode": "exec",
             "codex_auth_mode": "custom",
             "codex_wire_api": "responses",
             "codex_base_url": "https://provider.example/v1",
@@ -529,6 +546,12 @@ mod tests {
             "codex_approval_policy": "never",
             "codex_network_access": true,
             "codex_allow_danger_bypass": false
+        }))
+        .is_empty());
+
+        assert!(validate_codex_subagents_shape(&serde_json::json!({
+            "codex_mode": "app_server",
+            "codex_approval_policy": "on-request"
         }))
         .is_empty());
     }

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -490,8 +490,11 @@ impl ActorChildRunner {
         let mut tools = spec.disabled_tools.clone().unwrap_or_default();
         tools.sort();
         let caps = &spec.capabilities;
+        // The worker constructs its executor exactly once. In particular,
+        // Codex exec and app-server workers are not interchangeable.
+        let executor = serde_json::to_string(&spec.executor).unwrap_or_default();
         format!(
-            "{role}\u{1}{provider}\u{1}{model}\u{1}{workspace}\u{1}{}\u{1}d={}\u{1}ns={}\u{1}by={}\u{1}ep={}\u{1}md={}\u{1}nha={}\u{1}gro={}",
+            "{role}\u{1}{provider}\u{1}{model}\u{1}{workspace}\u{1}{}\u{1}d={}\u{1}ns={}\u{1}by={}\u{1}ep={}\u{1}md={}\u{1}nha={}\u{1}gro={}\u{1}executor={executor}",
             tools.join(","),
             spec.identity.depth,
             caps.nested_spawn,
@@ -1531,6 +1534,7 @@ mod tests {
         ExecutorSpec::Codex {
             binary: None,
             model: None,
+            mode: None,
             sandbox: None,
             inherit_user_config,
             auth_mode: auth_mode.map(str::to_string),
@@ -1935,6 +1939,20 @@ mod tests {
             base_fp,
             ActorChildRunner::fingerprint(&gro),
             "guardian_read_only must split"
+        );
+    }
+
+    #[test]
+    fn fingerprint_splits_codex_exec_and_app_server_workers() {
+        let mut exec = spec_with("explorer", "p", "m", Some("/ws"), None);
+        exec.executor = codex_executor(Some("inherit"), None);
+        let mut app_server = exec.clone();
+        if let ExecutorSpec::Codex { mode, .. } = &mut app_server.executor {
+            *mode = Some("app_server".to_string());
+        }
+        assert_ne!(
+            ActorChildRunner::fingerprint(&exec),
+            ActorChildRunner::fingerprint(&app_server)
         );
     }
 

--- a/crates/engine/bamboo-engine/src/external_agents/config.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/config.rs
@@ -35,7 +35,7 @@ pub struct ExternalAgentProfile {
     /// Actor protocol only: which engine the worker runs.
     /// `"bamboo_runtime"` (default) for the real agent loop, `"echo"` for a
     /// dependency-free smoke run through the whole chain, `"claude_code"` to
-    /// drive the official Claude Code CLI, or `"codex"` for `codex exec`.
+    /// drive the official Claude Code CLI, or `"codex"` for the selected Codex mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub executor: Option<String>,
     /// `executor = "claude_code"` only: override the `claude` executable.
@@ -71,6 +71,9 @@ pub struct ExternalAgentProfile {
     /// `executor = "codex"` only: `--model` override.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_model: Option<String>,
+    /// `exec` (default) or long-lived `app_server` JSON-RPC mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_mode: Option<bamboo_config::CodexMode>,
     /// `inherit | api_key | custom | bamboo` (unset defaults to bamboo).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_auth_mode: Option<bamboo_config::CodexAuthMode>,
@@ -254,8 +257,9 @@ mod tests {
                     "protocol": "actor",
                     "permission_profile": "research",
                     "executor": "codex",
+                    "codex_mode": "app_server",
                     "codex_sandbox": "read-only",
-                    "codex_approval_policy": "never",
+                    "codex_approval_policy": "on-request",
                     "codex_network_access": false,
                     "codex_allow_danger_bypass": false
                 }
@@ -266,12 +270,16 @@ mod tests {
             .remove("codex_research")
             .expect("typed Codex profile");
         assert_eq!(
+            profile.codex_mode,
+            Some(bamboo_config::CodexMode::AppServer)
+        );
+        assert_eq!(
             profile.codex_sandbox,
             Some(bamboo_config::CodexSandbox::ReadOnly)
         );
         assert_eq!(
             profile.codex_approval_policy,
-            Some(bamboo_config::CodexApprovalPolicy::Never)
+            Some(bamboo_config::CodexApprovalPolicy::OnRequest)
         );
         assert_eq!(profile.codex_network_access, Some(false));
         assert_eq!(profile.codex_allow_danger_bypass, Some(false));

--- a/crates/engine/bamboo-engine/src/external_agents/runtime.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/runtime.rs
@@ -29,6 +29,14 @@ fn codex_wire_api_name(wire_api: bamboo_config::CodexWireApi) -> String {
     .to_string()
 }
 
+fn codex_mode_name(mode: bamboo_config::CodexMode) -> String {
+    match mode {
+        bamboo_config::CodexMode::Exec => "exec",
+        bamboo_config::CodexMode::AppServer => "app_server",
+    }
+    .to_string()
+}
+
 fn codex_sandbox_name(sandbox: bamboo_config::CodexSandbox) -> String {
     match sandbox {
         bamboo_config::CodexSandbox::ReadOnly => "read-only",
@@ -42,6 +50,7 @@ fn codex_approval_policy_name(policy: bamboo_config::CodexApprovalPolicy) -> Str
     match policy {
         bamboo_config::CodexApprovalPolicy::Never => "never",
         bamboo_config::CodexApprovalPolicy::OnFailure => "on-failure",
+        bamboo_config::CodexApprovalPolicy::OnRequest => "on-request",
     }
     .to_string()
 }
@@ -219,6 +228,7 @@ pub fn build_external_child_runner_with_codex_tokens(
                 Some("codex") => bamboo_subagent::provision::ExecutorSpec::Codex {
                     binary: profile.codex_binary.clone(),
                     model: profile.codex_model.clone(),
+                    mode: profile.codex_mode.map(codex_mode_name),
                     sandbox: profile.codex_sandbox.map(codex_sandbox_name),
                     inherit_user_config: None,
                     auth_mode: Some(codex_auth_mode_name(
@@ -426,6 +436,7 @@ fn subagent_executor_spec(
         Some("codex") => bamboo_subagent::provision::ExecutorSpec::Codex {
             binary: sub.codex_binary.clone(),
             model: sub.codex_model.clone(),
+            mode: sub.codex_mode.map(codex_mode_name),
             sandbox: sub.codex_sandbox.map(codex_sandbox_name),
             inherit_user_config: None,
             auth_mode: Some(codex_auth_mode_name(
@@ -701,11 +712,11 @@ pub fn extract_provider_credentials(
 #[cfg(test)]
 mod codex_runtime_config_tests {
     use super::{
-        codex_approval_policy_name, codex_auth_mode_name, codex_base_url, codex_sandbox_name,
-        codex_wire_api_name, subagent_executor_spec,
+        codex_approval_policy_name, codex_auth_mode_name, codex_base_url, codex_mode_name,
+        codex_sandbox_name, codex_wire_api_name, subagent_executor_spec,
     };
     use bamboo_config::{
-        CodexApprovalPolicy, CodexAuthMode, CodexSandbox, CodexWireApi, CredentialRef,
+        CodexApprovalPolicy, CodexAuthMode, CodexMode, CodexSandbox, CodexWireApi, CredentialRef,
     };
     use bamboo_llm::Config;
     use bamboo_subagent::provision::ExecutorSpec;
@@ -716,6 +727,7 @@ mod codex_runtime_config_tests {
         config.server.port = 5700;
 
         assert_eq!(codex_auth_mode_name(CodexAuthMode::Bamboo), "bamboo");
+        assert_eq!(codex_mode_name(CodexMode::AppServer), "app_server");
         assert_eq!(codex_wire_api_name(CodexWireApi::Responses), "responses");
         assert_eq!(codex_sandbox_name(CodexSandbox::ReadOnly), "read-only");
         assert_eq!(
@@ -750,6 +762,7 @@ mod codex_runtime_config_tests {
         subagents.executor = Some("codex".to_string());
         subagents.codex_binary = Some("/opt/codex/bin/codex".to_string());
         subagents.codex_model = Some("gpt-5.4".to_string());
+        subagents.codex_mode = Some(CodexMode::AppServer);
         subagents.codex_auth_mode = Some(CodexAuthMode::Custom);
         subagents.codex_base_url = Some("https://provider.example/v1".to_string());
         subagents.codex_wire_api = Some(CodexWireApi::Responses);
@@ -758,7 +771,7 @@ mod codex_runtime_config_tests {
         );
         subagents.codex_forward_env = Some(vec!["HTTPS_PROXY".to_string()]);
         subagents.codex_sandbox = Some(CodexSandbox::WorkspaceWrite);
-        subagents.codex_approval_policy = Some(CodexApprovalPolicy::OnFailure);
+        subagents.codex_approval_policy = Some(CodexApprovalPolicy::OnRequest);
         subagents.codex_network_access = Some(true);
         subagents.codex_allow_danger_bypass = Some(false);
 
@@ -766,6 +779,7 @@ mod codex_runtime_config_tests {
         let ExecutorSpec::Codex {
             binary,
             model,
+            mode,
             sandbox,
             auth_mode,
             base_url,
@@ -782,6 +796,7 @@ mod codex_runtime_config_tests {
         };
         assert_eq!(binary.as_deref(), Some("/opt/codex/bin/codex"));
         assert_eq!(model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(mode.as_deref(), Some("app_server"));
         assert_eq!(sandbox.as_deref(), Some("workspace-write"));
         assert_eq!(auth_mode.as_deref(), Some("custom"));
         assert_eq!(base_url.as_deref(), Some("https://provider.example/v1"));
@@ -791,7 +806,7 @@ mod codex_runtime_config_tests {
             Some("provider.codex-work.api_key")
         );
         assert_eq!(forward_env, Some(vec!["HTTPS_PROXY".to_string()]));
-        assert_eq!(approval_policy.as_deref(), Some("on-failure"));
+        assert_eq!(approval_policy.as_deref(), Some("on-request"));
         assert_eq!(network_access, Some(true));
         assert_eq!(allow_danger_bypass, Some(false));
     }

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -629,6 +629,17 @@ pub enum CodexWireApi {
     Responses,
 }
 
+/// Codex transport used by `executor = "codex"`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CodexMode {
+    /// One `codex exec --json` process per activation.
+    #[default]
+    Exec,
+    /// Long-lived `codex app-server` JSON-RPC session with approval relay.
+    AppServer,
+}
+
 /// OS sandbox selected for non-interactive `codex exec` children.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -638,16 +649,14 @@ pub enum CodexSandbox {
     DangerFullAccess,
 }
 
-/// Spawn-time approval policy for non-interactive `codex exec` children.
-///
-/// Interactive policies (`untrusted` / `on-request`) are intentionally not
-/// representable: exec mode has no approval relay, so either policy would
-/// eventually wait for a human that cannot answer.
+/// Codex approval policy. Mode-specific validation rejects interactive policy
+/// in exec mode and non-interactive policy in app-server mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum CodexApprovalPolicy {
     Never,
     OnFailure,
+    OnRequest,
 }
 
 /// Sub-agent execution settings.
@@ -678,7 +687,7 @@ pub struct SubagentsConfig {
     pub fabric_dir: Option<String>,
     /// Expert: `"echo"` swaps in a dependency-free smoke executor (no LLM)
     /// to verify the actor chain end-to-end; `"claude_code"` drives the
-    /// official Claude Code CLI; `"codex"` drives `codex exec --json`.
+    /// official Claude Code CLI; `"codex"` drives the selected Codex mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub executor: Option<String>,
     /// `executor = "claude_code"` only: override the `claude` executable.
@@ -716,6 +725,9 @@ pub struct SubagentsConfig {
     /// default model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_model: Option<String>,
+    /// `executor = "codex"` only: `exec` (default) or long-lived `app_server`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_mode: Option<CodexMode>,
     /// `executor = "codex"` only: authentication/provider mode. Unset defaults
     /// to `bamboo`, which keeps provider credentials in the parent process.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -739,8 +751,8 @@ pub struct SubagentsConfig {
     /// child permission profile and the parent session's bypass posture.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_sandbox: Option<CodexSandbox>,
-    /// Explicit non-interactive approval policy. Unset always resolves to an
-    /// explicit safe value; Bamboo never trusts the CLI's implicit default.
+    /// Mode-specific approval policy. Exec resolves to a non-interactive safe
+    /// value; app-server requires `on-request` and routes it to the parent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_approval_policy: Option<CodexApprovalPolicy>,
     /// Permit network access from a workspace-write sandbox.

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -1590,7 +1590,8 @@ fn validate_subagents(value: &SubagentsSection) -> Result<(), String> {
 /// root `/bamboo/config/validate` endpoint can return the same rules through its
 /// structured field-error contract.
 pub fn validate_codex_subagents_config(value: &SubagentsConfig) -> Result<(), String> {
-    let codex_fields_present = value.codex_auth_mode.is_some()
+    let codex_fields_present = value.codex_mode.is_some()
+        || value.codex_auth_mode.is_some()
         || value.codex_base_url.is_some()
         || value.codex_wire_api.is_some()
         || value.codex_provider_key_ref.is_some()
@@ -1603,6 +1604,24 @@ pub fn validate_codex_subagents_config(value: &SubagentsConfig) -> Result<(), St
         return Ok(());
     }
     let mode = value.codex_auth_mode.unwrap_or_default();
+    let transport = value.codex_mode.unwrap_or_default();
+
+    match (transport, value.codex_approval_policy) {
+        (crate::CodexMode::Exec, Some(crate::CodexApprovalPolicy::OnRequest)) => {
+            return Err(
+                "codex_approval_policy on-request requires codex_mode = app_server; exec mode has no approval relay"
+                    .to_string(),
+            )
+        }
+        (crate::CodexMode::AppServer, None | Some(crate::CodexApprovalPolicy::OnRequest)) => {}
+        (crate::CodexMode::AppServer, Some(_)) => {
+            return Err(
+                "codex_mode app_server requires codex_approval_policy = on-request"
+                    .to_string(),
+            )
+        }
+        (crate::CodexMode::Exec, _) => {}
+    }
 
     let forwarded = value.codex_forward_env.as_deref().unwrap_or_default();
     let mut names = BTreeSet::new();
@@ -4569,6 +4588,27 @@ mod tests {
             .contains("codex_allow_danger_bypass"));
         config.codex_allow_danger_bypass = Some(true);
         assert!(validate_codex_subagents_config(&config).is_ok());
+    }
+
+    #[test]
+    fn codex_transport_mode_requires_matching_approval_semantics() {
+        let mut config = SubagentsConfig {
+            executor: Some("codex".to_string()),
+            codex_mode: Some(crate::CodexMode::AppServer),
+            ..Default::default()
+        };
+        assert!(validate_codex_subagents_config(&config).is_ok());
+
+        config.codex_approval_policy = Some(crate::CodexApprovalPolicy::Never);
+        assert!(validate_codex_subagents_config(&config)
+            .unwrap_err()
+            .contains("requires codex_approval_policy = on-request"));
+
+        config.codex_mode = Some(crate::CodexMode::Exec);
+        config.codex_approval_policy = Some(crate::CodexApprovalPolicy::OnRequest);
+        assert!(validate_codex_subagents_config(&config)
+            .unwrap_err()
+            .contains("exec mode has no approval relay"));
     }
 
     fn directory_snapshot(root: &Path) -> BTreeMap<PathBuf, Option<Vec<u8>>> {

--- a/crates/infra/bamboo-subagent/src/codex_discovery.rs
+++ b/crates/infra/bamboo-subagent/src/codex_discovery.rs
@@ -75,6 +75,22 @@ pub async fn discover_codex_cli(binary: Option<&str>) -> Result<CodexCliDiscover
     })
 }
 
+/// Resolve Codex and additionally require the long-lived app-server surface.
+/// Never falls back to exec mode because that would silently remove runtime
+/// approval semantics selected by the caller.
+pub async fn discover_codex_app_server(binary: Option<&str>) -> Result<CodexCliDiscovery, String> {
+    let discovery = discover_codex_cli(binary).await?;
+    let path = PathBuf::from(&discovery.path);
+    verify_help_surface(&path, &["app-server", "--help"], &["stdio", "--listen"])
+        .await
+        .map_err(|error| {
+            format!(
+                "{error}; Codex app-server mode is unavailable: use codex_mode = \"exec\" or upgrade Codex CLI"
+            )
+        })?;
+    Ok(discovery)
+}
+
 /// Parse `codex-cli X.Y.Z` while tolerating vendor prefixes and a missing
 /// patch component.
 pub fn parse_codex_version(text: &str) -> Option<(u64, u64, u64)> {
@@ -192,7 +208,7 @@ async fn command_output(binary: &Path, args: &[&str]) -> Result<std::process::Ou
 
 #[cfg(test)]
 mod tests {
-    use super::parse_codex_version;
+    use super::{discover_codex_app_server, parse_codex_version};
 
     #[test]
     fn version_parser_accepts_current_and_rejects_noise() {
@@ -200,5 +216,30 @@ mod tests {
         assert_eq!(parse_codex_version("vendor v0.144.5"), Some((0, 144, 5)));
         assert_eq!(parse_codex_version("codex 1.2"), Some((1, 2, 0)));
         assert_eq!(parse_codex_version("not-a-version"), None);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn app_server_preflight_never_silently_downgrades_to_exec() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let directory = tempfile::tempdir().unwrap();
+        let binary = directory.path().join("codex-no-app-server.sh");
+        std::fs::write(
+            &binary,
+            r#"#!/bin/sh
+if [ "$1" = "--version" ]; then echo 'codex-cli 0.144.5'; exit 0; fi
+if [ "$1" = "exec" ]; then echo '--json --output-last-message --config --sandbox --dangerously-bypass-approvals-and-sandbox stdin'; exit 0; fi
+exit 2
+"#,
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&binary, permissions).unwrap();
+
+        let error = discover_codex_app_server(binary.to_str())
+            .await
+            .expect_err("app-server capability must be required");
+        assert!(error.contains("use codex_mode = \"exec\" or upgrade"));
     }
 }

--- a/crates/infra/bamboo-subagent/src/provision.rs
+++ b/crates/infra/bamboo-subagent/src/provision.rs
@@ -250,14 +250,16 @@ pub enum ExecutorSpec {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         forward_env: Option<Vec<String>>,
     },
-    /// Drive the official Codex CLI as a one-process-per-activation engine
-    /// over `codex exec --json`. Authentication and spawn-time permission
-    /// posture are explicit because exec mode has no runtime approval relay.
+    /// Drive the official Codex CLI in one-shot `exec` mode (default) or as a
+    /// long-lived `app-server` JSON-RPC peer with interactive approval relay.
     Codex {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         binary: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         model: Option<String>,
+        /// `exec | app_server`; absent preserves the one-shot exec default.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        mode: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         sandbox: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -279,7 +281,7 @@ pub enum ExecutorSpec {
         provider_key_ref: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         forward_env: Option<Vec<String>>,
-        /// `never | on-failure`; interactive approval policies are rejected.
+        /// `never | on-failure` in exec mode; `on-request` in app-server mode.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         approval_policy: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -640,6 +642,7 @@ mod tests {
         let codex = ExecutorSpec::Codex {
             binary: Some("/usr/local/bin/codex".into()),
             model: Some("gpt-5-codex".into()),
+            mode: Some("exec".into()),
             sandbox: Some("workspace-write".into()),
             inherit_user_config: Some(true),
             auth_mode: Some("inherit".into()),
@@ -665,6 +668,7 @@ mod tests {
         let minimal_codex = ExecutorSpec::Codex {
             binary: None,
             model: None,
+            mode: None,
             sandbox: None,
             inherit_user_config: None,
             auth_mode: None,

--- a/docs/codex-executor.md
+++ b/docs/codex-executor.md
@@ -1,9 +1,10 @@
 # Codex executor
 
-`subagents.executor = "codex"` runs one official Codex CLI process per child
-activation through `codex exec --json`. Bamboo passes the assignment through
-stdin, consumes bounded JSONL events, and captures the final answer separately
-with `--output-last-message`.
+`subagents.executor = "codex"` supports two transports. `codex_mode = "exec"`
+(the backward-compatible default) runs one `codex exec --json` process per
+activation. `codex_mode = "app_server"` keeps `codex app-server` alive and
+relays interactive command/file approvals through the parent Bamboo approval
+chain.
 
 The minimum supported version is **Codex CLI 0.144.0**. Bamboo verifies the
 installed version and the required `exec --json`, stdin prompt,
@@ -16,20 +17,36 @@ custom-provider Chat Completions wire, so `codex_wire_api` only accepts
 The Lotus Sub-agents settings card exposes the same fields and validates the
 pending patch through `POST /bamboo/config/validate` before saving. Its Detect
 button calls `POST /bamboo/config/codex/detect` with an optional
-`{"binary":"..."}` override. The response is the resolved `path` and
+`{"binary":"...","mode":"app_server"}` override. The response is the resolved `path` and
 `version`; the endpoint and worker share one discovery implementation, so a
 successful detection cannot bypass the worker's version/capability preflight.
 
-## Spawn contract
+## Transport contract
 
 | Concern | Codex executor behavior |
 |---|---|
-| Process lifetime | One `codex exec` process group per activation; a warm Bamboo worker may run many activations but never reuses a Codex process. |
+| Process lifetime | Exec mode: one process group per activation. App-server mode: one long-lived process per warm worker, with logical threads isolated by Bamboo session id. |
 | Prompt transport | The assignment is written to stdin (`-`), never placed in argv. |
 | Output | `--json --color never` JSONL plus a bounded `--output-last-message` fallback file. |
 | Model | `codex_model`, when set, becomes an explicit `--model`; otherwise the flag is omitted. |
 | Repository guard | A real Git workspace needs no override. `--skip-git-repo-check` is allowed only for a Bamboo-owned non-Git workspace. |
 | Cancellation | Bamboo snapshots the full descendant tree, sends SIGTERM deepest-first plus to the Codex process group, then escalates every survivor to SIGKILL after a bounded grace period. This also covers tool commands that create a new process group. |
+
+In `app_server` mode, Bamboo speaks newline-delimited JSON-RPC over stdio:
+`initialize`/`initialized`, `thread/start` or `thread/resume`, then
+`turn/start`. A warm worker retains the process, while a session-keyed state
+map prevents one logical child from inheriting another child's thread. Resume
+failure starts one new thread with the same bounded history rehydration used by
+exec mode. `turn/steer` handles live parent messages and cancellation first
+requests `turn/interrupt`, then uses the standard process-group TERM/KILL
+ladder if the server does not finish within the grace period.
+
+`item/commandExecution/requestApproval` and
+`item/fileChange/requestApproval` are converted to Bamboo `Bash` and
+`ApplyPatch` approval calls. Missing bridges, relay errors, and the 300-second
+deadline all answer `decline`; approval answers `accept`. Legacy
+`execCommandApproval`/`applyPatchApproval` requests remain compatible. There
+is no silent fallback to exec mode when app-server capability detection fails.
 
 ## Event mapping
 
@@ -57,7 +74,7 @@ personal Codex login is deliberately opt-in.
 | `inherit` | Leaves `CODEX_HOME` unset, so Codex uses the invoking user's `~/.codex/config.toml` and `auth.json`. | The user's configured provider; a ChatGPT login uses that user's subscription. | Inherits the user's full Codex configuration, so use only when that ambient authority is intended. |
 | `api_key` | Uses `<child-state>/codex-home`; `OPENAI_API_KEY` must be named explicitly in `codex_forward_env`. | OpenAI API billing for that key. | Bamboo never forwards `OPENAI_API_KEY` implicitly. The key is process-environment only. |
 | `custom` | Uses the isolated home and a generated `model_providers.custom` entry. The key is selected by `codex_provider_key_ref`. | The configured third-party/proxy provider and its billing policy. | `config.toml` contains only `env_key = "BAMBOO_CODEX_PROVIDER_KEY"`; the referenced key is injected into that environment variable and never written to disk. |
-| `bamboo` | Uses the isolated home and a generated `model_providers.bamboo` entry pointing at the parent loopback `/openai/v1` surface. | The parent Bamboo provider/routing configuration; recommended default. | The parent mints a fresh `bcx1_` token for each activation, binds it to the child session and Responses/models paths, and revokes it on every exit path. No upstream provider key reaches Codex. |
+| `bamboo` | Uses the isolated home and a generated `model_providers.bamboo` entry pointing at the parent loopback `/openai/v1` surface. | The parent Bamboo provider/routing configuration; recommended default. | The parent mints a fresh `bcx1_` token for each activation, binds it to the child session and Responses/models paths, and revokes it on every exit path. In app-server mode Codex command-auth reads that token from a Bamboo-owned `0600` file on demand; the file is cleared at turn end, so the long-lived process never freezes a revoked token in its environment. No upstream provider key reaches Codex. |
 
 Because `bamboo` deliberately targets the parent through `127.0.0.1`, it
 requires local actor placement. A remote worker must use `custom` with an
@@ -74,6 +91,19 @@ Recommended parent-routed mode (also the default when the mode is absent):
     "executor": "codex",
     "codex_auth_mode": "bamboo",
     "codex_model": "gpt-5.4"
+  }
+}
+```
+
+Interactive parent approval relay:
+
+```json
+{
+  "subagents": {
+    "executor": "codex",
+    "codex_mode": "app_server",
+    "codex_approval_policy": "on-request",
+    "codex_auth_mode": "bamboo"
   }
 }
 ```
@@ -133,10 +163,12 @@ permission knobs before spawn and never relies on the CLI's implicit defaults:
 | workspace network enabled | the workspace-write flags plus `--config sandbox_workspace_write.network_access=true` |
 
 `codex_sandbox` can explicitly select `read-only`, `workspace-write`, or
-`danger-full-access`; `codex_approval_policy` accepts only the non-interactive
-`never` and `on-failure` values. `codex_network_access` applies only to
-workspace-write. The same fields are available globally under `subagents` and
-per named `ExternalAgentProfile`.
+`danger-full-access`. In exec mode, `codex_approval_policy` accepts only
+`never` and `on-failure`; `on-request` is rejected with an instruction to use
+app-server. In app-server mode, unset or `on-request` is accepted and every
+other policy is rejected, so config cannot silently remove the relay.
+`codex_network_access` applies only to workspace-write. The same fields are
+available globally under `subagents` and per named `ExternalAgentProfile`.
 
 Disabling the OS sandbox is double-gated. A `danger-full-access` request becomes
 `--dangerously-bypass-approvals-and-sandbox` only when the child session's

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -257,13 +257,14 @@ in-process runtime toggle.
 | `claude_code_inherit_user_config` | `false`/unset adds `--strict-mcp-config --setting-sources project`, sandboxing the child from your personal `claude` config. |
 | `claude_code_forward_env` | Extra environment variable **names** forwarded verbatim into the child (on top of a fixed allowlist: `HOME`/`PATH`/`SHELL`/`TERM`/`LANG`/`LC_*`/`TMPDIR`/`USER`/`LOGNAME`). |
 | `codex_binary` / `codex_model` | Codex executable and optional `--model` override. |
+| `codex_mode` | `"exec"` (default, one process per activation) or `"app_server"` (long-lived JSON-RPC with parent approval relay). Missing app-server capability fails clearly and never downgrades. |
 | `codex_auth_mode` | `"inherit"` \| `"api_key"` \| `"custom"` \| `"bamboo"`; unset defaults to the recommended `"bamboo"` parent-provider mode. |
 | `codex_base_url` | Absolute HTTP(S) URL for `custom` mode only; credentials, query parameters, and fragments are rejected. |
 | `codex_wire_api` | `"responses"` (the only protocol accepted by supported Codex CLI versions). |
 | `codex_provider_key_ref` | Existing Bamboo provider credential reference used only by `custom` mode; the key is injected through an environment variable and is not written to the generated Codex config. |
 | `codex_forward_env` | Extra environment names after `env_clear()`; `api_key` mode requires an explicit `OPENAI_API_KEY`, and other modes reject it. `CODEX_*` and Bamboo's managed provider-key variable are reserved. |
 | `codex_sandbox` | Optional explicit `"read-only"` \| `"workspace-write"` \| `"danger-full-access"`. Unset derives a safe value from the child profile and live parent bypass posture. |
-| `codex_approval_policy` | Optional explicit `"never"` \| `"on-failure"`. Interactive policies are rejected because `codex exec` has no approval relay. |
+| `codex_approval_policy` | Exec mode accepts optional `"never"` \| `"on-failure"`; app-server mode accepts unset or `"on-request"`. Cross-mode combinations are rejected. |
 | `codex_network_access` | Enables network access inside `workspace-write`; incompatible with an explicit `read-only` sandbox. |
 | `codex_allow_danger_bypass` | Second gate for disabling the OS sandbox. The live parent must also be in bypass mode; root workers always downgrade and warn. |
 | `remote_placements` / `schedulable_placements` | Where a sub-agent may run (local / a named Cluster Fabric node) and whether schedules may target it. |

--- a/src/bin/bamboo.rs
+++ b/src/bin/bamboo.rs
@@ -349,6 +349,11 @@ enum Commands {
     #[command(name = "subagent-worker", hide = true)]
     SubagentWorker,
 
+    /// Internal Codex command-auth helper. The token stays in a Bamboo-owned
+    /// 0600 file so a long-lived app-server can refresh per-run credentials.
+    #[command(name = "codex-provider-token", hide = true)]
+    CodexProviderToken { path: PathBuf },
+
     /// Run a sub-agent actor from the terminal (spawns the real worker
     /// process + WebSocket chain against your configured providers).
     Actor {
@@ -1304,6 +1309,7 @@ async fn main() {
             // installs none.
         }
         Some(Commands::SubagentWorker)
+        | Some(Commands::CodexProviderToken { .. })
         | Some(Commands::Actor { .. })
         | Some(Commands::Broker { .. })
         | Some(Commands::BrokerAgent { .. })
@@ -1550,6 +1556,16 @@ async fn main() {
             if let Err(e) = bamboo_agent::subagent_worker::run().await {
                 eprintln!("subagent-worker failed: {e}");
                 std::process::exit(1);
+            }
+        }
+
+        Commands::CodexProviderToken { path } => {
+            match bamboo_agent::codex_cli_executor::read_codex_provider_token(&path) {
+                Ok(token) => println!("{token}"),
+                Err(error) => {
+                    eprintln!("{error}");
+                    std::process::exit(1);
+                }
             }
         }
 

--- a/src/broker_agent.rs
+++ b/src/broker_agent.rs
@@ -186,6 +186,7 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
             ExecutorSpec::Codex {
                 ref binary,
                 ref model,
+                ref mode,
                 ref sandbox,
                 ref inherit_user_config,
                 ref auth_mode,
@@ -209,30 +210,65 @@ pub async fn run(args: BrokerAgentArgs) -> Result<(), String> {
                     &spec.secrets.provider_credentials,
                     &forward_env,
                 )?;
-                let permissions = crate::codex_cli_executor::resolve_codex_permission_config(
-                    sandbox.as_deref(),
-                    approval_policy.as_deref(),
-                    network_access.unwrap_or(false),
-                    allow_danger_bypass.unwrap_or(false),
-                    permission_profile.clone(),
-                    spec.capabilities.bypass,
-                    workspace_owned.unwrap_or(false),
-                )?;
-                Arc::new(
-                    crate::codex_cli_executor::CodexExecutor::new(
-                        binary.clone(),
-                        model.clone(),
-                        spec.workspace.clone(),
-                        Some(crate::codex_cli_executor::resolve_codex_state_dir(
-                            &spec.storage_dir,
-                            &spec.identity.child_id,
-                        )),
-                        forward_env,
-                        auth,
-                        permissions,
-                    )
-                    .await?,
-                )
+                let state_dir = Some(crate::codex_cli_executor::resolve_codex_state_dir(
+                    &spec.storage_dir,
+                    &spec.identity.child_id,
+                ));
+                match mode.as_deref().unwrap_or("exec") {
+                    "exec" => {
+                        let permissions =
+                            crate::codex_cli_executor::resolve_codex_permission_config(
+                                sandbox.as_deref(),
+                                approval_policy.as_deref(),
+                                network_access.unwrap_or(false),
+                                allow_danger_bypass.unwrap_or(false),
+                                permission_profile.clone(),
+                                spec.capabilities.bypass,
+                                workspace_owned.unwrap_or(false),
+                            )?;
+                        Arc::new(
+                            crate::codex_cli_executor::CodexExecutor::new(
+                                binary.clone(),
+                                model.clone(),
+                                spec.workspace.clone(),
+                                state_dir,
+                                forward_env,
+                                auth,
+                                permissions,
+                            )
+                            .await?,
+                        )
+                    }
+                    "app_server" => {
+                        let permissions =
+                            crate::codex_cli_executor::resolve_codex_app_server_permission_config(
+                                sandbox.as_deref(),
+                                approval_policy.as_deref(),
+                                network_access.unwrap_or(false),
+                                allow_danger_bypass.unwrap_or(false),
+                                permission_profile.clone(),
+                                spec.capabilities.bypass,
+                                workspace_owned.unwrap_or(false),
+                            )?;
+                        Arc::new(
+                            crate::codex_app_server_executor::CodexAppServerExecutor::new(
+                                binary.clone(),
+                                model.clone(),
+                                spec.workspace.clone(),
+                                state_dir,
+                                forward_env,
+                                auth,
+                                permissions,
+                            )
+                            .await?,
+                        )
+                    }
+                    other => {
+                        return Err(format!(
+                            "unknown Codex mode '{other}'; expected exec or app_server"
+                        ))
+                    }
+                }
             }
             _ => Arc::new(BambooRuntimeExecutor::build(&spec).await?),
         };

--- a/src/codex_app_server_executor.rs
+++ b/src/codex_app_server_executor.rs
@@ -1,0 +1,1669 @@
+//! Long-lived Codex app-server executor with Bamboo approval relay.
+//!
+//! The app-server process is retained by a warm actor worker, while logical
+//! Codex threads are keyed by Bamboo session id. Server-to-client approval
+//! requests are relayed through `HostBridge` and fail closed after 300 seconds.
+
+use std::collections::{HashMap, HashSet};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio_util::sync::CancellationToken;
+
+use bamboo_agent_core::{AgentEvent, TokenUsage, ToolResult};
+use bamboo_subagent::codex_discovery::discover_codex_app_server;
+use bamboo_subagent::executor::{ChildExecutor, ChildOutcome, EventSink, HostBridge, SteerInbox};
+use bamboo_subagent::executor_util::{build_rehydrated_turn, write_json_atomic};
+use bamboo_subagent::proto::RunSpec;
+
+use crate::codex_cli_executor::{
+    read_bounded_line, terminate_child, CodexAuthConfig, CodexAuthMode, CodexPermissionConfig,
+};
+
+const MAX_STDOUT_LINE_BYTES: usize = 10 * 1024 * 1024;
+const STDERR_TAIL_BYTES: usize = 16 * 1024;
+const TOOL_RESULT_TRUNCATE_CHARS: usize = 20_000;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+const APPROVAL_RELAY_TIMEOUT: Duration = Duration::from_secs(300);
+const INTERRUPT_GRACE: Duration = Duration::from_secs(5);
+const CODEX_PROVIDER_ENV: &str = "BAMBOO_CODEX_PROVIDER_KEY";
+const SESSION_STORE_FILE: &str = "codex-app-server-sessions.json";
+const TOKEN_FILE: &str = "codex-app-server-provider-token";
+const MAX_LOGICAL_SESSIONS: usize = 256;
+
+const ENV_ALLOWLIST: &[&str] = &[
+    "HOME", "PATH", "SHELL", "TERM", "LANG", "TMPDIR", "USER", "LOGNAME",
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AppServerSessionState {
+    thread_id: String,
+    workspace: Option<String>,
+    codex_home_mode: String,
+    updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct AppServerSessionStore {
+    #[serde(default)]
+    sessions: HashMap<String, AppServerSessionState>,
+}
+
+struct AppServerConnection {
+    child: Child,
+    write_tx: mpsc::UnboundedSender<Value>,
+    incoming_rx: mpsc::Receiver<Value>,
+    pending: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
+    next_id: AtomicU64,
+    stderr_tail: Arc<Mutex<String>>,
+    writer_task: tokio::task::JoinHandle<()>,
+    reader_task: tokio::task::JoinHandle<()>,
+}
+
+impl AppServerConnection {
+    fn is_alive(&mut self) -> bool {
+        matches!(self.child.try_wait(), Ok(None))
+            && !self.writer_task.is_finished()
+            && !self.reader_task.is_finished()
+    }
+
+    fn send(&self, value: Value) -> Result<(), String> {
+        self.write_tx
+            .send(value)
+            .map_err(|_| "Codex app-server stdin writer closed".to_string())
+    }
+
+    async fn request(&self, method: &str, params: Value) -> Result<Value, String> {
+        self.request_with_timeout(method, params, REQUEST_TIMEOUT)
+            .await
+    }
+
+    async fn request_with_timeout(
+        &self,
+        method: &str,
+        params: Value,
+        timeout: Duration,
+    ) -> Result<Value, String> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.pending.lock().await.insert(id, reply_tx);
+        if let Err(error) = self.send(json!({"id": id, "method": method, "params": params})) {
+            self.pending.lock().await.remove(&id);
+            return Err(error);
+        }
+        let response = match tokio::time::timeout(timeout, reply_rx).await {
+            Ok(Ok(response)) => response,
+            Ok(Err(_)) => {
+                return Err(format!(
+                    "Codex app-server closed while waiting for {method} response"
+                ))
+            }
+            Err(_) => {
+                self.pending.lock().await.remove(&id);
+                return Err(format!(
+                    "Codex app-server {method} request timed out after {}s",
+                    timeout.as_secs()
+                ));
+            }
+        };
+        if let Some(error) = response.get("error") {
+            return Err(format!(
+                "Codex app-server {method} failed: {}",
+                value_text(error)
+            ));
+        }
+        Ok(response.get("result").cloned().unwrap_or(Value::Null))
+    }
+
+    async fn stderr_summary(&self) -> String {
+        self.stderr_tail.lock().await.trim().to_string()
+    }
+}
+
+impl Drop for AppServerConnection {
+    fn drop(&mut self) {
+        self.writer_task.abort();
+        self.reader_task.abort();
+        #[cfg(unix)]
+        if let Some(pgid) = self.child.id().map(|pid| pid as libc::pid_t) {
+            // The executor normally uses the graceful interrupt plus
+            // TERM/KILL ladder. Drop is the last-resort worker-shutdown path,
+            // so synchronously kill the whole process group rather than
+            // allowing an in-flight Codex tool descendant to outlive Bamboo.
+            // SAFETY: a negative live child pid targets only its process group.
+            let _ = unsafe { libc::kill(-pgid, libc::SIGKILL) };
+        }
+        let _ = self.child.start_kill();
+    }
+}
+
+/// `codex app-server` implementation of the Codex executor mode.
+pub struct CodexAppServerExecutor {
+    binary: PathBuf,
+    version: String,
+    model: Option<String>,
+    permissions: CodexPermissionConfig,
+    workspace: Option<String>,
+    state_dir: PathBuf,
+    forward_env: Vec<String>,
+    auth: CodexAuthConfig,
+    approval_timeout: Duration,
+    run_lock: Mutex<()>,
+    connection: Mutex<Option<AppServerConnection>>,
+}
+
+struct RunTokenGuard {
+    file: std::fs::File,
+}
+
+impl Drop for RunTokenGuard {
+    fn drop(&mut self) {
+        if let Err(error) = self.file.set_len(0) {
+            tracing::warn!(%error, "codex app-server: clear per-run provider token");
+        }
+    }
+}
+
+impl CodexAppServerExecutor {
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new(
+        binary: Option<String>,
+        model: Option<String>,
+        workspace: Option<String>,
+        state_dir: Option<PathBuf>,
+        forward_env: Vec<String>,
+        auth: CodexAuthConfig,
+        permissions: CodexPermissionConfig,
+    ) -> Result<Self, String> {
+        let discovery = discover_codex_app_server(binary.as_deref()).await?;
+        let state_dir = state_dir.ok_or_else(|| {
+            "Codex app-server mode requires a Bamboo-managed state directory".to_string()
+        })?;
+        secure_directory(&state_dir).await?;
+        let executor = Self {
+            binary: PathBuf::from(discovery.path),
+            version: discovery.version,
+            model,
+            permissions,
+            workspace,
+            state_dir,
+            forward_env,
+            auth,
+            approval_timeout: APPROVAL_RELAY_TIMEOUT,
+            run_lock: Mutex::new(()),
+            connection: Mutex::new(None),
+        };
+        executor.prepare_auth_home().await?;
+        Ok(executor)
+    }
+
+    fn codex_home(&self) -> Option<PathBuf> {
+        self.auth
+            .isolated()
+            .then(|| self.state_dir.join("codex-app-server-home"))
+    }
+
+    fn codex_home_mode(&self) -> &'static str {
+        if self.auth.isolated() {
+            "isolated"
+        } else {
+            "inherit"
+        }
+    }
+
+    fn token_path(&self) -> PathBuf {
+        self.state_dir.join(TOKEN_FILE)
+    }
+
+    fn session_store_path(&self) -> PathBuf {
+        self.state_dir.join(SESSION_STORE_FILE)
+    }
+
+    async fn prepare_auth_home(&self) -> Result<(), String> {
+        let Some(home) = self.codex_home() else {
+            return Ok(());
+        };
+        secure_directory(&home).await?;
+        let auth_path = home.join("auth.json");
+        match tokio::fs::remove_file(&auth_path).await {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "remove stale isolated Codex auth '{}': {error}",
+                    auth_path.display()
+                ))
+            }
+        }
+        let helper = std::env::current_exe()
+            .map_err(|error| format!("resolve Bamboo token helper executable: {error}"))?;
+        let config = self
+            .auth
+            .generated_app_server_config_toml(&helper, &self.token_path())?;
+        let config_path = home.join("config.toml");
+        tokio::fs::write(&config_path, config)
+            .await
+            .map_err(|error| {
+                format!(
+                    "write isolated Codex app-server config '{}': {error}",
+                    config_path.display()
+                )
+            })?;
+        secure_file(&config_path).await?;
+        Ok(())
+    }
+
+    fn install_run_token(&self, spec: &RunSpec) -> Result<Option<RunTokenGuard>, String> {
+        if self.auth.mode() != CodexAuthMode::Bamboo {
+            return Ok(None);
+        }
+        let token = spec
+            .secrets
+            .codex_provider_token
+            .as_ref()
+            .map(bamboo_subagent::proto::SecretValue::expose)
+            .ok_or_else(|| {
+                "Codex bamboo auth requires a fresh per-run provider token".to_string()
+            })?;
+        let mut guard = RunTokenGuard {
+            file: open_secret_for_replace(&self.token_path())?,
+        };
+        guard
+            .file
+            .write_all(token.as_bytes())
+            .map_err(|error| format!("write Codex app-server provider token: {error}"))?;
+        guard
+            .file
+            .sync_data()
+            .map_err(|error| format!("sync Codex app-server provider token: {error}"))?;
+        Ok(Some(guard))
+    }
+
+    async fn load_session_store(&self) -> AppServerSessionStore {
+        let Ok(bytes) = tokio::fs::read(self.session_store_path()).await else {
+            return AppServerSessionStore::default();
+        };
+        serde_json::from_slice(&bytes).unwrap_or_default()
+    }
+
+    async fn save_session_store(&self, store: &AppServerSessionStore) {
+        if let Err(error) = write_json_atomic(&self.session_store_path(), store).await {
+            tracing::warn!(%error, "codex app-server: persist logical session map");
+        }
+    }
+
+    async fn stored_thread(&self, logical_session: &str) -> Option<String> {
+        let store = self.load_session_store().await;
+        let state = store.sessions.get(logical_session)?;
+        if state.workspace != self.workspace || state.codex_home_mode != self.codex_home_mode() {
+            return None;
+        }
+        (!state.thread_id.trim().is_empty()).then(|| state.thread_id.clone())
+    }
+
+    async fn store_thread(&self, logical_session: &str, thread_id: &str) {
+        let mut store = self.load_session_store().await;
+        store.sessions.insert(
+            logical_session.to_string(),
+            AppServerSessionState {
+                thread_id: thread_id.to_string(),
+                workspace: self.workspace.clone(),
+                codex_home_mode: self.codex_home_mode().to_string(),
+                updated_at: Utc::now(),
+            },
+        );
+        prune_session_store(&mut store, logical_session);
+        self.save_session_store(&store).await;
+    }
+
+    async fn forget_thread(&self, logical_session: &str) {
+        let mut store = self.load_session_store().await;
+        if store.sessions.remove(logical_session).is_some() {
+            self.save_session_store(&store).await;
+        }
+    }
+
+    fn build_command(&self) -> Result<Command, String> {
+        let mut command = Command::new(&self.binary);
+        command.arg("app-server").arg("--listen").arg("stdio://");
+        command.env_clear();
+        for (key, value) in std::env::vars() {
+            if ENV_ALLOWLIST.contains(&key.as_str()) || key.starts_with("LC_") {
+                command.env(key, value);
+            }
+        }
+        if let Some(home) = self.codex_home() {
+            command.env("CODEX_HOME", home);
+        }
+        for name in &self.forward_env {
+            if let Ok(value) = std::env::var(name) {
+                command.env(name, value);
+            }
+        }
+        if self.auth.mode() == CodexAuthMode::Custom {
+            let key = self.auth.provider_key().ok_or_else(|| {
+                "Codex custom provider key was not resolved at provisioning".to_string()
+            })?;
+            command.env(CODEX_PROVIDER_ENV, key);
+        }
+        command.stdin(Stdio::piped());
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+        command.kill_on_drop(true);
+        #[cfg(unix)]
+        command.process_group(0);
+        Ok(command)
+    }
+
+    async fn start_connection(&self) -> Result<AppServerConnection, String> {
+        self.prepare_auth_home().await?;
+        let mut child = self.build_command()?.spawn().map_err(|error| {
+            format!(
+                "spawn Codex app-server '{}': {error}",
+                self.binary.display()
+            )
+        })?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "Codex app-server has no stdin pipe".to_string())?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "Codex app-server has no stdout pipe".to_string())?;
+        let stderr = child.stderr.take();
+
+        let (write_tx, mut write_rx) = mpsc::unbounded_channel::<Value>();
+        let writer_task = tokio::spawn(async move {
+            let mut stdin = stdin;
+            while let Some(value) = write_rx.recv().await {
+                let Ok(mut bytes) = serde_json::to_vec(&value) else {
+                    continue;
+                };
+                bytes.push(b'\n');
+                if stdin.write_all(&bytes).await.is_err() || stdin.flush().await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let pending: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        // Match the proven cc-connect posture: bounded event buffering applies
+        // backpressure instead of allowing a noisy app-server to grow memory
+        // without limit. Client responses bypass this queue via `pending`.
+        let (incoming_tx, incoming_rx) = mpsc::channel(128);
+        let reader_pending = pending.clone();
+        let reader_task = tokio::spawn(async move {
+            let mut reader = BufReader::new(stdout);
+            loop {
+                let line = match read_bounded_line(&mut reader, MAX_STDOUT_LINE_BYTES).await {
+                    Ok(Some(line)) => line,
+                    Ok(None) => break,
+                    Err(error) => {
+                        let _ = incoming_tx
+                            .send(json!({
+                                "method": "bamboo/transport/error",
+                                "params": {"message": error.to_string()}
+                            }))
+                            .await;
+                        break;
+                    }
+                };
+                let value: Value = match serde_json::from_slice(&line) {
+                    Ok(value) => value,
+                    Err(error) => {
+                        let _ = incoming_tx
+                            .send(json!({
+                                "method": "bamboo/transport/error",
+                                "params": {"message": format!("invalid JSONL: {error}")}
+                            }))
+                            .await;
+                        break;
+                    }
+                };
+                if value.get("method").is_none() {
+                    if let Some(id) = value.get("id").and_then(Value::as_u64) {
+                        if let Some(reply) = reader_pending.lock().await.remove(&id) {
+                            let _ = reply.send(value);
+                            continue;
+                        }
+                    }
+                }
+                if incoming_tx.send(value).await.is_err() {
+                    break;
+                }
+            }
+            reader_pending.lock().await.clear();
+        });
+
+        let stderr_tail = Arc::new(Mutex::new(String::new()));
+        if let Some(stderr) = stderr {
+            let tail = stderr_tail.clone();
+            tokio::spawn(async move { drain_stderr_tail(stderr, tail).await });
+        }
+        let connection = AppServerConnection {
+            child,
+            write_tx,
+            incoming_rx,
+            pending,
+            next_id: AtomicU64::new(1),
+            stderr_tail,
+            writer_task,
+            reader_task,
+        };
+        connection
+            .request(
+                "initialize",
+                json!({
+                    "clientInfo": {
+                        "name": "bamboo",
+                        "title": "Bamboo",
+                        "version": env!("CARGO_PKG_VERSION")
+                    },
+                    "capabilities": {"experimentalApi": true}
+                }),
+            )
+            .await?;
+        connection.send(json!({"method": "initialized", "params": {}}))?;
+        Ok(connection)
+    }
+
+    async fn ensure_connection<'a>(
+        &'a self,
+        slot: &'a mut Option<AppServerConnection>,
+    ) -> Result<&'a mut AppServerConnection, String> {
+        let alive = slot.as_mut().is_some_and(AppServerConnection::is_alive);
+        if !alive {
+            if let Some(mut stale) = slot.take() {
+                terminate_child(&mut stale.child).await;
+            }
+            *slot = Some(self.start_connection().await?);
+        }
+        Ok(slot.as_mut().expect("connection installed"))
+    }
+
+    fn thread_params(&self, sandbox: &str) -> Value {
+        let mut params = json!({
+            "approvalPolicy": "on-request",
+            "approvalsReviewer": "user",
+            "sandbox": sandbox,
+            "cwd": self.workspace,
+            "model": self.model,
+        });
+        remove_null_object_fields(&mut params);
+        params
+    }
+
+    async fn start_thread(
+        &self,
+        connection: &AppServerConnection,
+        sandbox: &str,
+    ) -> Result<String, String> {
+        let result = connection
+            .request("thread/start", self.thread_params(sandbox))
+            .await?;
+        result
+            .pointer("/thread/id")
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty())
+            .map(str::to_string)
+            .ok_or_else(|| "Codex thread/start response omitted thread.id".to_string())
+    }
+
+    async fn resume_thread(
+        &self,
+        connection: &AppServerConnection,
+        thread_id: &str,
+        sandbox: &str,
+    ) -> Result<(), String> {
+        let mut params = self.thread_params(sandbox);
+        params["threadId"] = Value::String(thread_id.to_string());
+        connection
+            .request("thread/resume", params)
+            .await
+            .map(|_| ())
+    }
+
+    async fn start_turn(
+        &self,
+        connection: &AppServerConnection,
+        thread_id: &str,
+        prompt: &str,
+        sandbox: &str,
+        network_access: bool,
+        reasoning_effort: Option<&str>,
+    ) -> Result<String, String> {
+        let mut params = json!({
+            "threadId": thread_id,
+            "input": [{"type": "text", "text": prompt, "text_elements": []}],
+            "approvalPolicy": "on-request",
+            "approvalsReviewer": "user",
+            "cwd": self.workspace,
+            "model": self.model,
+            "effort": reasoning_effort,
+            "sandboxPolicy": sandbox_policy(sandbox, self.workspace.as_deref(), network_access),
+        });
+        remove_null_object_fields(&mut params);
+        let result = connection.request("turn/start", params).await?;
+        result
+            .pointer("/turn/id")
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty())
+            .map(str::to_string)
+            .ok_or_else(|| "Codex turn/start response omitted turn.id".to_string())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn drive_turn(
+        &self,
+        connection: &mut AppServerConnection,
+        thread_id: &str,
+        turn_id: &str,
+        events: &EventSink,
+        steer: &mut SteerInbox,
+        approval_tasks: &mut Vec<tokio::task::JoinHandle<()>>,
+        force_cancelled: bool,
+    ) -> ChildOutcome {
+        let mut state = AppRunState::default();
+        let mut steer_open = true;
+        loop {
+            tokio::select! {
+                maybe_message = steer.recv(), if steer_open => {
+                    if let Some(message) = maybe_message {
+                        if let Err(error) = connection.request("turn/steer", json!({
+                            "threadId": thread_id,
+                            "expectedTurnId": turn_id,
+                            "input": [{"type": "text", "text": message, "text_elements": []}],
+                        })).await {
+                            events.emit(json!({
+                                "type": "runner_progress",
+                                "session_id": thread_id,
+                                "round_count": 1,
+                                "executor": "codex_app_server",
+                                "phase": "steer_rejected",
+                                "message": error,
+                            }));
+                        }
+                    } else {
+                        steer_open = false;
+                    }
+                }
+                incoming = connection.incoming_rx.recv() => {
+                    let Some(message) = incoming else {
+                        let stderr = connection.stderr_summary().await;
+                        let suffix = if stderr.is_empty() { String::new() } else { format!("; stderr: {stderr}") };
+                        return ChildOutcome::error(format!("Codex app-server transport closed{suffix}"));
+                    };
+                    let method = message.get("method").and_then(Value::as_str).unwrap_or("");
+                    if message.get("id").is_some() {
+                        if is_approval_method(method) {
+                            if !approval_matches_active_turn(&message, thread_id, turn_id) {
+                                let _ = connection.send(approval_response(&message, false));
+                                continue;
+                            }
+                            approval_tasks.push(spawn_approval_relay(
+                                connection.write_tx.clone(),
+                                message,
+                                events.host().cloned(),
+                                self.approval_timeout,
+                            ));
+                        } else {
+                            let id = message.get("id").cloned().unwrap_or(Value::Null);
+                            let _ = connection.send(json!({
+                                "id": id,
+                                "error": {"code": -32601, "message": format!("unsupported server request: {method}")}
+                            }));
+                        }
+                        continue;
+                    }
+                    if method == "bamboo/transport/error" {
+                        return ChildOutcome::error(error_message(&message, "Codex app-server transport error"));
+                    }
+                    if let Some(outcome) = handle_notification(
+                        method,
+                        message.get("params").unwrap_or(&Value::Null),
+                        thread_id,
+                        turn_id,
+                        events,
+                        &mut state,
+                        force_cancelled,
+                    ) {
+                        return outcome;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn run_inner(
+        &self,
+        spec: &RunSpec,
+        events: &EventSink,
+        steer: &mut SteerInbox,
+        cancel: &CancellationToken,
+    ) -> ChildOutcome {
+        let logical_session = match spec
+            .permission_policy
+            .as_ref()
+            .map(|policy| policy.session_id.trim())
+            .filter(|id| !id.is_empty())
+        {
+            Some(id) => id.to_string(),
+            None => return ChildOutcome::error(
+                "Codex app-server mode requires a logical session id in RunSpec.permission_policy",
+            ),
+        };
+        let parent_bypass = spec
+            .permission_policy
+            .as_ref()
+            .map(|policy| policy.bypass_permissions)
+            .unwrap_or(self.permissions.provisioned_bypass());
+        let (sandbox, network_access, warnings) =
+            self.permissions.app_server_posture(parent_bypass);
+        for warning in warnings {
+            events.emit(json!({
+                "type": "runner_progress",
+                "session_id": logical_session,
+                "round_count": 0,
+                "level": "warning",
+                "message": warning,
+            }));
+        }
+        events.emit(json!({
+            "type": "runner_progress",
+            "session_id": logical_session,
+            "round_count": 0,
+            "executor": "codex_app_server",
+            "binary": self.binary,
+            "version": self.version,
+            "model": self.model,
+            "auth_mode": self.auth.mode().as_str(),
+            "codex_home_mode": self.codex_home_mode(),
+            "sandbox": sandbox,
+            "approval_policy": "on-request",
+            "approvals_reviewer": "user",
+            "network_access": network_access,
+            "permission_profile": self.permissions.permission_profile(),
+        }));
+
+        if spec.messages.is_empty() {
+            self.forget_thread(&logical_session).await;
+        }
+        let mut slot = self.connection.lock().await;
+        let connection = match self.ensure_connection(&mut slot).await {
+            Ok(connection) => connection,
+            Err(error) => return ChildOutcome::error(error),
+        };
+
+        while connection.incoming_rx.try_recv().is_ok() {}
+        let stored = if spec.messages.is_empty() {
+            None
+        } else {
+            self.stored_thread(&logical_session).await
+        };
+        let (thread_id, prompt) = if let Some(thread_id) = stored {
+            match self.resume_thread(connection, &thread_id, &sandbox).await {
+                Ok(()) => (thread_id, spec.assignment.clone()),
+                Err(error) => {
+                    tracing::warn!(%error, "codex app-server: resume failed; rehydrating once");
+                    events.emit(json!({
+                        "type": "runner_progress",
+                        "session_id": logical_session,
+                        "round_count": 0,
+                        "executor": "codex_app_server",
+                        "phase": "resume_fallback",
+                        "message": "resume failed; starting a new thread with bounded history rehydration",
+                    }));
+                    self.forget_thread(&logical_session).await;
+                    let new_id = match self.start_thread(connection, &sandbox).await {
+                        Ok(id) => id,
+                        Err(error) => return ChildOutcome::error(error),
+                    };
+                    (
+                        new_id,
+                        build_rehydrated_turn(&spec.messages, &spec.assignment),
+                    )
+                }
+            }
+        } else {
+            let thread_id = match self.start_thread(connection, &sandbox).await {
+                Ok(id) => id,
+                Err(error) => return ChildOutcome::error(error),
+            };
+            let prompt = if spec.messages.is_empty() {
+                spec.assignment.clone()
+            } else {
+                build_rehydrated_turn(&spec.messages, &spec.assignment)
+            };
+            (thread_id, prompt)
+        };
+        self.store_thread(&logical_session, &thread_id).await;
+
+        let turn_id = match self
+            .start_turn(
+                connection,
+                &thread_id,
+                &prompt,
+                &sandbox,
+                network_access,
+                spec.reasoning_effort.as_deref(),
+            )
+            .await
+        {
+            Ok(id) => id,
+            Err(error) => return ChildOutcome::error(error),
+        };
+        events.emit(event_json(AgentEvent::RunnerProgress {
+            session_id: thread_id.clone(),
+            round_count: 1,
+        }));
+        let mut approval_tasks = Vec::new();
+        let outcome = tokio::select! {
+            outcome = self.drive_turn(
+                connection,
+                &thread_id,
+                &turn_id,
+                events,
+                steer,
+                &mut approval_tasks,
+                false,
+            ) => outcome,
+            _ = cancel.cancelled() => {
+                let interrupt = connection.request_with_timeout(
+                    "turn/interrupt",
+                    json!({"threadId": thread_id, "turnId": turn_id}),
+                    INTERRUPT_GRACE,
+                ).await;
+                if let Err(error) = interrupt {
+                    tracing::warn!(%error, "codex app-server: graceful interrupt failed");
+                }
+                match tokio::time::timeout(
+                    INTERRUPT_GRACE,
+                    self.drive_turn(
+                        connection,
+                        &thread_id,
+                        &turn_id,
+                        events,
+                        steer,
+                        &mut approval_tasks,
+                        true,
+                    ),
+                ).await {
+                    Ok(_) => ChildOutcome::cancelled(),
+                    Err(_) => {
+                        if let Some(mut connection) = slot.take() {
+                            terminate_child(&mut connection.child).await;
+                        }
+                        ChildOutcome::cancelled()
+                    }
+                }
+            }
+        };
+        for task in approval_tasks {
+            task.abort();
+        }
+        outcome
+    }
+}
+
+#[async_trait]
+impl ChildExecutor for CodexAppServerExecutor {
+    async fn run(
+        &self,
+        spec: RunSpec,
+        events: EventSink,
+        mut steer: SteerInbox,
+        cancel: CancellationToken,
+    ) -> ChildOutcome {
+        // A warm executor owns one long-lived app-server and one refreshable
+        // token file. Serialize activations so a queued run cannot overwrite
+        // or clear the token still in use by the active run.
+        let _run_guard = self.run_lock.lock().await;
+        let _token_guard = match self.install_run_token(&spec) {
+            Ok(guard) => guard,
+            Err(error) => return ChildOutcome::error(error),
+        };
+        let outcome = self.run_inner(&spec, &events, &mut steer, &cancel).await;
+        outcome
+    }
+}
+
+#[derive(Default)]
+struct AppRunState {
+    last_agent_message: String,
+    last_agent_item_id: Option<String>,
+    usage: TokenUsage,
+    started_items: HashSet<String>,
+}
+
+fn handle_notification(
+    method: &str,
+    params: &Value,
+    thread_id: &str,
+    turn_id: &str,
+    events: &EventSink,
+    state: &mut AppRunState,
+    force_cancelled: bool,
+) -> Option<ChildOutcome> {
+    if params
+        .get("threadId")
+        .and_then(Value::as_str)
+        .is_some_and(|id| id != thread_id)
+        || params
+            .get("turnId")
+            .and_then(Value::as_str)
+            .is_some_and(|id| id != turn_id)
+    {
+        return None;
+    }
+    match method {
+        "item/agentMessage/delta" => {
+            if let Some(delta) = params.get("delta").and_then(Value::as_str) {
+                let item_id = params
+                    .get("itemId")
+                    .and_then(Value::as_str)
+                    .unwrap_or("codex-agent-message");
+                if state.last_agent_item_id.as_deref() != Some(item_id) {
+                    state.last_agent_item_id = Some(item_id.to_string());
+                    state.last_agent_message.clear();
+                }
+                state.last_agent_message.push_str(delta);
+                events.emit(event_json(AgentEvent::Token {
+                    content: delta.to_string(),
+                }));
+            }
+        }
+        "item/reasoning/textDelta" | "item/reasoning/summaryTextDelta" => {
+            if let Some(delta) = params.get("delta").and_then(Value::as_str) {
+                events.emit(event_json(AgentEvent::ReasoningToken {
+                    content: delta.to_string(),
+                }));
+            }
+        }
+        "item/commandExecution/outputDelta" | "item/fileChange/outputDelta" => {
+            if let (Some(item_id), Some(delta)) = (
+                params.get("itemId").and_then(Value::as_str),
+                params.get("delta").and_then(Value::as_str),
+            ) {
+                events.emit(event_json(AgentEvent::ToolToken {
+                    tool_call_id: item_id.to_string(),
+                    content: delta.to_string(),
+                }));
+            }
+        }
+        "item/mcpToolCall/progress" => {
+            if let (Some(item_id), Some(message)) = (
+                params.get("itemId").and_then(Value::as_str),
+                params.get("message").and_then(Value::as_str),
+            ) {
+                events.emit(event_json(AgentEvent::ToolToken {
+                    tool_call_id: item_id.to_string(),
+                    content: message.to_string(),
+                }));
+            }
+        }
+        "item/started" => {
+            if let Some(item) = params.get("item") {
+                emit_item_started(item, events, state);
+            }
+        }
+        "item/completed" => {
+            if let Some(item) = params.get("item") {
+                emit_item_completed(item, events, state);
+            }
+        }
+        "thread/tokenUsage/updated" => {
+            state.usage = parse_app_server_usage(params.get("tokenUsage"));
+        }
+        "turn/completed" => {
+            if force_cancelled {
+                events.emit(event_json(AgentEvent::Cancelled {
+                    message: Some("Codex app-server turn interrupted".to_string()),
+                }));
+                return Some(ChildOutcome::cancelled());
+            }
+            let turn = params.get("turn").unwrap_or(&Value::Null);
+            match turn.get("status").and_then(Value::as_str) {
+                Some("completed") => {
+                    events.emit(event_json(AgentEvent::Complete { usage: state.usage }));
+                    return Some(ChildOutcome::completed(state.last_agent_message.clone()));
+                }
+                Some("interrupted") => {
+                    events.emit(event_json(AgentEvent::Cancelled {
+                        message: Some("Codex app-server turn interrupted".to_string()),
+                    }));
+                    return Some(ChildOutcome::cancelled());
+                }
+                _ => {
+                    let message = error_message(turn, "Codex app-server turn failed");
+                    events.emit(event_json(AgentEvent::Error {
+                        message: message.clone(),
+                    }));
+                    return Some(ChildOutcome::error(message));
+                }
+            }
+        }
+        "error" => {
+            let message = error_message(params, "Codex app-server error");
+            events.emit(event_json(AgentEvent::Error {
+                message: message.clone(),
+            }));
+            return Some(ChildOutcome::error(message));
+        }
+        other => tracing::debug!(
+            method = other,
+            "codex app-server: unrecognized notification"
+        ),
+    }
+    None
+}
+
+fn emit_item_started(item: &Value, events: &EventSink, state: &mut AppRunState) {
+    let item_id = item
+        .get("id")
+        .and_then(Value::as_str)
+        .unwrap_or("codex-item");
+    if !state.started_items.insert(item_id.to_string()) {
+        return;
+    }
+    let (tool_name, arguments) = match item.get("type").and_then(Value::as_str) {
+        Some("commandExecution") => (
+            "Bash".to_string(),
+            json!({"command": item.get("command"), "cwd": item.get("cwd")}),
+        ),
+        Some("fileChange") => (
+            "ApplyPatch".to_string(),
+            json!({"changes": item.get("changes")}),
+        ),
+        Some("mcpToolCall") => (
+            format!(
+                "{}::{}",
+                item.get("server").and_then(Value::as_str).unwrap_or("mcp"),
+                item.get("tool").and_then(Value::as_str).unwrap_or("tool")
+            ),
+            item.get("arguments").cloned().unwrap_or_else(|| json!({})),
+        ),
+        Some("dynamicToolCall") => (
+            item.get("tool")
+                .or_else(|| item.get("name"))
+                .and_then(Value::as_str)
+                .unwrap_or("DynamicTool")
+                .to_string(),
+            item.get("arguments").cloned().unwrap_or_else(|| json!({})),
+        ),
+        Some("webSearch") => ("WebSearch".to_string(), json!({"query": item.get("query")})),
+        _ => return,
+    };
+    events.emit(event_json(AgentEvent::ToolStart {
+        tool_call_id: item_id.to_string(),
+        tool_name,
+        arguments,
+    }));
+}
+
+fn emit_item_completed(item: &Value, events: &EventSink, state: &mut AppRunState) {
+    if item.get("type").and_then(Value::as_str) == Some("agentMessage") {
+        if let Some(text) = item.get("text").and_then(Value::as_str) {
+            state.last_agent_item_id = item.get("id").and_then(Value::as_str).map(str::to_string);
+            state.last_agent_message = text.to_string();
+        }
+        return;
+    }
+    emit_item_started(item, events, state);
+    let item_id = item
+        .get("id")
+        .and_then(Value::as_str)
+        .unwrap_or("codex-item");
+    if !state.started_items.contains(item_id) {
+        return;
+    }
+    let status = item.get("status").and_then(Value::as_str).unwrap_or("");
+    let error = item
+        .get("error")
+        .filter(|value| !value.is_null())
+        .map(value_text)
+        .or_else(|| {
+            matches!(status, "failed" | "declined" | "error").then(|| {
+                item.get("aggregatedOutput")
+                    .map(value_text)
+                    .unwrap_or_else(|| format!("Codex tool finished with status {status}"))
+            })
+        });
+    if let Some(error) = error {
+        events.emit(event_json(AgentEvent::ToolError {
+            tool_call_id: item_id.to_string(),
+            error: truncate_chars(&error, TOOL_RESULT_TRUNCATE_CHARS),
+        }));
+    } else {
+        let result = item
+            .get("aggregatedOutput")
+            .or_else(|| item.get("result"))
+            .or_else(|| item.get("changes"))
+            .map(value_text)
+            .unwrap_or_else(|| status.to_string());
+        events.emit(event_json(AgentEvent::ToolComplete {
+            tool_call_id: item_id.to_string(),
+            result: ToolResult::text(true, truncate_chars(&result, TOOL_RESULT_TRUNCATE_CHARS)),
+        }));
+    }
+}
+
+fn is_approval_method(method: &str) -> bool {
+    matches!(
+        method,
+        "item/commandExecution/requestApproval"
+            | "item/fileChange/requestApproval"
+            | "execCommandApproval"
+            | "applyPatchApproval"
+    )
+}
+
+fn spawn_approval_relay(
+    write_tx: mpsc::UnboundedSender<Value>,
+    request: Value,
+    host: Option<HostBridge>,
+    timeout: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let id = request.get("id").cloned().unwrap_or(Value::Null);
+        let method = request
+            .get("method")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let params = request.get("params").cloned().unwrap_or_else(|| json!({}));
+        let is_command = method.contains("commandExecution") || method == "execCommandApproval";
+        let body = if is_command {
+            json!({
+                "tool_name": "Bash",
+                "permission_type": "command_execution",
+                "resource": params.get("command").cloned().unwrap_or(Value::Null),
+                "question": params.get("reason").cloned().unwrap_or_else(|| Value::String("Codex requests permission to execute a command".to_string())),
+                "input": params,
+            })
+        } else {
+            json!({
+                "tool_name": "ApplyPatch",
+                "permission_type": "file_change",
+                "resource": params.get("grantRoot").or_else(|| params.get("path")).cloned().unwrap_or(Value::Null),
+                "question": params.get("reason").cloned().unwrap_or_else(|| Value::String("Codex requests permission to modify files".to_string())),
+                "input": params,
+            })
+        };
+        let approved = if let Some(host) = host {
+            match tokio::time::timeout(timeout, host.approval_call(body)).await {
+                Ok(Ok(reply)) => reply
+                    .get("approved")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+                Ok(Err(error)) => {
+                    tracing::warn!(%error, "codex app-server: approval relay failed closed");
+                    false
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        seconds = timeout.as_secs(),
+                        "codex app-server: approval relay timed out; denying"
+                    );
+                    false
+                }
+            }
+        } else {
+            tracing::warn!("codex app-server: approval host bridge unavailable; denying");
+            false
+        };
+        let _ = write_tx.send(approval_response_parts(id, &method, approved));
+    })
+}
+
+fn approval_matches_active_turn(request: &Value, thread_id: &str, turn_id: &str) -> bool {
+    let params = request.get("params").unwrap_or(&Value::Null);
+    !params
+        .get("threadId")
+        .and_then(Value::as_str)
+        .is_some_and(|id| id != thread_id)
+        && !params
+            .get("turnId")
+            .and_then(Value::as_str)
+            .is_some_and(|id| id != turn_id)
+}
+
+fn approval_response(request: &Value, approved: bool) -> Value {
+    approval_response_parts(
+        request.get("id").cloned().unwrap_or(Value::Null),
+        request.get("method").and_then(Value::as_str).unwrap_or(""),
+        approved,
+    )
+}
+
+fn approval_response_parts(id: Value, method: &str, approved: bool) -> Value {
+    let decision = if matches!(method, "execCommandApproval" | "applyPatchApproval") {
+        if approved {
+            "approved"
+        } else {
+            "denied"
+        }
+    } else if approved {
+        "accept"
+    } else {
+        "decline"
+    };
+    json!({"id": id, "result": {"decision": decision}})
+}
+
+fn sandbox_policy(sandbox: &str, workspace: Option<&str>, network_access: bool) -> Value {
+    match sandbox {
+        "read-only" => json!({"type": "readOnly", "networkAccess": false}),
+        "danger-full-access" => json!({"type": "dangerFullAccess"}),
+        _ => json!({
+            "type": "workspaceWrite",
+            "writableRoots": workspace.into_iter().collect::<Vec<_>>(),
+            "networkAccess": network_access,
+        }),
+    }
+}
+
+fn parse_app_server_usage(value: Option<&Value>) -> TokenUsage {
+    let usage = value
+        .and_then(|value| value.get("last"))
+        .unwrap_or(&Value::Null);
+    TokenUsage {
+        prompt_tokens: usage
+            .get("inputTokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        completion_tokens: usage
+            .get("outputTokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        total_tokens: usage
+            .get("totalTokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+    }
+}
+
+fn event_json(event: AgentEvent) -> Value {
+    serde_json::to_value(event)
+        .unwrap_or_else(|_| json!({"type": "error", "message": "serialize agent event"}))
+}
+
+fn error_message(value: &Value, fallback: &str) -> String {
+    value
+        .pointer("/error/message")
+        .or_else(|| value.get("message"))
+        .or_else(|| value.get("error"))
+        .map(value_text)
+        .filter(|message| !message.is_empty())
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+fn value_text(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.clone(),
+        Value::Null => String::new(),
+        value => value.to_string(),
+    }
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut output: String = value.chars().take(max_chars).collect();
+    output.push_str("\n… truncated by Bamboo …");
+    output
+}
+
+fn remove_null_object_fields(value: &mut Value) {
+    if let Some(object) = value.as_object_mut() {
+        object.retain(|_, value| !value.is_null());
+    }
+}
+
+fn prune_session_store(store: &mut AppServerSessionStore, current_session: &str) {
+    while store.sessions.len() > MAX_LOGICAL_SESSIONS {
+        let oldest = store
+            .sessions
+            .iter()
+            .filter(|(session, _)| session.as_str() != current_session)
+            .min_by_key(|(_, state)| state.updated_at)
+            .map(|(session, _)| session.clone());
+        let Some(oldest) = oldest else {
+            break;
+        };
+        store.sessions.remove(&oldest);
+    }
+}
+
+fn open_secret_for_replace(path: &Path) -> Result<std::fs::File, String> {
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    let file = options
+        .open(path)
+        .map_err(|error| format!("open Codex app-server provider token: {error}"))?;
+    if !file
+        .metadata()
+        .map_err(|error| format!("inspect Codex app-server provider token: {error}"))?
+        .is_file()
+    {
+        return Err("Codex app-server provider token path is not a regular file".to_string());
+    }
+    #[cfg(unix)]
+    file.set_permissions(std::os::unix::fs::PermissionsExt::from_mode(0o600))
+        .map_err(|error| format!("secure Codex app-server provider token: {error}"))?;
+    Ok(file)
+}
+
+async fn secure_directory(path: &Path) -> Result<(), String> {
+    tokio::fs::create_dir_all(path).await.map_err(|error| {
+        format!(
+            "create Codex app-server state '{}': {error}",
+            path.display()
+        )
+    })?;
+    #[cfg(unix)]
+    tokio::fs::set_permissions(path, std::os::unix::fs::PermissionsExt::from_mode(0o700))
+        .await
+        .map_err(|error| {
+            format!(
+                "secure Codex app-server state '{}': {error}",
+                path.display()
+            )
+        })?;
+    Ok(())
+}
+
+async fn secure_file(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    tokio::fs::set_permissions(path, std::os::unix::fs::PermissionsExt::from_mode(0o600))
+        .await
+        .map_err(|error| format!("secure Codex app-server file '{}': {error}", path.display()))?;
+    Ok(())
+}
+
+async fn drain_stderr_tail(stderr: tokio::process::ChildStderr, tail: Arc<Mutex<String>>) {
+    use tokio::io::AsyncBufReadExt;
+    let mut reader = BufReader::new(stderr);
+    let mut buffer = Vec::new();
+    loop {
+        buffer.clear();
+        match reader.read_until(b'\n', &mut buffer).await {
+            Ok(0) | Err(_) => return,
+            Ok(_) => {
+                let mut tail = tail.lock().await;
+                tail.push_str(&String::from_utf8_lossy(&buffer));
+                if tail.len() > STDERR_TAIL_BYTES {
+                    let excess = tail.len() - STDERR_TAIL_BYTES;
+                    let cut = tail
+                        .char_indices()
+                        .map(|(index, _)| index)
+                        .find(|index| *index >= excess)
+                        .unwrap_or(tail.len());
+                    tail.drain(..cut);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codex_cli_executor::{
+        resolve_codex_app_server_permission_config, resolve_codex_auth_config,
+    };
+    use bamboo_subagent::executor::HostBridge;
+    use bamboo_subagent::proto::{PermissionPolicyContext, RunSecrets, SecretValue};
+
+    #[cfg(unix)]
+    fn write_stub_codex(path: &Path) {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::write(
+            path,
+            r###"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo 'codex-cli 0.144.5'
+  exit 0
+fi
+if [ "$1" = "exec" ]; then
+  echo '--json --output-last-message --config --sandbox --dangerously-bypass-approvals-and-sandbox stdin'
+  exit 0
+fi
+if [ "$1" = "app-server" ] && [ "$2" = "--help" ]; then
+  echo '--listen stdio:// --stdio'
+  exit 0
+fi
+if [ "$1" != "app-server" ]; then
+  exit 2
+fi
+IFS= read -r initialize
+echo '{"id":1,"result":{"userAgent":"stub/0.144.5"}}'
+IFS= read -r initialized
+IFS= read -r thread_start
+echo '{"id":2,"result":{"thread":{"id":"thread-stub"}}}'
+IFS= read -r turn_start
+echo '{"id":3,"result":{"turn":{"id":"turn-stub","status":"inProgress","items":[]}}}'
+echo '{"id":41,"method":"item/commandExecution/requestApproval","params":{"threadId":"thread-stub","turnId":"turn-stub","itemId":"item-1","command":"touch marker","cwd":"/tmp","reason":"stub command","startedAtMs":1}}'
+IFS= read -r approval
+case "$approval" in
+  *'"decision":"accept"'*) text='stub approved' ;;
+  *) text='stub denied' ;;
+esac
+printf '{"method":"item/agentMessage/delta","params":{"threadId":"thread-stub","turnId":"turn-stub","itemId":"item-2","delta":"%s"}}\n' "$text"
+echo '{"method":"turn/completed","params":{"threadId":"thread-stub","turn":{"id":"turn-stub","status":"completed","items":[]}}}'
+while IFS= read -r ignored; do :; done
+"###,
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[cfg(unix)]
+    async fn run_stub_with_decision(approved: bool) -> (ChildOutcome, Vec<Value>) {
+        let root = tempfile::tempdir().unwrap();
+        let binary = root.path().join("codex-stub.sh");
+        write_stub_codex(&binary);
+        let permissions = resolve_codex_app_server_permission_config(
+            Some("workspace-write"),
+            Some("on-request"),
+            false,
+            false,
+            None,
+            false,
+            false,
+        )
+        .unwrap();
+        let executor = CodexAppServerExecutor::new(
+            Some(binary.to_string_lossy().into_owned()),
+            None,
+            Some(root.path().to_string_lossy().into_owned()),
+            Some(root.path().join("state")),
+            Vec::new(),
+            CodexAuthConfig::inherit(),
+            permissions,
+        )
+        .await
+        .unwrap();
+        let (sink, mut event_rx) = EventSink::channel();
+        let (host, mut host_rx) = HostBridge::channel();
+        let approval_task = tokio::spawn(async move {
+            let request = host_rx.recv().await.expect("approval request");
+            assert_eq!(request.body["tool_name"], "Bash");
+            request.reply.send(json!({"approved": approved})).unwrap();
+        });
+        let outcome = executor
+            .run(
+                RunSpec {
+                    assignment: "exercise approval".to_string(),
+                    reasoning_effort: None,
+                    permission_policy: Some(PermissionPolicyContext {
+                        revision: 1,
+                        bypass_permissions: false,
+                        session_id: format!("stub-{approved}"),
+                        workspace_path: Some(root.path().to_string_lossy().into_owned()),
+                        inherit_session_grants: false,
+                        policy: json!({}),
+                    }),
+                    messages: Vec::new(),
+                    secrets: RunSecrets::default(),
+                },
+                sink.with_host_bridge(host),
+                SteerInbox::disconnected(),
+                CancellationToken::new(),
+            )
+            .await;
+        approval_task.await.unwrap();
+        let mut events = Vec::new();
+        while let Ok(event) = event_rx.try_recv() {
+            events.push(event);
+        }
+        (outcome, events)
+    }
+
+    #[test]
+    fn recorded_fixture_covers_handshake_and_approval_round_trip() {
+        let rows =
+            include_str!("../tests/fixtures/codex-app-server/0.144.5-handshake-approval.jsonl")
+                .lines()
+                .map(|line| serde_json::from_str::<Value>(line).expect("valid JSONL row"))
+                .collect::<Vec<_>>();
+        assert_eq!(rows[0]["message"]["method"], "initialize");
+        assert!(rows.iter().any(|row| {
+            row["direction"] == "client" && row["message"]["method"] == "initialized"
+        }));
+        assert!(rows.iter().any(|row| {
+            row["direction"] == "client" && row["message"]["method"] == "thread/start"
+        }));
+        let approval = rows
+            .iter()
+            .find(|row| row["message"]["method"] == "item/fileChange/requestApproval")
+            .expect("approval request");
+        let approval_id = approval["message"]["id"].clone();
+        assert!(rows.iter().any(|row| {
+            row["direction"] == "client"
+                && row["message"]["id"] == approval_id
+                && row["message"]["result"]["decision"] == "accept"
+        }));
+        assert_eq!(rows.last().unwrap()["message"]["method"], "turn/completed");
+    }
+
+    #[tokio::test]
+    async fn current_command_approval_relays_allow_to_accept() {
+        let (write_tx, mut write_rx) = mpsc::unbounded_channel();
+        let (host, mut host_rx) = HostBridge::channel();
+        let task = spawn_approval_relay(
+            write_tx,
+            json!({
+                "id": 9,
+                "method": "item/commandExecution/requestApproval",
+                "params": {"command": "touch marker", "cwd": "/tmp", "reason": "write marker"}
+            }),
+            Some(host),
+            Duration::from_secs(1),
+        );
+        let request = host_rx.recv().await.expect("host approval request");
+        assert_eq!(request.body["tool_name"], "Bash");
+        assert_eq!(request.body["resource"], "touch marker");
+        request
+            .reply
+            .send(json!({"approved": true}))
+            .expect("host reply accepted");
+        task.await.unwrap();
+        let response = write_rx.recv().await.expect("app-server response");
+        assert_eq!(response, json!({"id": 9, "result": {"decision": "accept"}}));
+    }
+
+    #[tokio::test]
+    async fn approval_timeout_fails_closed_to_decline() {
+        let (write_tx, mut write_rx) = mpsc::unbounded_channel();
+        let (host, mut host_rx) = HostBridge::channel();
+        let task = spawn_approval_relay(
+            write_tx,
+            json!({
+                "id": "approval-10",
+                "method": "item/fileChange/requestApproval",
+                "params": {"grantRoot": "/tmp/workspace"}
+            }),
+            Some(host),
+            Duration::from_millis(10),
+        );
+        let held_request = host_rx.recv().await.expect("host approval request");
+        task.await.unwrap();
+        drop(held_request);
+        let response = write_rx.recv().await.expect("app-server response");
+        assert_eq!(
+            response,
+            json!({"id": "approval-10", "result": {"decision": "decline"}})
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_apply_patch_denial_uses_legacy_decision_shape() {
+        let (write_tx, mut write_rx) = mpsc::unbounded_channel();
+        let task = spawn_approval_relay(
+            write_tx,
+            json!({"id": 11, "method": "applyPatchApproval", "params": {}}),
+            None,
+            Duration::from_secs(1),
+        );
+        task.await.unwrap();
+        assert_eq!(
+            write_rx.recv().await.unwrap(),
+            json!({"id": 11, "result": {"decision": "denied"}})
+        );
+    }
+
+    #[test]
+    fn approval_from_another_loaded_thread_is_denied_without_relay() {
+        let request = json!({
+            "id": 12,
+            "method": "item/commandExecution/requestApproval",
+            "params": {"threadId": "other", "turnId": "turn-stub"}
+        });
+        assert!(!approval_matches_active_turn(
+            &request,
+            "thread-stub",
+            "turn-stub"
+        ));
+        assert_eq!(
+            approval_response(&request, false),
+            json!({"id": 12, "result": {"decision": "decline"}})
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn subprocess_stub_completes_full_handshake_and_allow_path() {
+        let (outcome, events) = run_stub_with_decision(true).await;
+        assert_eq!(outcome.result.as_deref(), Some("stub approved"));
+        assert!(events.iter().any(|event| event["type"] == "complete"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn subprocess_stub_returns_denial_to_model_and_completes() {
+        let (outcome, events) = run_stub_with_decision(false).await;
+        assert_eq!(outcome.result.as_deref(), Some("stub denied"));
+        assert!(events
+            .iter()
+            .any(|event| event["type"] == "token" && event["content"] == "stub denied"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bamboo_auth_token_file_is_per_run_secret_and_cleared() {
+        let root = tempfile::tempdir().unwrap();
+        let binary = root.path().join("codex-stub.sh");
+        write_stub_codex(&binary);
+        let auth = resolve_codex_auth_config(
+            Some("bamboo"),
+            false,
+            Some("http://127.0.0.1:9562/openai/v1".to_string()),
+            Some("responses".to_string()),
+            None,
+            &[],
+            &[],
+        )
+        .unwrap();
+        let permissions = resolve_codex_app_server_permission_config(
+            Some("workspace-write"),
+            Some("on-request"),
+            false,
+            false,
+            None,
+            false,
+            false,
+        )
+        .unwrap();
+        let executor = CodexAppServerExecutor::new(
+            Some(binary.to_string_lossy().into_owned()),
+            None,
+            Some(root.path().to_string_lossy().into_owned()),
+            Some(root.path().join("state")),
+            Vec::new(),
+            auth,
+            permissions,
+        )
+        .await
+        .unwrap();
+        let spec = RunSpec {
+            assignment: "token lifecycle".to_string(),
+            reasoning_effort: None,
+            permission_policy: None,
+            messages: Vec::new(),
+            secrets: RunSecrets {
+                codex_provider_token: Some(SecretValue::new("bcx1_app_server_secret")),
+            },
+        };
+        let token_guard = executor
+            .install_run_token(&spec)
+            .unwrap()
+            .expect("bamboo auth installs a token guard");
+        assert_eq!(
+            tokio::fs::read_to_string(executor.token_path())
+                .await
+                .unwrap(),
+            "bcx1_app_server_secret"
+        );
+        let config = tokio::fs::read_to_string(
+            executor
+                .codex_home()
+                .expect("isolated home")
+                .join("config.toml"),
+        )
+        .await
+        .unwrap();
+        assert!(config.contains("codex-provider-token"));
+        assert!(!config.contains("bcx1_app_server_secret"));
+        drop(token_guard);
+        assert!(tokio::fs::read(executor.token_path())
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn logical_session_store_is_bounded_and_preserves_current_session() {
+        let mut store = AppServerSessionStore::default();
+        let base = Utc::now();
+        for index in 0..=MAX_LOGICAL_SESSIONS {
+            store.sessions.insert(
+                format!("session-{index}"),
+                AppServerSessionState {
+                    thread_id: format!("thread-{index}"),
+                    workspace: Some("/workspace".to_string()),
+                    codex_home_mode: "inherit".to_string(),
+                    updated_at: base + chrono::Duration::seconds(index as i64),
+                },
+            );
+        }
+
+        prune_session_store(&mut store, "session-0");
+
+        assert_eq!(store.sessions.len(), MAX_LOGICAL_SESSIONS);
+        assert!(store.sessions.contains_key("session-0"));
+        assert!(!store.sessions.contains_key("session-1"));
+    }
+}

--- a/src/codex_cli_executor.rs
+++ b/src/codex_cli_executor.rs
@@ -66,7 +66,7 @@ pub enum CodexAuthMode {
 }
 
 impl CodexAuthMode {
-    fn as_str(self) -> &'static str {
+    pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::Inherit => "inherit",
             Self::ApiKey => "api_key",
@@ -101,7 +101,7 @@ impl CodexAuthConfig {
         self.mode
     }
 
-    fn isolated(&self) -> bool {
+    pub(crate) fn isolated(&self) -> bool {
         self.mode != CodexAuthMode::Inherit
     }
 
@@ -145,6 +145,114 @@ impl CodexAuthConfig {
         toml::to_string(&toml::Value::Table(root))
             .map_err(|error| format!("serialize isolated Codex config.toml: {error}"))
     }
+
+    /// App-server stays alive across activations, while Bamboo provider tokens
+    /// are intentionally minted and revoked per activation. Use Codex's
+    /// command-backed auth hook to read the current 0600 token file instead of
+    /// freezing the first token in the process environment.
+    pub(crate) fn generated_app_server_config_toml(
+        &self,
+        token_helper: &Path,
+        token_path: &Path,
+    ) -> Result<String, String> {
+        if self.mode != CodexAuthMode::Bamboo {
+            return self.generated_config_toml();
+        }
+        let base_url = self
+            .base_url
+            .as_ref()
+            .ok_or_else(|| "Codex auth mode 'bamboo' requires a provider base URL".to_string())?;
+        let mut auth = toml::Table::new();
+        auth.insert(
+            "command".to_string(),
+            toml::Value::String(token_helper.to_string_lossy().into_owned()),
+        );
+        auth.insert(
+            "args".to_string(),
+            toml::Value::Array(vec![
+                toml::Value::String("codex-provider-token".to_string()),
+                toml::Value::String(token_path.to_string_lossy().into_owned()),
+            ]),
+        );
+        auth.insert("timeout_ms".to_string(), toml::Value::Integer(5_000));
+        auth.insert("refresh_interval_ms".to_string(), toml::Value::Integer(1));
+        let mut provider = toml::Table::new();
+        provider.insert(
+            "name".to_string(),
+            toml::Value::String("Bamboo bamboo".to_string()),
+        );
+        provider.insert(
+            "base_url".to_string(),
+            toml::Value::String(base_url.clone()),
+        );
+        provider.insert(
+            "wire_api".to_string(),
+            toml::Value::String(self.wire_api.clone()),
+        );
+        provider.insert("auth".to_string(), toml::Value::Table(auth));
+        let mut providers = toml::Table::new();
+        providers.insert("bamboo".to_string(), toml::Value::Table(provider));
+        let mut root = toml::Table::new();
+        root.insert(
+            "model_provider".to_string(),
+            toml::Value::String("bamboo".to_string()),
+        );
+        root.insert("model_providers".to_string(), toml::Value::Table(providers));
+        toml::to_string(&toml::Value::Table(root))
+            .map_err(|error| format!("serialize isolated Codex app-server config.toml: {error}"))
+    }
+
+    pub(crate) fn provider_key(&self) -> Option<&str> {
+        self.provider_key.as_deref()
+    }
+}
+
+/// Read the short-lived Bamboo provider token for Codex command-backed auth.
+/// The final path component is opened without following symlinks on Unix, and
+/// permissions are verified on the opened descriptor to avoid check/open races.
+pub fn read_codex_provider_token(path: &Path) -> Result<String, String> {
+    #[cfg(not(unix))]
+    {
+        let metadata = std::fs::symlink_metadata(path)
+            .map_err(|error| format!("inspect Codex provider token: {error}"))?;
+        if metadata.file_type().is_symlink() {
+            return Err("Codex provider token path must not be a symlink".to_string());
+        }
+    }
+
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|error| format!("open Codex provider token: {error}"))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("inspect Codex provider token: {error}"))?;
+    if !metadata.is_file() {
+        return Err("Codex provider token path must be a regular file".to_string());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        if metadata.permissions().mode() & 0o077 != 0 {
+            return Err(
+                "Codex provider token file must not be accessible by group/other".to_string(),
+            );
+        }
+    }
+    let mut token = String::new();
+    std::io::Read::read_to_string(&mut file, &mut token)
+        .map_err(|error| format!("read Codex provider token: {error}"))?;
+    let token = token.trim();
+    if token.is_empty() {
+        return Err("Codex provider token file is empty".to_string());
+    }
+    Ok(token.to_string())
 }
 
 /// Resolve and validate the public provision fields plus the one referenced
@@ -248,6 +356,7 @@ impl CodexSandbox {
 enum CodexApprovalPolicy {
     Never,
     OnFailure,
+    OnRequest,
 }
 
 impl CodexApprovalPolicy {
@@ -255,11 +364,10 @@ impl CodexApprovalPolicy {
         match raw {
             "never" => Ok(Self::Never),
             "on-failure" => Ok(Self::OnFailure),
-            "untrusted" | "on-request" => Err(format!(
-                "Codex approval policy '{raw}' is interactive and unsupported by non-interactive exec mode"
-            )),
+            "on-request" => Ok(Self::OnRequest),
+            "untrusted" => Err("Codex approval policy 'untrusted' is unsupported; use on-request in app_server mode".to_string()),
             other => Err(format!(
-                "unknown Codex approval policy '{other}'; expected never or on-failure"
+                "unknown Codex approval policy '{other}'; expected never, on-failure, or on-request"
             )),
         }
     }
@@ -268,6 +376,7 @@ impl CodexApprovalPolicy {
         match self {
             Self::Never => "never",
             Self::OnFailure => "on-failure",
+            Self::OnRequest => "on-request",
         }
     }
 }
@@ -429,6 +538,12 @@ pub fn resolve_codex_permission_config(
     let approval_policy = approval_policy
         .map(CodexApprovalPolicy::parse)
         .transpose()?;
+    if approval_policy == Some(CodexApprovalPolicy::OnRequest) {
+        return Err(
+            "Codex approval policy 'on-request' requires codex_mode = \"app_server\"; non-interactive exec mode has no approval relay"
+                .to_string(),
+        );
+    }
     let profile_read_only = permission_profile
         .as_deref()
         .is_some_and(profile_is_read_only);
@@ -448,6 +563,68 @@ pub fn resolve_codex_permission_config(
         provisioned_bypass,
         workspace_owned,
     })
+}
+
+/// App-server mode always routes approvals to Bamboo. Accepting `never` or
+/// `on-failure` here would make the selected transport's safety contract lie.
+#[allow(clippy::too_many_arguments)]
+pub fn resolve_codex_app_server_permission_config(
+    sandbox: Option<&str>,
+    approval_policy: Option<&str>,
+    network_access: bool,
+    allow_danger_bypass: bool,
+    permission_profile: Option<String>,
+    provisioned_bypass: bool,
+    workspace_owned: bool,
+) -> Result<CodexPermissionConfig, String> {
+    match approval_policy {
+        None | Some("on-request") => {}
+        Some(other) => {
+            return Err(format!(
+                "Codex approval policy '{other}' is incompatible with codex_mode = \"app_server\"; use on-request"
+            ))
+        }
+    }
+    let sandbox = sandbox.map(CodexSandbox::parse).transpose()?;
+    let profile_read_only = permission_profile
+        .as_deref()
+        .is_some_and(profile_is_read_only);
+    if network_access
+        && (sandbox == Some(CodexSandbox::ReadOnly) || (sandbox.is_none() && profile_read_only))
+    {
+        return Err(
+            "Codex network access requires an effective workspace-write sandbox".to_string(),
+        );
+    }
+    Ok(CodexPermissionConfig {
+        sandbox,
+        approval_policy: Some(CodexApprovalPolicy::OnRequest),
+        network_access,
+        allow_danger_bypass,
+        permission_profile,
+        provisioned_bypass,
+        workspace_owned,
+    })
+}
+
+impl CodexPermissionConfig {
+    pub(crate) fn app_server_posture(&self, bypass: bool) -> (String, bool, Vec<String>) {
+        let mut policy = self.effective(bypass, running_as_root());
+        policy.approval_policy = CodexApprovalPolicy::OnRequest;
+        (
+            policy.sandbox.as_str().to_string(),
+            policy.network_access,
+            policy.warnings,
+        )
+    }
+
+    pub(crate) fn permission_profile(&self) -> Option<&str> {
+        self.permission_profile.as_deref()
+    }
+
+    pub(crate) fn provisioned_bypass(&self) -> bool {
+        self.provisioned_bypass
+    }
 }
 
 #[cfg(unix)]
@@ -1661,7 +1838,7 @@ fn process_group_exists(pgid: libc::pid_t) -> bool {
 }
 
 #[cfg(unix)]
-async fn terminate_child(child: &mut Child) {
+pub(crate) async fn terminate_child(child: &mut Child) {
     let Some(pgid) = child.id().map(|pid| pid as libc::pid_t) else {
         return;
     };
@@ -1696,7 +1873,7 @@ async fn terminate_child(child: &mut Child) {
 }
 
 #[cfg(not(unix))]
-async fn terminate_child(child: &mut Child) {
+pub(crate) async fn terminate_child(child: &mut Child) {
     if tokio::time::timeout(SIGTERM_WAIT, child.wait())
         .await
         .is_ok()
@@ -1707,7 +1884,10 @@ async fn terminate_child(child: &mut Child) {
     let _ = child.wait().await;
 }
 
-async fn read_bounded_line<R>(reader: &mut R, max_bytes: usize) -> std::io::Result<Option<Vec<u8>>>
+pub(crate) async fn read_bounded_line<R>(
+    reader: &mut R,
+    max_bytes: usize,
+) -> std::io::Result<Option<Vec<u8>>>
 where
     R: tokio::io::AsyncBufRead + Unpin,
 {
@@ -2257,6 +2437,18 @@ mod tests {
         assert!(generated.contains("model_provider = \"bamboo\""));
         assert!(generated.contains("http://127.0.0.1:9562/openai/v1"));
         assert!(!generated.contains("bcx1_"));
+        let app_server_generated = bamboo
+            .generated_app_server_config_toml(
+                Path::new("/opt/bamboo/bin/bamboo"),
+                Path::new("/private/state/codex-provider-token"),
+            )
+            .unwrap();
+        assert!(app_server_generated.contains("[model_providers.bamboo.auth]"));
+        assert!(app_server_generated.contains("command = \"/opt/bamboo/bin/bamboo\""));
+        assert!(app_server_generated.contains("\"codex-provider-token\""));
+        assert!(app_server_generated.contains("refresh_interval_ms = 1"));
+        assert!(!app_server_generated.contains("env_key"));
+        assert!(!app_server_generated.contains("bcx1_"));
         let mut bamboo_executor = fixture_executor();
         bamboo_executor.state_dir = Some(state.path().to_path_buf());
         bamboo_executor.auth = bamboo;
@@ -2549,6 +2741,30 @@ mod tests {
                     .as_str()
                     .is_some_and(|error| error.contains("Operation not permitted"))
         }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provider_token_reader_checks_open_descriptor_and_rejects_symlinks() {
+        use std::os::unix::fs::{symlink, PermissionsExt as _};
+
+        let root = tempfile::tempdir().unwrap();
+        let token = root.path().join("token");
+        std::fs::write(&token, "  bcx1_short_lived  \n").unwrap();
+        std::fs::set_permissions(&token, std::fs::Permissions::from_mode(0o600)).unwrap();
+        assert_eq!(
+            read_codex_provider_token(&token).unwrap(),
+            "bcx1_short_lived"
+        );
+
+        let link = root.path().join("token-link");
+        symlink(&token, &link).unwrap();
+        assert!(read_codex_provider_token(&link).is_err());
+
+        std::fs::set_permissions(&token, std::fs::Permissions::from_mode(0o640)).unwrap();
+        assert!(read_codex_provider_token(&token)
+            .unwrap_err()
+            .contains("group/other"));
     }
 
     #[cfg(unix)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,9 @@ pub mod claude_code_executor;
 /// `ChildExecutor` (`ExecutorSpec::Codex`).
 pub mod codex_cli_executor;
 
+/// Long-lived `codex app-server` executor with interactive approval relay.
+pub mod codex_app_server_executor;
+
 /// The `bamboo broker-agent serve` worker: connect to a central broker and
 /// answer Ask/Task (query/steer) for its mailbox; deployable local/Docker/remote.
 pub mod broker_agent;

--- a/src/subagent_worker.rs
+++ b/src/subagent_worker.rs
@@ -36,6 +36,7 @@ use bamboo_subagent::transport::WsServer;
 use futures::StreamExt;
 
 use crate::claude_code_executor::ClaudeCodeExecutor;
+use crate::codex_app_server_executor::CodexAppServerExecutor;
 use crate::codex_cli_executor::CodexExecutor;
 
 /// How long a finished actor's isolated storage is retained for debugging
@@ -112,6 +113,7 @@ pub async fn run() -> std::result::Result<(), String> {
         ExecutorSpec::Codex {
             binary,
             model,
+            mode,
             sandbox,
             inherit_user_config,
             auth_mode,
@@ -135,30 +137,64 @@ pub async fn run() -> std::result::Result<(), String> {
                 &spec.secrets.provider_credentials,
                 &forward_env,
             )?;
-            let permissions = crate::codex_cli_executor::resolve_codex_permission_config(
-                sandbox.as_deref(),
-                approval_policy.as_deref(),
-                network_access.unwrap_or(false),
-                allow_danger_bypass.unwrap_or(false),
-                permission_profile.clone(),
-                spec.capabilities.bypass,
-                workspace_owned.unwrap_or(false),
-            )?;
-            Arc::new(
-                CodexExecutor::new(
-                    binary.clone(),
-                    model.clone(),
-                    spec.workspace.clone(),
-                    Some(crate::codex_cli_executor::resolve_codex_state_dir(
-                        &spec.storage_dir,
-                        &spec.identity.child_id,
-                    )),
-                    forward_env,
-                    auth,
-                    permissions,
-                )
-                .await?,
-            )
+            let state_dir = Some(crate::codex_cli_executor::resolve_codex_state_dir(
+                &spec.storage_dir,
+                &spec.identity.child_id,
+            ));
+            match mode.as_deref().unwrap_or("exec") {
+                "exec" => {
+                    let permissions = crate::codex_cli_executor::resolve_codex_permission_config(
+                        sandbox.as_deref(),
+                        approval_policy.as_deref(),
+                        network_access.unwrap_or(false),
+                        allow_danger_bypass.unwrap_or(false),
+                        permission_profile.clone(),
+                        spec.capabilities.bypass,
+                        workspace_owned.unwrap_or(false),
+                    )?;
+                    Arc::new(
+                        CodexExecutor::new(
+                            binary.clone(),
+                            model.clone(),
+                            spec.workspace.clone(),
+                            state_dir,
+                            forward_env,
+                            auth,
+                            permissions,
+                        )
+                        .await?,
+                    )
+                }
+                "app_server" => {
+                    let permissions =
+                        crate::codex_cli_executor::resolve_codex_app_server_permission_config(
+                            sandbox.as_deref(),
+                            approval_policy.as_deref(),
+                            network_access.unwrap_or(false),
+                            allow_danger_bypass.unwrap_or(false),
+                            permission_profile.clone(),
+                            spec.capabilities.bypass,
+                            workspace_owned.unwrap_or(false),
+                        )?;
+                    Arc::new(
+                        CodexAppServerExecutor::new(
+                            binary.clone(),
+                            model.clone(),
+                            spec.workspace.clone(),
+                            state_dir,
+                            forward_env,
+                            auth,
+                            permissions,
+                        )
+                        .await?,
+                    )
+                }
+                other => {
+                    return Err(format!(
+                        "unknown Codex mode '{other}'; expected exec or app_server"
+                    ))
+                }
+            }
         }
         ExecutorSpec::CliAdapter { .. } => {
             return Err("cli_adapter executor is not implemented yet".to_string());

--- a/tests/e2e_codex_app_server_manual.rs
+++ b/tests/e2e_codex_app_server_manual.rs
@@ -1,0 +1,163 @@
+//! Manual live smoke for Codex app-server mode.
+//!
+//! Run explicitly with an authenticated Codex installation:
+//! `cargo test --test e2e_codex_app_server_manual -- --ignored --nocapture`
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use bamboo_agent::codex_app_server_executor::CodexAppServerExecutor;
+use bamboo_agent::codex_cli_executor::{
+    resolve_codex_app_server_permission_config, CodexAuthConfig,
+};
+use bamboo_subagent::executor::{ChildExecutor, EventSink, HostBridge, SteerInbox};
+use bamboo_subagent::proto::{PermissionPolicyContext, RunSecrets, RunSpec};
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+#[ignore = "requires an authenticated real Codex CLI and intentionally exercises allow/deny command approvals"]
+async fn live_app_server_relays_allow_and_deny_across_resume() {
+    let workspace = tempfile::tempdir().unwrap();
+    let state = tempfile::tempdir().unwrap();
+    let home = std::env::var_os("HOME").expect("HOME is required for the live sandbox probe");
+    let marker = std::path::PathBuf::from(home).join(format!(
+        ".bamboo-codex-app-server-approval-{}",
+        std::process::id()
+    ));
+    let _ = tokio::fs::remove_file(&marker).await;
+
+    let permissions = resolve_codex_app_server_permission_config(
+        Some("workspace-write"),
+        Some("on-request"),
+        false,
+        false,
+        None,
+        false,
+        false,
+    )
+    .unwrap();
+    let executor = CodexAppServerExecutor::new(
+        None,
+        None,
+        Some(workspace.path().to_string_lossy().into_owned()),
+        Some(state.path().to_path_buf()),
+        Vec::new(),
+        CodexAuthConfig::inherit(),
+        permissions,
+    )
+    .await
+    .unwrap();
+
+    let (sink, mut event_rx) = EventSink::channel();
+    let (host, mut host_rx) = HostBridge::channel();
+    let approvals = Arc::new(Mutex::new(Vec::new()));
+    let seen = approvals.clone();
+    let approval_task = tokio::spawn(async move {
+        let mut decisions = std::collections::VecDeque::from([true, false]);
+        while let Some(request) = host_rx.recv().await {
+            seen.lock().await.push(request.body.clone());
+            let approved = decisions.pop_front().unwrap_or(false);
+            let _ = request
+                .reply
+                .send(serde_json::json!({"approved": approved}));
+        }
+    });
+    let prompt = format!(
+        "Use a shell command to create exactly this file outside the workspace, then report whether it succeeded: {}",
+        marker.display()
+    );
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(180),
+        executor.run(
+            RunSpec {
+                assignment: prompt,
+                reasoning_effort: None,
+                permission_policy: Some(PermissionPolicyContext {
+                    revision: 1,
+                    bypass_permissions: false,
+                    session_id: "manual-codex-app-server".to_string(),
+                    workspace_path: Some(workspace.path().to_string_lossy().into_owned()),
+                    inherit_session_grants: false,
+                    policy: serde_json::json!({}),
+                }),
+                messages: Vec::new(),
+                secrets: RunSecrets::default(),
+            },
+            sink.with_host_bridge(host.clone()),
+            SteerInbox::disconnected(),
+            CancellationToken::new(),
+        ),
+    )
+    .await
+    .expect("live Codex turn timeout");
+    assert_eq!(
+        outcome.status,
+        bamboo_subagent::proto::TerminalStatus::Completed
+    );
+    let allowed_executed = marker.exists();
+    let _ = tokio::fs::remove_file(&marker).await;
+    assert!(allowed_executed, "approved command did not execute");
+    let mut saw_complete = false;
+    while let Ok(event) = event_rx.try_recv() {
+        saw_complete |= event["type"] == "complete";
+    }
+    assert!(saw_complete);
+
+    let denied_marker = marker.with_file_name(format!(
+        ".bamboo-codex-app-server-denied-{}",
+        std::process::id()
+    ));
+    let _ = tokio::fs::remove_file(&denied_marker).await;
+    let (deny_sink, mut deny_events) = EventSink::channel();
+    let deny_outcome = tokio::time::timeout(
+        Duration::from_secs(180),
+        executor.run(
+            RunSpec {
+                assignment: format!(
+                    "Again use a shell command to create this exact file outside the workspace, then explain the result: {}",
+                    denied_marker.display()
+                ),
+                reasoning_effort: None,
+                permission_policy: Some(PermissionPolicyContext {
+                    revision: 2,
+                    bypass_permissions: false,
+                    session_id: "manual-codex-app-server".to_string(),
+                    workspace_path: Some(workspace.path().to_string_lossy().into_owned()),
+                    inherit_session_grants: false,
+                    policy: serde_json::json!({}),
+                }),
+                messages: vec![serde_json::json!({"role": "user", "content": "prior turn"})],
+                secrets: RunSecrets::default(),
+            },
+            deny_sink.with_host_bridge(host),
+            SteerInbox::disconnected(),
+            CancellationToken::new(),
+        ),
+    )
+    .await
+    .expect("live Codex deny turn timeout");
+    approval_task.abort();
+
+    let denied_executed = denied_marker.exists();
+    let _ = tokio::fs::remove_file(&denied_marker).await;
+    assert_eq!(
+        deny_outcome.status,
+        bamboo_subagent::proto::TerminalStatus::Completed
+    );
+    assert!(!denied_executed, "denied command unexpectedly executed");
+    assert!(
+        deny_outcome
+            .result
+            .as_deref()
+            .is_some_and(|text| !text.is_empty()),
+        "model did not receive/surface the denied tool result"
+    );
+    assert!(
+        approvals.lock().await.len() >= 2,
+        "expected allow and deny approvals"
+    );
+    assert!(
+        std::iter::from_fn(|| deny_events.try_recv().ok()).any(|event| event["type"] == "complete")
+    );
+}

--- a/tests/fixtures/codex-app-server/0.144.5-handshake-approval.jsonl
+++ b/tests/fixtures/codex-app-server/0.144.5-handshake-approval.jsonl
@@ -1,0 +1,11 @@
+{"direction":"client","message":{"id":1,"method":"initialize","params":{"clientInfo":{"name":"bamboo","title":"Bamboo","version":"0.0.0"},"capabilities":{"experimentalApi":true}}}}
+{"direction":"server","message":{"id":1,"result":{"userAgent":"codex_cli_rs/0.144.5"}}}
+{"direction":"client","message":{"method":"initialized","params":{}}}
+{"direction":"client","message":{"id":2,"method":"thread/start","params":{"approvalPolicy":"on-request","approvalsReviewer":"user","cwd":"/tmp/workspace","sandbox":"workspace-write"}}}
+{"direction":"server","message":{"id":2,"result":{"thread":{"id":"019f8977-a6ab-7d73-a3f5-510904f03bb3"},"model":"gpt-5.4","modelProvider":"bamboo","cwd":"/tmp/workspace","approvalPolicy":"on-request","approvalsReviewer":"user","sandbox":{"type":"workspaceWrite"}}}}
+{"direction":"client","message":{"id":3,"method":"turn/start","params":{"threadId":"019f8977-a6ab-7d73-a3f5-510904f03bb3","input":[{"type":"text","text":"write marker.txt","text_elements":[]}],"approvalPolicy":"on-request","approvalsReviewer":"user","sandboxPolicy":{"type":"workspaceWrite","writableRoots":["/tmp/workspace"],"networkAccess":false}}}}
+{"direction":"server","message":{"id":3,"result":{"turn":{"id":"019f8977-b2dd-7862-b10a-1ce2ca0c6c6f","status":"inProgress","items":[]}}}}
+{"direction":"server","message":{"id":41,"method":"item/fileChange/requestApproval","params":{"threadId":"019f8977-a6ab-7d73-a3f5-510904f03bb3","turnId":"019f8977-b2dd-7862-b10a-1ce2ca0c6c6f","itemId":"item_1","reason":"write marker.txt","grantRoot":"/tmp/workspace","startedAtMs":1784730000000}}}
+{"direction":"client","message":{"id":41,"result":{"decision":"accept"}}}
+{"direction":"server","message":{"method":"item/agentMessage/delta","params":{"threadId":"019f8977-a6ab-7d73-a3f5-510904f03bb3","turnId":"019f8977-b2dd-7862-b10a-1ce2ca0c6c6f","itemId":"item_2","delta":"Done."}}}
+{"direction":"server","message":{"method":"turn/completed","params":{"threadId":"019f8977-a6ab-7d73-a3f5-510904f03bb3","turn":{"id":"019f8977-b2dd-7862-b10a-1ce2ca0c6c6f","status":"completed","items":[]}}}}


### PR DESCRIPTION
## Summary

- add codex_mode = app_server as a long-lived JSON-RPC executor alongside the backward-compatible exec mode
- relay command and file approval requests through the existing parent HostBridge with a 300-second fail-closed timeout
- preserve session-scoped threads, resume with bounded history fallback, support steering, and interrupt then terminate the full process group on cancellation
- add app-server capability detection, mode-specific config validation, command-backed per-run Bamboo auth, recorded protocol fixtures, docs, and live allow/deny coverage

Refs #574

## Test Plan

- cargo fmt --all -- --check
- cargo test -- --skip server::tls::tests::build_rustls_config_succeeds_on_valid_self_signed_cert
- cargo clippy --workspace --all-targets
- cargo clippy -p bamboo-agent --all-targets --no-deps -- -D warnings
- cargo test --test e2e_codex_app_server_manual -- --ignored --nocapture

The one skipped TLS test fails with UnsupportedCertVersion on this macOS host and was independently reproduced at clean origin/main 47e14402; all other workspace tests pass.