### PR TITLE
fix: persist transcripts across agent errors

### DIFF
--- a/crates/core/bamboo-domain/src/session/persistence.rs
+++ b/crates/core/bamboo-domain/src/session/persistence.rs
@@ -3,6 +3,32 @@ use std::sync::Arc;
 
 use crate::session::types::Session;
 
+/// Merge messages from a live runner snapshot into an already-durable
+/// transcript without ever removing or rewriting a durable message.
+///
+/// Runtime sessions are append-oriented, and every newly-created message has a
+/// stable id.  A runner may nevertheless be holding a snapshot that predates a
+/// concurrent append (for example, an injected child-completion message).  A
+/// terminal/error checkpoint must not full-save that stale snapshot: doing so
+/// would shrink the transcript.  Keep the durable ordering and append only the
+/// live messages whose ids are not durable yet.
+pub fn append_missing_runtime_messages(session: &mut Session, durable: &Session) -> usize {
+    let mut seen = durable
+        .messages
+        .iter()
+        .map(|message| message.id.clone())
+        .collect::<std::collections::HashSet<_>>();
+    let missing = session
+        .messages
+        .iter()
+        .filter(|message| seen.insert(message.id.clone()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let appended = missing.len();
+    session.messages = durable.messages.iter().cloned().chain(missing).collect();
+    appended
+}
+
 /// Port for runtime (non-authoritative) session persistence.
 ///
 /// Implementors must:
@@ -13,6 +39,22 @@ use crate::session::types::Session;
 pub trait RuntimeSessionPersistence: Send + Sync {
     /// Persist the session, merging any newer authoritative metadata from disk.
     async fn save_runtime_session(&self, session: &mut Session) -> io::Result<()>;
+
+    /// Append-safe checkpoint used at the shared engine execute boundary.
+    ///
+    /// Unlike [`save_runtime_session`](Self::save_runtime_session), this must
+    /// preserve messages that were appended durably by a concurrent writer
+    /// after the runner loaded its snapshot.  Implementations that can provide
+    /// a per-session transaction should override this method and perform the
+    /// load/merge/save under one lock.  The default still reconciles against a
+    /// latest snapshot for lightweight/custom SDK persisters; the built-in
+    /// storage implementation supplies the atomic variant.
+    async fn checkpoint_runtime_session(&self, session: &mut Session) -> io::Result<()> {
+        if let Some(durable) = self.load_runtime_session(&session.id).await? {
+            append_missing_runtime_messages(session, &durable);
+        }
+        self.save_runtime_session(session).await
+    }
 
     /// Load the latest runtime-visible session snapshot when the persistence
     /// implementation can coordinate reads. Tools may update a repository-owned
@@ -37,6 +79,10 @@ pub trait RuntimeSessionPersistence: Send + Sync {
 impl<T: RuntimeSessionPersistence + ?Sized> RuntimeSessionPersistence for Arc<T> {
     async fn save_runtime_session(&self, session: &mut Session) -> io::Result<()> {
         (**self).save_runtime_session(session).await
+    }
+
+    async fn checkpoint_runtime_session(&self, session: &mut Session) -> io::Result<()> {
+        (**self).checkpoint_runtime_session(session).await
     }
 
     async fn load_runtime_session(&self, session_id: &str) -> io::Result<Option<Session>> {

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -1714,6 +1714,12 @@ pub(super) async fn run_pipeline(
         let mut round_activity = RoundActivity::default();
 
         for attempt in 1..=MAX_LLM_TURN_ATTEMPTS {
+            // Retry cleanup may remove only an interrupted record created by
+            // THIS attempt.  An older durable interrupted tail can legitimately
+            // be the session's starting point and must never be mistaken for a
+            // transient record when context preparation/provider dispatch fails
+            // before streaming starts.
+            let attempt_tail_message_id = session.messages.last().map(|message| message.id.clone());
             let llm_output = match crate::runtime::runner::round_lifecycle::execute_llm_round(
                 session,
                 config,
@@ -1829,6 +1835,16 @@ pub(super) async fn run_pipeline(
                             break;
                         }
                     } else if should_retry_turn_error(&error) && attempt < MAX_LLM_TURN_ATTEMPTS {
+                        // A failed stream may have materialized already-visible
+                        // output as an interrupted transcript record.  Keep it
+                        // only when the error becomes terminal; a retry must not
+                        // feed the partial assistant turn back into the next
+                        // provider request or leave duplicate failed attempts in
+                        // the durable transcript.
+                        crate::runtime::runner::round_lifecycle::discard_latest_interrupted_assistant_output(
+                            session,
+                            attempt_tail_message_id.as_deref(),
+                        );
                         let delay_ms = LLM_RETRY_BASE_DELAY_MS * (1u64 << (attempt - 1));
                         tracing::warn!(
                             "[{}] Turn {} LLM call failed (attempt {}/{}): {}. Retrying in {}ms",
@@ -1975,6 +1991,10 @@ pub(super) async fn run_pipeline(
                 }
                 Err(error) => {
                     if should_retry_turn_error(&error) && attempt < MAX_LLM_TURN_ATTEMPTS {
+                        crate::runtime::runner::round_lifecycle::discard_latest_interrupted_assistant_output(
+                            session,
+                            attempt_tail_message_id.as_deref(),
+                        );
                         let delay_ms = LLM_RETRY_BASE_DELAY_MS * (1u64 << (attempt - 1));
                         tracing::warn!(
                             "[{}] Turn {} post-LLM handling failed (attempt {}/{}): {}. Retrying in {}ms",

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle.rs
@@ -21,6 +21,7 @@ mod token_budget;
 mod token_estimation;
 
 pub(crate) use context_preparation::force_overflow_context_recovery;
+pub(crate) use stream_execution::discard_latest_interrupted_assistant_output;
 
 pub(crate) struct RoundLlmExecutionOutput {
     pub stream_output: StreamHandlingOutput,

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
@@ -23,7 +23,7 @@ use bamboo_agent_core::agent::events::TokenBudgetUsage;
 use bamboo_agent_core::tools::ToolSchema;
 use bamboo_agent_core::{
     AgentError, AgentEvent, ContextBlock, ContextBlockPriority, ContextBlockStability,
-    ContextBlockType, Message, Role, Session,
+    ContextBlockType, Message, MessagePhase, Role, Session,
 };
 use bamboo_compression::PreparedContext;
 use bamboo_domain::ReasoningEffort;
@@ -51,6 +51,79 @@ pub(in crate::runtime::runner) struct LlmStreamFrame<'a> {
 
 const SESSION_RESPONSES_PREVIOUS_RESPONSE_ID_KEY: &str = "responses.previous_response_id";
 const CONVERSATION_SUMMARY_START_MARKER: &str = "<!-- CONVERSATION_SUMMARY_START -->";
+const INTERRUPTED_ASSISTANT_OUTPUT_KIND: &str = "interrupted_assistant_output";
+
+fn interruption_kind(error: &AgentError) -> &'static str {
+    match error {
+        AgentError::Cancelled => "cancelled",
+        AgentError::StreamTimeout(_) => "stream_timeout",
+        AgentError::LLMOverflow(_) => "llm_overflow",
+        AgentError::LLM(_) => "llm_error",
+        _ => "execution_error",
+    }
+}
+
+/// Materialize already-received semantic output as a non-executable transcript
+/// record before the stream error leaves the round.
+///
+/// Partial tool-call fragments are diagnostic metadata only.  They are never
+/// assigned to `Message::tool_calls`, so a resume cannot replay an incomplete
+/// call as though the model had completed it.
+fn append_interrupted_assistant_output(
+    session: &mut Session,
+    partial: crate::runtime::stream::handler::InterruptedStreamOutput,
+    error: &AgentError,
+) -> bool {
+    if partial.content.is_empty()
+        && partial.reasoning_content.is_empty()
+        && partial.partial_tool_calls.is_empty()
+    {
+        return false;
+    }
+
+    let partial_tool_calls = (!partial.partial_tool_calls.is_empty()).then(|| {
+        serde_json::to_value(&partial.partial_tool_calls).unwrap_or(serde_json::Value::Null)
+    });
+    let mut message = Message::assistant_with_reasoning(
+        partial.content,
+        None,
+        (!partial.reasoning_content.is_empty()).then_some(partial.reasoning_content),
+    );
+    message.phase = Some(MessagePhase::Commentary);
+    message.reasoning_signature = None;
+    message.metadata = Some(serde_json::json!({
+        "runtime_kind": INTERRUPTED_ASSISTANT_OUTPUT_KIND,
+        "interrupted": true,
+        "interruption_kind": interruption_kind(error),
+        "partial_tool_calls": partial_tool_calls,
+    }));
+    session.add_message(message);
+    true
+}
+
+/// Remove the transient partial record before a retry.  A terminal attempt
+/// leaves it in place for the shared execute-boundary checkpoint.
+pub(crate) fn discard_latest_interrupted_assistant_output(
+    session: &mut Session,
+    attempt_tail_message_id: Option<&str>,
+) -> bool {
+    let interrupted = session.messages.last().is_some_and(|message| {
+        if Some(message.id.as_str()) == attempt_tail_message_id {
+            return false;
+        }
+        message
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get("runtime_kind"))
+            .and_then(serde_json::Value::as_str)
+            == Some(INTERRUPTED_ASSISTANT_OUTPUT_KIND)
+    });
+    if interrupted {
+        session.messages.pop();
+        session.updated_at = chrono::Utc::now();
+    }
+    interrupted
+}
 
 fn session_previous_response_id(session: &Session) -> Option<&str> {
     session
@@ -851,27 +924,44 @@ pub(super) async fn execute_llm_stream(
     // Keep that first stream silent; the pipeline verifies and executes the
     // model-issued call, then later rounds stream normally once activation is
     // mirrored into the runner-owned Session.
-    let stream_output =
+    let stream_output_result =
         if crate::runtime::runner::session_setup::skill_context::explicit_activation_pending(
             session,
         ) {
-            crate::runtime::stream::handler::consume_llm_stream_silent_with_context(
+            crate::runtime::stream::handler::consume_llm_stream_silent_with_context_and_partial(
                 stream,
                 cancel_token,
                 session_id,
                 &timeout_context,
             )
-            .await?
+            .await
         } else {
-            crate::runtime::stream::handler::consume_llm_stream_with_context(
+            crate::runtime::stream::handler::consume_llm_stream_with_context_and_partial(
                 stream,
                 event_tx,
                 cancel_token,
                 session_id,
                 &timeout_context,
             )
-            .await?
+            .await
         };
+    let stream_output = match stream_output_result {
+        Ok(output) => output,
+        Err(failure) => {
+            let appended = append_interrupted_assistant_output(
+                session,
+                failure.partial_output,
+                &failure.error,
+            );
+            if appended {
+                tracing::warn!(
+                    "[{}] Preserved interrupted partial assistant output in the live transcript",
+                    session_id
+                );
+            }
+            return Err(failure.error);
+        }
+    };
 
     // Update session token usage with actual output/thinking/cache stats from the LLM response.
     if let Some(ref mut usage) = session.token_usage {

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -773,6 +773,33 @@ impl AgentRuntime {
         )
         .await;
 
+        // The runtime is the one shared execute boundary for HTTP, child-agent
+        // and direct SDK callers.  Checkpoint here on every outcome so durable
+        // transcript correctness never depends on a caller-specific finalize
+        // wrapper (and normal completions without a TaskLoopContext are saved
+        // too).  The checkpoint is append-safe: a stale live snapshot cannot
+        // shrink/rewrite messages appended concurrently on disk.
+        //
+        // Persistence failure must not replace the execution outcome.  In
+        // particular, callers need the original LLM/cancellation error for
+        // retry and terminal-status mapping; the failed durability attempt is
+        // recorded separately.
+        if let Err(checkpoint_error) = self.persistence.checkpoint_runtime_session(session).await {
+            match &result {
+                Ok(()) => tracing::warn!(
+                    session_id = %session.id,
+                    error = %checkpoint_error,
+                    "failed to checkpoint session transcript after successful execution"
+                ),
+                Err(execution_error) => tracing::warn!(
+                    session_id = %session.id,
+                    error = %checkpoint_error,
+                    execution_error = %execution_error,
+                    "failed to checkpoint session transcript after execution error"
+                ),
+            }
+        }
+
         result
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
@@ -79,6 +79,45 @@ pub struct StreamHandlingOutput {
     pub input_tokens: u64,
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct PartialToolCallSnapshot {
+    pub id: String,
+    pub tool_type: String,
+    pub name: String,
+    pub arguments: String,
+    pub index: Option<u32>,
+}
+
+/// Crate-private interrupted-stream payload.  Keeping this separate from the
+/// public successful [`StreamHandlingOutput`] avoids a source-breaking public
+/// field while retaining fragments that finalization intentionally drops or
+/// normalizes.
+pub(crate) struct InterruptedStreamOutput {
+    pub content: String,
+    pub reasoning_content: String,
+    pub partial_tool_calls: Vec<PartialToolCallSnapshot>,
+}
+
+impl From<&bamboo_agent_core::tools::PartialToolCall> for PartialToolCallSnapshot {
+    fn from(value: &bamboo_agent_core::tools::PartialToolCall) -> Self {
+        Self {
+            id: value.id.clone(),
+            tool_type: value.tool_type.clone(),
+            name: value.name.clone(),
+            arguments: value.arguments.clone(),
+            index: value.index,
+        }
+    }
+}
+
+/// A stream failure together with every semantic fragment accumulated before
+/// the failure.  The agent round uses this to create a durable, explicitly
+/// interrupted assistant record instead of losing already-visible output.
+pub(crate) struct StreamHandlingFailure {
+    pub error: AgentError,
+    pub partial_output: InterruptedStreamOutput,
+}
+
 pub async fn consume_llm_stream(
     stream: LLMStream,
     event_tx: &mpsc::Sender<AgentEvent>,
@@ -112,6 +151,23 @@ pub async fn consume_llm_stream_with_context(
     .await
 }
 
+pub(crate) async fn consume_llm_stream_with_context_and_partial(
+    stream: LLMStream,
+    event_tx: &mpsc::Sender<AgentEvent>,
+    cancel_token: &CancellationToken,
+    session_id: &str,
+    timeout_context: &StreamTimeoutContext,
+) -> Result<StreamHandlingOutput, StreamHandlingFailure> {
+    consume::consume_llm_stream_internal_with_partial(
+        stream,
+        Some(event_tx),
+        cancel_token,
+        session_id,
+        timeout_context,
+    )
+    .await
+}
+
 pub async fn consume_llm_stream_silent(
     stream: LLMStream,
     cancel_token: &CancellationToken,
@@ -134,6 +190,22 @@ pub async fn consume_llm_stream_silent_with_context(
 ) -> Result<StreamHandlingOutput, AgentError> {
     consume::consume_llm_stream_internal(stream, None, cancel_token, session_id, timeout_context)
         .await
+}
+
+pub(crate) async fn consume_llm_stream_silent_with_context_and_partial(
+    stream: LLMStream,
+    cancel_token: &CancellationToken,
+    session_id: &str,
+    timeout_context: &StreamTimeoutContext,
+) -> Result<StreamHandlingOutput, StreamHandlingFailure> {
+    consume::consume_llm_stream_internal_with_partial(
+        stream,
+        None,
+        cancel_token,
+        session_id,
+        timeout_context,
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/consume.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/consume.rs
@@ -10,7 +10,7 @@ use bamboo_llm::{LLMChunk, LLMStream};
 
 use super::chunk_handling::handle_chunk_result;
 use super::stream_state::StreamAccumulationState;
-use super::{StreamHandlingOutput, StreamTimeoutContext};
+use super::{StreamHandlingFailure, StreamHandlingOutput, StreamTimeoutContext};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StreamTimeoutPhase {
@@ -112,12 +112,30 @@ fn preview_for_log(value: &str, max_chars: usize) -> String {
 }
 
 pub(super) async fn consume_llm_stream_internal(
-    mut stream: LLMStream,
+    stream: LLMStream,
     event_tx: Option<&mpsc::Sender<AgentEvent>>,
     cancel_token: &CancellationToken,
     session_id: &str,
     timeout_context: &StreamTimeoutContext,
 ) -> Result<StreamHandlingOutput, AgentError> {
+    consume_llm_stream_internal_with_partial(
+        stream,
+        event_tx,
+        cancel_token,
+        session_id,
+        timeout_context,
+    )
+    .await
+    .map_err(|failure| failure.error)
+}
+
+pub(super) async fn consume_llm_stream_internal_with_partial(
+    mut stream: LLMStream,
+    event_tx: Option<&mpsc::Sender<AgentEvent>>,
+    cancel_token: &CancellationToken,
+    session_id: &str,
+    timeout_context: &StreamTimeoutContext,
+) -> Result<StreamHandlingOutput, StreamHandlingFailure> {
     let mut state = StreamAccumulationState::new();
     let policy = timeout_context.policy;
     let started_at = tokio::time::Instant::now();
@@ -146,7 +164,12 @@ pub(super) async fn consume_llm_stream_internal(
         // the earliest independent watchdog deadline.
         let chunk_result = tokio::select! {
             biased;
-            _ = cancel_token.cancelled() => return Err(AgentError::Cancelled),
+            _ = cancel_token.cancelled() => {
+                return Err(StreamHandlingFailure {
+                    error: AgentError::Cancelled,
+                    partial_output: state.into_interrupted_output(),
+                });
+            },
             next = stream.next() => match next {
                 Some(chunk_result) => chunk_result,
                 None => break,
@@ -158,15 +181,18 @@ pub(super) async fn consume_llm_stream_internal(
                 } else {
                     (semantic_phase, semantic_timeout)
                 };
-                return Err(timeout_error(
-                    timeout_context,
-                    session_id,
-                    phase,
-                    deadline,
-                    now,
-                    last_transport_at,
-                    last_semantic_at,
-                ));
+                return Err(StreamHandlingFailure {
+                    error: timeout_error(
+                        timeout_context,
+                        session_id,
+                        phase,
+                        deadline,
+                        now,
+                        last_transport_at,
+                        last_semantic_at,
+                    ),
+                    partial_output: state.into_interrupted_output(),
+                });
             }
         };
 
@@ -180,19 +206,29 @@ pub(super) async fn consume_llm_stream_internal(
                 // semantic timer merely because `stream.next()` is intentionally
                 // ordered before the timer in the biased select. A semantic
                 // chunk ready at the boundary is accepted above and resets it.
-                return Err(timeout_error(
-                    timeout_context,
-                    session_id,
-                    semantic_phase,
-                    semantic_timeout,
-                    now,
-                    last_transport_at,
-                    last_semantic_at,
-                ));
+                return Err(StreamHandlingFailure {
+                    error: timeout_error(
+                        timeout_context,
+                        session_id,
+                        semantic_phase,
+                        semantic_timeout,
+                        now,
+                        last_transport_at,
+                        last_semantic_at,
+                    ),
+                    partial_output: state.into_interrupted_output(),
+                });
             }
         }
 
-        handle_chunk_result(chunk_result, &mut state, event_tx, session_id).await?;
+        if let Err(error) =
+            handle_chunk_result(chunk_result, &mut state, event_tx, session_id).await
+        {
+            return Err(StreamHandlingFailure {
+                error,
+                partial_output: state.into_interrupted_output(),
+            });
+        }
     }
 
     let output = state.into_output();

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/stream_state.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/stream_state.rs
@@ -1,6 +1,6 @@
 use bamboo_agent_core::tools::ToolCallAccumulator;
 
-use super::StreamHandlingOutput;
+use super::{InterruptedStreamOutput, PartialToolCallSnapshot, StreamHandlingOutput};
 
 pub(super) struct StreamAccumulationState {
     response_id: Option<String>,
@@ -108,6 +108,19 @@ impl StreamAccumulationState {
             cache_creation_input_tokens: self.cache_creation_input_tokens,
             cache_read_input_tokens: self.cache_read_input_tokens,
             input_tokens: self.input_tokens,
+        }
+    }
+
+    pub(super) fn into_interrupted_output(self) -> InterruptedStreamOutput {
+        InterruptedStreamOutput {
+            content: self.content,
+            reasoning_content: self.reasoning_content,
+            partial_tool_calls: self
+                .tool_calls
+                .parts()
+                .iter()
+                .map(PartialToolCallSnapshot::from)
+                .collect(),
         }
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/tests.rs
@@ -1,14 +1,21 @@
 use std::sync::Arc;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
+use async_trait::async_trait;
 use bamboo_agent_core::composition::CompositionExecutor;
+use bamboo_agent_core::storage::Storage;
 use bamboo_agent_core::tools::{
     execute_tool_call, handle_tool_result_with_agentic_support, AgenticToolResult, FunctionCall,
-    ToolCall, ToolExecutor, ToolHandlingOutcome, ToolRegistry, ToolResult,
+    ToolCall, ToolError, ToolExecutor, ToolHandlingOutcome, ToolRegistry, ToolResult, ToolSchema,
 };
-use bamboo_agent_core::{AgentEvent, Session};
+use bamboo_agent_core::{AgentEvent, Message, Session};
+use bamboo_domain::RuntimeSessionPersistence;
+use bamboo_llm::{LLMChunk, LLMError, LLMProvider, LLMStream};
 use bamboo_tools::BuiltinToolExecutor;
-use tokio::sync::mpsc;
+use futures::stream;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::{mpsc, RwLock};
+use tokio_util::sync::CancellationToken;
 
 use super::config::AgentLoopConfig;
 
@@ -245,4 +252,535 @@ async fn execute_tool_call_falls_back_when_composition_misses_tool() {
 
     assert!(result.success);
     assert!(!result.result.is_empty());
+}
+
+struct CompletedTranscriptProvider;
+
+#[async_trait]
+impl LLMProvider for CompletedTranscriptProvider {
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[bamboo_agent_core::tools::ToolSchema],
+        _max_output_tokens: Option<u32>,
+        _model: &str,
+    ) -> Result<LLMStream, LLMError> {
+        Ok(Box::pin(stream::iter(vec![
+            Ok(LLMChunk::Token("durable final answer".to_string())),
+            Ok(LLMChunk::Done),
+        ])))
+    }
+}
+
+struct PartialThenTerminalErrorProvider;
+
+#[async_trait]
+impl LLMProvider for PartialThenTerminalErrorProvider {
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[bamboo_agent_core::tools::ToolSchema],
+        _max_output_tokens: Option<u32>,
+        _model: &str,
+    ) -> Result<LLMStream, LLMError> {
+        // An early indexed argument fragment has neither provider id nor tool
+        // name yet.  Finalizing ToolCallAccumulator would drop it; the
+        // interrupted-output snapshot must retain it verbatim without inventing
+        // an id or exposing it as an executable Message::tool_calls entry.
+        let partial_call = ToolCall {
+            id: String::new(),
+            tool_type: String::new(),
+            function: FunctionCall {
+                name: String::new(),
+                arguments: r#"{"file_path""#.to_string(),
+            },
+        };
+        Ok(Box::pin(stream::iter(vec![
+            Ok(LLMChunk::Token("visible before failure".to_string())),
+            Ok(LLMChunk::ToolCallsIndexed(vec![(0, partial_call)])),
+            Err(LLMError::Api(
+                "authentication error: intentional terminal stream failure".to_string(),
+            )),
+        ])))
+    }
+}
+
+struct NeverCalledTranscriptProvider;
+
+#[async_trait]
+impl LLMProvider for NeverCalledTranscriptProvider {
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[bamboo_agent_core::tools::ToolSchema],
+        _max_output_tokens: Option<u32>,
+        _model: &str,
+    ) -> Result<LLMStream, LLMError> {
+        panic!("pre-cancelled direct execute must not call the provider")
+    }
+}
+
+struct ImmediateTerminalErrorProvider;
+
+#[async_trait]
+impl LLMProvider for ImmediateTerminalErrorProvider {
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[bamboo_agent_core::tools::ToolSchema],
+        _max_output_tokens: Option<u32>,
+        _model: &str,
+    ) -> Result<LLMStream, LLMError> {
+        Err(LLMError::Api(
+            "authentication error: original execution failure".to_string(),
+        ))
+    }
+}
+
+struct MidLoopThenPartialErrorProvider {
+    calls: AtomicUsize,
+}
+
+struct RetryBeforeStreamThenSuccessProvider {
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl LLMProvider for RetryBeforeStreamThenSuccessProvider {
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSchema],
+        _max_output_tokens: Option<u32>,
+        _model: &str,
+    ) -> Result<LLMStream, LLMError> {
+        match self.calls.fetch_add(1, Ordering::SeqCst) {
+            0 => Err(LLMError::Api(
+                "temporary provider dispatch failure".to_string(),
+            )),
+            1 => Ok(Box::pin(stream::iter(vec![
+                Ok(LLMChunk::Token("retry recovered".to_string())),
+                Ok(LLMChunk::Done),
+            ]))),
+            call => panic!("unexpected LLM call {call}"),
+        }
+    }
+}
+
+#[async_trait]
+impl LLMProvider for MidLoopThenPartialErrorProvider {
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSchema],
+        _max_output_tokens: Option<u32>,
+        _model: &str,
+    ) -> Result<LLMStream, LLMError> {
+        match self.calls.fetch_add(1, Ordering::SeqCst) {
+            0 => Ok(Box::pin(stream::iter(vec![
+                Ok(LLMChunk::ToolCalls(vec![make_tool_call(
+                    "mid-loop-call",
+                    "Read",
+                    r#"{"file_path":"demo"}"#,
+                )])),
+                Ok(LLMChunk::Done),
+            ]))),
+            1 => {
+                let fragment = ToolCall {
+                    id: String::new(),
+                    tool_type: String::new(),
+                    function: FunctionCall {
+                        name: String::new(),
+                        arguments: "{\"next".to_string(),
+                    },
+                };
+                Ok(Box::pin(stream::iter(vec![
+                    Ok(LLMChunk::Token("second-round partial".to_string())),
+                    Ok(LLMChunk::ToolCallsIndexed(vec![(0, fragment)])),
+                    Err(LLMError::Api(
+                        "authentication error: terminal second-round failure".to_string(),
+                    )),
+                ])))
+            }
+            call => panic!("unexpected LLM call {call}"),
+        }
+    }
+}
+
+struct SuccessfulReadToolExecutor;
+
+#[async_trait]
+impl ToolExecutor for SuccessfulReadToolExecutor {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, ToolError> {
+        assert_eq!(call.id, "mid-loop-call");
+        Ok(ToolResult {
+            success: true,
+            result: "mid-loop tool result".to_string(),
+            display_preference: None,
+            images: Vec::new(),
+        })
+    }
+
+    fn list_tools(&self) -> Vec<ToolSchema> {
+        vec![ToolSchema {
+            schema_type: "function".to_string(),
+            function: bamboo_agent_core::tools::FunctionSchema {
+                name: "Read".to_string(),
+                description: "test read".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+            },
+        }]
+    }
+}
+
+struct FailingCheckpointPersistence {
+    attempts: AtomicUsize,
+}
+
+#[async_trait]
+impl RuntimeSessionPersistence for FailingCheckpointPersistence {
+    async fn save_runtime_session(&self, _session: &mut Session) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    async fn checkpoint_runtime_session(&self, _session: &mut Session) -> std::io::Result<()> {
+        self.attempts.fetch_add(1, Ordering::SeqCst);
+        Err(std::io::Error::other("intentional checkpoint failure"))
+    }
+}
+
+async fn build_direct_execute_agent(
+    provider: Arc<dyn LLMProvider>,
+    persistence_override: Option<Arc<dyn RuntimeSessionPersistence>>,
+    tools_override: Option<Arc<dyn ToolExecutor>>,
+) -> (tempfile::TempDir, crate::runtime::Agent, Arc<dyn Storage>) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let session_store = Arc::new(
+        bamboo_storage::SessionStoreV2::new(temp.path().join("sessions"))
+            .await
+            .expect("session store"),
+    );
+    let storage: Arc<dyn Storage> = session_store.clone();
+    let persistence = persistence_override.unwrap_or_else(|| {
+        Arc::new(bamboo_storage::LockedSessionStore::new(storage.clone()))
+            as Arc<dyn RuntimeSessionPersistence>
+    });
+    let metrics = bamboo_metrics::MetricsCollector::spawn(
+        Arc::new(bamboo_metrics::SqliteMetricsStorage::new(
+            temp.path().join("metrics.db"),
+        )),
+        7,
+    );
+    let agent = crate::runtime::Agent::builder()
+        .storage(storage.clone())
+        .persistence(persistence)
+        .attachment_reader(session_store)
+        .skill_manager(Arc::new(bamboo_skills::SkillManager::new()))
+        .metrics_collector(metrics)
+        .config(Arc::new(RwLock::new(bamboo_llm::Config::default())))
+        .provider(provider)
+        .default_tools(tools_override.unwrap_or_else(|| Arc::new(BuiltinToolExecutor::new())))
+        .build()
+        .expect("direct execute agent");
+    (temp, agent, storage)
+}
+
+fn direct_request(
+    event_tx: mpsc::Sender<AgentEvent>,
+    cancel_token: CancellationToken,
+) -> crate::runtime::ExecuteRequest {
+    crate::runtime::ExecuteRequestBuilder::new("", event_tx, cancel_token)
+        .model("test-model")
+        .build()
+}
+
+#[tokio::test]
+async fn direct_execute_checkpoints_normal_completion_without_task_context() {
+    let (_temp, agent, storage) =
+        build_direct_execute_agent(Arc::new(CompletedTranscriptProvider), None, None).await;
+    let mut session = Session::new("direct-normal-checkpoint", "test-model");
+    session.add_message(Message::user("finish normally"));
+    storage.save_session(&session).await.unwrap();
+
+    let (event_tx, _event_rx) = mpsc::channel(32);
+    agent
+        .execute(
+            &mut session,
+            direct_request(event_tx, CancellationToken::new()),
+        )
+        .await
+        .expect("normal execute");
+
+    let saved = storage
+        .load_session(&session.id)
+        .await
+        .unwrap()
+        .expect("saved session");
+    assert!(saved
+        .messages
+        .iter()
+        .any(|message| message.content == "durable final answer"));
+    assert!(saved.agent_runtime_state.as_ref().is_some_and(|state| {
+        matches!(state.status, bamboo_domain::AgentStatusState::Completed)
+    }));
+}
+
+#[tokio::test]
+async fn retryable_pre_stream_error_does_not_delete_existing_interrupted_tail() {
+    let provider = Arc::new(RetryBeforeStreamThenSuccessProvider {
+        calls: AtomicUsize::new(0),
+    });
+    let (_temp, agent, storage) = build_direct_execute_agent(provider.clone(), None, None).await;
+    let mut session = Session::new("retry-preserves-old-interrupted", "test-model");
+    session.add_message(Message::user("base"));
+    let mut old_interrupted = Message::assistant("old interrupted output", None);
+    old_interrupted.id = "old-interrupted".to_string();
+    old_interrupted.metadata = Some(serde_json::json!({
+        "runtime_kind": "interrupted_assistant_output",
+        "interrupted": true,
+        "interruption_kind": "llm_error",
+    }));
+    session.add_message(old_interrupted);
+    storage.save_session(&session).await.unwrap();
+    let (event_tx, _event_rx) = mpsc::channel(64);
+
+    agent
+        .execute(
+            &mut session,
+            direct_request(event_tx, CancellationToken::new()),
+        )
+        .await
+        .expect("retry should recover");
+
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+    let saved = storage
+        .load_session(&session.id)
+        .await
+        .unwrap()
+        .expect("saved session");
+    assert!(saved
+        .messages
+        .iter()
+        .any(|message| message.id == "old-interrupted"));
+    assert!(saved
+        .messages
+        .iter()
+        .any(|message| message.content == "retry recovered"));
+}
+
+#[tokio::test]
+async fn direct_execute_persists_partial_stream_error_without_false_completion_or_tool_replay() {
+    let (_temp, agent, storage) =
+        build_direct_execute_agent(Arc::new(PartialThenTerminalErrorProvider), None, None).await;
+    let mut session = Session::new("direct-partial-error", "test-model");
+    session.add_message(Message::user("start streaming"));
+    storage.save_session(&session).await.unwrap();
+
+    let (event_tx, mut event_rx) = mpsc::channel(64);
+    let error = agent
+        .execute(
+            &mut session,
+            direct_request(event_tx, CancellationToken::new()),
+        )
+        .await
+        .expect_err("stream must fail");
+    assert!(matches!(error, bamboo_agent_core::AgentError::LLM(_)));
+
+    let saved = storage
+        .load_session(&session.id)
+        .await
+        .unwrap()
+        .expect("saved session");
+    let interrupted = saved
+        .messages
+        .iter()
+        .find(|message| {
+            message
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("runtime_kind"))
+                .and_then(serde_json::Value::as_str)
+                == Some("interrupted_assistant_output")
+        })
+        .expect("interrupted partial assistant message");
+    assert_eq!(interrupted.content, "visible before failure");
+    assert!(
+        interrupted.tool_calls.is_none(),
+        "partial calls are not executable"
+    );
+    assert!(interrupted
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("partial_tool_calls"))
+        .is_some_and(|calls| calls.is_array()));
+    let fragment = interrupted
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("partial_tool_calls"))
+        .and_then(serde_json::Value::as_array)
+        .and_then(|calls| calls.first())
+        .expect("raw partial tool-call fragment");
+    assert_eq!(fragment["id"], "");
+    assert_eq!(fragment["name"], "");
+    assert_eq!(fragment["arguments"], r#"{"file_path""#);
+    assert_eq!(fragment["index"], 0);
+    assert!(!saved.agent_runtime_state.as_ref().is_some_and(|state| {
+        matches!(state.status, bamboo_domain::AgentStatusState::Completed)
+    }));
+    while let Ok(event) = event_rx.try_recv() {
+        assert!(!matches!(event, AgentEvent::Complete { .. }));
+    }
+}
+
+#[tokio::test]
+async fn direct_execute_cancel_checkpoints_committed_messages_without_false_completion() {
+    let (_temp, agent, storage) =
+        build_direct_execute_agent(Arc::new(NeverCalledTranscriptProvider), None, None).await;
+    let mut durable = Session::new("direct-cancel-checkpoint", "test-model");
+    durable.add_message(Message::user("base"));
+    storage.save_session(&durable).await.unwrap();
+
+    let mut session = durable;
+    let tool_call = make_tool_call("committed-call", "Read", r#"{"file_path":"x"}"#);
+    session.add_message(Message::assistant("", Some(vec![tool_call])));
+    session.add_message(Message::tool_result("committed-call", "committed result"));
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+    let (event_tx, mut event_rx) = mpsc::channel(32);
+
+    let error = agent
+        .execute(&mut session, direct_request(event_tx, cancel))
+        .await
+        .expect_err("cancelled execute");
+    assert!(matches!(error, bamboo_agent_core::AgentError::Cancelled));
+
+    let saved = storage
+        .load_session(&session.id)
+        .await
+        .unwrap()
+        .expect("saved session");
+    assert!(saved
+        .messages
+        .iter()
+        .any(|message| message.content == "committed result"));
+    assert!(!saved.agent_runtime_state.as_ref().is_some_and(|state| {
+        matches!(state.status, bamboo_domain::AgentStatusState::Completed)
+    }));
+    while let Ok(event) = event_rx.try_recv() {
+        assert!(!matches!(event, AgentEvent::Complete { .. }));
+    }
+}
+
+#[tokio::test]
+async fn direct_execute_mid_loop_error_persists_tool_round_and_interrupted_next_round() {
+    let provider = Arc::new(MidLoopThenPartialErrorProvider {
+        calls: AtomicUsize::new(0),
+    });
+    let (_temp, agent, storage) = build_direct_execute_agent(
+        provider.clone(),
+        None,
+        Some(Arc::new(SuccessfulReadToolExecutor)),
+    )
+    .await;
+    let mut session = Session::new("direct-mid-loop-error", "test-model");
+    session.add_message(Message::user("run a tool then fail"));
+    storage.save_session(&session).await.unwrap();
+    let (event_tx, mut event_rx) = mpsc::channel(128);
+
+    let error = agent
+        .execute(
+            &mut session,
+            direct_request(event_tx, CancellationToken::new()),
+        )
+        .await
+        .expect_err("second round must fail");
+    assert!(matches!(
+        error,
+        bamboo_agent_core::AgentError::LLM(message)
+            if message.contains("terminal second-round failure")
+    ));
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+
+    let saved = storage
+        .load_session(&session.id)
+        .await
+        .unwrap()
+        .expect("saved session");
+    let assistant_tool_call = saved
+        .messages
+        .iter()
+        .find(|message| {
+            message
+                .tool_calls
+                .as_ref()
+                .is_some_and(|calls| calls.iter().any(|call| call.id == "mid-loop-call"))
+        })
+        .expect("first-round assistant tool call");
+    assert!(assistant_tool_call.content.is_empty());
+    assert!(saved.messages.iter().any(|message| {
+        message.tool_call_id.as_deref() == Some("mid-loop-call")
+            && message.content == "mid-loop tool result"
+    }));
+    let interrupted = saved
+        .messages
+        .iter()
+        .find(|message| {
+            message
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("runtime_kind"))
+                .and_then(serde_json::Value::as_str)
+                == Some("interrupted_assistant_output")
+        })
+        .expect("second-round interrupted output");
+    assert_eq!(interrupted.content, "second-round partial");
+    assert!(interrupted.tool_calls.is_none());
+    let fragment = interrupted
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("partial_tool_calls"))
+        .and_then(serde_json::Value::as_array)
+        .and_then(|calls| calls.first())
+        .expect("second-round raw tool fragment");
+    assert_eq!(fragment["id"], "");
+    assert_eq!(fragment["name"], "");
+    assert_eq!(fragment["arguments"], "{\"next");
+    assert_eq!(fragment["index"], 0);
+    assert!(!saved.agent_runtime_state.as_ref().is_some_and(|state| {
+        matches!(state.status, bamboo_domain::AgentStatusState::Completed)
+    }));
+    while let Ok(event) = event_rx.try_recv() {
+        assert!(!matches!(event, AgentEvent::Complete { .. }));
+    }
+}
+
+#[tokio::test]
+async fn checkpoint_failure_does_not_mask_original_execution_error() {
+    let persistence = Arc::new(FailingCheckpointPersistence {
+        attempts: AtomicUsize::new(0),
+    });
+    let (_temp, agent, _storage) = build_direct_execute_agent(
+        Arc::new(ImmediateTerminalErrorProvider),
+        Some(persistence.clone()),
+        None,
+    )
+    .await;
+    let mut session = Session::new("direct-checkpoint-failure", "test-model");
+    session.add_message(Message::user("fail"));
+    let (event_tx, _event_rx) = mpsc::channel(32);
+
+    let error = agent
+        .execute(
+            &mut session,
+            direct_request(event_tx, CancellationToken::new()),
+        )
+        .await
+        .expect_err("provider error");
+
+    assert!(matches!(
+        error,
+        bamboo_agent_core::AgentError::LLM(message)
+            if message.contains("original execution failure")
+    ));
+    assert_eq!(persistence.attempts.load(Ordering::SeqCst), 1);
 }

--- a/crates/engine/bamboo-engine/src/session_repository.rs
+++ b/crates/engine/bamboo-engine/src/session_repository.rs
@@ -258,6 +258,23 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
         result
     }
 
+    async fn checkpoint_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {
+        // The execute-boundary checkpoint uses LockedSessionStore's atomic
+        // append-safe transcript merge, then publishes that reconciled snapshot
+        // to the runtime cache.  On failure, leave the existing cache alone: the
+        // checkpoint may have failed to load the latest durable transcript, and
+        // replacing a fresher cache entry with the stale runner snapshot would
+        // set up a later SHRINK write.
+        let result = self.persistence.checkpoint_runtime_session(session).await;
+        if result.is_ok() {
+            self.cache.insert(
+                session.id.clone(),
+                Arc::new(parking_lot::RwLock::new(session.clone())),
+            );
+        }
+        result
+    }
+
     async fn load_runtime_session(&self, session_id: &str) -> std::io::Result<Option<Session>> {
         self.try_load(session_id).await
     }

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -195,6 +195,37 @@ impl LockedSessionStore {
         self.merge_save_runtime_inner(session, true).await
     }
 
+    /// Persist an execute-boundary transcript checkpoint without allowing a
+    /// stale runner snapshot to shrink or rewrite the durable message log.
+    ///
+    /// The latest load, append-only message reconciliation, metadata merge and
+    /// save all happen while holding the same per-session lock.  Loading is
+    /// deliberately fail-closed: falling back to a blind full save when the
+    /// latest transcript cannot be read would reintroduce the SHRINK hazard
+    /// this checkpoint exists to prevent.
+    pub async fn checkpoint_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {
+        let _guard = self.acquire_lock(&session.id).await;
+        let latest = self.storage.load_session(&session.id).await?;
+
+        if let Some(latest) = latest.as_ref() {
+            let incoming_count = session.messages.len();
+            let durable_count = latest.messages.len();
+            let appended = bamboo_domain::append_missing_runtime_messages(session, latest);
+            tracing::debug!(
+                "[{}] append-safe runtime checkpoint: durable={}, incoming={}, appended={}, saved={}",
+                session.id,
+                durable_count,
+                incoming_count,
+                appended,
+                session.messages.len(),
+            );
+            apply_authoritative_metadata(session, latest);
+            adopt_disk_bypass_permissions(session, latest);
+        }
+
+        self.storage.save_session(session).await
+    }
+
     /// Like [`Self::merge_save_runtime`] but does NOT adopt the on-disk
     /// `bypass_permissions` — the caller's in-memory value is authoritative and
     /// persists as-is.
@@ -299,6 +330,10 @@ impl LockedSessionStore {
 impl RuntimeSessionPersistence for LockedSessionStore {
     async fn save_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {
         self.merge_save_runtime(session).await
+    }
+
+    async fn checkpoint_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {
+        LockedSessionStore::checkpoint_runtime_session(self, session).await
     }
 
     async fn load_runtime_session(&self, session_id: &str) -> std::io::Result<Option<Session>> {
@@ -522,6 +557,51 @@ mod tests {
             1,
             "merge_save_runtime clobbers concurrent appends — this is why config patches must use update_runtime_config"
         );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_runtime_session_preserves_disk_suffix_and_appends_live_messages() {
+        use bamboo_domain::session::types::Message;
+
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let session_id = "checkpoint-no-shrink";
+
+        let mut baseline = fresh(session_id);
+        baseline.add_message(Message::user("base"));
+        storage.save_session(&baseline).await.unwrap();
+        let mut runner_snapshot = baseline.clone();
+
+        let mut durable = baseline;
+        let mut disk_only = Message::user("concurrent injected message");
+        disk_only.id = "disk-only".to_string();
+        durable.add_message(disk_only);
+        storage.save_session(&durable).await.unwrap();
+
+        let mut live_only = Message::assistant("partial runner output", None);
+        live_only.id = "live-only".to_string();
+        runner_snapshot.add_message(live_only);
+
+        store
+            .checkpoint_runtime_session(&mut runner_snapshot)
+            .await
+            .unwrap();
+
+        let saved = storage.load_session(session_id).await.unwrap().unwrap();
+        let ids = saved
+            .messages
+            .iter()
+            .map(|message| message.id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ids,
+            vec![durable.messages[0].id.as_str(), "disk-only", "live-only"]
+        );
+        assert_eq!(runner_snapshot.messages.len(), saved.messages.len());
+        assert_eq!(runner_snapshot.messages[1].id, saved.messages[1].id);
+        assert_eq!(runner_snapshot.messages[2].id, saved.messages[2].id);
+        assert_eq!(saved.messages[1].content, "concurrent injected message");
+        assert_eq!(saved.messages[2].content, "partial runner output");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- checkpoint session transcripts at the shared `AgentRuntime::execute` boundary on success, error, and cancellation
- add an append-safe, per-session-locked checkpoint that preserves concurrent disk-only messages
- retain interrupted streaming content and raw partial tool-call fragments as non-executable transcript metadata
- keep retry cleanup attempt-scoped so historical interrupted output is never deleted

## Root cause

The engine accumulated messages in its in-memory `Session`, but error paths skipped finalization and relied on individual callers to save the mutated session. Direct SDK and sub-agent callers did not, so mid-loop work could disappear. A blind full save also risked reverting concurrent durable appends.

## Test Plan

- `cargo check -p bamboo-engine --lib`
- `cargo fmt --all -- --check`
- `cargo test -p bamboo-engine runtime::tests:: -- --nocapture` (19 passed)
- `cargo test -p bamboo-engine runtime::stream::handler::tests` (14 passed)
- `cargo test -p bamboo-storage checkpoint_runtime_session_preserves_disk_suffix_and_appends_live_messages` (1 passed)

Parent-agent exact-head review passed for `483b6f90badf3e6fed0f95f0f97267af771fc599`.

Closes #663