### PR TITLE
refactor(server): finish API error-envelope consistency (#251)

### DIFF
--- a/crates/app/bamboo-server/src/error.rs
+++ b/crates/app/bamboo-server/src/error.rs
@@ -105,6 +105,32 @@ pub fn error_value(message: impl Into<String>) -> serde_json::Value {
     serde_json::json!({ "message": message.into(), "type": "api_error" })
 }
 
+/// Build bamboo's canonical JSON error response for code paths that cannot
+/// return an [`AppError`] directly (most notably middleware and handlers that
+/// must preserve extra response headers).
+pub fn json_error(status: StatusCode, message: impl Into<String>) -> HttpResponse {
+    json_error_with_code(status, message.into(), None)
+}
+
+/// Preserve an existing `actix_web::Result` signature while ensuring the
+/// framework error is rendered with bamboo's canonical JSON envelope instead
+/// of Actix's default `text/plain` convenience-error body.
+pub fn json_internal_server_error(message: impl Into<String>) -> actix_web::Error {
+    let message = message.into();
+    let response = json_error(StatusCode::INTERNAL_SERVER_ERROR, message.clone());
+    actix_web::error::InternalError::from_response(message, response).into()
+}
+
+fn json_error_with_code(status: StatusCode, message: String, code: Option<&str>) -> HttpResponse {
+    HttpResponse::build(status).json(JsonErrorWrapper {
+        error: JsonError {
+            message,
+            r#type: "api_error".to_string(),
+            code: code.map(str::to_string),
+        },
+    })
+}
+
 impl ResponseError for AppError {
     fn status_code(&self) -> StatusCode {
         match self {
@@ -126,21 +152,13 @@ impl ResponseError for AppError {
 
     fn error_response(&self) -> HttpResponse {
         let status_code = self.status_code();
-        let error_response = JsonErrorWrapper {
-            error: JsonError {
-                message: self.to_string(),
-                r#type: "api_error".to_string(),
-                code: match self {
-                    AppError::ProxyAuthRequired => Some("proxy_auth_required".to_string()),
-                    AppError::ConfigRecoveryPending(_) => {
-                        Some("config_recovery_pending".to_string())
-                    }
-                    AppError::ConfigConflict { .. } => Some("config_revision_conflict".to_string()),
-                    _ => None,
-                },
-            },
+        let code = match self {
+            AppError::ProxyAuthRequired => Some("proxy_auth_required"),
+            AppError::ConfigRecoveryPending(_) => Some("config_recovery_pending"),
+            AppError::ConfigConflict { .. } => Some("config_revision_conflict"),
+            _ => None,
         };
-        HttpResponse::build(status_code).json(error_response)
+        json_error_with_code(status_code, self.to_string(), code)
     }
 }
 
@@ -305,5 +323,125 @@ mod tests {
             app_err_body["error"]["type"], helper_error["type"],
             "AppError and error_value must use the same error \"type\" tag"
         );
+    }
+
+    #[actix_web::test]
+    async fn shared_json_error_helpers_use_the_canonical_envelope() {
+        let response = json_error(StatusCode::TOO_MANY_REQUESTS, "slow down");
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        let bytes = actix_web::body::to_bytes(response.into_body())
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"]["message"], "slow down");
+        assert_eq!(body["error"]["type"], "api_error");
+
+        let error = json_internal_server_error("storage failed");
+        let response = error.error_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let bytes = actix_web::body::to_bytes(response.into_body())
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"]["message"], "storage failed");
+        assert_eq!(body["error"]["type"], "api_error");
+    }
+
+    /// Source-level tripwire for Bamboo's native HTTP surface. Vendor-compat
+    /// handlers and the native WS frame protocol intentionally own different
+    /// wire contracts, but native REST handlers and middleware must not
+    /// reintroduce either a flat `error` value or Actix's text/plain
+    /// convenience errors.
+    #[test]
+    fn native_http_error_sources_use_the_canonical_envelope() {
+        let source_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let flat_error = regex::Regex::new(r#""error"\s*:\s*([^,}\n]+)"#).unwrap();
+        let actix_convenience_error = regex::Regex::new(
+            r"\bError(?:BadRequest|Unauthorized|Forbidden|NotFound|MethodNotAllowed|NotAcceptable|RequestTimeout|Conflict|Gone|PreconditionFailed|ExpectationFailed|PayloadTooLarge|UnsupportedMediaType|UnprocessableEntity|TooManyRequests|InternalServerError|NotImplemented|BadGateway|ServiceUnavailable|GatewayTimeout)\s*\(",
+        )
+        .unwrap();
+        let mut violations = Vec::new();
+
+        for entry in walkdir::WalkDir::new(source_root.join("handlers"))
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "rs"))
+        {
+            let relative = entry.path().strip_prefix(&source_root).unwrap();
+            let relative = relative.to_string_lossy().replace('\\', "/");
+            if relative.starts_with("handlers/openai/")
+                || relative.starts_with("handlers/anthropic/")
+                || relative.starts_with("handlers/gemini/")
+                || relative.starts_with("handlers/agent/ws_v2/")
+            {
+                continue;
+            }
+            inspect_native_error_source(
+                entry.path(),
+                &relative,
+                &flat_error,
+                &actix_convenience_error,
+                &mut violations,
+            );
+        }
+        inspect_native_error_source(
+            &source_root.join("rate_limit.rs"),
+            "rate_limit.rs",
+            &flat_error,
+            &actix_convenience_error,
+            &mut violations,
+        );
+
+        assert!(
+            violations.is_empty(),
+            "native HTTP errors must use AppError/error_value/json_error; vendor SSE and WS frames are excluded:\n{}",
+            violations.join("\n")
+        );
+    }
+
+    fn inspect_native_error_source(
+        path: &std::path::Path,
+        relative: &str,
+        flat_error: &regex::Regex,
+        actix_convenience_error: &regex::Regex,
+        violations: &mut Vec<String>,
+    ) {
+        let source = std::fs::read_to_string(path).unwrap();
+        for capture in flat_error.captures_iter(&source) {
+            let matched = capture.get(0).unwrap();
+            let line_number = source[..matched.start()]
+                .bytes()
+                .filter(|byte| *byte == b'\n')
+                .count()
+                + 1;
+            let line_start = source[..matched.start()]
+                .rfind('\n')
+                .map_or(0, |position| position + 1);
+            let line_end = source[matched.start()..]
+                .find('\n')
+                .map_or(source.len(), |position| matched.start() + position);
+            if source[line_start..line_end].trim_start().starts_with("//") {
+                continue;
+            }
+            let value = capture.get(1).unwrap().as_str().trim_start();
+            if !value.starts_with("crate::error::error_value(")
+                && !value.starts_with("error_value(")
+                && !value.starts_with('{')
+            {
+                violations.push(format!(
+                    "{relative}:{line_number}: flat error value starts with `{value}`"
+                ));
+            }
+        }
+        for matched in actix_convenience_error.find_iter(&source) {
+            let line_number = source[..matched.start()]
+                .bytes()
+                .filter(|byte| *byte == b'\n')
+                .count()
+                + 1;
+            violations.push(format!(
+                "{relative}:{line_number}: Actix convenience error renders text/plain"
+            ));
+        }
     }
 }

--- a/crates/app/bamboo-server/src/handlers/agent/dev.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/dev.rs
@@ -12,7 +12,7 @@ pub async fn reset(state: web::Data<AppState>) -> Result<HttpResponse> {
         .session_store
         .dev_reset()
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(format!("Reset failed: {e}")))?;
+        .map_err(|e| crate::error::json_internal_server_error(format!("Reset failed: {e}")))?;
 
     // Clear in-memory cache too.
     state.sessions.clear();

--- a/crates/app/bamboo-server/src/handlers/agent/ledger/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ledger/handlers.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::fmt::Display;
 
-use actix_web::{error::ErrorInternalServerError, web, Error, HttpResponse, Result};
+use actix_web::{web, Error, HttpResponse, Result};
 use chrono::{DateTime, NaiveDate, Utc};
 use serde_json::json;
 
@@ -87,7 +87,7 @@ pub async fn agenda(
 // ── response helpers (match the neighboring schedules handlers) ─────────────
 
 fn internal_server_error(action: &str, error: impl Display) -> Error {
-    ErrorInternalServerError(format!("Failed to {action}: {error}"))
+    crate::error::json_internal_server_error(format!("Failed to {action}: {error}"))
 }
 
 fn bad_request(message: impl Into<String>) -> HttpResponse {

--- a/crates/app/bamboo-server/src/handlers/agent/messages/shared.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/messages/shared.rs
@@ -1,4 +1,4 @@
-use actix_web::{error::ErrorInternalServerError, web, HttpResponse, Result};
+use actix_web::{web, HttpResponse, Result};
 use chrono::Utc;
 
 use crate::app_state::{AgentStatus, AppState};
@@ -25,11 +25,9 @@ pub(super) async fn load_session_or_404(
     state: &web::Data<AppState>,
     session_id: &str,
 ) -> Result<Option<Session>> {
-    state
-        .storage
-        .load_session(session_id)
-        .await
-        .map_err(|e| ErrorInternalServerError(format!("Failed to load session: {e}")))
+    state.storage.load_session(session_id).await.map_err(|e| {
+        crate::error::json_internal_server_error(format!("Failed to load session: {e}"))
+    })
 }
 
 pub(super) fn clear_derived_context_state(session: &mut Session) {
@@ -46,7 +44,9 @@ pub(super) async fn save_and_cache_session(
         .persistence
         .merge_save_runtime(&mut session)
         .await
-        .map_err(|e| ErrorInternalServerError(format!("Failed to save session: {e}")))?;
+        .map_err(|e| {
+            crate::error::json_internal_server_error(format!("Failed to save session: {e}"))
+        })?;
 
     state.sessions.insert(
         session_id.to_string(),

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/errors.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/errors.rs
@@ -6,11 +6,9 @@
 //! rule (neither the trait nor the type is local), short of adding an
 //! `actix-web` dependency to the `infra`-layer `bamboo-plugin` crate, which
 //! would be a much heavier coupling than one mapping fn. So this is a plain
-//! function, called at every plugin handler's error path — the same shape
-//! `handlers/agent/mcp` and `handlers/agent/prompt_presets` already use for
-//! their ad hoc `HttpResponse::X().json(json!({"error": ...}))` responses
-//! (a flat `{ "error": "<message>" }` body, NOT the nested
-//! `AppError`/`JsonErrorWrapper` shape `crate::error` uses elsewhere).
+//! function, called at every plugin handler's error path. Bodies use Bamboo's
+//! canonical nested `{ "error": { "message", "type" } }` envelope via
+//! [`crate::error::error_value`], matching every other native HTTP handler.
 //!
 //! # Status map (frozen — shared with the parallel CLI agent's expectations)
 //!
@@ -99,7 +97,9 @@ pub fn plugin_error_response(error: &PluginError) -> HttpResponse {
 
     match actionable_status {
         Some(status) => {
-            let body = serde_json::json!({ "error": error.to_string() });
+            let body = serde_json::json!({
+                "error": crate::error::error_value(error.to_string())
+            });
             HttpResponse::build(status).json(body)
         }
         None => {
@@ -107,7 +107,9 @@ pub fn plugin_error_response(error: &PluginError) -> HttpResponse {
             // can contain a local filesystem path) is logged server-side
             // only; the HTTP body is a fixed, generic message.
             tracing::error!(%error, "plugin operation failed with an internal error");
-            let body = serde_json::json!({ "error": GENERIC_INTERNAL_ERROR_MESSAGE });
+            let body = serde_json::json!({
+                "error": crate::error::error_value(GENERIC_INTERNAL_ERROR_MESSAGE)
+            });
             HttpResponse::InternalServerError().json(body)
         }
     }
@@ -195,7 +197,7 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn error_body_is_a_flat_error_string() {
+    async fn error_body_uses_the_canonical_nested_envelope() {
         let error = PluginError::NotFound("demo".to_string());
         let response = plugin_error_response(&error);
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
@@ -206,7 +208,12 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&bytes).expect("valid json");
         assert_eq!(
             json,
-            serde_json::json!({ "error": "plugin not found: demo" })
+            serde_json::json!({
+                "error": {
+                    "message": "plugin not found: demo",
+                    "type": "api_error"
+                }
+            })
         );
     }
 
@@ -240,7 +247,12 @@ mod tests {
             let json: serde_json::Value = serde_json::from_slice(&bytes).expect("valid json");
             assert_eq!(
                 json,
-                serde_json::json!({ "error": "internal error during plugin operation" }),
+                serde_json::json!({
+                    "error": {
+                        "message": "internal error during plugin operation",
+                        "type": "api_error"
+                    }
+                }),
                 "500 body must be the fixed generic message, not {error}'s own Display text"
             );
 

--- a/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/plugin/tests.rs
@@ -115,6 +115,13 @@ async fn body_json(response: actix_web::dev::ServiceResponse) -> serde_json::Val
     serde_json::from_slice(&bytes).expect("valid json body")
 }
 
+fn error_message(body: &serde_json::Value) -> &str {
+    assert_eq!(body["error"]["type"], "api_error");
+    body["error"]["message"]
+        .as_str()
+        .expect("canonical error.message string")
+}
+
 // ---------------------------------------------------------------------
 // install -> 201, list shows it, second install -> 409 AlreadyInstalled,
 // delete -> gone.
@@ -167,10 +174,7 @@ async fn install_list_reinstall_conflict_then_delete() {
     assert_eq!(resp.status(), StatusCode::CONFLICT);
     let error = body_json(resp).await;
     assert!(
-        error["error"]
-            .as_str()
-            .unwrap()
-            .contains("already installed"),
+        error_message(&error).contains("already installed"),
         "error message should mention already installed: {error}"
     );
 
@@ -213,7 +217,7 @@ async fn install_with_invalid_manifest_returns_400() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let error = body_json(resp).await;
     assert!(
-        error["error"].as_str().unwrap().contains("invalid"),
+        error_message(&error).contains("invalid"),
         "error message should mention the manifest is invalid: {error}"
     );
 }
@@ -273,7 +277,7 @@ async fn install_with_foreign_mcp_conflict_returns_409() {
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::CONFLICT);
     let error = body_json(resp).await;
-    let message = error["error"].as_str().unwrap();
+    let message = error_message(&error);
     assert!(message.contains("mcp server"), "{message}");
     assert!(message.contains("shared-tool"), "{message}");
 
@@ -338,7 +342,7 @@ async fn update_with_mismatched_path_id_returns_400_and_rolls_back() {
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let error = body_json(resp).await;
-    let message = error["error"].as_str().unwrap();
+    let message = error_message(&error);
     assert!(message.contains("some-other-id"), "{message}");
     assert!(message.contains("hello-plugin"), "{message}");
 
@@ -453,7 +457,7 @@ async fn install_url_with_untrusted_host_returns_403_before_fetch() {
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     let error = body_json(resp).await;
-    let message = error["error"].as_str().unwrap();
+    let message = error_message(&error);
     assert!(message.contains("trusted_hosts"), "{message}");
     assert!(
         message.contains("allow_untrusted_host") || message.contains("allow-untrusted-host"),
@@ -502,7 +506,7 @@ async fn install_url_with_no_checksum_or_allow_unverified_returns_400_after_host
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let error = body_json(resp).await;
-    let message = error["error"].as_str().unwrap();
+    let message = error_message(&error);
     assert!(message.contains("sha256"), "{message}");
     assert!(message.contains("allow_unverified"), "{message}");
 
@@ -536,10 +540,7 @@ async fn install_url_with_wrong_bundle_sha256_returns_400_and_installs_nothing()
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let error = body_json(resp).await;
-    assert!(
-        error["error"].as_str().unwrap().contains("mismatch"),
-        "{error}"
-    );
+    assert!(error_message(&error).contains("mismatch"), "{error}");
 
     let req = test::TestRequest::get().uri("/api/v1/plugins").to_request();
     let resp = test::call_service(&app, req).await;
@@ -676,10 +677,7 @@ async fn install_url_with_insecure_true_still_refuses_a_wrong_sha256() {
     let resp = test::call_service(&app, req).await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     let error = body_json(resp).await;
-    assert!(
-        error["error"].as_str().unwrap().contains("mismatch"),
-        "{error}"
-    );
+    assert!(error_message(&error).contains("mismatch"), "{error}");
 
     let req = test::TestRequest::get().uri("/api/v1/plugins").to_request();
     let resp = test::call_service(&app, req).await;

--- a/crates/app/bamboo-server/src/handlers/agent/prompt_presets/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/prompt_presets/handlers.rs
@@ -49,7 +49,7 @@ fn normalize_requested_id(value: Option<&str>) -> Option<String> {
 pub async fn list_prompt_presets(state: web::Data<AppState>) -> Result<HttpResponse> {
     let store_path = store_file_path(&state.app_data_dir);
     let store = load_store(&store_path).await.map_err(|error| {
-        actix_web::error::ErrorInternalServerError(format!(
+        crate::error::json_internal_server_error(format!(
             "Failed to load prompt preset store: {error}"
         ))
     })?;
@@ -76,7 +76,7 @@ pub async fn create_prompt_preset(
 
     let store_path = store_file_path(&state.app_data_dir);
     let mut store = load_store(&store_path).await.map_err(|error| {
-        actix_web::error::ErrorInternalServerError(format!(
+        crate::error::json_internal_server_error(format!(
             "Failed to load prompt preset store: {error}"
         ))
     })?;
@@ -121,7 +121,7 @@ pub async fn create_prompt_preset(
     store.prompts.push(created.clone());
 
     save_store(&store_path, &store).await.map_err(|error| {
-        actix_web::error::ErrorInternalServerError(format!(
+        crate::error::json_internal_server_error(format!(
             "Failed to persist prompt preset store: {error}"
         ))
     })?;
@@ -144,7 +144,7 @@ pub async fn patch_prompt_preset(
 
     let store_path = store_file_path(&state.app_data_dir);
     let mut store = load_store(&store_path).await.map_err(|error| {
-        actix_web::error::ErrorInternalServerError(format!(
+        crate::error::json_internal_server_error(format!(
             "Failed to load prompt preset store: {error}"
         ))
     })?;
@@ -178,7 +178,7 @@ pub async fn patch_prompt_preset(
     let updated = preset.clone();
 
     save_store(&store_path, &store).await.map_err(|error| {
-        actix_web::error::ErrorInternalServerError(format!(
+        crate::error::json_internal_server_error(format!(
             "Failed to persist prompt preset store: {error}"
         ))
     })?;
@@ -200,7 +200,7 @@ pub async fn delete_prompt_preset(
 
     let store_path = store_file_path(&state.app_data_dir);
     let mut store = load_store(&store_path).await.map_err(|error| {
-        actix_web::error::ErrorInternalServerError(format!(
+        crate::error::json_internal_server_error(format!(
             "Failed to load prompt preset store: {error}"
         ))
     })?;
@@ -212,7 +212,7 @@ pub async fn delete_prompt_preset(
     }
 
     save_store(&store_path, &store).await.map_err(|error| {
-        actix_web::error::ErrorInternalServerError(format!(
+        crate::error::json_internal_server_error(format!(
             "Failed to persist prompt preset store: {error}"
         ))
     })?;

--- a/crates/app/bamboo-server/src/handlers/agent/schedules/handlers/response.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/schedules/handlers/response.rs
@@ -1,9 +1,9 @@
 use std::fmt::Display;
 
-use actix_web::{error::ErrorInternalServerError, Error, HttpResponse};
+use actix_web::{Error, HttpResponse};
 
 pub(super) fn internal_server_error(action: &str, error: impl Display) -> Error {
-    ErrorInternalServerError(format!("Failed to {action}: {error}"))
+    crate::error::json_internal_server_error(format!("Failed to {action}: {error}"))
 }
 
 pub(super) fn schedule_not_found(schedule_id: &str) -> HttpResponse {

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
@@ -64,7 +64,7 @@ pub async fn create_session(
         .save_session(&session)
         .await
         .map_err(|error| {
-            actix_web::error::ErrorInternalServerError(format!("Failed to save session: {error}"))
+            crate::error::json_internal_server_error(format!("Failed to save session: {error}"))
         })?;
 
     state.sessions.insert(

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/discoverable_tools.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/discoverable_tools.rs
@@ -64,7 +64,7 @@ pub async fn activate_discoverable_tools(
         .load_session(&session_id)
         .await
         .map_err(|error| {
-            actix_web::error::ErrorInternalServerError(format!("Failed to load session: {error}"))
+            crate::error::json_internal_server_error(format!("Failed to load session: {error}"))
         })?
     else {
         return Ok(HttpResponse::NotFound().json(serde_json::json!({
@@ -81,7 +81,7 @@ pub async fn activate_discoverable_tools(
         .merge_save_runtime(&mut session)
         .await
         .map_err(|error| {
-            actix_web::error::ErrorInternalServerError(format!("Failed to save session: {error}"))
+            crate::error::json_internal_server_error(format!("Failed to save session: {error}"))
         })?;
 
     state.sessions.insert(
@@ -111,7 +111,7 @@ pub async fn deactivate_discoverable_tools(
         .load_session(&session_id)
         .await
         .map_err(|error| {
-            actix_web::error::ErrorInternalServerError(format!("Failed to load session: {error}"))
+            crate::error::json_internal_server_error(format!("Failed to load session: {error}"))
         })?
     else {
         return Ok(HttpResponse::NotFound().json(serde_json::json!({
@@ -128,7 +128,7 @@ pub async fn deactivate_discoverable_tools(
         .merge_save_runtime(&mut session)
         .await
         .map_err(|error| {
-            actix_web::error::ErrorInternalServerError(format!("Failed to save session: {error}"))
+            crate::error::json_internal_server_error(format!("Failed to save session: {error}"))
         })?;
 
     state.sessions.insert(

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
@@ -77,7 +77,7 @@ pub async fn patch_session(
                 return Ok(precondition_failed(&session_id, current));
             }
             Err(err) => {
-                return Err(actix_web::error::ErrorInternalServerError(err.to_string()));
+                return Err(crate::error::json_internal_server_error(err.to_string()));
             }
         }
     }
@@ -102,7 +102,7 @@ pub async fn patch_session(
                 return Ok(precondition_failed(&session_id, current));
             }
             Err(err) => {
-                return Err(actix_web::error::ErrorInternalServerError(err.to_string()));
+                return Err(crate::error::json_internal_server_error(err.to_string()));
             }
         }
     }
@@ -141,7 +141,7 @@ pub async fn patch_session(
                 return Ok(precondition_failed(&session_id, current));
             }
             Err(err) => {
-                return Err(actix_web::error::ErrorInternalServerError(err.to_string()));
+                return Err(crate::error::json_internal_server_error(err.to_string()));
             }
         }
     }
@@ -210,9 +210,7 @@ pub async fn patch_session(
             })
             .await
             .map_err(|error| {
-                actix_web::error::ErrorInternalServerError(format!(
-                    "Failed to save session: {error}"
-                ))
+                crate::error::json_internal_server_error(format!("Failed to save session: {error}"))
             })?;
 
         let Some(session) = updated else {

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/regenerate_title.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/regenerate_title.rs
@@ -20,7 +20,7 @@ pub async fn regenerate_session_title(
         .load_session(&session_id)
         .await
         .map_err(|error| {
-            actix_web::error::ErrorInternalServerError(format!("Failed to load session: {error}"))
+            crate::error::json_internal_server_error(format!("Failed to load session: {error}"))
         })?
         .is_some();
 

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/system_prompt.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/system_prompt.rs
@@ -20,9 +20,7 @@ pub async fn get_system_prompt_snapshot(
             .load_session(&session_id)
             .await
             .map_err(|error| {
-                actix_web::error::ErrorInternalServerError(format!(
-                    "Failed to load session: {error}"
-                ))
+                crate::error::json_internal_server_error(format!("Failed to load session: {error}"))
             })? {
             Some(session) => session,
             None => {

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/maintenance.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/maintenance.rs
@@ -22,7 +22,7 @@ pub async fn clear_session(
         .clear_session(&session_id)
         .await
         .map_err(|error| {
-            actix_web::error::ErrorInternalServerError(format!("Failed to clear session: {error}"))
+            crate::error::json_internal_server_error(format!("Failed to clear session: {error}"))
         })?;
 
     if !cleared {
@@ -61,7 +61,7 @@ async fn load_session_from_state_or_storage(
         .load_session(session_id)
         .await
         .map_err(|error| {
-            actix_web::error::ErrorInternalServerError(format!("Failed to load session: {error}"))
+            crate::error::json_internal_server_error(format!("Failed to load session: {error}"))
         })
 }
 
@@ -109,7 +109,7 @@ pub async fn run_project_dream(
     let result = run_project_auto_dream_once(&ctx, &project_key)
         .await
         .map_err(|error| {
-            actix_web::error::ErrorInternalServerError(format!(
+            crate::error::json_internal_server_error(format!(
                 "Failed to run project Dream generation: {error}"
             ))
         })?;
@@ -159,7 +159,7 @@ pub async fn cleanup_sessions(
         .cleanup(mode, req.keep_pinned)
         .await
         .map_err(|error| {
-            actix_web::error::ErrorInternalServerError(format!("Cleanup failed: {error}"))
+            crate::error::json_internal_server_error(format!("Cleanup failed: {error}"))
         })?;
 
     if !result.deleted_session_ids.is_empty() {

--- a/crates/app/bamboo-server/src/handlers/agent/subagent_snapshot.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/subagent_snapshot.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use actix_web::{error::ErrorInternalServerError, web, HttpResponse, Result};
+use actix_web::{web, HttpResponse, Result};
 use bamboo_engine::external_agents::approval_registry::{ApprovalState, DurableApproval};
 use serde::Serialize;
 
@@ -65,7 +65,7 @@ pub async fn handler(state: web::Data<AppState>) -> Result<HttpResponse> {
     let approval_snapshot = state
         .approval_registry
         .lock()
-        .map_err(|_| ErrorInternalServerError("approval registry lock poisoned"))?
+        .map_err(|_| crate::error::json_internal_server_error("approval registry lock poisoned"))?
         .unresolved_snapshot();
 
     let unresolved_by_child = unresolved_by_child(&approval_snapshot.approvals);
@@ -121,7 +121,7 @@ pub async fn handler(state: web::Data<AppState>) -> Result<HttpResponse> {
                     .storage
                     .load_runtime_control_plane(&entry.id)
                     .await
-                    .map_err(ErrorInternalServerError)?
+                    .map_err(|error| crate::error::json_internal_server_error(error.to_string()))?
                     .is_some_and(|session| {
                         session
                             .agent_runtime_state

--- a/crates/app/bamboo-server/src/handlers/workflow_runs.rs
+++ b/crates/app/bamboo-server/src/handlers/workflow_runs.rs
@@ -121,27 +121,30 @@ pub async fn restart(
 fn workflow_error(error: WorkflowRunError) -> HttpResponse {
     let message = error.to_string();
     match error {
-        WorkflowRunError::NotFound => {
-            HttpResponse::NotFound().json(serde_json::json!({"error": message}))
-        }
-        WorkflowRunError::Terminal => {
-            HttpResponse::Conflict().json(serde_json::json!({"error": message}))
-        }
+        WorkflowRunError::NotFound => HttpResponse::NotFound().json(serde_json::json!({
+            "error": crate::error::error_value(message)
+        })),
+        WorkflowRunError::Terminal => HttpResponse::Conflict().json(serde_json::json!({
+            "error": crate::error::error_value(message)
+        })),
         WorkflowRunError::Storage(details) => {
             let recovery_run_id = recovery_run_id_from_storage_details(&details);
             HttpResponse::InternalServerError().json(match recovery_run_id {
                 Some(run_id) => serde_json::json!({
-                    "error": "workflow storage unavailable; run recovery is required",
+                    "error": crate::error::error_value(
+                        "workflow storage unavailable; run recovery is required"
+                    ),
                     "recovery_run_id": run_id,
                 }),
-                None => serde_json::json!({"error": "workflow storage unavailable"}),
+                None => serde_json::json!({
+                    "error": crate::error::error_value("workflow storage unavailable")
+                }),
             })
         }
         WorkflowRunError::Compile(_)
         | WorkflowRunError::InvalidInput(_)
-        | WorkflowRunError::Preflight(_) => {
-            HttpResponse::BadRequest().json(serde_json::json!({"error": message}))
-        }
+        | WorkflowRunError::Preflight(_) => HttpResponse::BadRequest()
+            .json(serde_json::json!({ "error": crate::error::error_value(message) })),
     }
 }
 
@@ -201,10 +204,45 @@ mod tests {
             value["recovery_run_id"],
             "123e4567-e89b-12d3-a456-426614174000"
         );
-        assert!(!value["error"]
+        assert_eq!(value["error"]["type"], "api_error");
+        assert_eq!(
+            value["error"]["message"],
+            "workflow storage unavailable; run recovery is required"
+        );
+        assert!(!value["error"]["message"]
             .as_str()
             .unwrap_or_default()
             .contains("failure"));
         assert_eq!(recovery_run_id_from_storage_details("disk /secret"), None);
+    }
+
+    #[actix_web::test]
+    async fn workflow_errors_preserve_status_and_use_canonical_envelope() {
+        let cases = [
+            (
+                WorkflowRunError::NotFound,
+                actix_web::http::StatusCode::NOT_FOUND,
+            ),
+            (
+                WorkflowRunError::Terminal,
+                actix_web::http::StatusCode::CONFLICT,
+            ),
+            (
+                WorkflowRunError::InvalidInput("bad args".to_string()),
+                actix_web::http::StatusCode::BAD_REQUEST,
+            ),
+        ];
+
+        for (error, expected_status) in cases {
+            let expected_message = error.to_string();
+            let response = workflow_error(error);
+            assert_eq!(response.status(), expected_status);
+            let body = actix_web::body::to_bytes(response.into_body())
+                .await
+                .expect("body");
+            let value: serde_json::Value = serde_json::from_slice(&body).expect("json");
+            assert_eq!(value["error"]["message"], expected_message);
+            assert_eq!(value["error"]["type"], "api_error");
+        }
     }
 }

--- a/crates/app/bamboo-server/src/rate_limit.rs
+++ b/crates/app/bamboo-server/src/rate_limit.rs
@@ -11,11 +11,10 @@
 //!   construction actix-governor's `GovernorConfigBuilder::finish()` used);
 //! - on throttle: `429 Too Many Requests` with `retry-after` and
 //!   `x-ratelimit-after` headers (seconds until the bucket admits again) and
-//!   a `text/plain` body — byte-for-byte what actix-governor's `NoOpMiddleware`
-//!   path produced;
+//!   Bamboo's canonical nested JSON error envelope;
 //! - on key-extraction failure: whatever response the extractor's error
-//!   produces (bamboo's `ClientIpKeyExtractor` mirrors actix-governor's
-//!   `SimpleKeyExtractionError` default: `500`, `text/plain`).
+//!   produces (bamboo's `ClientIpKeyExtractor` returns `500` with the same
+//!   canonical nested JSON error envelope).
 //!
 //! actix-governor features bamboo never configured — per-method filtering,
 //! `permissive` mode, whitelisted keys, and the `x-ratelimit-limit` /
@@ -33,7 +32,7 @@ use std::time::Duration;
 use actix_web::body::{EitherBody, MessageBody};
 use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::http::StatusCode;
-use actix_web::{Error, HttpResponse, HttpResponseBuilder, ResponseError};
+use actix_web::{Error, HttpResponse, ResponseError};
 use futures::future::LocalBoxFuture;
 use governor::clock::{Clock, DefaultClock};
 use governor::state::keyed::DefaultKeyedStateStore;
@@ -56,11 +55,7 @@ pub trait KeyExtractor: Clone + 'static {
     fn extract(&self, req: &ServiceRequest) -> Result<Self::Key, Self::KeyExtractionError>;
 }
 
-/// A minimal extraction-failure error: fixed status + `text/plain` body.
-///
-/// Matches `actix_governor::SimpleKeyExtractionError`'s default (status
-/// `500`, content-type `text/plain`) — the only shape bamboo ever used (it
-/// never called that type's `set_status_code`/`set_content_type`).
+/// A minimal extraction-failure error with Bamboo's canonical JSON body.
 #[derive(Debug, Clone, Copy)]
 pub struct SimpleKeyExtractionError(pub &'static str);
 
@@ -84,9 +79,7 @@ impl ResponseError for SimpleKeyExtractionError {
     }
 
     fn error_response(&self) -> HttpResponse {
-        HttpResponseBuilder::new(self.status_code())
-            .content_type("text/plain; charset=utf-8")
-            .body(self.0)
+        crate::error::json_error(self.status_code(), self.0)
     }
 }
 
@@ -206,11 +199,18 @@ where
                 let wait_time = negative
                     .wait_time_from(DefaultClock::default().now())
                     .as_secs();
-                let response = HttpResponse::build(StatusCode::TOO_MANY_REQUESTS)
-                    .insert_header(("retry-after", wait_time))
-                    .insert_header(("x-ratelimit-after", wait_time))
-                    .content_type("text/plain; charset=utf-8")
-                    .body(format!("Too many requests, retry in {wait_time}s"));
+                let mut response = crate::error::json_error(
+                    StatusCode::TOO_MANY_REQUESTS,
+                    format!("Too many requests, retry in {wait_time}s"),
+                );
+                response.headers_mut().insert(
+                    actix_web::http::header::RETRY_AFTER,
+                    actix_web::http::header::HeaderValue::from(wait_time),
+                );
+                response.headers_mut().insert(
+                    actix_web::http::header::HeaderName::from_static("x-ratelimit-after"),
+                    actix_web::http::header::HeaderValue::from(wait_time),
+                );
                 let response = req.into_response(response).map_into_right_body();
                 Box::pin(async move { Ok(response) })
             }
@@ -270,6 +270,11 @@ mod tests {
             res.headers().contains_key("x-ratelimit-after"),
             "a 429 must carry x-ratelimit-after"
         );
+        let body: serde_json::Value = test::read_body_json(res).await;
+        assert_eq!(body["error"]["type"], "api_error");
+        assert!(body["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.starts_with("Too many requests, retry in ")));
     }
 
     #[actix_web::test]
@@ -340,5 +345,11 @@ mod tests {
             .expect_err("extraction failure must reach the caller as an Err");
         let response = err.error_response();
         assert_eq!(response.status(), HttpStatusCode::INTERNAL_SERVER_ERROR);
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["error"]["message"], "no key for you");
+        assert_eq!(body["error"]["type"], "api_error");
     }
 }

--- a/src/admin_cli.rs
+++ b/src/admin_cli.rs
@@ -342,7 +342,7 @@ pub async fn respond(conn: ConnArgs, session_id: &str, answer: &str) -> anyhow::
     if status.as_u16() == 404 {
         anyhow::bail!("session '{session_id}' not found");
     }
-    let error = body.get("error").and_then(|e| e.as_str()).unwrap_or("");
+    let error = server_error_message(&body);
     if status.as_u16() == 400 && error.contains("No pending question") {
         anyhow::bail!(
             "session '{session_id}' has no pending question — nothing to answer \
@@ -581,13 +581,13 @@ pub async fn session_delete(conn: ConnArgs, session_id: &str, yes: bool) -> anyh
         anyhow::bail!("session '{session_id}' not found");
     }
     let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
-    let error = body.get("error").and_then(|e| e.as_str()).unwrap_or("");
+    let error = server_error_message(&body);
     anyhow::bail!(
         "delete failed: HTTP {status}{}",
         if error.is_empty() {
             String::new()
         } else {
-            format!(" ({error})")
+            format!(" {error}")
         }
     );
 }
@@ -1062,10 +1062,17 @@ fn read_json_payload(source: &str) -> anyhow::Result<serde_json::Value> {
     serde_json::from_str(text.trim()).map_err(|e| anyhow::anyhow!("payload is not valid JSON: {e}"))
 }
 
-/// Pull the server's `{"error": "..."}` detail out of an error body, if any.
+/// Pull the server's canonical `{"error":{"message":"..."}}` detail out of
+/// an error body. The flat-string fallback keeps this CLI compatible with
+/// older Bamboo servers during rolling upgrades.
 pub(crate) fn server_error_message(body: &serde_json::Value) -> String {
     body.get("error")
-        .and_then(|e| e.as_str())
+        .and_then(|error| {
+            error
+                .get("message")
+                .and_then(serde_json::Value::as_str)
+                .or_else(|| error.as_str())
+        })
         .map(|e| format!("({e})"))
         .unwrap_or_default()
 }
@@ -1712,7 +1719,13 @@ mod tests {
     }
 
     #[test]
-    fn server_error_message_extracts_error_field() {
+    fn server_error_message_extracts_nested_and_legacy_error_fields() {
+        assert_eq!(
+            server_error_message(&serde_json::json!({
+                "error": {"message": "name is required", "type": "api_error"}
+            })),
+            "(name is required)"
+        );
         assert_eq!(
             server_error_message(&serde_json::json!({"error":"name is required"})),
             "(name is required)"

--- a/src/plugin_cli.rs
+++ b/src/plugin_cli.rs
@@ -26,8 +26,9 @@
 //! - Errors: 409 (Conflict / AlreadyInstalled), 422 (UnsupportedPlatform), 404
 //!   (NotFound), 403 (`url` source: untrusted host / unsigned-or-untrusted
 //!   signature), 400 (bad manifest/artifact/bundle checksum, or a `url`
-//!   install missing both `sha256` and `allow_unverified`); body
-//!   `{"error": "..."}`.
+//!   install missing both `sha256` and `allow_unverified`); the body uses
+//!   the canonical `{"error":{"message":"...","type":"api_error"}}`
+//!   envelope (while the CLI still accepts older flat-string responses).
 //!
 //! # URL installs: three trust layers, secure by default
 //!


### PR DESCRIPTION
## Summary

Closes #251 by finishing the remaining native Bamboo API error-envelope drift on top of the earlier API-surface work in #382, #384, #386, #506, and #527.

- add shared canonical JSON response helpers for middleware and `actix_web::Result` paths
- convert residual native REST 500s from Actix's `text/plain` convenience errors to `{"error":{"message","type":"api_error"}}`
- normalize plugin, workflow-run, rate-limit, and key-extraction errors while preserving status codes, recovery metadata, throttling headers, and sanitized 500 messages
- keep the Bamboo CLI compatible with both the canonical nested envelope and legacy flat-string responses
- add a source-level regression guard plus representative response-shape tests so new native REST handlers cannot silently reintroduce flat/text errors
- leave OpenAI, Anthropic, Gemini compatibility responses and native WebSocket event frames unchanged because they have distinct wire contracts

Together with the already-merged #251 phases, this completes the seven findings: canonical `/api/v1` plus legacy aliases, canonical native error envelopes, 201 create semantics, nested session subresources plus aliases, deduplicated settings routes, health/readiness endpoints, and synchronized public-route policy.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo check -p bamboo-server`
- `cargo clippy -p bamboo-server --tests --all-targets --no-deps`
- `cargo test -p bamboo-server routes::tests -- --nocapture`
- `cargo test -p bamboo-server health -- --nocapture`
- `cargo test -p bamboo-server native_http_error_sources_use_the_canonical_envelope -- --nocapture`
- plugin, workflow-run, rate-limit, create-session, and shared helper tests
- `cargo test -p bamboo-agent admin_cli::tests -- --nocapture`
- `cargo test -p bamboo-server --lib -- --nocapture`: 1532 passed, 1 ignored; the sole `UnsupportedCertVersion` failure was reproduced identically in a clean detached worktree at current `origin/main` (`051b2d7f`) and is unrelated to this change

Closes #251
