### PR TITLE
feat: add revisioned per-section reset API (#679)

### DIFF
--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -1479,6 +1479,106 @@ impl AppState {
         Ok(revision)
     }
 
+    /// Reset the complete provider section and all provider-owned credentials
+    /// in one recoverable exact transaction guarded by the typed section
+    /// revision. Runtime publication remains last-known-good when the default
+    /// provider cannot be initialized without credentials.
+    pub(crate) async fn reset_provider_section(
+        &self,
+        expected_revision: u64,
+    ) -> Result<u64, ConfigSectionMutationError> {
+        let config_io_lock = self.config_io_lock.clone();
+        let config = self.config.clone();
+        let app_data_dir = self.app_data_dir.clone();
+        let config_facade = self.config_facade.clone();
+        let account_sink = self.account_sink.clone();
+        let provider_registry = self.provider_registry.clone();
+        let provider = self.provider.clone();
+        let config_live_health = self.config_live_health.clone();
+        let transaction = tokio::spawn(async move {
+            let _io = config_io_lock.lock().await;
+            ensure_provider_mcp_migration_ready(&app_data_dir)
+                .map_err(ConfigSectionMutationError::Store)?;
+            let facade = config_facade.as_ref().ok_or_else(|| {
+                ConfigSectionMutationError::Invalid(
+                    "provider reset requires the modular configuration facade".to_string(),
+                )
+            })?;
+            let current = config.read().await.clone();
+            let provider_intents = BTreeSet::from([
+                "openai".to_string(),
+                "anthropic".to_string(),
+                "gemini".to_string(),
+                "bodhi".to_string(),
+            ]);
+            let provider_instance_intents = current.provider_instances.keys().cloned().collect();
+            let mut candidate = current;
+            apply_runtime_section(SectionId::Providers, &Config::default(), &mut candidate);
+
+            let transaction_dir = app_data_dir.clone();
+            let candidate = tokio::task::spawn_blocking(move || {
+                bamboo_config::persist_provider_reset_credential_transaction_at_revision(
+                    &transaction_dir,
+                    &mut candidate,
+                    &provider_intents,
+                    &provider_instance_intents,
+                    expected_revision,
+                )?;
+                load_committed_effective_config(&transaction_dir)
+            })
+            .await
+            .map_err(|error| {
+                ConfigSectionMutationError::Runtime(format!(
+                    "provider reset transaction task failed: {error}"
+                ))
+            })?
+            .map_err(ConfigSectionMutationError::Store)?;
+
+            *config.write().await = candidate.clone();
+            publish_exact_facade_commit(
+                Some(facade),
+                &account_sink,
+                &[SectionId::Credentials, SectionId::Providers],
+            )
+            .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
+
+            match bamboo_llm::ProviderRegistry::from_config(&candidate, app_data_dir).await {
+                Ok(registry) => {
+                    if let Some(candidate_provider) = registry.get_default() {
+                        provider_registry.replace_with(registry);
+                        *provider.write().await = candidate_provider;
+                    } else {
+                        publish_section_failure(
+                            &config_live_health,
+                            &account_sink,
+                            "providers",
+                            SectionStatus::Degraded,
+                            "provider reset committed; default provider is not initialized"
+                                .to_string(),
+                        );
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(error = %error, "provider reset committed but runtime initialization failed");
+                    publish_section_failure(
+                        &config_live_health,
+                        &account_sink,
+                        "providers",
+                        SectionStatus::Degraded,
+                        "provider reset committed; retaining last-known-good runtime".to_string(),
+                    );
+                }
+            }
+
+            Ok(facade.registry().providers.snapshot().revision)
+        });
+        transaction.await.map_err(|error| {
+            ConfigSectionMutationError::Runtime(format!(
+                "provider reset transaction task failed: {error}"
+            ))
+        })?
+    }
+
     /// Stage MCP connection/initialization/tool discovery, perform the CAS at
     /// the manager's pre-publication boundary, then publish the config snapshot
     /// before the prepared runtimes and finally emit one section event.
@@ -1570,6 +1670,182 @@ impl AppState {
             Some(revision),
         );
         Ok(revision)
+    }
+
+    /// Reset MCP metadata and its owned credentials at the runtime manager's
+    /// pre-publication boundary, preserving the same durable-before-live
+    /// ordering as a normal typed MCP write.
+    pub(crate) async fn reset_mcp_section(
+        &self,
+        expected_revision: u64,
+    ) -> Result<u64, ConfigSectionMutationError> {
+        let _io = self.config_io_lock.lock().await;
+        ensure_provider_mcp_migration_ready(&self.app_data_dir)
+            .map_err(ConfigSectionMutationError::Store)?;
+        let facade = self.config_facade.as_ref().ok_or_else(|| {
+            ConfigSectionMutationError::Invalid(
+                "MCP reset requires the modular configuration facade".to_string(),
+            )
+        })?;
+        let candidate_mcp = McpConfig::default();
+        let mut candidate_config = self.config.read().await.clone();
+        candidate_config.mcp = candidate_mcp.clone();
+        let mut committed_config = None;
+        let mut store_error = None;
+        let data_dir = self.app_data_dir.clone();
+        let result = self
+            .mcp_manager
+            .reconcile_from_config_transactional_after(&candidate_mcp, || async {
+                let mut live_config = self.config.write().await;
+                match bamboo_config::persist_mcp_reset_credential_transaction_at_revision(
+                    &data_dir,
+                    &mut candidate_config,
+                    expected_revision,
+                )
+                .and_then(|_| load_committed_effective_config(&data_dir))
+                {
+                    Ok(committed) => {
+                        *live_config = committed.clone();
+                        committed_config = Some(committed);
+                        Ok(())
+                    }
+                    Err(error) => {
+                        store_error = Some(error);
+                        Err(bamboo_mcp::McpError::InvalidConfig(
+                            "MCP reset durable commit failed".to_string(),
+                        ))
+                    }
+                }
+            })
+            .await;
+        if let Some(error) = store_error {
+            return Err(ConfigSectionMutationError::Store(error));
+        }
+        if result.is_err() || committed_config.is_none() {
+            let message =
+                "MCP reset runtime initialization failed; retaining last-known-good runtime"
+                    .to_string();
+            publish_section_failure(
+                &self.mcp_config_live_health,
+                &self.account_sink,
+                "mcp",
+                SectionStatus::Degraded,
+                message.clone(),
+            );
+            return Err(ConfigSectionMutationError::Runtime(message));
+        }
+        publish_exact_facade_commit(
+            Some(facade),
+            &self.account_sink,
+            &[SectionId::Credentials, SectionId::Mcp],
+        )
+        .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
+        let revision = facade.registry().mcp.snapshot().revision;
+        publish_section_success(
+            &self.mcp_config_live_health,
+            &self.account_sink,
+            "mcp",
+            self.app_data_dir.join("mcp.json"),
+            section_is_unhealthy(&self.mcp_config_live_health),
+            Some(revision),
+        );
+        Ok(revision)
+    }
+
+    /// Reset a credential-backed non-provider section using the typed section
+    /// revision as the client CAS authority. The exact transaction rebases on
+    /// the latest unrelated credential document while clearing only references
+    /// owned by this section.
+    pub(crate) async fn reset_credential_backed_section(
+        &self,
+        id: SectionId,
+        expected_revision: u64,
+    ) -> Result<u64, ConfigSectionMutationError> {
+        if !matches!(
+            id,
+            SectionId::Core
+                | SectionId::Notifications
+                | SectionId::Connect
+                | SectionId::Env
+                | SectionId::ClusterFabric
+                | SectionId::AccessControl
+        ) {
+            return Err(ConfigSectionMutationError::Invalid(
+                "section is not a credential-backed reset domain".to_string(),
+            ));
+        }
+        let config_io_lock = self.config_io_lock.clone();
+        let config = self.config.clone();
+        let app_data_dir = self.app_data_dir.clone();
+        let config_facade = self.config_facade.clone();
+        let account_sink = self.account_sink.clone();
+        let provider_registry = self.provider_registry.clone();
+        let provider = self.provider.clone();
+        let mcp_manager = self.mcp_manager.clone();
+        let transaction = tokio::spawn(async move {
+            let _io = config_io_lock.lock().await;
+            ensure_provider_mcp_migration_ready(&app_data_dir)
+                .map_err(ConfigSectionMutationError::Store)?;
+            let facade = config_facade.as_ref().ok_or_else(|| {
+                ConfigSectionMutationError::Invalid(
+                    "section reset requires the modular configuration facade".to_string(),
+                )
+            })?;
+            let mut candidate = config.read().await.clone();
+            apply_runtime_section(id, &Config::default(), &mut candidate);
+            let transaction_dir = app_data_dir.clone();
+            let candidate = tokio::task::spawn_blocking(move || {
+                bamboo_config::persist_credential_backed_section_reset_at_revision(
+                    &transaction_dir,
+                    &mut candidate,
+                    id,
+                    expected_revision,
+                )?;
+                load_committed_effective_config(&transaction_dir)
+            })
+            .await
+            .map_err(|error| {
+                ConfigSectionMutationError::Runtime(format!(
+                    "section reset transaction task failed: {error}"
+                ))
+            })?
+            .map_err(ConfigSectionMutationError::Store)?;
+
+            if id == SectionId::Env {
+                candidate.publish_env_vars();
+            }
+            *config.write().await = candidate.clone();
+            publish_exact_facade_commit(Some(facade), &account_sink, &[SectionId::Credentials, id])
+                .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
+
+            if id == SectionId::Core {
+                match bamboo_llm::ProviderRegistry::from_config(&candidate, app_data_dir.clone())
+                    .await
+                {
+                    Ok(registry) => {
+                        if let Some(candidate_provider) = registry.get_default() {
+                            provider_registry.replace_with(registry);
+                            *provider.write().await = candidate_provider;
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(error = %error, "core reset committed but provider reload failed");
+                    }
+                }
+                mcp_manager.reconcile_from_config(&candidate.mcp).await;
+            }
+
+            facade
+                .registry()
+                .envelope_value(id)
+                .map(|envelope| envelope.revision)
+                .map_err(ConfigSectionMutationError::Store)
+        });
+        transaction.await.map_err(|error| {
+            ConfigSectionMutationError::Runtime(format!(
+                "section reset transaction task failed: {error}"
+            ))
+        })?
     }
 }
 
@@ -2514,6 +2790,28 @@ impl AppState {
         ),
         AppError,
     > {
+        self.update_core_with_proxy_credential(expected_revision, effects, move |candidate| {
+            candidate.proxy_auth = auth;
+        })
+        .await
+    }
+
+    async fn update_core_with_proxy_credential<F>(
+        &self,
+        expected_revision: u64,
+        effects: ConfigUpdateEffects,
+        update: F,
+    ) -> Result<
+        (
+            Config,
+            bamboo_config::CredentialStatus,
+            bamboo_config::CredentialStoreHealth,
+        ),
+        AppError,
+    >
+    where
+        F: FnOnce(&mut Config) + Send + 'static,
+    {
         let config_io_lock = self.config_io_lock.clone();
         let config = self.config.clone();
         let app_data_dir = self.app_data_dir.clone();
@@ -2534,7 +2832,7 @@ impl AppState {
                 let cfg = config.read().await;
                 reject_if_recovery_pending(&cfg)?;
                 let mut candidate = cfg.clone();
-                candidate.proxy_auth = auth;
+                update(&mut candidate);
                 candidate.assign_connect_platform_ids();
                 candidate.refresh_encrypted_secrets().map_err(|error| {
                     AppError::InternalError(anyhow::anyhow!(

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
@@ -29,6 +29,12 @@ pub struct ClearCredentialRequest {
     pub expected_revision: u64,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResetCredentialsRequest {
+    pub expected_revision: u64,
+}
+
 pub async fn list_credentials(app_state: web::Data<AppState>) -> Result<HttpResponse, AppError> {
     let (statuses, health) = app_state
         .credential_store
@@ -84,6 +90,26 @@ pub async fn clear_credential(
         .map_err(map_store_mutation_error)?;
     publish_credential_event(&app_state, revision);
     Ok(HttpResponse::Ok().json(envelope(status, CredentialStoreHealth::committed(revision))))
+}
+
+pub async fn reset_credentials(
+    app_state: web::Data<AppState>,
+    payload: web::Json<ResetCredentialsRequest>,
+) -> Result<HttpResponse, AppError> {
+    let _io = app_state.config_io_lock.lock().await;
+    let config = app_state.config.read().await.clone();
+    let (revision, statuses) = app_state
+        .credential_store
+        .clear_all_unreferenced(&config, payload.expected_revision)
+        .map_err(|error| match error {
+            ConfigStoreError::Validation(message) => AppError::BadRequest(message),
+            other => map_store_mutation_error(other),
+        })?;
+    publish_credential_event(&app_state, revision);
+    Ok(HttpResponse::Ok().json(envelope(
+        statuses,
+        CredentialStoreHealth::committed(revision),
+    )))
 }
 
 pub async fn get_live_config_health(
@@ -499,5 +525,68 @@ mod tests {
         );
         assert_eq!(bamboo_config::Config::current_env_vars(), before_runtime);
         assert_eq!(state.config.read().await.env_vars, before_config.env_vars);
+    }
+
+    #[actix_web::test]
+    async fn reset_clears_all_orphans_in_one_cas_but_rejects_live_references() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x63; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let orphan = CredentialRef::parse("custom.orphan.token").unwrap();
+        let active = CredentialRef::parse("env.ACTIVE.value").unwrap();
+        state
+            .credential_store
+            .replace(orphan, "orphan-secret", CredentialSource::User, 0)
+            .unwrap();
+        state
+            .credential_store
+            .replace(active.clone(), "active-secret", CredentialSource::User, 1)
+            .unwrap();
+        state
+            .config
+            .write()
+            .await
+            .env_vars
+            .push(bamboo_config::EnvVarEntry {
+                name: "ACTIVE".to_string(),
+                value: "active-secret".to_string(),
+                secret: true,
+                value_encrypted: None,
+                credential_ref: Some(active),
+                configured: true,
+                description: None,
+            });
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .route("/credentials/reset", web::post().to(reset_credentials)),
+        )
+        .await;
+
+        let rejected = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/credentials/reset")
+                .set_json(serde_json::json!({"expected_revision": 2}))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(rejected.status(), actix_web::http::StatusCode::BAD_REQUEST);
+        assert_eq!(state.credential_store.statuses().unwrap().len(), 2);
+
+        state.config.write().await.env_vars.clear();
+        let reset = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/credentials/reset")
+                .set_json(serde_json::json!({"expected_revision": 2}))
+                .to_request(),
+        )
+        .await;
+        assert!(reset.status().is_success());
+        let reset: serde_json::Value = test::read_body_json(reset).await;
+        assert_eq!(reset["revision"], 3);
+        assert_eq!(reset["data"], serde_json::json!([]));
+        assert!(state.credential_store.statuses().unwrap().is_empty());
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/mod.rs
@@ -18,13 +18,13 @@ pub use config_endpoints::{
 };
 pub use credentials::{
     clear_credential, get_credential_status, get_live_config_health, list_credentials,
-    replace_credential,
+    replace_credential, reset_credentials,
 };
 pub use notifications::get_notification_config;
 pub use proxy_auth::{get_proxy_auth_status, set_proxy_auth};
 pub use sections::{
     get_mcp_section, get_provider_section, get_typed_section, put_mcp_section,
-    put_provider_section, put_typed_section,
+    put_provider_section, put_typed_section, reset_typed_section,
 };
 pub use tools::get_bamboo_tools;
 pub use types::ProxyAuthPayload;

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -1,5 +1,9 @@
 use actix_web::{web, HttpResponse};
-use bamboo_config::{patch::is_masked_api_key, ConfigStoreError, ProviderConfigs, SectionEnvelope};
+use bamboo_config::{
+    patch::is_masked_api_key, ConfigStoreError, HooksSection, MemorySection, ModelLimitsSection,
+    ModelPolicySection, ProviderConfigs, SectionEnvelope, SectionId, SubagentsSection,
+    ToolsSkillsSection,
+};
 use bamboo_mcp::McpConfig;
 use serde::{de::Error as _, Deserialize, Deserializer};
 use serde_json::{json, Map, Value};
@@ -30,6 +34,12 @@ pub struct PutMcpSectionRequest {
 pub struct PutTypedSectionRequest {
     pub expected_revision: u64,
     pub data: Value,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResetTypedSectionRequest {
+    pub expected_revision: u64,
 }
 
 /// Read-only, secret-free provider section projection. Credential values,
@@ -162,6 +172,78 @@ pub async fn put_typed_section(
         .envelope_value(id)
         .map_err(|error| map_mutation_error(ConfigSectionMutationError::Store(error)))?;
     Ok(HttpResponse::Ok().json(envelope))
+}
+
+/// Reset exactly one section to its backend-owned default using the typed
+/// section revision as the CAS authority. Credential-backed resets rebase on
+/// unrelated credential changes inside their recoverable exact transaction.
+pub async fn reset_typed_section(
+    app_state: web::Data<AppState>,
+    path: web::Path<String>,
+    payload: web::Json<ResetTypedSectionRequest>,
+) -> Result<HttpResponse, AppError> {
+    let name = path.into_inner();
+    let id = section_id(&name)?;
+    let expected_revision = payload.expected_revision;
+
+    match id {
+        SectionId::Core
+        | SectionId::Notifications
+        | SectionId::Connect
+        | SectionId::Env
+        | SectionId::ClusterFabric
+        | SectionId::AccessControl => {
+            app_state
+                .reset_credential_backed_section(id, expected_revision)
+                .await
+                .map_err(map_mutation_error)?;
+        }
+        SectionId::Providers => {
+            app_state
+                .reset_provider_section(expected_revision)
+                .await
+                .map_err(map_mutation_error)?;
+        }
+        SectionId::Mcp => {
+            app_state
+                .reset_mcp_section(expected_revision)
+                .await
+                .map_err(map_mutation_error)?;
+        }
+        SectionId::Credentials => {
+            return super::credentials::reset_credentials(
+                app_state,
+                web::Json(super::credentials::ResetCredentialsRequest { expected_revision }),
+            )
+            .await;
+        }
+        ordinary => {
+            let candidate = default_section_value(ordinary)?;
+            app_state
+                .put_ordinary_section(ordinary, expected_revision, candidate)
+                .await
+                .map_err(map_mutation_error)?;
+        }
+    }
+
+    get_typed_section(app_state, web::Path::from(name)).await
+}
+
+fn default_section_value(id: SectionId) -> Result<Value, AppError> {
+    let value = match id {
+        SectionId::ToolsSkills => serde_json::to_value(ToolsSkillsSection::default()),
+        SectionId::Memory => serde_json::to_value(MemorySection::default()),
+        SectionId::Subagents => serde_json::to_value(SubagentsSection::default()),
+        SectionId::Hooks => serde_json::to_value(HooksSection::default()),
+        SectionId::ModelPolicy => serde_json::to_value(ModelPolicySection::default()),
+        SectionId::ModelLimits => serde_json::to_value(ModelLimitsSection::default()),
+        _ => {
+            return Err(AppError::BadRequest(
+                "this section requires its dedicated reset path".to_string(),
+            ))
+        }
+    };
+    value.map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))
 }
 
 fn section_id(name: &str) -> Result<bamboo_config::SectionId, AppError> {
@@ -504,7 +586,7 @@ mod tests {
         HeaderConfig, McpConfig, McpServerConfig, ReconnectConfig, StdioConfig,
         StreamableHttpConfig, TransportConfig,
     };
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
     use std::time::Duration;
 
     fn server(id: &str, transport: TransportConfig) -> McpServerConfig {
@@ -1291,5 +1373,432 @@ mod tests {
             .await
             .proxy_auth_credential_ref
             .is_none());
+    }
+
+    #[actix_web::test]
+    async fn ordinary_section_reset_uses_backend_default_and_section_cas() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/sections/{section}", web::put().to(put_typed_section))
+                .route(
+                    "/sections/{section}/reset",
+                    web::post().to(reset_typed_section),
+                ),
+        )
+        .await;
+
+        let updated = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/sections/model-limits")
+                .set_json(json!({
+                    "expected_revision": 0,
+                    "data": [{"model": "custom", "max_tokens": 42}]
+                }))
+                .to_request(),
+        )
+        .await;
+        assert!(updated.status().is_success());
+
+        let reset = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/sections/model-limits/reset")
+                .set_json(json!({"expected_revision": 1}))
+                .to_request(),
+        )
+        .await;
+        assert!(reset.status().is_success());
+        let reset: Value = test::read_body_json(reset).await;
+        assert_eq!(reset["revision"], 2);
+        assert_eq!(reset["data"], json!([]));
+
+        let stale = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/sections/model-limits/reset")
+                .set_json(json!({"expected_revision": 1}))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale.status(), actix_web::http::StatusCode::CONFLICT);
+
+        let repeated = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/sections/model-limits/reset")
+                .set_json(json!({"expected_revision": 2}))
+                .to_request(),
+        )
+        .await;
+        assert!(repeated.status().is_success());
+        let repeated: Value = test::read_body_json(repeated).await;
+        assert_eq!(repeated["revision"], 3);
+        assert_eq!(repeated["data"], json!([]));
+    }
+
+    #[actix_web::test]
+    async fn notification_reset_atomically_clears_owned_secret_and_rejects_stale_cas() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x61; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        state
+            .update_notification_credentials(
+                0,
+                BTreeSet::from(["ntfy".to_string()]),
+                false,
+                |config| {
+                    config.notifications.ntfy.enabled = true;
+                    config.notifications.ntfy.topic = "alerts".to_string();
+                    config.notifications.ntfy.token = Some("never-return-reset-secret".to_string());
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        let reference = bamboo_config::credential_ref("notification", "ntfy", "token").unwrap();
+        assert!(
+            state
+                .credential_store
+                .status(&reference)
+                .unwrap()
+                .configured
+        );
+        let unrelated = bamboo_config::CredentialRef::parse("custom.unrelated.token").unwrap();
+        state
+            .credential_store
+            .replace(
+                unrelated.clone(),
+                "preserved-unrelated-secret",
+                bamboo_config::CredentialSource::User,
+                1,
+            )
+            .unwrap();
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/sections/{section}/reset",
+            web::post().to(reset_typed_section),
+        ))
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/sections/notifications/reset")
+                .set_json(json!({"expected_revision": 1}))
+                .to_request(),
+        )
+        .await;
+        let status = response.status();
+        let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+        assert!(status.is_success(), "unexpected response {status}: {body}");
+        assert!(!body.contains("never-return-reset-secret"));
+        assert!(!body.contains("preserved-unrelated-secret"));
+        assert!(body.contains("\"revision\":2"));
+        assert!(
+            !state
+                .credential_store
+                .status(&reference)
+                .unwrap()
+                .configured
+        );
+        assert!(
+            state
+                .credential_store
+                .status(&unrelated)
+                .unwrap()
+                .configured
+        );
+        assert_eq!(state.config.read().await.notifications, Default::default());
+
+        let stale = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/sections/notifications/reset")
+                .set_json(json!({"expected_revision": 1}))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale.status(), actix_web::http::StatusCode::CONFLICT);
+    }
+
+    #[actix_web::test]
+    async fn core_reset_clears_proxy_credential_with_core_metadata() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x64; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        state.config.write().await.http_proxy = "http://proxy.example:8080".to_string();
+        state
+            .update_proxy_auth_credential(
+                Some(bamboo_config::ProxyAuth {
+                    username: "proxy-user".to_string(),
+                    password: "proxy-reset-secret".to_string(),
+                }),
+                0,
+                Default::default(),
+            )
+            .await
+            .unwrap();
+        let reference = bamboo_config::credential_ref("proxy", "default", "auth").unwrap();
+        assert!(
+            state
+                .credential_store
+                .status(&reference)
+                .unwrap()
+                .configured
+        );
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/sections/{section}/reset",
+            web::post().to(reset_typed_section),
+        ))
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/sections/core/reset")
+                .set_json(json!({"expected_revision": 1}))
+                .to_request(),
+        )
+        .await;
+        let status = response.status();
+        let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+        assert!(status.is_success(), "unexpected response {status}: {body}");
+        assert!(!body.contains("proxy-reset-secret"));
+        assert!(state.config.read().await.http_proxy.is_empty());
+        assert!(state.config.read().await.proxy_auth.is_none());
+        assert!(
+            !state
+                .credential_store
+                .status(&reference)
+                .unwrap()
+                .configured
+        );
+    }
+
+    #[actix_web::test]
+    async fn access_control_reset_restores_none_and_clears_verifier() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x65; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        state
+            .update_access_control_credentials(0, true, BTreeSet::new(), |config| {
+                config.access_control = Some(bamboo_config::AccessControlConfig {
+                    password_enabled: true,
+                    password_hash: Some("a".repeat(64)),
+                    password_salt: Some("b".repeat(32)),
+                    password_configured: true,
+                    ..Default::default()
+                });
+                Ok(())
+            })
+            .await
+            .unwrap();
+        let reference = bamboo_config::config_crypto::access_password_credential_ref().unwrap();
+        assert!(
+            state
+                .credential_store
+                .status(&reference)
+                .unwrap()
+                .configured
+        );
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/sections/{section}/reset",
+            web::post().to(reset_typed_section),
+        ))
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/sections/access-control/reset")
+                .set_json(json!({"expected_revision": 1}))
+                .to_request(),
+        )
+        .await;
+        let status = response.status();
+        let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+        assert!(status.is_success(), "unexpected response {status}: {body}");
+        assert!(state.config.read().await.access_control.is_none());
+        assert!(
+            !state
+                .credential_store
+                .status(&reference)
+                .unwrap()
+                .configured
+        );
+    }
+
+    #[actix_web::test]
+    async fn provider_reset_clears_owned_credential_and_uses_provider_revision() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x62; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        state
+            .update_config_with_provider_credentials(
+                |config| {
+                    config.provider = "openai".to_string();
+                    config.providers_mut().openai = Some(OpenAIConfig {
+                        api_key: "provider-reset-secret".to_string(),
+                        model: Some("custom-model".to_string()),
+                        ..Default::default()
+                    });
+                    Ok(())
+                },
+                BTreeSet::from(["openai".to_string()]),
+                BTreeSet::new(),
+                Default::default(),
+            )
+            .await
+            .unwrap();
+        let reference = bamboo_config::credential_ref("provider", "openai", "api_key").unwrap();
+        assert!(
+            state
+                .credential_store
+                .status(&reference)
+                .unwrap()
+                .configured
+        );
+        let revision = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .providers
+            .snapshot()
+            .revision;
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/sections/{section}/reset",
+            web::post().to(reset_typed_section),
+        ))
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/sections/providers/reset")
+                .set_json(json!({"expected_revision": revision}))
+                .to_request(),
+        )
+        .await;
+        let status = response.status();
+        let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+        assert!(status.is_success(), "unexpected response {status}: {body}");
+        assert!(!body.contains("provider-reset-secret"));
+        assert!(
+            !state
+                .credential_store
+                .status(&reference)
+                .unwrap()
+                .configured
+        );
+        assert!(state.config.read().await.providers().openai.is_none());
+
+        let stale = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/sections/providers/reset")
+                .set_json(json!({"expected_revision": revision}))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale.status(), actix_web::http::StatusCode::CONFLICT);
+    }
+
+    #[actix_web::test]
+    async fn mcp_reset_clears_owned_credentials_at_runtime_commit_boundary() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x66; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                let health = state
+                    .mcp_config_live_health
+                    .read()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .clone();
+                if health.status == SectionStatus::Healthy && health.revision == 0 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .unwrap();
+        let reference = bamboo_config::credential_ref("mcp", "reset-server", "env_TOKEN").unwrap();
+        state
+            .credential_store
+            .replace(
+                reference.clone(),
+                "mcp-reset-secret",
+                bamboo_config::CredentialSource::User,
+                0,
+            )
+            .unwrap();
+        state
+            .put_mcp_section(
+                0,
+                McpConfig {
+                    version: 1,
+                    servers: vec![server(
+                        "reset-server",
+                        TransportConfig::Stdio(StdioConfig {
+                            command: "disabled-command".to_string(),
+                            args: Vec::new(),
+                            cwd: None,
+                            env: HashMap::from([(
+                                "TOKEN".to_string(),
+                                "mcp-reset-secret".to_string(),
+                            )]),
+                            env_encrypted: HashMap::new(),
+                            env_credential_refs: HashMap::from([(
+                                "TOKEN".to_string(),
+                                reference.as_str().to_string(),
+                            )]),
+                            startup_timeout_ms: 500,
+                        }),
+                    )],
+                },
+            )
+            .await
+            .unwrap();
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/sections/{section}/reset",
+            web::post().to(reset_typed_section),
+        ))
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/sections/mcp/reset")
+                .set_json(json!({"expected_revision": 1}))
+                .to_request(),
+        )
+        .await;
+        let status = response.status();
+        let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+        assert!(status.is_success(), "unexpected response {status}: {body}");
+        assert!(!body.contains("mcp-reset-secret"));
+        assert!(state.config.read().await.mcp.servers.is_empty());
+        assert!(
+            !state
+                .credential_store
+                .status(&reference)
+                .unwrap()
+                .configured
+        );
+
+        let stale = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/sections/mcp/reset")
+                .set_json(json!({"expected_revision": 1}))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale.status(), actix_web::http::StatusCode::CONFLICT);
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/mod.rs
@@ -30,7 +30,8 @@ pub use bamboo_config::{
     get_mcp_section, get_model_limit_defaults, get_notification_config, get_provider_section,
     get_proxy_auth_status, get_typed_section, list_credentials, put_mcp_section,
     put_provider_section, put_typed_section, replace_credential, reset_bamboo_config,
-    set_bamboo_config, set_proxy_auth, validate_bamboo_config_patch, ProxyAuthPayload,
+    reset_credentials, reset_typed_section, set_bamboo_config, set_proxy_auth,
+    validate_bamboo_config_patch, ProxyAuthPayload,
 };
 pub use cluster_fabric::{
     create_cluster, create_node, delete_cluster, delete_node, get_node, list_nodes, node_deploy,

--- a/crates/app/bamboo-server/src/routes/bamboo_v1.rs
+++ b/crates/app/bamboo-server/src/routes/bamboo_v1.rs
@@ -162,6 +162,10 @@ pub(crate) fn bamboo_relative_routes() -> impl HttpServiceFactory {
             web::put().to(settings::put_typed_section),
         )
         .route(
+            "/bamboo/config/sections/{section}/reset",
+            web::post().to(settings::reset_typed_section),
+        )
+        .route(
             "/bamboo/config/credentials",
             web::get().to(settings::list_credentials),
         )

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -122,6 +122,7 @@ struct SectionLayoutCompletionLedger {
 #[serde(rename_all = "snake_case")]
 enum ExactTransactionScope {
     Providers,
+    Mcp,
     ProxyAuth,
     EnvVars,
     Notifications,
@@ -824,6 +825,7 @@ enum MigrationFault {
 fn authoritative_section_file(scope: ExactTransactionScope) -> &'static str {
     match scope {
         ExactTransactionScope::Providers => PROVIDERS_FILE,
+        ExactTransactionScope::Mcp => MCP_FILE,
         ExactTransactionScope::ProxyAuth => CORE_FILE,
         ExactTransactionScope::EnvVars => ENV_FILE,
         ExactTransactionScope::Notifications => NOTIFICATIONS_FILE,
@@ -1692,6 +1694,9 @@ pub fn persist_connect_credential_transaction_at_revision(
         None,
         Some((secret_intents, expected_revision)),
         None,
+        None,
+        None,
+        None,
         #[cfg(test)]
         None,
     )
@@ -1727,6 +1732,9 @@ pub fn persist_access_control_credential_transaction_at_revision(
         None,
         None,
         Some((password_intent, device_intents, expected_revision)),
+        None,
+        None,
+        None,
         #[cfg(test)]
         None,
     )
@@ -1754,6 +1762,9 @@ pub fn persist_cluster_fabric_credential_transaction_at_revision(
         false,
         None,
         Some((node_intents, expected_revision)),
+        None,
+        None,
+        None,
         None,
         None,
         #[cfg(test)]
@@ -1809,6 +1820,110 @@ pub fn persist_provider_instance_credential_transaction(
     .map(|_| ())
 }
 
+/// Reset the provider domain and its owned credentials under the provider
+/// section revision supplied by a typed client. Compatibility writes may
+/// rebase, but an explicit reset must fail when its section snapshot is stale.
+pub fn persist_provider_reset_credential_transaction_at_revision(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    provider_intents: &BTreeSet<String>,
+    provider_instance_intents: &BTreeSet<String>,
+    expected_revision: u64,
+) -> ConfigStoreResult<u64> {
+    persist_provider_credential_transaction_with_instances_at_revision_inner(
+        data_dir.as_ref(),
+        config,
+        provider_intents,
+        provider_instance_intents,
+        None,
+        &BTreeSet::new(),
+        None,
+        false,
+        &BTreeSet::new(),
+        false,
+        None,
+        Some(expected_revision),
+        #[cfg(test)]
+        None,
+    )
+}
+
+/// Reset MCP metadata and every MCP-owned credential reference in one exact
+/// transaction guarded by the MCP section revision.
+pub fn persist_mcp_reset_credential_transaction_at_revision(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    expected_revision: u64,
+) -> ConfigStoreResult<u64> {
+    persist_exact_credential_transaction_inner(
+        data_dir.as_ref(),
+        config,
+        &BTreeSet::new(),
+        &BTreeSet::new(),
+        None,
+        &BTreeSet::new(),
+        None,
+        false,
+        &BTreeSet::new(),
+        false,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(expected_revision),
+        None,
+        #[cfg(test)]
+        None,
+    )
+}
+
+/// Reset one credential-backed section at its typed section revision while
+/// rebasing safely over unrelated credential-document changes. The section is
+/// the client CAS authority; its owned references are cleared from the latest
+/// credential snapshot inside the same cross-process transaction lock.
+pub fn persist_credential_backed_section_reset_at_revision(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    section: crate::SectionId,
+    expected_revision: u64,
+) -> ConfigStoreResult<u64> {
+    let scope = match section {
+        crate::SectionId::Core => ExactTransactionScope::ProxyAuth,
+        crate::SectionId::Notifications => ExactTransactionScope::Notifications,
+        crate::SectionId::Connect => ExactTransactionScope::Connect,
+        crate::SectionId::Env => ExactTransactionScope::EnvVars,
+        crate::SectionId::ClusterFabric => ExactTransactionScope::ClusterFabric,
+        crate::SectionId::AccessControl => ExactTransactionScope::AccessControl,
+        _ => {
+            return Err(ConfigStoreError::Validation(
+                "section is not a credential-backed reset domain".to_string(),
+            ))
+        }
+    };
+    persist_exact_credential_transaction_inner(
+        data_dir.as_ref(),
+        config,
+        &BTreeSet::new(),
+        &BTreeSet::new(),
+        None,
+        &BTreeSet::new(),
+        None,
+        false,
+        &BTreeSet::new(),
+        false,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some((scope, expected_revision)),
+        #[cfg(test)]
+        None,
+    )
+}
+
 #[cfg(test)]
 fn persist_provider_credential_transaction_inner(
     data_dir: &Path,
@@ -1851,6 +1966,40 @@ fn persist_provider_credential_transaction_with_instances_inner(
     notification_expected_revision: Option<u64>,
     #[cfg(test)] fault: Option<MigrationFault>,
 ) -> ConfigStoreResult<u64> {
+    persist_provider_credential_transaction_with_instances_at_revision_inner(
+        data_dir,
+        config,
+        provider_intents,
+        provider_instance_intents,
+        proxy_expected_revision,
+        env_intents,
+        env_expected_revision,
+        notification_transaction,
+        notification_intents,
+        notification_reset,
+        notification_expected_revision,
+        None,
+        #[cfg(test)]
+        fault,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn persist_provider_credential_transaction_with_instances_at_revision_inner(
+    data_dir: &Path,
+    config: &mut crate::Config,
+    provider_intents: &BTreeSet<String>,
+    provider_instance_intents: &BTreeSet<String>,
+    proxy_expected_revision: Option<u64>,
+    env_intents: &BTreeSet<String>,
+    env_expected_revision: Option<u64>,
+    notification_transaction: bool,
+    notification_intents: &BTreeSet<String>,
+    notification_reset: bool,
+    notification_expected_revision: Option<u64>,
+    provider_expected_revision: Option<u64>,
+    #[cfg(test)] fault: Option<MigrationFault>,
+) -> ConfigStoreResult<u64> {
     persist_exact_credential_transaction_inner(
         data_dir,
         config,
@@ -1864,6 +2013,9 @@ fn persist_provider_credential_transaction_with_instances_inner(
         notification_reset,
         notification_expected_revision,
         None,
+        None,
+        None,
+        provider_expected_revision,
         None,
         None,
         #[cfg(test)]
@@ -1887,18 +2039,23 @@ fn persist_exact_credential_transaction_inner(
     cluster_transaction: Option<(&BTreeSet<String>, u64)>,
     connect_transaction: Option<(&crate::patch::ConnectSecretIntents, u64)>,
     access_transaction: Option<(bool, &BTreeSet<String>, u64)>,
+    provider_expected_revision: Option<u64>,
+    mcp_expected_revision: Option<u64>,
+    reset_scope: Option<(ExactTransactionScope, u64)>,
     #[cfg(test)] fault: Option<MigrationFault>,
 ) -> ConfigStoreResult<u64> {
-    let proxy_only = provider_intents.len() == 1
+    let reset_is = |scope| reset_scope.is_some_and(|(reset, _)| reset == scope);
+    let proxy_only = (provider_intents.len() == 1
         && provider_intents.contains("__proxy_auth")
-        && provider_instance_intents.is_empty();
+        && provider_instance_intents.is_empty())
+        || reset_is(ExactTransactionScope::ProxyAuth);
     let env_only = provider_intents.is_empty()
         && provider_instance_intents.is_empty()
-        && !env_intents.is_empty();
+        && (!env_intents.is_empty() || reset_is(ExactTransactionScope::EnvVars));
     let notification_only = provider_intents.is_empty()
         && provider_instance_intents.is_empty()
         && env_intents.is_empty()
-        && notification_transaction
+        && (notification_transaction || reset_is(ExactTransactionScope::Notifications))
         && cluster_transaction.is_none()
         && connect_transaction.is_none()
         && access_transaction.is_none();
@@ -1906,7 +2063,7 @@ fn persist_exact_credential_transaction_inner(
         && provider_instance_intents.is_empty()
         && env_intents.is_empty()
         && !notification_transaction
-        && cluster_transaction.is_some()
+        && (cluster_transaction.is_some() || reset_is(ExactTransactionScope::ClusterFabric))
         && connect_transaction.is_none()
         && access_transaction.is_none();
     let connect_only = provider_intents.is_empty()
@@ -1914,7 +2071,7 @@ fn persist_exact_credential_transaction_inner(
         && env_intents.is_empty()
         && !notification_transaction
         && cluster_transaction.is_none()
-        && connect_transaction.is_some()
+        && (connect_transaction.is_some() || reset_is(ExactTransactionScope::Connect))
         && access_transaction.is_none();
     let access_only = provider_intents.is_empty()
         && provider_instance_intents.is_empty()
@@ -1922,7 +2079,15 @@ fn persist_exact_credential_transaction_inner(
         && !notification_transaction
         && cluster_transaction.is_none()
         && connect_transaction.is_none()
-        && access_transaction.is_some();
+        && (access_transaction.is_some() || reset_is(ExactTransactionScope::AccessControl));
+    let mcp_only = mcp_expected_revision.is_some()
+        && provider_intents.is_empty()
+        && provider_instance_intents.is_empty()
+        && env_intents.is_empty()
+        && !notification_transaction
+        && cluster_transaction.is_none()
+        && connect_transaction.is_none()
+        && access_transaction.is_none();
     if !env_intents.is_empty() && !env_only {
         return Err(ConfigStoreError::Validation(
             "env credentials must be updated in their own transaction".to_string(),
@@ -1961,7 +2126,9 @@ fn persist_exact_credential_transaction_inner(
     )?;
     discard_uncommitted(data_dir)?;
 
-    let exact_scope = if proxy_only {
+    let exact_scope = if let Some((scope, _)) = reset_scope {
+        Some(scope)
+    } else if proxy_only {
         Some(ExactTransactionScope::ProxyAuth)
     } else if env_only {
         Some(ExactTransactionScope::EnvVars)
@@ -1973,6 +2140,8 @@ fn persist_exact_credential_transaction_inner(
         Some(ExactTransactionScope::AccessControl)
     } else if cluster_only {
         Some(ExactTransactionScope::ClusterFabric)
+    } else if mcp_only {
+        Some(ExactTransactionScope::Mcp)
     } else if crate::section_layout_is_active(data_dir)? {
         Some(ExactTransactionScope::Providers)
     } else {
@@ -1985,6 +2154,36 @@ fn persist_exact_credential_transaction_inner(
     } else {
         None
     };
+    if let (Some(expected), Some(section), Some(ExactTransactionScope::Providers)) = (
+        provider_expected_revision,
+        active_section.as_ref(),
+        exact_scope,
+    ) {
+        if section.expected_revision != expected {
+            return Err(ConfigStoreError::Conflict {
+                expected,
+                actual: section.expected_revision,
+            });
+        }
+    }
+    if let (Some(expected), Some(section), Some(ExactTransactionScope::Mcp)) =
+        (mcp_expected_revision, active_section.as_ref(), exact_scope)
+    {
+        if section.expected_revision != expected {
+            return Err(ConfigStoreError::Conflict {
+                expected,
+                actual: section.expected_revision,
+            });
+        }
+    }
+    if let (Some((_, expected)), Some(section)) = (reset_scope, active_section.as_ref()) {
+        if section.expected_revision != expected {
+            return Err(ConfigStoreError::Conflict {
+                expected,
+                actual: section.expected_revision,
+            });
+        }
+    }
 
     let credentials_original = read_target_or_empty(&data_dir.join(CREDENTIALS_FILE))?;
     let providers_original = read_target_or_empty(&data_dir.join(PROVIDERS_FILE))?;
@@ -2000,6 +2199,17 @@ fn persist_exact_credential_transaction_inner(
             &config_original
         },
     )?;
+    let persisted_provider_refs =
+        provider_refs_from_document(if exact_scope == Some(ExactTransactionScope::Providers) {
+            domain_original
+        } else {
+            &config_original
+        })?;
+    let persisted_mcp_refs = if mcp_only {
+        mcp_refs_from_document(domain_original)?
+    } else {
+        BTreeSet::new()
+    };
     let persisted_env_refs = env_refs_from_document(domain_original)?;
     let persisted_notification_refs = notification_refs_from_document(domain_original)?;
     let persisted_connect_refs = if connect_only {
@@ -2012,10 +2222,51 @@ fn persist_exact_credential_transaction_inner(
     } else {
         crate::credential_store::PersistedAccessCredentialRefs::default()
     };
-    let persisted_cluster_refs = if cluster_transaction.is_some() {
+    let persisted_cluster_refs = if cluster_only {
         cluster_node_refs_from_document(domain_original)?
     } else {
         BTreeMap::new()
+    };
+    let reset_refs = if let Some((scope, _)) = reset_scope {
+        let mut references = BTreeSet::new();
+        match scope {
+            ExactTransactionScope::ProxyAuth => {
+                let root: Value = serde_json::from_slice(domain_original)?;
+                let reference = root
+                    .get("proxy_auth_credential_ref")
+                    .and_then(Value::as_str)
+                    .map(|value| CredentialRef::parse(value.to_string()))
+                    .transpose()?
+                    .unwrap_or(credential_ref("proxy", "default", "auth")?);
+                references.insert(reference);
+            }
+            ExactTransactionScope::EnvVars => {
+                references.extend(persisted_env_refs.values().cloned());
+            }
+            ExactTransactionScope::Notifications => {
+                references.extend(persisted_notification_refs.values().cloned());
+            }
+            ExactTransactionScope::Connect => {
+                for (token, app_secret) in persisted_connect_refs.values() {
+                    references.extend(token.iter().chain(app_secret.iter()).cloned());
+                }
+            }
+            ExactTransactionScope::AccessControl => {
+                references.extend(persisted_access_refs.password.iter().cloned());
+                references.extend(persisted_access_refs.devices.values().cloned());
+            }
+            ExactTransactionScope::ClusterFabric => {
+                for metadata in persisted_cluster_refs.values() {
+                    references.extend(metadata.references().cloned());
+                }
+            }
+            ExactTransactionScope::Providers | ExactTransactionScope::Mcp => {
+                unreachable!("provider and MCP resets use their runtime-staged exact transactions")
+            }
+        }
+        references
+    } else {
+        BTreeSet::new()
     };
     if env_only {
         for name in env_intents {
@@ -2093,7 +2344,9 @@ fn persist_exact_credential_transaction_inner(
         }
     }
     let store = CredentialStore::open(data_dir);
-    let prepared = if env_only {
+    let prepared = if reset_scope.is_some() {
+        Some(store.prepare_clear_owned_references(config, &reset_refs)?)
+    } else if env_only {
         store.prepare_env_var_intents(config, env_intents, &persisted_env_refs)?
     } else if notification_only {
         store.prepare_notification_intents(
@@ -2113,10 +2366,13 @@ fn persist_exact_credential_transaction_inner(
             device_intents,
             &persisted_access_refs,
         )?
+    } else if mcp_only {
+        Some(store.prepare_clear_owned_references(config, &persisted_mcp_refs)?)
     } else {
         store.prepare_provider_api_key_intents(
             config,
             provider_intents,
+            &persisted_provider_refs,
             provider_instance_intents,
             &persisted_instance_refs,
         )?
@@ -2124,7 +2380,7 @@ fn persist_exact_credential_transaction_inner(
     let Some(mut prepared) = prepared else {
         return store.revision_unchecked();
     };
-    if proxy_only {
+    if proxy_only && reset_scope.is_none() {
         let expected = proxy_expected_revision.ok_or_else(|| {
             ConfigStoreError::Validation(
                 "proxy auth credential revision precondition is required".to_string(),
@@ -2137,7 +2393,7 @@ fn persist_exact_credential_transaction_inner(
             });
         }
     }
-    if env_only {
+    if env_only && reset_scope.is_none() {
         let expected = env_expected_revision.ok_or_else(|| {
             ConfigStoreError::Validation(
                 "env credential revision precondition is required".to_string(),
@@ -2150,7 +2406,7 @@ fn persist_exact_credential_transaction_inner(
             });
         }
     }
-    if notification_only {
+    if notification_only && reset_scope.is_none() {
         let expected = notification_expected_revision.ok_or_else(|| {
             ConfigStoreError::Validation(
                 "notification credential revision precondition is required".to_string(),
@@ -2202,7 +2458,11 @@ fn persist_exact_credential_transaction_inner(
         )
     } else if notification_only {
         (
-            prepare_notification_config_document(domain_original, config, notification_reset)?,
+            prepare_notification_config_document(
+                domain_original,
+                config,
+                notification_reset || reset_is(ExactTransactionScope::Notifications),
+            )?,
             providers_original.clone(),
         )
     } else if cluster_only {
@@ -2218,6 +2478,11 @@ fn persist_exact_credential_transaction_inner(
     } else if access_only {
         (
             prepare_access_control_config_document(domain_original, config)?,
+            providers_original.clone(),
+        )
+    } else if mcp_only {
+        (
+            serde_json::to_vec_pretty(&config.mcp)?,
             providers_original.clone(),
         )
     } else {
@@ -4014,6 +4279,70 @@ fn provider_instance_refs_from_document(
             ))
         })
         .collect()
+}
+
+fn provider_refs_from_document(bytes: &[u8]) -> ConfigStoreResult<BTreeMap<String, CredentialRef>> {
+    if bytes.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+    let root: Value = serde_json::from_slice(bytes)?;
+    ["openai", "anthropic", "gemini", "bodhi"]
+        .into_iter()
+        .filter_map(|provider| {
+            root.get(provider)
+                .and_then(|value| value.get("credential_ref"))
+                .map(|value| (provider, value))
+        })
+        .map(|(provider, value)| {
+            let value = value.as_str().ok_or_else(|| {
+                ConfigStoreError::Validation(
+                    "provider credential reference must be a string".to_string(),
+                )
+            })?;
+            Ok((
+                provider.to_string(),
+                CredentialRef::parse(value.to_string())?,
+            ))
+        })
+        .collect()
+}
+
+fn mcp_refs_from_document(bytes: &[u8]) -> ConfigStoreResult<BTreeSet<CredentialRef>> {
+    if bytes.is_empty() {
+        return Ok(BTreeSet::new());
+    }
+    fn collect(value: &Value, output: &mut BTreeSet<CredentialRef>) -> ConfigStoreResult<()> {
+        match value {
+            Value::Object(object) => {
+                for (key, value) in object {
+                    if key == "credential_ref" {
+                        if let Some(reference) = value.as_str() {
+                            output.insert(CredentialRef::parse(reference.to_string())?);
+                        }
+                    } else if key.ends_with("credential_refs") {
+                        if let Some(references) = value.as_object() {
+                            for reference in references.values().filter_map(Value::as_str) {
+                                output.insert(CredentialRef::parse(reference.to_string())?);
+                            }
+                        }
+                    } else {
+                        collect(value, output)?;
+                    }
+                }
+            }
+            Value::Array(values) => {
+                for value in values {
+                    collect(value, output)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+    let root: Value = serde_json::from_slice(bytes)?;
+    let mut references = BTreeSet::new();
+    collect(&root, &mut references)?;
+    Ok(references)
 }
 
 fn env_refs_from_document(bytes: &[u8]) -> ConfigStoreResult<BTreeMap<String, CredentialRef>> {
@@ -5851,6 +6180,7 @@ fn section_data_as_legacy_root(
 ) -> ConfigStoreResult<Value> {
     let root = match scope {
         ExactTransactionScope::Providers
+        | ExactTransactionScope::Mcp
         | ExactTransactionScope::ProxyAuth
         | ExactTransactionScope::Notifications => data,
         ExactTransactionScope::EnvVars => serde_json::json!({ "env_vars": data }),
@@ -5908,6 +6238,7 @@ fn prepare_active_exact_section_document(
     )?;
     let mut updated_data = match scope {
         ExactTransactionScope::Providers
+        | ExactTransactionScope::Mcp
         | ExactTransactionScope::ProxyAuth
         | ExactTransactionScope::Notifications => Value::Object(updated_root),
         ExactTransactionScope::EnvVars => updated_root
@@ -5979,6 +6310,7 @@ fn prepare_active_exact_section_document(
             }
         }
         ExactTransactionScope::Providers
+        | ExactTransactionScope::Mcp
         | ExactTransactionScope::ProxyAuth
         | ExactTransactionScope::ClusterFabric
         | ExactTransactionScope::AccessControl => {}
@@ -6780,9 +7112,11 @@ fn rollback_exact_authority_member(
 ) -> ConfigStoreResult<()> {
     match exact_authority_file(manifest) {
         Some(CONFIG_FILE) => match manifest.exact_scope {
-            Some(ExactTransactionScope::Providers) => Err(ConfigStoreError::Validation(
-                "provider exact transaction has no legacy root authority".to_string(),
-            )),
+            Some(ExactTransactionScope::Providers) | Some(ExactTransactionScope::Mcp) => {
+                Err(ConfigStoreError::Validation(
+                    "runtime section exact transaction has no legacy root authority".to_string(),
+                ))
+            }
             Some(ExactTransactionScope::ProxyAuth) => {
                 rollback_proxy_config_member(data_dir, manifest)
             }
@@ -7202,6 +7536,9 @@ fn abort_exact_transaction(data_dir: &Path, manifest: &MigrationManifest) -> Con
     match manifest.exact_scope {
         Some(ExactTransactionScope::Providers) => {
             abort_active_exact_transaction(data_dir, manifest, ExactTransactionScope::Providers)
+        }
+        Some(ExactTransactionScope::Mcp) => {
+            abort_active_exact_transaction(data_dir, manifest, ExactTransactionScope::Mcp)
         }
         Some(ExactTransactionScope::ProxyAuth) => abort_proxy_exact_transaction(data_dir, manifest),
         Some(ExactTransactionScope::EnvVars) => abort_env_exact_transaction(data_dir, manifest),
@@ -8357,6 +8694,7 @@ fn merge_active_section_data(
             merge_active_cluster_data(current, original, staged)
         }
         ExactTransactionScope::Providers
+        | ExactTransactionScope::Mcp
         | ExactTransactionScope::ProxyAuth
         | ExactTransactionScope::Notifications
         | ExactTransactionScope::Connect
@@ -10682,6 +11020,11 @@ fn validate_manifest(manifest: &MigrationManifest) -> ConfigStoreResult<()> {
                 && unique.contains(CREDENTIALS_FILE)
                 && unique.contains(PROVIDERS_FILE)
         }
+        (true, Some(ExactTransactionScope::Mcp)) => {
+            manifest.files.len() == 2
+                && unique.contains(CREDENTIALS_FILE)
+                && unique.contains(MCP_FILE)
+        }
         (true, Some(ExactTransactionScope::ProxyAuth)) => {
             manifest.files.len() == 2
                 && (unique.contains(CONFIG_FILE) ^ unique.contains(CORE_FILE))
@@ -10692,13 +11035,7 @@ fn validate_manifest(manifest: &MigrationManifest) -> ConfigStoreResult<()> {
                     .is_some_and(|file| file.touched_credential_refs.len() == 1)
         }
         (true, Some(ExactTransactionScope::EnvVars)) => {
-            manifest.files.len() == 2
-                && (unique.contains(CONFIG_FILE) ^ unique.contains(ENV_FILE))
-                && manifest
-                    .files
-                    .iter()
-                    .find(|file| file.name == CREDENTIALS_FILE)
-                    .is_some_and(|file| !file.touched_credential_refs.is_empty())
+            manifest.files.len() == 2 && (unique.contains(CONFIG_FILE) ^ unique.contains(ENV_FILE))
         }
         (true, Some(ExactTransactionScope::Notifications)) => {
             manifest.files.len() == 2

--- a/crates/infra/bamboo-config/src/credential_store.rs
+++ b/crates/infra/bamboo-config/src/credential_store.rs
@@ -496,6 +496,75 @@ impl CredentialStore {
         self.with_transaction_lock(|| self.clear_unchecked(credential_ref, expected_revision))
     }
 
+    /// Clear the standalone credential document in one CAS commit, but only
+    /// after every config-owned reference has been removed through its owning
+    /// domain transaction. This is the final step of a section-by-section
+    /// reset; it must never detach a live config reference from its secret.
+    pub fn clear_all_unreferenced(
+        &self,
+        config: &crate::Config,
+        expected_revision: u64,
+    ) -> ConfigStoreResult<(u64, Vec<CredentialStatus>)> {
+        self.with_transaction_lock(|| {
+            let referenced = config_credential_ref_counts(config)?;
+            if !referenced.is_empty() {
+                return Err(ConfigStoreError::Validation(
+                    "credentials still referenced by configuration must be reset through their owning sections"
+                        .to_string(),
+                ));
+            }
+            let revision = self.store.commit(
+                expected_revision,
+                CredentialDocument::default(),
+                validate_document,
+            )?;
+            Ok((revision, Vec::new()))
+        })
+    }
+
+    pub(crate) fn prepare_clear_owned_references(
+        &self,
+        config: &crate::Config,
+        references: &BTreeSet<CredentialRef>,
+    ) -> ConfigStoreResult<PreparedProviderCredentialUpdate> {
+        let candidate_counts = config_credential_ref_counts(config)?;
+        let (mut document, health) = self.load_document_with_health()?;
+        if health.status == SectionStatus::Degraded {
+            return Err(ConfigStoreError::Validation(
+                "credential document is unavailable for section reset".to_string(),
+            ));
+        }
+        let mut changed = false;
+        let mut required_refs = Vec::new();
+        for reference in references {
+            if candidate_counts.get(reference).copied().unwrap_or(0) == 0 {
+                changed |= document.entries.remove(reference).is_some();
+            } else {
+                required_refs.push(reference.clone());
+            }
+        }
+        validate_document(&document).map_err(ConfigStoreError::Validation)?;
+        ensure_required_entries(&document, &required_refs)?;
+        let revision = if changed {
+            health.revision.checked_add(1).ok_or_else(|| {
+                ConfigStoreError::Validation("configuration revision counter exhausted".to_string())
+            })?
+        } else {
+            health.revision
+        };
+        Ok(PreparedProviderCredentialUpdate {
+            bytes: serde_json::to_vec_pretty(&serde_json::json!({
+                "schema_version": CREDENTIAL_SCHEMA_VERSION,
+                "revision": revision,
+                "data": document,
+            }))?,
+            expected_revision: health.revision,
+            revision,
+            touched_refs: references.iter().cloned().collect(),
+            required_refs,
+        })
+    }
+
     /// Clear an internally managed rotating credential at the latest durable
     /// revision. Client-facing clears remain explicit-CAS via [`Self::clear`].
     pub fn clear_system_managed(
@@ -603,6 +672,7 @@ impl CredentialStore {
         &self,
         config: &mut crate::Config,
         provider_intents: &BTreeSet<String>,
+        persisted_provider_refs: &BTreeMap<String, CredentialRef>,
         provider_instance_intents: &BTreeSet<String>,
         persisted_instance_refs: &BTreeMap<String, CredentialRef>,
     ) -> ConfigStoreResult<Option<PreparedProviderCredentialUpdate>> {
@@ -630,19 +700,24 @@ impl CredentialStore {
         macro_rules! plan_env {
             ($name:literal, $field:ident) => {
                 if provider_intents.contains($name) {
-                    if let Some(provider) = config.providers.$field.as_ref() {
-                        let reference = credential_ref("provider", $name, "api_key")?;
-                        let secret = (!provider.api_key_from_env
-                            && !provider.api_key.trim().is_empty())
-                        .then(|| provider.api_key.trim().to_string());
-                        updates.push(PlannedUpdate {
-                            target: PlannedProviderTarget::BuiltIn($name),
-                            removes_candidate_consumer: provider.credential_ref.as_ref()
-                                == Some(&reference),
-                            reference,
-                            secret,
-                        });
-                    }
+                    let provider = config.providers.$field.as_ref();
+                    let reference = provider
+                        .and_then(|provider| provider.credential_ref.clone())
+                        .or_else(|| persisted_provider_refs.get($name).cloned())
+                        .unwrap_or(credential_ref("provider", $name, "api_key")?);
+                    let secret = provider
+                        .filter(|provider| {
+                            !provider.api_key_from_env && !provider.api_key.trim().is_empty()
+                        })
+                        .map(|provider| provider.api_key.trim().to_string());
+                    updates.push(PlannedUpdate {
+                        target: PlannedProviderTarget::BuiltIn($name),
+                        removes_candidate_consumer: provider
+                            .and_then(|provider| provider.credential_ref.as_ref())
+                            == Some(&reference),
+                        reference,
+                        secret,
+                    });
                 }
             };
         }
@@ -650,17 +725,21 @@ impl CredentialStore {
         plan_env!("anthropic", anthropic);
         plan_env!("gemini", gemini);
         if provider_intents.contains("bodhi") {
-            if let Some(provider) = config.providers.bodhi.as_ref() {
-                let reference = credential_ref("provider", "bodhi", "api_key")?;
-                updates.push(PlannedUpdate {
-                    target: PlannedProviderTarget::BuiltIn("bodhi"),
-                    removes_candidate_consumer: provider.credential_ref.as_ref()
-                        == Some(&reference),
-                    reference,
-                    secret: (!provider.api_key.trim().is_empty())
-                        .then(|| provider.api_key.trim().to_string()),
-                });
-            }
+            let provider = config.providers.bodhi.as_ref();
+            let reference = provider
+                .and_then(|provider| provider.credential_ref.clone())
+                .or_else(|| persisted_provider_refs.get("bodhi").cloned())
+                .unwrap_or(credential_ref("provider", "bodhi", "api_key")?);
+            updates.push(PlannedUpdate {
+                target: PlannedProviderTarget::BuiltIn("bodhi"),
+                removes_candidate_consumer: provider
+                    .and_then(|provider| provider.credential_ref.as_ref())
+                    == Some(&reference),
+                reference,
+                secret: provider
+                    .filter(|provider| !provider.api_key.trim().is_empty())
+                    .map(|provider| provider.api_key.trim().to_string()),
+            });
         }
 
         for instance_id in provider_instance_intents {
@@ -1429,6 +1508,7 @@ impl CredentialStore {
         persisted: &PersistedAccessCredentialRefs,
     ) -> ConfigStoreResult<Option<PreparedProviderCredentialUpdate>> {
         let candidate_counts = config_credential_ref_counts(config)?;
+        let reset_domain = config.access_control.is_none();
         let access = config.access_control.get_or_insert_with(Default::default);
         let mut device_ids = BTreeSet::new();
         if access.devices.iter().any(|device| {
@@ -1637,7 +1717,7 @@ impl CredentialStore {
             "data": document,
         }))?;
         let touched_refs = touched_refs.into_iter().collect::<Vec<_>>();
-        Ok(Some(PreparedProviderCredentialUpdate {
+        let prepared = PreparedProviderCredentialUpdate {
             bytes,
             expected_revision: health.revision,
             revision,
@@ -1646,7 +1726,11 @@ impl CredentialStore {
                 .into_iter()
                 .filter(|reference| touched_refs.contains(reference))
                 .collect(),
-        }))
+        };
+        if reset_domain {
+            config.access_control = None;
+        }
+        Ok(Some(prepared))
     }
 
     /// Prepare one or more node credential mutations without publishing them.


### PR DESCRIPTION
## Summary

- add `POST /bamboo/config/sections/{section}/reset` with typed section CAS semantics
- reset ordinary sections from backend-owned defaults
- reset provider, MCP, and credential-backed domains through recoverable exact transactions
- atomically scrub section-owned credentials while preserving unrelated/shared references
- publish runtime state and section events at the existing staged commit boundaries
- expose safe credentials reset behavior that rejects still-referenced entries

## Why

The modular configuration layout rejects the legacy whole-config reset because it cannot provide a recoverable multi-section commit. Lotus #114 needs a safe one-section-at-a-time reset contract without client-authored defaults or echoed secret masks.

## Test Plan

Exact head: `eb9b8243bdaf62842266cec57debe2eaa89b56e7`

- `cargo fmt --all -- --check`
- `cargo test -p bamboo-config` (572 passed)
- `cargo test -p bamboo-server handlers::settings::bamboo_config` (83 passed)
- `cargo clippy -p bamboo-config --all-targets -- -D warnings`
- `cargo clippy -p bamboo-server --lib --no-deps -- -A clippy::too-many-arguments -D warnings`

Parent-agent exact-head review completed against the SHA above with no remaining findings. Any head change invalidates that approval and requires a fresh review.

Closes #679