### PR TITLE
feat: add revisioned provider settings contract (#686)

### DIFF
--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -1479,6 +1479,117 @@ impl AppState {
         Ok(revision)
     }
 
+    /// Replace the complete provider-owned settings domain under the typed
+    /// provider section revision. Provider metadata and explicitly touched
+    /// built-in/instance credentials share one recoverable exact transaction;
+    /// runtime construction is staged before the durable CAS boundary.
+    pub(crate) async fn put_provider_settings<F>(
+        &self,
+        expected_revision: u64,
+        update: F,
+    ) -> Result<u64, ConfigSectionMutationError>
+    where
+        F: FnOnce(
+                &Config,
+                &mut Config,
+            )
+                -> Result<(BTreeSet<String>, BTreeSet<String>), ConfigSectionMutationError>
+            + Send
+            + 'static,
+    {
+        let config_io_lock = self.config_io_lock.clone();
+        let config = self.config.clone();
+        let app_data_dir = self.app_data_dir.clone();
+        let config_facade = self.config_facade.clone();
+        let account_sink = self.account_sink.clone();
+        let provider_registry = self.provider_registry.clone();
+        let provider = self.provider.clone();
+        let config_live_health = self.config_live_health.clone();
+        let transaction = tokio::spawn(async move {
+            let _io = config_io_lock.lock().await;
+            ensure_provider_mcp_migration_ready(&app_data_dir)
+                .map_err(ConfigSectionMutationError::Store)?;
+            let facade = config_facade.as_ref().ok_or_else(|| {
+                ConfigSectionMutationError::Invalid(
+                    "provider settings require the modular configuration facade".to_string(),
+                )
+            })?;
+            let current = config.read().await.clone();
+            let mut candidate = current.clone();
+            let (provider_intents, provider_instance_intents) = update(&current, &mut candidate)?;
+
+            let (candidate, registry, candidate_provider) =
+                match prepare_provider_candidate(candidate, &app_data_dir).await {
+                    Ok(prepared) => prepared,
+                    Err(_) => {
+                        let message =
+                        "provider runtime initialization failed; retaining last-known-good runtime"
+                            .to_string();
+                        publish_section_failure(
+                            &config_live_health,
+                            &account_sink,
+                            "providers",
+                            SectionStatus::Degraded,
+                            message.clone(),
+                        );
+                        return Err(ConfigSectionMutationError::Runtime(message));
+                    }
+                };
+
+            // Acquire publication guards before the durable boundary. The
+            // detached task owns them until config and provider runtime are
+            // published, so request cancellation cannot strand disk ahead of
+            // process state.
+            let mut live_config = config.write().await;
+            let mut live_provider = provider.write().await;
+            let transaction_dir = app_data_dir.clone();
+            let committed = tokio::task::spawn_blocking(move || {
+                let mut durable_candidate = candidate;
+                bamboo_config::persist_provider_credential_transaction_at_revision(
+                    &transaction_dir,
+                    &mut durable_candidate,
+                    &provider_intents,
+                    &provider_instance_intents,
+                    expected_revision,
+                )?;
+                load_committed_effective_config(&transaction_dir)
+            })
+            .await
+            .map_err(|error| {
+                ConfigSectionMutationError::Runtime(format!(
+                    "provider settings transaction task failed: {error}"
+                ))
+            })?
+            .map_err(ConfigSectionMutationError::Store)?;
+
+            committed.publish_env_vars();
+            *live_config = committed;
+            provider_registry.replace_with(registry);
+            *live_provider = candidate_provider;
+            publish_exact_facade_commit(
+                Some(facade),
+                &account_sink,
+                &[SectionId::Credentials, SectionId::Providers],
+            )
+            .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
+            let provider_snapshot = facade.registry().providers.snapshot();
+            set_live_health_revision(
+                &config_live_health,
+                provider_snapshot.revision,
+                Some((
+                    provider_snapshot.source_path.clone(),
+                    SectionSourceKind::File,
+                )),
+            );
+            Ok(provider_snapshot.revision)
+        });
+        transaction.await.map_err(|error| {
+            ConfigSectionMutationError::Runtime(format!(
+                "provider settings transaction task failed: {error}"
+            ))
+        })?
+    }
+
     /// Reset the complete provider section and all provider-owned credentials
     /// in one recoverable exact transaction guarded by the typed section
     /// revision. Runtime publication remains last-known-good when the default
@@ -1541,6 +1652,15 @@ impl AppState {
                 &[SectionId::Credentials, SectionId::Providers],
             )
             .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
+            let provider_snapshot = facade.registry().providers.snapshot();
+            set_live_health_revision(
+                &config_live_health,
+                provider_snapshot.revision,
+                Some((
+                    provider_snapshot.source_path.clone(),
+                    SectionSourceKind::File,
+                )),
+            );
 
             match bamboo_llm::ProviderRegistry::from_config(&candidate, app_data_dir).await {
                 Ok(registry) => {
@@ -1569,8 +1689,7 @@ impl AppState {
                     );
                 }
             }
-
-            Ok(facade.registry().providers.snapshot().revision)
+            Ok(provider_snapshot.revision)
         });
         transaction.await.map_err(|error| {
             ConfigSectionMutationError::Runtime(format!(
@@ -3444,6 +3563,98 @@ mod live_reload_tests {
             "cancellation while waiting for publication guards must precede durable commit"
         );
         drop(held_provider);
+    }
+
+    #[test]
+    fn cancelled_provider_settings_request_finishes_exact_commit_and_live_publication() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x71; 32]);
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .max_blocking_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let state = Arc::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+            wait_for_mcp_health(&state, SectionStatus::Healthy, 0).await;
+
+            let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+            let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+            let blocker = tokio::task::spawn_blocking(move || {
+                let _ = started_tx.send(());
+                release_rx.recv().unwrap();
+            });
+            started_rx.await.unwrap();
+
+            let operation_state = state.clone();
+            let operation = tokio::spawn(async move {
+                operation_state
+                    .put_provider_settings(0, |_current, candidate| {
+                        candidate.provider = "openai".to_string();
+                        candidate.providers_mut().openai = Some(bamboo_config::OpenAIConfig {
+                            api_key: "provider-settings-cancel-secret".to_string(),
+                            model: Some("provider-settings-cancel-model".to_string()),
+                            ..Default::default()
+                        });
+                        Ok((BTreeSet::from(["openai".to_string()]), BTreeSet::new()))
+                    })
+                    .await
+            });
+
+            tokio::time::timeout(Duration::from_secs(1), async {
+                loop {
+                    if state.config_io_lock.try_lock().is_err() {
+                        break;
+                    }
+                    assert!(!operation.is_finished());
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("provider settings mutation acquires the config IO lock");
+            operation.abort();
+            let _ = operation.await;
+            release_tx.send(()).unwrap();
+            blocker.await.unwrap();
+
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    let committed = std::fs::read(dir.path().join("providers.json"))
+                        .ok()
+                        .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                        .is_some_and(|value| {
+                            value["revision"] == 1
+                                && value["data"]["openai"]["model"]
+                                    == "provider-settings-cancel-model"
+                        });
+                    if committed {
+                        break;
+                    }
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("owned provider settings transaction completes after cancellation");
+
+            let converged =
+                tokio::time::timeout(Duration::from_secs(5), state.config_io_lock.lock())
+                    .await
+                    .expect("owned provider runtime publication completes after cancellation");
+            drop(converged);
+            let live = state.config.read().await;
+            let openai = live.providers().openai.as_ref().unwrap();
+            assert_eq!(
+                openai.model.as_deref(),
+                Some("provider-settings-cancel-model")
+            );
+            assert_eq!(openai.api_key, "provider-settings-cancel-secret");
+            drop(live);
+            let providers = std::fs::read_to_string(dir.path().join("providers.json")).unwrap();
+            let credentials = std::fs::read_to_string(dir.path().join("credentials.json")).unwrap();
+            assert!(!providers.contains("provider-settings-cancel-secret"));
+            assert!(!credentials.contains("provider-settings-cancel-secret"));
+        });
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/mod.rs
@@ -23,8 +23,9 @@ pub use credentials::{
 pub use notifications::get_notification_config;
 pub use proxy_auth::{get_proxy_auth_status, set_proxy_auth};
 pub use sections::{
-    get_mcp_section, get_provider_section, get_typed_section, put_mcp_section,
-    put_provider_section, put_typed_section, reset_typed_section,
+    get_mcp_section, get_provider_section, get_provider_settings_section, get_typed_section,
+    put_mcp_section, put_provider_section, put_provider_settings_section, put_typed_section,
+    reset_typed_section,
 };
 pub use tools::get_bamboo_tools;
 pub use types::ProxyAuthPayload;

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -1,12 +1,13 @@
 use actix_web::{web, HttpResponse};
 use bamboo_config::{
-    patch::is_masked_api_key, ConfigStoreError, HooksSection, MemorySection, ModelLimitsSection,
-    ModelPolicySection, ProviderConfigs, SectionEnvelope, SectionId, SubagentsSection,
-    ToolsSkillsSection,
+    patch::is_masked_api_key, ConfigStoreError, DefaultsConfig, FeatureFlags, HooksSection,
+    MemorySection, ModelLimitsSection, ModelPolicySection, ProviderConfigs, ProviderInstanceConfig,
+    SectionEnvelope, SectionId, SubagentsSection, ToolsSkillsSection,
 };
 use bamboo_mcp::McpConfig;
-use serde::{de::Error as _, Deserialize, Deserializer};
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
 use serde_json::{json, Map, Value};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use crate::{
     app_state::{AppState, ConfigSectionMutationError},
@@ -42,6 +43,62 @@ pub struct ResetTypedSectionRequest {
     pub expected_revision: u64,
 }
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PutProviderSettingsRequest {
+    pub expected_revision: u64,
+    #[serde(deserialize_with = "deserialize_provider_settings_candidate")]
+    pub data: ProviderSettingsData,
+    #[serde(default)]
+    pub credential_changes: ProviderCredentialChanges,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderSettingsData {
+    pub provider: String,
+    #[serde(default)]
+    pub providers: ProviderConfigs,
+    #[serde(default)]
+    pub defaults: Option<DefaultsConfig>,
+    #[serde(default)]
+    pub features: FeatureFlags,
+    #[serde(default)]
+    pub provider_instances: HashMap<String, ProviderInstanceConfig>,
+    #[serde(default, alias = "default_provider_instance")]
+    pub default_provider_instance_id: Option<String>,
+    // Read-only response fields are accepted and ignored so the canonical
+    // response data can be round-tripped without client-side shape surgery.
+    #[serde(default)]
+    pub available_providers: Vec<String>,
+    #[serde(default)]
+    pub credential_status: Value,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderCredentialChanges {
+    #[serde(default)]
+    pub providers: BTreeMap<String, ProviderCredentialChange>,
+    #[serde(default)]
+    pub provider_instances: BTreeMap<String, ProviderCredentialChange>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum ProviderCredentialChange {
+    Replace { value: String },
+    Clear,
+}
+
+#[derive(Serialize)]
+struct ProviderCredentialStatusView {
+    credential_ref: Option<String>,
+    configured: bool,
+    source: Option<String>,
+    updated_at: Option<String>,
+}
+
 /// Read-only, secret-free provider section projection. Credential values,
 /// ciphertext, UI masks, request override headers, and forward-compatible
 /// unknown fields are intentionally excluded; callers use the credential
@@ -63,6 +120,167 @@ pub async fn get_provider_section(
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .clone();
     Ok(HttpResponse::Ok().json(section_envelope(data, health)))
+}
+
+/// Canonical provider-settings projection for editable UI state. Unlike the
+/// compact diagnostics endpoint above, this contains every non-secret field
+/// owned by providers.json plus explicit credential status metadata.
+pub async fn get_provider_settings_section(
+    app_state: web::Data<AppState>,
+) -> Result<HttpResponse, AppError> {
+    let _io = app_state.config_io_lock.lock().await;
+    let config = app_state.config.read().await.clone();
+    let providers = sanitized_provider_metadata(config.providers())?;
+    let provider_instances = sanitized_provider_instance_metadata(&config.provider_instances)?;
+    let mut builtin_status = Map::new();
+
+    macro_rules! builtin_status {
+        ($name:literal, $field:ident, $from_env:expr) => {
+            if let Some(provider) = config.providers().$field.as_ref() {
+                builtin_status.insert(
+                    $name.to_string(),
+                    serde_json::to_value(provider_credential_status(
+                        &app_state,
+                        provider.credential_ref.as_ref(),
+                        $from_env,
+                        !provider.api_key.trim().is_empty() || provider.api_key_encrypted.is_some(),
+                    )?)?,
+                );
+            }
+        };
+    }
+    builtin_status!(
+        "openai",
+        openai,
+        config
+            .providers()
+            .openai
+            .as_ref()
+            .is_some_and(|p| p.api_key_from_env)
+    );
+    builtin_status!(
+        "anthropic",
+        anthropic,
+        config
+            .providers()
+            .anthropic
+            .as_ref()
+            .is_some_and(|p| p.api_key_from_env)
+    );
+    builtin_status!(
+        "gemini",
+        gemini,
+        config
+            .providers()
+            .gemini
+            .as_ref()
+            .is_some_and(|p| p.api_key_from_env)
+    );
+    builtin_status!("bodhi", bodhi, false);
+
+    let mut instance_status = Map::new();
+    for (id, instance) in &config.provider_instances {
+        instance_status.insert(
+            id.clone(),
+            serde_json::to_value(provider_credential_status(
+                &app_state,
+                instance.credential_ref.as_ref(),
+                false,
+                !instance.api_key.trim().is_empty() || instance.api_key_encrypted.is_some(),
+            )?)?,
+        );
+    }
+
+    let data = json!({
+        "provider": config.provider,
+        "providers": providers,
+        "defaults": config.defaults,
+        "features": config.features,
+        "provider_instances": provider_instances,
+        "default_provider_instance_id": config.default_provider_instance,
+        "available_providers": bamboo_llm::AVAILABLE_PROVIDERS,
+        "credential_status": {
+            "providers": builtin_status,
+            "provider_instances": instance_status,
+        },
+    });
+    let health = app_state
+        .config_live_health
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    Ok(HttpResponse::Ok().json(section_envelope(data, health)))
+}
+
+pub async fn put_provider_settings_section(
+    app_state: web::Data<AppState>,
+    payload: web::Json<PutProviderSettingsRequest>,
+) -> Result<HttpResponse, AppError> {
+    let payload = payload.into_inner();
+    validate_provider_shape(&payload.data.providers).map_err(AppError::BadRequest)?;
+    validate_provider_instance_shape(&payload.data.provider_instances)
+        .map_err(AppError::BadRequest)?;
+    let expected_revision = payload.expected_revision;
+    let data = payload.data;
+    let credential_changes = payload.credential_changes;
+    app_state
+        .put_provider_settings(expected_revision, move |current, candidate| {
+            let mut provider_intents = credential_changes
+                .providers
+                .keys()
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            let mut provider_instance_intents = credential_changes
+                .provider_instances
+                .keys()
+                .cloned()
+                .collect::<BTreeSet<_>>();
+
+            let ProviderSettingsData {
+                provider,
+                providers,
+                defaults,
+                features,
+                provider_instances,
+                default_provider_instance_id,
+                available_providers: _,
+                credential_status: _,
+            } = data;
+
+            for name in ["openai", "anthropic", "gemini", "bodhi"] {
+                if provider_exists(current.providers(), name) && !provider_exists(&providers, name)
+                {
+                    provider_intents.insert(name.to_string());
+                }
+            }
+            provider_instance_intents.extend(
+                current
+                    .provider_instances
+                    .keys()
+                    .filter(|id| !provider_instances.contains_key(*id))
+                    .cloned(),
+            );
+
+            candidate.provider = provider;
+            *candidate.providers_mut() = providers;
+            candidate.defaults = defaults;
+            candidate.features = features;
+            candidate.provider_instances = provider_instances;
+            candidate.default_provider_instance = default_provider_instance_id;
+            retain_provider_settings_server_owned_fields(current, candidate);
+            apply_provider_credential_changes(candidate, &credential_changes.providers)?;
+            apply_provider_instance_credential_changes(
+                candidate,
+                &credential_changes.provider_instances,
+            )?;
+            bamboo_llm::validate_provider_config(candidate).map_err(|error| {
+                ConfigSectionMutationError::Invalid(format!("invalid provider settings: {error}"))
+            })?;
+            Ok((provider_intents, provider_instance_intents))
+        })
+        .await
+        .map_err(map_mutation_error)?;
+    get_provider_settings_section(app_state).await
 }
 
 /// Read-only MCP section projection. Transport diagnostics remain visible,
@@ -271,6 +489,444 @@ fn map_mutation_error(error: ConfigSectionMutationError) -> AppError {
     }
 }
 
+fn sanitized_provider_metadata(providers: &ProviderConfigs) -> Result<Value, AppError> {
+    let mut providers = providers.clone();
+    providers.extra.clear();
+    macro_rules! sanitize {
+        ($field:ident) => {
+            if let Some(provider) = providers.$field.as_mut() {
+                provider.api_key.clear();
+                provider.api_key_encrypted = None;
+                provider.credential_ref = None;
+                provider.base_url = safe_url_diagnostic(provider.base_url.as_deref());
+                provider.extra.clear();
+            }
+        };
+    }
+    sanitize!(openai);
+    sanitize!(anthropic);
+    sanitize!(gemini);
+    if let Some(provider) = providers.copilot.as_mut() {
+        provider.extra.clear();
+    }
+    if let Some(provider) = providers.bodhi.as_mut() {
+        provider.api_key.clear();
+        provider.api_key_encrypted = None;
+        provider.credential_ref = None;
+        provider.base_url = safe_url_diagnostic(provider.base_url.as_deref());
+        provider.extra.clear();
+    }
+    let mut value = serde_json::to_value(providers)?;
+    scrub_unsafe_request_override_literals(&mut value);
+    Ok(value)
+}
+
+fn sanitized_provider_instance_metadata(
+    instances: &HashMap<String, ProviderInstanceConfig>,
+) -> Result<Value, AppError> {
+    let mut instances = instances.clone();
+    for instance in instances.values_mut() {
+        instance.api_key.clear();
+        instance.api_key_encrypted = None;
+        instance.credential_ref = None;
+        instance.base_url = safe_url_diagnostic(instance.base_url.as_deref());
+        instance.extra.clear();
+    }
+    let mut value = serde_json::to_value(instances)?;
+    scrub_unsafe_request_override_literals(&mut value);
+    Ok(value)
+}
+
+fn scrub_unsafe_request_override_literals(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            if let Some(headers) = object.get_mut("headers").and_then(Value::as_object_mut) {
+                headers.retain(|name, expression| {
+                    !is_sensitive_header_name(name) || is_external_template_reference(expression)
+                });
+            }
+            if let Some(patches) = object.get_mut("body_patch").and_then(Value::as_array_mut) {
+                patches.retain(|patch| {
+                    let Some(patch) = patch.as_object() else {
+                        return false;
+                    };
+                    !patch
+                        .get("path")
+                        .and_then(Value::as_str)
+                        .is_some_and(is_sensitive_override_path)
+                        || patch
+                            .get("value")
+                            .is_none_or(is_external_template_reference)
+                });
+            }
+            for value in object.values_mut() {
+                scrub_unsafe_request_override_literals(value);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                scrub_unsafe_request_override_literals(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn provider_credential_status(
+    app_state: &AppState,
+    credential_ref: Option<&bamboo_config::CredentialRef>,
+    from_environment: bool,
+    runtime_configured: bool,
+) -> Result<ProviderCredentialStatusView, AppError> {
+    if let Some(reference) = credential_ref {
+        let status = app_state
+            .credential_store
+            .status(reference)
+            .map_err(|error| map_mutation_error(ConfigSectionMutationError::Store(error)))?;
+        let source = status.configured.then_some(match status.source {
+            bamboo_config::CredentialSource::User => "user",
+            bamboo_config::CredentialSource::Migrated => "migrated",
+            bamboo_config::CredentialSource::Environment => "environment",
+            bamboo_config::CredentialSource::ExternalStore => "external_store",
+        });
+        return Ok(ProviderCredentialStatusView {
+            credential_ref: Some(reference.as_str().to_string()),
+            configured: status.configured,
+            source: source.map(str::to_string),
+            updated_at: status.updated_at.map(|value| value.to_rfc3339()),
+        });
+    }
+    Ok(ProviderCredentialStatusView {
+        credential_ref: None,
+        configured: from_environment || runtime_configured,
+        source: if from_environment {
+            Some("environment".to_string())
+        } else if runtime_configured {
+            Some("migrated".to_string())
+        } else {
+            None
+        },
+        updated_at: None,
+    })
+}
+
+fn provider_exists(providers: &ProviderConfigs, name: &str) -> bool {
+    match name {
+        "openai" => providers.openai.is_some(),
+        "anthropic" => providers.anthropic.is_some(),
+        "gemini" => providers.gemini.is_some(),
+        "copilot" => providers.copilot.is_some(),
+        "bodhi" => providers.bodhi.is_some(),
+        _ => false,
+    }
+}
+
+fn retain_provider_settings_server_owned_fields(
+    current: &bamboo_config::Config,
+    candidate: &mut bamboo_config::Config,
+) {
+    // Unknown forward-compatible metadata is intentionally not exposed by the
+    // network DTO because its contents cannot be classified as non-secret.
+    // Preserve it from the process-owned snapshot just like credential refs.
+    candidate.providers_mut().extra = current.providers().extra.clone();
+    macro_rules! retain_env_provider {
+        ($field:ident) => {
+            if let (Some(current), Some(candidate)) = (
+                current.providers().$field.as_ref(),
+                candidate.providers_mut().$field.as_mut(),
+            ) {
+                candidate.api_key = current.api_key.clone();
+                candidate.api_key_encrypted = current.api_key_encrypted.clone();
+                candidate.credential_ref = current.credential_ref.clone();
+                candidate.api_key_from_env = current.api_key_from_env;
+                candidate.extra = current.extra.clone();
+            }
+        };
+    }
+    retain_env_provider!(openai);
+    retain_env_provider!(anthropic);
+    retain_env_provider!(gemini);
+    if let (Some(current), Some(candidate)) = (
+        current.providers().bodhi.as_ref(),
+        candidate.providers_mut().bodhi.as_mut(),
+    ) {
+        candidate.api_key = current.api_key.clone();
+        candidate.api_key_encrypted = current.api_key_encrypted.clone();
+        candidate.credential_ref = current.credential_ref.clone();
+        candidate.extra = current.extra.clone();
+    }
+    if let (Some(current), Some(candidate)) = (
+        current.providers().copilot.as_ref(),
+        candidate.providers_mut().copilot.as_mut(),
+    ) {
+        candidate.extra = current.extra.clone();
+    }
+    for (id, instance) in &mut candidate.provider_instances {
+        if let Some(current) = current.provider_instances.get(id) {
+            instance.api_key = current.api_key.clone();
+            instance.api_key_encrypted = current.api_key_encrypted.clone();
+            instance.credential_ref = current.credential_ref.clone();
+            instance.extra = current.extra.clone();
+        }
+    }
+}
+
+fn apply_provider_credential_changes(
+    candidate: &mut bamboo_config::Config,
+    changes: &BTreeMap<String, ProviderCredentialChange>,
+) -> Result<(), ConfigSectionMutationError> {
+    macro_rules! apply_env_provider {
+        ($name:literal, $field:ident) => {
+            if let Some(change) = changes.get($name) {
+                match candidate.providers_mut().$field.as_mut() {
+                    Some(provider) => match change {
+                        ProviderCredentialChange::Replace { value } if !value.trim().is_empty() => {
+                            provider.api_key = value.clone();
+                            provider.api_key_encrypted = None;
+                            provider.api_key_from_env = false;
+                        }
+                        ProviderCredentialChange::Replace { .. } => {
+                            return Err(ConfigSectionMutationError::Invalid(format!(
+                                "replacement credential for '{}' must not be empty",
+                                $name
+                            )));
+                        }
+                        ProviderCredentialChange::Clear => {
+                            provider.api_key.clear();
+                            provider.api_key_encrypted = None;
+                            provider.api_key_from_env = false;
+                        }
+                    },
+                    None if matches!(change, ProviderCredentialChange::Clear) => {}
+                    None => {
+                        return Err(ConfigSectionMutationError::Invalid(format!(
+                            "credential replacement targets missing provider '{}'",
+                            $name
+                        )));
+                    }
+                }
+            }
+        };
+    }
+    apply_env_provider!("openai", openai);
+    apply_env_provider!("anthropic", anthropic);
+    apply_env_provider!("gemini", gemini);
+    if let Some(change) = changes.get("bodhi") {
+        match candidate.providers_mut().bodhi.as_mut() {
+            Some(provider) => match change {
+                ProviderCredentialChange::Replace { value } if !value.trim().is_empty() => {
+                    provider.api_key = value.clone();
+                    provider.api_key_encrypted = None;
+                }
+                ProviderCredentialChange::Replace { .. } => {
+                    return Err(ConfigSectionMutationError::Invalid(
+                        "replacement credential for 'bodhi' must not be empty".to_string(),
+                    ));
+                }
+                ProviderCredentialChange::Clear => {
+                    provider.api_key.clear();
+                    provider.api_key_encrypted = None;
+                }
+            },
+            None if matches!(change, ProviderCredentialChange::Clear) => {}
+            None => {
+                return Err(ConfigSectionMutationError::Invalid(
+                    "credential replacement targets missing provider 'bodhi'".to_string(),
+                ));
+            }
+        }
+    }
+    if let Some(name) = changes
+        .keys()
+        .find(|name| !matches!(name.as_str(), "openai" | "anthropic" | "gemini" | "bodhi"))
+    {
+        return Err(ConfigSectionMutationError::Invalid(format!(
+            "unknown provider credential target '{name}'"
+        )));
+    }
+    Ok(())
+}
+
+fn apply_provider_instance_credential_changes(
+    candidate: &mut bamboo_config::Config,
+    changes: &BTreeMap<String, ProviderCredentialChange>,
+) -> Result<(), ConfigSectionMutationError> {
+    for (id, change) in changes {
+        match candidate.provider_instances.get_mut(id) {
+            Some(instance) => match change {
+                ProviderCredentialChange::Replace { value } if !value.trim().is_empty() => {
+                    instance.api_key = value.clone();
+                    instance.api_key_encrypted = None;
+                }
+                ProviderCredentialChange::Replace { .. } => {
+                    return Err(ConfigSectionMutationError::Invalid(format!(
+                        "replacement credential for provider instance '{id}' must not be empty"
+                    )));
+                }
+                ProviderCredentialChange::Clear => {
+                    instance.api_key.clear();
+                    instance.api_key_encrypted = None;
+                }
+            },
+            None if matches!(change, ProviderCredentialChange::Clear) => {}
+            None => {
+                return Err(ConfigSectionMutationError::Invalid(format!(
+                    "credential replacement targets missing provider instance '{id}'"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_provider_instance_shape(
+    instances: &HashMap<String, ProviderInstanceConfig>,
+) -> Result<(), String> {
+    for (id, instance) in instances {
+        if id.trim().is_empty() {
+            return Err("provider instance id must not be empty".to_string());
+        }
+        if !instance.extra.is_empty() {
+            return Err(format!(
+                "unknown fields are not accepted for provider instance '{id}'"
+            ));
+        }
+        if let Some(url) = instance.base_url.as_deref() {
+            validate_public_url(url)?;
+        }
+    }
+    Ok(())
+}
+
+fn deserialize_provider_settings_candidate<'de, D>(
+    deserializer: D,
+) -> Result<ProviderSettingsData, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut value = Value::deserialize(deserializer)?;
+    if let Some(object) = value.as_object_mut() {
+        object.remove("available_providers");
+        object.remove("credential_status");
+    }
+    reject_provider_settings_secret_fields(&value).map_err(D::Error::custom)?;
+    serde_json::from_value(value).map_err(D::Error::custom)
+}
+
+fn reject_provider_settings_secret_fields(value: &Value) -> Result<(), String> {
+    match value {
+        Value::Object(object) => {
+            for (key, value) in object {
+                let normalized = key.to_ascii_lowercase();
+                if matches!(
+                    normalized.as_str(),
+                    "api_key" | "api_key_encrypted" | "credential_ref"
+                ) {
+                    return Err(format!(
+                        "secret-bearing field '{key}' is not accepted; use credential_changes"
+                    ));
+                }
+                if normalized == "headers" {
+                    reject_sensitive_header_literals(value)?;
+                }
+                if normalized == "body_patch" {
+                    reject_sensitive_body_patch_literals(value)?;
+                }
+                reject_provider_settings_secret_fields(value)?;
+            }
+            Ok(())
+        }
+        Value::Array(values) => {
+            for value in values {
+                reject_provider_settings_secret_fields(value)?;
+            }
+            Ok(())
+        }
+        Value::String(value) if is_masked_api_key(value) => {
+            Err("masked secret placeholders are not accepted".to_string())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn reject_sensitive_header_literals(value: &Value) -> Result<(), String> {
+    let Some(headers) = value.as_object() else {
+        return Ok(());
+    };
+    for (name, expression) in headers {
+        if is_sensitive_header_name(name) && !is_external_template_reference(expression) {
+            return Err(format!(
+                "sensitive request override header '{name}' must use an env_ref or generated value"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn reject_sensitive_body_patch_literals(value: &Value) -> Result<(), String> {
+    let Some(patches) = value.as_array() else {
+        return Ok(());
+    };
+    for patch in patches.iter().filter_map(Value::as_object) {
+        let sensitive_path = patch
+            .get("path")
+            .and_then(Value::as_str)
+            .is_some_and(is_sensitive_override_path);
+        if sensitive_path
+            && patch
+                .get("value")
+                .is_some_and(|value| !is_external_template_reference(value))
+        {
+            return Err(
+                "sensitive request override body values must use an env_ref or generated value"
+                    .to_string(),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn is_sensitive_header_name(name: &str) -> bool {
+    let normalized = name.to_ascii_lowercase().replace('_', "-");
+    [
+        "authorization",
+        "api-key",
+        "apikey",
+        "token",
+        "secret",
+        "password",
+        "cookie",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle))
+}
+
+fn is_sensitive_override_path(path: &str) -> bool {
+    let normalized = path.to_ascii_lowercase();
+    [
+        "api_key",
+        "api-key",
+        "apikey",
+        "token",
+        "secret",
+        "password",
+        "authorization",
+        "cookie",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle))
+}
+
+fn is_external_template_reference(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    matches!(
+        object.get("type").and_then(Value::as_str),
+        Some("env_ref") | Some("generated")
+    ) && object.get("fallback").is_none_or(Value::is_null)
+}
+
 fn deserialize_provider_candidate<'de, D>(deserializer: D) -> Result<ProviderConfigs, D::Error>
 where
     D: Deserializer<'de>,
@@ -345,9 +1001,9 @@ fn validate_provider_shape(candidate: &ProviderConfigs) -> Result<(), String> {
     macro_rules! validate {
         ($field:ident) => {
             if let Some(provider) = &candidate.$field {
-                if !provider.extra.is_empty() || provider.request_overrides.is_some() {
+                if !provider.extra.is_empty() {
                     return Err(
-                        "unknown provider fields and request overrides are not accepted by the typed endpoint"
+                        "unknown provider fields are not accepted by the typed endpoint"
                             .to_string(),
                     );
                 }
@@ -361,10 +1017,9 @@ fn validate_provider_shape(candidate: &ProviderConfigs) -> Result<(), String> {
     validate!(anthropic);
     validate!(gemini);
     if let Some(provider) = &candidate.copilot {
-        if !provider.extra.is_empty() || provider.request_overrides.is_some() {
+        if !provider.extra.is_empty() {
             return Err(
-                "unknown provider fields and request overrides are not accepted by the typed endpoint"
-                    .to_string(),
+                "unknown provider fields are not accepted by the typed endpoint".to_string(),
             );
         }
     }
@@ -603,6 +1258,29 @@ mod tests {
         }
     }
 
+    fn editable_provider_settings() -> Value {
+        json!({
+            "provider": "openai",
+            "providers": {
+                "openai": {
+                    "base_url": "https://openai.example.test/v1",
+                    "model": "gpt-initial"
+                },
+                "anthropic": {
+                    "base_url": "https://anthropic.example.test/v1",
+                    "model": "claude-initial"
+                }
+            },
+            "defaults": null,
+            "features": {
+                "provider_model_ref": false,
+                "dynamic_model_routing": false
+            },
+            "provider_instances": {},
+            "default_provider_instance_id": null
+        })
+    }
+
     #[actix_web::test]
     async fn typed_sections_expose_health_and_diagnostics_without_secret_material() {
         let dir = tempfile::tempdir().unwrap();
@@ -696,6 +1374,10 @@ mod tests {
             App::new()
                 .app_data(state)
                 .route("/providers", web::get().to(get_provider_section))
+                .route(
+                    "/provider-settings",
+                    web::get().to(get_provider_settings_section),
+                )
                 .route("/mcp", web::get().to(get_mcp_section)),
         )
         .await;
@@ -739,6 +1421,41 @@ mod tests {
         );
         assert_eq!(
             provider["data"]["providers"]["openai"]["base_url"],
+            "https://provider.example/v1"
+        );
+
+        let provider_settings_response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/provider-settings")
+                .to_request(),
+        )
+        .await;
+        assert!(provider_settings_response.status().is_success());
+        let provider_settings_body =
+            String::from_utf8(test::read_body(provider_settings_response).await.to_vec()).unwrap();
+        for forbidden in [
+            "provider-plaintext-secret",
+            "provider-ciphertext-secret",
+            "override-header-secret",
+            "unknown-provider-secret",
+            "provider-url-secret",
+            "query-secret",
+            "****...****",
+            "api_key_encrypted",
+        ] {
+            assert!(
+                !provider_settings_body.contains(forbidden),
+                "provider settings leaked {forbidden}"
+            );
+        }
+        let provider_settings: Value = serde_json::from_str(&provider_settings_body).unwrap();
+        assert_eq!(
+            provider_settings["data"]["providers"]["openai"]["model"],
+            "diagnostic-model"
+        );
+        assert_eq!(
+            provider_settings["data"]["providers"]["openai"]["base_url"],
             "https://provider.example/v1"
         );
 
@@ -1013,6 +1730,308 @@ mod tests {
             stale_after_external.status(),
             actix_web::http::StatusCode::CONFLICT
         );
+    }
+
+    #[actix_web::test]
+    async fn provider_settings_round_trip_is_full_cas_and_credentials_are_explicit_and_redacted() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x70; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let app = test::init_service(
+            App::new().app_data(state.clone()).service(
+                web::resource("/provider-settings")
+                    .route(web::get().to(get_provider_settings_section))
+                    .route(web::put().to(put_provider_settings_section)),
+            ),
+        )
+        .await;
+        let openai_secret = "provider-settings-openai-secret";
+        let anthropic_secret = "provider-settings-anthropic-secret";
+        let instance_secret = "provider-settings-instance-secret";
+        let deleted_instance_secret = "provider-settings-deleted-instance-secret";
+
+        let created = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/provider-settings")
+                .set_json(json!({
+                    "expected_revision": 0,
+                    "data": editable_provider_settings(),
+                    "credential_changes": {
+                        "providers": {
+                            "openai": {"action": "replace", "value": openai_secret},
+                            "anthropic": {"action": "replace", "value": anthropic_secret}
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        let status = created.status();
+        let created_body = String::from_utf8(test::read_body(created).await.to_vec()).unwrap();
+        assert!(
+            status.is_success(),
+            "unexpected provider settings response {status}: {created_body}"
+        );
+        for secret in [
+            openai_secret,
+            anthropic_secret,
+            instance_secret,
+            deleted_instance_secret,
+        ] {
+            assert!(!created_body.contains(secret), "response leaked {secret}");
+        }
+        for forbidden in ["\"api_key\":", "\"api_key_encrypted\":"] {
+            assert!(
+                !created_body.contains(forbidden),
+                "response leaked secret-bearing field {forbidden}"
+            );
+        }
+        let created: Value = serde_json::from_str(&created_body).unwrap();
+        assert_eq!(created["revision"], 1);
+        assert_eq!(
+            created["data"]["credential_status"]["providers"]["openai"]["configured"],
+            true
+        );
+        assert_eq!(
+            created["data"]["credential_status"]["providers"]["anthropic"]["source"],
+            "user"
+        );
+        let hidden_forward_value = "server-owned-forward-metadata";
+        state
+            .config
+            .write()
+            .await
+            .providers_mut()
+            .openai
+            .as_mut()
+            .unwrap()
+            .extra
+            .insert(
+                "future_provider_metadata".to_string(),
+                json!(hidden_forward_value),
+            );
+
+        let mut edited = created["data"].clone();
+        edited["features"]["provider_model_ref"] = json!(true);
+        edited["defaults"] = json!({
+            "chat": {"provider": "openai", "model": "gpt-edited"},
+            "fast": {"provider": "openai", "model": "gpt-fast"}
+        });
+        edited["providers"]["openai"]["model"] = json!("gpt-edited");
+        edited["providers"]["openai"]["request_overrides"] = json!({
+            "common": {
+                "headers": {
+                    "Authorization": {"type": "env_ref", "name": "PROVIDER_AUTH"}
+                }
+            }
+        });
+        edited["provider_instances"]["work"] = json!({
+            "provider_type": "openai",
+            "label": "Work",
+            "model": "gpt-work",
+            "enabled": true
+        });
+        edited["provider_instances"]["personal"] = json!({
+            "provider_type": "openai",
+            "label": "Personal",
+            "model": "gpt-personal",
+            "enabled": false
+        });
+        edited["default_provider_instance_id"] = json!("work");
+
+        let updated = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/provider-settings")
+                .set_json(json!({
+                    "expected_revision": 1,
+                    "data": edited,
+                    "credential_changes": {
+                        "provider_instances": {
+                            "work": {"action": "replace", "value": instance_secret},
+                            "personal": {
+                                "action": "replace",
+                                "value": deleted_instance_secret
+                            }
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        let status = updated.status();
+        let updated_body = String::from_utf8(test::read_body(updated).await.to_vec()).unwrap();
+        assert!(
+            status.is_success(),
+            "unexpected provider settings response {status}: {updated_body}"
+        );
+        for secret in [
+            openai_secret,
+            anthropic_secret,
+            instance_secret,
+            deleted_instance_secret,
+        ] {
+            assert!(!updated_body.contains(secret), "response leaked {secret}");
+        }
+        assert!(!updated_body.contains(hidden_forward_value));
+        let updated: Value = serde_json::from_str(&updated_body).unwrap();
+        assert_eq!(updated["revision"], 2);
+        assert_eq!(
+            updated["data"]["providers"]["openai"]["model"],
+            "gpt-edited"
+        );
+        assert_eq!(updated["data"]["defaults"]["fast"]["model"], "gpt-fast");
+        assert_eq!(updated["data"]["features"]["provider_model_ref"], true);
+        assert_eq!(updated["data"]["default_provider_instance_id"], "work");
+        assert_eq!(
+            updated["data"]["credential_status"]["provider_instances"]["work"]["configured"],
+            true
+        );
+
+        let stale = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/provider-settings")
+                .set_json(json!({
+                    "expected_revision": 1,
+                    "data": editable_provider_settings()
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale.status(), actix_web::http::StatusCode::CONFLICT);
+        assert_eq!(
+            state
+                .config
+                .read()
+                .await
+                .defaults
+                .as_ref()
+                .unwrap()
+                .fast
+                .as_ref()
+                .unwrap()
+                .model,
+            "gpt-fast"
+        );
+
+        let mut cleared = updated["data"].clone();
+        cleared["provider_instances"] = json!({});
+        cleared["default_provider_instance_id"] = Value::Null;
+        let cleared = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/provider-settings")
+                .set_json(json!({
+                    "expected_revision": 2,
+                    "data": cleared,
+                    "credential_changes": {
+                        "provider_instances": {
+                            "work": {"action": "clear"}
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        let status = cleared.status();
+        let cleared_body = String::from_utf8(test::read_body(cleared).await.to_vec()).unwrap();
+        assert!(
+            status.is_success(),
+            "unexpected provider settings response {status}: {cleared_body}"
+        );
+        let cleared: Value = serde_json::from_str(&cleared_body).unwrap();
+        assert_eq!(cleared["revision"], 3);
+        assert!(cleared["data"]["provider_instances"]["work"].is_null());
+        assert!(cleared["data"]["provider_instances"]["personal"].is_null());
+
+        let mut metadata_only = cleared["data"].clone();
+        metadata_only["providers"]["openai"]["model"] = json!("gpt-metadata-only");
+        metadata_only["features"]["dynamic_model_routing"] = json!(true);
+        let metadata_only = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/provider-settings")
+                .set_json(json!({
+                    "expected_revision": 3,
+                    "data": metadata_only
+                }))
+                .to_request(),
+        )
+        .await;
+        let status = metadata_only.status();
+        let metadata_only_body =
+            String::from_utf8(test::read_body(metadata_only).await.to_vec()).unwrap();
+        assert!(
+            status.is_success(),
+            "unexpected provider settings response {status}: {metadata_only_body}"
+        );
+        let metadata_only: Value = serde_json::from_str(&metadata_only_body).unwrap();
+        assert_eq!(metadata_only["revision"], 4);
+        assert_eq!(
+            metadata_only["data"]["providers"]["openai"]["model"],
+            "gpt-metadata-only"
+        );
+        assert_eq!(
+            metadata_only["data"]["features"]["dynamic_model_routing"],
+            true
+        );
+        assert_eq!(
+            state
+                .config
+                .read()
+                .await
+                .providers()
+                .openai
+                .as_ref()
+                .unwrap()
+                .extra["future_provider_metadata"],
+            hidden_forward_value
+        );
+
+        let mut unknown = metadata_only["data"].clone();
+        unknown["providers"]["openai"]["future_client_field"] = json!("must-reject");
+        let unknown = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/provider-settings")
+                .set_json(json!({
+                    "expected_revision": 4,
+                    "data": unknown
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(unknown.status(), actix_web::http::StatusCode::BAD_REQUEST);
+
+        let store = bamboo_config::CredentialStore::open(dir.path());
+        let openai_ref = bamboo_config::credential_ref("provider", "openai", "api_key").unwrap();
+        let work_ref =
+            bamboo_config::credential_ref("provider_instance", "work", "api_key").unwrap();
+        let personal_ref =
+            bamboo_config::credential_ref("provider_instance", "personal", "api_key").unwrap();
+        assert!(store.status(&openai_ref).unwrap().configured);
+        assert!(!store.status(&work_ref).unwrap().configured);
+        assert!(!store.status(&personal_ref).unwrap().configured);
+        assert_eq!(store.revision().unwrap(), 4);
+        for path in [
+            dir.path().join("providers.json"),
+            dir.path().join("credentials.json"),
+        ] {
+            let disk = std::fs::read_to_string(&path).unwrap();
+            for secret in [
+                openai_secret,
+                anthropic_secret,
+                instance_secret,
+                deleted_instance_secret,
+            ] {
+                assert!(!disk.contains(secret), "disk leaked {secret}");
+            }
+            if path.ends_with("providers.json") {
+                assert!(disk.contains(hidden_forward_value));
+            }
+        }
     }
 
     #[actix_web::test]
@@ -1301,6 +2320,40 @@ mod tests {
         assert!(serde_json::from_value::<PutMcpSectionRequest>(json!({
             "expected_revision": 0,
             "data": {"server": {"command": "cmd****name"}}
+        }))
+        .is_ok());
+    }
+
+    #[::core::prelude::v1::test]
+    fn provider_settings_accept_external_override_refs_and_reject_secret_literals() {
+        let mut literal = editable_provider_settings();
+        literal["providers"]["openai"]["request_overrides"] = json!({
+            "common": {"headers": {"Authorization": "Bearer secret"}}
+        });
+        assert!(serde_json::from_value::<PutProviderSettingsRequest>(json!({
+            "expected_revision": 0,
+            "data": literal
+        }))
+        .is_err());
+
+        let mut external = editable_provider_settings();
+        external["providers"]["openai"]["request_overrides"] = json!({
+            "common": {
+                "headers": {
+                    "Authorization": {"type": "env_ref", "name": "PROVIDER_AUTH"}
+                },
+                "body_patch": [{
+                    "path": "auth.token",
+                    "value": {"type": "generated", "generator": "uuid"}
+                }, {
+                    "path": "legacy.api_key",
+                    "op": "remove"
+                }]
+            }
+        });
+        assert!(serde_json::from_value::<PutProviderSettingsRequest>(json!({
+            "expected_revision": 0,
+            "data": external
         }))
         .is_ok());
     }

--- a/crates/app/bamboo-server/src/handlers/settings/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/mod.rs
@@ -28,10 +28,10 @@ pub use bamboo_config::{
     clear_credential, confirm_config_recovery, detect_codex_cli, get_bamboo_config,
     get_bamboo_tools, get_config_recovery_status, get_credential_status, get_live_config_health,
     get_mcp_section, get_model_limit_defaults, get_notification_config, get_provider_section,
-    get_proxy_auth_status, get_typed_section, list_credentials, put_mcp_section,
-    put_provider_section, put_typed_section, replace_credential, reset_bamboo_config,
-    reset_credentials, reset_typed_section, set_bamboo_config, set_proxy_auth,
-    validate_bamboo_config_patch, ProxyAuthPayload,
+    get_provider_settings_section, get_proxy_auth_status, get_typed_section, list_credentials,
+    put_mcp_section, put_provider_section, put_provider_settings_section, put_typed_section,
+    replace_credential, reset_bamboo_config, reset_credentials, reset_typed_section,
+    set_bamboo_config, set_proxy_auth, validate_bamboo_config_patch, ProxyAuthPayload,
 };
 pub use cluster_fabric::{
     create_cluster, create_node, delete_cluster, delete_node, get_node, list_nodes, node_deploy,

--- a/crates/app/bamboo-server/src/routes/bamboo_v1.rs
+++ b/crates/app/bamboo-server/src/routes/bamboo_v1.rs
@@ -138,6 +138,14 @@ pub(crate) fn bamboo_relative_routes() -> impl HttpServiceFactory {
             web::get().to(settings::get_live_config_health),
         )
         .route(
+            "/bamboo/config/provider-settings",
+            web::get().to(settings::get_provider_settings_section),
+        )
+        .route(
+            "/bamboo/config/provider-settings",
+            web::put().to(settings::put_provider_settings_section),
+        )
+        .route(
             "/bamboo/config/sections/providers",
             web::get().to(settings::get_provider_section),
         )

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -1820,6 +1820,35 @@ pub fn persist_provider_instance_credential_transaction(
     .map(|_| ())
 }
 
+/// Persist a complete provider metadata/API-key mutation through the exact
+/// provider + credential transaction at the typed provider section revision.
+/// Metadata-only updates participate in the same CAS transaction even when
+/// the credential document itself has no changed entries.
+pub fn persist_provider_credential_transaction_at_revision(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    provider_intents: &BTreeSet<String>,
+    provider_instance_intents: &BTreeSet<String>,
+    expected_revision: u64,
+) -> ConfigStoreResult<u64> {
+    persist_provider_credential_transaction_with_instances_at_revision_inner(
+        data_dir.as_ref(),
+        config,
+        provider_intents,
+        provider_instance_intents,
+        None,
+        &BTreeSet::new(),
+        None,
+        false,
+        &BTreeSet::new(),
+        false,
+        None,
+        Some(expected_revision),
+        #[cfg(test)]
+        None,
+    )
+}
+
 /// Reset the provider domain and its owned credentials under the provider
 /// section revision supplied by a typed client. Compatibility writes may
 /// rebase, but an explicit reset must fail when its section snapshot is stale.
@@ -2377,8 +2406,10 @@ fn persist_exact_credential_transaction_inner(
             &persisted_instance_refs,
         )?
     };
-    let Some(mut prepared) = prepared else {
-        return store.revision_unchecked();
+    let mut prepared = match prepared {
+        Some(prepared) => prepared,
+        None if provider_expected_revision.is_some() => store.prepare_provider_metadata_update()?,
+        None => return store.revision_unchecked(),
     };
     if proxy_only && reset_scope.is_none() {
         let expected = proxy_expected_revision.ok_or_else(|| {

--- a/crates/infra/bamboo-config/src/credential_store.rs
+++ b/crates/infra/bamboo-config/src/credential_store.rs
@@ -222,6 +222,33 @@ impl CredentialCommitAuthority<'_> {
 }
 
 impl CredentialStore {
+    /// Prepare an unchanged credential document so a provider-metadata-only
+    /// exact transaction can still use the provider section revision as its
+    /// CAS authority. The transaction layer advances this revision only when
+    /// the provider domain itself changes.
+    pub(crate) fn prepare_provider_metadata_update(
+        &self,
+    ) -> ConfigStoreResult<PreparedProviderCredentialUpdate> {
+        let (document, health) = self.load_document_with_health()?;
+        if health.status == SectionStatus::Degraded {
+            return Err(ConfigStoreError::Validation(
+                "credential document is unavailable for provider update".to_string(),
+            ));
+        }
+        let bytes = serde_json::to_vec_pretty(&serde_json::json!({
+            "schema_version": CREDENTIAL_SCHEMA_VERSION,
+            "revision": health.revision,
+            "data": document,
+        }))?;
+        Ok(PreparedProviderCredentialUpdate {
+            bytes,
+            expected_revision: health.revision,
+            revision: health.revision,
+            touched_refs: Vec::new(),
+            required_refs: Vec::new(),
+        })
+    }
+
     pub fn open(data_dir: impl AsRef<Path>) -> Self {
         Self {
             store: AtomicJsonStore::new(


### PR DESCRIPTION
## Summary

- add canonical `GET/PUT /bamboo/config/provider-settings` with a complete non-secret provider/settings DTO
- make provider metadata, built-in credentials, and provider-instance credentials one recoverable exact CAS transaction
- preserve server-owned forward metadata, publish runtime state after durable commit, and finish publication after request cancellation
- add explicit credential replace/clear/status semantics and reject secret-bearing or unsafe override literals

Closes #686

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy -p bamboo-config -p bamboo-server --all-targets --no-deps -- -D warnings -A clippy::too_many_arguments -A clippy::bool_assert_comparison -A clippy::items_after_test_module`
- `cargo test -p bamboo-config` (572 passed)
- `cargo test -p bamboo-server -- --skip server::tls::tests::build_rustls_config_succeeds_on_valid_self_signed_cert` (1596 passed, 1 ignored, 1 filtered; 16 WebSocket integration tests passed; doc tests passed)

The skipped TLS self-signed-certificate test fails with `UnsupportedCertVersion` on this machine and was reproduced unchanged in a clean detached `origin/main@3998d264` worktree, so it is a confirmed baseline/environment failure.