### PR TITLE
fix: make MCP settings credential-safe and revisioned (#701)

### DIFF
--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -1709,7 +1709,11 @@ impl AppState {
         let _io = self.config_io_lock.lock().await;
         ensure_provider_mcp_migration_ready(&self.app_data_dir)
             .map_err(ConfigSectionMutationError::Store)?;
-        retain_mcp_credentials(&self.config.read().await.mcp, &mut candidate);
+        retain_mcp_credentials(
+            &self.config.read().await.mcp,
+            &mut candidate,
+            &BTreeSet::new(),
+        );
         validate_mcp_config(&candidate).map_err(ConfigSectionMutationError::Invalid)?;
         let mut hydration_config = Config::default();
         hydration_config.mcp = candidate;
@@ -1789,6 +1793,119 @@ impl AppState {
             Some(revision),
         );
         Ok(revision)
+    }
+
+    /// Replace editable MCP metadata and explicitly touched credentials under
+    /// one section CAS. Runtime construction is staged first; credential and
+    /// MCP documents cross the durable boundary together.
+    pub(crate) async fn put_mcp_settings(
+        &self,
+        expected_revision: u64,
+        candidate: McpConfig,
+        credential_intents: BTreeSet<bamboo_config::CredentialRef>,
+    ) -> Result<u64, ConfigSectionMutationError> {
+        if credential_intents.is_empty() {
+            return self.put_mcp_section(expected_revision, candidate).await;
+        }
+
+        let config_io_lock = self.config_io_lock.clone();
+        let config = self.config.clone();
+        let app_data_dir = self.app_data_dir.clone();
+        let config_facade = self.config_facade.clone();
+        let account_sink = self.account_sink.clone();
+        let mcp_manager = self.mcp_manager.clone();
+        let mcp_config_live_health = self.mcp_config_live_health.clone();
+        let transaction = tokio::spawn(async move {
+            let _io = config_io_lock.lock().await;
+            ensure_provider_mcp_migration_ready(&app_data_dir)
+                .map_err(ConfigSectionMutationError::Store)?;
+            let facade = config_facade.as_ref().ok_or_else(|| {
+                ConfigSectionMutationError::Invalid(
+                    "MCP settings require the modular configuration facade".to_string(),
+                )
+            })?;
+            let current = config.read().await.clone();
+            let mut runtime_candidate = candidate;
+            materialize_mcp_touched_replacements(&mut runtime_candidate, &credential_intents)
+                .map_err(ConfigSectionMutationError::Invalid)?;
+            retain_mcp_credentials(&current.mcp, &mut runtime_candidate, &credential_intents);
+            validate_mcp_config(&runtime_candidate).map_err(ConfigSectionMutationError::Invalid)?;
+
+            let mut transaction_error = None;
+            let transaction_dir = app_data_dir.clone();
+            let mut durable_candidate = current;
+            durable_candidate.mcp = runtime_candidate.clone();
+            let result = mcp_manager
+                .reconcile_from_config_transactional_after(&runtime_candidate, || async {
+                    let mut live_config = config.write().await;
+                    let commit = tokio::task::spawn_blocking(move || {
+                        bamboo_config::persist_mcp_credential_transaction_at_revision(
+                            &transaction_dir,
+                            &mut durable_candidate,
+                            &credential_intents,
+                            expected_revision,
+                        )?;
+                        load_committed_effective_config(&transaction_dir)
+                    })
+                    .await;
+                    match commit {
+                        Ok(Ok(committed)) => {
+                            *live_config = committed;
+                            Ok(())
+                        }
+                        Ok(Err(error)) => {
+                            transaction_error = Some(ConfigSectionMutationError::Store(error));
+                            Err(bamboo_mcp::McpError::InvalidConfig(
+                                "MCP settings durable transaction failed".to_string(),
+                            ))
+                        }
+                        Err(error) => {
+                            transaction_error = Some(ConfigSectionMutationError::Runtime(format!(
+                                "MCP settings transaction task failed: {error}"
+                            )));
+                            Err(bamboo_mcp::McpError::InvalidConfig(
+                                "MCP settings durable transaction failed".to_string(),
+                            ))
+                        }
+                    }
+                })
+                .await;
+            if let Some(error) = transaction_error {
+                return Err(error);
+            }
+            if result.is_err() {
+                let message =
+                    "MCP runtime initialization failed; retaining last-known-good runtime"
+                        .to_string();
+                publish_section_failure(
+                    &mcp_config_live_health,
+                    &account_sink,
+                    "mcp",
+                    SectionStatus::Degraded,
+                    message.clone(),
+                );
+                return Err(ConfigSectionMutationError::Runtime(message));
+            }
+
+            publish_exact_facade_commit(
+                Some(facade),
+                &account_sink,
+                &[SectionId::Credentials, SectionId::Mcp],
+            )
+            .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
+            let snapshot = facade.registry().mcp.snapshot();
+            set_live_health_revision(
+                &mcp_config_live_health,
+                snapshot.revision,
+                Some((snapshot.source_path.clone(), SectionSourceKind::File)),
+            );
+            Ok(snapshot.revision)
+        });
+        transaction.await.map_err(|error| {
+            ConfigSectionMutationError::Runtime(format!(
+                "MCP settings transaction task failed: {error}"
+            ))
+        })?
     }
 
     /// Reset MCP metadata and its owned credentials at the runtime manager's
@@ -2068,7 +2185,11 @@ fn retain_provider_credentials(current: &ProviderConfigs, candidate: &mut Provid
     }
 }
 
-fn retain_mcp_credentials(current: &McpConfig, candidate: &mut McpConfig) {
+fn retain_mcp_credentials(
+    current: &McpConfig,
+    candidate: &mut McpConfig,
+    touched: &BTreeSet<bamboo_config::CredentialRef>,
+) {
     for candidate_server in &mut candidate.servers {
         let Some(current_server) = current
             .servers
@@ -2077,29 +2198,183 @@ fn retain_mcp_credentials(current: &McpConfig, candidate: &mut McpConfig) {
         else {
             continue;
         };
-        match (&current_server.transport, &mut candidate_server.transport) {
-            (TransportConfig::Stdio(current), TransportConfig::Stdio(candidate)) => {
-                if candidate.env.is_empty()
-                    && candidate.env_encrypted.is_empty()
-                    && candidate.env_credential_refs.is_empty()
-                {
-                    candidate.env = current.env.clone();
-                    candidate.env_encrypted = current.env_encrypted.clone();
-                    candidate.env_credential_refs = current.env_credential_refs.clone();
+        if let (TransportConfig::Stdio(current), TransportConfig::Stdio(candidate)) =
+            (&current_server.transport, &mut candidate_server.transport)
+        {
+            if candidate.env.is_empty()
+                && candidate.env_encrypted.is_empty()
+                && candidate.env_credential_refs.is_empty()
+            {
+                for (name, reference) in &current.env_credential_refs {
+                    if mcp_credential_ref_is_touched(Some(reference), touched) {
+                        continue;
+                    }
+                    candidate
+                        .env_credential_refs
+                        .insert(name.clone(), reference.clone());
+                    if let Some(value) = current.env.get(name) {
+                        candidate.env.insert(name.clone(), value.clone());
+                    }
+                    if let Some(value) = current.env_encrypted.get(name) {
+                        candidate.env_encrypted.insert(name.clone(), value.clone());
+                    }
+                }
+            } else {
+                for (name, reference) in &current.env_credential_refs {
+                    if candidate.env_credential_refs.get(name) != Some(reference) {
+                        continue;
+                    }
+                    if candidate.env.get(name).is_none_or(|value| value.is_empty()) {
+                        if let Some(value) = current.env.get(name) {
+                            candidate.env.insert(name.clone(), value.clone());
+                        }
+                    }
                 }
             }
-            (TransportConfig::Sse(current), TransportConfig::Sse(candidate))
-                if candidate.headers.is_empty() =>
-            {
-                candidate.headers = current.headers.clone();
+        }
+        match (&current_server.transport, &mut candidate_server.transport) {
+            (TransportConfig::Sse(current), TransportConfig::Sse(candidate)) => {
+                retain_mcp_header_credentials(&current.headers, &mut candidate.headers)
             }
             (
                 TransportConfig::StreamableHttp(current),
                 TransportConfig::StreamableHttp(candidate),
-            ) if candidate.headers.is_empty() => {
-                candidate.headers = current.headers.clone();
-            }
+            ) => retain_mcp_header_credentials(&current.headers, &mut candidate.headers),
             _ => {}
+        }
+    }
+}
+
+fn materialize_mcp_touched_replacements(
+    candidate: &mut McpConfig,
+    touched: &BTreeSet<bamboo_config::CredentialRef>,
+) -> Result<(), String> {
+    let mut replacements = BTreeMap::<bamboo_config::CredentialRef, String>::new();
+    for server in &candidate.servers {
+        match &server.transport {
+            TransportConfig::Stdio(stdio) => {
+                for (name, raw_reference) in &stdio.env_credential_refs {
+                    let reference = bamboo_config::CredentialRef::parse(raw_reference.clone())
+                        .map_err(|_| "MCP credential reference is invalid".to_string())?;
+                    if let Some(value) = stdio
+                        .env
+                        .get(name)
+                        .filter(|value| touched.contains(&reference) && !value.is_empty())
+                    {
+                        insert_mcp_replacement(&mut replacements, reference, value)?;
+                    }
+                }
+            }
+            TransportConfig::Sse(http) => {
+                collect_mcp_header_replacements(&http.headers, touched, &mut replacements)?
+            }
+            TransportConfig::StreamableHttp(http) => {
+                collect_mcp_header_replacements(&http.headers, touched, &mut replacements)?
+            }
+        }
+    }
+    if replacements.is_empty() {
+        return Ok(());
+    }
+    for server in &mut candidate.servers {
+        match &mut server.transport {
+            TransportConfig::Stdio(stdio) => {
+                for (name, raw_reference) in &stdio.env_credential_refs {
+                    let reference = bamboo_config::CredentialRef::parse(raw_reference.clone())
+                        .map_err(|_| "MCP credential reference is invalid".to_string())?;
+                    if let Some(value) = replacements.get(&reference) {
+                        stdio.env.insert(name.clone(), value.clone());
+                    }
+                }
+            }
+            TransportConfig::Sse(http) => {
+                apply_mcp_header_replacements(&mut http.headers, &replacements)?
+            }
+            TransportConfig::StreamableHttp(http) => {
+                apply_mcp_header_replacements(&mut http.headers, &replacements)?
+            }
+        }
+    }
+    Ok(())
+}
+
+fn collect_mcp_header_replacements(
+    headers: &[bamboo_mcp::HeaderConfig],
+    touched: &BTreeSet<bamboo_config::CredentialRef>,
+    replacements: &mut BTreeMap<bamboo_config::CredentialRef, String>,
+) -> Result<(), String> {
+    for header in headers {
+        let Some(raw_reference) = header.credential_ref.as_ref() else {
+            continue;
+        };
+        let reference = bamboo_config::CredentialRef::parse(raw_reference.clone())
+            .map_err(|_| "MCP credential reference is invalid".to_string())?;
+        if touched.contains(&reference) && !header.value.is_empty() {
+            insert_mcp_replacement(replacements, reference, &header.value)?;
+        }
+    }
+    Ok(())
+}
+
+fn insert_mcp_replacement(
+    replacements: &mut BTreeMap<bamboo_config::CredentialRef, String>,
+    reference: bamboo_config::CredentialRef,
+    value: &str,
+) -> Result<(), String> {
+    match replacements.get(&reference) {
+        Some(existing) if existing != value => {
+            Err("MCP updates assign conflicting values to one credential reference".to_string())
+        }
+        Some(_) => Ok(()),
+        None => {
+            replacements.insert(reference, value.to_string());
+            Ok(())
+        }
+    }
+}
+
+fn apply_mcp_header_replacements(
+    headers: &mut [bamboo_mcp::HeaderConfig],
+    replacements: &BTreeMap<bamboo_config::CredentialRef, String>,
+) -> Result<(), String> {
+    for header in headers {
+        let Some(raw_reference) = header.credential_ref.as_ref() else {
+            continue;
+        };
+        let reference = bamboo_config::CredentialRef::parse(raw_reference.clone())
+            .map_err(|_| "MCP credential reference is invalid".to_string())?;
+        if let Some(value) = replacements.get(&reference) {
+            header.value = value.clone();
+        }
+    }
+    Ok(())
+}
+
+fn mcp_credential_ref_is_touched(
+    raw_reference: Option<&String>,
+    touched: &BTreeSet<bamboo_config::CredentialRef>,
+) -> bool {
+    raw_reference
+        .and_then(|raw| bamboo_config::CredentialRef::parse(raw.clone()).ok())
+        .is_some_and(|reference| touched.contains(&reference))
+}
+
+fn retain_mcp_header_credentials(
+    current: &[bamboo_mcp::HeaderConfig],
+    candidate: &mut [bamboo_mcp::HeaderConfig],
+) {
+    for candidate_header in candidate {
+        let Some(current_header) = current
+            .iter()
+            .find(|header| header.name == candidate_header.name)
+        else {
+            continue;
+        };
+        if candidate_header.credential_ref == current_header.credential_ref
+            && candidate_header.value.is_empty()
+        {
+            candidate_header.value = current_header.value.clone();
+            candidate_header.value_encrypted = current_header.value_encrypted.clone();
         }
     }
 }
@@ -3286,6 +3561,113 @@ mod live_reload_tests {
             "data": config,
         }))
         .unwrap()
+    }
+
+    #[test]
+    fn touched_shared_mcp_refs_stage_replacements_and_preserve_surviving_clears() {
+        let shared =
+            bamboo_config::CredentialRef::parse("mcp.shared.env_token".to_string()).unwrap();
+        let mut current = disabled_mcp_config("first");
+        let mut second = current.servers[0].clone();
+        second.id = "second".to_string();
+        current.servers.push(second);
+        for server in &mut current.servers {
+            let TransportConfig::Stdio(stdio) = &mut server.transport else {
+                unreachable!()
+            };
+            stdio
+                .env
+                .insert("TOKEN".to_string(), "old-shared-secret".to_string());
+            stdio
+                .env_credential_refs
+                .insert("TOKEN".to_string(), shared.as_str().to_string());
+        }
+        let touched = BTreeSet::from([shared]);
+
+        let mut replace = current.clone();
+        for server in &mut replace.servers {
+            let TransportConfig::Stdio(stdio) = &mut server.transport else {
+                unreachable!()
+            };
+            stdio.env.get_mut("TOKEN").unwrap().clear();
+        }
+        let TransportConfig::Stdio(first) = &mut replace.servers[0].transport else {
+            unreachable!()
+        };
+        first
+            .env
+            .insert("TOKEN".to_string(), "new-shared-secret".to_string());
+        materialize_mcp_touched_replacements(&mut replace, &touched).unwrap();
+        retain_mcp_credentials(&current, &mut replace, &touched);
+        for server in &replace.servers {
+            let TransportConfig::Stdio(stdio) = &server.transport else {
+                unreachable!()
+            };
+            assert_eq!(stdio.env["TOKEN"], "new-shared-secret");
+        }
+
+        let mut clear_one = current.clone();
+        for server in &mut clear_one.servers {
+            let TransportConfig::Stdio(stdio) = &mut server.transport else {
+                unreachable!()
+            };
+            stdio.env.get_mut("TOKEN").unwrap().clear();
+        }
+        let TransportConfig::Stdio(first) = &mut clear_one.servers[0].transport else {
+            unreachable!()
+        };
+        first.env.remove("TOKEN");
+        first.env_credential_refs.remove("TOKEN");
+        materialize_mcp_touched_replacements(&mut clear_one, &touched).unwrap();
+        retain_mcp_credentials(&current, &mut clear_one, &touched);
+        let TransportConfig::Stdio(first) = &clear_one.servers[0].transport else {
+            unreachable!()
+        };
+        assert!(!first.env.contains_key("TOKEN"));
+        assert!(!first.env_credential_refs.contains_key("TOKEN"));
+        let TransportConfig::Stdio(second) = &clear_one.servers[1].transport else {
+            unreachable!()
+        };
+        assert_eq!(second.env["TOKEN"], "old-shared-secret");
+        assert_eq!(second.env_credential_refs["TOKEN"], "mcp.shared.env_token");
+
+        let header_ref =
+            bamboo_config::CredentialRef::parse("mcp.shared.header_token".to_string()).unwrap();
+        let current_http = McpConfig {
+            version: 1,
+            servers: vec![McpServerConfig {
+                id: "http".to_string(),
+                name: None,
+                enabled: false,
+                transport: TransportConfig::Sse(bamboo_mcp::SseConfig {
+                    url: "https://example.test/sse".to_string(),
+                    headers: vec![bamboo_mcp::HeaderConfig {
+                        name: "Authorization".to_string(),
+                        value: "old-header-secret".to_string(),
+                        value_encrypted: None,
+                        credential_ref: Some(header_ref.as_str().to_string()),
+                    }],
+                    connect_timeout_ms: 100,
+                }),
+                request_timeout_ms: 100,
+                healthcheck_interval_ms: 100,
+                reconnect: ReconnectConfig::default(),
+                allowed_tools: vec![],
+                denied_tools: vec![],
+            }],
+        };
+        let mut delete_all_headers = current_http.clone();
+        let TransportConfig::Sse(candidate) = &mut delete_all_headers.servers[0].transport else {
+            unreachable!()
+        };
+        candidate.headers.clear();
+        let touched = BTreeSet::from([header_ref]);
+        materialize_mcp_touched_replacements(&mut delete_all_headers, &touched).unwrap();
+        retain_mcp_credentials(&current_http, &mut delete_all_headers, &touched);
+        let TransportConfig::Sse(candidate) = &delete_all_headers.servers[0].transport else {
+            unreachable!()
+        };
+        assert!(candidate.headers.is_empty());
     }
 
     fn install_unrecoverable_pending_provider_migration(dir: &Path) {

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -1,10 +1,11 @@
 use actix_web::{web, HttpResponse};
 use bamboo_config::{
-    patch::is_masked_api_key, ConfigStoreError, DefaultsConfig, FeatureFlags, HooksSection,
-    MemorySection, ModelLimitsSection, ModelPolicySection, ProviderConfigs, ProviderInstanceConfig,
-    RequestOverridesConfig, SectionEnvelope, SectionId, SubagentsSection, ToolsSkillsSection,
+    credential_ref, patch::is_masked_api_key, ConfigStoreError, CredentialRef, DefaultsConfig,
+    FeatureFlags, HooksSection, MemorySection, ModelLimitsSection, ModelPolicySection,
+    ProviderConfigs, ProviderInstanceConfig, RequestOverridesConfig, SectionEnvelope, SectionId,
+    SubagentsSection, ToolsSkillsSection,
 };
-use bamboo_mcp::McpConfig;
+use bamboo_mcp::{McpConfig, McpServerConfig, TransportConfig};
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
 use serde_json::{json, Map, Value};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -26,8 +27,50 @@ pub struct PutProviderSectionRequest {
 #[serde(deny_unknown_fields)]
 pub struct PutMcpSectionRequest {
     pub expected_revision: u64,
-    #[serde(deserialize_with = "deserialize_mcp_candidate")]
-    pub data: McpConfig,
+    #[serde(deserialize_with = "deserialize_mcp_settings_candidate")]
+    pub data: McpSettingsData,
+    #[serde(default)]
+    pub credential_changes: McpCredentialChanges,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct McpSettingsData {
+    #[serde(default = "default_mcp_version")]
+    pub version: u32,
+    #[serde(default)]
+    pub servers: Vec<McpServerConfig>,
+    #[serde(default)]
+    pub credential_status: Value,
+}
+
+impl McpSettingsData {
+    fn into_config(self) -> McpConfig {
+        McpConfig {
+            version: self.version,
+            servers: self.servers,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct McpCredentialChanges {
+    #[serde(default)]
+    pub servers: BTreeMap<String, McpServerCredentialChanges>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct McpServerCredentialChanges {
+    #[serde(default)]
+    pub env: BTreeMap<String, Option<String>>,
+    #[serde(default)]
+    pub headers: BTreeMap<String, Option<String>>,
+}
+
+fn default_mcp_version() -> u32 {
+    1
 }
 
 #[derive(Debug, Deserialize)]
@@ -388,21 +431,28 @@ pub async fn put_provider_settings_section(
     get_provider_settings_section(app_state).await
 }
 
-/// Read-only MCP section projection. Transport diagnostics remain visible,
-/// while environment/header values and legacy ciphertext never enter the DTO.
+/// Editable MCP section projection. Every transport field needed for a
+/// round-trip remains visible, while credential values and server-managed
+/// references never enter the DTO.
 pub async fn get_mcp_section(app_state: web::Data<AppState>) -> Result<HttpResponse, AppError> {
     let _io = app_state.config_io_lock.lock().await;
-    let config = app_state.config.read().await.clone();
-    let servers = config
-        .mcp
-        .servers
-        .iter()
-        .map(mcp_server_diagnostics)
-        .collect::<Vec<_>>();
-    let data = json!({
-        "version": config.mcp.version,
-        "servers": servers,
-    });
+    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
+        AppError::BadRequest(
+            "typed MCP settings require the modular configuration facade".to_string(),
+        )
+    })?;
+    let snapshot = facade.registry().mcp.snapshot();
+    let config = secret_free_mcp_config(&snapshot.data.0);
+    let statuses = app_state
+        .credential_store
+        .statuses_with_health()
+        .map_err(super::credentials::map_store_read_error)?
+        .0;
+    let data = McpSettingsData {
+        version: config.version,
+        credential_status: mcp_credential_status(&snapshot.data.0, &statuses),
+        servers: config.servers,
+    };
     let health = app_state
         .mcp_config_live_health
         .read()
@@ -428,8 +478,27 @@ pub async fn put_mcp_section(
     payload: web::Json<PutMcpSectionRequest>,
 ) -> Result<HttpResponse, AppError> {
     let payload = payload.into_inner();
+    let current = app_state
+        .config_facade
+        .as_ref()
+        .ok_or_else(|| {
+            AppError::BadRequest(
+                "typed MCP settings require the modular configuration facade".to_string(),
+            )
+        })?
+        .registry()
+        .mcp
+        .snapshot()
+        .data
+        .0
+        .clone();
+    let mut candidate = payload.data.into_config();
+    retain_mcp_server_managed_refs(&current, &mut candidate);
+    let intents =
+        apply_mcp_credential_changes(&current, &mut candidate, payload.credential_changes)
+            .map_err(map_mutation_error)?;
     app_state
-        .put_mcp_section(payload.expected_revision, payload.data)
+        .put_mcp_settings(payload.expected_revision, candidate, intents)
         .await
         .map_err(map_mutation_error)?;
     get_mcp_section(app_state).await
@@ -1068,21 +1137,23 @@ where
     Ok(candidate)
 }
 
-fn deserialize_mcp_candidate<'de, D>(deserializer: D) -> Result<McpConfig, D::Error>
+fn deserialize_mcp_settings_candidate<'de, D>(deserializer: D) -> Result<McpSettingsData, D::Error>
 where
     D: Deserializer<'de>,
 {
     let value = Value::deserialize(deserializer)?;
-    reject_secret_fields(&value, SecretPolicy::Mcp).map_err(D::Error::custom)?;
-    let candidate: McpConfig = serde_json::from_value(value).map_err(D::Error::custom)?;
-    validate_mcp_public_shape(&candidate).map_err(D::Error::custom)?;
+    let candidate: McpSettingsData = serde_json::from_value(value).map_err(D::Error::custom)?;
+    let config = McpConfig {
+        version: candidate.version,
+        servers: candidate.servers.clone(),
+    };
+    validate_mcp_settings_public_shape(&config).map_err(D::Error::custom)?;
     Ok(candidate)
 }
 
 #[derive(Clone, Copy)]
 enum SecretPolicy {
     Provider,
-    Mcp,
 }
 
 fn reject_secret_fields(value: &Value, policy: SecretPolicy) -> Result<(), String> {
@@ -1095,12 +1166,6 @@ fn reject_secret_fields(value: &Value, policy: SecretPolicy) -> Result<(), Strin
                         normalized.as_str(),
                         "api_key" | "api_key_encrypted" | "request_overrides"
                     ),
-                    SecretPolicy::Mcp => {
-                        matches!(normalized.as_str(), "env_encrypted" | "value_encrypted")
-                            || (matches!(normalized.as_str(), "env" | "headers")
-                                && !value.as_object().is_some_and(Map::is_empty)
-                                && !value.as_array().is_some_and(Vec::is_empty))
-                    }
                 };
                 if forbidden {
                     return Err(format!(
@@ -1179,6 +1244,56 @@ fn validate_mcp_public_shape(candidate: &McpConfig) -> Result<(), String> {
     Ok(())
 }
 
+fn validate_mcp_settings_public_shape(candidate: &McpConfig) -> Result<(), String> {
+    validate_mcp_public_shape(candidate)?;
+    let mut ids = BTreeSet::new();
+    for server in &candidate.servers {
+        if server.id.trim().is_empty() || !ids.insert(server.id.clone()) {
+            return Err("MCP server ids must be non-empty and unique".to_string());
+        }
+        match &server.transport {
+            TransportConfig::Stdio(stdio) => {
+                if stdio.env.keys().any(|name| name.trim().is_empty()) {
+                    return Err("MCP environment variable names cannot be empty".to_string());
+                }
+                if stdio.env.values().any(|value| !value.is_empty())
+                    || !stdio.env_encrypted.is_empty()
+                    || !stdio.env_credential_refs.is_empty()
+                {
+                    return Err(
+                        "MCP config data cannot contain credential values or references; use credential_changes"
+                            .to_string(),
+                    );
+                }
+            }
+            TransportConfig::Sse(http) => validate_mcp_public_headers(&http.headers)?,
+            TransportConfig::StreamableHttp(http) => validate_mcp_public_headers(&http.headers)?,
+        }
+    }
+    Ok(())
+}
+
+fn validate_mcp_public_headers(headers: &[bamboo_mcp::HeaderConfig]) -> Result<(), String> {
+    let mut names = BTreeSet::new();
+    if headers
+        .iter()
+        .any(|header| header.name.trim().is_empty() || !names.insert(header.name.clone()))
+    {
+        return Err("MCP header names must be non-empty and unique".to_string());
+    }
+    if headers.iter().any(|header| {
+        !header.value.is_empty()
+            || header.value_encrypted.is_some()
+            || header.credential_ref.is_some()
+    }) {
+        return Err(
+            "MCP config data cannot contain credential values or references; use credential_changes"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 fn validate_public_url(raw: &str) -> Result<(), String> {
     let url = url::Url::parse(raw).map_err(|_| "section URL is invalid".to_string())?;
     if !url.username().is_empty()
@@ -1194,10 +1309,7 @@ fn validate_public_url(raw: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn section_envelope(
-    data: Value,
-    health: crate::app_state::ConfigLiveHealth,
-) -> SectionEnvelope<Value> {
+fn section_envelope<T>(data: T, health: crate::app_state::ConfigLiveHealth) -> SectionEnvelope<T> {
     SectionEnvelope {
         data,
         revision: health.revision,
@@ -1298,68 +1410,397 @@ fn safe_url_diagnostic(raw: Option<&str>) -> Option<String> {
     Some(url.to_string())
 }
 
-fn mcp_server_diagnostics(server: &bamboo_mcp::McpServerConfig) -> Value {
-    let transport = match &server.transport {
-        bamboo_mcp::TransportConfig::Stdio(stdio) => {
-            let mut env_keys = stdio.env.keys().cloned().collect::<Vec<_>>();
-            env_keys.extend(stdio.env_encrypted.keys().cloned());
-            env_keys.extend(stdio.env_credential_refs.keys().cloned());
-            env_keys.sort();
-            env_keys.dedup();
-            json!({
-                "type": "stdio",
-                "command": stdio.command,
-                "arg_count": stdio.args.len(),
-                "cwd_configured": stdio.cwd.is_some(),
-                "env_keys": env_keys,
-                "startup_timeout_ms": stdio.startup_timeout_ms,
-            })
+fn secret_free_mcp_config(config: &McpConfig) -> McpConfig {
+    let mut public = config.clone();
+    for server in &mut public.servers {
+        match &mut server.transport {
+            TransportConfig::Stdio(stdio) => {
+                let mut names = stdio.env.keys().cloned().collect::<BTreeSet<_>>();
+                names.extend(stdio.env_encrypted.keys().cloned());
+                names.extend(stdio.env_credential_refs.keys().cloned());
+                stdio.env = names
+                    .into_iter()
+                    .map(|name| (name, String::new()))
+                    .collect();
+                stdio.env_encrypted.clear();
+                stdio.env_credential_refs.clear();
+            }
+            TransportConfig::Sse(http) => {
+                http.url = safe_url_diagnostic(Some(&http.url)).unwrap_or_default();
+                make_headers_secret_free(&mut http.headers);
+            }
+            TransportConfig::StreamableHttp(http) => {
+                http.url = safe_url_diagnostic(Some(&http.url)).unwrap_or_default();
+                make_headers_secret_free(&mut http.headers);
+            }
         }
-        bamboo_mcp::TransportConfig::Sse(sse) => {
-            http_transport_diagnostics("sse", &sse.url, &sse.headers, sse.connect_timeout_ms)
-        }
-        bamboo_mcp::TransportConfig::StreamableHttp(http) => http_transport_diagnostics(
-            "streamable_http",
-            &http.url,
-            &http.headers,
-            http.connect_timeout_ms,
-        ),
-    };
-
-    json!({
-        "id": server.id,
-        "name": server.name,
-        "enabled": server.enabled,
-        "transport": transport,
-        "request_timeout_ms": server.request_timeout_ms,
-        "healthcheck_interval_ms": server.healthcheck_interval_ms,
-        "reconnect": server.reconnect,
-        "allowed_tools": server.allowed_tools,
-        "denied_tools": server.denied_tools,
-    })
+    }
+    public
 }
 
-fn http_transport_diagnostics(
-    kind: &str,
-    url: &str,
-    headers: &[bamboo_mcp::HeaderConfig],
-    connect_timeout_ms: u64,
+fn make_headers_secret_free(headers: &mut [bamboo_mcp::HeaderConfig]) {
+    for header in headers {
+        header.value.clear();
+        header.value_encrypted = None;
+        header.credential_ref = None;
+    }
+}
+
+fn mcp_credential_status(
+    config: &McpConfig,
+    statuses: &[bamboo_config::CredentialStatus],
 ) -> Value {
-    let mut header_names = headers
+    let by_ref = statuses
         .iter()
-        .filter_map(|header| {
-            let name = header.name.trim();
-            (!name.is_empty()).then(|| name.to_string())
+        .map(|status| (status.credential_ref.as_str(), status))
+        .collect::<BTreeMap<_, _>>();
+    let mut servers = Map::new();
+    for server in &config.servers {
+        let mut env = Map::new();
+        let mut headers = Map::new();
+        match &server.transport {
+            TransportConfig::Stdio(stdio) => {
+                let mut names = stdio.env.keys().cloned().collect::<BTreeSet<_>>();
+                names.extend(stdio.env_encrypted.keys().cloned());
+                names.extend(stdio.env_credential_refs.keys().cloned());
+                for name in names {
+                    let status = stdio
+                        .env_credential_refs
+                        .get(&name)
+                        .and_then(|raw_reference| by_ref.get(raw_reference.as_str()).copied());
+                    env.insert(name, mcp_credential_status_value(status));
+                }
+            }
+            TransportConfig::Sse(http) => {
+                collect_mcp_header_status(&http.headers, &by_ref, &mut headers)
+            }
+            TransportConfig::StreamableHttp(http) => {
+                collect_mcp_header_status(&http.headers, &by_ref, &mut headers)
+            }
+        }
+        servers.insert(
+            server.id.clone(),
+            json!({
+                "env": env,
+                "headers": headers,
+            }),
+        );
+    }
+    Value::Object(servers)
+}
+
+fn collect_mcp_header_status<'a>(
+    headers_config: &[bamboo_mcp::HeaderConfig],
+    by_ref: &BTreeMap<&'a str, &'a bamboo_config::CredentialStatus>,
+    output: &mut Map<String, Value>,
+) {
+    for header in headers_config {
+        let status = header
+            .credential_ref
+            .as_deref()
+            .and_then(|raw_reference| by_ref.get(raw_reference).copied());
+        output.insert(header.name.clone(), mcp_credential_status_value(status));
+    }
+}
+
+fn mcp_credential_status_value(status: Option<&bamboo_config::CredentialStatus>) -> Value {
+    status.map_or_else(
+        || {
+            json!({
+                "configured": false,
+                "source": "missing",
+                "updated_at": null,
+            })
+        },
+        |status| {
+            json!({
+                "configured": status.configured,
+                "source": status.source,
+                "updated_at": status.updated_at,
+            })
+        },
+    )
+}
+
+fn retain_mcp_server_managed_refs(current: &McpConfig, candidate: &mut McpConfig) {
+    for candidate_server in &mut candidate.servers {
+        let Some(current_server) = current
+            .servers
+            .iter()
+            .find(|server| server.id == candidate_server.id)
+        else {
+            continue;
+        };
+        match (&current_server.transport, &mut candidate_server.transport) {
+            (TransportConfig::Stdio(current), TransportConfig::Stdio(candidate)) => {
+                candidate.env_credential_refs = current
+                    .env_credential_refs
+                    .iter()
+                    .filter(|(name, _)| candidate.env.contains_key(name.as_str()))
+                    .map(|(name, reference)| (name.clone(), reference.clone()))
+                    .collect();
+            }
+            (TransportConfig::Sse(current), TransportConfig::Sse(candidate)) => {
+                retain_mcp_header_refs(&current.headers, &mut candidate.headers)
+            }
+            (
+                TransportConfig::StreamableHttp(current),
+                TransportConfig::StreamableHttp(candidate),
+            ) => retain_mcp_header_refs(&current.headers, &mut candidate.headers),
+            _ => {}
+        }
+    }
+}
+
+fn retain_mcp_header_refs(
+    current: &[bamboo_mcp::HeaderConfig],
+    candidate: &mut [bamboo_mcp::HeaderConfig],
+) {
+    for candidate_header in candidate {
+        candidate_header.credential_ref = current
+            .iter()
+            .find(|header| header.name == candidate_header.name)
+            .and_then(|header| header.credential_ref.clone());
+    }
+}
+
+fn apply_mcp_credential_changes(
+    current: &McpConfig,
+    candidate: &mut McpConfig,
+    changes: McpCredentialChanges,
+) -> Result<BTreeSet<CredentialRef>, ConfigSectionMutationError> {
+    let current_refs = mcp_credential_refs(current)?;
+    let mut intents = BTreeSet::new();
+    for (server_id, server_changes) in changes.servers {
+        for (name, value) in server_changes.env {
+            let reference = current_mcp_env_ref(current, &server_id, &name)?.map_or_else(
+                || {
+                    credential_ref("mcp", &server_id, &format!("env_{name}"))
+                        .map_err(ConfigSectionMutationError::Store)
+                },
+                Ok,
+            )?;
+            apply_mcp_env_change(candidate, &server_id, &name, value, &reference)?;
+            intents.insert(reference);
+        }
+        for (name, value) in server_changes.headers {
+            let reference = current_mcp_header_ref(current, &server_id, &name)?.map_or_else(
+                || {
+                    credential_ref("mcp", &server_id, &format!("header_{name}"))
+                        .map_err(ConfigSectionMutationError::Store)
+                },
+                Ok,
+            )?;
+            apply_mcp_header_change(candidate, &server_id, &name, value, &reference)?;
+            intents.insert(reference);
+        }
+    }
+    let candidate_refs = mcp_credential_refs(candidate)?;
+    if current_refs
+        .symmetric_difference(&candidate_refs)
+        .any(|reference| !intents.contains(reference))
+    {
+        return Err(ConfigSectionMutationError::Invalid(
+            "MCP credentials require explicit replace or clear actions".to_string(),
+        ));
+    }
+    Ok(intents)
+}
+
+fn mcp_credential_refs(
+    config: &McpConfig,
+) -> Result<BTreeSet<CredentialRef>, ConfigSectionMutationError> {
+    let mut references = BTreeSet::new();
+    for server in &config.servers {
+        match &server.transport {
+            TransportConfig::Stdio(stdio) => {
+                for raw in stdio.env_credential_refs.values() {
+                    references.insert(CredentialRef::parse(raw.clone()).map_err(|_| {
+                        ConfigSectionMutationError::Invalid(
+                            "MCP credential reference is invalid".to_string(),
+                        )
+                    })?);
+                }
+            }
+            TransportConfig::Sse(http) => collect_mcp_header_refs(&http.headers, &mut references)?,
+            TransportConfig::StreamableHttp(http) => {
+                collect_mcp_header_refs(&http.headers, &mut references)?
+            }
+        }
+    }
+    Ok(references)
+}
+
+fn collect_mcp_header_refs(
+    headers: &[bamboo_mcp::HeaderConfig],
+    output: &mut BTreeSet<CredentialRef>,
+) -> Result<(), ConfigSectionMutationError> {
+    for raw in headers
+        .iter()
+        .filter_map(|header| header.credential_ref.as_ref())
+    {
+        output.insert(CredentialRef::parse(raw.clone()).map_err(|_| {
+            ConfigSectionMutationError::Invalid("MCP credential reference is invalid".to_string())
+        })?);
+    }
+    Ok(())
+}
+
+fn current_mcp_env_ref(
+    config: &McpConfig,
+    server_id: &str,
+    name: &str,
+) -> Result<Option<CredentialRef>, ConfigSectionMutationError> {
+    let Some(server) = config.servers.iter().find(|server| server.id == server_id) else {
+        return Ok(None);
+    };
+    let TransportConfig::Stdio(stdio) = &server.transport else {
+        return Ok(None);
+    };
+    stdio
+        .env_credential_refs
+        .get(name)
+        .map(|raw| {
+            CredentialRef::parse(raw.clone()).map_err(|_| {
+                ConfigSectionMutationError::Invalid(
+                    "MCP credential reference is invalid".to_string(),
+                )
+            })
         })
-        .collect::<Vec<_>>();
-    header_names.sort();
-    header_names.dedup();
-    json!({
-        "type": kind,
-        "url": safe_url_diagnostic(Some(url)),
-        "header_names": header_names,
-        "connect_timeout_ms": connect_timeout_ms,
-    })
+        .transpose()
+}
+
+fn current_mcp_header_ref(
+    config: &McpConfig,
+    server_id: &str,
+    name: &str,
+) -> Result<Option<CredentialRef>, ConfigSectionMutationError> {
+    let Some(server) = config.servers.iter().find(|server| server.id == server_id) else {
+        return Ok(None);
+    };
+    let headers = match &server.transport {
+        TransportConfig::Sse(http) => &http.headers,
+        TransportConfig::StreamableHttp(http) => &http.headers,
+        TransportConfig::Stdio(_) => return Ok(None),
+    };
+    headers
+        .iter()
+        .find(|header| header.name == name)
+        .and_then(|header| header.credential_ref.as_ref())
+        .map(|raw| {
+            CredentialRef::parse(raw.clone()).map_err(|_| {
+                ConfigSectionMutationError::Invalid(
+                    "MCP credential reference is invalid".to_string(),
+                )
+            })
+        })
+        .transpose()
+}
+
+fn apply_mcp_env_change(
+    candidate: &mut McpConfig,
+    server_id: &str,
+    name: &str,
+    value: Option<String>,
+    reference: &CredentialRef,
+) -> Result<(), ConfigSectionMutationError> {
+    if value.as_deref().is_some_and(is_masked_api_key) {
+        return Err(ConfigSectionMutationError::Invalid(
+            "masked MCP credential placeholders are not accepted".to_string(),
+        ));
+    }
+    let server = candidate
+        .servers
+        .iter_mut()
+        .find(|server| server.id == server_id);
+    match (server, value) {
+        (Some(server), Some(value)) if !value.is_empty() => {
+            let TransportConfig::Stdio(stdio) = &mut server.transport else {
+                return Err(ConfigSectionMutationError::Invalid(
+                    "MCP environment credentials require a stdio server".to_string(),
+                ));
+            };
+            stdio.env.insert(name.to_string(), value);
+            stdio
+                .env_credential_refs
+                .insert(name.to_string(), reference.as_str().to_string());
+        }
+        (_, Some(_)) => {
+            return Err(ConfigSectionMutationError::Invalid(
+                "MCP credential replacement cannot be empty".to_string(),
+            ))
+        }
+        (Some(server), None) => {
+            if let TransportConfig::Stdio(stdio) = &mut server.transport {
+                stdio.env.remove(name);
+                stdio.env_credential_refs.remove(name);
+            }
+        }
+        (None, None) => {}
+    }
+    Ok(())
+}
+
+fn apply_mcp_header_change(
+    candidate: &mut McpConfig,
+    server_id: &str,
+    name: &str,
+    value: Option<String>,
+    reference: &CredentialRef,
+) -> Result<(), ConfigSectionMutationError> {
+    if value.as_deref().is_some_and(is_masked_api_key) {
+        return Err(ConfigSectionMutationError::Invalid(
+            "masked MCP credential placeholders are not accepted".to_string(),
+        ));
+    }
+    let server = candidate
+        .servers
+        .iter_mut()
+        .find(|server| server.id == server_id);
+    match (server, value) {
+        (Some(server), Some(value)) if !value.is_empty() => {
+            let headers = match &mut server.transport {
+                TransportConfig::Sse(http) => &mut http.headers,
+                TransportConfig::StreamableHttp(http) => &mut http.headers,
+                TransportConfig::Stdio(_) => {
+                    return Err(ConfigSectionMutationError::Invalid(
+                        "MCP header credentials require an HTTP server".to_string(),
+                    ))
+                }
+            };
+            let header = headers
+                .iter_mut()
+                .find(|header| header.name == name)
+                .ok_or_else(|| {
+                    ConfigSectionMutationError::Invalid(
+                        "MCP header credential target is missing from the server config"
+                            .to_string(),
+                    )
+                })?;
+            header.value = value;
+            header.credential_ref = Some(reference.as_str().to_string());
+        }
+        (_, Some(_)) => {
+            return Err(ConfigSectionMutationError::Invalid(
+                "MCP credential replacement cannot be empty".to_string(),
+            ))
+        }
+        (Some(server), None) => {
+            let headers = match &mut server.transport {
+                TransportConfig::Sse(http) => Some(&mut http.headers),
+                TransportConfig::StreamableHttp(http) => Some(&mut http.headers),
+                TransportConfig::Stdio(_) => None,
+            };
+            if let Some(headers) = headers {
+                if let Some(header) = headers.iter_mut().find(|header| header.name == name) {
+                    header.value.clear();
+                    header.credential_ref = None;
+                }
+            }
+        }
+        (None, None) => {}
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1413,8 +1854,30 @@ mod tests {
 
     #[actix_web::test]
     async fn typed_sections_expose_health_and_diagnostics_without_secret_material() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x49; 32]);
         let dir = tempfile::tempdir().unwrap();
         let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let env_reference = bamboo_config::credential_ref("mcp", "stdio", "env_TOKEN").unwrap();
+        let header_reference =
+            bamboo_config::credential_ref("mcp", "http", "header_Authorization").unwrap();
+        state
+            .credential_store
+            .replace(
+                env_reference.clone(),
+                "mcp-env-plaintext-secret",
+                bamboo_config::CredentialSource::User,
+                0,
+            )
+            .unwrap();
+        state
+            .credential_store
+            .replace(
+                header_reference.clone(),
+                "mcp-header-plaintext-secret",
+                bamboo_config::CredentialSource::User,
+                1,
+            )
+            .unwrap();
         {
             let mut config = state.config.write().await;
             *config.providers_mut() = ProviderConfigs {
@@ -1450,34 +1913,38 @@ mod tests {
                             command: "diagnostic-command".to_string(),
                             args: vec!["mcp-argument-secret".to_string()],
                             cwd: Some("/safe/workspace".to_string()),
-                            env: HashMap::from([(
+                            env: HashMap::new(),
+                            env_encrypted: HashMap::new(),
+                            env_credential_refs: HashMap::from([(
                                 "TOKEN".to_string(),
-                                "mcp-env-plaintext-secret".to_string(),
+                                env_reference.as_str().to_string(),
                             )]),
-                            env_encrypted: HashMap::from([(
-                                "LEGACY_TOKEN".to_string(),
-                                "mcp-env-ciphertext-secret".to_string(),
-                            )]),
-                            env_credential_refs: HashMap::new(),
                             startup_timeout_ms: 4_000,
                         }),
                     ),
                     server(
                         "http",
                         TransportConfig::StreamableHttp(StreamableHttpConfig {
-                            url: "https://mcp-url-secret@mcp.example/rpc?token=mcp-query-secret"
-                                .to_string(),
+                            url: "https://mcp.example/rpc".to_string(),
                             headers: vec![HeaderConfig {
                                 name: "Authorization".to_string(),
-                                value: "mcp-header-plaintext-secret".to_string(),
-                                value_encrypted: Some("mcp-header-ciphertext-secret".to_string()),
-                                credential_ref: None,
+                                value: String::new(),
+                                value_encrypted: None,
+                                credential_ref: Some(header_reference.as_str().to_string()),
                             }],
                             connect_timeout_ms: 5_000,
                         }),
                     ),
                 ],
             };
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .mcp
+                .commit(0, bamboo_config::McpSection(config.mcp.clone()))
+                .unwrap();
         }
         {
             let mut health = state
@@ -1595,15 +2062,11 @@ mod tests {
         let mcp_body = String::from_utf8(test::read_body(mcp_response).await.to_vec()).unwrap();
         for forbidden in [
             "mcp-env-plaintext-secret",
-            "mcp-env-ciphertext-secret",
             "mcp-header-plaintext-secret",
-            "mcp-header-ciphertext-secret",
-            "mcp-argument-secret",
-            "mcp-url-secret",
-            "mcp-query-secret",
             "****...****",
             "value_encrypted",
             "env_encrypted",
+            "credential_ref",
         ] {
             assert!(!mcp_body.contains(forbidden), "leaked {forbidden}");
         }
@@ -1617,20 +2080,31 @@ mod tests {
         );
         assert_eq!(mcp["last_error"], "redacted runtime failure");
         assert_eq!(
-            mcp["data"]["servers"][0]["transport"]["env_keys"],
-            json!(["LEGACY_TOKEN", "TOKEN"])
+            mcp["data"]["servers"][0]["transport"]["env"],
+            json!({"TOKEN": ""})
         );
         assert_eq!(
-            mcp["data"]["servers"][1]["transport"]["header_names"],
-            json!(["Authorization"])
+            mcp["data"]["servers"][1]["transport"]["headers"][0],
+            json!({"name": "Authorization", "value": ""})
         );
         assert_eq!(
             mcp["data"]["servers"][1]["transport"]["url"],
             "https://mcp.example/rpc"
         );
-        assert_eq!(mcp["data"]["servers"][0]["transport"]["arg_count"], 1);
         assert_eq!(
-            mcp["data"]["servers"][0]["transport"]["cwd_configured"],
+            mcp["data"]["servers"][0]["transport"]["args"],
+            json!(["mcp-argument-secret"])
+        );
+        assert_eq!(
+            mcp["data"]["servers"][0]["transport"]["cwd"],
+            "/safe/workspace"
+        );
+        assert_eq!(
+            mcp["data"]["credential_status"]["stdio"]["env"]["TOKEN"]["configured"],
+            true
+        );
+        assert_eq!(
+            mcp["data"]["credential_status"]["http"]["headers"]["Authorization"]["configured"],
             true
         );
     }
@@ -1804,7 +2278,13 @@ mod tests {
                 .to_request(),
         )
         .await;
-        assert_eq!(stale.status(), actix_web::http::StatusCode::CONFLICT);
+        let stale_status = stale.status();
+        let stale_body = String::from_utf8(test::read_body(stale).await.to_vec()).unwrap();
+        assert_eq!(
+            stale_status,
+            actix_web::http::StatusCode::CONFLICT,
+            "unexpected stale response: {stale_body}"
+        );
         assert_eq!(
             state
                 .config
@@ -2513,7 +2993,25 @@ mod tests {
                 ),
             ],
         };
-        state.config.write().await.mcp = current;
+        state.config.write().await.mcp = current.clone();
+        let mut durable_current = current;
+        let TransportConfig::Stdio(stdio) = &mut durable_current.servers[0].transport else {
+            unreachable!()
+        };
+        stdio.env.clear();
+        let TransportConfig::StreamableHttp(http) = &mut durable_current.servers[1].transport
+        else {
+            unreachable!()
+        };
+        http.headers[0].value.clear();
+        state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .mcp
+            .commit(0, bamboo_config::McpSection(durable_current))
+            .unwrap();
         let mut feed = state.account_sink.subscribe();
 
         let app = test::init_service(
@@ -2531,7 +3029,7 @@ mod tests {
                         command: "updated-disabled-command".to_string(),
                         args: vec!["--safe".to_string()],
                         cwd: None,
-                        env: HashMap::new(),
+                        env: HashMap::from([("TOKEN".to_string(), String::new())]),
                         env_encrypted: HashMap::new(),
                         env_credential_refs: std::collections::HashMap::new(),
                         startup_timeout_ms: 500,
@@ -2541,7 +3039,12 @@ mod tests {
                     "preserved-http",
                     TransportConfig::StreamableHttp(StreamableHttpConfig {
                         url: "https://mcp.example/rpc".to_string(),
-                        headers: Vec::new(),
+                        headers: vec![HeaderConfig {
+                            name: "Authorization".to_string(),
+                            value: String::new(),
+                            value_encrypted: None,
+                            credential_ref: None,
+                        }],
                         connect_timeout_ms: 500,
                     }),
                 ),
@@ -2551,7 +3054,13 @@ mod tests {
             &app,
             test::TestRequest::put()
                 .uri("/mcp")
-                .set_json(json!({"expected_revision": 0, "data": candidate.clone()}))
+                .set_json(json!({
+                    "expected_revision": 1,
+                    "data": {
+                        "version": candidate.version,
+                        "servers": candidate.servers,
+                    }
+                }))
                 .to_request(),
         )
         .await;
@@ -2582,7 +3091,7 @@ mod tests {
                     &event.event,
                     bamboo_agent_core::AgentEvent::ConfigChanged { section, revision }
                         | bamboo_agent_core::AgentEvent::ConfigRecovered { section, revision }
-                        if section == "mcp" && *revision == 1
+                        if section == "mcp" && *revision == 2
                 ) {
                     break;
                 }
@@ -2615,10 +3124,10 @@ mod tests {
                 .read()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .revision,
-            1
+            2
         );
 
-        let mut failing = candidate;
+        let mut failing = state.config.read().await.mcp.clone();
         failing.servers[0].enabled = true;
         if let TransportConfig::Stdio(stdio) = &mut failing.servers[0].transport {
             stdio.command = "definitely-not-a-real-mcp-command-597".to_string();
@@ -2627,14 +3136,20 @@ mod tests {
             &app,
             test::TestRequest::put()
                 .uri("/mcp")
-                .set_json(json!({"expected_revision": 1, "data": failing}))
+                .set_json(json!({
+                    "expected_revision": 2,
+                    "data": {
+                        "version": failing.version,
+                        "servers": secret_free_mcp_config(&failing).servers,
+                    }
+                }))
                 .to_request(),
         )
         .await;
         assert_eq!(failure.status(), actix_web::http::StatusCode::BAD_REQUEST);
         let persisted: Value =
             serde_json::from_slice(&std::fs::read(dir.path().join("mcp.json")).unwrap()).unwrap();
-        assert_eq!(persisted["revision"], 1);
+        assert_eq!(persisted["revision"], 2);
         assert!(
             !state.config.read().await.mcp.servers[0].enabled,
             "runtime failure must retain the last-known-good config"
@@ -2644,8 +3159,341 @@ mod tests {
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone();
-        assert_eq!(health.revision, 1);
+        assert_eq!(health.revision, 2);
         assert_eq!(health.status, SectionStatus::Degraded);
+    }
+
+    #[actix_web::test]
+    async fn mcp_settings_credentials_replace_clear_and_stale_cas_are_atomic_and_secret_free() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                let health = state
+                    .mcp_config_live_health
+                    .read()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .clone();
+                if health.status == SectionStatus::Healthy && health.revision == 0 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("initial MCP runtime reconciliation completes");
+        let mut feed = state.account_sink.subscribe();
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .route("/mcp", web::get().to(get_mcp_section))
+                .route("/mcp", web::put().to(put_mcp_section)),
+        )
+        .await;
+        let first_env_secret = "mcp-env-first-secret-701";
+        let first_header_secret = "mcp-header-first-secret-701";
+        let initial = json!({
+            "version": 1,
+            "servers": [
+                {
+                    "id": "stdio",
+                    "name": "Editable stdio",
+                    "enabled": false,
+                    "transport": {
+                        "type": "stdio",
+                        "command": "node",
+                        "args": ["server.js", "--safe"],
+                        "cwd": "/tmp/mcp-701",
+                        "env": {"TOKEN": ""},
+                        "startup_timeout_ms": 500
+                    },
+                    "request_timeout_ms": 2_000,
+                    "healthcheck_interval_ms": 3_000,
+                    "reconnect": {"enabled": true, "max_attempts": 4, "delay_ms": 250},
+                    "allowed_tools": ["read"],
+                    "denied_tools": ["delete"]
+                },
+                {
+                    "id": "http",
+                    "name": "Editable HTTP",
+                    "enabled": false,
+                    "transport": {
+                        "type": "streamable_http",
+                        "url": "https://mcp.example/rpc",
+                        "headers": [{"name": "Authorization", "value": ""}],
+                        "connect_timeout_ms": 500
+                    }
+                }
+            ],
+            "credential_status": {}
+        });
+        let response = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/mcp")
+                .set_json(json!({
+                    "expected_revision": 0,
+                    "data": initial,
+                    "credential_changes": {
+                        "servers": {
+                            "stdio": {"env": {"TOKEN": first_env_secret}},
+                            "http": {"headers": {"Authorization": first_header_secret}}
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        let status = response.status();
+        let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+        assert!(status.is_success(), "unexpected response {status}: {body}");
+        for forbidden in [
+            first_env_secret,
+            first_header_secret,
+            "****...****",
+            "credential_ref",
+            "ciphertext",
+        ] {
+            assert!(!body.contains(forbidden), "response leaked {forbidden}");
+        }
+        let first: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(first["revision"], 1);
+        let first_servers = first["data"]["servers"].as_array().unwrap();
+        let first_stdio = first_servers
+            .iter()
+            .find(|server| server["id"] == "stdio")
+            .unwrap();
+        assert_eq!(
+            first_stdio["transport"]["args"],
+            json!(["server.js", "--safe"])
+        );
+        assert_eq!(first_stdio["transport"]["cwd"], "/tmp/mcp-701");
+        assert_eq!(first_stdio["reconnect"]["max_attempts"], 4);
+        assert_eq!(
+            first["data"]["credential_status"]["stdio"]["env"]["TOKEN"]["configured"],
+            true
+        );
+        assert_eq!(
+            first["data"]["credential_status"]["stdio"]["env"]["TOKEN"]["source"],
+            "user"
+        );
+        assert_eq!(
+            first["data"]["credential_status"]["http"]["headers"]["Authorization"]["configured"],
+            true
+        );
+        let mcp_disk = std::fs::read_to_string(dir.path().join("mcp.json")).unwrap();
+        let credential_disk = std::fs::read_to_string(dir.path().join("credentials.json")).unwrap();
+        assert!(!mcp_disk.contains(first_env_secret));
+        assert!(!mcp_disk.contains(first_header_secret));
+        assert!(!credential_disk.contains(first_env_secret));
+        assert!(!credential_disk.contains(first_header_secret));
+        assert!(mcp_disk.contains("mcp.stdio.env_TOKEN"));
+        assert!(mcp_disk.contains("mcp.http.header_Authorization"));
+        let env_reference = bamboo_config::credential_ref("mcp", "stdio", "env_TOKEN").unwrap();
+        let header_reference =
+            bamboo_config::credential_ref("mcp", "http", "header_Authorization").unwrap();
+        assert_eq!(
+            state
+                .credential_store
+                .resolve(&env_reference)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            first_env_secret
+        );
+        assert_eq!(
+            state
+                .credential_store
+                .resolve(&header_reference)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            first_header_secret
+        );
+
+        let mut missing_explicit_clear = first["data"].clone();
+        missing_explicit_clear["servers"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|server| server["id"] == "stdio")
+            .unwrap()["transport"]["env"]
+            .as_object_mut()
+            .unwrap()
+            .remove("TOKEN");
+        let implicit_clear = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/mcp")
+                .set_json(json!({
+                    "expected_revision": 1,
+                    "data": missing_explicit_clear
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            implicit_clear.status(),
+            actix_web::http::StatusCode::BAD_REQUEST
+        );
+
+        let masked_replacement = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/mcp")
+                .set_json(json!({
+                    "expected_revision": 1,
+                    "data": first["data"].clone(),
+                    "credential_changes": {
+                        "servers": {
+                            "stdio": {"env": {"TOKEN": "****...****"}}
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            masked_replacement.status(),
+            actix_web::http::StatusCode::BAD_REQUEST
+        );
+        let masked_header_replacement = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/mcp")
+                .set_json(json!({
+                    "expected_revision": 1,
+                    "data": first["data"].clone(),
+                    "credential_changes": {
+                        "servers": {
+                            "http": {"headers": {"Authorization": "****...****"}}
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            masked_header_replacement.status(),
+            actix_web::http::StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .mcp
+                .snapshot()
+                .revision,
+            1
+        );
+
+        let stale = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/mcp")
+                .set_json(json!({
+                    "expected_revision": 0,
+                    "data": first["data"].clone()
+                }))
+                .to_request(),
+        )
+        .await;
+        let stale_status = stale.status();
+        let stale_body = String::from_utf8(test::read_body(stale).await.to_vec()).unwrap();
+        assert_eq!(
+            stale_status,
+            actix_web::http::StatusCode::CONFLICT,
+            "unexpected stale response: {stale_body}"
+        );
+
+        let second_env_secret = "mcp-env-second-secret-701";
+        let second_header_secret = "mcp-header-second-secret-701";
+        let replaced = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/mcp")
+                .set_json(json!({
+                    "expected_revision": 1,
+                    "data": first["data"].clone(),
+                    "credential_changes": {
+                        "servers": {
+                            "stdio": {"env": {"TOKEN": second_env_secret}},
+                            "http": {"headers": {"Authorization": second_header_secret}}
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        let replaced_body = String::from_utf8(test::read_body(replaced).await.to_vec()).unwrap();
+        assert!(!replaced_body.contains(second_env_secret));
+        assert!(!replaced_body.contains(second_header_secret));
+        let replaced: Value = serde_json::from_str(&replaced_body).unwrap();
+        assert_eq!(replaced["revision"], 2);
+
+        let cleared = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/mcp")
+                .set_json(json!({
+                    "expected_revision": 2,
+                    "data": replaced["data"].clone(),
+                    "credential_changes": {
+                        "servers": {
+                            "stdio": {"env": {"TOKEN": null}},
+                            "http": {"headers": {"Authorization": null}}
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        let cleared_status = cleared.status();
+        let cleared_body = String::from_utf8(test::read_body(cleared).await.to_vec()).unwrap();
+        assert!(
+            cleared_status.is_success(),
+            "unexpected response {cleared_status}: {cleared_body}"
+        );
+        let cleared: Value = serde_json::from_str(&cleared_body).unwrap();
+        assert_eq!(cleared["revision"], 3);
+        assert_eq!(
+            cleared["data"]["credential_status"]["http"]["headers"]["Authorization"]["configured"],
+            false
+        );
+        for reference in [env_reference, header_reference] {
+            assert!(state
+                .credential_store
+                .resolve(&reference)
+                .unwrap()
+                .is_none());
+        }
+        let disk_after_clear = std::fs::read_to_string(dir.path().join("mcp.json")).unwrap();
+        assert!(!disk_after_clear.contains("mcp.stdio.env_TOKEN"));
+        assert!(!disk_after_clear.contains("mcp.http.header_Authorization"));
+
+        for revision in 1..=3 {
+            tokio::time::timeout(Duration::from_secs(2), async {
+                loop {
+                    let event = feed.recv().await.unwrap();
+                    if matches!(
+                        &event.event,
+                        bamboo_agent_core::AgentEvent::ConfigChanged {
+                            section,
+                            revision: event_revision
+                        } | bamboo_agent_core::AgentEvent::ConfigRecovered {
+                            section,
+                            revision: event_revision
+                        } if section == "mcp" && *event_revision == revision
+                    ) {
+                        break;
+                    }
+                }
+            })
+            .await
+            .expect("MCP section event is published");
+        }
     }
 
     #[::core::prelude::v1::test]
@@ -2658,8 +3506,22 @@ mod tests {
             assert!(serde_json::from_value::<PutProviderSectionRequest>(payload).is_err());
         }
         for payload in [
-            json!({"expected_revision": 0, "data": {"server": {"command": "cmd", "env": {"TOKEN": "secret"}}}}),
-            json!({"expected_revision": 0, "data": {"server": {"url": "https://example.test/mcp?token=secret"}}}),
+            json!({"expected_revision": 0, "data": {"servers": [{
+                "id": "stdio",
+                "transport": {"type": "stdio", "command": "cmd", "env": {"TOKEN": "secret"}}
+            }]}}),
+            json!({"expected_revision": 0, "data": {"servers": [{
+                "id": "http",
+                "transport": {"type": "streamable_http", "url": "https://example.test/mcp?token=secret"}
+            }]}}),
+            json!({"expected_revision": 0, "data": {"servers": [{
+                "id": "forged",
+                "transport": {
+                    "type": "stdio",
+                    "command": "cmd",
+                    "env_credential_refs": {"TOKEN": "mcp.forged.env_TOKEN"}
+                }
+            }]}}),
         ] {
             assert!(serde_json::from_value::<PutMcpSectionRequest>(payload).is_err());
         }
@@ -2671,7 +3533,10 @@ mod tests {
         .is_ok());
         assert!(serde_json::from_value::<PutMcpSectionRequest>(json!({
             "expected_revision": 0,
-            "data": {"server": {"command": "cmd****name"}}
+            "data": {"servers": [{
+                "id": "stdio",
+                "transport": {"type": "stdio", "command": "cmd****name"}
+            }]}
         }))
         .is_ok());
     }

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -1884,6 +1884,7 @@ pub fn persist_mcp_reset_credential_transaction_at_revision(
     config: &mut crate::Config,
     expected_revision: u64,
 ) -> ConfigStoreResult<u64> {
+    let intents = BTreeSet::new();
     persist_exact_credential_transaction_inner(
         data_dir.as_ref(),
         config,
@@ -1900,10 +1901,63 @@ pub fn persist_mcp_reset_credential_transaction_at_revision(
         None,
         None,
         None,
-        Some(expected_revision),
+        Some((&intents, expected_revision)),
         None,
         #[cfg(test)]
         None,
+    )
+}
+
+/// Persist MCP metadata and every explicitly touched environment/header
+/// credential in one recoverable exact transaction guarded by the MCP section
+/// revision.
+pub fn persist_mcp_credential_transaction_at_revision(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    intents: &BTreeSet<CredentialRef>,
+    expected_revision: u64,
+) -> ConfigStoreResult<u64> {
+    persist_mcp_credential_transaction_inner(
+        data_dir.as_ref(),
+        config,
+        intents,
+        expected_revision,
+        None,
+    )
+}
+
+fn persist_mcp_credential_transaction_inner(
+    data_dir: &Path,
+    config: &mut crate::Config,
+    intents: &BTreeSet<CredentialRef>,
+    expected_revision: u64,
+    #[cfg_attr(not(test), allow(unused_variables))] fault: Option<MigrationFault>,
+) -> ConfigStoreResult<u64> {
+    if !crate::section_layout_is_active(data_dir)? {
+        return Err(ConfigStoreError::Validation(
+            "MCP credential updates require the modular configuration layout".to_string(),
+        ));
+    }
+    persist_exact_credential_transaction_inner(
+        data_dir,
+        config,
+        &BTreeSet::new(),
+        &BTreeSet::new(),
+        None,
+        &BTreeSet::new(),
+        None,
+        false,
+        &BTreeSet::new(),
+        false,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some((intents, expected_revision)),
+        None,
+        #[cfg(test)]
+        fault,
     )
 }
 
@@ -2069,7 +2123,7 @@ fn persist_exact_credential_transaction_inner(
     connect_transaction: Option<(&crate::patch::ConnectSecretIntents, u64)>,
     access_transaction: Option<(bool, &BTreeSet<String>, u64)>,
     provider_expected_revision: Option<u64>,
-    mcp_expected_revision: Option<u64>,
+    mcp_transaction: Option<(&BTreeSet<CredentialRef>, u64)>,
     reset_scope: Option<(ExactTransactionScope, u64)>,
     #[cfg(test)] fault: Option<MigrationFault>,
 ) -> ConfigStoreResult<u64> {
@@ -2109,7 +2163,7 @@ fn persist_exact_credential_transaction_inner(
         && cluster_transaction.is_none()
         && connect_transaction.is_none()
         && (access_transaction.is_some() || reset_is(ExactTransactionScope::AccessControl));
-    let mcp_only = mcp_expected_revision.is_some()
+    let mcp_only = mcp_transaction.is_some()
         && provider_intents.is_empty()
         && provider_instance_intents.is_empty()
         && env_intents.is_empty()
@@ -2195,9 +2249,11 @@ fn persist_exact_credential_transaction_inner(
             });
         }
     }
-    if let (Some(expected), Some(section), Some(ExactTransactionScope::Mcp)) =
-        (mcp_expected_revision, active_section.as_ref(), exact_scope)
-    {
+    if let (Some(expected), Some(section), Some(ExactTransactionScope::Mcp)) = (
+        mcp_transaction.map(|(_, revision)| revision),
+        active_section.as_ref(),
+        exact_scope,
+    ) {
         if section.expected_revision != expected {
             return Err(ConfigStoreError::Conflict {
                 expected,
@@ -2395,8 +2451,12 @@ fn persist_exact_credential_transaction_inner(
             device_intents,
             &persisted_access_refs,
         )?
-    } else if mcp_only {
-        Some(store.prepare_clear_owned_references(config, &persisted_mcp_refs)?)
+    } else if let Some((intents, _)) = mcp_transaction {
+        if intents.is_empty() {
+            Some(store.prepare_clear_owned_references(config, &persisted_mcp_refs)?)
+        } else {
+            store.prepare_mcp_intents(config, intents, &persisted_mcp_refs)?
+        }
     } else {
         store.prepare_provider_api_key_intents(
             config,
@@ -2555,8 +2615,13 @@ fn persist_exact_credential_transaction_inner(
             original_data != candidate_data,
         )
     } else if let (Some(section), Some(scope)) = (active_section.as_ref(), exact_scope) {
-        let (bytes, changed) =
-            prepare_active_exact_section_document(section, scope, &config_bytes)?;
+        let credential_changed = mcp_only && prepared.revision != prepared.expected_revision;
+        let (bytes, changed) = prepare_active_exact_section_document(
+            section,
+            scope,
+            &config_bytes,
+            credential_changed,
+        )?;
         (
             section.name,
             section.original.as_slice(),
@@ -6262,6 +6327,7 @@ fn prepare_active_exact_section_document(
     section: &ActiveExactSection,
     scope: ExactTransactionScope,
     updated_legacy_root: &[u8],
+    force_revision: bool,
 ) -> ConfigStoreResult<(Vec<u8>, bool)> {
     let updated_root = parse_config_root_object(
         updated_legacy_root,
@@ -6350,7 +6416,7 @@ fn prepare_active_exact_section_document(
     let object = envelope.as_object_mut().ok_or_else(|| {
         ConfigStoreError::Validation("authoritative section envelope is invalid".to_string())
     })?;
-    let changed = object.get("data") != Some(&updated_data);
+    let changed = force_revision || object.get("data") != Some(&updated_data);
     let revision = if changed {
         section.expected_revision.checked_add(1).ok_or_else(|| {
             ConfigStoreError::Validation("configuration revision counter exhausted".to_string())
@@ -13808,6 +13874,91 @@ mod tests {
         assert_eq!(manifest.files[1].name, authoritative_section_file(expected));
         assert!(!manifest.files.iter().any(|file| file.name == CONFIG_FILE));
         assert!(manifest.files[1].expected_revision.is_some());
+    }
+
+    #[test]
+    fn active_mcp_exact_transaction_recovers_metadata_and_credentials_together() {
+        let _key = crate::encryption::set_test_encryption_key([0x56; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let root_before = read_target_or_empty(&dir.path().join(CONFIG_FILE)).unwrap();
+        let facade = crate::ConfigFacade::open(dir.path()).unwrap();
+        let expected_revision = facade.registry().mcp.snapshot().revision;
+        let mut candidate = facade.effective_config();
+        let reference = credential_ref("mcp", "recoverable", "env_TOKEN").unwrap();
+        candidate
+            .mcp
+            .servers
+            .push(bamboo_domain::mcp_config::McpServerConfig {
+                id: "recoverable".to_string(),
+                name: Some("Recoverable MCP".to_string()),
+                enabled: false,
+                transport: bamboo_domain::mcp_config::TransportConfig::Stdio(
+                    bamboo_domain::mcp_config::StdioConfig {
+                        command: "unused".to_string(),
+                        args: vec!["--safe".to_string()],
+                        cwd: Some("/tmp/mcp-recovery".to_string()),
+                        env: std::collections::HashMap::from([(
+                            "TOKEN".to_string(),
+                            "recoverable-mcp-secret".to_string(),
+                        )]),
+                        env_encrypted: Default::default(),
+                        env_credential_refs: std::collections::HashMap::from([(
+                            "TOKEN".to_string(),
+                            reference.as_str().to_string(),
+                        )]),
+                        startup_timeout_ms: 100,
+                    },
+                ),
+                request_timeout_ms: 100,
+                healthcheck_interval_ms: 100,
+                reconnect: Default::default(),
+                allowed_tools: vec!["read".to_string()],
+                denied_tools: vec!["delete".to_string()],
+            });
+        let intents = BTreeSet::from([reference.clone()]);
+
+        assert!(persist_mcp_credential_transaction_inner(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            expected_revision,
+            Some(MigrationFault::AfterCredentials),
+        )
+        .is_err());
+        assert!(ensure_provider_mcp_migration_ready(dir.path()).is_err());
+
+        let outcome = migrate_with_fault(dir.path(), MigrationFault::None).unwrap();
+        assert!(outcome.resumed);
+        ensure_provider_mcp_migration_ready(dir.path()).unwrap();
+        assert_active_exact_manifest(dir.path(), ExactTransactionScope::Mcp);
+        let fresh = crate::ConfigFacade::open(dir.path()).unwrap();
+        assert_eq!(fresh.registry().mcp.snapshot().revision, 1);
+        assert_eq!(fresh.registry().credentials.snapshot().revision, 1);
+        let mut hydrated = fresh.effective_config();
+        hydrated
+            .hydrate_mcp_credentials_from_store(dir.path())
+            .unwrap();
+        let bamboo_domain::mcp_config::TransportConfig::Stdio(stdio) =
+            &hydrated.mcp.servers[0].transport
+        else {
+            panic!("expected stdio MCP transport");
+        };
+        assert_eq!(stdio.args, vec!["--safe"]);
+        assert_eq!(stdio.cwd.as_deref(), Some("/tmp/mcp-recovery"));
+        assert_eq!(stdio.env["TOKEN"], "recoverable-mcp-secret");
+        assert_eq!(
+            CredentialStore::open(dir.path())
+                .resolve(&reference)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            "recoverable-mcp-secret"
+        );
+        assert_eq!(
+            read_target_or_empty(&dir.path().join(CONFIG_FILE)).unwrap(),
+            root_before
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/credential_store.rs
+++ b/crates/infra/bamboo-config/src/credential_store.rs
@@ -911,6 +911,154 @@ impl CredentialStore {
         }))
     }
 
+    /// Prepare explicitly touched MCP environment/header secrets without
+    /// publishing either the credential document or MCP metadata. The exact
+    /// transaction owner stages both documents together after this returns.
+    pub(crate) fn prepare_mcp_intents(
+        &self,
+        config: &mut crate::Config,
+        intents: &BTreeSet<CredentialRef>,
+        persisted_refs: &BTreeSet<CredentialRef>,
+    ) -> ConfigStoreResult<Option<PreparedProviderCredentialUpdate>> {
+        if intents.is_empty() {
+            return Ok(None);
+        }
+
+        let candidate_ref_counts = config_credential_ref_counts(config)?;
+        let mut secrets_by_ref = BTreeMap::<CredentialRef, String>::new();
+        for server in &config.mcp.servers {
+            match &server.transport {
+                bamboo_domain::mcp_config::TransportConfig::Stdio(stdio) => {
+                    for (name, raw_reference) in &stdio.env_credential_refs {
+                        let reference = CredentialRef::parse(raw_reference.clone())?;
+                        if !intents.contains(&reference) {
+                            continue;
+                        }
+                        if let Some(secret) = stdio.env.get(name).filter(|value| !value.is_empty())
+                        {
+                            match secrets_by_ref.get(&reference) {
+                                Some(existing) if existing != secret => {
+                                    return Err(ConfigStoreError::Validation(
+                                        "MCP updates assign conflicting values to one credential reference"
+                                            .to_string(),
+                                    ));
+                                }
+                                Some(_) => {}
+                                None => {
+                                    secrets_by_ref.insert(reference, secret.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+                bamboo_domain::mcp_config::TransportConfig::Sse(http) => {
+                    collect_mcp_header_secrets(
+                        http.headers.as_slice(),
+                        intents,
+                        &mut secrets_by_ref,
+                    )?
+                }
+                bamboo_domain::mcp_config::TransportConfig::StreamableHttp(http) => {
+                    collect_mcp_header_secrets(
+                        http.headers.as_slice(),
+                        intents,
+                        &mut secrets_by_ref,
+                    )?
+                }
+            }
+        }
+
+        for reference in intents {
+            if !persisted_refs.contains(reference)
+                && !candidate_ref_counts.contains_key(reference)
+                && !secrets_by_ref.contains_key(reference)
+            {
+                return Err(ConfigStoreError::Validation(
+                    "MCP credential intent does not belong to the MCP section".to_string(),
+                ));
+            }
+        }
+
+        let required_refs = intents
+            .iter()
+            .filter(|reference| {
+                secrets_by_ref.contains_key(*reference)
+                    || candidate_ref_counts.get(*reference).copied().unwrap_or(0) > 0
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let (mut document, health) = self.load_document_with_health()?;
+        if health.status == SectionStatus::Degraded {
+            return Err(ConfigStoreError::Validation(
+                "credential document is unavailable for MCP update".to_string(),
+            ));
+        }
+
+        let mut changed = false;
+        for reference in intents {
+            if let Some(secret) = secrets_by_ref.get(reference) {
+                let ciphertext = crate::encryption::encrypt(secret).map_err(|_| {
+                    ConfigStoreError::Validation("credential encryption failed".to_string())
+                })?;
+                document.entries.insert(
+                    reference.clone(),
+                    CredentialEntry {
+                        ciphertext,
+                        source: CredentialSource::User,
+                        updated_at: Utc::now(),
+                        key_version: ENCRYPTION_KEY_VERSION,
+                        migration_generation: None,
+                    },
+                );
+                changed = true;
+            } else if candidate_ref_counts.get(reference).copied().unwrap_or(0) == 0 {
+                changed |= document.entries.remove(reference).is_some();
+            }
+        }
+
+        // Runtime candidates carry plaintext just long enough to stage the
+        // replacement runtime. The durable MCP document contains references
+        // only, including for untouched credentials copied from live state.
+        for server in &mut config.mcp.servers {
+            match &mut server.transport {
+                bamboo_domain::mcp_config::TransportConfig::Stdio(stdio) => {
+                    stdio.env_encrypted.clear();
+                    for name in stdio.env_credential_refs.keys() {
+                        stdio.env.remove(name);
+                    }
+                }
+                bamboo_domain::mcp_config::TransportConfig::Sse(http) => {
+                    clear_mcp_header_plaintext(&mut http.headers)
+                }
+                bamboo_domain::mcp_config::TransportConfig::StreamableHttp(http) => {
+                    clear_mcp_header_plaintext(&mut http.headers)
+                }
+            }
+        }
+
+        validate_document(&document).map_err(ConfigStoreError::Validation)?;
+        ensure_required_entries(&document, &required_refs)?;
+        let revision = if changed {
+            health.revision.checked_add(1).ok_or_else(|| {
+                ConfigStoreError::Validation("configuration revision counter exhausted".to_string())
+            })?
+        } else {
+            health.revision
+        };
+        let bytes = serde_json::to_vec_pretty(&serde_json::json!({
+            "schema_version": CREDENTIAL_SCHEMA_VERSION,
+            "revision": revision,
+            "data": document,
+        }))?;
+        Ok(Some(PreparedProviderCredentialUpdate {
+            bytes,
+            expected_revision: health.revision,
+            revision,
+            touched_refs: intents.iter().cloned().collect(),
+            required_refs,
+        }))
+    }
+
     /// Prepare the fixed proxy-auth credential update without publishing it.
     /// The caller commits these bytes together with root metadata through the
     /// recoverable exact transaction manifest.
@@ -2660,6 +2808,43 @@ pub(crate) fn config_credential_ref_counts(
         }
     }
     Ok(counts)
+}
+
+fn collect_mcp_header_secrets(
+    headers: &[bamboo_domain::mcp_config::HeaderConfig],
+    intents: &BTreeSet<CredentialRef>,
+    secrets_by_ref: &mut BTreeMap<CredentialRef, String>,
+) -> ConfigStoreResult<()> {
+    for header in headers {
+        let Some(raw_reference) = header.credential_ref.as_ref() else {
+            continue;
+        };
+        let reference = CredentialRef::parse(raw_reference.clone())?;
+        if !intents.contains(&reference) || header.value.is_empty() {
+            continue;
+        }
+        match secrets_by_ref.get(&reference) {
+            Some(existing) if existing != &header.value => {
+                return Err(ConfigStoreError::Validation(
+                    "MCP updates assign conflicting values to one credential reference".to_string(),
+                ));
+            }
+            Some(_) => {}
+            None => {
+                secrets_by_ref.insert(reference, header.value.clone());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn clear_mcp_header_plaintext(headers: &mut [bamboo_domain::mcp_config::HeaderConfig]) {
+    for header in headers {
+        if header.credential_ref.is_some() {
+            header.value.clear();
+        }
+        header.value_encrypted = None;
+    }
 }
 
 fn parse_credential_ref_list(values: &[String]) -> ConfigStoreResult<Vec<CredentialRef>> {


### PR DESCRIPTION
## Summary

- replace the read-only MCP diagnostic projection with a secret-free, fully editable section DTO
- add expected-revision CAS plus explicit per-server env/header credential replace and clear actions
- commit MCP metadata and touched credentials in one recoverable exact transaction before runtime/config publication
- preserve untouched/shared credentials, reject forged refs, plaintext config fields, mask placeholders, and implicit credential deletion
- retain last-known-good runtime on validation/startup failure and preserve dotted config feed events

Closes #701

## Test Plan

- `cargo fmt --all -- --check`
- CI-equivalent strict `cargo clippy --all-features ... -D warnings`
- MCP typed-section suite: 17/17 passed
- exact MCP credential transaction recovery test passed
- MCP watcher invalid/LKG/recovered test passed
- shared credential replace/partial-clear/all-header-delete regression passed
- original main-target CI passed Test, E2E, Lint, docs, security, CodeQL, and Linux/macOS/Windows release builds

## Review contract

Parent-agent review is recorded separately against exact head `86270ee06190cd2ae566d116d4e0c7ad52197aa6` on base `dev@eb966b8c8be5792be14514a6a05e3f9143f828cb`. Any new head or base invalidates that review and requires a full re-review.