### PR TITLE
fix: generate rustls-compatible TLS fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,34 @@ jobs:
         # drifting from the real API (bamboo-agent#255).
         run: cargo build --examples
 
+  tls-fixture-test:
+    name: TLS Fixture (${{ matrix.os }})
+    # Keep the test-only certificate generator portable across the OpenSSL and
+    # LibreSSL variants on every supported host. The release build matrix below
+    # does not compile or execute #[cfg(test)] code.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          shared-key: bamboo-ci-tls-fixture-${{ matrix.os }}
+          cache-on-failure: true
+
+      - name: Verify OpenSSL
+        run: openssl version
+
+      - name: Run TLS fixture tests
+        run: cargo test --locked -p bamboo-server --lib server::tls::tests -- --nocapture
+
   e2e-test:
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/crates/app/bamboo-server/src/server/tls.rs
+++ b/crates/app/bamboo-server/src/server/tls.rs
@@ -101,32 +101,66 @@ mod tests {
         dir
     }
 
-    /// Generate a throwaway self-signed cert + PKCS#8 key via openssl, returning
-    /// `None` (skip) if openssl is unavailable in the test environment.
-    fn gen_self_signed(dir: &Path) -> Option<(PathBuf, PathBuf)> {
+    /// Generate a throwaway X.509 v3 self-signed cert + PKCS#8 key via openssl.
+    ///
+    /// `Ok(None)` is reserved for an absent openssl executable. A present
+    /// executable that fails must fail the test instead of silently skipping
+    /// the rustls success path.
+    fn gen_self_signed(dir: &Path) -> Result<Option<(PathBuf, PathBuf)>, String> {
         let cert = dir.join("cert.pem");
         let key = dir.join("key.pem");
-        let status = Command::new("openssl")
+        let output = Command::new("openssl")
+            .args(["req", "-x509", "-newkey", "rsa:2048", "-keyout"])
+            .arg(&key)
+            .arg("-out")
+            .arg(&cert)
             .args([
-                "req",
-                "-x509",
-                "-newkey",
-                "rsa:2048",
-                "-keyout",
-                key.to_str().unwrap(),
-                "-out",
-                cert.to_str().unwrap(),
                 "-days",
                 "1",
                 "-nodes",
                 "-subj",
                 "/CN=localhost",
+                // An X.509 extension forces v3 output. macOS LibreSSL otherwise
+                // emits a v1 certificate that pinned rustls-webpki rejects.
+                "-addext",
+                "basicConstraints=critical,CA:FALSE",
             ])
-            .status();
-        match status {
-            Ok(s) if s.success() => Some((cert, key)),
-            _ => None,
+            .output();
+        let output = match output {
+            Ok(output) => output,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(format!("failed to launch openssl: {error}")),
+        };
+        if !output.status.success() {
+            return Err(format!(
+                "openssl failed to generate the TLS fixture ({}): {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
         }
+        Ok(Some((cert, key)))
+    }
+
+    fn assert_x509_v3(cert: &Path) {
+        let output = Command::new("openssl")
+            .args(["x509", "-in"])
+            .arg(cert)
+            .args(["-noout", "-text"])
+            .output()
+            .expect("openssl that generated the fixture should remain available");
+        assert!(
+            output.status.success(),
+            "openssl failed to inspect generated TLS fixture ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+        let certificate_text = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            certificate_text
+                .lines()
+                .any(|line| line.trim() == "Version: 3 (0x2)"),
+            "expected generated TLS fixture to be X.509 v3:\n{certificate_text}"
+        );
     }
 
     #[test]
@@ -168,7 +202,9 @@ mod tests {
     fn build_rustls_config_errors_on_missing_key_in_keyfile() {
         let dir = tmp_dir();
         // A valid-looking cert file but a key file with no key block.
-        let Some((cert, _key)) = gen_self_signed(&dir) else {
+        let Some((cert, _key)) =
+            gen_self_signed(&dir).expect("present openssl should generate the TLS fixture")
+        else {
             eprintln!("skipping: openssl unavailable");
             return;
         };
@@ -195,10 +231,13 @@ mod tests {
         // cert/key pair) when openssl is available to mint a throwaway cert.
         // Skips gracefully on environments without openssl.
         let dir = tmp_dir();
-        let Some((cert, key)) = gen_self_signed(&dir) else {
+        let Some((cert, key)) =
+            gen_self_signed(&dir).expect("present openssl should generate the TLS fixture")
+        else {
             eprintln!("skipping build_rustls_config success test: openssl unavailable");
             return;
         };
+        assert_x509_v3(&cert);
         let tls = TlsConfig {
             cert_file: cert,
             key_file: key,


### PR DESCRIPTION
## Summary

- force the OpenSSL-generated test certificate to X.509 v3 with an explicit basic-constraints extension, preventing macOS LibreSSL from emitting the v1 certificate rejected by pinned rustls
- reserve the test skip for an actually missing `openssl` executable; present-tool launch or generation failures now fail loudly
- inspect the generated certificate and assert exact X.509 v3 output before the rustls success path
- add an always-running Ubuntu/macOS/Windows TLS fixture matrix with an OpenSSL preflight
- leave production `build_rustls_config` and its fail-closed validation unchanged

Closes #706

## Test Plan

- [x] reproduced the clean-baseline `UnsupportedCertVersion` failure and confirmed the original fixture was X.509 v1
- [x] `cargo test -p bamboo-server --lib server::tls::tests::build_rustls_config_succeeds_on_valid_self_signed_cert -- --exact --nocapture` (1 passed)
- [x] `cargo test -p bamboo-server --lib server::tls::tests -- --nocapture` (4 passed)
- [x] full `cargo test --locked -p bamboo-server --lib -- --test-threads=1` (1601 passed, 1 ignored)
- [x] verified LibreSSL 3.3.6 and OpenSSL 3.6.3 both generate accepted v3 fixtures
- [x] verified missing `openssl` skips explicitly and a present failing executable makes the test exit 101
- [x] CI-equivalent strict Clippy, `cargo fmt --all -- --check`, `git diff --check`, and `actionlint .github/workflows/ci.yml`
- [ ] GitHub TLS fixture matrix confirms Ubuntu, macOS, and Windows hosted runners

## Adversarial Review

A fresh reviewer challenged certificate-version determinism, OpenSSL/LibreSSL and Windows portability, textual version inspection, skip semantics, production fail-closed behavior, fresh-checkout prerequisites, and CI enforcement. Its initial cross-platform CI finding was fixed with the focused matrix; re-review reported no remaining actionable findings.

## Screenshots

N/A — test fixture and CI-only change.