### PR TITLE
test: eliminate Codex stub ETXTBSY race (#709)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/codex.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/codex.rs
@@ -38,38 +38,23 @@ pub async fn detect_codex_cli(
 
 #[cfg(all(test, unix))]
 mod tests {
-    use std::io::Write as _;
-    use std::os::unix::fs::PermissionsExt as _;
-
     use actix_web::{body::to_bytes, http::StatusCode};
 
     use super::*;
 
-    fn write_codex_stub() -> (tempfile::TempDir, String) {
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("codex");
-        let mut file = std::fs::File::create(&path).unwrap();
-        writeln!(file, "#!/bin/sh").unwrap();
-        writeln!(
-            file,
-            r#"case "$*" in
-  "--version") echo 'codex-cli 0.144.5' ;;
-  "exec --help") echo '--json --output-last-message --config --sandbox --dangerously-bypass-approvals-and-sandbox prompt from stdin' ;;
-  "exec resume --help") echo '--json' ;;
-  "app-server --help") echo '--listen stdio:// --stdio' ;;
-  *) exit 2 ;;
-esac"#
-        )
-        .unwrap();
-        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
-        permissions.set_mode(0o755);
-        std::fs::set_permissions(&path, permissions).unwrap();
-        (directory, path.to_string_lossy().into_owned())
+    fn codex_stub_fixture() -> String {
+        // During a parallel Linux suite, a concurrently spawned child can briefly inherit an
+        // O_CLOEXEC writer until its own exec. Never opening this tracked inode for writing
+        // prevents that transient descriptor from making the fixture text-busy.
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/handlers/settings/bamboo_config/fixtures/codex-stub")
+            .to_string_lossy()
+            .into_owned()
     }
 
     #[actix_web::test]
     async fn detect_returns_the_shared_preflight_path_and_version() {
-        let (_directory, binary) = write_codex_stub();
+        let binary = codex_stub_fixture();
         let response = detect_codex_cli(web::Json(DetectCodexRequest {
             binary: Some(binary.clone()),
             mode: None,
@@ -97,7 +82,7 @@ esac"#
 
     #[actix_web::test]
     async fn app_server_detection_uses_the_extra_capability_gate() {
-        let (_directory, binary) = write_codex_stub();
+        let binary = codex_stub_fixture();
         let response = detect_codex_cli(web::Json(DetectCodexRequest {
             binary: Some(binary),
             mode: Some("app_server".to_string()),
@@ -105,5 +90,31 @@ esac"#
         .await
         .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[actix_web::test]
+    async fn tracked_codex_stub_survives_repeated_parallel_detection() {
+        const STRESS_ITERATIONS: usize = 32;
+
+        for iteration in 0..STRESS_ITERATIONS {
+            let binary = codex_stub_fixture();
+            let exec_detection = detect_codex_cli(web::Json(DetectCodexRequest {
+                binary: Some(binary.clone()),
+                mode: None,
+            }));
+            let app_server_detection = detect_codex_cli(web::Json(DetectCodexRequest {
+                binary: Some(binary),
+                mode: Some("app_server".to_string()),
+            }));
+
+            let (exec_response, app_server_response) =
+                tokio::join!(exec_detection, app_server_detection);
+            for (mode, response) in [("exec", exec_response), ("app_server", app_server_response)] {
+                let response = response.unwrap_or_else(|error| {
+                    panic!("{mode} detection failed during stress iteration {iteration}: {error}")
+                });
+                assert_eq!(response.status(), StatusCode::OK);
+            }
+        }
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/fixtures/codex-stub
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/fixtures/codex-stub
@@ -1,0 +1,8 @@
+#!/bin/sh
+case "$*" in
+  "--version") echo 'codex-cli 0.144.5' ;;
+  "exec --help") echo '--json --output-last-message --config --sandbox --dangerously-bypass-approvals-and-sandbox prompt from stdin' ;;
+  "exec resume --help") echo '--json' ;;
+  "app-server --help") echo '--listen stdio:// --stdio' ;;
+  *) exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

- replace the runtime-written temporary `codex` test script with a tracked, read-only fixture under the crate's packaged `src/**/*` tree
- resolve the fixture through `CARGO_MANIFEST_DIR` for both exec and app-server detection tests
- add 32-iteration parallel detection coverage while leaving production Codex discovery and fail-closed errors unchanged
- preserve the fixture as a Git `100755` blob and include it in the `bamboo-server` Cargo package

This removes the Linux race class rather than retrying it: during a parallel suite, a concurrently spawned child can transiently inherit an `O_CLOEXEC` writer until its own exec. The test process now never opens the executable inode for writing, so no child can inherit that writer.

## Adversarial review history

The first unpushed implementation (`flush(); drop(file);`) was rejected as **High / merge-blocking**. An identical 32-iteration stress test passed unchanged dev baseline, proving that test did not distinguish the proposed fix; baseline already dropped the local `File` before the caller could execute it. The rejected commit was replaced before push.

Fresh re-review of head `2ad065926cb883f9988dce0ee8332bfba489f250` found no actionable issues. Sixteen simultaneous test processes, each running 32 iterations across both detection modes, passed without changing fixture content or mode.

## Test Plan

- `cargo test --locked -p bamboo-server --lib handlers::settings::bamboo_config::codex::tests -- --nocapture` — 4 passed
- `cargo test --locked -p bamboo-server --all-features --lib` — 1602 passed, 1 ignored
- `cargo test --locked -p bamboo-server --tests handlers::settings::bamboo_config::codex::tests -- --nocapture` — 4 passed
- exact CI all-features Clippy command with `-D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `git ls-tree HEAD .../fixtures/codex-stub` — mode `100755`
- `cargo package -p bamboo-server --allow-dirty --no-verify --list` — fixture included

## Screenshots

Not applicable; test-only change.

Closes #709
