### PR TITLE
test: isolate command-environment cache fixtures (#711)

### DIFF
--- a/crates/engine/bamboo-tools/src/tools/bash.rs
+++ b/crates/engine/bamboo-tools/src/tools/bash.rs
@@ -659,8 +659,10 @@ mod tests {
     use bamboo_agent_core::tools::ToolExecutionSessionFlags;
     use bamboo_agent_core::{AgentEvent, ToolExecutionContext};
     use bamboo_infrastructure::process::{
-        clear_command_environment_cache_for_tests, prime_command_environment_cache_for_tests,
         CommandEnvironmentDiagnostics, CommandEnvironmentSource, PythonDiscoveryDiagnostics,
+    };
+    use bamboo_infrastructure::test_support::{
+        override_command_environment, CommandEnvironmentOverrideGuard,
     };
     use serde_json::Value;
     use std::collections::HashMap;
@@ -713,17 +715,16 @@ mod tests {
         }
     }
 
-    fn prime_test_command_environment() {
-        clear_command_environment_cache_for_tests();
-        prime_command_environment_cache_for_tests(
+    fn test_command_environment() -> CommandEnvironmentOverrideGuard {
+        override_command_environment(
             HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]),
             test_environment_diagnostics(),
-        );
+        )
     }
 
     #[tokio::test]
     async fn bash_foreground_returns_stdout_stderr_and_streams_tokens() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let tool = BashTool::new();
         let (tx, mut rx) = mpsc::channel(32);
 
@@ -797,7 +798,7 @@ mod tests {
 
     #[tokio::test]
     async fn bash_foreground_tolerates_invalid_utf8_stderr() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let tool = BashTool::new();
         let result = tool
             .invoke(
@@ -820,7 +821,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn bash_foreground_failure_includes_full_python_tried_list() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let tool = BashTool::new();
         let out = tool
             .invoke(
@@ -845,7 +846,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn bash_foreground_sets_stdout_truncated_when_output_exceeds_cap() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let tool = BashTool::new();
         let out = tool
             .invoke(
@@ -868,7 +869,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn bash_background_honors_explicit_timeout() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let tool = BashTool::new();
         let out = tool
             .invoke(
@@ -916,7 +917,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn bash_background_emits_completion_event_with_exit_code() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let (tx, mut rx) = mpsc::channel(8);
         let shell =
             super::bash_runtime::spawn_background("true", None, Some(tx), None, false, None)
@@ -950,7 +951,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn bash_background_emits_completion_event_for_failing_command() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let (tx, mut rx) = mpsc::channel(8);
         let shell =
             super::bash_runtime::spawn_background("false", None, Some(tx), None, false, None)
@@ -983,7 +984,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn bash_background_emits_killed_when_shell_is_killed() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let (tx, mut rx) = mpsc::channel(8);
         let shell =
             super::bash_runtime::spawn_background("sleep 30", None, Some(tx), None, false, None)
@@ -1018,7 +1019,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn bash_background_without_sender_still_completes() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let shell = super::bash_runtime::spawn_background("true", None, None, None, false, None)
             .await
             .expect("background shell should spawn");
@@ -1043,7 +1044,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn bash_background_drops_completion_when_channel_saturated() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         // Capacity-1 channel pre-filled so the single slot is occupied.
         let (tx, mut rx) = mpsc::channel::<AgentEvent>(1);
         tx.try_send(AgentEvent::Token {
@@ -1090,7 +1091,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn bash_tool_background_dispatch_emits_completion_event() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let tool = BashTool::new();
         let (tx, mut rx) = mpsc::channel(8);
         let ctx = ToolExecutionContext::for_dispatch(
@@ -1142,7 +1143,7 @@ mod tests {
 
     #[tokio::test]
     async fn bash_resolves_relative_workdir_from_session_workspace() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let tool = BashTool::new();
         let dir = tempfile::tempdir().unwrap();
         let base = dir.path().join("base");
@@ -1184,7 +1185,7 @@ mod tests {
 
     #[tokio::test]
     async fn bash_rejects_workdir_that_is_not_directory() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let tool = BashTool::new();
         let file = tempfile::NamedTempFile::new().unwrap();
 
@@ -1209,7 +1210,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn running_shells_for_session_filters_by_session_and_status() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
 
         // Two long-running shells owned by sess-A.
         let a1 = super::bash_runtime::spawn_background(
@@ -1300,7 +1301,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn auto_path_fast_command_returns_synchronous_result() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let tool = BashTool::new();
         let (tx, _rx) = mpsc::channel(32);
         let ctx = ToolExecutionContext {
@@ -1345,7 +1346,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn auto_path_promotes_long_command_to_background() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let tool = BashTool::new();
         let session_id = "session_auto_promote";
         let (tx, mut rx) = mpsc::channel(8);
@@ -1414,7 +1415,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn force_sync_does_not_promote_and_times_out() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let tool = BashTool::new();
 
         let out = tool
@@ -1451,7 +1452,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn auto_path_does_not_promote_when_not_resume_capable() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let tool = BashTool::new();
 
         let out = tool
@@ -1485,7 +1486,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn adopt_running_child_preserves_seeded_output() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let shell = bamboo_infrastructure::process::preferred_bash_shell();
         let mut cmd = tokio::process::Command::new(&shell.program);
         bamboo_infrastructure::process::hide_window_for_tokio_command(&mut cmd);
@@ -1564,7 +1565,7 @@ mod tests {
 
     #[tokio::test]
     async fn background_completion_pushes_to_sink_with_output_tail() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let recorder = RecordingSink::default();
         let sink: std::sync::Arc<dyn bamboo_agent_core::BashCompletionSink> =
             std::sync::Arc::new(recorder.clone());
@@ -1596,7 +1597,7 @@ mod tests {
 
     #[tokio::test]
     async fn background_completion_carries_nonzero_exit_code() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let recorder = RecordingSink::default();
         let sink: std::sync::Arc<dyn bamboo_agent_core::BashCompletionSink> =
             std::sync::Arc::new(recorder.clone());
@@ -1627,7 +1628,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn killed_background_shell_pushes_killed_to_sink() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let recorder = RecordingSink::default();
         let sink: std::sync::Arc<dyn bamboo_agent_core::BashCompletionSink> =
             std::sync::Arc::new(recorder.clone());
@@ -1656,7 +1657,7 @@ mod tests {
 
     #[tokio::test]
     async fn untagged_shell_does_not_invoke_sink() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let recorder = RecordingSink::default();
         let sink: std::sync::Arc<dyn bamboo_agent_core::BashCompletionSink> =
             std::sync::Arc::new(recorder.clone());

--- a/crates/engine/bamboo-tools/src/tools/bash_input.rs
+++ b/crates/engine/bamboo-tools/src/tools/bash_input.rs
@@ -147,8 +147,10 @@ impl Tool for BashInputTool {
 mod tests {
     use super::*;
     use bamboo_infrastructure::process::{
-        clear_command_environment_cache_for_tests, prime_command_environment_cache_for_tests,
         CommandEnvironmentDiagnostics, CommandEnvironmentSource, PythonDiscoveryDiagnostics,
+    };
+    use bamboo_infrastructure::test_support::{
+        override_command_environment, CommandEnvironmentOverrideGuard,
     };
     use std::collections::HashMap;
     use tokio::time::{sleep, Duration, Instant};
@@ -174,12 +176,11 @@ mod tests {
         }
     }
 
-    fn prime_test_command_environment() {
-        clear_command_environment_cache_for_tests();
-        prime_command_environment_cache_for_tests(
+    fn test_command_environment() -> CommandEnvironmentOverrideGuard {
+        override_command_environment(
             HashMap::from([("PATH".to_string(), "/usr/bin:/bin".to_string())]),
             test_environment_diagnostics(),
-        );
+        )
     }
 
     /// Helper: poll `shell`'s output until a line containing `needle` appears,
@@ -202,7 +203,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn bash_input_feeds_interactive_shell_and_output_appears() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         // `cat` echoes its stdin to stdout — perfect for round-trip verification.
         let shell = bash_runtime::spawn_background("cat", None, None, None, true, None)
             .await
@@ -236,7 +237,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn write_stdin_errors_on_non_interactive_shell() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let shell = bash_runtime::spawn_background("sleep 5", None, None, None, false, None)
             .await
             .expect("spawn non-interactive shell");
@@ -258,7 +259,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn write_stdin_errors_on_exited_interactive_shell() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let shell = bash_runtime::spawn_background("true", None, None, None, true, None)
             .await
             .expect("spawn interactive shell");
@@ -295,7 +296,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn non_interactive_stdin_reader_gets_eof_and_terminates() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         // `cat` reads stdin; with Stdio::null() it receives immediate EOF and exits 0.
         let shell = bash_runtime::spawn_background("cat", None, None, None, false, None)
             .await
@@ -345,7 +346,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn bash_input_errors_on_non_interactive_shell_via_tool() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let shell = bash_runtime::spawn_background("sleep 5", None, None, None, false, None)
             .await
             .expect("spawn non-interactive shell");
@@ -385,7 +386,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn bash_input_append_newline_false_sends_utf8_bytes() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let shell = bash_runtime::spawn_background("cat", None, None, None, true, None)
             .await
             .expect("spawn interactive shell");
@@ -449,7 +450,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn bash_input_eof_closes_stdin_and_lets_consumer_terminate() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let shell = bash_runtime::spawn_background("cat", None, None, None, true, None)
             .await
             .expect("spawn interactive shell");
@@ -497,7 +498,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn bash_input_eof_allows_empty_input() {
-        prime_test_command_environment();
+        let _command_environment = test_command_environment();
         let shell = bash_runtime::spawn_background("cat", None, None, None, true, None)
             .await
             .expect("spawn interactive shell");

--- a/crates/infra/bamboo-infrastructure/src/lib.rs
+++ b/crates/infra/bamboo-infrastructure/src/lib.rs
@@ -22,6 +22,8 @@ pub use process::{
     ProcessHandle, ProcessInfo, ProcessRegistrationConfig, ProcessRegistry, ProcessType,
 };
 
+// Legacy test-utils exports retained for downstream source compatibility.
+// New tests should use `test_support::override_command_environment`.
 #[cfg(any(test, feature = "test-utils"))]
 pub use process::process_utils::{
     clear_command_environment_cache_for_tests, prime_command_environment_cache_for_tests,
@@ -37,7 +39,36 @@ pub mod registry {
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_support {
+    use std::collections::HashMap;
     use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    use crate::process::process_utils;
+    use crate::CommandEnvironmentDiagnostics;
+
+    /// Same-thread scope for a deterministic command environment in tests.
+    ///
+    /// This wrapper is deliberately non-`Send`: keep it alive while polling the
+    /// code under test on the same thread. The default `#[tokio::test]` runtime
+    /// is current-thread and satisfies that contract. The override never clears
+    /// or primes the process-global login-shell cache, so other parallel tests
+    /// and in-flight production-cache refreshes remain isolated.
+    #[must_use = "keep the guard alive for the full command-environment test scope"]
+    pub struct CommandEnvironmentOverrideGuard {
+        _inner: process_utils::CommandEnvironmentOverrideGuard,
+    }
+
+    /// Install a deterministic command environment for the current test thread.
+    ///
+    /// Dropping the returned guard restores the previous override, including
+    /// when scopes are nested.
+    pub fn override_command_environment(
+        env: HashMap<String, String>,
+        diagnostics: CommandEnvironmentDiagnostics,
+    ) -> CommandEnvironmentOverrideGuard {
+        CommandEnvironmentOverrideGuard {
+            _inner: process_utils::override_command_environment_for_tests(env, diagnostics),
+        }
+    }
 
     /// The single crate-wide lock guarding all tests that mutate process-global
     /// state — environment variables (`BAMBOO_DATA_DIR`, `HOME`, `BAMBOO_*`, the

--- a/crates/infra/bamboo-infrastructure/src/process/process_utils.rs
+++ b/crates/infra/bamboo-infrastructure/src/process/process_utils.rs
@@ -1,9 +1,15 @@
+#[cfg(any(test, feature = "test-utils"))]
+use std::cell::RefCell;
 use std::collections::HashMap;
+#[cfg(any(test, feature = "test-utils"))]
+use std::marker::PhantomData;
 #[cfg(target_os = "windows")]
 use std::path::Path;
 use std::path::PathBuf;
 #[cfg(not(target_os = "windows"))]
 use std::process::Stdio;
+#[cfg(any(test, feature = "test-utils"))]
+use std::rc::Rc;
 use std::sync::{OnceLock, RwLock};
 use std::time::{Duration, Instant};
 
@@ -132,6 +138,58 @@ struct ImportedCommandEnvironment {
     diagnostics: CommandEnvironmentDiagnostics,
 }
 
+#[cfg(any(test, feature = "test-utils"))]
+thread_local! {
+    /// Test-only environment selection is deliberately separate from the
+    /// process-global production cache. Rust's test harness runs tests on
+    /// parallel OS threads, so a scoped thread-local override lets each test
+    /// observe its own fixture without clearing, priming, or racing a real
+    /// login-shell refresh.
+    static COMMAND_ENVIRONMENT_OVERRIDE_FOR_TESTS:
+        RefCell<Option<ImportedCommandEnvironment>> = const { RefCell::new(None) };
+}
+
+/// Restores the previous test-only command environment when its scope ends.
+///
+/// The `Rc` marker deliberately makes this guard `!Send` and `!Sync`: callers
+/// must execute `build_command_environment` on the same thread that installed
+/// the override. This matches the default current-thread Tokio test runtime and
+/// prevents a multi-threaded test from silently losing its thread-local fixture.
+#[cfg(any(test, feature = "test-utils"))]
+#[must_use = "keep the guard alive for the full command-environment test scope"]
+pub(crate) struct CommandEnvironmentOverrideGuard {
+    previous: Option<ImportedCommandEnvironment>,
+    _same_thread: PhantomData<Rc<()>>,
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl Drop for CommandEnvironmentOverrideGuard {
+    fn drop(&mut self) {
+        let previous = self.previous.take();
+        COMMAND_ENVIRONMENT_OVERRIDE_FOR_TESTS.with(|slot| {
+            slot.replace(previous);
+        });
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+pub(crate) fn override_command_environment_for_tests(
+    env: HashMap<String, String>,
+    diagnostics: CommandEnvironmentDiagnostics,
+) -> CommandEnvironmentOverrideGuard {
+    let imported = ImportedCommandEnvironment { env, diagnostics };
+    let previous = COMMAND_ENVIRONMENT_OVERRIDE_FOR_TESTS.with(|slot| slot.replace(Some(imported)));
+    CommandEnvironmentOverrideGuard {
+        previous,
+        _same_thread: PhantomData,
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+fn read_command_environment_override_for_tests() -> Option<ImportedCommandEnvironment> {
+    COMMAND_ENVIRONMENT_OVERRIDE_FOR_TESTS.with(|slot| slot.borrow().clone())
+}
+
 #[cfg(not(target_os = "windows"))]
 #[derive(Debug, Clone)]
 struct CachedUnixShellEnvironment {
@@ -181,6 +239,11 @@ pub async fn build_command_environment(
 }
 
 async fn imported_command_environment() -> ImportedCommandEnvironment {
+    #[cfg(any(test, feature = "test-utils"))]
+    if let Some(imported) = read_command_environment_override_for_tests() {
+        return imported;
+    }
+
     #[cfg(target_os = "windows")]
     {
         ImportedCommandEnvironment::from_process_env(None)
@@ -884,6 +947,14 @@ async fn import_unix_shell_environment() -> Result<ImportedCommandEnvironment, S
     Ok(ImportedCommandEnvironment { env, diagnostics })
 }
 
+/// Clear the process-global command-environment cache for legacy test callers.
+///
+/// New tests should prefer
+/// [`crate::test_support::override_command_environment`], whose scoped
+/// thread-local fixture cannot race parallel tests or an in-flight cache
+/// refresh. This compatibility helper intentionally retains its original
+/// global mutation semantics and is available only in test builds or with the
+/// `test-utils` feature.
 #[cfg(any(test, feature = "test-utils"))]
 pub fn clear_command_environment_cache_for_tests() {
     #[cfg(not(target_os = "windows"))]
@@ -892,6 +963,14 @@ pub fn clear_command_environment_cache_for_tests() {
     }
 }
 
+/// Prime the process-global command-environment cache for legacy test callers.
+///
+/// New tests should prefer
+/// [`crate::test_support::override_command_environment`], whose scoped
+/// thread-local fixture cannot race parallel tests or an in-flight cache
+/// refresh. This compatibility helper intentionally retains its original
+/// global mutation semantics and is available only in test builds or with the
+/// `test-utils` feature.
 #[cfg(any(test, feature = "test-utils"))]
 pub fn prime_command_environment_cache_for_tests(
     env: HashMap<String, String>,
@@ -899,6 +978,9 @@ pub fn prime_command_environment_cache_for_tests(
 ) {
     #[cfg(not(target_os = "windows"))]
     write_cached_unix_shell_environment(ImportedCommandEnvironment { env, diagnostics });
+
+    #[cfg(target_os = "windows")]
+    let _ = (env, diagnostics);
 }
 
 #[cfg(target_os = "windows")]
@@ -1112,6 +1194,144 @@ pub fn hide_window_for_tokio_command(command: &mut tokio::process::Command) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn overridden_environment(marker: &str) -> ImportedCommandEnvironment {
+        ImportedCommandEnvironment {
+            env: HashMap::from([
+                ("PATH".to_string(), "/usr/bin:/bin".to_string()),
+                ("BAMBOO_TEST_ENV_MARKER".to_string(), marker.to_string()),
+            ]),
+            diagnostics: CommandEnvironmentDiagnostics::inherited_process(Some(marker.to_string())),
+        }
+    }
+
+    #[tokio::test]
+    async fn command_environment_override_restores_nested_scope() {
+        assert!(read_command_environment_override_for_tests().is_none());
+
+        let outer = overridden_environment("outer");
+        let outer_guard =
+            override_command_environment_for_tests(outer.env.clone(), outer.diagnostics.clone());
+        let prepared = build_command_environment(&HashMap::new()).await;
+        assert_eq!(
+            prepared.env.get("BAMBOO_TEST_ENV_MARKER"),
+            Some(&"outer".to_string())
+        );
+
+        {
+            let inner = overridden_environment("inner");
+            let _inner_guard = override_command_environment_for_tests(
+                inner.env.clone(),
+                inner.diagnostics.clone(),
+            );
+            let prepared = build_command_environment(&HashMap::new()).await;
+            assert_eq!(
+                prepared.env.get("BAMBOO_TEST_ENV_MARKER"),
+                Some(&"inner".to_string())
+            );
+        }
+
+        let prepared = build_command_environment(&HashMap::new()).await;
+        assert_eq!(
+            prepared.env.get("BAMBOO_TEST_ENV_MARKER"),
+            Some(&"outer".to_string())
+        );
+
+        drop(outer_guard);
+        assert!(read_command_environment_override_for_tests().is_none());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn command_environment_overrides_survive_parallel_real_cache_mutation() {
+        use std::sync::{Arc, Barrier};
+
+        const WORKERS: usize = 8;
+        const ITERATIONS: usize = 128;
+
+        // Keep any other process-global cache test out of this mutation window.
+        // Downstream tests do not need this lock: their scoped overrides never
+        // touch the production cache.
+        let _cache_test_guard = crate::test_support::env_cache_lock_acquire();
+        let previous_cache = unix_shell_env_cache()
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        let start = Arc::new(Barrier::new(WORKERS + 1));
+
+        let workers = (0..WORKERS)
+            .map(|worker| {
+                let start = Arc::clone(&start);
+                std::thread::spawn(move || {
+                    let marker = format!("worker-{worker}");
+                    let imported = overridden_environment(&marker);
+                    let guard =
+                        override_command_environment_for_tests(imported.env, imported.diagnostics);
+                    start.wait();
+
+                    let runtime = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .expect("build current-thread runtime");
+                    runtime.block_on(async {
+                        for _ in 0..ITERATIONS {
+                            let prepared = build_command_environment(&HashMap::new()).await;
+                            assert_eq!(
+                                prepared
+                                    .env
+                                    .get("BAMBOO_TEST_ENV_MARKER")
+                                    .map(String::as_str),
+                                Some(marker.as_str())
+                            );
+                            assert_eq!(
+                                prepared.diagnostics.import_error.as_deref(),
+                                Some(marker.as_str())
+                            );
+                            tokio::task::yield_now().await;
+                        }
+                    });
+
+                    drop(guard);
+                    assert!(read_command_environment_override_for_tests().is_none());
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let mutator = std::thread::spawn({
+            let start = Arc::clone(&start);
+            move || {
+                start.wait();
+                for iteration in 0..(WORKERS * ITERATIONS) {
+                    if iteration % 2 == 0 {
+                        if let Ok(mut cache) = unix_shell_env_cache().write() {
+                            *cache = None;
+                        }
+                    } else {
+                        let mut imported = overridden_environment("production-cache");
+                        imported.diagnostics =
+                            CommandEnvironmentDiagnostics::unix_login_shell("/bin/sh".to_string());
+                        write_cached_unix_shell_environment(imported);
+                    }
+                    std::thread::yield_now();
+                }
+            }
+        });
+
+        let worker_results = workers
+            .into_iter()
+            .map(std::thread::JoinHandle::join)
+            .collect::<Vec<_>>();
+        let mutator_result = mutator.join();
+
+        *unix_shell_env_cache()
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = previous_cache;
+
+        for result in worker_results {
+            result.expect("parallel command-environment worker");
+        }
+        mutator_result.expect("production cache mutator");
+    }
 
     #[test]
     fn parse_env_output_ignores_leading_noise_and_handles_multiline_values() {

--- a/crates/infra/bamboo-infrastructure/tests/test_utils_api.rs
+++ b/crates/infra/bamboo-infrastructure/tests/test_utils_api.rs
@@ -1,0 +1,32 @@
+#![cfg(feature = "test-utils")]
+
+use std::collections::HashMap;
+
+use bamboo_infrastructure::CommandEnvironmentDiagnostics;
+
+type ClearCache = fn();
+type PrimeCache = fn(HashMap<String, String>, CommandEnvironmentDiagnostics);
+
+#[test]
+fn legacy_command_environment_helpers_remain_available_at_all_public_paths() {
+    let root_clear: ClearCache = bamboo_infrastructure::clear_command_environment_cache_for_tests;
+    let process_clear: ClearCache =
+        bamboo_infrastructure::process::clear_command_environment_cache_for_tests;
+    let compatibility_clear: ClearCache =
+        bamboo_infrastructure::process_utils::clear_command_environment_cache_for_tests;
+
+    let root_prime: PrimeCache = bamboo_infrastructure::prime_command_environment_cache_for_tests;
+    let process_prime: PrimeCache =
+        bamboo_infrastructure::process::prime_command_environment_cache_for_tests;
+    let compatibility_prime: PrimeCache =
+        bamboo_infrastructure::process_utils::prime_command_environment_cache_for_tests;
+
+    let _ = (
+        root_clear,
+        process_clear,
+        compatibility_clear,
+        root_prime,
+        process_prime,
+        compatibility_prime,
+    );
+}


### PR DESCRIPTION
## Summary

- replace Bamboo Tools tests that clear/prime the process-global Unix command-environment cache with a scoped thread-local fixture
- restore nested fixture state through an RAII guard that is deliberately same-thread (`!Send`/`!Sync`)
- add causal stress coverage: eight distinct thread-local fixtures remain stable while a ninth thread repeatedly clears/rewrites the real global cache
- retain the existing public `test-utils` clear/prime helpers at crate-root, `process`, and compatibility `process_utils` paths, with a downstream-style API regression
- leave production cache import, refresh, diagnostics, and #709 unchanged

Closes #711.

## Adversarial review

The first review rejected the original local SHA as **Medium / merge-blocking** because it removed published `test-utils` symbols and would break downstream test compilation. The implementation was amended to restore exact, non-deprecated legacy signatures and all three public paths. A second fresh reviewer found no remaining actionable issues on exact head `f201c43263a3b506f583c378c5c86dba57b96482`.

## Test Plan

- `cargo test -p bamboo-infrastructure --all-features command_environment_override -- --nocapture`
- causal real-cache mutation stress repeated 100 times during implementation and 32 times during fresh review
- original failing Bash test repeated 32 times during fresh review
- `cargo test -p bamboo-tools --all-features --lib -- --test-threads=64` (330/330)
- `cargo test -p bamboo-tools --tests` repeated 3 times; package integration 1/1
- downstream API integration test for all six legacy function paths (1/1)
- `cargo check -p bamboo-infrastructure -p bamboo-tools` with `test-utils` off
- affected all-target/all-feature Clippy with `-D warnings`
- Windows GNU all-target compile check
- exact workspace gates: `cargo test --all-features --lib --tests` and `cargo test --tests`
- `cargo fmt --all -- --check` and `git diff --check`

## Residuals

- the scoped API intentionally requires same-thread/LIFO use; current Tokio tests satisfy that contract
- retained legacy helpers remain global/racy for compatibility, but repository tests no longer call them
- native Linux execution is delegated to CI because the local host is macOS