### PR TITLE
test: isolate credential env cache assertions (#712)

### DIFF
--- a/crates/app/bamboo-server/Cargo.toml
+++ b/crates/app/bamboo-server/Cargo.toml
@@ -150,6 +150,11 @@ notify = "8"
 prost = "0.13"
 tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "native-tls"] }
 
+[features]
+# Test-only scoped access to bamboo-config's process-global env-cache fixtures.
+# Kept out of defaults so production builds retain the ordinary global path.
+test-utils = ["bamboo-config/test-utils"]
+
 [dev-dependencies]
 tempfile = "3"
 wiremock = "0.6"
@@ -165,5 +170,14 @@ awc = { version = "3", features = ["rustls-0_23"] }
 actix-codec = "0.5"
 bamboo-infrastructure = { path = "../../infra/bamboo-infrastructure", features = ["test-utils"] }
 bamboo-llm = { path = "../../infra/bamboo-llm" }
+# Existing server unit tests use bamboo-config's encryption and transaction
+# fixtures under the default `cargo test` path. This dev-only edge keeps those
+# tests available; the package feature above separately selects integration
+# tests that must opt in to the scoped env-cache fixture.
 bamboo-config = { path = "../../infra/bamboo-config", features = ["test-utils"] }
 bamboo-storage = { path = "../../infra/bamboo-storage" }
+
+[[test]]
+name = "env_cache_isolation"
+path = "tests/env_cache_isolation.rs"
+required-features = ["test-utils"]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
@@ -466,10 +466,16 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "test-utils")]
     #[actix_web::test]
     async fn generic_mutations_reject_env_refs_without_changing_any_layer() {
         let dir = tempfile::tempdir().unwrap();
         let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        // Keep both runtime-cache publications and reads in this Actix
+        // current-thread scope. Rejected handlers can still mutate the scoped
+        // cache (and fail the assertion), while parallel AppState tests cannot
+        // replace it from another test-harness thread.
+        let _env_cache = bamboo_config::test_support::isolate_env_vars_cache();
         let reference = CredentialRef::parse("env.TOKEN.value").unwrap();
         state
             .credential_store

--- a/crates/app/bamboo-server/tests/env_cache_isolation.rs
+++ b/crates/app/bamboo-server/tests/env_cache_isolation.rs
@@ -1,0 +1,178 @@
+use std::sync::{mpsc, Arc, Barrier};
+use std::time::Duration;
+
+use bamboo_config::{Config, EnvVarEntry};
+
+const CACHE_OWNER: &str = "BAMBOO_ENV_CACHE_TEST_OWNER";
+
+struct ResetGlobalEnvCache;
+
+impl Drop for ResetGlobalEnvCache {
+    fn drop(&mut self) {
+        Config::default().publish_env_vars();
+    }
+}
+
+fn config_with_marker(value: &str, description: &str) -> Config {
+    let mut config = Config::default();
+    config.env_vars.push(EnvVarEntry {
+        name: CACHE_OWNER.to_string(),
+        value: value.to_string(),
+        secret: false,
+        value_encrypted: None,
+        credential_ref: None,
+        configured: true,
+        description: Some(description.to_string()),
+    });
+    config
+}
+
+fn current_marker() -> (Option<String>, Option<String>) {
+    let value = Config::current_env_vars().get(CACHE_OWNER).cloned();
+    let description = Config::current_prompt_safe_env_vars()
+        .into_iter()
+        .find(|entry| entry.name == CACHE_OWNER)
+        .and_then(|entry| entry.description);
+    (value, description)
+}
+
+#[test]
+fn scoped_env_cache_survives_parallel_global_publication_and_restores_nested_state() {
+    // This dedicated integration-test binary intentionally exercises one
+    // unscoped process-global publisher. Reset on entry and through RAII on
+    // every exit. If more tests are ever added to this binary and run in
+    // parallel, they must share a serialization guard around the global phase.
+    Config::default().publish_env_vars();
+    let reset_global_cache = ResetGlobalEnvCache;
+
+    let global = config_with_marker("global-base", "global base metadata");
+    global.publish_env_vars();
+    assert_eq!(
+        current_marker(),
+        (
+            Some("global-base".to_string()),
+            Some("global base metadata".to_string())
+        )
+    );
+
+    {
+        let _outer = bamboo_config::test_support::isolate_env_vars_cache();
+        config_with_marker("outer", "outer metadata").publish_env_vars();
+        assert_eq!(
+            current_marker(),
+            (
+                Some("outer".to_string()),
+                Some("outer metadata".to_string())
+            )
+        );
+
+        {
+            let _inner = bamboo_config::test_support::isolate_env_vars_cache();
+            config_with_marker("inner", "inner metadata").publish_env_vars();
+            assert_eq!(
+                current_marker(),
+                (
+                    Some("inner".to_string()),
+                    Some("inner metadata".to_string())
+                )
+            );
+        }
+
+        assert_eq!(
+            current_marker(),
+            (
+                Some("outer".to_string()),
+                Some("outer metadata".to_string())
+            ),
+            "dropping an inner isolation scope must restore the outer snapshot"
+        );
+    }
+
+    assert_eq!(
+        current_marker(),
+        (
+            Some("global-base".to_string()),
+            Some("global base metadata".to_string())
+        ),
+        "dropping the outer isolation scope must reveal the global snapshot"
+    );
+
+    const WORKERS: usize = 8;
+    const ITERATIONS: usize = 128;
+    let (result_tx, result_rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        let phase = Arc::new(Barrier::new(WORKERS + 1));
+        let workers = (0..WORKERS)
+            .map(|worker| {
+                let phase = Arc::clone(&phase);
+                std::thread::spawn(move || {
+                    let _isolation = bamboo_config::test_support::isolate_env_vars_cache();
+                    let marker = format!("scoped-worker-{worker}");
+                    let description = format!("scoped metadata {worker}");
+                    let config = config_with_marker(&marker, &description);
+                    let mut contaminated = false;
+
+                    for _ in 0..ITERATIONS {
+                        config.publish_env_vars();
+                        phase.wait();
+                        phase.wait();
+                        contaminated |=
+                            current_marker() != (Some(marker.clone()), Some(description.clone()));
+                        phase.wait();
+                    }
+
+                    contaminated
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let global_phase = Arc::clone(&phase);
+        let global_publisher = std::thread::spawn(move || {
+            let mut last = (String::new(), String::new());
+            for iteration in 0..ITERATIONS {
+                global_phase.wait();
+                last = (
+                    format!("global-publisher-{iteration}"),
+                    format!("global metadata {iteration}"),
+                );
+                config_with_marker(&last.0, &last.1).publish_env_vars();
+                global_phase.wait();
+                global_phase.wait();
+            }
+            last
+        });
+
+        let worker_results = workers
+            .into_iter()
+            .map(std::thread::JoinHandle::join)
+            .collect::<Vec<_>>();
+        let global_result = global_publisher.join();
+        let _ = result_tx.send((worker_results, global_result));
+    });
+
+    let (worker_results, global_result) = result_rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("parallel env-cache rendezvous timed out");
+
+    for result in worker_results {
+        assert!(
+            !result.expect("parallel scoped env-cache worker"),
+            "a scoped env-cache worker observed another publisher's value or metadata"
+        );
+    }
+
+    let global_result = global_result.expect("unscoped global env-cache publisher");
+    assert_eq!(
+        current_marker(),
+        (Some(global_result.0), Some(global_result.1)),
+        "the unscoped publisher must continue to update the process-global cache"
+    );
+
+    drop(reset_global_cache);
+    assert_eq!(
+        current_marker(),
+        (None, None),
+        "the standalone regression must not leave its global marker behind"
+    );
+}

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -4070,6 +4070,13 @@ impl Config {
     /// Update the global env vars cache (called on config load / reload).
     pub fn publish_env_vars(&self) {
         let map = self.env_vars_as_map();
+
+        #[cfg(any(test, feature = "test-utils"))]
+        if crate::test_support::env_vars_cache_override_is_active() {
+            crate::test_support::publish_env_vars_to_override(map, self.prompt_safe_env_vars());
+            return;
+        }
+
         let mut env_guard = env_vars_cache().write().recover_poison();
         *env_guard = map;
 
@@ -4080,11 +4087,21 @@ impl Config {
 
     /// Read the current env vars snapshot (called by Bash tool at process spawn time).
     pub fn current_env_vars() -> HashMap<String, String> {
+        #[cfg(any(test, feature = "test-utils"))]
+        if let Some(env_vars) = crate::test_support::current_env_vars_override() {
+            return env_vars;
+        }
+
         env_vars_cache().read().recover_poison().clone()
     }
 
     /// Read the current prompt-safe env var snapshot (names + metadata only; no secret values).
     pub fn current_prompt_safe_env_vars() -> Vec<PromptSafeEnvVarEntry> {
+        #[cfg(any(test, feature = "test-utils"))]
+        if let Some(env_vars) = crate::test_support::current_prompt_safe_env_vars_override() {
+            return env_vars;
+        }
+
         prompt_safe_env_vars_cache().read().recover_poison().clone()
     }
 

--- a/crates/infra/bamboo-config/src/lib.rs
+++ b/crates/infra/bamboo-config/src/lib.rs
@@ -53,9 +53,104 @@ pub use subagents_config::SubagentsConfigModule;
 /// (env vars, the encryption-key var, the env-vars snapshot). Tests across
 /// `config`, `encryption` and `paths` acquire this single lock so they
 /// serialize instead of racing under parallel execution.
-#[cfg(test)]
+#[cfg(any(test, feature = "test-utils"))]
 pub mod test_support {
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::marker::PhantomData;
+    use std::rc::Rc;
     use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    use crate::PromptSafeEnvVarEntry;
+
+    #[derive(Clone)]
+    pub(crate) struct EnvVarsCacheSnapshot {
+        env_vars: HashMap<String, String>,
+        prompt_safe_env_vars: Vec<PromptSafeEnvVarEntry>,
+    }
+
+    thread_local! {
+        /// Test-only env snapshots are deliberately separate from the
+        /// process-global runtime cache. Rust's test harness runs tests on
+        /// parallel OS threads, so each scoped test can publish and inspect its
+        /// own snapshot without racing unrelated server `AppState` publishers.
+        static ENV_VARS_CACHE_OVERRIDE_FOR_TESTS:
+            RefCell<Option<EnvVarsCacheSnapshot>> = const { RefCell::new(None) };
+    }
+
+    /// Restores the previous test-only env snapshot when its scope ends.
+    ///
+    /// The `Rc` marker deliberately makes this guard `!Send` and `!Sync`:
+    /// callers must poll code under test on the same thread that installed the
+    /// isolation scope. Default Tokio and Actix test runtimes are
+    /// current-thread, so in-scope `publish_env_vars` writes remain observable
+    /// while unrelated test threads continue to use the process-global cache.
+    #[must_use = "keep the guard alive for the full env-cache test scope"]
+    pub struct EnvVarsCacheIsolationGuard {
+        previous: Option<EnvVarsCacheSnapshot>,
+        _same_thread: PhantomData<Rc<()>>,
+    }
+
+    impl Drop for EnvVarsCacheIsolationGuard {
+        fn drop(&mut self) {
+            let previous = self.previous.take();
+            ENV_VARS_CACHE_OVERRIDE_FOR_TESTS.with(|slot| {
+                slot.replace(previous);
+            });
+        }
+    }
+
+    /// Isolate `Config` env-cache reads and publications to the current thread.
+    ///
+    /// The isolated cache starts with the currently visible snapshot. Both
+    /// `Config::publish_env_vars` and the two snapshot readers honor it, so a
+    /// mutation performed by code under test on this thread is still detected;
+    /// only publishers from unrelated parallel test threads are excluded.
+    pub fn isolate_env_vars_cache() -> EnvVarsCacheIsolationGuard {
+        let snapshot = EnvVarsCacheSnapshot {
+            env_vars: crate::Config::current_env_vars(),
+            prompt_safe_env_vars: crate::Config::current_prompt_safe_env_vars(),
+        };
+        let previous = ENV_VARS_CACHE_OVERRIDE_FOR_TESTS.with(|slot| slot.replace(Some(snapshot)));
+        EnvVarsCacheIsolationGuard {
+            previous,
+            _same_thread: PhantomData,
+        }
+    }
+
+    pub(crate) fn env_vars_cache_override_is_active() -> bool {
+        ENV_VARS_CACHE_OVERRIDE_FOR_TESTS.with(|slot| slot.borrow().is_some())
+    }
+
+    pub(crate) fn publish_env_vars_to_override(
+        env_vars: HashMap<String, String>,
+        prompt_safe_env_vars: Vec<PromptSafeEnvVarEntry>,
+    ) {
+        ENV_VARS_CACHE_OVERRIDE_FOR_TESTS.with(|slot| {
+            let mut slot = slot.borrow_mut();
+            let snapshot = slot
+                .as_mut()
+                .expect("env-cache override must be active before publication");
+            snapshot.env_vars = env_vars;
+            snapshot.prompt_safe_env_vars = prompt_safe_env_vars;
+        });
+    }
+
+    pub(crate) fn current_env_vars_override() -> Option<HashMap<String, String>> {
+        ENV_VARS_CACHE_OVERRIDE_FOR_TESTS.with(|slot| {
+            slot.borrow()
+                .as_ref()
+                .map(|snapshot| snapshot.env_vars.clone())
+        })
+    }
+
+    pub(crate) fn current_prompt_safe_env_vars_override() -> Option<Vec<PromptSafeEnvVarEntry>> {
+        ENV_VARS_CACHE_OVERRIDE_FOR_TESTS.with(|slot| {
+            slot.borrow()
+                .as_ref()
+                .map(|snapshot| snapshot.prompt_safe_env_vars.clone())
+        })
+    }
 
     pub fn env_cache_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();


### PR DESCRIPTION
## Summary

- add a test-only, thread-local RAII scope for Bamboo config env-cache publications and reads
- isolate the credential rejection regression from unrelated parallel `AppState` publishers while preserving same-thread mutations under test
- add a deterministic concurrent publisher regression and explicit non-default `bamboo-server/test-utils` feature forwarding
- restore the dedicated integration binary's global cache after the regression

Production/default normal dependency behavior is unchanged; the scoped API is only compiled for tests or `test-utils`.

Closes #712

## Test Plan

- `cargo test -p bamboo-server --all-features --lib --tests --no-fail-fast` — 1602 passed, 1 ignored; integration 1/1; `ws_v2_live` 16/16
- `cargo test -p bamboo-server --tests --no-fail-fast` — 1601 passed, 1 ignored; `ws_v2_live` 16/16; feature-gated tests skipped
- exact credential regression repeated 32/32
- concurrent env-cache isolation regression repeated 100/100
- independent cold-target exact unit and integration tests — 1/1 each
- `cargo check -p bamboo-server`
- `cargo check -p bamboo-config --no-default-features`
- `cargo clippy -p bamboo-config --all-features --all-targets -- -D warnings`
- `cargo fmt --all --check`

A fresh adversarial review of commit `d8c60c82185316c57d59c120000750747345f24b` reported no findings. The known macOS oversized `__eh_frame` linker warning is tracked separately in #715.

## Screenshots

N/A — test infrastructure only.