### PR TITLE
refactor: make engine and server strict Clippy clean (#714)

### DIFF
--- a/crates/app/bamboo-sdk/src/agent/mod.rs
+++ b/crates/app/bamboo-sdk/src/agent/mod.rs
@@ -1698,16 +1698,18 @@ mod reexecute_and_child_approval_tests {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let _live_guard = bamboo_engine::external_agents::live::register("child-x", tx, 0, None);
         let (approval_event_tx, _approval_event_rx) = tokio::sync::mpsc::channel(4);
-        bamboo_engine::external_agents::live::register_pending_approval_observed(
-            None,
-            "parent-x",
-            "child-x",
-            0,
-            "req-1",
-            "shell",
-            "execute",
-            "cargo test",
-            approval_event_tx,
+        bamboo_engine::external_agents::live::observe_pending_approval(
+            bamboo_engine::external_agents::live::PendingApprovalObservation {
+                registry: None,
+                parent_session_id: "parent-x",
+                child_id: "child-x",
+                child_attempt: 0,
+                request_id: "req-1",
+                tool_name: "shell",
+                permission: "execute",
+                resource: "cargo test",
+                event_tx: approval_event_tx,
+            },
         );
 
         assert!(agent.answer_child_approval("child-x", "req-1", true));

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/mod.rs
@@ -191,10 +191,10 @@ pub async fn handler(
             is_child_session,
         } => {
             let session = *session;
-            ready::handle_execute_ready(
-                &state,
-                &session_id,
-                ready::ReadyExecution {
+            ready::handle_execute_ready(ready::ExecuteReadyContext {
+                state: &state,
+                session_id: &session_id,
+                ready: ready::ReadyExecution {
                     session,
                     startup_guard: &mut startup_guard,
                     startup_turn_id: startup_turn_id.clone(),
@@ -206,12 +206,12 @@ pub async fn handler(
                     no_human_approver: req.no_human_approver,
                     run_budget: req.run_budget,
                 },
-                &config,
-                &config_snapshot,
+                config: &config,
+                config_snapshot: &config_snapshot,
                 image_fallback,
-                disabled_tools_vec,
-                disabled_skill_ids_vec,
-            )
+                disabled_tools: disabled_tools_vec,
+                disabled_skill_ids: disabled_skill_ids_vec,
+            })
             .await
         }
 

--- a/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/handler/ready.rs
@@ -45,17 +45,29 @@ pub(super) struct ReadyExecution<'a> {
     pub run_budget: Option<bamboo_config::RunBudgetConfig>,
 }
 
+pub(super) struct ExecuteReadyContext<'a> {
+    pub state: &'a web::Data<AppState>,
+    pub session_id: &'a str,
+    pub ready: ReadyExecution<'a>,
+    pub config: &'a ExecutionConfigSnapshot,
+    pub config_snapshot: &'a Config,
+    pub image_fallback: Option<ImageFallbackConfig>,
+    pub disabled_tools: Vec<String>,
+    pub disabled_skill_ids: Vec<String>,
+}
+
 /// Reserve the runner, persist, and spawn the agent loop for a ready session.
-pub(super) async fn handle_execute_ready(
-    state: &web::Data<AppState>,
-    session_id: &str,
-    ready: ReadyExecution<'_>,
-    config: &ExecutionConfigSnapshot,
-    config_snapshot: &Config,
-    image_fallback: Option<ImageFallbackConfig>,
-    disabled_tools_vec: Vec<String>,
-    disabled_skill_ids_vec: Vec<String>,
-) -> HttpResponse {
+pub(super) async fn handle_execute_ready(context: ExecuteReadyContext<'_>) -> HttpResponse {
+    let ExecuteReadyContext {
+        state,
+        session_id,
+        ready,
+        config,
+        config_snapshot,
+        image_fallback,
+        disabled_tools,
+        disabled_skill_ids,
+    } = context;
     let mut session = ready.session;
 
     // #74: re-derive the "no interactive human approver" posture per
@@ -130,8 +142,8 @@ pub(super) async fn handle_execute_ready(
         );
     }
 
-    let disabled_tools: BTreeSet<String> = disabled_tools_vec.into_iter().collect();
-    let disabled_skill_ids: BTreeSet<String> = disabled_skill_ids_vec.into_iter().collect();
+    let disabled_tools: BTreeSet<String> = disabled_tools.into_iter().collect();
+    let disabled_skill_ids: BTreeSet<String> = disabled_skill_ids.into_iter().collect();
     let resolved_provider_name = session_effective_model_ref(&session)
         .map(|model_ref| model_ref.provider)
         .unwrap_or_else(|| config.provider_name.clone());

--- a/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/execute/runtime/execution.rs
@@ -17,7 +17,9 @@ use bamboo_engine::session_app::provider_model::session_effective_model_ref;
 
 use bamboo_engine::config::GoldConfig;
 use bamboo_engine::execution::agent_spawn::{SessionExecutionArgs, SessionExecutionReservation};
-use bamboo_engine::{AuxiliaryModelConfig, ImageFallbackConfig, ModelRoster};
+use bamboo_engine::{
+    AuxiliaryModelConfig, DisabledFilterResolver, ImageFallbackConfig, ModelRoster,
+};
 use bamboo_llm::{Config, LLMProvider};
 
 use super::session_state;
@@ -131,7 +133,7 @@ pub(crate) fn make_auxiliary_model_resolver(
 /// freeze it as a floor and break re-enable.
 pub(crate) fn make_disabled_filter_resolver(
     state: &actix_web::web::Data<AppState>,
-) -> Arc<dyn Fn() -> (BTreeSet<String>, BTreeSet<String>) + Send + Sync> {
+) -> DisabledFilterResolver {
     let config = state.config.clone();
     let cached_config = Arc::new(StdRwLock::new(
         config

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
@@ -564,12 +564,9 @@ mod tests {
         .await;
         assert_eq!(prompt.status(), StatusCode::OK);
         let prompt: Value = test::read_body_json(prompt).await;
-        assert_eq!(
-            prompt["project_context"]
-                .as_str()
-                .is_some_and(|value| value.contains(owner.id.as_str())),
-            true
-        );
+        assert!(prompt["project_context"]
+            .as_str()
+            .is_some_and(|value| value.contains(owner.id.as_str())));
         let effective = prompt["effective_system_prompt"]
             .as_str()
             .expect("effective prompt");

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/forwarders.rs
@@ -298,16 +298,16 @@ pub(crate) fn spawn_agent_forwarder(
                         }
                     }
                     Err(broadcast::error::RecvError::Lagged(skipped)) => {
-                        match handle_agent_lag(
-                            &state,
-                            &session_id,
-                            &out,
+                        match handle_agent_lag(AgentLagContext {
+                            state: &state,
+                            session_id: &session_id,
+                            out: &out,
                             encoding,
-                            &ch,
-                            &seq,
+                            channel: &ch,
+                            seq: &seq,
                             skipped,
-                            awaiting_children,
-                        )
+                            own_terminal_already_emitted: awaiting_children,
+                        })
                         .await
                         {
                             LagOutcome::Continue => continue,
@@ -418,16 +418,16 @@ pub(crate) fn spawn_agent_forwarder(
                                 }
                                 flush_deadline = None;
                             }
-                            match handle_agent_lag(
-                                &state,
-                                &session_id,
-                                &out,
+                            match handle_agent_lag(AgentLagContext {
+                                state: &state,
+                                session_id: &session_id,
+                                out: &out,
                                 encoding,
-                                &ch,
-                                &seq,
+                                channel: &ch,
+                                seq: &seq,
                                 skipped,
-                                awaiting_children,
-                            )
+                                own_terminal_already_emitted: awaiting_children,
+                            })
                             .await
                             {
                                 LagOutcome::Continue => {}
@@ -496,6 +496,18 @@ enum LagOutcome {
     Disconnected,
 }
 
+/// Named state for one broadcast-lag recovery decision.
+struct AgentLagContext<'a> {
+    state: &'a web::Data<AppState>,
+    session_id: &'a str,
+    out: &'a OutboundTx,
+    encoding: Encoding,
+    channel: &'a str,
+    seq: &'a AgentSeq,
+    skipped: u64,
+    own_terminal_already_emitted: bool,
+}
+
 /// Recover from a broadcast-ring overrun on an `agent.{sid}` channel (#543).
 ///
 /// Agent events have NO durable journal (unlike the feed), so a lag gap is
@@ -520,16 +532,17 @@ enum LagOutcome {
 /// mirroring the normal `is_child_completed && !has_running_child` close — and
 /// never a second, synthesized terminal event for a session whose completion
 /// the client already saw.
-async fn handle_agent_lag(
-    state: &web::Data<AppState>,
-    session_id: &str,
-    out: &OutboundTx,
-    encoding: Encoding,
-    ch: &str,
-    seq: &AgentSeq,
-    skipped: u64,
-    own_terminal_already_emitted: bool,
-) -> LagOutcome {
+async fn handle_agent_lag(context: AgentLagContext<'_>) -> LagOutcome {
+    let AgentLagContext {
+        state,
+        session_id,
+        out,
+        encoding,
+        channel,
+        seq,
+        skipped,
+        own_terminal_already_emitted,
+    } = context;
     tracing::warn!(
         "[{}] ws_v2 agent channel lagged: {} events lost to broadcast-ring overrun; \
          emitting gap control (client must reconcile via REST)",
@@ -539,7 +552,7 @@ async fn handle_agent_lag(
     if !send_env(
         out,
         encoding,
-        ServerEnvelope::control(ch, seq.next(), gap_control(skipped)),
+        ServerEnvelope::control(channel, seq.next(), gap_control(skipped)),
     )
     .await
     {
@@ -568,14 +581,14 @@ async fn handle_agent_lag(
     // In the awaiting-children window the parent's terminal was already
     // delivered — a second one would be a spurious duplicate completion.
     if !own_terminal_already_emitted
-        && !emit_agent_event(out, encoding, ch, seq, terminal_event).await
+        && !emit_agent_event(out, encoding, channel, seq, terminal_event).await
     {
         return LagOutcome::Disconnected;
     }
     let _ = send_env(
         out,
         encoding,
-        ServerEnvelope::control(ch, seq.next(), terminal_control("complete")),
+        ServerEnvelope::control(channel, seq.next(), terminal_control("complete")),
     )
     .await;
     LagOutcome::Stop

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -463,20 +463,30 @@ async fn drive(
                 match msg {
                     // The inbound frame type that matches the active encoding.
                     Some(Ok(Message::Text(text))) if encoding == Encoding::Json => {
-                        let keep_open = handle_client_bytes(
-                            &state, &mut forwarders, &mut queues,
-                            &sys_tx, batch_ms, encoding, text.as_bytes(), &mut authorized,
-                        )
+                        let keep_open = handle_client_bytes(ClientDispatchContext {
+                            state: &state,
+                            forwarders: &mut forwarders,
+                            queues: &mut queues,
+                            sys_tx: &sys_tx,
+                            batch_ms,
+                            encoding,
+                            authorized: &mut authorized,
+                        }, text.as_bytes())
                         .await;
                         if !keep_open {
                             break;
                         }
                     }
                     Some(Ok(Message::Binary(bytes))) if encoding == Encoding::Msgpack => {
-                        let keep_open = handle_client_bytes(
-                            &state, &mut forwarders, &mut queues,
-                            &sys_tx, batch_ms, encoding, &bytes, &mut authorized,
-                        )
+                        let keep_open = handle_client_bytes(ClientDispatchContext {
+                            state: &state,
+                            forwarders: &mut forwarders,
+                            queues: &mut queues,
+                            sys_tx: &sys_tx,
+                            batch_ms,
+                            encoding,
+                            authorized: &mut authorized,
+                        }, &bytes)
                         .await;
                         if !keep_open {
                             break;
@@ -516,6 +526,17 @@ async fn drive(
     let _ = session.close(None).await;
 }
 
+/// Mutable connection state shared by the decode and dispatch steps.
+struct ClientDispatchContext<'a> {
+    state: &'a web::Data<AppState>,
+    forwarders: &'a mut HashMap<String, tokio::task::JoinHandle<()>>,
+    queues: &'a mut StreamMap<String, ReceiverStream<OutFrame>>,
+    sys_tx: &'a mpsc::Sender<OutFrame>,
+    batch_ms: u64,
+    encoding: Encoding,
+    authorized: &'a mut bool,
+}
+
 /// Decode one inbound frame's bytes per the connection's [`Encoding`] (serde_json
 /// for `Json`, rmp-serde for `Msgpack`) and dispatch the resulting [`ClientFrame`].
 /// A malformed body logs and is ignored — it NEVER tears down the connection, in
@@ -528,27 +549,15 @@ async fn drive(
 ///
 /// Returns `false` to signal the driver to CLOSE the connection (a `hello` that
 /// presents an INVALID device credential); `true` to keep it open.
-async fn handle_client_bytes(
-    state: &web::Data<AppState>,
-    forwarders: &mut HashMap<String, tokio::task::JoinHandle<()>>,
-    queues: &mut StreamMap<String, ReceiverStream<OutFrame>>,
-    sys_tx: &mpsc::Sender<OutFrame>,
-    batch_ms: u64,
-    encoding: Encoding,
-    bytes: &[u8],
-    authorized: &mut bool,
-) -> bool {
-    let frame: ClientFrame = match decode_client_frame(encoding, bytes) {
+async fn handle_client_bytes(context: ClientDispatchContext<'_>, bytes: &[u8]) -> bool {
+    let frame: ClientFrame = match decode_client_frame(context.encoding, bytes) {
         Ok(f) => f,
         Err(e) => {
             tracing::debug!("ws_v2: ignoring malformed client frame: {e}");
             return true;
         }
     };
-    handle_client_frame(
-        state, forwarders, queues, sys_tx, batch_ms, encoding, frame, authorized,
-    )
-    .await
+    handle_client_frame(context, frame).await
 }
 
 /// Dispatch one decoded client frame. A malformed/unknown frame logs and is
@@ -563,16 +572,17 @@ async fn handle_client_bytes(
 ///
 /// Returns `false` to signal the driver to CLOSE the connection (a `hello` that
 /// presents an INVALID device credential); `true` to keep it open.
-async fn handle_client_frame(
-    state: &web::Data<AppState>,
-    forwarders: &mut HashMap<String, tokio::task::JoinHandle<()>>,
-    queues: &mut StreamMap<String, ReceiverStream<OutFrame>>,
-    sys_tx: &mpsc::Sender<OutFrame>,
-    batch_ms: u64,
-    encoding: Encoding,
-    frame: ClientFrame,
-    authorized: &mut bool,
-) -> bool {
+async fn handle_client_frame(context: ClientDispatchContext<'_>, frame: ClientFrame) -> bool {
+    let ClientDispatchContext {
+        state,
+        forwarders,
+        queues,
+        sys_tx,
+        batch_ms,
+        encoding,
+        authorized,
+    } = context;
+
     // Auth gate (#189). Until the connection is authorized, no frame may serve a
     // channel or cancel a session — the only frame that can change anything is a
     // `hello` that carries a verifiable device credential.
@@ -1042,14 +1052,16 @@ mod tests {
         let mut authorized = false;
         assert!(
             handle_client_frame(
-                &state,
-                &mut forwarders,
-                &mut queues,
-                &sys_tx,
-                0,
-                Encoding::Json,
+                ClientDispatchContext {
+                    state: &state,
+                    forwarders: &mut forwarders,
+                    queues: &mut queues,
+                    sys_tx: &sys_tx,
+                    batch_ms: 0,
+                    encoding: Encoding::Json,
+                    authorized: &mut authorized,
+                },
                 ClientFrame::Ping,
-                &mut authorized,
             )
             .await
         );
@@ -1061,14 +1073,16 @@ mod tests {
         authorized = true;
         assert!(
             handle_client_frame(
-                &state,
-                &mut forwarders,
-                &mut queues,
-                &sys_tx,
-                0,
-                Encoding::Json,
+                ClientDispatchContext {
+                    state: &state,
+                    forwarders: &mut forwarders,
+                    queues: &mut queues,
+                    sys_tx: &sys_tx,
+                    batch_ms: 0,
+                    encoding: Encoding::Json,
+                    authorized: &mut authorized,
+                },
                 ClientFrame::Ping,
-                &mut authorized,
             )
             .await
         );
@@ -1098,14 +1112,16 @@ mod tests {
         ] {
             assert!(
                 handle_client_frame(
-                    &state,
-                    &mut forwarders,
-                    &mut queues,
-                    &sys_tx,
-                    0,
-                    Encoding::Json,
+                    ClientDispatchContext {
+                        state: &state,
+                        forwarders: &mut forwarders,
+                        queues: &mut queues,
+                        sys_tx: &sys_tx,
+                        batch_ms: 0,
+                        encoding: Encoding::Json,
+                        authorized: &mut authorized,
+                    },
                     frame,
-                    &mut authorized,
                 )
                 .await
             );

--- a/crates/app/bamboo-server/src/project_context.rs
+++ b/crates/app/bamboo-server/src/project_context.rs
@@ -112,67 +112,6 @@ fn validate_workspace_assignment_with(
     })
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn confinement_final_path_is_the_authority_for_ownership_and_persistence() {
-        let data = tempfile::tempdir().expect("data");
-        let raw = tempfile::tempdir().expect("raw workspace");
-        let confined = tempfile::tempdir().expect("confined workspace");
-        std::fs::write(raw.path().join("raw-only.txt"), "RAW MUST NOT BE USED")
-            .expect("raw fixture");
-        std::fs::write(confined.path().join("final-only.txt"), "FINAL").expect("final fixture");
-        let store = ProjectStore::open(data.path()).expect("Project store");
-        let owner = store
-            .create_with_bindings(
-                "Owner",
-                None,
-                vec![bamboo_domain::WorkspaceBinding {
-                    path: confined.path().to_string_lossy().into_owned(),
-                    label: None,
-                    git_common_dir: None,
-                }],
-            )
-            .expect("owner Project");
-        let other = store.create("Other", None).expect("other Project");
-
-        let resolved = validate_workspace_assignment_with(
-            &store,
-            Some(&owner.id),
-            Some(raw.path().to_string_lossy().as_ref()),
-            |_| confined.path().to_path_buf(),
-        )
-        .expect("same owner");
-        assert_eq!(
-            resolved.as_deref(),
-            Some(confined.path().canonicalize().unwrap().as_path())
-        );
-        assert!(resolved
-            .as_ref()
-            .is_some_and(|path| path.join("final-only.txt").exists()));
-        assert!(!resolved
-            .as_ref()
-            .is_some_and(|path| path.join("raw-only.txt").exists()));
-
-        let conflict = validate_workspace_assignment_with(
-            &store,
-            Some(&other.id),
-            Some(raw.path().to_string_lossy().as_ref()),
-            |_| confined.path().to_path_buf(),
-        )
-        .expect_err("final workspace owner must win over the raw request");
-        assert!(matches!(
-            conflict,
-            ProjectWorkspaceValidationError::Conflict {
-                owner_project_id,
-                ..
-            } if owner_project_id == owner.id
-        ));
-    }
-}
-
 pub struct ProjectStoreContextSource {
     store: Arc<ProjectStore>,
 }
@@ -248,5 +187,66 @@ impl ProjectContextSource for ProjectStoreContextSource {
             .find_workspace_owner_for_path(&display)
             .map(|owner| owner.map(|project| project.id))
             .map_err(|error| ProjectContextError::Source(error.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn confinement_final_path_is_the_authority_for_ownership_and_persistence() {
+        let data = tempfile::tempdir().expect("data");
+        let raw = tempfile::tempdir().expect("raw workspace");
+        let confined = tempfile::tempdir().expect("confined workspace");
+        std::fs::write(raw.path().join("raw-only.txt"), "RAW MUST NOT BE USED")
+            .expect("raw fixture");
+        std::fs::write(confined.path().join("final-only.txt"), "FINAL").expect("final fixture");
+        let store = ProjectStore::open(data.path()).expect("Project store");
+        let owner = store
+            .create_with_bindings(
+                "Owner",
+                None,
+                vec![bamboo_domain::WorkspaceBinding {
+                    path: confined.path().to_string_lossy().into_owned(),
+                    label: None,
+                    git_common_dir: None,
+                }],
+            )
+            .expect("owner Project");
+        let other = store.create("Other", None).expect("other Project");
+
+        let resolved = validate_workspace_assignment_with(
+            &store,
+            Some(&owner.id),
+            Some(raw.path().to_string_lossy().as_ref()),
+            |_| confined.path().to_path_buf(),
+        )
+        .expect("same owner");
+        assert_eq!(
+            resolved.as_deref(),
+            Some(confined.path().canonicalize().unwrap().as_path())
+        );
+        assert!(resolved
+            .as_ref()
+            .is_some_and(|path| path.join("final-only.txt").exists()));
+        assert!(!resolved
+            .as_ref()
+            .is_some_and(|path| path.join("raw-only.txt").exists()));
+
+        let conflict = validate_workspace_assignment_with(
+            &store,
+            Some(&other.id),
+            Some(raw.path().to_string_lossy().as_ref()),
+            |_| confined.path().to_path_buf(),
+        )
+        .expect_err("final workspace owner must win over the raw request");
+        assert!(matches!(
+            conflict,
+            ProjectWorkspaceValidationError::Conflict {
+                owner_project_id,
+                ..
+            } if owner_project_id == owner.id
+        ));
     }
 }

--- a/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/actor_adapter.rs
@@ -1218,22 +1218,22 @@ impl ExternalChildRunner for ActorChildRunner {
                 self.approval_registry.clone(),
             );
 
-            let result = drive(
-                &mut *client,
-                &job.parent_session_id,
-                &job.child_session_id,
-                attempt as u32,
-                self.approval_registry.as_ref(),
-                self.approval_decider.as_ref(),
-                self.approval_reviewer.as_ref(),
-                escalation.clone(),
-                &event_tx,
-                &cancel_token,
-                &mut live_rx,
-                &mut delivery_rx,
-                session,
-                session_inbox_runtime.as_ref(),
-                bound_activation_run_id.as_deref(),
+            let result = drive(ActorDriveContext {
+                client: &mut *client,
+                parent_session_id: &job.parent_session_id,
+                child_session_id: &job.child_session_id,
+                child_attempt: attempt as u32,
+                approval_registry: self.approval_registry.as_ref(),
+                approval_decider: self.approval_decider.as_ref(),
+                approval_reviewer: self.approval_reviewer.as_ref(),
+                escalation_bridge: escalation.clone(),
+                event_tx: &event_tx,
+                cancel_token: &cancel_token,
+                live_rx: &mut live_rx,
+                delivery_rx: &mut delivery_rx,
+                logical_session: session,
+                session_inbox_runtime: session_inbox_runtime.as_ref(),
+                activation_run_id: bound_activation_run_id.as_deref(),
                 initial_inflight_claims,
                 // First-frame watchdog for EVERY placement: a wedged-but-connected
                 // worker (subscribed ≠ serving — e.g. stuck on a prior LLM call) emits
@@ -1241,8 +1241,8 @@ impl ExternalChildRunner for ActorChildRunner {
                 // turns the "running-but-unresponsive" hang into a recoverable
                 // WorkerUnresponsive (reap+respawn local / re-pick schedulable / error
                 // on a fixed remote endpoint).
-                Some(WORKER_FIRST_FRAME_TIMEOUT),
-            )
+                first_frame_timeout: Some(WORKER_FIRST_FRAME_TIMEOUT),
+            })
             .await;
             if let (Some(binding), Some(run_id)) = (
                 session_inbox_runtime.as_ref(),
@@ -1719,6 +1719,27 @@ async fn forward_next_canonical_claim(
     Ok(())
 }
 
+/// Borrowed and per-run-owned inputs for one actor frame pump.
+struct ActorDriveContext<'a> {
+    client: &'a mut dyn bamboo_subagent::ChildLink,
+    parent_session_id: &'a str,
+    child_session_id: &'a str,
+    child_attempt: u32,
+    approval_registry: Option<&'a super::approval_registry::SharedApprovalRegistry>,
+    approval_decider: Option<&'a Arc<dyn ChildApprovalDecider>>,
+    approval_reviewer: Option<&'a Arc<dyn ChildApprovalReviewer>>,
+    escalation_bridge: Option<bamboo_subagent::executor::HostBridge>,
+    event_tx: &'a mpsc::Sender<AgentEvent>,
+    cancel_token: &'a CancellationToken,
+    live_rx: &'a mut mpsc::UnboundedReceiver<ParentFrame>,
+    delivery_rx: &'a mut mpsc::UnboundedReceiver<u64>,
+    logical_session: &'a mut Session,
+    session_inbox_runtime: Option<&'a SessionInboxRuntimeBinding>,
+    activation_run_id: Option<&'a str>,
+    initial_inflight_claims: VecDeque<SessionInboxClaim>,
+    first_frame_timeout: Option<Duration>,
+}
+
 /// Pump child frames -> parent events until a terminal frame (or cancellation).
 /// On success, yields the actor's final result text (for session write-back).
 /// `live_rx` carries in-band frames (steering messages) from the live registry.
@@ -1729,25 +1750,27 @@ async fn forward_next_canonical_claim(
 /// UP to the parent run. Owning it for the call's lifetime is what lets a
 /// fire-and-forget grandchild that outlives its spawning run still escalate to
 /// the correct (then-current) parent bridge rather than a stale/overwritten one.
-async fn drive(
-    client: &mut dyn bamboo_subagent::ChildLink,
-    parent_session_id: &str,
-    child_session_id: &str,
-    child_attempt: u32,
-    approval_registry: Option<&super::approval_registry::SharedApprovalRegistry>,
-    approval_decider: Option<&Arc<dyn ChildApprovalDecider>>,
-    approval_reviewer: Option<&Arc<dyn ChildApprovalReviewer>>,
-    escalation_bridge: Option<bamboo_subagent::executor::HostBridge>,
-    event_tx: &mpsc::Sender<AgentEvent>,
-    cancel_token: &CancellationToken,
-    live_rx: &mut mpsc::UnboundedReceiver<ParentFrame>,
-    delivery_rx: &mut mpsc::UnboundedReceiver<u64>,
-    logical_session: &mut Session,
-    session_inbox_runtime: Option<&SessionInboxRuntimeBinding>,
-    activation_run_id: Option<&str>,
-    initial_inflight_claims: VecDeque<SessionInboxClaim>,
-    first_frame_timeout: Option<Duration>,
-) -> crate::runtime::runner::Result<Option<String>> {
+async fn drive(context: ActorDriveContext<'_>) -> crate::runtime::runner::Result<Option<String>> {
+    let ActorDriveContext {
+        client,
+        parent_session_id,
+        child_session_id,
+        child_attempt,
+        approval_registry,
+        approval_decider,
+        approval_reviewer,
+        escalation_bridge,
+        event_tx,
+        cancel_token,
+        live_rx,
+        delivery_rx,
+        logical_session,
+        session_inbox_runtime,
+        activation_run_id,
+        initial_inflight_claims,
+        first_frame_timeout,
+    } = context;
+
     // First-frame watchdog: a live worker emits its first frame (run-started /
     // first token) within seconds; total silence past the deadline means the
     // worker is dead (e.g. a pooled worker that exited right after checkout), so
@@ -2566,25 +2589,25 @@ mod tests {
         let cancel = CancellationToken::new();
         let (_live_tx, mut live_rx) = mpsc::unbounded_channel();
         let (_delivery_tx, mut delivery_rx) = mpsc::unbounded_channel();
-        let result = drive(
-            &mut link,
-            "parent",
-            session_id,
-            0,
-            None,
-            None,
-            None,
-            None,
-            &event_tx,
-            &cancel,
-            &mut live_rx,
-            &mut delivery_rx,
-            &mut session,
-            Some(&binding),
-            Some(run_id),
-            claims,
-            Some(Duration::from_secs(1)),
-        )
+        let result = drive(ActorDriveContext {
+            client: &mut link,
+            parent_session_id: "parent",
+            child_session_id: session_id,
+            child_attempt: 0,
+            approval_registry: None,
+            approval_decider: None,
+            approval_reviewer: None,
+            escalation_bridge: None,
+            event_tx: &event_tx,
+            cancel_token: &cancel,
+            live_rx: &mut live_rx,
+            delivery_rx: &mut delivery_rx,
+            logical_session: &mut session,
+            session_inbox_runtime: Some(&binding),
+            activation_run_id: Some(run_id),
+            initial_inflight_claims: claims,
+            first_frame_timeout: Some(Duration::from_secs(1)),
+        })
         .await
         .unwrap();
         assert_eq!(result.as_deref(), Some("done"));
@@ -3238,25 +3261,25 @@ mod tests {
 
         let result = tokio::time::timeout(
             Duration::from_secs(1),
-            drive(
-                &mut link,
-                "parent-reviewer",
-                "child-reviewer",
-                0,
-                None,
-                None,
-                Some(&reviewer),
-                None,
-                &event_tx,
-                &cancel,
-                &mut live_rx,
-                &mut delivery_rx,
-                &mut logical_session,
-                None,
-                None,
-                VecDeque::new(),
-                None,
-            ),
+            drive(ActorDriveContext {
+                client: &mut link,
+                parent_session_id: "parent-reviewer",
+                child_session_id: "child-reviewer",
+                child_attempt: 0,
+                approval_registry: None,
+                approval_decider: None,
+                approval_reviewer: Some(&reviewer),
+                escalation_bridge: None,
+                event_tx: &event_tx,
+                cancel_token: &cancel,
+                live_rx: &mut live_rx,
+                delivery_rx: &mut delivery_rx,
+                logical_session: &mut logical_session,
+                session_inbox_runtime: None,
+                activation_run_id: None,
+                initial_inflight_claims: VecDeque::new(),
+                first_frame_timeout: None,
+            }),
         )
         .await
         .expect("worker must receive the reviewer verdict before terminating");
@@ -3299,25 +3322,25 @@ mod tests {
 
         let result = tokio::time::timeout(
             Duration::from_secs(1),
-            drive(
-                &mut link,
-                "parent-no-reviewer",
-                "child-no-reviewer",
-                0,
-                None,
-                None,
-                None,
-                None,
-                &event_tx,
-                &cancel,
-                &mut live_rx,
-                &mut delivery_rx,
-                &mut logical_session,
-                None,
-                None,
-                VecDeque::new(),
-                None,
-            ),
+            drive(ActorDriveContext {
+                client: &mut link,
+                parent_session_id: "parent-no-reviewer",
+                child_session_id: "child-no-reviewer",
+                child_attempt: 0,
+                approval_registry: None,
+                approval_decider: None,
+                approval_reviewer: None,
+                escalation_bridge: None,
+                event_tx: &event_tx,
+                cancel_token: &cancel,
+                live_rx: &mut live_rx,
+                delivery_rx: &mut delivery_rx,
+                logical_session: &mut logical_session,
+                session_inbox_runtime: None,
+                activation_run_id: None,
+                initial_inflight_claims: VecDeque::new(),
+                first_frame_timeout: None,
+            }),
         )
         .await
         .expect("fail-closed reply must unblock the child immediately");
@@ -3357,25 +3380,25 @@ mod tests {
         let (_delivery_tx, mut delivery_rx) = mpsc::unbounded_channel();
         let mut logical_session = Session::new("child-x", "model");
         let mut link = SilentLink;
-        let r = drive(
-            &mut link,
-            "parent-x",
-            "child-x",
-            0,
-            None,
-            None,
-            None,
-            None,
-            &event_tx,
-            &cancel,
-            &mut live_rx,
-            &mut delivery_rx,
-            &mut logical_session,
-            None,
-            None,
-            VecDeque::new(),
-            Some(Duration::from_millis(100)),
-        )
+        let r = drive(ActorDriveContext {
+            client: &mut link,
+            parent_session_id: "parent-x",
+            child_session_id: "child-x",
+            child_attempt: 0,
+            approval_registry: None,
+            approval_decider: None,
+            approval_reviewer: None,
+            escalation_bridge: None,
+            event_tx: &event_tx,
+            cancel_token: &cancel,
+            live_rx: &mut live_rx,
+            delivery_rx: &mut delivery_rx,
+            logical_session: &mut logical_session,
+            session_inbox_runtime: None,
+            activation_run_id: None,
+            initial_inflight_claims: VecDeque::new(),
+            first_frame_timeout: Some(Duration::from_millis(100)),
+        })
         .await;
         assert!(
             matches!(r, Err(AgentError::WorkerUnresponsive(_))),
@@ -3393,25 +3416,25 @@ mod tests {
         let mut link = InstantTerminalLink { done: false };
         // Even a tiny timeout must NOT trip: the terminal frame arrives first and
         // disarms the watchdog.
-        let r = drive(
-            &mut link,
-            "parent-y",
-            "child-y",
-            0,
-            None,
-            None,
-            None,
-            None,
-            &event_tx,
-            &cancel,
-            &mut live_rx,
-            &mut delivery_rx,
-            &mut logical_session,
-            None,
-            None,
-            VecDeque::new(),
-            Some(Duration::from_millis(50)),
-        )
+        let r = drive(ActorDriveContext {
+            client: &mut link,
+            parent_session_id: "parent-y",
+            child_session_id: "child-y",
+            child_attempt: 0,
+            approval_registry: None,
+            approval_decider: None,
+            approval_reviewer: None,
+            escalation_bridge: None,
+            event_tx: &event_tx,
+            cancel_token: &cancel,
+            live_rx: &mut live_rx,
+            delivery_rx: &mut delivery_rx,
+            logical_session: &mut logical_session,
+            session_inbox_runtime: None,
+            activation_run_id: None,
+            initial_inflight_claims: VecDeque::new(),
+            first_frame_timeout: Some(Duration::from_millis(50)),
+        })
         .await;
         assert_eq!(r.ok().flatten().as_deref(), Some("done"));
     }

--- a/crates/engine/bamboo-engine/src/external_agents/live.rs
+++ b/crates/engine/bamboo-engine/src/external_agents/live.rs
@@ -68,20 +68,34 @@ pub fn initialize_durable_approvals(
     Ok((std::sync::Arc::new(Mutex::new(registry)), events))
 }
 
+/// Named identity, audit, and delivery inputs for one observed approval.
+pub struct PendingApprovalObservation<'a> {
+    pub registry: Option<&'a SharedApprovalRegistry>,
+    pub parent_session_id: &'a str,
+    pub child_id: &'a str,
+    pub child_attempt: u32,
+    pub request_id: &'a str,
+    pub tool_name: &'a str,
+    pub permission: &'a str,
+    pub resource: &'a str,
+    pub event_tx: mpsc::Sender<AgentEvent>,
+}
+
 /// Record a `(child_id, request_id)` as a pending human-loop approval. Called
 /// just before surfacing `ChildApprovalRequested` so an external POST can be
 /// correlated against a genuinely-pending request.
-pub fn register_pending_approval_observed(
-    registry: Option<&SharedApprovalRegistry>,
-    parent_session_id: &str,
-    child_id: &str,
-    child_attempt: u32,
-    request_id: &str,
-    tool_name: &str,
-    permission: &str,
-    resource: &str,
-    event_tx: mpsc::Sender<AgentEvent>,
-) -> (u64, String) {
+pub fn observe_pending_approval(observation: PendingApprovalObservation<'_>) -> (u64, String) {
+    let PendingApprovalObservation {
+        registry,
+        parent_session_id,
+        child_id,
+        child_attempt,
+        request_id,
+        tool_name,
+        permission,
+        resource,
+        event_tx,
+    } = observation;
     let now = chrono::Utc::now();
     let version = now.timestamp_micros().max(0) as u64;
     let created_at = now.to_rfc3339();
@@ -128,20 +142,52 @@ pub fn register_pending_approval_observed(
     (version, created_at)
 }
 
+/// Backward-compatible positional wrapper for existing engine consumers.
+///
+/// New call sites should use [`observe_pending_approval`] so each approval
+/// identity and audit field is named at the call site.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "public compatibility wrapper; the typed observation is the canonical API"
+)]
+pub fn register_pending_approval_observed(
+    registry: Option<&SharedApprovalRegistry>,
+    parent_session_id: &str,
+    child_id: &str,
+    child_attempt: u32,
+    request_id: &str,
+    tool_name: &str,
+    permission: &str,
+    resource: &str,
+    event_tx: mpsc::Sender<AgentEvent>,
+) -> (u64, String) {
+    observe_pending_approval(PendingApprovalObservation {
+        registry,
+        parent_session_id,
+        child_id,
+        child_attempt,
+        request_id,
+        tool_name,
+        permission,
+        resource,
+        event_tx,
+    })
+}
+
 #[cfg(test)]
 fn register_pending_approval(child_id: &str, request_id: &str) {
     let (event_tx, _rx) = mpsc::channel(1);
-    let _ = register_pending_approval_observed(
-        None,
-        "test-parent",
+    let _ = observe_pending_approval(PendingApprovalObservation {
+        registry: None,
+        parent_session_id: "test-parent",
         child_id,
-        0,
+        child_attempt: 0,
         request_id,
-        "test-tool",
-        "test-permission",
-        "test-resource",
+        tool_name: "test-tool",
+        permission: "test-permission",
+        resource: "test-resource",
         event_tx,
-    );
+    });
 }
 
 /// One-shot consume of a `(child_id, request_id)` pending pair: remove it and
@@ -699,17 +745,17 @@ mod tests {
         let (wire_tx, _wire_rx) = mpsc::unbounded_channel();
         let _guard = register("c-audit", wire_tx, 0, None);
         let (event_tx, mut event_rx) = mpsc::channel(8);
-        register_pending_approval_observed(
-            None,
-            "parent-audit",
-            "c-audit",
-            0,
-            "req-audit",
-            "Bash",
-            "execute",
-            "/tmp/x",
+        observe_pending_approval(PendingApprovalObservation {
+            registry: None,
+            parent_session_id: "parent-audit",
+            child_id: "c-audit",
+            child_attempt: 0,
+            request_id: "req-audit",
+            tool_name: "Bash",
+            permission: "execute",
+            resource: "/tmp/x",
             event_tx,
-        );
+        });
 
         assert!(deliver_approval_checked(
             None,
@@ -736,17 +782,17 @@ mod tests {
         let (wire_tx, _wire_rx) = mpsc::unbounded_channel();
         let _guard = register("c-versioned", wire_tx, 7, Some(registry.clone()));
         let (event_tx, mut event_rx) = mpsc::channel(4);
-        let (pending_version, _) = register_pending_approval_observed(
-            Some(&registry),
-            "parent-versioned",
-            "c-versioned",
-            7,
-            "req-versioned",
-            "Bash",
-            "execute",
-            "/tmp/versioned",
+        let (pending_version, _) = observe_pending_approval(PendingApprovalObservation {
+            registry: Some(&registry),
+            parent_session_id: "parent-versioned",
+            child_id: "c-versioned",
+            child_attempt: 7,
+            request_id: "req-versioned",
+            tool_name: "Bash",
+            permission: "execute",
+            resource: "/tmp/versioned",
             event_tx,
-        );
+        });
 
         assert!(deliver_approval_checked(
             Some(&registry),
@@ -768,17 +814,17 @@ mod tests {
     #[tokio::test]
     async fn timeout_and_disconnect_emit_terminal_outcomes() {
         let (event_tx, mut event_rx) = mpsc::channel(8);
-        register_pending_approval_observed(
-            None,
-            "parent-audit",
-            "c-expire",
-            0,
-            "req-expire",
-            "Bash",
-            "execute",
-            "/tmp/x",
-            event_tx.clone(),
-        );
+        observe_pending_approval(PendingApprovalObservation {
+            registry: None,
+            parent_session_id: "parent-audit",
+            child_id: "c-expire",
+            child_attempt: 0,
+            request_id: "req-expire",
+            tool_name: "Bash",
+            permission: "execute",
+            resource: "/tmp/x",
+            event_tx: event_tx.clone(),
+        });
         assert!(expire_pending_approval(None, "c-expire", "req-expire"));
         assert!(!expire_pending_approval(None, "c-expire", "req-expire"));
         assert!(matches!(
@@ -786,17 +832,17 @@ mod tests {
             Some(AgentEvent::ChildApprovalChanged { status, .. }) if status == "expired"
         ));
 
-        register_pending_approval_observed(
-            None,
-            "parent-audit",
-            "c-disconnect",
-            0,
-            "req-disconnect",
-            "Write",
-            "write",
-            "/tmp/y",
+        observe_pending_approval(PendingApprovalObservation {
+            registry: None,
+            parent_session_id: "parent-audit",
+            child_id: "c-disconnect",
+            child_attempt: 0,
+            request_id: "req-disconnect",
+            tool_name: "Write",
+            permission: "write",
+            resource: "/tmp/y",
             event_tx,
-        );
+        });
         clear_pending_approvals_for(None, "c-disconnect", 0);
         assert!(matches!(
             event_rx.recv().await,

--- a/crates/engine/bamboo-engine/src/lib.rs
+++ b/crates/engine/bamboo-engine/src/lib.rs
@@ -61,7 +61,8 @@ pub use runtime::agent::{AgentBuilder, DirectExecutionLease};
 // `AgentRuntime::execute`.
 pub use runtime::config::{
     ApprovalDelegate, AuxiliaryModelConfig, BashResumeHook, ChildApprovalOutcome,
-    ChildApprovalRequest, GuardianConfig, GuardianSpawner, ImageFallbackConfig, ImageFallbackMode,
+    ChildApprovalRequest, DisabledFilterResolver, DisabledFilterSets, GuardianConfig,
+    GuardianSpawner, ImageFallbackConfig, ImageFallbackMode,
 };
 pub use runtime::execution::runner_state::{AgentRunner, AgentStatus};
 pub use runtime::hooks::{

--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -19,6 +19,12 @@ use serde::{Deserialize, Serialize};
 
 use super::hooks::HookRunner;
 
+/// The live disabled tool and skill-id sets resolved at a round boundary.
+pub type DisabledFilterSets = (BTreeSet<String>, BTreeSet<String>);
+
+/// Late-bound resolver for disabled tool and skill-id filters.
+pub type DisabledFilterResolver = Arc<dyn Fn() -> DisabledFilterSets + Send + Sync>;
+
 #[derive(Clone, Default)]
 pub struct AuxiliaryModelConfig {
     pub fast_model_name: Option<String>,
@@ -501,8 +507,7 @@ pub struct AgentLoopConfig {
     /// `disabled_tools` / `disabled_skill_ids` fields below are used (#44 behavior).
     /// Re-resolved each round at the tool-schema filter, so disabling/re-enabling a
     /// tool mid-run takes effect on the next round. #136.
-    pub(crate) disabled_filter_resolver:
-        Option<Arc<dyn Fn() -> (BTreeSet<String>, BTreeSet<String>) + Send + Sync>>,
+    pub(crate) disabled_filter_resolver: Option<DisabledFilterResolver>,
     /// Server-level usage guidance contributed by the run's tool executor —
     /// chiefly the `instructions` connected MCP servers return from `initialize`.
     /// Captured once at config construction (from `ToolExecutor::tool_guidance`)

--- a/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
+++ b/crates/engine/bamboo-engine/src/runtime/execution/agent_spawn.rs
@@ -18,8 +18,8 @@ use bamboo_domain::ReasoningEffort;
 use bamboo_llm::LLMProvider;
 
 use crate::runtime::config::{
-    AuxiliaryModelConfig, BashCompletionSink, BashResumeHook, GoldConfig, GuardianConfig,
-    GuardianSpawner, ImageFallbackConfig,
+    AuxiliaryModelConfig, BashCompletionSink, BashResumeHook, DisabledFilterResolver, GoldConfig,
+    GuardianConfig, GuardianSpawner, ImageFallbackConfig,
 };
 use crate::runtime::execution::child_completion::ChildCompletion;
 use crate::runtime::execution::runner_lifecycle::{
@@ -530,8 +530,7 @@ pub struct SessionExecutionArgs {
     /// Optional per-round live resolver for the disabled tool/skill sets (#136).
     /// When `None` the per-run snapshot is used (sub-agent spawns pass `None`, so
     /// short-lived children keep the spawn-time snapshot — by design).
-    pub disabled_filter_resolver:
-        Option<Arc<dyn Fn() -> (BTreeSet<String>, BTreeSet<String>) + Send + Sync>>,
+    pub disabled_filter_resolver: Option<DisabledFilterResolver>,
     pub disabled_tools: Option<BTreeSet<String>>,
     pub disabled_skill_ids: Option<BTreeSet<String>>,
     pub selected_skill_ids: Option<Vec<String>>,
@@ -590,8 +589,7 @@ struct ExecuteRequestParams {
     model_roster: ModelRoster,
     reasoning_effort: Option<ReasoningEffort>,
     auxiliary_model_resolver: Option<Arc<dyn Fn() -> AuxiliaryModelConfig + Send + Sync>>,
-    disabled_filter_resolver:
-        Option<Arc<dyn Fn() -> (BTreeSet<String>, BTreeSet<String>) + Send + Sync>>,
+    disabled_filter_resolver: Option<DisabledFilterResolver>,
     disabled_tools: Option<BTreeSet<String>>,
     disabled_skill_ids: Option<BTreeSet<String>>,
     selected_skill_ids: Option<Vec<String>>,

--- a/crates/engine/bamboo-engine/src/runtime/managers/adapters/tool.rs
+++ b/crates/engine/bamboo-engine/src/runtime/managers/adapters/tool.rs
@@ -76,20 +76,22 @@ impl ToolManager for DefaultToolManager {
             biased;
             _ = cancel.cancelled() => return Err(AgentError::Cancelled),
             result = crate::runtime::runner::tool_execution::execute_round_tool_calls(
-                tool_calls,
-                &frame,
-                session,
-                &mut runtime_state,
-                task_context,
-                config
-                    .summarization_model_name
-                    .as_deref()
-                    .or(config.background_model_name.as_deref()),
-                config
-                    .summarization_model_provider
-                    .as_ref()
-                    .or(config.background_model_provider.as_ref()),
-                tool_schemas,
+                crate::runtime::runner::tool_execution::RoundToolExecution {
+                    tool_calls,
+                    frame: &frame,
+                    session,
+                    runtime_state: &mut runtime_state,
+                    task_context,
+                    compression_model_name: config
+                        .summarization_model_name
+                        .as_deref()
+                        .or(config.background_model_name.as_deref()),
+                    compression_model_provider: config
+                        .summarization_model_provider
+                        .as_ref()
+                        .or(config.background_model_provider.as_ref()),
+                    tool_schemas,
+                },
             ) => result?,
         };
         if !config.hook_runner.is_empty() {

--- a/crates/engine/bamboo-engine/src/runtime/mod.rs
+++ b/crates/engine/bamboo-engine/src/runtime/mod.rs
@@ -22,8 +22,9 @@ pub use agent::{Agent, AgentBuilder};
 pub use bamboo_domain::RuntimeSessionPersistence;
 pub use complexity_classifier::{ComplexityClassifier, TaskComplexity};
 pub use config::{
-    ApprovalDelegate, ChildApprovalOutcome, ChildApprovalRequest, GoldConfig, GuardianConfig,
-    GuardianSpawner, ImageFallbackConfig, ImageFallbackMode,
+    ApprovalDelegate, ChildApprovalOutcome, ChildApprovalRequest, DisabledFilterResolver,
+    DisabledFilterSets, GoldConfig, GuardianConfig, GuardianSpawner, ImageFallbackConfig,
+    ImageFallbackMode,
 };
 // `AgentLoopConfig` is intentionally NOT re-exported: its fields are `pub(crate)`,
 // so it is unconstructible outside the engine. Internal call sites reach it via

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -1291,19 +1291,21 @@ async fn handle_tool_calls_path(
         biased;
         _ = cancel_token.cancelled() => return Err(AgentError::Cancelled),
         result = crate::runtime::runner::tool_execution::execute_round_tool_calls(
-            &stream_output.tool_calls,
-            frame,
-            session,
-            runtime_state,
-            task_context,
-            compression_model
-                .as_deref()
-                .or(auxiliary_models.background_model_name.as_deref()),
-            auxiliary_models
-                .summarization_model_provider
-                .as_ref()
-                .or(auxiliary_models.background_model_provider.as_ref()),
-            &tool_schemas,
+            crate::runtime::runner::tool_execution::RoundToolExecution {
+                tool_calls: &stream_output.tool_calls,
+                frame,
+                session,
+                runtime_state,
+                task_context,
+                compression_model_name: compression_model
+                    .as_deref()
+                    .or(auxiliary_models.background_model_name.as_deref()),
+                compression_model_provider: auxiliary_models
+                    .summarization_model_provider
+                    .as_ref()
+                    .or(auxiliary_models.background_model_provider.as_ref()),
+                tool_schemas: &tool_schemas,
+            },
         ) => result?,
     };
 
@@ -5496,18 +5498,18 @@ mod tests {
 
         let result = tokio::time::timeout(
             Duration::from_secs(10),
-            execute_round_tool_calls(
-                std::slice::from_ref(&single_read_call()),
-                &frame,
-                &mut session,
-                &mut runtime_state,
-                &mut task_context,
+            execute_round_tool_calls(crate::runtime::runner::tool_execution::RoundToolExecution {
+                tool_calls: std::slice::from_ref(&single_read_call()),
+                frame: &frame,
+                session: &mut session,
+                runtime_state: &mut runtime_state,
+                task_context: &mut task_context,
                 // No compression model -> mid-turn compression short-circuits, so
                 // the healthy path is exercised without any auxiliary LLM call.
-                None,
-                None,
-                &tool_schemas,
-            ),
+                compression_model_name: None,
+                compression_model_provider: None,
+                tool_schemas: &tool_schemas,
+            }),
         )
         .await
         .expect("normal tool batch did not complete within 10s");

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution.rs
@@ -410,16 +410,31 @@ async fn maybe_apply_mid_turn_context_compression_after_tool(
     }
 }
 
+pub(crate) struct RoundToolExecution<'a, 'frame> {
+    pub(crate) tool_calls: &'a [ToolCall],
+    pub(crate) frame: &'a crate::runtime::runner::round_frame::RoundFrame<'frame>,
+    pub(crate) session: &'a mut Session,
+    pub(crate) runtime_state: &'a mut AgentRuntimeState,
+    pub(crate) task_context: &'a mut Option<TaskLoopContext>,
+    pub(crate) compression_model_name: Option<&'a str>,
+    pub(crate) compression_model_provider: Option<&'a Arc<dyn LLMProvider>>,
+    pub(crate) tool_schemas: &'a [ToolSchema],
+}
+
 pub(crate) async fn execute_round_tool_calls(
-    tool_calls: &[ToolCall],
-    frame: &crate::runtime::runner::round_frame::RoundFrame<'_>,
-    session: &mut Session,
-    runtime_state: &mut AgentRuntimeState,
-    task_context: &mut Option<TaskLoopContext>,
-    compression_model_name: Option<&str>,
-    compression_model_provider: Option<&Arc<dyn LLMProvider>>,
-    tool_schemas: &[ToolSchema],
+    execution: RoundToolExecution<'_, '_>,
 ) -> Result<RoundToolExecutionResult, AgentError> {
+    let RoundToolExecution {
+        tool_calls,
+        frame,
+        session,
+        runtime_state,
+        task_context,
+        compression_model_name,
+        compression_model_provider,
+        tool_schemas,
+    } = execution;
+
     // Bind frame fields as locals so the rest of the function body stays unchanged.
     let event_tx = frame.event_tx;
     let metrics_collector = frame.metrics_collector;

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification.rs
@@ -289,16 +289,29 @@ pub(super) async fn suspend_for_pending_question(
     persist_session_after_question(config, session, session_id).await;
 }
 
-pub(super) async fn maybe_handle_user_question_tool(
-    tool_call: &ToolCall,
-    result: &ToolResult,
-    session: &mut Session,
-    event_tx: &mpsc::Sender<AgentEvent>,
-    metrics_collector: Option<&MetricsCollector>,
-    session_id: &str,
-    round_id: &str,
-    config: &AgentLoopConfig,
-) -> bool {
+pub(super) struct UserQuestionToolContext<'a> {
+    pub(super) tool_call: &'a ToolCall,
+    pub(super) result: &'a ToolResult,
+    pub(super) session: &'a mut Session,
+    pub(super) event_tx: &'a mpsc::Sender<AgentEvent>,
+    pub(super) metrics_collector: Option<&'a MetricsCollector>,
+    pub(super) session_id: &'a str,
+    pub(super) round_id: &'a str,
+    pub(super) config: &'a AgentLoopConfig,
+}
+
+pub(super) async fn maybe_handle_user_question_tool(context: UserQuestionToolContext<'_>) -> bool {
+    let UserQuestionToolContext {
+        tool_call,
+        result,
+        session,
+        event_tx,
+        metrics_collector,
+        session_id,
+        round_id,
+        config,
+    } = context;
+
     if !should_handle_user_question_tool(tool_call, result) {
         return false;
     }

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/clarification/tests.rs
@@ -1,6 +1,6 @@
 use tokio::sync::mpsc;
 
-use super::maybe_handle_user_question_tool;
+use super::{maybe_handle_user_question_tool, UserQuestionToolContext};
 use crate::runtime::config::AgentLoopConfig;
 use bamboo_agent_core::tools::{FunctionCall, ToolCall, ToolResult};
 use bamboo_agent_core::{AgentEvent, Role, Session};
@@ -33,16 +33,16 @@ async fn maybe_handle_user_question_tool_sets_pending_question_and_emits_events(
     let (tx, mut rx) = mpsc::channel(8);
     let mut session = Session::new("session-1", "model");
 
-    let handled = maybe_handle_user_question_tool(
-        &tool_call,
-        &result,
-        &mut session,
-        &tx,
-        None,
-        "session-1",
-        "round-1",
-        &AgentLoopConfig::default(),
-    )
+    let handled = maybe_handle_user_question_tool(UserQuestionToolContext {
+        tool_call: &tool_call,
+        result: &result,
+        session: &mut session,
+        event_tx: &tx,
+        metrics_collector: None,
+        session_id: "session-1",
+        round_id: "round-1",
+        config: &AgentLoopConfig::default(),
+    })
     .await;
 
     assert!(handled);
@@ -126,16 +126,16 @@ async fn maybe_handle_user_question_tool_handles_request_permissions() {
     let (tx, mut rx) = mpsc::channel(8);
     let mut session = Session::new("session-perm", "model");
 
-    let handled = maybe_handle_user_question_tool(
-        &tool_call,
-        &result,
-        &mut session,
-        &tx,
-        None,
-        "session-perm",
-        "round-1",
-        &AgentLoopConfig::default(),
-    )
+    let handled = maybe_handle_user_question_tool(UserQuestionToolContext {
+        tool_call: &tool_call,
+        result: &result,
+        session: &mut session,
+        event_tx: &tx,
+        metrics_collector: None,
+        session_id: "session-perm",
+        round_id: "round-1",
+        config: &AgentLoopConfig::default(),
+    })
     .await;
 
     assert!(
@@ -266,16 +266,16 @@ async fn maybe_handle_user_question_tool_persists_exit_plan_file_and_emits_updat
         updated_at: Utc::now(),
     });
 
-    let handled = maybe_handle_user_question_tool(
-        &tool_call,
-        &result,
-        &mut session,
-        &tx,
-        None,
-        "session-exit-plan",
-        "round-1",
-        &config,
-    )
+    let handled = maybe_handle_user_question_tool(UserQuestionToolContext {
+        tool_call: &tool_call,
+        result: &result,
+        session: &mut session,
+        event_tx: &tx,
+        metrics_collector: None,
+        session_id: "session-exit-plan",
+        round_id: "round-1",
+        config: &config,
+    })
     .await;
 
     assert!(handled);
@@ -372,16 +372,16 @@ async fn maybe_handle_user_question_tool_ignores_unrelated_tool_calls() {
     let (tx, mut rx) = mpsc::channel(4);
     let mut session = Session::new("session-1", "model");
 
-    let handled = maybe_handle_user_question_tool(
-        &tool_call,
-        &result,
-        &mut session,
-        &tx,
-        None,
-        "session-1",
-        "round-1",
-        &AgentLoopConfig::default(),
-    )
+    let handled = maybe_handle_user_question_tool(UserQuestionToolContext {
+        tool_call: &tool_call,
+        result: &result,
+        session: &mut session,
+        event_tx: &tx,
+        metrics_collector: None,
+        session_id: "session-1",
+        round_id: "round-1",
+        config: &AgentLoopConfig::default(),
+    })
     .await;
 
     assert!(!handled);

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/execution_paths/success_path.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/execution_paths/success_path.rs
@@ -97,16 +97,16 @@ pub(super) async fn handle_successful_tool_result(mut ctx: SuccessPathContext<'_
         ctx.round,
     );
 
-    if clarification::maybe_handle_user_question_tool(
-        ctx.tool_call,
-        ctx.result,
-        ctx.session,
-        ctx.event_tx,
-        ctx.metrics_collector,
-        ctx.session_id,
-        ctx.round_id,
-        ctx.config,
-    )
+    if clarification::maybe_handle_user_question_tool(clarification::UserQuestionToolContext {
+        tool_call: ctx.tool_call,
+        result: ctx.result,
+        session: ctx.session,
+        event_tx: ctx.event_tx,
+        metrics_collector: ctx.metrics_collector,
+        session_id: ctx.session_id,
+        round_id: ctx.round_id,
+        config: ctx.config,
+    })
     .await
     {
         ctx.state.mark_awaiting_clarification();

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -23,8 +23,9 @@ use bamboo_metrics::MetricsCollector;
 use bamboo_skills::SkillManager;
 
 use crate::runtime::config::{
-    AgentLoopConfig, AuxiliaryModelConfig, BashCompletionSink, BashResumeHook, GoldConfig,
-    GuardianConfig, GuardianSpawner, ImageFallbackConfig, PromptMemoryFlags,
+    AgentLoopConfig, AuxiliaryModelConfig, BashCompletionSink, BashResumeHook,
+    DisabledFilterResolver, GoldConfig, GuardianConfig, GuardianSpawner, ImageFallbackConfig,
+    PromptMemoryFlags,
 };
 use crate::runtime::hooks::HookRunner;
 use crate::runtime::model_roster::{ModelRoster, RoleModel};
@@ -276,8 +277,7 @@ pub struct ExecuteRequest {
     pub auxiliary_model_resolver: Option<Arc<dyn Fn() -> AuxiliaryModelConfig + Send + Sync>>,
     /// Optional per-round live resolver for the disabled tool/skill sets (#136).
     /// When `None`, the snapshotted `disabled_tools`/`disabled_skill_ids` are used.
-    pub disabled_filter_resolver:
-        Option<Arc<dyn Fn() -> (BTreeSet<String>, BTreeSet<String>) + Send + Sync>>,
+    pub disabled_filter_resolver: Option<DisabledFilterResolver>,
     /// When `None`, falls back to `Config::disabled_tool_names()`.
     pub disabled_tools: Option<BTreeSet<String>>,
     /// When `None`, falls back to `Config::disabled_skill_ids()`.
@@ -345,8 +345,7 @@ pub struct ExecuteRequestBuilder {
     summarization_model_provider: Option<Arc<dyn LLMProvider>>,
     reasoning_effort: Option<ReasoningEffort>,
     auxiliary_model_resolver: Option<Arc<dyn Fn() -> AuxiliaryModelConfig + Send + Sync>>,
-    disabled_filter_resolver:
-        Option<Arc<dyn Fn() -> (BTreeSet<String>, BTreeSet<String>) + Send + Sync>>,
+    disabled_filter_resolver: Option<DisabledFilterResolver>,
     disabled_tools: Option<BTreeSet<String>>,
     disabled_skill_ids: Option<BTreeSet<String>>,
     selected_skill_ids: Option<Vec<String>>,
@@ -502,10 +501,7 @@ impl ExecuteRequestBuilder {
     }
 
     /// Set the per-round resolver for the live disabled tool/skill sets (#136).
-    pub fn disabled_filter_resolver(
-        mut self,
-        v: Arc<dyn Fn() -> (BTreeSet<String>, BTreeSet<String>) + Send + Sync>,
-    ) -> Self {
+    pub fn disabled_filter_resolver(mut self, v: DisabledFilterResolver) -> Self {
         self.disabled_filter_resolver = Some(v);
         self
     }

--- a/crates/engine/bamboo-engine/src/session_activation.rs
+++ b/crates/engine/bamboo-engine/src/session_activation.rs
@@ -16,6 +16,9 @@ use bamboo_domain::{
 };
 use tokio::sync::{mpsc, watch, Mutex, RwLock};
 
+type AsyncRollback =
+    Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> + Send + 'static>;
+
 /// A reservation whose runner slot already exists but whose task has not yet
 /// been launched. The router publishes the logical owner before calling
 /// `launch`, so even an immediately-completing task participates in the
@@ -23,9 +26,7 @@ use tokio::sync::{mpsc, watch, Mutex, RwLock};
 pub struct SessionActivationLaunch {
     pub run_id: String,
     launch: Option<Box<dyn FnOnce() + Send + 'static>>,
-    rollback: Option<
-        Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> + Send + 'static>,
-    >,
+    rollback: Option<AsyncRollback>,
     rollback_completion: Option<Arc<RollbackCompletion>>,
 }
 


### PR DESCRIPTION
## Summary

- replace repeated disabled-filter callback shapes with shared transparent aliases
- group high-arity actor, approval, execution, tool, and WebSocket inputs into named typed contexts
- preserve the public positional approval API through one narrowly justified compatibility wrapper
- directly fix the boolean assertion and test-module ordering diagnostics

The change is behavior-preserving and does not alter request contracts, routing, cancellation, approval, WebSocket, compression, or activation semantics.

Closes #714

## Test Plan

- `cargo clippy -p bamboo-config -p bamboo-server --all-features --lib --tests -- -D warnings`
- `cargo clippy -p bamboo-config -p bamboo-server --all-features --lib --tests --no-deps -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo test --all-features --lib --tests` — engine 1202/1202; server 1602 passed + 1 ignored; `ws_v2_live` 16/16
- `cargo test --tests` — engine 1202/1202; server 1601 passed + 1 ignored; `ws_v2_live` 16/16
- focused behavior suites — engine 377, server 51, SDK 1
- independent adversarial reviewer suites — engine 47, server 33, SDK 1
- `cargo build --examples`
- `cargo fmt --all -- --check`

A fresh adversarial review of exact commit `7ffd64091a3e74e231e0f97aa1320af7cc391bd6` reported no findings. The known macOS oversized `__eh_frame` linker warning remains tracked in #715. An unrelated timing-sensitive create-session test-isolation finding was filed separately as #717; this PR contains no fix for it, and both full test gates passed.

## Screenshots

N/A — internal Rust refactor only.