### PR TITLE
fix: upgrade russh to 0.62.4 (#719)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,15 +2347,16 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-rc.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto",
+ "rand_core 0.10.1",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -2645,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-rc.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1685663e23882cd8517dcbcb1c23a6ebff4433c22dfb681d760219b62cd1b849"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -4258,7 +4259,7 @@ dependencies = [
  "module-lattice",
  "pkcs8",
  "rand_core 0.10.1",
- "sha3",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -4640,9 +4641,9 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bb40a5099e2c38a09dd29321a7a7f045f165a54317679c7cdfb0cbaf8f6b1e"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4653,9 +4654,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492f329d7eb11d22dadc988626b9ea1f503b4ab043a8b1e4e2cc4ae45dabdd70"
+checksum = "d17b851e6b3e378ab4ecb07fa2ed23f4d15f075735f8fec9fa1e7bdce5f8301f"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4667,9 +4668,9 @@ dependencies = [
 
 [[package]]
 name = "p521"
-version = "0.14.0-rc.15"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff42e4ace5424e3b6d7cb82514be89866b85af87015f80341e37dcc21a66ce6e"
+checksum = "4ad64cc32c2dc466317c12ee5853e61f159f9eab1fe7efade0395dc2e7b43449"
 dependencies = [
  "base16ct",
  "ecdsa",
@@ -5780,9 +5781,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.62.2"
+version = "0.62.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6c3c1dd0a9ad3a9915a2f6e907d158f9a7e9ac32ddc772b003faafc027d9a8"
+checksum = "b8b67b5a0d8068c89dcbe9d95df986af7a851d1f3c604525274c37468e60464f"
 dependencies = [
  "aes",
  "bitflags 2.13.0",
@@ -5837,7 +5838,7 @@ dependencies = [
  "sec1",
  "sha1 0.11.0",
  "sha2 0.11.0",
- "sha3",
+ "sha3 0.12.0",
  "signature",
  "spki",
  "ssh-encoding",
@@ -6291,6 +6292,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6414,6 +6426,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "sqlite-wasm-rs"

--- a/crates/app/bamboo-broker/Cargo.toml
+++ b/crates/app/bamboo-broker/Cargo.toml
@@ -38,7 +38,7 @@ tokio-tungstenite = { version = "0.29", default-features = false, features = ["c
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
 rustls-pemfile = "2"
-russh = { version = "0.62", default-features = false, features = ["ring", "flate2", "rsa"] }
+russh = { version = "0.62.4", default-features = false, features = ["ring", "flate2", "rsa"] }
 russh-sftp = "2.3.0"
 sha2 = "0.11"
 # Per-connection message-rate limiting (#53). The broker is a plain

--- a/crates/app/bamboo-server/Cargo.toml
+++ b/crates/app/bamboo-server/Cargo.toml
@@ -116,14 +116,10 @@ base64 = "0.22"
 # `Verifier::verify`, and test keypairs use `SigningKey::from_bytes` (a fixed
 # 32-byte "secret"), so no CSPRNG feature (`rand_core`) is needed anywhere.
 #
-# Pinned to the exact prerelease `russh` (SSH deploy, `bamboo-broker`) already
-# requires (`=3.0.0-rc.1`) — a looser `"3"` requirement lets cargo prefer the
-# stable `3.0.0` release for THIS crate while russh is stuck on the `-rc.1`
-# exact pin, and cargo refuses to select two versions of the same crate for
-# one dependency graph; matching russh's exact pin keeps a single resolved
-# version (the one already in Cargo.lock, adding no new crate to the tree).
-# TODO: move to a stable release once russh's pin does.
-ed25519-dalek = { version = "=3.0.0-rc.1" }
+# Keep the direct pin aligned with the stable release selected by `russh`
+# (SSH deploy, `bamboo-broker`) so signature verification and SSH host-key
+# support share one resolved version.
+ed25519-dalek = { version = "=3.0.0" }
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Plugin source staging (`src/plugin_source.rs`): unpacking a local/remote
 # `.tar.gz`/`.tgz` plugin bundle or platform-artifact archive. `flate2` is


### PR DESCRIPTION
## Summary

- raise Bamboo's direct `russh` floor from `0.62`/locked `0.62.2` to patched `0.62.4`, resolving `GHSA-g9hv-x236-4qp3`, `GHSA-cqjc-rmpq-xprq`, and `GHSA-5xvq-cp9x-6p6r`
- align Bamboo Server's exact `ed25519-dalek` pin from `3.0.0-rc.1` to stable `3.0.0`, matching russh 0.62.4 and preserving a single shared version
- keep the lockfile transition limited to russh-required stable Crypto packages and SHA-3 0.12; no advisory suppression, `aws-lc-sys`, `cmake`, or unrelated dependency update

## Test Plan

- `cargo test --workspace --all-features`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo audit` — 763 dependencies, clean
- focused broker deploy tests — 9 passed
- focused SSH/reverse-tunnel tests — 4 passed
- stable Ed25519 signature tests — 7 passed
- disposable live OpenSSH fixture — 1 passed, covering password auth, TOFU, SFTP upload/chmod, remote launch, and reverse tunnel; fixture removed afterward
- fresh adversarial review — no findings; independent fresh-target broker 90 tests, signature 7 tests, workspace check, Clippy, audit, format, graph/feature verification

## Screenshots

Not applicable; dependency/security-only change.

## Scope boundaries

- The pre-existing declared Rust 1.84 versus resolved dependency Rust 1.85 mismatch is tracked separately in #720 and is not changed here.
- The pre-existing macOS oversized `__eh_frame` linker warning is tracked in #715.

Closes #719