### PR TITLE
fix: isolate create-session workspace providers

### DIFF
--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -204,47 +204,66 @@ impl AppState {
 
         let config = Arc::new(RwLock::new(config));
 
-        // Wire the configured-default-workspace resolver into agent-core. This keeps
-        // the dependency arrow pointing down (agent-core owns only the slot; the
-        // server fills it). The closure reads the server's LIVE in-memory config —
-        // not a fresh disk-reading Config::new(), which would diverge from the live
-        // config and clobber the global env-var cache (#38). `try_read` never blocks
-        // (the resolver is called from sync code, so a blocking read could deadlock);
-        // on the rare write-lock contention it returns the last successfully-resolved
-        // path so a session never transiently falls back to the process cwd.
-        {
+        // Build one coherent configured-default/root provider pair. The process
+        // globals below intentionally remain first-registration-wins, while
+        // this AppState retains the same pair for instance-scoped Project
+        // preview and post-persistence publication (#717).
+        //
+        // The default closure reads the LIVE in-memory config, not a fresh
+        // disk-reading Config::new() (#38). `try_read` never blocks (the
+        // resolver is called from sync code); on write-lock contention it
+        // returns the last successful value rather than transiently falling
+        // back to another source.
+        let live_default_workspace: Arc<dyn Fn() -> Option<PathBuf> + Send + Sync> = {
             let config_for_workspace = config.clone();
             let last_known: Arc<std::sync::Mutex<Option<PathBuf>>> =
                 Arc::new(std::sync::Mutex::new(None));
-            bamboo_agent_core::workspace_state::set_default_workspace_provider(Box::new(
-                move || match config_for_workspace.try_read() {
-                    Ok(cfg) => {
-                        let path = cfg.get_default_work_area_path();
-                        if let Ok(mut cache) = last_known.lock() {
-                            *cache = path.clone();
-                        }
-                        path
+            Arc::new(move || match config_for_workspace.try_read() {
+                Ok(cfg) => {
+                    let path = cfg.get_default_work_area_path();
+                    if let Ok(mut cache) = last_known.lock() {
+                        *cache = path.clone();
                     }
-                    Err(_) => last_known.lock().ok().and_then(|c| c.clone()),
-                },
-            ));
-        }
+                    path
+                }
+                Err(_) => last_known.lock().ok().and_then(|cache| cache.clone()),
+            })
+        };
 
-        // Issue #217: wire the workspace-root + confinement policy into
-        // agent-core, mirroring the default-workspace provider just above.
-        // This is what lets `workspace_or_process_cwd` default a session with
-        // NO configured/explicit workspace to `data_dir/workspaces/{session}`
-        // instead of falling through to the server process's cwd, and lets
-        // `set_workspace` pin/relocate an explicit path when confinement is
-        // enabled (`BAMBOO_WORKSPACE_CONFINE` / `BAMBOO_WORKSPACE_ROOT`).
-        // Read fresh from the environment on every call (not captured here)
-        // so an operator-set env var is honored the same way `bamboo_dir()`
-        // itself is — no config-file knob needed.
-        bamboo_agent_core::workspace_state::set_workspace_root_provider(Box::new(|| {
-            bamboo_agent_core::workspace_state::WorkspaceRootConfig {
-                root: bamboo_config::paths::resolve_workspace_root(),
-                confine: bamboo_config::paths::workspace_confinement_enforced(),
-            }
+        // Issue #217: the root provider re-reads operator env policy on every
+        // call. Its no-override fallback is this AppState's own data directory,
+        // not the unrelated process-global bamboo_dir that another test state
+        // may have registered first.
+        let live_workspace_root: Arc<
+            dyn Fn() -> bamboo_agent_core::workspace_state::WorkspaceRootConfig + Send + Sync,
+        > = {
+            let app_data_dir = data_dir.clone();
+            Arc::new(
+                move || bamboo_agent_core::workspace_state::WorkspaceRootConfig {
+                    root: bamboo_config::paths::resolve_workspace_root_in(&app_data_dir),
+                    confine: bamboo_config::paths::workspace_confinement_enforced(),
+                },
+            )
+        };
+
+        let workspace_resolver = bamboo_agent_core::workspace_state::WorkspaceResolver::new(
+            {
+                let provider = live_default_workspace.clone();
+                move || provider()
+            },
+            {
+                let provider = live_workspace_root.clone();
+                move || provider()
+            },
+        );
+
+        bamboo_agent_core::workspace_state::set_default_workspace_provider(Box::new({
+            let provider = live_default_workspace;
+            move || provider()
+        }));
+        bamboo_agent_core::workspace_state::set_workspace_root_provider(Box::new({
+            let provider = live_workspace_root;
+            move || provider()
         }));
 
         let (permission_checker, permission_section) =
@@ -470,9 +489,12 @@ impl AppState {
         // Interactive execution paths pass an explicit tool surface override:
         // root sessions use ToolSurface::Root; child sessions use ToolSurface::Child.
         let project_context_resolver = Arc::new(
-            bamboo_engine::project_context::ProjectContextResolver::new(Arc::new(
-                crate::project_context::ProjectStoreContextSource::new(project_store.clone()),
-            )),
+            bamboo_engine::project_context::ProjectContextResolver::new_with_workspace_resolver(
+                Arc::new(crate::project_context::ProjectStoreContextSource::new(
+                    project_store.clone(),
+                )),
+                workspace_resolver.clone(),
+            ),
         );
         let agent = Arc::new(
             bamboo_engine::Agent::builder()
@@ -951,6 +973,7 @@ impl AppState {
             session_store,
             project_store,
             project_context_resolver,
+            workspace_resolver,
             session_repo,
             persistence,
             session_inbox,

--- a/crates/app/bamboo-server/src/app_state/mod.rs
+++ b/crates/app/bamboo-server/src/app_state/mod.rs
@@ -242,6 +242,12 @@ pub struct AppState {
     /// resolve one authoritative Project/workspace identity.
     pub project_context_resolver: Arc<bamboo_engine::project_context::ProjectContextResolver>,
 
+    /// Instance-scoped live workspace providers used for preview and
+    /// post-persistence publication. The equivalent process-global providers
+    /// remain first-registration-wins; retaining this pair prevents parallel
+    /// test AppStates from resolving through a sibling state's config/root.
+    pub(crate) workspace_resolver: bamboo_agent_core::workspace_state::WorkspaceResolver,
+
     /// Per-session write serialisation + metadata-merge persistence layer.
     ///
     /// Wraps the same [`Storage`] as `self.storage`, adding per-session

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/mod.rs
@@ -12,15 +12,28 @@ use bamboo_engine::session_app::metadata::SessionMetadataService;
 mod images;
 mod request;
 
-// Sync runtime workspace so tools can resolve the working directory.
-fn sync_runtime_workspace(session_id: &str, workspace_path: Option<&str>) {
+/// Publish the validated workspace after its session checkpoint is durable.
+///
+/// Project-context preview is AppState-scoped, so publication must use the
+/// same provider pair rather than a sibling state's process-global first-wins
+/// root. `workspace_source` is a non-secret diagnostic label.
+fn sync_runtime_workspace(
+    state: &AppState,
+    session_id: &str,
+    workspace_path: Option<&str>,
+    workspace_source: &str,
+) {
     if let Some(workspace) = workspace_path
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(std::path::PathBuf::from)
         .and_then(|path| std::fs::canonicalize(&path).ok().or(Some(path)))
     {
-        bamboo_tools::tools::workspace_state::publish_resolved_workspace(session_id, workspace);
+        state.workspace_resolver.publish_resolved_workspace(
+            session_id,
+            workspace,
+            workspace_source,
+        );
     }
 }
 
@@ -292,6 +305,15 @@ pub async fn handler(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     let global_default_prompt =
         bamboo_engine::prompt_defaults::read_global_default_system_prompt_template();
     let builtin_fallback_prompt = crate::app_state::DEFAULT_BASE_PROMPT;
+    let configured_default_workspace = config_snapshot
+        .get_default_work_area_path()
+        .as_deref()
+        .map(bamboo_config::paths::path_to_display_string);
+    let session_fallback_path = state
+        .workspace_resolver
+        .preview_session_fallback(&session_id)
+        .as_deref()
+        .map(bamboo_config::paths::path_to_display_string);
 
     let data_dir = Some(state.app_data_dir.clone());
     let mut project_preflight = bamboo_agent_core::Session::new(&session_id, &model);
@@ -300,9 +322,12 @@ pub async fn handler(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     }
     if let Some(workspace) = final_workspace_display.as_deref() {
         project_preflight.set_workspace_path_meta(workspace);
-    } else if let Some(workspace) = config_snapshot.get_default_work_area_path() {
-        project_preflight
-            .set_workspace_path_meta(bamboo_config::paths::path_to_display_string(&workspace));
+    } else if let Some(workspace) = configured_default_workspace.as_deref() {
+        project_preflight.set_workspace_path_meta(workspace);
+    } else if let Some(workspace) = session_fallback_path.as_deref() {
+        // This owning-state fallback is explicit so Project preflight cannot
+        // observe a same-id runtime entry published by another AppState.
+        project_preflight.set_workspace_path_meta(workspace);
     }
     if let Err(error) = state
         .project_context_resolver
@@ -328,10 +353,7 @@ pub async fn handler(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
         workspace_path: workspace_was_explicit
             .then(|| project_preflight.workspace_path_meta())
             .flatten(),
-        default_workspace_path: config_snapshot
-            .get_default_work_area_path()
-            .as_deref()
-            .map(bamboo_config::paths::path_to_display_string),
+        default_workspace_path: configured_default_workspace,
         selected_skill_ids: req.selected_skill_ids.clone(),
         workflow_selection: req.workflow_selection.clone(),
         orchestration_opt_in: req.orchestration_opt_in,
@@ -355,6 +377,9 @@ pub async fn handler(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
             );
         }
     };
+    let authoritative_workspace_present = authoritative_session
+        .as_ref()
+        .is_some_and(|session| session.workspace_path_meta().is_some());
     if req.project_id.is_none() {
         input.project_id = authoritative_session.as_ref().and_then(|session| {
             match bamboo_engine::project_context::ProjectContextResolver::session_project_identity(
@@ -418,14 +443,27 @@ pub async fn handler(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     } else {
         input.workspace_path = None;
     }
+    let workspace_source = if workspace_was_explicit {
+        "request"
+    } else if authoritative_workspace_present {
+        "session"
+    } else if input.default_workspace_path.is_some() {
+        "configured_default"
+    } else {
+        "session_fallback"
+    };
+    let workspace_fallback_policy =
+        bamboo_engine::session_app::types::ChatWorkspaceFallbackPolicy::Authoritative {
+            session_fallback_path,
+        };
 
-    let mut session =
-        match bamboo_engine::session_app::chat::prepare_chat_turn_from_authoritative_session(
-            authoritative_session,
-            input,
-            global_default_prompt.as_str(),
-            builtin_fallback_prompt,
-        ) {
+    let mut session = match bamboo_engine::session_app::chat::prepare_chat_turn_from_authoritative_session_with_workspace_policy(
+        authoritative_session,
+        input,
+        global_default_prompt.as_str(),
+        builtin_fallback_prompt,
+        workspace_fallback_policy,
+    ) {
             Ok(session) => session,
             Err(bamboo_engine::session_app::errors::ChatError::InvalidWorkflowSelection(error)) => {
                 return HttpResponse::BadRequest().json(serde_json::json!({
@@ -483,7 +521,12 @@ pub async fn handler(state: web::Data<AppState>, req: web::Json<ChatRequest>) ->
     if let Err(response) = save_and_cache_session_locked(state.as_ref(), &session).await {
         return response;
     }
-    sync_runtime_workspace(&session_id, session.workspace_path_meta().as_deref());
+    sync_runtime_workspace(
+        state.as_ref(),
+        &session_id,
+        session.workspace_path_meta().as_deref(),
+        workspace_source,
+    );
     if session_was_created {
         state.account_sink.record(
             Some(&session_id),

--- a/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/chat/handler/tests.rs
@@ -197,18 +197,31 @@ fn resolve_workspace_path_uses_request_then_metadata() {
 // disk fallback is unit-tested directly + deterministically in bamboo-engine's
 // session_app::chat (default_workspace_from_data_dir_reads_configured_work_area).
 
-#[test]
-fn sync_runtime_workspace_persists_workspace_for_tools() {
-    let temp_dir = tempfile::tempdir().expect("temp dir should be created");
-    let workspace = temp_dir.path().join("workspace");
-    std::fs::create_dir_all(&workspace).expect("workspace should exist");
+#[actix_web::test]
+async fn sync_runtime_workspace_materializes_with_the_states_provider() {
+    let app_home = tempfile::tempdir().expect("app home");
+    let state = crate::AppState::new(app_home.path().to_path_buf())
+        .await
+        .expect("app state");
+    let root = bamboo_config::paths::resolve_workspace_root_in(app_home.path());
+    let workspace = root.join("session-runtime-workspace");
     let session_id = "session-runtime-workspace";
+    assert!(!workspace.exists());
 
-    sync_runtime_workspace(session_id, Some(workspace.to_string_lossy().as_ref()));
+    sync_runtime_workspace(
+        &state,
+        session_id,
+        Some(workspace.to_string_lossy().as_ref()),
+        "session_fallback",
+    );
 
     let resolved = bamboo_tools::tools::workspace_state::get_workspace(session_id)
         .expect("workspace should be stored");
-    assert_eq!(resolved, workspace.canonicalize().unwrap_or(workspace));
+    assert_eq!(resolved, workspace);
+    assert!(
+        resolved.is_dir(),
+        "instance root should materialize fallback"
+    );
 }
 
 #[test]

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/create.rs
@@ -7,17 +7,44 @@ use bamboo_engine::model_config_helper::normalize_gold_config_json;
 
 use super::super::super::types::{CreateSessionRequest, CreateSessionResponse, SessionSummary};
 
-/// Sync runtime workspace so tools can resolve the working directory. Mirrors
-/// `chat::handler::sync_runtime_workspace` — #480 gives `POST /sessions` the
-/// same `workspace_path` semantics as `POST /chat`.
-fn sync_runtime_workspace(session_id: &str, workspace_path: Option<&str>) {
+/// Sync runtime workspace so tools can resolve the working directory. #480
+/// gives `POST /sessions` the same `workspace_path` semantics as `POST /chat`;
+/// this create path additionally uses its AppState-scoped provider pair so
+/// preview and post-persistence materialization cannot cross test states.
+fn sync_runtime_workspace(
+    state: &AppState,
+    session_id: &str,
+    workspace_path: Option<&str>,
+    workspace_source: &str,
+) {
     if let Some(workspace) = workspace_path
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(std::path::PathBuf::from)
         .and_then(|path| std::fs::canonicalize(&path).ok().or(Some(path)))
     {
-        bamboo_tools::tools::workspace_state::publish_resolved_workspace(session_id, workspace);
+        let workspace_root = state
+            .workspace_resolver
+            .workspace_root_config()
+            .map(|config| config.root);
+        let workspace_root_display = workspace_root
+            .as_deref()
+            .map(bamboo_config::paths::path_to_display_string)
+            .unwrap_or_else(|| "<unregistered>".to_string());
+        let published = state.workspace_resolver.publish_resolved_workspace(
+            session_id,
+            workspace,
+            workspace_source,
+        );
+        if !published.is_dir() {
+            tracing::warn!(
+                session_id,
+                path = %published.display(),
+                workspace_root = %workspace_root_display,
+                workspace_source,
+                "create-session workspace publication did not produce a usable directory"
+            );
+        }
     }
 }
 
@@ -126,11 +153,16 @@ pub async fn create_session(
         global_default_prompt.as_str(),
         &config_snapshot,
     );
-    if let Some(workspace) = final_workspace_display.as_deref() {
+    let configured_default_workspace = config_snapshot.get_default_work_area_path();
+    let workspace_source = if let Some(workspace) = final_workspace_display.as_deref() {
         session.set_workspace_path_meta(workspace);
-    } else if let Some(workspace) = config_snapshot.get_default_work_area_path() {
+        "request"
+    } else if let Some(workspace) = configured_default_workspace {
         session.set_workspace_path_meta(bamboo_config::paths::path_to_display_string(&workspace));
-    }
+        "configured_default"
+    } else {
+        "session_fallback"
+    };
     if let Err(error) = state
         .project_context_resolver
         .refresh_session_prompt_read_only(&mut session)
@@ -200,7 +232,12 @@ pub async fn create_session(
     // and only after the authoritative session is durable. A storage failure
     // must not leave an orphan runtime workspace entry for an ID the API never
     // created.
-    sync_runtime_workspace(&id, session.workspace_path_meta().as_deref());
+    sync_runtime_workspace(
+        state.get_ref(),
+        &id,
+        session.workspace_path_meta().as_deref(),
+        workspace_source,
+    );
 
     // Publish onto the account change feed so other clients insert the new
     // session into their list without polling `GET /sessions`.
@@ -431,15 +468,21 @@ mod tests {
         let workspace = session
             .workspace_path_meta()
             .expect("validated session fallback workspace");
+        let workspace_root = bamboo_config::paths::resolve_workspace_root_in(&state.app_data_dir);
         assert!(
             std::path::Path::new(&workspace).is_dir(),
-            "authoritative create must materialize the validated fallback"
+            "authoritative create must materialize the validated fallback: \
+             resolved={workspace}, root={}, source=session_fallback",
+            workspace_root.display(),
         );
         assert_eq!(
             bamboo_agent_core::workspace_state::get_workspace(&session_id)
                 .as_deref()
                 .map(bamboo_config::paths::path_to_display_string),
-            Some(workspace)
+            Some(workspace.clone()),
+            "runtime publication drifted: resolved={workspace}, root={}, \
+             source=session_fallback",
+            workspace_root.display(),
         );
         assert!(
             bamboo_tools::tools::workspace_state::workspace_or_process_cwd(Some(&session_id))

--- a/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/sessions/handlers/crud/patch.rs
@@ -329,9 +329,10 @@ pub async fn patch_session(
                 .map(std::path::PathBuf::from)
                 .and_then(|path| std::fs::canonicalize(&path).ok().or(Some(path)))
             {
-                bamboo_tools::tools::workspace_state::publish_resolved_workspace(
+                state.workspace_resolver.publish_resolved_workspace(
                     &session_id,
                     workspace,
+                    "project_reassignment",
                 );
             }
             state.account_sink.record(

--- a/crates/app/bamboo-server/tests/chat_workspace_provider_isolation.rs
+++ b/crates/app/bamboo-server/tests/chat_workspace_provider_isolation.rs
@@ -1,0 +1,166 @@
+use actix_web::{test, web, App};
+use bamboo_server::{configure_routes, AppState};
+
+/// Regression for #717's chat publication seam.
+///
+/// `provider_owner` deterministically owns the process-global first-wins
+/// workspace providers and advertises a real configured foreign default. A
+/// second AppState with no configured default then creates and continues a chat
+/// without an explicit workspace. The request state's authoritative `None`
+/// must suppress that process-global default so preview and post-save
+/// publication use its own session fallback.
+#[actix_web::test]
+async fn repeated_chat_materializes_request_states_own_session_fallback() {
+    let provider_owner_home = tempfile::tempdir().expect("provider owner home");
+    let foreign_default = tempfile::tempdir().expect("foreign default");
+    let mut provider_owner_config = bamboo_config::Config::default();
+    provider_owner_config.default_work_area = Some(bamboo_config::DefaultWorkAreaConfig {
+        path: Some(foreign_default.path().to_string_lossy().into_owned()),
+    });
+    provider_owner_config
+        .save_to_dir(provider_owner_home.path().to_path_buf())
+        .expect("persist provider owner config");
+    bamboo_config::paths::init_bamboo_dir(provider_owner_home.path().to_path_buf());
+    let provider_owner = web::Data::new(
+        AppState::new(provider_owner_home.path().to_path_buf())
+            .await
+            .expect("provider owner state"),
+    );
+    assert_eq!(
+        provider_owner
+            .config
+            .read()
+            .await
+            .get_default_work_area_path()
+            .as_deref(),
+        Some(foreign_default.path()),
+        "provider owner must register the foreign default before request state construction"
+    );
+
+    let request_home = tempfile::tempdir().expect("request state home");
+    let request_state = web::Data::new(
+        AppState::new(request_home.path().to_path_buf())
+            .await
+            .expect("request state"),
+    );
+    assert!(
+        request_state
+            .config
+            .read()
+            .await
+            .get_default_work_area_path()
+            .is_none(),
+        "request state live config must authoritatively have no default"
+    );
+    let provider_owner_root =
+        bamboo_config::paths::resolve_workspace_root_in(provider_owner_home.path());
+    let request_root = bamboo_config::paths::resolve_workspace_root_in(request_home.path());
+    let session_id = "chat-instance-workspace-isolation";
+    let fallback = bamboo_agent_core::workspace_state::preview_default_session_workspace_dir(
+        &request_root,
+        session_id,
+    );
+    let expected = bamboo_agent_core::workspace_state::preview_pin_workspace_path(
+        &fallback,
+        &request_root,
+        bamboo_config::paths::workspace_confinement_enforced(),
+    );
+    eprintln!(
+        "chat_workspace_provider_schedule: provider_owner_root={}, foreign_default={}, \
+         request_state_root={}, expected={}, source=session_fallback",
+        provider_owner_root.display(),
+        foreign_default.path().display(),
+        request_root.display(),
+        expected.display(),
+    );
+
+    let app = test::init_service(
+        App::new()
+            .app_data(request_state.clone())
+            .configure(configure_routes),
+    )
+    .await;
+    let first = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/v1/chat")
+            .set_json(serde_json::json!({
+                "session_id": session_id,
+                "message": "first message",
+                "model": "test-model"
+            }))
+            .to_request(),
+    )
+    .await;
+    assert!(
+        first.status().is_success(),
+        "first chat should persist the session, got {}",
+        first.status()
+    );
+
+    let persisted = request_state
+        .storage
+        .load_session(session_id)
+        .await
+        .expect("load first chat")
+        .expect("first chat session");
+    let first_workspace = persisted
+        .workspace_path_meta()
+        .map(std::path::PathBuf::from)
+        .expect("first chat must persist fallback metadata");
+    assert_eq!(
+        first_workspace,
+        expected,
+        "chat_workspace_provider_schedule: provider_owner_root={}, foreign_default={}, \
+         request_state_root={}, resolved={}, source=session_fallback",
+        provider_owner_root.display(),
+        foreign_default.path().display(),
+        request_root.display(),
+        first_workspace.display(),
+    );
+    assert_ne!(
+        first_workspace,
+        foreign_default.path(),
+        "request-state chat must not persist the first-wins provider owner's default"
+    );
+    assert_eq!(
+        bamboo_agent_core::workspace_state::get_workspace(session_id).as_deref(),
+        Some(first_workspace.as_path()),
+        "first chat runtime publication must preserve the validated candidate"
+    );
+    let first_materialized = first_workspace.is_dir();
+
+    let second = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/v1/chat")
+            .set_json(serde_json::json!({
+                "session_id": session_id,
+                "message": "second message",
+                "model": "test-model"
+            }))
+            .to_request(),
+    )
+    .await;
+    let second_status = second.status();
+    let second_body = test::read_body(second).await;
+    assert!(
+        second_status.is_success(),
+        "second chat failed after first durable fallback: status={second_status}, body={}, \
+         provider_owner_root={}, foreign_default={}, request_state_root={}, resolved={}, \
+         materialized={}, source=session_fallback",
+        String::from_utf8_lossy(&second_body),
+        provider_owner_root.display(),
+        foreign_default.path().display(),
+        request_root.display(),
+        first_workspace.display(),
+        first_materialized,
+    );
+    assert!(
+        first_workspace.is_dir(),
+        "request-state fallback was not materialized: request_state_root={}, resolved={}, \
+         source=session_fallback",
+        request_root.display(),
+        first_workspace.display(),
+    );
+}

--- a/crates/app/bamboo-server/tests/create_session_workspace_provider_isolation.rs
+++ b/crates/app/bamboo-server/tests/create_session_workspace_provider_isolation.rs
@@ -1,0 +1,101 @@
+use actix_web::{http::StatusCode, test, web, App};
+use bamboo_server::{configure_routes, AppState};
+use serde_json::Value;
+
+/// Regression for #717.
+///
+/// `AppState::new` intentionally registers process-global workspace providers
+/// with first-registration-wins semantics. This separate test binary gives us
+/// a deterministic schedule: `provider_owner` registers first and advertises
+/// a foreign configured default, while the create request is served by a
+/// second state with no configured default. The request state must resolve,
+/// persist, publish, and materialize its own session fallback without observing
+/// the first state's provider.
+#[actix_web::test]
+async fn create_fallback_is_isolated_from_foreign_first_registered_provider() {
+    let provider_owner_home = tempfile::tempdir().expect("provider owner home");
+    bamboo_config::paths::init_bamboo_dir(provider_owner_home.path().to_path_buf());
+    let provider_owner = web::Data::new(
+        AppState::new(provider_owner_home.path().to_path_buf())
+            .await
+            .expect("provider owner state"),
+    );
+    let foreign_default = tempfile::tempdir().expect("foreign default workspace");
+    provider_owner.config.write().await.default_work_area =
+        Some(bamboo_config::DefaultWorkAreaConfig {
+            path: Some(foreign_default.path().to_string_lossy().into_owned()),
+        });
+
+    let request_home = tempfile::tempdir().expect("request state home");
+    let request_state = web::Data::new(
+        AppState::new(request_home.path().to_path_buf())
+            .await
+            .expect("request state"),
+    );
+    let request_root = bamboo_config::paths::resolve_workspace_root_in(request_home.path());
+    let provider_owner_root =
+        bamboo_config::paths::resolve_workspace_root_in(provider_owner_home.path());
+    eprintln!(
+        "workspace_provider_schedule: provider_owner_root={}, foreign_default={}, \
+         request_state_root={}, expected_source=session_fallback",
+        provider_owner_root.display(),
+        foreign_default.path().display(),
+        request_root.display(),
+    );
+
+    let app = test::init_service(
+        App::new()
+            .app_data(request_state.clone())
+            .configure(configure_routes),
+    )
+    .await;
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/v1/sessions")
+            .set_json(serde_json::json!({ "title": "isolated fallback" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body: Value = test::read_body_json(response).await;
+    let session_id = body["session"]["id"].as_str().expect("session id");
+    let resolved = body["session"]["workspace_path"]
+        .as_str()
+        .map(std::path::PathBuf::from)
+        .expect("resolved fallback");
+    let fallback = bamboo_agent_core::workspace_state::preview_default_session_workspace_dir(
+        &request_root,
+        session_id,
+    );
+    let expected = bamboo_agent_core::workspace_state::preview_pin_workspace_path(
+        &fallback,
+        &request_root,
+        bamboo_config::paths::workspace_confinement_enforced(),
+    );
+
+    assert_eq!(
+        resolved,
+        expected,
+        "workspace_provider_schedule: provider_owner_root={}, request_state_root={}, \
+         resolved={}, source=session_fallback",
+        provider_owner_root.display(),
+        request_root.display(),
+        resolved.display(),
+    );
+    assert!(
+        resolved.is_dir(),
+        "workspace_provider_schedule: resolved fallback was not materialized; \
+         request_state_root={}, resolved={}, source=session_fallback",
+        request_root.display(),
+        resolved.display(),
+    );
+    assert_eq!(
+        bamboo_agent_core::workspace_state::get_workspace(session_id).as_deref(),
+        Some(resolved.as_path()),
+        "workspace_provider_schedule: runtime publication drifted; \
+         request_state_root={}, resolved={}, source=session_fallback",
+        request_root.display(),
+        resolved.display(),
+    );
+}

--- a/crates/core/bamboo-agent-core/src/workspace_state.rs
+++ b/crates/core/bamboo-agent-core/src/workspace_state.rs
@@ -342,6 +342,22 @@ impl WorkspaceResolver {
         }
     }
 
+    /// Preview this resolver's session-scoped root fallback only.
+    ///
+    /// Unlike [`Self::resolve_session_workspace_candidate`], this deliberately
+    /// does not consult the process-global runtime registry or a configured
+    /// default. Server transaction paths use it when their own live config
+    /// snapshot has authoritatively resolved no default workspace.
+    pub fn preview_session_fallback(&self, session_id: &str) -> Option<PathBuf> {
+        let config = self.workspace_root_config()?;
+        let fallback = preview_default_session_workspace_dir(&config.root, session_id);
+        Some(preview_pin_workspace_path(
+            &fallback,
+            &config.root,
+            config.confine,
+        ))
+    }
+
     /// Publish a previously validated candidate through this instance's root.
     ///
     /// Missing paths are materialized only when they are contained by this
@@ -755,6 +771,29 @@ mod tests {
             0,
             "publishing an existing directory must not evaluate the root provider"
         );
+    }
+
+    #[test]
+    fn instance_session_fallback_ignores_same_id_runtime_registry_state() {
+        let state_dir = tempfile::tempdir().unwrap();
+        let root = state_dir.path().join("workspaces");
+        let foreign_workspace = tempfile::tempdir().unwrap();
+        let session_id = "instance-fallback-ignores-runtime";
+        publish_resolved_workspace(session_id, foreign_workspace.path().to_path_buf());
+        let resolver = WorkspaceResolver::new(|| None, {
+            let root = root.clone();
+            move || WorkspaceRootConfig {
+                root: root.clone(),
+                confine: false,
+            }
+        });
+
+        let fallback = resolver
+            .preview_session_fallback(session_id)
+            .expect("instance session fallback");
+
+        assert_eq!(fallback, root.join(session_id));
+        assert_ne!(fallback, foreign_workspace.path());
     }
 
     #[test]

--- a/crates/core/bamboo-agent-core/src/workspace_state.rs
+++ b/crates/core/bamboo-agent-core/src/workspace_state.rs
@@ -1,6 +1,6 @@
 use dashmap::DashMap;
 use std::path::{Component, Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 
 const MAX_TRACKED_WORKSPACES: usize = 2_000;
@@ -35,19 +35,48 @@ pub fn set_workspace(session_id: &str, workspace: PathBuf) -> PathBuf {
 /// validation. The exact supplied path is stored; confinement is not evaluated
 /// a second time, closing the preview/check/publish TOCTOU.
 pub fn publish_resolved_workspace(session_id: &str, workspace: PathBuf) -> PathBuf {
+    publish_resolved_workspace_with_root(
+        session_id,
+        workspace,
+        || WORKSPACE_ROOT_PROVIDER.get().map(|provider| provider()),
+        "process_global",
+    )
+}
+
+fn publish_resolved_workspace_with_root<R>(
+    session_id: &str,
+    workspace: PathBuf,
+    root_config: R,
+    source: &str,
+) -> PathBuf
+where
+    R: FnOnce() -> Option<WorkspaceRootConfig>,
+{
     if !workspace.exists() {
-        if let Some(provider) = WORKSPACE_ROOT_PROVIDER.get() {
-            let cfg = provider();
-            let root = canonicalize_best_effort(&cfg.root);
+        if let Some(config) = root_config() {
+            let root = canonicalize_best_effort(&config.root);
             let candidate = canonicalize_best_effort(&workspace);
             if candidate.starts_with(&root) {
                 if let Err(error) = std::fs::create_dir_all(&candidate) {
                     tracing::warn!(
                         path = %candidate.display(),
+                        workspace_root = %root.display(),
+                        workspace_source = source,
                         %error,
                         "failed to materialize validated workspace"
                     );
                 }
+            } else {
+                // A configured default may disappear after preview. Never
+                // recreate a missing arbitrary path outside the authoritative
+                // root; emit enough non-secret context to diagnose the race.
+                tracing::warn!(
+                    path = %candidate.display(),
+                    workspace_root = %root.display(),
+                    workspace_source = source,
+                    "validated workspace is missing outside the workspace root; \
+                     refusing to recreate it"
+                );
             }
         }
     }
@@ -241,6 +270,96 @@ pub fn set_workspace_root_provider(provider: WorkspaceRootProvider) {
 /// Whether a workspace-root provider has been registered.
 pub fn has_workspace_root_provider() -> bool {
     WORKSPACE_ROOT_PROVIDER.get().is_some()
+}
+
+type SharedDefaultWorkspaceProvider = Arc<dyn Fn() -> Option<PathBuf> + Send + Sync>;
+type SharedWorkspaceRootProvider = Arc<dyn Fn() -> Option<WorkspaceRootConfig> + Send + Sync>;
+
+/// One coherent default/root provider pair.
+///
+/// The process-wide registration APIs remain first-wins for production and
+/// embedding compatibility. A server `AppState` also retains an instance of
+/// this resolver so multiple states in one test process cannot mix the first
+/// state's live config with another state's session persistence.
+#[derive(Clone)]
+pub struct WorkspaceResolver {
+    default_provider: SharedDefaultWorkspaceProvider,
+    root_provider: SharedWorkspaceRootProvider,
+}
+
+impl WorkspaceResolver {
+    /// Build an instance-scoped resolver from live providers.
+    pub fn new<D, R>(default_provider: D, root_provider: R) -> Self
+    where
+        D: Fn() -> Option<PathBuf> + Send + Sync + 'static,
+        R: Fn() -> WorkspaceRootConfig + Send + Sync + 'static,
+    {
+        Self {
+            default_provider: Arc::new(default_provider),
+            root_provider: Arc::new(move || Some(root_provider())),
+        }
+    }
+
+    /// Dynamically delegate to the process-global first-wins providers.
+    ///
+    /// Registration state is intentionally read on every call, not captured
+    /// here, so a resolver constructed before server bootstrap retains the
+    /// historical no-provider/provider transition semantics.
+    pub fn from_process_globals() -> Self {
+        Self {
+            default_provider: Arc::new(get_configured_default_workspace),
+            root_provider: Arc::new(|| WORKSPACE_ROOT_PROVIDER.get().map(|provider| provider())),
+        }
+    }
+
+    /// Return the current instance root and confinement policy.
+    pub fn workspace_root_config(&self) -> Option<WorkspaceRootConfig> {
+        (self.root_provider)()
+    }
+
+    /// Resolve a session workspace through this provider pair without
+    /// publishing state or creating directories.
+    pub fn resolve_session_workspace_candidate(
+        &self,
+        session_id: &str,
+        preferred: Option<PathBuf>,
+    ) -> Option<PathBuf> {
+        preferred
+            .or_else(|| peek_workspace(session_id))
+            .or_else(|| (self.default_provider)())
+            .or_else(|| {
+                self.workspace_root_config()
+                    .map(|config| preview_default_session_workspace_dir(&config.root, session_id))
+            })
+            .map(|path| self.preview_workspace_path(path))
+    }
+
+    /// Apply this instance's confinement policy without filesystem mutation.
+    pub fn preview_workspace_path(&self, workspace: PathBuf) -> PathBuf {
+        match self.workspace_root_config() {
+            Some(config) => preview_pin_workspace_path(&workspace, &config.root, config.confine),
+            None => workspace,
+        }
+    }
+
+    /// Publish a previously validated candidate through this instance's root.
+    ///
+    /// Missing paths are materialized only when they are contained by this
+    /// resolver's root. `source` is a non-secret diagnostic label supplied by
+    /// the caller (for example `session_fallback`).
+    pub fn publish_resolved_workspace(
+        &self,
+        session_id: &str,
+        workspace: PathBuf,
+        source: &str,
+    ) -> PathBuf {
+        publish_resolved_workspace_with_root(
+            session_id,
+            workspace,
+            || self.workspace_root_config(),
+            source,
+        )
+    }
 }
 
 fn pin_via_provider(path: PathBuf) -> PathBuf {
@@ -613,6 +732,110 @@ mod tests {
         assert!(relocated.starts_with(canonicalize_best_effort(&root)));
         assert!(!root.exists());
         assert!(!relocated.exists());
+    }
+
+    #[test]
+    fn existing_workspace_publication_does_not_resolve_root_provider() {
+        let workspace = tempfile::tempdir().unwrap();
+        let root_provider_calls = std::cell::Cell::new(0);
+
+        let published = publish_resolved_workspace_with_root(
+            "existing-workspace-lazy-root",
+            workspace.path().to_path_buf(),
+            || {
+                root_provider_calls.set(root_provider_calls.get() + 1);
+                None
+            },
+            "test",
+        );
+
+        assert_eq!(published, workspace.path());
+        assert_eq!(
+            root_provider_calls.get(),
+            0,
+            "publishing an existing directory must not evaluate the root provider"
+        );
+    }
+
+    #[test]
+    fn instance_resolver_materializes_its_own_fallback_and_confines_preferred_paths() {
+        let state_dir = tempfile::tempdir().unwrap();
+        let root = state_dir.path().join("workspaces");
+        let resolver = WorkspaceResolver::new(|| None, {
+            let root = root.clone();
+            move || WorkspaceRootConfig {
+                root: root.clone(),
+                confine: true,
+            }
+        });
+
+        let fallback = resolver
+            .resolve_session_workspace_candidate("instance-fallback", None)
+            .expect("instance fallback");
+        assert_eq!(
+            fallback,
+            canonicalize_best_effort(&root).join("instance-fallback")
+        );
+        assert!(!fallback.exists(), "preview must remain side-effect free");
+        let published = resolver.publish_resolved_workspace(
+            "instance-fallback",
+            fallback.clone(),
+            "session_fallback",
+        );
+        assert_eq!(published, fallback);
+        assert!(published.is_dir());
+
+        let outside = state_dir.path().join("outside/project");
+        std::fs::create_dir_all(&outside).unwrap();
+        let confined = resolver
+            .resolve_session_workspace_candidate("instance-confined", Some(outside.clone()))
+            .expect("confined candidate");
+        assert_ne!(confined, outside);
+        assert!(confined.starts_with(canonicalize_best_effort(&root)));
+        assert!(!confined.exists(), "confinement preview must not create");
+        resolver.publish_resolved_workspace("instance-confined", confined.clone(), "request");
+        assert!(confined.is_dir());
+    }
+
+    #[test]
+    fn instance_resolver_does_not_recreate_vanished_default_outside_its_root() {
+        let state_dir = tempfile::tempdir().unwrap();
+        let root = state_dir.path().join("workspaces");
+        let vanished_default = state_dir.path().join("foreign/vanished-default");
+        let resolver = WorkspaceResolver::new(
+            {
+                let vanished_default = vanished_default.clone();
+                move || Some(vanished_default.clone())
+            },
+            {
+                let root = root.clone();
+                move || WorkspaceRootConfig {
+                    root: root.clone(),
+                    confine: false,
+                }
+            },
+        );
+
+        let candidate = resolver
+            .resolve_session_workspace_candidate("vanished-default", None)
+            .expect("configured default candidate");
+        assert_eq!(candidate, vanished_default);
+        assert!(!candidate.exists());
+        let published = resolver.publish_resolved_workspace(
+            "vanished-default",
+            candidate.clone(),
+            "configured_default",
+        );
+
+        assert_eq!(published, candidate);
+        assert!(
+            !candidate.exists(),
+            "a missing configured default outside the instance root must not be recreated"
+        );
+        assert_eq!(
+            get_workspace("vanished-default").as_deref(),
+            Some(candidate.as_path())
+        );
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/project_context.rs
+++ b/crates/engine/bamboo-engine/src/project_context.rs
@@ -150,6 +150,7 @@ pub trait ProjectContextSource: Send + Sync {
 #[derive(Clone)]
 pub struct ProjectContextResolver {
     source: Arc<dyn ProjectContextSource>,
+    workspace_resolver: bamboo_agent_core::workspace_state::WorkspaceResolver,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -192,7 +193,26 @@ impl ProjectMemoryScope {
 
 impl ProjectContextResolver {
     pub fn new(source: Arc<dyn ProjectContextSource>) -> Self {
-        Self { source }
+        Self {
+            source,
+            workspace_resolver:
+                bamboo_agent_core::workspace_state::WorkspaceResolver::from_process_globals(),
+        }
+    }
+
+    /// Build a Project resolver against one coherent workspace-provider pair.
+    ///
+    /// The server uses this form so preview/ownership validation cannot observe
+    /// a different `AppState`'s process-global first-wins provider. Other
+    /// embeddings retain [`Self::new`]'s dynamic global behavior.
+    pub fn new_with_workspace_resolver(
+        source: Arc<dyn ProjectContextSource>,
+        workspace_resolver: bamboo_agent_core::workspace_state::WorkspaceResolver,
+    ) -> Self {
+        Self {
+            source,
+            workspace_resolver,
+        }
     }
 
     /// Return the stable, opaque Project id persisted on the session.
@@ -317,7 +337,7 @@ impl ProjectContextResolver {
         session: &Session,
         workspace: Option<&Path>,
     ) -> Result<Option<ResolvedProjectContext>, ProjectContextError> {
-        let workspace = Self::resolve_workspace_candidate(session, workspace)?;
+        let workspace = self.resolve_workspace_candidate_for_instance(session, workspace)?;
         self.resolve_with_final_workspace(session, workspace).await
     }
 
@@ -330,15 +350,33 @@ impl ProjectContextResolver {
         session: &Session,
         workspace: Option<&Path>,
     ) -> Result<Option<PathBuf>, ProjectContextError> {
+        Self::resolve_workspace_candidate_with(
+            &bamboo_agent_core::workspace_state::WorkspaceResolver::from_process_globals(),
+            session,
+            workspace,
+        )
+    }
+
+    fn resolve_workspace_candidate_for_instance(
+        &self,
+        session: &Session,
+        workspace: Option<&Path>,
+    ) -> Result<Option<PathBuf>, ProjectContextError> {
+        Self::resolve_workspace_candidate_with(&self.workspace_resolver, session, workspace)
+    }
+
+    fn resolve_workspace_candidate_with(
+        workspace_resolver: &bamboo_agent_core::workspace_state::WorkspaceResolver,
+        session: &Session,
+        workspace: Option<&Path>,
+    ) -> Result<Option<PathBuf>, ProjectContextError> {
         let preferred = workspace
             .map(Path::to_path_buf)
             .or_else(|| session.workspace_path_meta().map(PathBuf::from));
-        bamboo_agent_core::workspace_state::resolve_session_workspace_candidate(
-            &session.id,
-            preferred,
-        )
-        .map(|candidate| resolve_final_workspace(&candidate))
-        .transpose()
+        workspace_resolver
+            .resolve_session_workspace_candidate(&session.id, preferred)
+            .map(|candidate| resolve_final_workspace_with(&candidate, workspace_resolver))
+            .transpose()
     }
 
     async fn resolve_with_final_workspace(
@@ -448,15 +486,16 @@ impl ProjectContextResolver {
         session: &mut Session,
         sync_runtime_workspace: bool,
     ) -> Result<Option<ResolvedProjectContext>, ProjectContextError> {
-        let workspace = Self::resolve_workspace_candidate(session, None)?;
+        let workspace = self.resolve_workspace_candidate_for_instance(session, None)?;
         let resolved = self
             .resolve_with_final_workspace(session, workspace.clone())
             .await?;
         if let Some(workspace) = workspace.as_deref() {
             let final_workspace = if sync_runtime_workspace {
-                bamboo_tools::tools::workspace_state::publish_resolved_workspace(
+                self.workspace_resolver.publish_resolved_workspace(
                     &session.id,
                     workspace.into(),
+                    "project_context_refresh",
                 )
             } else {
                 workspace.to_path_buf()
@@ -512,7 +551,10 @@ impl ProjectContextResolver {
     }
 }
 
-fn resolve_final_workspace(workspace: &Path) -> Result<PathBuf, ProjectContextError> {
+fn resolve_final_workspace_with(
+    workspace: &Path,
+    workspace_resolver: &bamboo_agent_core::workspace_state::WorkspaceResolver,
+) -> Result<PathBuf, ProjectContextError> {
     if workspace.exists() && !workspace.is_dir() {
         return Err(ProjectContextError::WorkspaceInvalid {
             workspace: workspace.to_string_lossy().into_owned(),
@@ -520,7 +562,7 @@ fn resolve_final_workspace(workspace: &Path) -> Result<PathBuf, ProjectContextEr
         });
     }
     let canonical = std::fs::canonicalize(workspace).unwrap_or_else(|_| workspace.to_path_buf());
-    let final_workspace = bamboo_agent_core::workspace_state::preview_workspace_path(canonical);
+    let final_workspace = workspace_resolver.preview_workspace_path(canonical);
     if final_workspace.exists() && !final_workspace.is_dir() {
         return Err(ProjectContextError::WorkspaceInvalid {
             workspace: final_workspace.to_string_lossy().into_owned(),

--- a/crates/engine/bamboo-engine/src/session_app/chat.rs
+++ b/crates/engine/bamboo-engine/src/session_app/chat.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 use super::errors::ChatError;
 use super::provider_model::{derive_model_ref, persist_legacy_model_provider, persist_model_ref};
 use super::repository::SessionAccess;
-use super::types::ChatTurnInput;
+use super::types::{ChatTurnInput, ChatWorkspaceFallbackPolicy};
 
 // ---- Metadata keys ----
 const BASE_SYSTEM_PROMPT_KEY: &str = "base_system_prompt";
@@ -108,6 +108,28 @@ pub fn prepare_chat_turn_from_authoritative_session(
     global_default_prompt: &str,
     builtin_fallback_prompt: &str,
 ) -> Result<Session, ChatError> {
+    prepare_chat_turn_from_authoritative_session_with_workspace_policy(
+        existing,
+        input,
+        global_default_prompt,
+        builtin_fallback_prompt,
+        ChatWorkspaceFallbackPolicy::Legacy,
+    )
+}
+
+/// Prepare a turn with an explicit caller-owned workspace fallback policy.
+///
+/// The server uses this entrypoint after loading its own live config snapshot
+/// and previewing its AppState-scoped session fallback. Existing callers use
+/// [`prepare_chat_turn_from_authoritative_session`] and preserve legacy
+/// process-global/data-directory fallback behavior.
+pub fn prepare_chat_turn_from_authoritative_session_with_workspace_policy(
+    existing: Option<Session>,
+    input: ChatTurnInput,
+    global_default_prompt: &str,
+    builtin_fallback_prompt: &str,
+    workspace_fallback_policy: ChatWorkspaceFallbackPolicy,
+) -> Result<Session, ChatError> {
     let (mut session, session_start_source) = match existing {
         Some(session) => (session, "resume"),
         None => (
@@ -171,6 +193,7 @@ pub fn prepare_chat_turn_from_authoritative_session(
         &mut session,
         input.workspace_path.as_deref(),
         input.default_workspace_path.as_deref(),
+        &workspace_fallback_policy,
         input.data_dir.as_deref(),
     );
 
@@ -306,13 +329,20 @@ pub fn resolve_workspace_path(
     workspace_path_from_request: Option<&str>,
     data_dir: Option<&Path>,
 ) -> Option<String> {
-    resolve_workspace_path_with_default(session, workspace_path_from_request, None, data_dir)
+    resolve_workspace_path_with_default(
+        session,
+        workspace_path_from_request,
+        None,
+        &ChatWorkspaceFallbackPolicy::Legacy,
+        data_dir,
+    )
 }
 
 fn resolve_workspace_path_with_default(
     session: &mut Session,
     workspace_path_from_request: Option<&str>,
     default_workspace_path: Option<&str>,
+    fallback_policy: &ChatWorkspaceFallbackPolicy,
     data_dir: Option<&Path>,
 ) -> Option<String> {
     if let Some(path) = workspace_path_from_request {
@@ -323,7 +353,9 @@ fn resolve_workspace_path_with_default(
         .map(ToString::to_string)
         .or_else(|| session.workspace_path_meta())
         .or_else(|| default_workspace_path.map(ToString::to_string))
-        .or_else(|| resolve_default_workspace(data_dir));
+        .or_else(|| {
+            resolve_workspace_fallback_with(fallback_policy, || resolve_default_workspace(data_dir))
+        });
     if let Some(workspace) = resolved.as_ref() {
         // Persist the effective post-lock choice, including a live-config or
         // session-root fallback. Otherwise the subsequent Project resolver
@@ -332,6 +364,21 @@ fn resolve_workspace_path_with_default(
         session.set_workspace_path_meta(workspace.clone());
     }
     resolved
+}
+
+fn resolve_workspace_fallback_with<L>(
+    fallback_policy: &ChatWorkspaceFallbackPolicy,
+    legacy_lookup: L,
+) -> Option<String>
+where
+    L: FnOnce() -> Option<String>,
+{
+    match fallback_policy {
+        ChatWorkspaceFallbackPolicy::Legacy => legacy_lookup(),
+        ChatWorkspaceFallbackPolicy::Authoritative {
+            session_fallback_path,
+        } => session_fallback_path.clone(),
+    }
 }
 
 /// Resolve the configured default workspace (display string), preferring the
@@ -1018,6 +1065,104 @@ mod tests {
             .metadata
             .get(PROMPT_COMPONENT_FLAGS_KEY)
             .is_some_and(|flags| flags.contains("enhance=0")));
+    }
+
+    #[test]
+    fn authoritative_none_uses_session_fallback_during_prompt_composition() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let foreign_default = fixture.path().join("foreign-default");
+        std::fs::create_dir_all(&foreign_default).expect("foreign default");
+        std::fs::write(
+            fixture.path().join("config.json"),
+            serde_json::json!({
+                "default_work_area": { "path": foreign_default.to_string_lossy() }
+            })
+            .to_string(),
+        )
+        .expect("write legacy config");
+        let session_fallback = fixture
+            .path()
+            .join("request-state-root/workspaces/session-enhance");
+        let session_fallback_display = path_to_display_string(&session_fallback);
+        let mut input = chat_turn_input(None);
+        input.data_dir = Some(fixture.path().to_path_buf());
+
+        let session = prepare_chat_turn_from_authoritative_session_with_workspace_policy(
+            None,
+            input,
+            "global",
+            "builtin",
+            ChatWorkspaceFallbackPolicy::Authoritative {
+                session_fallback_path: Some(session_fallback_display.clone()),
+            },
+        )
+        .expect("authoritative turn");
+
+        assert_eq!(
+            session.workspace_path_meta().as_deref(),
+            Some(session_fallback_display.as_str())
+        );
+        let system_prompt = system_message_content(&session);
+        assert!(
+            system_prompt.contains(&session_fallback_display),
+            "session fallback must participate in prepare-stage prompt composition"
+        );
+        assert!(
+            !system_prompt.contains(foreign_default.to_string_lossy().as_ref()),
+            "authoritative None must suppress the legacy configured default"
+        );
+        assert!(
+            session
+                .prompt_snapshot
+                .as_ref()
+                .and_then(|snapshot| snapshot.workspace_context.as_deref())
+                .is_some_and(|context| context.contains(&session_fallback_display)),
+            "prompt snapshot must retain the authoritative session fallback"
+        );
+    }
+
+    #[test]
+    fn authoritative_none_without_session_fallback_skips_legacy_lookup() {
+        let resolved = resolve_workspace_fallback_with(
+            &ChatWorkspaceFallbackPolicy::Authoritative {
+                session_fallback_path: None,
+            },
+            || panic!("authoritative None must not read a process-global or disk default"),
+        );
+
+        assert_eq!(resolved, None);
+    }
+
+    #[test]
+    fn legacy_policy_preserves_non_server_default_workspace_lookup() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let configured_default = fixture.path().join("configured-default");
+        std::fs::create_dir_all(&configured_default).expect("configured default");
+        std::fs::write(
+            fixture.path().join("config.json"),
+            serde_json::json!({
+                "default_work_area": { "path": configured_default.to_string_lossy() }
+            })
+            .to_string(),
+        )
+        .expect("write config");
+        let mut input = chat_turn_input(None);
+        input.data_dir = Some(fixture.path().to_path_buf());
+
+        let session =
+            prepare_chat_turn_from_authoritative_session(None, input, "global", "builtin")
+                .expect("legacy turn");
+        let resolved = session
+            .workspace_path_meta()
+            .map(PathBuf::from)
+            .expect("legacy configured default");
+
+        assert_eq!(
+            resolved.canonicalize().expect("resolved canonical"),
+            configured_default
+                .canonicalize()
+                .expect("configured canonical")
+        );
     }
 
     // The non-server disk fallback (`default_workspace_from_data_dir`) tested

--- a/crates/engine/bamboo-engine/src/session_app/types.rs
+++ b/crates/engine/bamboo-engine/src/session_app/types.rs
@@ -34,6 +34,23 @@ pub struct ExecutionConfigSnapshot {
 
 // ---- Chat types ----
 
+/// Fallback policy used after request, durable-session, and caller-configured
+/// workspace candidates are absent.
+///
+/// Existing SDK/CLI call paths retain [`Self::Legacy`], including their
+/// process-global provider or data-directory config lookup. The server uses
+/// [`Self::Authoritative`] because its live config snapshot is authoritative
+/// even when it contains no configured default; it supplies the owning
+/// AppState's session-root fallback without consulting process-global state.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum ChatWorkspaceFallbackPolicy {
+    #[default]
+    Legacy,
+    Authoritative {
+        session_fallback_path: Option<String>,
+    },
+}
+
 /// Input for the chat turn use case.
 pub struct ChatTurnInput {
     pub session_id: String,

--- a/crates/infra/bamboo-config/src/paths.rs
+++ b/crates/infra/bamboo-config/src/paths.rs
@@ -237,9 +237,20 @@ pub fn subagents_dir() -> PathBuf {
 /// global — it re-reads the environment every call, matching the pattern of
 /// [`resolve_bamboo_dir`] vs [`bamboo_dir`].
 pub fn resolve_workspace_root() -> PathBuf {
+    resolve_workspace_root_in(&bamboo_dir())
+}
+
+/// Resolve the workspace root for one explicit Bamboo data directory.
+///
+/// This is the instance-scoped counterpart to [`resolve_workspace_root`].
+/// Server tests may construct more than one `AppState` in a process even
+/// though [`bamboo_dir`] is intentionally first-registration-wins. Passing the
+/// owning state's data directory keeps its fallback workspaces isolated while
+/// preserving the operator's `BAMBOO_WORKSPACE_ROOT` override.
+pub fn resolve_workspace_root_in(bamboo_data_dir: &Path) -> PathBuf {
     std::env::var("BAMBOO_WORKSPACE_ROOT")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| bamboo_dir().join("workspaces"))
+        .unwrap_or_else(|_| bamboo_data_dir.join("workspaces"))
 }
 
 /// Whether explicit workspace paths must be canonicalized and confined to
@@ -456,6 +467,11 @@ mod tests {
         std::env::remove_var("BAMBOO_WORKSPACE_ROOT");
 
         assert_eq!(resolve_workspace_root(), bamboo_dir().join("workspaces"));
+        let explicit_data_dir = PathBuf::from("/instance/data");
+        assert_eq!(
+            resolve_workspace_root_in(&explicit_data_dir),
+            explicit_data_dir.join("workspaces")
+        );
 
         if let Some(val) = original {
             std::env::set_var("BAMBOO_WORKSPACE_ROOT", val);
@@ -470,6 +486,10 @@ mod tests {
         std::env::set_var("BAMBOO_WORKSPACE_ROOT", "/mnt/tenant-workspaces");
         assert_eq!(
             resolve_workspace_root(),
+            PathBuf::from("/mnt/tenant-workspaces")
+        );
+        assert_eq!(
+            resolve_workspace_root_in(Path::new("/ignored/instance/data")),
             PathBuf::from("/mnt/tenant-workspaces")
         );
 


### PR DESCRIPTION
## Summary

- retain an AppState-scoped live default/root `WorkspaceResolver` while preserving the process-global first-registration-wins APIs
- use the owning AppState resolver for create-session Project preview and post-save publication/materialization
- align chat and Project-reassignment publication with the same AppState resolver and preserve durable save → cache → publication ordering
- add a typed server-only authoritative fallback policy so a live-config `None` cannot inherit another AppState's global default, while existing SDK/CLI entrypoints retain legacy provider/data-dir fallback behavior
- add deterministic two-AppState regressions for create and repeated chat, including foreign configured defaults, same-session runtime pollution, diagnostics, and confinement

Fixes #717

## Test Plan

- `cargo fmt --all -- --check`
- total and latest-delta `git diff --check`
- strict all-features Clippy with CI's deny/allow set
- `cargo test --locked -p bamboo-server --lib` — 1601 passed, 1 ignored on the initial implementation
- create-session focused module — 9/9
- chat focused module — 30/30
- PATCH focused module — 8/8
- full `bamboo-server` E2E — 208/208
- original CI regression — 1/1
- create and chat isolation integrations — normal and `BAMBOO_WORKSPACE_CONFINE=1`, 1/1 each
- concurrent create-module stress — 450/450 implementation run; 144/144 independent review run
- `bamboo-agent-core` — 139/139; workspace-focused 23/23
- engine authoritative/legacy fallback policy — 3/3
- `bamboo-config` — 573/573

## Screenshots

Not applicable; backend/test-isolation change only.

## Review Notes

- First adversarial review caught eager root-provider evaluation for already-existing workspaces; the first pushed commit made lookup lazy and added a call-count regression.
- Initial PR CI then exposed a deterministic chat continuation regression: preview used the request AppState but publication used a sibling process-global provider. The second commit switches chat/PATCH publication to the owning resolver and adds the exact E2E coverage.
- A fresh pre-push review caught a second foreign-default branch before it reached GitHub. The final local amendment introduced the authoritative fallback policy and strengthened the chat integration. A new fresh reviewer reproduced the old head red, validated exact `2e6a9bbee269d04b584c4563959dfff92208a29b`, and reported no Medium+ or merge-blocking findings.
- Known macOS `__eh_frame section too large` linker warnings remain tracked separately in #715.