### PR TITLE
fix: unify cluster fabric mutation CAS

### DIFF
--- a/crates/app/bamboo-server-tools/Cargo.toml
+++ b/crates/app/bamboo-server-tools/Cargo.toml
@@ -35,6 +35,7 @@ sha2 = "0.11"
 hex = "0.4"
 
 [dev-dependencies]
+bamboo-config = { path = "../../infra/bamboo-config", features = ["test-utils"] }
 tempfile = "3"
 futures = "0.3"
 tokio-util = "0.7"

--- a/crates/app/bamboo-server-tools/src/cluster_tool.rs
+++ b/crates/app/bamboo-server-tools/src/cluster_tool.rs
@@ -42,6 +42,9 @@ impl ClusterTool {
 fn to_tool_error(e: FabricError) -> ToolError {
     match e {
         FabricError::NotFound(m) | FabricError::BadRequest(m) => ToolError::InvalidArguments(m),
+        FabricError::Conflict { expected, actual } => ToolError::Execution(format!(
+            "cluster configuration conflict: expected revision {expected}, current revision {actual}"
+        )),
         FabricError::Internal(m) => ToolError::Execution(m),
     }
 }

--- a/crates/app/bamboo-server-tools/src/cluster_tool.rs
+++ b/crates/app/bamboo-server-tools/src/cluster_tool.rs
@@ -45,6 +45,7 @@ fn to_tool_error(e: FabricError) -> ToolError {
         FabricError::Conflict { expected, actual } => ToolError::Execution(format!(
             "cluster configuration conflict: expected revision {expected}, current revision {actual}"
         )),
+        FabricError::Committed(m) => ToolError::Execution(m),
         FabricError::Internal(m) => ToolError::Execution(m),
     }
 }

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -229,7 +229,7 @@ impl FabricDeployer {
     async fn snapshot_locked(&self, expected_revision: u64) -> FabricResult<FabricCommitSnapshot> {
         let mut config = self.config.read().await.clone();
         let section = if let Some(facade) = &self.config_facade {
-            let actual = facade.registry().cluster_fabric.snapshot().revision;
+            let actual = self.cluster_revision_locked();
             if expected_revision != actual {
                 return Err(FabricError::Conflict {
                     expected: expected_revision,
@@ -269,13 +269,61 @@ impl FabricDeployer {
         })
     }
 
-    pub async fn current_cluster_revision(&self) -> FabricResult<u64> {
-        let _io = self.config_io_lock.lock().await;
-        Ok(self
-            .config_facade
+    fn cluster_revision_locked(&self) -> u64 {
+        self.config_facade
             .as_ref()
             .map(|facade| facade.registry().cluster_fabric.snapshot().revision)
-            .unwrap_or(0))
+            .unwrap_or(0)
+    }
+
+    pub async fn current_cluster_revision(&self) -> FabricResult<u64> {
+        let _io = self.config_io_lock.lock().await;
+        Ok(self.cluster_revision_locked())
+    }
+
+    /// Reconcile stale process-bound worker states during server startup using
+    /// the process-owned section authority. The durable section commit happens
+    /// before runtime adoption and event publication, and the same config lock
+    /// prevents the health monitor or an operator mutation from racing boot.
+    pub async fn reconcile_stale_nodes_on_boot(&self) -> FabricResult<usize> {
+        let _io = self.config_io_lock.lock().await;
+        let stale = {
+            let config = self.config.read().await;
+            config
+                .cluster_fabric
+                .nodes
+                .iter()
+                .filter(|node| {
+                    node.state.as_ref().is_some_and(|state| {
+                        matches!(state.status, NodeStatus::Running | NodeStatus::Deploying)
+                    })
+                })
+                .count()
+        };
+        if stale == 0 {
+            return Ok(0);
+        }
+
+        let expected_revision = self.cluster_revision_locked();
+        self.persist_node_update_locked(expected_revision, |config| {
+            for node in &mut config.cluster_fabric.nodes {
+                if let Some(state) = node.state.as_mut() {
+                    if matches!(state.status, NodeStatus::Running | NodeStatus::Deploying) {
+                        state.status = NodeStatus::Unreachable;
+                        state.last_error =
+                            Some("orchestrator restarted; worker no longer tracked".to_string());
+                    }
+                }
+            }
+            Ok(())
+        })
+        .await?;
+        tracing::info!(
+            reconciled = stale,
+            revision = expected_revision + 1,
+            "cluster-fabric: marked stale Running nodes Unreachable on boot"
+        );
+        Ok(stale)
     }
 
     /// Commit one engine-owned node mutation through the cluster-fabric
@@ -308,7 +356,7 @@ impl FabricDeployer {
         F: FnOnce(&mut Config) -> FabricResult<()> + Send,
     {
         if let Some(facade) = &self.config_facade {
-            let actual = facade.registry().cluster_fabric.snapshot().revision;
+            let actual = self.cluster_revision_locked();
             if expected_revision != actual {
                 return Err(FabricError::Conflict {
                     expected: expected_revision,
@@ -826,11 +874,13 @@ impl FabricDeployer {
         node_id: &str,
         probe_timeout: Duration,
     ) -> FabricResult<NodeState> {
-        let (node, broker) = {
+        let (node, broker, observed_revision) = {
+            let _io = self.config_io_lock.lock().await;
             let cfg = self.config.read().await;
             (
                 self.node_snapshot(&cfg, node_id)?,
                 cfg.subagents().broker.clone(),
+                self.cluster_revision_locked(),
             )
         };
         let current = node.state.clone().unwrap_or_default();
@@ -873,17 +923,42 @@ impl FabricDeployer {
             ))
         };
 
-        // Re-check after the unlocked probe. A status flip is an authoritative
-        // section mutation; a steady heartbeat remains runtime-only to avoid
-        // revision churn.
-        let live = {
+        // Bind the unlocked probe to the section revision and worker identity
+        // captured before it started. A redeploy or node edit that wins while
+        // the probe is in flight makes this observation stale; discard it
+        // rather than applying it against the winner's newer revision.
+        let _io = self.config_io_lock.lock().await;
+        let actual_revision = self.cluster_revision_locked();
+        let (live, identity_matches) = {
             let cfg = self.config.read().await;
             let Some(node) = cfg.cluster_fabric.node(node_id) else {
                 return Ok(current);
             };
-            node.state.clone().unwrap_or_default()
+            let live = node.state.clone().unwrap_or_default();
+            let live_worker_id = live
+                .worker_id
+                .clone()
+                .unwrap_or_else(|| worker_id_for(node));
+            let live_role = node
+                .deploy
+                .default_role
+                .clone()
+                .unwrap_or_else(|| "general-purpose".to_string());
+            let live_broker = cfg
+                .subagents()
+                .broker
+                .clone()
+                .filter(|candidate| !candidate.endpoint.trim().is_empty());
+            let identity_matches = actual_revision == observed_revision
+                && live.status == current.status
+                && live_worker_id == worker_id
+                && live_role == role
+                && live_broker.as_ref() == Some(&broker);
+            (live, identity_matches)
         };
-        if !matches!(live.status, NodeStatus::Running | NodeStatus::Unreachable) {
+        if !identity_matches
+            || !matches!(live.status, NodeStatus::Running | NodeStatus::Unreachable)
+        {
             return Ok(live);
         }
         let from = live.status;
@@ -891,23 +966,17 @@ impl FabricDeployer {
             status: new_status,
             last_health: Some(chrono::Utc::now().to_rfc3339()),
             last_error: new_error,
-            ..live
+            ..live.clone()
         };
         if from != new_status {
-            let expected_revision = self.current_cluster_revision().await?;
             let committed_next = next.clone();
             let snapshot = self
-                .persist_node_update_at_revision(expected_revision, |config| {
-                    let Some(node) = config.cluster_fabric.node_mut(node_id) else {
-                        return Ok(());
-                    };
+                .persist_node_update_locked(observed_revision, |config| {
+                    let node = config
+                        .cluster_fabric
+                        .node_mut(node_id)
+                        .ok_or_else(|| FabricError::NotFound(format!("Node '{node_id}'")))?;
                     let current = node.state.clone().unwrap_or_default();
-                    if !matches!(
-                        current.status,
-                        NodeStatus::Running | NodeStatus::Unreachable
-                    ) {
-                        return Ok(());
-                    }
                     node.state = Some(NodeState {
                         status: committed_next.status,
                         last_health: committed_next.last_health.clone(),
@@ -922,7 +991,7 @@ impl FabricDeployer {
                 .cluster_fabric
                 .node(node_id)
                 .and_then(|node| node.state.clone())
-                .unwrap_or(current);
+                .unwrap_or(live);
             tracing::info!(
                 audit = "cluster_fabric.health",
                 node = node_id,
@@ -934,17 +1003,22 @@ impl FabricDeployer {
             return Ok(adopted);
         }
 
-        let _io = self.config_io_lock.lock().await;
         let mut cfg = self.config.write().await;
         let Some(node) = cfg.cluster_fabric.node_mut(node_id) else {
             return Ok(current);
         };
-        let current = node.state.clone().unwrap_or_default();
-        if !matches!(
-            current.status,
-            NodeStatus::Running | NodeStatus::Unreachable
-        ) {
-            return Ok(current);
+        let latest = node.state.clone().unwrap_or_default();
+        let latest_worker_id = latest
+            .worker_id
+            .clone()
+            .unwrap_or_else(|| worker_id_for(node));
+        let latest_role = node
+            .deploy
+            .default_role
+            .clone()
+            .unwrap_or_else(|| "general-purpose".to_string());
+        if latest.status != live.status || latest_worker_id != worker_id || latest_role != role {
+            return Ok(latest);
         }
         node.state = Some(next.clone());
         Ok(next)
@@ -1911,7 +1985,7 @@ mod health_check_tests {
     };
     use bamboo_config::{BrokerClientConfig, Config};
     use std::collections::HashMap;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex as StdMutex};
     use tokio::sync::{Mutex, RwLock};
 
     async fn start_broker() -> (String, tempfile::TempDir) {
@@ -1977,6 +2051,129 @@ mod health_check_tests {
             Arc::new(Mutex::new(HashMap::new())),
             "/usr/bin/true",
         ))
+    }
+
+    struct ModularDeployerFixture {
+        deployer: Arc<FabricDeployer>,
+        facade: Arc<ConfigFacade>,
+        data_dir: tempfile::TempDir,
+        events: Arc<StdMutex<Vec<ConfigSectionEvent>>>,
+    }
+
+    fn modular_deployer_with(nodes: Vec<Node>, endpoint: &str) -> ModularDeployerFixture {
+        let dir = tempfile::tempdir().unwrap();
+        let facade = Arc::new(ConfigFacade::open_or_migrate(dir.path()).unwrap());
+        let mut candidate = facade.effective_config();
+        candidate.cluster_fabric.nodes = nodes;
+        let revision = bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+            dir.path(),
+            &mut candidate,
+            &BTreeMap::new(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(revision, 1);
+        assert!(facade
+            .registry()
+            .reload_if_changed(SectionId::ClusterFabric)
+            .is_some());
+
+        let mut runtime = facade.effective_config();
+        runtime.subagents_mut().broker = Some(BrokerClientConfig {
+            endpoint: endpoint.into(),
+            token: "t".into(),
+            token_encrypted: None,
+            credential_ref: None,
+            configured: false,
+        });
+        let config = Arc::new(RwLock::new(runtime));
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let event_log = events.clone();
+        let deployer = Arc::new(
+            FabricDeployer::new(
+                config,
+                Arc::new(Mutex::new(())),
+                dir.path().to_path_buf(),
+                Arc::new(Mutex::new(HashMap::new())),
+                "/usr/bin/true",
+            )
+            .with_modular_persistence(
+                facade.clone(),
+                Arc::new(CredentialStore::open(dir.path())),
+                Arc::new(move |event| event_log.lock().unwrap().push(event.clone())),
+            ),
+        );
+        ModularDeployerFixture {
+            deployer,
+            facade,
+            data_dir: dir,
+            events,
+        }
+    }
+
+    #[tokio::test]
+    async fn boot_reconcile_advances_the_process_facade_before_runtime_and_event() {
+        let node = running_node("a", "node-a", "mon");
+        let fixture = modular_deployer_with(vec![node], "");
+
+        assert_eq!(
+            fixture
+                .deployer
+                .reconcile_stale_nodes_on_boot()
+                .await
+                .unwrap(),
+            1
+        );
+        let process_snapshot = fixture.facade.registry().cluster_fabric.snapshot();
+        assert_eq!(process_snapshot.revision, 2);
+        assert_eq!(
+            process_snapshot
+                .data
+                .0
+                .node("a")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Unreachable
+        );
+        assert_eq!(
+            fixture
+                .deployer
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("a")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Unreachable
+        );
+        let reopened = ConfigFacade::open(fixture.data_dir.path()).unwrap();
+        assert_eq!(reopened.registry().cluster_fabric.snapshot().revision, 2);
+        assert_eq!(
+            reopened
+                .effective_config()
+                .cluster_fabric
+                .node("a")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Unreachable
+        );
+        assert_eq!(
+            fixture.events.lock().unwrap().as_slice(),
+            &[ConfigSectionEvent::Changed {
+                section: "cluster-fabric".to_string(),
+                revision: 2,
+            }]
+        );
     }
 
     #[tokio::test]
@@ -2069,6 +2266,58 @@ mod health_check_tests {
             NodeStatus::Stopped,
             "Stopped not overwritten to Unreachable"
         );
+    }
+
+    #[tokio::test]
+    async fn stale_probe_does_not_overwrite_a_newer_redeploy_revision() {
+        let (endpoint, _dir) = start_broker().await;
+        let fixture =
+            modular_deployer_with(vec![running_node("a", "old-worker", "old-role")], &endpoint);
+        let deployer = fixture.deployer.clone();
+        let probe = {
+            let deployer = deployer.clone();
+            tokio::spawn(async move {
+                deployer
+                    .health_check_within("a", Duration::from_millis(1500))
+                    .await
+            })
+        };
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let winning_revision = deployer.current_cluster_revision().await.unwrap();
+        let winner = deployer
+            .persist_node_update_at_revision(winning_revision, |config| {
+                let node = config.cluster_fabric.node_mut("a").unwrap();
+                node.deploy.default_role = Some("new-role".to_string());
+                node.state = Some(NodeState {
+                    status: NodeStatus::Running,
+                    worker_id: Some("new-worker".to_string()),
+                    ..Default::default()
+                });
+                Ok(())
+            })
+            .await
+            .unwrap();
+        assert_eq!(winner.section.revision, 2);
+
+        let observed = probe.await.unwrap().unwrap();
+        assert_eq!(observed.status, NodeStatus::Running);
+        assert_eq!(observed.worker_id.as_deref(), Some("new-worker"));
+        let process_snapshot = fixture.facade.registry().cluster_fabric.snapshot();
+        assert_eq!(
+            process_snapshot.revision, 2,
+            "the stale probe must not create revision 3"
+        );
+        let node = deployer
+            .config
+            .read()
+            .await
+            .cluster_fabric
+            .node("a")
+            .cloned()
+            .unwrap();
+        assert_eq!(node.deploy.default_role.as_deref(), Some("new-role"));
+        assert_eq!(node.state.unwrap().worker_id.as_deref(), Some("new-worker"));
     }
 }
 

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -2491,7 +2491,8 @@ mod lifecycle_persistence_tests {
             Err(error) => error,
             Ok(_) => panic!("the injected persistent recovery failure must surface"),
         };
-        assert!(matches!(deploy_error, FabricError::Committed(_)));
+        assert!(matches!(&deploy_error, FabricError::Committed(_)));
+        assert!(deploy_error.to_string().contains("indeterminate"));
         assert!(
             deploy_fixture
                 .registry
@@ -2512,7 +2513,8 @@ mod lifecycle_persistence_tests {
                 .as_ref()
                 .unwrap()
                 .status,
-            NodeStatus::Running
+            NodeStatus::Deploying,
+            "process runtime must remain at the pre-final-persist authority"
         );
         assert_eq!(
             deploy_fixture
@@ -2521,20 +2523,15 @@ mod lifecycle_persistence_tests {
                 .cluster_fabric
                 .snapshot()
                 .revision,
-            3
+            2
         );
         assert_eq!(
             deploy_fixture.events.lock().unwrap().as_slice(),
-            &[
-                ConfigSectionEvent::Changed {
-                    section: "cluster-fabric".to_string(),
-                    revision: 2,
-                },
-                ConfigSectionEvent::Changed {
-                    section: "cluster-fabric".to_string(),
-                    revision: 3,
-                },
-            ]
+            &[ConfigSectionEvent::Changed {
+                section: "cluster-fabric".to_string(),
+                revision: 2,
+            }],
+            "an unproven final candidate must not publish an event"
         );
         let recovered_deploy = ConfigFacade::open_or_migrate(deploy_fixture._data_dir.path())
             .expect("later startup recovery");
@@ -2577,10 +2574,11 @@ mod lifecycle_persistence_tests {
             Err(error) => error,
             Ok(_) => panic!("the injected persistent recovery failure must surface"),
         };
-        assert!(matches!(stop_error, FabricError::Committed(_)));
+        assert!(matches!(&stop_error, FabricError::Committed(_)));
+        assert!(stop_error.to_string().contains("indeterminate"));
         assert!(
             stop_fixture.registry.lock().await.is_empty(),
-            "a committed Stopped candidate must still shut down the worker"
+            "an indeterminate Stopped candidate must preserve the completed shutdown"
         );
         assert_eq!(
             stop_fixture
@@ -2594,7 +2592,8 @@ mod lifecycle_persistence_tests {
                 .as_ref()
                 .unwrap()
                 .status,
-            NodeStatus::Stopped
+            NodeStatus::Running,
+            "process runtime must remain at the pre-final-persist authority"
         );
         assert_eq!(
             stop_fixture
@@ -2603,14 +2602,12 @@ mod lifecycle_persistence_tests {
                 .cluster_fabric
                 .snapshot()
                 .revision,
-            2
+            1
         );
         assert_eq!(
             stop_fixture.events.lock().unwrap().as_slice(),
-            &[ConfigSectionEvent::Changed {
-                section: "cluster-fabric".to_string(),
-                revision: 2,
-            }]
+            &[],
+            "an unproven final candidate must not publish an event"
         );
         let recovered_stop = ConfigFacade::open_or_migrate(stop_fixture._data_dir.path())
             .expect("later startup recovery");

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -357,13 +357,6 @@ impl FabricDeployer {
     async fn snapshot_locked(&self, expected_revision: u64) -> FabricResult<FabricCommitSnapshot> {
         let mut config = self.config.read().await.clone();
         if self.config_facade.is_some() {
-            let actual = self.cluster_revision_locked();
-            if expected_revision != actual {
-                return Err(FabricError::Conflict {
-                    expected: expected_revision,
-                    actual,
-                });
-            }
             let data_dir = self.data_dir.clone();
             let exact = tokio::task::spawn_blocking(move || {
                 bamboo_config::read_exact_cluster_fabric_snapshot(
@@ -514,15 +507,37 @@ impl FabricDeployer {
         F: FnOnce(&mut Config) -> FabricResult<()> + Send,
     {
         if let Some(facade) = &self.config_facade {
-            let actual = self.cluster_revision_locked();
-            if expected_revision != actual {
+            let mut candidate = self.config.read().await.clone();
+            let snapshot_dir = self.data_dir.clone();
+            // Lifecycle persistence starts from the exact durable metadata
+            // generation without hydrating secrets. In particular, stop must
+            // remain able to clear live state when an unrelated active
+            // credential is corrupt; materialization is reported explicitly
+            // after a changed commit.
+            let exact = tokio::task::spawn_blocking(move || {
+                bamboo_config::read_exact_cluster_fabric_snapshot(&snapshot_dir, None)
+            })
+            .await
+            .map_err(|error| {
+                FabricError::Internal(format!("cluster snapshot task failed: {error}"))
+            })?
+            .map_err(map_config_store_error)?;
+            if exact.section.revision != expected_revision {
                 return Err(FabricError::Conflict {
                     expected: expected_revision,
-                    actual,
+                    actual: exact.section.revision,
                 });
             }
-
-            let mut candidate = self.config.read().await.clone();
+            if exact.section.status != SectionStatus::Healthy
+                || exact.section.source_kind != SectionSourceKind::File
+                || exact.credential_health.status == SectionStatus::Degraded
+            {
+                return Err(FabricError::BadRequest(
+                    "revision-bound cluster mutations require healthy primary authorities"
+                        .to_string(),
+                ));
+            }
+            candidate.cluster_fabric = exact.cluster_fabric;
             update(&mut candidate)?;
             let data_dir = self.data_dir.clone();
             let commit_facade = facade.clone();
@@ -2058,6 +2073,90 @@ mod lifecycle_persistence_tests {
                 },
             )]),
         )
+    }
+
+    #[tokio::test]
+    async fn stale_lifecycle_candidate_starts_from_exact_durable_generation() {
+        let fixture = modular_running_fixture("/usr/bin/true");
+        let external = ConfigFacade::open(fixture._data_dir.path()).unwrap();
+        let mut external_candidate = external.effective_config();
+        external_candidate
+            .cluster_fabric
+            .clusters
+            .push(bamboo_config::Cluster {
+                name: "external-cluster".to_string(),
+                description: Some("durable-r2-field".to_string()),
+                node_ids: vec!["n1".to_string()],
+            });
+        assert_eq!(
+            bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+                fixture._data_dir.path(),
+                &mut external_candidate,
+                &BTreeMap::new(),
+                1,
+            )
+            .unwrap(),
+            2
+        );
+        assert_eq!(
+            fixture.facade.registry().cluster_fabric.snapshot().revision,
+            1
+        );
+        assert!(fixture
+            .config
+            .read()
+            .await
+            .cluster_fabric
+            .cluster("external-cluster")
+            .is_none());
+
+        let committed = fixture
+            .deployer
+            .persist_node_update_at_revision(2, |config| {
+                config.cluster_fabric.node_mut("n1").unwrap().label = "engine-r3-edit".to_string();
+                Ok(())
+            })
+            .await
+            .unwrap();
+        assert_eq!(committed.section.revision, 3);
+        assert_eq!(
+            committed.config.cluster_fabric.node("n1").unwrap().label,
+            "engine-r3-edit"
+        );
+        assert_eq!(
+            committed
+                .config
+                .cluster_fabric
+                .cluster("external-cluster")
+                .unwrap()
+                .description
+                .as_deref(),
+            Some("durable-r2-field")
+        );
+        assert_eq!(
+            fixture.facade.registry().cluster_fabric.snapshot().revision,
+            3
+        );
+
+        let runtime_before_conflict = fixture.config.read().await.cluster_fabric.clone();
+        let conflict = fixture
+            .deployer
+            .persist_node_update_at_revision(2, |config| {
+                config.cluster_fabric.nodes.clear();
+                Ok(())
+            })
+            .await;
+        assert!(matches!(
+            conflict,
+            Err(FabricError::Conflict {
+                expected: 2,
+                actual: 3
+            })
+        ));
+        assert_eq!(
+            fixture.config.read().await.cluster_fabric,
+            runtime_before_conflict
+        );
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -36,16 +36,24 @@ use crate::deploy_agent::{Deployed, DeployedRegistry};
 pub enum FabricError {
     NotFound(String),
     BadRequest(String),
-    Conflict { expected: u64, actual: u64 },
+    Conflict {
+        expected: u64,
+        actual: u64,
+    },
+    /// The durable transaction committed, but its process-local publication
+    /// invariant failed. Lifecycle callers must not compensate the already
+    /// authoritative action as if the CAS had failed before commit.
+    Committed(String),
     Internal(String),
 }
 
 impl std::fmt::Display for FabricError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FabricError::NotFound(m) | FabricError::BadRequest(m) | FabricError::Internal(m) => {
-                write!(f, "{m}")
-            }
+            FabricError::NotFound(m)
+            | FabricError::BadRequest(m)
+            | FabricError::Committed(m)
+            | FabricError::Internal(m) => write!(f, "{m}"),
             FabricError::Conflict { expected, actual } => {
                 write!(
                     f,
@@ -136,6 +144,101 @@ fn run_deploy_before_final_persist_test_hook(data_dir: &Path) {
         .remove(data_dir);
     if let Some(hook) = hook {
         hook(data_dir);
+    }
+}
+
+#[cfg(test)]
+struct AfterCommitBeforeAdoptionTestHook {
+    expected_revision: u64,
+    hook: Box<dyn FnOnce(&Path) + Send + 'static>,
+}
+
+#[cfg(test)]
+fn after_commit_before_adoption_test_hooks(
+) -> &'static std::sync::Mutex<HashMap<PathBuf, AfterCommitBeforeAdoptionTestHook>> {
+    static HOOKS: std::sync::OnceLock<
+        std::sync::Mutex<HashMap<PathBuf, AfterCommitBeforeAdoptionTestHook>>,
+    > = std::sync::OnceLock::new();
+    HOOKS.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+fn set_after_commit_before_adoption_test_hook(
+    data_dir: &Path,
+    expected_revision: u64,
+    hook: impl FnOnce(&Path) + Send + 'static,
+) {
+    after_commit_before_adoption_test_hooks()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(
+            data_dir.to_path_buf(),
+            AfterCommitBeforeAdoptionTestHook {
+                expected_revision,
+                hook: Box::new(hook),
+            },
+        );
+}
+
+#[cfg(test)]
+fn run_after_commit_before_adoption_test_hook(data_dir: &Path, expected_revision: u64) {
+    let hook = {
+        let mut hooks = after_commit_before_adoption_test_hooks()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if hooks
+            .get(data_dir)
+            .is_some_and(|hook| hook.expected_revision == expected_revision)
+        {
+            hooks.remove(data_dir)
+        } else {
+            None
+        }
+    };
+    if let Some(hook) = hook {
+        (hook.hook)(data_dir);
+    }
+}
+
+#[cfg(test)]
+struct HealthAfterProbeTestHook {
+    reached: tokio::sync::oneshot::Sender<()>,
+    release: tokio::sync::oneshot::Receiver<()>,
+}
+
+#[cfg(test)]
+fn health_after_probe_test_hooks(
+) -> &'static std::sync::Mutex<HashMap<PathBuf, HealthAfterProbeTestHook>> {
+    static HOOKS: std::sync::OnceLock<
+        std::sync::Mutex<HashMap<PathBuf, HealthAfterProbeTestHook>>,
+    > = std::sync::OnceLock::new();
+    HOOKS.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+fn set_health_after_probe_test_hook(
+    data_dir: &Path,
+    reached: tokio::sync::oneshot::Sender<()>,
+    release: tokio::sync::oneshot::Receiver<()>,
+) {
+    health_after_probe_test_hooks()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(
+            data_dir.to_path_buf(),
+            HealthAfterProbeTestHook { reached, release },
+        );
+}
+
+#[cfg(test)]
+async fn run_health_after_probe_test_hook(data_dir: &Path) {
+    let hook = health_after_probe_test_hooks()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(data_dir);
+    if let Some(hook) = hook {
+        let _ = hook.reached.send(());
+        let _ = hook.release.await;
     }
 }
 
@@ -430,60 +533,105 @@ impl FabricDeployer {
             let mut candidate = self.config.read().await.clone();
             update(&mut candidate)?;
             let data_dir = self.data_dir.clone();
-            let revision = tokio::task::spawn_blocking(move || {
-                bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
-                    &data_dir,
-                    &mut candidate,
-                    &BTreeMap::new(),
-                    expected_revision,
-                )
+            let commit_facade = facade.clone();
+            let (mut candidate, commit) = tokio::task::spawn_blocking(move || {
+                let commit =
+                    bamboo_config::persist_cluster_fabric_credential_transaction_with_adoption(
+                        &data_dir,
+                        &mut candidate,
+                        &BTreeMap::new(),
+                        expected_revision,
+                        commit_facade.as_ref(),
+                        |_, _| {
+                            #[cfg(test)]
+                            run_after_commit_before_adoption_test_hook(
+                                &data_dir,
+                                expected_revision,
+                            );
+                        },
+                    )?;
+                Ok::<_, ConfigStoreError>((candidate, commit))
             })
             .await
             .map_err(|error| FabricError::Internal(format!("persist task failed: {error}")))?
             .map_err(map_config_store_error)?;
 
-            if let Some(event) = facade.registry().reload_if_changed(SectionId::Credentials) {
-                if matches!(event, ConfigSectionEvent::Invalid { .. }) {
-                    return Err(FabricError::Internal(
-                        "committed credential section became invalid before publication"
-                            .to_string(),
-                    ));
+            // The transaction returns the exact hydrated candidate it
+            // installed. Adopt that runtime before exposing the already
+            // captured section event; do not reread a later disk winner.
+            let bamboo_config::ClusterFabricTransactionCommit {
+                revision,
+                adoption,
+                credential_adoption,
+                runtime,
+            } = commit;
+            let runtime = match runtime {
+                Ok(bamboo_config::ClusterFabricRuntimeSnapshot {
+                    cluster_fabric,
+                    credential_statuses,
+                    credential_health,
+                }) => {
+                    candidate.cluster_fabric = cluster_fabric;
+                    Ok((credential_statuses, credential_health))
                 }
-            }
-            let event = facade
-                .registry()
-                .reload_if_changed(SectionId::ClusterFabric);
-            if let Some(event @ ConfigSectionEvent::Invalid { .. }) = event.as_ref() {
-                if let Some(publish) = &self.publish_event {
-                    publish(event);
+                Err(error) if revision == expected_revision => {
+                    return Err(FabricError::Internal(format!(
+                        "cluster configuration at revision {revision} could not materialize its exact runtime credentials: {error}"
+                    )));
                 }
-                return Err(FabricError::Internal(
-                    "committed cluster section became invalid before publication".to_string(),
-                ));
-            }
-
+                Err(error) => {
+                    candidate.clear_cluster_runtime_credentials();
+                    Err(error)
+                }
+            };
+            *self.config.write().await = candidate.clone();
+            let event = match adoption {
+                Some(Ok(event)) => Some(event),
+                Some(Err(error)) => {
+                    return Err(FabricError::Committed(format!(
+                        "cluster configuration committed at revision {} but process adoption failed: {error}",
+                        revision
+                    )));
+                }
+                None if revision == expected_revision => None,
+                None => {
+                    return Err(FabricError::Committed(format!(
+                        "cluster configuration committed at revision {} without a process adoption result",
+                        revision
+                    )));
+                }
+            };
             let section = facade
                 .registry()
                 .envelope_value(SectionId::ClusterFabric)
-                .map_err(map_config_store_error)?;
+                .map_err(|error| {
+                    FabricError::Committed(format!(
+                        "cluster configuration committed at revision {} but its exact envelope is unavailable: {error}",
+                        revision
+                    ))
+                })?;
             if section.revision != revision {
-                return Err(FabricError::Internal(
-                    "committed cluster revision did not match the adopted revision".to_string(),
-                ));
+                return Err(FabricError::Committed(format!(
+                    "cluster configuration committed at revision {} but facade retained revision {}",
+                    revision, section.revision
+                )));
             }
-
-            let mut adopted = self.config.read().await.clone();
-            adopted.cluster_fabric = self
-                .hydrate_cluster_fabric(facade.effective_config().cluster_fabric.clone())
-                .await?;
-            *self.config.write().await = adopted.clone();
 
             if let (Some(event), Some(publish)) = (event.as_ref(), self.publish_event.as_ref()) {
                 publish(event);
             }
-            let (credential_statuses, credential_health) = self.credential_snapshot();
+            if let Some(Err(error)) = credential_adoption {
+                return Err(FabricError::Committed(format!(
+                    "cluster configuration committed at revision {revision} but credential facade adoption failed: {error}"
+                )));
+            }
+            let (credential_statuses, credential_health) = runtime.map_err(|error| {
+                FabricError::Committed(format!(
+                    "cluster configuration committed at revision {revision} but could not materialize its exact runtime credentials: {error}"
+                ))
+            })?;
             return Ok(FabricCommitSnapshot {
-                config: adopted,
+                config: candidate,
                 section,
                 credential_statuses,
                 credential_health,
@@ -831,6 +979,12 @@ impl FabricDeployer {
             .await
         {
             Ok(snapshot) => snapshot,
+            Err(error @ FabricError::Committed(_)) => {
+                // The Running state is already durable/runtime authoritative.
+                // Keep the matching verified worker instead of compensating a
+                // transaction that did not fail before its commit point.
+                return Err(error);
+            }
             Err(error) => {
                 let deployed = self
                     .registry
@@ -889,7 +1043,7 @@ impl FabricDeployer {
             status: NodeStatus::Stopped,
             ..Default::default()
         };
-        let persisted = self
+        let persisted = match self
             .persist_node_update_locked(expected_revision, |config| {
                 let node = config
                     .cluster_fabric
@@ -898,7 +1052,11 @@ impl FabricDeployer {
                 node.state = Some(state.clone());
                 Ok(())
             })
-            .await?;
+            .await
+        {
+            outcome @ (Ok(_) | Err(FabricError::Committed(_))) => outcome,
+            Err(error) => return Err(error),
+        };
         // The durable CAS succeeds before the external worker is affected.
         // Remove under the registry lock and shut down outside that lock; the
         // configuration guard remains held so no later lifecycle mutation can
@@ -911,6 +1069,11 @@ impl FabricDeployer {
         if let Some(d) = removed {
             d.handle.shutdown().await;
         }
+        let persisted = match persisted {
+            Ok(snapshot) => snapshot,
+            Err(error @ FabricError::Committed(_)) => return Err(error),
+            Err(_) => unreachable!("pre-commit stop errors return before worker shutdown"),
+        };
         tracing::info!(
             audit = "cluster_fabric.stop",
             node = node_id,
@@ -996,17 +1159,11 @@ impl FabricDeployer {
         node_id: &str,
         probe_timeout: Duration,
     ) -> FabricResult<NodeState> {
-        let deployer = self.clone();
-        let node_id = node_id.to_string();
-        join_fabric_task(
-            "cluster-fabric health check",
-            tokio::spawn(async move {
-                deployer
-                    .health_check_within_inner(&node_id, probe_timeout)
-                    .await
-            }),
-        )
-        .await
+        // The potentially long broker probe belongs to the requesting owner:
+        // cancelling or replacing that owner cancels the probe too. Only the
+        // short final state transition below is detached once it owns the
+        // config guard and has revalidated the observation.
+        self.health_check_within_inner(node_id, probe_timeout).await
     }
 
     async fn health_check_within_inner(
@@ -1049,6 +1206,8 @@ impl FabricDeployer {
         let alive = verify_worker_connected(&broker, &worker_id, &role, probe_timeout)
             .await
             .is_ok();
+        #[cfg(test)]
+        run_health_after_probe_test_hook(&self.data_dir).await;
 
         let new_status = if alive {
             NodeStatus::Running
@@ -1067,7 +1226,7 @@ impl FabricDeployer {
         // captured before it started. A redeploy or node edit that wins while
         // the probe is in flight makes this observation stale; discard it
         // rather than applying it against the winner's newer revision.
-        let _io = self.config_io_lock.lock().await;
+        let io = self.config_io_lock.clone().lock_owned().await;
         let actual_revision = self.cluster_revision_locked();
         let (live, identity_matches) = {
             let cfg = self.config.read().await;
@@ -1110,37 +1269,50 @@ impl FabricDeployer {
         };
         if from != new_status {
             let committed_next = next.clone();
-            let snapshot = self
-                .persist_node_update_locked(observed_revision, |config| {
-                    let node = config
+            let deployer = self.clone();
+            let node_id = node_id.to_string();
+            let worker_id = worker_id.clone();
+            return join_fabric_task(
+                "cluster-fabric health state transaction",
+                tokio::spawn(async move {
+                    // Move the already-acquired guard into the finalizer. From
+                    // this point request cancellation cannot strand a durable
+                    // state flip before runtime/facade/event publication.
+                    let _io = io;
+                    let snapshot = deployer
+                        .persist_node_update_locked(observed_revision, |config| {
+                            let node =
+                                config.cluster_fabric.node_mut(&node_id).ok_or_else(|| {
+                                    FabricError::NotFound(format!("Node '{node_id}'"))
+                                })?;
+                            let current = node.state.clone().unwrap_or_default();
+                            node.state = Some(NodeState {
+                                status: committed_next.status,
+                                last_health: committed_next.last_health.clone(),
+                                last_error: committed_next.last_error.clone(),
+                                ..current
+                            });
+                            Ok(())
+                        })
+                        .await?;
+                    let adopted = snapshot
+                        .config
                         .cluster_fabric
-                        .node_mut(node_id)
-                        .ok_or_else(|| FabricError::NotFound(format!("Node '{node_id}'")))?;
-                    let current = node.state.clone().unwrap_or_default();
-                    node.state = Some(NodeState {
-                        status: committed_next.status,
-                        last_health: committed_next.last_health.clone(),
-                        last_error: committed_next.last_error.clone(),
-                        ..current
-                    });
-                    Ok(())
-                })
-                .await?;
-            let adopted = snapshot
-                .config
-                .cluster_fabric
-                .node(node_id)
-                .and_then(|node| node.state.clone())
-                .unwrap_or(live);
-            tracing::info!(
-                audit = "cluster_fabric.health",
-                node = node_id,
-                worker_id = %worker_id,
-                from = ?from,
-                to = ?adopted.status,
-                "node health changed",
-            );
-            return Ok(adopted);
+                        .node(&node_id)
+                        .and_then(|node| node.state.clone())
+                        .unwrap_or(live);
+                    tracing::info!(
+                        audit = "cluster_fabric.health",
+                        node = node_id,
+                        worker_id = %worker_id,
+                        from = ?from,
+                        to = ?adopted.status,
+                        "node health changed",
+                    );
+                    Ok(adopted)
+                }),
+            )
+            .await;
         }
 
         let mut cfg = self.config.write().await;
@@ -1839,6 +2011,148 @@ mod lifecycle_persistence_tests {
         }
     }
 
+    #[tokio::test]
+    async fn changed_lifecycle_commit_publishes_secret_free_runtime_before_committed_error() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let initial_facade = ConfigFacade::open_or_migrate(data_dir.path()).unwrap();
+        let password_ref = bamboo_config::cluster_password_credential_ref("secret-node").unwrap();
+        let mut candidate = initial_facade.effective_config();
+        candidate.cluster_fabric.nodes.push(Node {
+            id: "secret-node".to_string(),
+            label: "before-corruption".to_string(),
+            placement: NodePlacement::Ssh(SshTarget {
+                host: "corrupt.example.test".to_string(),
+                port: 22,
+                username: "operator".to_string(),
+                auth: SshAuth::Password {
+                    password: String::new(),
+                    password_encrypted: None,
+                },
+                host_key_fingerprint: None,
+            }),
+            trust_level: TrustLevel::Trusted,
+            deploy: DeployProfile::default(),
+            state: None,
+            enabled: true,
+        });
+        let revision = bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+            data_dir.path(),
+            &mut candidate,
+            &BTreeMap::from([(
+                "secret-node".to_string(),
+                bamboo_config::ClusterNodeCredentialIntents {
+                    password: bamboo_config::ClusterCredentialAction::Replace(
+                        "initial-password".to_string(),
+                    ),
+                    private_key: bamboo_config::ClusterCredentialAction::Clear,
+                    passphrase: bamboo_config::ClusterCredentialAction::Clear,
+                },
+            )]),
+            0,
+        )
+        .unwrap();
+        assert_eq!(revision, 1);
+        candidate
+            .hydrate_cluster_credentials_from_store(data_dir.path())
+            .unwrap();
+
+        let facade = Arc::new(ConfigFacade::open(data_dir.path()).unwrap());
+        let config = Arc::new(RwLock::new(candidate));
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let event_log = events.clone();
+        let deployer = FabricDeployer::new(
+            config.clone(),
+            Arc::new(Mutex::new(())),
+            data_dir.path().to_path_buf(),
+            Arc::new(Mutex::new(HashMap::new())),
+            "/usr/bin/true",
+        )
+        .with_modular_persistence(
+            facade.clone(),
+            Arc::new(CredentialStore::open(data_dir.path())),
+            Arc::new(move |event| event_log.lock().unwrap().push(event.clone())),
+        );
+
+        let credentials_path = data_dir.path().join("credentials.json");
+        let mut document: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&credentials_path).unwrap()).unwrap();
+        document["data"]["entries"][password_ref.as_str()]["ciphertext"] =
+            serde_json::Value::String("corrupt-ciphertext".to_string());
+        std::fs::write(
+            credentials_path,
+            serde_json::to_vec_pretty(&document).unwrap(),
+        )
+        .unwrap();
+
+        let noop = deployer
+            .persist_node_update_at_revision(1, |_| Ok(()))
+            .await;
+        match noop {
+            Err(FabricError::Internal(_)) => {}
+            Err(error) => panic!("no-op materialization error was misclassified: {error}"),
+            Ok(_) => panic!("corrupt credential unexpectedly materialized"),
+        }
+        let runtime = config.read().await;
+        let node = runtime.cluster_fabric.node("secret-node").unwrap();
+        let NodePlacement::Ssh(target) = &node.placement else {
+            panic!("expected SSH placement")
+        };
+        let SshAuth::Password { password, .. } = &target.auth else {
+            panic!("expected password authentication")
+        };
+        assert_eq!(
+            password, "initial-password",
+            "a true no-op materialization failure must preserve the old runtime"
+        );
+        drop(runtime);
+        assert_eq!(facade.registry().cluster_fabric.snapshot().revision, 1);
+        assert!(events.lock().unwrap().is_empty());
+
+        let result = deployer
+            .persist_node_update_at_revision(1, |config| {
+                config.cluster_fabric.node_mut("secret-node").unwrap().label =
+                    "committed-metadata".to_string();
+                Ok(())
+            })
+            .await;
+        match result {
+            Err(FabricError::Committed(_)) => {}
+            Err(error) => panic!("post-commit materialization error was misclassified: {error}"),
+            Ok(_) => panic!("corrupt credential unexpectedly materialized"),
+        }
+
+        let runtime = config.read().await;
+        let node = runtime.cluster_fabric.node("secret-node").unwrap();
+        assert_eq!(node.label, "committed-metadata");
+        let NodePlacement::Ssh(target) = &node.placement else {
+            panic!("expected SSH placement")
+        };
+        let SshAuth::Password {
+            password,
+            password_encrypted,
+        } = &target.auth
+        else {
+            panic!("expected password authentication")
+        };
+        assert!(password.is_empty());
+        assert!(password_encrypted.is_none());
+        drop(runtime);
+
+        let section = facade.registry().cluster_fabric.snapshot();
+        assert_eq!(section.revision, 2);
+        assert_eq!(
+            section.data.0.node("secret-node").unwrap().label,
+            "committed-metadata"
+        );
+        assert_eq!(
+            events.lock().unwrap().as_slice(),
+            &[ConfigSectionEvent::Changed {
+                section: "cluster-fabric".to_string(),
+                revision: 2,
+            }]
+        );
+    }
+
     async fn start_broker() -> (String, tempfile::TempDir) {
         let data_dir = tempfile::tempdir().unwrap();
         let core = Arc::new(bamboo_broker::BrokerCore::new(data_dir.path()));
@@ -2232,6 +2546,225 @@ mod lifecycle_persistence_tests {
         if let Some(replacement) = replacement {
             replacement.handle.shutdown().await;
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn external_commit_after_running_durable_commit_waits_for_exact_adoption() {
+        let (endpoint, _broker_dir) = start_broker().await;
+        let fixture = modular_running_fixture("/usr/bin/true");
+        let _worker = join_expected_worker(&fixture, &endpoint).await;
+        insert_prior_worker(&fixture).await;
+
+        let (external_done_tx, external_done_rx) = std::sync::mpsc::sync_channel(1);
+        set_after_commit_before_adoption_test_hook(fixture._data_dir.path(), 2, move |data_dir| {
+            let data_dir = data_dir.to_path_buf();
+            let (started_tx, started_rx) = std::sync::mpsc::sync_channel(0);
+            std::thread::spawn(move || {
+                started_tx.send(()).unwrap();
+                let external = ConfigFacade::open(&data_dir).unwrap();
+                let mut winner = external.effective_config();
+                winner.cluster_fabric.node_mut("n1").unwrap().label =
+                    "external-after-running".to_string();
+                let result =
+                    bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+                        &data_dir,
+                        &mut winner,
+                        &BTreeMap::new(),
+                        3,
+                    );
+                external_done_tx.send(result).unwrap();
+            });
+            started_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("external writer must be launched at the post-commit boundary");
+        });
+
+        let result = fixture
+            .deployer
+            .deploy_at_revision("n1", false, 1)
+            .await
+            .unwrap();
+        assert_eq!(result.snapshot.section.revision, 3);
+        assert_eq!(
+            result
+                .snapshot
+                .config
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .label,
+            "node"
+        );
+        assert_eq!(
+            fixture.facade.registry().cluster_fabric.snapshot().revision,
+            3,
+            "the process facade must adopt the exact Running commit first"
+        );
+        assert_eq!(
+            fixture.events.lock().unwrap().as_slice(),
+            &[
+                ConfigSectionEvent::Changed {
+                    section: "cluster-fabric".to_string(),
+                    revision: 2,
+                },
+                ConfigSectionEvent::Changed {
+                    section: "cluster-fabric".to_string(),
+                    revision: 3,
+                },
+            ]
+        );
+        assert!(
+            fixture
+                .registry
+                .lock()
+                .await
+                .contains_key(&crate::registry_keys::node_key("n1")),
+            "a committed Running worker must not be compensated"
+        );
+
+        assert_eq!(
+            tokio::task::spawn_blocking(move || {
+                external_done_rx
+                    .recv_timeout(Duration::from_secs(10))
+                    .expect("external writer must finish after adoption")
+                    .unwrap()
+            })
+            .await
+            .unwrap(),
+            4
+        );
+        let reopened = ConfigFacade::open(fixture._data_dir.path()).unwrap();
+        assert_eq!(reopened.registry().cluster_fabric.snapshot().revision, 4);
+        assert_eq!(
+            reopened
+                .effective_config()
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .label,
+            "external-after-running"
+        );
+
+        // Model the production watcher after it obtains the same local config
+        // guard: the later winner is applied and emitted strictly after r3.
+        {
+            let _io = fixture.config_io_lock.lock().await;
+            let event = fixture
+                .facade
+                .registry()
+                .reload_if_changed(SectionId::ClusterFabric)
+                .expect("later external revision must be observable");
+            let mut runtime = fixture.config.read().await.clone();
+            runtime.cluster_fabric = fixture.facade.effective_config().cluster_fabric.clone();
+            *fixture.config.write().await = runtime;
+            fixture.events.lock().unwrap().push(event);
+        }
+        assert_eq!(
+            fixture.facade.registry().cluster_fabric.snapshot().revision,
+            4
+        );
+        assert_eq!(
+            fixture
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .label,
+            "external-after-running"
+        );
+        assert_eq!(
+            fixture.events.lock().unwrap().last(),
+            Some(&ConfigSectionEvent::Changed {
+                section: "cluster-fabric".to_string(),
+                revision: 4,
+            })
+        );
+
+        let replacement = fixture
+            .registry
+            .lock()
+            .await
+            .remove(&crate::registry_keys::node_key("n1"));
+        if let Some(replacement) = replacement {
+            replacement.handle.shutdown().await;
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn external_commit_after_stopped_durable_commit_cannot_skip_worker_shutdown() {
+        let fixture = modular_running_fixture("/usr/bin/true");
+        insert_prior_worker(&fixture).await;
+
+        let (external_done_tx, external_done_rx) = std::sync::mpsc::sync_channel(1);
+        set_after_commit_before_adoption_test_hook(fixture._data_dir.path(), 1, move |data_dir| {
+            let data_dir = data_dir.to_path_buf();
+            let (started_tx, started_rx) = std::sync::mpsc::sync_channel(0);
+            std::thread::spawn(move || {
+                started_tx.send(()).unwrap();
+                let external = ConfigFacade::open(&data_dir).unwrap();
+                let mut winner = external.effective_config();
+                winner.cluster_fabric.node_mut("n1").unwrap().label =
+                    "external-after-stop".to_string();
+                let result =
+                    bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+                        &data_dir,
+                        &mut winner,
+                        &BTreeMap::new(),
+                        2,
+                    );
+                external_done_tx.send(result).unwrap();
+            });
+            started_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("external writer must be launched at the post-commit boundary");
+        });
+
+        let result = fixture.deployer.stop_at_revision("n1", 1).await.unwrap();
+        assert_eq!(result.snapshot.section.revision, 2);
+        assert_eq!(result.value.status, NodeStatus::Stopped);
+        assert!(
+            fixture.registry.lock().await.is_empty(),
+            "the committed stop must always shut down its registered worker"
+        );
+        assert_eq!(
+            fixture.events.lock().unwrap().as_slice(),
+            &[ConfigSectionEvent::Changed {
+                section: "cluster-fabric".to_string(),
+                revision: 2,
+            }]
+        );
+
+        assert_eq!(
+            tokio::task::spawn_blocking(move || {
+                external_done_rx
+                    .recv_timeout(Duration::from_secs(10))
+                    .expect("external writer must finish after adoption")
+                    .unwrap()
+            })
+            .await
+            .unwrap(),
+            3
+        );
+        let reopened = ConfigFacade::open(fixture._data_dir.path()).unwrap();
+        let durable = reopened.effective_config();
+        assert_eq!(reopened.registry().cluster_fabric.snapshot().revision, 3);
+        assert_eq!(
+            durable.cluster_fabric.node("n1").unwrap().label,
+            "external-after-stop"
+        );
+        assert_eq!(
+            durable
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Stopped
+        );
     }
 
     #[tokio::test]
@@ -2985,6 +3518,101 @@ mod health_check_tests {
             .unwrap();
         assert_eq!(node.deploy.default_role.as_deref(), Some("new-role"));
         assert_eq!(node.state.unwrap().worker_id.as_deref(), Some("new-worker"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_probe_cannot_outlive_owner_and_overwrite_replacement_owner() {
+        let (endpoint, _dir) = start_broker().await;
+        let fixture =
+            modular_deployer_with(vec![running_node("a", "old-worker", "old-role")], &endpoint);
+        let (reached_tx, reached_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        set_health_after_probe_test_hook(fixture.data_dir.path(), reached_tx, release_rx);
+
+        let probe = {
+            let deployer = fixture.deployer.clone();
+            tokio::spawn(async move {
+                deployer
+                    .health_check_within("a", Duration::from_millis(150))
+                    .await
+            })
+        };
+        tokio::time::timeout(Duration::from_secs(5), reached_rx)
+            .await
+            .expect("probe must reach its owner-cancellable boundary")
+            .expect("probe boundary signal must remain live");
+        probe.abort();
+        assert!(probe.await.unwrap_err().is_cancelled());
+        assert!(
+            release_tx.send(()).is_err(),
+            "cancelling the owner must drop the suspended probe"
+        );
+
+        let replacement_facade = Arc::new(ConfigFacade::open(fixture.data_dir.path()).unwrap());
+        let replacement_config =
+            Arc::new(RwLock::new(fixture.deployer.config.read().await.clone()));
+        let replacement_events = Arc::new(StdMutex::new(Vec::new()));
+        let replacement_event_log = replacement_events.clone();
+        let replacement = Arc::new(
+            FabricDeployer::new(
+                replacement_config.clone(),
+                Arc::new(Mutex::new(())),
+                fixture.data_dir.path().to_path_buf(),
+                Arc::new(Mutex::new(HashMap::new())),
+                "/usr/bin/true",
+            )
+            .with_modular_persistence(
+                replacement_facade.clone(),
+                Arc::new(CredentialStore::open(fixture.data_dir.path())),
+                Arc::new(move |event| replacement_event_log.lock().unwrap().push(event.clone())),
+            ),
+        );
+        let winner = replacement
+            .persist_node_update_at_revision(1, |config| {
+                let node = config.cluster_fabric.node_mut("a").unwrap();
+                node.label = "replacement-owner".to_string();
+                node.deploy.default_role = Some("new-role".to_string());
+                node.state = Some(NodeState {
+                    status: NodeStatus::Running,
+                    worker_id: Some("new-worker".to_string()),
+                    ..Default::default()
+                });
+                Ok(())
+            })
+            .await
+            .unwrap();
+        assert_eq!(winner.section.revision, 2);
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let reopened = ConfigFacade::open(fixture.data_dir.path()).unwrap();
+        assert_eq!(
+            reopened.registry().cluster_fabric.snapshot().revision,
+            2,
+            "the cancelled stale probe must never create revision 3"
+        );
+        let replacement_node = replacement_config
+            .read()
+            .await
+            .cluster_fabric
+            .node("a")
+            .cloned()
+            .unwrap();
+        assert_eq!(replacement_node.label, "replacement-owner");
+        assert_eq!(
+            replacement_node.state.unwrap().worker_id.as_deref(),
+            Some("new-worker")
+        );
+        assert_eq!(
+            replacement_events.lock().unwrap().as_slice(),
+            &[ConfigSectionEvent::Changed {
+                section: "cluster-fabric".to_string(),
+                revision: 2,
+            }]
+        );
+        assert!(
+            fixture.events.lock().unwrap().is_empty(),
+            "the cancelled owner must publish no stale health event"
+        );
     }
 }
 

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -20,7 +20,7 @@ use bamboo_broker::{
     RusshDeployer, SshDeployer, UploadSpec, ORCHESTRATOR_ID,
 };
 use bamboo_config::cluster_fabric::{
-    ClusterFabricConfig, Node, NodePlacement, NodeState, NodeStatus, SshAuth, SshTarget,
+    Node, NodePlacement, NodeState, NodeStatus, SshAuth, SshTarget,
 };
 use bamboo_config::{
     BrokerClientConfig, Config, ConfigFacade, ConfigSectionEvent, ConfigStoreError,
@@ -354,27 +354,9 @@ impl FabricDeployer {
         }
     }
 
-    async fn hydrate_cluster_fabric(
-        &self,
-        fabric: ClusterFabricConfig,
-    ) -> FabricResult<ClusterFabricConfig> {
-        let data_dir = self.data_dir.clone();
-        tokio::task::spawn_blocking(move || {
-            let mut config = Config::default();
-            config.cluster_fabric = fabric;
-            config.hydrate_cluster_credentials_from_store(&data_dir)?;
-            Ok::<_, ConfigStoreError>(config.cluster_fabric.clone())
-        })
-        .await
-        .map_err(|error| {
-            FabricError::Internal(format!("credential hydration task failed: {error}"))
-        })?
-        .map_err(map_config_store_error)
-    }
-
     async fn snapshot_locked(&self, expected_revision: u64) -> FabricResult<FabricCommitSnapshot> {
         let mut config = self.config.read().await.clone();
-        let section = if let Some(facade) = &self.config_facade {
+        if self.config_facade.is_some() {
             let actual = self.cluster_revision_locked();
             if expected_revision != actual {
                 return Err(FabricError::Conflict {
@@ -382,21 +364,36 @@ impl FabricDeployer {
                     actual,
                 });
             }
-            config.cluster_fabric = self
-                .hydrate_cluster_fabric(facade.effective_config().cluster_fabric.clone())
-                .await?;
-            facade
-                .registry()
-                .envelope_value(SectionId::ClusterFabric)
-                .map_err(map_config_store_error)?
-        } else {
-            if expected_revision != 0 {
-                return Err(FabricError::Conflict {
-                    expected: expected_revision,
-                    actual: 0,
-                });
-            }
-            SectionEnvelope {
+            let data_dir = self.data_dir.clone();
+            let exact = tokio::task::spawn_blocking(move || {
+                bamboo_config::read_exact_cluster_fabric_snapshot(
+                    &data_dir,
+                    Some(expected_revision),
+                )
+            })
+            .await
+            .map_err(|error| {
+                FabricError::Internal(format!("cluster snapshot task failed: {error}"))
+            })?
+            .map_err(map_config_store_error)?;
+            config.cluster_fabric = exact.cluster_fabric;
+            return Ok(FabricCommitSnapshot {
+                config,
+                section: exact.section,
+                credential_statuses: exact.credential_statuses,
+                credential_health: exact.credential_health,
+            });
+        }
+        if expected_revision != 0 {
+            return Err(FabricError::Conflict {
+                expected: expected_revision,
+                actual: 0,
+            });
+        }
+        let (credential_statuses, credential_health) = self.credential_snapshot();
+        Ok(FabricCommitSnapshot {
+            config,
+            section: SectionEnvelope {
                 data: serde_json::Value::Null,
                 revision: 0,
                 loaded_at: chrono::Utc::now(),
@@ -404,12 +401,7 @@ impl FabricDeployer {
                 source_kind: SectionSourceKind::Default,
                 status: SectionStatus::Healthy,
                 last_error: None,
-            }
-        };
-        let (credential_statuses, credential_health) = self.credential_snapshot();
-        Ok(FabricCommitSnapshot {
-            config,
-            section,
+            },
             credential_statuses,
             credential_health,
         })
@@ -563,6 +555,7 @@ impl FabricDeployer {
                 revision,
                 adoption,
                 credential_adoption,
+                committed_recovery,
                 runtime,
             } = commit;
             let runtime = match runtime {
@@ -619,6 +612,11 @@ impl FabricDeployer {
 
             if let (Some(event), Some(publish)) = (event.as_ref(), self.publish_event.as_ref()) {
                 publish(event);
+            }
+            if let Err(error) = committed_recovery {
+                return Err(FabricError::Committed(format!(
+                    "cluster configuration committed at revision {revision} but transaction recovery failed: {error}"
+                )));
             }
             if let Some(Err(error)) = credential_adoption {
                 return Err(FabricError::Committed(format!(
@@ -1943,27 +1941,19 @@ mod lifecycle_persistence_tests {
         events: Arc<StdMutex<Vec<ConfigSectionEvent>>>,
     }
 
-    fn modular_running_fixture(bamboo_bin: &str) -> ModularFixture {
+    fn modular_fixture_with_node(
+        bamboo_bin: &str,
+        node: Node,
+        node_intents: BTreeMap<String, bamboo_config::ClusterNodeCredentialIntents>,
+    ) -> ModularFixture {
         let data_dir = tempfile::tempdir().unwrap();
         let facade = Arc::new(ConfigFacade::open_or_migrate(data_dir.path()).unwrap());
         let mut candidate = facade.effective_config();
-        candidate.cluster_fabric.nodes.push(Node {
-            id: "n1".to_string(),
-            label: "node".to_string(),
-            placement: NodePlacement::Local,
-            trust_level: TrustLevel::Trusted,
-            deploy: DeployProfile::default(),
-            state: Some(NodeState {
-                status: NodeStatus::Running,
-                worker_id: Some("cluster-node-n1".to_string()),
-                ..Default::default()
-            }),
-            enabled: true,
-        });
+        candidate.cluster_fabric.nodes.push(node);
         let revision = bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
             data_dir.path(),
             &mut candidate,
-            &BTreeMap::new(),
+            &node_intents,
             0,
         )
         .unwrap();
@@ -1974,6 +1964,9 @@ mod lifecycle_persistence_tests {
             .is_some());
 
         let mut runtime = facade.effective_config();
+        runtime
+            .hydrate_cluster_credentials_from_store(data_dir.path())
+            .unwrap();
         runtime.subagents_mut().broker = Some(BrokerClientConfig {
             endpoint: "ws://127.0.0.1:9".to_string(),
             token: "test-token".to_string(),
@@ -2009,6 +2002,62 @@ mod lifecycle_persistence_tests {
             deployer,
             events,
         }
+    }
+
+    fn modular_running_fixture(bamboo_bin: &str) -> ModularFixture {
+        modular_fixture_with_node(
+            bamboo_bin,
+            Node {
+                id: "n1".to_string(),
+                label: "node".to_string(),
+                placement: NodePlacement::Local,
+                trust_level: TrustLevel::Trusted,
+                deploy: DeployProfile::default(),
+                state: Some(NodeState {
+                    status: NodeStatus::Running,
+                    worker_id: Some("cluster-node-n1".to_string()),
+                    ..Default::default()
+                }),
+                enabled: true,
+            },
+            BTreeMap::new(),
+        )
+    }
+
+    fn modular_password_fixture(bamboo_bin: &str, password: &str) -> ModularFixture {
+        modular_fixture_with_node(
+            bamboo_bin,
+            Node {
+                id: "n1".to_string(),
+                label: "password-generation-one".to_string(),
+                placement: NodePlacement::Ssh(SshTarget {
+                    host: "preflight-must-not-run.invalid".to_string(),
+                    port: 22,
+                    username: "operator".to_string(),
+                    auth: SshAuth::Password {
+                        password: String::new(),
+                        password_encrypted: None,
+                    },
+                    host_key_fingerprint: None,
+                }),
+                trust_level: TrustLevel::Trusted,
+                deploy: DeployProfile::default(),
+                state: Some(NodeState {
+                    status: NodeStatus::Running,
+                    worker_id: Some("cluster-node-n1".to_string()),
+                    ..Default::default()
+                }),
+                enabled: true,
+            },
+            BTreeMap::from([(
+                "n1".to_string(),
+                bamboo_config::ClusterNodeCredentialIntents {
+                    password: bamboo_config::ClusterCredentialAction::Replace(password.to_string()),
+                    private_key: bamboo_config::ClusterCredentialAction::Clear,
+                    passphrase: bamboo_config::ClusterCredentialAction::Clear,
+                },
+            )]),
+        )
     }
 
     #[tokio::test]
@@ -2216,6 +2265,521 @@ mod lifecycle_persistence_tests {
                 handle: bamboo_broker::DeployedAgent::from_parts("old-worker", child, None),
             },
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn deploy_recovers_after_manifest_without_compensating_verified_worker() {
+        let (endpoint, _broker_dir) = start_broker().await;
+        let fixture = modular_running_fixture("/usr/bin/true");
+        let _worker = join_expected_worker(&fixture, &endpoint).await;
+        insert_prior_worker(&fixture).await;
+
+        set_deploy_before_final_persist_test_hook(fixture._data_dir.path(), move |data_dir| {
+            bamboo_config::set_cluster_exact_commit_test_fault(
+                data_dir.to_path_buf(),
+                bamboo_config::ClusterExactCommitTestFault::AfterManifest,
+            );
+        });
+
+        let result = fixture
+            .deployer
+            .deploy_at_revision("n1", false, 1)
+            .await
+            .expect("the committed Running transaction must recover in place");
+        assert_eq!(result.snapshot.section.revision, 3);
+        assert_eq!(result.value.status, NodeStatus::Running);
+        assert!(
+            fixture
+                .registry
+                .lock()
+                .await
+                .contains_key(&crate::registry_keys::node_key("n1")),
+            "post-manifest recovery must not compensate the verified worker"
+        );
+        assert_eq!(
+            fixture
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Running
+        );
+        assert_eq!(
+            fixture.facade.registry().cluster_fabric.snapshot().revision,
+            3
+        );
+        assert_eq!(
+            fixture.events.lock().unwrap().as_slice(),
+            &[
+                ConfigSectionEvent::Changed {
+                    section: "cluster-fabric".to_string(),
+                    revision: 2,
+                },
+                ConfigSectionEvent::Changed {
+                    section: "cluster-fabric".to_string(),
+                    revision: 3,
+                },
+            ]
+        );
+        let reopened = ConfigFacade::open(fixture._data_dir.path()).unwrap();
+        assert_eq!(reopened.registry().cluster_fabric.snapshot().revision, 3);
+        assert_eq!(
+            reopened
+                .effective_config()
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Running
+        );
+        bamboo_config::ensure_provider_mcp_migration_ready(fixture._data_dir.path()).unwrap();
+
+        let replacement = fixture
+            .registry
+            .lock()
+            .await
+            .remove(&crate::registry_keys::node_key("n1"));
+        if let Some(replacement) = replacement {
+            replacement.handle.shutdown().await;
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn persistent_recovery_failure_remains_committed_for_deploy_and_stop() {
+        let (endpoint, _broker_dir) = start_broker().await;
+        let deploy_fixture = modular_running_fixture("/usr/bin/true");
+        let _worker = join_expected_worker(&deploy_fixture, &endpoint).await;
+        insert_prior_worker(&deploy_fixture).await;
+        set_deploy_before_final_persist_test_hook(
+            deploy_fixture._data_dir.path(),
+            move |data_dir| {
+                bamboo_config::set_cluster_exact_commit_test_fault(
+                    data_dir.to_path_buf(),
+                    bamboo_config::ClusterExactCommitTestFault::AfterManifestRecoveryFailure,
+                );
+            },
+        );
+
+        let deploy_error = match deploy_fixture
+            .deployer
+            .deploy_at_revision("n1", false, 1)
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("the injected persistent recovery failure must surface"),
+        };
+        assert!(matches!(deploy_error, FabricError::Committed(_)));
+        assert!(
+            deploy_fixture
+                .registry
+                .lock()
+                .await
+                .contains_key(&crate::registry_keys::node_key("n1")),
+            "a committed Running candidate must retain its verified worker"
+        );
+        assert_eq!(
+            deploy_fixture
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Running
+        );
+        assert_eq!(
+            deploy_fixture
+                .facade
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            3
+        );
+        assert_eq!(
+            deploy_fixture.events.lock().unwrap().as_slice(),
+            &[
+                ConfigSectionEvent::Changed {
+                    section: "cluster-fabric".to_string(),
+                    revision: 2,
+                },
+                ConfigSectionEvent::Changed {
+                    section: "cluster-fabric".to_string(),
+                    revision: 3,
+                },
+            ]
+        );
+        let recovered_deploy = ConfigFacade::open_or_migrate(deploy_fixture._data_dir.path())
+            .expect("later startup recovery");
+        assert_eq!(
+            recovered_deploy
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            3
+        );
+        assert_eq!(
+            recovered_deploy
+                .effective_config()
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Running
+        );
+        let replacement = deploy_fixture
+            .registry
+            .lock()
+            .await
+            .remove(&crate::registry_keys::node_key("n1"));
+        if let Some(replacement) = replacement {
+            replacement.handle.shutdown().await;
+        }
+
+        let stop_fixture = modular_running_fixture("/usr/bin/true");
+        insert_prior_worker(&stop_fixture).await;
+        bamboo_config::set_cluster_exact_commit_test_fault(
+            stop_fixture._data_dir.path().to_path_buf(),
+            bamboo_config::ClusterExactCommitTestFault::AfterManifestRecoveryFailure,
+        );
+        let stop_error = match stop_fixture.deployer.stop_at_revision("n1", 1).await {
+            Err(error) => error,
+            Ok(_) => panic!("the injected persistent recovery failure must surface"),
+        };
+        assert!(matches!(stop_error, FabricError::Committed(_)));
+        assert!(
+            stop_fixture.registry.lock().await.is_empty(),
+            "a committed Stopped candidate must still shut down the worker"
+        );
+        assert_eq!(
+            stop_fixture
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Stopped
+        );
+        assert_eq!(
+            stop_fixture
+                .facade
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            2
+        );
+        assert_eq!(
+            stop_fixture.events.lock().unwrap().as_slice(),
+            &[ConfigSectionEvent::Changed {
+                section: "cluster-fabric".to_string(),
+                revision: 2,
+            }]
+        );
+        let recovered_stop = ConfigFacade::open_or_migrate(stop_fixture._data_dir.path())
+            .expect("later startup recovery");
+        assert_eq!(
+            recovered_stop.registry().cluster_fabric.snapshot().revision,
+            2
+        );
+        assert_eq!(
+            recovered_stop
+                .effective_config()
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Stopped
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_recovers_after_credential_install_and_still_shuts_down_worker() {
+        let fixture = modular_running_fixture("/usr/bin/true");
+        insert_prior_worker(&fixture).await;
+        bamboo_config::set_cluster_exact_commit_test_fault(
+            fixture._data_dir.path().to_path_buf(),
+            bamboo_config::ClusterExactCommitTestFault::AfterCredentialInstall,
+        );
+
+        let result = fixture
+            .deployer
+            .stop_at_revision("n1", 1)
+            .await
+            .expect("the committed Stopped transaction must recover in place");
+        assert_eq!(result.snapshot.section.revision, 2);
+        assert_eq!(result.value.status, NodeStatus::Stopped);
+        assert!(
+            fixture.registry.lock().await.is_empty(),
+            "post-install recovery must still perform the authoritative shutdown"
+        );
+        assert_eq!(
+            fixture
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Stopped
+        );
+        assert_eq!(
+            fixture.facade.registry().cluster_fabric.snapshot().revision,
+            2
+        );
+        assert_eq!(
+            fixture.events.lock().unwrap().as_slice(),
+            &[ConfigSectionEvent::Changed {
+                section: "cluster-fabric".to_string(),
+                revision: 2,
+            }]
+        );
+        let reopened = ConfigFacade::open(fixture._data_dir.path()).unwrap();
+        assert_eq!(reopened.registry().cluster_fabric.snapshot().revision, 2);
+        assert_eq!(
+            reopened
+                .effective_config()
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Stopped
+        );
+        bamboo_config::ensure_provider_mcp_migration_ready(fixture._data_dir.path()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn stale_local_facade_cannot_authorize_preflight_over_newer_durable_revision() {
+        let fixture = modular_running_fixture("/usr/bin/true");
+        let external = ConfigFacade::open(fixture._data_dir.path()).unwrap();
+        let mut winner = external.effective_config();
+        winner.cluster_fabric.node_mut("n1").unwrap().label = "durable-generation-two".to_string();
+        let revision = bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+            fixture._data_dir.path(),
+            &mut winner,
+            &BTreeMap::new(),
+            1,
+        )
+        .unwrap();
+        assert_eq!(revision, 2);
+        assert_eq!(
+            fixture.facade.registry().cluster_fabric.snapshot().revision,
+            1,
+            "the first process facade intentionally remains stale"
+        );
+
+        let error = match fixture.deployer.test_at_revision("n1", 1).await {
+            Err(error) => error,
+            Ok(_) => panic!("a stale process facade must not authorize local preflight"),
+        };
+        assert!(matches!(
+            error,
+            FabricError::Conflict {
+                expected: 1,
+                actual: 2
+            }
+        ));
+        assert_eq!(
+            fixture
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .label,
+            "node",
+            "the rejected preflight must not adopt a later generation implicitly"
+        );
+    }
+
+    #[tokio::test]
+    async fn degraded_backup_cannot_mix_newer_credentials_into_revision_bound_preflight() {
+        let fixture = modular_password_fixture("/usr/bin/true", "generation-one-password");
+        let password_ref = bamboo_config::cluster_password_credential_ref("n1").unwrap();
+        let external = ConfigFacade::open(fixture._data_dir.path()).unwrap();
+        let mut winner = external.effective_config();
+        winner.cluster_fabric.node_mut("n1").unwrap().label = "password-generation-two".to_string();
+        let revision = bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+            fixture._data_dir.path(),
+            &mut winner,
+            &BTreeMap::from([(
+                "n1".to_string(),
+                bamboo_config::ClusterNodeCredentialIntents {
+                    password: bamboo_config::ClusterCredentialAction::Replace(
+                        "generation-two-password".to_string(),
+                    ),
+                    private_key: bamboo_config::ClusterCredentialAction::Clear,
+                    passphrase: bamboo_config::ClusterCredentialAction::Clear,
+                },
+            )]),
+            1,
+        )
+        .unwrap();
+        assert_eq!(revision, 2);
+        assert_eq!(
+            CredentialStore::open(fixture._data_dir.path())
+                .resolve(&password_ref)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            "generation-two-password",
+            "the credential primary intentionally belongs to r2"
+        );
+        std::fs::write(
+            fixture._data_dir.path().join("cluster-fabric.json"),
+            b"{invalid-generation-two-primary",
+        )
+        .unwrap();
+        assert_eq!(
+            fixture.facade.registry().cluster_fabric.snapshot().revision,
+            1,
+            "the action process intentionally retains its r1 facade"
+        );
+        let exact_error = match bamboo_config::read_exact_cluster_fabric_snapshot(
+            fixture._data_dir.path(),
+            Some(2),
+        ) {
+            Err(error) => error,
+            Ok(_) => panic!("a backup is never the r2 CAS authority"),
+        };
+        assert!(
+            matches!(exact_error, ConfigStoreError::Validation(message)
+                if message.contains("healthy primary section")),
+            "degraded authority must fail closed before comparing its backup revision"
+        );
+
+        let error = match fixture.deployer.test_at_revision("n1", 1).await {
+            Err(error) => error,
+            Ok(_) => panic!("a degraded section backup must not authorize preflight"),
+        };
+        match error {
+            FabricError::BadRequest(message) => {
+                assert!(message.contains("require a healthy primary"));
+            }
+            other => panic!("degraded exact read returned the wrong error: {other}"),
+        }
+        let runtime = fixture.config.read().await;
+        let NodePlacement::Ssh(target) = &runtime.cluster_fabric.node("n1").unwrap().placement
+        else {
+            panic!("expected SSH placement")
+        };
+        let SshAuth::Password { password, .. } = &target.auth else {
+            panic!("expected password authentication")
+        };
+        assert_eq!(
+            password, "generation-one-password",
+            "the rejected action must never hydrate r1 metadata with r2 credentials"
+        );
+        assert!(fixture.events.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn degraded_credential_backup_cannot_mix_with_current_cluster_preflight() {
+        let fixture = modular_password_fixture("/usr/bin/true", "generation-one-password");
+        let password_ref = bamboo_config::cluster_password_credential_ref("n1").unwrap();
+        let external = ConfigFacade::open(fixture._data_dir.path()).unwrap();
+        let mut winner = external.effective_config();
+        winner.cluster_fabric.node_mut("n1").unwrap().label = "password-generation-two".to_string();
+        let revision = bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+            fixture._data_dir.path(),
+            &mut winner,
+            &BTreeMap::from([(
+                "n1".to_string(),
+                bamboo_config::ClusterNodeCredentialIntents {
+                    password: bamboo_config::ClusterCredentialAction::Replace(
+                        "generation-two-password".to_string(),
+                    ),
+                    private_key: bamboo_config::ClusterCredentialAction::Clear,
+                    passphrase: bamboo_config::ClusterCredentialAction::Clear,
+                },
+            )]),
+            1,
+        )
+        .unwrap();
+        assert_eq!(revision, 2);
+        assert!(fixture
+            .facade
+            .registry()
+            .reload_if_changed(SectionId::ClusterFabric)
+            .is_some());
+        assert_eq!(
+            fixture.facade.registry().cluster_fabric.snapshot().revision,
+            2
+        );
+        assert_eq!(
+            CredentialStore::open(fixture._data_dir.path())
+                .resolve(&password_ref)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            "generation-two-password"
+        );
+        std::fs::write(
+            fixture._data_dir.path().join("credentials.json"),
+            b"{invalid-generation-two-primary",
+        )
+        .unwrap();
+
+        let error = match fixture.deployer.test_at_revision("n1", 2).await {
+            Err(error) => error,
+            Ok(_) => panic!("a degraded credential backup must not authorize preflight"),
+        };
+        match error {
+            FabricError::BadRequest(message) => {
+                assert!(message.contains("healthy primary credential"));
+            }
+            other => panic!("degraded exact credential read returned the wrong error: {other}"),
+        }
+        let runtime = fixture.config.read().await;
+        let node = runtime.cluster_fabric.node("n1").unwrap();
+        assert_eq!(
+            node.label, "password-generation-one",
+            "the rejected action must not adopt current metadata implicitly"
+        );
+        let NodePlacement::Ssh(target) = &node.placement else {
+            panic!("expected SSH placement")
+        };
+        let SshAuth::Password { password, .. } = &target.auth else {
+            panic!("expected password authentication")
+        };
+        assert_eq!(
+            password, "generation-one-password",
+            "the rejected action must never hydrate r2 metadata with r1 credentials"
+        );
+        assert!(fixture.events.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -80,6 +80,10 @@ fn map_config_store_error(error: ConfigStoreError) -> FabricError {
             FabricError::Conflict { expected, actual }
         }
         ConfigStoreError::Validation(message) => FabricError::BadRequest(message),
+        ConfigStoreError::CommitIndeterminate(message) => FabricError::Committed(format!(
+            "cluster configuration outcome is indeterminate; preserve the external lifecycle \
+             action until recovery resolves it: {message}"
+        )),
         ConfigStoreError::Io(error) => {
             FabricError::Internal(format!("cluster configuration storage failed: {error}"))
         }
@@ -1945,6 +1949,17 @@ mod lifecycle_persistence_tests {
     use super::*;
     use bamboo_config::cluster_fabric::{DeployProfile, TrustLevel};
     use std::sync::Mutex as StdMutex;
+
+    #[test]
+    fn indeterminate_config_commit_maps_to_non_compensating_lifecycle_error() {
+        let error = map_config_store_error(ConfigStoreError::CommitIndeterminate(
+            "recovery may still commit".to_string(),
+        ));
+        assert!(matches!(error, FabricError::Committed(_)));
+        assert!(error
+            .to_string()
+            .contains("preserve the external lifecycle action"));
+    }
 
     struct ModularFixture {
         _data_dir: tempfile::TempDir,

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -2627,7 +2627,9 @@ mod lifecycle_persistence_tests {
 
     #[tokio::test]
     async fn degraded_backup_cannot_mix_newer_credentials_into_revision_bound_preflight() {
-        let fixture = modular_password_fixture("/usr/bin/true", "generation-one-password");
+        let generation_one_secret = uuid::Uuid::new_v4().to_string();
+        let generation_two_secret = uuid::Uuid::new_v4().to_string();
+        let fixture = modular_password_fixture("/usr/bin/true", &generation_one_secret);
         let password_ref = bamboo_config::cluster_password_credential_ref("n1").unwrap();
         let external = ConfigFacade::open(fixture._data_dir.path()).unwrap();
         let mut winner = external.effective_config();
@@ -2639,7 +2641,7 @@ mod lifecycle_persistence_tests {
                 "n1".to_string(),
                 bamboo_config::ClusterNodeCredentialIntents {
                     password: bamboo_config::ClusterCredentialAction::Replace(
-                        "generation-two-password".to_string(),
+                        generation_two_secret.clone(),
                     ),
                     private_key: bamboo_config::ClusterCredentialAction::Clear,
                     passphrase: bamboo_config::ClusterCredentialAction::Clear,
@@ -2655,7 +2657,7 @@ mod lifecycle_persistence_tests {
                 .unwrap()
                 .unwrap()
                 .expose(),
-            "generation-two-password",
+            generation_two_secret,
             "the credential primary intentionally belongs to r2"
         );
         std::fs::write(
@@ -2700,7 +2702,7 @@ mod lifecycle_persistence_tests {
             panic!("expected password authentication")
         };
         assert_eq!(
-            password, "generation-one-password",
+            password, &generation_one_secret,
             "the rejected action must never hydrate r1 metadata with r2 credentials"
         );
         assert!(fixture.events.lock().unwrap().is_empty());
@@ -2708,7 +2710,9 @@ mod lifecycle_persistence_tests {
 
     #[tokio::test]
     async fn degraded_credential_backup_cannot_mix_with_current_cluster_preflight() {
-        let fixture = modular_password_fixture("/usr/bin/true", "generation-one-password");
+        let generation_one_secret = uuid::Uuid::new_v4().to_string();
+        let generation_two_secret = uuid::Uuid::new_v4().to_string();
+        let fixture = modular_password_fixture("/usr/bin/true", &generation_one_secret);
         let password_ref = bamboo_config::cluster_password_credential_ref("n1").unwrap();
         let external = ConfigFacade::open(fixture._data_dir.path()).unwrap();
         let mut winner = external.effective_config();
@@ -2720,7 +2724,7 @@ mod lifecycle_persistence_tests {
                 "n1".to_string(),
                 bamboo_config::ClusterNodeCredentialIntents {
                     password: bamboo_config::ClusterCredentialAction::Replace(
-                        "generation-two-password".to_string(),
+                        generation_two_secret.clone(),
                     ),
                     private_key: bamboo_config::ClusterCredentialAction::Clear,
                     passphrase: bamboo_config::ClusterCredentialAction::Clear,
@@ -2745,7 +2749,7 @@ mod lifecycle_persistence_tests {
                 .unwrap()
                 .unwrap()
                 .expose(),
-            "generation-two-password"
+            generation_two_secret
         );
         std::fs::write(
             fixture._data_dir.path().join("credentials.json"),
@@ -2776,7 +2780,7 @@ mod lifecycle_persistence_tests {
             panic!("expected password authentication")
         };
         assert_eq!(
-            password, "generation-one-password",
+            password, &generation_one_secret,
             "the rejected action must never hydrate r2 metadata with r1 credentials"
         );
         assert!(fixture.events.lock().unwrap().is_empty());

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -8,7 +8,7 @@
 //! `bamboo-config`'s `Node` and `bamboo-broker`'s deployers) keeps placement/
 //! auth handling in one place.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -20,9 +20,13 @@ use bamboo_broker::{
     RusshDeployer, SshDeployer, UploadSpec, ORCHESTRATOR_ID,
 };
 use bamboo_config::cluster_fabric::{
-    Node, NodePlacement, NodeState, NodeStatus, SshAuth, SshTarget,
+    ClusterFabricConfig, Node, NodePlacement, NodeState, NodeStatus, SshAuth, SshTarget,
 };
-use bamboo_config::{BrokerClientConfig, Config};
+use bamboo_config::{
+    BrokerClientConfig, Config, ConfigFacade, ConfigSectionEvent, ConfigStoreError,
+    CredentialStatus, CredentialStore, CredentialStoreHealth, SectionEnvelope, SectionId,
+    SectionSourceKind, SectionStatus,
+};
 use bamboo_subagent::{AgentRef, AskMode};
 
 use crate::deploy_agent::{Deployed, DeployedRegistry};
@@ -32,6 +36,7 @@ use crate::deploy_agent::{Deployed, DeployedRegistry};
 pub enum FabricError {
     NotFound(String),
     BadRequest(String),
+    Conflict { expected: u64, actual: u64 },
     Internal(String),
 }
 
@@ -41,11 +46,56 @@ impl std::fmt::Display for FabricError {
             FabricError::NotFound(m) | FabricError::BadRequest(m) | FabricError::Internal(m) => {
                 write!(f, "{m}")
             }
+            FabricError::Conflict { expected, actual } => {
+                write!(
+                    f,
+                    "cluster configuration conflict: expected revision {expected}, current revision {actual}"
+                )
+            }
         }
     }
 }
 
 type FabricResult<T> = Result<T, FabricError>;
+
+fn map_config_store_error(error: ConfigStoreError) -> FabricError {
+    match error {
+        ConfigStoreError::Conflict { expected, actual } => {
+            FabricError::Conflict { expected, actual }
+        }
+        ConfigStoreError::Validation(message) => FabricError::BadRequest(message),
+        ConfigStoreError::Io(error) => {
+            FabricError::Internal(format!("cluster configuration storage failed: {error}"))
+        }
+        ConfigStoreError::Json(_) => {
+            FabricError::Internal("cluster configuration document is invalid".to_string())
+        }
+        ConfigStoreError::Watch(error) => {
+            FabricError::Internal(format!("cluster configuration watch failed: {error}"))
+        }
+    }
+}
+
+/// Exact, adopted cluster-fabric snapshot bound to one lifecycle read or
+/// durable mutation. This type deliberately has no `Debug`/`Serialize`
+/// implementation: the runtime `Config` may contain hydrated SSH secrets and
+/// must only be projected through the server's redacted response builder.
+pub struct FabricCommitSnapshot {
+    pub config: Config,
+    pub section: SectionEnvelope<serde_json::Value>,
+    pub credential_statuses: Vec<CredentialStatus>,
+    pub credential_health: CredentialStoreHealth,
+}
+
+/// Lifecycle result paired with the exact cluster snapshot it observed or
+/// committed. HTTP callers use the snapshot for their redacted envelope;
+/// agent-tool callers can consume only `value`.
+pub struct FabricActionResult<T> {
+    pub value: T,
+    pub snapshot: FabricCommitSnapshot,
+}
+
+type FabricEventPublisher = Arc<dyn Fn(&ConfigSectionEvent) + Send + Sync>;
 
 /// The shared fabric deploy engine: turns persisted nodes into running
 /// `broker-agent` workers, holding their handles + persisting `NodeState`.
@@ -55,6 +105,12 @@ pub struct FabricDeployer {
     /// `AppState::update_config`'s io-lock — #126).
     config_io_lock: Arc<Mutex<()>>,
     data_dir: PathBuf,
+    /// Process-owned modular section authority. Production installs this
+    /// together with the credential store and event publisher; legacy unit
+    /// fixtures retain the compatibility fallback.
+    config_facade: Option<Arc<ConfigFacade>>,
+    credential_store: Option<Arc<CredentialStore>>,
+    publish_event: Option<FabricEventPublisher>,
     /// Worker handles, keyed by node id — SHARED with `deploy_agent` so both
     /// surfaces see/manage the same workers.
     registry: DeployedRegistry,
@@ -97,10 +153,28 @@ impl FabricDeployer {
             config,
             config_io_lock,
             data_dir: data_dir.into(),
+            config_facade: None,
+            credential_store: None,
+            publish_event: None,
             registry,
             bamboo_bin: bamboo_bin.into(),
             recovery: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Attach the process-owned modular authorities used by production. Every
+    /// durable lifecycle write then participates in the cluster-fabric section
+    /// CAS and publishes the same authoritative section event as operator CRUD.
+    pub fn with_modular_persistence(
+        mut self,
+        config_facade: Arc<ConfigFacade>,
+        credential_store: Arc<CredentialStore>,
+        publish_event: FabricEventPublisher,
+    ) -> Self {
+        self.config_facade = Some(config_facade);
+        self.credential_store = Some(credential_store);
+        self.publish_event = Some(publish_event);
+        self
     }
 
     /// The shared worker registry (so `deploy_agent` can reuse it).
@@ -115,15 +189,243 @@ impl FabricDeployer {
             .ok_or_else(|| FabricError::NotFound(format!("Node '{node_id}'")))
     }
 
+    fn credential_snapshot(&self) -> (Vec<CredentialStatus>, CredentialStoreHealth) {
+        let store = self
+            .credential_store
+            .clone()
+            .unwrap_or_else(|| Arc::new(CredentialStore::open(&self.data_dir)));
+        match store.statuses_with_health() {
+            Ok(snapshot) => snapshot,
+            Err(_) => (
+                Vec::new(),
+                CredentialStoreHealth {
+                    revision: 0,
+                    status: SectionStatus::Degraded,
+                    source: SectionSourceKind::Default,
+                    last_error: Some("credential status is unavailable".to_string()),
+                },
+            ),
+        }
+    }
+
+    async fn hydrate_cluster_fabric(
+        &self,
+        fabric: ClusterFabricConfig,
+    ) -> FabricResult<ClusterFabricConfig> {
+        let data_dir = self.data_dir.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut config = Config::default();
+            config.cluster_fabric = fabric;
+            config.hydrate_cluster_credentials_from_store(&data_dir)?;
+            Ok::<_, ConfigStoreError>(config.cluster_fabric.clone())
+        })
+        .await
+        .map_err(|error| {
+            FabricError::Internal(format!("credential hydration task failed: {error}"))
+        })?
+        .map_err(map_config_store_error)
+    }
+
+    async fn snapshot_locked(&self, expected_revision: u64) -> FabricResult<FabricCommitSnapshot> {
+        let mut config = self.config.read().await.clone();
+        let section = if let Some(facade) = &self.config_facade {
+            let actual = facade.registry().cluster_fabric.snapshot().revision;
+            if expected_revision != actual {
+                return Err(FabricError::Conflict {
+                    expected: expected_revision,
+                    actual,
+                });
+            }
+            config.cluster_fabric = self
+                .hydrate_cluster_fabric(facade.effective_config().cluster_fabric.clone())
+                .await?;
+            facade
+                .registry()
+                .envelope_value(SectionId::ClusterFabric)
+                .map_err(map_config_store_error)?
+        } else {
+            if expected_revision != 0 {
+                return Err(FabricError::Conflict {
+                    expected: expected_revision,
+                    actual: 0,
+                });
+            }
+            SectionEnvelope {
+                data: serde_json::Value::Null,
+                revision: 0,
+                loaded_at: chrono::Utc::now(),
+                source_path: self.data_dir.join("config.json"),
+                source_kind: SectionSourceKind::Default,
+                status: SectionStatus::Healthy,
+                last_error: None,
+            }
+        };
+        let (credential_statuses, credential_health) = self.credential_snapshot();
+        Ok(FabricCommitSnapshot {
+            config,
+            section,
+            credential_statuses,
+            credential_health,
+        })
+    }
+
+    pub async fn current_cluster_revision(&self) -> FabricResult<u64> {
+        let _io = self.config_io_lock.lock().await;
+        Ok(self
+            .config_facade
+            .as_ref()
+            .map(|facade| facade.registry().cluster_fabric.snapshot().revision)
+            .unwrap_or(0))
+    }
+
+    /// Commit one engine-owned node mutation through the cluster-fabric
+    /// section authority. Runtime publication occurs only after the durable
+    /// CAS succeeds; the matching section event is emitted only after runtime
+    /// adopts the committed snapshot.
+    async fn persist_node_update_at_revision<F>(
+        &self,
+        expected_revision: u64,
+        update: F,
+    ) -> FabricResult<FabricCommitSnapshot>
+    where
+        F: FnOnce(&mut Config) -> FabricResult<()> + Send,
+    {
+        let _io = self.config_io_lock.lock().await;
+        self.persist_node_update_locked(expected_revision, update)
+            .await
+    }
+
+    /// Locked half of [`Self::persist_node_update_at_revision`]. Lifecycle
+    /// operations hold the same guard across their external worker action, so
+    /// a validated revision cannot become stale after a worker is stopped or
+    /// deployed but before its resulting state is committed.
+    async fn persist_node_update_locked<F>(
+        &self,
+        expected_revision: u64,
+        update: F,
+    ) -> FabricResult<FabricCommitSnapshot>
+    where
+        F: FnOnce(&mut Config) -> FabricResult<()> + Send,
+    {
+        if let Some(facade) = &self.config_facade {
+            let actual = facade.registry().cluster_fabric.snapshot().revision;
+            if expected_revision != actual {
+                return Err(FabricError::Conflict {
+                    expected: expected_revision,
+                    actual,
+                });
+            }
+
+            let mut candidate = self.config.read().await.clone();
+            update(&mut candidate)?;
+            let data_dir = self.data_dir.clone();
+            let revision = tokio::task::spawn_blocking(move || {
+                bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+                    &data_dir,
+                    &mut candidate,
+                    &BTreeMap::new(),
+                    expected_revision,
+                )
+            })
+            .await
+            .map_err(|error| FabricError::Internal(format!("persist task failed: {error}")))?
+            .map_err(map_config_store_error)?;
+
+            if let Some(event) = facade.registry().reload_if_changed(SectionId::Credentials) {
+                if matches!(event, ConfigSectionEvent::Invalid { .. }) {
+                    return Err(FabricError::Internal(
+                        "committed credential section became invalid before publication"
+                            .to_string(),
+                    ));
+                }
+            }
+            let event = facade
+                .registry()
+                .reload_if_changed(SectionId::ClusterFabric);
+            if let Some(event @ ConfigSectionEvent::Invalid { .. }) = event.as_ref() {
+                if let Some(publish) = &self.publish_event {
+                    publish(event);
+                }
+                return Err(FabricError::Internal(
+                    "committed cluster section became invalid before publication".to_string(),
+                ));
+            }
+
+            let section = facade
+                .registry()
+                .envelope_value(SectionId::ClusterFabric)
+                .map_err(map_config_store_error)?;
+            if section.revision != revision {
+                return Err(FabricError::Internal(
+                    "committed cluster revision did not match the adopted revision".to_string(),
+                ));
+            }
+
+            let mut adopted = self.config.read().await.clone();
+            adopted.cluster_fabric = self
+                .hydrate_cluster_fabric(facade.effective_config().cluster_fabric.clone())
+                .await?;
+            *self.config.write().await = adopted.clone();
+
+            if let (Some(event), Some(publish)) = (event.as_ref(), self.publish_event.as_ref()) {
+                publish(event);
+            }
+            let (credential_statuses, credential_health) = self.credential_snapshot();
+            return Ok(FabricCommitSnapshot {
+                config: adopted,
+                section,
+                credential_statuses,
+                credential_health,
+            });
+        }
+
+        // Compatibility-only test fixtures have no modular facade. Preserve
+        // the same durable-before-runtime ordering without pretending to offer
+        // a revision other than zero.
+        if expected_revision != 0 {
+            return Err(FabricError::Conflict {
+                expected: expected_revision,
+                actual: 0,
+            });
+        }
+        let mut candidate = self.config.read().await.clone();
+        update(&mut candidate)?;
+        let durable_candidate = candidate.clone();
+        let data_dir = self.data_dir.clone();
+        tokio::task::spawn_blocking(move || durable_candidate.save_to_dir(data_dir))
+            .await
+            .map_err(|error| FabricError::Internal(format!("persist task failed: {error}")))?
+            .map_err(|error| FabricError::Internal(format!("save config failed: {error}")))?;
+        *self.config.write().await = candidate;
+        self.snapshot_locked(0).await
+    }
+
     /// Deploy a worker onto a node and persist its running state.
     ///
     /// `echo=true` runs the dependency-free echo executor (no LLM) — a
     /// connectivity smoke test.
     pub async fn deploy(&self, node_id: &str, echo: bool) -> FabricResult<NodeState> {
+        let expected_revision = self.current_cluster_revision().await?;
+        Ok(self
+            .deploy_at_revision(node_id, echo, expected_revision)
+            .await?
+            .value)
+    }
+
+    /// Deploy against an operator-captured cluster-fabric revision and return
+    /// the exact adopted snapshot from the final state commit.
+    pub async fn deploy_at_revision(
+        &self,
+        node_id: &str,
+        echo: bool,
+        expected_revision: u64,
+    ) -> FabricResult<FabricActionResult<NodeState>> {
+        let _io = self.config_io_lock.lock().await;
+        let action_snapshot = self.snapshot_locked(expected_revision).await?;
         let (mut node, broker) = {
-            let cfg = self.config.read().await;
+            let cfg = &action_snapshot.config;
             (
-                self.node_snapshot(&cfg, node_id)?,
+                self.node_snapshot(cfg, node_id)?,
                 cfg.subagents().broker.clone(),
             )
         };
@@ -178,12 +480,11 @@ impl FabricDeployer {
         // deliver it (local stdin / russh file-upload) ship it; others fall back to
         // the legacy argv+env self-resolve (spec_json is then ignored, harmless).
         let spec_json = {
-            let cfg = self.config.read().await;
             build_resident_spec(
                 &node,
                 &broker.endpoint,
                 &broker.token,
-                &cfg,
+                &action_snapshot.config,
                 echo,
                 &worker_id,
             )
@@ -228,7 +529,15 @@ impl FabricDeployer {
                     last_error: Some(e.to_string()),
                     ..Default::default()
                 };
-                let _ = self.persist_state(node_id, Some(failed)).await;
+                self.persist_node_update_locked(expected_revision, |config| {
+                    let node = config
+                        .cluster_fabric
+                        .node_mut(node_id)
+                        .ok_or_else(|| FabricError::NotFound(format!("Node '{node_id}'")))?;
+                    node.state = Some(failed);
+                    Ok(())
+                })
+                .await?;
                 tracing::warn!(
                     audit = "cluster_fabric.deploy",
                     node = node_id,
@@ -260,11 +569,11 @@ impl FabricDeployer {
         );
 
         // TOFU: pin the observed host-key fingerprint if not already set.
-        if let Some(cell) = build.observed_fp {
-            if let Some(fp) = cell.lock().await.clone() {
-                self.pin_fingerprint_if_absent(node_id, &fp).await;
-            }
-        }
+        let observed_fingerprint = if let Some(cell) = build.observed_fp {
+            cell.lock().await.clone()
+        } else {
+            None
+        };
 
         // Verify-on-deploy: exec'ing the worker used to report "running" even when
         // the worker never dialed home (phantom success — e.g. a missing/incompatible
@@ -307,7 +616,15 @@ impl FabricDeployer {
                 last_error: Some(msg.clone()),
                 ..Default::default()
             };
-            let _ = self.persist_state(node_id, Some(failed)).await;
+            self.persist_node_update_locked(expected_revision, |config| {
+                let node = config
+                    .cluster_fabric
+                    .node_mut(node_id)
+                    .ok_or_else(|| FabricError::NotFound(format!("Node '{node_id}'")))?;
+                node.state = Some(failed);
+                Ok(())
+            })
+            .await?;
             tracing::warn!(
                 audit = "cluster_fabric.deploy",
                 node = node_id,
@@ -335,18 +652,87 @@ impl FabricDeployer {
             deployed_at: Some(chrono::Utc::now().to_rfc3339()),
             ..Default::default()
         };
-        self.persist_state(node_id, Some(state.clone())).await?;
-        Ok(state)
+        let response_state = state.clone();
+        let placement = node.placement.clone();
+        let snapshot = match self
+            .persist_node_update_locked(expected_revision, move |config| {
+                let target = config
+                    .cluster_fabric
+                    .node_mut(node_id)
+                    .ok_or_else(|| FabricError::NotFound(format!("Node '{node_id}'")))?;
+                if target.placement != placement {
+                    return Err(FabricError::Internal(
+                        "runtime cluster placement diverged from the adopted action snapshot"
+                            .to_string(),
+                    ));
+                }
+                if let (Some(fingerprint), NodePlacement::Ssh(ssh)) =
+                    (observed_fingerprint, &mut target.placement)
+                {
+                    if ssh.host_key_fingerprint.is_none() {
+                        ssh.host_key_fingerprint = Some(fingerprint);
+                    }
+                }
+                target.state = Some(state.clone());
+                Ok(())
+            })
+            .await
+        {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                let deployed = self
+                    .registry
+                    .lock()
+                    .await
+                    .remove(&crate::registry_keys::node_key(node_id));
+                if let Some(deployed) = deployed {
+                    deployed.handle.shutdown().await;
+                }
+                return Err(error);
+            }
+        };
+        Ok(FabricActionResult {
+            value: response_state,
+            snapshot,
+        })
     }
 
     /// Stop a node's worker (if running) and persist the stopped state.
     pub async fn stop(&self, node_id: &str) -> FabricResult<NodeState> {
-        {
-            let cfg = self.config.read().await;
-            self.node_snapshot(&cfg, node_id)?;
-        }
-        // Remove under the lock, shut down outside it: shutdown is graceful now
-        // (SIGTERM + drain grace, #49) and must not hold the shared registry.
+        let expected_revision = self.current_cluster_revision().await?;
+        Ok(self
+            .stop_at_revision(node_id, expected_revision)
+            .await?
+            .value)
+    }
+
+    /// Stop against an operator-captured cluster-fabric revision.
+    pub async fn stop_at_revision(
+        &self,
+        node_id: &str,
+        expected_revision: u64,
+    ) -> FabricResult<FabricActionResult<NodeState>> {
+        let _io = self.config_io_lock.lock().await;
+        let snapshot = self.snapshot_locked(expected_revision).await?;
+        self.node_snapshot(&snapshot.config, node_id)?;
+        let state = NodeState {
+            status: NodeStatus::Stopped,
+            ..Default::default()
+        };
+        let persisted = self
+            .persist_node_update_locked(expected_revision, |config| {
+                let node = config
+                    .cluster_fabric
+                    .node_mut(node_id)
+                    .ok_or_else(|| FabricError::NotFound(format!("Node '{node_id}'")))?;
+                node.state = Some(state.clone());
+                Ok(())
+            })
+            .await?;
+        // The durable CAS succeeds before the external worker is affected.
+        // Remove under the registry lock and shut down outside that lock; the
+        // configuration guard remains held so no later lifecycle mutation can
+        // overtake the stop before the worker has actually exited.
         let removed = self
             .registry
             .lock()
@@ -360,20 +746,32 @@ impl FabricDeployer {
             node = node_id,
             outcome = "stopped"
         );
-        let state = NodeState {
-            status: NodeStatus::Stopped,
-            ..Default::default()
-        };
-        self.persist_state(node_id, Some(state.clone())).await?;
-        Ok(state)
+        Ok(FabricActionResult {
+            value: state,
+            snapshot: persisted,
+        })
     }
 
     /// Connectivity preflight: connect + auth + `uname`, WITHOUT deploying.
     pub async fn test(&self, node_id: &str) -> FabricResult<String> {
-        let node = {
-            let cfg = self.config.read().await;
-            self.node_snapshot(&cfg, node_id)?
-        };
+        let expected_revision = self.current_cluster_revision().await?;
+        Ok(self
+            .test_at_revision(node_id, expected_revision)
+            .await?
+            .value)
+    }
+
+    /// Preflight against an operator-captured cluster-fabric revision. The
+    /// operation does not mutate config, so the returned snapshot is the exact
+    /// validated base.
+    pub async fn test_at_revision(
+        &self,
+        node_id: &str,
+        expected_revision: u64,
+    ) -> FabricResult<FabricActionResult<String>> {
+        let _io = self.config_io_lock.lock().await;
+        let snapshot = self.snapshot_locked(expected_revision).await?;
+        let node = self.node_snapshot(&snapshot.config, node_id)?;
         let build = build_deployer(&node, &self.bamboo_bin).map_err(FabricError::BadRequest)?;
         let result = build.deployer.preflight().await;
         tracing::info!(
@@ -382,7 +780,8 @@ impl FabricDeployer {
             placement = placement_env(&node),
             outcome = if result.is_ok() { "ok" } else { "failed" },
         );
-        result.map_err(|e| FabricError::Internal(format!("preflight failed: {e}")))
+        let value = result.map_err(|e| FabricError::Internal(format!("preflight failed: {e}")))?;
+        Ok(FabricActionResult { value, snapshot })
     }
 
     /// Tail the last `lines` lines of a node worker's log.
@@ -474,49 +873,80 @@ impl FabricDeployer {
             ))
         };
 
-        // Commit under the io + write lock, RE-CHECKING the live status. The probe
-        // above ran UNLOCKED for up to `probe_timeout`, so a concurrent stop()/
-        // deploy() may have moved this node out of the monitored set meanwhile —
-        // blindly writing back the stale decision would e.g. resurrect a
-        // user-Stopped node as Unreachable and hand it to auto-recover. If the live
-        // status is no longer Running/Unreachable, the concurrent write wins.
-        let _io = self.config_io_lock.lock().await;
-        let (next, from, snapshot) = {
-            let mut cfg = self.config.write().await;
-            let Some(node) = cfg.cluster_fabric.node_mut(node_id) else {
+        // Re-check after the unlocked probe. A status flip is an authoritative
+        // section mutation; a steady heartbeat remains runtime-only to avoid
+        // revision churn.
+        let live = {
+            let cfg = self.config.read().await;
+            let Some(node) = cfg.cluster_fabric.node(node_id) else {
                 return Ok(current);
             };
-            let live = node.state.clone().unwrap_or_default();
-            if !matches!(live.status, NodeStatus::Running | NodeStatus::Unreachable) {
-                return Ok(live); // moved out of the monitored set mid-probe → leave it
-            }
-            let from = live.status;
-            let next = NodeState {
-                status: new_status,
-                last_health: Some(chrono::Utc::now().to_rfc3339()),
-                last_error: new_error,
-                ..live
-            };
-            node.state = Some(next.clone());
-            // A status FLIP is durable + audited; a steady-state heartbeat stays in
-            // memory only (no config.json churn) — so snapshot to disk only on a flip.
-            (next, from, (from != new_status).then(|| cfg.clone()))
+            node.state.clone().unwrap_or_default()
         };
-        if let Some(snapshot) = snapshot {
-            let data_dir = self.data_dir.clone();
-            tokio::task::spawn_blocking(move || snapshot.save_to_dir(data_dir))
-                .await
-                .map_err(|e| FabricError::Internal(format!("persist task: {e}")))?
-                .map_err(|e| FabricError::Internal(format!("save config: {e}")))?;
+        if !matches!(live.status, NodeStatus::Running | NodeStatus::Unreachable) {
+            return Ok(live);
+        }
+        let from = live.status;
+        let next = NodeState {
+            status: new_status,
+            last_health: Some(chrono::Utc::now().to_rfc3339()),
+            last_error: new_error,
+            ..live
+        };
+        if from != new_status {
+            let expected_revision = self.current_cluster_revision().await?;
+            let committed_next = next.clone();
+            let snapshot = self
+                .persist_node_update_at_revision(expected_revision, |config| {
+                    let Some(node) = config.cluster_fabric.node_mut(node_id) else {
+                        return Ok(());
+                    };
+                    let current = node.state.clone().unwrap_or_default();
+                    if !matches!(
+                        current.status,
+                        NodeStatus::Running | NodeStatus::Unreachable
+                    ) {
+                        return Ok(());
+                    }
+                    node.state = Some(NodeState {
+                        status: committed_next.status,
+                        last_health: committed_next.last_health.clone(),
+                        last_error: committed_next.last_error.clone(),
+                        ..current
+                    });
+                    Ok(())
+                })
+                .await?;
+            let adopted = snapshot
+                .config
+                .cluster_fabric
+                .node(node_id)
+                .and_then(|node| node.state.clone())
+                .unwrap_or(current);
             tracing::info!(
                 audit = "cluster_fabric.health",
                 node = node_id,
                 worker_id = %worker_id,
                 from = ?from,
-                to = ?next.status,
+                to = ?adopted.status,
                 "node health changed",
             );
+            return Ok(adopted);
         }
+
+        let _io = self.config_io_lock.lock().await;
+        let mut cfg = self.config.write().await;
+        let Some(node) = cfg.cluster_fabric.node_mut(node_id) else {
+            return Ok(current);
+        };
+        let current = node.state.clone().unwrap_or_default();
+        if !matches!(
+            current.status,
+            NodeStatus::Running | NodeStatus::Unreachable
+        ) {
+            return Ok(current);
+        }
+        node.state = Some(next.clone());
         Ok(next)
     }
 
@@ -692,44 +1122,34 @@ impl FabricDeployer {
         }))
     }
 
-    /// Persist `state` onto a node (engine-owned field): io-lock + atomic save,
-    /// mirroring `AppState::update_config` minus the provider/MCP side effects.
-    async fn persist_state(&self, node_id: &str, state: Option<NodeState>) -> FabricResult<()> {
-        let _io = self.config_io_lock.lock().await;
-        let snapshot = {
-            let mut cfg = self.config.write().await;
-            let node = cfg
+    /// Persist an engine-owned node state against a specific section revision.
+    async fn persist_state_at_revision(
+        &self,
+        node_id: &str,
+        state: Option<NodeState>,
+        expected_revision: u64,
+    ) -> FabricResult<FabricCommitSnapshot> {
+        self.persist_node_update_at_revision(expected_revision, |config| {
+            let node = config
                 .cluster_fabric
                 .node_mut(node_id)
                 .ok_or_else(|| FabricError::NotFound(format!("Node '{node_id}'")))?;
             node.state = state;
-            cfg.clone()
-        };
-        let data_dir = self.data_dir.clone();
-        tokio::task::spawn_blocking(move || snapshot.save_to_dir(data_dir))
-            .await
-            .map_err(|e| FabricError::Internal(format!("persist task: {e}")))?
-            .map_err(|e| FabricError::Internal(format!("save config: {e}")))?;
-        Ok(())
+            Ok(())
+        })
+        .await
     }
 
-    /// Pin `fp` onto a node's SSH target if it has no fingerprint yet (TOFU).
-    async fn pin_fingerprint_if_absent(&self, node_id: &str, fp: &str) {
-        let _io = self.config_io_lock.lock().await;
-        let snapshot = {
-            let mut cfg = self.config.write().await;
-            if let Some(node) = cfg.cluster_fabric.node_mut(node_id) {
-                if let NodePlacement::Ssh(target) = &mut node.placement {
-                    if target.host_key_fingerprint.is_some() {
-                        return;
-                    }
-                    target.host_key_fingerprint = Some(fp.to_string());
-                }
-            }
-            cfg.clone()
-        };
-        let data_dir = self.data_dir.clone();
-        let _ = tokio::task::spawn_blocking(move || snapshot.save_to_dir(data_dir)).await;
+    /// Internal monitor/recovery writes adopt the current cluster revision at
+    /// the moment the mutation begins and still use the same durable CAS path.
+    async fn persist_state(
+        &self,
+        node_id: &str,
+        state: Option<NodeState>,
+    ) -> FabricResult<FabricCommitSnapshot> {
+        let expected_revision = self.current_cluster_revision().await?;
+        self.persist_state_at_revision(node_id, state, expected_revision)
+            .await
     }
 }
 
@@ -1118,6 +1538,61 @@ fn build_russh(node: &Node, target: &SshTarget) -> Result<RusshDeployer, String>
     )
     .with_fingerprint(target.host_key_fingerprint.clone())
     .with_upload(upload))
+}
+
+#[cfg(test)]
+mod lifecycle_persistence_tests {
+    use super::*;
+    use bamboo_config::cluster_fabric::{DeployProfile, TrustLevel};
+
+    #[tokio::test]
+    async fn failed_durable_state_write_does_not_advance_runtime() {
+        let root = tempfile::tempdir().unwrap();
+        let invalid_data_dir = root.path().join("not-a-directory");
+        std::fs::write(&invalid_data_dir, b"file").unwrap();
+
+        let mut config = Config::default();
+        config.cluster_fabric.nodes.push(Node {
+            id: "n1".to_string(),
+            label: "node".to_string(),
+            placement: NodePlacement::Local,
+            trust_level: TrustLevel::Trusted,
+            deploy: DeployProfile::default(),
+            state: None,
+            enabled: true,
+        });
+        let config = Arc::new(RwLock::new(config));
+        let deployer = FabricDeployer::new(
+            config.clone(),
+            Arc::new(Mutex::new(())),
+            invalid_data_dir,
+            Arc::new(Mutex::new(HashMap::new())),
+            "/usr/bin/true",
+        );
+
+        let result = deployer
+            .persist_state_at_revision(
+                "n1",
+                Some(NodeState {
+                    status: NodeStatus::Stopped,
+                    ..Default::default()
+                }),
+                0,
+            )
+            .await;
+        assert!(result.is_err(), "invalid data directory must fail");
+        assert!(
+            config
+                .read()
+                .await
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .is_none(),
+            "runtime must retain the pre-commit state when persistence fails"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/app/bamboo-server-tools/src/fabric_deploy.rs
+++ b/crates/app/bamboo-server-tools/src/fabric_deploy.rs
@@ -58,6 +58,14 @@ impl std::fmt::Display for FabricError {
 
 type FabricResult<T> = Result<T, FabricError>;
 
+async fn join_fabric_task<T>(
+    context: &'static str,
+    task: tokio::task::JoinHandle<FabricResult<T>>,
+) -> FabricResult<T> {
+    task.await
+        .map_err(|error| FabricError::Internal(format!("{context} task failed: {error}")))?
+}
+
 fn map_config_store_error(error: ConfigStoreError) -> FabricError {
     match error {
         ConfigStoreError::Conflict { expected, actual } => {
@@ -97,8 +105,43 @@ pub struct FabricActionResult<T> {
 
 type FabricEventPublisher = Arc<dyn Fn(&ConfigSectionEvent) + Send + Sync>;
 
+#[cfg(test)]
+type DeployBeforeFinalPersistTestHook = Box<dyn FnOnce(&Path) + Send + 'static>;
+
+#[cfg(test)]
+fn deploy_before_final_persist_test_hooks(
+) -> &'static std::sync::Mutex<HashMap<PathBuf, DeployBeforeFinalPersistTestHook>> {
+    static HOOKS: std::sync::OnceLock<
+        std::sync::Mutex<HashMap<PathBuf, DeployBeforeFinalPersistTestHook>>,
+    > = std::sync::OnceLock::new();
+    HOOKS.get_or_init(|| std::sync::Mutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+fn set_deploy_before_final_persist_test_hook(
+    data_dir: &Path,
+    hook: impl FnOnce(&Path) + Send + 'static,
+) {
+    deploy_before_final_persist_test_hooks()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(data_dir.to_path_buf(), Box::new(hook));
+}
+
+#[cfg(test)]
+fn run_deploy_before_final_persist_test_hook(data_dir: &Path) {
+    let hook = deploy_before_final_persist_test_hooks()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(data_dir);
+    if let Some(hook) = hook {
+        hook(data_dir);
+    }
+}
+
 /// The shared fabric deploy engine: turns persisted nodes into running
 /// `broker-agent` workers, holding their handles + persisting `NodeState`.
+#[derive(Clone)]
 pub struct FabricDeployer {
     config: Arc<RwLock<Config>>,
     /// Serializes the mutate+persist of a fabric config write (same guarantee as
@@ -285,7 +328,19 @@ impl FabricDeployer {
     /// the process-owned section authority. The durable section commit happens
     /// before runtime adoption and event publication, and the same config lock
     /// prevents the health monitor or an operator mutation from racing boot.
+    /// The detached task owns the whole transaction so cancellation of the
+    /// server-construction future cannot strand disk ahead of the process
+    /// facade/runtime publication.
     pub async fn reconcile_stale_nodes_on_boot(&self) -> FabricResult<usize> {
+        let deployer = self.clone();
+        join_fabric_task(
+            "cluster-fabric boot reconcile",
+            tokio::spawn(async move { deployer.reconcile_stale_nodes_on_boot_inner().await }),
+        )
+        .await
+    }
+
+    async fn reconcile_stale_nodes_on_boot_inner(&self) -> FabricResult<usize> {
         let _io = self.config_io_lock.lock().await;
         let stale = {
             let config = self.config.read().await;
@@ -336,11 +391,19 @@ impl FabricDeployer {
         update: F,
     ) -> FabricResult<FabricCommitSnapshot>
     where
-        F: FnOnce(&mut Config) -> FabricResult<()> + Send,
+        F: FnOnce(&mut Config) -> FabricResult<()> + Send + 'static,
     {
-        let _io = self.config_io_lock.lock().await;
-        self.persist_node_update_locked(expected_revision, update)
-            .await
+        let deployer = self.clone();
+        join_fabric_task(
+            "cluster-fabric state transaction",
+            tokio::spawn(async move {
+                let _io = deployer.config_io_lock.lock().await;
+                deployer
+                    .persist_node_update_locked(expected_revision, update)
+                    .await
+            }),
+        )
+        .await
     }
 
     /// Locked half of [`Self::persist_node_update_at_revision`]. Lifecycle
@@ -468,6 +531,25 @@ impl FabricDeployer {
         echo: bool,
         expected_revision: u64,
     ) -> FabricResult<FabricActionResult<NodeState>> {
+        let deployer = self.clone();
+        let node_id = node_id.to_string();
+        join_fabric_task(
+            "cluster-fabric deploy",
+            tokio::spawn(async move {
+                deployer
+                    .deploy_at_revision_inner(&node_id, echo, expected_revision)
+                    .await
+            }),
+        )
+        .await
+    }
+
+    async fn deploy_at_revision_inner(
+        &self,
+        node_id: &str,
+        echo: bool,
+        expected_revision: u64,
+    ) -> FabricResult<FabricActionResult<NodeState>> {
         let _io = self.config_io_lock.lock().await;
         let action_snapshot = self.snapshot_locked(expected_revision).await?;
         let (mut node, broker) = {
@@ -556,6 +638,26 @@ impl FabricDeployer {
             tls_ca_cert: None,
         };
 
+        // Publish a durable deployment intent before replacing any live worker.
+        // If the external action or its final state commit fails, the last
+        // durable state is therefore Deploying (or the subsequently committed
+        // Failed state), never the old Running claim with an empty registry.
+        let mut deploying = node.state.clone().unwrap_or_default();
+        deploying.status = NodeStatus::Deploying;
+        deploying.last_error = None;
+        let deployment_revision = self
+            .persist_node_update_locked(expected_revision, |config| {
+                let node = config
+                    .cluster_fabric
+                    .node_mut(node_id)
+                    .ok_or_else(|| FabricError::NotFound(format!("Node '{node_id}'")))?;
+                node.state = Some(deploying);
+                Ok(())
+            })
+            .await?
+            .section
+            .revision;
+
         // Release any prior worker FIRST so its reverse tunnel frees the broker
         // port before the new deploy requests the same forward. Remove under the
         // lock, shut down outside it: shutdown is graceful now (SIGTERM + drain
@@ -577,7 +679,7 @@ impl FabricDeployer {
                     last_error: Some(e.to_string()),
                     ..Default::default()
                 };
-                self.persist_node_update_locked(expected_revision, |config| {
+                self.persist_node_update_locked(deployment_revision, |config| {
                     let node = config
                         .cluster_fabric
                         .node_mut(node_id)
@@ -664,7 +766,7 @@ impl FabricDeployer {
                 last_error: Some(msg.clone()),
                 ..Default::default()
             };
-            self.persist_node_update_locked(expected_revision, |config| {
+            self.persist_node_update_locked(deployment_revision, |config| {
                 let node = config
                     .cluster_fabric
                     .node_mut(node_id)
@@ -702,8 +804,10 @@ impl FabricDeployer {
         };
         let response_state = state.clone();
         let placement = node.placement.clone();
+        #[cfg(test)]
+        run_deploy_before_final_persist_test_hook(&self.data_dir);
         let snapshot = match self
-            .persist_node_update_locked(expected_revision, move |config| {
+            .persist_node_update_locked(deployment_revision, move |config| {
                 let target = config
                     .cluster_fabric
                     .node_mut(node_id)
@@ -756,6 +860,24 @@ impl FabricDeployer {
 
     /// Stop against an operator-captured cluster-fabric revision.
     pub async fn stop_at_revision(
+        &self,
+        node_id: &str,
+        expected_revision: u64,
+    ) -> FabricResult<FabricActionResult<NodeState>> {
+        let deployer = self.clone();
+        let node_id = node_id.to_string();
+        join_fabric_task(
+            "cluster-fabric stop",
+            tokio::spawn(async move {
+                deployer
+                    .stop_at_revision_inner(&node_id, expected_revision)
+                    .await
+            }),
+        )
+        .await
+    }
+
+    async fn stop_at_revision_inner(
         &self,
         node_id: &str,
         expected_revision: u64,
@@ -870,6 +992,24 @@ impl FabricDeployer {
     /// config.json every tick. Presence is checked (never a task ping), so a live
     /// LLM worker is never disturbed — same rationale as the deploy verify.
     async fn health_check_within(
+        &self,
+        node_id: &str,
+        probe_timeout: Duration,
+    ) -> FabricResult<NodeState> {
+        let deployer = self.clone();
+        let node_id = node_id.to_string();
+        join_fabric_task(
+            "cluster-fabric health check",
+            tokio::spawn(async move {
+                deployer
+                    .health_check_within_inner(&node_id, probe_timeout)
+                    .await
+            }),
+        )
+        .await
+    }
+
+    async fn health_check_within_inner(
         &self,
         node_id: &str,
         probe_timeout: Duration,
@@ -1203,10 +1343,11 @@ impl FabricDeployer {
         state: Option<NodeState>,
         expected_revision: u64,
     ) -> FabricResult<FabricCommitSnapshot> {
-        self.persist_node_update_at_revision(expected_revision, |config| {
+        let node_id = node_id.to_string();
+        self.persist_node_update_at_revision(expected_revision, move |config| {
             let node = config
                 .cluster_fabric
-                .node_mut(node_id)
+                .node_mut(&node_id)
                 .ok_or_else(|| FabricError::NotFound(format!("Node '{node_id}'")))?;
             node.state = state;
             Ok(())
@@ -1618,6 +1759,150 @@ fn build_russh(node: &Node, target: &SshTarget) -> Result<RusshDeployer, String>
 mod lifecycle_persistence_tests {
     use super::*;
     use bamboo_config::cluster_fabric::{DeployProfile, TrustLevel};
+    use std::sync::Mutex as StdMutex;
+
+    struct ModularFixture {
+        _data_dir: tempfile::TempDir,
+        facade: Arc<ConfigFacade>,
+        config: Arc<RwLock<Config>>,
+        config_io_lock: Arc<Mutex<()>>,
+        registry: DeployedRegistry,
+        deployer: Arc<FabricDeployer>,
+        events: Arc<StdMutex<Vec<ConfigSectionEvent>>>,
+    }
+
+    fn modular_running_fixture(bamboo_bin: &str) -> ModularFixture {
+        let data_dir = tempfile::tempdir().unwrap();
+        let facade = Arc::new(ConfigFacade::open_or_migrate(data_dir.path()).unwrap());
+        let mut candidate = facade.effective_config();
+        candidate.cluster_fabric.nodes.push(Node {
+            id: "n1".to_string(),
+            label: "node".to_string(),
+            placement: NodePlacement::Local,
+            trust_level: TrustLevel::Trusted,
+            deploy: DeployProfile::default(),
+            state: Some(NodeState {
+                status: NodeStatus::Running,
+                worker_id: Some("cluster-node-n1".to_string()),
+                ..Default::default()
+            }),
+            enabled: true,
+        });
+        let revision = bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+            data_dir.path(),
+            &mut candidate,
+            &BTreeMap::new(),
+            0,
+        )
+        .unwrap();
+        assert_eq!(revision, 1);
+        assert!(facade
+            .registry()
+            .reload_if_changed(SectionId::ClusterFabric)
+            .is_some());
+
+        let mut runtime = facade.effective_config();
+        runtime.subagents_mut().broker = Some(BrokerClientConfig {
+            endpoint: "ws://127.0.0.1:9".to_string(),
+            token: "test-token".to_string(),
+            token_encrypted: None,
+            credential_ref: None,
+            configured: false,
+        });
+        let config = Arc::new(RwLock::new(runtime));
+        let config_io_lock = Arc::new(Mutex::new(()));
+        let registry = Arc::new(Mutex::new(HashMap::new()));
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let event_log = events.clone();
+        let deployer = Arc::new(
+            FabricDeployer::new(
+                config.clone(),
+                config_io_lock.clone(),
+                data_dir.path().to_path_buf(),
+                registry.clone(),
+                bamboo_bin,
+            )
+            .with_modular_persistence(
+                facade.clone(),
+                Arc::new(CredentialStore::open(data_dir.path())),
+                Arc::new(move |event| event_log.lock().unwrap().push(event.clone())),
+            ),
+        );
+        ModularFixture {
+            _data_dir: data_dir,
+            facade,
+            config,
+            config_io_lock,
+            registry,
+            deployer,
+            events,
+        }
+    }
+
+    async fn start_broker() -> (String, tempfile::TempDir) {
+        let data_dir = tempfile::tempdir().unwrap();
+        let core = Arc::new(bamboo_broker::BrokerCore::new(data_dir.path()));
+        let server = Arc::new(bamboo_broker::BrokerServer::new(core, "test-token"));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = server.serve(listener).await;
+        });
+        (format!("ws://{address}"), data_dir)
+    }
+
+    async fn join_expected_worker(
+        fixture: &ModularFixture,
+        endpoint: &str,
+    ) -> bamboo_broker::BrokerClient {
+        fixture.config.write().await.subagents_mut().broker = Some(BrokerClientConfig {
+            endpoint: endpoint.to_string(),
+            token: "test-token".to_string(),
+            token_encrypted: None,
+            credential_ref: None,
+            configured: false,
+        });
+        let node = fixture
+            .config
+            .read()
+            .await
+            .cluster_fabric
+            .node("n1")
+            .cloned()
+            .unwrap();
+        let worker_id = worker_id_for(&node);
+        let role = node
+            .deploy
+            .default_role
+            .clone()
+            .unwrap_or_else(|| "general-purpose".to_string());
+        let mut worker = bamboo_broker::BrokerClient::connect(
+            endpoint,
+            AgentRef {
+                session_id: worker_id,
+                role: Some(role),
+            },
+            "test-token",
+        )
+        .await
+        .unwrap();
+        worker.subscribe().await.unwrap();
+        worker
+    }
+
+    async fn insert_prior_worker(fixture: &ModularFixture) {
+        let child = tokio::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        fixture.registry.lock().await.insert(
+            crate::registry_keys::node_key("n1"),
+            Deployed {
+                env: "local".to_string(),
+                handle: bamboo_broker::DeployedAgent::from_parts("old-worker", child, None),
+            },
+        );
+    }
 
     #[tokio::test]
     async fn failed_durable_state_write_does_not_advance_runtime() {
@@ -1665,6 +1950,388 @@ mod lifecycle_persistence_tests {
                 .state
                 .is_none(),
             "runtime must retain the pre-commit state when persistence fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_state_caller_still_finishes_disk_runtime_facade_and_event_publication() {
+        let fixture = modular_running_fixture("/usr/bin/true");
+        let guard = fixture.config_io_lock.lock().await;
+        let caller = {
+            let deployer = fixture.deployer.clone();
+            tokio::spawn(async move {
+                deployer
+                    .persist_state_at_revision(
+                        "n1",
+                        Some(NodeState {
+                            status: NodeStatus::Stopped,
+                            ..Default::default()
+                        }),
+                        1,
+                    )
+                    .await
+            })
+        };
+
+        // Let the public future spawn its transaction owner, then cancel only
+        // the caller while that owner is blocked behind the shared config lock.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        caller.abort();
+        let join_error = match caller.await {
+            Err(error) => error,
+            Ok(_) => panic!("the caller must be cancelled while its transaction stays alive"),
+        };
+        assert!(join_error.is_cancelled());
+        drop(guard);
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let revision = fixture.facade.registry().cluster_fabric.snapshot().revision;
+                let status = fixture
+                    .config
+                    .read()
+                    .await
+                    .cluster_fabric
+                    .node("n1")
+                    .and_then(|node| node.state.as_ref())
+                    .map(|state| state.status);
+                if revision == 2
+                    && status == Some(NodeStatus::Stopped)
+                    && fixture.events.lock().unwrap().len() == 1
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("detached lifecycle state transaction must finish after caller cancellation");
+
+        let reopened = ConfigFacade::open(fixture._data_dir.path()).unwrap();
+        assert_eq!(reopened.registry().cluster_fabric.snapshot().revision, 2);
+        assert_eq!(
+            reopened
+                .effective_config()
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Stopped
+        );
+        assert_eq!(
+            fixture.events.lock().unwrap().as_slice(),
+            &[ConfigSectionEvent::Changed {
+                section: "cluster-fabric".to_string(),
+                revision: 2,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_stop_caller_still_commits_and_shuts_down_the_registered_worker() {
+        let fixture = modular_running_fixture("/usr/bin/true");
+        insert_prior_worker(&fixture).await;
+        let guard = fixture.config_io_lock.lock().await;
+        let caller = {
+            let deployer = fixture.deployer.clone();
+            tokio::spawn(async move { deployer.stop_at_revision("n1", 1).await })
+        };
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        caller.abort();
+        let join_error = match caller.await {
+            Err(error) => error,
+            Ok(_) => panic!("the request-facing stop caller must be cancelled"),
+        };
+        assert!(join_error.is_cancelled());
+        drop(guard);
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let revision = fixture.facade.registry().cluster_fabric.snapshot().revision;
+                let status = fixture
+                    .config
+                    .read()
+                    .await
+                    .cluster_fabric
+                    .node("n1")
+                    .and_then(|node| node.state.as_ref())
+                    .map(|state| state.status);
+                if revision == 2
+                    && status == Some(NodeStatus::Stopped)
+                    && fixture.registry.lock().await.is_empty()
+                    && fixture.events.lock().unwrap().len() == 1
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("detached stop must finish commit and worker shutdown");
+
+        let reopened = ConfigFacade::open(fixture._data_dir.path()).unwrap();
+        assert_eq!(reopened.registry().cluster_fabric.snapshot().revision, 2);
+        assert_eq!(
+            reopened
+                .effective_config()
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Stopped
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_redeploy_never_leaves_the_old_running_claim_after_worker_replacement() {
+        let fixture = modular_running_fixture("/definitely/missing/bamboo");
+        insert_prior_worker(&fixture).await;
+
+        let error = match fixture.deployer.deploy_at_revision("n1", true, 1).await {
+            Err(error) => error,
+            Ok(_) => panic!("the replacement binary does not exist"),
+        };
+        assert!(matches!(error, FabricError::Internal(_)));
+        assert!(fixture.registry.lock().await.is_empty());
+        let process_snapshot = fixture.facade.registry().cluster_fabric.snapshot();
+        assert_eq!(
+            process_snapshot.revision, 3,
+            "Deploying intent and Failed result are distinct durable commits"
+        );
+        assert_eq!(
+            process_snapshot
+                .data
+                .0
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Failed
+        );
+        assert_eq!(
+            fixture
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Failed
+        );
+        assert_eq!(
+            fixture.events.lock().unwrap().as_slice(),
+            &[
+                ConfigSectionEvent::Changed {
+                    section: "cluster-fabric".to_string(),
+                    revision: 2,
+                },
+                ConfigSectionEvent::Changed {
+                    section: "cluster-fabric".to_string(),
+                    revision: 3,
+                },
+            ]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_deploy_caller_cannot_strand_a_verified_worker_before_final_publication() {
+        let (endpoint, _broker_dir) = start_broker().await;
+        let fixture = modular_running_fixture("/usr/bin/true");
+        let _worker = join_expected_worker(&fixture, &endpoint).await;
+        insert_prior_worker(&fixture).await;
+
+        let (reached_tx, reached_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        set_deploy_before_final_persist_test_hook(fixture._data_dir.path(), move |_| {
+            reached_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+        let caller = {
+            let deployer = fixture.deployer.clone();
+            tokio::spawn(async move { deployer.deploy_at_revision("n1", false, 1).await })
+        };
+        tokio::task::spawn_blocking(move || {
+            reached_rx
+                .recv_timeout(Duration::from_secs(10))
+                .expect("deploy must reach the final persistence boundary")
+        })
+        .await
+        .unwrap();
+
+        caller.abort();
+        let join_error = match caller.await {
+            Err(error) => error,
+            Ok(_) => panic!("the request-facing deploy caller must be cancelled"),
+        };
+        assert!(join_error.is_cancelled());
+        assert!(
+            fixture
+                .registry
+                .lock()
+                .await
+                .contains_key(&crate::registry_keys::node_key("n1")),
+            "the detached owner still controls the verified replacement"
+        );
+        release_tx.send(()).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let revision = fixture.facade.registry().cluster_fabric.snapshot().revision;
+                let status = fixture
+                    .config
+                    .read()
+                    .await
+                    .cluster_fabric
+                    .node("n1")
+                    .and_then(|node| node.state.as_ref())
+                    .map(|state| state.status);
+                if revision == 3
+                    && status == Some(NodeStatus::Running)
+                    && fixture.events.lock().unwrap().len() == 2
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("detached deploy must finish final durable/runtime/event publication");
+        let reopened = ConfigFacade::open(fixture._data_dir.path()).unwrap();
+        assert_eq!(reopened.registry().cluster_fabric.snapshot().revision, 3);
+        assert_eq!(
+            reopened
+                .effective_config()
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Running
+        );
+
+        let replacement = fixture
+            .registry
+            .lock()
+            .await
+            .remove(&crate::registry_keys::node_key("n1"));
+        if let Some(replacement) = replacement {
+            replacement.handle.shutdown().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn final_redeploy_cas_loss_leaves_durable_deploying_intent_not_stale_running() {
+        let (endpoint, _broker_dir) = start_broker().await;
+        let fixture = modular_running_fixture("/usr/bin/true");
+        let _worker = join_expected_worker(&fixture, &endpoint).await;
+        insert_prior_worker(&fixture).await;
+
+        set_deploy_before_final_persist_test_hook(fixture._data_dir.path(), move |data_dir| {
+            let external = ConfigFacade::open(data_dir).unwrap();
+            let mut winner = external.effective_config();
+            let node = winner.cluster_fabric.node_mut("n1").unwrap();
+            assert_eq!(
+                node.state.as_ref().unwrap().status,
+                NodeStatus::Deploying,
+                "the destructive replacement must follow a durable intent"
+            );
+            node.label = "external-winner".to_string();
+            let revision =
+                bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+                    data_dir,
+                    &mut winner,
+                    &BTreeMap::new(),
+                    2,
+                )
+                .unwrap();
+            assert_eq!(revision, 3);
+        });
+
+        let error = match fixture.deployer.deploy_at_revision("n1", false, 1).await {
+            Err(error) => error,
+            Ok(_) => panic!("the cross-process revision winner must reject the final deploy CAS"),
+        };
+        assert!(matches!(
+            error,
+            FabricError::Conflict {
+                expected: 2,
+                actual: 3
+            }
+        ));
+        assert!(
+            fixture.registry.lock().await.is_empty(),
+            "the rejected replacement worker must be compensated"
+        );
+        assert_eq!(
+            fixture
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Deploying,
+            "runtime must never retain the destroyed old Running claim"
+        );
+        assert_eq!(
+            fixture
+                .facade
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .data
+                .0
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Deploying
+        );
+        let reopened = ConfigFacade::open(fixture._data_dir.path()).unwrap();
+        let durable = reopened.effective_config();
+        assert_eq!(reopened.registry().cluster_fabric.snapshot().revision, 3);
+        assert_eq!(
+            durable
+                .cluster_fabric
+                .node("n1")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Deploying
+        );
+        assert_eq!(
+            durable.cluster_fabric.node("n1").unwrap().label,
+            "external-winner"
+        );
+        assert_eq!(
+            fixture.events.lock().unwrap().as_slice(),
+            &[ConfigSectionEvent::Changed {
+                section: "cluster-fabric".to_string(),
+                revision: 2,
+            }]
         );
     }
 }

--- a/crates/app/bamboo-server-tools/src/lib.rs
+++ b/crates/app/bamboo-server-tools/src/lib.rs
@@ -26,7 +26,7 @@ pub use ask_agent::AskAgentTool;
 pub use cluster_tool::ClusterTool;
 pub use compact::CompactContextTool;
 pub use deploy_agent::{DeployAgentTool, Deployed, DeployedRegistry};
-pub use fabric_deploy::{FabricDeployer, FabricError};
+pub use fabric_deploy::{FabricActionResult, FabricCommitSnapshot, FabricDeployer, FabricError};
 pub use ledger::{LedgerScheduleBridge, LedgerTool};
 pub use memory::MemoryTool;
 pub use notify::{NotificationDispatcher, NotifyTool};

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -761,13 +761,25 @@ impl AppState {
             Arc::new(tokio::sync::Mutex::new(HashMap::new()));
         let fabric_bamboo_bin =
             std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("bamboo"));
-        let fabric_deployer = Arc::new(bamboo_server_tools::FabricDeployer::new(
+        let credential_store = Arc::new(bamboo_config::CredentialStore::open(&bamboo_home_dir));
+        let mut fabric_deployer = bamboo_server_tools::FabricDeployer::new(
             config.clone(),
             config_io_lock.clone(),
             bamboo_home_dir.clone(),
             fabric_registry,
             fabric_bamboo_bin,
-        ));
+        );
+        if let Some(facade) = config_facade.clone() {
+            let event_sink = account_sink.clone();
+            fabric_deployer = fabric_deployer.with_modular_persistence(
+                facade,
+                credential_store.clone(),
+                Arc::new(move |event| {
+                    super::config_runtime::publish_registry_event(&event_sink, event);
+                }),
+            );
+        }
+        let fabric_deployer = Arc::new(fabric_deployer);
         // Cluster health monitor: periodically probe deployed workers on the bus and
         // flip node status live (Running↔Unreachable) + auto-recover. Server-scoped
         // — it runs under BOTH the embedded and an external broker (it reads the
@@ -951,8 +963,6 @@ impl AppState {
                 mcp_manager.clone(),
                 account_sink.clone(),
             );
-        let credential_store = Arc::new(bamboo_config::CredentialStore::open(&bamboo_home_dir));
-
         Ok(Self {
             app_data_dir: bamboo_home_dir,
             config,

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -779,6 +779,12 @@ impl AppState {
                 }),
             );
         }
+        if let Err(error) = fabric_deployer.reconcile_stale_nodes_on_boot().await {
+            tracing::warn!(
+                error = %error,
+                "cluster-fabric boot reconcile failed; retaining the last adopted state"
+            );
+        }
         let fabric_deployer = Arc::new(fabric_deployer);
         // Cluster health monitor: periodically probe deployed workers on the bus and
         // flip node status live (Running↔Unreachable) + auto-recover. Server-scoped
@@ -919,12 +925,6 @@ impl AppState {
         // spawn scheduler, clobbered resume, expired wait lease, ...). Spawned
         // AFTER `set_root_tools` above so a boot-time parent resume can spawn.
         child_completion_coordinator.spawn_child_wait_watchdog();
-
-        // Cluster-fabric reconcile: session-bound workers died with the previous
-        // bamboo process (kill-on-drop child / in-memory russh session), so any
-        // persisted `Running`/`Deploying` node state is stale on boot. Flip it to
-        // `Unreachable` so the UI/agent see reality (a redeploy brings it back).
-        reconcile_fabric_on_boot(&config, &bamboo_home_dir).await;
 
         // `ServiceManager` (issue #479 / epic #477 prereq): supervises
         // long-running "service" plugins. Always constructed — fully inert
@@ -1208,41 +1208,108 @@ async fn broker_endpoint_reachable(endpoint: &str) -> bool {
     )
 }
 
-/// On boot, mark stale cluster-fabric node state as `Unreachable`: workers
-/// deployed by the previous process were session-bound (they died with it), so a
-/// persisted `Running`/`Deploying` status no longer reflects reality. Best-effort
-/// + persisted so the UI and `cluster status` don't show phantom-running nodes.
-async fn reconcile_fabric_on_boot(
-    config: &Arc<RwLock<bamboo_llm::Config>>,
-    data_dir: &std::path::Path,
-) {
-    use bamboo_config::cluster_fabric::NodeStatus;
-
-    let snapshot = {
-        let mut cfg = config.write().await;
-        let mut changed = 0usize;
-        for node in &mut cfg.cluster_fabric.nodes {
-            if let Some(state) = node.state.as_mut() {
-                if matches!(state.status, NodeStatus::Running | NodeStatus::Deploying) {
-                    state.status = NodeStatus::Unreachable;
-                    state.last_error =
-                        Some("orchestrator restarted; worker no longer tracked".to_string());
-                    changed += 1;
-                }
-            }
-        }
-        if changed == 0 {
-            return;
-        }
-        tracing::info!(
-            reconciled = changed,
-            "cluster-fabric: marked stale Running nodes Unreachable on boot"
-        );
-        cfg.clone()
+#[cfg(test)]
+mod fabric_boot_reconcile_tests {
+    use super::*;
+    use bamboo_config::cluster_fabric::{
+        DeployProfile, Node, NodePlacement, NodeState, NodeStatus, TrustLevel,
     };
+    use bamboo_config::{ClusterNodeCredentialIntents, ConfigFacade};
+    use std::collections::BTreeMap;
 
-    if let Err(e) = snapshot.save_to_dir(data_dir.to_path_buf()) {
-        tracing::warn!("cluster-fabric boot reconcile: failed to persist: {e}");
+    #[tokio::test]
+    async fn restart_reconcile_keeps_runtime_process_facade_and_disk_on_one_revision() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x7b; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let first = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        first
+            .update_cluster_fabric_credentials(
+                0,
+                BTreeMap::from([(
+                    "boot-node".to_string(),
+                    ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(Node {
+                        id: "boot-node".to_string(),
+                        label: "boot-node".to_string(),
+                        placement: NodePlacement::Local,
+                        trust_level: TrustLevel::Trusted,
+                        deploy: DeployProfile::default(),
+                        state: Some(NodeState {
+                            status: NodeStatus::Running,
+                            worker_id: Some("stale-worker".to_string()),
+                            ..Default::default()
+                        }),
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            first
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            1
+        );
+        drop(first);
+
+        let restarted = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        let process_snapshot = restarted
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .cluster_fabric
+            .snapshot();
+        assert_eq!(process_snapshot.revision, 2);
+        assert_eq!(
+            process_snapshot
+                .data
+                .0
+                .node("boot-node")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Unreachable
+        );
+        assert_eq!(
+            restarted
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("boot-node")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Unreachable
+        );
+        let reopened = ConfigFacade::open(dir.path()).unwrap();
+        assert_eq!(reopened.registry().cluster_fabric.snapshot().revision, 2);
+        assert_eq!(
+            reopened
+                .effective_config()
+                .cluster_fabric
+                .node("boot-node")
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .status,
+            NodeStatus::Unreachable
+        );
     }
 }
 

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -137,6 +137,41 @@ fn run_generic_before_event_test_hook(data_dir: &Path) {
     }
 }
 
+#[cfg(test)]
+type GenericBeforeProviderPublishTestHook = Box<dyn FnOnce() + Send + 'static>;
+#[cfg(test)]
+type GenericBeforeProviderPublishTestHooks =
+    std::sync::Mutex<std::collections::HashMap<PathBuf, GenericBeforeProviderPublishTestHook>>;
+
+#[cfg(test)]
+fn generic_before_provider_publish_test_hooks() -> &'static GenericBeforeProviderPublishTestHooks {
+    static HOOKS: std::sync::OnceLock<GenericBeforeProviderPublishTestHooks> =
+        std::sync::OnceLock::new();
+    HOOKS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+#[cfg(test)]
+fn set_generic_before_provider_publish_test_hook(
+    data_dir: &Path,
+    hook: impl FnOnce() + Send + 'static,
+) {
+    generic_before_provider_publish_test_hooks()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(data_dir.to_path_buf(), Box::new(hook));
+}
+
+#[cfg(test)]
+fn run_generic_before_provider_publish_test_hook(data_dir: &Path) {
+    let hook = generic_before_provider_publish_test_hooks()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(data_dir);
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
 struct FacadeRuntimeMaterialization {
     config: Config,
     failures: BTreeSet<SectionId>,
@@ -3018,7 +3053,9 @@ impl AppState {
             // Hold the config-IO lock across BOTH the in-memory mutation AND the
             // disk persist, so a concurrent reload_config can't read the disk in
             // the gap before we persist and then clobber this mutation with the
-            // stale copy (#126). Slow side effects run after this block unlocks.
+            // stale copy (#126). Effects stay inside the same owned lifetime:
+            // otherwise a later writer can publish its runtime and then be
+            // overwritten by this task's older async provider/MCP effects.
             let snapshot = {
                 let _io = io;
                 let commit = Self::persist_config_snapshot(
@@ -3053,19 +3090,18 @@ impl AppState {
                 // boundary as durable commit and live installation. Otherwise a
                 // later local writer can enqueue r2 before this task enqueues r1.
                 publish_exact_facade_events(&account_sink, &events)?;
+                Self::apply_config_effects_owned(
+                    snapshot.clone(),
+                    effects,
+                    app_data_dir,
+                    config,
+                    provider_registry,
+                    provider,
+                    mcp_manager,
+                )
+                .await?;
                 snapshot
             };
-
-            Self::apply_config_effects_owned(
-                snapshot.clone(),
-                effects,
-                app_data_dir,
-                config,
-                provider_registry,
-                provider,
-                mcp_manager,
-            )
-            .await?;
             Ok::<_, AppError>(snapshot)
         });
         transaction.await.map_err(|error| {
@@ -3147,7 +3183,7 @@ impl AppState {
         let provider = self.provider.clone();
         let mcp_manager = self.mcp_manager.clone();
         let transaction = tokio::spawn(async move {
-            let (snapshot, enforcement_newly_off) = {
+            let snapshot = {
                 let _io = io;
                 let data_dir = app_data_dir.clone();
                 let commit_facade = config_facade.clone();
@@ -3216,21 +3252,21 @@ impl AppState {
                     *cfg = snapshot.clone();
                 }
                 publish_exact_facade_events(&account_sink, &events)?;
-                (snapshot, enforcement_newly_off)
+                if enforcement_newly_off {
+                    warn_plugin_trust_enforcement_off();
+                }
+                Self::apply_config_effects_owned(
+                    snapshot.clone(),
+                    effects,
+                    app_data_dir,
+                    config,
+                    provider_registry,
+                    provider,
+                    mcp_manager,
+                )
+                .await?;
+                snapshot
             };
-            if enforcement_newly_off {
-                warn_plugin_trust_enforcement_off();
-            }
-            Self::apply_config_effects_owned(
-                snapshot.clone(),
-                effects,
-                app_data_dir,
-                config,
-                provider_registry,
-                provider,
-                mcp_manager,
-            )
-            .await?;
             Ok::<_, AppError>(snapshot)
         });
         transaction.await.map_err(|error| {
@@ -4171,8 +4207,9 @@ impl AppState {
         let mcp_manager = self.mcp_manager.clone();
         let transaction = tokio::spawn(async move {
             // Same #126 serialization as update_config: mutate + persist under
-            // the config-IO lock so a reload can't interleave; effects run
-            // unlocked but remain owned by this cancellation-independent task.
+            // the config-IO lock so a reload can't interleave. Provider/MCP
+            // effects also remain serialized so an older replacement cannot
+            // overwrite a later writer's runtime after an async suspension.
             let new_config = {
                 let _io = io;
                 let commit = Self::persist_config_snapshot(
@@ -4208,19 +4245,18 @@ impl AppState {
                     warn_plugin_trust_enforcement_off();
                 }
                 publish_exact_facade_events(&account_sink, &events)?;
+                Self::apply_config_effects_owned(
+                    published.clone(),
+                    effects,
+                    app_data_dir,
+                    config,
+                    provider_registry,
+                    provider,
+                    mcp_manager,
+                )
+                .await?;
                 published
             };
-
-            Self::apply_config_effects_owned(
-                new_config.clone(),
-                effects,
-                app_data_dir,
-                config,
-                provider_registry,
-                provider,
-                mcp_manager,
-            )
-            .await?;
             Ok::<_, AppError>(new_config)
         });
         transaction.await.map_err(|error| {
@@ -4240,13 +4276,12 @@ impl AppState {
         mcp_manager: Arc<McpServerManager>,
     ) -> Result<(), AppError> {
         if effects.reload_provider {
-            // Match `reload_provider`: if a later writer won after the
-            // serialization lock was released, initialize from that current
-            // live snapshot rather than regressing runtime to this task's
-            // older committed candidate.
+            // The caller retains config_io_lock through provider construction
+            // and publication, so this current live snapshot cannot be
+            // superseded while an awaited runtime build is in flight.
             let live_config = config.read().await.clone();
             let candidate_registry =
-                bamboo_llm::ProviderRegistry::from_config(&live_config, app_data_dir)
+                bamboo_llm::ProviderRegistry::from_config(&live_config, app_data_dir.clone())
                     .await
                     .map_err(|e| {
                         AppError::InternalError(anyhow::anyhow!(
@@ -4271,6 +4306,8 @@ impl AppState {
                     bamboo_llm::LLMError::Auth(message)
                 ))
             })?;
+            #[cfg(test)]
+            run_generic_before_provider_publish_test_hook(&app_data_dir);
             let mut live_provider = provider.write().await;
             provider_registry.replace_with(candidate_registry);
             *live_provider = candidate_provider;
@@ -5726,6 +5763,138 @@ mod live_reload_tests {
         .await
         .map(|revisions| assert_eq!(revisions, vec![1, 2]))
         .expect("both serialized core events must reach the journal");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn generic_runtime_effects_finish_before_later_config_writer() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("mcp-fixture.py");
+        std::fs::write(
+            &script,
+            r#"import json
+import sys
+
+for line in sys.stdin:
+    request = json.loads(line)
+    request_id = request.get("id")
+    if request_id is None:
+        continue
+    if request.get("method") == "initialize":
+        result = {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {"tools": {"listChanged": False}},
+            "serverInfo": {"name": "config-order-fixture", "version": "1.0.0"},
+        }
+    elif request.get("method") == "tools/list":
+        result = {"tools": []}
+    else:
+        result = {}
+    print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}), flush=True)
+"#,
+        )
+        .unwrap();
+        let python = ["python3", "python"]
+            .into_iter()
+            .find(|command| {
+                std::process::Command::new(command)
+                    .arg("--version")
+                    .output()
+                    .is_ok_and(|output| output.status.success())
+            })
+            .expect("a Python interpreter is required for the MCP ordering fixture");
+
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stop_config_watcher(&mut state);
+        let state = Arc::new(state);
+        let held_provider = state.provider.write().await;
+        let (provider_ready_tx, provider_ready_rx) = std::sync::mpsc::channel();
+        set_generic_before_provider_publish_test_hook(dir.path(), move || {
+            provider_ready_tx.send(()).unwrap();
+        });
+
+        let first = {
+            let state = state.clone();
+            tokio::spawn(async move {
+                state
+                    .update_config(
+                        |config| {
+                            config.provider = "copilot".to_string();
+                            Ok(())
+                        },
+                        ConfigUpdateEffects {
+                            reload_provider: true,
+                            reconcile_mcp: true,
+                        },
+                    )
+                    .await
+            })
+        };
+        tokio::task::spawn_blocking(move || provider_ready_rx.recv().unwrap())
+            .await
+            .unwrap();
+        assert!(
+            state.config_io_lock.try_lock().is_err(),
+            "the first writer must retain config_io_lock until its runtime effects finish"
+        );
+        assert!(
+            !first.is_finished(),
+            "the first writer must still be waiting to publish its provider"
+        );
+
+        let later_mcp = McpConfig {
+            version: 1,
+            servers: vec![McpServerConfig {
+                id: "later-winner".to_string(),
+                name: None,
+                enabled: true,
+                transport: TransportConfig::Stdio(StdioConfig {
+                    command: python.to_string(),
+                    args: vec![script.to_string_lossy().into_owned()],
+                    cwd: None,
+                    env: std::collections::HashMap::new(),
+                    env_encrypted: std::collections::HashMap::new(),
+                    env_credential_refs: std::collections::HashMap::new(),
+                    startup_timeout_ms: 2_000,
+                }),
+                request_timeout_ms: 2_000,
+                healthcheck_interval_ms: 10_000,
+                reconnect: ReconnectConfig {
+                    enabled: false,
+                    ..Default::default()
+                },
+                allowed_tools: vec![],
+                denied_tools: vec![],
+            }],
+        };
+        let second = {
+            let state = state.clone();
+            tokio::spawn(async move {
+                state
+                    .update_config(
+                        move |config| {
+                            config.mcp = later_mcp;
+                            Ok(())
+                        },
+                        ConfigUpdateEffects {
+                            reload_provider: false,
+                            reconcile_mcp: true,
+                        },
+                    )
+                    .await
+            })
+        };
+
+        drop(held_provider);
+        first.await.unwrap().unwrap();
+        let published = second.await.unwrap().unwrap();
+        assert_eq!(published.mcp.servers[0].id, "later-winner");
+        assert_eq!(state.config.read().await.mcp.servers[0].id, "later-winner");
+        assert_eq!(
+            state.mcp_manager.list_servers(),
+            vec!["later-winner".to_string()],
+            "the later durable config generation must remain the final runtime generation"
+        );
+        state.mcp_manager.shutdown_all().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -108,6 +108,37 @@ fn run_credential_after_commit_before_live_test_hook(data_dir: &Path, section: S
     }
 }
 
+#[cfg(test)]
+type GenericBeforeEventTestHook = Box<dyn FnOnce() + Send + 'static>;
+#[cfg(test)]
+type GenericBeforeEventTestHooks =
+    std::sync::Mutex<std::collections::HashMap<PathBuf, GenericBeforeEventTestHook>>;
+
+#[cfg(test)]
+fn generic_before_event_test_hooks() -> &'static GenericBeforeEventTestHooks {
+    static HOOKS: std::sync::OnceLock<GenericBeforeEventTestHooks> = std::sync::OnceLock::new();
+    HOOKS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+#[cfg(test)]
+fn set_generic_before_event_test_hook(data_dir: &Path, hook: impl FnOnce() + Send + 'static) {
+    generic_before_event_test_hooks()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(data_dir.to_path_buf(), Box::new(hook));
+}
+
+#[cfg(test)]
+fn run_generic_before_event_test_hook(data_dir: &Path) {
+    let hook = generic_before_event_test_hooks()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(data_dir);
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
 struct FacadeRuntimeMaterialization {
     config: Config,
     failures: BTreeSet<SectionId>,
@@ -2939,7 +2970,7 @@ impl AppState {
         // before we persist and then clobber this mutation with the stale copy
         // (#126). The lock is dropped before apply_config_effects — slow side
         // effects (provider reload) don't need to block reloads/other updates.
-        let (snapshot, events) = {
+        let snapshot = {
             let _io = self.config_io_lock.lock().await;
             let (mut snapshot, live_base, enforcement_newly_off) = {
                 let cfg = self.config.read().await;
@@ -3012,10 +3043,16 @@ impl AppState {
                 snapshot.publish_env_vars();
                 *cfg = snapshot.clone();
             }
-            (snapshot, events)
+            // Keep synchronous event enqueue inside the same serialization
+            // boundary as durable commit and live installation. Otherwise a
+            // later local writer can enqueue r2 while this task is preempted
+            // after unlocking, then this task can enqueue stale r1.
+            #[cfg(test)]
+            run_generic_before_event_test_hook(&self.app_data_dir);
+            publish_exact_facade_events(&self.account_sink, &events)?;
+            snapshot
         };
 
-        publish_exact_facade_events(&self.account_sink, &events)?;
         self.apply_config_effects(snapshot.clone(), effects).await?;
         Ok(snapshot)
     }
@@ -3037,7 +3074,7 @@ impl AppState {
         }
         let config_facade = self.config_facade.clone();
         let account_sink = self.account_sink.clone();
-        let (snapshot, enforcement_newly_off, events) = {
+        let (snapshot, enforcement_newly_off) = {
             let _io = self.config_io_lock.lock().await;
             let (mut candidate, live_base, enforcement_newly_off) = {
                 let cfg = self.config.read().await;
@@ -3157,12 +3194,12 @@ impl AppState {
                 snapshot.publish_env_vars();
                 *cfg = snapshot.clone();
             }
-            (snapshot, enforcement_newly_off, events)
+            publish_exact_facade_events(&account_sink, &events)?;
+            (snapshot, enforcement_newly_off)
         };
         if enforcement_newly_off {
             warn_plugin_trust_enforcement_off();
         }
-        publish_exact_facade_events(&account_sink, &events)?;
         self.apply_config_effects(snapshot.clone(), effects).await?;
         Ok(snapshot)
     }
@@ -4082,7 +4119,7 @@ impl AppState {
 
         // Same #126 serialization as update_config: mutate + persist under the
         // config-IO lock so a reload can't interleave; effects run unlocked.
-        let (new_config, events) = {
+        let new_config = {
             let _io = self.config_io_lock.lock().await;
             restore_authoritative_cluster_fabric(self.config_facade.as_ref(), &mut new_config);
             let (was_off, live_base) = {
@@ -4122,10 +4159,10 @@ impl AppState {
             if enforcement_newly_off {
                 warn_plugin_trust_enforcement_off();
             }
-            (published, events)
+            publish_exact_facade_events(&self.account_sink, &events)?;
+            published
         };
 
-        publish_exact_facade_events(&self.account_sink, &events)?;
         self.apply_config_effects(new_config.clone(), effects)
             .await?;
         Ok(new_config)
@@ -5300,6 +5337,298 @@ mod live_reload_tests {
             runtime_before_conflict,
             "a durable CAS conflict must not overwrite the process runtime"
         );
+    }
+
+    #[tokio::test]
+    async fn stale_process_cluster_noop_catches_up_exact_durable_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stop_config_watcher(&mut state);
+
+        let external = bamboo_config::ConfigFacade::open(dir.path()).unwrap();
+        let mut external_candidate = external.effective_config();
+        external_candidate
+            .cluster_fabric
+            .nodes
+            .push(bamboo_config::Node {
+                id: "external-node".to_string(),
+                label: "external-r1".to_string(),
+                placement: bamboo_config::NodePlacement::Local,
+                trust_level: bamboo_config::TrustLevel::Trusted,
+                deploy: bamboo_config::DeployProfile::default(),
+                state: None,
+                enabled: true,
+            });
+        assert_eq!(
+            bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut external_candidate,
+                &BTreeMap::from([(
+                    "external-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                0,
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            0
+        );
+        let baseline_seq = state.account_sink.latest_seq();
+
+        let committed = state
+            .update_cluster_fabric_credentials(1, BTreeMap::new(), |_| Ok(()))
+            .await
+            .unwrap();
+        assert_eq!(committed.section.revision, 1);
+        assert_eq!(
+            committed
+                .config
+                .cluster_fabric
+                .node("external-node")
+                .unwrap()
+                .label,
+            "external-r1"
+        );
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            1
+        );
+        assert_eq!(
+            state
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("external-node")
+                .unwrap()
+                .label,
+            "external-r1"
+        );
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            baseline_seq,
+        )
+        .unwrap();
+        let revisions = events
+            .iter()
+            .filter_map(|event| match &event.event {
+                AgentEvent::ConfigChanged { section, revision } if section == "cluster-fabric" => {
+                    Some(*revision)
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(revisions, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn stale_process_cluster_reset_noop_catches_up_exact_durable_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stop_config_watcher(&mut state);
+
+        let external = bamboo_config::ConfigFacade::open(dir.path()).unwrap();
+        let mut external_candidate = external.effective_config();
+        external_candidate
+            .cluster_fabric
+            .nodes
+            .push(bamboo_config::Node {
+                id: "reset-node".to_string(),
+                label: "reset-node".to_string(),
+                placement: bamboo_config::NodePlacement::Local,
+                trust_level: bamboo_config::TrustLevel::Trusted,
+                deploy: bamboo_config::DeployProfile::default(),
+                state: None,
+                enabled: true,
+            });
+        assert_eq!(
+            bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut external_candidate,
+                &BTreeMap::from([(
+                    "reset-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                0,
+            )
+            .unwrap(),
+            1
+        );
+        let reset_facade = bamboo_config::ConfigFacade::open(dir.path()).unwrap();
+        let mut reset_candidate = reset_facade.effective_config();
+        reset_candidate.cluster_fabric = bamboo_config::ClusterFabricConfig::default();
+        let external_reset = bamboo_config::persist_cluster_fabric_reset_at_revision_with_adoption(
+            dir.path(),
+            &mut reset_candidate,
+            1,
+            &reset_facade,
+            |_, _| {},
+        )
+        .unwrap();
+        assert_eq!(external_reset.revision, 2);
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            0
+        );
+        let baseline_seq = state.account_sink.latest_seq();
+
+        let committed = state
+            .reset_credential_backed_section(SectionId::ClusterFabric, 2)
+            .await
+            .unwrap();
+        let CredentialBackedResetCommit::Cluster(committed) = committed else {
+            panic!("cluster reset must return its exact snapshot")
+        };
+        assert_eq!(committed.section.revision, 2);
+        assert!(committed.config.cluster_fabric.nodes.is_empty());
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            2
+        );
+        assert!(state.config.read().await.cluster_fabric.nodes.is_empty());
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            baseline_seq,
+        )
+        .unwrap();
+        let revisions = events
+            .iter()
+            .filter_map(|event| match &event.event {
+                AgentEvent::ConfigChanged { section, revision } if section == "cluster-fabric" => {
+                    Some(*revision)
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(revisions, vec![2]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn generic_events_follow_serialized_local_commit_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stop_config_watcher(&mut state);
+        let state = Arc::new(state);
+        let baseline_seq = state.account_sink.latest_seq();
+        let (reached_tx, reached_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        set_generic_before_event_test_hook(dir.path(), move || {
+            reached_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+
+        let first = {
+            let state = state.clone();
+            tokio::spawn(async move {
+                state
+                    .update_config(
+                        |config| {
+                            config.server.port = 22_231;
+                            Ok(())
+                        },
+                        ConfigUpdateEffects::default(),
+                    )
+                    .await
+            })
+        };
+        tokio::task::spawn_blocking(move || reached_rx.recv().unwrap())
+            .await
+            .unwrap();
+        let second = {
+            let state = state.clone();
+            tokio::spawn(async move {
+                state
+                    .update_config(
+                        |config| {
+                            config.server.port = 22_232;
+                            Ok(())
+                        },
+                        ConfigUpdateEffects::default(),
+                    )
+                    .await
+            })
+        };
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !second.is_finished(),
+            "the later writer must remain behind the first writer's event"
+        );
+        let events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            baseline_seq,
+        )
+        .unwrap();
+        assert!(
+            events.iter().all(|event| !matches!(
+                &event.event,
+                AgentEvent::ConfigChanged { section, .. } if section == "core"
+            )),
+            "neither local commit can publish while the first owns config_io_lock"
+        );
+
+        release_tx.send(()).unwrap();
+        assert_eq!(first.await.unwrap().unwrap().server.port, 22_231);
+        assert_eq!(second.await.unwrap().unwrap().server.port, 22_232);
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                let events = bamboo_engine::events::journal::read_since(
+                    state.account_sink.events_dir(),
+                    baseline_seq,
+                )
+                .unwrap();
+                let revisions = events
+                    .iter()
+                    .filter_map(|event| match &event.event {
+                        AgentEvent::ConfigChanged { section, revision } if section == "core" => {
+                            Some(*revision)
+                        }
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
+                if revisions.len() == 2 {
+                    break revisions;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .map(|revisions| assert_eq!(revisions, vec![1, 2]))
+        .expect("both serialized core events must reach the journal");
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -4310,6 +4310,177 @@ mod live_reload_tests {
     }
 
     #[tokio::test]
+    async fn stale_stopped_watcher_compatibility_writers_catch_up_without_overwriting_cluster() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x72; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        state
+            .update_cluster_fabric_credentials(
+                0,
+                BTreeMap::from([(
+                    "shared-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(bamboo_config::Node {
+                        id: "shared-node".to_string(),
+                        label: "generation-one".to_string(),
+                        placement: bamboo_config::NodePlacement::Local,
+                        trust_level: bamboo_config::TrustLevel::Trusted,
+                        deploy: bamboo_config::DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        stop_config_watcher(&mut state);
+
+        let external = bamboo_config::ConfigFacade::open(dir.path()).unwrap();
+        let mut external_candidate = external.effective_config();
+        external_candidate
+            .cluster_fabric
+            .node_mut("shared-node")
+            .unwrap()
+            .label = "external-generation-two".to_string();
+        assert_eq!(
+            bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut external_candidate,
+                &BTreeMap::new(),
+                1,
+            )
+            .unwrap(),
+            2
+        );
+        let cluster_path = dir.path().join("cluster-fabric.json");
+        let cluster_r2 = std::fs::read(&cluster_path).unwrap();
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            1
+        );
+        assert_eq!(
+            state
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("shared-node")
+                .unwrap()
+                .label,
+            "generation-one"
+        );
+
+        let published = state
+            .update_config(|_| Ok(()), ConfigUpdateEffects::default())
+            .await
+            .unwrap();
+        assert_eq!(
+            published.cluster_fabric.node("shared-node").unwrap().label,
+            "external-generation-two"
+        );
+        assert_eq!(std::fs::read(&cluster_path).unwrap(), cluster_r2);
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            2,
+            "compatibility publication must catch the stopped watcher up to r2"
+        );
+        assert_eq!(
+            state
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("shared-node")
+                .unwrap()
+                .label,
+            "external-generation-two"
+        );
+
+        let external = bamboo_config::ConfigFacade::open(dir.path()).unwrap();
+        let mut external_candidate = external.effective_config();
+        external_candidate
+            .cluster_fabric
+            .node_mut("shared-node")
+            .unwrap()
+            .label = "external-generation-three".to_string();
+        assert_eq!(
+            bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut external_candidate,
+                &BTreeMap::new(),
+                2,
+            )
+            .unwrap(),
+            3
+        );
+        let cluster_r3 = std::fs::read(&cluster_path).unwrap();
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            2,
+            "the stopped watcher must remain stale before replace_config"
+        );
+
+        let mut replacement = state.config.read().await.clone();
+        replacement.server.port = 23_333;
+        let published = state
+            .replace_config(replacement, ConfigUpdateEffects::default())
+            .await
+            .unwrap();
+        assert_eq!(published.server.port, 23_333);
+        assert_eq!(
+            published.cluster_fabric.node("shared-node").unwrap().label,
+            "external-generation-three"
+        );
+        assert_eq!(std::fs::read(&cluster_path).unwrap(), cluster_r3);
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            3
+        );
+        assert_eq!(
+            state
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("shared-node")
+                .unwrap()
+                .label,
+            "external-generation-three"
+        );
+    }
+
+    #[tokio::test]
     async fn cluster_commit_installs_runtime_before_one_authoritative_event() {
         let _key = bamboo_config::encryption::set_test_encryption_key([0x71; 32]);
         let dir = tempfile::tempdir().unwrap();

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -714,19 +714,37 @@ pub(super) fn publish_registry_event(
     account_sink.record(None, &event);
 }
 
-fn publish_exact_facade_commit(
+/// Reload exact durable authorities into the process facade without making the
+/// resulting events externally observable yet. Compatibility writers use this
+/// phase to materialize and install the same facade generation in AppState
+/// before publishing Changed/Recovered.
+fn capture_exact_facade_commit_events(
     facade: Option<&std::sync::Arc<bamboo_config::ConfigFacade>>,
-    account_sink: &bamboo_engine::events::AccountEventSink,
     sections: &[SectionId],
-) -> Result<(), AppError> {
+) -> Vec<ConfigSectionEvent> {
     let Some(facade) = facade else {
-        return Ok(());
+        return Vec::new();
     };
+    let mut events = Vec::new();
     for section in sections {
         let Some(event) = facade.registry().reload_if_changed(*section) else {
             continue;
         };
-        publish_registry_event(account_sink, &event);
+        let invalid = matches!(&event, ConfigSectionEvent::Invalid { .. });
+        events.push(event);
+        if invalid {
+            break;
+        }
+    }
+    events
+}
+
+fn publish_exact_facade_events(
+    account_sink: &bamboo_engine::events::AccountEventSink,
+    events: &[ConfigSectionEvent],
+) -> Result<(), AppError> {
+    for event in events {
+        publish_registry_event(account_sink, event);
         if matches!(event, ConfigSectionEvent::Invalid { .. }) {
             return Err(AppError::InternalError(anyhow::anyhow!(
                 "committed configuration section became invalid before publication"
@@ -734,6 +752,15 @@ fn publish_exact_facade_commit(
         }
     }
     Ok(())
+}
+
+fn publish_exact_facade_commit(
+    facade: Option<&std::sync::Arc<bamboo_config::ConfigFacade>>,
+    account_sink: &bamboo_engine::events::AccountEventSink,
+    sections: &[SectionId],
+) -> Result<(), AppError> {
+    let events = capture_exact_facade_commit_events(facade, sections);
+    publish_exact_facade_events(account_sink, &events)
 }
 
 fn apply_runtime_section(id: SectionId, source: &Config, target: &mut Config) {
@@ -2790,7 +2817,10 @@ impl AppState {
         new_config
     }
 
-    async fn persist_config_snapshot(&self, config: Config) -> anyhow::Result<()> {
+    async fn persist_config_snapshot(
+        &self,
+        config: Config,
+    ) -> anyhow::Result<Vec<ConfigSectionEvent>> {
         let data_dir = self.app_data_dir.clone();
         if self.config_facade.is_some() {
             tokio::task::spawn_blocking(move || {
@@ -2802,14 +2832,16 @@ impl AppState {
                 .iter()
                 .map(|descriptor| descriptor.id)
                 .collect::<Vec<_>>();
-            publish_exact_facade_commit(self.config_facade.as_ref(), &self.account_sink, &sections)
-                .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+            Ok(capture_exact_facade_commit_events(
+                self.config_facade.as_ref(),
+                &sections,
+            ))
         } else {
             tokio::task::spawn_blocking(move || config.save_to_dir(data_dir))
                 .await
                 .map_err(|e| anyhow::anyhow!("Config save task failed: {e}"))??;
+            Ok(Vec::new())
         }
-        Ok(())
     }
 
     /// Unified config update entrypoint.
@@ -2878,7 +2910,8 @@ impl AppState {
             if enforcement_newly_off {
                 warn_plugin_trust_enforcement_off();
             }
-            self.persist_config_snapshot(snapshot.clone())
+            let events = self
+                .persist_config_snapshot(snapshot.clone())
                 .await
                 .map_err(|e| {
                     AppError::InternalError(anyhow::anyhow!("Failed to save config: {e}"))
@@ -2893,6 +2926,10 @@ impl AppState {
                 snapshot.publish_env_vars();
                 *cfg = snapshot.clone();
             }
+            // Preserve the established ordering relative to optional runtime
+            // effects: config events precede those effects, but now only after
+            // the matching materialized snapshot is live.
+            publish_exact_facade_events(&self.account_sink, &events)?;
             snapshot
         };
 
@@ -3815,7 +3852,8 @@ impl AppState {
                 reject_if_recovery_pending(&cfg)?;
                 cfg.plugin_trust.enforcement_is_off()
             };
-            self.persist_config_snapshot(new_config.clone())
+            let events = self
+                .persist_config_snapshot(new_config.clone())
                 .await
                 .map_err(|e| {
                     AppError::InternalError(anyhow::anyhow!("Failed to save config: {e}"))
@@ -3828,6 +3866,9 @@ impl AppState {
             let enforcement_newly_off = !was_off && published.plugin_trust.enforcement_is_off();
             published.publish_env_vars();
             *self.config.write().await = published.clone();
+            // `record` is nonblocking, so this must remain after the live
+            // AppState write rather than inside persistence/reload capture.
+            publish_exact_facade_events(&self.account_sink, &events)?;
             // Same live signal as `update_config` — a full-config replace (JSON
             // merge / PATCH endpoints) that transitions plugin_trust.enforcement
             // into `Off` must warn just as loudly as a targeted set.
@@ -4247,6 +4288,28 @@ mod live_reload_tests {
         next_config_event(feed, "mcp").await
     }
 
+    async fn wait_for_cluster_facade_revision(state: &AppState, expected: u64) {
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                if state
+                    .config_facade
+                    .as_ref()
+                    .unwrap()
+                    .registry()
+                    .cluster_fabric
+                    .snapshot()
+                    .revision
+                    == expected
+                {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("cluster facade revision did not advance");
+    }
+
     #[tokio::test]
     async fn compatibility_update_cannot_reintroduce_an_unrevisioned_cluster_mutation() {
         let _key = bamboo_config::encryption::set_test_encryption_key([0x70; 32]);
@@ -4337,6 +4400,7 @@ mod live_reload_tests {
             .await
             .unwrap();
         stop_config_watcher(&mut state);
+        let state = Arc::new(state);
 
         let external = bamboo_config::ConfigFacade::open(dir.path()).unwrap();
         let mut external_candidate = external.effective_config();
@@ -4380,10 +4444,66 @@ mod live_reload_tests {
             "generation-one"
         );
 
-        let published = state
-            .update_config(|_| Ok(()), ConfigUpdateEffects::default())
+        let mut feed = state.account_sink.subscribe();
+        let stale_runtime = state.config.read().await;
+        let updating = {
+            let state = state.clone();
+            tokio::spawn(async move {
+                state
+                    .update_config(|_| Ok(()), ConfigUpdateEffects::default())
+                    .await
+            })
+        };
+        wait_for_cluster_facade_revision(&state, 2).await;
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(300),
+                next_config_event(&mut feed, "cluster-fabric"),
+            )
             .await
-            .unwrap();
+            .is_err(),
+            "r2 event became observable while live AppState config was still r1"
+        );
+        assert_eq!(
+            stale_runtime
+                .cluster_fabric
+                .node("shared-node")
+                .unwrap()
+                .label,
+            "generation-one"
+        );
+        drop(stale_runtime);
+
+        let event = next_config_event(&mut feed, "cluster-fabric").await;
+        assert!(matches!(
+            event,
+            AgentEvent::ConfigChanged {
+                section,
+                revision: 2
+            } if section == "cluster-fabric"
+        ));
+        assert_eq!(
+            state
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("shared-node")
+                .unwrap()
+                .label,
+            "external-generation-two",
+            "r2 must be live before its event is observable"
+        );
+        let published = updating.await.unwrap().unwrap();
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(300),
+                next_config_event(&mut feed, "cluster-fabric"),
+            )
+            .await
+            .is_err(),
+            "r2 catch-up published a duplicate cluster event"
+        );
         assert_eq!(
             published.cluster_fabric.node("shared-node").unwrap().label,
             "external-generation-two"
@@ -4446,10 +4566,66 @@ mod live_reload_tests {
 
         let mut replacement = state.config.read().await.clone();
         replacement.server.port = 23_333;
-        let published = state
-            .replace_config(replacement, ConfigUpdateEffects::default())
+        let mut feed = state.account_sink.subscribe();
+        let stale_runtime = state.config.read().await;
+        let replacing = {
+            let state = state.clone();
+            tokio::spawn(async move {
+                state
+                    .replace_config(replacement, ConfigUpdateEffects::default())
+                    .await
+            })
+        };
+        wait_for_cluster_facade_revision(&state, 3).await;
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(300),
+                next_config_event(&mut feed, "cluster-fabric"),
+            )
             .await
-            .unwrap();
+            .is_err(),
+            "r3 event became observable while live AppState config was still r2"
+        );
+        assert_eq!(
+            stale_runtime
+                .cluster_fabric
+                .node("shared-node")
+                .unwrap()
+                .label,
+            "external-generation-two"
+        );
+        drop(stale_runtime);
+
+        let event = next_config_event(&mut feed, "cluster-fabric").await;
+        assert!(matches!(
+            event,
+            AgentEvent::ConfigChanged {
+                section,
+                revision: 3
+            } if section == "cluster-fabric"
+        ));
+        assert_eq!(
+            state
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("shared-node")
+                .unwrap()
+                .label,
+            "external-generation-three",
+            "r3 must be live before its event is observable"
+        );
+        let published = replacing.await.unwrap().unwrap();
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(300),
+                next_config_event(&mut feed, "cluster-fabric"),
+            )
+            .await
+            .is_err(),
+            "r3 catch-up published a duplicate cluster event"
+        );
         assert_eq!(published.server.port, 23_333);
         assert_eq!(
             published.cluster_fabric.node("shared-node").unwrap().label,

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -2994,6 +2994,9 @@ impl AppState {
                     AppError::ConfigConflict { expected, actual }
                 }
                 ConfigStoreError::Validation(message) => AppError::BadRequest(message),
+                ConfigStoreError::CommitIndeterminate(message) => AppError::InternalError(
+                    anyhow::anyhow!("configuration commit outcome is indeterminate: {message}"),
+                ),
                 ConfigStoreError::Io(error) => AppError::StorageError(error),
                 ConfigStoreError::Json(_) => {
                     AppError::BadRequest("configuration document is invalid".to_string())
@@ -3072,6 +3075,9 @@ impl AppState {
                     AppError::ConfigConflict { expected, actual }
                 }
                 ConfigStoreError::Validation(message) => AppError::BadRequest(message),
+                ConfigStoreError::CommitIndeterminate(message) => AppError::InternalError(
+                    anyhow::anyhow!("configuration commit outcome is indeterminate: {message}"),
+                ),
                 ConfigStoreError::Io(error) => AppError::StorageError(error),
                 ConfigStoreError::Json(_) => {
                     AppError::BadRequest("configuration document is invalid".to_string())
@@ -3148,6 +3154,11 @@ impl AppState {
                     AppError::ConfigConflict { expected, actual }
                 }
                 ConfigStoreError::Validation(message) => AppError::BadRequest(message),
+                ConfigStoreError::CommitIndeterminate(message) => {
+                    AppError::InternalError(anyhow::anyhow!(
+                        "configuration commit outcome is indeterminate: {message}"
+                    ))
+                }
                 ConfigStoreError::Io(error) => AppError::StorageError(error),
                 ConfigStoreError::Json(_) => {
                     AppError::BadRequest("configuration document is invalid".to_string())
@@ -3221,6 +3232,9 @@ impl AppState {
                     AppError::ConfigConflict { expected, actual }
                 }
                 ConfigStoreError::Validation(message) => AppError::BadRequest(message),
+                ConfigStoreError::CommitIndeterminate(message) => AppError::InternalError(
+                    anyhow::anyhow!("configuration commit outcome is indeterminate: {message}"),
+                ),
                 ConfigStoreError::Io(error) => AppError::StorageError(error),
                 ConfigStoreError::Json(_) => {
                     AppError::BadRequest("configuration document is invalid".to_string())
@@ -3294,6 +3308,9 @@ impl AppState {
                     AppError::ConfigConflict { expected, actual }
                 }
                 ConfigStoreError::Validation(message) => AppError::BadRequest(message),
+                ConfigStoreError::CommitIndeterminate(message) => AppError::InternalError(
+                    anyhow::anyhow!("configuration commit outcome is indeterminate: {message}"),
+                ),
                 ConfigStoreError::Io(error) => AppError::StorageError(error),
                 ConfigStoreError::Json(_) => {
                     AppError::BadRequest("configuration document is invalid".to_string())
@@ -3432,6 +3449,9 @@ impl AppState {
                     AppError::ConfigConflict { expected, actual }
                 }
                 ConfigStoreError::Validation(message) => AppError::BadRequest(message),
+                ConfigStoreError::CommitIndeterminate(message) => AppError::InternalError(
+                    anyhow::anyhow!("configuration commit outcome is indeterminate: {message}"),
+                ),
                 ConfigStoreError::Io(error) => AppError::StorageError(error),
                 ConfigStoreError::Json(_) => {
                     AppError::BadRequest("configuration document is invalid".to_string())
@@ -3488,6 +3508,9 @@ impl AppState {
                     AppError::ConfigConflict { expected, actual }
                 }
                 ConfigStoreError::Validation(message) => AppError::BadRequest(message),
+                ConfigStoreError::CommitIndeterminate(message) => AppError::InternalError(
+                    anyhow::anyhow!("configuration commit outcome is indeterminate: {message}"),
+                ),
                 ConfigStoreError::Io(error) => AppError::StorageError(error),
                 ConfigStoreError::Json(_) => {
                     AppError::BadRequest("configuration document is invalid".to_string())
@@ -3684,6 +3707,9 @@ impl AppState {
                     AppError::ConfigConflict { expected, actual }
                 }
                 ConfigStoreError::Validation(message) => AppError::BadRequest(message),
+                ConfigStoreError::CommitIndeterminate(message) => AppError::InternalError(
+                    anyhow::anyhow!("configuration commit outcome is indeterminate: {message}"),
+                ),
                 ConfigStoreError::Io(error) => AppError::StorageError(error),
                 ConfigStoreError::Json(_) => {
                     AppError::BadRequest("configuration document is invalid".to_string())
@@ -3740,11 +3766,11 @@ impl AppState {
                         ConfigStoreError::Conflict { expected, actual } => {
                             AppError::ConfigConflict { expected, actual }
                         }
-                        ConfigStoreError::Validation(_) | ConfigStoreError::Json(_) => {
-                            AppError::InternalError(anyhow::anyhow!(
-                                "credential store validation failed"
-                            ))
-                        }
+                        ConfigStoreError::Validation(_)
+                        | ConfigStoreError::CommitIndeterminate(_)
+                        | ConfigStoreError::Json(_) => AppError::InternalError(anyhow::anyhow!(
+                            "credential store validation failed"
+                        )),
                         ConfigStoreError::Io(error) => AppError::StorageError(error),
                         ConfigStoreError::Watch(error) => AppError::InternalError(anyhow::anyhow!(
                             "configuration watch failed: {error}"

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -1,9 +1,7 @@
 use super::*;
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::Path;
-#[cfg(test)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -2927,26 +2925,38 @@ impl AppState {
     }
 
     async fn persist_config_snapshot(
-        &self,
+        data_dir: PathBuf,
+        config_facade: Option<Arc<bamboo_config::ConfigFacade>>,
         config: Config,
     ) -> anyhow::Result<Option<bamboo_config::FacadeConfigCommit>> {
-        let data_dir = self.app_data_dir.clone();
-        if let Some(facade) = self.config_facade.clone() {
+        if let Some(facade) = config_facade {
             tokio::task::spawn_blocking(move || {
-                bamboo_config::persist_facade_effective_config_with_adoption(
-                    data_dir,
+                let result = bamboo_config::persist_facade_effective_config_with_adoption(
+                    &data_dir,
                     &config,
                     facade.as_ref(),
-                )
+                );
+                #[cfg(test)]
+                if result.is_ok() {
+                    run_generic_before_event_test_hook(&data_dir);
+                }
+                result
             })
             .await
             .map_err(|e| anyhow::anyhow!("Config save task failed: {e}"))?
             .map(Some)
             .map_err(Into::into)
         } else {
-            tokio::task::spawn_blocking(move || config.save_to_dir(data_dir))
-                .await
-                .map_err(|e| anyhow::anyhow!("Config save task failed: {e}"))??;
+            tokio::task::spawn_blocking(move || {
+                let result = config.save_to_dir(data_dir.clone());
+                #[cfg(test)]
+                if result.is_ok() {
+                    run_generic_before_event_test_hook(&data_dir);
+                }
+                result
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("Config save task failed: {e}"))??;
             Ok(None)
         }
     }
@@ -2965,96 +2975,104 @@ impl AppState {
     where
         F: FnOnce(&mut Config) -> Result<(), AppError>,
     {
-        // Hold the config-IO lock across BOTH the in-memory mutation AND the disk
-        // persist, so a concurrent reload_config can't read the disk in the gap
-        // before we persist and then clobber this mutation with the stale copy
-        // (#126). The lock is dropped before apply_config_effects — slow side
-        // effects (provider reload) don't need to block reloads/other updates.
-        let snapshot = {
-            let _io = self.config_io_lock.lock().await;
-            let (mut snapshot, live_base, enforcement_newly_off) = {
-                let cfg = self.config.read().await;
-                // Refuse the whole operation (no in-memory mutation, no disk
-                // write) while a config-corruption recovery is pending
-                // confirmation (#153) — `save_to_dir` would reject the persist
-                // anyway, but checking here BEFORE `update()` runs keeps the
-                // in-memory config frozen exactly at the recovered state
-                // instead of silently drifting further from what's on disk.
-                reject_if_recovery_pending(&cfg)?;
-                let was_off = cfg.plugin_trust.enforcement_is_off();
-                let live_base = cfg.clone();
-                let mut candidate = cfg.clone();
-                restore_authoritative_cluster_fabric(self.config_facade.as_ref(), &mut candidate);
-                update(&mut candidate)?;
-                // No caller of this compatibility entrypoint owns cluster CAS.
-                restore_authoritative_cluster_fabric(self.config_facade.as_ref(), &mut candidate);
-                // Backfill any missing connect.platforms id (#496) on the live
-                // in-memory config itself — not just inside `save_to_dir`'s
-                // internal save-copy — so the response this update returns
-                // (and any GET immediately after) already reflects the id a
-                // client can round-trip on its next PATCH.
-                candidate.assign_connect_platform_ids();
-                // Same live-vs-save-copy treatment for ciphertext (#516):
-                // `save_to_dir` refreshes `*_encrypted` only on its save-time
-                // clone, so a secret set through this entrypoint (e.g. a
-                // provider instance created over HTTP) would otherwise stay
-                // plaintext-only in memory — and the next settings-PATCH merge
-                // (`build_merged_config`'s serde round-trip drops plaintext)
-                // would lose the key entirely.
-                candidate.refresh_encrypted_secrets().map_err(|e| {
-                    AppError::InternalError(anyhow::anyhow!(
-                        "Failed to refresh encrypted secrets: {e}"
-                    ))
-                })?;
-                let newly_off = !was_off && candidate.plugin_trust.enforcement_is_off();
-                (candidate, live_base, newly_off)
-            };
-            // Loud signal at the MOMENT plugin_trust.enforcement is flipped off
-            // live (e.g. via `bamboo config set plugin_trust.enforcement off`
-            // over HTTP), mirroring the boot-time warn in `AppState::new` — so
-            // this security-relevant relaxation is never applied silently. Only
-            // on the transition into `Off` (not every unrelated config write
-            // while already off).
-            if enforcement_newly_off {
-                warn_plugin_trust_enforcement_off();
-            }
-            let commit = self
-                .persist_config_snapshot(snapshot.clone())
+        // Cancellation while waiting for either guard is pre-commit and leaves
+        // every authority untouched. After candidate construction there is no
+        // await before the owned guard and candidate enter the detached task.
+        let io = self.config_io_lock.clone().lock_owned().await;
+        let (mut snapshot, live_base, enforcement_newly_off) = {
+            let cfg = self.config.read().await;
+            // Refuse the whole operation (no in-memory mutation, no disk
+            // write) while a config-corruption recovery is pending
+            // confirmation (#153) — `save_to_dir` would reject the persist
+            // anyway, but checking here BEFORE `update()` runs keeps the
+            // in-memory config frozen exactly at the recovered state.
+            reject_if_recovery_pending(&cfg)?;
+            let was_off = cfg.plugin_trust.enforcement_is_off();
+            let live_base = cfg.clone();
+            let mut candidate = cfg.clone();
+            restore_authoritative_cluster_fabric(self.config_facade.as_ref(), &mut candidate);
+            update(&mut candidate)?;
+            // No caller of this compatibility entrypoint owns cluster CAS.
+            restore_authoritative_cluster_fabric(self.config_facade.as_ref(), &mut candidate);
+            candidate.assign_connect_platform_ids();
+            candidate.refresh_encrypted_secrets().map_err(|e| {
+                AppError::InternalError(anyhow::anyhow!("Failed to refresh encrypted secrets: {e}"))
+            })?;
+            let newly_off = !was_off && candidate.plugin_trust.enforcement_is_off();
+            (candidate, live_base, newly_off)
+        };
+        if enforcement_newly_off {
+            warn_plugin_trust_enforcement_off();
+        }
+        let config = self.config.clone();
+        let app_data_dir = self.app_data_dir.clone();
+        let config_facade = self.config_facade.clone();
+        let account_sink = self.account_sink.clone();
+        let provider_registry = self.provider_registry.clone();
+        let provider = self.provider.clone();
+        let mcp_manager = self.mcp_manager.clone();
+        // The detached task owns every step after dispatch. Dropping the
+        // request's JoinHandle cannot strand a completed durable/facade commit
+        // ahead of live publication, its exact events, or requested effects.
+        let transaction = tokio::spawn(async move {
+            // Hold the config-IO lock across BOTH the in-memory mutation AND the
+            // disk persist, so a concurrent reload_config can't read the disk in
+            // the gap before we persist and then clobber this mutation with the
+            // stale copy (#126). Slow side effects run after this block unlocks.
+            let snapshot = {
+                let _io = io;
+                let commit = Self::persist_config_snapshot(
+                    app_data_dir.clone(),
+                    config_facade.clone(),
+                    snapshot.clone(),
+                )
                 .await
                 .map_err(|e| {
                     AppError::InternalError(anyhow::anyhow!("Failed to save config: {e}"))
                 })?;
-            let events = match commit {
-                Some(commit) => {
-                    let mut published = live_base;
-                    let events =
-                        install_facade_config_commit(commit, &mut published).map_err(|e| {
-                            AppError::InternalError(anyhow::anyhow!(
-                                "failed to install committed configuration section: {e}"
-                            ))
-                        })?;
-                    snapshot = published;
-                    events
+                let events = match commit {
+                    Some(commit) => {
+                        let mut published = live_base;
+                        let events =
+                            install_facade_config_commit(commit, &mut published).map_err(|e| {
+                                AppError::InternalError(anyhow::anyhow!(
+                                    "failed to install committed configuration section: {e}"
+                                ))
+                            })?;
+                        snapshot = published;
+                        events
+                    }
+                    None => Vec::new(),
+                };
+                {
+                    let mut cfg = config.write().await;
+                    snapshot.publish_env_vars();
+                    *cfg = snapshot.clone();
                 }
-                None => Vec::new(),
+                // Keep synchronous event enqueue inside the same serialization
+                // boundary as durable commit and live installation. Otherwise a
+                // later local writer can enqueue r2 before this task enqueues r1.
+                publish_exact_facade_events(&account_sink, &events)?;
+                snapshot
             };
-            {
-                let mut cfg = self.config.write().await;
-                snapshot.publish_env_vars();
-                *cfg = snapshot.clone();
-            }
-            // Keep synchronous event enqueue inside the same serialization
-            // boundary as durable commit and live installation. Otherwise a
-            // later local writer can enqueue r2 while this task is preempted
-            // after unlocking, then this task can enqueue stale r1.
-            #[cfg(test)]
-            run_generic_before_event_test_hook(&self.app_data_dir);
-            publish_exact_facade_events(&self.account_sink, &events)?;
-            snapshot
-        };
 
-        self.apply_config_effects(snapshot.clone(), effects).await?;
-        Ok(snapshot)
+            Self::apply_config_effects_owned(
+                snapshot.clone(),
+                effects,
+                app_data_dir,
+                config,
+                provider_registry,
+                provider,
+                mcp_manager,
+            )
+            .await?;
+            Ok::<_, AppError>(snapshot)
+        });
+        transaction.await.map_err(|error| {
+            AppError::InternalError(anyhow::anyhow!(
+                "config update transaction task failed: {error}"
+            ))
+        })?
     }
 
     /// Compatibility provider update whose credential and metadata documents
@@ -3072,136 +3090,154 @@ impl AppState {
         if provider_intents.is_empty() && provider_instance_intents.is_empty() {
             return self.update_config(update, effects).await;
         }
+        let io = self.config_io_lock.clone().lock_owned().await;
         let config_facade = self.config_facade.clone();
-        let account_sink = self.account_sink.clone();
-        let (snapshot, enforcement_newly_off) = {
-            let _io = self.config_io_lock.lock().await;
-            let (mut candidate, live_base, enforcement_newly_off) = {
-                let cfg = self.config.read().await;
-                reject_if_recovery_pending(&cfg)?;
-                let was_off = cfg.plugin_trust.enforcement_is_off();
-                let live_base = cfg.clone();
-                let mut candidate = cfg.clone();
-                restore_authoritative_cluster_fabric(config_facade.as_ref(), &mut candidate);
-                update(&mut candidate)?;
-                // Provider compatibility updates never own cluster CAS.
-                restore_authoritative_cluster_fabric(config_facade.as_ref(), &mut candidate);
-                // Provider plaintext may be present until the exact credential
-                // transaction assigns its durable reference. Compare every
-                // other section against a candidate whose provider projection
-                // is replaced with the current durable domain; the exact
-                // transaction below remains the sole provider validator.
-                let mut non_provider_candidate = candidate.clone();
-                apply_runtime_section(SectionId::Providers, &cfg, &mut non_provider_candidate);
-                let mut comparison_base = cfg.clone();
-                restore_authoritative_cluster_fabric(config_facade.as_ref(), &mut comparison_base);
-                let mut changed = bamboo_config::changed_facade_sections(
-                    &comparison_base,
-                    &non_provider_candidate,
-                )
-                .map_err(|_| {
+        let (mut candidate, live_base, enforcement_newly_off) = {
+            let cfg = self.config.read().await;
+            reject_if_recovery_pending(&cfg)?;
+            let was_off = cfg.plugin_trust.enforcement_is_off();
+            let live_base = cfg.clone();
+            let mut candidate = cfg.clone();
+            restore_authoritative_cluster_fabric(config_facade.as_ref(), &mut candidate);
+            update(&mut candidate)?;
+            // Provider compatibility updates never own cluster CAS.
+            restore_authoritative_cluster_fabric(config_facade.as_ref(), &mut candidate);
+            // Provider plaintext may be present until the exact credential
+            // transaction assigns its durable reference. Compare every other
+            // section against a candidate whose provider projection is
+            // replaced with the current durable domain.
+            let mut non_provider_candidate = candidate.clone();
+            apply_runtime_section(SectionId::Providers, &cfg, &mut non_provider_candidate);
+            let mut comparison_base = cfg.clone();
+            restore_authoritative_cluster_fabric(config_facade.as_ref(), &mut comparison_base);
+            let mut changed =
+                bamboo_config::changed_facade_sections(&comparison_base, &non_provider_candidate)
+                    .map_err(|_| {
                     AppError::InternalError(anyhow::anyhow!(
                         "failed to compare modular configuration sections"
                     ))
                 })?;
-                // The compatibility wire shape can normalize duplicated
-                // external-broker metadata while leaving the actual subagents
-                // module byte-for-byte equivalent. That is an unchanged echo,
-                // not a second section mutation.
-                if serde_json::to_value(cfg.subagents()).ok()
-                    == serde_json::to_value(candidate.subagents()).ok()
-                {
-                    changed.retain(|section| *section != SectionId::Subagents);
-                }
-                if let Some(other) = changed
-                    .into_iter()
-                    .find(|section| *section != SectionId::Providers)
-                {
-                    return Err(AppError::BadRequest(format!(
-                        "provider credential updates cannot be combined with {} changes; split the request",
-                        other.descriptor().name
-                    )));
-                }
-                candidate.assign_connect_platform_ids();
-                candidate.refresh_encrypted_secrets().map_err(|error| {
-                    AppError::InternalError(anyhow::anyhow!(
-                        "Failed to refresh encrypted secrets: {error}"
-                    ))
-                })?;
-                let newly_off = !was_off && candidate.plugin_trust.enforcement_is_off();
-                (candidate, live_base, newly_off)
-            };
-            let data_dir = self.app_data_dir.clone();
-            let commit_facade = config_facade.clone();
-            let (candidate, commit) = tokio::task::spawn_blocking(move || {
-                if let Some(facade) = commit_facade {
-                    let commit =
-                        bamboo_config::persist_provider_instance_credential_transaction_with_adoption(
+            if serde_json::to_value(cfg.subagents()).ok()
+                == serde_json::to_value(candidate.subagents()).ok()
+            {
+                changed.retain(|section| *section != SectionId::Subagents);
+            }
+            if let Some(other) = changed
+                .into_iter()
+                .find(|section| *section != SectionId::Providers)
+            {
+                return Err(AppError::BadRequest(format!(
+                    "provider credential updates cannot be combined with {} changes; split the request",
+                    other.descriptor().name
+                )));
+            }
+            candidate.assign_connect_platform_ids();
+            candidate.refresh_encrypted_secrets().map_err(|error| {
+                AppError::InternalError(anyhow::anyhow!(
+                    "Failed to refresh encrypted secrets: {error}"
+                ))
+            })?;
+            let newly_off = !was_off && candidate.plugin_trust.enforcement_is_off();
+            (candidate, live_base, newly_off)
+        };
+        let config = self.config.clone();
+        let app_data_dir = self.app_data_dir.clone();
+        let account_sink = self.account_sink.clone();
+        let provider_registry = self.provider_registry.clone();
+        let provider = self.provider.clone();
+        let mcp_manager = self.mcp_manager.clone();
+        let transaction = tokio::spawn(async move {
+            let (snapshot, enforcement_newly_off) = {
+                let _io = io;
+                let data_dir = app_data_dir.clone();
+                let commit_facade = config_facade.clone();
+                let (candidate, commit) = tokio::task::spawn_blocking(move || {
+                    let result = if let Some(facade) = commit_facade {
+                        let commit =
+                            bamboo_config::persist_provider_instance_credential_transaction_with_adoption(
+                                &data_dir,
+                                &mut candidate,
+                                &provider_intents,
+                                &provider_instance_intents,
+                                facade.as_ref(),
+                            )?;
+                        Ok::<_, ConfigStoreError>((candidate, Some(commit)))
+                    } else {
+                        bamboo_config::persist_provider_instance_credential_transaction(
                             &data_dir,
                             &mut candidate,
                             &provider_intents,
                             &provider_instance_intents,
-                            facade.as_ref(),
                         )?;
-                    Ok::<_, ConfigStoreError>((candidate, Some(commit)))
-                } else {
-                    bamboo_config::persist_provider_instance_credential_transaction(
-                        &data_dir,
-                        &mut candidate,
-                        &provider_intents,
-                        &provider_instance_intents,
-                    )?;
-                    Ok((load_committed_effective_config(&data_dir)?, None))
-                }
-            })
-            .await
-            .map_err(|error| {
-                AppError::InternalError(anyhow::anyhow!(
-                    "provider credential transaction task failed: {error}"
-                ))
-            })?
-            .map_err(|error| match error {
-                ConfigStoreError::Conflict { expected, actual } => {
-                    AppError::ConfigConflict { expected, actual }
-                }
-                ConfigStoreError::Validation(message) => AppError::BadRequest(message),
-                ConfigStoreError::CommitIndeterminate(message) => AppError::InternalError(
-                    anyhow::anyhow!("configuration commit outcome is indeterminate: {message}"),
-                ),
-                ConfigStoreError::Io(error) => AppError::StorageError(error),
-                ConfigStoreError::Json(_) => {
-                    AppError::BadRequest("configuration document is invalid".to_string())
-                }
-                ConfigStoreError::Watch(error) => {
-                    AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
-                }
-            })?;
-            let (snapshot, events) = match commit {
-                Some(commit) => {
-                    let mut published = live_base;
-                    let installed = install_credential_section_commit(commit, &mut published)
-                        .map_err(|error| {
+                        Ok((load_committed_effective_config(&data_dir)?, None))
+                    };
+                    #[cfg(test)]
+                    run_generic_before_event_test_hook(&data_dir);
+                    result
+                })
+                .await
+                .map_err(|error| {
+                    AppError::InternalError(anyhow::anyhow!(
+                        "provider credential transaction task failed: {error}"
+                    ))
+                })?
+                .map_err(|error| match error {
+                    ConfigStoreError::Conflict { expected, actual } => {
+                        AppError::ConfigConflict { expected, actual }
+                    }
+                    ConfigStoreError::Validation(message) => AppError::BadRequest(message),
+                    ConfigStoreError::CommitIndeterminate(message) => AppError::InternalError(
+                        anyhow::anyhow!("configuration commit outcome is indeterminate: {message}"),
+                    ),
+                    ConfigStoreError::Io(error) => AppError::StorageError(error),
+                    ConfigStoreError::Json(_) => {
+                        AppError::BadRequest("configuration document is invalid".to_string())
+                    }
+                    ConfigStoreError::Watch(error) => AppError::InternalError(anyhow::anyhow!(
+                        "configuration watch failed: {error}"
+                    )),
+                })?;
+                let (snapshot, events) = match commit {
+                    Some(commit) => {
+                        let mut published = live_base;
+                        let installed = install_credential_section_commit(commit, &mut published)
+                            .map_err(|error| {
                             AppError::InternalError(anyhow::anyhow!(
                                 "provider process adoption failed: {error}"
                             ))
                         })?;
-                    (published, installed.events)
+                        (published, installed.events)
+                    }
+                    None => (candidate, Vec::new()),
+                };
+                {
+                    let mut cfg = config.write().await;
+                    snapshot.publish_env_vars();
+                    *cfg = snapshot.clone();
                 }
-                None => (candidate, Vec::new()),
+                publish_exact_facade_events(&account_sink, &events)?;
+                (snapshot, enforcement_newly_off)
             };
-            {
-                let mut cfg = self.config.write().await;
-                snapshot.publish_env_vars();
-                *cfg = snapshot.clone();
+            if enforcement_newly_off {
+                warn_plugin_trust_enforcement_off();
             }
-            publish_exact_facade_events(&account_sink, &events)?;
-            (snapshot, enforcement_newly_off)
-        };
-        if enforcement_newly_off {
-            warn_plugin_trust_enforcement_off();
-        }
-        self.apply_config_effects(snapshot.clone(), effects).await?;
-        Ok(snapshot)
+            Self::apply_config_effects_owned(
+                snapshot.clone(),
+                effects,
+                app_data_dir,
+                config,
+                provider_registry,
+                provider,
+                mcp_manager,
+            )
+            .await?;
+            Ok::<_, AppError>(snapshot)
+        });
+        transaction.await.map_err(|error| {
+            AppError::InternalError(anyhow::anyhow!(
+                "provider config transaction task failed: {error}"
+            ))
+        })?
     }
 
     /// Mutate user env vars through the recoverable credentials.json +
@@ -4117,74 +4153,135 @@ impl AppState {
             AppError::InternalError(anyhow::anyhow!("Failed to refresh encrypted secrets: {e}"))
         })?;
 
-        // Same #126 serialization as update_config: mutate + persist under the
-        // config-IO lock so a reload can't interleave; effects run unlocked.
-        let new_config = {
-            let _io = self.config_io_lock.lock().await;
-            restore_authoritative_cluster_fabric(self.config_facade.as_ref(), &mut new_config);
-            let (was_off, live_base) = {
-                let cfg = self.config.read().await;
-                // Same guard as `update_config` (#153): a full-config replace
-                // must not silently blow away an unconfirmed recovery either.
-                reject_if_recovery_pending(&cfg)?;
-                (cfg.plugin_trust.enforcement_is_off(), cfg.clone())
-            };
-            let commit = self
-                .persist_config_snapshot(new_config.clone())
+        let io = self.config_io_lock.clone().lock_owned().await;
+        restore_authoritative_cluster_fabric(self.config_facade.as_ref(), &mut new_config);
+        let (was_off, live_base) = {
+            let cfg = self.config.read().await;
+            // Same guard as `update_config` (#153): a full-config replace must
+            // not silently blow away an unconfirmed recovery either.
+            reject_if_recovery_pending(&cfg)?;
+            (cfg.plugin_trust.enforcement_is_off(), cfg.clone())
+        };
+        let config = self.config.clone();
+        let app_data_dir = self.app_data_dir.clone();
+        let config_facade = self.config_facade.clone();
+        let account_sink = self.account_sink.clone();
+        let provider_registry = self.provider_registry.clone();
+        let provider = self.provider.clone();
+        let mcp_manager = self.mcp_manager.clone();
+        let transaction = tokio::spawn(async move {
+            // Same #126 serialization as update_config: mutate + persist under
+            // the config-IO lock so a reload can't interleave; effects run
+            // unlocked but remain owned by this cancellation-independent task.
+            let new_config = {
+                let _io = io;
+                let commit = Self::persist_config_snapshot(
+                    app_data_dir.clone(),
+                    config_facade.clone(),
+                    new_config.clone(),
+                )
                 .await
                 .map_err(|e| {
                     AppError::InternalError(anyhow::anyhow!("Failed to save config: {e}"))
                 })?;
-            let mut published = if commit.is_some() {
-                live_base
-            } else {
-                new_config
-            };
-            let events = match commit {
-                Some(commit) => {
-                    install_facade_config_commit(commit, &mut published).map_err(|error| {
-                        AppError::InternalError(anyhow::anyhow!(
-                            "failed to install committed configuration section: {error}"
-                        ))
-                    })?
+                let mut published = if commit.is_some() {
+                    live_base
+                } else {
+                    new_config
+                };
+                let events = match commit {
+                    Some(commit) => {
+                        install_facade_config_commit(commit, &mut published).map_err(|error| {
+                            AppError::InternalError(anyhow::anyhow!(
+                                "failed to install committed configuration section: {error}"
+                            ))
+                        })?
+                    }
+                    None => Vec::new(),
+                };
+                let enforcement_newly_off = !was_off && published.plugin_trust.enforcement_is_off();
+                published.publish_env_vars();
+                *config.write().await = published.clone();
+                // Same live signal as `update_config` — a full-config replace
+                // that transitions plugin_trust.enforcement into `Off` warns.
+                if enforcement_newly_off {
+                    warn_plugin_trust_enforcement_off();
                 }
-                None => Vec::new(),
+                publish_exact_facade_events(&account_sink, &events)?;
+                published
             };
-            let enforcement_newly_off = !was_off && published.plugin_trust.enforcement_is_off();
-            published.publish_env_vars();
-            *self.config.write().await = published.clone();
-            // Same live signal as `update_config` — a full-config replace (JSON
-            // merge / PATCH endpoints) that transitions plugin_trust.enforcement
-            // into `Off` must warn just as loudly as a targeted set.
-            if enforcement_newly_off {
-                warn_plugin_trust_enforcement_off();
-            }
-            publish_exact_facade_events(&self.account_sink, &events)?;
-            published
-        };
 
-        self.apply_config_effects(new_config.clone(), effects)
+            Self::apply_config_effects_owned(
+                new_config.clone(),
+                effects,
+                app_data_dir,
+                config,
+                provider_registry,
+                provider,
+                mcp_manager,
+            )
             .await?;
-        Ok(new_config)
+            Ok::<_, AppError>(new_config)
+        });
+        transaction.await.map_err(|error| {
+            AppError::InternalError(anyhow::anyhow!(
+                "config replacement transaction task failed: {error}"
+            ))
+        })?
     }
 
-    async fn apply_config_effects(
-        &self,
+    async fn apply_config_effects_owned(
         new_config: Config,
         effects: ConfigUpdateEffects,
+        app_data_dir: PathBuf,
+        config: Arc<RwLock<Config>>,
+        provider_registry: Arc<bamboo_llm::ProviderRegistry>,
+        provider: Arc<RwLock<Arc<dyn LLMProvider>>>,
+        mcp_manager: Arc<McpServerManager>,
     ) -> Result<(), AppError> {
         if effects.reload_provider {
-            self.reload_provider().await.map_err(|e| {
+            // Match `reload_provider`: if a later writer won after the
+            // serialization lock was released, initialize from that current
+            // live snapshot rather than regressing runtime to this task's
+            // older committed candidate.
+            let live_config = config.read().await.clone();
+            let candidate_registry =
+                bamboo_llm::ProviderRegistry::from_config(&live_config, app_data_dir)
+                    .await
+                    .map_err(|e| {
+                        AppError::InternalError(anyhow::anyhow!(
+                            "Failed to reload provider after updating config: {e}"
+                        ))
+                    })?;
+            let default_provider_name = candidate_registry.default_provider_name();
+            let candidate_provider = candidate_registry.get_default().ok_or_else(|| {
+                let message = if live_config.has_provider_instances() {
+                    format!(
+                        "Default provider instance '{}' is not available or failed to initialize",
+                        default_provider_name
+                    )
+                } else {
+                    format!(
+                        "Provider '{}' is not available or failed to initialize",
+                        live_config.provider
+                    )
+                };
                 AppError::InternalError(anyhow::anyhow!(
-                    "Failed to reload provider after updating config: {e}"
+                    "Failed to reload provider after updating config: {}",
+                    bamboo_llm::LLMError::Auth(message)
                 ))
             })?;
+            let mut live_provider = provider.write().await;
+            provider_registry.replace_with(candidate_registry);
+            *live_provider = candidate_provider;
+            tracing::info!(
+                default_provider = %default_provider_name,
+                "Provider reloaded successfully"
+            );
         }
 
         if effects.reconcile_mcp {
-            self.mcp_manager
-                .reconcile_from_config(&new_config.mcp)
-                .await;
+            mcp_manager.reconcile_from_config(&new_config.mcp).await;
         }
 
         Ok(())
@@ -5629,6 +5726,231 @@ mod live_reload_tests {
         .await
         .map(|revisions| assert_eq!(revisions, vec![1, 2]))
         .expect("both serialized core events must reach the journal");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn generic_update_cancellation_after_commit_finishes_publication() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stop_config_watcher(&mut state);
+        let state = Arc::new(state);
+        let mut feed = state.account_sink.subscribe();
+        let (reached_tx, reached_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        set_generic_before_event_test_hook(dir.path(), move || {
+            reached_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+
+        let operation = {
+            let state = state.clone();
+            tokio::spawn(async move {
+                state
+                    .update_config(
+                        |config| {
+                            config.server.port = 22_240;
+                            Ok(())
+                        },
+                        ConfigUpdateEffects::default(),
+                    )
+                    .await
+            })
+        };
+        tokio::task::spawn_blocking(move || reached_rx.recv().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .core
+                .snapshot()
+                .revision,
+            1,
+            "the abort boundary must follow durable commit and facade adoption"
+        );
+        operation.abort();
+        assert!(operation.await.unwrap_err().is_cancelled());
+        release_tx.send(()).unwrap();
+        let converged = tokio::time::timeout(Duration::from_secs(5), state.config_io_lock.lock())
+            .await
+            .expect("detached generic update must finish live publication");
+        drop(converged);
+
+        assert_eq!(state.config.read().await.server.port, 22_240);
+        assert_eq!(
+            bamboo_config::ConfigFacade::open(dir.path())
+                .unwrap()
+                .effective_config()
+                .server
+                .port,
+            22_240
+        );
+        assert!(matches!(
+            next_config_event(&mut feed, "core").await,
+            AgentEvent::ConfigChanged {
+                section,
+                revision: 1
+            } if section == "core"
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn provider_update_cancellation_after_commit_finishes_publication() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x7d; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stop_config_watcher(&mut state);
+        let state = Arc::new(state);
+        let mut feed = state.account_sink.subscribe();
+        let (reached_tx, reached_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        set_generic_before_event_test_hook(dir.path(), move || {
+            reached_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+
+        let operation = {
+            let state = state.clone();
+            tokio::spawn(async move {
+                state
+                    .update_config_with_provider_credentials(
+                        |config| {
+                            config.provider = "openai".to_string();
+                            config.providers_mut().openai = Some(bamboo_config::OpenAIConfig {
+                                api_key: "cancellation-secret".to_string(),
+                                model: Some("cancellation-model".to_string()),
+                                ..Default::default()
+                            });
+                            Ok(())
+                        },
+                        BTreeSet::from(["openai".to_string()]),
+                        BTreeSet::new(),
+                        ConfigUpdateEffects::default(),
+                    )
+                    .await
+            })
+        };
+        tokio::task::spawn_blocking(move || reached_rx.recv().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .providers
+                .snapshot()
+                .revision,
+            1,
+            "the abort boundary must follow provider durable/facade adoption"
+        );
+        operation.abort();
+        assert!(operation.await.unwrap_err().is_cancelled());
+        release_tx.send(()).unwrap();
+        let converged = tokio::time::timeout(Duration::from_secs(5), state.config_io_lock.lock())
+            .await
+            .expect("detached provider update must finish live publication");
+        drop(converged);
+
+        assert_eq!(state.config.read().await.provider, "openai");
+        let durable = bamboo_config::ConfigFacade::open(dir.path())
+            .unwrap()
+            .effective_config();
+        assert_eq!(durable.provider, "openai");
+        assert_eq!(
+            durable
+                .providers()
+                .openai
+                .as_ref()
+                .unwrap()
+                .model
+                .as_deref(),
+            Some("cancellation-model")
+        );
+        assert!(matches!(
+            next_config_event(&mut feed, "providers").await,
+            AgentEvent::ConfigChanged {
+                section,
+                revision: 1
+            } if section == "providers"
+        ));
+        for file in ["providers.json", "credentials.json"] {
+            assert!(
+                !std::fs::read_to_string(dir.path().join(file))
+                    .unwrap()
+                    .contains("cancellation-secret"),
+                "{file} must remain secret-free"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn replace_config_cancellation_after_commit_finishes_publication() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stop_config_watcher(&mut state);
+        let state = Arc::new(state);
+        let mut replacement = state.config.read().await.clone();
+        replacement.server.port = 22_241;
+        let mut feed = state.account_sink.subscribe();
+        let (reached_tx, reached_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        set_generic_before_event_test_hook(dir.path(), move || {
+            reached_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+
+        let operation = {
+            let state = state.clone();
+            tokio::spawn(async move {
+                state
+                    .replace_config(replacement, ConfigUpdateEffects::default())
+                    .await
+            })
+        };
+        tokio::task::spawn_blocking(move || reached_rx.recv().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .core
+                .snapshot()
+                .revision,
+            1,
+            "the abort boundary must follow replacement durable/facade adoption"
+        );
+        operation.abort();
+        assert!(operation.await.unwrap_err().is_cancelled());
+        release_tx.send(()).unwrap();
+        let converged = tokio::time::timeout(Duration::from_secs(5), state.config_io_lock.lock())
+            .await
+            .expect("detached replacement must finish live publication");
+        drop(converged);
+
+        assert_eq!(state.config.read().await.server.port, 22_241);
+        assert_eq!(
+            bamboo_config::ConfigFacade::open(dir.path())
+                .unwrap()
+                .effective_config()
+                .server
+                .port,
+            22_241
+        );
+        assert!(matches!(
+            next_config_event(&mut feed, "core").await,
+            AgentEvent::ConfigChanged {
+                section,
+                revision: 1
+            } if section == "core"
+        ));
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -635,7 +635,7 @@ async fn wait_for_section_file_settle(data_dir: &Path, id: SectionId) {
     }
 }
 
-fn publish_registry_event(
+pub(super) fn publish_registry_event(
     account_sink: &bamboo_engine::events::AccountEventSink,
     event: &ConfigSectionEvent,
 ) {
@@ -3152,7 +3152,7 @@ impl AppState {
             bamboo_config::ClusterNodeCredentialIntents,
         >,
         update: F,
-    ) -> Result<(Config, u64), AppError>
+    ) -> Result<bamboo_server_tools::FabricCommitSnapshot, AppError>
     where
         F: FnOnce(&mut Config) -> Result<(), AppError> + Send + 'static,
     {
@@ -3161,6 +3161,7 @@ impl AppState {
         let app_data_dir = self.app_data_dir.clone();
         let account_sink = self.account_sink.clone();
         let config_facade = self.config_facade.clone();
+        let credential_store = self.credential_store.clone();
         let transaction = tokio::spawn(async move {
             let _io = config_io_lock.lock().await;
             let mut candidate = {
@@ -3209,7 +3210,38 @@ impl AppState {
                     "committed cluster revision did not match the published revision"
                 )));
             }
-            Ok::<_, AppError>((candidate, published_revision))
+            let facade = config_facade.as_ref().ok_or_else(|| {
+                AppError::BadRequest(
+                    "cluster mutations require the modular configuration facade".to_string(),
+                )
+            })?;
+            let section = facade
+                .registry()
+                .envelope_value(SectionId::ClusterFabric)
+                .map_err(|error| {
+                    AppError::InternalError(anyhow::anyhow!(
+                        "committed cluster section envelope is unavailable: {error}"
+                    ))
+                })?;
+            let (credential_statuses, credential_health) =
+                match credential_store.statuses_with_health() {
+                    Ok(snapshot) => snapshot,
+                    Err(_) => (
+                        Vec::new(),
+                        bamboo_config::CredentialStoreHealth {
+                            revision: 0,
+                            status: SectionStatus::Degraded,
+                            source: SectionSourceKind::Default,
+                            last_error: Some("credential status is unavailable".to_string()),
+                        },
+                    ),
+                };
+            Ok::<_, AppError>(bamboo_server_tools::FabricCommitSnapshot {
+                config: candidate,
+                section,
+                credential_statuses,
+                credential_health,
+            })
         });
         transaction.await.map_err(|error| {
             AppError::InternalError(anyhow::anyhow!(
@@ -3877,7 +3909,7 @@ mod live_reload_tests {
             state: None,
             enabled: true,
         };
-        let (_, committed) = state
+        let committed = state
             .update_cluster_fabric_credentials(
                 revision,
                 BTreeMap::from([(
@@ -3891,6 +3923,7 @@ mod live_reload_tests {
             )
             .await
             .unwrap();
+        let committed = committed.section.revision;
         assert_eq!(committed, revision + 1);
         assert_eq!(observer.await.unwrap(), committed);
 

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -678,6 +678,39 @@ fn publish_exact_facade_commit(
     Ok(())
 }
 
+/// Refresh both durable members of a cluster exact transaction while exposing
+/// only the authoritative cluster-fabric event. The credential document is an
+/// internal implementation detail; clients use the cluster section revision.
+fn publish_cluster_facade_commit(
+    facade: Option<&std::sync::Arc<bamboo_config::ConfigFacade>>,
+    account_sink: &bamboo_engine::events::AccountEventSink,
+) -> Result<u64, AppError> {
+    let facade = facade.ok_or_else(|| {
+        AppError::BadRequest(
+            "cluster mutations require the modular configuration facade".to_string(),
+        )
+    })?;
+    if let Some(event) = facade.registry().reload_if_changed(SectionId::Credentials) {
+        if matches!(event, ConfigSectionEvent::Invalid { .. }) {
+            return Err(AppError::InternalError(anyhow::anyhow!(
+                "committed credential section became invalid before publication"
+            )));
+        }
+    }
+    if let Some(event) = facade
+        .registry()
+        .reload_if_changed(SectionId::ClusterFabric)
+    {
+        if matches!(event, ConfigSectionEvent::Invalid { .. }) {
+            return Err(AppError::InternalError(anyhow::anyhow!(
+                "committed cluster section became invalid before publication"
+            )));
+        }
+        publish_registry_event(account_sink, &event);
+    }
+    Ok(facade.registry().cluster_fabric.snapshot().revision)
+}
+
 fn apply_runtime_section(id: SectionId, source: &Config, target: &mut Config) {
     match id {
         SectionId::Core => {
@@ -1336,7 +1369,10 @@ impl AppState {
     ) -> Result<u64, ConfigSectionMutationError> {
         if matches!(
             id,
-            SectionId::Providers | SectionId::Mcp | SectionId::Credentials
+            SectionId::Providers
+                | SectionId::Mcp
+                | SectionId::Credentials
+                | SectionId::ClusterFabric
         ) {
             return Err(ConfigSectionMutationError::Invalid(
                 "this section requires its dedicated endpoint".to_string(),
@@ -2051,8 +2087,17 @@ impl AppState {
                 candidate.publish_env_vars();
             }
             *config.write().await = candidate.clone();
-            publish_exact_facade_commit(Some(facade), &account_sink, &[SectionId::Credentials, id])
+            if id == SectionId::ClusterFabric {
+                publish_cluster_facade_commit(Some(facade), &account_sink)
+                    .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
+            } else {
+                publish_exact_facade_commit(
+                    Some(facade),
+                    &account_sink,
+                    &[SectionId::Credentials, id],
+                )
                 .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
+            }
 
             if id == SectionId::Core {
                 match bamboo_llm::ProviderRegistry::from_config(&candidate, app_data_dir.clone())
@@ -3102,7 +3147,10 @@ impl AppState {
     pub async fn update_cluster_fabric_credentials<F>(
         &self,
         expected_revision: u64,
-        node_intents: std::collections::BTreeSet<String>,
+        node_intents: std::collections::BTreeMap<
+            String,
+            bamboo_config::ClusterNodeCredentialIntents,
+        >,
         update: F,
     ) -> Result<(Config, u64), AppError>
     where
@@ -3153,13 +3201,15 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            publish_exact_facade_commit(
-                config_facade.as_ref(),
-                &account_sink,
-                &[SectionId::Credentials, SectionId::ClusterFabric],
-            )?;
             *config.write().await = candidate.clone();
-            Ok::<_, AppError>((candidate, revision))
+            let published_revision =
+                publish_cluster_facade_commit(config_facade.as_ref(), &account_sink)?;
+            if published_revision != revision {
+                return Err(AppError::InternalError(anyhow::anyhow!(
+                    "committed cluster revision did not match the published revision"
+                )));
+            }
+            Ok::<_, AppError>((candidate, published_revision))
         });
         transaction.await.map_err(|error| {
             AppError::InternalError(anyhow::anyhow!(
@@ -3770,6 +3820,107 @@ mod live_reload_tests {
         feed: &mut tokio::sync::broadcast::Receiver<Arc<bamboo_engine::events::ChangeEvent>>,
     ) -> AgentEvent {
         next_config_event(feed, "mcp").await
+    }
+
+    #[tokio::test]
+    async fn cluster_commit_installs_runtime_before_one_authoritative_event() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x71; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        let revision = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .cluster_fabric
+            .snapshot()
+            .revision;
+        let baseline_seq = state.account_sink.latest_seq();
+        let mut feed = state.account_sink.subscribe();
+        let runtime = state.config.clone();
+        let observer = tokio::spawn(async move {
+            tokio::time::timeout(Duration::from_secs(3), async move {
+                loop {
+                    let event = feed.recv().await.unwrap();
+                    match &event.event {
+                        AgentEvent::ConfigChanged { section, .. } if section == "credentials" => {
+                            panic!("cluster mutation published an internal credential event")
+                        }
+                        AgentEvent::ConfigChanged { section, revision }
+                            if section == "cluster-fabric" =>
+                        {
+                            assert!(
+                                runtime
+                                    .read()
+                                    .await
+                                    .cluster_fabric
+                                    .node("event-node")
+                                    .is_some(),
+                                "event observer saw the old runtime snapshot"
+                            );
+                            return *revision;
+                        }
+                        _ => {}
+                    }
+                }
+            })
+            .await
+            .expect("cluster event timed out")
+        });
+
+        let node = bamboo_config::Node {
+            id: "event-node".to_string(),
+            label: "event-node".to_string(),
+            placement: bamboo_config::NodePlacement::Local,
+            trust_level: bamboo_config::TrustLevel::Trusted,
+            deploy: bamboo_config::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        };
+        let (_, committed) = state
+            .update_cluster_fabric_credentials(
+                revision,
+                BTreeMap::from([(
+                    "event-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                move |config| {
+                    config.cluster_fabric.nodes.push(node);
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(committed, revision + 1);
+        assert_eq!(observer.await.unwrap(), committed);
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            baseline_seq,
+        )
+        .unwrap();
+        let cluster_events = events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    &event.event,
+                    AgentEvent::ConfigChanged { section, revision: event_revision }
+                        if section == "cluster-fabric" && *event_revision == committed
+                )
+            })
+            .count();
+        let credential_events = events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    &event.event,
+                    AgentEvent::ConfigChanged { section, .. } if section == "credentials"
+                )
+            })
+            .count();
+        assert_eq!(cluster_events, 1);
+        assert_eq!(credential_events, 0);
     }
 
     async fn wait_for_facade_health(

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -757,6 +757,19 @@ fn apply_runtime_section(id: SectionId, source: &Config, target: &mut Config) {
     }
 }
 
+/// Compatibility config writers never own the cluster-fabric section. Rebase
+/// their detached candidate on the process facade's last-known-good cluster
+/// projection so runtime-only heartbeat updates cannot become an unrevisioned
+/// durable cluster mutation.
+fn restore_authoritative_cluster_fabric(
+    facade: Option<&std::sync::Arc<bamboo_config::ConfigFacade>>,
+    candidate: &mut Config,
+) {
+    if let Some(facade) = facade {
+        candidate.cluster_fabric = facade.registry().cluster_fabric.snapshot().data.0.clone();
+    }
+}
+
 fn section_is_unhealthy(health: &std::sync::RwLock<ConfigLiveHealth>) -> bool {
     health
         .read()
@@ -1355,6 +1368,11 @@ pub(crate) enum ConfigSectionMutationError {
     Store(ConfigStoreError),
     Invalid(String),
     Runtime(String),
+}
+
+pub(crate) enum CredentialBackedResetCommit {
+    Section,
+    Cluster(Box<bamboo_server_tools::FabricCommitSnapshot>),
 }
 
 impl AppState {
@@ -2032,7 +2050,7 @@ impl AppState {
         &self,
         id: SectionId,
         expected_revision: u64,
-    ) -> Result<u64, ConfigSectionMutationError> {
+    ) -> Result<CredentialBackedResetCommit, ConfigSectionMutationError> {
         if !matches!(
             id,
             SectionId::Core
@@ -2054,6 +2072,7 @@ impl AppState {
         let provider_registry = self.provider_registry.clone();
         let provider = self.provider.clone();
         let mcp_manager = self.mcp_manager.clone();
+        let credential_store = self.credential_store.clone();
         let transaction = tokio::spawn(async move {
             let _io = config_io_lock.lock().await;
             ensure_provider_mcp_migration_ready(&app_data_dir)
@@ -2066,14 +2085,15 @@ impl AppState {
             let mut candidate = config.read().await.clone();
             apply_runtime_section(id, &Config::default(), &mut candidate);
             let transaction_dir = app_data_dir.clone();
-            let candidate = tokio::task::spawn_blocking(move || {
-                bamboo_config::persist_credential_backed_section_reset_at_revision(
+            let (candidate, revision) = tokio::task::spawn_blocking(move || {
+                let revision = bamboo_config::persist_credential_backed_section_reset_at_revision(
                     &transaction_dir,
                     &mut candidate,
                     id,
                     expected_revision,
                 )?;
-                load_committed_effective_config(&transaction_dir)
+                let committed = load_committed_effective_config(&transaction_dir)?;
+                Ok::<_, ConfigStoreError>((committed, revision))
             })
             .await
             .map_err(|error| {
@@ -2087,9 +2107,40 @@ impl AppState {
                 candidate.publish_env_vars();
             }
             *config.write().await = candidate.clone();
-            if id == SectionId::ClusterFabric {
-                publish_cluster_facade_commit(Some(facade), &account_sink)
+            let commit = if id == SectionId::ClusterFabric {
+                let published_revision = publish_cluster_facade_commit(Some(facade), &account_sink)
                     .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
+                if published_revision != revision {
+                    return Err(ConfigSectionMutationError::Runtime(
+                        "committed cluster revision did not match the published revision"
+                            .to_string(),
+                    ));
+                }
+                let section = facade
+                    .registry()
+                    .envelope_value(SectionId::ClusterFabric)
+                    .map_err(ConfigSectionMutationError::Store)?;
+                let (credential_statuses, credential_health) =
+                    match credential_store.statuses_with_health() {
+                        Ok(snapshot) => snapshot,
+                        Err(_) => (
+                            Vec::new(),
+                            bamboo_config::CredentialStoreHealth {
+                                revision: 0,
+                                status: SectionStatus::Degraded,
+                                source: SectionSourceKind::Default,
+                                last_error: Some("credential status is unavailable".to_string()),
+                            },
+                        ),
+                    };
+                CredentialBackedResetCommit::Cluster(Box::new(
+                    bamboo_server_tools::FabricCommitSnapshot {
+                        config: candidate.clone(),
+                        section,
+                        credential_statuses,
+                        credential_health,
+                    },
+                ))
             } else {
                 publish_exact_facade_commit(
                     Some(facade),
@@ -2097,7 +2148,12 @@ impl AppState {
                     &[SectionId::Credentials, id],
                 )
                 .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
-            }
+                facade
+                    .registry()
+                    .envelope_value(id)
+                    .map_err(ConfigSectionMutationError::Store)?;
+                CredentialBackedResetCommit::Section
+            };
 
             if id == SectionId::Core {
                 match bamboo_llm::ProviderRegistry::from_config(&candidate, app_data_dir.clone())
@@ -2116,11 +2172,7 @@ impl AppState {
                 mcp_manager.reconcile_from_config(&candidate.mcp).await;
             }
 
-            facade
-                .registry()
-                .envelope_value(id)
-                .map(|envelope| envelope.revision)
-                .map_err(ConfigSectionMutationError::Store)
+            Ok(commit)
         });
         transaction.await.map_err(|error| {
             ConfigSectionMutationError::Runtime(format!(
@@ -2676,7 +2728,10 @@ impl AppState {
                 reject_if_recovery_pending(&cfg)?;
                 let was_off = cfg.plugin_trust.enforcement_is_off();
                 let mut candidate = cfg.clone();
+                restore_authoritative_cluster_fabric(self.config_facade.as_ref(), &mut candidate);
                 update(&mut candidate)?;
+                // No caller of this compatibility entrypoint owns cluster CAS.
+                restore_authoritative_cluster_fabric(self.config_facade.as_ref(), &mut candidate);
                 // Backfill any missing connect.platforms id (#496) on the live
                 // in-memory config itself — not just inside `save_to_dir`'s
                 // internal save-copy — so the response this update returns
@@ -2753,7 +2808,10 @@ impl AppState {
                 reject_if_recovery_pending(&cfg)?;
                 let was_off = cfg.plugin_trust.enforcement_is_off();
                 let mut candidate = cfg.clone();
+                restore_authoritative_cluster_fabric(config_facade.as_ref(), &mut candidate);
                 update(&mut candidate)?;
+                // Provider compatibility updates never own cluster CAS.
+                restore_authoritative_cluster_fabric(config_facade.as_ref(), &mut candidate);
                 // Provider plaintext may be present until the exact credential
                 // transaction assigns its durable reference. Compare every
                 // other section against a candidate whose provider projection
@@ -2761,14 +2819,17 @@ impl AppState {
                 // transaction below remains the sole provider validator.
                 let mut non_provider_candidate = candidate.clone();
                 apply_runtime_section(SectionId::Providers, &cfg, &mut non_provider_candidate);
-                let mut changed =
-                    bamboo_config::changed_facade_sections(&cfg, &non_provider_candidate).map_err(
-                        |_| {
-                            AppError::InternalError(anyhow::anyhow!(
-                                "failed to compare modular configuration sections"
-                            ))
-                        },
-                    )?;
+                let mut comparison_base = cfg.clone();
+                restore_authoritative_cluster_fabric(config_facade.as_ref(), &mut comparison_base);
+                let mut changed = bamboo_config::changed_facade_sections(
+                    &comparison_base,
+                    &non_provider_candidate,
+                )
+                .map_err(|_| {
+                    AppError::InternalError(anyhow::anyhow!(
+                        "failed to compare modular configuration sections"
+                    ))
+                })?;
                 // The compatibility wire shape can normalize duplicated
                 // external-broker metadata while leaving the actual subagents
                 // module byte-for-byte equivalent. That is an unchanged echo,
@@ -3445,6 +3506,7 @@ impl AppState {
         // config-IO lock so a reload can't interleave; effects run unlocked.
         let new_config = {
             let _io = self.config_io_lock.lock().await;
+            restore_authoritative_cluster_fabric(self.config_facade.as_ref(), &mut new_config);
             let was_off = {
                 let cfg = self.config.read().await;
                 // Same guard as `update_config` (#153): a full-config replace
@@ -3852,6 +3914,68 @@ mod live_reload_tests {
         feed: &mut tokio::sync::broadcast::Receiver<Arc<bamboo_engine::events::ChangeEvent>>,
     ) -> AgentEvent {
         next_config_event(feed, "mcp").await
+    }
+
+    #[tokio::test]
+    async fn compatibility_update_cannot_reintroduce_an_unrevisioned_cluster_mutation() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x70; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        state
+            .update_cluster_fabric_credentials(
+                0,
+                std::collections::BTreeMap::from([(
+                    "owned-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(bamboo_config::Node {
+                        id: "owned-node".to_string(),
+                        label: "revisioned-label".to_string(),
+                        placement: bamboo_config::NodePlacement::Local,
+                        trust_level: bamboo_config::TrustLevel::Trusted,
+                        deploy: bamboo_config::DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        let cluster_path = dir.path().join("cluster-fabric.json");
+        let cluster_before = std::fs::read(&cluster_path).unwrap();
+
+        let updated = state
+            .update_config(
+                |config| {
+                    config.server.port = 21_000;
+                    config.cluster_fabric.node_mut("owned-node").unwrap().label =
+                        "unrevisioned-label".to_string();
+                    Ok(())
+                },
+                ConfigUpdateEffects::default(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(updated.server.port, 21_000);
+        assert_eq!(
+            updated.cluster_fabric.node("owned-node").unwrap().label,
+            "revisioned-label"
+        );
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            1
+        );
+        assert_eq!(std::fs::read(cluster_path).unwrap(), cluster_before);
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -73,6 +73,41 @@ fn run_cluster_after_commit_before_adoption_test_hook(data_dir: &Path, expected_
     }
 }
 
+#[cfg(test)]
+type CredentialCommitTestHook = Box<dyn FnOnce() + Send + 'static>;
+#[cfg(test)]
+type CredentialCommitTestHooks =
+    std::sync::Mutex<std::collections::HashMap<(PathBuf, SectionId), CredentialCommitTestHook>>;
+
+#[cfg(test)]
+fn credential_after_commit_before_live_test_hooks() -> &'static CredentialCommitTestHooks {
+    static HOOKS: std::sync::OnceLock<CredentialCommitTestHooks> = std::sync::OnceLock::new();
+    HOOKS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+#[cfg(test)]
+fn set_credential_after_commit_before_live_test_hook(
+    data_dir: &Path,
+    section: SectionId,
+    hook: impl FnOnce() + Send + 'static,
+) {
+    credential_after_commit_before_live_test_hooks()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert((data_dir.to_path_buf(), section), Box::new(hook));
+}
+
+#[cfg(test)]
+fn run_credential_after_commit_before_live_test_hook(data_dir: &Path, section: SectionId) {
+    let hook = credential_after_commit_before_live_test_hooks()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&(data_dir.to_path_buf(), section));
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
 struct FacadeRuntimeMaterialization {
     config: Config,
     failures: BTreeSet<SectionId>,
@@ -714,31 +749,6 @@ pub(super) fn publish_registry_event(
     account_sink.record(None, &event);
 }
 
-/// Reload exact durable authorities into the process facade without making the
-/// resulting events externally observable yet. Compatibility writers use this
-/// phase to materialize and install the same facade generation in AppState
-/// before publishing Changed/Recovered.
-fn capture_exact_facade_commit_events(
-    facade: Option<&std::sync::Arc<bamboo_config::ConfigFacade>>,
-    sections: &[SectionId],
-) -> Vec<ConfigSectionEvent> {
-    let Some(facade) = facade else {
-        return Vec::new();
-    };
-    let mut events = Vec::new();
-    for section in sections {
-        let Some(event) = facade.registry().reload_if_changed(*section) else {
-            continue;
-        };
-        let invalid = matches!(&event, ConfigSectionEvent::Invalid { .. });
-        events.push(event);
-        if invalid {
-            break;
-        }
-    }
-    events
-}
-
 fn publish_exact_facade_events(
     account_sink: &bamboo_engine::events::AccountEventSink,
     events: &[ConfigSectionEvent],
@@ -754,13 +764,48 @@ fn publish_exact_facade_events(
     Ok(())
 }
 
-fn publish_exact_facade_commit(
-    facade: Option<&std::sync::Arc<bamboo_config::ConfigFacade>>,
-    account_sink: &bamboo_engine::events::AccountEventSink,
-    sections: &[SectionId],
-) -> Result<(), AppError> {
-    let events = capture_exact_facade_commit_events(facade, sections);
-    publish_exact_facade_events(account_sink, &events)
+struct InstalledCredentialSectionCommit {
+    events: Vec<ConfigSectionEvent>,
+    metadata: bamboo_config::CredentialSectionRuntimeMetadata,
+}
+
+fn install_credential_section_commit(
+    commit: bamboo_config::CredentialSectionTransactionCommit,
+    target: &mut Config,
+) -> Result<InstalledCredentialSectionCommit, ConfigStoreError> {
+    let bamboo_config::CredentialSectionTransactionCommit {
+        revision: _,
+        section_adoption,
+        credential_adoption,
+        runtime,
+    } = commit;
+    let metadata = runtime?.install_into(target);
+    let mut events = Vec::new();
+    if let Some(adoption) = credential_adoption {
+        if let Some(event) = adoption? {
+            events.push(event);
+        }
+    }
+    if let Some(adoption) = section_adoption {
+        events.push(adoption?);
+    }
+    Ok(InstalledCredentialSectionCommit { events, metadata })
+}
+
+fn install_facade_config_commit(
+    commit: bamboo_config::FacadeConfigCommit,
+    target: &mut Config,
+) -> Result<Vec<ConfigSectionEvent>, ConfigStoreError> {
+    let bamboo_config::FacadeConfigCommit {
+        section_adoption,
+        runtime,
+    } = commit;
+    if let Some(runtime) = runtime? {
+        runtime.install_into(target);
+    }
+    section_adoption
+        .map(|adoption| adoption.map(|event| vec![event]))
+        .unwrap_or_else(|| Ok(Vec::new()))
 }
 
 fn apply_runtime_section(id: SectionId, source: &Config, target: &mut Config) {
@@ -1649,16 +1694,19 @@ impl AppState {
             let mut live_config = config.write().await;
             let mut live_provider = provider.write().await;
             let transaction_dir = app_data_dir.clone();
-            let committed = tokio::task::spawn_blocking(move || {
+            let commit_facade = facade.clone();
+            let (mut committed, commit) = tokio::task::spawn_blocking(move || {
                 let mut durable_candidate = candidate;
-                bamboo_config::persist_provider_credential_transaction_at_revision(
+                let commit =
+                    bamboo_config::persist_provider_credential_transaction_at_revision_with_adoption(
                     &transaction_dir,
                     &mut durable_candidate,
                     &provider_intents,
                     &provider_instance_intents,
                     expected_revision,
+                    commit_facade.as_ref(),
                 )?;
-                load_committed_effective_config(&transaction_dir)
+                Ok::<_, ConfigStoreError>((durable_candidate, commit))
             })
             .await
             .map_err(|error| {
@@ -1668,16 +1716,14 @@ impl AppState {
             })?
             .map_err(ConfigSectionMutationError::Store)?;
 
+            let installed = install_credential_section_commit(commit, &mut committed)
+                .map_err(ConfigSectionMutationError::Store)?;
             committed.publish_env_vars();
             *live_config = committed;
             provider_registry.replace_with(registry);
             *live_provider = candidate_provider;
-            publish_exact_facade_commit(
-                Some(facade),
-                &account_sink,
-                &[SectionId::Credentials, SectionId::Providers],
-            )
-            .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
+            publish_exact_facade_events(&account_sink, &installed.events)
+                .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
             let provider_snapshot = facade.registry().providers.snapshot();
             set_live_health_revision(
                 &config_live_health,
@@ -1733,15 +1779,18 @@ impl AppState {
             apply_runtime_section(SectionId::Providers, &Config::default(), &mut candidate);
 
             let transaction_dir = app_data_dir.clone();
-            let candidate = tokio::task::spawn_blocking(move || {
-                bamboo_config::persist_provider_reset_credential_transaction_at_revision(
+            let commit_facade = facade.clone();
+            let (mut candidate, commit) = tokio::task::spawn_blocking(move || {
+                let commit =
+                    bamboo_config::persist_provider_reset_credential_transaction_at_revision_with_adoption(
                     &transaction_dir,
                     &mut candidate,
                     &provider_intents,
                     &provider_instance_intents,
                     expected_revision,
+                    commit_facade.as_ref(),
                 )?;
-                load_committed_effective_config(&transaction_dir)
+                Ok::<_, ConfigStoreError>((candidate, commit))
             })
             .await
             .map_err(|error| {
@@ -1751,13 +1800,9 @@ impl AppState {
             })?
             .map_err(ConfigSectionMutationError::Store)?;
 
+            let installed = install_credential_section_commit(commit, &mut candidate)
+                .map_err(ConfigSectionMutationError::Store)?;
             *config.write().await = candidate.clone();
-            publish_exact_facade_commit(
-                Some(facade),
-                &account_sink,
-                &[SectionId::Credentials, SectionId::Providers],
-            )
-            .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
             let provider_snapshot = facade.registry().providers.snapshot();
             set_live_health_revision(
                 &config_live_health,
@@ -1767,33 +1812,40 @@ impl AppState {
                     SectionSourceKind::File,
                 )),
             );
+            publish_exact_facade_events(&account_sink, &installed.events)
+                .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
 
-            match bamboo_llm::ProviderRegistry::from_config(&candidate, app_data_dir).await {
+            let runtime_failure = match bamboo_llm::ProviderRegistry::from_config(
+                &candidate,
+                app_data_dir,
+            )
+            .await
+            {
                 Ok(registry) => {
                     if let Some(candidate_provider) = registry.get_default() {
                         provider_registry.replace_with(registry);
                         *provider.write().await = candidate_provider;
+                        None
                     } else {
-                        publish_section_failure(
-                            &config_live_health,
-                            &account_sink,
-                            "providers",
-                            SectionStatus::Degraded,
+                        Some(
                             "provider reset committed; default provider is not initialized"
                                 .to_string(),
-                        );
+                        )
                     }
                 }
                 Err(error) => {
                     tracing::warn!(error = %error, "provider reset committed but runtime initialization failed");
-                    publish_section_failure(
-                        &config_live_health,
-                        &account_sink,
-                        "providers",
-                        SectionStatus::Degraded,
-                        "provider reset committed; retaining last-known-good runtime".to_string(),
-                    );
+                    Some("provider reset committed; retaining last-known-good runtime".to_string())
                 }
+            };
+            if let Some(message) = runtime_failure {
+                publish_section_failure(
+                    &config_live_health,
+                    &account_sink,
+                    "providers",
+                    SectionStatus::Degraded,
+                    message,
+                );
             }
             Ok(provider_snapshot.revision)
         });
@@ -1938,25 +1990,41 @@ impl AppState {
             validate_mcp_config(&runtime_candidate).map_err(ConfigSectionMutationError::Invalid)?;
 
             let mut transaction_error = None;
+            let mut commit_events = Vec::new();
             let transaction_dir = app_data_dir.clone();
+            let commit_facade = facade.clone();
             let mut durable_candidate = current;
             durable_candidate.mcp = runtime_candidate.clone();
             let result = mcp_manager
                 .reconcile_from_config_transactional_after(&runtime_candidate, || async {
                     let mut live_config = config.write().await;
                     let commit = tokio::task::spawn_blocking(move || {
-                        bamboo_config::persist_mcp_credential_transaction_at_revision(
+                        let commit =
+                            bamboo_config::persist_mcp_credential_transaction_at_revision_with_adoption(
                             &transaction_dir,
                             &mut durable_candidate,
                             &credential_intents,
                             expected_revision,
+                            commit_facade.as_ref(),
                         )?;
-                        load_committed_effective_config(&transaction_dir)
+                        Ok::<_, ConfigStoreError>((durable_candidate, commit))
                     })
                     .await;
                     match commit {
-                        Ok(Ok(committed)) => {
+                        Ok(Ok((mut committed, commit))) => {
+                            let installed =
+                                match install_credential_section_commit(commit, &mut committed) {
+                                    Ok(installed) => installed,
+                                    Err(error) => {
+                                        transaction_error =
+                                            Some(ConfigSectionMutationError::Store(error));
+                                        return Err(bamboo_mcp::McpError::InvalidConfig(
+                                            "MCP settings process adoption failed".to_string(),
+                                        ));
+                                    }
+                                };
                             *live_config = committed;
+                            commit_events = installed.events;
                             Ok(())
                         }
                         Ok(Err(error)) => {
@@ -1993,12 +2061,8 @@ impl AppState {
                 return Err(ConfigSectionMutationError::Runtime(message));
             }
 
-            publish_exact_facade_commit(
-                Some(facade),
-                &account_sink,
-                &[SectionId::Credentials, SectionId::Mcp],
-            )
-            .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
+            publish_exact_facade_events(&account_sink, &commit_events)
+                .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
             let snapshot = facade.registry().mcp.snapshot();
             set_live_health_revision(
                 &mcp_config_live_health,
@@ -2032,23 +2096,34 @@ impl AppState {
         let candidate_mcp = McpConfig::default();
         let mut candidate_config = self.config.read().await.clone();
         candidate_config.mcp = candidate_mcp.clone();
-        let mut committed_config = None;
+        let mut committed = false;
+        let mut commit_events = Vec::new();
         let mut store_error = None;
         let data_dir = self.app_data_dir.clone();
         let result = self
             .mcp_manager
             .reconcile_from_config_transactional_after(&candidate_mcp, || async {
                 let mut live_config = self.config.write().await;
-                match bamboo_config::persist_mcp_reset_credential_transaction_at_revision(
+                match bamboo_config::persist_mcp_reset_credential_transaction_at_revision_with_adoption(
                     &data_dir,
                     &mut candidate_config,
                     expected_revision,
-                )
-                .and_then(|_| load_committed_effective_config(&data_dir))
-                {
-                    Ok(committed) => {
-                        *live_config = committed.clone();
-                        committed_config = Some(committed);
+                    facade.as_ref(),
+                ) {
+                    Ok(commit) => {
+                        match install_credential_section_commit(commit, &mut candidate_config) {
+                            Ok(installed) => {
+                                *live_config = candidate_config.clone();
+                                commit_events = installed.events;
+                                committed = true;
+                            }
+                            Err(error) => {
+                                store_error = Some(error);
+                                return Err(bamboo_mcp::McpError::InvalidConfig(
+                                    "MCP reset process adoption failed".to_string(),
+                                ));
+                            }
+                        }
                         Ok(())
                     }
                     Err(error) => {
@@ -2063,7 +2138,7 @@ impl AppState {
         if let Some(error) = store_error {
             return Err(ConfigSectionMutationError::Store(error));
         }
-        if result.is_err() || committed_config.is_none() {
+        if result.is_err() || !committed {
             let message =
                 "MCP reset runtime initialization failed; retaining last-known-good runtime"
                     .to_string();
@@ -2076,12 +2151,8 @@ impl AppState {
             );
             return Err(ConfigSectionMutationError::Runtime(message));
         }
-        publish_exact_facade_commit(
-            Some(facade),
-            &self.account_sink,
-            &[SectionId::Credentials, SectionId::Mcp],
-        )
-        .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
+        publish_exact_facade_events(&self.account_sink, &commit_events)
+            .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
         let revision = facade.registry().mcp.snapshot().revision;
         publish_section_success(
             &self.mcp_config_live_health,
@@ -2149,7 +2220,7 @@ impl AppState {
             apply_runtime_section(id, &Config::default(), &mut candidate);
             let transaction_dir = app_data_dir.clone();
             let commit_facade = facade.clone();
-            let (mut candidate, revision, cluster_commit) =
+            let (mut candidate, revision, cluster_commit, section_commit) =
                 tokio::task::spawn_blocking(move || {
                     if id == SectionId::ClusterFabric {
                         let commit =
@@ -2161,17 +2232,18 @@ impl AppState {
                                 |_, _| {},
                             )?;
                         let revision = commit.revision;
-                        Ok::<_, ConfigStoreError>((candidate, revision, Some(commit)))
+                        Ok::<_, ConfigStoreError>((candidate, revision, Some(commit), None))
                     } else {
-                        let revision =
-                            bamboo_config::persist_credential_backed_section_reset_at_revision(
+                        let commit =
+                            bamboo_config::persist_credential_backed_section_reset_at_revision_with_adoption(
                                 &transaction_dir,
                                 &mut candidate,
                                 id,
                                 expected_revision,
+                                commit_facade.as_ref(),
                             )?;
-                        let committed = load_committed_effective_config(&transaction_dir)?;
-                        Ok((committed, revision, None))
+                        let revision = commit.revision;
+                        Ok((candidate, revision, None, Some(commit)))
                     }
                 })
                 .await
@@ -2218,10 +2290,22 @@ impl AppState {
                 }
                 None => None,
             };
+            let section_events = match section_commit {
+                Some(commit) => {
+                    install_credential_section_commit(commit, &mut candidate)
+                        .map_err(ConfigSectionMutationError::Store)?
+                        .events
+                }
+                None => Vec::new(),
+            };
             if id == SectionId::Env {
                 candidate.publish_env_vars();
             }
             *config.write().await = candidate.clone();
+            if id != SectionId::ClusterFabric {
+                publish_exact_facade_events(&account_sink, &section_events)
+                    .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
+            }
             let commit = if id == SectionId::ClusterFabric {
                 let (cluster_adoption, credential_adoption, committed_recovery, cluster_runtime) =
                     cluster_runtime.expect("cluster reset captures an exact runtime");
@@ -2285,12 +2369,6 @@ impl AppState {
                     },
                 ))
             } else {
-                publish_exact_facade_commit(
-                    Some(facade),
-                    &account_sink,
-                    &[SectionId::Credentials, id],
-                )
-                .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
                 facade
                     .registry()
                     .envelope_value(id)
@@ -2820,27 +2898,25 @@ impl AppState {
     async fn persist_config_snapshot(
         &self,
         config: Config,
-    ) -> anyhow::Result<Vec<ConfigSectionEvent>> {
+    ) -> anyhow::Result<Option<bamboo_config::FacadeConfigCommit>> {
         let data_dir = self.app_data_dir.clone();
-        if self.config_facade.is_some() {
+        if let Some(facade) = self.config_facade.clone() {
             tokio::task::spawn_blocking(move || {
-                bamboo_config::persist_facade_effective_config(data_dir, &config)
+                bamboo_config::persist_facade_effective_config_with_adoption(
+                    data_dir,
+                    &config,
+                    facade.as_ref(),
+                )
             })
             .await
-            .map_err(|e| anyhow::anyhow!("Config save task failed: {e}"))??;
-            let sections = bamboo_config::SECTION_DESCRIPTORS
-                .iter()
-                .map(|descriptor| descriptor.id)
-                .collect::<Vec<_>>();
-            Ok(capture_exact_facade_commit_events(
-                self.config_facade.as_ref(),
-                &sections,
-            ))
+            .map_err(|e| anyhow::anyhow!("Config save task failed: {e}"))?
+            .map(Some)
+            .map_err(Into::into)
         } else {
             tokio::task::spawn_blocking(move || config.save_to_dir(data_dir))
                 .await
                 .map_err(|e| anyhow::anyhow!("Config save task failed: {e}"))??;
-            Ok(Vec::new())
+            Ok(None)
         }
     }
 
@@ -2863,9 +2939,9 @@ impl AppState {
         // before we persist and then clobber this mutation with the stale copy
         // (#126). The lock is dropped before apply_config_effects — slow side
         // effects (provider reload) don't need to block reloads/other updates.
-        let snapshot = {
+        let (snapshot, events) = {
             let _io = self.config_io_lock.lock().await;
-            let (snapshot, enforcement_newly_off) = {
+            let (mut snapshot, live_base, enforcement_newly_off) = {
                 let cfg = self.config.read().await;
                 // Refuse the whole operation (no in-memory mutation, no disk
                 // write) while a config-corruption recovery is pending
@@ -2875,6 +2951,7 @@ impl AppState {
                 // instead of silently drifting further from what's on disk.
                 reject_if_recovery_pending(&cfg)?;
                 let was_off = cfg.plugin_trust.enforcement_is_off();
+                let live_base = cfg.clone();
                 let mut candidate = cfg.clone();
                 restore_authoritative_cluster_fabric(self.config_facade.as_ref(), &mut candidate);
                 update(&mut candidate)?;
@@ -2899,7 +2976,7 @@ impl AppState {
                     ))
                 })?;
                 let newly_off = !was_off && candidate.plugin_trust.enforcement_is_off();
-                (candidate, newly_off)
+                (candidate, live_base, newly_off)
             };
             // Loud signal at the MOMENT plugin_trust.enforcement is flipped off
             // live (e.g. via `bamboo config set plugin_trust.enforcement off`
@@ -2910,29 +2987,35 @@ impl AppState {
             if enforcement_newly_off {
                 warn_plugin_trust_enforcement_off();
             }
-            let events = self
+            let commit = self
                 .persist_config_snapshot(snapshot.clone())
                 .await
                 .map_err(|e| {
                     AppError::InternalError(anyhow::anyhow!("Failed to save config: {e}"))
                 })?;
-            let snapshot = self
-                .config_facade
-                .as_ref()
-                .map(|facade| load_facade_effective_config(facade, &self.app_data_dir))
-                .unwrap_or(snapshot);
+            let events = match commit {
+                Some(commit) => {
+                    let mut published = live_base;
+                    let events =
+                        install_facade_config_commit(commit, &mut published).map_err(|e| {
+                            AppError::InternalError(anyhow::anyhow!(
+                                "failed to install committed configuration section: {e}"
+                            ))
+                        })?;
+                    snapshot = published;
+                    events
+                }
+                None => Vec::new(),
+            };
             {
                 let mut cfg = self.config.write().await;
                 snapshot.publish_env_vars();
                 *cfg = snapshot.clone();
             }
-            // Preserve the established ordering relative to optional runtime
-            // effects: config events precede those effects, but now only after
-            // the matching materialized snapshot is live.
-            publish_exact_facade_events(&self.account_sink, &events)?;
-            snapshot
+            (snapshot, events)
         };
 
+        publish_exact_facade_events(&self.account_sink, &events)?;
         self.apply_config_effects(snapshot.clone(), effects).await?;
         Ok(snapshot)
     }
@@ -2954,12 +3037,13 @@ impl AppState {
         }
         let config_facade = self.config_facade.clone();
         let account_sink = self.account_sink.clone();
-        let (snapshot, enforcement_newly_off) = {
+        let (snapshot, enforcement_newly_off, events) = {
             let _io = self.config_io_lock.lock().await;
-            let (mut candidate, enforcement_newly_off) = {
+            let (mut candidate, live_base, enforcement_newly_off) = {
                 let cfg = self.config.read().await;
                 reject_if_recovery_pending(&cfg)?;
                 let was_off = cfg.plugin_trust.enforcement_is_off();
+                let live_base = cfg.clone();
                 let mut candidate = cfg.clone();
                 restore_authoritative_cluster_fabric(config_facade.as_ref(), &mut candidate);
                 update(&mut candidate)?;
@@ -3008,17 +3092,30 @@ impl AppState {
                     ))
                 })?;
                 let newly_off = !was_off && candidate.plugin_trust.enforcement_is_off();
-                (candidate, newly_off)
+                (candidate, live_base, newly_off)
             };
             let data_dir = self.app_data_dir.clone();
-            let candidate = tokio::task::spawn_blocking(move || {
-                bamboo_config::persist_provider_instance_credential_transaction(
-                    &data_dir,
-                    &mut candidate,
-                    &provider_intents,
-                    &provider_instance_intents,
-                )?;
-                load_committed_effective_config(&data_dir)
+            let commit_facade = config_facade.clone();
+            let (candidate, commit) = tokio::task::spawn_blocking(move || {
+                if let Some(facade) = commit_facade {
+                    let commit =
+                        bamboo_config::persist_provider_instance_credential_transaction_with_adoption(
+                            &data_dir,
+                            &mut candidate,
+                            &provider_intents,
+                            &provider_instance_intents,
+                            facade.as_ref(),
+                        )?;
+                    Ok::<_, ConfigStoreError>((candidate, Some(commit)))
+                } else {
+                    bamboo_config::persist_provider_instance_credential_transaction(
+                        &data_dir,
+                        &mut candidate,
+                        &provider_intents,
+                        &provider_instance_intents,
+                    )?;
+                    Ok((load_committed_effective_config(&data_dir)?, None))
+                }
             })
             .await
             .map_err(|error| {
@@ -3042,21 +3139,30 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            publish_exact_facade_commit(
-                config_facade.as_ref(),
-                &account_sink,
-                &[SectionId::Credentials, SectionId::Providers],
-            )?;
+            let (snapshot, events) = match commit {
+                Some(commit) => {
+                    let mut published = live_base;
+                    let installed = install_credential_section_commit(commit, &mut published)
+                        .map_err(|error| {
+                            AppError::InternalError(anyhow::anyhow!(
+                                "provider process adoption failed: {error}"
+                            ))
+                        })?;
+                    (published, installed.events)
+                }
+                None => (candidate, Vec::new()),
+            };
             {
                 let mut cfg = self.config.write().await;
-                candidate.publish_env_vars();
-                *cfg = candidate.clone();
+                snapshot.publish_env_vars();
+                *cfg = snapshot.clone();
             }
-            (candidate, enforcement_newly_off)
+            (snapshot, enforcement_newly_off, events)
         };
         if enforcement_newly_off {
             warn_plugin_trust_enforcement_off();
         }
+        publish_exact_facade_events(&account_sink, &events)?;
         self.apply_config_effects(snapshot.clone(), effects).await?;
         Ok(snapshot)
     }
@@ -3089,17 +3195,38 @@ impl AppState {
                 candidate
             };
             let transaction_dir = app_data_dir.clone();
-            let (candidate, revision) = tokio::task::spawn_blocking(move || {
-                let revision = bamboo_config::persist_env_var_credential_transaction_at_revision(
-                    &transaction_dir,
-                    &mut candidate,
-                    &env_intents,
-                    expected_revision,
-                )?;
-                // Reload from the durable authority selected by the layout.
-                // Active modular layouts never publish stale config.json.
-                let committed = load_committed_effective_config(&transaction_dir)?;
-                Ok::<_, ConfigStoreError>((committed, revision))
+            let commit_facade = config_facade.clone();
+            let (mut candidate, revision, commit) = tokio::task::spawn_blocking(move || {
+                if let Some(facade) = commit_facade {
+                    let commit =
+                        bamboo_config::persist_env_var_credential_transaction_at_revision_with_adoption(
+                            &transaction_dir,
+                            &mut candidate,
+                            &env_intents,
+                            expected_revision,
+                            facade.as_ref(),
+                        )?;
+                    #[cfg(test)]
+                    run_credential_after_commit_before_live_test_hook(
+                        &transaction_dir,
+                        SectionId::Env,
+                    );
+                    let revision = commit.revision;
+                    Ok::<_, ConfigStoreError>((candidate, revision, Some(commit)))
+                } else {
+                    let revision =
+                        bamboo_config::persist_env_var_credential_transaction_at_revision(
+                            &transaction_dir,
+                            &mut candidate,
+                            &env_intents,
+                            expected_revision,
+                        )?;
+                    Ok((
+                        load_committed_effective_config(&transaction_dir)?,
+                        revision,
+                        None,
+                    ))
+                }
             })
             .await
             .map_err(|error| {
@@ -3123,13 +3250,21 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            publish_exact_facade_commit(
-                config_facade.as_ref(),
-                &account_sink,
-                &[SectionId::Credentials, SectionId::Env],
-            )?;
+            let events = match commit {
+                Some(commit) => {
+                    install_credential_section_commit(commit, &mut candidate)
+                        .map_err(|error| {
+                            AppError::InternalError(anyhow::anyhow!(
+                                "env process adoption failed: {error}"
+                            ))
+                        })?
+                        .events
+                }
+                None => Vec::new(),
+            };
             candidate.publish_env_vars();
             *config.write().await = candidate.clone();
+            publish_exact_facade_events(&account_sink, &events)?;
             Ok::<_, AppError>((candidate, revision))
         });
         transaction.await.map_err(|error| {
@@ -3168,17 +3303,35 @@ impl AppState {
                 candidate
             };
             let transaction_dir = app_data_dir.clone();
-            let (candidate, revision) = tokio::task::spawn_blocking(move || {
-                let revision =
-                    bamboo_config::persist_notification_credential_transaction_at_revision_with_reset(
+            let commit_facade = config_facade.clone();
+            let (mut candidate, revision, commit) = tokio::task::spawn_blocking(move || {
+                if let Some(facade) = commit_facade {
+                    let commit =
+                        bamboo_config::persist_notification_credential_transaction_at_revision_with_reset_and_adoption(
+                            &transaction_dir,
+                            &mut candidate,
+                            &secret_intents,
+                            reset_domain,
+                            expected_revision,
+                            facade.as_ref(),
+                        )?;
+                    let revision = commit.revision;
+                    Ok::<_, ConfigStoreError>((candidate, revision, Some(commit)))
+                } else {
+                    let revision =
+                        bamboo_config::persist_notification_credential_transaction_at_revision_with_reset(
                             &transaction_dir,
                             &mut candidate,
                             &secret_intents,
                             reset_domain,
                             expected_revision,
                         )?;
-                let committed = load_committed_effective_config(&transaction_dir)?;
-                Ok::<_, ConfigStoreError>((committed, revision))
+                    Ok((
+                        load_committed_effective_config(&transaction_dir)?,
+                        revision,
+                        None,
+                    ))
+                }
             })
             .await
             .map_err(|error| {
@@ -3204,12 +3357,20 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            publish_exact_facade_commit(
-                config_facade.as_ref(),
-                &account_sink,
-                &[SectionId::Credentials, SectionId::Notifications],
-            )?;
+            let events = match commit {
+                Some(commit) => {
+                    install_credential_section_commit(commit, &mut candidate)
+                        .map_err(|error| {
+                            AppError::InternalError(anyhow::anyhow!(
+                                "notification process adoption failed: {error}"
+                            ))
+                        })?
+                        .events
+                }
+                None => Vec::new(),
+            };
             *config.write().await = candidate.clone();
+            publish_exact_facade_events(&account_sink, &events)?;
             Ok::<_, AppError>((candidate, revision))
         });
         transaction.await.map_err(|error| {
@@ -3248,15 +3409,33 @@ impl AppState {
                 candidate
             };
             let transaction_dir = app_data_dir.clone();
-            let (candidate, revision) = tokio::task::spawn_blocking(move || {
-                let revision = bamboo_config::persist_connect_credential_transaction_at_revision(
-                    &transaction_dir,
-                    &mut candidate,
-                    &secret_intents,
-                    expected_revision,
-                )?;
-                let committed = load_committed_effective_config(&transaction_dir)?;
-                Ok::<_, ConfigStoreError>((committed, revision))
+            let commit_facade = config_facade.clone();
+            let (mut candidate, revision, commit) = tokio::task::spawn_blocking(move || {
+                if let Some(facade) = commit_facade {
+                    let commit =
+                        bamboo_config::persist_connect_credential_transaction_at_revision_with_adoption(
+                            &transaction_dir,
+                            &mut candidate,
+                            &secret_intents,
+                            expected_revision,
+                            facade.as_ref(),
+                        )?;
+                    let revision = commit.revision;
+                    Ok::<_, ConfigStoreError>((candidate, revision, Some(commit)))
+                } else {
+                    let revision =
+                        bamboo_config::persist_connect_credential_transaction_at_revision(
+                            &transaction_dir,
+                            &mut candidate,
+                            &secret_intents,
+                            expected_revision,
+                        )?;
+                    Ok((
+                        load_committed_effective_config(&transaction_dir)?,
+                        revision,
+                        None,
+                    ))
+                }
             })
             .await
             .map_err(|error| {
@@ -3280,12 +3459,20 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            publish_exact_facade_commit(
-                config_facade.as_ref(),
-                &account_sink,
-                &[SectionId::Credentials, SectionId::Connect],
-            )?;
+            let events = match commit {
+                Some(commit) => {
+                    install_credential_section_commit(commit, &mut candidate)
+                        .map_err(|error| {
+                            AppError::InternalError(anyhow::anyhow!(
+                                "connect process adoption failed: {error}"
+                            ))
+                        })?
+                        .events
+                }
+                None => Vec::new(),
+            };
             *config.write().await = candidate.clone();
+            publish_exact_facade_events(&account_sink, &events)?;
             Ok::<_, AppError>((candidate, revision))
         });
         transaction.await.map_err(|error| {
@@ -3322,17 +3509,35 @@ impl AppState {
                 candidate
             };
             let transaction_dir = app_data_dir.clone();
-            let (candidate, revision) = tokio::task::spawn_blocking(move || {
-                let revision =
-                    bamboo_config::persist_access_control_credential_transaction_at_revision(
+            let commit_facade = config_facade.clone();
+            let (mut candidate, revision, commit) = tokio::task::spawn_blocking(move || {
+                if let Some(facade) = commit_facade {
+                    let commit =
+                        bamboo_config::persist_access_control_credential_transaction_at_revision_with_adoption(
                         &transaction_dir,
                         &mut candidate,
                         password_intent,
                         &device_intents,
                         expected_revision,
+                        facade.as_ref(),
                     )?;
-                let committed = load_committed_effective_config(&transaction_dir)?;
-                Ok::<_, ConfigStoreError>((committed, revision))
+                    let revision = commit.revision;
+                    Ok::<_, ConfigStoreError>((candidate, revision, Some(commit)))
+                } else {
+                    let revision =
+                        bamboo_config::persist_access_control_credential_transaction_at_revision(
+                            &transaction_dir,
+                            &mut candidate,
+                            password_intent,
+                            &device_intents,
+                            expected_revision,
+                        )?;
+                    Ok((
+                        load_committed_effective_config(&transaction_dir)?,
+                        revision,
+                        None,
+                    ))
+                }
             })
             .await
             .map_err(|error| {
@@ -3356,12 +3561,20 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            publish_exact_facade_commit(
-                config_facade.as_ref(),
-                &account_sink,
-                &[SectionId::Credentials, SectionId::AccessControl],
-            )?;
+            let events = match commit {
+                Some(commit) => {
+                    install_credential_section_commit(commit, &mut candidate)
+                        .map_err(|error| {
+                            AppError::InternalError(anyhow::anyhow!(
+                                "access-control process adoption failed: {error}"
+                            ))
+                        })?
+                        .events
+                }
+                None => Vec::new(),
+            };
             *config.write().await = candidate.clone();
+            publish_exact_facade_events(&account_sink, &events)?;
             Ok::<_, AppError>((candidate, revision))
         });
         transaction.await.map_err(|error| {
@@ -3722,16 +3935,29 @@ impl AppState {
                         bamboo_config::CredentialRef::parse("proxy.default.auth")
                             .expect("canonical proxy credential reference is valid")
                     });
-            let (candidate, reference) = tokio::task::spawn_blocking(move || {
-                bamboo_config::persist_proxy_auth_credential_transaction_at_revision(
-                    &transaction_dir,
-                    &mut candidate,
-                    expected_revision,
-                )?;
-                Ok::<_, ConfigStoreError>((
-                    load_committed_effective_config(&transaction_dir)?,
-                    status_reference,
-                ))
+            let commit_facade = config_facade.clone();
+            let (mut candidate, reference, commit) = tokio::task::spawn_blocking(move || {
+                if let Some(facade) = commit_facade {
+                    let commit =
+                        bamboo_config::persist_proxy_auth_credential_transaction_at_revision_with_adoption(
+                            &transaction_dir,
+                            &mut candidate,
+                            expected_revision,
+                            facade.as_ref(),
+                        )?;
+                    Ok::<_, ConfigStoreError>((candidate, status_reference, Some(commit)))
+                } else {
+                    bamboo_config::persist_proxy_auth_credential_transaction_at_revision(
+                        &transaction_dir,
+                        &mut candidate,
+                        expected_revision,
+                    )?;
+                    Ok((
+                        load_committed_effective_config(&transaction_dir)?,
+                        status_reference,
+                        None,
+                    ))
+                }
             })
             .await
             .map_err(|error| {
@@ -3755,18 +3981,26 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-
-            publish_exact_facade_commit(
-                config_facade.as_ref(),
-                &account_sink,
-                &[SectionId::Credentials, SectionId::Core],
-            )?;
+            let installed = match commit {
+                Some(commit) => Some(
+                    install_credential_section_commit(commit, &mut candidate).map_err(|error| {
+                        AppError::InternalError(anyhow::anyhow!(
+                            "proxy process adoption failed: {error}"
+                        ))
+                    })?,
+                ),
+                None => None,
+            };
 
             // No fallible metadata read occurs before publication. Once the
             // transaction commits, a response error can no longer leave live
             // config behind its durable credential/config pair.
             candidate.publish_env_vars();
             *config.write().await = candidate.clone();
+
+            if let Some(installed) = installed.as_ref() {
+                publish_exact_facade_events(&account_sink, &installed.events)?;
+            }
 
             if effects.reload_provider {
                 match bamboo_llm::ProviderRegistry::from_config(&candidate, app_data_dir.clone())
@@ -3796,7 +4030,12 @@ impl AppState {
                 mcp_manager.reconcile_from_config(&candidate.mcp).await;
             }
 
-            let (status, health) =
+            let (status, health) = if let Some(installed) = installed {
+                (
+                    installed.metadata.status(&reference),
+                    installed.metadata.credential_health,
+                )
+            } else {
                 credential_store
                     .status_with_health(&reference)
                     .map_err(|error| match error {
@@ -3812,7 +4051,8 @@ impl AppState {
                         ConfigStoreError::Watch(error) => AppError::InternalError(anyhow::anyhow!(
                             "configuration watch failed: {error}"
                         )),
-                    })?;
+                    })?
+            };
             Ok::<_, AppError>((candidate, status, health))
         });
         transaction.await.map_err(|error| {
@@ -3842,42 +4082,50 @@ impl AppState {
 
         // Same #126 serialization as update_config: mutate + persist under the
         // config-IO lock so a reload can't interleave; effects run unlocked.
-        let new_config = {
+        let (new_config, events) = {
             let _io = self.config_io_lock.lock().await;
             restore_authoritative_cluster_fabric(self.config_facade.as_ref(), &mut new_config);
-            let was_off = {
+            let (was_off, live_base) = {
                 let cfg = self.config.read().await;
                 // Same guard as `update_config` (#153): a full-config replace
                 // must not silently blow away an unconfirmed recovery either.
                 reject_if_recovery_pending(&cfg)?;
-                cfg.plugin_trust.enforcement_is_off()
+                (cfg.plugin_trust.enforcement_is_off(), cfg.clone())
             };
-            let events = self
+            let commit = self
                 .persist_config_snapshot(new_config.clone())
                 .await
                 .map_err(|e| {
                     AppError::InternalError(anyhow::anyhow!("Failed to save config: {e}"))
                 })?;
-            let published = self
-                .config_facade
-                .as_ref()
-                .map(|facade| load_facade_effective_config(facade, &self.app_data_dir))
-                .unwrap_or(new_config);
+            let mut published = if commit.is_some() {
+                live_base
+            } else {
+                new_config
+            };
+            let events = match commit {
+                Some(commit) => {
+                    install_facade_config_commit(commit, &mut published).map_err(|error| {
+                        AppError::InternalError(anyhow::anyhow!(
+                            "failed to install committed configuration section: {error}"
+                        ))
+                    })?
+                }
+                None => Vec::new(),
+            };
             let enforcement_newly_off = !was_off && published.plugin_trust.enforcement_is_off();
             published.publish_env_vars();
             *self.config.write().await = published.clone();
-            // `record` is nonblocking, so this must remain after the live
-            // AppState write rather than inside persistence/reload capture.
-            publish_exact_facade_events(&self.account_sink, &events)?;
             // Same live signal as `update_config` — a full-config replace (JSON
             // merge / PATCH endpoints) that transitions plugin_trust.enforcement
             // into `Off` must warn just as loudly as a targeted set.
             if enforcement_newly_off {
                 warn_plugin_trust_enforcement_off();
             }
-            published
+            (published, events)
         };
 
+        publish_exact_facade_events(&self.account_sink, &events)?;
         self.apply_config_effects(new_config.clone(), effects)
             .await?;
         Ok(new_config)
@@ -4288,28 +4536,6 @@ mod live_reload_tests {
         next_config_event(feed, "mcp").await
     }
 
-    async fn wait_for_cluster_facade_revision(state: &AppState, expected: u64) {
-        tokio::time::timeout(Duration::from_secs(3), async {
-            loop {
-                if state
-                    .config_facade
-                    .as_ref()
-                    .unwrap()
-                    .registry()
-                    .cluster_fabric
-                    .snapshot()
-                    .revision
-                    == expected
-                {
-                    return;
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .expect("cluster facade revision did not advance");
-    }
-
     #[tokio::test]
     async fn compatibility_update_cannot_reintroduce_an_unrevisioned_cluster_mutation() {
         let _key = bamboo_config::encryption::set_test_encryption_key([0x70; 32]);
@@ -4373,7 +4599,7 @@ mod live_reload_tests {
     }
 
     #[tokio::test]
-    async fn stale_stopped_watcher_compatibility_writers_catch_up_without_overwriting_cluster() {
+    async fn stopped_watcher_compatibility_writers_install_only_their_owned_section() {
         let _key = bamboo_config::encryption::set_test_encryption_key([0x72; 32]);
         let dir = tempfile::tempdir().unwrap();
         let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
@@ -4444,69 +4670,53 @@ mod live_reload_tests {
             "generation-one"
         );
 
-        let mut feed = state.account_sink.subscribe();
+        let baseline_seq = state.account_sink.latest_seq();
+        let mut core_feed = state.account_sink.subscribe();
+        let mut cluster_feed = state.account_sink.subscribe();
         let stale_runtime = state.config.read().await;
         let updating = {
             let state = state.clone();
             tokio::spawn(async move {
                 state
-                    .update_config(|_| Ok(()), ConfigUpdateEffects::default())
+                    .update_config(
+                        |config| {
+                            config.server.port = 23_332;
+                            Ok(())
+                        },
+                        ConfigUpdateEffects::default(),
+                    )
                     .await
             })
         };
-        wait_for_cluster_facade_revision(&state, 2).await;
         assert!(
             tokio::time::timeout(
-                Duration::from_millis(300),
-                next_config_event(&mut feed, "cluster-fabric"),
+                Duration::from_millis(100),
+                next_config_event(&mut core_feed, "core"),
             )
             .await
             .is_err(),
-            "r2 event became observable while live AppState config was still r1"
+            "core event became observable while the old AppState snapshot was held"
         );
-        assert_eq!(
-            stale_runtime
-                .cluster_fabric
-                .node("shared-node")
-                .unwrap()
-                .label,
-            "generation-one"
-        );
+        assert_ne!(stale_runtime.server.port, 23_332);
         drop(stale_runtime);
-
-        let event = next_config_event(&mut feed, "cluster-fabric").await;
-        assert!(matches!(
-            event,
-            AgentEvent::ConfigChanged {
-                section,
-                revision: 2
-            } if section == "cluster-fabric"
-        ));
-        assert_eq!(
-            state
-                .config
-                .read()
-                .await
-                .cluster_fabric
-                .node("shared-node")
-                .unwrap()
-                .label,
-            "external-generation-two",
-            "r2 must be live before its event is observable"
-        );
         let published = updating.await.unwrap().unwrap();
+        assert!(matches!(
+            next_config_event(&mut core_feed, "core").await,
+            AgentEvent::ConfigChanged { section, .. } if section == "core"
+        ));
+        assert_eq!(state.config.read().await.server.port, 23_332);
         assert!(
             tokio::time::timeout(
                 Duration::from_millis(300),
-                next_config_event(&mut feed, "cluster-fabric"),
+                next_config_event(&mut cluster_feed, "cluster-fabric"),
             )
             .await
             .is_err(),
-            "r2 catch-up published a duplicate cluster event"
+            "an unrelated compatibility update published a cluster event"
         );
         assert_eq!(
             published.cluster_fabric.node("shared-node").unwrap().label,
-            "external-generation-two"
+            "generation-one"
         );
         assert_eq!(std::fs::read(&cluster_path).unwrap(), cluster_r2);
         assert_eq!(
@@ -4518,8 +4728,8 @@ mod live_reload_tests {
                 .cluster_fabric
                 .snapshot()
                 .revision,
-            2,
-            "compatibility publication must catch the stopped watcher up to r2"
+            1,
+            "an unrelated compatibility update must not catch up cluster"
         );
         assert_eq!(
             state
@@ -4530,8 +4740,28 @@ mod live_reload_tests {
                 .node("shared-node")
                 .unwrap()
                 .label,
-            "external-generation-two"
+            "generation-one"
         );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            baseline_seq,
+        )
+        .unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    &event.event,
+                    AgentEvent::ConfigChanged { section, .. } if section == "core"
+                ))
+                .count(),
+            1
+        );
+        assert!(!events.iter().any(|event| matches!(
+            &event.event,
+            AgentEvent::ConfigChanged { section, .. } if section == "cluster-fabric"
+        )));
 
         let external = bamboo_config::ConfigFacade::open(dir.path()).unwrap();
         let mut external_candidate = external.effective_config();
@@ -4560,13 +4790,15 @@ mod live_reload_tests {
                 .cluster_fabric
                 .snapshot()
                 .revision,
-            2,
+            1,
             "the stopped watcher must remain stale before replace_config"
         );
 
         let mut replacement = state.config.read().await.clone();
         replacement.server.port = 23_333;
-        let mut feed = state.account_sink.subscribe();
+        let baseline_seq = state.account_sink.latest_seq();
+        let mut core_feed = state.account_sink.subscribe();
+        let mut cluster_feed = state.account_sink.subscribe();
         let stale_runtime = state.config.read().await;
         let replacing = {
             let state = state.clone();
@@ -4576,60 +4808,36 @@ mod live_reload_tests {
                     .await
             })
         };
-        wait_for_cluster_facade_revision(&state, 3).await;
         assert!(
             tokio::time::timeout(
-                Duration::from_millis(300),
-                next_config_event(&mut feed, "cluster-fabric"),
+                Duration::from_millis(100),
+                next_config_event(&mut core_feed, "core"),
             )
             .await
             .is_err(),
-            "r3 event became observable while live AppState config was still r2"
+            "replacement event became observable while the old AppState snapshot was held"
         );
-        assert_eq!(
-            stale_runtime
-                .cluster_fabric
-                .node("shared-node")
-                .unwrap()
-                .label,
-            "external-generation-two"
-        );
+        assert_ne!(stale_runtime.server.port, 23_333);
         drop(stale_runtime);
-
-        let event = next_config_event(&mut feed, "cluster-fabric").await;
-        assert!(matches!(
-            event,
-            AgentEvent::ConfigChanged {
-                section,
-                revision: 3
-            } if section == "cluster-fabric"
-        ));
-        assert_eq!(
-            state
-                .config
-                .read()
-                .await
-                .cluster_fabric
-                .node("shared-node")
-                .unwrap()
-                .label,
-            "external-generation-three",
-            "r3 must be live before its event is observable"
-        );
         let published = replacing.await.unwrap().unwrap();
+        assert!(matches!(
+            next_config_event(&mut core_feed, "core").await,
+            AgentEvent::ConfigChanged { section, .. } if section == "core"
+        ));
+        assert_eq!(state.config.read().await.server.port, 23_333);
         assert!(
             tokio::time::timeout(
                 Duration::from_millis(300),
-                next_config_event(&mut feed, "cluster-fabric"),
+                next_config_event(&mut cluster_feed, "cluster-fabric"),
             )
             .await
             .is_err(),
-            "r3 catch-up published a duplicate cluster event"
+            "an unrelated compatibility replacement published a cluster event"
         );
         assert_eq!(published.server.port, 23_333);
         assert_eq!(
             published.cluster_fabric.node("shared-node").unwrap().label,
-            "external-generation-three"
+            "generation-one"
         );
         assert_eq!(std::fs::read(&cluster_path).unwrap(), cluster_r3);
         assert_eq!(
@@ -4641,7 +4849,7 @@ mod live_reload_tests {
                 .cluster_fabric
                 .snapshot()
                 .revision,
-            3
+            1
         );
         assert_eq!(
             state
@@ -4652,8 +4860,211 @@ mod live_reload_tests {
                 .node("shared-node")
                 .unwrap()
                 .label,
-            "external-generation-three"
+            "generation-one"
         );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            baseline_seq,
+        )
+        .unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    &event.event,
+                    AgentEvent::ConfigChanged { section, .. } if section == "core"
+                ))
+                .count(),
+            1
+        );
+        assert!(!events.iter().any(|event| matches!(
+            &event.event,
+            AgentEvent::ConfigChanged { section, .. } if section == "cluster-fabric"
+        )));
+    }
+
+    #[tokio::test]
+    async fn env_credential_commit_installs_owned_runtime_before_exact_events() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x73; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        state
+            .update_cluster_fabric_credentials(
+                0,
+                BTreeMap::from([(
+                    "shared-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(bamboo_config::Node {
+                        id: "shared-node".to_string(),
+                        label: "generation-one".to_string(),
+                        placement: bamboo_config::NodePlacement::Local,
+                        trust_level: bamboo_config::TrustLevel::Trusted,
+                        deploy: bamboo_config::DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        stop_config_watcher(&mut state);
+        let state = Arc::new(state);
+
+        let external = bamboo_config::ConfigFacade::open(dir.path()).unwrap();
+        let mut external_candidate = external.effective_config();
+        external_candidate
+            .cluster_fabric
+            .node_mut("shared-node")
+            .unwrap()
+            .label = "external-generation-two".to_string();
+        bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+            dir.path(),
+            &mut external_candidate,
+            &BTreeMap::new(),
+            1,
+        )
+        .unwrap();
+        let cluster_path = dir.path().join("cluster-fabric.json");
+        let cluster_r2 = std::fs::read(&cluster_path).unwrap();
+        let expected_revision = state.credential_store.revision().unwrap();
+
+        let (reached_tx, reached_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        set_credential_after_commit_before_live_test_hook(dir.path(), SectionId::Env, move || {
+            reached_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+        let baseline_seq = state.account_sink.latest_seq();
+        let mut credential_feed = state.account_sink.subscribe();
+        let mut env_feed = state.account_sink.subscribe();
+        let mut cluster_feed = state.account_sink.subscribe();
+        let updating = {
+            let state = state.clone();
+            tokio::spawn(async move {
+                state
+                    .update_env_var_credentials(
+                        expected_revision,
+                        BTreeSet::from(["TOKEN".to_string()]),
+                        |config| {
+                            config.env_vars.push(bamboo_config::EnvVarEntry {
+                                name: "TOKEN".to_string(),
+                                value: "exact-secret".to_string(),
+                                secret: true,
+                                value_encrypted: None,
+                                credential_ref: None,
+                                configured: true,
+                                description: None,
+                            });
+                            Ok(())
+                        },
+                    )
+                    .await
+            })
+        };
+        tokio::task::spawn_blocking(move || reached_rx.recv().unwrap())
+            .await
+            .unwrap();
+        let stale_runtime = state.config.read().await;
+        release_tx.send(()).unwrap();
+        for (feed, section) in [
+            (&mut credential_feed, "credentials"),
+            (&mut env_feed, "env"),
+            (&mut cluster_feed, "cluster-fabric"),
+        ] {
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), next_config_event(feed, section),)
+                    .await
+                    .is_err(),
+                "{section} event became observable before the owned runtime install"
+            );
+        }
+        assert!(
+            stale_runtime
+                .env_vars
+                .iter()
+                .all(|entry| entry.name != "TOKEN"),
+            "the held runtime must still be the pre-commit env generation"
+        );
+        assert_eq!(
+            stale_runtime
+                .cluster_fabric
+                .node("shared-node")
+                .unwrap()
+                .label,
+            "generation-one"
+        );
+        drop(stale_runtime);
+
+        let (published, revision) = updating.await.unwrap().unwrap();
+        assert!(revision > expected_revision);
+        assert!(published
+            .env_vars
+            .iter()
+            .any(|entry| entry.name == "TOKEN" && entry.value == "exact-secret"));
+        assert_eq!(
+            published.cluster_fabric.node("shared-node").unwrap().label,
+            "generation-one"
+        );
+        assert!(matches!(
+            next_config_event(&mut credential_feed, "credentials").await,
+            AgentEvent::ConfigChanged { section, .. } if section == "credentials"
+        ));
+        assert!(matches!(
+            next_config_event(&mut env_feed, "env").await,
+            AgentEvent::ConfigChanged { section, .. } if section == "env"
+        ));
+        assert!(tokio::time::timeout(
+            Duration::from_millis(300),
+            next_config_event(&mut cluster_feed, "cluster-fabric"),
+        )
+        .await
+        .is_err());
+        assert_eq!(std::fs::read(cluster_path).unwrap(), cluster_r2);
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            1
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            baseline_seq,
+        )
+        .unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    &event.event,
+                    AgentEvent::ConfigChanged { section, .. } if section == "credentials"
+                ))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    &event.event,
+                    AgentEvent::ConfigChanged { section, .. } if section == "env"
+                ))
+                .count(),
+            1
+        );
+        assert!(!events.iter().any(|event| matches!(
+            &event.event,
+            AgentEvent::ConfigChanged { section, .. } if section == "cluster-fabric"
+        )));
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -2149,6 +2149,7 @@ impl AppState {
                         revision: _,
                         adoption,
                         credential_adoption,
+                        committed_recovery,
                         runtime,
                     } = commit;
                     let runtime = match runtime {
@@ -2174,7 +2175,7 @@ impl AppState {
                             Err(error)
                         }
                     };
-                    Some((adoption, credential_adoption, runtime))
+                    Some((adoption, credential_adoption, committed_recovery, runtime))
                 }
                 None => None,
             };
@@ -2183,7 +2184,7 @@ impl AppState {
             }
             *config.write().await = candidate.clone();
             let commit = if id == SectionId::ClusterFabric {
-                let (cluster_adoption, credential_adoption, cluster_runtime) =
+                let (cluster_adoption, credential_adoption, committed_recovery, cluster_runtime) =
                     cluster_runtime.expect("cluster reset captures an exact runtime");
                 let event = match cluster_adoption {
                     Some(Ok(event)) => Some(event),
@@ -2219,6 +2220,11 @@ impl AppState {
                 }
                 if let Some(event) = event.as_ref() {
                     publish_registry_event(&account_sink, event);
+                }
+                if let Err(error) = committed_recovery {
+                    return Err(ConfigSectionMutationError::Runtime(format!(
+                        "cluster reset committed at revision {revision} but transaction recovery failed: {error}"
+                    )));
                 }
                 if let Some(Err(error)) = credential_adoption {
                     return Err(ConfigSectionMutationError::Runtime(format!(
@@ -3377,6 +3383,7 @@ impl AppState {
                 revision,
                 adoption,
                 credential_adoption,
+                committed_recovery,
                 runtime,
             } = commit;
             let runtime = match runtime {
@@ -3432,6 +3439,11 @@ impl AppState {
             }
             if let Some(event) = event.as_ref() {
                 publish_registry_event(&account_sink, event);
+            }
+            if let Err(error) = committed_recovery {
+                return Err(AppError::InternalError(anyhow::anyhow!(
+                    "cluster configuration committed at revision {revision} but transaction recovery failed: {error}"
+                )));
             }
             if let Some(Err(error)) = credential_adoption {
                 return Err(AppError::InternalError(anyhow::anyhow!(
@@ -4224,6 +4236,109 @@ mod live_reload_tests {
             .count();
         assert_eq!(cluster_events, 1);
         assert_eq!(credential_events, 0);
+    }
+
+    #[tokio::test]
+    async fn operator_cluster_crud_recovers_before_finish_and_converges_once() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x72; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        let baseline_seq = state.account_sink.latest_seq();
+        bamboo_config::set_cluster_exact_commit_test_fault(
+            dir.path().to_path_buf(),
+            bamboo_config::ClusterExactCommitTestFault::BeforeFinish,
+        );
+
+        let committed = state
+            .update_cluster_fabric_credentials(
+                0,
+                BTreeMap::from([(
+                    "recovered-crud-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(bamboo_config::Node {
+                        id: "recovered-crud-node".to_string(),
+                        label: "recovered-crud-node".to_string(),
+                        placement: bamboo_config::NodePlacement::Local,
+                        trust_level: bamboo_config::TrustLevel::Trusted,
+                        deploy: bamboo_config::DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .expect("operator CRUD must recover the committed transaction");
+        assert_eq!(committed.section.revision, 1);
+        assert_eq!(
+            committed
+                .config
+                .cluster_fabric
+                .node("recovered-crud-node")
+                .unwrap()
+                .label,
+            "recovered-crud-node"
+        );
+        assert_eq!(
+            state
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("recovered-crud-node")
+                .unwrap()
+                .label,
+            "recovered-crud-node"
+        );
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            1
+        );
+        let reopened = bamboo_config::ConfigFacade::open(dir.path()).unwrap();
+        assert_eq!(reopened.registry().cluster_fabric.snapshot().revision, 1);
+        assert_eq!(
+            reopened
+                .effective_config()
+                .cluster_fabric
+                .node("recovered-crud-node")
+                .unwrap()
+                .label,
+            "recovered-crud-node"
+        );
+        bamboo_config::ensure_provider_mcp_migration_ready(dir.path()).unwrap();
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            baseline_seq,
+        )
+        .unwrap();
+        let cluster_events = events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    &event.event,
+                    AgentEvent::ConfigChanged { section, revision }
+                        if section == "cluster-fabric" && *revision == 1
+                )
+            })
+            .count();
+        assert_eq!(cluster_events, 1);
+        assert!(!events.iter().any(|event| {
+            matches!(
+                &event.event,
+                AgentEvent::ConfigChanged { section, .. } if section == "credentials"
+            )
+        }));
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -2,6 +2,8 @@ use super::*;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
+#[cfg(test)]
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -14,6 +16,62 @@ use bamboo_mcp::{McpConfig, McpServerManager, TransportConfig};
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use serde_json::Value;
+
+#[cfg(test)]
+struct ClusterAfterCommitBeforeAdoptionTestHook {
+    expected_revision: u64,
+    hook: Box<dyn FnOnce(&Path) + Send + 'static>,
+}
+
+#[cfg(test)]
+fn cluster_after_commit_before_adoption_test_hooks() -> &'static std::sync::Mutex<
+    std::collections::HashMap<PathBuf, ClusterAfterCommitBeforeAdoptionTestHook>,
+> {
+    static HOOKS: std::sync::OnceLock<
+        std::sync::Mutex<
+            std::collections::HashMap<PathBuf, ClusterAfterCommitBeforeAdoptionTestHook>,
+        >,
+    > = std::sync::OnceLock::new();
+    HOOKS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+#[cfg(test)]
+fn set_cluster_after_commit_before_adoption_test_hook(
+    data_dir: &Path,
+    expected_revision: u64,
+    hook: impl FnOnce(&Path) + Send + 'static,
+) {
+    cluster_after_commit_before_adoption_test_hooks()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(
+            data_dir.to_path_buf(),
+            ClusterAfterCommitBeforeAdoptionTestHook {
+                expected_revision,
+                hook: Box::new(hook),
+            },
+        );
+}
+
+#[cfg(test)]
+fn run_cluster_after_commit_before_adoption_test_hook(data_dir: &Path, expected_revision: u64) {
+    let hook = {
+        let mut hooks = cluster_after_commit_before_adoption_test_hooks()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if hooks
+            .get(data_dir)
+            .is_some_and(|hook| hook.expected_revision == expected_revision)
+        {
+            hooks.remove(data_dir)
+        } else {
+            None
+        }
+    };
+    if let Some(hook) = hook {
+        (hook.hook)(data_dir);
+    }
+}
 
 struct FacadeRuntimeMaterialization {
     config: Config,
@@ -676,39 +734,6 @@ fn publish_exact_facade_commit(
         }
     }
     Ok(())
-}
-
-/// Refresh both durable members of a cluster exact transaction while exposing
-/// only the authoritative cluster-fabric event. The credential document is an
-/// internal implementation detail; clients use the cluster section revision.
-fn publish_cluster_facade_commit(
-    facade: Option<&std::sync::Arc<bamboo_config::ConfigFacade>>,
-    account_sink: &bamboo_engine::events::AccountEventSink,
-) -> Result<u64, AppError> {
-    let facade = facade.ok_or_else(|| {
-        AppError::BadRequest(
-            "cluster mutations require the modular configuration facade".to_string(),
-        )
-    })?;
-    if let Some(event) = facade.registry().reload_if_changed(SectionId::Credentials) {
-        if matches!(event, ConfigSectionEvent::Invalid { .. }) {
-            return Err(AppError::InternalError(anyhow::anyhow!(
-                "committed credential section became invalid before publication"
-            )));
-        }
-    }
-    if let Some(event) = facade
-        .registry()
-        .reload_if_changed(SectionId::ClusterFabric)
-    {
-        if matches!(event, ConfigSectionEvent::Invalid { .. }) {
-            return Err(AppError::InternalError(anyhow::anyhow!(
-                "committed cluster section became invalid before publication"
-            )));
-        }
-        publish_registry_event(account_sink, &event);
-    }
-    Ok(facade.registry().cluster_fabric.snapshot().revision)
 }
 
 fn apply_runtime_section(id: SectionId, source: &Config, target: &mut Config) {
@@ -2072,7 +2097,6 @@ impl AppState {
         let provider_registry = self.provider_registry.clone();
         let provider = self.provider.clone();
         let mcp_manager = self.mcp_manager.clone();
-        let credential_store = self.credential_store.clone();
         let transaction = tokio::spawn(async move {
             let _io = config_io_lock.lock().await;
             ensure_provider_mcp_migration_ready(&app_data_dir)
@@ -2085,54 +2109,128 @@ impl AppState {
             let mut candidate = config.read().await.clone();
             apply_runtime_section(id, &Config::default(), &mut candidate);
             let transaction_dir = app_data_dir.clone();
-            let (candidate, revision) = tokio::task::spawn_blocking(move || {
-                let revision = bamboo_config::persist_credential_backed_section_reset_at_revision(
-                    &transaction_dir,
-                    &mut candidate,
-                    id,
-                    expected_revision,
-                )?;
-                let committed = load_committed_effective_config(&transaction_dir)?;
-                Ok::<_, ConfigStoreError>((committed, revision))
-            })
-            .await
-            .map_err(|error| {
-                ConfigSectionMutationError::Runtime(format!(
-                    "section reset transaction task failed: {error}"
-                ))
-            })?
-            .map_err(ConfigSectionMutationError::Store)?;
+            let commit_facade = facade.clone();
+            let (mut candidate, revision, cluster_commit) =
+                tokio::task::spawn_blocking(move || {
+                    if id == SectionId::ClusterFabric {
+                        let commit =
+                            bamboo_config::persist_cluster_fabric_reset_at_revision_with_adoption(
+                                &transaction_dir,
+                                &mut candidate,
+                                expected_revision,
+                                commit_facade.as_ref(),
+                                |_, _| {},
+                            )?;
+                        let revision = commit.revision;
+                        Ok::<_, ConfigStoreError>((candidate, revision, Some(commit)))
+                    } else {
+                        let revision =
+                            bamboo_config::persist_credential_backed_section_reset_at_revision(
+                                &transaction_dir,
+                                &mut candidate,
+                                id,
+                                expected_revision,
+                            )?;
+                        let committed = load_committed_effective_config(&transaction_dir)?;
+                        Ok((committed, revision, None))
+                    }
+                })
+                .await
+                .map_err(|error| {
+                    ConfigSectionMutationError::Runtime(format!(
+                        "section reset transaction task failed: {error}"
+                    ))
+                })?
+                .map_err(ConfigSectionMutationError::Store)?;
 
+            let cluster_runtime = match cluster_commit {
+                Some(commit) => {
+                    let bamboo_config::ClusterFabricTransactionCommit {
+                        revision: _,
+                        adoption,
+                        credential_adoption,
+                        runtime,
+                    } = commit;
+                    let runtime = match runtime {
+                        Ok(bamboo_config::ClusterFabricRuntimeSnapshot {
+                            cluster_fabric,
+                            credential_statuses,
+                            credential_health,
+                        }) => {
+                            candidate.cluster_fabric = cluster_fabric;
+                            Ok((credential_statuses, credential_health))
+                        }
+                        Err(error) if revision == expected_revision => {
+                            // A semantic no-op did not cross a durable boundary,
+                            // so preserve the ordinary store error contract.
+                            return Err(ConfigSectionMutationError::Store(error));
+                        }
+                        Err(error) => {
+                            // The reset metadata and facade are already
+                            // committed. Publish the exact secret-free reset
+                            // candidate instead of retaining the pre-reset
+                            // runtime while reporting the post-commit failure.
+                            candidate.clear_cluster_runtime_credentials();
+                            Err(error)
+                        }
+                    };
+                    Some((adoption, credential_adoption, runtime))
+                }
+                None => None,
+            };
             if id == SectionId::Env {
                 candidate.publish_env_vars();
             }
             *config.write().await = candidate.clone();
             let commit = if id == SectionId::ClusterFabric {
-                let published_revision = publish_cluster_facade_commit(Some(facade), &account_sink)
-                    .map_err(|error| ConfigSectionMutationError::Runtime(error.to_string()))?;
-                if published_revision != revision {
-                    return Err(ConfigSectionMutationError::Runtime(
-                        "committed cluster revision did not match the published revision"
-                            .to_string(),
-                    ));
-                }
+                let (cluster_adoption, credential_adoption, cluster_runtime) =
+                    cluster_runtime.expect("cluster reset captures an exact runtime");
+                let event = match cluster_adoption {
+                    Some(Ok(event)) => Some(event),
+                    Some(Err(error)) => {
+                        return Err(ConfigSectionMutationError::Runtime(format!(
+                            "cluster reset committed at revision {revision} but process adoption failed: {error}"
+                        )));
+                    }
+                    None if revision == expected_revision => None,
+                    None => {
+                        return Err(ConfigSectionMutationError::Runtime(format!(
+                            "cluster reset committed at revision {revision} without a process adoption result"
+                        )));
+                    }
+                };
                 let section = facade
                     .registry()
                     .envelope_value(SectionId::ClusterFabric)
-                    .map_err(ConfigSectionMutationError::Store)?;
+                    .map_err(|error| {
+                        if revision == expected_revision {
+                            ConfigSectionMutationError::Store(error)
+                        } else {
+                            ConfigSectionMutationError::Runtime(format!(
+                                "cluster reset committed at revision {revision} but its exact envelope is unavailable: {error}"
+                            ))
+                        }
+                    })?;
+                if section.revision != revision {
+                    return Err(ConfigSectionMutationError::Runtime(format!(
+                        "cluster reset committed at revision {revision} but facade retained revision {}",
+                        section.revision
+                    )));
+                }
+                if let Some(event) = event.as_ref() {
+                    publish_registry_event(&account_sink, event);
+                }
+                if let Some(Err(error)) = credential_adoption {
+                    return Err(ConfigSectionMutationError::Runtime(format!(
+                        "cluster reset committed at revision {revision} but credential facade adoption failed: {error}"
+                    )));
+                }
                 let (credential_statuses, credential_health) =
-                    match credential_store.statuses_with_health() {
-                        Ok(snapshot) => snapshot,
-                        Err(_) => (
-                            Vec::new(),
-                            bamboo_config::CredentialStoreHealth {
-                                revision: 0,
-                                status: SectionStatus::Degraded,
-                                source: SectionSourceKind::Default,
-                                last_error: Some("credential status is unavailable".to_string()),
-                            },
-                        ),
-                    };
+                    cluster_runtime.map_err(|error| {
+                        ConfigSectionMutationError::Runtime(format!(
+                            "cluster reset committed at revision {revision} but could not materialize its exact runtime credentials: {error}"
+                        ))
+                    })?;
                 CredentialBackedResetCommit::Cluster(Box::new(
                     bamboo_server_tools::FabricCommitSnapshot {
                         config: candidate.clone(),
@@ -3222,9 +3320,13 @@ impl AppState {
         let app_data_dir = self.app_data_dir.clone();
         let account_sink = self.account_sink.clone();
         let config_facade = self.config_facade.clone();
-        let credential_store = self.credential_store.clone();
         let transaction = tokio::spawn(async move {
             let _io = config_io_lock.lock().await;
+            let facade = config_facade.as_ref().ok_or_else(|| {
+                AppError::BadRequest(
+                    "cluster mutations require the modular configuration facade".to_string(),
+                )
+            })?;
             let mut candidate = {
                 let current = config.read().await;
                 reject_if_recovery_pending(&current)?;
@@ -3233,16 +3335,24 @@ impl AppState {
                 candidate
             };
             let transaction_dir = app_data_dir.clone();
-            let (candidate, revision) = tokio::task::spawn_blocking(move || {
-                let revision =
-                    bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+            let commit_facade = facade.clone();
+            let (mut candidate, commit) = tokio::task::spawn_blocking(move || {
+                let commit =
+                    bamboo_config::persist_cluster_fabric_credential_transaction_with_adoption(
                         &transaction_dir,
                         &mut candidate,
                         &node_intents,
                         expected_revision,
+                        commit_facade.as_ref(),
+                        |_, _| {
+                            #[cfg(test)]
+                            run_cluster_after_commit_before_adoption_test_hook(
+                                &transaction_dir,
+                                expected_revision,
+                            );
+                        },
                     )?;
-                let committed = load_committed_effective_config(&transaction_dir)?;
-                Ok::<_, ConfigStoreError>((committed, revision))
+                Ok::<_, ConfigStoreError>((candidate, commit))
             })
             .await
             .map_err(|error| {
@@ -3263,19 +3373,48 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
+            let bamboo_config::ClusterFabricTransactionCommit {
+                revision,
+                adoption,
+                credential_adoption,
+                runtime,
+            } = commit;
+            let runtime = match runtime {
+                Ok(bamboo_config::ClusterFabricRuntimeSnapshot {
+                    cluster_fabric,
+                    credential_statuses,
+                    credential_health,
+                }) => {
+                    candidate.cluster_fabric = cluster_fabric;
+                    Ok((credential_statuses, credential_health))
+                }
+                Err(error) if revision == expected_revision => {
+                    return Err(AppError::InternalError(anyhow::anyhow!(
+                        "cluster configuration at revision {revision} could not materialize its exact runtime credentials: {error}"
+                    )));
+                }
+                Err(error) => {
+                    candidate.clear_cluster_runtime_credentials();
+                    Err(error)
+                }
+            };
             *config.write().await = candidate.clone();
-            let published_revision =
-                publish_cluster_facade_commit(config_facade.as_ref(), &account_sink)?;
-            if published_revision != revision {
-                return Err(AppError::InternalError(anyhow::anyhow!(
-                    "committed cluster revision did not match the published revision"
-                )));
-            }
-            let facade = config_facade.as_ref().ok_or_else(|| {
-                AppError::BadRequest(
-                    "cluster mutations require the modular configuration facade".to_string(),
-                )
-            })?;
+            let event = match adoption {
+                Some(Ok(event)) => Some(event),
+                Some(Err(error)) => {
+                    return Err(AppError::InternalError(anyhow::anyhow!(
+                        "cluster configuration committed at revision {} but process adoption failed: {error}",
+                        revision
+                    )));
+                }
+                None if revision == expected_revision => None,
+                None => {
+                    return Err(AppError::InternalError(anyhow::anyhow!(
+                        "cluster configuration committed at revision {} without a process adoption result",
+                        revision
+                    )));
+                }
+            };
             let section = facade
                 .registry()
                 .envelope_value(SectionId::ClusterFabric)
@@ -3284,19 +3423,26 @@ impl AppState {
                         "committed cluster section envelope is unavailable: {error}"
                     ))
                 })?;
-            let (credential_statuses, credential_health) =
-                match credential_store.statuses_with_health() {
-                    Ok(snapshot) => snapshot,
-                    Err(_) => (
-                        Vec::new(),
-                        bamboo_config::CredentialStoreHealth {
-                            revision: 0,
-                            status: SectionStatus::Degraded,
-                            source: SectionSourceKind::Default,
-                            last_error: Some("credential status is unavailable".to_string()),
-                        },
-                    ),
-                };
+            if section.revision != revision {
+                return Err(AppError::InternalError(anyhow::anyhow!(
+                    "cluster configuration committed at revision {} but facade retained revision {}",
+                    revision,
+                    section.revision
+                )));
+            }
+            if let Some(event) = event.as_ref() {
+                publish_registry_event(&account_sink, event);
+            }
+            if let Some(Err(error)) = credential_adoption {
+                return Err(AppError::InternalError(anyhow::anyhow!(
+                    "cluster configuration committed at revision {revision} but credential facade adoption failed: {error}"
+                )));
+            }
+            let (credential_statuses, credential_health) = runtime.map_err(|error| {
+                AppError::InternalError(anyhow::anyhow!(
+                    "cluster configuration committed at revision {revision} but could not materialize its exact runtime credentials: {error}"
+                ))
+            })?;
             Ok::<_, AppError>(bamboo_server_tools::FabricCommitSnapshot {
                 config: candidate,
                 section,
@@ -4078,6 +4224,634 @@ mod live_reload_tests {
             .count();
         assert_eq!(cluster_events, 1);
         assert_eq!(credential_events, 0);
+    }
+
+    #[tokio::test]
+    async fn cluster_replace_and_keep_noop_retain_the_exact_hydrated_runtime() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x73; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        let baseline_seq = state.account_sink.latest_seq();
+        let password_ref = bamboo_config::cluster_password_credential_ref("secret-node").unwrap();
+        let password_from = |config: &Config| match &config
+            .cluster_fabric
+            .node("secret-node")
+            .expect("secret node exists")
+            .placement
+        {
+            bamboo_config::NodePlacement::Ssh(target) => match &target.auth {
+                bamboo_config::SshAuth::Password { password, .. } => password.clone(),
+                _ => panic!("expected password authentication"),
+            },
+            _ => panic!("expected SSH placement"),
+        };
+
+        let replaced = state
+            .update_cluster_fabric_credentials(
+                0,
+                BTreeMap::from([(
+                    "secret-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents {
+                        password: bamboo_config::ClusterCredentialAction::Replace(
+                            "exact-password".to_string(),
+                        ),
+                        private_key: bamboo_config::ClusterCredentialAction::Clear,
+                        passphrase: bamboo_config::ClusterCredentialAction::Clear,
+                    },
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(bamboo_config::Node {
+                        id: "secret-node".to_string(),
+                        label: "secret-node".to_string(),
+                        placement: bamboo_config::NodePlacement::Ssh(bamboo_config::SshTarget {
+                            host: "secret.example.test".to_string(),
+                            port: 22,
+                            username: "operator".to_string(),
+                            auth: bamboo_config::SshAuth::Password {
+                                password: String::new(),
+                                password_encrypted: None,
+                            },
+                            host_key_fingerprint: None,
+                        }),
+                        trust_level: bamboo_config::TrustLevel::Trusted,
+                        deploy: bamboo_config::DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(replaced.section.revision, 1);
+        assert_eq!(password_from(&replaced.config), "exact-password");
+        assert_eq!(
+            password_from(&*state.config.read().await),
+            "exact-password",
+            "live runtime must install the under-lock hydrated candidate"
+        );
+        assert_eq!(replaced.credential_health.revision, 1);
+        assert_eq!(replaced.credential_statuses.len(), 1);
+        assert_eq!(replaced.credential_statuses[0].credential_ref, password_ref);
+        assert!(replaced.credential_statuses[0].configured);
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let replace_events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            baseline_seq,
+        )
+        .unwrap();
+        let cluster_revisions = replace_events
+            .iter()
+            .filter_map(|event| match &event.event {
+                AgentEvent::ConfigChanged { section, revision } if section == "cluster-fabric" => {
+                    Some(*revision)
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(cluster_revisions, vec![1]);
+        assert!(!replace_events.iter().any(|event| {
+            matches!(
+                &event.event,
+                AgentEvent::ConfigChanged { section, .. }
+                    | AgentEvent::ConfigInvalid { section, .. }
+                    | AgentEvent::ConfigRecovered { section, .. }
+                    if section == "credentials"
+            )
+        }));
+
+        let noop_baseline_seq = state.account_sink.latest_seq();
+        let kept = state
+            .update_cluster_fabric_credentials(
+                1,
+                BTreeMap::from([(
+                    "secret-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents {
+                        password: bamboo_config::ClusterCredentialAction::Keep,
+                        private_key: bamboo_config::ClusterCredentialAction::Clear,
+                        passphrase: bamboo_config::ClusterCredentialAction::Clear,
+                    },
+                )]),
+                |config| {
+                    let node = config
+                        .cluster_fabric
+                        .node_mut("secret-node")
+                        .expect("secret node exists");
+                    let bamboo_config::NodePlacement::Ssh(target) = &mut node.placement else {
+                        panic!("expected SSH placement")
+                    };
+                    let bamboo_config::SshAuth::Password {
+                        password,
+                        password_encrypted,
+                    } = &mut target.auth
+                    else {
+                        panic!("expected password authentication")
+                    };
+                    password.clear();
+                    *password_encrypted = None;
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(kept.section.revision, 1);
+        assert_eq!(kept.credential_health.revision, 1);
+        assert_eq!(password_from(&kept.config), "exact-password");
+        assert_eq!(
+            password_from(&*state.config.read().await),
+            "exact-password",
+            "semantic no-op must retain the exact credential snapshot"
+        );
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let noop_events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            noop_baseline_seq,
+        )
+        .unwrap();
+        assert!(!noop_events.iter().any(|event| {
+            matches!(
+                &event.event,
+                AgentEvent::ConfigChanged { section, .. }
+                    | AgentEvent::ConfigInvalid { section, .. }
+                    | AgentEvent::ConfigRecovered { section, .. }
+                    if section == "cluster-fabric" || section == "credentials"
+            )
+        }));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn later_external_credential_winner_remains_observable_after_exact_cluster_commit() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x74; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        let baseline_seq = state.account_sink.latest_seq();
+        let password_ref =
+            bamboo_config::cluster_password_credential_ref("credential-race-node").unwrap();
+        let external_ref = password_ref.clone();
+        let (external_done_tx, external_done_rx) = std::sync::mpsc::sync_channel(1);
+        set_cluster_after_commit_before_adoption_test_hook(dir.path(), 0, move |data_dir| {
+            let data_dir = data_dir.to_path_buf();
+            let (started_tx, started_rx) = std::sync::mpsc::sync_channel(0);
+            std::thread::spawn(move || {
+                started_tx.send(()).unwrap();
+                let result = bamboo_config::CredentialStore::open(&data_dir).replace(
+                    external_ref,
+                    "later-external-password",
+                    bamboo_config::CredentialSource::User,
+                    1,
+                );
+                external_done_tx.send(result).unwrap();
+            });
+            started_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("external credential writer must launch under the commit lock");
+        });
+
+        let committed = state
+            .update_cluster_fabric_credentials(
+                0,
+                BTreeMap::from([(
+                    "credential-race-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents {
+                        password: bamboo_config::ClusterCredentialAction::Replace(
+                            "exact-commit-password".to_string(),
+                        ),
+                        private_key: bamboo_config::ClusterCredentialAction::Clear,
+                        passphrase: bamboo_config::ClusterCredentialAction::Clear,
+                    },
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(bamboo_config::Node {
+                        id: "credential-race-node".to_string(),
+                        label: "credential-race-node".to_string(),
+                        placement: bamboo_config::NodePlacement::Ssh(bamboo_config::SshTarget {
+                            host: "race.example.test".to_string(),
+                            port: 22,
+                            username: "operator".to_string(),
+                            auth: bamboo_config::SshAuth::Password {
+                                password: String::new(),
+                                password_encrypted: None,
+                            },
+                            host_key_fingerprint: None,
+                        }),
+                        trust_level: bamboo_config::TrustLevel::Trusted,
+                        deploy: bamboo_config::DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        let committed_password = match &committed
+            .config
+            .cluster_fabric
+            .node("credential-race-node")
+            .unwrap()
+            .placement
+        {
+            bamboo_config::NodePlacement::Ssh(target) => match &target.auth {
+                bamboo_config::SshAuth::Password { password, .. } => password,
+                _ => panic!("expected password authentication"),
+            },
+            _ => panic!("expected SSH placement"),
+        };
+        assert_eq!(committed.section.revision, 1);
+        assert_eq!(committed.credential_health.revision, 1);
+        assert_eq!(committed_password, "exact-commit-password");
+
+        let external_revision = tokio::task::spawn_blocking(move || {
+            external_done_rx
+                .recv_timeout(Duration::from_secs(10))
+                .expect("external credential writer must complete")
+                .unwrap()
+                .0
+        })
+        .await
+        .unwrap();
+        assert_eq!(external_revision, 2);
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let facade_revision = state
+                    .config_facade
+                    .as_ref()
+                    .unwrap()
+                    .registry()
+                    .credentials
+                    .snapshot()
+                    .revision;
+                let events = bamboo_engine::events::journal::read_since(
+                    state.account_sink.events_dir(),
+                    baseline_seq,
+                )
+                .unwrap();
+                let saw_external_event = events.iter().any(|event| {
+                    matches!(
+                        &event.event,
+                        AgentEvent::ConfigChanged { section, revision }
+                            if section == "credentials" && *revision == 2
+                    )
+                });
+                if facade_revision == 2 && saw_external_event {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("watcher must expose the later credential revision");
+        tokio::time::sleep(Duration::from_millis(250)).await;
+
+        let runtime_password = match &state
+            .config
+            .read()
+            .await
+            .cluster_fabric
+            .node("credential-race-node")
+            .unwrap()
+            .placement
+        {
+            bamboo_config::NodePlacement::Ssh(target) => match &target.auth {
+                bamboo_config::SshAuth::Password { password, .. } => password.clone(),
+                _ => panic!("expected password authentication"),
+            },
+            _ => panic!("expected SSH placement"),
+        };
+        assert_eq!(
+            runtime_password, "exact-commit-password",
+            "a status-only credential event must not rewrite the exact cluster runtime"
+        );
+        let credential_dir = dir.path().to_path_buf();
+        let durable_password = tokio::task::spawn_blocking(move || {
+            bamboo_config::CredentialStore::open(credential_dir)
+                .resolve(&password_ref)
+                .unwrap()
+                .unwrap()
+                .expose()
+                .to_string()
+        })
+        .await
+        .unwrap();
+        assert_eq!(durable_password, "later-external-password");
+
+        let events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            baseline_seq,
+        )
+        .unwrap();
+        let relevant = events
+            .iter()
+            .filter_map(|event| match &event.event {
+                AgentEvent::ConfigChanged { section, revision }
+                    if section == "cluster-fabric" || section == "credentials" =>
+                {
+                    Some((section.as_str(), *revision))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            relevant,
+            vec![("cluster-fabric", 1), ("credentials", 2)],
+            "the exact cluster event must precede the genuine later credential winner"
+        );
+    }
+
+    #[tokio::test]
+    async fn changed_cluster_commit_publishes_secret_free_runtime_before_materialization_error() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x75; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        let password_ref =
+            bamboo_config::cluster_password_credential_ref("corrupt-secret-node").unwrap();
+        state
+            .update_cluster_fabric_credentials(
+                0,
+                BTreeMap::from([(
+                    "corrupt-secret-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents {
+                        password: bamboo_config::ClusterCredentialAction::Replace(
+                            "initial-password".to_string(),
+                        ),
+                        private_key: bamboo_config::ClusterCredentialAction::Clear,
+                        passphrase: bamboo_config::ClusterCredentialAction::Clear,
+                    },
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(bamboo_config::Node {
+                        id: "corrupt-secret-node".to_string(),
+                        label: "before-corruption".to_string(),
+                        placement: bamboo_config::NodePlacement::Ssh(bamboo_config::SshTarget {
+                            host: "corrupt.example.test".to_string(),
+                            port: 22,
+                            username: "operator".to_string(),
+                            auth: bamboo_config::SshAuth::Password {
+                                password: String::new(),
+                                password_encrypted: None,
+                            },
+                            host_key_fingerprint: None,
+                        }),
+                        trust_level: bamboo_config::TrustLevel::Trusted,
+                        deploy: bamboo_config::DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+
+        let credentials_path = dir.path().join("credentials.json");
+        let mut document: Value =
+            serde_json::from_slice(&std::fs::read(&credentials_path).unwrap()).unwrap();
+        document["data"]["entries"][password_ref.as_str()]["ciphertext"] =
+            Value::String("corrupt-ciphertext".to_string());
+        std::fs::write(
+            &credentials_path,
+            serde_json::to_vec_pretty(&document).unwrap(),
+        )
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        let noop_baseline_seq = state.account_sink.latest_seq();
+        let noop = state
+            .update_cluster_fabric_credentials(1, BTreeMap::new(), |_| Ok(()))
+            .await;
+        match noop {
+            Err(AppError::InternalError(_)) => {}
+            Err(error) => panic!("no-op materialization error was misclassified: {error}"),
+            Ok(_) => panic!("corrupt credential unexpectedly materialized"),
+        }
+        let runtime = state.config.read().await;
+        let node = runtime.cluster_fabric.node("corrupt-secret-node").unwrap();
+        let bamboo_config::NodePlacement::Ssh(target) = &node.placement else {
+            panic!("expected SSH placement")
+        };
+        let bamboo_config::SshAuth::Password { password, .. } = &target.auth else {
+            panic!("expected password authentication")
+        };
+        assert_eq!(
+            password, "initial-password",
+            "a true no-op materialization failure must preserve the old runtime"
+        );
+        drop(runtime);
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            1
+        );
+        let noop_events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            noop_baseline_seq,
+        )
+        .unwrap();
+        assert!(!noop_events.iter().any(|event| {
+            matches!(
+                &event.event,
+                AgentEvent::ConfigChanged { section, .. } if section == "cluster-fabric"
+            )
+        }));
+
+        let baseline_seq = state.account_sink.latest_seq();
+        let result = state
+            .update_cluster_fabric_credentials(1, BTreeMap::new(), |config| {
+                config
+                    .cluster_fabric
+                    .node_mut("corrupt-secret-node")
+                    .unwrap()
+                    .label = "committed-metadata".to_string();
+                Ok(())
+            })
+            .await;
+        match result {
+            Err(AppError::InternalError(_)) => {}
+            Err(error) => panic!("post-commit materialization error was misclassified: {error}"),
+            Ok(_) => panic!("corrupt credential unexpectedly materialized"),
+        }
+
+        let runtime = state.config.read().await;
+        let node = runtime.cluster_fabric.node("corrupt-secret-node").unwrap();
+        assert_eq!(node.label, "committed-metadata");
+        let bamboo_config::NodePlacement::Ssh(target) = &node.placement else {
+            panic!("expected SSH placement")
+        };
+        let bamboo_config::SshAuth::Password {
+            password,
+            password_encrypted,
+        } = &target.auth
+        else {
+            panic!("expected password authentication")
+        };
+        assert!(password.is_empty());
+        assert!(password_encrypted.is_none());
+        drop(runtime);
+
+        let section = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .cluster_fabric
+            .snapshot();
+        assert_eq!(section.revision, 2);
+        assert_eq!(
+            section.data.0.node("corrupt-secret-node").unwrap().label,
+            "committed-metadata"
+        );
+        let events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            baseline_seq,
+        )
+        .unwrap();
+        let cluster_revisions = events
+            .iter()
+            .filter_map(|event| match &event.event {
+                AgentEvent::ConfigChanged { section, revision } if section == "cluster-fabric" => {
+                    Some(*revision)
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(cluster_revisions, vec![2]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn cluster_commit_adopts_exact_revision_before_later_external_winner() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x72; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        let baseline_seq = state.account_sink.latest_seq();
+        let (external_done_tx, external_done_rx) = std::sync::mpsc::sync_channel(1);
+        set_cluster_after_commit_before_adoption_test_hook(dir.path(), 0, move |data_dir| {
+            let data_dir = data_dir.to_path_buf();
+            let (started_tx, started_rx) = std::sync::mpsc::sync_channel(0);
+            std::thread::spawn(move || {
+                started_tx.send(()).unwrap();
+                let external = bamboo_config::ConfigFacade::open(&data_dir).unwrap();
+                let mut winner = external.effective_config();
+                winner.cluster_fabric.node_mut("race-node").unwrap().label =
+                    "external-winner".to_string();
+                let result =
+                    bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+                        &data_dir,
+                        &mut winner,
+                        &BTreeMap::new(),
+                        1,
+                    );
+                external_done_tx.send(result).unwrap();
+            });
+            started_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("external writer must launch after the durable commit");
+        });
+
+        let committed = state
+            .update_cluster_fabric_credentials(
+                0,
+                BTreeMap::from([(
+                    "race-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(bamboo_config::Node {
+                        id: "race-node".to_string(),
+                        label: "api-commit".to_string(),
+                        placement: bamboo_config::NodePlacement::Local,
+                        trust_level: bamboo_config::TrustLevel::Trusted,
+                        deploy: bamboo_config::DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(committed.section.revision, 1);
+        assert_eq!(
+            committed
+                .config
+                .cluster_fabric
+                .node("race-node")
+                .unwrap()
+                .label,
+            "api-commit",
+            "the response must remain bound to its exact committed candidate"
+        );
+        assert_eq!(
+            tokio::task::spawn_blocking(move || {
+                external_done_rx
+                    .recv_timeout(Duration::from_secs(10))
+                    .expect("later external winner must complete")
+                    .unwrap()
+            })
+            .await
+            .unwrap(),
+            2
+        );
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let facade_revision = state
+                    .config_facade
+                    .as_ref()
+                    .unwrap()
+                    .registry()
+                    .cluster_fabric
+                    .snapshot()
+                    .revision;
+                let runtime_label = state
+                    .config
+                    .read()
+                    .await
+                    .cluster_fabric
+                    .node("race-node")
+                    .map(|node| node.label.clone());
+                if facade_revision == 2 && runtime_label.as_deref() == Some("external-winner") {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("watcher must apply the later external revision");
+
+        let events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            baseline_seq,
+        )
+        .unwrap();
+        let revisions = events
+            .iter()
+            .filter_map(|event| match &event.event {
+                AgentEvent::ConfigChanged { section, revision } if section == "cluster-fabric" => {
+                    Some(*revision)
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            revisions,
+            vec![1, 2],
+            "the exact API event must precede the later watcher winner exactly once"
+        );
+        assert!(!events.iter().any(|event| {
+            matches!(
+                &event.event,
+                AgentEvent::ConfigChanged { section, .. } if section == "credentials"
+            )
+        }));
     }
 
     async fn wait_for_facade_health(

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -2097,8 +2097,20 @@ impl AppState {
         let provider_registry = self.provider_registry.clone();
         let provider = self.provider.clone();
         let mcp_manager = self.mcp_manager.clone();
+        let deployed_registry = self.fabric_deployer.registry();
         let transaction = tokio::spawn(async move {
             let _io = config_io_lock.lock().await;
+            if id == SectionId::ClusterFabric {
+                let deployed = deployed_registry.lock().await;
+                if let Some(node_id) = deployed.keys().find_map(|key| {
+                    let (source, node_id) = bamboo_server_tools::registry_keys::split(key);
+                    (source == "node").then(|| node_id.to_string())
+                }) {
+                    return Err(ConfigSectionMutationError::Invalid(format!(
+                        "node '{node_id}' is deployed; stop it before resetting cluster-fabric"
+                    )));
+                }
+            }
             ensure_provider_mcp_migration_ready(&app_data_dir)
                 .map_err(ConfigSectionMutationError::Store)?;
             let facade = config_facade.as_ref().ok_or_else(|| {
@@ -3321,13 +3333,70 @@ impl AppState {
     where
         F: FnOnce(&mut Config) -> Result<(), AppError> + Send + 'static,
     {
+        self.update_cluster_fabric_credentials_guarded(
+            expected_revision,
+            node_intents,
+            None,
+            update,
+        )
+        .await
+    }
+
+    /// Delete one cluster node only while its lifecycle registry entry is
+    /// absent. The guard is evaluated after acquiring `config_io_lock`, the
+    /// same lock used by deploy/stop, so the check and durable mutation cannot
+    /// race a worker lifecycle transition.
+    pub(crate) async fn delete_cluster_node_credentials<F>(
+        &self,
+        expected_revision: u64,
+        node_id: String,
+        node_intents: std::collections::BTreeMap<
+            String,
+            bamboo_config::ClusterNodeCredentialIntents,
+        >,
+        update: F,
+    ) -> Result<bamboo_server_tools::FabricCommitSnapshot, AppError>
+    where
+        F: FnOnce(&mut Config) -> Result<(), AppError> + Send + 'static,
+    {
+        self.update_cluster_fabric_credentials_guarded(
+            expected_revision,
+            node_intents,
+            Some(node_id),
+            update,
+        )
+        .await
+    }
+
+    async fn update_cluster_fabric_credentials_guarded<F>(
+        &self,
+        expected_revision: u64,
+        node_intents: std::collections::BTreeMap<
+            String,
+            bamboo_config::ClusterNodeCredentialIntents,
+        >,
+        required_stopped_node: Option<String>,
+        update: F,
+    ) -> Result<bamboo_server_tools::FabricCommitSnapshot, AppError>
+    where
+        F: FnOnce(&mut Config) -> Result<(), AppError> + Send + 'static,
+    {
         let config_io_lock = self.config_io_lock.clone();
         let config = self.config.clone();
         let app_data_dir = self.app_data_dir.clone();
         let account_sink = self.account_sink.clone();
         let config_facade = self.config_facade.clone();
+        let deployed_registry = self.fabric_deployer.registry();
         let transaction = tokio::spawn(async move {
             let _io = config_io_lock.lock().await;
+            if let Some(node_id) = required_stopped_node.as_deref() {
+                let deployed = deployed_registry.lock().await;
+                if deployed.contains_key(&bamboo_server_tools::registry_keys::node_key(node_id)) {
+                    return Err(AppError::BadRequest(format!(
+                        "node '{node_id}' is deployed; stop it before deleting it"
+                    )));
+                }
+            }
             let facade = config_facade.as_ref().ok_or_else(|| {
                 AppError::BadRequest(
                     "cluster mutations require the modular configuration facade".to_string(),
@@ -3336,10 +3405,58 @@ impl AppState {
             let mut candidate = {
                 let current = config.read().await;
                 reject_if_recovery_pending(&current)?;
-                let mut candidate = current.clone();
-                update(&mut candidate)?;
-                candidate
+                current.clone()
             };
+            // A process-local runtime can lag a commit from another process.
+            // Build the request from the exact durable generation named by the
+            // client. `None` deliberately selects the secret-free read: using
+            // `Some(expected_revision)` would hydrate first and prevent an
+            // explicit Clear/Replace from repairing corrupt ciphertext. The
+            // returned status metadata is still crypto-validated. An untouched
+            // corrupt active ref retains the established commit-first contract:
+            // a metadata change can durably commit and then report its exact
+            // runtime materialization error (covered by
+            // `changed_cluster_commit_publishes_secret_free_runtime_before_materialization_error`).
+            // The compound writer rechecks the same revision before committing,
+            // so an intervening winner becomes a conflict.
+            let snapshot_dir = app_data_dir.clone();
+            let exact = tokio::task::spawn_blocking(move || {
+                bamboo_config::read_exact_cluster_fabric_snapshot(&snapshot_dir, None)
+            })
+            .await
+            .map_err(|error| {
+                AppError::InternalError(anyhow::anyhow!("cluster snapshot task failed: {error}"))
+            })?
+            .map_err(|error| match error {
+                ConfigStoreError::Conflict { expected, actual } => {
+                    AppError::ConfigConflict { expected, actual }
+                }
+                ConfigStoreError::Validation(message) => AppError::BadRequest(message),
+                ConfigStoreError::Io(error) => AppError::StorageError(error),
+                ConfigStoreError::Json(_) => {
+                    AppError::BadRequest("configuration document is invalid".to_string())
+                }
+                ConfigStoreError::Watch(error) => {
+                    AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
+                }
+            })?;
+            if exact.section.revision != expected_revision {
+                return Err(AppError::ConfigConflict {
+                    expected: expected_revision,
+                    actual: exact.section.revision,
+                });
+            }
+            if exact.section.status != SectionStatus::Healthy
+                || exact.section.source_kind != SectionSourceKind::File
+                || exact.credential_health.status == SectionStatus::Degraded
+            {
+                return Err(AppError::BadRequest(
+                    "revision-bound cluster mutations require healthy primary authorities"
+                        .to_string(),
+                ));
+            }
+            candidate.cluster_fabric = exact.cluster_fabric;
+            update(&mut candidate)?;
             let transaction_dir = app_data_dir.clone();
             let commit_facade = facade.clone();
             let (mut candidate, commit) = tokio::task::spawn_blocking(move || {
@@ -3831,6 +3948,36 @@ mod live_reload_tests {
 
     struct WorkingProvider;
 
+    fn stop_config_watcher(state: &mut AppState) {
+        state.config_watcher.stop.store(true, Ordering::Relaxed);
+        if let Some(task) = state.config_watcher.apply_task.take() {
+            task.abort();
+        }
+        if let Some(task) = state.config_watcher.watcher_task.take() {
+            task.join().unwrap();
+        }
+    }
+
+    async fn insert_registry_worker(state: &AppState, key: String, worker_id: &str) {
+        #[cfg(unix)]
+        let child = tokio::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        #[cfg(windows)]
+        let child = tokio::process::Command::new("cmd")
+            .args(["/C", "timeout", "/T", "30", "/NOBREAK"])
+            .spawn()
+            .unwrap();
+        state.fabric_deployer.registry().lock().await.insert(
+            key,
+            bamboo_server_tools::Deployed {
+                env: "test".to_string(),
+                handle: bamboo_broker::DeployedAgent::from_parts(worker_id, child, None),
+            },
+        );
+    }
+
     fn disabled_mcp_config(id: &str) -> McpConfig {
         McpConfig {
             version: 1,
@@ -4236,6 +4383,324 @@ mod live_reload_tests {
             .count();
         assert_eq!(cluster_events, 1);
         assert_eq!(credential_events, 0);
+    }
+
+    #[tokio::test]
+    async fn stale_process_cluster_candidate_rebases_on_exact_durable_client_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        state
+            .update_cluster_fabric_credentials(
+                0,
+                BTreeMap::from([(
+                    "shared-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(bamboo_config::Node {
+                        id: "shared-node".to_string(),
+                        label: "generation-one".to_string(),
+                        placement: bamboo_config::NodePlacement::Local,
+                        trust_level: bamboo_config::TrustLevel::Trusted,
+                        deploy: bamboo_config::DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        stop_config_watcher(&mut state);
+
+        let external = bamboo_config::ConfigFacade::open(dir.path()).unwrap();
+        let mut external_candidate = external.effective_config();
+        external_candidate
+            .cluster_fabric
+            .clusters
+            .push(bamboo_config::Cluster {
+                name: "external-cluster".to_string(),
+                description: Some("durable-r2-field".to_string()),
+                node_ids: vec!["shared-node".to_string()],
+            });
+        assert_eq!(
+            bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut external_candidate,
+                &BTreeMap::new(),
+                1,
+            )
+            .unwrap(),
+            2
+        );
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            1
+        );
+        assert!(
+            state
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .cluster("external-cluster")
+                .is_none(),
+            "the process runtime is intentionally stale at r1"
+        );
+
+        let committed = state
+            .update_cluster_fabric_credentials(2, BTreeMap::new(), |config| {
+                config.cluster_fabric.node_mut("shared-node").unwrap().label =
+                    "client-r3-edit".to_string();
+                Ok(())
+            })
+            .await
+            .unwrap();
+        assert_eq!(committed.section.revision, 3);
+        assert_eq!(
+            committed
+                .config
+                .cluster_fabric
+                .node("shared-node")
+                .unwrap()
+                .label,
+            "client-r3-edit"
+        );
+        assert_eq!(
+            committed
+                .config
+                .cluster_fabric
+                .cluster("external-cluster")
+                .unwrap()
+                .description
+                .as_deref(),
+            Some("durable-r2-field")
+        );
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            3,
+            "compound adoption must safely catch the stale r1 facade up to r3"
+        );
+
+        let runtime_before_conflict = state.config.read().await.cluster_fabric.clone();
+        let conflict = state
+            .update_cluster_fabric_credentials(2, BTreeMap::new(), |config| {
+                config.cluster_fabric.nodes.clear();
+                config.cluster_fabric.clusters.clear();
+                Ok(())
+            })
+            .await;
+        assert!(matches!(
+            conflict,
+            Err(AppError::ConfigConflict {
+                expected: 2,
+                actual: 3
+            })
+        ));
+        assert_eq!(
+            state.config.read().await.cluster_fabric,
+            runtime_before_conflict,
+            "a durable CAS conflict must not overwrite the process runtime"
+        );
+    }
+
+    #[tokio::test]
+    async fn deployed_node_delete_and_cluster_reset_reject_before_commit_and_remain_stoppable() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        state
+            .update_cluster_fabric_credentials(
+                0,
+                BTreeMap::from([(
+                    "live-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(bamboo_config::Node {
+                        id: "live-node".to_string(),
+                        label: "live-node".to_string(),
+                        placement: bamboo_config::NodePlacement::Local,
+                        trust_level: bamboo_config::TrustLevel::Trusted,
+                        deploy: bamboo_config::DeployProfile::default(),
+                        state: Some(bamboo_config::NodeState {
+                            status: bamboo_config::NodeStatus::Running,
+                            worker_id: Some("live-worker".to_string()),
+                            ..Default::default()
+                        }),
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        insert_registry_worker(
+            &state,
+            bamboo_server_tools::registry_keys::node_key("live-node"),
+            "live-worker",
+        )
+        .await;
+        let transaction_marker = dir.path().join("config-credential-migration.json");
+        let marker_before_guard = std::fs::read(&transaction_marker).ok();
+        bamboo_config::set_cluster_exact_commit_test_fault(
+            dir.path().to_path_buf(),
+            bamboo_config::ClusterExactCommitTestFault::AfterManifestRecoveryFailure,
+        );
+
+        let delete = state
+            .delete_cluster_node_credentials(
+                1,
+                "live-node".to_string(),
+                BTreeMap::from([(
+                    "live-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                |config| {
+                    config
+                        .cluster_fabric
+                        .nodes
+                        .retain(|node| node.id != "live-node");
+                    Ok(())
+                },
+            )
+            .await;
+        assert!(matches!(delete, Err(AppError::BadRequest(_))));
+        let reset = state
+            .reset_credential_backed_section(SectionId::ClusterFabric, 1)
+            .await;
+        assert!(matches!(reset, Err(ConfigSectionMutationError::Invalid(_))));
+        assert_eq!(
+            std::fs::read(&transaction_marker).ok(),
+            marker_before_guard,
+            "registry guards must reject before opening a new durable transaction"
+        );
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            1
+        );
+        assert!(state
+            .config
+            .read()
+            .await
+            .cluster_fabric
+            .node("live-node")
+            .is_some());
+        assert!(state
+            .fabric_deployer
+            .registry()
+            .lock()
+            .await
+            .contains_key(&bamboo_server_tools::registry_keys::node_key("live-node")));
+
+        bamboo_config::clear_cluster_exact_commit_test_fault(dir.path());
+        let stopped = state
+            .fabric_deployer
+            .stop_at_revision("live-node", 1)
+            .await
+            .unwrap();
+        assert_eq!(stopped.snapshot.section.revision, 2);
+        assert!(!state
+            .fabric_deployer
+            .registry()
+            .lock()
+            .await
+            .contains_key(&bamboo_server_tools::registry_keys::node_key("live-node")));
+        let deleted = state
+            .delete_cluster_node_credentials(
+                2,
+                "live-node".to_string(),
+                BTreeMap::from([(
+                    "live-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                |config| {
+                    config
+                        .cluster_fabric
+                        .nodes
+                        .retain(|node| node.id != "live-node");
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(deleted.section.revision, 3);
+        assert!(deleted.config.cluster_fabric.node("live-node").is_none());
+    }
+
+    #[tokio::test]
+    async fn unrelated_agent_registry_entry_does_not_block_cluster_reset() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        state
+            .update_cluster_fabric_credentials(
+                0,
+                BTreeMap::from([(
+                    "reset-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(bamboo_config::Node {
+                        id: "reset-node".to_string(),
+                        label: "reset-node".to_string(),
+                        placement: bamboo_config::NodePlacement::Local,
+                        trust_level: bamboo_config::TrustLevel::Trusted,
+                        deploy: bamboo_config::DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        let agent_key = bamboo_server_tools::registry_keys::agent_key("unrelated-agent");
+        insert_registry_worker(&state, agent_key.clone(), "unrelated-agent").await;
+
+        state
+            .reset_credential_backed_section(SectionId::ClusterFabric, 1)
+            .await
+            .unwrap();
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            2
+        );
+        assert!(state.config.read().await.cluster_fabric.nodes.is_empty());
+        let unrelated = state
+            .fabric_deployer
+            .registry()
+            .lock()
+            .await
+            .remove(&agent_key)
+            .expect("agent registry entry must survive cluster reset");
+        unrelated.handle.shutdown().await;
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/app_state/mod.rs
+++ b/crates/app/bamboo-server/src/app_state/mod.rs
@@ -497,6 +497,7 @@ mod builder;
 mod config_runtime;
 pub(crate) use config_runtime::ConfigLiveHealth;
 pub(crate) use config_runtime::ConfigSectionMutationError;
+pub(crate) use config_runtime::CredentialBackedResetCommit;
 pub mod init;
 pub mod parent_approval_reviewer;
 mod persistence;

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/common.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/common.rs
@@ -126,6 +126,9 @@ fn map_config_store_error(error: bamboo_config::ConfigStoreError) -> AppError {
             AppError::ConfigConflict { expected, actual }
         }
         bamboo_config::ConfigStoreError::Validation(message) => AppError::BadRequest(message),
+        bamboo_config::ConfigStoreError::CommitIndeterminate(message) => AppError::InternalError(
+            anyhow::anyhow!("configuration commit outcome is indeterminate: {message}"),
+        ),
         bamboo_config::ConfigStoreError::Io(error) => AppError::StorageError(error),
         bamboo_config::ConfigStoreError::Json(_) => {
             AppError::BadRequest("configuration document is invalid".to_string())

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
@@ -51,6 +51,12 @@ pub async fn set_bamboo_config(
             "expected_revision is only valid for a dedicated revisioned config domain".to_string(),
         ));
     }
+    if patch_obj.contains_key("cluster_fabric") {
+        return Err(AppError::BadRequest(
+            "cluster_fabric must be changed through the dedicated revisioned cluster API"
+                .to_string(),
+        ));
+    }
     let mut model_limits_patch = take_model_limits_patch(&mut patch_obj);
     config_manager::sanitize_root_patch(&mut patch_obj);
     if model_limits_patch.is_some() && !patch_obj.is_empty() {
@@ -72,14 +78,6 @@ pub async fn set_bamboo_config(
     let new_config = app_state
         .update_config_with_provider_credentials(
             move |config| {
-                if patch_obj.contains_key("cluster_fabric")
-                    && !config.cluster_fabric.credential_refs.is_empty()
-                {
-                    return Err(AppError::BadRequest(
-                        "cluster_fabric with isolated credentials must be changed through the dedicated node API"
-                            .to_string(),
-                    ));
-                }
                 let current = config.clone();
                 let mut patch_obj = patch_obj;
                 remove_unchanged_access_control_echo(&current, &mut patch_obj)?;
@@ -527,6 +525,47 @@ mod tests {
             let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
             assert!(body.contains("revisioned env-vars API"));
         }
+    }
+
+    #[actix_web::test]
+    async fn root_patch_and_validation_reject_cluster_fabric_bypass() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let cluster_path = dir.path().join("cluster-fabric.json");
+        let before = std::fs::read(&cluster_path).unwrap();
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .route("/config", web::post().to(set_bamboo_config))
+                .route(
+                    "/config/validate",
+                    web::post().to(crate::handlers::settings::validate_bamboo_config_patch),
+                ),
+        )
+        .await;
+        for uri in ["/config", "/config/validate"] {
+            let response = test::call_service(
+                &app,
+                test::TestRequest::post()
+                    .uri(uri)
+                    .set_json(serde_json::json!({
+                        "cluster_fabric": {
+                            "nodes": [{
+                                "id": "bypass",
+                                "label": "bypass",
+                                "placement": {"type": "local"}
+                            }]
+                        }
+                    }))
+                    .to_request(),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{uri}");
+            let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+            assert!(body.contains("revisioned cluster API"));
+        }
+        assert_eq!(std::fs::read(cluster_path).unwrap(), before);
+        assert!(state.config.read().await.cluster_fabric.nodes.is_empty());
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
@@ -124,7 +124,18 @@ pub async fn set_bamboo_config(
         }
     }
 
-    Ok(HttpResponse::Ok().json(redacted_config_json(&new_config, &app_state.app_data_dir).await?))
+    // The live config deliberately retains the current node heartbeat/runtime
+    // state while this unrelated compatibility write installs only its owned
+    // section. Preserve the established POST contract by returning the
+    // operator-owned cluster projection, not a transient runtime heartbeat
+    // that was ignored rather than committed by this request.
+    let mut response_config = new_config;
+    for node in &mut response_config.cluster_fabric.nodes {
+        node.state = None;
+    }
+    response_config.sanitize_cluster_fabric_for_disk();
+    Ok(HttpResponse::Ok()
+        .json(redacted_config_json(&response_config, &app_state.app_data_dir).await?))
 }
 
 pub(super) fn remove_unchanged_access_control_echo(

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
@@ -175,15 +175,39 @@ async fn remove_unchanged_cluster_fabric_echo(
     let current = app_state.config.read().await.clone();
     let current_value = current.to_compatibility_value()?;
     let redacted_current = redact_config_for_api(current_value, &current);
-    if redacted_current.get("cluster_fabric") != Some(incoming) {
+    let Some(current_cluster) = redacted_current.get("cluster_fabric") else {
+        return Err(cluster_fabric_patch_error());
+    };
+    if cluster_fabric_without_runtime_state(current_cluster)
+        != cluster_fabric_without_runtime_state(incoming)
+    {
         return Err(cluster_fabric_patch_error());
     }
 
-    // Compatibility clients POST the complete redacted GET payload. Ignore an
-    // exact cluster echo before routing any other dedicated domain, but never
-    // merge it: the redacted shape omits server-owned credential references.
+    // Compatibility clients POST the complete redacted GET payload. Ignore a
+    // semantically unchanged operator-owned cluster echo before routing any
+    // other domain. Runtime node state may advance between GET and POST, and is
+    // ignored here as well as on persistence; all other cluster fields must
+    // still match exactly.
     patch_obj.remove("cluster_fabric");
     Ok(())
+}
+
+fn cluster_fabric_without_runtime_state(cluster: &Value) -> Value {
+    let mut cluster = cluster.clone();
+    let Some(nodes) = cluster
+        .as_object_mut()
+        .and_then(|object| object.get_mut("nodes"))
+        .and_then(Value::as_array_mut)
+    else {
+        return cluster;
+    };
+    for node in nodes {
+        if let Some(node) = node.as_object_mut() {
+            node.remove("state");
+        }
+    }
+    cluster
 }
 
 fn cluster_fabric_patch_error() -> AppError {
@@ -637,6 +661,14 @@ mod tests {
             )
             .await
             .unwrap();
+        let cluster_revision = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .cluster_fabric
+            .snapshot()
+            .revision;
         let cluster_path = dir.path().join("cluster-fabric.json");
         let cluster_before = std::fs::read(&cluster_path).unwrap();
         let credentials_before = std::fs::read(state.credential_store.path()).unwrap();
@@ -674,11 +706,87 @@ mod tests {
         let response: Value = test::read_body_json(response).await;
         assert_eq!(response["cluster_fabric"], cluster_echo);
         assert_eq!(response["server"]["port"], 19_999);
-        assert_eq!(std::fs::read(cluster_path).unwrap(), cluster_before);
+        assert_eq!(std::fs::read(&cluster_path).unwrap(), cluster_before);
         assert_eq!(
             std::fs::read(state.credential_store.path()).unwrap(),
             credentials_before
         );
+
+        {
+            let mut config = state.config.write().await;
+            config.cluster_fabric.node_mut("echo-node").unwrap().state =
+                Some(bamboo_config::NodeState {
+                    status: bamboo_config::NodeStatus::Running,
+                    worker_id: Some("heartbeat-worker".to_string()),
+                    last_health: Some("runtime-only-heartbeat".to_string()),
+                    ..Default::default()
+                });
+        }
+        let mut heartbeat_echo: Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get().uri("/config").to_request(),
+        )
+        .await;
+        assert_eq!(
+            heartbeat_echo["cluster_fabric"]["nodes"][0]["state"]["last_health"],
+            "runtime-only-heartbeat"
+        );
+        state
+            .config
+            .write()
+            .await
+            .cluster_fabric
+            .node_mut("echo-node")
+            .unwrap()
+            .state
+            .as_mut()
+            .unwrap()
+            .last_health = Some("newer-runtime-only-heartbeat".to_string());
+        heartbeat_echo["server"]["port"] = serde_json::json!(20_000);
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/config")
+                .set_json(&heartbeat_echo)
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let response: Value = test::read_body_json(response).await;
+        assert_eq!(response["server"]["port"], 20_000);
+        assert!(!response.to_string().contains("runtime-only-heartbeat"));
+        assert!(!response
+            .to_string()
+            .contains("newer-runtime-only-heartbeat"));
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            cluster_revision
+        );
+        assert_eq!(std::fs::read(&cluster_path).unwrap(), cluster_before);
+        assert_eq!(
+            std::fs::read(state.credential_store.path()).unwrap(),
+            credentials_before
+        );
+        assert!(state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .cluster_fabric
+            .snapshot()
+            .data
+            .0
+            .node("echo-node")
+            .unwrap()
+            .state
+            .is_none());
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
@@ -24,6 +24,7 @@ pub async fn set_bamboo_config(
             "env_vars must be changed through the dedicated revisioned env-vars API".to_string(),
         ));
     }
+    remove_unchanged_cluster_fabric_echo(&app_state, &mut patch_obj).await?;
     if patch_obj.contains_key("notifications") {
         let has_other_domain = patch_obj
             .keys()
@@ -49,12 +50,6 @@ pub async fn set_bamboo_config(
     if patch_obj.remove("expected_revision").is_some() {
         return Err(AppError::BadRequest(
             "expected_revision is only valid for a dedicated revisioned config domain".to_string(),
-        ));
-    }
-    if patch_obj.contains_key("cluster_fabric") {
-        return Err(AppError::BadRequest(
-            "cluster_fabric must be changed through the dedicated revisioned cluster API"
-                .to_string(),
         ));
     }
     let mut model_limits_patch = take_model_limits_patch(&mut patch_obj);
@@ -163,6 +158,37 @@ fn access_control_patch_error() -> AppError {
     AppError::BadRequest(
         "access_control must be changed through the dedicated password, pairing, and device APIs"
             .to_string(),
+    )
+}
+
+async fn remove_unchanged_cluster_fabric_echo(
+    app_state: &AppState,
+    patch_obj: &mut Map<String, Value>,
+) -> Result<(), AppError> {
+    let Some(incoming) = patch_obj.get("cluster_fabric") else {
+        return Ok(());
+    };
+    if incoming.is_null() {
+        return Err(cluster_fabric_patch_error());
+    }
+
+    let current = app_state.config.read().await.clone();
+    let current_value = current.to_compatibility_value()?;
+    let redacted_current = redact_config_for_api(current_value, &current);
+    if redacted_current.get("cluster_fabric") != Some(incoming) {
+        return Err(cluster_fabric_patch_error());
+    }
+
+    // Compatibility clients POST the complete redacted GET payload. Ignore an
+    // exact cluster echo before routing any other dedicated domain, but never
+    // merge it: the redacted shape omits server-owned credential references.
+    patch_obj.remove("cluster_fabric");
+    Ok(())
+}
+
+fn cluster_fabric_patch_error() -> AppError {
+    AppError::BadRequest(
+        "cluster_fabric must be changed through the dedicated revisioned cluster API".to_string(),
     )
 }
 
@@ -566,6 +592,93 @@ mod tests {
         }
         assert_eq!(std::fs::read(cluster_path).unwrap(), before);
         assert!(state.config.read().await.cluster_fabric.nodes.is_empty());
+    }
+
+    #[actix_web::test]
+    async fn legacy_root_get_post_accepts_only_an_unchanged_redacted_cluster_echo() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x65; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let reference = bamboo_config::cluster_password_credential_ref("echo-node").unwrap();
+        state
+            .update_cluster_fabric_credentials(
+                0,
+                std::collections::BTreeMap::from([(
+                    "echo-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents {
+                        password: bamboo_config::ClusterCredentialAction::Replace(
+                            "echo-secret".to_string(),
+                        ),
+                        private_key: bamboo_config::ClusterCredentialAction::Clear,
+                        passphrase: bamboo_config::ClusterCredentialAction::Clear,
+                    },
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(bamboo_config::Node {
+                        id: "echo-node".to_string(),
+                        label: "echo-node".to_string(),
+                        placement: bamboo_config::NodePlacement::Ssh(bamboo_config::SshTarget {
+                            host: "echo.example".to_string(),
+                            port: 22,
+                            username: "deploy".to_string(),
+                            auth: bamboo_config::SshAuth::Password {
+                                password: String::new(),
+                                password_encrypted: None,
+                            },
+                            host_key_fingerprint: None,
+                        }),
+                        trust_level: bamboo_config::TrustLevel::Trusted,
+                        deploy: bamboo_config::DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        let cluster_path = dir.path().join("cluster-fabric.json");
+        let cluster_before = std::fs::read(&cluster_path).unwrap();
+        let credentials_before = std::fs::read(state.credential_store.path()).unwrap();
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .route(
+                    "/config",
+                    web::get().to(crate::handlers::settings::get_bamboo_config),
+                )
+                .route("/config", web::post().to(set_bamboo_config)),
+        )
+        .await;
+
+        let mut full_config: Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get().uri("/config").to_request(),
+        )
+        .await;
+        let cluster_echo = full_config["cluster_fabric"].clone();
+        assert!(cluster_echo.get("credential_refs").is_none());
+        assert!(!cluster_echo.to_string().contains(reference.as_str()));
+        assert!(!cluster_echo.to_string().contains("echo-secret"));
+
+        full_config["server"]["port"] = serde_json::json!(19_999);
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/config")
+                .set_json(&full_config)
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let response: Value = test::read_body_json(response).await;
+        assert_eq!(response["cluster_fabric"], cluster_echo);
+        assert_eq!(response["server"]["port"], 19_999);
+        assert_eq!(std::fs::read(cluster_path).unwrap(), cluster_before);
+        assert_eq!(
+            std::fs::read(state.credential_store.path()).unwrap(),
+            credentials_before
+        );
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
@@ -239,6 +239,9 @@ pub(super) fn map_store_read_error(error: ConfigStoreError) -> AppError {
         ConfigStoreError::Validation(_) => {
             AppError::InternalError(anyhow::anyhow!("credential store validation failed"))
         }
+        ConfigStoreError::CommitIndeterminate(message) => AppError::InternalError(anyhow::anyhow!(
+            "credential transaction outcome is indeterminate: {message}"
+        )),
         ConfigStoreError::Json(_) => {
             AppError::InternalError(anyhow::anyhow!("credential store document is invalid"))
         }

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
@@ -879,20 +879,23 @@ mod tests {
             .credential_store
             .replace(active.clone(), "active-secret", CredentialSource::User, 1)
             .unwrap();
+        let durable_env = bamboo_config::EnvSection(vec![bamboo_config::EnvVarEntry {
+            name: "ACTIVE".to_string(),
+            value: String::new(),
+            secret: true,
+            value_encrypted: None,
+            credential_ref: Some(active),
+            configured: true,
+            description: None,
+        }]);
         state
-            .config
-            .write()
-            .await
-            .env_vars
-            .push(bamboo_config::EnvVarEntry {
-                name: "ACTIVE".to_string(),
-                value: "active-secret".to_string(),
-                secret: true,
-                value_encrypted: None,
-                credential_ref: Some(active),
-                configured: true,
-                description: None,
-            });
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .env
+            .commit(0, durable_env)
+            .unwrap();
         let app = test::init_service(
             App::new()
                 .app_data(state.clone())
@@ -911,7 +914,14 @@ mod tests {
         assert_eq!(rejected.status(), actix_web::http::StatusCode::BAD_REQUEST);
         assert_eq!(state.credential_store.statuses().unwrap().len(), 2);
 
-        state.config.write().await.env_vars.clear();
+        state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .env
+            .commit(1, bamboo_config::EnvSection::default())
+            .unwrap();
         let reset = test::call_service(
             &app,
             test::TestRequest::post()

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
@@ -36,10 +36,11 @@ pub struct ResetCredentialsRequest {
 }
 
 pub async fn list_credentials(app_state: web::Data<AppState>) -> Result<HttpResponse, AppError> {
-    let (statuses, health) = app_state
+    let (mut statuses, health) = app_state
         .credential_store
         .statuses_with_health()
         .map_err(map_store_read_error)?;
+    statuses.retain(|status| !is_cluster_credential_ref(&status.credential_ref));
     Ok(HttpResponse::Ok().json(envelope(statuses, health)))
 }
 
@@ -48,6 +49,7 @@ pub async fn get_credential_status(
     path: web::Path<String>,
 ) -> Result<HttpResponse, AppError> {
     let credential_ref = parse_credential_ref(path.into_inner())?;
+    reject_cluster_credential_ref(&credential_ref)?;
     let (status, health) = app_state
         .credential_store
         .status_with_health(&credential_ref)
@@ -160,6 +162,7 @@ async fn reject_managed_credential_ref(
     app_state: &AppState,
     credential_ref: &CredentialRef,
 ) -> Result<(), AppError> {
+    reject_cluster_credential_ref(credential_ref)?;
     let config = app_state.config.read().await;
     if config.proxy_auth_credential_ref.as_ref() == Some(credential_ref) {
         return Err(AppError::BadRequest(
@@ -196,6 +199,20 @@ async fn reject_managed_credential_ref(
     {
         return Err(AppError::BadRequest(
             "active cluster credentials must be changed through the dedicated revisioned cluster-fabric API"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn is_cluster_credential_ref(credential_ref: &CredentialRef) -> bool {
+    credential_ref.as_str().starts_with("cluster.")
+}
+
+fn reject_cluster_credential_ref(credential_ref: &CredentialRef) -> Result<(), AppError> {
+    if is_cluster_credential_ref(credential_ref) {
+        return Err(AppError::BadRequest(
+            "cluster credential references are reserved for the dedicated revisioned cluster-fabric API"
                 .to_string(),
         ));
     }
@@ -485,6 +502,103 @@ mod tests {
                 .as_ref()
                 .map(|auth| auth.username.as_str()),
             Some("active")
+        );
+    }
+
+    #[actix_web::test]
+    async fn cluster_credential_namespace_is_hidden_and_reserved_without_an_owner() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x66; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let cluster_ref = CredentialRef::parse("cluster.unowned.password").unwrap();
+        let ordinary_ref = CredentialRef::parse("custom.visible.token").unwrap();
+        state
+            .credential_store
+            .replace(
+                cluster_ref.clone(),
+                "unowned-cluster-secret",
+                CredentialSource::User,
+                0,
+            )
+            .unwrap();
+        state
+            .credential_store
+            .replace(
+                ordinary_ref.clone(),
+                "ordinary-secret",
+                CredentialSource::User,
+                1,
+            )
+            .unwrap();
+        assert!(state
+            .config
+            .read()
+            .await
+            .cluster_fabric
+            .credential_refs
+            .is_empty());
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .route("/credentials", web::get().to(list_credentials))
+                .route(
+                    "/credentials/{credential_ref}",
+                    web::get().to(get_credential_status),
+                )
+                .route(
+                    "/credentials/{credential_ref}",
+                    web::put().to(replace_credential),
+                )
+                .route(
+                    "/credentials/{credential_ref}",
+                    web::delete().to(clear_credential),
+                ),
+        )
+        .await;
+
+        let list: serde_json::Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get().uri("/credentials").to_request(),
+        )
+        .await;
+        assert_eq!(list["revision"], 2);
+        assert_eq!(list["data"].as_array().unwrap().len(), 1);
+        assert!(list.to_string().contains(ordinary_ref.as_str()));
+        assert!(!list.to_string().contains(cluster_ref.as_str()));
+
+        let uri = format!("/credentials/{}", cluster_ref.as_str());
+        for request in [
+            test::TestRequest::get().uri(&uri).to_request(),
+            test::TestRequest::put()
+                .uri(&uri)
+                .set_json(serde_json::json!({
+                    "expected_revision": 2,
+                    "value": "generic-replacement"
+                }))
+                .to_request(),
+            test::TestRequest::delete()
+                .uri(&uri)
+                .set_json(serde_json::json!({"expected_revision": 2}))
+                .to_request(),
+        ] {
+            let response = test::call_service(&app, request).await;
+            assert_eq!(response.status(), actix_web::http::StatusCode::BAD_REQUEST);
+            let body: serde_json::Value = test::read_body_json(response).await;
+            assert!(body["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("reserved"));
+        }
+        assert_eq!(state.credential_store.revision().unwrap(), 2);
+        assert_eq!(
+            state
+                .credential_store
+                .resolve(&cluster_ref)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            "unowned-cluster-secret"
         );
     }
 

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
@@ -184,6 +184,21 @@ async fn reject_managed_credential_ref(
                 .to_string(),
         ));
     }
+    if config
+        .cluster_fabric
+        .credential_refs
+        .values()
+        .any(|metadata| {
+            metadata
+                .references()
+                .any(|reference| reference == credential_ref)
+        })
+    {
+        return Err(AppError::BadRequest(
+            "active cluster credentials must be changed through the dedicated revisioned cluster-fabric API"
+                .to_string(),
+        ));
+    }
     Ok(())
 }
 
@@ -221,7 +236,14 @@ pub(super) fn map_store_read_error(error: ConfigStoreError) -> AppError {
 mod tests {
     use super::*;
     use actix_web::{test, App};
-    use bamboo_config::CredentialStatus;
+    use bamboo_config::{
+        cluster_fabric::{
+            ClusterCredentialAction, ClusterNodeCredentialIntents, DeployProfile, Node,
+            NodePlacement, SshAuth, SshTarget, TrustLevel,
+        },
+        CredentialStatus,
+    };
+    use std::collections::BTreeMap;
     use std::time::Duration;
 
     #[::core::prelude::v1::test]
@@ -464,6 +486,201 @@ mod tests {
                 .map(|auth| auth.username.as_str()),
             Some("active")
         );
+    }
+
+    #[actix_web::test]
+    async fn generic_replace_clear_and_reset_preserve_active_cluster_credentials() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x64; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let password_ref = bamboo_config::cluster_password_credential_ref("password-node").unwrap();
+        let private_key_ref =
+            bamboo_config::cluster_private_key_credential_ref("key-node").unwrap();
+        let passphrase_ref = bamboo_config::cluster_passphrase_credential_ref("key-node").unwrap();
+        let intents = BTreeMap::from([
+            (
+                "password-node".to_string(),
+                ClusterNodeCredentialIntents {
+                    password: ClusterCredentialAction::Replace("password-secret".to_string()),
+                    private_key: ClusterCredentialAction::Clear,
+                    passphrase: ClusterCredentialAction::Clear,
+                },
+            ),
+            (
+                "key-node".to_string(),
+                ClusterNodeCredentialIntents {
+                    password: ClusterCredentialAction::Clear,
+                    private_key: ClusterCredentialAction::Replace("private-key-secret".to_string()),
+                    passphrase: ClusterCredentialAction::Replace("passphrase-secret".to_string()),
+                },
+            ),
+        ]);
+        state
+            .update_cluster_fabric_credentials(0, intents, |config| {
+                config.cluster_fabric.nodes = vec![
+                    Node {
+                        id: "password-node".to_string(),
+                        label: "password-node".to_string(),
+                        placement: NodePlacement::Ssh(SshTarget {
+                            host: "password.example".to_string(),
+                            port: 22,
+                            username: "deploy".to_string(),
+                            auth: SshAuth::Password {
+                                password: String::new(),
+                                password_encrypted: None,
+                            },
+                            host_key_fingerprint: None,
+                        }),
+                        trust_level: TrustLevel::Trusted,
+                        deploy: DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    },
+                    Node {
+                        id: "key-node".to_string(),
+                        label: "key-node".to_string(),
+                        placement: NodePlacement::Ssh(SshTarget {
+                            host: "key.example".to_string(),
+                            port: 22,
+                            username: "deploy".to_string(),
+                            auth: SshAuth::PrivateKey {
+                                private_key: String::new(),
+                                private_key_encrypted: None,
+                                private_key_path: None,
+                                passphrase: String::new(),
+                                passphrase_encrypted: None,
+                            },
+                            host_key_fingerprint: None,
+                        }),
+                        trust_level: TrustLevel::Trusted,
+                        deploy: DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    },
+                ];
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        let orphan = CredentialRef::parse("custom.cluster-reset.orphan").unwrap();
+        let before_orphan_revision = state.credential_store.revision().unwrap();
+        state
+            .credential_store
+            .replace(
+                orphan.clone(),
+                "unrelated-orphan",
+                CredentialSource::User,
+                before_orphan_revision,
+            )
+            .unwrap();
+        let credential_revision = state.credential_store.revision().unwrap();
+        let cluster_revision = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .cluster_fabric
+            .snapshot()
+            .revision;
+        let before_store = std::fs::read(state.credential_store.path()).unwrap();
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .route("/credentials/reset", web::post().to(reset_credentials))
+                .route(
+                    "/credentials/{credential_ref}",
+                    web::put().to(replace_credential),
+                )
+                .route(
+                    "/credentials/{credential_ref}",
+                    web::delete().to(clear_credential),
+                ),
+        )
+        .await;
+
+        for reference in [&password_ref, &private_key_ref, &passphrase_ref] {
+            let uri = format!("/credentials/{}", reference.as_str());
+            let replace = test::call_service(
+                &app,
+                test::TestRequest::put()
+                    .uri(&uri)
+                    .set_json(serde_json::json!({
+                        "expected_revision": credential_revision,
+                        "value": "generic-replacement-must-not-win"
+                    }))
+                    .to_request(),
+            )
+            .await;
+            assert_eq!(replace.status(), actix_web::http::StatusCode::BAD_REQUEST);
+            let replace: serde_json::Value = test::read_body_json(replace).await;
+            assert!(replace["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("dedicated revisioned cluster-fabric API"));
+
+            let clear = test::call_service(
+                &app,
+                test::TestRequest::delete()
+                    .uri(&uri)
+                    .set_json(serde_json::json!({
+                        "expected_revision": credential_revision
+                    }))
+                    .to_request(),
+            )
+            .await;
+            assert_eq!(clear.status(), actix_web::http::StatusCode::BAD_REQUEST);
+            let clear: serde_json::Value = test::read_body_json(clear).await;
+            assert!(clear["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("dedicated revisioned cluster-fabric API"));
+        }
+
+        let reset = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/credentials/reset")
+                .set_json(serde_json::json!({
+                    "expected_revision": credential_revision
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(reset.status(), actix_web::http::StatusCode::BAD_REQUEST);
+        let reset: serde_json::Value = test::read_body_json(reset).await;
+        assert!(reset["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("credentials still referenced by configuration"));
+
+        assert_eq!(
+            std::fs::read(state.credential_store.path()).unwrap(),
+            before_store
+        );
+        assert_eq!(
+            state.credential_store.revision().unwrap(),
+            credential_revision
+        );
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .cluster_fabric
+                .snapshot()
+                .revision,
+            cluster_revision
+        );
+        for reference in [&password_ref, &private_key_ref, &passphrase_ref] {
+            assert!(
+                state.credential_store.status(reference).unwrap().configured,
+                "{} must remain configured",
+                reference.as_str()
+            );
+        }
+        assert!(state.credential_store.status(&orphan).unwrap().configured);
     }
 
     #[cfg(feature = "test-utils")]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -514,6 +514,9 @@ pub async fn get_typed_section(
     match id {
         bamboo_config::SectionId::Providers => get_provider_section(app_state).await,
         bamboo_config::SectionId::Mcp => get_mcp_section(app_state).await,
+        bamboo_config::SectionId::ClusterFabric => {
+            super::super::cluster_fabric::get_cluster_section(app_state).await
+        }
         _ => {
             let _io = app_state.config_io_lock.lock().await;
             let facade = app_state.config_facade.as_ref().ok_or_else(|| {
@@ -544,6 +547,7 @@ pub async fn put_typed_section(
         bamboo_config::SectionId::Providers
             | bamboo_config::SectionId::Mcp
             | bamboo_config::SectionId::Credentials
+            | bamboo_config::SectionId::ClusterFabric
     ) {
         return Err(AppError::BadRequest(
             "this section requires its dedicated endpoint".to_string(),
@@ -3643,6 +3647,50 @@ mod tests {
             .await
             .proxy_auth_credential_ref
             .is_none());
+    }
+
+    #[actix_web::test]
+    async fn generic_cluster_section_put_cannot_bypass_dedicated_transaction() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let cluster_path = dir.path().join("cluster-fabric.json");
+        let before = std::fs::read(&cluster_path).unwrap();
+        let app = test::init_service(
+            App::new().app_data(state.clone()).service(
+                web::resource("/sections/{section}")
+                    .route(web::get().to(get_typed_section))
+                    .route(web::put().to(put_typed_section)),
+            ),
+        )
+        .await;
+
+        let initial: Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get()
+                .uri("/sections/cluster-fabric")
+                .to_request(),
+        )
+        .await;
+        let rejected = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/sections/cluster-fabric")
+                .set_json(json!({
+                    "expected_revision": initial["revision"],
+                    "data": {
+                        "nodes": [{
+                            "id": "bypass",
+                            "label": "bypass",
+                            "placement": {"type": "local"}
+                        }]
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(rejected.status(), actix_web::http::StatusCode::BAD_REQUEST);
+        assert_eq!(std::fs::read(cluster_path).unwrap(), before);
+        assert!(state.config.read().await.cluster_fabric.nodes.is_empty());
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -11,7 +11,7 @@ use serde_json::{json, Map, Value};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use crate::{
-    app_state::{AppState, ConfigSectionMutationError},
+    app_state::{AppState, ConfigSectionMutationError, CredentialBackedResetCommit},
     error::AppError,
 };
 
@@ -589,10 +589,13 @@ pub async fn reset_typed_section(
         | SectionId::Env
         | SectionId::ClusterFabric
         | SectionId::AccessControl => {
-            app_state
+            let commit = app_state
                 .reset_credential_backed_section(id, expected_revision)
                 .await
                 .map_err(map_mutation_error)?;
+            if let CredentialBackedResetCommit::Cluster(snapshot) = commit {
+                return cluster_reset_response(*snapshot);
+            }
         }
         SectionId::Providers => {
             app_state
@@ -623,6 +626,13 @@ pub async fn reset_typed_section(
     }
 
     get_typed_section(app_state, web::Path::from(name)).await
+}
+
+fn cluster_reset_response(
+    snapshot: bamboo_server_tools::FabricCommitSnapshot,
+) -> Result<HttpResponse, AppError> {
+    let section = super::super::cluster_fabric::committed_cluster_section(snapshot)?;
+    Ok(HttpResponse::Ok().json(section))
 }
 
 fn default_section_value(id: SectionId) -> Result<Value, AppError> {
@@ -3691,6 +3701,130 @@ mod tests {
         assert_eq!(rejected.status(), actix_web::http::StatusCode::BAD_REQUEST);
         assert_eq!(std::fs::read(cluster_path).unwrap(), before);
         assert!(state.config.read().await.cluster_fabric.nodes.is_empty());
+    }
+
+    #[actix_web::test]
+    async fn delayed_cluster_reset_response_stays_bound_to_its_exact_commit() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x67; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let reference = bamboo_config::cluster_password_credential_ref("reset-race-node").unwrap();
+        state
+            .update_cluster_fabric_credentials(
+                0,
+                BTreeMap::from([(
+                    "reset-race-node".to_string(),
+                    bamboo_config::ClusterNodeCredentialIntents {
+                        password: bamboo_config::ClusterCredentialAction::Replace(
+                            "reset-race-secret".to_string(),
+                        ),
+                        private_key: bamboo_config::ClusterCredentialAction::Clear,
+                        passphrase: bamboo_config::ClusterCredentialAction::Clear,
+                    },
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(bamboo_config::Node {
+                        id: "reset-race-node".to_string(),
+                        label: "reset-race-node".to_string(),
+                        placement: bamboo_config::NodePlacement::Ssh(bamboo_config::SshTarget {
+                            host: "reset.example.test".to_string(),
+                            port: 22,
+                            username: "deploy".to_string(),
+                            auth: bamboo_config::SshAuth::Password {
+                                password: String::new(),
+                                password_encrypted: None,
+                            },
+                            host_key_fingerprint: None,
+                        }),
+                        trust_level: bamboo_config::TrustLevel::Trusted,
+                        deploy: bamboo_config::DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            state
+                .credential_store
+                .status(&reference)
+                .unwrap()
+                .configured
+        );
+
+        let reset = state
+            .reset_credential_backed_section(SectionId::ClusterFabric, 1)
+            .await
+            .unwrap();
+        let CredentialBackedResetCommit::Cluster(reset_snapshot) = reset else {
+            panic!("cluster reset must return its exact committed snapshot");
+        };
+        assert!(
+            !state
+                .credential_store
+                .status(&reference)
+                .unwrap()
+                .configured
+        );
+
+        let (release_response, wait_for_second_commit) = tokio::sync::oneshot::channel();
+        let response = async move {
+            wait_for_second_commit.await.unwrap();
+            let response = cluster_reset_response(*reset_snapshot).unwrap();
+            let body = actix_web::body::to_bytes(response.into_body())
+                .await
+                .unwrap();
+            String::from_utf8(body.to_vec()).unwrap()
+        };
+        let second_commit = async {
+            let result = state
+                .update_cluster_fabric_credentials(
+                    2,
+                    BTreeMap::from([(
+                        "queued-node".to_string(),
+                        bamboo_config::ClusterNodeCredentialIntents::clear_all(),
+                    )]),
+                    |config| {
+                        config.cluster_fabric.nodes.push(bamboo_config::Node {
+                            id: "queued-node".to_string(),
+                            label: "queued-second-commit".to_string(),
+                            placement: bamboo_config::NodePlacement::Local,
+                            trust_level: bamboo_config::TrustLevel::Trusted,
+                            deploy: bamboo_config::DeployProfile::default(),
+                            state: None,
+                            enabled: true,
+                        });
+                        Ok(())
+                    },
+                )
+                .await;
+            release_response.send(()).unwrap();
+            result
+        };
+        let (body, second) = tokio::join!(response, second_commit);
+        let second = second.unwrap();
+        let body_value: Value = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(body_value["revision"], 2);
+        assert_eq!(body_value["data"]["nodes"], json!([]));
+        assert!(body_value["data"].get("clusters").is_none());
+        assert!(!body.contains("reset-race-secret"));
+        assert!(!body.contains(reference.as_str()));
+        assert!(!body.contains("credential_ref"));
+        assert_eq!(second.section.revision, 3);
+        assert_eq!(
+            state
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("queued-node")
+                .unwrap()
+                .label,
+            "queued-second-commit"
+        );
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -665,6 +665,11 @@ fn map_mutation_error(error: ConfigSectionMutationError) -> AppError {
         ConfigSectionMutationError::Store(ConfigStoreError::Validation(message))
         | ConfigSectionMutationError::Invalid(message)
         | ConfigSectionMutationError::Runtime(message) => AppError::BadRequest(message),
+        ConfigSectionMutationError::Store(ConfigStoreError::CommitIndeterminate(message)) => {
+            AppError::InternalError(anyhow::anyhow!(
+                "section transaction outcome is indeterminate: {message}"
+            ))
+        }
         ConfigSectionMutationError::Store(ConfigStoreError::Io(error)) => {
             AppError::StorageError(error)
         }

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/validation.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/validation.rs
@@ -32,6 +32,12 @@ pub async fn validate_bamboo_config_patch(
             "env_vars must be changed through the dedicated revisioned env-vars API".to_string(),
         ));
     }
+    if patch_obj.contains_key("cluster_fabric") {
+        return Err(AppError::BadRequest(
+            "cluster_fabric must be changed through the dedicated revisioned cluster API"
+                .to_string(),
+        ));
+    }
     config_manager::sanitize_root_patch(&mut patch_obj);
 
     let lifecycle_schema_issues = patch_obj

--- a/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/deploy.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/deploy.rs
@@ -16,6 +16,7 @@ fn map_err(e: FabricError) -> AppError {
         FabricError::NotFound(m) => AppError::NotFound(m),
         FabricError::BadRequest(m) => AppError::BadRequest(m),
         FabricError::Conflict { expected, actual } => AppError::ConfigConflict { expected, actual },
+        FabricError::Committed(m) => AppError::InternalError(anyhow::anyhow!(m)),
         FabricError::Internal(m) => AppError::InternalError(anyhow::anyhow!(m)),
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/deploy.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/deploy.rs
@@ -6,7 +6,7 @@
 //! [`FabricError`] to the HTTP [`AppError`].
 
 use bamboo_config::cluster_fabric::NodeState;
-use bamboo_server_tools::FabricError;
+use bamboo_server_tools::{FabricActionResult, FabricError};
 
 use crate::app_state::AppState;
 use crate::error::AppError;
@@ -15,6 +15,7 @@ fn map_err(e: FabricError) -> AppError {
     match e {
         FabricError::NotFound(m) => AppError::NotFound(m),
         FabricError::BadRequest(m) => AppError::BadRequest(m),
+        FabricError::Conflict { expected, actual } => AppError::ConfigConflict { expected, actual },
         FabricError::Internal(m) => AppError::InternalError(anyhow::anyhow!(m)),
     }
 }
@@ -23,26 +24,35 @@ pub async fn deploy_node(
     app_state: &AppState,
     node_id: &str,
     echo: bool,
-) -> Result<NodeState, AppError> {
+    expected_revision: u64,
+) -> Result<FabricActionResult<NodeState>, AppError> {
     app_state
         .fabric_deployer
-        .deploy(node_id, echo)
+        .deploy_at_revision(node_id, echo, expected_revision)
         .await
         .map_err(map_err)
 }
 
-pub async fn stop_node(app_state: &AppState, node_id: &str) -> Result<NodeState, AppError> {
+pub async fn stop_node(
+    app_state: &AppState,
+    node_id: &str,
+    expected_revision: u64,
+) -> Result<FabricActionResult<NodeState>, AppError> {
     app_state
         .fabric_deployer
-        .stop(node_id)
+        .stop_at_revision(node_id, expected_revision)
         .await
         .map_err(map_err)
 }
 
-pub async fn test_node(app_state: &AppState, node_id: &str) -> Result<String, AppError> {
+pub async fn test_node(
+    app_state: &AppState,
+    node_id: &str,
+    expected_revision: u64,
+) -> Result<FabricActionResult<String>, AppError> {
     app_state
         .fabric_deployer
-        .test(node_id)
+        .test_at_revision(node_id, expected_revision)
         .await
         .map_err(map_err)
 }

--- a/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/mod.rs
@@ -22,8 +22,8 @@ use bamboo_config::cluster_fabric::{
     ClusterNodeCredentialRefs, DeployProfile, Node, NodePlacement, SshAuth, SshTarget, TrustLevel,
 };
 use bamboo_config::{
-    patch::is_masked_api_key, CredentialSource, CredentialStatus, SectionEnvelope, SectionId,
-    SectionStatus,
+    patch::is_masked_api_key, ConfigStoreError, CredentialSource, CredentialStatus,
+    SectionEnvelope, SectionStatus,
 };
 use bamboo_server_tools::FabricCommitSnapshot;
 
@@ -461,31 +461,49 @@ fn project_cluster_section(
     Ok(envelope)
 }
 
-fn cluster_section_envelope(app_state: &AppState) -> Result<SectionEnvelope<Value>, AppError> {
-    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
+async fn cluster_section_envelope(
+    app_state: &AppState,
+) -> Result<SectionEnvelope<Value>, AppError> {
+    app_state.config_facade.as_ref().ok_or_else(|| {
         AppError::BadRequest(
             "cluster settings require the modular configuration facade".to_string(),
         )
     })?;
-    let snapshot = facade.registry().cluster_fabric.snapshot();
-    let fabric = snapshot.data.0.clone();
-    let (statuses, store_healthy) = match app_state.credential_store.statuses_with_health() {
-        Ok((statuses, health)) => (statuses, health.status != SectionStatus::Degraded),
-        Err(_) => (Vec::new(), false),
-    };
-    let envelope = facade
-        .registry()
-        .envelope_value(SectionId::ClusterFabric)
-        .map_err(|_| {
-            AppError::InternalError(anyhow::anyhow!("cluster section envelope is unavailable"))
-        })?;
-    project_cluster_section(fabric, envelope, statuses, store_healthy)
+    let data_dir = app_state.app_data_dir.clone();
+    let exact = tokio::task::spawn_blocking(move || {
+        bamboo_config::read_exact_cluster_fabric_snapshot(&data_dir, None)
+    })
+    .await
+    .map_err(|error| {
+        AppError::InternalError(anyhow::anyhow!("cluster snapshot task failed: {error}"))
+    })?
+    .map_err(|error| match error {
+        ConfigStoreError::Io(error) => AppError::StorageError(error),
+        ConfigStoreError::Json(_) | ConfigStoreError::Validation(_) => {
+            AppError::InternalError(anyhow::anyhow!("cluster section snapshot is unavailable"))
+        }
+        ConfigStoreError::Conflict { .. } => AppError::InternalError(anyhow::anyhow!(
+            "cluster section snapshot returned an unexpected conflict"
+        )),
+        ConfigStoreError::Watch(error) => AppError::InternalError(anyhow::anyhow!(
+            "cluster section snapshot watch failed: {error}"
+        )),
+    })?;
+    let store_healthy = exact.section.status != SectionStatus::Degraded
+        && exact.credential_health.status != SectionStatus::Degraded;
+    project_cluster_section(
+        exact.cluster_fabric,
+        exact.section,
+        exact.credential_statuses,
+        store_healthy,
+    )
 }
 
 pub(super) fn committed_cluster_section(
     snapshot: FabricCommitSnapshot,
 ) -> Result<SectionEnvelope<Value>, AppError> {
-    let store_healthy = snapshot.credential_health.status != SectionStatus::Degraded;
+    let store_healthy = snapshot.section.status != SectionStatus::Degraded
+        && snapshot.credential_health.status != SectionStatus::Degraded;
     project_cluster_section(
         snapshot.config.cluster_fabric.clone(),
         snapshot.section,
@@ -498,7 +516,7 @@ pub(super) async fn get_cluster_section(
     app_state: web::Data<AppState>,
 ) -> Result<HttpResponse, AppError> {
     let _io = app_state.config_io_lock.lock().await;
-    Ok(HttpResponse::Ok().json(cluster_section_envelope(&app_state)?))
+    Ok(HttpResponse::Ok().json(cluster_section_envelope(&app_state).await?))
 }
 
 fn replace_node_membership(
@@ -1173,6 +1191,166 @@ mod tests {
                 .label,
             "second-commit"
         );
+    }
+
+    #[actix_web::test]
+    async fn cluster_get_reads_one_newer_durable_metadata_and_credential_generation() {
+        // Credential hydration runs on the blocking pool, so use the stable
+        // key-file path instead of the test-only thread-local key override.
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        state
+            .update_cluster_fabric_credentials(
+                0,
+                BTreeMap::from([(
+                    "coherent-node".to_string(),
+                    ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(Node {
+                        id: "coherent-node".to_string(),
+                        label: "generation-one".to_string(),
+                        placement: NodePlacement::Local,
+                        trust_level: TrustLevel::Trusted,
+                        deploy: DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+
+        // Hold the process publication lock so the first facade/runtime stay
+        // at r1 while a second facade commits r2 to durable storage.
+        let guard = state.config_io_lock.lock().await;
+        let local_facade = state.config_facade.as_ref().unwrap();
+        assert_eq!(
+            local_facade.registry().cluster_fabric.snapshot().revision,
+            1
+        );
+        let external = bamboo_config::ConfigFacade::open(dir.path()).unwrap();
+        let mut winner = external.effective_config();
+        let node = winner.cluster_fabric.node_mut("coherent-node").unwrap();
+        node.label = "generation-two".to_string();
+        node.placement = NodePlacement::Ssh(SshTarget {
+            host: "generation-two.example.test".to_string(),
+            port: 22,
+            username: "operator".to_string(),
+            auth: SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+            host_key_fingerprint: None,
+        });
+        let revision = bamboo_config::persist_cluster_fabric_credential_transaction_at_revision(
+            dir.path(),
+            &mut winner,
+            &BTreeMap::from([(
+                "coherent-node".to_string(),
+                ClusterNodeCredentialIntents {
+                    password: ClusterCredentialAction::Replace(
+                        "generation-two-password".to_string(),
+                    ),
+                    private_key: ClusterCredentialAction::Clear,
+                    passphrase: ClusterCredentialAction::Clear,
+                },
+            )]),
+            1,
+        )
+        .unwrap();
+        assert_eq!(revision, 2);
+        assert_eq!(
+            local_facade.registry().cluster_fabric.snapshot().revision,
+            1,
+            "the local facade remains intentionally stale behind the held publication lock"
+        );
+
+        if let Err(error) = bamboo_config::read_exact_cluster_fabric_snapshot(dir.path(), None) {
+            panic!("exact durable cluster read failed before GET projection: {error}");
+        }
+        let envelope = cluster_section_envelope(&state)
+            .await
+            .expect("GET projection must read the coherent durable generation");
+        assert_eq!(envelope.revision, 2);
+        let node = envelope.data["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|node| node["id"] == "coherent-node")
+            .unwrap();
+        assert_eq!(node["label"], "generation-two");
+        assert_eq!(node["placement"]["type"], "ssh");
+        assert_eq!(node["placement"]["auth"]["method"], "password");
+        assert_eq!(
+            envelope.data["credential_status"]["coherent-node"]["password"]["state"],
+            "configured"
+        );
+        let encoded = serde_json::to_string(&envelope).unwrap();
+        assert!(!encoded.contains("generation-two-password"));
+        assert!(!encoded.contains("credential_ref"));
+        assert_eq!(
+            state
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("coherent-node")
+                .unwrap()
+                .label,
+            "generation-one",
+            "the read must not depend on or silently mutate the stale process runtime"
+        );
+
+        let cluster_primary = std::fs::read(dir.path().join("cluster-fabric.json")).unwrap();
+        std::fs::write(dir.path().join("cluster-fabric.json"), b"{invalid-primary").unwrap();
+        let degraded = cluster_section_envelope(&state)
+            .await
+            .expect("GET must retain the validated durable backup LKG");
+        assert_eq!(degraded.revision, 1);
+        assert_eq!(
+            degraded.source_kind,
+            bamboo_config::SectionSourceKind::Backup
+        );
+        assert_eq!(degraded.status, SectionStatus::Degraded);
+        assert_eq!(
+            degraded.last_error.as_deref(),
+            Some("cluster configuration is unavailable")
+        );
+        assert_eq!(
+            degraded.data["nodes"][0]["label"], "generation-one",
+            "the degraded envelope must identify the exact backup generation"
+        );
+        assert_eq!(
+            degraded.data["credential_status"]["coherent-node"]["password"]["state"], "missing",
+            "the r1 backup metadata truthfully has no password configured"
+        );
+
+        std::fs::write(dir.path().join("cluster-fabric.json"), cluster_primary).unwrap();
+        for suffix in ["bak", "bak.1", "bak.2"] {
+            let path = dir.path().join(format!("credentials.json.{suffix}"));
+            match std::fs::remove_file(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => panic!("remove credential backup: {error}"),
+            }
+        }
+        std::fs::write(
+            dir.path().join("credentials.json"),
+            b"{invalid-credential-primary",
+        )
+        .unwrap();
+        let unavailable_credentials = cluster_section_envelope(&state)
+            .await
+            .expect("GET must remain available with redacted credential errors");
+        assert_eq!(unavailable_credentials.revision, 2);
+        assert_eq!(unavailable_credentials.status, SectionStatus::Healthy);
+        assert_eq!(
+            unavailable_credentials.data["credential_status"]["coherent-node"]["password"]["state"],
+            "error"
+        );
+        drop(guard);
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/mod.rs
@@ -25,6 +25,7 @@ use bamboo_config::{
     patch::is_masked_api_key, CredentialSource, CredentialStatus, SectionEnvelope, SectionId,
     SectionStatus,
 };
+use bamboo_server_tools::FabricCommitSnapshot;
 
 use crate::app_state::AppState;
 use crate::error::AppError;
@@ -415,24 +416,16 @@ fn node_credential_status(
     }
 }
 
-fn cluster_section_envelope(app_state: &AppState) -> Result<SectionEnvelope<Value>, AppError> {
-    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
-        AppError::BadRequest(
-            "cluster settings require the modular configuration facade".to_string(),
-        )
-    })?;
-    let snapshot = facade.registry().cluster_fabric.snapshot();
-    let fabric = snapshot.data.0.clone();
-    let (statuses, store_healthy) = match app_state.credential_store.statuses_with_health() {
-        Ok((statuses, health)) => (
-            statuses
-                .into_iter()
-                .map(|status| (status.credential_ref.as_str().to_string(), status))
-                .collect::<BTreeMap<_, _>>(),
-            health.status != SectionStatus::Degraded,
-        ),
-        Err(_) => (BTreeMap::new(), false),
-    };
+fn project_cluster_section(
+    fabric: ClusterFabricConfig,
+    mut envelope: SectionEnvelope<Value>,
+    statuses: Vec<CredentialStatus>,
+    store_healthy: bool,
+) -> Result<SectionEnvelope<Value>, AppError> {
+    let statuses = statuses
+        .into_iter()
+        .map(|status| (status.credential_ref.as_str().to_string(), status))
+        .collect::<BTreeMap<_, _>>();
     let mut credential_status = BTreeMap::new();
     for node in &fabric.nodes {
         credential_status.insert(
@@ -461,17 +454,44 @@ fn cluster_section_envelope(app_state: &AppState) -> Result<SectionEnvelope<Valu
         serde_json::to_value(credential_status)
             .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?,
     );
-    let mut envelope = facade
-        .registry()
-        .envelope_value(SectionId::ClusterFabric)
-        .map_err(|_| {
-            AppError::InternalError(anyhow::anyhow!("cluster section envelope is unavailable"))
-        })?;
     envelope.data = data;
     if envelope.last_error.is_some() {
         envelope.last_error = Some("cluster configuration is unavailable".to_string());
     }
     Ok(envelope)
+}
+
+fn cluster_section_envelope(app_state: &AppState) -> Result<SectionEnvelope<Value>, AppError> {
+    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
+        AppError::BadRequest(
+            "cluster settings require the modular configuration facade".to_string(),
+        )
+    })?;
+    let snapshot = facade.registry().cluster_fabric.snapshot();
+    let fabric = snapshot.data.0.clone();
+    let (statuses, store_healthy) = match app_state.credential_store.statuses_with_health() {
+        Ok((statuses, health)) => (statuses, health.status != SectionStatus::Degraded),
+        Err(_) => (Vec::new(), false),
+    };
+    let envelope = facade
+        .registry()
+        .envelope_value(SectionId::ClusterFabric)
+        .map_err(|_| {
+            AppError::InternalError(anyhow::anyhow!("cluster section envelope is unavailable"))
+        })?;
+    project_cluster_section(fabric, envelope, statuses, store_healthy)
+}
+
+fn committed_cluster_section(
+    snapshot: FabricCommitSnapshot,
+) -> Result<SectionEnvelope<Value>, AppError> {
+    let store_healthy = snapshot.credential_health.status != SectionStatus::Degraded;
+    project_cluster_section(
+        snapshot.config.cluster_fabric.clone(),
+        snapshot.section,
+        snapshot.credential_statuses,
+        store_healthy,
+    )
 }
 
 pub(super) async fn get_cluster_section(
@@ -529,13 +549,12 @@ struct ClusterMutationResponse {
     section: SectionEnvelope<Value>,
 }
 
-async fn cluster_mutation_response(
-    app_state: web::Data<AppState>,
+fn cluster_mutation_response(
     status: StatusCode,
     node_id: Option<String>,
+    snapshot: FabricCommitSnapshot,
 ) -> Result<HttpResponse, AppError> {
-    let _io = app_state.config_io_lock.lock().await;
-    let section = cluster_section_envelope(&app_state)?;
+    let section = committed_cluster_section(snapshot)?;
     Ok(HttpResponse::build(status).json(ClusterMutationResponse { node_id, section }))
 }
 
@@ -601,7 +620,7 @@ pub async fn create_node(
     let node_id_for_update = node_id.clone();
     let node_intents = BTreeMap::from([(node_id.clone(), credential_changes.into_domain())]);
 
-    app_state
+    let snapshot = app_state
         .update_cluster_fabric_credentials(expected_revision, node_intents, move |cfg| {
             cfg.cluster_fabric.nodes.push(node.clone());
             replace_node_membership(
@@ -613,7 +632,7 @@ pub async fn create_node(
         })
         .await?;
 
-    cluster_mutation_response(app_state, StatusCode::CREATED, Some(node_id)).await
+    cluster_mutation_response(StatusCode::CREATED, Some(node_id), snapshot)
 }
 
 /// `PUT /v1/bamboo/settings/nodes/{id}` — update a node (secret-preserving).
@@ -639,7 +658,7 @@ pub async fn update_node(
     let placement = placement.into_domain();
     let node_intents = BTreeMap::from([(id.clone(), credential_changes.into_domain())]);
 
-    app_state
+    let snapshot = app_state
         .update_cluster_fabric_credentials(expected_revision, node_intents, move |cfg| {
             let existing = cfg
                 .cluster_fabric
@@ -666,7 +685,7 @@ pub async fn update_node(
         })
         .await?;
 
-    cluster_mutation_response(app_state, StatusCode::OK, Some(id_for_response)).await
+    cluster_mutation_response(StatusCode::OK, Some(id_for_response), snapshot)
 }
 
 /// `DELETE /v1/bamboo/settings/nodes/{id}` — remove a node.
@@ -679,7 +698,7 @@ pub async fn delete_node(
     let expected_revision = query.expected_revision;
     let id_for_update = id.clone();
 
-    app_state
+    let snapshot = app_state
         .update_cluster_fabric_credentials(
             expected_revision,
             BTreeMap::from([(id.clone(), ClusterNodeCredentialIntents::clear_all())]),
@@ -699,7 +718,7 @@ pub async fn delete_node(
         )
         .await?;
 
-    cluster_mutation_response(app_state, StatusCode::OK, Some(id)).await
+    cluster_mutation_response(StatusCode::OK, Some(id), snapshot)
 }
 
 // ─── Cluster handlers ──────────────────────────────────────────────────
@@ -715,7 +734,7 @@ pub async fn create_cluster(
     }
     let expected_revision = req.expected_revision;
 
-    app_state
+    let snapshot = app_state
         .update_cluster_fabric_credentials(expected_revision, BTreeMap::new(), move |cfg| {
             if cfg.cluster_fabric.cluster(&req.name).is_some() {
                 return Err(AppError::BadRequest(format!(
@@ -732,7 +751,7 @@ pub async fn create_cluster(
         })
         .await?;
 
-    cluster_mutation_response(app_state, StatusCode::CREATED, None).await
+    cluster_mutation_response(StatusCode::CREATED, None, snapshot)
 }
 
 /// `PUT /v1/bamboo/settings/clusters/{name}` — update a cluster.
@@ -748,7 +767,7 @@ pub async fn update_cluster(
     }
     let expected_revision = req.expected_revision;
 
-    app_state
+    let snapshot = app_state
         .update_cluster_fabric_credentials(expected_revision, BTreeMap::new(), move |cfg| {
             if req.name != name && cfg.cluster_fabric.cluster(&req.name).is_some() {
                 return Err(AppError::BadRequest(format!(
@@ -769,7 +788,7 @@ pub async fn update_cluster(
         })
         .await?;
 
-    cluster_mutation_response(app_state, StatusCode::OK, None).await
+    cluster_mutation_response(StatusCode::OK, None, snapshot)
 }
 
 /// `DELETE /v1/bamboo/settings/clusters/{name}` — remove a cluster (nodes kept).
@@ -781,7 +800,7 @@ pub async fn delete_cluster(
     let name = path.into_inner();
     let expected_revision = query.expected_revision;
 
-    app_state
+    let snapshot = app_state
         .update_cluster_fabric_credentials(expected_revision, BTreeMap::new(), move |cfg| {
             let before = cfg.cluster_fabric.clusters.len();
             cfg.cluster_fabric.clusters.retain(|c| c.name != name);
@@ -792,7 +811,7 @@ pub async fn delete_cluster(
         })
         .await?;
 
-    cluster_mutation_response(app_state, StatusCode::OK, None).await
+    cluster_mutation_response(StatusCode::OK, None, snapshot)
 }
 
 // ─── Lifecycle ─────────────────────────────────────────────────────────
@@ -818,9 +837,33 @@ pub async fn node_status(
 /// Query params for `node_deploy`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct DeployQuery {
+    pub expected_revision: u64,
     /// Deploy the no-LLM echo executor (connectivity smoke test).
     #[serde(default)]
     pub echo: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LifecycleQuery {
+    pub expected_revision: u64,
+}
+
+#[derive(Serialize)]
+struct NodeStateMutationResponse {
+    id: String,
+    state: bamboo_config::cluster_fabric::NodeState,
+    #[serde(flatten)]
+    section: SectionEnvelope<Value>,
+}
+
+#[derive(Serialize)]
+struct NodeTestResponse {
+    id: String,
+    ok: bool,
+    preflight: String,
+    #[serde(flatten)]
+    section: SectionEnvelope<Value>,
 }
 
 /// `POST /v1/bamboo/settings/nodes/{id}/deploy` — deploy a worker for the node.
@@ -830,28 +873,46 @@ pub async fn node_deploy(
     query: web::Query<DeployQuery>,
 ) -> Result<HttpResponse, AppError> {
     let id = path.into_inner();
-    let state = deploy::deploy_node(&app_state, &id, query.echo).await?;
-    Ok(HttpResponse::Ok().json(json!({ "id": id, "state": state })))
+    let result = deploy::deploy_node(&app_state, &id, query.echo, query.expected_revision).await?;
+    let section = committed_cluster_section(result.snapshot)?;
+    Ok(HttpResponse::Ok().json(NodeStateMutationResponse {
+        id,
+        state: result.value,
+        section,
+    }))
 }
 
 /// `POST /v1/bamboo/settings/nodes/{id}/stop` — stop the node's worker.
 pub async fn node_stop(
     app_state: web::Data<AppState>,
     path: web::Path<String>,
+    query: web::Query<LifecycleQuery>,
 ) -> Result<HttpResponse, AppError> {
     let id = path.into_inner();
-    let state = deploy::stop_node(&app_state, &id).await?;
-    Ok(HttpResponse::Ok().json(json!({ "id": id, "state": state })))
+    let result = deploy::stop_node(&app_state, &id, query.expected_revision).await?;
+    let section = committed_cluster_section(result.snapshot)?;
+    Ok(HttpResponse::Ok().json(NodeStateMutationResponse {
+        id,
+        state: result.value,
+        section,
+    }))
 }
 
 /// `POST /v1/bamboo/settings/nodes/{id}/test` — connectivity preflight (no deploy).
 pub async fn node_test(
     app_state: web::Data<AppState>,
     path: web::Path<String>,
+    query: web::Query<LifecycleQuery>,
 ) -> Result<HttpResponse, AppError> {
     let id = path.into_inner();
-    let info = deploy::test_node(&app_state, &id).await?;
-    Ok(HttpResponse::Ok().json(json!({ "id": id, "ok": true, "preflight": info })))
+    let result = deploy::test_node(&app_state, &id, query.expected_revision).await?;
+    let section = committed_cluster_section(result.snapshot)?;
+    Ok(HttpResponse::Ok().json(NodeTestResponse {
+        id,
+        ok: true,
+        preflight: result.value,
+        section,
+    }))
 }
 
 /// Query params for `node_logs`.
@@ -1050,6 +1111,71 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn delayed_mutation_response_stays_bound_to_its_own_commit_snapshot() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x73; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        let first = state
+            .update_cluster_fabric_credentials(
+                0,
+                BTreeMap::from([(
+                    "race-node".to_string(),
+                    ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                |config| {
+                    config.cluster_fabric.nodes.push(Node {
+                        id: "race-node".to_string(),
+                        label: "first-commit".to_string(),
+                        placement: NodePlacement::Local,
+                        trust_level: TrustLevel::Trusted,
+                        deploy: DeployProfile::default(),
+                        state: None,
+                        enabled: true,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        state
+            .update_cluster_fabric_credentials(
+                1,
+                BTreeMap::from([(
+                    "race-node".to_string(),
+                    ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                |config| {
+                    config.cluster_fabric.node_mut("race-node").unwrap().label =
+                        "second-commit".to_string();
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+
+        let response =
+            cluster_mutation_response(StatusCode::OK, Some("race-node".to_string()), first)
+                .unwrap();
+        let body = actix_web::body::to_bytes(response.into_body())
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["revision"], 1);
+        assert_eq!(body["data"]["nodes"][0]["label"], "first-commit");
+        assert_eq!(
+            state
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node("race-node")
+                .unwrap()
+                .label,
+            "second-commit"
+        );
+    }
+
+    #[actix_web::test]
     async fn node_api_returns_one_redacted_section_revision_and_canonical_conflicts() {
         let _key = bamboo_config::encryption::set_test_encryption_key([0x72; 32]);
         let dir = tempfile::tempdir().unwrap();
@@ -1059,6 +1185,7 @@ mod tests {
                 .app_data(state.clone())
                 .route("/nodes", web::post().to(create_node))
                 .route("/nodes/{id}", web::put().to(update_node))
+                .route("/nodes/{id}/stop", web::post().to(node_stop))
                 .route("/clusters", web::post().to(create_cluster))
                 .route("/clusters/{name}", web::put().to(update_cluster))
                 .route("/clusters/{name}", web::delete().to(delete_cluster)),
@@ -1313,5 +1440,32 @@ mod tests {
             .unwrap()
             .iter()
             .any(|cluster| cluster["name"] == "crud-cluster"));
+
+        let stale_stop = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&format!("/nodes/{node_id}/stop?expected_revision=4"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale_stop.status(), StatusCode::CONFLICT);
+
+        let stopped = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&format!("/nodes/{node_id}/stop?expected_revision=5"))
+                .to_request(),
+        )
+        .await;
+        let stopped_status = stopped.status();
+        let stopped_body = String::from_utf8(test::read_body(stopped).await.to_vec()).unwrap();
+        assert_eq!(stopped_status, StatusCode::OK, "{stopped_body}");
+        assert!(!stopped_body.contains(create_secret));
+        assert!(!stopped_body.contains("credential_ref"));
+        assert!(!stopped_body.contains("****"));
+        let stopped: Value = serde_json::from_str(&stopped_body).unwrap();
+        assert_eq!(stopped["revision"], 6);
+        assert_eq!(stopped["state"]["status"], "stopped");
+        assert_eq!(stopped["data"]["nodes"][0]["state"]["status"], "stopped");
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/mod.rs
@@ -717,8 +717,9 @@ pub async fn delete_node(
     let id_for_update = id.clone();
 
     let snapshot = app_state
-        .update_cluster_fabric_credentials(
+        .delete_cluster_node_credentials(
             expected_revision,
+            id.clone(),
             BTreeMap::from([(id.clone(), ClusterNodeCredentialIntents::clear_all())]),
             move |cfg| {
                 let before = cfg.cluster_fabric.nodes.len();
@@ -1302,6 +1303,29 @@ mod tests {
             "generation-one",
             "the read must not depend on or silently mutate the stale process runtime"
         );
+
+        let credentials_path = dir.path().join("credentials.json");
+        let credential_primary = std::fs::read(&credentials_path).unwrap();
+        let password_ref = bamboo_config::cluster_password_credential_ref("coherent-node").unwrap();
+        let mut corrupt_ciphertext: Value = serde_json::from_slice(&credential_primary).unwrap();
+        corrupt_ciphertext["data"]["entries"][password_ref.as_str()]["ciphertext"] =
+            Value::String("nonempty-but-undecryptable".to_string());
+        std::fs::write(
+            &credentials_path,
+            serde_json::to_vec_pretty(&corrupt_ciphertext).unwrap(),
+        )
+        .unwrap();
+        let corrupt_status = cluster_section_envelope(&state)
+            .await
+            .expect("GET must project corrupt ciphertext as status metadata");
+        assert_eq!(
+            corrupt_status.data["credential_status"]["coherent-node"]["password"]["state"],
+            "error"
+        );
+        assert!(!serde_json::to_string(&corrupt_status)
+            .unwrap()
+            .contains("generation-two-password"));
+        std::fs::write(&credentials_path, credential_primary).unwrap();
 
         let cluster_primary = std::fs::read(dir.path().join("cluster-fabric.json")).unwrap();
         std::fs::write(dir.path().join("cluster-fabric.json"), b"{invalid-primary").unwrap();

--- a/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/mod.rs
@@ -479,7 +479,9 @@ async fn cluster_section_envelope(
     })?
     .map_err(|error| match error {
         ConfigStoreError::Io(error) => AppError::StorageError(error),
-        ConfigStoreError::Json(_) | ConfigStoreError::Validation(_) => {
+        ConfigStoreError::Json(_)
+        | ConfigStoreError::Validation(_)
+        | ConfigStoreError::CommitIndeterminate(_) => {
             AppError::InternalError(anyhow::anyhow!("cluster section snapshot is unavailable"))
         }
         ConfigStoreError::Conflict { .. } => AppError::InternalError(anyhow::anyhow!(

--- a/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/mod.rs
@@ -482,7 +482,7 @@ fn cluster_section_envelope(app_state: &AppState) -> Result<SectionEnvelope<Valu
     project_cluster_section(fabric, envelope, statuses, store_healthy)
 }
 
-fn committed_cluster_section(
+pub(super) fn committed_cluster_section(
     snapshot: FabricCommitSnapshot,
 ) -> Result<SectionEnvelope<Value>, AppError> {
     let store_healthy = snapshot.credential_health.status != SectionStatus::Degraded;

--- a/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/mod.rs
@@ -6,23 +6,28 @@
 //! until the deploy engine lands in P2; `status` returns the persisted state
 //! (no live SSH probe yet).
 //!
-//! Secrets (SSH password / private key / passphrase) never leave the backend:
-//! responses are redacted ([`redact_node_value`]) and updates that re-send the
-//! mask sentinel preserve the stored ciphertext.
+//! Secrets (SSH password / private key / passphrase) never enter ordinary node
+//! payloads or responses. Dedicated request-only keep/replace/clear actions are
+//! committed with node and membership metadata under one section revision.
 
-use actix_web::{web, HttpResponse};
+use actix_web::{http::StatusCode, web, HttpResponse};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::{BTreeMap, BTreeSet};
 use uuid::Uuid;
 
 use bamboo_config::cluster_fabric::{
-    Cluster, DeployProfile, Node, NodePlacement, SshAuth, TrustLevel,
+    Cluster, ClusterCredentialAction, ClusterFabricConfig, ClusterNodeCredentialIntents,
+    ClusterNodeCredentialRefs, DeployProfile, Node, NodePlacement, SshAuth, SshTarget, TrustLevel,
+};
+use bamboo_config::{
+    patch::is_masked_api_key, CredentialSource, CredentialStatus, SectionEnvelope, SectionId,
+    SectionStatus,
 };
 
-use crate::app_state::{AppState, ConfigUpdateEffects};
+use crate::app_state::AppState;
 use crate::error::AppError;
-
-use super::redaction::masked_secret_marker;
 
 mod deploy;
 
@@ -36,17 +41,74 @@ pub struct FabricListResponse {
 }
 
 /// Create/replace payload for a node. `id`/`state` are server-owned and ignored.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct NodeUpsertRequest {
     pub expected_revision: u64,
     pub label: String,
-    pub placement: NodePlacement,
+    pub placement: NodePlacementRequest,
     #[serde(default)]
     pub trust_level: TrustLevel,
     #[serde(default)]
     pub deploy: DeployProfile,
     #[serde(default = "default_true")]
     pub enabled: bool,
+    pub credential_changes: NodeCredentialChangesRequest,
+    #[serde(default)]
+    pub membership: Option<NodeMembershipRequest>,
+}
+
+/// Secret-free operator placement. SSH credential material is accepted only
+/// through `credential_changes`, never through the ordinary node document.
+#[derive(Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum NodePlacementRequest {
+    Local,
+    Ssh {
+        host: String,
+        #[serde(default = "default_ssh_port")]
+        port: u16,
+        username: String,
+        auth: SshAuthRequest,
+        #[serde(default)]
+        host_key_fingerprint: Option<String>,
+    },
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(tag = "method", rename_all = "snake_case", deny_unknown_fields)]
+pub enum SshAuthRequest {
+    SystemSshConfig {},
+    Password {},
+    PrivateKey {
+        #[serde(default)]
+        private_key_path: Option<String>,
+    },
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+pub enum CredentialActionRequest {
+    Keep,
+    Replace { value: String },
+    Clear,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeCredentialChangesRequest {
+    pub password: CredentialActionRequest,
+    pub private_key: CredentialActionRequest,
+    pub passphrase: CredentialActionRequest,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeMembershipRequest {
+    /// Replace the node's complete cluster membership with these existing
+    /// or newly-created cluster names as part of the same node transaction.
+    #[serde(default)]
+    pub cluster_names: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -59,9 +121,15 @@ fn default_true() -> bool {
     true
 }
 
+fn default_ssh_port() -> u16 {
+    22
+}
+
 /// Create/replace payload for a cluster.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ClusterUpsertRequest {
+    pub expected_revision: u64,
     pub name: String,
     #[serde(default)]
     pub description: Option<String>,
@@ -75,171 +143,400 @@ fn validate_node(req: &NodeUpsertRequest) -> Result<(), AppError> {
     if req.label.trim().is_empty() {
         return Err(AppError::BadRequest("Node label is required".into()));
     }
-    if let NodePlacement::Ssh(target) = &req.placement {
-        if target.host.trim().is_empty() {
+    if let NodePlacementRequest::Ssh {
+        host,
+        port,
+        username,
+        ..
+    } = &req.placement
+    {
+        if host.trim().is_empty() {
             return Err(AppError::BadRequest("SSH host is required".into()));
         }
-        if target.username.trim().is_empty() {
+        if username.trim().is_empty() {
             return Err(AppError::BadRequest("SSH username is required".into()));
         }
-        if target.port == 0 {
+        if *port == 0 {
             return Err(AppError::BadRequest("SSH port must be non-zero".into()));
         }
-        let carries_ciphertext = match &target.auth {
-            SshAuth::SystemSshConfig => false,
-            SshAuth::Password {
-                password_encrypted, ..
-            } => password_encrypted.is_some(),
-            SshAuth::PrivateKey {
-                private_key_encrypted,
-                passphrase_encrypted,
-                ..
-            } => private_key_encrypted.is_some() || passphrase_encrypted.is_some(),
-        };
-        if carries_ciphertext {
-            return Err(AppError::BadRequest(
-                "SSH credential ciphertext is server-managed".into(),
-            ));
+    }
+    validate_credential_actions(&req.placement, &req.credential_changes)?;
+    Ok(())
+}
+
+fn validate_credential_actions(
+    placement: &NodePlacementRequest,
+    changes: &NodeCredentialChangesRequest,
+) -> Result<(), AppError> {
+    for action in [&changes.password, &changes.private_key, &changes.passphrase] {
+        if let CredentialActionRequest::Replace { value } = action {
+            if value.is_empty() || is_masked_api_key(value) {
+                return Err(AppError::BadRequest(
+                    "credential replacements must be nonempty and must not use a mask sentinel"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+    let is_clear =
+        |action: &CredentialActionRequest| matches!(action, CredentialActionRequest::Clear);
+    match placement {
+        NodePlacementRequest::Local
+        | NodePlacementRequest::Ssh {
+            auth: SshAuthRequest::SystemSshConfig {},
+            ..
+        } => {
+            if !is_clear(&changes.password)
+                || !is_clear(&changes.private_key)
+                || !is_clear(&changes.passphrase)
+            {
+                return Err(AppError::BadRequest(
+                    "this placement requires clearing all stored SSH credentials".to_string(),
+                ));
+            }
+        }
+        NodePlacementRequest::Ssh {
+            auth: SshAuthRequest::Password {},
+            ..
+        } => {
+            if is_clear(&changes.password) {
+                return Err(AppError::BadRequest(
+                    "password authentication requires keep or replace".to_string(),
+                ));
+            }
+            if !is_clear(&changes.private_key) || !is_clear(&changes.passphrase) {
+                return Err(AppError::BadRequest(
+                    "password authentication requires clearing private-key credentials".to_string(),
+                ));
+            }
+        }
+        NodePlacementRequest::Ssh {
+            auth: SshAuthRequest::PrivateKey { private_key_path },
+            ..
+        } => {
+            if !is_clear(&changes.password) {
+                return Err(AppError::BadRequest(
+                    "private-key authentication requires clearing the password credential"
+                        .to_string(),
+                ));
+            }
+            let uses_path = private_key_path
+                .as_deref()
+                .is_some_and(|path| !path.trim().is_empty());
+            if uses_path && !is_clear(&changes.private_key) {
+                return Err(AppError::BadRequest(
+                    "private-key-path authentication requires clearing the inline private key"
+                        .to_string(),
+                ));
+            }
+            if !uses_path && is_clear(&changes.private_key) {
+                return Err(AppError::BadRequest(
+                    "private-key authentication requires an inline key or key path".to_string(),
+                ));
+            }
         }
     }
     Ok(())
 }
 
-// ─── Secret redaction & preservation ───────────────────────────────────
+impl NodePlacementRequest {
+    fn into_domain(self) -> NodePlacement {
+        match self {
+            Self::Local => NodePlacement::Local,
+            Self::Ssh {
+                host,
+                port,
+                username,
+                auth,
+                host_key_fingerprint,
+            } => NodePlacement::Ssh(SshTarget {
+                host,
+                port,
+                username,
+                auth: match auth {
+                    SshAuthRequest::SystemSshConfig {} => SshAuth::SystemSshConfig,
+                    SshAuthRequest::Password {} => SshAuth::Password {
+                        password: String::new(),
+                        password_encrypted: None,
+                    },
+                    SshAuthRequest::PrivateKey { private_key_path } => SshAuth::PrivateKey {
+                        private_key: String::new(),
+                        private_key_encrypted: None,
+                        private_key_path: private_key_path.filter(|path| !path.trim().is_empty()),
+                        passphrase: String::new(),
+                        passphrase_encrypted: None,
+                    },
+                },
+                host_key_fingerprint,
+            }),
+        }
+    }
+}
 
-/// Serialize a node to JSON with all SSH secret material masked / stripped.
-fn redact_node_value(node: &Node) -> Value {
+impl CredentialActionRequest {
+    fn into_domain(self) -> ClusterCredentialAction {
+        match self {
+            Self::Keep => ClusterCredentialAction::Keep,
+            Self::Replace { value } => ClusterCredentialAction::Replace(value),
+            Self::Clear => ClusterCredentialAction::Clear,
+        }
+    }
+}
+
+impl NodeCredentialChangesRequest {
+    fn into_domain(self) -> ClusterNodeCredentialIntents {
+        ClusterNodeCredentialIntents {
+            password: self.password.into_domain(),
+            private_key: self.private_key.into_domain(),
+            passphrase: self.passphrase.into_domain(),
+        }
+    }
+}
+
+// ─── Secret-free section projection ────────────────────────────────────
+
+/// Serialize a node without any secret fields, ciphertext, or mask sentinel.
+fn secret_free_node_value(node: &Node) -> Value {
     let mut value = serde_json::to_value(node).unwrap_or(Value::Null);
     if let Some(auth) = value
         .get_mut("placement")
         .and_then(|p| p.get_mut("auth"))
         .and_then(|a| a.as_object_mut())
     {
-        for field in ["password", "private_key", "passphrase"] {
-            if auth.get(field).and_then(|v| v.as_str()).is_some() {
-                auth.insert(field.to_string(), Value::String(masked_secret_marker()));
-            }
-            // Never expose ciphertext over the API.
-            auth.remove(&format!("{field}_encrypted"));
+        for field in [
+            "password",
+            "password_encrypted",
+            "private_key",
+            "private_key_encrypted",
+            "passphrase",
+            "passphrase_encrypted",
+        ] {
+            auth.remove(field);
         }
     }
     value
 }
 
-/// Carry forward the existing secret when an update re-sends the mask sentinel
-/// (or an empty secret) on the SAME auth variant. Changing the auth method
-/// discards the old secret (a fresh one is required).
-///
-/// The `existing` node here is the in-memory config node, whose secrets are
-/// hydrated to PLAINTEXT (its `*_encrypted` are `None` — ciphertext is only
-/// materialized on the disk-bound clone). So the source of truth to carry is the
-/// old plaintext; `refresh_cluster_fabric_encrypted` re-encrypts it on save.
-#[cfg(test)]
-fn preserve_node_secrets(existing: &Node, incoming: &mut Node) {
-    let (NodePlacement::Ssh(old), NodePlacement::Ssh(new)) =
-        (&existing.placement, &mut incoming.placement)
-    else {
-        return;
-    };
-    match (&old.auth, &mut new.auth) {
-        (
-            SshAuth::Password {
-                password: old_pw,
-                password_encrypted: old_enc,
-            },
-            SshAuth::Password {
-                password,
-                password_encrypted,
-            },
-        ) => {
-            preserve_secret(password, password_encrypted, old_pw, old_enc);
-        }
-        (
-            SshAuth::PrivateKey {
-                private_key: old_pk,
-                private_key_encrypted: old_pk_enc,
-                passphrase: old_pp,
-                passphrase_encrypted: old_pp_enc,
-                ..
-            },
-            SshAuth::PrivateKey {
-                private_key,
-                private_key_encrypted,
-                passphrase,
-                passphrase_encrypted,
-                ..
-            },
-        ) => {
-            preserve_secret(private_key, private_key_encrypted, old_pk, old_pk_enc);
-            preserve_secret(passphrase, passphrase_encrypted, old_pp, old_pp_enc);
-        }
-        _ => {}
-    }
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ClusterCredentialState {
+    Configured,
+    FromEnv,
+    Missing,
+    Error,
 }
 
-/// Until node CRUD is backed by the exact credential/config transaction, a
-/// node that already owns isolated refs may only receive metadata edits and a
-/// redacted keep round-trip. Accepting a real replacement, auth switch, or
-/// delete here would return success while leaving the old store value behind.
-#[cfg(test)]
-fn ensure_managed_node_secret_unchanged(
-    existing: &Node,
-    incoming: &NodePlacement,
-) -> Result<(), AppError> {
-    let unchanged = match (&existing.placement, incoming) {
-        (NodePlacement::Ssh(old), NodePlacement::Ssh(new)) => match (&old.auth, &new.auth) {
-            (SshAuth::SystemSshConfig, SshAuth::SystemSshConfig) => true,
-            (SshAuth::Password { .. }, SshAuth::Password { password, .. }) => {
-                password.trim().is_empty() || password == &masked_secret_marker()
-            }
-            (
-                SshAuth::PrivateKey { .. },
-                SshAuth::PrivateKey {
-                    private_key,
-                    passphrase,
-                    ..
-                },
-            ) => {
-                (private_key.trim().is_empty() || private_key == &masked_secret_marker())
-                    && (passphrase.trim().is_empty() || passphrase == &masked_secret_marker())
-            }
-            _ => false,
+#[derive(Serialize)]
+struct ClusterCredentialFieldStatus {
+    state: ClusterCredentialState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<CredentialSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    updated_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Serialize)]
+struct ClusterNodeCredentialStatusView {
+    password: ClusterCredentialFieldStatus,
+    private_key: ClusterCredentialFieldStatus,
+    passphrase: ClusterCredentialFieldStatus,
+}
+
+fn credential_field_status(
+    configured: bool,
+    reference: Option<&bamboo_config::CredentialRef>,
+    statuses: &BTreeMap<String, CredentialStatus>,
+    store_healthy: bool,
+) -> ClusterCredentialFieldStatus {
+    if !configured {
+        return ClusterCredentialFieldStatus {
+            state: ClusterCredentialState::Missing,
+            source: None,
+            updated_at: None,
+        };
+    }
+    if !store_healthy {
+        return ClusterCredentialFieldStatus {
+            state: ClusterCredentialState::Error,
+            source: None,
+            updated_at: None,
+        };
+    }
+    let Some(status) = reference.and_then(|reference| statuses.get(reference.as_str())) else {
+        return ClusterCredentialFieldStatus {
+            state: ClusterCredentialState::Error,
+            source: None,
+            updated_at: None,
+        };
+    };
+    if !status.configured {
+        return ClusterCredentialFieldStatus {
+            state: ClusterCredentialState::Error,
+            source: Some(status.source),
+            updated_at: status.updated_at,
+        };
+    }
+    ClusterCredentialFieldStatus {
+        state: if status.source == CredentialSource::Environment {
+            ClusterCredentialState::FromEnv
+        } else {
+            ClusterCredentialState::Configured
         },
-        (NodePlacement::Local, NodePlacement::Local) => true,
-        _ => false,
-    };
-    if unchanged {
-        Ok(())
-    } else {
-        Err(AppError::BadRequest(
-            "isolated cluster credentials cannot be changed until the revisioned node credential API is available"
-                .to_string(),
-        ))
+        source: Some(status.source),
+        updated_at: status.updated_at,
     }
 }
 
-/// If `plaintext` is empty or the mask sentinel, replace it with the existing
-/// secret so it survives a redacted round-trip: prefer the old plaintext (what
-/// the hydrated in-memory config holds), else the old ciphertext.
-#[cfg(test)]
-fn preserve_secret(
-    plaintext: &mut String,
-    encrypted: &mut Option<String>,
-    old_plaintext: &str,
-    old_encrypted: &Option<String>,
-) {
-    let keep = plaintext.trim().is_empty() || plaintext == &masked_secret_marker();
-    if !keep {
-        return;
+fn node_credential_status(
+    metadata: Option<&ClusterNodeCredentialRefs>,
+    statuses: &BTreeMap<String, CredentialStatus>,
+    store_healthy: bool,
+) -> ClusterNodeCredentialStatusView {
+    let metadata = metadata.cloned().unwrap_or_default();
+    ClusterNodeCredentialStatusView {
+        password: credential_field_status(
+            metadata.password_configured,
+            metadata.password_credential_ref.as_ref(),
+            statuses,
+            store_healthy,
+        ),
+        private_key: credential_field_status(
+            metadata.private_key_configured,
+            metadata.private_key_credential_ref.as_ref(),
+            statuses,
+            store_healthy,
+        ),
+        passphrase: credential_field_status(
+            metadata.passphrase_configured,
+            metadata.passphrase_credential_ref.as_ref(),
+            statuses,
+            store_healthy,
+        ),
     }
-    plaintext.clear();
-    if !old_plaintext.trim().is_empty() {
-        // Hydrated in-memory case: carry plaintext; refresh re-encrypts on save.
-        *plaintext = old_plaintext.to_string();
-    } else if encrypted.is_none() {
-        // Loaded-but-unhydrated case: carry the stored ciphertext as-is.
-        *encrypted = old_encrypted.clone();
+}
+
+fn cluster_section_envelope(app_state: &AppState) -> Result<SectionEnvelope<Value>, AppError> {
+    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
+        AppError::BadRequest(
+            "cluster settings require the modular configuration facade".to_string(),
+        )
+    })?;
+    let snapshot = facade.registry().cluster_fabric.snapshot();
+    let fabric = snapshot.data.0.clone();
+    let (statuses, store_healthy) = match app_state.credential_store.statuses_with_health() {
+        Ok((statuses, health)) => (
+            statuses
+                .into_iter()
+                .map(|status| (status.credential_ref.as_str().to_string(), status))
+                .collect::<BTreeMap<_, _>>(),
+            health.status != SectionStatus::Degraded,
+        ),
+        Err(_) => (BTreeMap::new(), false),
+    };
+    let mut credential_status = BTreeMap::new();
+    for node in &fabric.nodes {
+        credential_status.insert(
+            node.id.clone(),
+            node_credential_status(
+                fabric.credential_refs.get(&node.id),
+                &statuses,
+                store_healthy,
+            ),
+        );
     }
+    let mut data = serde_json::to_value(&fabric)
+        .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
+    let object = data.as_object_mut().ok_or_else(|| {
+        AppError::InternalError(anyhow::anyhow!(
+            "cluster section projection is not an object"
+        ))
+    })?;
+    object.remove("credential_refs");
+    object.insert(
+        "nodes".to_string(),
+        Value::Array(fabric.nodes.iter().map(secret_free_node_value).collect()),
+    );
+    object.insert(
+        "credential_status".to_string(),
+        serde_json::to_value(credential_status)
+            .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?,
+    );
+    let mut envelope = facade
+        .registry()
+        .envelope_value(SectionId::ClusterFabric)
+        .map_err(|_| {
+            AppError::InternalError(anyhow::anyhow!("cluster section envelope is unavailable"))
+        })?;
+    envelope.data = data;
+    if envelope.last_error.is_some() {
+        envelope.last_error = Some("cluster configuration is unavailable".to_string());
+    }
+    Ok(envelope)
+}
+
+pub(super) async fn get_cluster_section(
+    app_state: web::Data<AppState>,
+) -> Result<HttpResponse, AppError> {
+    let _io = app_state.config_io_lock.lock().await;
+    Ok(HttpResponse::Ok().json(cluster_section_envelope(&app_state)?))
+}
+
+fn replace_node_membership(
+    fabric: &mut ClusterFabricConfig,
+    node_id: &str,
+    membership: Option<&NodeMembershipRequest>,
+) -> Result<(), AppError> {
+    let Some(membership) = membership else {
+        return Ok(());
+    };
+    let mut names = BTreeSet::new();
+    for name in &membership.cluster_names {
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(AppError::BadRequest(
+                "Cluster membership names must be nonempty".to_string(),
+            ));
+        }
+        if !names.insert(name.to_string()) {
+            return Err(AppError::BadRequest(
+                "Cluster membership names must be unique".to_string(),
+            ));
+        }
+    }
+    for name in &names {
+        if fabric.cluster(name).is_none() {
+            fabric.clusters.push(Cluster {
+                name: name.clone(),
+                description: None,
+                node_ids: Vec::new(),
+            });
+        }
+    }
+    for cluster in &mut fabric.clusters {
+        cluster.node_ids.retain(|member| member != node_id);
+        if names.contains(&cluster.name) {
+            cluster.node_ids.push(node_id.to_string());
+        }
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct ClusterMutationResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    node_id: Option<String>,
+    #[serde(flatten)]
+    section: SectionEnvelope<Value>,
+}
+
+async fn cluster_mutation_response(
+    app_state: web::Data<AppState>,
+    status: StatusCode,
+    node_id: Option<String>,
+) -> Result<HttpResponse, AppError> {
+    let _io = app_state.config_io_lock.lock().await;
+    let section = cluster_section_envelope(&app_state)?;
+    Ok(HttpResponse::build(status).json(ClusterMutationResponse { node_id, section }))
 }
 
 // ─── Node handlers ─────────────────────────────────────────────────────
@@ -251,7 +548,7 @@ pub async fn list_nodes(app_state: web::Data<AppState>) -> Result<HttpResponse, 
         .cluster_fabric
         .nodes
         .iter()
-        .map(redact_node_value)
+        .map(secret_free_node_value)
         .collect();
     Ok(HttpResponse::Ok().json(FabricListResponse {
         nodes,
@@ -270,7 +567,7 @@ pub async fn get_node(
         .cluster_fabric
         .node(&id)
         .ok_or_else(|| AppError::NotFound(format!("Node '{id}'")))?;
-    Ok(HttpResponse::Ok().json(redact_node_value(node)))
+    Ok(HttpResponse::Ok().json(secret_free_node_value(node)))
 }
 
 /// `POST /v1/bamboo/settings/nodes` — create a node.
@@ -280,41 +577,43 @@ pub async fn create_node(
 ) -> Result<HttpResponse, AppError> {
     let req = payload.into_inner();
     validate_node(&req)?;
-
-    let expected_revision = req.expected_revision;
+    let NodeUpsertRequest {
+        expected_revision,
+        label,
+        placement,
+        trust_level,
+        deploy,
+        enabled,
+        credential_changes,
+        membership,
+    } = req;
 
     let node = Node {
         id: Uuid::new_v4().to_string(),
-        label: req.label,
-        placement: req.placement,
-        trust_level: req.trust_level,
-        deploy: req.deploy,
+        label,
+        placement: placement.into_domain(),
+        trust_level,
+        deploy,
         state: None,
-        enabled: req.enabled,
+        enabled,
     };
     let node_id = node.id.clone();
+    let node_id_for_update = node_id.clone();
+    let node_intents = BTreeMap::from([(node_id.clone(), credential_changes.into_domain())]);
 
-    let updated = app_state
-        .update_cluster_fabric_credentials(
-            expected_revision,
-            std::iter::once(node_id.clone()).collect(),
-            move |cfg| {
-                cfg.cluster_fabric.nodes.push(node.clone());
-                Ok(())
-            },
-        )
+    app_state
+        .update_cluster_fabric_credentials(expected_revision, node_intents, move |cfg| {
+            cfg.cluster_fabric.nodes.push(node.clone());
+            replace_node_membership(
+                &mut cfg.cluster_fabric,
+                &node_id_for_update,
+                membership.as_ref(),
+            )?;
+            Ok(())
+        })
         .await?;
 
-    let (updated, revision) = updated;
-
-    let created = updated
-        .cluster_fabric
-        .node(&node_id)
-        .ok_or_else(|| AppError::InternalError(anyhow::anyhow!("created node missing")))?;
-    Ok(HttpResponse::Created().json(json!({
-        "revision": revision,
-        "node": redact_node_value(created),
-    })))
+    cluster_mutation_response(app_state, StatusCode::CREATED, Some(node_id)).await
 }
 
 /// `PUT /v1/bamboo/settings/nodes/{id}` — update a node (secret-preserving).
@@ -326,49 +625,48 @@ pub async fn update_node(
     let id = path.into_inner();
     let req = payload.into_inner();
     validate_node(&req)?;
-    let expected_revision = req.expected_revision;
+    let NodeUpsertRequest {
+        expected_revision,
+        label,
+        placement,
+        trust_level,
+        deploy,
+        enabled,
+        credential_changes,
+        membership,
+    } = req;
     let id_for_response = id.clone();
+    let placement = placement.into_domain();
+    let node_intents = BTreeMap::from([(id.clone(), credential_changes.into_domain())]);
 
-    let updated = app_state
-        .update_cluster_fabric_credentials(
-            expected_revision,
-            std::iter::once(id.clone()).collect(),
-            move |cfg| {
-                let existing = cfg
-                    .cluster_fabric
-                    .node(&id)
-                    .cloned()
-                    .ok_or_else(|| AppError::NotFound(format!("Node '{id}'")))?;
-                let node = Node {
-                    id: existing.id.clone(),
-                    label: req.label.clone(),
-                    placement: req.placement.clone(),
-                    trust_level: req.trust_level,
-                    deploy: req.deploy.clone(),
-                    state: existing.state.clone(), // engine-owned: preserve
-                    enabled: req.enabled,
-                };
+    app_state
+        .update_cluster_fabric_credentials(expected_revision, node_intents, move |cfg| {
+            let existing = cfg
+                .cluster_fabric
+                .node(&id)
+                .cloned()
+                .ok_or_else(|| AppError::NotFound(format!("Node '{id}'")))?;
+            let node = Node {
+                id: existing.id.clone(),
+                label: label.clone(),
+                placement: placement.clone(),
+                trust_level,
+                deploy: deploy.clone(),
+                state: existing.state.clone(), // engine-owned: preserve
+                enabled,
+            };
 
-                let slot = cfg
-                    .cluster_fabric
-                    .node_mut(&id)
-                    .expect("node existed above");
-                *slot = node;
-                Ok(())
-            },
-        )
+            let slot = cfg
+                .cluster_fabric
+                .node_mut(&id)
+                .expect("node existed above");
+            *slot = node;
+            replace_node_membership(&mut cfg.cluster_fabric, &id, membership.as_ref())?;
+            Ok(())
+        })
         .await?;
 
-    let (updated, revision) = updated;
-
-    let node = updated
-        .cluster_fabric
-        .node(&id_for_response)
-        .ok_or_else(|| AppError::InternalError(anyhow::anyhow!("updated node missing")))?;
-    Ok(HttpResponse::Ok().json(json!({
-        "revision": revision,
-        "node": redact_node_value(node),
-    })))
+    cluster_mutation_response(app_state, StatusCode::OK, Some(id_for_response)).await
 }
 
 /// `DELETE /v1/bamboo/settings/nodes/{id}` — remove a node.
@@ -379,28 +677,29 @@ pub async fn delete_node(
 ) -> Result<HttpResponse, AppError> {
     let id = path.into_inner();
     let expected_revision = query.expected_revision;
+    let id_for_update = id.clone();
 
-    let (_, revision) = app_state
+    app_state
         .update_cluster_fabric_credentials(
             expected_revision,
-            std::iter::once(id.clone()).collect(),
+            BTreeMap::from([(id.clone(), ClusterNodeCredentialIntents::clear_all())]),
             move |cfg| {
                 let before = cfg.cluster_fabric.nodes.len();
-                cfg.cluster_fabric.nodes.retain(|n| n.id != id);
+                cfg.cluster_fabric.nodes.retain(|n| n.id != id_for_update);
                 if cfg.cluster_fabric.nodes.len() == before {
-                    return Err(AppError::NotFound(format!("Node '{id}'")));
+                    return Err(AppError::NotFound(format!("Node '{id_for_update}'")));
                 }
                 // Drop the node from any cluster membership too.
                 for cluster in &mut cfg.cluster_fabric.clusters {
-                    cluster.node_ids.retain(|nid| nid != &id);
+                    cluster.node_ids.retain(|nid| nid != &id_for_update);
                 }
-                cfg.cluster_fabric.credential_refs.remove(&id);
+                cfg.cluster_fabric.credential_refs.remove(&id_for_update);
                 Ok(())
             },
         )
         .await?;
 
-    Ok(HttpResponse::Ok().json(json!({ "success": true, "revision": revision })))
+    cluster_mutation_response(app_state, StatusCode::OK, Some(id)).await
 }
 
 // ─── Cluster handlers ──────────────────────────────────────────────────
@@ -414,28 +713,26 @@ pub async fn create_cluster(
     if req.name.trim().is_empty() {
         return Err(AppError::BadRequest("Cluster name is required".into()));
     }
+    let expected_revision = req.expected_revision;
 
-    let updated = app_state
-        .update_config(
-            move |cfg| {
-                if cfg.cluster_fabric.cluster(&req.name).is_some() {
-                    return Err(AppError::BadRequest(format!(
-                        "Cluster '{}' already exists",
-                        req.name
-                    )));
-                }
-                cfg.cluster_fabric.clusters.push(Cluster {
-                    name: req.name.clone(),
-                    description: req.description.clone(),
-                    node_ids: req.node_ids.clone(),
-                });
-                Ok(())
-            },
-            ConfigUpdateEffects::default(),
-        )
+    app_state
+        .update_cluster_fabric_credentials(expected_revision, BTreeMap::new(), move |cfg| {
+            if cfg.cluster_fabric.cluster(&req.name).is_some() {
+                return Err(AppError::BadRequest(format!(
+                    "Cluster '{}' already exists",
+                    req.name
+                )));
+            }
+            cfg.cluster_fabric.clusters.push(Cluster {
+                name: req.name.clone(),
+                description: req.description.clone(),
+                node_ids: req.node_ids.clone(),
+            });
+            Ok(())
+        })
         .await?;
 
-    Ok(HttpResponse::Created().json(json!({ "clusters": updated.cluster_fabric.clusters })))
+    cluster_mutation_response(app_state, StatusCode::CREATED, None).await
 }
 
 /// `PUT /v1/bamboo/settings/clusters/{name}` — update a cluster.
@@ -446,53 +743,56 @@ pub async fn update_cluster(
 ) -> Result<HttpResponse, AppError> {
     let name = path.into_inner();
     let req = payload.into_inner();
+    if req.name.trim().is_empty() {
+        return Err(AppError::BadRequest("Cluster name is required".into()));
+    }
+    let expected_revision = req.expected_revision;
 
-    let updated = app_state
-        .update_config(
-            move |cfg| {
-                let cluster = cfg
-                    .cluster_fabric
-                    .clusters
-                    .iter_mut()
-                    .find(|c| c.name == name)
-                    .ok_or_else(|| AppError::NotFound(format!("Cluster '{name}'")))?;
-                cluster.description = req.description.clone();
-                cluster.node_ids = req.node_ids.clone();
-                // Allow rename via the body.
-                if !req.name.trim().is_empty() {
-                    cluster.name = req.name.clone();
-                }
-                Ok(())
-            },
-            ConfigUpdateEffects::default(),
-        )
+    app_state
+        .update_cluster_fabric_credentials(expected_revision, BTreeMap::new(), move |cfg| {
+            if req.name != name && cfg.cluster_fabric.cluster(&req.name).is_some() {
+                return Err(AppError::BadRequest(format!(
+                    "Cluster '{}' already exists",
+                    req.name
+                )));
+            }
+            let cluster = cfg
+                .cluster_fabric
+                .clusters
+                .iter_mut()
+                .find(|c| c.name == name)
+                .ok_or_else(|| AppError::NotFound(format!("Cluster '{name}'")))?;
+            cluster.description = req.description.clone();
+            cluster.node_ids = req.node_ids.clone();
+            cluster.name = req.name.clone();
+            Ok(())
+        })
         .await?;
 
-    Ok(HttpResponse::Ok().json(json!({ "clusters": updated.cluster_fabric.clusters })))
+    cluster_mutation_response(app_state, StatusCode::OK, None).await
 }
 
 /// `DELETE /v1/bamboo/settings/clusters/{name}` — remove a cluster (nodes kept).
 pub async fn delete_cluster(
     app_state: web::Data<AppState>,
     path: web::Path<String>,
+    query: web::Query<NodeDeleteQuery>,
 ) -> Result<HttpResponse, AppError> {
     let name = path.into_inner();
+    let expected_revision = query.expected_revision;
 
-    let updated = app_state
-        .update_config(
-            move |cfg| {
-                let before = cfg.cluster_fabric.clusters.len();
-                cfg.cluster_fabric.clusters.retain(|c| c.name != name);
-                if cfg.cluster_fabric.clusters.len() == before {
-                    return Err(AppError::NotFound(format!("Cluster '{name}'")));
-                }
-                Ok(())
-            },
-            ConfigUpdateEffects::default(),
-        )
+    app_state
+        .update_cluster_fabric_credentials(expected_revision, BTreeMap::new(), move |cfg| {
+            let before = cfg.cluster_fabric.clusters.len();
+            cfg.cluster_fabric.clusters.retain(|c| c.name != name);
+            if cfg.cluster_fabric.clusters.len() == before {
+                return Err(AppError::NotFound(format!("Cluster '{name}'")));
+            }
+            Ok(())
+        })
         .await?;
 
-    Ok(HttpResponse::Ok().json(json!({ "clusters": updated.cluster_fabric.clusters })))
+    cluster_mutation_response(app_state, StatusCode::OK, None).await
 }
 
 // ─── Lifecycle ─────────────────────────────────────────────────────────
@@ -581,7 +881,8 @@ pub async fn node_logs(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bamboo_config::cluster_fabric::SshTarget;
+    use actix_web::{test, App};
+    use bamboo_config::{credential_ref, CredentialRef};
 
     fn pw_node(password: &str, encrypted: Option<&str>) -> Node {
         Node {
@@ -604,158 +905,405 @@ mod tests {
         }
     }
 
-    #[test]
-    fn redaction_masks_password_and_strips_ciphertext() {
+    #[::core::prelude::v1::test]
+    fn public_node_projection_omits_plaintext_ciphertext_and_masks() {
         let node = pw_node("hunter2", Some("ciphertext"));
-        let v = redact_node_value(&node);
+        let v = secret_free_node_value(&node);
         let auth = &v["placement"]["auth"];
-        assert_eq!(auth["password"], masked_secret_marker());
+        assert!(auth.get("password").is_none());
         assert!(auth.get("password_encrypted").is_none());
+        let encoded = serde_json::to_string(&v).unwrap();
+        assert!(!encoded.contains("hunter2"));
+        assert!(!encoded.contains("ciphertext"));
+        assert!(!encoded.contains("****"));
     }
 
-    #[test]
-    fn redaction_omits_password_when_unset() {
-        // SystemSshConfig has no secret fields → nothing to mask.
-        let mut node = pw_node("", None);
-        node.placement = NodePlacement::Ssh(SshTarget {
-            host: "h".into(),
-            port: 22,
-            username: "u".into(),
-            auth: SshAuth::SystemSshConfig,
-            host_key_fingerprint: None,
+    #[::core::prelude::v1::test]
+    fn request_rejects_credentials_inside_placement() {
+        let request = serde_json::json!({
+            "expected_revision": 1,
+            "label": "node",
+            "placement": {
+                "type": "ssh",
+                "host": "example.test",
+                "username": "deploy",
+                "auth": {"method": "password", "password": "must-not-enter-placement"}
+            },
+            "credential_changes": {
+                "password": {"action": "replace", "value": "request-only-secret"},
+                "private_key": {"action": "clear"},
+                "passphrase": {"action": "clear"}
+            }
         });
-        let v = redact_node_value(&node);
-        assert_eq!(v["placement"]["auth"]["method"], "system_ssh_config");
+        let error = match serde_json::from_value::<NodeUpsertRequest>(request) {
+            Ok(_) => panic!("placement credential must be rejected"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("unknown field `password`"));
+        assert!(!error.to_string().contains("must-not-enter-placement"));
     }
 
-    #[test]
-    fn update_with_mask_preserves_existing_ciphertext() {
-        let existing = pw_node("", Some("stored-cipher"));
-        let mut incoming = pw_node(&masked_secret_marker(), None);
-        preserve_node_secrets(&existing, &mut incoming);
-        let NodePlacement::Ssh(t) = &incoming.placement else {
-            panic!()
-        };
-        let SshAuth::Password {
-            password,
-            password_encrypted,
-        } = &t.auth
-        else {
-            panic!()
-        };
-        assert!(password.is_empty(), "masked plaintext cleared");
-        assert_eq!(
-            password_encrypted.as_deref(),
-            Some("stored-cipher"),
-            "old ciphertext carried forward"
-        );
-    }
-
-    #[test]
-    fn update_with_mask_carries_hydrated_plaintext() {
-        // The realistic case: the in-memory existing node holds PLAINTEXT (it
-        // was hydrated on load); its ciphertext is None. A masked update must
-        // carry the plaintext forward so refresh can re-encrypt it on save.
-        let existing = pw_node("s3cr3t", None);
-        let mut incoming = pw_node(&masked_secret_marker(), None);
-        preserve_node_secrets(&existing, &mut incoming);
-        let NodePlacement::Ssh(t) = &incoming.placement else {
-            panic!()
-        };
-        let SshAuth::Password { password, .. } = &t.auth else {
-            panic!()
-        };
-        assert_eq!(password, "s3cr3t", "hydrated plaintext carried forward");
-    }
-
-    #[test]
-    fn update_with_new_secret_overrides() {
-        let existing = pw_node("", Some("old-cipher"));
-        let mut incoming = pw_node("brand-new-password", None);
-        preserve_node_secrets(&existing, &mut incoming);
-        let NodePlacement::Ssh(t) = &incoming.placement else {
-            panic!()
-        };
-        let SshAuth::Password {
-            password,
-            password_encrypted,
-        } = &t.auth
-        else {
-            panic!()
-        };
-        assert_eq!(password, "brand-new-password", "new plaintext kept");
-        assert!(
-            password_encrypted.is_none(),
-            "no carry-forward; refresh will encrypt the new plaintext"
-        );
-    }
-
-    #[test]
-    fn changing_auth_method_does_not_carry_secret() {
-        let existing = pw_node("", Some("old-cipher"));
-        let mut incoming = pw_node("", None);
-        incoming.placement = NodePlacement::Ssh(SshTarget {
-            host: "h".into(),
+    #[::core::prelude::v1::test]
+    fn password_request_accepts_explicit_keep_or_replace_only() {
+        let placement = NodePlacementRequest::Ssh {
+            host: "example.test".to_string(),
             port: 22,
-            username: "u".into(),
-            auth: SshAuth::SystemSshConfig,
+            username: "deploy".to_string(),
+            auth: SshAuthRequest::Password {},
             host_key_fingerprint: None,
-        });
-        // Should be a no-op (variant changed) — no panic, no carry.
-        preserve_node_secrets(&existing, &mut incoming);
-        let NodePlacement::Ssh(t) = &incoming.placement else {
-            panic!()
         };
-        assert!(matches!(t.auth, SshAuth::SystemSshConfig));
+        let valid = NodeCredentialChangesRequest {
+            password: CredentialActionRequest::Keep,
+            private_key: CredentialActionRequest::Clear,
+            passphrase: CredentialActionRequest::Clear,
+        };
+        validate_credential_actions(&placement, &valid).unwrap();
+
+        let cleared = NodeCredentialChangesRequest {
+            password: CredentialActionRequest::Clear,
+            private_key: CredentialActionRequest::Clear,
+            passphrase: CredentialActionRequest::Clear,
+        };
+        assert!(validate_credential_actions(&placement, &cleared).is_err());
     }
 
-    #[test]
-    fn isolated_password_update_accepts_only_redacted_keep() {
-        let stored_secret = Uuid::new_v4().to_string();
-        let existing = pw_node(&stored_secret, None);
-        let masked = pw_node(&masked_secret_marker(), None);
-        ensure_managed_node_secret_unchanged(&existing, &masked.placement).unwrap();
-        let empty_secret = String::new();
-        let empty = pw_node(&empty_secret, None);
-        ensure_managed_node_secret_unchanged(&existing, &empty.placement).unwrap();
-
-        let replacement_secret = Uuid::new_v4().to_string();
-        let replacement = pw_node(&replacement_secret, None);
-        let error =
-            ensure_managed_node_secret_unchanged(&existing, &replacement.placement).unwrap_err();
-        assert!(error.to_string().contains("cannot be changed"));
-    }
-
-    #[test]
-    fn isolated_password_update_rejects_auth_switch() {
-        let stored_secret = Uuid::new_v4().to_string();
-        let existing = pw_node(&stored_secret, None);
-        let switched = NodePlacement::Ssh(SshTarget {
-            host: "h".into(),
+    #[::core::prelude::v1::test]
+    fn credential_replacement_rejects_mask_sentinel() {
+        let placement = NodePlacementRequest::Ssh {
+            host: "example.test".to_string(),
             port: 22,
-            username: "u".into(),
-            auth: SshAuth::SystemSshConfig,
+            username: "deploy".to_string(),
+            auth: SshAuthRequest::Password {},
             host_key_fingerprint: None,
-        });
-        assert!(ensure_managed_node_secret_unchanged(&existing, &switched).is_err());
-    }
-
-    #[test]
-    fn node_validation_rejects_client_ciphertext() {
-        let client_ciphertext = Uuid::new_v4().to_string();
-        let empty_password = String::new();
-        let node = pw_node(&empty_password, Some(&client_ciphertext));
-        let request = NodeUpsertRequest {
-            expected_revision: 0,
-            label: node.label,
-            placement: node.placement,
-            trust_level: node.trust_level,
-            deploy: node.deploy,
-            enabled: node.enabled,
         };
-        assert!(validate_node(&request)
+        let invalid = NodeCredentialChangesRequest {
+            password: CredentialActionRequest::Replace {
+                value: "****...****".to_string(),
+            },
+            private_key: CredentialActionRequest::Clear,
+            passphrase: CredentialActionRequest::Clear,
+        };
+        assert!(validate_credential_actions(&placement, &invalid)
             .unwrap_err()
             .to_string()
-            .contains("server-managed"));
+            .contains("mask sentinel"));
+    }
+
+    #[::core::prelude::v1::test]
+    fn membership_replacement_creates_missing_cluster_in_candidate() {
+        let node = pw_node("", None);
+        let mut fabric = ClusterFabricConfig {
+            nodes: vec![node],
+            clusters: vec![Cluster {
+                name: "old".to_string(),
+                description: None,
+                node_ids: vec!["n1".to_string()],
+            }],
+            ..ClusterFabricConfig::default()
+        };
+        replace_node_membership(
+            &mut fabric,
+            "n1",
+            Some(&NodeMembershipRequest {
+                cluster_names: vec!["new".to_string()],
+            }),
+        )
+        .unwrap();
+        assert!(fabric.cluster("old").unwrap().node_ids.is_empty());
+        assert_eq!(fabric.cluster("new").unwrap().node_ids, ["n1"]);
+    }
+
+    #[::core::prelude::v1::test]
+    fn credential_status_distinguishes_configured_missing_and_error_without_refs() {
+        let reference: CredentialRef = credential_ref("cluster", "n1", "password").unwrap();
+        let metadata = ClusterNodeCredentialRefs {
+            password_credential_ref: Some(reference.clone()),
+            password_configured: true,
+            ..ClusterNodeCredentialRefs::default()
+        };
+        let status = CredentialStatus {
+            credential_ref: reference,
+            configured: true,
+            source: CredentialSource::User,
+            updated_at: None,
+        };
+        let statuses = BTreeMap::from([(status.credential_ref.as_str().to_string(), status)]);
+        let healthy = node_credential_status(Some(&metadata), &statuses, true);
+        let healthy_json = serde_json::to_value(healthy).unwrap();
+        assert_eq!(healthy_json["password"]["state"], "configured");
+        assert_eq!(healthy_json["private_key"]["state"], "missing");
+        assert!(!healthy_json.to_string().contains("cluster.n1.password"));
+
+        let error = node_credential_status(Some(&metadata), &statuses, false);
+        assert_eq!(
+            serde_json::to_value(error).unwrap()["password"]["state"],
+            "error"
+        );
+    }
+
+    #[actix_web::test]
+    async fn node_api_returns_one_redacted_section_revision_and_canonical_conflicts() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x72; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .route("/nodes", web::post().to(create_node))
+                .route("/nodes/{id}", web::put().to(update_node))
+                .route("/clusters", web::post().to(create_cluster))
+                .route("/clusters/{name}", web::put().to(update_cluster))
+                .route("/clusters/{name}", web::delete().to(delete_cluster)),
+        )
+        .await;
+        let create_secret = "create-request-only-secret";
+        let created = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/nodes")
+                .set_json(json!({
+                    "expected_revision": 0,
+                    "label": "node",
+                    "placement": {
+                        "type": "ssh",
+                        "host": "example.test",
+                        "username": "deploy",
+                        "auth": {"method": "password"}
+                    },
+                    "credential_changes": {
+                        "password": {"action": "replace", "value": create_secret},
+                        "private_key": {"action": "clear"},
+                        "passphrase": {"action": "clear"}
+                    },
+                    "membership": {"cluster_names": ["created-with-node"]}
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(created.status(), StatusCode::CREATED);
+        let created_body = String::from_utf8(test::read_body(created).await.to_vec()).unwrap();
+        assert!(!created_body.contains(create_secret));
+        assert!(!created_body.contains("****"));
+        assert!(!created_body.contains("credential_ref"));
+        let created: Value = serde_json::from_str(&created_body).unwrap();
+        assert_eq!(created["revision"], 1);
+        let node_id = created["node_id"].as_str().unwrap();
+        assert_eq!(
+            created["data"]["credential_status"][node_id]["password"]["state"],
+            "configured"
+        );
+        assert_eq!(created["data"]["clusters"][0]["node_ids"], json!([node_id]));
+        let auth = &created["data"]["nodes"][0]["placement"]["auth"];
+        assert_eq!(auth["method"], "password");
+        assert!(auth.get("password").is_none());
+
+        let unrelated = CredentialRef::parse("custom.unrelated.cluster_test").unwrap();
+        let credential_revision = state.credential_store.revision().unwrap();
+        state
+            .credential_store
+            .replace(
+                unrelated.clone(),
+                "unrelated-secret",
+                CredentialSource::User,
+                credential_revision,
+            )
+            .unwrap();
+        let updated = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri(&format!("/nodes/{node_id}"))
+                .set_json(json!({
+                    "expected_revision": 1,
+                    "label": "updated",
+                    "placement": {
+                        "type": "ssh",
+                        "host": "example.test",
+                        "username": "deploy",
+                        "auth": {"method": "password"}
+                    },
+                    "credential_changes": {
+                        "password": {"action": "keep"},
+                        "private_key": {"action": "clear"},
+                        "passphrase": {"action": "clear"}
+                    },
+                    "membership": {"cluster_names": ["created-with-node"]}
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            updated.status(),
+            StatusCode::OK,
+            "unrelated credential revision must not create a false 409"
+        );
+        let updated: Value = test::read_body_json(updated).await;
+        assert_eq!(updated["revision"], 2);
+        assert_eq!(updated["data"]["nodes"][0]["label"], "updated");
+        assert_eq!(
+            state
+                .credential_store
+                .resolve(&unrelated)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            "unrelated-secret"
+        );
+
+        let stale = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri(&format!("/nodes/{node_id}"))
+                .set_json(json!({
+                    "expected_revision": 1,
+                    "label": "stale",
+                    "placement": {
+                        "type": "ssh",
+                        "host": "example.test",
+                        "username": "deploy",
+                        "auth": {"method": "password"}
+                    },
+                    "credential_changes": {
+                        "password": {"action": "keep"},
+                        "private_key": {"action": "clear"},
+                        "passphrase": {"action": "clear"}
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale.status(), StatusCode::CONFLICT);
+        let stale: Value = test::read_body_json(stale).await;
+        assert_eq!(stale["error"]["code"], "config_revision_conflict");
+        assert!(stale["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("expected 1, actual 2"));
+        assert_eq!(
+            state
+                .config
+                .read()
+                .await
+                .cluster_fabric
+                .node(node_id)
+                .unwrap()
+                .label,
+            "updated"
+        );
+
+        let stale_create = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/clusters")
+                .set_json(json!({
+                    "expected_revision": 1,
+                    "name": "crud-cluster",
+                    "node_ids": [node_id]
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale_create.status(), StatusCode::CONFLICT);
+        let stale_create: Value = test::read_body_json(stale_create).await;
+        assert_eq!(
+            stale_create["error"]["message"],
+            "Configuration revision conflict: expected 1, actual 2"
+        );
+
+        let created_cluster = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/clusters")
+                .set_json(json!({
+                    "expected_revision": 2,
+                    "name": "crud-cluster",
+                    "node_ids": [node_id]
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(created_cluster.status(), StatusCode::CREATED);
+        let created_cluster: Value = test::read_body_json(created_cluster).await;
+        assert_eq!(created_cluster["revision"], 3);
+        assert!(created_cluster["data"]["clusters"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|cluster| cluster["name"] == "crud-cluster"));
+
+        let stale_update = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/clusters/crud-cluster")
+                .set_json(json!({
+                    "expected_revision": 2,
+                    "name": "crud-cluster",
+                    "description": "stale",
+                    "node_ids": [node_id]
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale_update.status(), StatusCode::CONFLICT);
+        let stale_update: Value = test::read_body_json(stale_update).await;
+        assert_eq!(
+            stale_update["error"]["message"],
+            "Configuration revision conflict: expected 2, actual 3"
+        );
+
+        let updated_cluster = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/clusters/crud-cluster")
+                .set_json(json!({
+                    "expected_revision": 3,
+                    "name": "crud-cluster",
+                    "description": "updated",
+                    "node_ids": [node_id]
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(updated_cluster.status(), StatusCode::OK);
+        let updated_cluster: Value = test::read_body_json(updated_cluster).await;
+        assert_eq!(updated_cluster["revision"], 4);
+        assert_eq!(
+            updated_cluster["data"]["clusters"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|cluster| cluster["name"] == "crud-cluster")
+                .unwrap()["description"],
+            "updated"
+        );
+
+        let stale_delete = test::call_service(
+            &app,
+            test::TestRequest::delete()
+                .uri("/clusters/crud-cluster?expected_revision=3")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale_delete.status(), StatusCode::CONFLICT);
+        let stale_delete: Value = test::read_body_json(stale_delete).await;
+        assert_eq!(
+            stale_delete["error"]["message"],
+            "Configuration revision conflict: expected 3, actual 4"
+        );
+
+        let deleted_cluster = test::call_service(
+            &app,
+            test::TestRequest::delete()
+                .uri("/clusters/crud-cluster?expected_revision=4")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(deleted_cluster.status(), StatusCode::OK);
+        let deleted_cluster: Value = test::read_body_json(deleted_cluster).await;
+        assert_eq!(deleted_cluster["revision"], 5);
+        assert!(!deleted_cluster["data"]["clusters"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|cluster| cluster["name"] == "crud-cluster"));
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/cluster_fabric/mod.rs
@@ -991,7 +991,15 @@ mod tests {
 
     #[::core::prelude::v1::test]
     fn membership_replacement_creates_missing_cluster_in_candidate() {
-        let node = pw_node("", None);
+        let node = Node {
+            id: "n1".to_string(),
+            label: "n1".to_string(),
+            placement: NodePlacement::Local,
+            trust_level: TrustLevel::Trusted,
+            deploy: DeployProfile::default(),
+            state: None,
+            enabled: true,
+        };
         let mut fabric = ClusterFabricConfig {
             nodes: vec![node],
             clusters: vec![Cluster {

--- a/crates/app/bamboo-server/src/handlers/settings/env_vars/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/env_vars/handlers.rs
@@ -587,10 +587,11 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn committed_reload_preserves_external_root_rebase_in_live_snapshot() {
+    async fn committed_env_write_preserves_external_root_bytes_without_cross_section_adoption() {
         let _serial = encryption_test_lock().lock().await;
         let dir = tempfile::tempdir().unwrap();
         let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let baseline_seq = state.account_sink.latest_seq();
         bamboo_config::set_env_transaction_test_hook(|data_dir| {
             let path = data_dir.join("config.json");
             let mut root: serde_json::Value = std::fs::read(&path)
@@ -623,14 +624,35 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(revision, 1);
-        assert_eq!(committed.extra["external_root_marker"], "preserved");
-        assert_eq!(
-            state.config.read().await.extra["external_root_marker"],
-            "preserved"
+        assert!(
+            !committed.extra.contains_key("external_root_marker"),
+            "an unrevisioned external root field must not be installed with the env commit"
+        );
+        assert!(
+            !state
+                .config
+                .read()
+                .await
+                .extra
+                .contains_key("external_root_marker"),
+            "the live process must advance only the owned env section"
         );
         let root: serde_json::Value =
             serde_json::from_slice(&std::fs::read(dir.path().join("config.json")).unwrap())
                 .unwrap();
         assert_eq!(root["external_root_marker"], "preserved");
+        let facade = state.config_facade.as_ref().unwrap();
+        assert_eq!(facade.registry().core.snapshot().revision, 0);
+        assert_eq!(facade.registry().env.snapshot().revision, 1);
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        let events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            baseline_seq,
+        )
+        .unwrap();
+        assert!(!events.iter().any(|event| matches!(
+            &event.event,
+            bamboo_agent_core::AgentEvent::ConfigChanged { section, .. } if section == "core"
+        )));
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/redaction/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/redaction/mod.rs
@@ -242,26 +242,30 @@ pub fn redact_config_for_api(mut value: Value, config: &Config) -> Value {
     // Cluster-fabric credentials are represented by status metadata on the
     // section endpoint. Never expose plaintext, ciphertext, or mask markers
     // through the legacy root configuration response.
-    if let Some(nodes) = root
+    if let Some(fabric) = root
         .get_mut("cluster_fabric")
-        .and_then(|f| f.get_mut("nodes"))
-        .and_then(|v| v.as_array_mut())
+        .and_then(Value::as_object_mut)
     {
-        for node in nodes.iter_mut() {
-            if let Some(auth) = node
-                .get_mut("placement")
-                .and_then(|p| p.get_mut("auth"))
-                .and_then(|a| a.as_object_mut())
-            {
-                for field in [
-                    "password",
-                    "password_encrypted",
-                    "private_key",
-                    "private_key_encrypted",
-                    "passphrase",
-                    "passphrase_encrypted",
-                ] {
-                    auth.remove(field);
+        // Stable references reveal the existence and storage layout of
+        // credentials. The dedicated cluster section exposes only status.
+        fabric.remove("credential_refs");
+        if let Some(nodes) = fabric.get_mut("nodes").and_then(Value::as_array_mut) {
+            for node in nodes.iter_mut() {
+                if let Some(auth) = node
+                    .get_mut("placement")
+                    .and_then(|p| p.get_mut("auth"))
+                    .and_then(|a| a.as_object_mut())
+                {
+                    for field in [
+                        "password",
+                        "password_encrypted",
+                        "private_key",
+                        "private_key_encrypted",
+                        "passphrase",
+                        "passphrase_encrypted",
+                    ] {
+                        auth.remove(field);
+                    }
                 }
             }
         }

--- a/crates/app/bamboo-server/src/handlers/settings/redaction/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/redaction/mod.rs
@@ -5,15 +5,6 @@ mod constants;
 mod mcp;
 mod provider;
 
-/// Return the public marker used in place of secrets in API responses.
-///
-/// Build the marker as a display value instead of letting a string literal
-/// flow into credential-shaped fields. The marker is not authentication
-/// material, and this keeps credential scanners focused on actual secrets.
-pub(super) fn masked_secret_marker() -> String {
-    "****".to_owned() + "..." + "****"
-}
-
 #[cfg(test)]
 mod tests;
 
@@ -248,7 +239,9 @@ pub fn redact_config_for_api(mut value: Value, config: &Config) -> Value {
         }
     }
 
-    // Redact cluster-fabric SSH secrets on each node's placement.auth.
+    // Cluster-fabric credentials are represented by status metadata on the
+    // section endpoint. Never expose plaintext, ciphertext, or mask markers
+    // through the legacy root configuration response.
     if let Some(nodes) = root
         .get_mut("cluster_fabric")
         .and_then(|f| f.get_mut("nodes"))
@@ -260,11 +253,15 @@ pub fn redact_config_for_api(mut value: Value, config: &Config) -> Value {
                 .and_then(|p| p.get_mut("auth"))
                 .and_then(|a| a.as_object_mut())
             {
-                for field in ["password", "private_key", "passphrase"] {
-                    if auth.get(field).and_then(|v| v.as_str()).is_some() {
-                        auth.insert(field.to_string(), Value::String("****...****".to_string()));
-                    }
-                    auth.remove(&format!("{field}_encrypted"));
+                for field in [
+                    "password",
+                    "password_encrypted",
+                    "private_key",
+                    "private_key_encrypted",
+                    "passphrase",
+                    "passphrase_encrypted",
+                ] {
+                    auth.remove(field);
                 }
             }
         }

--- a/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
@@ -73,6 +73,18 @@ fn redact_config_removes_all_cluster_fabric_secret_representations() {
     let config = Config::default();
     let input = json!({
         "cluster_fabric": {
+            "credential_refs": {
+                "password-node": {
+                    "password_credential_ref": "cluster.password-node.password",
+                    "password_configured": true
+                },
+                "key-node": {
+                    "private_key_credential_ref": "cluster.key-node.private_key",
+                    "private_key_configured": true,
+                    "passphrase_credential_ref": "cluster.key-node.passphrase",
+                    "passphrase_configured": true
+                }
+            },
             "nodes": [
                 {
                     "id": "password-node",
@@ -103,6 +115,10 @@ fn redact_config_removes_all_cluster_fabric_secret_representations() {
     });
 
     let redacted = redact_config_for_api(input, &config);
+    assert!(
+        redacted["cluster_fabric"].get("credential_refs").is_none(),
+        "legacy root responses must not expose cluster credential references"
+    );
     let nodes = redacted["cluster_fabric"]["nodes"]
         .as_array()
         .expect("cluster nodes should remain visible");
@@ -131,6 +147,9 @@ fn redact_config_removes_all_cluster_fabric_secret_representations() {
         "encrypted-private-key",
         "plain-passphrase",
         "encrypted-passphrase",
+        "cluster.password-node.password",
+        "cluster.key-node.private_key",
+        "cluster.key-node.passphrase",
         "****...****",
     ] {
         assert!(

--- a/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/redaction/tests.rs
@@ -69,6 +69,78 @@ fn redact_config_masks_configured_provider_and_removes_proxy_encrypted_keys() {
 }
 
 #[test]
+fn redact_config_removes_all_cluster_fabric_secret_representations() {
+    let config = Config::default();
+    let input = json!({
+        "cluster_fabric": {
+            "nodes": [
+                {
+                    "id": "password-node",
+                    "placement": {
+                        "type": "ssh",
+                        "auth": {
+                            "type": "password",
+                            "password": "plain-password",
+                            "password_encrypted": "encrypted-password"
+                        }
+                    }
+                },
+                {
+                    "id": "key-node",
+                    "placement": {
+                        "type": "ssh",
+                        "auth": {
+                            "type": "private_key",
+                            "private_key": "plain-private-key",
+                            "private_key_encrypted": "encrypted-private-key",
+                            "passphrase": "plain-passphrase",
+                            "passphrase_encrypted": "encrypted-passphrase"
+                        }
+                    }
+                }
+            ]
+        }
+    });
+
+    let redacted = redact_config_for_api(input, &config);
+    let nodes = redacted["cluster_fabric"]["nodes"]
+        .as_array()
+        .expect("cluster nodes should remain visible");
+
+    for node in nodes {
+        let auth = node["placement"]["auth"]
+            .as_object()
+            .expect("safe auth metadata should remain visible");
+        for field in [
+            "password",
+            "password_encrypted",
+            "private_key",
+            "private_key_encrypted",
+            "passphrase",
+            "passphrase_encrypted",
+        ] {
+            assert!(!auth.contains_key(field), "{field} must not be returned");
+        }
+    }
+
+    let serialized = serde_json::to_string(&redacted).expect("redacted config should serialize");
+    for forbidden in [
+        "plain-password",
+        "encrypted-password",
+        "plain-private-key",
+        "encrypted-private-key",
+        "plain-passphrase",
+        "encrypted-passphrase",
+        "****...****",
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "redacted config leaked {forbidden}"
+        );
+    }
+}
+
+#[test]
 fn redact_config_removes_all_access_control_verifiers_but_keeps_safe_device_metadata() {
     let config = Config::default();
     let input = json!({

--- a/crates/infra/bamboo-config/src/cluster_fabric.rs
+++ b/crates/infra/bamboo-config/src/cluster_fabric.rs
@@ -135,6 +135,39 @@ impl ClusterNodeCredentialRefs {
     }
 }
 
+/// Explicit operator intent for one isolated cluster credential.
+///
+/// Deliberately does not implement `Debug` or serialization: replacement
+/// values are request-only secret material and must never enter ordinary
+/// configuration documents, logs, events, or diagnostics.
+#[derive(Clone, PartialEq, Eq)]
+pub enum ClusterCredentialAction {
+    Keep,
+    Replace(String),
+    Clear,
+}
+
+/// Explicit password/private-key/passphrase actions for one node mutation.
+///
+/// Every HTTP mutation supplies all three actions, so an omitted field can
+/// never ambiguously mean both "keep" and "clear".
+#[derive(Clone, PartialEq, Eq)]
+pub struct ClusterNodeCredentialIntents {
+    pub password: ClusterCredentialAction,
+    pub private_key: ClusterCredentialAction,
+    pub passphrase: ClusterCredentialAction,
+}
+
+impl ClusterNodeCredentialIntents {
+    pub fn clear_all() -> Self {
+        Self {
+            password: ClusterCredentialAction::Clear,
+            private_key: ClusterCredentialAction::Clear,
+            passphrase: ClusterCredentialAction::Clear,
+        }
+    }
+}
+
 pub fn cluster_password_credential_ref(node_id: &str) -> ConfigStoreResult<CredentialRef> {
     credential_ref("cluster", node_id, "password")
 }
@@ -238,7 +271,7 @@ pub enum SshAuth {
     /// Stored password.
     Password {
         /// Plaintext — hydrated in memory, empty on disk.
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "String::is_empty")]
         password: String,
         /// Ciphertext on disk.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -248,7 +281,7 @@ pub enum SshAuth {
     /// (not a secret). An optional passphrase is always a secret.
     PrivateKey {
         /// Inline PEM plaintext — hydrated in memory, empty on disk.
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "String::is_empty")]
         private_key: String,
         /// Ciphertext of the inline PEM on disk.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -257,7 +290,7 @@ pub enum SshAuth {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         private_key_path: Option<String>,
         /// Optional key passphrase plaintext — hydrated in memory, empty on disk.
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "String::is_empty")]
         passphrase: String,
         /// Ciphertext of the passphrase on disk.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -424,7 +457,7 @@ impl Config {
 
         let mut requested = Vec::<(usize, Field, CredentialRef)>::new();
         let mut seen_refs = BTreeSet::new();
-        let other_counts = crate::credential_store::config_credential_ref_counts(self)?;
+        let consumer_counts = crate::credential_store::config_credential_ref_counts(self)?;
         for (index, node) in self.cluster_fabric.nodes.iter().enumerate() {
             let metadata = self.cluster_fabric.credential_refs.get(&node.id);
             let empty = ClusterNodeCredentialRefs::default();
@@ -447,7 +480,10 @@ impl Config {
                         "cluster credential reference is not canonical".to_string(),
                     ));
                 }
-                if other_counts.get(reference).copied().unwrap_or(0) != 0
+                // The shared inventory includes this cluster metadata slot.
+                // Exactly one consumer is therefore the expected exclusive
+                // state; any additional consumer remains fail-closed.
+                if consumer_counts.get(reference).copied().unwrap_or(0) != 1
                     || !seen_refs.insert(reference.clone())
                 {
                     return Err(crate::ConfigStoreError::Validation(

--- a/crates/infra/bamboo-config/src/cluster_fabric.rs
+++ b/crates/infra/bamboo-config/src/cluster_fabric.rs
@@ -100,7 +100,7 @@ impl ClusterFabricConfig {
 }
 
 /// Metadata for one node's isolated SSH credentials.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ClusterNodeCredentialRefs {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub password_credential_ref: Option<CredentialRef>,
@@ -114,6 +114,29 @@ pub struct ClusterNodeCredentialRefs {
     pub passphrase_credential_ref: Option<CredentialRef>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub passphrase_configured: bool,
+}
+
+impl std::fmt::Debug for ClusterNodeCredentialRefs {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ClusterNodeCredentialRefs")
+            .field(
+                "password_reference_present",
+                &self.password_credential_ref.is_some(),
+            )
+            .field("password_configured", &self.password_configured)
+            .field(
+                "private_key_reference_present",
+                &self.private_key_credential_ref.is_some(),
+            )
+            .field("private_key_configured", &self.private_key_configured)
+            .field(
+                "passphrase_reference_present",
+                &self.passphrase_credential_ref.is_some(),
+            )
+            .field("passphrase_configured", &self.passphrase_configured)
+            .finish()
+    }
 }
 
 impl ClusterNodeCredentialRefs {
@@ -261,7 +284,7 @@ fn default_ssh_port() -> u16 {
 /// How to authenticate the SSH connection. Secret material is encrypted at rest
 /// (the `*_encrypted` fields); plaintext is hydrated in memory and cleared
 /// before disk, exactly like [`crate::config::EnvVarEntry`].
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "method", rename_all = "snake_case")]
 pub enum SshAuth {
     /// Use the bamboo host's own ssh agent/config (→ system-ssh deployer). No
@@ -296,6 +319,45 @@ pub enum SshAuth {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         passphrase_encrypted: Option<String>,
     },
+}
+
+impl std::fmt::Debug for SshAuth {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SystemSshConfig => formatter.write_str("SystemSshConfig"),
+            Self::Password {
+                password,
+                password_encrypted,
+            } => formatter
+                .debug_struct("Password")
+                .field("password_configured", &!password.is_empty())
+                .field(
+                    "legacy_password_ciphertext_present",
+                    &password_encrypted.is_some(),
+                )
+                .finish(),
+            Self::PrivateKey {
+                private_key,
+                private_key_encrypted,
+                private_key_path,
+                passphrase,
+                passphrase_encrypted,
+            } => formatter
+                .debug_struct("PrivateKey")
+                .field("inline_private_key_configured", &!private_key.is_empty())
+                .field(
+                    "legacy_private_key_ciphertext_present",
+                    &private_key_encrypted.is_some(),
+                )
+                .field("private_key_path", private_key_path)
+                .field("passphrase_configured", &!passphrase.is_empty())
+                .field(
+                    "legacy_passphrase_ciphertext_present",
+                    &passphrase_encrypted.is_some(),
+                )
+                .finish(),
+        }
+    }
 }
 
 /// What to launch on the node + which artifact to upload (RFC v2 §6).
@@ -373,6 +435,39 @@ impl Config {
     pub fn hydrate_cluster_credentials_from_store(
         &mut self,
         data_dir: &std::path::Path,
+    ) -> ConfigStoreResult<()> {
+        // Preserve the historical no-store-read path for clusters without
+        // credential references. The validator still runs so inconsistent
+        // configured flags, orphaned metadata, or stray plaintext fail closed.
+        if !self
+            .cluster_fabric
+            .credential_refs
+            .values()
+            .any(|metadata| metadata.references().next().is_some())
+        {
+            return self.hydrate_cluster_credentials(None);
+        }
+
+        let store = crate::CredentialStore::open(data_dir);
+        // One transaction lock performs readiness/recovery once and captures
+        // one immutable document for every cluster reference.
+        let (snapshot, _, _) = store.snapshot_with_health()?;
+        self.hydrate_cluster_credentials(Some(&snapshot))
+    }
+
+    /// Resolve one cluster runtime from an immutable credential document
+    /// captured under the credential migration lock. Compound transactions use
+    /// this exact snapshot before admitting a later cross-process writer.
+    pub(crate) fn hydrate_cluster_credentials_from_snapshot(
+        &mut self,
+        credentials: &crate::credential_store::CredentialDocumentLkg,
+    ) -> ConfigStoreResult<()> {
+        self.hydrate_cluster_credentials(Some(credentials))
+    }
+
+    fn hydrate_cluster_credentials(
+        &mut self,
+        credentials: Option<&crate::credential_store::CredentialDocumentLkg>,
     ) -> ConfigStoreResult<()> {
         #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
         enum Field {
@@ -555,10 +650,14 @@ impl Config {
             }
         }
 
-        let store = crate::CredentialStore::open(data_dir);
         let mut resolved = Vec::with_capacity(requested.len());
         for (index, field, reference) in requested {
-            let secret = store.resolve(&reference)?.ok_or_else(|| {
+            let credentials = credentials.ok_or_else(|| {
+                crate::ConfigStoreError::Validation(
+                    "referenced cluster credential is unavailable".to_string(),
+                )
+            })?;
+            let secret = credentials.resolve(&reference)?.ok_or_else(|| {
                 crate::ConfigStoreError::Validation(
                     "referenced cluster credential is unavailable".to_string(),
                 )
@@ -596,7 +695,7 @@ impl Config {
 
     /// Remove legacy/cached cluster secrets from a runtime snapshot. Used both
     /// before store hydration and when migration readiness is unavailable.
-    pub(crate) fn clear_cluster_runtime_credentials(&mut self) {
+    pub fn clear_cluster_runtime_credentials(&mut self) {
         for node in &mut self.cluster_fabric.nodes {
             let NodePlacement::Ssh(target) = &mut node.placement else {
                 continue;
@@ -1118,6 +1217,175 @@ mod tests {
         ] {
             assert!(!durable.contains(forbidden), "persisted {forbidden}");
         }
+    }
+
+    #[test]
+    fn recursive_config_debug_redacts_all_cluster_credential_forms() {
+        let _key = crate::encryption::set_test_encryption_key([0xc7; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let password_ref = cluster_password_credential_ref("password-debug").unwrap();
+        let key_ref = cluster_private_key_credential_ref("key-debug").unwrap();
+        let passphrase_ref = cluster_passphrase_credential_ref("key-debug").unwrap();
+        let store = crate::CredentialStore::open(dir.path());
+        for (revision, (reference, value)) in [
+            (&password_ref, "debug-password-plaintext"),
+            (&key_ref, "debug-private-key-plaintext"),
+            (&passphrase_ref, "debug-passphrase-plaintext"),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            store
+                .replace(
+                    reference.clone(),
+                    value,
+                    crate::CredentialSource::User,
+                    revision as u64,
+                )
+                .unwrap();
+        }
+
+        let mut config = Config::default();
+        config.cluster_fabric.nodes.push(ssh_node(
+            "password-debug",
+            SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        config.cluster_fabric.nodes.push(ssh_node(
+            "key-debug",
+            SshAuth::PrivateKey {
+                private_key: String::new(),
+                private_key_encrypted: None,
+                private_key_path: Some("/safe/on-host/key".to_string()),
+                passphrase: String::new(),
+                passphrase_encrypted: None,
+            },
+        ));
+        config.cluster_fabric.credential_refs.insert(
+            "password-debug".to_string(),
+            ClusterNodeCredentialRefs {
+                password_credential_ref: Some(password_ref.clone()),
+                password_configured: true,
+                ..ClusterNodeCredentialRefs::default()
+            },
+        );
+        config.cluster_fabric.credential_refs.insert(
+            "key-debug".to_string(),
+            ClusterNodeCredentialRefs {
+                private_key_credential_ref: Some(key_ref.clone()),
+                private_key_configured: true,
+                passphrase_credential_ref: Some(passphrase_ref.clone()),
+                passphrase_configured: true,
+                ..ClusterNodeCredentialRefs::default()
+            },
+        );
+        config
+            .hydrate_cluster_credentials_from_store(dir.path())
+            .unwrap();
+
+        let NodePlacement::Ssh(password_target) = &mut config.cluster_fabric.nodes[0].placement
+        else {
+            panic!("expected password SSH node")
+        };
+        let SshAuth::Password {
+            password_encrypted, ..
+        } = &mut password_target.auth
+        else {
+            panic!("expected password auth")
+        };
+        *password_encrypted = Some("debug-password-ciphertext".to_string());
+
+        let NodePlacement::Ssh(key_target) = &mut config.cluster_fabric.nodes[1].placement else {
+            panic!("expected private-key SSH node")
+        };
+        let SshAuth::PrivateKey {
+            private_key_encrypted,
+            passphrase_encrypted,
+            ..
+        } = &mut key_target.auth
+        else {
+            panic!("expected private-key auth")
+        };
+        *private_key_encrypted = Some("debug-private-key-ciphertext".to_string());
+        *passphrase_encrypted = Some("********debug-mask-sentinel".to_string());
+
+        let recursive_debug = format!("{config:?}");
+        let values_debug = format!("{:?}", config.section_values());
+        for forbidden in [
+            "debug-password-plaintext",
+            "debug-private-key-plaintext",
+            "debug-passphrase-plaintext",
+            "debug-password-ciphertext",
+            "debug-private-key-ciphertext",
+            "********debug-mask-sentinel",
+            password_ref.as_str(),
+            key_ref.as_str(),
+            passphrase_ref.as_str(),
+        ] {
+            assert!(
+                !recursive_debug.contains(forbidden),
+                "Config Debug leaked {forbidden}"
+            );
+            assert!(
+                !values_debug.contains(forbidden),
+                "ConfigValues Debug leaked {forbidden}"
+            );
+        }
+        assert!(recursive_debug.contains("password_configured: true"));
+        assert!(recursive_debug.contains("inline_private_key_configured: true"));
+        assert!(recursive_debug.contains("passphrase_configured: true"));
+        assert!(recursive_debug.contains("legacy_password_ciphertext_present: true"));
+        assert!(recursive_debug.contains("legacy_private_key_ciphertext_present: true"));
+        assert!(recursive_debug.contains("legacy_passphrase_ciphertext_present: true"));
+    }
+
+    #[test]
+    fn cluster_without_credential_refs_does_not_read_the_credential_document() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("credentials.json"), b"{invalid").unwrap();
+        let mut config = Config::default();
+        config
+            .cluster_fabric
+            .nodes
+            .push(ssh_node("system-node", SshAuth::SystemSshConfig));
+
+        config
+            .hydrate_cluster_credentials_from_store(dir.path())
+            .unwrap();
+    }
+
+    #[test]
+    fn cluster_credential_snapshot_preserves_transaction_readiness_checks() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config-credential-migration.json"),
+            b"{invalid",
+        )
+        .unwrap();
+        let reference = cluster_password_credential_ref("node").unwrap();
+        let mut config = Config::default();
+        config.cluster_fabric.nodes.push(ssh_node(
+            "node",
+            SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        config.cluster_fabric.credential_refs.insert(
+            "node".to_string(),
+            ClusterNodeCredentialRefs {
+                password_credential_ref: Some(reference),
+                password_configured: true,
+                ..ClusterNodeCredentialRefs::default()
+            },
+        );
+
+        let error = config
+            .hydrate_cluster_credentials_from_store(dir.path())
+            .unwrap_err();
+        assert!(error.to_string().contains("migration is pending"));
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/config_crypto.rs
+++ b/crates/infra/bamboo-config/src/config_crypto.rs
@@ -10,6 +10,31 @@ use serde::{Deserialize, Serialize};
 use super::{Config, ProxyAuth};
 use crate::patch::ProviderApiKeyIntents;
 
+trait CredentialResolver {
+    fn resolve(
+        &self,
+        credential_ref: &crate::CredentialRef,
+    ) -> crate::ConfigStoreResult<Option<crate::SecretValue>>;
+}
+
+impl CredentialResolver for crate::CredentialStore {
+    fn resolve(
+        &self,
+        credential_ref: &crate::CredentialRef,
+    ) -> crate::ConfigStoreResult<Option<crate::SecretValue>> {
+        crate::CredentialStore::resolve(self, credential_ref)
+    }
+}
+
+impl CredentialResolver for crate::credential_store::CredentialDocumentLkg {
+    fn resolve(
+        &self,
+        credential_ref: &crate::CredentialRef,
+    ) -> crate::ConfigStoreResult<Option<crate::SecretValue>> {
+        self.resolve(credential_ref)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct AccessVerifierRecord {
     pub hash: String,
@@ -60,7 +85,7 @@ fn decode_access_verifier(secret: &str) -> crate::ConfigStoreResult<AccessVerifi
 }
 
 fn hydrate_header_credentials(
-    store: &crate::CredentialStore,
+    resolver: &impl CredentialResolver,
     headers: &mut [bamboo_domain::mcp_config::HeaderConfig],
 ) -> crate::ConfigStoreResult<()> {
     for header in headers {
@@ -71,7 +96,7 @@ fn hydrate_header_credentials(
             continue;
         };
         let reference = crate::CredentialRef::parse(raw_reference.clone())?;
-        header.value = store
+        header.value = resolver
             .resolve(&reference)?
             .ok_or_else(|| {
                 crate::ConfigStoreError::Validation(
@@ -208,20 +233,33 @@ impl Config {
     /// Hydrate proxy authentication from its isolated credential-store entry.
     /// The stored secret is the JSON representation of [`crate::ProxyAuth`].
     pub fn hydrate_proxy_auth_from_store(&mut self, data_dir: &std::path::Path) -> Result<()> {
+        let store = crate::CredentialStore::open(data_dir);
+        self.hydrate_proxy_auth_from_resolver(&store)
+            .map_err(anyhow::Error::from)
+    }
+
+    pub(crate) fn hydrate_proxy_auth_from_snapshot(
+        &mut self,
+        snapshot: &crate::credential_store::CredentialDocumentLkg,
+    ) -> crate::ConfigStoreResult<()> {
+        self.hydrate_proxy_auth_from_resolver(snapshot)
+    }
+
+    fn hydrate_proxy_auth_from_resolver(
+        &mut self,
+        resolver: &impl CredentialResolver,
+    ) -> crate::ConfigStoreResult<()> {
         let Some(reference) = self.proxy_auth_credential_ref.as_ref() else {
             return Ok(());
         };
-        let value = crate::CredentialStore::open(data_dir)
-            .resolve(reference)
-            .map_err(anyhow::Error::from)?;
+        let value = resolver.resolve(reference)?;
         let Some(value) = value else {
             self.proxy_auth = None;
             return Ok(());
         };
-        self.proxy_auth = Some(
-            serde_json::from_str(value.expose())
-                .context("Failed to parse proxy auth credential")?,
-        );
+        self.proxy_auth = Some(serde_json::from_str(value.expose()).map_err(|_| {
+            crate::ConfigStoreError::Validation("proxy auth credential is invalid".to_string())
+        })?);
         self.proxy_auth_encrypted = None;
         Ok(())
     }
@@ -282,12 +320,26 @@ impl Config {
         data_dir: &std::path::Path,
     ) -> crate::ConfigStoreResult<()> {
         let store = crate::CredentialStore::open(data_dir);
+        self.hydrate_provider_credentials_from_resolver(&store)
+    }
+
+    pub(crate) fn hydrate_provider_credentials_from_snapshot(
+        &mut self,
+        snapshot: &crate::credential_store::CredentialDocumentLkg,
+    ) -> crate::ConfigStoreResult<()> {
+        self.hydrate_provider_credentials_from_resolver(snapshot)
+    }
+
+    fn hydrate_provider_credentials_from_resolver(
+        &mut self,
+        resolver: &impl CredentialResolver,
+    ) -> crate::ConfigStoreResult<()> {
         macro_rules! hydrate {
             ($provider:expr) => {
                 if let Some(provider) = $provider {
                     if provider.api_key.trim().is_empty() {
                         if let Some(reference) = provider.credential_ref.as_ref() {
-                            provider.api_key = store
+                            provider.api_key = resolver
                                 .resolve(reference)?
                                 .ok_or_else(|| {
                                     crate::ConfigStoreError::Validation(
@@ -308,7 +360,7 @@ impl Config {
         for instance in self.provider_instances.values_mut() {
             if instance.api_key.trim().is_empty() {
                 if let Some(reference) = instance.credential_ref.as_ref() {
-                    instance.api_key = store
+                    instance.api_key = resolver
                         .resolve(reference)?
                         .ok_or_else(|| {
                             crate::ConfigStoreError::Validation(
@@ -528,6 +580,20 @@ impl Config {
         data_dir: &std::path::Path,
     ) -> crate::ConfigStoreResult<()> {
         let store = crate::CredentialStore::open(data_dir);
+        self.hydrate_mcp_credentials_from_resolver(&store)
+    }
+
+    pub(crate) fn hydrate_mcp_credentials_from_snapshot(
+        &mut self,
+        snapshot: &crate::credential_store::CredentialDocumentLkg,
+    ) -> crate::ConfigStoreResult<()> {
+        self.hydrate_mcp_credentials_from_resolver(snapshot)
+    }
+
+    fn hydrate_mcp_credentials_from_resolver(
+        &mut self,
+        resolver: &impl CredentialResolver,
+    ) -> crate::ConfigStoreResult<()> {
         for server in &mut self.mcp.servers {
             match &mut server.transport {
                 bamboo_domain::mcp_config::TransportConfig::Stdio(stdio) => {
@@ -536,7 +602,7 @@ impl Config {
                             continue;
                         }
                         let reference = crate::CredentialRef::parse(raw_reference.clone())?;
-                        let secret = store.resolve(&reference)?.ok_or_else(|| {
+                        let secret = resolver.resolve(&reference)?.ok_or_else(|| {
                             crate::ConfigStoreError::Validation(
                                 "referenced MCP credential is unavailable".to_string(),
                             )
@@ -545,10 +611,10 @@ impl Config {
                     }
                 }
                 bamboo_domain::mcp_config::TransportConfig::Sse(config) => {
-                    hydrate_header_credentials(&store, &mut config.headers)?;
+                    hydrate_header_credentials(resolver, &mut config.headers)?;
                 }
                 bamboo_domain::mcp_config::TransportConfig::StreamableHttp(config) => {
-                    hydrate_header_credentials(&store, &mut config.headers)?;
+                    hydrate_header_credentials(resolver, &mut config.headers)?;
                 }
             }
         }
@@ -668,6 +734,20 @@ impl Config {
         data_dir: &std::path::Path,
     ) -> crate::ConfigStoreResult<()> {
         let store = crate::CredentialStore::open(data_dir);
+        self.hydrate_env_var_credentials_from_resolver(&store)
+    }
+
+    pub(crate) fn hydrate_env_var_credentials_from_snapshot(
+        &mut self,
+        snapshot: &crate::credential_store::CredentialDocumentLkg,
+    ) -> crate::ConfigStoreResult<()> {
+        self.hydrate_env_var_credentials_from_resolver(snapshot)
+    }
+
+    fn hydrate_env_var_credentials_from_resolver(
+        &mut self,
+        resolver: &impl CredentialResolver,
+    ) -> crate::ConfigStoreResult<()> {
         for entry in &mut self.env_vars {
             if !entry.secret {
                 entry.credential_ref = None;
@@ -678,7 +758,7 @@ impl Config {
                 entry.configured = false;
                 continue;
             };
-            match store.resolve(reference)? {
+            match resolver.resolve(reference)? {
                 Some(secret) => {
                     entry.value = secret.expose().to_string();
                     entry.configured = true;
@@ -813,6 +893,21 @@ impl Config {
         &mut self,
         data_dir: &std::path::Path,
     ) -> crate::ConfigStoreResult<()> {
+        let store = crate::CredentialStore::open(data_dir);
+        self.hydrate_notification_credentials_from_resolver(&store)
+    }
+
+    pub(crate) fn hydrate_notification_credentials_from_snapshot(
+        &mut self,
+        snapshot: &crate::credential_store::CredentialDocumentLkg,
+    ) -> crate::ConfigStoreResult<()> {
+        self.hydrate_notification_credentials_from_resolver(snapshot)
+    }
+
+    fn hydrate_notification_credentials_from_resolver(
+        &mut self,
+        resolver: &impl CredentialResolver,
+    ) -> crate::ConfigStoreResult<()> {
         let reference_counts = crate::credential_store::config_credential_ref_counts(self)?;
         for reference in [
             self.notifications.ntfy.credential_ref.as_ref(),
@@ -828,10 +923,9 @@ impl Config {
                 ));
             }
         }
-        let store = crate::CredentialStore::open(data_dir);
         let ntfy = &mut self.notifications.ntfy;
         if let Some(reference) = ntfy.credential_ref.as_ref() {
-            match store.resolve(reference)? {
+            match resolver.resolve(reference)? {
                 Some(secret) => {
                     ntfy.token = Some(secret.expose().to_string());
                     ntfy.configured = true;
@@ -851,7 +945,7 @@ impl Config {
 
         let bark = &mut self.notifications.bark;
         if let Some(reference) = bark.credential_ref.as_ref() {
-            match store.resolve(reference)? {
+            match resolver.resolve(reference)? {
                 Some(secret) => {
                     bark.device_key = Some(secret.expose().to_string());
                     bark.configured = true;
@@ -982,16 +1076,31 @@ impl Config {
     ) -> crate::ConfigStoreResult<()> {
         let store = crate::CredentialStore::open(data_dir);
         let allow_legacy_runtime_value = !crate::section_layout_is_active(data_dir)?;
+        self.hydrate_connect_credentials_from_resolver(&store, allow_legacy_runtime_value)
+    }
+
+    pub(crate) fn hydrate_connect_credentials_from_snapshot(
+        &mut self,
+        snapshot: &crate::credential_store::CredentialDocumentLkg,
+    ) -> crate::ConfigStoreResult<()> {
+        self.hydrate_connect_credentials_from_resolver(snapshot, false)
+    }
+
+    fn hydrate_connect_credentials_from_resolver(
+        &mut self,
+        resolver: &impl CredentialResolver,
+        allow_legacy_runtime_value: bool,
+    ) -> crate::ConfigStoreResult<()> {
         for platform in &mut self.connect.platforms {
             hydrate_optional_connect_secret(
-                &store,
+                resolver,
                 platform.token_credential_ref.as_ref(),
                 platform.token_configured,
                 &mut platform.token,
                 allow_legacy_runtime_value,
             )?;
             hydrate_optional_connect_secret(
-                &store,
+                resolver,
                 platform.app_secret_credential_ref.as_ref(),
                 platform.app_secret_configured,
                 &mut platform.app_secret,
@@ -1010,10 +1119,24 @@ impl Config {
         &mut self,
         data_dir: &std::path::Path,
     ) -> crate::ConfigStoreResult<()> {
+        let store = crate::CredentialStore::open(data_dir);
+        self.hydrate_access_control_credentials_from_resolver(&store)
+    }
+
+    pub(crate) fn hydrate_access_control_credentials_from_snapshot(
+        &mut self,
+        snapshot: &crate::credential_store::CredentialDocumentLkg,
+    ) -> crate::ConfigStoreResult<()> {
+        self.hydrate_access_control_credentials_from_resolver(snapshot)
+    }
+
+    fn hydrate_access_control_credentials_from_resolver(
+        &mut self,
+        resolver: &impl CredentialResolver,
+    ) -> crate::ConfigStoreResult<()> {
         let Some(access) = self.access_control.as_mut() else {
             return Ok(());
         };
-        let store = crate::CredentialStore::open(data_dir);
         match access.password_credential_ref.as_ref() {
             Some(reference) => {
                 if reference != &access_password_credential_ref()? || !access.password_configured {
@@ -1021,7 +1144,7 @@ impl Config {
                         "access-control password credential metadata is invalid".to_string(),
                     ));
                 }
-                let secret = store.resolve(reference)?.ok_or_else(|| {
+                let secret = resolver.resolve(reference)?.ok_or_else(|| {
                     crate::ConfigStoreError::Validation(
                         "access-control password verifier is unavailable".to_string(),
                     )
@@ -1053,7 +1176,7 @@ impl Config {
                     "access-control device credential metadata is invalid".to_string(),
                 ));
             }
-            let secret = store.resolve(reference)?.ok_or_else(|| {
+            let secret = resolver.resolve(reference)?.ok_or_else(|| {
                 crate::ConfigStoreError::Validation(
                     "access-control device verifier is unavailable".to_string(),
                 )
@@ -1219,14 +1342,14 @@ impl Config {
 }
 
 fn hydrate_optional_connect_secret(
-    store: &crate::CredentialStore,
+    resolver: &impl CredentialResolver,
     reference: Option<&crate::CredentialRef>,
     configured: bool,
     target: &mut Option<String>,
     allow_legacy_runtime_value: bool,
 ) -> crate::ConfigStoreResult<()> {
     match reference {
-        Some(reference) => match store.resolve(reference)? {
+        Some(reference) => match resolver.resolve(reference)? {
             Some(secret) => *target = Some(secret.expose().to_string()),
             None if configured => {
                 return Err(crate::ConfigStoreError::Validation(

--- a/crates/infra/bamboo-config/src/config_store.rs
+++ b/crates/infra/bamboo-config/src/config_store.rs
@@ -1400,6 +1400,59 @@ where
         self.commit_inner(expected_revision, candidate, || {})
     }
 
+    /// Adopt a snapshot that was durably installed by a compound transaction
+    /// while that transaction still owns its cross-process commit lock.
+    ///
+    /// This deliberately performs no filesystem write. The caller must supply
+    /// the exact immutable candidate installed by the transaction and invoke
+    /// this method before releasing the transaction's external serialization
+    /// lock. Keeping the ordinary live-section operation lock around the
+    /// validation and publication prevents a watcher reload from interleaving
+    /// with the known commit.
+    pub(crate) fn adopt_committed(
+        &self,
+        expected_revision: u64,
+        committed_revision: u64,
+        candidate: T,
+    ) -> ConfigStoreResult<ConfigSectionEvent> {
+        let _operation = self
+            .operation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let current = self.snapshot();
+        if current.revision != expected_revision {
+            return Err(ConfigStoreError::Conflict {
+                expected: expected_revision,
+                actual: current.revision,
+            });
+        }
+        let next_revision = expected_revision.checked_add(1).ok_or_else(|| {
+            ConfigStoreError::Validation("section revision counter exhausted".to_string())
+        })?;
+        if committed_revision != next_revision {
+            return Err(ConfigStoreError::Validation(format!(
+                "committed section revision {committed_revision} does not follow expected revision {expected_revision}"
+            )));
+        }
+        (self.validate)(&candidate).map_err(ConfigStoreError::Validation)?;
+        self.publish(
+            SectionSnapshot {
+                data: Arc::new(candidate),
+                revision: committed_revision,
+                loaded_at: Utc::now(),
+                source_path: self.store.path().to_path_buf(),
+                source_kind: SectionSourceKind::File,
+                status: SectionStatus::Healthy,
+                last_error: None,
+            },
+            LiveRepairAuthority::None,
+        );
+        Ok(ConfigSectionEvent::Changed {
+            section: self.name.clone(),
+            revision: committed_revision,
+        })
+    }
+
     fn commit_inner<F>(
         &self,
         expected_revision: u64,
@@ -3277,6 +3330,96 @@ mod tests {
         let durable = section.store.load().unwrap().unwrap();
         assert_eq!(durable.revision, 1);
         assert_eq!(durable.data.value, "external");
+    }
+
+    #[test]
+    fn adopt_committed_validates_and_never_writes_the_durable_document() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("example.json");
+        let section = LiveSection::open(
+            "example",
+            AtomicJsonStore::new(&path, 1),
+            Example {
+                value: "default".into(),
+            },
+            |candidate: &Example| {
+                (candidate.value != "invalid")
+                    .then_some(())
+                    .ok_or_else(|| "invalid candidate".to_string())
+            },
+        )
+        .unwrap();
+        let durable = serde_json::to_vec_pretty(&RevisionedDocument {
+            schema_version: 1,
+            revision: 1,
+            data: Example {
+                value: "committed".into(),
+            },
+        })
+        .unwrap();
+        std::fs::write(&path, &durable).unwrap();
+
+        assert!(matches!(
+            section.adopt_committed(
+                1,
+                2,
+                Example {
+                    value: "wrong-base".into(),
+                },
+            ),
+            Err(ConfigStoreError::Conflict {
+                expected: 1,
+                actual: 0
+            })
+        ));
+        assert!(matches!(
+            section.adopt_committed(
+                0,
+                2,
+                Example {
+                    value: "skipped-revision".into(),
+                },
+            ),
+            Err(ConfigStoreError::Validation(_))
+        ));
+        assert!(matches!(
+            section.adopt_committed(
+                0,
+                1,
+                Example {
+                    value: "invalid".into(),
+                },
+            ),
+            Err(ConfigStoreError::Validation(_))
+        ));
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            durable,
+            "rejected adoptions must never rewrite the compound transaction"
+        );
+
+        assert_eq!(
+            section
+                .adopt_committed(
+                    0,
+                    1,
+                    Example {
+                        value: "committed".into(),
+                    },
+                )
+                .unwrap(),
+            ConfigSectionEvent::Changed {
+                section: "example".to_string(),
+                revision: 1,
+            }
+        );
+        assert_eq!(section.snapshot().revision, 1);
+        assert_eq!(section.snapshot().data.value, "committed");
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            durable,
+            "successful adoption is process-local and must not touch disk"
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/config_store.rs
+++ b/crates/infra/bamboo-config/src/config_store.rs
@@ -1409,6 +1409,7 @@ where
     /// lock. Keeping the ordinary live-section operation lock around the
     /// validation and publication prevents a watcher reload from interleaving
     /// with the known commit.
+    #[allow(dead_code)]
     pub(crate) fn adopt_committed(
         &self,
         expected_revision: u64,
@@ -1433,6 +1434,58 @@ where
             return Err(ConfigStoreError::Validation(format!(
                 "committed section revision {committed_revision} does not follow expected revision {expected_revision}"
             )));
+        }
+        (self.validate)(&candidate).map_err(ConfigStoreError::Validation)?;
+        self.publish(
+            SectionSnapshot {
+                data: Arc::new(candidate),
+                revision: committed_revision,
+                loaded_at: Utc::now(),
+                source_path: self.store.path().to_path_buf(),
+                source_kind: SectionSourceKind::File,
+                status: SectionStatus::Healthy,
+                last_error: None,
+            },
+            LiveRepairAuthority::None,
+        );
+        Ok(ConfigSectionEvent::Changed {
+            section: self.name.clone(),
+            revision: committed_revision,
+        })
+    }
+
+    /// Adopt a compound commit whose durable base revision was validated by
+    /// the caller while it still owns the cross-process transaction lock.
+    ///
+    /// Unlike [`Self::adopt_committed`], this permits a process-local snapshot
+    /// to lag behind `expected_revision`. The caller's durable CAS is the
+    /// authority for the skipped local generations; a local snapshot ahead of
+    /// that validated base is still rejected and is never republished at an
+    /// already-observed revision.
+    pub(crate) fn adopt_committed_from_durable_base(
+        &self,
+        expected_revision: u64,
+        committed_revision: u64,
+        candidate: T,
+    ) -> ConfigStoreResult<ConfigSectionEvent> {
+        let _operation = self
+            .operation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let current = self.snapshot();
+        let next_revision = expected_revision.checked_add(1).ok_or_else(|| {
+            ConfigStoreError::Validation("section revision counter exhausted".to_string())
+        })?;
+        if committed_revision != next_revision {
+            return Err(ConfigStoreError::Validation(format!(
+                "committed section revision {committed_revision} does not follow expected revision {expected_revision}"
+            )));
+        }
+        if current.revision > expected_revision {
+            return Err(ConfigStoreError::Conflict {
+                expected: expected_revision,
+                actual: current.revision,
+            });
         }
         (self.validate)(&candidate).map_err(ConfigStoreError::Validation)?;
         self.publish(
@@ -3420,6 +3473,63 @@ mod tests {
             durable,
             "successful adoption is process-local and must not touch disk"
         );
+    }
+
+    #[test]
+    fn durable_base_adoption_catches_up_only_a_snapshot_not_ahead_of_expected() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("example.json");
+        let section = LiveSection::open(
+            "example",
+            AtomicJsonStore::new(&path, 1),
+            Example {
+                value: "local-r0".into(),
+            },
+            |_| Ok(()),
+        )
+        .unwrap();
+        let durable = serde_json::to_vec_pretty(&RevisionedDocument {
+            schema_version: 1,
+            revision: 2,
+            data: Example {
+                value: "durable-r2".into(),
+            },
+        })
+        .unwrap();
+        std::fs::write(&path, &durable).unwrap();
+
+        assert_eq!(
+            section
+                .adopt_committed_from_durable_base(
+                    1,
+                    2,
+                    Example {
+                        value: "durable-r2".into(),
+                    },
+                )
+                .unwrap(),
+            ConfigSectionEvent::Changed {
+                section: "example".to_string(),
+                revision: 2,
+            }
+        );
+        assert_eq!(section.snapshot().revision, 2);
+        assert_eq!(section.snapshot().data.value, "durable-r2");
+        assert!(matches!(
+            section.adopt_committed_from_durable_base(
+                1,
+                2,
+                Example {
+                    value: "same-revision-divergence".into(),
+                },
+            ),
+            Err(ConfigStoreError::Conflict {
+                expected: 1,
+                actual: 2
+            })
+        ));
+        assert_eq!(section.snapshot().data.value, "durable-r2");
+        assert_eq!(std::fs::read(path).unwrap(), durable);
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/config_store.rs
+++ b/crates/infra/bamboo-config/src/config_store.rs
@@ -41,6 +41,11 @@ pub enum ConfigStoreError {
     Conflict { expected: u64, actual: u64 },
     #[error("configuration validation failed: {0}")]
     Validation(String),
+    /// The caller cannot prove whether the durable commit point won. Callers
+    /// that own an external side effect must retain it until recovery resolves
+    /// the transaction instead of compensating as if commit definitely failed.
+    #[error("configuration commit outcome is indeterminate: {0}")]
+    CommitIndeterminate(String),
     #[error("configuration watch failed")]
     Watch(#[from] notify::Error),
 }
@@ -55,6 +60,7 @@ pub(crate) fn repairable_live_lkg_error(error: &ConfigStoreError) -> bool {
         }
         ConfigStoreError::Io(_)
         | ConfigStoreError::Conflict { .. }
+        | ConfigStoreError::CommitIndeterminate(_)
         | ConfigStoreError::Watch(_) => false,
     }
 }

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -2593,10 +2593,17 @@ where
                         candidate: &crate::ClusterFabricConfig,
                         runtime: ConfigStoreResult<ExactClusterRuntimeSnapshot>,
                         recovery: ConfigStoreResult<()>| {
+        let runtime_ready = runtime.is_ok();
         exact_runtime = Some(runtime);
         committed_recovery = Some(recovery);
         transaction_changed = changed;
-        if changed {
+        if revision == expected_revision {
+            if runtime_ready {
+                adoption = facade
+                    .catch_up_committed_section(crate::SectionId::ClusterFabric)
+                    .map(Ok);
+            }
+        } else if changed {
             before_adoption(revision, candidate);
             adoption = Some(facade.adopt_committed_cluster_fabric(
                 expected_revision,
@@ -3304,10 +3311,17 @@ where
                         candidate: &crate::ClusterFabricConfig,
                         runtime: ConfigStoreResult<ExactClusterRuntimeSnapshot>,
                         recovery: ConfigStoreResult<()>| {
+        let runtime_ready = runtime.is_ok();
         exact_runtime = Some(runtime);
         committed_recovery = Some(recovery);
         transaction_changed = changed;
-        if changed {
+        if revision == expected_revision {
+            if runtime_ready {
+                adoption = facade
+                    .catch_up_committed_section(crate::SectionId::ClusterFabric)
+                    .map(Ok);
+            }
+        } else if changed {
             before_adoption(revision, candidate);
             adoption = Some(facade.adopt_committed_cluster_fabric(
                 expected_revision,

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -814,6 +814,8 @@ enum MigrationFault {
     AfterRebaseStageWrite,
     AfterRebaseManifest,
     BeforeExactCommitCredentialRace,
+    BeforeExactStagingUnrelatedCredentialRace,
+    BeforeExactCommitUnrelatedCredentialRace,
     AfterExactCommitCredentialRace,
     AfterExactCommitUnrelatedCredentialRace,
     AfterExactCommitCredentialClearRace,
@@ -1746,11 +1748,32 @@ pub fn persist_access_control_credential_transaction_at_revision(
 pub fn persist_cluster_fabric_credential_transaction_at_revision(
     data_dir: impl AsRef<Path>,
     config: &mut crate::Config,
-    node_intents: &BTreeSet<String>,
+    node_intents: &BTreeMap<String, crate::ClusterNodeCredentialIntents>,
     expected_revision: u64,
 ) -> ConfigStoreResult<u64> {
-    persist_exact_credential_transaction_inner(
+    persist_cluster_fabric_credential_transaction_inner(
         data_dir.as_ref(),
+        config,
+        node_intents,
+        expected_revision,
+        None,
+    )
+}
+
+fn persist_cluster_fabric_credential_transaction_inner(
+    data_dir: &Path,
+    config: &mut crate::Config,
+    node_intents: &BTreeMap<String, crate::ClusterNodeCredentialIntents>,
+    expected_revision: u64,
+    #[cfg_attr(not(test), allow(unused_variables))] fault: Option<MigrationFault>,
+) -> ConfigStoreResult<u64> {
+    if !crate::section_layout_is_active(data_dir)? {
+        return Err(ConfigStoreError::Validation(
+            "cluster credential updates require the modular configuration layout".to_string(),
+        ));
+    }
+    persist_exact_credential_transaction_inner(
+        data_dir,
         config,
         &BTreeSet::new(),
         &BTreeSet::new(),
@@ -1768,7 +1791,7 @@ pub fn persist_cluster_fabric_credential_transaction_at_revision(
         None,
         None,
         #[cfg(test)]
-        None,
+        fault,
     )
 }
 
@@ -2119,7 +2142,7 @@ fn persist_exact_credential_transaction_inner(
     notification_intents: &BTreeSet<String>,
     notification_reset: bool,
     notification_expected_revision: Option<u64>,
-    cluster_transaction: Option<(&BTreeSet<String>, u64)>,
+    cluster_transaction: Option<(&BTreeMap<String, crate::ClusterNodeCredentialIntents>, u64)>,
     connect_transaction: Option<(&crate::patch::ConnectSecretIntents, u64)>,
     access_transaction: Option<(bool, &BTreeSet<String>, u64)>,
     provider_expected_revision: Option<u64>,
@@ -2261,6 +2284,16 @@ fn persist_exact_credential_transaction_inner(
             });
         }
     }
+    if let (Some((_, expected)), Some(section), Some(ExactTransactionScope::ClusterFabric)) =
+        (cluster_transaction, active_section.as_ref(), exact_scope)
+    {
+        if section.expected_revision != expected {
+            return Err(ConfigStoreError::Conflict {
+                expected,
+                actual: section.expected_revision,
+            });
+        }
+    }
     if let (Some((_, expected)), Some(section)) = (reset_scope, active_section.as_ref()) {
         if section.expected_revision != expected {
             return Err(ConfigStoreError::Conflict {
@@ -2391,7 +2424,7 @@ fn persist_exact_credential_transaction_inner(
     }
     if let Some((node_intents, _)) = cluster_transaction {
         let mut refs = BTreeSet::new();
-        for node_id in node_intents {
+        for node_id in node_intents.keys() {
             refs.insert(crate::cluster_password_credential_ref(node_id)?);
             refs.insert(crate::cluster_private_key_credential_ref(node_id)?);
             refs.insert(crate::cluster_passphrase_credential_ref(node_id)?);
@@ -2468,7 +2501,9 @@ fn persist_exact_credential_transaction_inner(
     };
     let mut prepared = match prepared {
         Some(prepared) => prepared,
-        None if provider_expected_revision.is_some() => store.prepare_provider_metadata_update()?,
+        None if provider_expected_revision.is_some() || cluster_transaction.is_some() => {
+            store.prepare_provider_metadata_update()?
+        }
         None => return store.revision_unchecked(),
     };
     if proxy_only && reset_scope.is_none() {
@@ -2503,14 +2538,6 @@ fn persist_exact_credential_transaction_inner(
                 "notification credential revision precondition is required".to_string(),
             )
         })?;
-        if prepared.expected_revision != expected {
-            return Err(ConfigStoreError::Conflict {
-                expected,
-                actual: prepared.expected_revision,
-            });
-        }
-    }
-    if let Some((_, expected)) = cluster_transaction {
         if prepared.expected_revision != expected {
             return Err(ConfigStoreError::Conflict {
                 expected,
@@ -2615,7 +2642,8 @@ fn persist_exact_credential_transaction_inner(
             original_data != candidate_data,
         )
     } else if let (Some(section), Some(scope)) = (active_section.as_ref(), exact_scope) {
-        let credential_changed = mcp_only && prepared.revision != prepared.expected_revision;
+        let credential_changed =
+            (mcp_only || cluster_only) && prepared.revision != prepared.expected_revision;
         let (bytes, changed) = prepare_active_exact_section_document(
             section,
             scope,
@@ -2653,15 +2681,34 @@ fn persist_exact_credential_transaction_inner(
         || cluster_domain_changed
         || connect_domain_changed
         || access_domain_changed;
-    if exact_domain_changed {
+    if exact_domain_changed && !cluster_only {
         prepared.advance_revision_for_domain_change()?;
     }
-    if store.revision_unchecked()? != prepared.expected_revision {
+    let committed_authority_revision = if cluster_only && active_section.is_some() {
+        crate::section_facade::validate_section_envelope(authority_name, &authority_bytes, 0)?
+    } else {
+        prepared.revision
+    };
+    #[cfg(test)]
+    if fault == Some(MigrationFault::BeforeExactStagingUnrelatedCredentialRace) {
+        store.replace_unchecked(
+            credential_ref("provider", "anthropic", "api_key")?,
+            "concurrent-pre-staging-winner",
+            crate::CredentialSource::User,
+            prepared.expected_revision,
+        )?;
+    }
+    let current_credential_revision = store.revision_unchecked()?;
+    if current_credential_revision != prepared.expected_revision && !cluster_only {
         return Err(ConfigStoreError::Conflict {
             expected: prepared.expected_revision,
-            actual: store.revision_unchecked()?,
+            actual: current_credential_revision,
         });
     }
+    // Cluster-fabric's section revision is the public CAS authority. If an
+    // unrelated credential writer advances this internal member after
+    // preparation, stage the immutable base/candidate pair and let the exact
+    // installer perform its touched-ref three-way merge.
     // A true env-domain no-op keeps the CAS revision and avoids publishing an
     // event or rewriting either durable member. Any credential or config
     // semantic change advances the one shared revision exactly once.
@@ -2674,7 +2721,7 @@ fn persist_exact_credential_transaction_inner(
         && !exact_domain_changed
         && prepared.revision == prepared.expected_revision
     {
-        return Ok(prepared.revision);
+        return Ok(committed_authority_revision);
     }
 
     let transaction_id = Uuid::new_v4().to_string();
@@ -2765,10 +2812,20 @@ fn persist_exact_credential_transaction_inner(
     write_manifest(data_dir.join(JOURNAL_FILE), &manifest)?;
 
     #[cfg(test)]
-    if fault == Some(MigrationFault::BeforeExactCommitCredentialRace) {
-        let reference = prepared.touched_refs.first().cloned().ok_or_else(|| {
-            ConfigStoreError::Validation("credential intent is empty".to_string())
-        })?;
+    if matches!(
+        fault,
+        Some(
+            MigrationFault::BeforeExactCommitCredentialRace
+                | MigrationFault::BeforeExactCommitUnrelatedCredentialRace
+        )
+    ) {
+        let reference = if fault == Some(MigrationFault::BeforeExactCommitCredentialRace) {
+            prepared.touched_refs.first().cloned().ok_or_else(|| {
+                ConfigStoreError::Validation("credential intent is empty".to_string())
+            })?
+        } else {
+            credential_ref("provider", "anthropic", "api_key")?
+        };
         store.replace_unchecked(
             reference,
             "concurrent-winner",
@@ -2784,6 +2841,13 @@ fn persist_exact_credential_transaction_inner(
         let current_sha256 = sha256(&current);
         if file.original_sha256.as_deref() != Some(current_sha256.as_str()) {
             if file.name == CREDENTIALS_FILE {
+                if exact_scope == Some(ExactTransactionScope::ClusterFabric) {
+                    // The cluster section is the external CAS authority. Commit
+                    // the manifest against its still-current revision and let
+                    // `install_exact_credential_member` three-way rebase this
+                    // internal member over unrelated credential winners.
+                    continue;
+                }
                 return Err(ConfigStoreError::Conflict {
                     expected: file.expected_revision.unwrap_or(0),
                     actual: store.revision_unchecked()?,
@@ -2865,7 +2929,14 @@ fn persist_exact_credential_transaction_inner(
         fault,
     )?;
     finish_transaction(data_dir, manifest)?;
-    store.revision_unchecked()
+    if cluster_only && active_section.is_some() {
+        Ok(committed_authority_revision)
+    } else {
+        // Credential-member rebases can advance beyond the initially staged
+        // revision. Preserve the existing exact-transaction return contract
+        // for every non-cluster domain.
+        store.revision_unchecked()
+    }
 }
 
 #[cfg(test)]
@@ -13864,6 +13935,40 @@ mod tests {
         (facade.effective_config(), revision)
     }
 
+    fn active_facade_config_and_cluster_revision(data_dir: &Path) -> (crate::Config, u64) {
+        let facade = crate::ConfigFacade::open(data_dir).unwrap();
+        let revision = facade.registry().cluster_fabric.snapshot().revision;
+        (facade.effective_config(), revision)
+    }
+
+    fn cluster_test_node(id: &str, auth: crate::SshAuth) -> crate::Node {
+        crate::Node {
+            id: id.to_string(),
+            label: id.to_string(),
+            placement: crate::NodePlacement::Ssh(crate::SshTarget {
+                host: "127.0.0.1".to_string(),
+                port: 22,
+                username: "deploy".to_string(),
+                auth,
+                host_key_fingerprint: None,
+            }),
+            trust_level: crate::TrustLevel::Trusted,
+            deploy: crate::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        }
+    }
+
+    fn password_intents(
+        action: crate::ClusterCredentialAction,
+    ) -> crate::ClusterNodeCredentialIntents {
+        crate::ClusterNodeCredentialIntents {
+            password: action,
+            private_key: crate::ClusterCredentialAction::Clear,
+            passphrase: crate::ClusterCredentialAction::Clear,
+        }
+    }
+
     fn assert_active_exact_manifest(data_dir: &Path, expected: ExactTransactionScope) {
         let manifest: MigrationManifest =
             serde_json::from_slice(&std::fs::read(data_dir.join(MANIFEST_FILE)).unwrap()).unwrap();
@@ -14267,9 +14372,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         crate::migrate_config_facade_layout(dir.path()).unwrap();
         let root_before = read_target_or_empty(&dir.path().join(CONFIG_FILE)).unwrap();
-        let intents = BTreeSet::from(["active-node".to_string()]);
 
-        let (mut set, revision) = active_facade_config_and_credential_revision(dir.path());
+        let (mut set, revision) = active_facade_config_and_cluster_revision(dir.path());
         set.cluster_fabric = serde_json::from_value(serde_json::json!({
             "nodes": [{
                 "id": "active-node",
@@ -14278,11 +14382,19 @@ mod tests {
                     "type": "ssh",
                     "host": "127.0.0.1",
                     "username": "deploy",
-                    "auth": {"method": "password", "password": "active-ssh-secret"}
+                    "auth": {"method": "password"}
                 }
             }]
         }))
         .unwrap();
+        let intents = BTreeMap::from([(
+            "active-node".to_string(),
+            crate::ClusterNodeCredentialIntents {
+                password: crate::ClusterCredentialAction::Replace("active-ssh-secret".to_string()),
+                private_key: crate::ClusterCredentialAction::Clear,
+                passphrase: crate::ClusterCredentialAction::Clear,
+            },
+        )]);
         persist_cluster_fabric_credential_transaction_at_revision(
             dir.path(),
             &mut set,
@@ -14292,9 +14404,13 @@ mod tests {
         .unwrap();
         assert_active_exact_manifest(dir.path(), ExactTransactionScope::ClusterFabric);
         let reference = crate::cluster_password_credential_ref("active-node").unwrap();
-        let (mut clear, revision) = active_facade_config_and_credential_revision(dir.path());
+        let (mut clear, revision) = active_facade_config_and_cluster_revision(dir.path());
         assert!(clear.cluster_fabric.credential_refs["active-node"].password_configured);
         clear.cluster_fabric.nodes.clear();
+        let intents = BTreeMap::from([(
+            "active-node".to_string(),
+            crate::ClusterNodeCredentialIntents::clear_all(),
+        )]);
         persist_cluster_fabric_credential_transaction_at_revision(
             dir.path(),
             &mut clear,
@@ -14302,7 +14418,7 @@ mod tests {
             revision,
         )
         .unwrap();
-        let (fresh, _) = active_facade_config_and_credential_revision(dir.path());
+        let (fresh, _) = active_facade_config_and_cluster_revision(dir.path());
         assert!(fresh.cluster_fabric.nodes.is_empty());
         assert!(!fresh
             .cluster_fabric
@@ -14316,6 +14432,690 @@ mod tests {
             read_target_or_empty(&dir.path().join(CONFIG_FILE)).unwrap(),
             root_before
         );
+    }
+
+    #[test]
+    fn cluster_section_revision_is_authoritative_and_rebases_unrelated_credentials() {
+        let _key = crate::encryption::set_test_encryption_key([0xb1; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let unrelated = credential_ref("provider", "anthropic", "api_key").unwrap();
+        let store = CredentialStore::open(dir.path());
+        store
+            .replace(
+                unrelated.clone(),
+                "unrelated-secret",
+                crate::CredentialSource::User,
+                0,
+            )
+            .unwrap();
+        assert_eq!(store.revision().unwrap(), 1);
+
+        let (mut candidate, section_revision) =
+            active_facade_config_and_cluster_revision(dir.path());
+        assert_eq!(section_revision, 0);
+        candidate.cluster_fabric.nodes.push(crate::Node {
+            id: "local-1".to_string(),
+            label: "local-1".to_string(),
+            placement: crate::NodePlacement::Local,
+            trust_level: crate::TrustLevel::Trusted,
+            deploy: crate::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        });
+        let intents = BTreeMap::from([(
+            "local-1".to_string(),
+            crate::ClusterNodeCredentialIntents::clear_all(),
+        )]);
+        let committed = persist_cluster_fabric_credential_transaction_at_revision(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            section_revision,
+        )
+        .unwrap();
+        assert_eq!(committed, 1, "the returned revision is the cluster section");
+        assert_eq!(
+            store.revision().unwrap(),
+            1,
+            "metadata-only cluster edits do not manufacture credential revisions"
+        );
+        assert_eq!(
+            store.resolve(&unrelated).unwrap().unwrap().expose(),
+            "unrelated-secret"
+        );
+
+        let cluster_before = std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap();
+        let credentials_before = std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap();
+        candidate.cluster_fabric.nodes[0].label = "stale-loser".to_string();
+        let error = persist_cluster_fabric_credential_transaction_at_revision(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            section_revision,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            ConfigStoreError::Conflict {
+                expected: 0,
+                actual: 1
+            }
+        ));
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+    }
+
+    #[test]
+    fn cluster_transaction_merges_unrelated_post_commit_credential_winner() {
+        let _key = crate::encryption::set_test_encryption_key([0xb2; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(crate::Node {
+            id: "race-local".to_string(),
+            label: "race-local".to_string(),
+            placement: crate::NodePlacement::Local,
+            trust_level: crate::TrustLevel::Trusted,
+            deploy: crate::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        });
+        let intents = BTreeMap::from([(
+            "race-local".to_string(),
+            crate::ClusterNodeCredentialIntents::clear_all(),
+        )]);
+
+        let committed = persist_cluster_fabric_credential_transaction_inner(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            revision,
+            Some(MigrationFault::AfterExactCommitUnrelatedCredentialRace),
+        )
+        .unwrap();
+        assert_eq!(committed, 1);
+        let unrelated = credential_ref("provider", "anthropic", "api_key").unwrap();
+        assert_eq!(
+            CredentialStore::open(dir.path())
+                .resolve(&unrelated)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            "concurrent-unrelated-winner"
+        );
+        let (fresh, revision) = active_facade_config_and_cluster_revision(dir.path());
+        assert_eq!(revision, 1);
+        assert!(fresh.cluster_fabric.node("race-local").is_some());
+    }
+
+    #[test]
+    fn cluster_transaction_rebases_unrelated_pre_manifest_credential_winner() {
+        let _key = crate::encryption::set_test_encryption_key([0xb6; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(crate::Node {
+            id: "pre-manifest-local".to_string(),
+            label: "pre-manifest-local".to_string(),
+            placement: crate::NodePlacement::Local,
+            trust_level: crate::TrustLevel::Trusted,
+            deploy: crate::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        });
+        let intents = BTreeMap::from([(
+            "pre-manifest-local".to_string(),
+            crate::ClusterNodeCredentialIntents::clear_all(),
+        )]);
+
+        let committed = persist_cluster_fabric_credential_transaction_inner(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            revision,
+            Some(MigrationFault::BeforeExactCommitUnrelatedCredentialRace),
+        )
+        .unwrap();
+        assert_eq!(committed, 1);
+        let unrelated = credential_ref("provider", "anthropic", "api_key").unwrap();
+        assert_eq!(
+            CredentialStore::open(dir.path())
+                .resolve(&unrelated)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            "concurrent-winner"
+        );
+        let (fresh, revision) = active_facade_config_and_cluster_revision(dir.path());
+        assert_eq!(revision, 1);
+        assert!(fresh.cluster_fabric.node("pre-manifest-local").is_some());
+    }
+
+    #[test]
+    fn cluster_transaction_rebases_unrelated_pre_staging_credential_winner() {
+        let _key = crate::encryption::set_test_encryption_key([0xb7; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(crate::Node {
+            id: "pre-staging-local".to_string(),
+            label: "pre-staging-local".to_string(),
+            placement: crate::NodePlacement::Local,
+            trust_level: crate::TrustLevel::Trusted,
+            deploy: crate::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        });
+        let intents = BTreeMap::from([(
+            "pre-staging-local".to_string(),
+            crate::ClusterNodeCredentialIntents::clear_all(),
+        )]);
+
+        let committed = persist_cluster_fabric_credential_transaction_inner(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            revision,
+            Some(MigrationFault::BeforeExactStagingUnrelatedCredentialRace),
+        )
+        .unwrap();
+        assert_eq!(committed, 1);
+        let unrelated = credential_ref("provider", "anthropic", "api_key").unwrap();
+        assert_eq!(
+            CredentialStore::open(dir.path())
+                .resolve(&unrelated)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            "concurrent-pre-staging-winner"
+        );
+        let (fresh, revision) = active_facade_config_and_cluster_revision(dir.path());
+        assert_eq!(revision, 1);
+        assert!(fresh.cluster_fabric.node("pre-staging-local").is_some());
+    }
+
+    #[test]
+    fn cluster_password_key_and_passphrase_actions_are_explicit_and_secret_free() {
+        let _key = crate::encryption::set_test_encryption_key([0xb3; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut create, revision) = active_facade_config_and_cluster_revision(dir.path());
+        create.cluster_fabric.nodes.push(cluster_test_node(
+            "ssh-1",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        let mut intents = BTreeMap::from([(
+            "ssh-1".to_string(),
+            password_intents(crate::ClusterCredentialAction::Replace(
+                "password-secret".to_string(),
+            )),
+        )]);
+        assert_eq!(
+            persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut create,
+                &intents,
+                revision,
+            )
+            .unwrap(),
+            1
+        );
+        let store = CredentialStore::open(dir.path());
+        let password_ref = crate::cluster_password_credential_ref("ssh-1").unwrap();
+        let key_ref = crate::cluster_private_key_credential_ref("ssh-1").unwrap();
+        let passphrase_ref = crate::cluster_passphrase_credential_ref("ssh-1").unwrap();
+        assert_eq!(
+            store.resolve(&password_ref).unwrap().unwrap().expose(),
+            "password-secret"
+        );
+
+        let (mut keep, revision) = active_facade_config_and_cluster_revision(dir.path());
+        keep.cluster_fabric.node_mut("ssh-1").unwrap().label = "kept".to_string();
+        intents.insert(
+            "ssh-1".to_string(),
+            password_intents(crate::ClusterCredentialAction::Keep),
+        );
+        assert_eq!(
+            persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut keep,
+                &intents,
+                revision,
+            )
+            .unwrap(),
+            2
+        );
+        assert_eq!(
+            store.resolve(&password_ref).unwrap().unwrap().expose(),
+            "password-secret"
+        );
+
+        let (mut switch, revision) = active_facade_config_and_cluster_revision(dir.path());
+        switch.cluster_fabric.node_mut("ssh-1").unwrap().placement =
+            crate::NodePlacement::Ssh(crate::SshTarget {
+                host: "127.0.0.1".to_string(),
+                port: 22,
+                username: "deploy".to_string(),
+                auth: crate::SshAuth::PrivateKey {
+                    private_key: String::new(),
+                    private_key_encrypted: None,
+                    private_key_path: None,
+                    passphrase: String::new(),
+                    passphrase_encrypted: None,
+                },
+                host_key_fingerprint: None,
+            });
+        intents.insert(
+            "ssh-1".to_string(),
+            crate::ClusterNodeCredentialIntents {
+                password: crate::ClusterCredentialAction::Clear,
+                private_key: crate::ClusterCredentialAction::Replace(
+                    "private-key-secret".to_string(),
+                ),
+                passphrase: crate::ClusterCredentialAction::Replace(
+                    "passphrase-secret".to_string(),
+                ),
+            },
+        );
+        assert_eq!(
+            persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut switch,
+                &intents,
+                revision,
+            )
+            .unwrap(),
+            3
+        );
+        assert!(store.resolve(&password_ref).unwrap().is_none());
+        assert_eq!(
+            store.resolve(&key_ref).unwrap().unwrap().expose(),
+            "private-key-secret"
+        );
+        assert_eq!(
+            store.resolve(&passphrase_ref).unwrap().unwrap().expose(),
+            "passphrase-secret"
+        );
+
+        let (mut clear_passphrase, revision) =
+            active_facade_config_and_cluster_revision(dir.path());
+        clear_passphrase
+            .cluster_fabric
+            .node_mut("ssh-1")
+            .unwrap()
+            .label = "clear-passphrase".to_string();
+        intents.insert(
+            "ssh-1".to_string(),
+            crate::ClusterNodeCredentialIntents {
+                password: crate::ClusterCredentialAction::Clear,
+                private_key: crate::ClusterCredentialAction::Keep,
+                passphrase: crate::ClusterCredentialAction::Clear,
+            },
+        );
+        assert_eq!(
+            persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut clear_passphrase,
+                &intents,
+                revision,
+            )
+            .unwrap(),
+            4
+        );
+        assert_eq!(
+            store.resolve(&key_ref).unwrap().unwrap().expose(),
+            "private-key-secret"
+        );
+        assert!(store.resolve(&passphrase_ref).unwrap().is_none());
+
+        let ordinary = std::fs::read_to_string(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap();
+        for forbidden in [
+            "password-secret",
+            "private-key-secret",
+            "passphrase-secret",
+            "****",
+            "password_encrypted",
+            "private_key_encrypted",
+            "passphrase_encrypted",
+        ] {
+            assert!(
+                !ordinary.contains(forbidden),
+                "ordinary cluster section leaked {forbidden}"
+            );
+        }
+        let section: Value = serde_json::from_str(&ordinary).unwrap();
+        let auth = &section["data"]["nodes"][0]["placement"]["auth"];
+        assert!(auth.get("password").is_none());
+        assert!(auth.get("private_key").is_none());
+        assert!(auth.get("passphrase").is_none());
+    }
+
+    #[test]
+    fn secret_only_cluster_replace_advances_section_revision_and_rejects_stale_writer() {
+        let _key = crate::encryption::set_test_encryption_key([0xb8; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+
+        let (mut create, revision) = active_facade_config_and_cluster_revision(dir.path());
+        create.cluster_fabric.nodes.push(cluster_test_node(
+            "secret-cas",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        let initial_intents = BTreeMap::from([(
+            "secret-cas".to_string(),
+            password_intents(crate::ClusterCredentialAction::Replace(
+                "initial-secret".to_string(),
+            )),
+        )]);
+        assert_eq!(
+            persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut create,
+                &initial_intents,
+                revision,
+            )
+            .unwrap(),
+            1
+        );
+
+        let (first_base, shared_revision) = active_facade_config_and_cluster_revision(dir.path());
+        assert_eq!(shared_revision, 1);
+        let mut first = first_base.clone();
+        let mut stale = first_base;
+        let winner_intents = BTreeMap::from([(
+            "secret-cas".to_string(),
+            password_intents(crate::ClusterCredentialAction::Replace(
+                "winner-secret".to_string(),
+            )),
+        )]);
+        assert_eq!(
+            persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut first,
+                &winner_intents,
+                shared_revision,
+            )
+            .unwrap(),
+            2,
+            "a secret-only write must advance the public cluster revision"
+        );
+
+        let stale_intents = BTreeMap::from([(
+            "secret-cas".to_string(),
+            password_intents(crate::ClusterCredentialAction::Replace(
+                "stale-loser-secret".to_string(),
+            )),
+        )]);
+        let error = persist_cluster_fabric_credential_transaction_at_revision(
+            dir.path(),
+            &mut stale,
+            &stale_intents,
+            shared_revision,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            ConfigStoreError::Conflict {
+                expected: 1,
+                actual: 2
+            }
+        ));
+        let reference = crate::cluster_password_credential_ref("secret-cas").unwrap();
+        assert_eq!(
+            CredentialStore::open(dir.path())
+                .resolve(&reference)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            "winner-secret"
+        );
+    }
+
+    #[test]
+    fn node_and_new_cluster_membership_commit_together_or_not_at_all() {
+        let _key = crate::encryption::set_test_encryption_key([0xb4; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(cluster_test_node(
+            "atomic-node",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        candidate.cluster_fabric.clusters.push(crate::Cluster {
+            name: "new-cluster".to_string(),
+            description: None,
+            node_ids: vec!["atomic-node".to_string()],
+        });
+        let intents = BTreeMap::from([(
+            "atomic-node".to_string(),
+            password_intents(crate::ClusterCredentialAction::Replace(
+                "atomic-secret".to_string(),
+            )),
+        )]);
+        assert_eq!(
+            persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut candidate,
+                &intents,
+                revision,
+            )
+            .unwrap(),
+            1
+        );
+        let (fresh, revision) = active_facade_config_and_cluster_revision(dir.path());
+        assert_eq!(revision, 1);
+        assert!(fresh.cluster_fabric.node("atomic-node").is_some());
+        assert_eq!(
+            fresh
+                .cluster_fabric
+                .cluster("new-cluster")
+                .unwrap()
+                .node_ids,
+            ["atomic-node"]
+        );
+
+        let cluster_before = std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap();
+        let credentials_before = std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap();
+        let (mut failed, revision) = active_facade_config_and_cluster_revision(dir.path());
+        failed.cluster_fabric.nodes.push(cluster_test_node(
+            "failed-node",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        failed.cluster_fabric.clusters.push(crate::Cluster {
+            name: "failed-cluster".to_string(),
+            description: None,
+            node_ids: vec!["failed-node".to_string()],
+        });
+        let failed_intents = BTreeMap::from([(
+            "failed-node".to_string(),
+            password_intents(crate::ClusterCredentialAction::Replace(
+                "failed-secret".to_string(),
+            )),
+        )]);
+        assert!(persist_cluster_fabric_credential_transaction_inner(
+            dir.path(),
+            &mut failed,
+            &failed_intents,
+            revision,
+            Some(MigrationFault::AfterStaging),
+        )
+        .is_err());
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+        let (fresh, fresh_revision) = active_facade_config_and_cluster_revision(dir.path());
+        assert_eq!(fresh_revision, revision);
+        assert!(fresh.cluster_fabric.node("failed-node").is_none());
+        assert!(fresh.cluster_fabric.cluster("failed-cluster").is_none());
+    }
+
+    #[test]
+    fn stale_node_delete_cannot_overwrite_concurrent_membership_edit() {
+        let _key = crate::encryption::set_test_encryption_key([0xb5; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut initial, revision) = active_facade_config_and_cluster_revision(dir.path());
+        initial.cluster_fabric.nodes.push(crate::Node {
+            id: "member".to_string(),
+            label: "member".to_string(),
+            placement: crate::NodePlacement::Local,
+            trust_level: crate::TrustLevel::Trusted,
+            deploy: crate::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        });
+        initial.cluster_fabric.clusters.push(crate::Cluster {
+            name: "first".to_string(),
+            description: None,
+            node_ids: vec!["member".to_string()],
+        });
+        let node_intents = BTreeMap::from([(
+            "member".to_string(),
+            crate::ClusterNodeCredentialIntents::clear_all(),
+        )]);
+        persist_cluster_fabric_credential_transaction_at_revision(
+            dir.path(),
+            &mut initial,
+            &node_intents,
+            revision,
+        )
+        .unwrap();
+
+        let (base, revision) = active_facade_config_and_cluster_revision(dir.path());
+        let mut membership_winner = base.clone();
+        membership_winner
+            .cluster_fabric
+            .clusters
+            .push(crate::Cluster {
+                name: "second".to_string(),
+                description: None,
+                node_ids: vec!["member".to_string()],
+            });
+        persist_cluster_fabric_credential_transaction_at_revision(
+            dir.path(),
+            &mut membership_winner,
+            &BTreeMap::new(),
+            revision,
+        )
+        .unwrap();
+
+        let mut stale_delete = base;
+        stale_delete.cluster_fabric.nodes.clear();
+        stale_delete.cluster_fabric.clusters.clear();
+        let error = persist_cluster_fabric_credential_transaction_at_revision(
+            dir.path(),
+            &mut stale_delete,
+            &node_intents,
+            revision,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            ConfigStoreError::Conflict { actual: 2, .. }
+        ));
+        let (fresh, _) = active_facade_config_and_cluster_revision(dir.path());
+        assert!(fresh.cluster_fabric.node("member").is_some());
+        assert_eq!(
+            fresh.cluster_fabric.cluster("second").unwrap().node_ids,
+            ["member"]
+        );
+    }
+
+    #[test]
+    fn active_cluster_exact_transaction_recovers_every_durable_boundary_atomically() {
+        for (index, fault) in [
+            MigrationFault::AfterManifest,
+            MigrationFault::AfterCredentials,
+            MigrationFault::AfterAuthoritativeSection,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let _key = crate::encryption::set_test_encryption_key([0xb7 + index as u8; 32]);
+            let dir = tempfile::tempdir().unwrap();
+            crate::migrate_config_facade_layout(dir.path()).unwrap();
+            let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+            let node_id = format!("recover-node-{index}");
+            let cluster_name = format!("recover-cluster-{index}");
+            let secret = format!("recover-cluster-secret-{index}");
+            candidate.cluster_fabric.nodes.push(cluster_test_node(
+                &node_id,
+                crate::SshAuth::Password {
+                    password: String::new(),
+                    password_encrypted: None,
+                },
+            ));
+            candidate.cluster_fabric.clusters.push(crate::Cluster {
+                name: cluster_name.clone(),
+                description: None,
+                node_ids: vec![node_id.clone()],
+            });
+            let intents = BTreeMap::from([(
+                node_id.clone(),
+                password_intents(crate::ClusterCredentialAction::Replace(secret.clone())),
+            )]);
+
+            let error = persist_cluster_fabric_credential_transaction_inner(
+                dir.path(),
+                &mut candidate,
+                &intents,
+                revision,
+                Some(fault),
+            )
+            .unwrap_err();
+            assert!(matches!(error, ConfigStoreError::Io(_)));
+            assert!(
+                crate::ConfigFacade::open(dir.path()).is_err(),
+                "a partial durable boundary must not open as a fresh facade"
+            );
+            assert!(recover_pending_config_transaction(dir.path()).unwrap());
+            let (fresh, committed_revision) = active_facade_config_and_cluster_revision(dir.path());
+            assert_eq!(committed_revision, revision + 1);
+            assert!(fresh.cluster_fabric.node(&node_id).is_some());
+            assert_eq!(
+                fresh
+                    .cluster_fabric
+                    .cluster(&cluster_name)
+                    .unwrap()
+                    .node_ids
+                    .as_slice(),
+                std::slice::from_ref(&node_id)
+            );
+            let reference = crate::cluster_password_credential_ref(&node_id).unwrap();
+            assert_eq!(
+                CredentialStore::open(dir.path())
+                    .resolve(&reference)
+                    .unwrap()
+                    .unwrap()
+                    .expose(),
+                secret
+            );
+            assert_active_exact_manifest(dir.path(), ExactTransactionScope::ClusterFabric);
+        }
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -1699,6 +1699,7 @@ pub fn persist_connect_credential_transaction_at_revision(
         None,
         None,
         None,
+        None,
         #[cfg(test)]
         None,
     )
@@ -1737,9 +1738,59 @@ pub fn persist_access_control_credential_transaction_at_revision(
         None,
         None,
         None,
+        None,
         #[cfg(test)]
         None,
     )
+}
+
+/// Result of a cluster-fabric compound commit whose process-local facade
+/// adoption was attempted before the cross-process transaction lock was
+/// released.
+pub struct ClusterFabricTransactionCommit {
+    pub revision: u64,
+    pub adoption: Option<ConfigStoreResult<crate::ConfigSectionEvent>>,
+    pub credential_adoption: Option<ConfigStoreResult<()>>,
+    /// Exact runtime and public credential metadata captured from one
+    /// immutable credential document before the transaction lock admitted
+    /// another writer. Present for changed and semantic no-op transactions.
+    pub runtime: ConfigStoreResult<ClusterFabricRuntimeSnapshot>,
+}
+
+pub struct ClusterFabricRuntimeSnapshot {
+    pub cluster_fabric: crate::ClusterFabricConfig,
+    pub credential_statuses: Vec<crate::CredentialStatus>,
+    pub credential_health: crate::CredentialStoreHealth,
+}
+
+struct ExactClusterRuntimeSnapshot {
+    runtime: ClusterFabricRuntimeSnapshot,
+    credential_lkg: crate::credential_store::CredentialDocumentLkg,
+}
+
+type ClusterPostCommit<'a> = &'a mut dyn FnMut(
+    u64,
+    bool,
+    &crate::ClusterFabricConfig,
+    ConfigStoreResult<ExactClusterRuntimeSnapshot>,
+);
+
+fn materialize_cluster_runtime_under_migration_lock(
+    config: &crate::Config,
+    store: &CredentialStore,
+) -> ConfigStoreResult<ExactClusterRuntimeSnapshot> {
+    let (credential_lkg, credential_statuses, credential_health) =
+        store.snapshot_with_health_unchecked()?;
+    let mut runtime = config.clone();
+    runtime.hydrate_cluster_credentials_from_snapshot(&credential_lkg)?;
+    Ok(ExactClusterRuntimeSnapshot {
+        runtime: ClusterFabricRuntimeSnapshot {
+            cluster_fabric: runtime.cluster_fabric.clone(),
+            credential_statuses,
+            credential_health,
+        },
+        credential_lkg,
+    })
 }
 
 /// Persist node metadata and every explicitly touched SSH credential through
@@ -1757,7 +1808,76 @@ pub fn persist_cluster_fabric_credential_transaction_at_revision(
         node_intents,
         expected_revision,
         None,
+        None,
     )
+}
+
+/// Persist a cluster-fabric compound transaction and adopt its exact immutable
+/// candidate into the supplied process facade while the migration lock still
+/// excludes later cross-process commits. An adoption failure is returned as a
+/// post-commit outcome rather than being confused with a failed durable CAS.
+pub fn persist_cluster_fabric_credential_transaction_with_adoption<F>(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    node_intents: &BTreeMap<String, crate::ClusterNodeCredentialIntents>,
+    expected_revision: u64,
+    facade: &crate::ConfigFacade,
+    mut before_adoption: F,
+) -> ConfigStoreResult<ClusterFabricTransactionCommit>
+where
+    F: FnMut(u64, &crate::ClusterFabricConfig),
+{
+    let mut adoption = None;
+    let mut exact_runtime = None;
+    let mut transaction_changed = false;
+    let mut callback =
+        |revision: u64,
+         changed: bool,
+         candidate: &crate::ClusterFabricConfig,
+         runtime: ConfigStoreResult<ExactClusterRuntimeSnapshot>| {
+            exact_runtime = Some(runtime);
+            transaction_changed = changed;
+            if changed {
+                before_adoption(revision, candidate);
+                adoption = Some(facade.adopt_committed_cluster_fabric(
+                    expected_revision,
+                    revision,
+                    candidate.clone(),
+                ));
+            }
+        };
+    let revision = persist_cluster_fabric_credential_transaction_inner(
+        data_dir.as_ref(),
+        config,
+        node_intents,
+        expected_revision,
+        Some(&mut callback),
+        None,
+    )?;
+    let (runtime, credential_adoption) = match exact_runtime.unwrap_or_else(|| {
+        Err(ConfigStoreError::Validation(
+            "cluster transaction omitted exact runtime materialization".to_string(),
+        ))
+    }) {
+        Ok(exact) => {
+            let runtime = exact.runtime;
+            let credential_adoption = transaction_changed.then(|| {
+                facade.adopt_captured_cluster_credentials(
+                    exact.credential_lkg,
+                    runtime.credential_statuses.clone(),
+                    runtime.credential_health.clone(),
+                )
+            });
+            (Ok(runtime), credential_adoption)
+        }
+        Err(error) => (Err(error), None),
+    };
+    Ok(ClusterFabricTransactionCommit {
+        revision,
+        adoption,
+        credential_adoption,
+        runtime,
+    })
 }
 
 fn persist_cluster_fabric_credential_transaction_inner(
@@ -1765,6 +1885,7 @@ fn persist_cluster_fabric_credential_transaction_inner(
     config: &mut crate::Config,
     node_intents: &BTreeMap<String, crate::ClusterNodeCredentialIntents>,
     expected_revision: u64,
+    cluster_post_commit: Option<ClusterPostCommit<'_>>,
     #[cfg_attr(not(test), allow(unused_variables))] fault: Option<MigrationFault>,
 ) -> ConfigStoreResult<u64> {
     if !crate::section_layout_is_active(data_dir)? {
@@ -1790,6 +1911,7 @@ fn persist_cluster_fabric_credential_transaction_inner(
         None,
         None,
         None,
+        cluster_post_commit,
         #[cfg(test)]
         fault,
     )
@@ -1926,6 +2048,7 @@ pub fn persist_mcp_reset_credential_transaction_at_revision(
         None,
         Some((&intents, expected_revision)),
         None,
+        None,
         #[cfg(test)]
         None,
     )
@@ -1979,6 +2102,7 @@ fn persist_mcp_credential_transaction_inner(
         None,
         Some((intents, expected_revision)),
         None,
+        None,
         #[cfg(test)]
         fault,
     )
@@ -2025,9 +2149,94 @@ pub fn persist_credential_backed_section_reset_at_revision(
         None,
         None,
         Some((scope, expected_revision)),
+        None,
         #[cfg(test)]
         None,
     )
+}
+
+/// Reset cluster-fabric and adopt its exact committed snapshot into one
+/// process facade before the cross-process transaction lock is released.
+pub fn persist_cluster_fabric_reset_at_revision_with_adoption<F>(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    expected_revision: u64,
+    facade: &crate::ConfigFacade,
+    mut before_adoption: F,
+) -> ConfigStoreResult<ClusterFabricTransactionCommit>
+where
+    F: FnMut(u64, &crate::ClusterFabricConfig),
+{
+    if !crate::section_layout_is_active(data_dir.as_ref())? {
+        return Err(ConfigStoreError::Validation(
+            "cluster reset requires the modular configuration layout".to_string(),
+        ));
+    }
+    let mut adoption = None;
+    let mut exact_runtime = None;
+    let mut transaction_changed = false;
+    let mut callback =
+        |revision: u64,
+         changed: bool,
+         candidate: &crate::ClusterFabricConfig,
+         runtime: ConfigStoreResult<ExactClusterRuntimeSnapshot>| {
+            exact_runtime = Some(runtime);
+            transaction_changed = changed;
+            if changed {
+                before_adoption(revision, candidate);
+                adoption = Some(facade.adopt_committed_cluster_fabric(
+                    expected_revision,
+                    revision,
+                    candidate.clone(),
+                ));
+            }
+        };
+    let revision = persist_exact_credential_transaction_inner(
+        data_dir.as_ref(),
+        config,
+        &BTreeSet::new(),
+        &BTreeSet::new(),
+        None,
+        &BTreeSet::new(),
+        None,
+        false,
+        &BTreeSet::new(),
+        false,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some((ExactTransactionScope::ClusterFabric, expected_revision)),
+        Some(&mut callback),
+        #[cfg(test)]
+        None,
+    )?;
+    let (runtime, credential_adoption) = match exact_runtime.unwrap_or_else(|| {
+        Err(ConfigStoreError::Validation(
+            "cluster reset omitted exact runtime materialization".to_string(),
+        ))
+    }) {
+        Ok(exact) => {
+            let runtime = exact.runtime;
+            let credential_adoption = transaction_changed.then(|| {
+                facade.adopt_captured_cluster_credentials(
+                    exact.credential_lkg,
+                    runtime.credential_statuses.clone(),
+                    runtime.credential_health.clone(),
+                )
+            });
+            (Ok(runtime), credential_adoption)
+        }
+        Err(error) => (Err(error), None),
+    };
+    Ok(ClusterFabricTransactionCommit {
+        revision,
+        adoption,
+        credential_adoption,
+        runtime,
+    })
 }
 
 #[cfg(test)]
@@ -2124,6 +2333,7 @@ fn persist_provider_credential_transaction_with_instances_at_revision_inner(
         provider_expected_revision,
         None,
         None,
+        None,
         #[cfg(test)]
         fault,
     )
@@ -2148,6 +2358,7 @@ fn persist_exact_credential_transaction_inner(
     provider_expected_revision: Option<u64>,
     mcp_transaction: Option<(&BTreeSet<CredentialRef>, u64)>,
     reset_scope: Option<(ExactTransactionScope, u64)>,
+    mut cluster_post_commit: Option<ClusterPostCommit<'_>>,
     #[cfg(test)] fault: Option<MigrationFault>,
 ) -> ConfigStoreResult<u64> {
     let reset_is = |scope| reset_scope.is_some_and(|(reset, _)| reset == scope);
@@ -2721,6 +2932,17 @@ fn persist_exact_credential_transaction_inner(
         && !exact_domain_changed
         && prepared.revision == prepared.expected_revision
     {
+        if cluster_only && active_section.is_some() {
+            if let Some(callback) = cluster_post_commit.as_mut() {
+                let runtime = materialize_cluster_runtime_under_migration_lock(config, &store);
+                callback(
+                    committed_authority_revision,
+                    false,
+                    &config.cluster_fabric,
+                    runtime,
+                );
+            }
+        }
         return Ok(committed_authority_revision);
     }
 
@@ -2930,6 +3152,15 @@ fn persist_exact_credential_transaction_inner(
     )?;
     finish_transaction(data_dir, manifest)?;
     if cluster_only && active_section.is_some() {
+        if let Some(callback) = cluster_post_commit.as_mut() {
+            let runtime = materialize_cluster_runtime_under_migration_lock(config, &store);
+            callback(
+                committed_authority_revision,
+                true,
+                &config.cluster_fabric,
+                runtime,
+            );
+        }
         Ok(committed_authority_revision)
     } else {
         // Credential-member rebases can advance beyond the initially staged
@@ -14537,6 +14768,7 @@ mod tests {
             &mut candidate,
             &intents,
             revision,
+            None,
             Some(MigrationFault::AfterExactCommitUnrelatedCredentialRace),
         )
         .unwrap();
@@ -14580,6 +14812,7 @@ mod tests {
             &mut candidate,
             &intents,
             revision,
+            None,
             Some(MigrationFault::BeforeExactCommitUnrelatedCredentialRace),
         )
         .unwrap();
@@ -14623,6 +14856,7 @@ mod tests {
             &mut candidate,
             &intents,
             revision,
+            None,
             Some(MigrationFault::BeforeExactStagingUnrelatedCredentialRace),
         )
         .unwrap();
@@ -14956,6 +15190,7 @@ mod tests {
             &mut failed,
             &failed_intents,
             revision,
+            None,
             Some(MigrationFault::AfterStaging),
         )
         .is_err());
@@ -15084,6 +15319,7 @@ mod tests {
                 &mut candidate,
                 &intents,
                 revision,
+                None,
                 Some(fault),
             )
             .unwrap_err();

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -2165,6 +2165,17 @@ fn report_cluster_committed_recovery_failure(
     Some(revision)
 }
 
+fn cluster_commit_indeterminate_error(
+    initial_error: &ConfigStoreError,
+    terminal_error: &ConfigStoreError,
+) -> ConfigStoreError {
+    ConfigStoreError::CommitIndeterminate(format!(
+        "cluster transaction has durable commit intent, but installed authority could not be \
+         proven; completion failed ({initial_error}), and recovery/inspection failed \
+         ({terminal_error})"
+    ))
+}
+
 /// One coherent durable cluster generation captured under the shared
 /// migration lock. The runtime fabric may contain hydrated SSH credentials,
 /// so this type deliberately does not implement `Debug` or `Serialize`.
@@ -3818,7 +3829,10 @@ fn persist_exact_credential_transaction_inner(
                 ) {
                     return Ok(revision);
                 }
-                return Err(inspection_error);
+                return Err(cluster_commit_indeterminate_error(
+                    &initial_error,
+                    &inspection_error,
+                ));
             }
         };
         let recovery = {
@@ -3871,7 +3885,10 @@ fn persist_exact_credential_transaction_inner(
                     ) {
                         return Ok(revision);
                     }
-                    return Err(load_error);
+                    return Err(cluster_commit_indeterminate_error(
+                        &initial_error,
+                        &load_error,
+                    ));
                 }
             },
             Err(recovery_error) => {
@@ -3898,7 +3915,10 @@ fn persist_exact_credential_transaction_inner(
                             ) {
                                 return Ok(revision);
                             }
-                            return Err(combined);
+                            return Err(cluster_commit_indeterminate_error(
+                                &initial_error,
+                                &combined,
+                            ));
                         }
                     };
                 if let Some(revision) = report_cluster_committed_recovery_failure(
@@ -3913,7 +3933,10 @@ fn persist_exact_credential_transaction_inner(
                 ) {
                     return Ok(revision);
                 }
-                return Err(recovery_error);
+                return Err(cluster_commit_indeterminate_error(
+                    &initial_error,
+                    &recovery_error,
+                ));
             }
         }
     }
@@ -16571,6 +16594,74 @@ mod tests {
             LiveClusterTransaction::Committed(_)
         ));
         clear_cluster_exact_commit_test_fault(dir.path());
+    }
+
+    #[test]
+    fn unproven_commit_recovery_failure_is_typed_without_callback_and_startup_recovers() {
+        let _key = crate::encryption::set_test_encryption_key([0xcc; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(crate::Node {
+            id: "startup-recovery-node".to_string(),
+            label: "startup-recovery-node".to_string(),
+            placement: crate::NodePlacement::Local,
+            trust_level: crate::TrustLevel::Trusted,
+            deploy: crate::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        });
+        let intents = BTreeMap::from([(
+            "startup-recovery-node".to_string(),
+            crate::ClusterNodeCredentialIntents::clear_all(),
+        )]);
+        let cluster_before = std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap();
+        let mut callbacks = 0;
+        let mut callback = |_: u64,
+                            _: bool,
+                            _: &crate::ClusterFabricConfig,
+                            _: ConfigStoreResult<ExactClusterRuntimeSnapshot>,
+                            _: ConfigStoreResult<()>| {
+            callbacks += 1;
+        };
+        set_cluster_exact_commit_test_fault(
+            dir.path().to_path_buf(),
+            ClusterExactCommitTestFault::AfterManifestRecoveryFailure,
+        );
+
+        let error = persist_cluster_fabric_credential_transaction_inner(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            revision,
+            Some(&mut callback),
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(&error, ConfigStoreError::CommitIndeterminate(_)));
+        assert_eq!(
+            callbacks, 0,
+            "an unproven candidate must not invoke the post-commit callback"
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before,
+            "the durable authority must remain at the pre-final-persist generation"
+        );
+        assert!(dir.path().join(MANIFEST_FILE).exists());
+
+        let reopened = crate::ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        assert_eq!(
+            reopened.registry().cluster_fabric.snapshot().revision,
+            revision + 1
+        );
+        assert!(reopened
+            .effective_config()
+            .cluster_fabric
+            .node("startup-recovery-node")
+            .is_some());
+        assert_active_exact_manifest(dir.path(), ExactTransactionScope::ClusterFabric);
+        assert_eq!(callbacks, 0);
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -1519,8 +1519,11 @@ pub fn ensure_provider_mcp_migration_ready(data_dir: impl AsRef<Path>) -> Config
         )
     })?;
     if manifest.state != MigrationState::Complete {
+        let journal_aborting = manifest.state == MigrationState::Pending
+            && matching_cluster_abort_journal(data_dir.as_ref(), &manifest)?;
         if manifest.migration_scope == Some(MigrationScope::ClusterFabric)
             && manifest.state == MigrationState::Pending
+            && !journal_aborting
             && provider_mcp_documents_are_migration_free(data_dir.as_ref())?
             && pending_cluster_refs_are_exclusive(data_dir.as_ref())?
         {
@@ -1984,6 +1987,11 @@ fn load_live_cluster_transaction_manifest(
         return Err(ConfigStoreError::Validation(
             "cluster transaction manifest no longer matches its commit".to_string(),
         ));
+    }
+    if manifest.state == MigrationState::Pending
+        && matching_cluster_abort_journal(data_dir, &manifest)?
+    {
+        return Ok(LiveClusterTransaction::Aborting);
     }
     if manifest.state == MigrationState::Aborting {
         return Ok(LiveClusterTransaction::Aborting);
@@ -4069,8 +4077,12 @@ fn pending_cluster_migration(data_dir: &Path) -> ConfigStoreResult<bool> {
     };
     let manifest: MigrationManifest = serde_json::from_slice(&bytes)?;
     validate_manifest(&manifest)?;
-    Ok(manifest.state == MigrationState::Pending
-        && manifest.migration_scope == Some(MigrationScope::ClusterFabric))
+    let pending = manifest.state == MigrationState::Pending
+        && manifest.migration_scope == Some(MigrationScope::ClusterFabric);
+    if pending && matching_cluster_abort_journal(data_dir, &manifest)? {
+        return Ok(false);
+    }
+    Ok(pending)
 }
 
 fn pending_cluster_refs_are_exclusive(data_dir: &Path) -> ConfigStoreResult<bool> {
@@ -8028,6 +8040,71 @@ fn write_manifest(path: PathBuf, manifest: &MigrationManifest) -> ConfigStoreRes
     AtomicFileStore::new(path).write_bytes_without_backup(&serde_json::to_vec_pretty(manifest)?)
 }
 
+fn validate_matching_cluster_journal(
+    manifest: &MigrationManifest,
+    journal: &MigrationManifest,
+) -> ConfigStoreResult<()> {
+    if manifest.exact_scope != Some(ExactTransactionScope::ClusterFabric)
+        || journal.exact_scope != Some(ExactTransactionScope::ClusterFabric)
+        || journal.transaction_id != manifest.transaction_id
+        || journal.stage_dir != manifest.stage_dir
+        || journal.migration_scope != manifest.migration_scope
+    {
+        return Err(ConfigStoreError::Validation(
+            "cluster abort journal does not match its committed manifest".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Return whether the immutable transaction journal carries durable non-commit
+/// intent for this exact cluster transaction.
+///
+/// The journal's original file members are the rollback authority and may
+/// differ from a rebased main manifest. Matching therefore compares identity
+/// and scope only, never candidate member metadata.
+fn matching_cluster_abort_journal(
+    data_dir: &Path,
+    manifest: &MigrationManifest,
+) -> ConfigStoreResult<bool> {
+    let Some(bytes) = read_optional_migration_file(&data_dir.join(JOURNAL_FILE))? else {
+        return Ok(false);
+    };
+    let journal: MigrationManifest = serde_json::from_slice(&bytes)?;
+    validate_manifest(&journal)?;
+    if journal.state != MigrationState::Aborting {
+        return Ok(false);
+    }
+    validate_matching_cluster_journal(manifest, &journal)?;
+    Ok(true)
+}
+
+/// Persist durable abort intent into the immutable journal before the mutable
+/// main manifest is transitioned. Only `state` changes; original staged-member
+/// metadata remains available for exact rollback after rebases or restart.
+fn persist_cluster_abort_journal(
+    data_dir: &Path,
+    manifest: &MigrationManifest,
+) -> ConfigStoreResult<()> {
+    let path = data_dir.join(JOURNAL_FILE);
+    let bytes = read_optional_migration_file(&path)?.ok_or_else(|| {
+        ConfigStoreError::Validation("cluster abort journal is missing".to_string())
+    })?;
+    let mut journal: MigrationManifest = serde_json::from_slice(&bytes)?;
+    validate_manifest(&journal)?;
+    validate_matching_cluster_journal(manifest, &journal)?;
+    if journal.state == MigrationState::Complete {
+        return Err(ConfigStoreError::Validation(
+            "a complete cluster journal cannot enter abort rollback".to_string(),
+        ));
+    }
+    if journal.state != MigrationState::Aborting {
+        journal.state = MigrationState::Aborting;
+        write_manifest(path, &journal)?;
+    }
+    Ok(())
+}
+
 fn recover_committed(
     data_dir: &Path,
     #[cfg(test)] fault: Option<MigrationFault>,
@@ -8045,6 +8122,15 @@ fn recover_committed(
         }
         cleanup_transaction_dirs(data_dir, &manifest)?;
         remove_file_if_exists(&data_dir.join(JOURNAL_FILE))?;
+        return Ok(None);
+    }
+    if manifest.state == MigrationState::Pending
+        && matching_cluster_abort_journal(data_dir, &manifest)?
+    {
+        // The journal was durably marked before a failed main-manifest abort
+        // transition. Resume rollback before any install validation; the
+        // original conflict may no longer exist after restart.
+        abort_cluster_exact_transaction(data_dir, &manifest, None)?;
         return Ok(None);
     }
     if manifest.state == MigrationState::Aborting {
@@ -8584,9 +8670,13 @@ fn abort_cluster_exact_transaction(
             "a complete cluster transaction cannot enter abort rollback".to_string(),
         ));
     }
+    // First persist non-commit intent into the immutable rollback journal. If
+    // this write fails, the transaction remains indeterminate/commit-intent
+    // and must not be reported through the typed non-commit path.
+    persist_cluster_abort_journal(data_dir, manifest)?;
     if let Some(tracker) = install_tracker {
-        // The caller must know this is a non-commit outcome even if persisting
-        // the durable Aborting marker itself fails.
+        // The journal is now durable, so this process can safely classify the
+        // result as non-commit even if the mutable main marker write fails.
         tracker.mark_aborting();
     }
     let mut aborting = manifest.clone();
@@ -15668,6 +15758,8 @@ mod tests {
         let _key = crate::encryption::set_test_encryption_key([0xbe; 32]);
         let dir = tempfile::tempdir().unwrap();
         crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let providers_path = dir.path().join(PROVIDERS_FILE);
+        let providers_before = std::fs::read(&providers_path).unwrap();
         let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
         candidate.cluster_fabric.nodes.push(cluster_test_node(
             "marker-failure-node",
@@ -15679,7 +15771,9 @@ mod tests {
         let abort_secret = Uuid::new_v4().to_string();
         let intents = BTreeMap::from([(
             "marker-failure-node".to_string(),
-            password_intents(crate::ClusterCredentialAction::Replace(abort_secret)),
+            password_intents(crate::ClusterCredentialAction::Replace(
+                abort_secret.clone(),
+            )),
         )]);
         let cluster_before = std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap();
         let credentials_before = std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap();
@@ -15729,28 +15823,49 @@ mod tests {
             MigrationState::Pending,
             "the injected marker failure must exercise the typed fallback"
         );
-        assert!(recover_committed(
-            dir.path(),
-            #[cfg(test)]
-            None,
-        )
-        .is_err());
-        let still_pending: MigrationManifest =
-            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
-        assert_eq!(still_pending.state, MigrationState::Pending);
-        assert_eq!(callbacks, 0);
+        let journal_path = dir.path().join(JOURNAL_FILE);
+        let journal: MigrationManifest =
+            serde_json::from_slice(&std::fs::read(&journal_path).unwrap()).unwrap();
+        assert_eq!(
+            journal.state,
+            MigrationState::Aborting,
+            "the immutable journal must retain durable non-commit intent"
+        );
+        let stage_dir = dir.path().join(&journal.stage_dir);
+        let backup_dir = dir
+            .path()
+            .join(format!("{BACKUP_PREFIX}{}", journal.transaction_id));
+        assert!(stage_dir.exists());
+        assert!(backup_dir.exists());
+        assert_ne!(
+            std::fs::read(&providers_path).unwrap(),
+            providers_before,
+            "the conflict must still be present before restart"
+        );
+
+        // Simulate a restart after the external conflict has disappeared. The
+        // Pending main manifest alone would now be installable, so recovery
+        // must honor the durable Aborting journal instead.
+        std::fs::write(&providers_path, &providers_before).unwrap();
+        assert!(matches!(
+            load_live_cluster_transaction_manifest(dir.path(), &manifest).unwrap(),
+            LiveClusterTransaction::Aborting
+        ));
+        assert!(crate::ensure_provider_mcp_migration_ready(dir.path()).is_err());
 
         clear_cluster_exact_commit_test_fault(dir.path());
-        let recovered_abort = recover_committed(
-            dir.path(),
-            #[cfg(test)]
-            None,
-        )
-        .unwrap_err();
-        assert!(recovered_abort
-            .to_string()
-            .contains("shared by another consumer"));
+        assert!(
+            !recover_pending_config_transaction(dir.path()).unwrap(),
+            "restart recovery must roll back rather than report a committed candidate"
+        );
+        assert!(
+            !recover_pending_config_transaction(dir.path()).unwrap(),
+            "completed abort recovery must be idempotent"
+        );
         assert!(!manifest_path.exists());
+        assert!(!journal_path.exists());
+        assert!(!stage_dir.exists());
+        assert!(!backup_dir.exists());
         assert_eq!(
             std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
             cluster_before
@@ -15759,6 +15874,24 @@ mod tests {
             std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
             credentials_before
         );
+        let password_ref = crate::cluster_password_credential_ref("marker-failure-node").unwrap();
+        assert!(CredentialStore::open(dir.path())
+            .resolve(&password_ref)
+            .unwrap()
+            .is_none());
+        let (fresh, _) = active_facade_config_and_cluster_revision(dir.path());
+        assert!(fresh.cluster_fabric.node("marker-failure-node").is_none());
+        for entry in std::fs::read_dir(dir.path()).unwrap() {
+            let entry = entry.unwrap();
+            if entry.file_type().unwrap().is_file() {
+                assert!(
+                    !String::from_utf8_lossy(&std::fs::read(entry.path()).unwrap())
+                        .contains(&abort_secret),
+                    "aborted cluster plaintext remained in {}",
+                    entry.path().display()
+                );
+            }
+        }
         assert_eq!(callbacks, 0);
     }
 

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -6,6 +6,7 @@
 //! before the commit point, and every reader recovers a committed transaction
 //! before reading any credential transaction member.
 
+use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi::OsStr;
 use std::fs::File;
@@ -100,6 +101,7 @@ enum FacadeSourceBase {
 #[serde(rename_all = "snake_case")]
 enum MigrationState {
     Pending,
+    Aborting,
     Complete,
 }
 
@@ -867,16 +869,18 @@ static ENV_TRANSACTION_TEST_HOOK: std::sync::Mutex<Option<EnvTransactionTestHook
 ///
 /// Test-only: production builds have neither this type nor the corresponding
 /// timing branches.
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, feature = "test-utils"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClusterExactCommitTestFault {
     AfterManifest,
     AfterManifestRecoveryFailure,
     AfterCredentialInstall,
     BeforeFinish,
+    AbortMarkerRecoveryFailure,
+    AbortCleanupRecoveryFailure,
 }
 
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, feature = "test-utils"))]
 static CLUSTER_EXACT_COMMIT_TEST_FAULTS: LazyLock<
     Mutex<BTreeMap<PathBuf, ClusterExactCommitTestFault>>,
 > = LazyLock::new(|| Mutex::new(BTreeMap::new()));
@@ -892,7 +896,7 @@ pub fn set_env_transaction_test_hook(hook: impl FnOnce(&Path) + Send + 'static) 
 
 /// Inject one recoverable failure into the next adopted cluster exact
 /// transaction for `data_dir`.
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, feature = "test-utils"))]
 pub fn set_cluster_exact_commit_test_fault(
     data_dir: impl Into<PathBuf>,
     fault: ClusterExactCommitTestFault,
@@ -903,7 +907,15 @@ pub fn set_cluster_exact_commit_test_fault(
         .insert(data_dir.into(), fault);
 }
 
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, feature = "test-utils"))]
+pub fn clear_cluster_exact_commit_test_fault(data_dir: impl AsRef<Path>) {
+    CLUSTER_EXACT_COMMIT_TEST_FAULTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(data_dir.as_ref());
+}
+
+#[cfg(any(test, feature = "test-utils"))]
 fn take_cluster_exact_commit_test_fault(
     data_dir: &Path,
     fault: ClusterExactCommitTestFault,
@@ -919,7 +931,7 @@ fn take_cluster_exact_commit_test_fault(
     }
 }
 
-#[cfg(feature = "test-utils")]
+#[cfg(any(test, feature = "test-utils"))]
 fn take_cluster_exact_after_manifest_test_fault(data_dir: &Path) -> bool {
     let mut faults = CLUSTER_EXACT_COMMIT_TEST_FAULTS
         .lock()
@@ -934,6 +946,24 @@ fn take_cluster_exact_after_manifest_test_fault(data_dir: &Path) -> bool {
         Some(ClusterExactCommitTestFault::AfterManifestRecoveryFailure) => true,
         _ => false,
     }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+fn cluster_abort_cleanup_test_fault(data_dir: &Path) -> bool {
+    CLUSTER_EXACT_COMMIT_TEST_FAULTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(data_dir)
+        == Some(&ClusterExactCommitTestFault::AbortCleanupRecoveryFailure)
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+fn cluster_abort_marker_test_fault(data_dir: &Path) -> bool {
+    CLUSTER_EXACT_COMMIT_TEST_FAULTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(data_dir)
+        == Some(&ClusterExactCommitTestFault::AbortMarkerRecoveryFailure)
 }
 
 /// Extract provider/MCP/root secrets into the isolated credential store.
@@ -1382,6 +1412,7 @@ fn install_section_split_migration_locked_inner(
     install_pending(
         data_dir,
         &mut manifest,
+        None,
         #[cfg(test)]
         Some(fault),
     )?;
@@ -1487,8 +1518,9 @@ pub fn ensure_provider_mcp_migration_ready(data_dir: impl AsRef<Path>) -> Config
             "provider/MCP/broker credential migration is pending".to_string(),
         )
     })?;
-    if manifest.state == MigrationState::Pending {
+    if manifest.state != MigrationState::Complete {
         if manifest.migration_scope == Some(MigrationScope::ClusterFabric)
+            && manifest.state == MigrationState::Pending
             && provider_mcp_documents_are_migration_free(data_dir.as_ref())?
             && pending_cluster_refs_are_exclusive(data_dir.as_ref())?
         {
@@ -1901,20 +1933,47 @@ fn load_staged_cluster_candidate_under_migration_lock(
     cluster_candidate_from_section_bytes(&bytes)
 }
 
-/// Return the still-live manifest for this exact cluster transaction.
+enum LiveClusterTransaction {
+    NotCommitted,
+    Aborting,
+    Committed(MigrationManifest),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClusterInstallOutcome {
+    CommitIntent,
+    Aborting,
+}
+
+struct ClusterInstallTracker(Cell<ClusterInstallOutcome>);
+
+impl ClusterInstallTracker {
+    fn new() -> Self {
+        Self(Cell::new(ClusterInstallOutcome::CommitIntent))
+    }
+
+    fn mark_aborting(&self) {
+        self.0.set(ClusterInstallOutcome::Aborting);
+    }
+
+    fn outcome(&self) -> ClusterInstallOutcome {
+        self.0.get()
+    }
+}
+
+/// Classify the still-live manifest for this exact cluster transaction.
 ///
-/// A Pending manifest remains recoverable commit intent even if an abort
-/// rolled members back but failed before changing the manifest state. A
-/// Complete manifest is different: abort writes Complete after rolling back,
-/// so only an authority that still equals the manifest candidate proves the
-/// transaction committed. Complete plus a missing/nonmatching authority is
-/// the recoverable tail of an intentional abort and is classified ordinary.
+/// `Aborting` is a durable non-commit outcome written before rollback starts.
+/// It can therefore never enter committed-candidate adoption, even if rollback
+/// or cleanup repeatedly fails. A Complete manifest is different: only an
+/// authority that still equals its candidate proves the transaction committed;
+/// Complete plus a missing/nonmatching authority is an intentional abort tail.
 fn load_live_cluster_transaction_manifest(
     data_dir: &Path,
     expected: &MigrationManifest,
-) -> ConfigStoreResult<Option<MigrationManifest>> {
+) -> ConfigStoreResult<LiveClusterTransaction> {
     let Some(bytes) = read_optional_migration_file(&data_dir.join(MANIFEST_FILE))? else {
-        return Ok(None);
+        return Ok(LiveClusterTransaction::NotCommitted);
     };
     let manifest: MigrationManifest = serde_json::from_slice(&bytes)?;
     validate_manifest(&manifest)?;
@@ -1925,6 +1984,9 @@ fn load_live_cluster_transaction_manifest(
         return Err(ConfigStoreError::Validation(
             "cluster transaction manifest no longer matches its commit".to_string(),
         ));
+    }
+    if manifest.state == MigrationState::Aborting {
+        return Ok(LiveClusterTransaction::Aborting);
     }
     if manifest.state == MigrationState::Complete {
         let authority = manifest
@@ -1938,10 +2000,10 @@ fn load_live_cluster_transaction_manifest(
             })?;
         let current = read_target_or_empty(&data_dir.join(CLUSTER_FABRIC_FILE))?;
         if sha256(&current) != authority.sha256 {
-            return Ok(None);
+            return Ok(LiveClusterTransaction::NotCommitted);
         }
     }
-    Ok(Some(manifest))
+    Ok(LiveClusterTransaction::Committed(manifest))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2062,7 +2124,7 @@ pub fn read_exact_cluster_fabric_snapshot(
         let data = serde_json::to_value(&stored.data)?;
 
         let credential_store = CredentialStore::open(data_dir);
-        let (credential_lkg, credential_statuses, credential_health) =
+        let (credential_lkg, mut credential_statuses, credential_health) =
             match credential_store.snapshot_with_health_unchecked() {
                 Ok((lkg, statuses, health)) => (Some(lkg), statuses, health),
                 Err(error) if expected_revision.is_some() => return Err(error),
@@ -2077,6 +2139,19 @@ pub fn read_exact_cluster_fabric_snapshot(
                     },
                 ),
             };
+        if expected_revision.is_none() {
+            if let Some(credential_lkg) = credential_lkg.as_ref() {
+                let active_refs = stored
+                    .data
+                    .0
+                    .credential_refs
+                    .values()
+                    .flat_map(|metadata| metadata.references().cloned())
+                    .collect::<BTreeSet<_>>();
+                credential_statuses =
+                    credential_lkg.statuses_with_cluster_crypto_validation(&active_refs);
+            }
+        }
         let credential_degraded = credential_health.status == crate::SectionStatus::Degraded;
         if expected_revision.is_some() && credential_degraded {
             return Err(ConfigStoreError::Validation(
@@ -3429,11 +3504,11 @@ fn persist_exact_credential_transaction_inner(
         }
     }
     write_manifest(data_dir.join(MANIFEST_FILE), &manifest)?;
-    #[cfg(feature = "test-utils")]
+    #[cfg(any(test, feature = "test-utils"))]
     let cluster_fault_after_manifest = cluster_only
         && active_section.is_some()
         && take_cluster_exact_after_manifest_test_fault(data_dir);
-    #[cfg(not(feature = "test-utils"))]
+    #[cfg(not(any(test, feature = "test-utils")))]
     let cluster_fault_after_manifest = false;
     if cluster_fault_after_manifest && cluster_post_commit.is_none() {
         return Err(ConfigStoreError::Validation(
@@ -3553,6 +3628,7 @@ fn persist_exact_credential_transaction_inner(
     let mut manifest = manifest;
     let adopted_cluster_transaction =
         cluster_only && active_section.is_some() && cluster_post_commit.is_some();
+    let cluster_install_tracker = adopted_cluster_transaction.then(ClusterInstallTracker::new);
     let mut installed_cluster_candidate = None;
     let completion = if cluster_fault_after_manifest {
         Err(ConfigStoreError::Validation(
@@ -3562,6 +3638,7 @@ fn persist_exact_credential_transaction_inner(
         match install_pending(
             data_dir,
             &mut manifest,
+            cluster_install_tracker.as_ref(),
             #[cfg(test)]
             fault,
         ) {
@@ -3574,14 +3651,14 @@ fn persist_exact_credential_transaction_inner(
                     Err(error)
                 } else {
                     installed_cluster_candidate = capture.expect("checked above");
-                    #[cfg(feature = "test-utils")]
+                    #[cfg(any(test, feature = "test-utils"))]
                     let before_finish_fault = cluster_only
                         && active_section.is_some()
                         && take_cluster_exact_commit_test_fault(
                             data_dir,
                             ClusterExactCommitTestFault::BeforeFinish,
                         );
-                    #[cfg(not(feature = "test-utils"))]
+                    #[cfg(not(any(test, feature = "test-utils")))]
                     let before_finish_fault = false;
                     if before_finish_fault {
                         Err(ConfigStoreError::Validation(
@@ -3595,13 +3672,24 @@ fn persist_exact_credential_transaction_inner(
         }
     };
     if let Err(initial_error) = completion {
+        if cluster_install_tracker
+            .as_ref()
+            .is_some_and(|tracker| tracker.outcome() == ClusterInstallOutcome::Aborting)
+        {
+            // An intentional abort is a typed non-commit result. Never infer
+            // commit from a still-Pending manifest when persisting the durable
+            // Aborting marker or rollback cleanup itself failed.
+            return Err(initial_error);
+        }
         if !adopted_cluster_transaction {
             return Err(initial_error);
         }
         let live_before_recovery = match load_live_cluster_transaction_manifest(data_dir, &manifest)
         {
-            Ok(None) => return Err(initial_error),
-            Ok(Some(live)) => live,
+            Ok(LiveClusterTransaction::NotCommitted | LiveClusterTransaction::Aborting) => {
+                return Err(initial_error);
+            }
+            Ok(LiveClusterTransaction::Committed(live)) => live,
             Err(inspection_error) => {
                 let revision = report_cluster_committed_recovery_failure(
                     data_dir,
@@ -3618,7 +3706,7 @@ fn persist_exact_credential_transaction_inner(
             }
         };
         let recovery = {
-            #[cfg(feature = "test-utils")]
+            #[cfg(any(test, feature = "test-utils"))]
             if take_cluster_exact_commit_test_fault(
                 data_dir,
                 ClusterExactCommitTestFault::AfterManifestRecoveryFailure,
@@ -3633,7 +3721,7 @@ fn persist_exact_credential_transaction_inner(
                     None,
                 )
             }
-            #[cfg(not(feature = "test-utils"))]
+            #[cfg(not(any(test, feature = "test-utils")))]
             recover_committed(
                 data_dir,
                 #[cfg(test)]
@@ -3661,8 +3749,10 @@ fn persist_exact_credential_transaction_inner(
             Err(recovery_error) => {
                 let live_after_recovery =
                     match load_live_cluster_transaction_manifest(data_dir, &manifest) {
-                        Ok(None) => return Err(recovery_error),
-                        Ok(Some(live)) => Some(live),
+                        Ok(
+                            LiveClusterTransaction::NotCommitted | LiveClusterTransaction::Aborting,
+                        ) => return Err(recovery_error),
+                        Ok(LiveClusterTransaction::Committed(live)) => Some(live),
                         Err(inspection_error) => {
                             let combined = ConfigStoreError::Validation(format!(
                                 "{recovery_error}; cluster transaction state inspection failed \
@@ -3845,6 +3935,7 @@ fn migrate_broker_locked(
     install_pending(
         data_dir,
         &mut manifest,
+        None,
         #[cfg(test)]
         fault,
     )?;
@@ -3953,6 +4044,7 @@ fn migrate_cluster_locked(
         install_pending(
             data_dir,
             &mut manifest,
+            None,
             #[cfg(test)]
             fault,
         )?;
@@ -4223,6 +4315,7 @@ fn migrate_inner_with_root_builtins_locked(
     install_pending(
         data_dir,
         &mut manifest,
+        None,
         #[cfg(test)]
         fault,
     )?;
@@ -7954,9 +8047,19 @@ fn recover_committed(
         remove_file_if_exists(&data_dir.join(JOURNAL_FILE))?;
         return Ok(None);
     }
+    if manifest.state == MigrationState::Aborting {
+        if manifest.exact_scope != Some(ExactTransactionScope::ClusterFabric) {
+            return Err(ConfigStoreError::Validation(
+                "only cluster exact transactions may resume abort rollback".to_string(),
+            ));
+        }
+        abort_cluster_exact_transaction(data_dir, &manifest, None)?;
+        return Ok(None);
+    }
     install_pending(
         data_dir,
         &mut manifest,
+        None,
         #[cfg(test)]
         fault,
     )?;
@@ -8471,13 +8574,44 @@ fn rollback_cluster_config_member(
 fn abort_cluster_exact_transaction(
     data_dir: &Path,
     manifest: &MigrationManifest,
+    install_tracker: Option<&ClusterInstallTracker>,
 ) -> ConfigStoreResult<()> {
     if manifest.exact_scope != Some(ExactTransactionScope::ClusterFabric) {
         return Ok(());
     }
-    rollback_exact_authority_member(data_dir, manifest)?;
-    rollback_exact_credential_member(data_dir, manifest)?;
-    let mut complete = manifest.clone();
+    if manifest.state == MigrationState::Complete {
+        return Err(ConfigStoreError::Validation(
+            "a complete cluster transaction cannot enter abort rollback".to_string(),
+        ));
+    }
+    if let Some(tracker) = install_tracker {
+        // The caller must know this is a non-commit outcome even if persisting
+        // the durable Aborting marker itself fails.
+        tracker.mark_aborting();
+    }
+    let mut aborting = manifest.clone();
+    aborting.state = MigrationState::Aborting;
+    if manifest.state != MigrationState::Aborting {
+        // Persist non-commit intent before touching either installed member.
+        // From this boundary onward recovery must resume rollback, never
+        // install or adopt the staged candidate.
+        #[cfg(any(test, feature = "test-utils"))]
+        if cluster_abort_marker_test_fault(data_dir) {
+            return Err(ConfigStoreError::Validation(
+                "injected persistent cluster abort marker failure".to_string(),
+            ));
+        }
+        write_manifest(data_dir.join(MANIFEST_FILE), &aborting)?;
+    }
+    #[cfg(any(test, feature = "test-utils"))]
+    if cluster_abort_cleanup_test_fault(data_dir) {
+        return Err(ConfigStoreError::Validation(
+            "injected persistent cluster abort cleanup failure".to_string(),
+        ));
+    }
+    rollback_exact_authority_member(data_dir, &aborting)?;
+    rollback_exact_credential_member(data_dir, &aborting)?;
+    let mut complete = aborting;
     complete.state = MigrationState::Complete;
     write_manifest(data_dir.join(MANIFEST_FILE), &complete)?;
     remove_file_if_exists(&data_dir.join(JOURNAL_FILE))?;
@@ -8486,7 +8620,11 @@ fn abort_cluster_exact_transaction(
     sync_dir(data_dir)
 }
 
-fn abort_exact_transaction(data_dir: &Path, manifest: &MigrationManifest) -> ConfigStoreResult<()> {
+fn abort_exact_transaction(
+    data_dir: &Path,
+    manifest: &MigrationManifest,
+    install_tracker: Option<&ClusterInstallTracker>,
+) -> ConfigStoreResult<()> {
     match manifest.exact_scope {
         Some(ExactTransactionScope::Providers) => {
             abort_active_exact_transaction(data_dir, manifest, ExactTransactionScope::Providers)
@@ -8504,7 +8642,7 @@ fn abort_exact_transaction(data_dir: &Path, manifest: &MigrationManifest) -> Con
             abort_access_control_exact_transaction(data_dir, manifest)
         }
         Some(ExactTransactionScope::ClusterFabric) => {
-            abort_cluster_exact_transaction(data_dir, manifest)
+            abort_cluster_exact_transaction(data_dir, manifest, install_tracker)
         }
         None => Ok(()),
     }
@@ -8642,6 +8780,7 @@ fn ensure_notification_consumers_or_abort(
 fn ensure_cluster_consumers_or_abort(
     data_dir: &Path,
     manifest: &MigrationManifest,
+    install_tracker: Option<&ClusterInstallTracker>,
 ) -> ConfigStoreResult<()> {
     if manifest.exact_scope != Some(ExactTransactionScope::ClusterFabric) {
         return Ok(());
@@ -8662,7 +8801,7 @@ fn ensure_cluster_consumers_or_abort(
         .map(|reference| CredentialRef::parse(reference.clone()))
         .collect::<ConfigStoreResult<BTreeSet<_>>>()?;
     if let Err(error) = ensure_cluster_refs_are_safe(data_dir, &refs, &[]) {
-        abort_cluster_exact_transaction(data_dir, manifest)?;
+        abort_cluster_exact_transaction(data_dir, manifest, install_tracker)?;
         return Err(error);
     }
     Ok(())
@@ -8947,7 +9086,7 @@ pub(crate) fn section_layout_completion_evidence_matches(
             Ok(manifest) => manifest,
             Err(_) => return Ok(false),
         };
-        if validate_manifest(&manifest).is_err() || manifest.state == MigrationState::Pending {
+        if validate_manifest(&manifest).is_err() || manifest.state != MigrationState::Complete {
             return Ok(false);
         }
         if is_section_layout_scope(manifest.migration_scope)
@@ -9245,9 +9384,15 @@ fn verify_section_split_completion(
 fn install_pending(
     data_dir: &Path,
     manifest: &mut MigrationManifest,
+    install_tracker: Option<&ClusterInstallTracker>,
     #[cfg(test)] fault: Option<MigrationFault>,
 ) -> ConfigStoreResult<()> {
     validate_manifest(manifest)?;
+    if manifest.state != MigrationState::Pending {
+        return Err(ConfigStoreError::Validation(
+            "only a pending transaction may install staged members".to_string(),
+        ));
+    }
     if manifest.migration_scope == Some(MigrationScope::ClusterFabric) {
         pending_cluster_refs_are_exclusive(data_dir)?;
     }
@@ -9255,7 +9400,7 @@ fn install_pending(
     ensure_notification_consumers_or_abort(data_dir, manifest)?;
     ensure_connect_consumers_or_abort(data_dir, manifest)?;
     ensure_access_consumers_or_abort(data_dir, manifest)?;
-    ensure_cluster_consumers_or_abort(data_dir, manifest)?;
+    ensure_cluster_consumers_or_abort(data_dir, manifest, install_tracker)?;
     let _stage_dir = validated_stage_dir(data_dir, &manifest.stage_dir)?;
     let names = manifest
         .files
@@ -9293,7 +9438,7 @@ fn install_pending(
             if fault == Some(MigrationFault::AfterCredentials) {
                 return Err(injected_fault());
             }
-            #[cfg(feature = "test-utils")]
+            #[cfg(any(test, feature = "test-utils"))]
             if manifest.exact_scope == Some(ExactTransactionScope::ClusterFabric)
                 && take_cluster_exact_commit_test_fault(
                     data_dir,
@@ -9330,6 +9475,7 @@ fn install_pending(
                             data_dir,
                             manifest,
                             file_index,
+                            install_tracker,
                             #[cfg(test)]
                             fault,
                         )?
@@ -9680,6 +9826,7 @@ fn install_rebased_active_section_member(
     data_dir: &Path,
     manifest: &mut MigrationManifest,
     file_index: usize,
+    install_tracker: Option<&ClusterInstallTracker>,
 ) -> ConfigStoreResult<bool> {
     let scope = manifest.exact_scope.ok_or_else(|| {
         ConfigStoreError::Validation("exact transaction scope is missing".to_string())
@@ -9707,13 +9854,13 @@ fn install_rebased_active_section_member(
     let (mut current_envelope, current_revision, current_data) =
         parse_exact_section_document(name, &current)?;
     if current_revision < original_revision {
-        abort_exact_transaction(data_dir, manifest)?;
+        abort_exact_transaction(data_dir, manifest, install_tracker)?;
         return Err(ConfigStoreError::Validation(
             "authoritative section revision moved backwards".to_string(),
         ));
     }
     if current_revision == original_revision && current_hash != sha256(&original) {
-        abort_exact_transaction(data_dir, manifest)?;
+        abort_exact_transaction(data_dir, manifest, install_tracker)?;
         return Err(ConfigStoreError::Validation(
             "authoritative section reused a revision with different content".to_string(),
         ));
@@ -9727,7 +9874,7 @@ fn install_rebased_active_section_member(
     ) {
         Ok(merged) => merged,
         Err(error) => {
-            abort_exact_transaction(data_dir, manifest)?;
+            abort_exact_transaction(data_dir, manifest, install_tracker)?;
             return Err(error);
         }
     };
@@ -9773,10 +9920,16 @@ fn install_rebased_exact_config_member(
     data_dir: &Path,
     manifest: &mut MigrationManifest,
     file_index: usize,
+    install_tracker: Option<&ClusterInstallTracker>,
     #[cfg(test)] fault: Option<MigrationFault>,
 ) -> ConfigStoreResult<bool> {
     if manifest.files[file_index].name != CONFIG_FILE {
-        return install_rebased_active_section_member(data_dir, manifest, file_index);
+        return install_rebased_active_section_member(
+            data_dir,
+            manifest,
+            file_index,
+            install_tracker,
+        );
     }
     if manifest.exact_scope == Some(ExactTransactionScope::EnvVars) {
         return install_rebased_env_config_member(data_dir, manifest, file_index);
@@ -9790,7 +9943,12 @@ fn install_rebased_exact_config_member(
         ));
     }
     if manifest.exact_scope == Some(ExactTransactionScope::ClusterFabric) {
-        return install_rebased_cluster_config_member(data_dir, manifest, file_index);
+        return install_rebased_cluster_config_member(
+            data_dir,
+            manifest,
+            file_index,
+            install_tracker,
+        );
     }
     install_rebased_proxy_config_member(
         data_dir,
@@ -9805,6 +9963,7 @@ fn install_rebased_cluster_config_member(
     data_dir: &Path,
     manifest: &mut MigrationManifest,
     file_index: usize,
+    install_tracker: Option<&ClusterInstallTracker>,
 ) -> ConfigStoreResult<bool> {
     let stage_dir = validated_stage_dir(data_dir, &manifest.stage_dir)?;
     let file = manifest.files[file_index].clone();
@@ -9829,7 +9988,7 @@ fn install_rebased_cluster_config_member(
     if current_object.get("cluster_fabric") != original_object.get("cluster_fabric")
         && current_object.get("cluster_fabric") != staged.get("cluster_fabric")
     {
-        abort_cluster_exact_transaction(data_dir, manifest)?;
+        abort_cluster_exact_transaction(data_dir, manifest, install_tracker)?;
         return Err(ConfigStoreError::Validation(
             "cluster metadata changed during committed transaction".to_string(),
         ));
@@ -15407,6 +15566,203 @@ mod tests {
     }
 
     #[test]
+    fn aborting_cluster_manifest_never_adopts_when_cleanup_recovery_keeps_failing() {
+        let _key = crate::encryption::set_test_encryption_key([0xbd; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(cluster_test_node(
+            "phantom-abort-node",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        let abort_secret = Uuid::new_v4().to_string();
+        let intents = BTreeMap::from([(
+            "phantom-abort-node".to_string(),
+            password_intents(crate::ClusterCredentialAction::Replace(abort_secret)),
+        )]);
+        let cluster_before = std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap();
+        let credentials_before = std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap();
+        let mut callbacks = 0;
+        let mut callback = |_: u64,
+                            _: bool,
+                            _: &crate::ClusterFabricConfig,
+                            _: ConfigStoreResult<ExactClusterRuntimeSnapshot>,
+                            _: ConfigStoreResult<()>| {
+            callbacks += 1;
+        };
+        set_cluster_exact_commit_test_fault(
+            dir.path().to_path_buf(),
+            ClusterExactCommitTestFault::AbortCleanupRecoveryFailure,
+        );
+
+        let error = persist_cluster_fabric_credential_transaction_inner(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            revision,
+            Some(&mut callback),
+            Some(MigrationFault::AfterExactClusterConsumerConflict),
+        )
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("persistent cluster abort cleanup failure"));
+        assert_eq!(callbacks, 0, "an aborting candidate must never be adopted");
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+
+        let manifest_path = dir.path().join(MANIFEST_FILE);
+        let manifest: MigrationManifest =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        assert_eq!(manifest.state, MigrationState::Aborting);
+        assert!(matches!(
+            load_live_cluster_transaction_manifest(dir.path(), &manifest).unwrap(),
+            LiveClusterTransaction::Aborting
+        ));
+        assert!(crate::ensure_provider_mcp_migration_ready(dir.path()).is_err());
+        assert!(
+            recover_committed(
+                dir.path(),
+                #[cfg(test)]
+                None,
+            )
+            .is_err(),
+            "recovery must resume abort and retain its fail-closed marker"
+        );
+        let persisted: MigrationManifest =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        assert_eq!(persisted.state, MigrationState::Aborting);
+        assert_eq!(callbacks, 0);
+
+        clear_cluster_exact_commit_test_fault(dir.path());
+        assert!(recover_committed(
+            dir.path(),
+            #[cfg(test)]
+            None,
+        )
+        .unwrap()
+        .is_none());
+        assert!(!manifest_path.exists());
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+        assert_eq!(callbacks, 0);
+    }
+
+    #[test]
+    fn abort_marker_failure_is_still_a_typed_noncommit_outcome() {
+        let _key = crate::encryption::set_test_encryption_key([0xbe; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(cluster_test_node(
+            "marker-failure-node",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        let abort_secret = Uuid::new_v4().to_string();
+        let intents = BTreeMap::from([(
+            "marker-failure-node".to_string(),
+            password_intents(crate::ClusterCredentialAction::Replace(abort_secret)),
+        )]);
+        let cluster_before = std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap();
+        let credentials_before = std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap();
+        let mut callbacks = 0;
+        let mut callback = |_: u64,
+                            _: bool,
+                            _: &crate::ClusterFabricConfig,
+                            _: ConfigStoreResult<ExactClusterRuntimeSnapshot>,
+                            _: ConfigStoreResult<()>| {
+            callbacks += 1;
+        };
+        set_cluster_exact_commit_test_fault(
+            dir.path().to_path_buf(),
+            ClusterExactCommitTestFault::AbortMarkerRecoveryFailure,
+        );
+
+        let error = persist_cluster_fabric_credential_transaction_inner(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            revision,
+            Some(&mut callback),
+            Some(MigrationFault::AfterExactClusterConsumerConflict),
+        )
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("persistent cluster abort marker failure"));
+        assert_eq!(
+            callbacks, 0,
+            "an in-memory abort outcome must bypass committed reporting"
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+
+        let manifest_path = dir.path().join(MANIFEST_FILE);
+        let manifest: MigrationManifest =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        assert_eq!(
+            manifest.state,
+            MigrationState::Pending,
+            "the injected marker failure must exercise the typed fallback"
+        );
+        assert!(recover_committed(
+            dir.path(),
+            #[cfg(test)]
+            None,
+        )
+        .is_err());
+        let still_pending: MigrationManifest =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        assert_eq!(still_pending.state, MigrationState::Pending);
+        assert_eq!(callbacks, 0);
+
+        clear_cluster_exact_commit_test_fault(dir.path());
+        let recovered_abort = recover_committed(
+            dir.path(),
+            #[cfg(test)]
+            None,
+        )
+        .unwrap_err();
+        assert!(recovered_abort
+            .to_string()
+            .contains("shared by another consumer"));
+        assert!(!manifest_path.exists());
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+        assert_eq!(callbacks, 0);
+    }
+
+    #[test]
     fn complete_cluster_abort_manifest_is_not_a_live_commit() {
         let _key = crate::encryption::set_test_encryption_key([0xbc; 32]);
         let dir = tempfile::tempdir().unwrap();
@@ -15442,9 +15798,10 @@ mod tests {
         write_manifest(manifest_path, &manifest).unwrap();
 
         assert!(
-            load_live_cluster_transaction_manifest(dir.path(), &manifest)
-                .unwrap()
-                .is_none(),
+            matches!(
+                load_live_cluster_transaction_manifest(dir.path(), &manifest).unwrap(),
+                LiveClusterTransaction::NotCommitted
+            ),
             "Complete plus rolled-back/nonmatching authority is an abort tail"
         );
     }
@@ -15774,6 +16131,220 @@ mod tests {
         assert!(auth.get("password").is_none());
         assert!(auth.get("private_key").is_none());
         assert!(auth.get("passphrase").is_none());
+    }
+
+    #[test]
+    fn exact_cluster_get_status_marks_corrupt_and_wrong_key_ciphertext_as_error_metadata() {
+        let key = crate::encryption::set_test_encryption_key([0xbe; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(cluster_test_node(
+            "status-node",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        let password_ref = crate::cluster_password_credential_ref("status-node").unwrap();
+        let status_secret = Uuid::new_v4().to_string();
+        assert_eq!(
+            persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut candidate,
+                &BTreeMap::from([(
+                    "status-node".to_string(),
+                    password_intents(crate::ClusterCredentialAction::Replace(
+                        status_secret.clone(),
+                    )),
+                )]),
+                revision,
+            )
+            .unwrap(),
+            1
+        );
+
+        let healthy = read_exact_cluster_fabric_snapshot(dir.path(), None).unwrap();
+        assert!(
+            healthy
+                .credential_statuses
+                .iter()
+                .find(|status| status.credential_ref == password_ref)
+                .unwrap()
+                .configured
+        );
+        let crate::NodePlacement::Ssh(target) = &healthy
+            .cluster_fabric
+            .node("status-node")
+            .unwrap()
+            .placement
+        else {
+            panic!("expected SSH placement")
+        };
+        let crate::SshAuth::Password { password, .. } = &target.auth else {
+            panic!("expected password authentication")
+        };
+        assert!(
+            password.is_empty(),
+            "GET status must not hydrate plaintext into Config"
+        );
+
+        let credentials_path = dir.path().join(CREDENTIALS_FILE);
+        let credentials = std::fs::read(&credentials_path).unwrap();
+        let mut corrupt: Value = serde_json::from_slice(&credentials).unwrap();
+        corrupt["data"]["entries"][password_ref.as_str()]["ciphertext"] =
+            Value::String("nonempty-but-not-ciphertext".to_string());
+        std::fs::write(
+            &credentials_path,
+            serde_json::to_vec_pretty(&corrupt).unwrap(),
+        )
+        .unwrap();
+        let corrupt = read_exact_cluster_fabric_snapshot(dir.path(), None).unwrap();
+        assert!(
+            !corrupt
+                .credential_statuses
+                .iter()
+                .find(|status| status.credential_ref == password_ref)
+                .unwrap()
+                .configured
+        );
+
+        std::fs::write(&credentials_path, credentials).unwrap();
+        drop(key);
+        let _wrong_key = crate::encryption::set_test_encryption_key([0xbf; 32]);
+        let wrong_key = read_exact_cluster_fabric_snapshot(dir.path(), None).unwrap();
+        assert!(
+            !wrong_key
+                .credential_statuses
+                .iter()
+                .find(|status| status.credential_ref == password_ref)
+                .unwrap()
+                .configured
+        );
+        let encoded = serde_json::to_string(&wrong_key.cluster_fabric).unwrap();
+        assert!(!encoded.contains(&status_secret));
+    }
+
+    #[test]
+    fn secret_free_cluster_snapshot_supports_explicit_corrupt_credential_repair() {
+        let _key = crate::encryption::set_test_encryption_key([0xc0; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(cluster_test_node(
+            "repair-node",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        let password_ref = crate::cluster_password_credential_ref("repair-node").unwrap();
+        let initial_secret = Uuid::new_v4().to_string();
+        assert_eq!(
+            persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut candidate,
+                &BTreeMap::from([(
+                    "repair-node".to_string(),
+                    password_intents(crate::ClusterCredentialAction::Replace(initial_secret,)),
+                )]),
+                revision,
+            )
+            .unwrap(),
+            1
+        );
+
+        let credentials_path = dir.path().join(CREDENTIALS_FILE);
+        let corrupt_active_password = || {
+            let mut document: Value =
+                serde_json::from_slice(&std::fs::read(&credentials_path).unwrap()).unwrap();
+            document["data"]["entries"][password_ref.as_str()]["ciphertext"] =
+                Value::String("corrupt-active-ciphertext".to_string());
+            std::fs::write(
+                &credentials_path,
+                serde_json::to_vec_pretty(&document).unwrap(),
+            )
+            .unwrap();
+        };
+        corrupt_active_password();
+        let exact = read_exact_cluster_fabric_snapshot(dir.path(), None).unwrap();
+        assert!(
+            !exact
+                .credential_statuses
+                .iter()
+                .find(|status| status.credential_ref == password_ref)
+                .unwrap()
+                .configured
+        );
+        let mut replacement = crate::Config::default();
+        replacement.cluster_fabric = exact.cluster_fabric;
+        let repaired_secret = Uuid::new_v4().to_string();
+        assert_eq!(
+            persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut replacement,
+                &BTreeMap::from([(
+                    "repair-node".to_string(),
+                    password_intents(crate::ClusterCredentialAction::Replace(
+                        repaired_secret.clone(),
+                    )),
+                )]),
+                1,
+            )
+            .unwrap(),
+            2
+        );
+        let replaced = read_exact_cluster_fabric_snapshot(dir.path(), Some(2)).unwrap();
+        let crate::NodePlacement::Ssh(target) = &replaced
+            .cluster_fabric
+            .node("repair-node")
+            .unwrap()
+            .placement
+        else {
+            panic!("expected SSH placement")
+        };
+        let crate::SshAuth::Password { password, .. } = &target.auth else {
+            panic!("expected password authentication")
+        };
+        assert_eq!(password, &repaired_secret);
+
+        corrupt_active_password();
+        let exact = read_exact_cluster_fabric_snapshot(dir.path(), None).unwrap();
+        let mut clearing = crate::Config::default();
+        clearing.cluster_fabric = exact.cluster_fabric;
+        clearing
+            .cluster_fabric
+            .node_mut("repair-node")
+            .unwrap()
+            .placement = crate::NodePlacement::Ssh(crate::SshTarget {
+            host: "repair.example.test".to_string(),
+            port: 22,
+            username: "operator".to_string(),
+            auth: crate::SshAuth::SystemSshConfig,
+            host_key_fingerprint: None,
+        });
+        assert_eq!(
+            persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut clearing,
+                &BTreeMap::from([(
+                    "repair-node".to_string(),
+                    crate::ClusterNodeCredentialIntents::clear_all(),
+                )]),
+                2,
+            )
+            .unwrap(),
+            3
+        );
+        let cleared = read_exact_cluster_fabric_snapshot(dir.path(), Some(3)).unwrap();
+        assert!(!cleared
+            .cluster_fabric
+            .credential_refs
+            .contains_key("repair-node"));
+        assert!(CredentialStore::open(dir.path())
+            .resolve(&password_ref)
+            .unwrap()
+            .is_none());
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -2587,7 +2587,6 @@ where
     let mut adoption = None;
     let mut exact_runtime = None;
     let mut committed_recovery = None;
-    let mut transaction_changed = false;
     let mut callback = |revision: u64,
                         changed: bool,
                         candidate: &crate::ClusterFabricConfig,
@@ -2596,7 +2595,6 @@ where
         let runtime_ready = runtime.is_ok();
         exact_runtime = Some(runtime);
         committed_recovery = Some(recovery);
-        transaction_changed = changed;
         if revision == expected_revision {
             if runtime_ready {
                 adoption = facade
@@ -2627,13 +2625,11 @@ where
     }) {
         Ok(exact) => {
             let runtime = exact.runtime;
-            let credential_adoption = transaction_changed.then(|| {
-                facade.adopt_captured_cluster_credentials(
-                    exact.credential_lkg,
-                    runtime.credential_statuses.clone(),
-                    runtime.credential_health.clone(),
-                )
-            });
+            let credential_adoption = Some(facade.adopt_captured_cluster_credentials(
+                exact.credential_lkg,
+                runtime.credential_statuses.clone(),
+                runtime.credential_health.clone(),
+            ));
             (Ok(runtime), credential_adoption)
         }
         Err(error) => (Err(error), None),
@@ -3305,7 +3301,6 @@ where
     let mut adoption = None;
     let mut exact_runtime = None;
     let mut committed_recovery = None;
-    let mut transaction_changed = false;
     let mut callback = |revision: u64,
                         changed: bool,
                         candidate: &crate::ClusterFabricConfig,
@@ -3314,7 +3309,6 @@ where
         let runtime_ready = runtime.is_ok();
         exact_runtime = Some(runtime);
         committed_recovery = Some(recovery);
-        transaction_changed = changed;
         if revision == expected_revision {
             if runtime_ready {
                 adoption = facade
@@ -3360,13 +3354,11 @@ where
     }) {
         Ok(exact) => {
             let runtime = exact.runtime;
-            let credential_adoption = transaction_changed.then(|| {
-                facade.adopt_captured_cluster_credentials(
-                    exact.credential_lkg,
-                    runtime.credential_statuses.clone(),
-                    runtime.credential_health.clone(),
-                )
-            });
+            let credential_adoption = Some(facade.adopt_captured_cluster_credentials(
+                exact.credential_lkg,
+                runtime.credential_statuses.clone(),
+                runtime.credential_health.clone(),
+            ));
             (Ok(runtime), credential_adoption)
         }
         Err(error) => (Err(error), None),
@@ -17772,6 +17764,160 @@ mod tests {
         let (fresh, fresh_revision) = active_facade_config_and_cluster_revision(dir.path());
         assert_eq!(fresh_revision, committed);
         assert_eq!(fresh.cluster_fabric, callback_candidate);
+    }
+
+    #[test]
+    fn adopted_cluster_semantic_noop_catches_up_exact_credential_generation() {
+        let _key = crate::encryption::set_test_encryption_key([0x7e; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let process_facade = crate::ConfigFacade::open(dir.path()).unwrap();
+        assert_eq!(
+            process_facade.registry().cluster_fabric.snapshot().revision,
+            0
+        );
+        assert_eq!(process_facade.registry().credentials.snapshot().revision, 0);
+
+        let external_facade = crate::ConfigFacade::open(dir.path()).unwrap();
+        let mut external = external_facade.effective_config();
+        external.cluster_fabric.nodes.push(cluster_test_node(
+            "credential-node",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        assert_eq!(
+            persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut external,
+                &BTreeMap::from([(
+                    "credential-node".to_string(),
+                    password_intents(crate::ClusterCredentialAction::Replace(
+                        "captured-password".to_string(),
+                    )),
+                )]),
+                0,
+            )
+            .unwrap(),
+            1
+        );
+
+        let fresh = crate::ConfigFacade::open(dir.path()).unwrap();
+        let mut retry = fresh.effective_config();
+        let commit = persist_cluster_fabric_credential_transaction_with_adoption(
+            dir.path(),
+            &mut retry,
+            &BTreeMap::from([(
+                "credential-node".to_string(),
+                password_intents(crate::ClusterCredentialAction::Keep),
+            )]),
+            1,
+            &process_facade,
+            |_, _| {},
+        )
+        .unwrap();
+        assert_eq!(commit.revision, 1);
+        assert!(matches!(
+            commit.adoption.unwrap().unwrap(),
+            crate::ConfigSectionEvent::Changed {
+                ref section,
+                revision: 1
+            } if section == "cluster-fabric"
+        ));
+        commit.credential_adoption.unwrap().unwrap();
+        assert_eq!(
+            process_facade.registry().cluster_fabric.snapshot().revision,
+            1
+        );
+        assert_eq!(process_facade.registry().credentials.snapshot().revision, 1);
+        let runtime = commit.runtime.unwrap();
+        let crate::NodePlacement::Ssh(target) = &runtime
+            .cluster_fabric
+            .node("credential-node")
+            .unwrap()
+            .placement
+        else {
+            panic!("credential node must remain SSH-placed")
+        };
+        let crate::SshAuth::Password { password, .. } = &target.auth else {
+            panic!("credential node must remain password-authenticated")
+        };
+        assert_eq!(password, "captured-password");
+    }
+
+    #[test]
+    fn adopted_cluster_reset_noop_catches_up_exact_credential_generation() {
+        let _key = crate::encryption::set_test_encryption_key([0x7f; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let process_facade = crate::ConfigFacade::open(dir.path()).unwrap();
+
+        let external_facade = crate::ConfigFacade::open(dir.path()).unwrap();
+        let mut external = external_facade.effective_config();
+        external.cluster_fabric.nodes.push(cluster_test_node(
+            "reset-credential-node",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        assert_eq!(
+            persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut external,
+                &BTreeMap::from([(
+                    "reset-credential-node".to_string(),
+                    password_intents(crate::ClusterCredentialAction::Replace(
+                        "reset-password".to_string(),
+                    )),
+                )]),
+                0,
+            )
+            .unwrap(),
+            1
+        );
+
+        let reset_facade = crate::ConfigFacade::open(dir.path()).unwrap();
+        let mut reset = reset_facade.effective_config();
+        reset.cluster_fabric = crate::ClusterFabricConfig::default();
+        assert_eq!(
+            persist_cluster_fabric_reset_at_revision_with_adoption(
+                dir.path(),
+                &mut reset,
+                1,
+                &reset_facade,
+                |_, _| {},
+            )
+            .unwrap()
+            .revision,
+            2
+        );
+        assert_eq!(
+            process_facade.registry().cluster_fabric.snapshot().revision,
+            0
+        );
+        assert_eq!(process_facade.registry().credentials.snapshot().revision, 0);
+
+        let fresh = crate::ConfigFacade::open(dir.path()).unwrap();
+        let mut retry = fresh.effective_config();
+        let commit = persist_cluster_fabric_reset_at_revision_with_adoption(
+            dir.path(),
+            &mut retry,
+            2,
+            &process_facade,
+            |_, _| {},
+        )
+        .unwrap();
+        assert_eq!(commit.revision, 2);
+        commit.adoption.unwrap().unwrap();
+        commit.credential_adoption.unwrap().unwrap();
+        assert_eq!(
+            process_facade.registry().cluster_fabric.snapshot().revision,
+            2
+        );
+        assert_eq!(process_facade.registry().credentials.snapshot().revision, 2);
+        assert!(commit.runtime.unwrap().cluster_fabric.nodes.is_empty());
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -822,6 +822,8 @@ enum MigrationFault {
     AfterExactCredentialRebaseStage,
     AfterExactCredentialRebaseManifest,
     AfterExactProxyConfigRebaseManifestExternalWrite,
+    AfterExactClusterConsumerConflict,
+    AfterExactClusterSectionRebase,
 }
 
 fn authoritative_section_file(scope: ExactTransactionScope) -> &'static str {
@@ -861,6 +863,24 @@ type EnvTransactionTestHook = Box<dyn FnOnce(&Path) + Send + 'static>;
 static ENV_TRANSACTION_TEST_HOOK: std::sync::Mutex<Option<EnvTransactionTestHook>> =
     std::sync::Mutex::new(None);
 
+/// One-shot crash boundary for an adopted cluster-fabric exact transaction.
+///
+/// Test-only: production builds have neither this type nor the corresponding
+/// timing branches.
+#[cfg(feature = "test-utils")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClusterExactCommitTestFault {
+    AfterManifest,
+    AfterManifestRecoveryFailure,
+    AfterCredentialInstall,
+    BeforeFinish,
+}
+
+#[cfg(feature = "test-utils")]
+static CLUSTER_EXACT_COMMIT_TEST_FAULTS: LazyLock<
+    Mutex<BTreeMap<PathBuf, ClusterExactCommitTestFault>>,
+> = LazyLock::new(|| Mutex::new(BTreeMap::new()));
+
 /// Install a one-shot hook immediately after an env exact manifest commits.
 /// Test-only: production builds have no hook or timing branch.
 #[cfg(feature = "test-utils")]
@@ -868,6 +888,52 @@ pub fn set_env_transaction_test_hook(hook: impl FnOnce(&Path) + Send + 'static) 
     *ENV_TRANSACTION_TEST_HOOK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(Box::new(hook));
+}
+
+/// Inject one recoverable failure into the next adopted cluster exact
+/// transaction for `data_dir`.
+#[cfg(feature = "test-utils")]
+pub fn set_cluster_exact_commit_test_fault(
+    data_dir: impl Into<PathBuf>,
+    fault: ClusterExactCommitTestFault,
+) {
+    CLUSTER_EXACT_COMMIT_TEST_FAULTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(data_dir.into(), fault);
+}
+
+#[cfg(feature = "test-utils")]
+fn take_cluster_exact_commit_test_fault(
+    data_dir: &Path,
+    fault: ClusterExactCommitTestFault,
+) -> bool {
+    let mut faults = CLUSTER_EXACT_COMMIT_TEST_FAULTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if faults.get(data_dir) == Some(&fault) {
+        faults.remove(data_dir);
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(feature = "test-utils")]
+fn take_cluster_exact_after_manifest_test_fault(data_dir: &Path) -> bool {
+    let mut faults = CLUSTER_EXACT_COMMIT_TEST_FAULTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    match faults.get(data_dir).copied() {
+        Some(ClusterExactCommitTestFault::AfterManifest) => {
+            faults.remove(data_dir);
+            true
+        }
+        // Retain this variant until the recovery attempt consumes its second
+        // deterministic failure below.
+        Some(ClusterExactCommitTestFault::AfterManifestRecoveryFailure) => true,
+        _ => false,
+    }
 }
 
 /// Extract provider/MCP/root secrets into the isolated credential store.
@@ -1751,6 +1817,10 @@ pub struct ClusterFabricTransactionCommit {
     pub revision: u64,
     pub adoption: Option<ConfigStoreResult<crate::ConfigSectionEvent>>,
     pub credential_adoption: Option<ConfigStoreResult<()>>,
+    /// A durable manifest crossed the commit point, but completing/recovering
+    /// its members failed. Callers must publish the captured secret-free
+    /// candidate and classify this as committed, never as a pre-commit error.
+    pub committed_recovery: ConfigStoreResult<()>,
     /// Exact runtime and public credential metadata captured from one
     /// immutable credential document before the transaction lock admitted
     /// another writer. Present for changed and semantic no-op transactions.
@@ -1773,6 +1843,7 @@ type ClusterPostCommit<'a> = &'a mut dyn FnMut(
     bool,
     &crate::ClusterFabricConfig,
     ConfigStoreResult<ExactClusterRuntimeSnapshot>,
+    ConfigStoreResult<()>,
 );
 
 fn materialize_cluster_runtime_under_migration_lock(
@@ -1790,6 +1861,256 @@ fn materialize_cluster_runtime_under_migration_lock(
             credential_health,
         },
         credential_lkg,
+    })
+}
+
+fn cluster_candidate_from_section_bytes(
+    bytes: &[u8],
+) -> ConfigStoreResult<(u64, crate::ClusterFabricConfig)> {
+    let (_, revision, data) = parse_exact_section_document(CLUSTER_FABRIC_FILE, bytes)?;
+    let section: crate::ClusterFabricSection = serde_json::from_value(data)?;
+    Ok((revision, section.0))
+}
+
+fn load_durable_cluster_candidate_under_migration_lock(
+    data_dir: &Path,
+) -> ConfigStoreResult<(u64, crate::ClusterFabricConfig)> {
+    let bytes = read_file_reject_symlink(&data_dir.join(CLUSTER_FABRIC_FILE))?;
+    cluster_candidate_from_section_bytes(&bytes)
+}
+
+fn load_staged_cluster_candidate_under_migration_lock(
+    data_dir: &Path,
+    manifest: &MigrationManifest,
+) -> ConfigStoreResult<(u64, crate::ClusterFabricConfig)> {
+    let authority = manifest
+        .files
+        .iter()
+        .find(|file| file.name == CLUSTER_FABRIC_FILE)
+        .ok_or_else(|| {
+            ConfigStoreError::Validation(
+                "cluster transaction authority is missing from its manifest".to_string(),
+            )
+        })?;
+    let bytes = read_managed_file(data_dir, &manifest.stage_dir, &authority.staged_name)?;
+    if sha256(&bytes) != authority.sha256 {
+        return Err(ConfigStoreError::Validation(
+            "staged cluster transaction authority failed integrity validation".to_string(),
+        ));
+    }
+    cluster_candidate_from_section_bytes(&bytes)
+}
+
+/// Return the still-live manifest for this exact cluster transaction.
+///
+/// A Pending manifest remains recoverable commit intent even if an abort
+/// rolled members back but failed before changing the manifest state. A
+/// Complete manifest is different: abort writes Complete after rolling back,
+/// so only an authority that still equals the manifest candidate proves the
+/// transaction committed. Complete plus a missing/nonmatching authority is
+/// the recoverable tail of an intentional abort and is classified ordinary.
+fn load_live_cluster_transaction_manifest(
+    data_dir: &Path,
+    expected: &MigrationManifest,
+) -> ConfigStoreResult<Option<MigrationManifest>> {
+    let Some(bytes) = read_optional_migration_file(&data_dir.join(MANIFEST_FILE))? else {
+        return Ok(None);
+    };
+    let manifest: MigrationManifest = serde_json::from_slice(&bytes)?;
+    validate_manifest(&manifest)?;
+    if manifest.transaction_id != expected.transaction_id
+        || manifest.stage_dir != expected.stage_dir
+        || manifest.exact_scope != Some(ExactTransactionScope::ClusterFabric)
+    {
+        return Err(ConfigStoreError::Validation(
+            "cluster transaction manifest no longer matches its commit".to_string(),
+        ));
+    }
+    if manifest.state == MigrationState::Complete {
+        let authority = manifest
+            .files
+            .iter()
+            .find(|file| file.name == CLUSTER_FABRIC_FILE)
+            .ok_or_else(|| {
+                ConfigStoreError::Validation(
+                    "cluster transaction authority is missing from its manifest".to_string(),
+                )
+            })?;
+        let current = read_target_or_empty(&data_dir.join(CLUSTER_FABRIC_FILE))?;
+        if sha256(&current) != authority.sha256 {
+            return Ok(None);
+        }
+    }
+    Ok(Some(manifest))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn report_cluster_committed_recovery_failure(
+    data_dir: &Path,
+    config: &mut crate::Config,
+    local_manifest: &MigrationManifest,
+    live_manifest: Option<&MigrationManifest>,
+    installed_candidate: Option<&(u64, crate::ClusterFabricConfig)>,
+    planned_revision: u64,
+    initial_error: &ConfigStoreError,
+    recovery_error: &ConfigStoreError,
+    cluster_post_commit: &mut Option<ClusterPostCommit<'_>>,
+) -> u64 {
+    let actual = installed_candidate
+        .cloned()
+        .or_else(|| {
+            live_manifest.and_then(|manifest| {
+                load_staged_cluster_candidate_under_migration_lock(data_dir, manifest).ok()
+            })
+        })
+        .or_else(|| {
+            live_manifest
+                .filter(|manifest| manifest.state == MigrationState::Complete)
+                .and_then(|_| load_durable_cluster_candidate_under_migration_lock(data_dir).ok())
+        })
+        .or_else(|| {
+            load_staged_cluster_candidate_under_migration_lock(data_dir, local_manifest).ok()
+        })
+        .unwrap_or_else(|| (planned_revision, config.cluster_fabric.clone()));
+    let (revision, candidate) = actual;
+    config.cluster_fabric = candidate;
+    let message = format!(
+        "cluster transaction committed at revision {revision}, completion failed \
+         ({initial_error}), and recovery failed ({recovery_error})"
+    );
+    if let Some(callback) = cluster_post_commit.as_mut() {
+        callback(
+            revision,
+            true,
+            &config.cluster_fabric,
+            Err(ConfigStoreError::Validation(message.clone())),
+            Err(ConfigStoreError::Validation(message)),
+        );
+    }
+    revision
+}
+
+/// One coherent durable cluster generation captured under the shared
+/// migration lock. The runtime fabric may contain hydrated SSH credentials,
+/// so this type deliberately does not implement `Debug` or `Serialize`.
+pub struct ExactClusterFabricReadSnapshot {
+    pub cluster_fabric: crate::ClusterFabricConfig,
+    pub section: crate::SectionEnvelope<Value>,
+    pub credential_statuses: Vec<crate::CredentialStatus>,
+    pub credential_health: crate::CredentialStoreHealth,
+}
+
+/// Recover readiness and read the durable cluster section plus one immutable
+/// credential generation while one migration lock excludes compound writers.
+///
+/// When `expected_revision` is present, the durable section itself is the CAS
+/// authority. A stale process facade therefore cannot authorize preflight or
+/// another external lifecycle action.
+pub fn read_exact_cluster_fabric_snapshot(
+    data_dir: impl AsRef<Path>,
+    expected_revision: Option<u64>,
+) -> ConfigStoreResult<ExactClusterFabricReadSnapshot> {
+    let data_dir = data_dir.as_ref();
+    with_migration_lock(data_dir, || {
+        recover_committed(
+            data_dir,
+            #[cfg(test)]
+            None,
+        )?;
+        ensure_provider_mcp_migration_ready(data_dir)?;
+
+        let primary_path = data_dir.join(CLUSTER_FABRIC_FILE);
+        let store = crate::AtomicJsonStore::<crate::ClusterFabricSection>::new(
+            &primary_path,
+            crate::section_facade::SECTION_SCHEMA_VERSION,
+        )
+        .with_raw_validator(crate::section_facade::validate_ordinary_section_raw);
+        let stored = store
+            .load_validated(crate::section_facade::validate_cluster_fabric)?
+            .ok_or_else(|| {
+                ConfigStoreError::Validation(
+                    "cluster section revision envelope is missing".to_string(),
+                )
+            })?;
+        let revision = stored.revision;
+        if let Some(expected) = expected_revision {
+            if stored.recovered_from_backup {
+                return Err(ConfigStoreError::Validation(
+                    "revision-bound cluster actions require a healthy primary section".to_string(),
+                ));
+            }
+            if expected != revision {
+                return Err(ConfigStoreError::Conflict {
+                    expected,
+                    actual: revision,
+                });
+            }
+        }
+        let source_kind = if stored.recovered_from_backup {
+            crate::SectionSourceKind::Backup
+        } else {
+            crate::SectionSourceKind::File
+        };
+        let status = if stored.recovered_from_backup {
+            crate::SectionStatus::Degraded
+        } else {
+            crate::SectionStatus::Healthy
+        };
+        let last_error = stored
+            .recovered_from_backup
+            .then(|| "primary document invalid; using last-known-good backup".to_string());
+        let data = serde_json::to_value(&stored.data)?;
+
+        let credential_store = CredentialStore::open(data_dir);
+        let (credential_lkg, credential_statuses, credential_health) =
+            match credential_store.snapshot_with_health_unchecked() {
+                Ok((lkg, statuses, health)) => (Some(lkg), statuses, health),
+                Err(error) if expected_revision.is_some() => return Err(error),
+                Err(_) => (
+                    None,
+                    Vec::new(),
+                    crate::CredentialStoreHealth {
+                        revision: 0,
+                        status: crate::SectionStatus::Degraded,
+                        source: crate::SectionSourceKind::Default,
+                        last_error: Some("credential status is unavailable".to_string()),
+                    },
+                ),
+            };
+        let credential_degraded = credential_health.status == crate::SectionStatus::Degraded;
+        if expected_revision.is_some() && credential_degraded {
+            return Err(ConfigStoreError::Validation(
+                "revision-bound cluster actions require a healthy primary credential section"
+                    .to_string(),
+            ));
+        }
+        let mut config = crate::Config::default();
+        config.cluster_fabric = stored.data.0;
+        // GET needs only secret-free metadata and statuses, so it never
+        // materializes plaintext. Revision-bound actions hydrate only after
+        // both primary authorities have passed the coherence checks above.
+        if expected_revision.is_some() && !stored.recovered_from_backup && !credential_degraded {
+            config.hydrate_cluster_credentials_from_snapshot(
+                credential_lkg
+                    .as_ref()
+                    .expect("revision-bound credential snapshot checked above"),
+            )?;
+        }
+
+        Ok(ExactClusterFabricReadSnapshot {
+            cluster_fabric: config.cluster_fabric.clone(),
+            section: crate::SectionEnvelope {
+                data,
+                revision,
+                loaded_at: chrono::Utc::now(),
+                source_path: stored.source_path,
+                source_kind,
+                status,
+                last_error,
+            },
+            credential_statuses,
+            credential_health,
+        })
     })
 }
 
@@ -1829,23 +2150,25 @@ where
 {
     let mut adoption = None;
     let mut exact_runtime = None;
+    let mut committed_recovery = None;
     let mut transaction_changed = false;
-    let mut callback =
-        |revision: u64,
-         changed: bool,
-         candidate: &crate::ClusterFabricConfig,
-         runtime: ConfigStoreResult<ExactClusterRuntimeSnapshot>| {
-            exact_runtime = Some(runtime);
-            transaction_changed = changed;
-            if changed {
-                before_adoption(revision, candidate);
-                adoption = Some(facade.adopt_committed_cluster_fabric(
-                    expected_revision,
-                    revision,
-                    candidate.clone(),
-                ));
-            }
-        };
+    let mut callback = |revision: u64,
+                        changed: bool,
+                        candidate: &crate::ClusterFabricConfig,
+                        runtime: ConfigStoreResult<ExactClusterRuntimeSnapshot>,
+                        recovery: ConfigStoreResult<()>| {
+        exact_runtime = Some(runtime);
+        committed_recovery = Some(recovery);
+        transaction_changed = changed;
+        if changed {
+            before_adoption(revision, candidate);
+            adoption = Some(facade.adopt_committed_cluster_fabric(
+                expected_revision,
+                revision,
+                candidate.clone(),
+            ));
+        }
+    };
     let revision = persist_cluster_fabric_credential_transaction_inner(
         data_dir.as_ref(),
         config,
@@ -1876,6 +2199,11 @@ where
         revision,
         adoption,
         credential_adoption,
+        committed_recovery: committed_recovery.unwrap_or_else(|| {
+            Err(ConfigStoreError::Validation(
+                "cluster transaction omitted its committed recovery outcome".to_string(),
+            ))
+        }),
         runtime,
     })
 }
@@ -2174,23 +2502,25 @@ where
     }
     let mut adoption = None;
     let mut exact_runtime = None;
+    let mut committed_recovery = None;
     let mut transaction_changed = false;
-    let mut callback =
-        |revision: u64,
-         changed: bool,
-         candidate: &crate::ClusterFabricConfig,
-         runtime: ConfigStoreResult<ExactClusterRuntimeSnapshot>| {
-            exact_runtime = Some(runtime);
-            transaction_changed = changed;
-            if changed {
-                before_adoption(revision, candidate);
-                adoption = Some(facade.adopt_committed_cluster_fabric(
-                    expected_revision,
-                    revision,
-                    candidate.clone(),
-                ));
-            }
-        };
+    let mut callback = |revision: u64,
+                        changed: bool,
+                        candidate: &crate::ClusterFabricConfig,
+                        runtime: ConfigStoreResult<ExactClusterRuntimeSnapshot>,
+                        recovery: ConfigStoreResult<()>| {
+        exact_runtime = Some(runtime);
+        committed_recovery = Some(recovery);
+        transaction_changed = changed;
+        if changed {
+            before_adoption(revision, candidate);
+            adoption = Some(facade.adopt_committed_cluster_fabric(
+                expected_revision,
+                revision,
+                candidate.clone(),
+            ));
+        }
+    };
     let revision = persist_exact_credential_transaction_inner(
         data_dir.as_ref(),
         config,
@@ -2235,6 +2565,11 @@ where
         revision,
         adoption,
         credential_adoption,
+        committed_recovery: committed_recovery.unwrap_or_else(|| {
+            Err(ConfigStoreError::Validation(
+                "cluster reset omitted its committed recovery outcome".to_string(),
+            ))
+        }),
         runtime,
     })
 }
@@ -2940,6 +3275,7 @@ fn persist_exact_credential_transaction_inner(
                     false,
                     &config.cluster_fabric,
                     runtime,
+                    Ok(()),
                 );
             }
         }
@@ -3094,6 +3430,17 @@ fn persist_exact_credential_transaction_inner(
     }
     write_manifest(data_dir.join(MANIFEST_FILE), &manifest)?;
     #[cfg(feature = "test-utils")]
+    let cluster_fault_after_manifest = cluster_only
+        && active_section.is_some()
+        && take_cluster_exact_after_manifest_test_fault(data_dir);
+    #[cfg(not(feature = "test-utils"))]
+    let cluster_fault_after_manifest = false;
+    if cluster_fault_after_manifest && cluster_post_commit.is_none() {
+        return Err(ConfigStoreError::Validation(
+            "injected cluster exact transaction fault after manifest".to_string(),
+        ));
+    }
+    #[cfg(feature = "test-utils")]
     if env_only {
         if let Some(hook) = ENV_TRANSACTION_TEST_HOOK
             .lock()
@@ -3140,28 +3487,236 @@ fn persist_exact_credential_transaction_inner(
         }
     }
     #[cfg(test)]
+    if fault == Some(MigrationFault::AfterExactClusterConsumerConflict) {
+        let reference = prepared.touched_refs.first().ok_or_else(|| {
+            ConfigStoreError::Validation("cluster credential intent is empty".to_string())
+        })?;
+        AtomicFileStore::new(data_dir.join(PROVIDERS_FILE)).write_bytes_without_backup(
+            &serde_json::to_vec_pretty(&serde_json::json!({
+                "test_external_consumer": {
+                    "credential_ref": reference.as_str()
+                }
+            }))?,
+        )?;
+    }
+    #[cfg(test)]
+    if fault == Some(MigrationFault::AfterExactClusterSectionRebase) {
+        let target = data_dir.join(CLUSTER_FABRIC_FILE);
+        let current = read_file_reject_symlink(&target)?;
+        let current_hash = sha256(&current);
+        let (mut envelope, revision, mut data) =
+            parse_exact_section_document(CLUSTER_FABRIC_FILE, &current)?;
+        let external = crate::Node {
+            id: "external-rebase-node".to_string(),
+            label: "external-rebase-node".to_string(),
+            placement: crate::NodePlacement::Local,
+            trust_level: crate::TrustLevel::Trusted,
+            deploy: crate::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        };
+        data.as_object_mut()
+            .ok_or_else(|| {
+                ConfigStoreError::Validation("cluster section data is invalid".to_string())
+            })?
+            .entry("nodes".to_string())
+            .or_insert_with(|| Value::Array(Vec::new()))
+            .as_array_mut()
+            .ok_or_else(|| {
+                ConfigStoreError::Validation("cluster node collection is invalid".to_string())
+            })?
+            .push(serde_json::to_value(external)?);
+        let next_revision = revision.checked_add(1).ok_or_else(|| {
+            ConfigStoreError::Validation("cluster section revision counter exhausted".to_string())
+        })?;
+        let object = envelope.as_object_mut().ok_or_else(|| {
+            ConfigStoreError::Validation("cluster section envelope is invalid".to_string())
+        })?;
+        object.insert("revision".to_string(), Value::from(next_revision));
+        object.insert("data".to_string(), data);
+        let bytes = serde_json::to_vec_pretty(&envelope)?;
+        crate::section_facade::validate_section_envelope(
+            CLUSTER_FABRIC_FILE,
+            &bytes,
+            next_revision,
+        )?;
+        if !AtomicFileStore::new(&target).write_bytes_if_hash(&current_hash, &bytes)? {
+            return Err(ConfigStoreError::Validation(
+                "cluster section changed during test race injection".to_string(),
+            ));
+        }
+    }
+    #[cfg(test)]
     if fault == Some(MigrationFault::AfterManifest) {
         return Err(injected_fault());
     }
     let mut manifest = manifest;
-    install_pending(
-        data_dir,
-        &mut manifest,
-        #[cfg(test)]
-        fault,
-    )?;
-    finish_transaction(data_dir, manifest)?;
+    let adopted_cluster_transaction =
+        cluster_only && active_section.is_some() && cluster_post_commit.is_some();
+    let mut installed_cluster_candidate = None;
+    let completion = if cluster_fault_after_manifest {
+        Err(ConfigStoreError::Validation(
+            "injected cluster exact transaction fault after manifest".to_string(),
+        ))
+    } else {
+        match install_pending(
+            data_dir,
+            &mut manifest,
+            #[cfg(test)]
+            fault,
+        ) {
+            Err(error) => Err(error),
+            Ok(()) => {
+                let capture = adopted_cluster_transaction
+                    .then(|| load_durable_cluster_candidate_under_migration_lock(data_dir))
+                    .transpose();
+                if let Err(error) = capture {
+                    Err(error)
+                } else {
+                    installed_cluster_candidate = capture.expect("checked above");
+                    #[cfg(feature = "test-utils")]
+                    let before_finish_fault = cluster_only
+                        && active_section.is_some()
+                        && take_cluster_exact_commit_test_fault(
+                            data_dir,
+                            ClusterExactCommitTestFault::BeforeFinish,
+                        );
+                    #[cfg(not(feature = "test-utils"))]
+                    let before_finish_fault = false;
+                    if before_finish_fault {
+                        Err(ConfigStoreError::Validation(
+                            "injected cluster exact transaction fault before finish".to_string(),
+                        ))
+                    } else {
+                        finish_transaction(data_dir, manifest.clone())
+                    }
+                }
+            }
+        }
+    };
+    if let Err(initial_error) = completion {
+        if !adopted_cluster_transaction {
+            return Err(initial_error);
+        }
+        let live_before_recovery = match load_live_cluster_transaction_manifest(data_dir, &manifest)
+        {
+            Ok(None) => return Err(initial_error),
+            Ok(Some(live)) => live,
+            Err(inspection_error) => {
+                let revision = report_cluster_committed_recovery_failure(
+                    data_dir,
+                    config,
+                    &manifest,
+                    None,
+                    installed_cluster_candidate.as_ref(),
+                    committed_authority_revision,
+                    &initial_error,
+                    &inspection_error,
+                    &mut cluster_post_commit,
+                );
+                return Ok(revision);
+            }
+        };
+        let recovery = {
+            #[cfg(feature = "test-utils")]
+            if take_cluster_exact_commit_test_fault(
+                data_dir,
+                ClusterExactCommitTestFault::AfterManifestRecoveryFailure,
+            ) {
+                Err(ConfigStoreError::Validation(
+                    "injected cluster exact transaction recovery failure".to_string(),
+                ))
+            } else {
+                recover_committed(
+                    data_dir,
+                    #[cfg(test)]
+                    None,
+                )
+            }
+            #[cfg(not(feature = "test-utils"))]
+            recover_committed(
+                data_dir,
+                #[cfg(test)]
+                None,
+            )
+        };
+        match recovery {
+            Ok(_) => match load_durable_cluster_candidate_under_migration_lock(data_dir) {
+                Ok(actual) => installed_cluster_candidate = Some(actual),
+                Err(load_error) => {
+                    let revision = report_cluster_committed_recovery_failure(
+                        data_dir,
+                        config,
+                        &manifest,
+                        Some(&live_before_recovery),
+                        installed_cluster_candidate.as_ref(),
+                        committed_authority_revision,
+                        &initial_error,
+                        &load_error,
+                        &mut cluster_post_commit,
+                    );
+                    return Ok(revision);
+                }
+            },
+            Err(recovery_error) => {
+                let live_after_recovery =
+                    match load_live_cluster_transaction_manifest(data_dir, &manifest) {
+                        Ok(None) => return Err(recovery_error),
+                        Ok(Some(live)) => Some(live),
+                        Err(inspection_error) => {
+                            let combined = ConfigStoreError::Validation(format!(
+                                "{recovery_error}; cluster transaction state inspection failed \
+                                 ({inspection_error})"
+                            ));
+                            let revision = report_cluster_committed_recovery_failure(
+                                data_dir,
+                                config,
+                                &manifest,
+                                None,
+                                installed_cluster_candidate.as_ref(),
+                                committed_authority_revision,
+                                &initial_error,
+                                &combined,
+                                &mut cluster_post_commit,
+                            );
+                            return Ok(revision);
+                        }
+                    };
+                let revision = report_cluster_committed_recovery_failure(
+                    data_dir,
+                    config,
+                    &manifest,
+                    live_after_recovery.as_ref(),
+                    installed_cluster_candidate.as_ref(),
+                    committed_authority_revision,
+                    &initial_error,
+                    &recovery_error,
+                    &mut cluster_post_commit,
+                );
+                return Ok(revision);
+            }
+        }
+    }
     if cluster_only && active_section.is_some() {
+        let (actual_revision, actual_candidate) = installed_cluster_candidate
+            .or_else(|| load_durable_cluster_candidate_under_migration_lock(data_dir).ok())
+            .ok_or_else(|| {
+                ConfigStoreError::Validation(
+                    "committed cluster transaction authority is unavailable".to_string(),
+                )
+            })?;
+        config.cluster_fabric = actual_candidate;
         if let Some(callback) = cluster_post_commit.as_mut() {
             let runtime = materialize_cluster_runtime_under_migration_lock(config, &store);
             callback(
-                committed_authority_revision,
+                actual_revision,
                 true,
                 &config.cluster_fabric,
                 runtime,
+                Ok(()),
             );
         }
-        Ok(committed_authority_revision)
+        Ok(actual_revision)
     } else {
         // Credential-member rebases can advance beyond the initially staged
         // revision. Preserve the existing exact-transaction return contract
@@ -8737,6 +9292,17 @@ fn install_pending(
             #[cfg(test)]
             if fault == Some(MigrationFault::AfterCredentials) {
                 return Err(injected_fault());
+            }
+            #[cfg(feature = "test-utils")]
+            if manifest.exact_scope == Some(ExactTransactionScope::ClusterFabric)
+                && take_cluster_exact_commit_test_fault(
+                    data_dir,
+                    ClusterExactCommitTestFault::AfterCredentialInstall,
+                )
+            {
+                return Err(ConfigStoreError::Validation(
+                    "injected cluster exact transaction fault after credential install".to_string(),
+                ));
             }
             continue;
         }
@@ -14785,6 +15351,182 @@ mod tests {
         let (fresh, revision) = active_facade_config_and_cluster_revision(dir.path());
         assert_eq!(revision, 1);
         assert!(fresh.cluster_fabric.node("race-local").is_some());
+    }
+
+    #[test]
+    fn adopted_cluster_transaction_does_not_publish_an_intentional_abort() {
+        let _key = crate::encryption::set_test_encryption_key([0xba; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(cluster_test_node(
+            "aborted-node",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        let intents = BTreeMap::from([(
+            "aborted-node".to_string(),
+            password_intents(crate::ClusterCredentialAction::Replace(
+                "must-roll-back".to_string(),
+            )),
+        )]);
+        let cluster_before = std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap();
+        let credentials_before = std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap();
+        let mut callbacks = 0;
+        let mut callback = |_: u64,
+                            _: bool,
+                            _: &crate::ClusterFabricConfig,
+                            _: ConfigStoreResult<ExactClusterRuntimeSnapshot>,
+                            _: ConfigStoreResult<()>| {
+            callbacks += 1;
+        };
+
+        let error = persist_cluster_fabric_credential_transaction_inner(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            revision,
+            Some(&mut callback),
+            Some(MigrationFault::AfterExactClusterConsumerConflict),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("shared by another consumer"));
+        assert_eq!(callbacks, 0, "a rolled-back intent must not be adopted");
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+        assert!(!dir.path().join(MANIFEST_FILE).exists());
+    }
+
+    #[test]
+    fn complete_cluster_abort_manifest_is_not_a_live_commit() {
+        let _key = crate::encryption::set_test_encryption_key([0xbc; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(crate::Node {
+            id: "never-installed".to_string(),
+            label: "never-installed".to_string(),
+            placement: crate::NodePlacement::Local,
+            trust_level: crate::TrustLevel::Trusted,
+            deploy: crate::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        });
+        let intents = BTreeMap::from([(
+            "never-installed".to_string(),
+            crate::ClusterNodeCredentialIntents::clear_all(),
+        )]);
+        assert!(persist_cluster_fabric_credential_transaction_inner(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            revision,
+            None,
+            Some(MigrationFault::AfterManifest),
+        )
+        .is_err());
+        let manifest_path = dir.path().join(MANIFEST_FILE);
+        let mut manifest: MigrationManifest =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        assert_eq!(manifest.state, MigrationState::Pending);
+        manifest.state = MigrationState::Complete;
+        write_manifest(manifest_path, &manifest).unwrap();
+
+        assert!(
+            load_live_cluster_transaction_manifest(dir.path(), &manifest)
+                .unwrap()
+                .is_none(),
+            "Complete plus rolled-back/nonmatching authority is an abort tail"
+        );
+    }
+
+    #[test]
+    fn adopted_cluster_transaction_reports_the_actual_rebased_candidate() {
+        let _key = crate::encryption::set_test_encryption_key([0xbb; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut baseline, revision) = active_facade_config_and_cluster_revision(dir.path());
+        baseline.cluster_fabric.nodes.push(crate::Node {
+            id: "baseline-node".to_string(),
+            label: "baseline-node".to_string(),
+            placement: crate::NodePlacement::Local,
+            trust_level: crate::TrustLevel::Trusted,
+            deploy: crate::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        });
+        persist_cluster_fabric_credential_transaction_at_revision(
+            dir.path(),
+            &mut baseline,
+            &BTreeMap::from([(
+                "baseline-node".to_string(),
+                crate::ClusterNodeCredentialIntents::clear_all(),
+            )]),
+            revision,
+        )
+        .unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(crate::Node {
+            id: "planned-node".to_string(),
+            label: "planned-node".to_string(),
+            placement: crate::NodePlacement::Local,
+            trust_level: crate::TrustLevel::Trusted,
+            deploy: crate::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        });
+        let intents = BTreeMap::from([(
+            "planned-node".to_string(),
+            crate::ClusterNodeCredentialIntents::clear_all(),
+        )]);
+        let mut observed = None;
+        let mut callback = |committed_revision: u64,
+                            changed: bool,
+                            committed: &crate::ClusterFabricConfig,
+                            runtime: ConfigStoreResult<ExactClusterRuntimeSnapshot>,
+                            recovery: ConfigStoreResult<()>| {
+            observed = Some((
+                committed_revision,
+                changed,
+                committed.clone(),
+                runtime.is_ok(),
+                recovery.is_ok(),
+            ));
+        };
+
+        let committed = persist_cluster_fabric_credential_transaction_inner(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            revision,
+            Some(&mut callback),
+            Some(MigrationFault::AfterExactClusterSectionRebase),
+        )
+        .unwrap();
+
+        assert_eq!(committed, 3);
+        let (callback_revision, changed, callback_candidate, runtime_ok, recovery_ok) =
+            observed.expect("post-commit callback");
+        assert_eq!(callback_revision, committed);
+        assert!(changed);
+        assert!(runtime_ok);
+        assert!(recovery_ok);
+        for node_id in ["external-rebase-node", "planned-node"] {
+            assert!(callback_candidate.node(node_id).is_some());
+            assert!(candidate.cluster_fabric.node(node_id).is_some());
+        }
+        let (fresh, fresh_revision) = active_facade_config_and_cluster_revision(dir.path());
+        assert_eq!(fresh_revision, committed);
+        assert_eq!(fresh.cluster_fabric, callback_candidate);
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -877,12 +877,21 @@ pub enum ClusterExactCommitTestFault {
     AfterCredentialInstall,
     BeforeFinish,
     AbortMarkerRecoveryFailure,
+    AbortJournalMarkerAndCleanupRecoveryFailure,
+    AbortBothMarkersRecoveryFailure,
     AbortCleanupRecoveryFailure,
 }
 
 #[cfg(any(test, feature = "test-utils"))]
+#[derive(Debug, Clone, Copy)]
+struct ClusterExactCommitTestFaultState {
+    fault: ClusterExactCommitTestFault,
+    cleanup_failure_observed: bool,
+}
+
+#[cfg(any(test, feature = "test-utils"))]
 static CLUSTER_EXACT_COMMIT_TEST_FAULTS: LazyLock<
-    Mutex<BTreeMap<PathBuf, ClusterExactCommitTestFault>>,
+    Mutex<BTreeMap<PathBuf, ClusterExactCommitTestFaultState>>,
 > = LazyLock::new(|| Mutex::new(BTreeMap::new()));
 
 /// Install a one-shot hook immediately after an env exact manifest commits.
@@ -904,7 +913,13 @@ pub fn set_cluster_exact_commit_test_fault(
     CLUSTER_EXACT_COMMIT_TEST_FAULTS
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .insert(data_dir.into(), fault);
+        .insert(
+            data_dir.into(),
+            ClusterExactCommitTestFaultState {
+                fault,
+                cleanup_failure_observed: false,
+            },
+        );
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -923,7 +938,10 @@ fn take_cluster_exact_commit_test_fault(
     let mut faults = CLUSTER_EXACT_COMMIT_TEST_FAULTS
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if faults.get(data_dir) == Some(&fault) {
+    if faults
+        .get(data_dir)
+        .is_some_and(|state| state.fault == fault)
+    {
         faults.remove(data_dir);
         true
     } else {
@@ -936,7 +954,7 @@ fn take_cluster_exact_after_manifest_test_fault(data_dir: &Path) -> bool {
     let mut faults = CLUSTER_EXACT_COMMIT_TEST_FAULTS
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    match faults.get(data_dir).copied() {
+    match faults.get(data_dir).map(|state| state.fault) {
         Some(ClusterExactCommitTestFault::AfterManifest) => {
             faults.remove(data_dir);
             true
@@ -950,11 +968,22 @@ fn take_cluster_exact_after_manifest_test_fault(data_dir: &Path) -> bool {
 
 #[cfg(any(test, feature = "test-utils"))]
 fn cluster_abort_cleanup_test_fault(data_dir: &Path) -> bool {
-    CLUSTER_EXACT_COMMIT_TEST_FAULTS
+    let mut faults = CLUSTER_EXACT_COMMIT_TEST_FAULTS
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .get(data_dir)
-        == Some(&ClusterExactCommitTestFault::AbortCleanupRecoveryFailure)
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(state) = faults.get_mut(data_dir) else {
+        return false;
+    };
+    match state.fault {
+        ClusterExactCommitTestFault::AbortCleanupRecoveryFailure => true,
+        ClusterExactCommitTestFault::AbortJournalMarkerAndCleanupRecoveryFailure
+            if !state.cleanup_failure_observed =>
+        {
+            state.cleanup_failure_observed = true;
+            true
+        }
+        _ => false,
+    }
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -963,7 +992,28 @@ fn cluster_abort_marker_test_fault(data_dir: &Path) -> bool {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .get(data_dir)
-        == Some(&ClusterExactCommitTestFault::AbortMarkerRecoveryFailure)
+        .is_some_and(|state| {
+            matches!(
+                state.fault,
+                ClusterExactCommitTestFault::AbortMarkerRecoveryFailure
+                    | ClusterExactCommitTestFault::AbortBothMarkersRecoveryFailure
+            )
+        })
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+fn cluster_abort_journal_marker_test_fault(data_dir: &Path) -> bool {
+    CLUSTER_EXACT_COMMIT_TEST_FAULTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(data_dir)
+        .is_some_and(|state| {
+            matches!(
+                state.fault,
+                ClusterExactCommitTestFault::AbortJournalMarkerAndCleanupRecoveryFailure
+                    | ClusterExactCommitTestFault::AbortBothMarkersRecoveryFailure
+            )
+        })
 }
 
 /// Extract provider/MCP/root secrets into the isolated credential store.
@@ -1945,6 +1995,7 @@ enum LiveClusterTransaction {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ClusterInstallOutcome {
     CommitIntent,
+    AbortAttempt,
     Aborting,
 }
 
@@ -1953,6 +2004,10 @@ struct ClusterInstallTracker(Cell<ClusterInstallOutcome>);
 impl ClusterInstallTracker {
     fn new() -> Self {
         Self(Cell::new(ClusterInstallOutcome::CommitIntent))
+    }
+
+    fn mark_abort_attempt(&self) {
+        self.0.set(ClusterInstallOutcome::AbortAttempt);
     }
 
     fn mark_aborting(&self) {
@@ -3682,11 +3737,13 @@ fn persist_exact_credential_transaction_inner(
     if let Err(initial_error) = completion {
         if cluster_install_tracker
             .as_ref()
-            .is_some_and(|tracker| tracker.outcome() == ClusterInstallOutcome::Aborting)
+            .is_some_and(|tracker| tracker.outcome() != ClusterInstallOutcome::CommitIntent)
         {
-            // An intentional abort is a typed non-commit result. Never infer
-            // commit from a still-Pending manifest when persisting the durable
-            // Aborting marker or rollback cleanup itself failed.
+            // Once an intentional abort has started, never infer commit or
+            // publish the staged candidate in this process. `AbortAttempt`
+            // covers the indeterminate case where neither redundant durable
+            // marker could be confirmed; `Aborting` covers either marker
+            // succeeding before rollback or cleanup failed.
             return Err(initial_error);
         }
         if !adopted_cluster_transaction {
@@ -8099,6 +8156,12 @@ fn persist_cluster_abort_journal(
         ));
     }
     if journal.state != MigrationState::Aborting {
+        #[cfg(any(test, feature = "test-utils"))]
+        if cluster_abort_journal_marker_test_fault(data_dir) {
+            return Err(ConfigStoreError::Validation(
+                "injected persistent cluster abort journal marker failure".to_string(),
+            ));
+        }
         journal.state = MigrationState::Aborting;
         write_manifest(path, &journal)?;
     }
@@ -8670,28 +8733,60 @@ fn abort_cluster_exact_transaction(
             "a complete cluster transaction cannot enter abort rollback".to_string(),
         ));
     }
-    // First persist non-commit intent into the immutable rollback journal. If
-    // this write fails, the transaction remains indeterminate/commit-intent
-    // and must not be reported through the typed non-commit path.
-    persist_cluster_abort_journal(data_dir, manifest)?;
-    if let Some(tracker) = install_tracker {
-        // The journal is now durable, so this process can safely classify the
-        // result as non-commit even if the mutable main marker write fails.
-        tracker.mark_aborting();
-    }
     let mut aborting = manifest.clone();
     aborting.state = MigrationState::Aborting;
-    if manifest.state != MigrationState::Aborting {
-        // Persist non-commit intent before touching either installed member.
-        // From this boundary onward recovery must resume rollback, never
-        // install or adopt the staged candidate.
-        #[cfg(any(test, feature = "test-utils"))]
-        if cluster_abort_marker_test_fault(data_dir) {
-            return Err(ConfigStoreError::Validation(
-                "injected persistent cluster abort marker failure".to_string(),
-            ));
+
+    if manifest.state == MigrationState::Aborting {
+        // A restart may arrive here after the main manifest was the successful
+        // fallback marker while the immutable journal remained Pending. The
+        // durable main state is already sufficient non-commit evidence; leave
+        // the journal's original rollback members untouched.
+        if let Some(tracker) = install_tracker {
+            tracker.mark_aborting();
         }
-        write_manifest(data_dir.join(MANIFEST_FILE), &aborting)?;
+    } else {
+        if let Some(tracker) = install_tracker {
+            // This process has chosen abort, even though neither durable marker
+            // is confirmed yet. A double write failure must not fall back into
+            // committed-candidate adoption in the caller.
+            tracker.mark_abort_attempt();
+        }
+
+        // Prefer the journal marker because it preserves a fallback if the
+        // mutable main marker cannot be written. If the journal transition
+        // fails, the main manifest is the redundant durable abort marker.
+        let journal_durable = persist_cluster_abort_journal(data_dir, manifest).is_ok();
+        if journal_durable {
+            if let Some(tracker) = install_tracker {
+                tracker.mark_aborting();
+            }
+        }
+
+        #[cfg(any(test, feature = "test-utils"))]
+        let main_marker = if cluster_abort_marker_test_fault(data_dir) {
+            Err(ConfigStoreError::Validation(
+                "injected persistent cluster abort marker failure".to_string(),
+            ))
+        } else {
+            write_manifest(data_dir.join(MANIFEST_FILE), &aborting)
+        };
+        #[cfg(not(any(test, feature = "test-utils")))]
+        let main_marker = write_manifest(data_dir.join(MANIFEST_FILE), &aborting);
+
+        match main_marker {
+            Ok(()) => {
+                if let Some(tracker) = install_tracker {
+                    tracker.mark_aborting();
+                }
+            }
+            Err(error) if journal_durable => return Err(error),
+            Err(_) => {
+                return Err(ConfigStoreError::Validation(
+                    "cluster abort intent could not be persisted to either durable marker"
+                        .to_string(),
+                ));
+            }
+        }
     }
     #[cfg(any(test, feature = "test-utils"))]
     if cluster_abort_cleanup_test_fault(data_dir) {
@@ -15893,6 +15988,213 @@ mod tests {
             }
         }
         assert_eq!(callbacks, 0);
+    }
+
+    #[test]
+    fn abort_journal_marker_failure_falls_back_to_main_abort_across_restart() {
+        let _key = crate::encryption::set_test_encryption_key([0xc5; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let providers_path = dir.path().join(PROVIDERS_FILE);
+        let providers_before = std::fs::read(&providers_path).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(cluster_test_node(
+            "journal-marker-failure-node",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        let abort_secret = Uuid::new_v4().to_string();
+        let intents = BTreeMap::from([(
+            "journal-marker-failure-node".to_string(),
+            password_intents(crate::ClusterCredentialAction::Replace(
+                abort_secret.clone(),
+            )),
+        )]);
+        let cluster_before = std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap();
+        let credentials_before = std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap();
+        let mut callbacks = 0;
+        let mut callback = |_: u64,
+                            _: bool,
+                            _: &crate::ClusterFabricConfig,
+                            _: ConfigStoreResult<ExactClusterRuntimeSnapshot>,
+                            _: ConfigStoreResult<()>| {
+            callbacks += 1;
+        };
+        set_cluster_exact_commit_test_fault(
+            dir.path().to_path_buf(),
+            ClusterExactCommitTestFault::AbortJournalMarkerAndCleanupRecoveryFailure,
+        );
+
+        let error = persist_cluster_fabric_credential_transaction_inner(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            revision,
+            Some(&mut callback),
+            Some(MigrationFault::AfterExactClusterConsumerConflict),
+        )
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("persistent cluster abort cleanup failure"));
+        assert_eq!(callbacks, 0);
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+
+        let manifest_path = dir.path().join(MANIFEST_FILE);
+        let manifest: MigrationManifest =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        assert_eq!(
+            manifest.state,
+            MigrationState::Aborting,
+            "the main manifest must be the redundant durable abort marker"
+        );
+        let journal_path = dir.path().join(JOURNAL_FILE);
+        let journal: MigrationManifest =
+            serde_json::from_slice(&std::fs::read(&journal_path).unwrap()).unwrap();
+        assert_eq!(
+            journal.state,
+            MigrationState::Pending,
+            "journal marker failure must preserve the original rollback journal"
+        );
+        let stage_dir = dir.path().join(&journal.stage_dir);
+        let backup_dir = dir
+            .path()
+            .join(format!("{BACKUP_PREFIX}{}", journal.transaction_id));
+        assert!(stage_dir.exists());
+        assert!(backup_dir.exists());
+        assert_ne!(std::fs::read(&providers_path).unwrap(), providers_before);
+
+        // The original conflict disappears before restart. Keep the injected
+        // journal failure active: recovery can succeed only if the durable main
+        // Aborting marker skips any attempt to mutate the Pending journal.
+        std::fs::write(&providers_path, &providers_before).unwrap();
+        assert!(matches!(
+            load_live_cluster_transaction_manifest(dir.path(), &manifest).unwrap(),
+            LiveClusterTransaction::Aborting
+        ));
+        assert!(crate::ensure_provider_mcp_migration_ready(dir.path()).is_err());
+        assert!(
+            !recover_pending_config_transaction(dir.path()).unwrap(),
+            "restart recovery must roll back from the main abort marker"
+        );
+        clear_cluster_exact_commit_test_fault(dir.path());
+        assert!(!recover_pending_config_transaction(dir.path()).unwrap());
+
+        assert!(!manifest_path.exists());
+        assert!(!journal_path.exists());
+        assert!(!stage_dir.exists());
+        assert!(!backup_dir.exists());
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+        let password_ref =
+            crate::cluster_password_credential_ref("journal-marker-failure-node").unwrap();
+        assert!(CredentialStore::open(dir.path())
+            .resolve(&password_ref)
+            .unwrap()
+            .is_none());
+        let (fresh, _) = active_facade_config_and_cluster_revision(dir.path());
+        assert!(fresh
+            .cluster_fabric
+            .node("journal-marker-failure-node")
+            .is_none());
+        for entry in std::fs::read_dir(dir.path()).unwrap() {
+            let entry = entry.unwrap();
+            if entry.file_type().unwrap().is_file() {
+                assert!(
+                    !String::from_utf8_lossy(&std::fs::read(entry.path()).unwrap())
+                        .contains(&abort_secret),
+                    "aborted cluster plaintext remained in {}",
+                    entry.path().display()
+                );
+            }
+        }
+        assert_eq!(callbacks, 0);
+    }
+
+    #[test]
+    fn abort_double_marker_failure_never_adopts_in_current_process() {
+        let _key = crate::encryption::set_test_encryption_key([0xc6; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(cluster_test_node(
+            "double-marker-failure-node",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        let intents = BTreeMap::from([(
+            "double-marker-failure-node".to_string(),
+            password_intents(crate::ClusterCredentialAction::Replace(
+                "double-marker-secret".to_string(),
+            )),
+        )]);
+        let cluster_before = std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap();
+        let credentials_before = std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap();
+        let mut callbacks = 0;
+        let mut callback = |_: u64,
+                            _: bool,
+                            _: &crate::ClusterFabricConfig,
+                            _: ConfigStoreResult<ExactClusterRuntimeSnapshot>,
+                            _: ConfigStoreResult<()>| {
+            callbacks += 1;
+        };
+        set_cluster_exact_commit_test_fault(
+            dir.path().to_path_buf(),
+            ClusterExactCommitTestFault::AbortBothMarkersRecoveryFailure,
+        );
+
+        let error = persist_cluster_fabric_credential_transaction_inner(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            revision,
+            Some(&mut callback),
+            Some(MigrationFault::AfterExactClusterConsumerConflict),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("either durable marker"));
+        assert_eq!(
+            callbacks, 0,
+            "an undurable abort attempt must bypass committed reporting"
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+
+        let manifest: MigrationManifest =
+            serde_json::from_slice(&std::fs::read(dir.path().join(MANIFEST_FILE)).unwrap())
+                .unwrap();
+        let journal: MigrationManifest =
+            serde_json::from_slice(&std::fs::read(dir.path().join(JOURNAL_FILE)).unwrap()).unwrap();
+        assert_eq!(manifest.state, MigrationState::Pending);
+        assert_eq!(journal.state, MigrationState::Pending);
+        assert!(matches!(
+            load_live_cluster_transaction_manifest(dir.path(), &manifest).unwrap(),
+            LiveClusterTransaction::Committed(_)
+        ));
+        clear_cluster_exact_commit_test_fault(dir.path());
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -31,6 +31,7 @@ const MIGRATION_VERSION: u32 = 1;
 const SECTION_LAYOUT_COMPLETION_LEDGER_VERSION: u32 = 1;
 const MANIFEST_FILE: &str = "config-credential-migration.json";
 const JOURNAL_FILE: &str = "config-credential-migration.journal.json";
+const CLUSTER_ABORT_FILE: &str = "config-credential-migration.cluster-abort.json";
 pub(crate) const SECTION_LAYOUT_COMPLETION_FILE: &str = "config-section-layout-completion.json";
 const LOCK_FILE: &str = ".config-credential-migration.lock";
 const STAGE_PREFIX: &str = ".config-credential-stage-v1-";
@@ -88,6 +89,19 @@ struct MigrationManifest {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     source_attestation: BTreeMap<String, FacadeSourceBase>,
     files: Vec<StagedFile>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct ClusterAbortRecord {
+    version: u32,
+    transaction_id: String,
+    stage_dir: String,
+    state: MigrationState,
+    exact_scope: ExactTransactionScope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    migration_scope: Option<MigrationScope>,
+    rollback_journal_sha256: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -879,6 +893,8 @@ pub enum ClusterExactCommitTestFault {
     AbortMarkerRecoveryFailure,
     AbortJournalMarkerAndCleanupRecoveryFailure,
     AbortBothMarkersRecoveryFailure,
+    AfterManifestAbortBothMarkersRecoveryFailure,
+    AbortAllMarkersRecoveryFailure,
     AbortCleanupRecoveryFailure,
 }
 
@@ -962,6 +978,7 @@ fn take_cluster_exact_after_manifest_test_fault(data_dir: &Path) -> bool {
         // Retain this variant until the recovery attempt consumes its second
         // deterministic failure below.
         Some(ClusterExactCommitTestFault::AfterManifestRecoveryFailure) => true,
+        Some(ClusterExactCommitTestFault::AfterManifestAbortBothMarkersRecoveryFailure) => true,
         _ => false,
     }
 }
@@ -977,6 +994,8 @@ fn cluster_abort_cleanup_test_fault(data_dir: &Path) -> bool {
     match state.fault {
         ClusterExactCommitTestFault::AbortCleanupRecoveryFailure => true,
         ClusterExactCommitTestFault::AbortJournalMarkerAndCleanupRecoveryFailure
+        | ClusterExactCommitTestFault::AbortBothMarkersRecoveryFailure
+        | ClusterExactCommitTestFault::AfterManifestAbortBothMarkersRecoveryFailure
             if !state.cleanup_failure_observed =>
         {
             state.cleanup_failure_observed = true;
@@ -997,6 +1016,8 @@ fn cluster_abort_marker_test_fault(data_dir: &Path) -> bool {
                 state.fault,
                 ClusterExactCommitTestFault::AbortMarkerRecoveryFailure
                     | ClusterExactCommitTestFault::AbortBothMarkersRecoveryFailure
+                    | ClusterExactCommitTestFault::AfterManifestAbortBothMarkersRecoveryFailure
+                    | ClusterExactCommitTestFault::AbortAllMarkersRecoveryFailure
             )
         })
 }
@@ -1012,7 +1033,20 @@ fn cluster_abort_journal_marker_test_fault(data_dir: &Path) -> bool {
                 state.fault,
                 ClusterExactCommitTestFault::AbortJournalMarkerAndCleanupRecoveryFailure
                     | ClusterExactCommitTestFault::AbortBothMarkersRecoveryFailure
+                    | ClusterExactCommitTestFault::AfterManifestAbortBothMarkersRecoveryFailure
+                    | ClusterExactCommitTestFault::AbortAllMarkersRecoveryFailure
             )
+        })
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+fn cluster_abort_record_test_fault(data_dir: &Path) -> bool {
+    CLUSTER_EXACT_COMMIT_TEST_FAULTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(data_dir)
+        .is_some_and(|state| {
+            state.fault == ClusterExactCommitTestFault::AbortAllMarkersRecoveryFailure
         })
 }
 
@@ -1380,6 +1414,7 @@ fn install_section_split_migration_locked_inner(
                     name.as_str(),
                     MANIFEST_FILE
                         | JOURNAL_FILE
+                        | CLUSTER_ABORT_FILE
                         | SECTION_LAYOUT_COMPLETION_FILE
                         | crate::SECTION_LAYOUT_FILE
                 )
@@ -1556,6 +1591,11 @@ fn validate_section_split_plan(
 pub fn ensure_provider_mcp_migration_ready(data_dir: impl AsRef<Path>) -> ConfigStoreResult<()> {
     let path = data_dir.as_ref().join(MANIFEST_FILE);
     let Some(bytes) = read_optional_migration_file(&path)? else {
+        if read_optional_migration_file(&data_dir.as_ref().join(CLUSTER_ABORT_FILE))?.is_some() {
+            return Err(ConfigStoreError::Validation(
+                "provider/MCP/broker credential migration is pending".to_string(),
+            ));
+        }
         return Ok(());
     };
     let manifest: MigrationManifest = serde_json::from_slice(&bytes).map_err(|_| {
@@ -1568,12 +1608,16 @@ pub fn ensure_provider_mcp_migration_ready(data_dir: impl AsRef<Path>) -> Config
             "provider/MCP/broker credential migration is pending".to_string(),
         )
     })?;
+    let aborting = manifest.exact_scope == Some(ExactTransactionScope::ClusterFabric)
+        && matching_cluster_abort_evidence(data_dir.as_ref(), &manifest)?;
+    if aborting {
+        return Err(ConfigStoreError::Validation(
+            "provider/MCP/broker credential migration is pending".to_string(),
+        ));
+    }
     if manifest.state != MigrationState::Complete {
-        let journal_aborting = manifest.state == MigrationState::Pending
-            && matching_cluster_abort_journal(data_dir.as_ref(), &manifest)?;
         if manifest.migration_scope == Some(MigrationScope::ClusterFabric)
             && manifest.state == MigrationState::Pending
-            && !journal_aborting
             && provider_mcp_documents_are_migration_free(data_dir.as_ref())?
             && pending_cluster_refs_are_exclusive(data_dir.as_ref())?
         {
@@ -1602,6 +1646,11 @@ pub(crate) fn recover_pending_config_transaction(
         data_dir
     };
     if read_optional_migration_file(&data_dir.join(MANIFEST_FILE))?.is_none() {
+        if read_optional_migration_file(&data_dir.join(CLUSTER_ABORT_FILE))?.is_some() {
+            return Err(ConfigStoreError::Validation(
+                "cluster abort recovery metadata has no committed manifest".to_string(),
+            ));
+        }
         return Ok(false);
     }
     with_provider_mcp_migration_lock(data_dir, || {
@@ -1964,28 +2013,6 @@ fn load_durable_cluster_candidate_under_migration_lock(
     cluster_candidate_from_section_bytes(&bytes)
 }
 
-fn load_staged_cluster_candidate_under_migration_lock(
-    data_dir: &Path,
-    manifest: &MigrationManifest,
-) -> ConfigStoreResult<(u64, crate::ClusterFabricConfig)> {
-    let authority = manifest
-        .files
-        .iter()
-        .find(|file| file.name == CLUSTER_FABRIC_FILE)
-        .ok_or_else(|| {
-            ConfigStoreError::Validation(
-                "cluster transaction authority is missing from its manifest".to_string(),
-            )
-        })?;
-    let bytes = read_managed_file(data_dir, &manifest.stage_dir, &authority.staged_name)?;
-    if sha256(&bytes) != authority.sha256 {
-        return Err(ConfigStoreError::Validation(
-            "staged cluster transaction authority failed integrity validation".to_string(),
-        ));
-    }
-    cluster_candidate_from_section_bytes(&bytes)
-}
-
 enum LiveClusterTransaction {
     NotCommitted,
     Aborting,
@@ -2043,9 +2070,7 @@ fn load_live_cluster_transaction_manifest(
             "cluster transaction manifest no longer matches its commit".to_string(),
         ));
     }
-    if manifest.state == MigrationState::Pending
-        && matching_cluster_abort_journal(data_dir, &manifest)?
-    {
+    if matching_cluster_abort_evidence(data_dir, &manifest)? {
         return Ok(LiveClusterTransaction::Aborting);
     }
     if manifest.state == MigrationState::Aborting {
@@ -2069,6 +2094,34 @@ fn load_live_cluster_transaction_manifest(
     Ok(LiveClusterTransaction::Committed(manifest))
 }
 
+fn load_installed_cluster_candidate_for_manifest(
+    data_dir: &Path,
+    manifest: &MigrationManifest,
+) -> ConfigStoreResult<Option<(u64, crate::ClusterFabricConfig)>> {
+    if manifest.exact_scope != Some(ExactTransactionScope::ClusterFabric) {
+        return Ok(None);
+    }
+    let authority_name = exact_authority_file(manifest).ok_or_else(|| {
+        ConfigStoreError::Validation(
+            "cluster transaction authority is missing from its manifest".to_string(),
+        )
+    })?;
+    let authority = manifest
+        .files
+        .iter()
+        .find(|file| file.name == authority_name)
+        .ok_or_else(|| {
+            ConfigStoreError::Validation(
+                "cluster transaction authority is missing from its manifest".to_string(),
+            )
+        })?;
+    let current = read_target_or_empty(&data_dir.join(authority_name))?;
+    if sha256(&current) != authority.sha256 {
+        return Ok(None);
+    }
+    load_durable_cluster_candidate_under_migration_lock(data_dir).map(Some)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn report_cluster_committed_recovery_failure(
     data_dir: &Path,
@@ -2076,27 +2129,24 @@ fn report_cluster_committed_recovery_failure(
     local_manifest: &MigrationManifest,
     live_manifest: Option<&MigrationManifest>,
     installed_candidate: Option<&(u64, crate::ClusterFabricConfig)>,
-    planned_revision: u64,
     initial_error: &ConfigStoreError,
     recovery_error: &ConfigStoreError,
     cluster_post_commit: &mut Option<ClusterPostCommit<'_>>,
-) -> u64 {
+) -> Option<u64> {
     let actual = installed_candidate
         .cloned()
         .or_else(|| {
             live_manifest.and_then(|manifest| {
-                load_staged_cluster_candidate_under_migration_lock(data_dir, manifest).ok()
+                load_installed_cluster_candidate_for_manifest(data_dir, manifest)
+                    .ok()
+                    .flatten()
             })
         })
         .or_else(|| {
-            live_manifest
-                .filter(|manifest| manifest.state == MigrationState::Complete)
-                .and_then(|_| load_durable_cluster_candidate_under_migration_lock(data_dir).ok())
-        })
-        .or_else(|| {
-            load_staged_cluster_candidate_under_migration_lock(data_dir, local_manifest).ok()
-        })
-        .unwrap_or_else(|| (planned_revision, config.cluster_fabric.clone()));
+            load_installed_cluster_candidate_for_manifest(data_dir, local_manifest)
+                .ok()
+                .flatten()
+        })?;
     let (revision, candidate) = actual;
     config.cluster_fabric = candidate;
     let message = format!(
@@ -2112,7 +2162,7 @@ fn report_cluster_committed_recovery_failure(
             Err(ConfigStoreError::Validation(message)),
         );
     }
-    revision
+    Some(revision)
 }
 
 /// One coherent durable cluster generation captured under the shared
@@ -3741,8 +3791,8 @@ fn persist_exact_credential_transaction_inner(
         {
             // Once an intentional abort has started, never infer commit or
             // publish the staged candidate in this process. `AbortAttempt`
-            // covers the indeterminate case where neither redundant durable
-            // marker could be confirmed; `Aborting` covers either marker
+            // covers the indeterminate case where none of the independent
+            // durable markers could be confirmed; `Aborting` covers any marker
             // succeeding before rollback or cleanup failed.
             return Err(initial_error);
         }
@@ -3756,18 +3806,19 @@ fn persist_exact_credential_transaction_inner(
             }
             Ok(LiveClusterTransaction::Committed(live)) => live,
             Err(inspection_error) => {
-                let revision = report_cluster_committed_recovery_failure(
+                if let Some(revision) = report_cluster_committed_recovery_failure(
                     data_dir,
                     config,
                     &manifest,
                     None,
                     installed_cluster_candidate.as_ref(),
-                    committed_authority_revision,
                     &initial_error,
                     &inspection_error,
                     &mut cluster_post_commit,
-                );
-                return Ok(revision);
+                ) {
+                    return Ok(revision);
+                }
+                return Err(inspection_error);
             }
         };
         let recovery = {
@@ -3780,35 +3831,47 @@ fn persist_exact_credential_transaction_inner(
                     "injected cluster exact transaction recovery failure".to_string(),
                 ))
             } else {
-                recover_committed(
+                recover_committed_with_cluster_tracker(
                     data_dir,
+                    cluster_install_tracker.as_ref(),
                     #[cfg(test)]
                     None,
                 )
             }
             #[cfg(not(any(test, feature = "test-utils")))]
-            recover_committed(
+            recover_committed_with_cluster_tracker(
                 data_dir,
+                cluster_install_tracker.as_ref(),
                 #[cfg(test)]
                 None,
             )
         };
+        if cluster_install_tracker
+            .as_ref()
+            .is_some_and(|tracker| tracker.outcome() != ClusterInstallOutcome::CommitIntent)
+        {
+            return match recovery {
+                Ok(_) => Err(initial_error),
+                Err(recovery_error) => Err(recovery_error),
+            };
+        }
         match recovery {
             Ok(_) => match load_durable_cluster_candidate_under_migration_lock(data_dir) {
                 Ok(actual) => installed_cluster_candidate = Some(actual),
                 Err(load_error) => {
-                    let revision = report_cluster_committed_recovery_failure(
+                    if let Some(revision) = report_cluster_committed_recovery_failure(
                         data_dir,
                         config,
                         &manifest,
                         Some(&live_before_recovery),
                         installed_cluster_candidate.as_ref(),
-                        committed_authority_revision,
                         &initial_error,
                         &load_error,
                         &mut cluster_post_commit,
-                    );
-                    return Ok(revision);
+                    ) {
+                        return Ok(revision);
+                    }
+                    return Err(load_error);
                 }
             },
             Err(recovery_error) => {
@@ -3823,32 +3886,34 @@ fn persist_exact_credential_transaction_inner(
                                 "{recovery_error}; cluster transaction state inspection failed \
                                  ({inspection_error})"
                             ));
-                            let revision = report_cluster_committed_recovery_failure(
+                            if let Some(revision) = report_cluster_committed_recovery_failure(
                                 data_dir,
                                 config,
                                 &manifest,
                                 None,
                                 installed_cluster_candidate.as_ref(),
-                                committed_authority_revision,
                                 &initial_error,
                                 &combined,
                                 &mut cluster_post_commit,
-                            );
-                            return Ok(revision);
+                            ) {
+                                return Ok(revision);
+                            }
+                            return Err(combined);
                         }
                     };
-                let revision = report_cluster_committed_recovery_failure(
+                if let Some(revision) = report_cluster_committed_recovery_failure(
                     data_dir,
                     config,
                     &manifest,
                     live_after_recovery.as_ref(),
                     installed_cluster_candidate.as_ref(),
-                    committed_authority_revision,
                     &initial_error,
                     &recovery_error,
                     &mut cluster_post_commit,
-                );
-                return Ok(revision);
+                ) {
+                    return Ok(revision);
+                }
+                return Err(recovery_error);
             }
         }
     }
@@ -8114,6 +8179,145 @@ fn validate_matching_cluster_journal(
     Ok(())
 }
 
+fn cluster_rollback_journal_sha256(journal: &MigrationManifest) -> ConfigStoreResult<String> {
+    validate_manifest(journal)?;
+    if journal.exact_scope != Some(ExactTransactionScope::ClusterFabric)
+        || journal.state == MigrationState::Complete
+    {
+        return Err(ConfigStoreError::Validation(
+            "cluster abort rollback journal is invalid".to_string(),
+        ));
+    }
+    let mut rollback_authority = journal.clone();
+    rollback_authority.state = MigrationState::Pending;
+    Ok(sha256(&serde_json::to_vec(&rollback_authority)?))
+}
+
+fn validate_cluster_abort_record(record: &ClusterAbortRecord) -> ConfigStoreResult<()> {
+    let canonical_transaction_id = Uuid::parse_str(&record.transaction_id)
+        .ok()
+        .map(|uuid| uuid.to_string());
+    if record.version != MIGRATION_VERSION
+        || canonical_transaction_id.as_deref() != Some(record.transaction_id.as_str())
+        || record.stage_dir != format!("{STAGE_PREFIX}{}", record.transaction_id)
+        || record.state != MigrationState::Aborting
+        || record.exact_scope != ExactTransactionScope::ClusterFabric
+        || record.migration_scope.is_some()
+        || !is_sha256_hex(&record.rollback_journal_sha256)
+    {
+        return Err(ConfigStoreError::Validation(
+            "cluster abort record is invalid".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_matching_cluster_abort_record(
+    manifest: &MigrationManifest,
+    record: &ClusterAbortRecord,
+) -> ConfigStoreResult<()> {
+    validate_cluster_abort_record(record)?;
+    if manifest.exact_scope != Some(ExactTransactionScope::ClusterFabric)
+        || record.transaction_id != manifest.transaction_id
+        || record.stage_dir != manifest.stage_dir
+        || Some(record.exact_scope) != manifest.exact_scope
+        || record.migration_scope != manifest.migration_scope
+    {
+        return Err(ConfigStoreError::Validation(
+            "cluster abort record does not match its committed manifest".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn read_cluster_abort_record(data_dir: &Path) -> ConfigStoreResult<Option<ClusterAbortRecord>> {
+    let Some(bytes) = read_optional_migration_file(&data_dir.join(CLUSTER_ABORT_FILE))? else {
+        return Ok(None);
+    };
+    let record: ClusterAbortRecord = serde_json::from_slice(&bytes)?;
+    validate_cluster_abort_record(&record)?;
+    Ok(Some(record))
+}
+
+fn matching_cluster_abort_record(
+    data_dir: &Path,
+    manifest: &MigrationManifest,
+) -> ConfigStoreResult<bool> {
+    let Some(record) = read_cluster_abort_record(data_dir)? else {
+        return Ok(false);
+    };
+    validate_matching_cluster_abort_record(manifest, &record)?;
+    let journal_bytes =
+        read_optional_migration_file(&data_dir.join(JOURNAL_FILE))?.ok_or_else(|| {
+            ConfigStoreError::Validation("cluster abort rollback journal is missing".to_string())
+        })?;
+    let journal: MigrationManifest = serde_json::from_slice(&journal_bytes)?;
+    validate_matching_cluster_journal(manifest, &journal)?;
+    if cluster_rollback_journal_sha256(&journal)? != record.rollback_journal_sha256 {
+        return Err(ConfigStoreError::Validation(
+            "cluster abort record does not match its rollback journal".to_string(),
+        ));
+    }
+    Ok(true)
+}
+
+fn persist_cluster_abort_record(
+    data_dir: &Path,
+    manifest: &MigrationManifest,
+) -> ConfigStoreResult<()> {
+    let journal_bytes =
+        read_optional_migration_file(&data_dir.join(JOURNAL_FILE))?.ok_or_else(|| {
+            ConfigStoreError::Validation("cluster abort rollback journal is missing".to_string())
+        })?;
+    let journal: MigrationManifest = serde_json::from_slice(&journal_bytes)?;
+    validate_matching_cluster_journal(manifest, &journal)?;
+    let record = ClusterAbortRecord {
+        version: MIGRATION_VERSION,
+        transaction_id: manifest.transaction_id.clone(),
+        stage_dir: manifest.stage_dir.clone(),
+        state: MigrationState::Aborting,
+        exact_scope: ExactTransactionScope::ClusterFabric,
+        migration_scope: manifest.migration_scope,
+        rollback_journal_sha256: cluster_rollback_journal_sha256(&journal)?,
+    };
+    let path = data_dir.join(CLUSTER_ABORT_FILE);
+    if let Some(existing) = read_cluster_abort_record(data_dir)? {
+        validate_matching_cluster_abort_record(manifest, &existing)?;
+        if existing != record {
+            return Err(ConfigStoreError::Validation(
+                "cluster abort record changed during rollback".to_string(),
+            ));
+        }
+        return Ok(());
+    }
+    #[cfg(any(test, feature = "test-utils"))]
+    if cluster_abort_record_test_fault(data_dir) {
+        return Err(ConfigStoreError::Validation(
+            "injected persistent cluster abort record failure".to_string(),
+        ));
+    }
+    AtomicFileStore::new(path).write_bytes_without_backup(&serde_json::to_vec_pretty(&record)?)
+}
+
+fn matching_cluster_abort_evidence(
+    data_dir: &Path,
+    manifest: &MigrationManifest,
+) -> ConfigStoreResult<bool> {
+    let journal_aborting = matching_cluster_abort_journal(data_dir, manifest)?;
+    let abort_record = matching_cluster_abort_record(data_dir, manifest)?;
+    Ok(journal_aborting || abort_record)
+}
+
+fn remove_matching_cluster_abort_record(
+    data_dir: &Path,
+    manifest: &MigrationManifest,
+) -> ConfigStoreResult<()> {
+    if !matching_cluster_abort_record(data_dir, manifest)? {
+        return Ok(());
+    }
+    remove_file_if_exists(&data_dir.join(CLUSTER_ABORT_FILE))
+}
+
 /// Return whether the immutable transaction journal carries durable non-commit
 /// intent for this exact cluster transaction.
 ///
@@ -8172,8 +8376,26 @@ fn recover_committed(
     data_dir: &Path,
     #[cfg(test)] fault: Option<MigrationFault>,
 ) -> ConfigStoreResult<Option<CredentialMigrationOutcome>> {
+    recover_committed_with_cluster_tracker(
+        data_dir,
+        None,
+        #[cfg(test)]
+        fault,
+    )
+}
+
+fn recover_committed_with_cluster_tracker(
+    data_dir: &Path,
+    install_tracker: Option<&ClusterInstallTracker>,
+    #[cfg(test)] fault: Option<MigrationFault>,
+) -> ConfigStoreResult<Option<CredentialMigrationOutcome>> {
     let path = data_dir.join(MANIFEST_FILE);
     let Some(bytes) = read_optional_migration_file(&path)? else {
+        if read_optional_migration_file(&data_dir.join(CLUSTER_ABORT_FILE))?.is_some() {
+            return Err(ConfigStoreError::Validation(
+                "cluster abort recovery metadata has no committed manifest".to_string(),
+            ));
+        }
         return Ok(None);
     };
     let mut manifest: MigrationManifest = serde_json::from_slice(&bytes)?;
@@ -8183,17 +8405,18 @@ fn recover_committed(
             verify_section_split_completion(data_dir, &manifest)?;
             persist_section_layout_completion_ledger(data_dir, &manifest)?;
         }
+        remove_matching_cluster_abort_record(data_dir, &manifest)?;
         cleanup_transaction_dirs(data_dir, &manifest)?;
         remove_file_if_exists(&data_dir.join(JOURNAL_FILE))?;
         return Ok(None);
     }
     if manifest.state == MigrationState::Pending
-        && matching_cluster_abort_journal(data_dir, &manifest)?
+        && matching_cluster_abort_evidence(data_dir, &manifest)?
     {
         // The journal was durably marked before a failed main-manifest abort
         // transition. Resume rollback before any install validation; the
         // original conflict may no longer exist after restart.
-        abort_cluster_exact_transaction(data_dir, &manifest, None)?;
+        abort_cluster_exact_transaction(data_dir, &manifest, install_tracker)?;
         return Ok(None);
     }
     if manifest.state == MigrationState::Aborting {
@@ -8202,13 +8425,13 @@ fn recover_committed(
                 "only cluster exact transactions may resume abort rollback".to_string(),
             ));
         }
-        abort_cluster_exact_transaction(data_dir, &manifest, None)?;
+        abort_cluster_exact_transaction(data_dir, &manifest, install_tracker)?;
         return Ok(None);
     }
     install_pending(
         data_dir,
         &mut manifest,
-        None,
+        install_tracker,
         #[cfg(test)]
         fault,
     )?;
@@ -8746,17 +8969,19 @@ fn abort_cluster_exact_transaction(
         }
     } else {
         if let Some(tracker) = install_tracker {
-            // This process has chosen abort, even though neither durable marker
-            // is confirmed yet. A double write failure must not fall back into
+            // This process has chosen abort, even though no durable marker is
+            // confirmed yet. Marker write failures must not fall back into
             // committed-candidate adoption in the caller.
             tracker.mark_abort_attempt();
         }
 
-        // Prefer the journal marker because it preserves a fallback if the
-        // mutable main marker cannot be written. If the journal transition
-        // fails, the main manifest is the redundant durable abort marker.
+        // The dedicated abort record binds this decision to the immutable
+        // rollback journal without changing its original members. Journal and
+        // main markers remain independent fallbacks, so any one confirmed
+        // durable write is sufficient non-commit evidence after restart.
+        let abort_record_durable = persist_cluster_abort_record(data_dir, manifest).is_ok();
         let journal_durable = persist_cluster_abort_journal(data_dir, manifest).is_ok();
-        if journal_durable {
+        if abort_record_durable || journal_durable {
             if let Some(tracker) = install_tracker {
                 tracker.mark_aborting();
             }
@@ -8779,10 +9004,10 @@ fn abort_cluster_exact_transaction(
                     tracker.mark_aborting();
                 }
             }
-            Err(error) if journal_durable => return Err(error),
+            Err(error) if abort_record_durable || journal_durable => return Err(error),
             Err(_) => {
-                return Err(ConfigStoreError::Validation(
-                    "cluster abort intent could not be persisted to either durable marker"
+                return Err(ConfigStoreError::CommitIndeterminate(
+                    "cluster transaction has no durable abort marker; recovery may still commit"
                         .to_string(),
                 ));
             }
@@ -8799,6 +9024,7 @@ fn abort_cluster_exact_transaction(
     let mut complete = aborting;
     complete.state = MigrationState::Complete;
     write_manifest(data_dir.join(MANIFEST_FILE), &complete)?;
+    remove_matching_cluster_abort_record(data_dir, &complete)?;
     remove_file_if_exists(&data_dir.join(JOURNAL_FILE))?;
     cleanup_transaction_dirs(data_dir, &complete)?;
     remove_file_if_exists(&data_dir.join(MANIFEST_FILE))?;
@@ -9576,6 +9802,14 @@ fn install_pending(
     if manifest.state != MigrationState::Pending {
         return Err(ConfigStoreError::Validation(
             "only a pending transaction may install staged members".to_string(),
+        ));
+    }
+    if manifest.exact_scope == Some(ExactTransactionScope::ClusterFabric)
+        && matching_cluster_abort_evidence(data_dir, manifest)?
+    {
+        abort_cluster_exact_transaction(data_dir, manifest, install_tracker)?;
+        return Err(ConfigStoreError::Validation(
+            "cluster transaction carries durable abort intent".to_string(),
         ));
     }
     if manifest.migration_scope == Some(MigrationScope::ClusterFabric) {
@@ -11307,6 +11541,13 @@ fn rollback_section_split_credentials(
 }
 
 fn finish_transaction(data_dir: &Path, mut manifest: MigrationManifest) -> ConfigStoreResult<()> {
+    if manifest.exact_scope == Some(ExactTransactionScope::ClusterFabric)
+        && matching_cluster_abort_evidence(data_dir, &manifest)?
+    {
+        return Err(ConfigStoreError::Validation(
+            "cluster transaction carries durable abort intent".to_string(),
+        ));
+    }
     let section_split = is_section_layout_scope(manifest.migration_scope);
     if section_split {
         verify_section_split_completion(data_dir, &manifest)?;
@@ -11769,6 +12010,11 @@ fn cleanup_transaction_dirs(
 }
 
 pub(crate) fn discard_uncommitted(data_dir: &Path) -> ConfigStoreResult<()> {
+    if read_optional_migration_file(&data_dir.join(CLUSTER_ABORT_FILE))?.is_some() {
+        return Err(ConfigStoreError::Validation(
+            "cluster abort recovery is still pending".to_string(),
+        ));
+    }
     let journal_path = data_dir.join(JOURNAL_FILE);
     let Some(bytes) = read_optional_migration_file(&journal_path)? else {
         return Ok(());
@@ -11797,6 +12043,10 @@ fn cleanup_orphan_transaction_dirs(data_dir: &Path) -> ConfigStoreResult<()> {
         })?;
         referenced.insert(manifest.stage_dir.clone());
         referenced.insert(format!("{BACKUP_PREFIX}{}", manifest.transaction_id));
+    }
+    if let Some(record) = read_cluster_abort_record(data_dir)? {
+        referenced.insert(record.stage_dir);
+        referenced.insert(format!("{BACKUP_PREFIX}{}", record.transaction_id));
     }
 
     let mut removed = false;
@@ -12227,7 +12477,7 @@ fn facade_source_attestation_is_valid(manifest: &MigrationManifest) -> bool {
         }
         if matches!(
             name.as_str(),
-            MANIFEST_FILE | JOURNAL_FILE | SECTION_LAYOUT_COMPLETION_FILE
+            MANIFEST_FILE | JOURNAL_FILE | CLUSTER_ABORT_FILE | SECTION_LAYOUT_COMPLETION_FILE
         ) || is_compound_internal_derivative_source(name)
         {
             if manifest.files.iter().any(|file| file.name == *name) {
@@ -12495,6 +12745,7 @@ fn valid_source_guard_name(name: &str) -> bool {
             name,
             MANIFEST_FILE
                 | JOURNAL_FILE
+                | CLUSTER_ABORT_FILE
                 | SECTION_LAYOUT_COMPLETION_FILE
                 | crate::SECTION_LAYOUT_FILE
         )
@@ -12837,7 +13088,7 @@ mod tests {
     fn migration_metadata_reads_reject_symlinks_without_following_targets() {
         use std::os::unix::fs::symlink;
 
-        for metadata_name in [MANIFEST_FILE, JOURNAL_FILE] {
+        for metadata_name in [MANIFEST_FILE, JOURNAL_FILE, CLUSTER_ABORT_FILE] {
             let dir = tempfile::tempdir().unwrap();
             let external = dir.path().join("external-metadata.json");
             let external_bytes = br#"{"external":"must-survive"}"#;
@@ -16127,10 +16378,12 @@ mod tests {
     }
 
     #[test]
-    fn abort_double_marker_failure_never_adopts_in_current_process() {
+    fn abort_double_marker_failure_recovers_durable_abort_after_restart() {
         let _key = crate::encryption::set_test_encryption_key([0xc6; 32]);
         let dir = tempfile::tempdir().unwrap();
         crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let providers_path = dir.path().join(PROVIDERS_FILE);
+        let providers_before = std::fs::read(&providers_path).unwrap();
         let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
         candidate.cluster_fabric.nodes.push(cluster_test_node(
             "double-marker-failure-node",
@@ -16139,10 +16392,11 @@ mod tests {
                 password_encrypted: None,
             },
         ));
+        let abort_secret = Uuid::new_v4().to_string();
         let intents = BTreeMap::from([(
             "double-marker-failure-node".to_string(),
             password_intents(crate::ClusterCredentialAction::Replace(
-                "double-marker-secret".to_string(),
+                abort_secret.clone(),
             )),
         )]);
         let cluster_before = std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap();
@@ -16169,10 +16423,12 @@ mod tests {
             Some(MigrationFault::AfterExactClusterConsumerConflict),
         )
         .unwrap_err();
-        assert!(error.to_string().contains("either durable marker"));
+        assert!(error
+            .to_string()
+            .contains("persistent cluster abort marker failure"));
         assert_eq!(
             callbacks, 0,
-            "an undurable abort attempt must bypass committed reporting"
+            "durable abort proof must bypass committed reporting"
         );
         assert_eq!(
             std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
@@ -16182,6 +16438,126 @@ mod tests {
             std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
             credentials_before
         );
+
+        let manifest_path = dir.path().join(MANIFEST_FILE);
+        let manifest: MigrationManifest =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        let journal_path = dir.path().join(JOURNAL_FILE);
+        let journal: MigrationManifest =
+            serde_json::from_slice(&std::fs::read(&journal_path).unwrap()).unwrap();
+        assert_eq!(manifest.state, MigrationState::Pending);
+        assert_eq!(journal.state, MigrationState::Pending);
+        let abort_path = dir.path().join(CLUSTER_ABORT_FILE);
+        let abort_record: ClusterAbortRecord =
+            serde_json::from_slice(&std::fs::read(&abort_path).unwrap()).unwrap();
+        validate_matching_cluster_abort_record(&manifest, &abort_record).unwrap();
+        assert_eq!(
+            abort_record.rollback_journal_sha256,
+            cluster_rollback_journal_sha256(&journal).unwrap()
+        );
+        assert!(matches!(
+            load_live_cluster_transaction_manifest(dir.path(), &manifest).unwrap(),
+            LiveClusterTransaction::Aborting
+        ));
+        assert!(crate::ensure_provider_mcp_migration_ready(dir.path()).is_err());
+
+        // Once the rejected external consumer disappears, only the dedicated
+        // abort proof distinguishes this tail from an ordinary Pending commit.
+        std::fs::write(&providers_path, &providers_before).unwrap();
+        clear_cluster_exact_commit_test_fault(dir.path());
+        assert!(!recover_pending_config_transaction(dir.path()).unwrap());
+        assert!(!recover_pending_config_transaction(dir.path()).unwrap());
+        assert!(!manifest_path.exists());
+        assert!(!journal_path.exists());
+        assert!(!abort_path.exists());
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+        let password_ref =
+            crate::cluster_password_credential_ref("double-marker-failure-node").unwrap();
+        assert!(CredentialStore::open(dir.path())
+            .resolve(&password_ref)
+            .unwrap()
+            .is_none());
+        let (fresh, _) = active_facade_config_and_cluster_revision(dir.path());
+        assert!(fresh
+            .cluster_fabric
+            .node("double-marker-failure-node")
+            .is_none());
+        for entry in std::fs::read_dir(dir.path()).unwrap() {
+            let entry = entry.unwrap();
+            if entry.file_type().unwrap().is_file() {
+                assert!(
+                    !String::from_utf8_lossy(&std::fs::read(entry.path()).unwrap())
+                        .contains(&abort_secret),
+                    "aborted cluster plaintext remained in {}",
+                    entry.path().display()
+                );
+            }
+        }
+        assert_eq!(callbacks, 0);
+    }
+
+    #[test]
+    fn all_abort_marker_write_failures_return_indeterminate_without_publication() {
+        let _key = crate::encryption::set_test_encryption_key([0xc7; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(cluster_test_node(
+            "indeterminate-marker-node",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        let intents = BTreeMap::from([(
+            "indeterminate-marker-node".to_string(),
+            password_intents(crate::ClusterCredentialAction::Replace(
+                "indeterminate-marker-secret".to_string(),
+            )),
+        )]);
+        let cluster_before = std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap();
+        let credentials_before = std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap();
+        let mut callbacks = 0;
+        let mut callback = |_: u64,
+                            _: bool,
+                            _: &crate::ClusterFabricConfig,
+                            _: ConfigStoreResult<ExactClusterRuntimeSnapshot>,
+                            _: ConfigStoreResult<()>| {
+            callbacks += 1;
+        };
+        set_cluster_exact_commit_test_fault(
+            dir.path().to_path_buf(),
+            ClusterExactCommitTestFault::AbortAllMarkersRecoveryFailure,
+        );
+
+        let error = persist_cluster_fabric_credential_transaction_inner(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            revision,
+            Some(&mut callback),
+            Some(MigrationFault::AfterExactClusterConsumerConflict),
+        )
+        .unwrap_err();
+        assert!(matches!(&error, ConfigStoreError::CommitIndeterminate(_)));
+        assert!(error.to_string().contains("outcome is indeterminate"));
+        assert_eq!(callbacks, 0);
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+        assert!(!dir.path().join(CLUSTER_ABORT_FILE).exists());
 
         let manifest: MigrationManifest =
             serde_json::from_slice(&std::fs::read(dir.path().join(MANIFEST_FILE)).unwrap())
@@ -16195,6 +16571,214 @@ mod tests {
             LiveClusterTransaction::Committed(_)
         ));
         clear_cluster_exact_commit_test_fault(dir.path());
+    }
+
+    #[test]
+    fn post_manifest_recovery_double_marker_failure_never_publishes_and_restarts_as_abort() {
+        let _key = crate::encryption::set_test_encryption_key([0xc8; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let providers_path = dir.path().join(PROVIDERS_FILE);
+        let providers_before = std::fs::read(&providers_path).unwrap();
+        let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+        candidate.cluster_fabric.nodes.push(cluster_test_node(
+            "post-manifest-abort-node",
+            crate::SshAuth::Password {
+                password: String::new(),
+                password_encrypted: None,
+            },
+        ));
+        let abort_secret = Uuid::new_v4().to_string();
+        let intents = BTreeMap::from([(
+            "post-manifest-abort-node".to_string(),
+            password_intents(crate::ClusterCredentialAction::Replace(
+                abort_secret.clone(),
+            )),
+        )]);
+        let cluster_before = std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap();
+        let credentials_before = std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap();
+        let mut callbacks = 0;
+        let mut callback = |_: u64,
+                            _: bool,
+                            _: &crate::ClusterFabricConfig,
+                            _: ConfigStoreResult<ExactClusterRuntimeSnapshot>,
+                            _: ConfigStoreResult<()>| {
+            callbacks += 1;
+        };
+        set_cluster_exact_commit_test_fault(
+            dir.path().to_path_buf(),
+            ClusterExactCommitTestFault::AfterManifestAbortBothMarkersRecoveryFailure,
+        );
+
+        let error = persist_cluster_fabric_credential_transaction_inner(
+            dir.path(),
+            &mut candidate,
+            &intents,
+            revision,
+            Some(&mut callback),
+            Some(MigrationFault::AfterExactClusterConsumerConflict),
+        )
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("persistent cluster abort marker failure"));
+        assert_eq!(
+            callbacks, 0,
+            "fallback recovery must propagate abort outcome instead of reporting a commit"
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+
+        let manifest_path = dir.path().join(MANIFEST_FILE);
+        let manifest: MigrationManifest =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        let journal_path = dir.path().join(JOURNAL_FILE);
+        let journal: MigrationManifest =
+            serde_json::from_slice(&std::fs::read(&journal_path).unwrap()).unwrap();
+        let abort_path = dir.path().join(CLUSTER_ABORT_FILE);
+        let abort_record: ClusterAbortRecord =
+            serde_json::from_slice(&std::fs::read(&abort_path).unwrap()).unwrap();
+        assert_eq!(manifest.state, MigrationState::Pending);
+        assert_eq!(journal.state, MigrationState::Pending);
+        validate_matching_cluster_abort_record(&manifest, &abort_record).unwrap();
+        assert_eq!(
+            abort_record.rollback_journal_sha256,
+            cluster_rollback_journal_sha256(&journal).unwrap()
+        );
+        assert!(matches!(
+            load_live_cluster_transaction_manifest(dir.path(), &manifest).unwrap(),
+            LiveClusterTransaction::Aborting
+        ));
+        assert!(crate::ensure_provider_mcp_migration_ready(dir.path()).is_err());
+
+        std::fs::write(&providers_path, &providers_before).unwrap();
+        clear_cluster_exact_commit_test_fault(dir.path());
+        assert!(
+            !recover_pending_config_transaction(dir.path()).unwrap(),
+            "restart must roll back a durably classified post-manifest abort"
+        );
+        assert!(!recover_pending_config_transaction(dir.path()).unwrap());
+        assert!(!manifest_path.exists());
+        assert!(!journal_path.exists());
+        assert!(!abort_path.exists());
+        assert_eq!(
+            std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+            cluster_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+        let password_ref =
+            crate::cluster_password_credential_ref("post-manifest-abort-node").unwrap();
+        assert!(CredentialStore::open(dir.path())
+            .resolve(&password_ref)
+            .unwrap()
+            .is_none());
+        let (fresh, _) = active_facade_config_and_cluster_revision(dir.path());
+        assert!(fresh
+            .cluster_fabric
+            .node("post-manifest-abort-node")
+            .is_none());
+        for entry in std::fs::read_dir(dir.path()).unwrap() {
+            let entry = entry.unwrap();
+            if entry.file_type().unwrap().is_file() {
+                assert!(
+                    !String::from_utf8_lossy(&std::fs::read(entry.path()).unwrap())
+                        .contains(&abort_secret),
+                    "aborted cluster plaintext remained in {}",
+                    entry.path().display()
+                );
+            }
+        }
+        assert_eq!(callbacks, 0);
+    }
+
+    #[test]
+    fn main_aborting_with_missing_or_corrupt_journal_fails_closed() {
+        for (index, corrupt) in [false, true].into_iter().enumerate() {
+            let _key = crate::encryption::set_test_encryption_key([0xc9 + index as u8; 32]);
+            let dir = tempfile::tempdir().unwrap();
+            crate::migrate_config_facade_layout(dir.path()).unwrap();
+            let (mut candidate, revision) = active_facade_config_and_cluster_revision(dir.path());
+            let node_id = format!("broken-abort-journal-node-{index}");
+            candidate.cluster_fabric.nodes.push(cluster_test_node(
+                &node_id,
+                crate::SshAuth::Password {
+                    password: String::new(),
+                    password_encrypted: None,
+                },
+            ));
+            let intents = BTreeMap::from([(
+                node_id.clone(),
+                password_intents(crate::ClusterCredentialAction::Replace(format!(
+                    "broken-abort-journal-secret-{index}"
+                ))),
+            )]);
+            let cluster_before = std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap();
+            let credentials_before = std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap();
+
+            assert!(persist_cluster_fabric_credential_transaction_inner(
+                dir.path(),
+                &mut candidate,
+                &intents,
+                revision,
+                None,
+                Some(MigrationFault::AfterManifest),
+            )
+            .is_err());
+            let manifest_path = dir.path().join(MANIFEST_FILE);
+            let mut manifest: MigrationManifest =
+                serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+            assert_eq!(manifest.state, MigrationState::Pending);
+            manifest.state = MigrationState::Aborting;
+            write_manifest(manifest_path.clone(), &manifest).unwrap();
+
+            let journal_path = dir.path().join(JOURNAL_FILE);
+            if corrupt {
+                std::fs::write(&journal_path, b"{corrupt").unwrap();
+            } else {
+                std::fs::remove_file(&journal_path).unwrap();
+            }
+
+            assert!(
+                recover_pending_config_transaction(dir.path()).is_err(),
+                "an Aborting main manifest must not guess without its rollback journal"
+            );
+            assert!(crate::ensure_provider_mcp_migration_ready(dir.path()).is_err());
+            assert!(
+                crate::ConfigFacade::open(dir.path()).is_err(),
+                "facade open must retain the prior live generation"
+            );
+            assert_eq!(
+                std::fs::read(dir.path().join(CLUSTER_FABRIC_FILE)).unwrap(),
+                cluster_before
+            );
+            assert_eq!(
+                std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+                credentials_before
+            );
+            let password_ref = crate::cluster_password_credential_ref(&node_id).unwrap();
+            assert!(CredentialStore::open(dir.path())
+                .resolve_unchecked(&password_ref)
+                .unwrap()
+                .is_none());
+            assert!(manifest_path.exists());
+            assert_eq!(
+                serde_json::from_slice::<MigrationManifest>(
+                    &std::fs::read(&manifest_path).unwrap()
+                )
+                .unwrap()
+                .state,
+                MigrationState::Aborting
+            );
+        }
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -147,6 +147,21 @@ enum ExactTransactionScope {
     ClusterFabric,
 }
 
+impl ExactTransactionScope {
+    fn section_id(self) -> crate::SectionId {
+        match self {
+            Self::Providers => crate::SectionId::Providers,
+            Self::Mcp => crate::SectionId::Mcp,
+            Self::ProxyAuth => crate::SectionId::Core,
+            Self::EnvVars => crate::SectionId::Env,
+            Self::Notifications => crate::SectionId::Notifications,
+            Self::Connect => crate::SectionId::Connect,
+            Self::AccessControl => crate::SectionId::AccessControl,
+            Self::ClusterFabric => crate::SectionId::ClusterFabric,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 enum MigrationScope {
@@ -1900,6 +1915,7 @@ pub fn persist_connect_credential_transaction_at_revision(
         None,
         None,
         None,
+        None,
         #[cfg(test)]
         None,
     )
@@ -1939,6 +1955,7 @@ pub fn persist_access_control_credential_transaction_at_revision(
         None,
         None,
         None,
+        None,
         #[cfg(test)]
         None,
     )
@@ -1965,6 +1982,226 @@ pub struct ClusterFabricRuntimeSnapshot {
     pub cluster_fabric: crate::ClusterFabricConfig,
     pub credential_statuses: Vec<crate::CredentialStatus>,
     pub credential_health: crate::CredentialStoreHealth,
+}
+
+/// Secret-free metadata returned after installing an exact owned-section
+/// runtime snapshot. The secret-bearing runtime and credential document LKG
+/// remain opaque and have no `Debug` or serialization implementation.
+pub struct CredentialSectionRuntimeMetadata {
+    pub credential_statuses: Vec<crate::CredentialStatus>,
+    pub credential_health: crate::CredentialStoreHealth,
+}
+
+impl CredentialSectionRuntimeMetadata {
+    pub fn status(&self, reference: &crate::CredentialRef) -> crate::CredentialStatus {
+        self.credential_statuses
+            .iter()
+            .find(|status| &status.credential_ref == reference)
+            .cloned()
+            .unwrap_or_else(|| crate::CredentialStatus {
+                credential_ref: reference.clone(),
+                configured: false,
+                source: crate::CredentialSource::User,
+                updated_at: None,
+            })
+    }
+}
+
+/// Exact runtime projection for one non-cluster credential-backed section.
+///
+/// Callers can install only the owned section into an existing process
+/// [`crate::Config`]; unrelated sections cannot be observed or replaced from
+/// this value.
+pub struct CredentialSectionRuntimeSnapshot {
+    section: crate::SectionId,
+    runtime: crate::Config,
+    credential_statuses: Vec<crate::CredentialStatus>,
+    credential_health: crate::CredentialStoreHealth,
+}
+
+impl CredentialSectionRuntimeSnapshot {
+    pub fn install_into(self, target: &mut crate::Config) -> CredentialSectionRuntimeMetadata {
+        crate::section_facade::apply_runtime_section(self.section, &self.runtime, target);
+        CredentialSectionRuntimeMetadata {
+            credential_statuses: self.credential_statuses,
+            credential_health: self.credential_health,
+        }
+    }
+}
+
+/// Result of a non-cluster exact credential transaction whose owned section
+/// was adopted while the shared migration lock still excluded later writers.
+pub struct CredentialSectionTransactionCommit {
+    pub revision: u64,
+    pub section_adoption: Option<ConfigStoreResult<crate::ConfigSectionEvent>>,
+    pub credential_adoption: Option<ConfigStoreResult<Option<crate::ConfigSectionEvent>>>,
+    pub runtime: ConfigStoreResult<CredentialSectionRuntimeSnapshot>,
+}
+
+struct ExactSectionRuntimeSnapshot {
+    runtime: CredentialSectionRuntimeSnapshot,
+    credential_lkg: crate::credential_store::CredentialDocumentLkg,
+}
+
+type SectionPostCommit<'a> = &'a mut dyn FnMut(
+    ExactTransactionScope,
+    u64,
+    u64,
+    bool,
+    Option<&crate::Config>,
+    ConfigStoreResult<ExactSectionRuntimeSnapshot>,
+);
+
+fn materialize_section_runtime_under_migration_lock(
+    mut runtime: crate::Config,
+    scope: ExactTransactionScope,
+    store: &CredentialStore,
+) -> ConfigStoreResult<ExactSectionRuntimeSnapshot> {
+    let (credential_lkg, credential_statuses, credential_health) =
+        store.snapshot_with_health_unchecked()?;
+    match scope {
+        ExactTransactionScope::Providers => {
+            runtime.hydrate_provider_credentials_from_snapshot(&credential_lkg)?;
+        }
+        ExactTransactionScope::Mcp => {
+            runtime.hydrate_mcp_credentials_from_snapshot(&credential_lkg)?;
+        }
+        ExactTransactionScope::ProxyAuth => {
+            runtime.hydrate_proxy_auth_from_snapshot(&credential_lkg)?;
+        }
+        ExactTransactionScope::EnvVars => {
+            runtime.hydrate_env_var_credentials_from_snapshot(&credential_lkg)?;
+        }
+        ExactTransactionScope::Notifications => {
+            runtime.hydrate_notification_credentials_from_snapshot(&credential_lkg)?;
+        }
+        ExactTransactionScope::Connect => {
+            runtime.hydrate_connect_credentials_from_snapshot(&credential_lkg)?;
+        }
+        ExactTransactionScope::AccessControl => {
+            runtime.hydrate_access_control_credentials_from_snapshot(&credential_lkg)?;
+        }
+        ExactTransactionScope::ClusterFabric => {
+            return Err(ConfigStoreError::Validation(
+                "cluster runtime uses its dedicated transaction snapshot".to_string(),
+            ));
+        }
+    }
+    runtime.apply_runtime_env_overrides();
+    Ok(ExactSectionRuntimeSnapshot {
+        runtime: CredentialSectionRuntimeSnapshot {
+            section: scope.section_id(),
+            runtime,
+            credential_statuses,
+            credential_health,
+        },
+        credential_lkg,
+    })
+}
+
+fn capture_section_post_commit(
+    data_dir: &Path,
+    scope: ExactTransactionScope,
+    expected_revision: u64,
+    committed_revision: u64,
+    changed: bool,
+    store: &CredentialStore,
+    callback: &mut SectionPostCommit<'_>,
+) {
+    match crate::section_facade::load_durable_effective_section_under_migration_lock(
+        data_dir,
+        scope.section_id(),
+    ) {
+        Ok(candidate) => {
+            let runtime =
+                materialize_section_runtime_under_migration_lock(candidate.clone(), scope, store);
+            callback(
+                scope,
+                expected_revision,
+                committed_revision,
+                changed,
+                Some(&candidate),
+                runtime,
+            );
+        }
+        Err(error) => callback(
+            scope,
+            expected_revision,
+            committed_revision,
+            changed,
+            None,
+            Err(error),
+        ),
+    }
+}
+
+fn persist_section_transaction_with_adoption<F>(
+    facade: &crate::ConfigFacade,
+    operation: F,
+) -> ConfigStoreResult<CredentialSectionTransactionCommit>
+where
+    F: FnOnce(SectionPostCommit<'_>) -> ConfigStoreResult<u64>,
+{
+    let mut section_adoption = None;
+    let mut exact_runtime = None;
+    let mut callback =
+        |scope: ExactTransactionScope,
+         expected_revision: u64,
+         committed_revision: u64,
+         changed: bool,
+         candidate: Option<&crate::Config>,
+         runtime: ConfigStoreResult<ExactSectionRuntimeSnapshot>| {
+            // Do not advance the process facade unless the exact runtime can
+            // also be installed. Otherwise the watcher would observe the
+            // already-adopted revision as unchanged and could never converge
+            // the live AppState after this post-commit failure.
+            if runtime.is_ok() {
+                section_adoption = if changed {
+                    Some(match candidate {
+                        Some(candidate) => facade.adopt_committed_section(
+                            scope.section_id(),
+                            expected_revision,
+                            committed_revision,
+                            candidate,
+                        ),
+                        None => Err(ConfigStoreError::Validation(
+                            "committed section candidate is unavailable for process adoption"
+                                .to_string(),
+                        )),
+                    })
+                } else {
+                    facade
+                        .catch_up_committed_section(scope.section_id())
+                        .map(Ok)
+                };
+            }
+            exact_runtime = Some(runtime);
+        };
+    let revision = operation(&mut callback)?;
+    let exact_runtime = exact_runtime.unwrap_or_else(|| {
+        Err(ConfigStoreError::Validation(
+            "exact section transaction omitted runtime materialization".to_string(),
+        ))
+    });
+    let (runtime, credential_adoption) = match exact_runtime {
+        Ok(exact) => {
+            let statuses = exact.runtime.credential_statuses.clone();
+            let health = exact.runtime.credential_health.clone();
+            let adoption = Some(facade.adopt_captured_credentials_with_event(
+                exact.credential_lkg,
+                statuses,
+                health,
+            ));
+            (Ok(exact.runtime), adoption)
+        }
+        Err(error) => (Err(error), None),
+    };
+    Ok(CredentialSectionTransactionCommit {
+        revision,
+        section_adoption,
+        credential_adoption,
+        runtime,
+    })
 }
 
 struct ExactClusterRuntimeSnapshot {
@@ -2438,6 +2675,7 @@ fn persist_cluster_fabric_credential_transaction_inner(
         None,
         None,
         None,
+        None,
         cluster_post_commit,
         #[cfg(test)]
         fault,
@@ -2576,6 +2814,7 @@ pub fn persist_mcp_reset_credential_transaction_at_revision(
         Some((&intents, expected_revision)),
         None,
         None,
+        None,
         #[cfg(test)]
         None,
     )
@@ -2630,6 +2869,7 @@ fn persist_mcp_credential_transaction_inner(
         Some((intents, expected_revision)),
         None,
         None,
+        None,
         #[cfg(test)]
         fault,
     )
@@ -2677,8 +2917,364 @@ pub fn persist_credential_backed_section_reset_at_revision(
         None,
         Some((scope, expected_revision)),
         None,
+        None,
         #[cfg(test)]
         None,
+    )
+}
+
+fn require_modular_exact_adoption(data_dir: &Path) -> ConfigStoreResult<()> {
+    if crate::section_layout_is_active(data_dir)? {
+        Ok(())
+    } else {
+        Err(ConfigStoreError::Validation(
+            "exact process adoption requires the modular configuration layout".to_string(),
+        ))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn persist_provider_family_with_adoption(
+    data_dir: &Path,
+    config: &mut crate::Config,
+    provider_intents: &BTreeSet<String>,
+    provider_instance_intents: &BTreeSet<String>,
+    proxy_expected_revision: Option<u64>,
+    env_intents: &BTreeSet<String>,
+    env_expected_revision: Option<u64>,
+    notification_transaction: bool,
+    notification_intents: &BTreeSet<String>,
+    notification_reset: bool,
+    notification_expected_revision: Option<u64>,
+    provider_expected_revision: Option<u64>,
+    facade: &crate::ConfigFacade,
+) -> ConfigStoreResult<CredentialSectionTransactionCommit> {
+    require_modular_exact_adoption(data_dir)?;
+    persist_section_transaction_with_adoption(facade, |post_commit| {
+        persist_exact_credential_transaction_inner(
+            data_dir,
+            config,
+            provider_intents,
+            provider_instance_intents,
+            proxy_expected_revision,
+            env_intents,
+            env_expected_revision,
+            notification_transaction,
+            notification_intents,
+            notification_reset,
+            notification_expected_revision,
+            None,
+            None,
+            None,
+            provider_expected_revision,
+            None,
+            None,
+            Some(post_commit),
+            None,
+            #[cfg(test)]
+            None,
+        )
+    })
+}
+
+pub fn persist_provider_instance_credential_transaction_with_adoption(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    provider_intents: &BTreeSet<String>,
+    provider_instance_intents: &BTreeSet<String>,
+    facade: &crate::ConfigFacade,
+) -> ConfigStoreResult<CredentialSectionTransactionCommit> {
+    if provider_intents.contains("__proxy_auth") {
+        return Err(ConfigStoreError::Validation(
+            "proxy auth requires the dedicated revisioned credential transaction".to_string(),
+        ));
+    }
+    persist_provider_family_with_adoption(
+        data_dir.as_ref(),
+        config,
+        provider_intents,
+        provider_instance_intents,
+        None,
+        &BTreeSet::new(),
+        None,
+        false,
+        &BTreeSet::new(),
+        false,
+        None,
+        None,
+        facade,
+    )
+}
+
+pub fn persist_provider_credential_transaction_at_revision_with_adoption(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    provider_intents: &BTreeSet<String>,
+    provider_instance_intents: &BTreeSet<String>,
+    expected_revision: u64,
+    facade: &crate::ConfigFacade,
+) -> ConfigStoreResult<CredentialSectionTransactionCommit> {
+    persist_provider_family_with_adoption(
+        data_dir.as_ref(),
+        config,
+        provider_intents,
+        provider_instance_intents,
+        None,
+        &BTreeSet::new(),
+        None,
+        false,
+        &BTreeSet::new(),
+        false,
+        None,
+        Some(expected_revision),
+        facade,
+    )
+}
+
+pub fn persist_provider_reset_credential_transaction_at_revision_with_adoption(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    provider_intents: &BTreeSet<String>,
+    provider_instance_intents: &BTreeSet<String>,
+    expected_revision: u64,
+    facade: &crate::ConfigFacade,
+) -> ConfigStoreResult<CredentialSectionTransactionCommit> {
+    persist_provider_credential_transaction_at_revision_with_adoption(
+        data_dir,
+        config,
+        provider_intents,
+        provider_instance_intents,
+        expected_revision,
+        facade,
+    )
+}
+
+pub fn persist_proxy_auth_credential_transaction_at_revision_with_adoption(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    expected_revision: u64,
+    facade: &crate::ConfigFacade,
+) -> ConfigStoreResult<CredentialSectionTransactionCommit> {
+    persist_provider_family_with_adoption(
+        data_dir.as_ref(),
+        config,
+        &BTreeSet::from(["__proxy_auth".to_string()]),
+        &BTreeSet::new(),
+        Some(expected_revision),
+        &BTreeSet::new(),
+        None,
+        false,
+        &BTreeSet::new(),
+        false,
+        None,
+        None,
+        facade,
+    )
+}
+
+pub fn persist_env_var_credential_transaction_at_revision_with_adoption(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    env_intents: &BTreeSet<String>,
+    expected_revision: u64,
+    facade: &crate::ConfigFacade,
+) -> ConfigStoreResult<CredentialSectionTransactionCommit> {
+    persist_provider_family_with_adoption(
+        data_dir.as_ref(),
+        config,
+        &BTreeSet::new(),
+        &BTreeSet::new(),
+        None,
+        env_intents,
+        Some(expected_revision),
+        false,
+        &BTreeSet::new(),
+        false,
+        None,
+        None,
+        facade,
+    )
+}
+
+pub fn persist_notification_credential_transaction_at_revision_with_reset_and_adoption(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    secret_intents: &BTreeSet<String>,
+    reset_domain: bool,
+    expected_revision: u64,
+    facade: &crate::ConfigFacade,
+) -> ConfigStoreResult<CredentialSectionTransactionCommit> {
+    persist_provider_family_with_adoption(
+        data_dir.as_ref(),
+        config,
+        &BTreeSet::new(),
+        &BTreeSet::new(),
+        None,
+        &BTreeSet::new(),
+        None,
+        true,
+        secret_intents,
+        reset_domain,
+        Some(expected_revision),
+        None,
+        facade,
+    )
+}
+
+enum ScopedSectionMutation<'a> {
+    Mcp(&'a BTreeSet<CredentialRef>),
+    Connect(&'a crate::patch::ConnectSecretIntents),
+    AccessControl {
+        password: bool,
+        devices: &'a BTreeSet<String>,
+    },
+    Reset,
+}
+
+fn persist_scoped_section_with_adoption(
+    data_dir: &Path,
+    config: &mut crate::Config,
+    scope: ExactTransactionScope,
+    expected_revision: u64,
+    facade: &crate::ConfigFacade,
+    mutation: ScopedSectionMutation<'_>,
+) -> ConfigStoreResult<CredentialSectionTransactionCommit> {
+    require_modular_exact_adoption(data_dir)?;
+    let (connect_transaction, access_transaction, mcp_transaction, reset) = match mutation {
+        ScopedSectionMutation::Mcp(intents) => (None, None, Some(intents), false),
+        ScopedSectionMutation::Connect(intents) => (Some(intents), None, None, false),
+        ScopedSectionMutation::AccessControl { password, devices } => {
+            (None, Some((password, devices)), None, false)
+        }
+        ScopedSectionMutation::Reset => (None, None, None, true),
+    };
+    persist_section_transaction_with_adoption(facade, |post_commit| {
+        persist_exact_credential_transaction_inner(
+            data_dir,
+            config,
+            &BTreeSet::new(),
+            &BTreeSet::new(),
+            None,
+            &BTreeSet::new(),
+            None,
+            false,
+            &BTreeSet::new(),
+            false,
+            None,
+            None,
+            connect_transaction.map(|intents| (intents, expected_revision)),
+            access_transaction
+                .as_ref()
+                .map(|(password, devices)| (*password, *devices, expected_revision)),
+            None,
+            mcp_transaction.map(|intents| (intents, expected_revision)),
+            reset.then_some((scope, expected_revision)),
+            Some(post_commit),
+            None,
+            #[cfg(test)]
+            None,
+        )
+    })
+}
+
+pub fn persist_mcp_credential_transaction_at_revision_with_adoption(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    intents: &BTreeSet<CredentialRef>,
+    expected_revision: u64,
+    facade: &crate::ConfigFacade,
+) -> ConfigStoreResult<CredentialSectionTransactionCommit> {
+    persist_scoped_section_with_adoption(
+        data_dir.as_ref(),
+        config,
+        ExactTransactionScope::Mcp,
+        expected_revision,
+        facade,
+        ScopedSectionMutation::Mcp(intents),
+    )
+}
+
+pub fn persist_mcp_reset_credential_transaction_at_revision_with_adoption(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    expected_revision: u64,
+    facade: &crate::ConfigFacade,
+) -> ConfigStoreResult<CredentialSectionTransactionCommit> {
+    let intents = BTreeSet::new();
+    persist_scoped_section_with_adoption(
+        data_dir.as_ref(),
+        config,
+        ExactTransactionScope::Mcp,
+        expected_revision,
+        facade,
+        ScopedSectionMutation::Mcp(&intents),
+    )
+}
+
+pub fn persist_connect_credential_transaction_at_revision_with_adoption(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    intents: &crate::patch::ConnectSecretIntents,
+    expected_revision: u64,
+    facade: &crate::ConfigFacade,
+) -> ConfigStoreResult<CredentialSectionTransactionCommit> {
+    persist_scoped_section_with_adoption(
+        data_dir.as_ref(),
+        config,
+        ExactTransactionScope::Connect,
+        expected_revision,
+        facade,
+        ScopedSectionMutation::Connect(intents),
+    )
+}
+
+pub fn persist_access_control_credential_transaction_at_revision_with_adoption(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    password_intent: bool,
+    device_intents: &BTreeSet<String>,
+    expected_revision: u64,
+    facade: &crate::ConfigFacade,
+) -> ConfigStoreResult<CredentialSectionTransactionCommit> {
+    persist_scoped_section_with_adoption(
+        data_dir.as_ref(),
+        config,
+        ExactTransactionScope::AccessControl,
+        expected_revision,
+        facade,
+        ScopedSectionMutation::AccessControl {
+            password: password_intent,
+            devices: device_intents,
+        },
+    )
+}
+
+pub fn persist_credential_backed_section_reset_at_revision_with_adoption(
+    data_dir: impl AsRef<Path>,
+    config: &mut crate::Config,
+    section: crate::SectionId,
+    expected_revision: u64,
+    facade: &crate::ConfigFacade,
+) -> ConfigStoreResult<CredentialSectionTransactionCommit> {
+    let scope = match section {
+        crate::SectionId::Core => ExactTransactionScope::ProxyAuth,
+        crate::SectionId::Notifications => ExactTransactionScope::Notifications,
+        crate::SectionId::Connect => ExactTransactionScope::Connect,
+        crate::SectionId::Env => ExactTransactionScope::EnvVars,
+        crate::SectionId::AccessControl => ExactTransactionScope::AccessControl,
+        _ => {
+            return Err(ConfigStoreError::Validation(
+                "section is not a non-cluster credential-backed reset domain".to_string(),
+            ))
+        }
+    };
+    persist_scoped_section_with_adoption(
+        data_dir.as_ref(),
+        config,
+        scope,
+        expected_revision,
+        facade,
+        ScopedSectionMutation::Reset,
     )
 }
 
@@ -2738,6 +3334,7 @@ where
         None,
         None,
         Some((ExactTransactionScope::ClusterFabric, expected_revision)),
+        None,
         Some(&mut callback),
         #[cfg(test)]
         None,
@@ -2868,6 +3465,7 @@ fn persist_provider_credential_transaction_with_instances_at_revision_inner(
         None,
         None,
         None,
+        None,
         #[cfg(test)]
         fault,
     )
@@ -2892,6 +3490,7 @@ fn persist_exact_credential_transaction_inner(
     provider_expected_revision: Option<u64>,
     mcp_transaction: Option<(&BTreeSet<CredentialRef>, u64)>,
     reset_scope: Option<(ExactTransactionScope, u64)>,
+    mut section_post_commit: Option<SectionPostCommit<'_>>,
     mut cluster_post_commit: Option<ClusterPostCommit<'_>>,
     #[cfg(test)] fault: Option<MigrationFault>,
 ) -> ConfigStoreResult<u64> {
@@ -3249,6 +3848,35 @@ fn persist_exact_credential_transaction_inner(
         None if provider_expected_revision.is_some() || cluster_transaction.is_some() => {
             store.prepare_provider_metadata_update()?
         }
+        None if section_post_commit.is_some() && active_section.is_some() => {
+            let expected_credential_revision = proxy_expected_revision
+                .or(env_expected_revision)
+                .or(notification_expected_revision)
+                .or_else(|| connect_transaction.map(|(_, revision)| revision))
+                .or_else(|| access_transaction.map(|(_, _, revision)| revision));
+            if let Some(expected) = expected_credential_revision {
+                let actual = store.revision_unchecked()?;
+                if actual != expected {
+                    return Err(ConfigStoreError::Conflict { expected, actual });
+                }
+            }
+            let scope = exact_scope.expect("active exact section has a scope");
+            let section = active_section
+                .as_ref()
+                .expect("guarded by active-section presence");
+            capture_section_post_commit(
+                data_dir,
+                scope,
+                section.expected_revision,
+                section.expected_revision,
+                false,
+                &store,
+                section_post_commit
+                    .as_mut()
+                    .expect("guarded by post-commit callback presence"),
+            );
+            return store.revision_unchecked();
+        }
         None => return store.revision_unchecked(),
     };
     if proxy_only && reset_scope.is_none() {
@@ -3429,7 +4057,7 @@ fn persist_exact_credential_transaction_inner(
     if exact_domain_changed && !cluster_only {
         prepared.advance_revision_for_domain_change()?;
     }
-    let committed_authority_revision = if cluster_only && active_section.is_some() {
+    let committed_authority_revision = if active_section.is_some() {
         crate::section_facade::validate_section_envelope(authority_name, &authority_bytes, 0)?
     } else {
         prepared.revision
@@ -3477,8 +4105,26 @@ fn persist_exact_credential_transaction_inner(
                     Ok(()),
                 );
             }
+        } else if let (Some(scope), Some(section), Some(callback)) = (
+            exact_scope,
+            active_section.as_ref(),
+            section_post_commit.as_mut(),
+        ) {
+            capture_section_post_commit(
+                data_dir,
+                scope,
+                section.expected_revision,
+                committed_authority_revision,
+                false,
+                &store,
+                callback,
+            );
         }
-        return Ok(committed_authority_revision);
+        return if cluster_only && active_section.is_some() {
+            Ok(committed_authority_revision)
+        } else {
+            store.revision_unchecked()
+        };
     }
 
     let transaction_id = Uuid::new_v4().to_string();
@@ -3960,6 +4606,24 @@ fn persist_exact_credential_transaction_inner(
             );
         }
         Ok(actual_revision)
+    } else if let (Some(scope), Some(section), Some(callback)) = (
+        exact_scope,
+        active_section.as_ref(),
+        section_post_commit.as_mut(),
+    ) {
+        capture_section_post_commit(
+            data_dir,
+            scope,
+            section.expected_revision,
+            committed_authority_revision,
+            committed_authority_revision != section.expected_revision,
+            &store,
+            callback,
+        );
+        // Credential-member rebases can advance beyond the initially staged
+        // revision. Keep the public credential revision distinct from the
+        // exact owned-section envelope revision passed to adoption above.
+        store.revision_unchecked()
     } else {
         // Credential-member rebases can advance beyond the initially staged
         // revision. Preserve the existing exact-transaction return contract
@@ -15587,6 +16251,106 @@ mod tests {
         assert_eq!(
             read_target_or_empty(&dir.path().join(CONFIG_FILE)).unwrap(),
             root_before
+        );
+    }
+
+    #[test]
+    fn adopted_env_semantic_noop_catches_up_only_the_stale_owned_generation() {
+        let _key = crate::encryption::set_test_encryption_key([0x5a; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let process_facade = crate::ConfigFacade::open(dir.path()).unwrap();
+        assert_eq!(process_facade.registry().env.snapshot().revision, 0);
+        assert_eq!(process_facade.registry().credentials.snapshot().revision, 0);
+
+        let external_facade = crate::ConfigFacade::open(dir.path()).unwrap();
+        let mut external = external_facade.effective_config();
+        external.env_vars.push(crate::EnvVarEntry {
+            name: "PUBLIC_VALUE".to_string(),
+            value: "durable-value".to_string(),
+            secret: false,
+            value_encrypted: None,
+            credential_ref: None,
+            configured: true,
+            description: Some("external generation".to_string()),
+        });
+        let intents = BTreeSet::from(["PUBLIC_VALUE".to_string()]);
+        let revision = persist_env_var_credential_transaction_at_revision(
+            dir.path(),
+            &mut external,
+            &intents,
+            0,
+        )
+        .unwrap();
+        assert_eq!(revision, 1);
+        assert_eq!(
+            process_facade.registry().env.snapshot().revision,
+            0,
+            "the process facade is intentionally stale before its no-op write"
+        );
+
+        let env_before = std::fs::read(dir.path().join(ENV_FILE)).unwrap();
+        let credentials_before = std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap();
+        let fresh = crate::ConfigFacade::open(dir.path()).unwrap();
+        let mut retry = fresh.effective_config();
+        let commit = persist_env_var_credential_transaction_at_revision_with_adoption(
+            dir.path(),
+            &mut retry,
+            &intents,
+            revision,
+            &process_facade,
+        )
+        .unwrap();
+        let CredentialSectionTransactionCommit {
+            revision: committed_revision,
+            section_adoption,
+            credential_adoption,
+            runtime,
+        } = commit;
+        assert_eq!(committed_revision, revision);
+        assert!(matches!(
+            section_adoption.unwrap().unwrap(),
+            crate::ConfigSectionEvent::Changed {
+                ref section,
+                revision: 1
+            } if section == "env"
+        ));
+        assert!(matches!(
+            credential_adoption.unwrap().unwrap().unwrap(),
+            crate::ConfigSectionEvent::Changed {
+                ref section,
+                revision: 1
+            } if section == "credentials"
+        ));
+
+        let mut live = crate::Config::default();
+        live.server.port = 42_424;
+        live.cluster_fabric.nodes.push(crate::Node {
+            id: "process-only-node".to_string(),
+            label: "process-only-node".to_string(),
+            placement: crate::NodePlacement::Local,
+            trust_level: crate::TrustLevel::Trusted,
+            deploy: crate::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        });
+        runtime.unwrap().install_into(&mut live);
+        assert_eq!(live.server.port, 42_424);
+        assert_eq!(live.cluster_fabric.nodes[0].id, "process-only-node");
+        assert!(live.env_vars.iter().any(|entry| {
+            entry.name == "PUBLIC_VALUE"
+                && entry.value == "durable-value"
+                && entry.description.as_deref() == Some("external generation")
+        }));
+        assert_eq!(process_facade.registry().env.snapshot().revision, 1);
+        assert_eq!(process_facade.registry().credentials.snapshot().revision, 1);
+        assert_eq!(
+            std::fs::read(dir.path().join(ENV_FILE)).unwrap(),
+            env_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
         );
     }
 

--- a/crates/infra/bamboo-config/src/credential_store.rs
+++ b/crates/infra/bamboo-config/src/credential_store.rs
@@ -206,6 +206,38 @@ impl CredentialDocumentLkg {
             })
             .transpose()
     }
+
+    /// Project secret-free status metadata while cryptographically validating
+    /// only the references owned by the active cluster generation.
+    ///
+    /// Decrypted values are dropped inside this authority and never returned
+    /// to GET/status callers. A present but undecryptable entry is represented
+    /// as `configured = false`, which the cluster projection renders as
+    /// `error` when durable metadata still says the field is configured.
+    pub(crate) fn statuses_with_cluster_crypto_validation(
+        &self,
+        active_refs: &BTreeSet<CredentialRef>,
+    ) -> Vec<CredentialStatus> {
+        self.document
+            .entries
+            .iter()
+            .map(|(credential_ref, entry)| {
+                let configured = if active_refs.contains(credential_ref) {
+                    crate::encryption::decrypt(&entry.ciphertext)
+                        .map(drop)
+                        .is_ok()
+                } else {
+                    true
+                };
+                CredentialStatus {
+                    credential_ref: credential_ref.clone(),
+                    configured,
+                    source: entry.source,
+                    updated_at: Some(entry.updated_at),
+                }
+            })
+            .collect()
+    }
 }
 
 pub(crate) struct CredentialMutation {
@@ -544,13 +576,21 @@ impl CredentialStore {
     /// after every config-owned reference has been removed through its owning
     /// domain transaction. This is the final step of a section-by-section
     /// reset; it must never detach a live config reference from its secret.
+    ///
+    /// `config` is retained for API compatibility only. It is deliberately not
+    /// an ownership authority: another process may have committed a newer
+    /// section generation than this process-local runtime has observed.
     pub fn clear_all_unreferenced(
         &self,
-        config: &crate::Config,
+        _config: &crate::Config,
         expected_revision: u64,
     ) -> ConfigStoreResult<(u64, Vec<CredentialStatus>)> {
         self.with_transaction_lock(|| {
-            let referenced = config_credential_ref_counts(config)?;
+            let durable =
+                crate::section_facade::load_durable_effective_config_under_migration_lock(
+                    self.data_dir(),
+                )?;
+            let referenced = config_credential_ref_counts(&durable)?;
             if !referenced.is_empty() {
                 return Err(ConfigStoreError::Validation(
                     "credentials still referenced by configuration must be reset through their owning sections"
@@ -2857,6 +2897,14 @@ pub(crate) fn config_credential_ref_counts(
             add(reference);
         }
     }
+    if let Some(reference) = config
+        .subagents()
+        .broker
+        .as_ref()
+        .and_then(|broker| broker.credential_ref.as_ref())
+    {
+        add(reference);
+    }
     for server in &config.mcp.servers {
         match &server.transport {
             bamboo_domain::mcp_config::TransportConfig::Stdio(stdio) => {
@@ -3067,6 +3115,107 @@ mod tests {
         assert_eq!(revision, 2);
         assert!(!status.configured);
         assert!(store.resolve(&reference).unwrap().is_none());
+    }
+
+    #[test]
+    fn generic_reset_uses_durable_cluster_owners_not_stale_runtime() {
+        let _key = crate::encryption::set_test_encryption_key([0x32; 32]);
+        let dir = TempDir::new().unwrap();
+        let facade = crate::ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let mut candidate = facade.effective_config();
+        candidate.cluster_fabric.nodes.push(crate::Node {
+            id: "durable-owner".to_string(),
+            label: "durable-owner".to_string(),
+            placement: crate::NodePlacement::Ssh(crate::SshTarget {
+                host: "durable.example.test".to_string(),
+                port: 22,
+                username: "operator".to_string(),
+                auth: crate::SshAuth::Password {
+                    password: String::new(),
+                    password_encrypted: None,
+                },
+                host_key_fingerprint: None,
+            }),
+            trust_level: crate::TrustLevel::Trusted,
+            deploy: crate::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        });
+        let password_ref = crate::cluster_password_credential_ref("durable-owner").unwrap();
+        let durable_secret = uuid::Uuid::new_v4().to_string();
+        assert_eq!(
+            crate::persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut candidate,
+                &BTreeMap::from([(
+                    "durable-owner".to_string(),
+                    crate::ClusterNodeCredentialIntents {
+                        password: crate::ClusterCredentialAction::Replace(durable_secret.clone(),),
+                        private_key: crate::ClusterCredentialAction::Clear,
+                        passphrase: crate::ClusterCredentialAction::Clear,
+                    },
+                )]),
+                0,
+            )
+            .unwrap(),
+            1
+        );
+
+        let store = CredentialStore::open(dir.path());
+        let stale_runtime = crate::Config::default();
+        let error = store.clear_all_unreferenced(&stale_runtime, 1).unwrap_err();
+        assert!(
+            matches!(error, ConfigStoreError::Validation(_)),
+            "a durable owner must reject generic reset"
+        );
+        assert_eq!(store.revision().unwrap(), 1);
+        assert_eq!(
+            store.resolve(&password_ref).unwrap().unwrap().expose(),
+            durable_secret.as_str()
+        );
+    }
+
+    #[test]
+    fn generic_reset_uses_durable_broker_owner_not_stale_runtime() {
+        let _key = crate::encryption::set_test_encryption_key([0x34; 32]);
+        let dir = TempDir::new().unwrap();
+        let broker_secret = uuid::Uuid::new_v4().to_string();
+        std::fs::write(dir.path().join("config.json"), b"{}").unwrap();
+        std::fs::write(
+            dir.path().join("broker.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "endpoint": "wss://broker.example.test/ws",
+                "token": broker_secret.clone()
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let facade = crate::ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let reference = facade
+            .registry()
+            .subagents
+            .snapshot()
+            .data
+            .external_broker
+            .as_ref()
+            .and_then(|broker| broker.credential_ref.clone())
+            .expect("durable broker must own its migrated credential");
+
+        let store = CredentialStore::open(dir.path());
+        let revision = store.revision().unwrap();
+        let stale_runtime = crate::Config::default();
+        let error = store
+            .clear_all_unreferenced(&stale_runtime, revision)
+            .unwrap_err();
+        assert!(
+            matches!(error, ConfigStoreError::Validation(_)),
+            "a durable broker owner must reject generic reset"
+        );
+        assert_eq!(store.revision().unwrap(), revision);
+        assert_eq!(
+            store.resolve(&reference).unwrap().unwrap().expose(),
+            broker_secret.as_str()
+        );
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/credential_store.rs
+++ b/crates/infra/bamboo-config/src/credential_store.rs
@@ -189,6 +189,23 @@ impl CredentialDocumentLkg {
     pub(crate) fn revision(&self) -> u64 {
         self.revision
     }
+
+    pub(crate) fn resolve(
+        &self,
+        credential_ref: &CredentialRef,
+    ) -> ConfigStoreResult<Option<SecretValue>> {
+        self.document
+            .entries
+            .get(credential_ref)
+            .map(|entry| {
+                crate::encryption::decrypt(&entry.ciphertext)
+                    .map(SecretValue)
+                    .map_err(|_| {
+                        ConfigStoreError::Validation("credential decryption failed".to_string())
+                    })
+            })
+            .transpose()
+    }
 }
 
 pub(crate) struct CredentialMutation {

--- a/crates/infra/bamboo-config/src/credential_store.rs
+++ b/crates/infra/bamboo-config/src/credential_store.rs
@@ -1910,13 +1910,13 @@ impl CredentialStore {
 
     /// Prepare one or more node credential mutations without publishing them.
     /// The caller commits the returned credential envelope together with the
-    /// narrowed `cluster_fabric` root domain through the exact transaction
-    /// manifest. Empty/masked required secrets keep an existing value;
-    /// an empty private-key passphrase is an explicit clear.
+    /// narrowed `cluster_fabric` section through the exact transaction
+    /// manifest. Secret values arrive only through explicit request-only
+    /// actions; ordinary node placement metadata must remain secret-free.
     pub(crate) fn prepare_cluster_node_intents(
         &self,
         config: &mut crate::Config,
-        node_intents: &BTreeSet<String>,
+        node_intents: &BTreeMap<String, crate::ClusterNodeCredentialIntents>,
         persisted_refs: &BTreeMap<String, crate::ClusterNodeCredentialRefs>,
     ) -> ConfigStoreResult<Option<PreparedProviderCredentialUpdate>> {
         if node_intents.is_empty() {
@@ -1943,7 +1943,7 @@ impl CredentialStore {
         let mut required_refs = BTreeSet::new();
         let mut changed = false;
 
-        for node_id in node_intents {
+        for (node_id, intents) in node_intents {
             let password_ref = crate::cluster_password_credential_ref(node_id)?;
             let private_key_ref = crate::cluster_private_key_credential_ref(node_id)?;
             let passphrase_ref = crate::cluster_passphrase_credential_ref(node_id)?;
@@ -1973,87 +1973,140 @@ impl CredentialStore {
                 }
             }
 
-            enum Action {
-                Keep,
-                Replace(String),
-                Clear,
-            }
             let (password, private_key, passphrase) = match config
                 .cluster_fabric
                 .node(node_id)
                 .map(|node| &node.placement)
             {
                 Some(crate::NodePlacement::Ssh(target)) => match &target.auth {
-                    crate::SshAuth::SystemSshConfig => {
-                        (Action::Clear, Action::Clear, Action::Clear)
-                    }
-                    crate::SshAuth::Password { password, .. } => {
-                        let password =
-                            if password.is_empty() || crate::patch::is_masked_api_key(password) {
-                                if persisted.password_configured {
-                                    Action::Keep
-                                } else {
-                                    return Err(ConfigStoreError::Validation(
-                                        "SSH password is required".to_string(),
-                                    ));
-                                }
-                            } else {
-                                Action::Replace(password.clone())
-                            };
-                        (password, Action::Clear, Action::Clear)
+                    crate::SshAuth::SystemSshConfig => (
+                        intents.password.clone(),
+                        intents.private_key.clone(),
+                        intents.passphrase.clone(),
+                    ),
+                    crate::SshAuth::Password {
+                        password,
+                        password_encrypted,
+                    } => {
+                        if !password.is_empty() || password_encrypted.is_some() {
+                            return Err(ConfigStoreError::Validation(
+                                "SSH placement metadata must not contain credentials".to_string(),
+                            ));
+                        }
+                        if matches!(intents.password, crate::ClusterCredentialAction::Clear) {
+                            return Err(ConfigStoreError::Validation(
+                                "password authentication requires keep or replace".to_string(),
+                            ));
+                        }
+                        (
+                            intents.password.clone(),
+                            intents.private_key.clone(),
+                            intents.passphrase.clone(),
+                        )
                     }
                     crate::SshAuth::PrivateKey {
                         private_key,
+                        private_key_encrypted,
                         private_key_path,
                         passphrase,
+                        passphrase_encrypted,
                         ..
                     } => {
-                        let private_key = if private_key.is_empty()
-                            || crate::patch::is_masked_api_key(private_key)
+                        if !private_key.is_empty()
+                            || private_key_encrypted.is_some()
+                            || !passphrase.is_empty()
+                            || passphrase_encrypted.is_some()
                         {
-                            if persisted.private_key_configured {
-                                Action::Keep
-                            } else if private_key_path
-                                .as_deref()
-                                .is_some_and(|path| !path.trim().is_empty())
-                            {
-                                Action::Clear
-                            } else {
-                                return Err(ConfigStoreError::Validation(
-                                    "an inline private key or private key path is required"
-                                        .to_string(),
-                                ));
-                            }
-                        } else {
-                            Action::Replace(private_key.clone())
-                        };
-                        let passphrase = if crate::patch::is_masked_api_key(passphrase) {
-                            if persisted.passphrase_configured {
-                                Action::Keep
-                            } else {
-                                return Err(ConfigStoreError::Validation(
-                                    "SSH passphrase mask has no stored value".to_string(),
-                                ));
-                            }
-                        } else if passphrase.is_empty() {
-                            Action::Clear
-                        } else {
-                            Action::Replace(passphrase.clone())
-                        };
-                        (Action::Clear, private_key, passphrase)
+                            return Err(ConfigStoreError::Validation(
+                                "SSH placement metadata must not contain credentials".to_string(),
+                            ));
+                        }
+                        let uses_key_path = private_key_path
+                            .as_deref()
+                            .is_some_and(|path| !path.trim().is_empty());
+                        if uses_key_path
+                            && !matches!(intents.private_key, crate::ClusterCredentialAction::Clear)
+                        {
+                            return Err(ConfigStoreError::Validation(
+                                "private-key-path authentication requires clearing the inline private key"
+                                    .to_string(),
+                            ));
+                        }
+                        if !uses_key_path
+                            && matches!(intents.private_key, crate::ClusterCredentialAction::Clear)
+                        {
+                            return Err(ConfigStoreError::Validation(
+                                "private-key authentication requires an inline key or key path"
+                                    .to_string(),
+                            ));
+                        }
+                        (
+                            intents.password.clone(),
+                            intents.private_key.clone(),
+                            intents.passphrase.clone(),
+                        )
                     }
                 },
-                Some(crate::NodePlacement::Local) | None => {
-                    (Action::Clear, Action::Clear, Action::Clear)
-                }
+                Some(crate::NodePlacement::Local) | None => (
+                    intents.password.clone(),
+                    intents.private_key.clone(),
+                    intents.passphrase.clone(),
+                ),
             };
 
+            let no_password = !matches!(
+                config
+                    .cluster_fabric
+                    .node(node_id)
+                    .map(|node| &node.placement),
+                Some(crate::NodePlacement::Ssh(crate::SshTarget {
+                    auth: crate::SshAuth::Password { .. },
+                    ..
+                }))
+            );
+            let no_private_key = !matches!(
+                config
+                    .cluster_fabric
+                    .node(node_id)
+                    .map(|node| &node.placement),
+                Some(crate::NodePlacement::Ssh(crate::SshTarget {
+                    auth: crate::SshAuth::PrivateKey { .. },
+                    ..
+                }))
+            );
+            if no_password && !matches!(password, crate::ClusterCredentialAction::Clear) {
+                return Err(ConfigStoreError::Validation(
+                    "password credential must be cleared for this authentication method"
+                        .to_string(),
+                ));
+            }
+            if no_private_key
+                && (!matches!(private_key, crate::ClusterCredentialAction::Clear)
+                    || !matches!(passphrase, crate::ClusterCredentialAction::Clear))
+            {
+                return Err(ConfigStoreError::Validation(
+                    "private-key credentials must be cleared for this authentication method"
+                        .to_string(),
+                ));
+            }
+            for action in [&password, &private_key, &passphrase] {
+                if let crate::ClusterCredentialAction::Replace(value) = action {
+                    if value.is_empty() || crate::patch::is_masked_api_key(value) {
+                        return Err(ConfigStoreError::Validation(
+                            "credential replacement must be nonempty and must not use a mask sentinel"
+                                .to_string(),
+                        ));
+                    }
+                }
+            }
+
             let mut metadata = crate::ClusterNodeCredentialRefs::default();
-            for (action, canonical, existing, reference_slot, configured_slot) in [
+            for (action, canonical, existing, was_configured, reference_slot, configured_slot) in [
                 (
                     password,
                     password_ref,
                     persisted.password_credential_ref,
+                    persisted.password_configured,
                     &mut metadata.password_credential_ref,
                     &mut metadata.password_configured,
                 ),
@@ -2061,6 +2114,7 @@ impl CredentialStore {
                     private_key,
                     private_key_ref,
                     persisted.private_key_credential_ref,
+                    persisted.private_key_configured,
                     &mut metadata.private_key_credential_ref,
                     &mut metadata.private_key_configured,
                 ),
@@ -2068,14 +2122,15 @@ impl CredentialStore {
                     passphrase,
                     passphrase_ref,
                     persisted.passphrase_credential_ref,
+                    persisted.passphrase_configured,
                     &mut metadata.passphrase_credential_ref,
                     &mut metadata.passphrase_configured,
                 ),
             ] {
                 let reference = existing.clone().unwrap_or(canonical);
                 match action {
-                    Action::Keep => {
-                        if !document.entries.contains_key(&reference) {
+                    crate::ClusterCredentialAction::Keep => {
+                        if !was_configured || !document.entries.contains_key(&reference) {
                             return Err(ConfigStoreError::Validation(
                                 "configured cluster credential is unavailable".to_string(),
                             ));
@@ -2085,7 +2140,7 @@ impl CredentialStore {
                         *reference_slot = Some(reference);
                         *configured_slot = true;
                     }
-                    Action::Replace(value) => {
+                    crate::ClusterCredentialAction::Replace(value) => {
                         if existing.is_none() && document.entries.contains_key(&reference) {
                             return Err(ConfigStoreError::Validation(
                                 "canonical cluster credential reference is already in use"
@@ -2119,7 +2174,7 @@ impl CredentialStore {
                         *reference_slot = Some(reference);
                         *configured_slot = true;
                     }
-                    Action::Clear => {
+                    crate::ClusterCredentialAction::Clear => {
                         if let Some(reference) = existing {
                             touched_refs.insert(reference.clone());
                             changed |= document.entries.remove(&reference).is_some();
@@ -2778,6 +2833,11 @@ pub(crate) fn config_credential_ref_counts(
             if let Some(reference) = device.token_credential_ref.as_ref() {
                 add(reference);
             }
+        }
+    }
+    for metadata in config.cluster_fabric.credential_refs.values() {
+        for reference in metadata.references() {
+            add(reference);
         }
     }
     for server in &config.mcp.servers {

--- a/crates/infra/bamboo-config/src/dot_path.rs
+++ b/crates/infra/bamboo-config/src/dot_path.rs
@@ -256,6 +256,10 @@ fn guard_reserved_paths(segments: &[&str], key: &str) -> Result<(), DotPathError
             reason: "environment variables are managed by the dedicated revisioned env API"
                 .to_string(),
         }),
+        ["cluster_fabric", ..] => Err(DotPathError::Unsupported {
+            key: key.to_string(),
+            reason: "cluster fabric is managed by the dedicated revisioned cluster API".to_string(),
+        }),
         ["notifications", "ntfy", "token"] | ["notifications", "bark", "device_key"] => {
             Err(DotPathError::SecretPath {
                 key: key.to_string(),
@@ -580,6 +584,9 @@ mod tests {
             "providers.anthropic.api_key_encrypted",
             "proxy_auth_encrypted",
             "subagents.broker.token",
+            "cluster_fabric",
+            "cluster_fabric.nodes",
+            "cluster_fabric.nodes.0.label",
         ] {
             let err = apply_dot_path_set(&config, key, json!("x")).unwrap_err();
             assert!(

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -4530,6 +4530,10 @@ pub fn persist_facade_effective_config(
     // is not part of the compatibility Config wire shape. Preserve its current
     // durable projection across unrelated root writes.
     candidate.subagents.external_broker = current.subagents.external_broker.clone();
+    // Compatibility/root writers never own cluster CAS. Rebase this field on
+    // the freshly opened durable facade, not the caller's possibly stale
+    // process projection, before validation and change detection.
+    candidate.cluster_fabric = current.cluster_fabric.clone();
     validate_projection(&candidate)?;
 
     crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
@@ -8434,5 +8438,87 @@ mod tests {
             reopened.registry().tools_skills.snapshot().revision,
             tools_revision
         );
+    }
+
+    #[test]
+    fn stale_compatibility_config_never_overwrites_newer_exact_cluster_authority() {
+        let _key = crate::encryption::set_test_encryption_key([90; 32]);
+        let dir = TempDir::new().unwrap();
+        let initial_facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let mut initial = initial_facade.effective_config();
+        initial.cluster_fabric.nodes.push(crate::Node {
+            id: "owned-node".to_string(),
+            label: "generation-one".to_string(),
+            placement: crate::NodePlacement::Local,
+            trust_level: crate::TrustLevel::Trusted,
+            deploy: crate::DeployProfile::default(),
+            state: None,
+            enabled: true,
+        });
+        let intents = std::collections::BTreeMap::from([(
+            "owned-node".to_string(),
+            crate::ClusterNodeCredentialIntents::clear_all(),
+        )]);
+        assert_eq!(
+            crate::persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut initial,
+                &intents,
+                0,
+            )
+            .unwrap(),
+            1
+        );
+
+        let stale_caller = ConfigFacade::open(dir.path()).unwrap().effective_config();
+        let mut external = stale_caller.clone();
+        external
+            .cluster_fabric
+            .node_mut("owned-node")
+            .unwrap()
+            .label = "external-generation-two".to_string();
+        assert_eq!(
+            crate::persist_cluster_fabric_credential_transaction_at_revision(
+                dir.path(),
+                &mut external,
+                &std::collections::BTreeMap::new(),
+                1,
+            )
+            .unwrap(),
+            2
+        );
+        let cluster_path = dir.path().join("cluster-fabric.json");
+        let cluster_r2 = std::fs::read(&cluster_path).unwrap();
+
+        assert!(
+            persist_facade_effective_config(dir.path(), &stale_caller)
+                .unwrap()
+                .is_empty(),
+            "a stale no-op must not manufacture a cluster revision"
+        );
+        assert_eq!(std::fs::read(&cluster_path).unwrap(), cluster_r2);
+
+        let mut unrelated = stale_caller;
+        unrelated.server.port = 22_222;
+        let events = persist_facade_effective_config(dir.path(), &unrelated).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            ConfigSectionEvent::Changed { section, .. } if section == "core"
+        ));
+        assert_eq!(std::fs::read(&cluster_path).unwrap(), cluster_r2);
+
+        let reopened = ConfigFacade::open(dir.path()).unwrap();
+        assert_eq!(reopened.registry().cluster_fabric.snapshot().revision, 2);
+        assert_eq!(
+            reopened
+                .effective_config()
+                .cluster_fabric
+                .node("owned-node")
+                .unwrap()
+                .label,
+            "external-generation-two"
+        );
+        assert_eq!(reopened.effective_config().server.port, 22_222);
     }
 }

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -29,7 +29,7 @@ use crate::{
     StreamTimeoutConfig, SubagentsConfig, ToolsConfig,
 };
 
-const SECTION_SCHEMA_VERSION: u32 = 1;
+pub(crate) const SECTION_SCHEMA_VERSION: u32 = 1;
 pub const SECTION_LAYOUT_VERSION: u32 = 1;
 pub const SECTION_LAYOUT_FILE: &str = "config-sections.json";
 const SECTION_LAYOUT_COMPLETION_VERSION: u32 = 1;
@@ -992,7 +992,7 @@ fn validate_ordinary_section_json(value: &Value) -> ConfigStoreResult<()> {
     validate_provider_override_credentials(value).map_err(crate::ConfigStoreError::Validation)
 }
 
-fn validate_ordinary_section_raw(value: &Value) -> Result<(), String> {
+pub(crate) fn validate_ordinary_section_raw(value: &Value) -> Result<(), String> {
     validate_ordinary_section_json(value).map_err(|error| error.to_string())
 }
 
@@ -1814,7 +1814,7 @@ pub(crate) fn validate_connect_isolated(value: &ConnectConfig) -> Result<(), Str
     Ok(())
 }
 
-fn validate_cluster_fabric(value: &ClusterFabricSection) -> Result<(), String> {
+pub(crate) fn validate_cluster_fabric(value: &ClusterFabricSection) -> Result<(), String> {
     use crate::cluster_fabric::{NodePlacement, SshAuth};
 
     let mut node_ids = BTreeSet::new();

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -1868,6 +1868,21 @@ fn validate_cluster_fabric(value: &ClusterFabricSection) -> Result<(), String> {
             }
         }
     }
+    let mut cluster_names = BTreeSet::new();
+    for cluster in &value.0.clusters {
+        if cluster.name.trim().is_empty() || !cluster_names.insert(cluster.name.as_str()) {
+            return Err("cluster names must be non-empty and unique".to_string());
+        }
+        let mut members = BTreeSet::new();
+        for node_id in &cluster.node_ids {
+            if !node_ids.contains(node_id.as_str()) {
+                return Err("cluster membership references an unknown node".to_string());
+            }
+            if !members.insert(node_id.as_str()) {
+                return Err("cluster membership must not contain duplicate nodes".to_string());
+            }
+        }
+    }
     validate_json_serializable(value)
 }
 

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -715,6 +715,52 @@ impl SectionProjection {
     }
 }
 
+pub(crate) fn apply_runtime_section(id: SectionId, source: &Config, target: &mut Config) {
+    match id {
+        SectionId::Core => {
+            target.http_proxy = source.http_proxy.clone();
+            target.https_proxy = source.https_proxy.clone();
+            target.proxy_auth = source.proxy_auth.clone();
+            target.proxy_auth_encrypted = None;
+            target.proxy_auth_credential_ref = source.proxy_auth_credential_ref.clone();
+            target.headless_auth = source.headless_auth;
+            target.server = source.server.clone();
+            target.default_work_area = source.default_work_area.clone();
+            target.run_budget = source.run_budget;
+            target.stream_timeout = source.stream_timeout;
+            target.extra = source.extra.clone();
+        }
+        SectionId::Providers => {
+            target.provider = source.provider.clone();
+            target.defaults = source.defaults.clone();
+            target.provider_instances = source.provider_instances.clone();
+            target.default_provider_instance = source.default_provider_instance.clone();
+            target.features = source.features.clone();
+            *target.providers_mut() = source.providers().clone();
+        }
+        SectionId::Mcp => target.mcp = source.mcp.clone(),
+        SectionId::ToolsSkills => {
+            target.tools = source.tools.clone();
+            target.skills = source.skills.clone();
+            target.plugin_trust = source.plugin_trust.clone();
+        }
+        SectionId::Memory => *target.memory_mut() = source.memory().clone(),
+        SectionId::Subagents => *target.subagents_mut() = source.subagents().clone(),
+        SectionId::Notifications => target.notifications = source.notifications.clone(),
+        SectionId::Connect => target.connect = source.connect.clone(),
+        SectionId::ClusterFabric => target.cluster_fabric = source.cluster_fabric.clone(),
+        SectionId::Env => target.env_vars = source.env_vars.clone(),
+        SectionId::AccessControl => target.access_control = source.access_control.clone(),
+        SectionId::Hooks => target.hooks = source.hooks.clone(),
+        SectionId::ModelPolicy => {
+            target.keyword_masking = source.keyword_masking.clone();
+            target.anthropic_model_mapping = source.anthropic_model_mapping.clone();
+            target.gemini_model_mapping = source.gemini_model_mapping.clone();
+        }
+        SectionId::ModelLimits | SectionId::Credentials => {}
+    }
+}
+
 fn plan_section_file<T>(
     data_dir: &Path,
     name: &'static str,
@@ -3477,13 +3523,23 @@ impl CredentialSection {
         statuses: Vec<CredentialStatus>,
         health: CredentialStoreHealth,
     ) -> ConfigStoreResult<()> {
+        self.adopt_captured_with_event(document_lkg, statuses, health)
+            .map(|_| ())
+    }
+
+    fn adopt_captured_with_event(
+        &self,
+        document_lkg: CredentialDocumentLkg,
+        statuses: Vec<CredentialStatus>,
+        health: CredentialStoreHealth,
+    ) -> ConfigStoreResult<Option<ConfigSectionEvent>> {
         let _operation = self
             .operation_lock
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let current = self.snapshot();
         if current.revision > health.revision {
-            return Ok(());
+            return Ok(None);
         }
         if current.revision == health.revision && current.data.as_ref() != &statuses {
             return Err(crate::ConfigStoreError::Validation(
@@ -3500,7 +3556,7 @@ impl CredentialSection {
             // under the transaction lock. Missing/default or degraded/backup
             // snapshots need no adoption when the facade already owns that
             // exact state.
-            return Ok(());
+            return Ok(None);
         }
         // Healthy/file snapshots continue through publication even when their
         // public status projection is unchanged, so the facade's opaque LKG is
@@ -3514,6 +3570,13 @@ impl CredentialSection {
             ));
         }
 
+        let observable_change = current.revision != health.revision
+            || current.status != health.status
+            || current.source_kind != health.source
+            || current.last_error != health.last_error
+            || current.data.as_ref() != &statuses;
+        let recovered =
+            current.status != SectionStatus::Healthy && health.status == SectionStatus::Healthy;
         *self
             .document_lkg
             .write()
@@ -3539,7 +3602,19 @@ impl CredentialSection {
                 status: health.status,
                 last_error: health.last_error,
             });
-        Ok(())
+        Ok(observable_change.then(|| {
+            if recovered {
+                ConfigSectionEvent::Recovered {
+                    section: SectionId::Credentials.descriptor().name.to_string(),
+                    revision: health.revision,
+                }
+            } else {
+                ConfigSectionEvent::Changed {
+                    section: SectionId::Credentials.descriptor().name.to_string(),
+                    revision: health.revision,
+                }
+            }
+        }))
     }
 
     pub fn reload(&self) -> ConfigStoreResult<Arc<CredentialSectionSnapshot>> {
@@ -4299,6 +4374,30 @@ pub(crate) fn load_durable_effective_config_under_migration_lock(
     Ok(registry.projection().into_config())
 }
 
+/// Reconstruct a runtime source for one exact owned section while the caller
+/// owns the shared migration lock.
+///
+/// Unlike the full ownership preflight above, this intentionally does not
+/// require the legacy-root completion attestation to remain active after the
+/// exact section commit. A compatibility process may recreate `config.json`
+/// after the commit point; that must not prevent adopting the still-healthy
+/// typed authority, nor authorize installing the recreated root wholesale.
+pub(crate) fn load_durable_effective_section_under_migration_lock(
+    data_dir: &Path,
+    id: SectionId,
+) -> ConfigStoreResult<Config> {
+    let registry = SectionRegistry::open_configured(data_dir, true)?;
+    let envelope = registry.envelope_value(id)?;
+    if envelope.status != SectionStatus::Healthy || envelope.source_kind != SectionSourceKind::File
+    {
+        return Err(crate::ConfigStoreError::Validation(format!(
+            "durable {} credential ownership is unavailable",
+            id.descriptor().name
+        )));
+    }
+    Ok(registry.projection().into_config())
+}
+
 /// Effective compatibility facade assembled from immutable section snapshots.
 pub struct ConfigFacade {
     registry: Arc<SectionRegistry>,
@@ -4375,6 +4474,55 @@ impl ConfigFacade {
             )
     }
 
+    /// Adopt one exact compound-transaction section while the shared
+    /// migration lock still excludes a later cross-process writer.
+    pub(crate) fn adopt_committed_section(
+        &self,
+        id: SectionId,
+        expected_revision: u64,
+        committed_revision: u64,
+        candidate: &Config,
+    ) -> ConfigStoreResult<ConfigSectionEvent> {
+        let projection =
+            SectionProjection::from_config(candidate, self.registry.projection().model_limits)?;
+        macro_rules! adopt {
+            ($field:ident, $candidate:expr) => {
+                self.registry.$field.adopt_committed_from_durable_base(
+                    expected_revision,
+                    committed_revision,
+                    $candidate,
+                )
+            };
+        }
+        match id {
+            SectionId::Core => adopt!(core, projection.core),
+            SectionId::Providers => adopt!(providers, projection.providers),
+            SectionId::Mcp => adopt!(mcp, projection.mcp),
+            SectionId::ToolsSkills => adopt!(tools_skills, projection.tools_skills),
+            SectionId::Memory => adopt!(memory, projection.memory),
+            SectionId::Subagents => adopt!(subagents, projection.subagents),
+            SectionId::Notifications => adopt!(notifications, projection.notifications),
+            SectionId::Connect => adopt!(connect, projection.connect),
+            SectionId::ClusterFabric => adopt!(cluster_fabric, projection.cluster_fabric),
+            SectionId::Env => adopt!(env, projection.env),
+            SectionId::AccessControl => adopt!(access_control, projection.access_control),
+            SectionId::Hooks => adopt!(hooks, projection.hooks),
+            SectionId::ModelPolicy => adopt!(model_policy, projection.model_policy),
+            SectionId::ModelLimits => adopt!(model_limits, projection.model_limits),
+            SectionId::Credentials => Err(crate::ConfigStoreError::Validation(
+                "credential snapshots require opaque credential adoption".to_string(),
+            )),
+        }
+    }
+
+    /// A semantic no-op can still name a durable owned generation newer than
+    /// this process. Reload it while the caller holds the migration lock so
+    /// the returned event and snapshot cannot be assembled from different
+    /// cross-process generations.
+    pub(crate) fn catch_up_committed_section(&self, id: SectionId) -> Option<ConfigSectionEvent> {
+        self.registry.reload_if_changed(id)
+    }
+
     pub(crate) fn adopt_captured_cluster_credentials(
         &self,
         document_lkg: CredentialDocumentLkg,
@@ -4384,6 +4532,17 @@ impl ConfigFacade {
         self.registry
             .credentials
             .adopt_captured(document_lkg, statuses, health)
+    }
+
+    pub(crate) fn adopt_captured_credentials_with_event(
+        &self,
+        document_lkg: CredentialDocumentLkg,
+        statuses: Vec<CredentialStatus>,
+        health: CredentialStoreHealth,
+    ) -> ConfigStoreResult<Option<ConfigSectionEvent>> {
+        self.registry
+            .credentials
+            .adopt_captured_with_event(document_lkg, statuses, health)
     }
 }
 
@@ -4510,18 +4669,92 @@ fn migrate_one_copilot_cache(
     Ok(())
 }
 
-/// Persist a compatibility [`Config`] through the active modular authorities.
-///
-/// This is the bridge used by legacy root PATCH/CLI callers during the
-/// compatibility window: `config.json` is never recreated after activation,
-/// and unchanged sections retain their own revisions. All candidates are
-/// validated before the first durable write; each changed member then uses the
-/// section's snapshot-bound CAS so a concurrent process/editor winner is never
-/// silently overwritten.
-pub fn persist_facade_effective_config(
+/// Opaque runtime projection for the one section changed by a compatibility
+/// write. It can install that owned section into an existing process config but
+/// cannot expose or replace unrelated sections.
+pub struct FacadeSectionRuntimeSnapshot {
+    section: SectionId,
+    runtime: Config,
+}
+
+impl FacadeSectionRuntimeSnapshot {
+    pub fn install_into(self, target: &mut Config) {
+        apply_runtime_section(self.section, &self.runtime, target);
+    }
+}
+
+/// Exact process-adoption result captured for a compatibility write while the
+/// shared migration lock still excluded a later writer.
+pub struct FacadeConfigCommit {
+    pub section_adoption: Option<ConfigStoreResult<ConfigSectionEvent>>,
+    pub runtime: ConfigStoreResult<Option<FacadeSectionRuntimeSnapshot>>,
+}
+
+fn materialize_facade_commit_runtime_under_lock(
+    data_dir: &Path,
+    section: SectionId,
+    mut runtime: Config,
+) -> ConfigStoreResult<FacadeSectionRuntimeSnapshot> {
+    let credentials = matches!(
+        section,
+        SectionId::Core
+            | SectionId::Providers
+            | SectionId::Mcp
+            | SectionId::Notifications
+            | SectionId::Connect
+            | SectionId::ClusterFabric
+            | SectionId::Env
+            | SectionId::AccessControl
+    )
+    .then(|| CredentialStore::open(data_dir).snapshot_with_health_unchecked())
+    .transpose()?
+    .map(|(snapshot, _, _)| snapshot);
+    match section {
+        SectionId::Core => runtime.hydrate_proxy_auth_from_snapshot(
+            credentials.as_ref().expect("credential-backed section"),
+        )?,
+        SectionId::Providers => runtime.hydrate_provider_credentials_from_snapshot(
+            credentials.as_ref().expect("credential-backed section"),
+        )?,
+        SectionId::Mcp => runtime.hydrate_mcp_credentials_from_snapshot(
+            credentials.as_ref().expect("credential-backed section"),
+        )?,
+        SectionId::Notifications => runtime.hydrate_notification_credentials_from_snapshot(
+            credentials.as_ref().expect("credential-backed section"),
+        )?,
+        SectionId::Connect => runtime.hydrate_connect_credentials_from_snapshot(
+            credentials.as_ref().expect("credential-backed section"),
+        )?,
+        SectionId::ClusterFabric => runtime.hydrate_cluster_credentials_from_snapshot(
+            credentials.as_ref().expect("credential-backed section"),
+        )?,
+        SectionId::Env => runtime.hydrate_env_var_credentials_from_snapshot(
+            credentials.as_ref().expect("credential-backed section"),
+        )?,
+        SectionId::AccessControl => runtime.hydrate_access_control_credentials_from_snapshot(
+            credentials.as_ref().expect("credential-backed section"),
+        )?,
+        SectionId::ToolsSkills
+        | SectionId::Memory
+        | SectionId::Subagents
+        | SectionId::Hooks
+        | SectionId::ModelPolicy
+        | SectionId::ModelLimits => {}
+        SectionId::Credentials => {
+            return Err(crate::ConfigStoreError::Validation(
+                "compatibility config cannot own the credential section".to_string(),
+            ))
+        }
+    }
+    runtime.apply_runtime_env_overrides();
+    Ok(FacadeSectionRuntimeSnapshot { section, runtime })
+}
+
+fn persist_facade_effective_config_inner(
     data_dir: impl AsRef<Path>,
     config: &Config,
-) -> ConfigStoreResult<Vec<ConfigSectionEvent>> {
+    process_facade: Option<&ConfigFacade>,
+) -> ConfigStoreResult<(Vec<ConfigSectionEvent>, Option<FacadeConfigCommit>)> {
     let data_dir = data_dir.as_ref();
     let facade = ConfigFacade::open(data_dir)?;
     let current = facade.registry.projection();
@@ -4570,37 +4803,101 @@ pub fn persist_facade_effective_config(
             )));
         }
         let mut events = Vec::new();
+        let mut committed = None;
         macro_rules! commit_if_changed {
-            ($field:ident, $candidate:expr) => {{
+            ($id:ident, $field:ident, $candidate:expr) => {{
                 let candidate = $candidate;
                 let snapshot = facade.registry.$field.snapshot();
                 if serde_json::to_value(snapshot.data.as_ref())?
                     != serde_json::to_value(&candidate)?
                 {
-                    events.push(
-                        facade
-                            .registry
-                            .$field
-                            .commit(snapshot.revision, candidate)?,
-                    );
+                    let expected_revision = snapshot.revision;
+                    let event = facade
+                        .registry
+                        .$field
+                        .commit(expected_revision, candidate)?;
+                    let committed_revision = match &event {
+                        ConfigSectionEvent::Changed { revision, .. }
+                        | ConfigSectionEvent::Recovered { revision, .. }
+                        | ConfigSectionEvent::Invalid { revision, .. } => *revision,
+                    };
+                    events.push(event);
+                    committed = Some((SectionId::$id, expected_revision, committed_revision));
                 }
             }};
         }
 
-        commit_if_changed!(core, candidate.core);
-        commit_if_changed!(providers, candidate.providers);
-        commit_if_changed!(mcp, candidate.mcp);
-        commit_if_changed!(tools_skills, candidate.tools_skills);
-        commit_if_changed!(memory, candidate.memory);
-        commit_if_changed!(subagents, candidate.subagents);
-        commit_if_changed!(notifications, candidate.notifications);
-        commit_if_changed!(connect, candidate.connect);
-        commit_if_changed!(cluster_fabric, candidate.cluster_fabric);
-        commit_if_changed!(env, candidate.env);
-        commit_if_changed!(access_control, candidate.access_control);
-        commit_if_changed!(hooks, candidate.hooks);
-        commit_if_changed!(model_policy, candidate.model_policy);
-        Ok(events)
+        commit_if_changed!(Core, core, candidate.core);
+        commit_if_changed!(Providers, providers, candidate.providers);
+        commit_if_changed!(Mcp, mcp, candidate.mcp);
+        commit_if_changed!(ToolsSkills, tools_skills, candidate.tools_skills);
+        commit_if_changed!(Memory, memory, candidate.memory);
+        commit_if_changed!(Subagents, subagents, candidate.subagents);
+        commit_if_changed!(Notifications, notifications, candidate.notifications);
+        commit_if_changed!(Connect, connect, candidate.connect);
+        commit_if_changed!(ClusterFabric, cluster_fabric, candidate.cluster_fabric);
+        commit_if_changed!(Env, env, candidate.env);
+        commit_if_changed!(AccessControl, access_control, candidate.access_control);
+        commit_if_changed!(Hooks, hooks, candidate.hooks);
+        commit_if_changed!(ModelPolicy, model_policy, candidate.model_policy);
+
+        let process_commit = process_facade.map(|process_facade| {
+            let Some((section, expected_revision, committed_revision)) = committed else {
+                return FacadeConfigCommit {
+                    section_adoption: None,
+                    runtime: Ok(None),
+                };
+            };
+            let exact = facade.effective_config();
+            let runtime =
+                materialize_facade_commit_runtime_under_lock(data_dir, section, exact).map(Some);
+            // A failed exact runtime must leave the process facade behind the
+            // durable revision. Its watcher can then observe and retry that
+            // generation instead of treating an uninstalled commit as current.
+            let section_adoption = runtime.as_ref().ok().map(|_| {
+                process_facade.adopt_committed_section(
+                    section,
+                    expected_revision,
+                    committed_revision,
+                    &facade.effective_config(),
+                )
+            });
+            FacadeConfigCommit {
+                section_adoption,
+                runtime,
+            }
+        });
+        Ok((events, process_commit))
+    })
+}
+
+/// Persist a compatibility [`Config`] through the active modular authorities
+/// and return the durable section events without adopting a process facade.
+pub fn persist_facade_effective_config(
+    data_dir: impl AsRef<Path>,
+    config: &Config,
+) -> ConfigStoreResult<Vec<ConfigSectionEvent>> {
+    persist_facade_effective_config_inner(data_dir, config, None).map(|(events, _)| events)
+}
+
+/// Persist a compatibility [`Config`] through the active modular authorities
+/// and capture the exact changed-section runtime for `process_facade`.
+///
+/// This is the bridge used by legacy root PATCH/CLI callers during the
+/// compatibility window: `config.json` is never recreated after activation,
+/// unchanged sections retain their own revisions, and the caller can install
+/// only the section it actually committed.
+pub fn persist_facade_effective_config_with_adoption(
+    data_dir: impl AsRef<Path>,
+    config: &Config,
+    process_facade: &ConfigFacade,
+) -> ConfigStoreResult<FacadeConfigCommit> {
+    let (_, commit) =
+        persist_facade_effective_config_inner(data_dir, config, Some(process_facade))?;
+    commit.ok_or_else(|| {
+        crate::ConfigStoreError::Validation(
+            "compatibility commit omitted process adoption result".to_string(),
+        )
     })
 }
 
@@ -8520,5 +8817,38 @@ mod tests {
             "external-generation-two"
         );
         assert_eq!(reopened.effective_config().server.port, 22_222);
+    }
+
+    #[test]
+    fn failed_compatibility_runtime_materialization_leaves_process_facade_reloadable() {
+        let _key = crate::encryption::set_test_encryption_key([91; 32]);
+        let dir = TempDir::new().unwrap();
+        let process_facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let reference = CredentialRef::parse("proxy.default.auth").unwrap();
+        CredentialStore::open(dir.path())
+            .replace(reference.clone(), "not-json", CredentialSource::User, 0)
+            .unwrap();
+
+        let mut candidate = process_facade.effective_config();
+        candidate.server.port = 22_223;
+        candidate.proxy_auth_credential_ref = Some(reference);
+        let core_before = process_facade.registry().core.snapshot().revision;
+
+        let commit =
+            persist_facade_effective_config_with_adoption(dir.path(), &candidate, &process_facade)
+                .unwrap();
+        assert!(commit.runtime.is_err());
+        assert!(
+            commit.section_adoption.is_none(),
+            "an unmaterialized runtime must not advance the process facade"
+        );
+        assert_eq!(
+            process_facade.registry().core.snapshot().revision,
+            core_before
+        );
+
+        let durable = ConfigFacade::open(dir.path()).unwrap();
+        assert_eq!(durable.registry().core.snapshot().revision, core_before + 1);
+        assert_eq!(durable.effective_config().server.port, 22_223);
     }
 }

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -4255,6 +4255,47 @@ impl SectionRegistry {
     }
 }
 
+/// Reconstruct the effective configuration from the coherent modular
+/// authorities while the caller owns the shared migration lock.
+///
+/// Credential ownership checks must use these durable snapshots rather than a
+/// process-local runtime that may lag a commit made by another process.
+pub(crate) fn load_durable_effective_config_under_migration_lock(
+    data_dir: &Path,
+) -> ConfigStoreResult<Config> {
+    if !section_layout_is_active(data_dir)? {
+        return Err(crate::ConfigStoreError::Validation(
+            "durable credential ownership requires the modular configuration layout".to_string(),
+        ));
+    }
+    let registry = SectionRegistry::open_configured(data_dir, true)?;
+    let health = registry.health()?;
+    for id in [
+        SectionId::Core,
+        SectionId::Providers,
+        SectionId::Mcp,
+        SectionId::Notifications,
+        SectionId::Connect,
+        SectionId::ClusterFabric,
+        SectionId::Env,
+        SectionId::AccessControl,
+        SectionId::Subagents,
+    ] {
+        let health = health
+            .iter()
+            .find(|health| health.section == id)
+            .expect("every durable credential owner has section health");
+        if health.status != SectionStatus::Healthy || health.source_kind != SectionSourceKind::File
+        {
+            return Err(crate::ConfigStoreError::Validation(format!(
+                "durable {} credential ownership is unavailable",
+                id.descriptor().name
+            )));
+        }
+    }
+    Ok(registry.projection().into_config())
+}
+
 /// Effective compatibility facade assembled from immutable section snapshots.
 pub struct ConfigFacade {
     registry: Arc<SectionRegistry>,
@@ -4322,11 +4363,13 @@ impl ConfigFacade {
         let mut sanitized = Config::default();
         sanitized.cluster_fabric = candidate;
         sanitized.sanitize_cluster_fabric_for_disk();
-        self.registry.cluster_fabric.adopt_committed(
-            expected_revision,
-            committed_revision,
-            ClusterFabricSection(sanitized.cluster_fabric.clone()),
-        )
+        self.registry
+            .cluster_fabric
+            .adopt_committed_from_durable_base(
+                expected_revision,
+                committed_revision,
+                ClusterFabricSection(sanitized.cluster_fabric.clone()),
+            )
     }
 
     pub(crate) fn adopt_captured_cluster_credentials(

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -3921,6 +3921,9 @@ fn error_category(error: &crate::ConfigStoreError) -> String {
         crate::ConfigStoreError::Json(_) => "credential document is invalid",
         crate::ConfigStoreError::Conflict { .. } => "credential revision conflict",
         crate::ConfigStoreError::Validation(_) => "credential document failed validation",
+        crate::ConfigStoreError::CommitIndeterminate(_) => {
+            "credential transaction outcome is indeterminate"
+        }
         crate::ConfigStoreError::Watch(_) => "credential store watch failed",
     }
     .to_string()

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -22,9 +22,9 @@ use crate::{
     AccessControlConfig, AnthropicModelMapping, AtomicJsonStore, BrokerClientConfig,
     ClusterFabricConfig, Config, ConfigSectionEvent, ConfigStoreResult, ConfigValues,
     ConnectConfig, CredentialRef, CredentialSource, CredentialStatus, CredentialStore,
-    DefaultWorkAreaConfig, DefaultsConfig, EnvVarEntry, FeatureFlags, GeminiModelMapping,
-    HooksConfig, KeywordMaskingConfig, LifecycleHooksConfig, LiveSection, MemoryConfig,
-    NotificationsConfig, PluginTrustConfig, ProviderConfigs, ProviderInstanceConfig,
+    CredentialStoreHealth, DefaultWorkAreaConfig, DefaultsConfig, EnvVarEntry, FeatureFlags,
+    GeminiModelMapping, HooksConfig, KeywordMaskingConfig, LifecycleHooksConfig, LiveSection,
+    MemoryConfig, NotificationsConfig, PluginTrustConfig, ProviderConfigs, ProviderInstanceConfig,
     RunBudgetConfig, SectionEnvelope, SectionSourceKind, SectionStatus, ServerConfig, SkillsConfig,
     StreamTimeoutConfig, SubagentsConfig, ToolsConfig,
 };
@@ -3463,6 +3463,85 @@ impl CredentialSection {
         }
     }
 
+    /// Silently adopt a credential snapshot captured by a compound
+    /// transaction while it held the migration lock. This method is called
+    /// only after that outer lock has been released, preserving the ordinary
+    /// credential mutation lock order (`operation_lock` then migration lock).
+    ///
+    /// A newer process-local snapshot always wins. Equal revisions must carry
+    /// identical public status data; otherwise the durable source reused a
+    /// revision and adoption fails closed.
+    fn adopt_captured(
+        &self,
+        document_lkg: CredentialDocumentLkg,
+        statuses: Vec<CredentialStatus>,
+        health: CredentialStoreHealth,
+    ) -> ConfigStoreResult<()> {
+        let _operation = self
+            .operation_lock
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let current = self.snapshot();
+        if current.revision > health.revision {
+            return Ok(());
+        }
+        if current.revision == health.revision && current.data.as_ref() != &statuses {
+            return Err(crate::ConfigStoreError::Validation(
+                "credential document reused the live revision with different data".to_string(),
+            ));
+        }
+        if current.revision == health.revision
+            && current.status == health.status
+            && current.source_kind == health.source
+            && current.last_error == health.last_error
+            && (health.status != SectionStatus::Healthy || health.source != SectionSourceKind::File)
+        {
+            // A cluster-only metadata commit still captures credential health
+            // under the transaction lock. Missing/default or degraded/backup
+            // snapshots need no adoption when the facade already owns that
+            // exact state.
+            return Ok(());
+        }
+        // Healthy/file snapshots continue through publication even when their
+        // public status projection is unchanged, so the facade's opaque LKG is
+        // the exact credential document captured by this compound commit.
+        if health.status != SectionStatus::Healthy
+            || health.source != SectionSourceKind::File
+            || document_lkg.revision() != health.revision
+        {
+            return Err(crate::ConfigStoreError::Validation(
+                "captured credential transaction snapshot is not healthy".to_string(),
+            ));
+        }
+
+        *self
+            .document_lkg
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Arc::new(document_lkg));
+        *self
+            .repair_authority
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = CredentialRepairAuthority::None;
+        *self
+            .trusted_lkg
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = true;
+        *self
+            .snapshot
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+            Arc::new(CredentialSectionSnapshot {
+                data: Arc::new(statuses),
+                revision: health.revision,
+                loaded_at: Utc::now(),
+                source_path: self.store.path().to_path_buf(),
+                source_kind: health.source,
+                status: health.status,
+                last_error: health.last_error,
+            });
+        Ok(())
+    }
+
     pub fn reload(&self) -> ConfigStoreResult<Arc<CredentialSectionSnapshot>> {
         let _operation = self
             .operation_lock
@@ -4228,6 +4307,37 @@ impl ConfigFacade {
 
     pub fn effective_config(&self) -> Config {
         self.registry.projection().into_config()
+    }
+
+    /// Publish the exact cluster-fabric snapshot installed by the credential
+    /// compound transaction. This is a process-local adoption only: the
+    /// transaction has already made both durable members authoritative and
+    /// must still hold its cross-process migration lock while calling here.
+    pub(crate) fn adopt_committed_cluster_fabric(
+        &self,
+        expected_revision: u64,
+        committed_revision: u64,
+        candidate: ClusterFabricConfig,
+    ) -> ConfigStoreResult<ConfigSectionEvent> {
+        let mut sanitized = Config::default();
+        sanitized.cluster_fabric = candidate;
+        sanitized.sanitize_cluster_fabric_for_disk();
+        self.registry.cluster_fabric.adopt_committed(
+            expected_revision,
+            committed_revision,
+            ClusterFabricSection(sanitized.cluster_fabric.clone()),
+        )
+    }
+
+    pub(crate) fn adopt_captured_cluster_credentials(
+        &self,
+        document_lkg: CredentialDocumentLkg,
+        statuses: Vec<CredentialStatus>,
+        health: CredentialStoreHealth,
+    ) -> ConfigStoreResult<()> {
+        self.registry
+            .credentials
+            .adopt_captured(document_lkg, statuses, health)
     }
 }
 

--- a/src/setup_cli.rs
+++ b/src/setup_cli.rs
@@ -247,12 +247,17 @@ pub fn run_config_set(
     dry_run: bool,
 ) -> Result<()> {
     let data_dir = data_dir.unwrap_or_else(bamboo_config::paths::resolve_bamboo_dir);
+    let parts: Vec<&str> = key.split('.').collect();
+    if matches!(parts.as_slice(), ["cluster_fabric", ..]) {
+        bail!(
+            "cluster_fabric is managed by the dedicated revisioned cluster API and cannot be changed with `bamboo config set`"
+        );
+    }
     let mut config = Config::from_data_dir_without_env(Some(data_dir.clone()));
     let mut provider_credential_intents = BTreeSet::new();
     let mut provider_instance_credential_intents = BTreeSet::new();
     let mut notification_credential_intents = BTreeSet::new();
 
-    let parts: Vec<&str> = key.split('.').collect();
     // `Some(outcome)` = generic dot-path set (validated new config inside);
     // `None` = a dedicated arm mutated `config` in place.
     let outcome = match parts.as_slice() {
@@ -892,6 +897,10 @@ mod tests {
             ("proxy_auth.username", "alice"),
             ("providers.anthropic.api_key_encrypted", "cipher"),
             ("provider_instances.nope.api_key", "sk-x"),
+            (
+                "cluster_fabric.nodes",
+                r#"[{"id":"cli-bypass","label":"cli-bypass","placement":{"type":"local"}}]"#,
+            ),
         ] {
             assert!(
                 run_config_set(key, value, Some(data_dir.clone()), false).is_err(),


### PR DESCRIPTION
## Summary

- make the `cluster-fabric` section revision the sole external CAS authority for node, credential, membership, cluster CRUD, boot reconciliation, health, and lifecycle-state mutations
- commit node metadata, optional membership, explicit password/private-key/passphrase keep/replace/clear actions, TOFU fingerprints, and lifecycle state through recoverable exact transactions
- return the exact installed/rebased cluster candidate and credential metadata while preserving redaction across API, event, disk, and Debug projections
- reject generic root/section/CLI/credential-namespace paths that could bypass dedicated cluster CAS or secret semantics
- reject node deletion and cluster reset while affected `node:*` workers are deployed, without blocking unrelated `agent:*` workers
- classify pre-commit, committed-recovery, intentional-abort, and indeterminate outcomes so lifecycle compensation never tears down a committed worker state
- persist independent rollback authorities and recover every post-manifest boundary without publishing staged or unproven data

### Exact process publication

- capture immutable section-local runtime snapshots for provider, MCP, proxy, env, notifications, connect, access-control, reset, and compatibility writes while the shared transaction lock excludes later writers
- install only the section actually committed into the current live config; never adopt an unrelated fresh root or a newer cluster generation under another section's revision
- adopt live runtime before publishing credential/section events, and publish each exact process-facade transition at most once
- serialize generic durable commit, live installation, and synchronous event enqueue so local journals cannot observe `r2` before `r1`
- give generic update, provider-credential update, and full replace cancellation-independent ownership after candidate construction, so aborting a request after durable/facade commit still completes live publication, exact events, and requested effects
- retain that owned serialization guard through provider construction/publication and MCP reconciliation, so an older detached writer cannot overwrite the runtime produced by a later commit
- catch a stopped/stale process facade up to the exact durable cluster generation when a cluster update or reset is a semantic no-op, without reporting a false post-commit adoption failure
- adopt the credential LKG/status/health captured under the same cluster transaction lock for changed, no-op, and reset-no-op outcomes; generation-aware adoption refuses later winners
- preserve a later external cluster generation even when the process watcher is stopped and a stale compatibility writer performs no-op/update/replace operations
- keep the process facade behind the durable revision when post-commit runtime materialization fails, so the watcher can observe and retry convergence instead of permanently treating an uninstalled generation as current
- keep compatibility POST responses operator-owned and secret-free while live state retains runtime-only cluster heartbeat data

## Why

Cluster mutations previously used three incompatible authorities: typed section writes used the section revision, node writes used the credential-store revision, and cluster CRUD/lifecycle paths were revisionless. That allowed stale overwrites, partial node-plus-membership updates, and cancellation/recovery windows that could leave durable storage, runtime, facade, events, and worker state inconsistent.

Adversarial reviews also found unrelated-root adoption by compatibility writers, false post-commit failures for stopped-watcher semantic no-ops, local event reordering after releasing the serialization lock, request cancellation that stranded durable/facade state ahead of live publication, no-op cluster catch-up that omitted the exact credential generation, and older provider/MCP effects that could overwrite a later successful writer's runtime. This revision uses exact owned-section snapshots, runtime-before-event publication, cancellation-independent transaction ownership, commit-ordered event enqueue, serialized runtime effects, and exact section-plus-credential no-op catch-up.

## Impact

Lotus can capture one cluster-fabric revision, preserve dirty drafts across refreshes, and receive canonical `409 Conflict` responses for stale node, membership, or lifecycle actions. Unrelated credential-store writes are rebased internally and do not create false cluster conflicts. Successful responses and live runtime are bound to the exact snapshot captured for the owned section, while genuinely later external generations remain observable.

## Test evidence

Exact head `1e058aa171f074fd020a79ec4eda2d9973bcbd8f`:

- `cargo test -p bamboo-server --lib app_state::config_runtime::live_reload_tests::` — 35 passed
- deterministic provider-block/MCP-later-winner regression proving runtime effects remain in commit order — passed
- `cargo clippy -p bamboo-config -p bamboo-server-tools -p bamboo-server --all-targets --all-features -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- GitHub Test (full unit/library, integration, and examples), E2E, Lint, MSRV, docs, security, cargo-deny, Linux/macOS/Windows TLS, and all CodeQL analyzers — passed

The immediately preceding exact head `485d68dba9b92cc1b804d644ac92fd8a1c6658ec` additionally passed `bamboo-config` (607), cluster-filtered server tests (28), live-reload server tests (34), and `bamboo-server-tools` (129 unit + 3 integration) during adversarial verification. Dev-only Promotion Source and the release build matrix are intentionally skipped by branch policy.

Focused regressions cover exact durable rebasing, stale-facade and semantic-no-op catch-up, exact credential-generation adoption, duplicate-publication rejection, stopped-watcher cross-section isolation, runtime-before-event and durable-order event publication, request cancellation after durable commit, commit-ordered provider/MCP effects, post-commit materialization failure recovery, durable reset ownership, deployed-worker guards, abort-marker and committed-recovery boundaries, indeterminate outcomes, cluster/credential degraded-authority rejection, secret-free status, later external winners, health-probe races, boot reconciliation, atomic membership, namespace rejection, canonical conflicts, and disk/API/event/log redaction.

## Follow-up

- #735 tracks revisioned reconciliation of a legacy `config.json` that reappears after modular-layout activation. This PR deliberately preserves those bytes without silently installing unrelated root fields under the current transaction's revision.
- #736 tracks pre-existing out-of-lock runtime publication in explicit provider reload and legacy MCP CRUD/import/connect handlers. Those paths do not mutate cluster-fabric authority and are intentionally kept outside this PR.

Closes #729
