### PR TITLE
fix: unify credential-backed section mutation CAS

### DIFF
--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -412,52 +412,14 @@ impl ConfigWatcherRuntime {
                 // a clone taken before an unrelated API update and clobber it.
                 let _io = config_io_lock.lock().await;
                 if let Some(facade) = config_facade.as_ref() {
-                    let mut publishable = Vec::new();
-                    for id in ordinary_watched {
-                        wait_for_section_file_settle(&data_dir, id).await;
-                        let Some(event) = facade.registry().reload_if_changed(id) else {
-                            continue;
-                        };
-                        if matches!(event, ConfigSectionEvent::Invalid { .. }) {
-                            publish_registry_event(&account_sink, &event);
-                        } else {
-                            publishable.push((id, event));
-                        }
-                    }
-                    if !publishable.is_empty() {
-                        let materialized = materialize_facade_effective_config(facade, &data_dir);
-                        let mut current = config.read().await.clone();
-                        let mut applied = Vec::new();
-                        for (id, event) in publishable {
-                            if materialized.failures.contains(&id) {
-                                if let Some(invalid) = facade.registry().mark_runtime_degraded(
-                                    id,
-                                    "configuration runtime hydration failed; retaining last-known-good runtime",
-                                ) {
-                                    publish_registry_event(&account_sink, &invalid);
-                                }
-                                continue;
-                            }
-                            apply_runtime_section(id, &materialized.config, &mut current);
-                            applied.push((id, event));
-                        }
-                        if !applied.is_empty() {
-                            let publishes_env = applied.iter().any(|(id, _)| *id == SectionId::Env);
-                            let enforcement_newly_off =
-                                !config.read().await.plugin_trust.enforcement_is_off()
-                                    && current.plugin_trust.enforcement_is_off();
-                            *config.write().await = current.clone();
-                            if publishes_env {
-                                current.publish_env_vars();
-                            }
-                            if enforcement_newly_off {
-                                warn_plugin_trust_enforcement_off();
-                            }
-                            for (_, event) in applied {
-                                publish_registry_event(&account_sink, &event);
-                            }
-                        }
-                    }
+                    reload_and_apply_ordinary_sections(
+                        &data_dir,
+                        &config,
+                        facade,
+                        &account_sink,
+                        ordinary_watched,
+                    )
+                    .await;
                 }
                 if provider_watched {
                     if let Some(facade) = config_facade.as_ref() {
@@ -792,6 +754,69 @@ async fn wait_for_section_file_settle(data_dir: &Path, id: SectionId) {
     }
 }
 
+/// Reload ordinary section authorities, install every successfully hydrated
+/// runtime generation, and only then publish its registry event.
+///
+/// The caller owns `config_io_lock`; keeping this sequence shared by the live
+/// watcher and focused regressions makes the event/runtime ordering explicit.
+async fn reload_and_apply_ordinary_sections(
+    data_dir: &Path,
+    config: &Arc<RwLock<Config>>,
+    facade: &bamboo_config::ConfigFacade,
+    account_sink: &bamboo_engine::events::AccountEventSink,
+    sections: impl IntoIterator<Item = SectionId>,
+) {
+    let mut publishable = Vec::new();
+    for id in sections {
+        wait_for_section_file_settle(data_dir, id).await;
+        let Some(event) = facade.registry().reload_if_changed(id) else {
+            continue;
+        };
+        if matches!(event, ConfigSectionEvent::Invalid { .. }) {
+            publish_registry_event(account_sink, &event);
+        } else {
+            publishable.push((id, event));
+        }
+    }
+    if publishable.is_empty() {
+        return;
+    }
+
+    let materialized = materialize_facade_effective_config(facade, data_dir);
+    let mut current = config.read().await.clone();
+    let mut applied = Vec::new();
+    for (id, event) in publishable {
+        if materialized.failures.contains(&id) {
+            if let Some(invalid) = facade.registry().mark_runtime_degraded(
+                id,
+                "configuration runtime hydration failed; retaining last-known-good runtime",
+            ) {
+                publish_registry_event(account_sink, &invalid);
+            }
+            continue;
+        }
+        apply_runtime_section(id, &materialized.config, &mut current);
+        applied.push((id, event));
+    }
+    if applied.is_empty() {
+        return;
+    }
+
+    let publishes_env = applied.iter().any(|(id, _)| *id == SectionId::Env);
+    let enforcement_newly_off = !config.read().await.plugin_trust.enforcement_is_off()
+        && current.plugin_trust.enforcement_is_off();
+    *config.write().await = current.clone();
+    if publishes_env {
+        current.publish_env_vars();
+    }
+    if enforcement_newly_off {
+        warn_plugin_trust_enforcement_off();
+    }
+    for (_, event) in applied {
+        publish_registry_event(account_sink, &event);
+    }
+}
+
 pub(super) fn publish_registry_event(
     account_sink: &bamboo_engine::events::AccountEventSink,
     event: &ConfigSectionEvent,
@@ -832,6 +857,55 @@ struct InstalledCredentialSectionCommit {
     events: Vec<ConfigSectionEvent>,
     metadata: bamboo_config::CredentialSectionRuntimeMetadata,
     section: Option<bamboo_config::SectionEnvelope<Value>>,
+}
+
+pub(crate) struct ExactCredentialSectionSnapshot {
+    pub config: Config,
+    pub section: bamboo_config::SectionEnvelope<Value>,
+    pub metadata: bamboo_config::CredentialSectionRuntimeMetadata,
+}
+
+fn map_exact_credential_store_error(error: ConfigStoreError) -> AppError {
+    match error {
+        ConfigStoreError::Conflict { expected, actual } => {
+            AppError::ConfigConflict { expected, actual }
+        }
+        ConfigStoreError::Validation(message) => AppError::BadRequest(message),
+        ConfigStoreError::CommitIndeterminate(message) => AppError::InternalError(anyhow::anyhow!(
+            "configuration commit outcome is indeterminate: {message}"
+        )),
+        ConfigStoreError::Io(error) => AppError::StorageError(error),
+        ConfigStoreError::Json(_) => {
+            AppError::BadRequest("configuration document is invalid".to_string())
+        }
+        ConfigStoreError::Watch(error) => {
+            AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
+        }
+    }
+}
+
+async fn install_exact_credential_section_mutation_base(
+    data_dir: PathBuf,
+    section: SectionId,
+    expected_revision: u64,
+    target: &mut Config,
+) -> Result<bamboo_config::CredentialSectionRuntimeMetadata, AppError> {
+    let exact = tokio::task::spawn_blocking(move || {
+        bamboo_config::read_exact_credential_section_snapshot(
+            data_dir,
+            section,
+            Some(expected_revision),
+        )
+    })
+    .await
+    .map_err(|error| {
+        AppError::InternalError(anyhow::anyhow!(
+            "{} exact mutation snapshot task failed: {error}",
+            section.descriptor().name
+        ))
+    })?
+    .map_err(map_exact_credential_store_error)?;
+    Ok(exact.install_into(target))
 }
 
 fn read_credential_runtime_metadata(
@@ -1550,11 +1624,70 @@ pub(crate) enum ConfigSectionMutationError {
 }
 
 pub(crate) enum CredentialBackedResetCommit {
-    Section,
+    Section(bamboo_config::SectionEnvelope<Value>),
     Cluster(Box<bamboo_server_tools::FabricCommitSnapshot>),
 }
 
 impl AppState {
+    #[cfg(test)]
+    pub(crate) fn stop_config_watcher_for_test(&mut self) {
+        self.config_watcher.stop.store(true, Ordering::Relaxed);
+        if let Some(task) = self.config_watcher.apply_task.take() {
+            task.abort();
+        }
+        if let Some(task) = self.config_watcher.watcher_task.take() {
+            let _ = task.join();
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn reload_ordinary_section_for_test(&self, id: SectionId) {
+        let _io = self.config_io_lock.lock().await;
+        let facade = self
+            .config_facade
+            .as_ref()
+            .expect("test ordinary reload requires the modular facade");
+        reload_and_apply_ordinary_sections(
+            &self.app_data_dir,
+            &self.config,
+            facade,
+            &self.account_sink,
+            std::iter::once(id),
+        )
+        .await;
+    }
+
+    /// Read one exact durable credential-backed section and its secret-free
+    /// credential status generation. The process facade may lag another
+    /// process, so GET handlers must not assemble these authorities
+    /// separately.
+    pub(crate) async fn read_exact_credential_section(
+        &self,
+        section: SectionId,
+    ) -> Result<ExactCredentialSectionSnapshot, AppError> {
+        let _io = self.config_io_lock.lock().await;
+        let data_dir = self.app_data_dir.clone();
+        let exact = tokio::task::spawn_blocking(move || {
+            bamboo_config::read_exact_credential_section_snapshot(data_dir, section, None)
+        })
+        .await
+        .map_err(|error| {
+            AppError::InternalError(anyhow::anyhow!(
+                "{} exact read snapshot task failed: {error}",
+                section.descriptor().name
+            ))
+        })?
+        .map_err(map_exact_credential_store_error)?;
+        let envelope = exact.section.clone();
+        let mut config = Config::default();
+        let metadata = exact.install_into(&mut config);
+        Ok(ExactCredentialSectionSnapshot {
+            config,
+            section: envelope,
+            metadata,
+        })
+    }
+
     /// Commit a single ordinary typed section with CAS, then publish exactly
     /// that section into the process-owned effective snapshot. Credential
     /// bindings are server-owned and cannot be forged or detached here.
@@ -1563,7 +1696,7 @@ impl AppState {
         id: SectionId,
         expected_revision: u64,
         candidate: Value,
-    ) -> Result<u64, ConfigSectionMutationError> {
+    ) -> Result<bamboo_config::SectionEnvelope<Value>, ConfigSectionMutationError> {
         if matches!(
             id,
             SectionId::Providers
@@ -1583,10 +1716,46 @@ impl AppState {
                 "typed section writes require the modular configuration facade".to_string(),
             )
         })?;
-        let current = facade
-            .registry()
-            .envelope_value(id)
+        let current = if id == SectionId::Core {
+            let data_dir = self.app_data_dir.clone();
+            let exact = tokio::task::spawn_blocking(move || {
+                bamboo_config::read_exact_credential_section_snapshot(
+                    data_dir,
+                    SectionId::Core,
+                    Some(expected_revision),
+                )
+            })
+            .await
+            .map_err(|error| {
+                ConfigSectionMutationError::Runtime(format!(
+                    "Core exact inventory snapshot task failed: {error}"
+                ))
+            })?
             .map_err(ConfigSectionMutationError::Store)?;
+            if let Some(reference) = exact
+                .section
+                .data
+                .get("proxy_auth_credential_ref")
+                .and_then(Value::as_str)
+            {
+                let configured = exact
+                    .credential_statuses
+                    .iter()
+                    .any(|status| status.credential_ref.as_str() == reference && status.configured);
+                if !configured {
+                    return Err(ConfigSectionMutationError::Invalid(
+                        "the active Core proxy credential is invalid; explicitly replace or clear it through the proxy-auth API"
+                            .to_string(),
+                    ));
+                }
+            }
+            exact.section
+        } else {
+            facade
+                .registry()
+                .envelope_value(id)
+                .map_err(ConfigSectionMutationError::Store)?
+        };
         if credential_reference_inventory(&current.data)
             != credential_reference_inventory(&candidate)
         {
@@ -1596,15 +1765,24 @@ impl AppState {
             ));
         }
 
-        let event = facade
-            .registry()
-            .commit_value(id, expected_revision, candidate)
-            .map_err(ConfigSectionMutationError::Store)?;
-        let revision = match &event {
-            ConfigSectionEvent::Changed { revision, .. }
-            | ConfigSectionEvent::Recovered { revision, .. }
-            | ConfigSectionEvent::Invalid { revision, .. } => *revision,
-        };
+        let (event, committed) = if id == SectionId::Core {
+            // Exact Core GETs may be ahead of this process's watcher. Keep the
+            // shared credential transaction lock from durable-base validation
+            // through the content-aware Core CAS and jump directly to the
+            // committed revision; never consume or publish the intermediate
+            // generation before its runtime has been installed.
+            bamboo_config::commit_core_metadata_from_durable_base(
+                &self.app_data_dir,
+                facade,
+                expected_revision,
+                candidate,
+            )
+        } else {
+            facade
+                .registry()
+                .commit_value_with_envelope(id, expected_revision, candidate)
+        }
+        .map_err(ConfigSectionMutationError::Store)?;
         let materialized = materialize_facade_effective_config(facade, &self.app_data_dir);
         if materialized.failures.contains(&id) {
             let message =
@@ -1629,7 +1807,7 @@ impl AppState {
             warn_plugin_trust_enforcement_off();
         }
         publish_registry_event(&self.account_sink, &event);
-        Ok(revision)
+        Ok(committed)
     }
 
     /// Validate and stage a provider runtime before the first durable CAS
@@ -2372,13 +2550,13 @@ impl AppState {
                 }
                 None => None,
             };
-            let section_events = match section_commit {
+            let (section_events, exact_section) = match section_commit {
                 Some(commit) => {
-                    install_credential_section_commit(commit, &mut candidate)
-                        .map_err(ConfigSectionMutationError::Store)?
-                        .events
+                    let installed = install_credential_section_commit(commit, &mut candidate)
+                        .map_err(ConfigSectionMutationError::Store)?;
+                    (installed.events, installed.section)
                 }
-                None => Vec::new(),
+                None => (Vec::new(), None),
             };
             if id == SectionId::Env {
                 candidate.publish_env_vars();
@@ -2451,11 +2629,20 @@ impl AppState {
                     },
                 ))
             } else {
-                facade
-                    .registry()
-                    .envelope_value(id)
-                    .map_err(ConfigSectionMutationError::Store)?;
-                CredentialBackedResetCommit::Section
+                let section = exact_section.ok_or_else(|| {
+                    ConfigSectionMutationError::Runtime(format!(
+                        "{} reset committed at revision {revision} without its exact envelope",
+                        id.descriptor().name
+                    ))
+                })?;
+                if section.revision != revision {
+                    return Err(ConfigSectionMutationError::Runtime(format!(
+                        "{} reset committed at revision {revision} but captured revision {}",
+                        id.descriptor().name,
+                        section.revision
+                    )));
+                }
+                CredentialBackedResetCommit::Section(section)
             };
 
             if id == SectionId::Core {
@@ -2981,7 +3168,7 @@ impl AppState {
         data_dir: PathBuf,
         config_facade: Option<Arc<bamboo_config::ConfigFacade>>,
         config: Config,
-    ) -> anyhow::Result<Option<bamboo_config::FacadeConfigCommit>> {
+    ) -> Result<Option<bamboo_config::FacadeConfigCommit>, AppError> {
         if let Some(facade) = config_facade {
             tokio::task::spawn_blocking(move || {
                 let result = bamboo_config::persist_facade_effective_config_with_adoption(
@@ -2996,9 +3183,11 @@ impl AppState {
                 result
             })
             .await
-            .map_err(|e| anyhow::anyhow!("Config save task failed: {e}"))?
+            .map_err(|error| {
+                AppError::InternalError(anyhow::anyhow!("Config save task failed: {error}"))
+            })?
             .map(Some)
-            .map_err(Into::into)
+            .map_err(map_exact_credential_store_error)
         } else {
             tokio::task::spawn_blocking(move || {
                 let result = config.save_to_dir(data_dir.clone());
@@ -3009,7 +3198,12 @@ impl AppState {
                 result
             })
             .await
-            .map_err(|e| anyhow::anyhow!("Config save task failed: {e}"))??;
+            .map_err(|error| {
+                AppError::InternalError(anyhow::anyhow!("Config save task failed: {error}"))
+            })?
+            .map_err(|error| {
+                AppError::InternalError(anyhow::anyhow!("Failed to save config: {error}"))
+            })?;
             Ok(None)
         }
     }
@@ -3047,10 +3241,14 @@ impl AppState {
             update(&mut candidate)?;
             // No caller of this compatibility entrypoint owns cluster CAS.
             restore_authoritative_cluster_fabric(self.config_facade.as_ref(), &mut candidate);
-            candidate.assign_connect_platform_ids();
-            candidate.refresh_encrypted_secrets().map_err(|e| {
-                AppError::InternalError(anyhow::anyhow!("Failed to refresh encrypted secrets: {e}"))
-            })?;
+            if self.config_facade.is_none() {
+                candidate.assign_connect_platform_ids();
+                candidate.refresh_encrypted_secrets().map_err(|e| {
+                    AppError::InternalError(anyhow::anyhow!(
+                        "Failed to refresh encrypted secrets: {e}"
+                    ))
+                })?;
+            }
             let newly_off = !was_off && candidate.plugin_trust.enforcement_is_off();
             (candidate, live_base, newly_off)
         };
@@ -3081,10 +3279,7 @@ impl AppState {
                     config_facade.clone(),
                     snapshot.clone(),
                 )
-                .await
-                .map_err(|e| {
-                    AppError::InternalError(anyhow::anyhow!("Failed to save config: {e}"))
-                })?;
+                .await?;
                 let events = match commit {
                     Some(commit) => {
                         let mut published = live_base;
@@ -3185,12 +3380,14 @@ impl AppState {
                     other.descriptor().name
                 )));
             }
-            candidate.assign_connect_platform_ids();
-            candidate.refresh_encrypted_secrets().map_err(|error| {
-                AppError::InternalError(anyhow::anyhow!(
-                    "Failed to refresh encrypted secrets: {error}"
-                ))
-            })?;
+            if config_facade.is_none() {
+                candidate.assign_connect_platform_ids();
+                candidate.refresh_encrypted_secrets().map_err(|error| {
+                    AppError::InternalError(anyhow::anyhow!(
+                        "Failed to refresh encrypted secrets: {error}"
+                    ))
+                })?;
+            }
             let newly_off = !was_off && candidate.plugin_trust.enforcement_is_off();
             (candidate, live_base, newly_off)
         };
@@ -3300,7 +3497,8 @@ impl AppState {
     pub async fn update_env_var_credentials<F>(
         &self,
         expected_revision: u64,
-        env_intents: std::collections::BTreeSet<String>,
+        mut env_intents: std::collections::BTreeSet<String>,
+        full_replace: bool,
         update: F,
     ) -> Result<
         (
@@ -3321,17 +3519,31 @@ impl AppState {
         let config_facade = self.config_facade.clone();
         let transaction = tokio::spawn(async move {
             let _io = config_io_lock.lock().await;
-            let mut candidate = {
+            let live_base = {
                 let current = config.read().await;
                 reject_if_recovery_pending(&current)?;
-                let mut candidate = current.clone();
-                update(&mut candidate)?;
-                candidate.assign_connect_platform_ids();
-                candidate
+                current.clone()
             };
+            let mut candidate = live_base.clone();
+            if config_facade.is_some() {
+                install_exact_credential_section_mutation_base(
+                    app_data_dir.clone(),
+                    SectionId::Env,
+                    expected_revision,
+                    &mut candidate,
+                )
+                .await?;
+            }
+            if full_replace {
+                env_intents.extend(candidate.env_vars.iter().map(|entry| entry.name.clone()));
+            }
+            update(&mut candidate)?;
+            if config_facade.is_none() {
+                candidate.assign_connect_platform_ids();
+            }
             let transaction_dir = app_data_dir.clone();
             let commit_facade = config_facade.clone();
-            let (mut candidate, revision, commit) = tokio::task::spawn_blocking(move || {
+            let (candidate, revision, commit) = tokio::task::spawn_blocking(move || {
                 if let Some(facade) = commit_facade {
                     let commit =
                         bamboo_config::persist_env_var_credential_transaction_at_revision_with_adoption(
@@ -3385,29 +3597,37 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            let installed = match commit {
+            let (published, installed) = match commit {
                 Some(commit) => {
-                    install_credential_section_commit(commit, &mut candidate).map_err(|error| {
-                        AppError::InternalError(anyhow::anyhow!(
-                            "env process adoption failed: {error}"
-                        ))
-                    })?
+                    let mut published = live_base;
+                    let installed = install_credential_section_commit(commit, &mut published)
+                        .map_err(|error| {
+                            AppError::InternalError(anyhow::anyhow!(
+                                "env process adoption failed: {error}"
+                            ))
+                        })?;
+                    (published, installed)
                 }
-                None => InstalledCredentialSectionCommit {
-                    events: Vec::new(),
-                    metadata: read_credential_runtime_metadata(&app_data_dir).map_err(|error| {
-                        AppError::InternalError(anyhow::anyhow!(
-                            "env credential status unavailable after commit: {error}"
-                        ))
-                    })?,
-                    section: None,
-                },
+                None => (
+                    candidate,
+                    InstalledCredentialSectionCommit {
+                        events: Vec::new(),
+                        metadata: read_credential_runtime_metadata(&app_data_dir).map_err(
+                            |error| {
+                                AppError::InternalError(anyhow::anyhow!(
+                                    "env credential status unavailable after commit: {error}"
+                                ))
+                            },
+                        )?,
+                        section: None,
+                    },
+                ),
             };
-            candidate.publish_env_vars();
-            *config.write().await = candidate.clone();
+            published.publish_env_vars();
+            *config.write().await = published.clone();
             publish_exact_facade_events(&account_sink, &installed.events)?;
             let section = installed.section;
-            Ok::<_, AppError>((candidate, revision, installed.metadata, section))
+            Ok::<_, AppError>((published, revision, installed.metadata, section))
         });
         transaction.await.map_err(|error| {
             AppError::InternalError(anyhow::anyhow!(
@@ -3445,16 +3665,25 @@ impl AppState {
         let config_facade = self.config_facade.clone();
         let transaction = tokio::spawn(async move {
             let _io = config_io_lock.lock().await;
-            let mut candidate = {
+            let live_base = {
                 let current = config.read().await;
                 reject_if_recovery_pending(&current)?;
-                let mut candidate = current.clone();
-                update(&mut candidate)?;
-                candidate
+                current.clone()
             };
+            let mut candidate = live_base.clone();
+            if config_facade.is_some() {
+                install_exact_credential_section_mutation_base(
+                    app_data_dir.clone(),
+                    SectionId::Notifications,
+                    expected_revision,
+                    &mut candidate,
+                )
+                .await?;
+            }
+            update(&mut candidate)?;
             let transaction_dir = app_data_dir.clone();
             let commit_facade = config_facade.clone();
-            let (mut candidate, revision, commit) = tokio::task::spawn_blocking(move || {
+            let (candidate, revision, commit) = tokio::task::spawn_blocking(move || {
                 if let Some(facade) = commit_facade {
                     let commit =
                         bamboo_config::persist_notification_credential_transaction_at_revision_with_reset_and_adoption(
@@ -3507,28 +3736,36 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            let installed = match commit {
+            let (published, installed) = match commit {
                 Some(commit) => {
-                    install_credential_section_commit(commit, &mut candidate).map_err(|error| {
-                        AppError::InternalError(anyhow::anyhow!(
-                            "notification process adoption failed: {error}"
-                        ))
-                    })?
+                    let mut published = live_base;
+                    let installed = install_credential_section_commit(commit, &mut published)
+                        .map_err(|error| {
+                            AppError::InternalError(anyhow::anyhow!(
+                                "notification process adoption failed: {error}"
+                            ))
+                        })?;
+                    (published, installed)
                 }
-                None => InstalledCredentialSectionCommit {
-                    events: Vec::new(),
-                    metadata: read_credential_runtime_metadata(&app_data_dir).map_err(|error| {
-                        AppError::InternalError(anyhow::anyhow!(
-                            "notification credential status unavailable after commit: {error}"
-                        ))
-                    })?,
-                    section: None,
-                },
+                None => (
+                    candidate,
+                    InstalledCredentialSectionCommit {
+                        events: Vec::new(),
+                        metadata: read_credential_runtime_metadata(&app_data_dir).map_err(
+                            |error| {
+                                AppError::InternalError(anyhow::anyhow!(
+                                    "notification credential status unavailable after commit: {error}"
+                                ))
+                            },
+                        )?,
+                        section: None,
+                    },
+                ),
             };
-            *config.write().await = candidate.clone();
+            *config.write().await = published.clone();
             publish_exact_facade_events(&account_sink, &installed.events)?;
             let section = installed.section;
-            Ok::<_, AppError>((candidate, revision, installed.metadata, section))
+            Ok::<_, AppError>((published, revision, installed.metadata, section))
         });
         transaction.await.map_err(|error| {
             AppError::InternalError(anyhow::anyhow!(
@@ -3565,17 +3802,26 @@ impl AppState {
         let config_facade = self.config_facade.clone();
         let transaction = tokio::spawn(async move {
             let _io = config_io_lock.lock().await;
-            let mut candidate = {
+            let live_base = {
                 let current = config.read().await;
                 reject_if_recovery_pending(&current)?;
-                let mut candidate = current.clone();
-                update(&mut candidate)?;
-                candidate.assign_connect_platform_ids();
-                candidate
+                current.clone()
             };
+            let mut candidate = live_base.clone();
+            if config_facade.is_some() {
+                install_exact_credential_section_mutation_base(
+                    app_data_dir.clone(),
+                    SectionId::Connect,
+                    expected_revision,
+                    &mut candidate,
+                )
+                .await?;
+            }
+            update(&mut candidate)?;
+            candidate.assign_connect_platform_ids();
             let transaction_dir = app_data_dir.clone();
             let commit_facade = config_facade.clone();
-            let (mut candidate, revision, commit) = tokio::task::spawn_blocking(move || {
+            let (candidate, revision, commit) = tokio::task::spawn_blocking(move || {
                 if let Some(facade) = commit_facade {
                     let commit =
                         bamboo_config::persist_connect_credential_transaction_at_revision_with_adoption(
@@ -3624,28 +3870,36 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            let installed = match commit {
+            let (published, installed) = match commit {
                 Some(commit) => {
-                    install_credential_section_commit(commit, &mut candidate).map_err(|error| {
-                        AppError::InternalError(anyhow::anyhow!(
-                            "connect process adoption failed: {error}"
-                        ))
-                    })?
+                    let mut published = live_base;
+                    let installed = install_credential_section_commit(commit, &mut published)
+                        .map_err(|error| {
+                            AppError::InternalError(anyhow::anyhow!(
+                                "connect process adoption failed: {error}"
+                            ))
+                        })?;
+                    (published, installed)
                 }
-                None => InstalledCredentialSectionCommit {
-                    events: Vec::new(),
-                    metadata: read_credential_runtime_metadata(&app_data_dir).map_err(|error| {
-                        AppError::InternalError(anyhow::anyhow!(
-                            "connect credential status unavailable after commit: {error}"
-                        ))
-                    })?,
-                    section: None,
-                },
+                None => (
+                    candidate,
+                    InstalledCredentialSectionCommit {
+                        events: Vec::new(),
+                        metadata: read_credential_runtime_metadata(&app_data_dir).map_err(
+                            |error| {
+                                AppError::InternalError(anyhow::anyhow!(
+                                    "connect credential status unavailable after commit: {error}"
+                                ))
+                            },
+                        )?,
+                        section: None,
+                    },
+                ),
             };
-            *config.write().await = candidate.clone();
+            *config.write().await = published.clone();
             publish_exact_facade_events(&account_sink, &installed.events)?;
             let section = installed.section;
-            Ok::<_, AppError>((candidate, revision, installed.metadata, section))
+            Ok::<_, AppError>((published, revision, installed.metadata, section))
         });
         transaction.await.map_err(|error| {
             AppError::InternalError(anyhow::anyhow!(
@@ -3681,16 +3935,25 @@ impl AppState {
         let config_facade = self.config_facade.clone();
         let transaction = tokio::spawn(async move {
             let _io = config_io_lock.lock().await;
-            let mut candidate = {
+            let live_base = {
                 let current = config.read().await;
                 reject_if_recovery_pending(&current)?;
-                let mut candidate = current.clone();
-                update(&mut candidate)?;
-                candidate
+                current.clone()
             };
+            let mut candidate = live_base.clone();
+            if config_facade.is_some() {
+                install_exact_credential_section_mutation_base(
+                    app_data_dir.clone(),
+                    SectionId::AccessControl,
+                    expected_revision,
+                    &mut candidate,
+                )
+                .await?;
+            }
+            update(&mut candidate)?;
             let transaction_dir = app_data_dir.clone();
             let commit_facade = config_facade.clone();
-            let (mut candidate, revision, commit) = tokio::task::spawn_blocking(move || {
+            let (candidate, revision, commit) = tokio::task::spawn_blocking(move || {
                 if let Some(facade) = commit_facade {
                     let commit =
                         bamboo_config::persist_access_control_credential_transaction_at_revision_with_adoption(
@@ -3741,28 +4004,36 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            let installed = match commit {
+            let (published, installed) = match commit {
                 Some(commit) => {
-                    install_credential_section_commit(commit, &mut candidate).map_err(|error| {
-                        AppError::InternalError(anyhow::anyhow!(
-                            "access-control process adoption failed: {error}"
-                        ))
-                    })?
+                    let mut published = live_base;
+                    let installed = install_credential_section_commit(commit, &mut published)
+                        .map_err(|error| {
+                            AppError::InternalError(anyhow::anyhow!(
+                                "access-control process adoption failed: {error}"
+                            ))
+                        })?;
+                    (published, installed)
                 }
-                None => InstalledCredentialSectionCommit {
-                    events: Vec::new(),
-                    metadata: read_credential_runtime_metadata(&app_data_dir).map_err(|error| {
-                        AppError::InternalError(anyhow::anyhow!(
-                            "access-control credential status unavailable after commit: {error}"
-                        ))
-                    })?,
-                    section: None,
-                },
+                None => (
+                    candidate,
+                    InstalledCredentialSectionCommit {
+                        events: Vec::new(),
+                        metadata: read_credential_runtime_metadata(&app_data_dir).map_err(
+                            |error| {
+                                AppError::InternalError(anyhow::anyhow!(
+                                    "access-control credential status unavailable after commit: {error}"
+                                ))
+                            },
+                        )?,
+                        section: None,
+                    },
+                ),
             };
-            *config.write().await = candidate.clone();
+            *config.write().await = published.clone();
             publish_exact_facade_events(&account_sink, &installed.events)?;
             let section = installed.section;
-            Ok::<_, AppError>((candidate, revision, installed.metadata, section))
+            Ok::<_, AppError>((published, revision, installed.metadata, section))
         });
         transaction.await.map_err(|error| {
             AppError::InternalError(anyhow::anyhow!(
@@ -4104,19 +4375,30 @@ impl AppState {
         // operation even when the caller disconnects.
         let transaction = tokio::spawn(async move {
             let _io = config_io_lock.lock().await;
-            let mut candidate = {
+            let live_base = {
                 let cfg = config.read().await;
                 reject_if_recovery_pending(&cfg)?;
-                let mut candidate = cfg.clone();
-                update(&mut candidate);
+                cfg.clone()
+            };
+            let mut candidate = live_base.clone();
+            if config_facade.is_some() {
+                install_exact_credential_section_mutation_base(
+                    app_data_dir.clone(),
+                    SectionId::Core,
+                    expected_revision,
+                    &mut candidate,
+                )
+                .await?;
+            }
+            update(&mut candidate);
+            if config_facade.is_none() {
                 candidate.assign_connect_platform_ids();
                 candidate.refresh_encrypted_secrets().map_err(|error| {
                     AppError::InternalError(anyhow::anyhow!(
                         "Failed to refresh encrypted secrets: {error}"
                     ))
                 })?;
-                candidate
-            };
+            }
             let transaction_dir = app_data_dir.clone();
             let status_reference =
                 candidate
@@ -4127,7 +4409,7 @@ impl AppState {
                             .expect("canonical proxy credential reference is valid")
                     });
             let commit_facade = config_facade.clone();
-            let (mut candidate, revision, reference, commit) =
+            let (candidate, revision, reference, commit) =
                 tokio::task::spawn_blocking(move || {
                 if let Some(facade) = commit_facade {
                     let commit =
@@ -4181,15 +4463,18 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            let installed = match commit {
-                Some(commit) => Some(
-                    install_credential_section_commit(commit, &mut candidate).map_err(|error| {
-                        AppError::InternalError(anyhow::anyhow!(
-                            "proxy process adoption failed: {error}"
-                        ))
-                    })?,
-                ),
-                None => None,
+            let (published, installed) = match commit {
+                Some(commit) => {
+                    let mut published = live_base;
+                    let installed = install_credential_section_commit(commit, &mut published)
+                        .map_err(|error| {
+                            AppError::InternalError(anyhow::anyhow!(
+                                "proxy process adoption failed: {error}"
+                            ))
+                        })?;
+                    (published, Some(installed))
+                }
+                None => (candidate, None),
             };
             let section = installed
                 .as_ref()
@@ -4198,15 +4483,15 @@ impl AppState {
             // No fallible metadata read occurs before publication. Once the
             // transaction commits, a response error can no longer leave live
             // config behind its durable credential/config pair.
-            candidate.publish_env_vars();
-            *config.write().await = candidate.clone();
+            published.publish_env_vars();
+            *config.write().await = published.clone();
 
             if let Some(installed) = installed.as_ref() {
                 publish_exact_facade_events(&account_sink, &installed.events)?;
             }
 
             if effects.reload_provider {
-                match bamboo_llm::ProviderRegistry::from_config(&candidate, app_data_dir.clone())
+                match bamboo_llm::ProviderRegistry::from_config(&published, app_data_dir.clone())
                     .await
                 {
                     Ok(candidate_registry) => {
@@ -4230,7 +4515,7 @@ impl AppState {
             }
 
             if effects.reconcile_mcp {
-                mcp_manager.reconcile_from_config(&candidate.mcp).await;
+                mcp_manager.reconcile_from_config(&published.mcp).await;
             }
 
             let (status, health) = if let Some(installed) = installed {
@@ -4256,7 +4541,7 @@ impl AppState {
                         )),
                     })?
             };
-            Ok::<_, AppError>((candidate, revision, status, health, section))
+            Ok::<_, AppError>((published, revision, status, health, section))
         });
         transaction.await.map_err(|error| {
             AppError::InternalError(anyhow::anyhow!(
@@ -4276,12 +4561,15 @@ impl AppState {
         // disk-persisted snapshot, and the value this call returns to the
         // caller (the settings-merge HTTP response) all agree on the same
         // ids — mirrors the `update_config` treatment above.
-        new_config.assign_connect_platform_ids();
-        // Keep ciphertext in sync with plaintext on the config that becomes
-        // the live in-memory state — same #516 rationale as `update_config`.
-        new_config.refresh_encrypted_secrets().map_err(|e| {
-            AppError::InternalError(anyhow::anyhow!("Failed to refresh encrypted secrets: {e}"))
-        })?;
+        if self.config_facade.is_none() {
+            new_config.assign_connect_platform_ids();
+            // Keep ciphertext in sync with plaintext on legacy layouts. In a
+            // modular layout the one owned section transaction is responsible
+            // for its credentials and unrelated runtime fields must not move.
+            new_config.refresh_encrypted_secrets().map_err(|e| {
+                AppError::InternalError(anyhow::anyhow!("Failed to refresh encrypted secrets: {e}"))
+            })?;
+        }
 
         let io = self.config_io_lock.clone().lock_owned().await;
         restore_authoritative_cluster_fabric(self.config_facade.as_ref(), &mut new_config);
@@ -4311,10 +4599,7 @@ impl AppState {
                     config_facade.clone(),
                     new_config.clone(),
                 )
-                .await
-                .map_err(|e| {
-                    AppError::InternalError(anyhow::anyhow!("Failed to save config: {e}"))
-                })?;
+                .await?;
                 let mut published = if commit.is_some() {
                     live_base
                 } else {
@@ -5150,6 +5435,128 @@ mod live_reload_tests {
     }
 
     #[tokio::test]
+    async fn exact_notification_publication_installs_only_its_owned_runtime_section() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        {
+            let mut live = state.config.write().await;
+            live.connect
+                .platforms
+                .push(bamboo_config::ConnectPlatformConfig {
+                    id: None,
+                    project_id: None,
+                    platform_type: "runtime-sentinel".to_string(),
+                    token: None,
+                    token_encrypted: None,
+                    token_credential_ref: None,
+                    token_configured: false,
+                    app_id: None,
+                    app_secret: None,
+                    app_secret_encrypted: None,
+                    app_secret_credential_ref: None,
+                    app_secret_configured: false,
+                    domain: None,
+                    allow_from: Vec::new(),
+                    admin_from: Vec::new(),
+                });
+            live.providers_mut().openai = Some(bamboo_config::OpenAIConfig {
+                api_key: "runtime-provider-sentinel".to_string(),
+                ..Default::default()
+            });
+        }
+        let connect_before = std::fs::read(dir.path().join("connect.json")).unwrap();
+        let (published, revision, _, section) = state
+            .update_notification_credentials(0, BTreeSet::new(), false, |candidate| {
+                candidate.notifications.ntfy.enabled = true;
+                candidate.notifications.ntfy.topic = "owned-notification".to_string();
+                // Deliberately perturb unrelated runtime-only state. Modular
+                // publication must discard both changes after committing only
+                // the Notifications section.
+                candidate.assign_connect_platform_ids();
+                candidate
+                    .providers_mut()
+                    .openai
+                    .as_mut()
+                    .unwrap()
+                    .api_key
+                    .clear();
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(revision, 1);
+        assert_eq!(section.unwrap().revision, 1);
+        assert_eq!(published.notifications.ntfy.topic, "owned-notification");
+        assert!(published.connect.platforms[0].id.is_none());
+        assert_eq!(
+            published.providers().openai.as_ref().unwrap().api_key,
+            "runtime-provider-sentinel"
+        );
+        let live = state.config.read().await;
+        assert!(live.connect.platforms[0].id.is_none());
+        assert_eq!(
+            live.providers().openai.as_ref().unwrap().api_key,
+            "runtime-provider-sentinel"
+        );
+        drop(live);
+        assert_eq!(
+            std::fs::read(dir.path().join("connect.json")).unwrap(),
+            connect_before
+        );
+        assert_eq!(
+            bamboo_config::ConfigFacade::open(dir.path())
+                .unwrap()
+                .registry()
+                .connect
+                .snapshot()
+                .revision,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn generic_update_cannot_forge_exact_core_credential_binding() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        let core_before = std::fs::read(dir.path().join("core.json")).unwrap();
+        let error = state
+            .update_config(
+                |candidate| {
+                    candidate.proxy_auth_credential_ref =
+                        Some(bamboo_config::CredentialRef::parse("proxy.default.auth").unwrap());
+                    Ok(())
+                },
+                ConfigUpdateEffects::default(),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, AppError::BadRequest(_)));
+        assert!(error.to_string().contains("credential bindings"));
+        assert_eq!(
+            std::fs::read(dir.path().join("core.json")).unwrap(),
+            core_before
+        );
+        assert!(state
+            .config
+            .read()
+            .await
+            .proxy_auth_credential_ref
+            .is_none());
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .core
+                .snapshot()
+                .revision,
+            0
+        );
+    }
+
+    #[tokio::test]
     async fn env_credential_commit_installs_owned_runtime_before_exact_events() {
         let _key = bamboo_config::encryption::set_test_encryption_key([0x73; 32]);
         let dir = tempfile::tempdir().unwrap();
@@ -5221,6 +5628,7 @@ mod live_reload_tests {
                     .update_env_var_credentials(
                         expected_revision,
                         BTreeSet::from(["TOKEN".to_string()]),
+                        false,
                         |config| {
                             config.env_vars.push(bamboo_config::EnvVarEntry {
                                 name: "TOKEN".to_string(),
@@ -5360,6 +5768,7 @@ mod live_reload_tests {
                     .update_env_var_credentials(
                         0,
                         BTreeSet::from(["TOKEN".to_string()]),
+                        false,
                         |config| {
                             config.env_vars.push(bamboo_config::EnvVarEntry {
                                 name: "TOKEN".to_string(),

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -831,6 +831,18 @@ fn publish_exact_facade_events(
 struct InstalledCredentialSectionCommit {
     events: Vec<ConfigSectionEvent>,
     metadata: bamboo_config::CredentialSectionRuntimeMetadata,
+    section: Option<bamboo_config::SectionEnvelope<Value>>,
+}
+
+fn read_credential_runtime_metadata(
+    data_dir: &std::path::Path,
+) -> Result<bamboo_config::CredentialSectionRuntimeMetadata, ConfigStoreError> {
+    let (credential_statuses, credential_health) =
+        bamboo_config::CredentialStore::open(data_dir).statuses_with_health()?;
+    Ok(bamboo_config::CredentialSectionRuntimeMetadata {
+        credential_statuses,
+        credential_health,
+    })
 }
 
 fn install_credential_section_commit(
@@ -841,8 +853,10 @@ fn install_credential_section_commit(
         revision: _,
         section_adoption,
         credential_adoption,
+        section,
         runtime,
     } = commit;
+    let section = section?;
     let metadata = runtime?.install_into(target);
     let mut events = Vec::new();
     if let Some(adoption) = credential_adoption {
@@ -853,7 +867,11 @@ fn install_credential_section_commit(
     if let Some(adoption) = section_adoption {
         events.push(adoption?);
     }
-    Ok(InstalledCredentialSectionCommit { events, metadata })
+    Ok(InstalledCredentialSectionCommit {
+        events,
+        metadata,
+        section: Some(section),
+    })
 }
 
 fn install_facade_config_commit(
@@ -3276,15 +3294,23 @@ impl AppState {
         })?
     }
 
-    /// Mutate user env vars through the recoverable credentials.json +
-    /// config.json exact transaction. The detached task owns the mutation so
-    /// request cancellation cannot strand durable metadata ahead of runtime.
+    /// Mutate user env vars through the recoverable Env-section + credential
+    /// exact transaction. The detached task owns the mutation so request
+    /// cancellation cannot strand durable metadata ahead of runtime.
     pub async fn update_env_var_credentials<F>(
         &self,
         expected_revision: u64,
         env_intents: std::collections::BTreeSet<String>,
         update: F,
-    ) -> Result<(Config, u64), AppError>
+    ) -> Result<
+        (
+            Config,
+            u64,
+            bamboo_config::CredentialSectionRuntimeMetadata,
+            Option<bamboo_config::SectionEnvelope<Value>>,
+        ),
+        AppError,
+    >
     where
         F: FnOnce(&mut Config) -> Result<(), AppError> + Send + 'static,
     {
@@ -3359,22 +3385,29 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            let events = match commit {
+            let installed = match commit {
                 Some(commit) => {
-                    install_credential_section_commit(commit, &mut candidate)
-                        .map_err(|error| {
-                            AppError::InternalError(anyhow::anyhow!(
-                                "env process adoption failed: {error}"
-                            ))
-                        })?
-                        .events
+                    install_credential_section_commit(commit, &mut candidate).map_err(|error| {
+                        AppError::InternalError(anyhow::anyhow!(
+                            "env process adoption failed: {error}"
+                        ))
+                    })?
                 }
-                None => Vec::new(),
+                None => InstalledCredentialSectionCommit {
+                    events: Vec::new(),
+                    metadata: read_credential_runtime_metadata(&app_data_dir).map_err(|error| {
+                        AppError::InternalError(anyhow::anyhow!(
+                            "env credential status unavailable after commit: {error}"
+                        ))
+                    })?,
+                    section: None,
+                },
             };
             candidate.publish_env_vars();
             *config.write().await = candidate.clone();
-            publish_exact_facade_events(&account_sink, &events)?;
-            Ok::<_, AppError>((candidate, revision))
+            publish_exact_facade_events(&account_sink, &installed.events)?;
+            let section = installed.section;
+            Ok::<_, AppError>((candidate, revision, installed.metadata, section))
         });
         transaction.await.map_err(|error| {
             AppError::InternalError(anyhow::anyhow!(
@@ -3384,7 +3417,7 @@ impl AppState {
     }
 
     /// Mutate notification metadata and ntfy/Bark credentials through the
-    /// recoverable credentials.json + config.json exact transaction. The
+    /// recoverable Notifications-section + credential exact transaction. The
     /// detached task completes durable commit and live publication even if the
     /// initiating HTTP request is cancelled.
     pub async fn update_notification_credentials<F>(
@@ -3393,7 +3426,15 @@ impl AppState {
         secret_intents: std::collections::BTreeSet<String>,
         reset_domain: bool,
         update: F,
-    ) -> Result<(Config, u64), AppError>
+    ) -> Result<
+        (
+            Config,
+            u64,
+            bamboo_config::CredentialSectionRuntimeMetadata,
+            Option<bamboo_config::SectionEnvelope<Value>>,
+        ),
+        AppError,
+    >
     where
         F: FnOnce(&mut Config) -> Result<(), AppError> + Send + 'static,
     {
@@ -3466,21 +3507,28 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            let events = match commit {
+            let installed = match commit {
                 Some(commit) => {
-                    install_credential_section_commit(commit, &mut candidate)
-                        .map_err(|error| {
-                            AppError::InternalError(anyhow::anyhow!(
-                                "notification process adoption failed: {error}"
-                            ))
-                        })?
-                        .events
+                    install_credential_section_commit(commit, &mut candidate).map_err(|error| {
+                        AppError::InternalError(anyhow::anyhow!(
+                            "notification process adoption failed: {error}"
+                        ))
+                    })?
                 }
-                None => Vec::new(),
+                None => InstalledCredentialSectionCommit {
+                    events: Vec::new(),
+                    metadata: read_credential_runtime_metadata(&app_data_dir).map_err(|error| {
+                        AppError::InternalError(anyhow::anyhow!(
+                            "notification credential status unavailable after commit: {error}"
+                        ))
+                    })?,
+                    section: None,
+                },
             };
             *config.write().await = candidate.clone();
-            publish_exact_facade_events(&account_sink, &events)?;
-            Ok::<_, AppError>((candidate, revision))
+            publish_exact_facade_events(&account_sink, &installed.events)?;
+            let section = installed.section;
+            Ok::<_, AppError>((candidate, revision, installed.metadata, section))
         });
         transaction.await.map_err(|error| {
             AppError::InternalError(anyhow::anyhow!(
@@ -3498,7 +3546,15 @@ impl AppState {
         expected_revision: u64,
         secret_intents: bamboo_config::patch::ConnectSecretIntents,
         update: F,
-    ) -> Result<(Config, u64), AppError>
+    ) -> Result<
+        (
+            Config,
+            u64,
+            bamboo_config::CredentialSectionRuntimeMetadata,
+            Option<bamboo_config::SectionEnvelope<Value>>,
+        ),
+        AppError,
+    >
     where
         F: FnOnce(&mut Config) -> Result<(), AppError> + Send + 'static,
     {
@@ -3568,21 +3624,28 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            let events = match commit {
+            let installed = match commit {
                 Some(commit) => {
-                    install_credential_section_commit(commit, &mut candidate)
-                        .map_err(|error| {
-                            AppError::InternalError(anyhow::anyhow!(
-                                "connect process adoption failed: {error}"
-                            ))
-                        })?
-                        .events
+                    install_credential_section_commit(commit, &mut candidate).map_err(|error| {
+                        AppError::InternalError(anyhow::anyhow!(
+                            "connect process adoption failed: {error}"
+                        ))
+                    })?
                 }
-                None => Vec::new(),
+                None => InstalledCredentialSectionCommit {
+                    events: Vec::new(),
+                    metadata: read_credential_runtime_metadata(&app_data_dir).map_err(|error| {
+                        AppError::InternalError(anyhow::anyhow!(
+                            "connect credential status unavailable after commit: {error}"
+                        ))
+                    })?,
+                    section: None,
+                },
             };
             *config.write().await = candidate.clone();
-            publish_exact_facade_events(&account_sink, &events)?;
-            Ok::<_, AppError>((candidate, revision))
+            publish_exact_facade_events(&account_sink, &installed.events)?;
+            let section = installed.section;
+            Ok::<_, AppError>((candidate, revision, installed.metadata, section))
         });
         transaction.await.map_err(|error| {
             AppError::InternalError(anyhow::anyhow!(
@@ -3599,7 +3662,15 @@ impl AppState {
         password_intent: bool,
         device_intents: std::collections::BTreeSet<String>,
         update: F,
-    ) -> Result<(Config, u64), AppError>
+    ) -> Result<
+        (
+            Config,
+            u64,
+            bamboo_config::CredentialSectionRuntimeMetadata,
+            Option<bamboo_config::SectionEnvelope<Value>>,
+        ),
+        AppError,
+    >
     where
         F: FnOnce(&mut Config) -> Result<(), AppError> + Send + 'static,
     {
@@ -3670,21 +3741,28 @@ impl AppState {
                     AppError::InternalError(anyhow::anyhow!("configuration watch failed: {error}"))
                 }
             })?;
-            let events = match commit {
+            let installed = match commit {
                 Some(commit) => {
-                    install_credential_section_commit(commit, &mut candidate)
-                        .map_err(|error| {
-                            AppError::InternalError(anyhow::anyhow!(
-                                "access-control process adoption failed: {error}"
-                            ))
-                        })?
-                        .events
+                    install_credential_section_commit(commit, &mut candidate).map_err(|error| {
+                        AppError::InternalError(anyhow::anyhow!(
+                            "access-control process adoption failed: {error}"
+                        ))
+                    })?
                 }
-                None => Vec::new(),
+                None => InstalledCredentialSectionCommit {
+                    events: Vec::new(),
+                    metadata: read_credential_runtime_metadata(&app_data_dir).map_err(|error| {
+                        AppError::InternalError(anyhow::anyhow!(
+                            "access-control credential status unavailable after commit: {error}"
+                        ))
+                    })?,
+                    section: None,
+                },
             };
             *config.write().await = candidate.clone();
-            publish_exact_facade_events(&account_sink, &events)?;
-            Ok::<_, AppError>((candidate, revision))
+            publish_exact_facade_events(&account_sink, &installed.events)?;
+            let section = installed.section;
+            Ok::<_, AppError>((candidate, revision, installed.metadata, section))
         });
         transaction.await.map_err(|error| {
             AppError::InternalError(anyhow::anyhow!(
@@ -3694,7 +3772,7 @@ impl AppState {
     }
 
     /// Mutate cluster-fabric node metadata and SSH credentials through the
-    /// recoverable credentials.json + config.json exact transaction. The
+    /// recoverable Cluster-section + credential exact transaction. The
     /// detached task owns durable commit, committed-root reload, and live
     /// publication so request cancellation cannot leave runtime behind disk.
     pub async fn update_cluster_fabric_credentials<F>(
@@ -3979,8 +4057,10 @@ impl AppState {
     ) -> Result<
         (
             Config,
+            u64,
             bamboo_config::CredentialStatus,
             bamboo_config::CredentialStoreHealth,
+            Option<bamboo_config::SectionEnvelope<Value>>,
         ),
         AppError,
     > {
@@ -3998,8 +4078,10 @@ impl AppState {
     ) -> Result<
         (
             Config,
+            u64,
             bamboo_config::CredentialStatus,
             bamboo_config::CredentialStoreHealth,
+            Option<bamboo_config::SectionEnvelope<Value>>,
         ),
         AppError,
     >
@@ -4045,7 +4127,8 @@ impl AppState {
                             .expect("canonical proxy credential reference is valid")
                     });
             let commit_facade = config_facade.clone();
-            let (mut candidate, reference, commit) = tokio::task::spawn_blocking(move || {
+            let (mut candidate, revision, reference, commit) =
+                tokio::task::spawn_blocking(move || {
                 if let Some(facade) = commit_facade {
                     let commit =
                         bamboo_config::persist_proxy_auth_credential_transaction_at_revision_with_adoption(
@@ -4054,15 +4137,23 @@ impl AppState {
                             expected_revision,
                             facade.as_ref(),
                         )?;
-                    Ok::<_, ConfigStoreError>((candidate, status_reference, Some(commit)))
+                    let revision = commit.revision;
+                    Ok::<_, ConfigStoreError>((
+                        candidate,
+                        revision,
+                        status_reference,
+                        Some(commit),
+                    ))
                 } else {
-                    bamboo_config::persist_proxy_auth_credential_transaction_at_revision(
+                    let revision =
+                        bamboo_config::persist_proxy_auth_credential_transaction_at_revision(
                         &transaction_dir,
                         &mut candidate,
                         expected_revision,
                     )?;
                     Ok((
                         load_committed_effective_config(&transaction_dir)?,
+                        revision,
                         status_reference,
                         None,
                     ))
@@ -4100,6 +4191,9 @@ impl AppState {
                 ),
                 None => None,
             };
+            let section = installed
+                .as_ref()
+                .and_then(|installed| installed.section.clone());
 
             // No fallible metadata read occurs before publication. Once the
             // transaction commits, a response error can no longer leave live
@@ -4162,7 +4256,7 @@ impl AppState {
                         )),
                     })?
             };
-            Ok::<_, AppError>((candidate, status, health))
+            Ok::<_, AppError>((candidate, revision, status, health, section))
         });
         transaction.await.map_err(|error| {
             AppError::InternalError(anyhow::anyhow!(
@@ -5101,7 +5195,14 @@ mod live_reload_tests {
         .unwrap();
         let cluster_path = dir.path().join("cluster-fabric.json");
         let cluster_r2 = std::fs::read(&cluster_path).unwrap();
-        let expected_revision = state.credential_store.revision().unwrap();
+        let expected_revision = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .env
+            .snapshot()
+            .revision;
 
         let (reached_tx, reached_rx) = std::sync::mpsc::channel();
         let (release_tx, release_rx) = std::sync::mpsc::channel();
@@ -5170,7 +5271,7 @@ mod live_reload_tests {
         );
         drop(stale_runtime);
 
-        let (published, revision) = updating.await.unwrap().unwrap();
+        let (published, revision, _, _) = updating.await.unwrap().unwrap();
         assert!(revision > expected_revision);
         assert!(published
             .env_vars
@@ -5236,6 +5337,87 @@ mod live_reload_tests {
             &event.event,
             AgentEvent::ConfigChanged { section, .. } if section == "cluster-fabric"
         )));
+    }
+
+    #[tokio::test]
+    async fn env_mutation_returns_its_captured_envelope_after_a_later_section_commit() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x74; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stop_config_watcher(&mut state);
+        let state = Arc::new(state);
+
+        let (reached_tx, reached_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        set_credential_after_commit_before_live_test_hook(dir.path(), SectionId::Env, move || {
+            reached_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+        let updating = {
+            let state = state.clone();
+            tokio::spawn(async move {
+                state
+                    .update_env_var_credentials(
+                        0,
+                        BTreeSet::from(["TOKEN".to_string()]),
+                        |config| {
+                            config.env_vars.push(bamboo_config::EnvVarEntry {
+                                name: "TOKEN".to_string(),
+                                value: "first-secret".to_string(),
+                                secret: true,
+                                value_encrypted: None,
+                                credential_ref: None,
+                                configured: true,
+                                description: Some("first generation".to_string()),
+                            });
+                            Ok(())
+                        },
+                    )
+                    .await
+            })
+        };
+        tokio::task::spawn_blocking(move || reached_rx.recv().unwrap())
+            .await
+            .unwrap();
+
+        let external_dir = dir.path().to_path_buf();
+        let process_facade = state.config_facade.clone().unwrap();
+        let later = tokio::task::spawn_blocking(move || {
+            let external = bamboo_config::ConfigFacade::open(&external_dir).unwrap();
+            let mut candidate = external.effective_config();
+            candidate.env_vars[0].description = Some("later generation".to_string());
+            bamboo_config::persist_env_var_credential_transaction_at_revision_with_adoption(
+                &external_dir,
+                &mut candidate,
+                &BTreeSet::from(["TOKEN".to_string()]),
+                1,
+                process_facade.as_ref(),
+            )
+            .unwrap()
+        })
+        .await
+        .unwrap();
+        assert_eq!(later.revision, 2);
+        assert_eq!(later.section.unwrap().revision, 2);
+        release_tx.send(()).unwrap();
+
+        let (_, revision, _, section) = updating.await.unwrap().unwrap();
+        let section = section.expect("modular mutation returns its exact section");
+        assert_eq!(revision, 1);
+        assert_eq!(section.revision, 1);
+        assert_eq!(section.data[0]["description"], "first generation");
+        assert_eq!(
+            state
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .env
+                .snapshot()
+                .revision,
+            2,
+            "the process facade advanced, but the response retained its own commit"
+        );
     }
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/config_manager.rs
+++ b/crates/app/bamboo-server/src/config_manager.rs
@@ -144,6 +144,42 @@ pub fn assert_json_object(value: Value) -> Result<Map<String, Value>, AppError> 
     }
 }
 
+/// Legacy full-config clients may echo the secret-free Core proxy projection,
+/// but they may not mutate it without the owned Core section revision.
+///
+/// Dropping only an exact lock-time echo preserves bounded compatibility while
+/// ensuring proxy URLs and the server-managed credential reference cannot
+/// bypass the typed Core/proxy-auth APIs.
+pub fn remove_unchanged_core_proxy_echo(
+    current: &Config,
+    patch_obj: &mut Map<String, Value>,
+) -> Result<(), AppError> {
+    if ["proxy_auth", "proxy_auth_encrypted"]
+        .iter()
+        .any(|field| patch_obj.contains_key(*field))
+    {
+        return Err(core_proxy_patch_error());
+    }
+    let current_value = current.to_compatibility_value()?;
+    for field in ["http_proxy", "https_proxy", "proxy_auth_credential_ref"] {
+        let Some(incoming) = patch_obj.get(field) else {
+            continue;
+        };
+        if current_value.get(field) != Some(incoming) {
+            return Err(core_proxy_patch_error());
+        }
+        patch_obj.remove(field);
+    }
+    Ok(())
+}
+
+fn core_proxy_patch_error() -> AppError {
+    AppError::BadRequest(
+        "proxy configuration must be changed through the dedicated revisioned Core and proxy-auth APIs"
+            .to_string(),
+    )
+}
+
 pub fn build_merged_config(
     current: &Config,
     patch_obj: Map<String, Value>,

--- a/crates/app/bamboo-server/src/handlers/settings/access_control.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/access_control.rs
@@ -1915,7 +1915,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let writer = AppState::new(dir.path().to_path_buf()).await.unwrap();
 
-        let old_password = format!("old-root-secret-{}", uuid::Uuid::new_v4());
+        let old_password = uuid::Uuid::new_v4().to_string();
         let old_salt = "11".repeat(16);
         let old_hash = compute_password_hash(&old_password, &old_salt).unwrap();
         writer
@@ -1950,7 +1950,7 @@ mod tests {
             assert!(verify_password(&stale_config, &old_password));
         }
 
-        let new_password = format!("new-root-secret-{}", uuid::Uuid::new_v4());
+        let new_password = uuid::Uuid::new_v4().to_string();
         let new_salt = "22".repeat(16);
         let new_hash = compute_password_hash(&new_password, &new_salt).unwrap();
         writer

--- a/crates/app/bamboo-server/src/handlers/settings/access_control.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/access_control.rs
@@ -678,36 +678,62 @@ fn build_access_status(config: &Config, req: &HttpRequest) -> AccessStatusRespon
     }
 }
 
+fn build_exact_access_status(
+    config: &Config,
+    statuses: &[bamboo_config::CredentialStatus],
+    health: &bamboo_config::CredentialStoreHealth,
+    req: &HttpRequest,
+) -> AccessStatusResponse {
+    let status_for = |reference: &bamboo_config::CredentialRef| {
+        statuses
+            .iter()
+            .find(|status| &status.credential_ref == reference)
+    };
+    let password_enabled = config.access_control.as_ref().is_some_and(|access| {
+        access.password_enabled
+            && credential_status_view(
+                access.password_credential_ref.as_ref(),
+                access.password_configured,
+                access.password_credential_ref.as_ref().and_then(status_for),
+                health,
+            )
+            .configured
+    });
+    let has_device = config.access_control.as_ref().is_some_and(|access| {
+        access.devices.iter().any(|device| {
+            !device.revoked
+                && credential_status_view(
+                    device.token_credential_ref.as_ref(),
+                    device.token_configured,
+                    device.token_credential_ref.as_ref().and_then(status_for),
+                    health,
+                )
+                .configured
+        })
+    });
+    let local_bypass = is_local_request(req);
+    AccessStatusResponse {
+        password_enabled,
+        local_bypass,
+        requires_password: (password_enabled || has_device) && !local_bypass,
+    }
+}
+
 pub async fn get_access_status(
     req: HttpRequest,
     app_state: web::Data<AppState>,
 ) -> Result<HttpResponse, AppError> {
-    let _io = app_state.config_io_lock.lock().await;
-    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
-        AppError::BadRequest("access settings require the modular configuration facade".to_string())
-    })?;
-    let section = facade
-        .registry()
-        .envelope_value(bamboo_config::SectionId::AccessControl)
-        .map_err(|error| {
-            AppError::InternalError(anyhow::anyhow!(
-                "access-control section envelope unavailable: {error}"
-            ))
-        })?;
-    let config = app_state.config.read().await.clone();
+    let exact = app_state
+        .read_exact_credential_section(bamboo_config::SectionId::AccessControl)
+        .await?;
+    let section = exact.section;
+    let config = exact.config;
     let reference = config
         .access_control
         .as_ref()
         .and_then(|access| access.password_credential_ref.clone());
-    let (statuses, credential_health) =
-        app_state
-            .credential_store
-            .statuses_with_health()
-            .map_err(|error| {
-                AppError::InternalError(anyhow::anyhow!(
-                    "access-control credential status unavailable: {error}"
-                ))
-            })?;
+    let statuses = exact.metadata.credential_statuses;
+    let credential_health = exact.metadata.credential_health;
     let credential = reference.as_ref().and_then(|reference| {
         statuses
             .iter()
@@ -724,7 +750,7 @@ pub async fn get_access_status(
         &credential_health,
     );
     Ok(HttpResponse::Ok().json(AccessStatusEnvelope {
-        runtime: build_access_status(&config, &req),
+        runtime: build_exact_access_status(&config, &statuses, &credential_health, &req),
         revision: section.revision,
         status: section.status,
         source_kind: section.source_kind,
@@ -823,28 +849,8 @@ pub async fn update_access_password(
         ));
     }
 
-    let current_config = app_state.config.read().await.clone();
-    let password_already_enabled = current_config
-        .access_control
-        .as_ref()
-        .map(|access| access.password_enabled)
-        .unwrap_or(false);
-
-    if password_already_enabled && !local_bypass {
-        let current_password = payload.current_password.trim();
-        if current_password.is_empty() {
-            return Err(AppError::Unauthorized(
-                "current_password is required".to_string(),
-            ));
-        }
-        if !verify_password(&current_config, current_password) {
-            return Err(AppError::Unauthorized(
-                "invalid current password".to_string(),
-            ));
-        }
-    }
-
     let expected_revision = payload.expected_revision;
+    let current_password = payload.current_password.trim().to_string();
     let (password_hash, salt_hex) = if matches!(action, AccessPasswordAction::Replace) {
         let mut salt_bytes = [0_u8; 16];
         rand::rng().fill(&mut salt_bytes);
@@ -864,6 +870,25 @@ pub async fn update_access_password(
             true,
             BTreeSet::new(),
             move |config| {
+                // Authorize against the exact durable AccessControl generation
+                // installed by the AppState updater. A stale process-local
+                // verifier must never authorize replacing a newer password.
+                let password_already_enabled = config
+                    .access_control
+                    .as_ref()
+                    .is_some_and(|access| access.password_enabled);
+                if password_already_enabled && !local_bypass {
+                    if current_password.is_empty() {
+                        return Err(AppError::Unauthorized(
+                            "current_password is required".to_string(),
+                        ));
+                    }
+                    if !verify_password(config, &current_password) {
+                        return Err(AppError::Unauthorized(
+                            "invalid current password".to_string(),
+                        ));
+                    }
+                }
                 // Mutate in place so an existing `access_control` keeps its paired
                 // `devices` across a root-password change. Replacing the whole
                 // struct with `devices: vec![]` would silently wipe every device
@@ -1618,17 +1643,111 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn access_status_reports_valid_ciphertext_with_invalid_verifier_as_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        state
+            .update_access_control_credentials(0, true, BTreeSet::new(), |config| {
+                config.access_control = Some(AccessControlConfig {
+                    password_enabled: true,
+                    password_hash: Some("a".repeat(64)),
+                    password_salt: Some("11".repeat(16)),
+                    password_configured: true,
+                    ..Default::default()
+                });
+                Ok(())
+            })
+            .await
+            .unwrap();
+        let reference = bamboo_config::config_crypto::access_password_credential_ref().unwrap();
+        state
+            .credential_store
+            .replace(
+                reference.clone(),
+                r#"{"hash":"not-a-valid-hash","salt":"11"}"#,
+                bamboo_config::CredentialSource::User,
+                1,
+            )
+            .unwrap();
+        let access_path = dir.path().join("access-control.json");
+        let credential_path = dir.path().join("credentials.json");
+        let access_before = std::fs::read(&access_path).unwrap();
+        let credentials_before = std::fs::read(&credential_path).unwrap();
+        let keep = state
+            .update_access_control_credentials(1, false, BTreeSet::new(), |config| {
+                config.access_control.as_mut().unwrap().updated_at =
+                    Some("metadata-keep-must-fail".to_string());
+                Ok(())
+            })
+            .await;
+        assert!(keep.is_err());
+        assert_eq!(std::fs::read(&access_path).unwrap(), access_before);
+        assert_eq!(std::fs::read(&credential_path).unwrap(), credentials_before);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .route("/access/status", web::get().to(get_access_status)),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            TestRequest::get()
+                .uri("/access/status")
+                .peer_addr("203.0.113.8:5700".parse().unwrap())
+                .insert_header((header::HOST, "bamboo.example.com"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = test::read_body_json(response).await;
+        assert_eq!(body["revision"], 1);
+        assert_eq!(body["password_enabled"], false);
+        assert_eq!(body["password_configured"], false);
+        assert_eq!(body["credential_state"], "error");
+
+        let (_, revision, metadata, section) = state
+            .update_access_control_credentials(1, true, BTreeSet::new(), |config| {
+                let access = config.access_control.as_mut().unwrap();
+                access.password_enabled = false;
+                access.password_hash = None;
+                access.password_salt = None;
+                access.password_configured = false;
+                Ok(())
+            })
+            .await
+            .unwrap();
+        assert_eq!(revision, 2);
+        assert!(!metadata.status(&reference).configured);
+        let section = section.unwrap();
+        assert_eq!(section.revision, 2);
+        assert!(section.data["password_credential_ref"].is_null());
+    }
+
+    #[actix_web::test]
     async fn password_replace_and_clear_use_access_revision_and_preserve_devices() {
         let _key = bamboo_config::encryption::set_test_encryption_key([0xd3; 32]);
         let dir = tempfile::tempdir().unwrap();
         let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
-        let mut events = state.account_sink.subscribe();
         let (device, _token) = issue_device_token("paired-device");
         let device_id = device.device_id.clone();
-        state.config.write().await.access_control = Some(AccessControlConfig {
-            devices: vec![device],
-            ..Default::default()
-        });
+        let device_intent = device_id.clone();
+        state
+            .update_access_control_credentials(
+                0,
+                false,
+                BTreeSet::from([device_intent]),
+                move |config| {
+                    config.access_control = Some(AccessControlConfig {
+                        devices: vec![device],
+                        ..Default::default()
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        let mut events = state.account_sink.subscribe();
         let app = test::init_service(
             App::new()
                 .app_data(state.clone())
@@ -1641,7 +1760,7 @@ mod tests {
             TestRequest::post()
                 .uri("/access/password")
                 .set_json(serde_json::json!({
-                    "expected_revision": 0,
+                    "expected_revision": 1,
                     "action": "replace",
                     "value": "root-replacement-secret"
                 }))
@@ -1650,8 +1769,8 @@ mod tests {
         .await;
         assert_eq!(replace.status(), StatusCode::OK);
         let replace: serde_json::Value = test::read_body_json(replace).await;
-        assert_eq!(replace["revision"], 1);
-        assert_eq!(replace["section"]["revision"], 1);
+        assert_eq!(replace["revision"], 2);
+        assert_eq!(replace["section"]["revision"], 2);
         assert_eq!(replace["credential"]["configured"], true);
         assert_eq!(replace["credential"]["state"], "configured");
         assert!(!replace.to_string().contains("root-replacement-secret"));
@@ -1661,7 +1780,7 @@ mod tests {
                 let event = events.recv().await.unwrap();
                 if matches!(
                     &event.event,
-                    bamboo_agent_core::AgentEvent::ConfigChanged { section, revision: 1 }
+                    bamboo_agent_core::AgentEvent::ConfigChanged { section, revision: 2 }
                         if section == "access-control"
                 ) {
                     break event;
@@ -1672,7 +1791,7 @@ mod tests {
         .unwrap();
         assert!(matches!(
             event.event,
-            bamboo_agent_core::AgentEvent::ConfigChanged { ref section, revision: 1 }
+            bamboo_agent_core::AgentEvent::ConfigChanged { ref section, revision: 2 }
                 if section == "access-control"
         ));
 
@@ -1681,7 +1800,7 @@ mod tests {
             TestRequest::post()
                 .uri("/access/password")
                 .set_json(serde_json::json!({
-                    "expected_revision": 1,
+                    "expected_revision": 2,
                     "action": "clear",
                     "current_password": "root-replacement-secret"
                 }))
@@ -1690,8 +1809,8 @@ mod tests {
         .await;
         assert_eq!(clear.status(), StatusCode::OK);
         let clear: serde_json::Value = test::read_body_json(clear).await;
-        assert_eq!(clear["revision"], 2);
-        assert_eq!(clear["section"]["revision"], 2);
+        assert_eq!(clear["revision"], 3);
+        assert_eq!(clear["section"]["revision"], 3);
         assert_eq!(clear["password_enabled"], false);
         assert_eq!(clear["credential"]["configured"], false);
         assert_eq!(clear["credential"]["state"], "missing");
@@ -1705,7 +1824,7 @@ mod tests {
             TestRequest::post()
                 .uri("/access/password")
                 .set_json(serde_json::json!({
-                    "expected_revision": 1,
+                    "expected_revision": 2,
                     "action": "replace",
                     "value": "stale-root-secret"
                 }))
@@ -1737,7 +1856,7 @@ mod tests {
             TestRequest::post()
                 .uri("/access/password")
                 .set_json(serde_json::json!({
-                    "expected_revision": 2,
+                    "expected_revision": 3,
                     "action": "replace",
                     "value": "****...****"
                 }))
@@ -1751,7 +1870,7 @@ mod tests {
             TestRequest::post()
                 .uri("/access/password")
                 .set_json(serde_json::json!({
-                    "expected_revision": 2,
+                    "expected_revision": 3,
                     "action": "replace",
                     "value": "ambiguous-value-secret",
                     "new_password": "ambiguous-legacy-secret"
@@ -1766,7 +1885,7 @@ mod tests {
             TestRequest::post()
                 .uri("/access/password")
                 .set_json(serde_json::json!({
-                    "expected_revision": 2,
+                    "expected_revision": 3,
                     "action": "clear",
                     "value": "unexpected-clear-secret"
                 }))
@@ -1789,6 +1908,105 @@ mod tests {
             assert!(!access_file.contains(secret));
             assert!(!credentials.contains(secret));
         }
+    }
+
+    #[actix_web::test]
+    async fn stale_process_old_password_cannot_authorize_newer_access_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let writer = AppState::new(dir.path().to_path_buf()).await.unwrap();
+
+        let old_salt = "11".repeat(16);
+        let old_hash = compute_password_hash("old-root-secret", &old_salt).unwrap();
+        writer
+            .update_access_control_credentials(0, true, BTreeSet::new(), move |config| {
+                config.access_control = Some(AccessControlConfig {
+                    password_enabled: true,
+                    password_hash: Some(old_hash),
+                    password_salt: Some(old_salt),
+                    password_configured: true,
+                    ..Default::default()
+                });
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        let mut stale = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stale.stop_config_watcher_for_test();
+        assert_eq!(
+            stale
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .access_control
+                .snapshot()
+                .revision,
+            1
+        );
+        {
+            let stale_config = stale.config.read().await;
+            assert!(verify_password(&stale_config, "old-root-secret"));
+        }
+
+        let new_salt = "22".repeat(16);
+        let new_hash = compute_password_hash("new-root-secret", &new_salt).unwrap();
+        writer
+            .update_access_control_credentials(1, true, BTreeSet::new(), move |config| {
+                let access = config.access_control.get_or_insert_with(Default::default);
+                access.password_enabled = true;
+                access.password_hash = Some(new_hash);
+                access.password_salt = Some(new_salt);
+                access.password_configured = true;
+                Ok(())
+            })
+            .await
+            .unwrap();
+        {
+            let stale_config = stale.config.read().await;
+            assert!(verify_password(&stale_config, "old-root-secret"));
+            assert!(!verify_password(&stale_config, "new-root-secret"));
+        }
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(stale))
+                .route("/access/password", web::post().to(update_access_password)),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            TestRequest::post()
+                .uri("/access/password")
+                .peer_addr("203.0.113.7:5700".parse().unwrap())
+                .insert_header((header::HOST, "bamboo.example.com"))
+                .set_json(serde_json::json!({
+                    "expected_revision": 2,
+                    "action": "replace",
+                    "current_password": "old-root-secret",
+                    "value": "unauthorized-third-secret"
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let exact = bamboo_config::read_exact_credential_section_snapshot(
+            dir.path(),
+            bamboo_config::SectionId::AccessControl,
+            Some(2),
+        )
+        .unwrap();
+        let mut durable = Config::default();
+        exact.install_into(&mut durable);
+        assert!(verify_password(&durable, "new-root-secret"));
+        assert!(!verify_password(&durable, "old-root-secret"));
+        assert!(!verify_password(&durable, "unauthorized-third-secret"));
+        assert!(
+            !std::fs::read_to_string(dir.path().join("credentials.json"))
+                .unwrap()
+                .contains("unauthorized-third-secret")
+        );
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/access_control.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/access_control.rs
@@ -1915,8 +1915,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let writer = AppState::new(dir.path().to_path_buf()).await.unwrap();
 
+        let old_password = format!("old-root-secret-{}", uuid::Uuid::new_v4());
         let old_salt = "11".repeat(16);
-        let old_hash = compute_password_hash("old-root-secret", &old_salt).unwrap();
+        let old_hash = compute_password_hash(&old_password, &old_salt).unwrap();
         writer
             .update_access_control_credentials(0, true, BTreeSet::new(), move |config| {
                 config.access_control = Some(AccessControlConfig {
@@ -1946,11 +1947,12 @@ mod tests {
         );
         {
             let stale_config = stale.config.read().await;
-            assert!(verify_password(&stale_config, "old-root-secret"));
+            assert!(verify_password(&stale_config, &old_password));
         }
 
+        let new_password = format!("new-root-secret-{}", uuid::Uuid::new_v4());
         let new_salt = "22".repeat(16);
-        let new_hash = compute_password_hash("new-root-secret", &new_salt).unwrap();
+        let new_hash = compute_password_hash(&new_password, &new_salt).unwrap();
         writer
             .update_access_control_credentials(1, true, BTreeSet::new(), move |config| {
                 let access = config.access_control.get_or_insert_with(Default::default);
@@ -1964,8 +1966,8 @@ mod tests {
             .unwrap();
         {
             let stale_config = stale.config.read().await;
-            assert!(verify_password(&stale_config, "old-root-secret"));
-            assert!(!verify_password(&stale_config, "new-root-secret"));
+            assert!(verify_password(&stale_config, &old_password));
+            assert!(!verify_password(&stale_config, &new_password));
         }
 
         let app = test::init_service(
@@ -1983,7 +1985,7 @@ mod tests {
                 .set_json(serde_json::json!({
                     "expected_revision": 2,
                     "action": "replace",
-                    "current_password": "old-root-secret",
+                    "current_password": old_password,
                     "value": "unauthorized-third-secret"
                 }))
                 .to_request(),
@@ -1999,8 +2001,8 @@ mod tests {
         .unwrap();
         let mut durable = Config::default();
         exact.install_into(&mut durable);
-        assert!(verify_password(&durable, "new-root-secret"));
-        assert!(!verify_password(&durable, "old-root-secret"));
+        assert!(verify_password(&durable, &new_password));
+        assert!(!verify_password(&durable, &old_password));
         assert!(!verify_password(&durable, "unauthorized-third-secret"));
         assert!(
             !std::fs::read_to_string(dir.path().join("credentials.json"))

--- a/crates/app/bamboo-server/src/handlers/settings/access_control.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/access_control.rs
@@ -18,24 +18,46 @@ use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::{app_state::AppState, error::AppError};
+use crate::{
+    app_state::AppState,
+    error::AppError,
+    handlers::settings::credential_action::{
+        credential_status_view, CredentialState, CredentialStatusView,
+    },
+};
 use bamboo_config::{Config, DeviceCredential};
 
-fn credential_revision(app_state: &AppState) -> Result<u64, AppError> {
-    bamboo_config::CredentialStore::open(&app_state.app_data_dir)
-        .revision()
-        .map_err(|error| {
-            AppError::InternalError(anyhow::anyhow!(
-                "access-control credential revision unavailable: {error}"
-            ))
-        })
+fn access_section_revision(app_state: &AppState) -> Result<u64, AppError> {
+    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
+        AppError::BadRequest("access settings require the modular configuration facade".to_string())
+    })?;
+    Ok(facade.registry().access_control.snapshot().revision)
 }
 
 #[derive(Serialize)]
-pub struct AccessStatusResponse {
+pub(crate) struct AccessStatusResponse {
     pub password_enabled: bool,
     pub local_bypass: bool,
     pub requires_password: bool,
+}
+
+#[derive(Serialize)]
+pub(crate) struct AccessStatusEnvelope {
+    #[serde(flatten)]
+    pub runtime: AccessStatusResponse,
+    /// The pre-auth status route exposes the authoritative generation and
+    /// health, but never the Access section's device metadata or local path.
+    pub revision: u64,
+    pub status: bamboo_config::SectionStatus,
+    pub source_kind: bamboo_config::SectionSourceKind,
+    pub loaded_at: chrono::DateTime<Utc>,
+    pub last_error: Option<String>,
+    pub password_configured: bool,
+    pub credential_state: CredentialState,
+    pub credential_ref: Option<String>,
+    pub credential_source: Option<bamboo_config::CredentialSource>,
+    pub credential_updated_at: Option<String>,
+    pub credential_health: bamboo_config::CredentialStoreHealth,
 }
 
 #[derive(Debug, Deserialize)]
@@ -48,18 +70,62 @@ pub struct VerifyPasswordResponse {
     pub success: bool,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccessPasswordAction {
+    Replace,
+    Clear,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct UpdatePasswordRequest {
+    /// Access-control section revision required for every password mutation.
+    pub expected_revision: u64,
+    /// Explicit replace/clear intent. Omission retains the legacy replace
+    /// behavior of `new_password`.
+    #[serde(default)]
+    pub action: Option<AccessPasswordAction>,
     #[serde(default)]
     pub current_password: String,
     #[serde(default)]
     pub new_password: String,
+    #[serde(default)]
+    pub value: String,
+}
+
+impl std::fmt::Debug for UpdatePasswordRequest {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("UpdatePasswordRequest")
+            .field("expected_revision", &self.expected_revision)
+            .field(
+                "action",
+                &self.action.map(|action| match action {
+                    AccessPasswordAction::Replace => "replace",
+                    AccessPasswordAction::Clear => "clear",
+                }),
+            )
+            .field(
+                "current_password",
+                &(!self.current_password.is_empty()).then_some("[REDACTED]"),
+            )
+            .field(
+                "replacement",
+                &(!(self.value.is_empty() && self.new_password.is_empty())).then_some("[REDACTED]"),
+            )
+            .finish()
+    }
 }
 
 #[derive(Serialize)]
-pub struct UpdatePasswordResponse {
+pub(crate) struct UpdatePasswordResponse {
     pub success: bool,
     pub password_enabled: bool,
+    pub revision: u64,
+    pub section: bamboo_config::SectionEnvelope<serde_json::Value>,
+    pub credential: CredentialStatusView,
+    pub credential_health: bamboo_config::CredentialStoreHealth,
 }
 
 const ACCESS_VERIFIED_COOKIE_NAME: &str = "bamboo_access_verified";
@@ -616,8 +682,63 @@ pub async fn get_access_status(
     req: HttpRequest,
     app_state: web::Data<AppState>,
 ) -> Result<HttpResponse, AppError> {
+    let _io = app_state.config_io_lock.lock().await;
+    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
+        AppError::BadRequest("access settings require the modular configuration facade".to_string())
+    })?;
+    let section = facade
+        .registry()
+        .envelope_value(bamboo_config::SectionId::AccessControl)
+        .map_err(|error| {
+            AppError::InternalError(anyhow::anyhow!(
+                "access-control section envelope unavailable: {error}"
+            ))
+        })?;
     let config = app_state.config.read().await.clone();
-    Ok(HttpResponse::Ok().json(build_access_status(&config, &req)))
+    let reference = config
+        .access_control
+        .as_ref()
+        .and_then(|access| access.password_credential_ref.clone());
+    let (statuses, credential_health) =
+        app_state
+            .credential_store
+            .statuses_with_health()
+            .map_err(|error| {
+                AppError::InternalError(anyhow::anyhow!(
+                    "access-control credential status unavailable: {error}"
+                ))
+            })?;
+    let credential = reference.as_ref().and_then(|reference| {
+        statuses
+            .iter()
+            .find(|status| &status.credential_ref == reference)
+    });
+    let expected_configured = config
+        .access_control
+        .as_ref()
+        .is_some_and(|access| access.password_configured);
+    let credential = credential_status_view(
+        reference.as_ref(),
+        expected_configured,
+        credential,
+        &credential_health,
+    );
+    Ok(HttpResponse::Ok().json(AccessStatusEnvelope {
+        runtime: build_access_status(&config, &req),
+        revision: section.revision,
+        status: section.status,
+        source_kind: section.source_kind,
+        loaded_at: section.loaded_at,
+        last_error: section.last_error,
+        password_configured: credential.configured,
+        credential_state: credential.state,
+        credential_ref: credential.credential_ref,
+        credential_source: credential.source,
+        credential_updated_at: credential
+            .updated_at
+            .map(|updated_at| updated_at.to_rfc3339()),
+        credential_health,
+    }))
 }
 
 pub async fn verify_access_password(
@@ -670,10 +791,36 @@ pub async fn update_access_password(
     payload: web::Json<UpdatePasswordRequest>,
 ) -> Result<HttpResponse, AppError> {
     let local_bypass = is_local_request(&req);
-    let new_password = payload.new_password.trim();
-
-    if new_password.is_empty() {
-        return Err(AppError::BadRequest("new_password is required".to_string()));
+    let payload = payload.into_inner();
+    let action = payload.action.unwrap_or(AccessPasswordAction::Replace);
+    if !payload.value.is_empty() && !payload.new_password.is_empty() {
+        return Err(AppError::BadRequest(
+            "password replace must use either value or new_password, not both".to_string(),
+        ));
+    }
+    let replacement = if payload.value.is_empty() {
+        payload.new_password.trim()
+    } else {
+        payload.value.trim()
+    };
+    if matches!(action, AccessPasswordAction::Replace) && replacement.is_empty() {
+        return Err(AppError::BadRequest(
+            "password replace requires a nonempty value".to_string(),
+        ));
+    }
+    if matches!(action, AccessPasswordAction::Replace)
+        && bamboo_config::patch::is_masked_api_key(replacement)
+    {
+        return Err(AppError::BadRequest(
+            "password value must not be a mask".to_string(),
+        ));
+    }
+    if matches!(action, AccessPasswordAction::Clear)
+        && !(payload.value.is_empty() && payload.new_password.is_empty())
+    {
+        return Err(AppError::BadRequest(
+            "password clear must not include a replacement value".to_string(),
+        ));
     }
 
     let current_config = app_state.config.read().await.clone();
@@ -697,16 +844,21 @@ pub async fn update_access_password(
         }
     }
 
-    let mut salt_bytes = [0_u8; 16];
-    rand::rng().fill(&mut salt_bytes);
-    let salt_hex = hex::encode(salt_bytes);
-    let password_hash = compute_password_hash(new_password, &salt_hex).ok_or_else(|| {
-        AppError::InternalError(anyhow::anyhow!("failed to compute password hash"))
-    })?;
+    let expected_revision = payload.expected_revision;
+    let (password_hash, salt_hex) = if matches!(action, AccessPasswordAction::Replace) {
+        let mut salt_bytes = [0_u8; 16];
+        rand::rng().fill(&mut salt_bytes);
+        let salt_hex = hex::encode(salt_bytes);
+        let password_hash = compute_password_hash(replacement, &salt_hex).ok_or_else(|| {
+            AppError::InternalError(anyhow::anyhow!("failed to compute password hash"))
+        })?;
+        (Some(password_hash), Some(salt_hex))
+    } else {
+        (None, None)
+    };
     let updated_at = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
 
-    let expected_revision = credential_revision(&app_state)?;
-    app_state
+    let (updated, revision, metadata, section) = app_state
         .update_access_control_credentials(
             expected_revision,
             true,
@@ -717,18 +869,44 @@ pub async fn update_access_password(
                 // struct with `devices: vec![]` would silently wipe every device
                 // token on every password update (#181).
                 let access = config.access_control.get_or_insert_with(Default::default);
-                access.password_enabled = true;
-                access.password_hash = Some(password_hash.clone());
-                access.password_salt = Some(salt_hex.clone());
+                access.password_enabled = matches!(action, AccessPasswordAction::Replace);
+                access.password_hash = password_hash.clone();
+                access.password_salt = salt_hex.clone();
                 access.updated_at = Some(updated_at.clone());
                 Ok(())
             },
         )
         .await?;
+    let configured = updated
+        .access_control
+        .as_ref()
+        .is_some_and(|access| access.password_configured);
+    let section = section.ok_or_else(|| {
+        AppError::InternalError(anyhow::anyhow!(
+            "access-control mutation completed without a typed section envelope"
+        ))
+    })?;
+    let reference =
+        bamboo_config::config_crypto::access_password_credential_ref().map_err(|error| {
+            AppError::InternalError(anyhow::anyhow!(
+                "access-control credential reference is invalid: {error}"
+            ))
+        })?;
+    let credential_status = metadata.status(&reference);
+    let credential = credential_status_view(
+        Some(&reference),
+        configured,
+        Some(&credential_status),
+        &metadata.credential_health,
+    );
 
     Ok(HttpResponse::Ok().json(UpdatePasswordResponse {
         success: true,
-        password_enabled: true,
+        password_enabled: configured,
+        revision,
+        section,
+        credential,
+        credential_health: metadata.credential_health,
     }))
 }
 
@@ -893,7 +1071,7 @@ async fn persist_new_device(app_state: &AppState, label: &str) -> Result<HttpRes
     let (credential, token) = issue_device_token(label);
     let device_id = credential.device_id.clone();
 
-    let expected_revision = credential_revision(app_state)?;
+    let expected_revision = access_section_revision(app_state)?;
     app_state
         .update_access_control_credentials(
             expected_revision,
@@ -1279,7 +1457,7 @@ pub async fn revoke_device(
     }
 
     let target = device_id.clone();
-    let expected_revision = credential_revision(&app_state)?;
+    let expected_revision = access_section_revision(&app_state)?;
     app_state
         .update_access_control_credentials(
             expected_revision,
@@ -1332,7 +1510,7 @@ pub async fn rotate_device(
     let (fresh, token) = issue_device_token("");
 
     let target = device_id.clone();
-    let expected_revision = credential_revision(&app_state)?;
+    let expected_revision = access_section_revision(&app_state)?;
     app_state
         .update_access_control_credentials(
             expected_revision,
@@ -1384,6 +1562,233 @@ mod tests {
             $(test_config!(@assign config, $field, $value);)*
             config
         }};
+    }
+
+    #[actix_web::test]
+    async fn public_access_status_exposes_revision_without_section_data_or_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        state.config.write().await.access_control = Some(AccessControlConfig {
+            devices: vec![bamboo_config::DeviceCredential {
+                device_id: "private-device-id".to_string(),
+                label: "private-device-label".to_string(),
+                token_hash: "private-token-hash".to_string(),
+                token_salt: "private-token-salt".to_string(),
+                token_credential_ref: None,
+                token_configured: false,
+                created_at: "2026-07-27T00:00:00Z".to_string(),
+                last_used_at: None,
+                revoked: false,
+            }],
+            ..Default::default()
+        });
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/access/status", web::get().to(get_access_status)),
+        )
+        .await;
+
+        let response = test::call_service(
+            &app,
+            TestRequest::get()
+                .uri("/access/status")
+                .insert_header((header::HOST, "bamboo.example.com"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = test::read_body_json(response).await;
+        assert_eq!(body["revision"], 0);
+        assert!(body.get("status").is_some());
+        assert!(body.get("source_kind").is_some());
+        assert!(body.get("section").is_none());
+        assert!(body.get("source_path").is_none());
+        let body = body.to_string();
+        let private_path = dir.path().to_string_lossy().to_string();
+        for private in [
+            private_path.as_str(),
+            "private-device-id",
+            "private-device-label",
+            "private-token-hash",
+            "private-token-salt",
+        ] {
+            assert!(!body.contains(private));
+        }
+    }
+
+    #[actix_web::test]
+    async fn password_replace_and_clear_use_access_revision_and_preserve_devices() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0xd3; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let mut events = state.account_sink.subscribe();
+        let (device, _token) = issue_device_token("paired-device");
+        let device_id = device.device_id.clone();
+        state.config.write().await.access_control = Some(AccessControlConfig {
+            devices: vec![device],
+            ..Default::default()
+        });
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .route("/access/password", web::post().to(update_access_password)),
+        )
+        .await;
+
+        let replace = test::call_service(
+            &app,
+            TestRequest::post()
+                .uri("/access/password")
+                .set_json(serde_json::json!({
+                    "expected_revision": 0,
+                    "action": "replace",
+                    "value": "root-replacement-secret"
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(replace.status(), StatusCode::OK);
+        let replace: serde_json::Value = test::read_body_json(replace).await;
+        assert_eq!(replace["revision"], 1);
+        assert_eq!(replace["section"]["revision"], 1);
+        assert_eq!(replace["credential"]["configured"], true);
+        assert_eq!(replace["credential"]["state"], "configured");
+        assert!(!replace.to_string().contains("root-replacement-secret"));
+        assert!(!replace.to_string().contains("********"));
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let event = events.recv().await.unwrap();
+                if matches!(
+                    &event.event,
+                    bamboo_agent_core::AgentEvent::ConfigChanged { section, revision: 1 }
+                        if section == "access-control"
+                ) {
+                    break event;
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert!(matches!(
+            event.event,
+            bamboo_agent_core::AgentEvent::ConfigChanged { ref section, revision: 1 }
+                if section == "access-control"
+        ));
+
+        let clear = test::call_service(
+            &app,
+            TestRequest::post()
+                .uri("/access/password")
+                .set_json(serde_json::json!({
+                    "expected_revision": 1,
+                    "action": "clear",
+                    "current_password": "root-replacement-secret"
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(clear.status(), StatusCode::OK);
+        let clear: serde_json::Value = test::read_body_json(clear).await;
+        assert_eq!(clear["revision"], 2);
+        assert_eq!(clear["section"]["revision"], 2);
+        assert_eq!(clear["password_enabled"], false);
+        assert_eq!(clear["credential"]["configured"], false);
+        assert_eq!(clear["credential"]["state"], "missing");
+        let access = state.config.read().await.access_control.clone().unwrap();
+        assert_eq!(access.devices.len(), 1);
+        assert_eq!(access.devices[0].device_id, device_id);
+        assert!(!access.password_enabled);
+
+        let stale = test::call_service(
+            &app,
+            TestRequest::post()
+                .uri("/access/password")
+                .set_json(serde_json::json!({
+                    "expected_revision": 1,
+                    "action": "replace",
+                    "value": "stale-root-secret"
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale.status(), StatusCode::CONFLICT);
+        let stale = String::from_utf8(test::read_body(stale).await.to_vec()).unwrap();
+        assert!(!stale.contains("stale-root-secret"));
+        let access = state.config.read().await.access_control.clone().unwrap();
+        assert_eq!(access.devices.len(), 1);
+        assert!(!access.password_enabled);
+
+        let missing_revision = test::call_service(
+            &app,
+            TestRequest::post()
+                .uri("/access/password")
+                .set_json(serde_json::json!({
+                    "action": "replace",
+                    "value": "missing-revision-secret"
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(missing_revision.status(), StatusCode::BAD_REQUEST);
+
+        let masked = test::call_service(
+            &app,
+            TestRequest::post()
+                .uri("/access/password")
+                .set_json(serde_json::json!({
+                    "expected_revision": 2,
+                    "action": "replace",
+                    "value": "****...****"
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(masked.status(), StatusCode::BAD_REQUEST);
+
+        let ambiguous = test::call_service(
+            &app,
+            TestRequest::post()
+                .uri("/access/password")
+                .set_json(serde_json::json!({
+                    "expected_revision": 2,
+                    "action": "replace",
+                    "value": "ambiguous-value-secret",
+                    "new_password": "ambiguous-legacy-secret"
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(ambiguous.status(), StatusCode::BAD_REQUEST);
+
+        let clear_with_value = test::call_service(
+            &app,
+            TestRequest::post()
+                .uri("/access/password")
+                .set_json(serde_json::json!({
+                    "expected_revision": 2,
+                    "action": "clear",
+                    "value": "unexpected-clear-secret"
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(clear_with_value.status(), StatusCode::BAD_REQUEST);
+
+        let access_file = std::fs::read_to_string(dir.path().join("access-control.json")).unwrap();
+        let credentials = std::fs::read_to_string(dir.path().join("credentials.json")).unwrap();
+        for secret in [
+            "root-replacement-secret",
+            "stale-root-secret",
+            "missing-revision-secret",
+            "ambiguous-value-secret",
+            "ambiguous-legacy-secret",
+            "unexpected-clear-secret",
+            "****...****",
+        ] {
+            assert!(!access_file.contains(secret));
+            assert!(!credentials.contains(secret));
+        }
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
@@ -234,6 +234,22 @@ async fn notification_payload_is_unchanged(
     if patch_obj.get("notifications").is_some_and(Value::is_null) {
         return Ok(false);
     }
+    for (channel, field) in [("ntfy", "token"), ("bark", "device_key")] {
+        if patch_obj
+            .get("notifications")
+            .and_then(Value::as_object)
+            .and_then(|notifications| notifications.get(channel))
+            .and_then(Value::as_object)
+            .and_then(|channel| channel.get(field))
+            .and_then(Value::as_str)
+            .is_some_and(bamboo_config::patch::is_masked_api_key)
+        {
+            return Err(AppError::BadRequest(
+                "notification credential value must not be a mask; omit it to keep the existing value"
+                    .to_string(),
+            ));
+        }
+    }
     let current = app_state.config.read().await.clone();
     let mut notification_patch = serde_json::Map::new();
     notification_patch.insert(
@@ -252,17 +268,17 @@ async fn set_notification_config(
     app_state: web::Data<AppState>,
     mut patch_obj: serde_json::Map<String, Value>,
 ) -> Result<HttpResponse, AppError> {
-    let explicit_revision = patch_obj.contains_key("expected_revision");
     let expected_revision = match patch_obj.remove("expected_revision") {
         Some(value) => value.as_u64().ok_or_else(|| {
             AppError::BadRequest(
                 "notification expected_revision must be an unsigned integer".to_string(),
             )
         })?,
-        None => app_state
-            .credential_store
-            .revision()
-            .map_err(super::super::credentials::map_store_read_error)?,
+        None => {
+            return Err(AppError::BadRequest(
+                "notification expected_revision is required".to_string(),
+            ))
+        }
     };
     if patch_obj.len() != 1 {
         return Err(AppError::BadRequest(
@@ -303,13 +319,10 @@ async fn set_notification_config(
                     Value::Null => {}
                     Value::String(value) => {
                         if bamboo_config::patch::is_masked_api_key(value) {
-                            if explicit_revision {
-                                return Err(AppError::BadRequest(
-                                    "notification credential value must not be a mask; omit it to keep the existing value"
-                                        .to_string(),
-                                ));
-                            }
-                            secret_intents.remove(channel);
+                            return Err(AppError::BadRequest(
+                                "notification credential value must not be a mask; omit it to keep the existing value"
+                                    .to_string(),
+                            ));
                         }
                     }
                     _ => {
@@ -323,7 +336,7 @@ async fn set_notification_config(
     }
     let patch_for_update = patch_obj;
     let intents_for_update = secret_intents.clone();
-    let (new_config, _) = app_state
+    let (new_config, _, _, _) = app_state
         .update_notification_credentials(
             expected_revision,
             secret_intents,
@@ -381,6 +394,28 @@ async fn connect_payload_is_unchanged(
     if patch_obj.get("connect").is_some_and(Value::is_null) {
         return Ok(false);
     }
+    if patch_obj
+        .get("connect")
+        .and_then(|connect| connect.get("platforms"))
+        .and_then(Value::as_array)
+        .is_some_and(|platforms| {
+            platforms.iter().any(|platform| {
+                platform.as_object().is_some_and(|platform| {
+                    ["token", "app_secret"].iter().any(|field| {
+                        platform
+                            .get(*field)
+                            .and_then(Value::as_str)
+                            .is_some_and(bamboo_config::patch::is_masked_api_key)
+                    })
+                })
+            })
+        })
+    {
+        return Err(AppError::BadRequest(
+            "connect credential value must not be a mask; omit it to keep the existing value"
+                .to_string(),
+        ));
+    }
     let current = app_state.config.read().await.clone();
     let mut connect_patch = serde_json::Map::new();
     connect_patch.insert(
@@ -399,17 +434,17 @@ async fn set_connect_config(
     app_state: web::Data<AppState>,
     mut patch_obj: serde_json::Map<String, Value>,
 ) -> Result<HttpResponse, AppError> {
-    let explicit_revision = patch_obj.contains_key("expected_revision");
     let expected_revision = match patch_obj.remove("expected_revision") {
         Some(value) => value.as_u64().ok_or_else(|| {
             AppError::BadRequest(
                 "connect expected_revision must be an unsigned integer".to_string(),
             )
         })?,
-        None => app_state
-            .credential_store
-            .revision()
-            .map_err(super::super::credentials::map_store_read_error)?,
+        None => {
+            return Err(AppError::BadRequest(
+                "connect expected_revision is required".to_string(),
+            ))
+        }
     };
     if patch_obj.len() != 1 {
         return Err(AppError::BadRequest(
@@ -461,15 +496,12 @@ async fn set_connect_config(
                     }
                     Value::String(value) => {
                         if bamboo_config::patch::is_masked_api_key(value) {
-                            if explicit_revision {
-                                return Err(AppError::BadRequest(
-                                    "connect credential value must not be a mask; omit it to keep the existing value"
-                                        .to_string(),
-                                ));
-                            }
-                        } else {
-                            intents.insert(index);
+                            return Err(AppError::BadRequest(
+                                "connect credential value must not be a mask; omit it to keep the existing value"
+                                    .to_string(),
+                            ));
                         }
+                        intents.insert(index);
                     }
                     _ => {
                         return Err(AppError::BadRequest(
@@ -484,7 +516,7 @@ async fn set_connect_config(
     config_manager::sanitize_root_patch(&mut patch_obj);
     let patch_for_update = patch_obj;
     let intents_for_update = secret_intents.clone();
-    let (new_config, _) = app_state
+    let (new_config, _, _, _) = app_state
         .update_connect_credentials(expected_revision, secret_intents, move |config| {
             let current = config.clone();
             let mut patch = patch_for_update;

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/set.rs
@@ -52,6 +52,8 @@ pub async fn set_bamboo_config(
             "expected_revision is only valid for a dedicated revisioned config domain".to_string(),
         ));
     }
+    let current = app_state.config.read().await.clone();
+    config_manager::remove_unchanged_core_proxy_echo(&current, &mut patch_obj)?;
     let mut model_limits_patch = take_model_limits_patch(&mut patch_obj);
     config_manager::sanitize_root_patch(&mut patch_obj);
     if model_limits_patch.is_some() && !patch_obj.is_empty() {
@@ -618,6 +620,122 @@ mod tests {
             let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
             assert!(body.contains("revisioned env-vars API"));
         }
+    }
+
+    #[actix_web::test]
+    async fn root_patch_and_validation_reject_core_proxy_bypass() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let core_before = std::fs::read(dir.path().join("core.json")).unwrap();
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/config", web::post().to(set_bamboo_config))
+                .route(
+                    "/config/validate",
+                    web::post().to(crate::handlers::settings::validate_bamboo_config_patch),
+                ),
+        )
+        .await;
+        for uri in ["/config", "/config/validate"] {
+            let response = test::call_service(
+                &app,
+                test::TestRequest::post()
+                    .uri(uri)
+                    .set_json(serde_json::json!({
+                        "http_proxy": "http://unrevisioned-proxy.test:8080"
+                    }))
+                    .to_request(),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{uri}");
+            let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+            assert!(body.contains("revisioned Core"), "{body}");
+        }
+        assert_eq!(
+            std::fs::read(dir.path().join("core.json")).unwrap(),
+            core_before
+        );
+    }
+
+    #[actix_web::test]
+    async fn stale_root_proxy_echo_cannot_rebase_an_unrelated_core_edit_over_exact_winner() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        state.stop_config_watcher_for_test();
+        let state = web::Data::new(state);
+
+        let external_facade = bamboo_config::ConfigFacade::open(dir.path()).unwrap();
+        let mut external_core = external_facade
+            .registry()
+            .envelope_value(bamboo_config::SectionId::Core)
+            .unwrap()
+            .data;
+        external_core["http_proxy"] = serde_json::json!("http://external-winner.test:8080");
+        external_facade
+            .registry()
+            .commit_value(bamboo_config::SectionId::Core, 0, external_core)
+            .unwrap();
+        let mut external = bamboo_config::ConfigFacade::open(dir.path())
+            .unwrap()
+            .effective_config();
+        external.proxy_auth = Some(bamboo_config::ProxyAuth {
+            username: "external-user".to_string(),
+            password: "external-password".to_string(),
+        });
+        assert_eq!(
+            bamboo_config::persist_proxy_auth_credential_transaction_at_revision(
+                dir.path(),
+                &mut external,
+                1,
+            )
+            .unwrap(),
+            2
+        );
+        let core_before = std::fs::read(dir.path().join("core.json")).unwrap();
+        let credentials_before = std::fs::read(dir.path().join("credentials.json")).unwrap();
+        assert_eq!(state.config.read().await.http_proxy, "");
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .route("/config", web::post().to(set_bamboo_config)),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/config")
+                .set_json(serde_json::json!({
+                    "http_proxy": "",
+                    "server": {"port": 22_226}
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            std::fs::read(dir.path().join("core.json")).unwrap(),
+            core_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join("credentials.json")).unwrap(),
+            credentials_before
+        );
+        let exact = bamboo_config::read_exact_credential_section_snapshot(
+            dir.path(),
+            bamboo_config::SectionId::Core,
+            Some(2),
+        )
+        .unwrap();
+        let mut committed = bamboo_llm::Config::default();
+        exact.install_into(&mut committed);
+        assert_eq!(committed.http_proxy, "http://external-winner.test:8080");
+        assert_eq!(
+            committed.proxy_auth.as_ref().unwrap().username,
+            "external-user"
+        );
+        assert_ne!(committed.server.port, 22_226);
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
@@ -218,8 +218,15 @@ async fn redacted_full_payload_update_preserves_access_control_and_rejects_mutat
         .iter()
         .map(|device| device.device_id.clone())
         .collect();
-    let expected_revision = app_state.credential_store.revision().unwrap();
-    let (committed, _) = app_state
+    let expected_revision = app_state
+        .config_facade
+        .as_ref()
+        .unwrap()
+        .registry()
+        .access_control
+        .snapshot()
+        .revision;
+    let (committed, _, _, _) = app_state
         .update_access_control_credentials(expected_revision, true, device_intents, move |config| {
             config.access_control = Some(fixture);
             Ok(())
@@ -1010,7 +1017,7 @@ async fn codex_provider_reference_round_trip_preserves_masked_provider_secret() 
 }
 
 #[actix_web::test]
-async fn redacted_full_payload_provider_update_preserves_notification_credential() {
+async fn secret_omitting_full_payload_provider_update_preserves_notification_credential() {
     use crate::app_state::AppState;
     use actix_web::{test, web, App};
 
@@ -1030,6 +1037,7 @@ async fn redacted_full_payload_provider_update_preserves_notification_credential
     let set_notification = test::TestRequest::post()
         .uri("/bamboo/config")
         .set_json(serde_json::json!({
+            "expected_revision": 0,
             "notifications": {
                 "ntfy": {
                     "enabled": true,
@@ -1056,6 +1064,10 @@ async fn redacted_full_payload_provider_update_preserves_notification_credential
         full_payload["notifications"]["ntfy"]["token"],
         "****...****"
     );
+    full_payload["notifications"]["ntfy"]
+        .as_object_mut()
+        .unwrap()
+        .remove("token");
     full_payload["provider"] = serde_json::json!("openai");
     full_payload["providers"] = serde_json::json!({
         "openai": {"api_key": "sk-provider-from-full-payload", "model": "gpt-test"}
@@ -1098,13 +1110,11 @@ async fn redacted_full_payload_provider_update_preserves_notification_credential
     assert!(!notifications.contains("token_encrypted"));
 }
 
-/// End-to-end: POST an ntfy token, confirm the GET response masks it, then
-/// POST again with the masked placeholder unchanged (as the UI would on an
-/// unrelated field edit) — the exact-mask keep-on-save rule must resolve that
-/// back to the live plaintext rather than wiping the stored secret. #430-style
-/// contract, applied to the new notification channel secrets.
+/// Root compatibility writes require the owned Notifications revision, reject
+/// a mask as data, and preserve the stored secret when the credential field is
+/// omitted explicitly.
 #[actix_web::test]
-async fn set_then_get_bamboo_config_masks_and_preserves_ntfy_token() {
+async fn notification_compatibility_write_rejects_masks_and_keeps_omitted_secret() {
     use crate::app_state::AppState;
     use actix_web::{test, web, App};
 
@@ -1127,6 +1137,7 @@ async fn set_then_get_bamboo_config_masks_and_preserves_ntfy_token() {
     let post = test::TestRequest::post()
         .uri("/bamboo/config")
         .set_json(serde_json::json!({
+            "expected_revision": 0,
             "notifications": {
                 "ntfy": {
                     "enabled": true,
@@ -1162,11 +1173,11 @@ async fn set_then_get_bamboo_config_masks_and_preserves_ntfy_token() {
     assert_eq!(body["notifications"]["ntfy"]["token"], "****...****");
     assert_eq!(body["notifications"]["ntfy"]["topic"], "bamboo-alerts");
 
-    // 3) Re-POST with the masked placeholder (as the UI echoes it back) plus
-    // an unrelated field change — the secret must survive untouched.
+    // 3) A masked placeholder is never accepted as data.
     let post2 = test::TestRequest::post()
         .uri("/bamboo/config")
         .set_json(serde_json::json!({
+            "expected_revision": 1,
             "notifications": {
                 "ntfy": {
                     "enabled": true,
@@ -1178,9 +1189,29 @@ async fn set_then_get_bamboo_config_masks_and_preserves_ntfy_token() {
         }))
         .to_request();
     let post2_resp = test::call_service(&app, post2).await;
+    assert_eq!(
+        post2_resp.status(),
+        actix_web::http::StatusCode::BAD_REQUEST
+    );
+
+    // 4) Omission is the bounded compatibility form of `keep`.
+    let post3 = test::TestRequest::post()
+        .uri("/bamboo/config")
+        .set_json(serde_json::json!({
+            "expected_revision": 1,
+            "notifications": {
+                "ntfy": {
+                    "enabled": true,
+                    "base_url": "https://ntfy.sh",
+                    "topic": "renamed-topic"
+                }
+            }
+        }))
+        .to_request();
+    let post3_resp = test::call_service(&app, post3).await;
     assert!(
-        post2_resp.status().is_success(),
-        "second set config should succeed"
+        post3_resp.status().is_success(),
+        "secret-omitting update should succeed"
     );
 
     let get2 = test::TestRequest::get().uri("/bamboo/config").to_request();
@@ -1195,12 +1226,11 @@ async fn set_then_get_bamboo_config_masks_and_preserves_ntfy_token() {
     );
 }
 
-/// End-to-end for #455: a settings PATCH that sets a bamboo-connect platform
-/// must persist into the standalone `connect.json` — NOT into `config.json`
-/// — while the settings API (GET redaction, masked-token keep-on-save)
-/// behaves exactly as it did before the persistence split.
+/// End-to-end for #455/#738: a compatibility settings write persists into the
+/// standalone `connect.json`, uses the Connect section revision, rejects masks,
+/// and treats omission as the bounded `keep` form.
 #[actix_web::test]
-async fn set_bamboo_config_persists_connect_into_connect_json_only_and_preserves_masked_token() {
+async fn connect_compatibility_write_is_revisioned_and_keeps_omitted_token() {
     use crate::app_state::AppState;
     use actix_web::{test, web, App};
 
@@ -1235,6 +1265,7 @@ async fn set_bamboo_config_persists_connect_into_connect_json_only_and_preserves
     let post = test::TestRequest::post()
         .uri("/bamboo/config")
         .set_json(serde_json::json!({
+            "expected_revision": 0,
             "connect": {
                 "platforms": [
                     { "type": "telegram", "token": "tg-real-secret", "allow_from": ["u1"] }
@@ -1290,12 +1321,11 @@ async fn set_bamboo_config_persists_connect_into_connect_json_only_and_preserves
     assert_eq!(body["connect"]["platforms"][0]["token"], "****...****");
     assert_eq!(body["connect"]["platforms"][0]["type"], "telegram");
 
-    // 3) Re-POST with the masked placeholder (as the UI echoes it back) plus
-    // an unrelated field change — the secret must survive untouched, and
-    // still land only in connect.json.
+    // 3) A masked placeholder is never accepted as data.
     let post2 = test::TestRequest::post()
         .uri("/bamboo/config")
         .set_json(serde_json::json!({
+            "expected_revision": 1,
             "connect": {
                 "platforms": [
                     { "type": "telegram", "token": "****...****", "allow_from": ["u1", "u2"] }
@@ -1304,9 +1334,27 @@ async fn set_bamboo_config_persists_connect_into_connect_json_only_and_preserves
         }))
         .to_request();
     let post2_resp = test::call_service(&app, post2).await;
+    assert_eq!(
+        post2_resp.status(),
+        actix_web::http::StatusCode::BAD_REQUEST
+    );
+
+    // 4) Omission is the bounded compatibility form of `keep`.
+    let post3 = test::TestRequest::post()
+        .uri("/bamboo/config")
+        .set_json(serde_json::json!({
+            "expected_revision": 1,
+            "connect": {
+                "platforms": [
+                    { "type": "telegram", "allow_from": ["u1", "u2"] }
+                ]
+            }
+        }))
+        .to_request();
+    let post3_resp = test::call_service(&app, post3).await;
     assert!(
-        post2_resp.status().is_success(),
-        "second set config should succeed"
+        post3_resp.status().is_success(),
+        "secret-omitting update should succeed"
     );
 
     let get2 = test::TestRequest::get().uri("/bamboo/config").to_request();
@@ -1328,7 +1376,7 @@ async fn set_bamboo_config_persists_connect_into_connect_json_only_and_preserves
         serde_json::from_str(&connect_text_after).expect("connect.json should parse");
     assert_eq!(
         connect_json_after["data"]["platforms"][0]["token_credential_ref"], reference,
-        "masked round-trip preserves the stable token reference"
+        "omission preserves the stable token reference"
     );
     assert_eq!(
         bamboo_config::CredentialStore::open(&data_dir)
@@ -1337,17 +1385,16 @@ async fn set_bamboo_config_persists_connect_into_connect_json_only_and_preserves
             .unwrap()
             .expose(),
         "tg-real-secret",
-        "masked round-trip preserves the real token in the credential store"
+        "omission preserves the real token in the credential store"
     );
     assert!(!config_file_path(&data_dir).exists());
 }
 
 /// Feishu adapter config plumbing (epic #447 phase 3, §2a): `app_id`/`domain`
-/// are plain fields, `app_secret` follows the exact same encrypted-at-rest +
-/// masked-GET + masked-preserve-on-PATCH contract as the Telegram `token`
-/// above.
+/// are plain fields, while `app_secret` is isolated, masks are rejected on
+/// write, and omission preserves the credential.
 #[actix_web::test]
-async fn set_bamboo_config_persists_feishu_app_secret_encrypted_and_preserves_masked_value() {
+async fn feishu_compatibility_write_rejects_mask_and_keeps_omitted_app_secret() {
     use crate::app_state::AppState;
     use actix_web::{test, web, App};
 
@@ -1373,6 +1420,7 @@ async fn set_bamboo_config_persists_feishu_app_secret_encrypted_and_preserves_ma
     let post = test::TestRequest::post()
         .uri("/bamboo/config")
         .set_json(serde_json::json!({
+            "expected_revision": 0,
             "connect": {
                 "platforms": [
                     {
@@ -1428,11 +1476,11 @@ async fn set_bamboo_config_persists_feishu_app_secret_encrypted_and_preserves_ma
     assert_eq!(body["connect"]["platforms"][0]["app_id"], "cli_real_app_id");
     assert_eq!(body["connect"]["platforms"][0]["domain"], "lark");
 
-    // 3) Re-POST with the masked placeholder plus an unrelated field change —
-    // the secret must survive untouched.
+    // 3) A masked placeholder is never accepted as data.
     let post2 = test::TestRequest::post()
         .uri("/bamboo/config")
         .set_json(serde_json::json!({
+            "expected_revision": 1,
             "connect": {
                 "platforms": [
                     {
@@ -1447,9 +1495,32 @@ async fn set_bamboo_config_persists_feishu_app_secret_encrypted_and_preserves_ma
         }))
         .to_request();
     let post2_resp = test::call_service(&app, post2).await;
+    assert_eq!(
+        post2_resp.status(),
+        actix_web::http::StatusCode::BAD_REQUEST
+    );
+
+    // 4) Omission is the bounded compatibility form of `keep`.
+    let post3 = test::TestRequest::post()
+        .uri("/bamboo/config")
+        .set_json(serde_json::json!({
+            "expected_revision": 1,
+            "connect": {
+                "platforms": [
+                    {
+                        "type": "feishu",
+                        "app_id": "cli_real_app_id",
+                        "domain": "lark",
+                        "allow_from": ["ou_1", "ou_2"]
+                    }
+                ]
+            }
+        }))
+        .to_request();
+    let post3_resp = test::call_service(&app, post3).await;
     assert!(
-        post2_resp.status().is_success(),
-        "second set config should succeed"
+        post3_resp.status().is_success(),
+        "secret-omitting update should succeed"
     );
 
     let get2 = test::TestRequest::get().uri("/bamboo/config").to_request();
@@ -1471,7 +1542,7 @@ async fn set_bamboo_config_persists_feishu_app_secret_encrypted_and_preserves_ma
         serde_json::from_str(&connect_text_after).expect("connect.json should parse");
     assert_eq!(
         connect_json_after["data"]["platforms"][0]["app_secret_credential_ref"], reference,
-        "masked round-trip preserves the stable app-secret reference"
+        "omission preserves the stable app-secret reference"
     );
     assert_eq!(
         bamboo_config::CredentialStore::open(&data_dir)
@@ -1480,19 +1551,14 @@ async fn set_bamboo_config_persists_feishu_app_secret_encrypted_and_preserves_ma
             .unwrap()
             .expose(),
         "feishu-real-secret",
-        "masked round-trip preserves the real app_secret in the credential store"
+        "omission preserves the real app_secret in the credential store"
     );
 }
 
-/// #490 end-to-end: the settings PATCH surface must preserve a masked secret
-/// even when a preceding platform entry is removed in the same request,
-/// shifting the kept entry's array index. Stored platforms are
-/// `[telegram, feishu]`; the client disables telegram and re-POSTs only the
-/// (still-masked) feishu entry, which now lands at index 0 instead of 1.
-/// Before the #490 fix, the positional type-guard (added for #454) saw
-/// telegram≠feishu at index 0 and silently dropped the feishu app_secret.
+/// #490/#738 end-to-end: omission must preserve a credential by stable
+/// platform id even when removing a preceding entry shifts its array index.
 #[actix_web::test]
-async fn set_bamboo_config_preserves_masked_secret_when_preceding_platform_removed() {
+async fn connect_omission_preserves_secret_when_preceding_platform_is_removed() {
     use crate::app_state::AppState;
     use actix_web::{test, web, App};
 
@@ -1517,6 +1583,7 @@ async fn set_bamboo_config_preserves_masked_secret_when_preceding_platform_remov
     let post = test::TestRequest::post()
         .uri("/bamboo/config")
         .set_json(serde_json::json!({
+            "expected_revision": 0,
             "connect": {
                 "platforms": [
                     { "type": "telegram", "token": "tg-real-secret", "allow_from": ["u1"] },
@@ -1546,17 +1613,18 @@ async fn set_bamboo_config_preserves_masked_secret_when_preceding_platform_remov
         .to_string();
     let feishu_ref = bamboo_config::credential_ref("connect", &feishu_id, "app_secret").unwrap();
 
-    // 3) Re-POST with telegram removed — the UI's echoed feishu entry (still
-    // masked) now sits at index 0, not index 1 where it was stored.
+    // 3) Re-POST with telegram removed and the Feishu secret omitted. The
+    // stable id identifies the same entry even though it moves to index 0.
     let post2 = test::TestRequest::post()
         .uri("/bamboo/config")
         .set_json(serde_json::json!({
+            "expected_revision": 1,
             "connect": {
                 "platforms": [
                     {
+                        "id": feishu_id,
                         "type": "feishu",
                         "app_id": "cli_real_app_id",
-                        "app_secret": "****...****",
                         "domain": "lark",
                         "allow_from": ["ou_1"]
                     }
@@ -1609,7 +1677,7 @@ async fn set_bamboo_config_preserves_masked_secret_when_preceding_platform_remov
             .unwrap()
             .expose(),
         "feishu-real-secret",
-        "masked secret must resolve by stable identity after a preceding entry was removed"
+        "omitted secret must resolve by stable identity after a preceding entry was removed"
     );
 }
 
@@ -1644,6 +1712,7 @@ async fn reset_bamboo_config_rejects_modular_layout_without_mutation() {
     let post = test::TestRequest::post()
         .uri("/bamboo/config")
         .set_json(serde_json::json!({
+            "expected_revision": 0,
             "connect": {
                 "platforms": [
                     { "type": "telegram", "token": "tg-reset-me", "allow_from": ["u1"] }
@@ -1699,10 +1768,14 @@ async fn reset_bamboo_config_rejection_preserves_connect_backup() {
     // Configure a connect platform, then change it again so a
     // `connect.json.bak` gets written (the save path backs up the previous
     // connect.json before overwriting it).
-    for token in ["tg-first-token", "tg-second-token"] {
+    for (expected_revision, token) in ["tg-first-token", "tg-second-token"]
+        .into_iter()
+        .enumerate()
+    {
         let post = test::TestRequest::post()
             .uri("/bamboo/config")
             .set_json(serde_json::json!({
+                "expected_revision": expected_revision,
                 "connect": {
                     "platforms": [
                         { "type": "telegram", "token": token, "allow_from": ["u1"] }

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/connect.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/connect.rs
@@ -1,0 +1,492 @@
+use actix_web::{web, HttpResponse};
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{
+    app_state::AppState,
+    error::AppError,
+    handlers::settings::credential_action::{credential_status_view, CredentialAction},
+};
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConnectMutationRequest {
+    expected_revision: u64,
+    data: ConnectMutationData,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConnectMutationData {
+    platforms: Vec<ConnectPlatformMutation>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConnectPlatformMutation {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    project_id: Option<bamboo_domain::ProjectId>,
+    #[serde(rename = "type")]
+    platform_type: String,
+    #[serde(default)]
+    app_id: Option<String>,
+    #[serde(default)]
+    domain: Option<String>,
+    #[serde(default)]
+    allow_from: Vec<String>,
+    #[serde(default)]
+    admin_from: Vec<String>,
+    #[serde(default)]
+    token_change: Option<CredentialAction>,
+    #[serde(default)]
+    app_secret_change: Option<CredentialAction>,
+}
+
+fn existing_platform<'a>(
+    current: &'a bamboo_config::ConnectConfig,
+    candidate: &ConnectPlatformMutation,
+    index: usize,
+) -> Option<&'a bamboo_config::ConnectPlatformConfig> {
+    candidate
+        .id
+        .as_deref()
+        .and_then(|id| {
+            current
+                .platforms
+                .iter()
+                .find(|platform| platform.id.as_deref() == Some(id))
+        })
+        .or_else(|| {
+            current
+                .platforms
+                .get(index)
+                .filter(|platform| platform.platform_type == candidate.platform_type)
+        })
+        .or_else(|| {
+            let mut matches = current
+                .platforms
+                .iter()
+                .filter(|platform| platform.platform_type == candidate.platform_type);
+            let first = matches.next();
+            first.filter(|_| matches.next().is_none())
+        })
+}
+
+fn apply_action(
+    action: Option<&CredentialAction>,
+    current_value: Option<String>,
+    current_ref: Option<bamboo_config::CredentialRef>,
+    current_configured: bool,
+) -> (Option<String>, Option<bamboo_config::CredentialRef>, bool) {
+    match action {
+        None | Some(CredentialAction::Keep) => (current_value, current_ref, current_configured),
+        Some(CredentialAction::Replace { value }) => (Some(value.clone()), current_ref, true),
+        Some(CredentialAction::Clear) => (None, current_ref, false),
+    }
+}
+
+fn connect_response(
+    section: bamboo_config::SectionEnvelope<serde_json::Value>,
+    config: &bamboo_config::Config,
+    statuses: Vec<bamboo_config::CredentialStatus>,
+    credential_health: bamboo_config::CredentialStoreHealth,
+) -> serde_json::Value {
+    let statuses = statuses
+        .into_iter()
+        .map(|status| (status.credential_ref.clone(), status))
+        .collect::<BTreeMap<_, _>>();
+    let active_refs = config
+        .connect
+        .platforms
+        .iter()
+        .flat_map(|platform| {
+            [
+                platform.token_credential_ref.clone(),
+                platform.app_secret_credential_ref.clone(),
+            ]
+        })
+        .flatten()
+        .collect::<BTreeSet<_>>();
+    let credentials = active_refs
+        .into_iter()
+        .map(|reference| {
+            credential_status_view(
+                Some(&reference),
+                true,
+                statuses.get(&reference),
+                &credential_health,
+            )
+        })
+        .collect::<Vec<_>>();
+    let credential_status = config
+        .connect
+        .platforms
+        .iter()
+        .enumerate()
+        .map(|(index, platform)| {
+            let key = platform
+                .id
+                .clone()
+                .unwrap_or_else(|| format!("index-{index}"));
+            let token_status = platform
+                .token_credential_ref
+                .as_ref()
+                .and_then(|reference| statuses.get(reference));
+            let app_secret_status = platform
+                .app_secret_credential_ref
+                .as_ref()
+                .and_then(|reference| statuses.get(reference));
+            (
+                key,
+                serde_json::json!({
+                    "token": credential_status_view(
+                        platform.token_credential_ref.as_ref(),
+                        platform.token_configured,
+                        token_status,
+                        &credential_health,
+                    ),
+                    "app_secret": credential_status_view(
+                        platform.app_secret_credential_ref.as_ref(),
+                        platform.app_secret_configured,
+                        app_secret_status,
+                        &credential_health,
+                    ),
+                }),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    serde_json::json!({
+        "revision": section.revision,
+        "section": section,
+        "credentials": credentials,
+        "credential_status": credential_status,
+        "credential_health": credential_health,
+    })
+}
+
+/// Return the Connect section and one secret-free credential status snapshot.
+pub async fn get_connect_config(app_state: web::Data<AppState>) -> Result<HttpResponse, AppError> {
+    let _io = app_state.config_io_lock.lock().await;
+    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
+        AppError::BadRequest(
+            "connect settings require the modular configuration facade".to_string(),
+        )
+    })?;
+    let section = facade
+        .registry()
+        .envelope_value(bamboo_config::SectionId::Connect)
+        .map_err(|error| {
+            AppError::InternalError(anyhow::anyhow!(
+                "connect section envelope unavailable: {error}"
+            ))
+        })?;
+    let config = app_state.config.read().await.clone();
+    let (statuses, health) = app_state
+        .credential_store
+        .statuses_with_health()
+        .map_err(super::credentials::map_store_read_error)?;
+    Ok(HttpResponse::Ok().json(connect_response(section, &config, statuses, health)))
+}
+
+/// Replace Connect metadata and explicitly keep, replace, or clear platform
+/// secrets using only the Connect section revision as the public CAS token.
+pub async fn put_connect_config(
+    app_state: web::Data<AppState>,
+    payload: web::Json<ConnectMutationRequest>,
+) -> Result<HttpResponse, AppError> {
+    let payload = payload.into_inner();
+    let mut ids = BTreeSet::new();
+    let mut intents = bamboo_config::patch::ConnectSecretIntents::default();
+    for (index, platform) in payload.data.platforms.iter().enumerate() {
+        if platform
+            .id
+            .as_deref()
+            .is_some_and(|id| id.trim().is_empty() || !ids.insert(id.to_string()))
+        {
+            return Err(AppError::BadRequest(
+                "connect platform ids must be nonempty and unique".to_string(),
+            ));
+        }
+        if platform.platform_type.trim().is_empty() {
+            return Err(AppError::BadRequest(
+                "connect platform type must be nonempty".to_string(),
+            ));
+        }
+        for (label, action, target) in [
+            (
+                "connect token",
+                platform.token_change.as_ref(),
+                &mut intents.token,
+            ),
+            (
+                "connect app secret",
+                platform.app_secret_change.as_ref(),
+                &mut intents.app_secret,
+            ),
+        ] {
+            if let Some(action) = action {
+                action.validate(label)?;
+                if !action.is_keep() {
+                    target.insert(index);
+                }
+            }
+        }
+    }
+
+    let expected_revision = payload.expected_revision;
+    let data = payload.data;
+    let (config, _, metadata, section) = app_state
+        .update_connect_credentials(expected_revision, intents, move |config| {
+            let current = config.connect.clone();
+            let mut platforms = Vec::with_capacity(data.platforms.len());
+            for (index, input) in data.platforms.into_iter().enumerate() {
+                let existing = existing_platform(&current, &input, index);
+                let (token, token_credential_ref, token_configured) = apply_action(
+                    input.token_change.as_ref(),
+                    existing.and_then(|platform| platform.token.clone()),
+                    existing.and_then(|platform| platform.token_credential_ref.clone()),
+                    existing.is_some_and(|platform| platform.token_configured),
+                );
+                let (app_secret, app_secret_credential_ref, app_secret_configured) = apply_action(
+                    input.app_secret_change.as_ref(),
+                    existing.and_then(|platform| platform.app_secret.clone()),
+                    existing.and_then(|platform| platform.app_secret_credential_ref.clone()),
+                    existing.is_some_and(|platform| platform.app_secret_configured),
+                );
+                platforms.push(bamboo_config::ConnectPlatformConfig {
+                    id: input.id,
+                    project_id: input.project_id,
+                    platform_type: input.platform_type,
+                    token,
+                    token_encrypted: None,
+                    token_credential_ref,
+                    token_configured,
+                    app_id: input.app_id,
+                    app_secret,
+                    app_secret_encrypted: None,
+                    app_secret_credential_ref,
+                    app_secret_configured,
+                    domain: input.domain,
+                    allow_from: input.allow_from,
+                    admin_from: input.admin_from,
+                });
+            }
+            config.connect = bamboo_config::ConnectConfig { platforms };
+            Ok(())
+        })
+        .await?;
+    let section = section.ok_or_else(|| {
+        AppError::InternalError(anyhow::anyhow!(
+            "connect mutation completed without a typed section envelope"
+        ))
+    })?;
+    Ok(HttpResponse::Ok().json(connect_response(
+        section,
+        &config,
+        metadata.credential_statuses,
+        metadata.credential_health,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::{http::StatusCode, test, App};
+
+    #[actix_web::test]
+    async fn action_debug_never_exposes_connect_secrets() {
+        let payload: ConnectMutationRequest = serde_json::from_value(serde_json::json!({
+            "expected_revision": 0,
+            "data": {
+                "platforms": [{
+                    "type": "telegram",
+                    "token_change": {"action": "replace", "value": "telegram-secret"}
+                }]
+            }
+        }))
+        .unwrap();
+        let debug = format!("{payload:?}");
+        assert!(!debug.contains("telegram-secret"));
+        assert!(debug.contains("[REDACTED]"));
+    }
+
+    #[actix_web::test]
+    async fn dedicated_connect_mutation_uses_section_cas_and_explicit_actions() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0xc5; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let mut events = state.account_sink.subscribe();
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .route("/connect", web::put().to(put_connect_config)),
+        )
+        .await;
+
+        let replace = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/connect")
+                .set_json(serde_json::json!({
+                    "expected_revision": 0,
+                    "data": {
+                        "platforms": [{
+                            "type": "telegram",
+                            "allow_from": ["owner"],
+                            "token_change": {
+                                "action": "replace",
+                                "value": "telegram-token-secret"
+                            }
+                        }]
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(replace.status(), StatusCode::OK);
+        let replace: serde_json::Value = test::read_body_json(replace).await;
+        assert_eq!(replace["revision"], 1);
+        assert_eq!(replace["section"]["revision"], 1);
+        assert_eq!(replace["credentials"][0]["configured"], true);
+        assert_eq!(replace["credentials"][0]["state"], "configured");
+        assert!(!replace.to_string().contains("telegram-token-secret"));
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let event = events.recv().await.unwrap();
+                if matches!(
+                    &event.event,
+                    bamboo_agent_core::AgentEvent::ConfigChanged { section, revision: 1 }
+                        if section == "connect"
+                ) {
+                    break event;
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert!(matches!(
+            event.event,
+            bamboo_agent_core::AgentEvent::ConfigChanged { ref section, revision: 1 }
+                if section == "connect"
+        ));
+        let platform_id = replace["section"]["data"]["platforms"][0]["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let stale = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/connect")
+                .set_json(serde_json::json!({
+                    "expected_revision": 0,
+                    "data": {
+                        "platforms": [{
+                            "id": platform_id,
+                            "type": "telegram",
+                            "allow_from": ["stale"],
+                            "token_change": {
+                                "action": "replace",
+                                "value": "stale-telegram-secret"
+                            }
+                        }]
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale.status(), StatusCode::CONFLICT);
+        assert!(!String::from_utf8(test::read_body(stale).await.to_vec())
+            .unwrap()
+            .contains("stale-telegram-secret"));
+
+        let keep = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/connect")
+                .set_json(serde_json::json!({
+                    "expected_revision": 1,
+                    "data": {
+                        "platforms": [{
+                            "id": platform_id,
+                            "type": "telegram",
+                            "allow_from": ["owner", "maintainer"],
+                            "token_change": {"action": "keep"}
+                        }]
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(keep.status(), StatusCode::OK);
+        let keep: serde_json::Value = test::read_body_json(keep).await;
+        assert_eq!(keep["section"]["revision"], 2);
+        assert_eq!(
+            state.config.read().await.connect.platforms[0]
+                .token
+                .as_deref(),
+            Some("telegram-token-secret")
+        );
+
+        let clear = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/connect")
+                .set_json(serde_json::json!({
+                    "expected_revision": 2,
+                    "data": {
+                        "platforms": [{
+                            "id": platform_id,
+                            "type": "telegram",
+                            "allow_from": ["owner", "maintainer"],
+                            "token_change": {"action": "clear"}
+                        }]
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(clear.status(), StatusCode::OK);
+        let clear: serde_json::Value = test::read_body_json(clear).await;
+        assert_eq!(clear["section"]["revision"], 3);
+        assert!(clear["credentials"].as_array().unwrap().is_empty());
+        assert_eq!(
+            clear["credential_status"][&platform_id]["token"]["state"],
+            "missing"
+        );
+        assert!(state.config.read().await.connect.platforms[0]
+            .token
+            .is_none());
+
+        let masked = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/connect")
+                .set_json(serde_json::json!({
+                    "expected_revision": 3,
+                    "data": {
+                        "platforms": [{
+                            "id": platform_id,
+                            "type": "telegram",
+                            "token_change": {
+                                "action": "replace",
+                                "value": "********"
+                            }
+                        }]
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(masked.status(), StatusCode::BAD_REQUEST);
+
+        let connect_file = std::fs::read_to_string(dir.path().join("connect.json")).unwrap();
+        let credential_file = std::fs::read_to_string(dir.path().join("credentials.json")).unwrap();
+        for secret in ["telegram-token-secret", "stale-telegram-secret", "********"] {
+            assert!(!connect_file.contains(secret));
+            assert!(!credential_file.contains(secret));
+        }
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/connect.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/connect.rs
@@ -168,26 +168,15 @@ fn connect_response(
 
 /// Return the Connect section and one secret-free credential status snapshot.
 pub async fn get_connect_config(app_state: web::Data<AppState>) -> Result<HttpResponse, AppError> {
-    let _io = app_state.config_io_lock.lock().await;
-    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
-        AppError::BadRequest(
-            "connect settings require the modular configuration facade".to_string(),
-        )
-    })?;
-    let section = facade
-        .registry()
-        .envelope_value(bamboo_config::SectionId::Connect)
-        .map_err(|error| {
-            AppError::InternalError(anyhow::anyhow!(
-                "connect section envelope unavailable: {error}"
-            ))
-        })?;
-    let config = app_state.config.read().await.clone();
-    let (statuses, health) = app_state
-        .credential_store
-        .statuses_with_health()
-        .map_err(super::credentials::map_store_read_error)?;
-    Ok(HttpResponse::Ok().json(connect_response(section, &config, statuses, health)))
+    let exact = app_state
+        .read_exact_credential_section(bamboo_config::SectionId::Connect)
+        .await?;
+    Ok(HttpResponse::Ok().json(connect_response(
+        exact.section,
+        &exact.config,
+        exact.metadata.credential_statuses,
+        exact.metadata.credential_health,
+    )))
 }
 
 /// Replace Connect metadata and explicitly keep, replace, or clear platform

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
@@ -67,7 +67,7 @@ pub async fn replace_credential(
     reject_managed_credential_ref(&app_state, &credential_ref).await?;
     let (revision, status) = app_state
         .credential_store
-        .replace(
+        .replace_unreferenced(
             credential_ref,
             &payload.value,
             CredentialSource::User,
@@ -88,7 +88,7 @@ pub async fn clear_credential(
     reject_managed_credential_ref(&app_state, &credential_ref).await?;
     let (revision, status) = app_state
         .credential_store
-        .clear(&credential_ref, payload.expected_revision)
+        .clear_unreferenced(&credential_ref, payload.expected_revision)
         .map_err(map_store_mutation_error)?;
     publish_credential_event(&app_state, revision);
     Ok(HttpResponse::Ok().json(envelope(status, CredentialStoreHealth::committed(revision))))
@@ -245,7 +245,10 @@ fn map_store_mutation_error(error: ConfigStoreError) -> AppError {
         ConfigStoreError::Conflict { expected, actual } => {
             AppError::ConfigConflict { expected, actual }
         }
-        ConfigStoreError::Validation(message) if message.starts_with("credential value ") => {
+        ConfigStoreError::Validation(message)
+            if message.starts_with("credential value ")
+                || message.starts_with("credential reference is managed by configuration") =>
+        {
             AppError::BadRequest(message)
         }
         other => map_store_read_error(other),
@@ -301,6 +304,18 @@ mod tests {
         assert_eq!(value["status"], "healthy");
         assert!(value["data"].get("value").is_none());
         assert!(value["data"].get("secret").is_none());
+    }
+
+    #[::core::prelude::v1::test]
+    fn durable_managed_reference_rejection_is_a_client_error() {
+        assert!(matches!(
+            map_store_mutation_error(ConfigStoreError::Validation(
+                "credential reference is managed by configuration and must be changed through its \
+                 owning section"
+                    .to_string()
+            )),
+            AppError::BadRequest(_)
+        ));
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
@@ -184,6 +184,27 @@ async fn reject_managed_credential_ref(
     {
         return Err(AppError::BadRequest(
             "notification credentials must be changed through the revisioned notification config API"
+            .to_string(),
+        ));
+    }
+    if config.connect.platforms.iter().any(|platform| {
+        platform.token_credential_ref.as_ref() == Some(credential_ref)
+            || platform.app_secret_credential_ref.as_ref() == Some(credential_ref)
+    }) {
+        return Err(AppError::BadRequest(
+            "connect credentials must be changed through the revisioned connect config API"
+                .to_string(),
+        ));
+    }
+    if config.access_control.as_ref().is_some_and(|access| {
+        access.password_credential_ref.as_ref() == Some(credential_ref)
+            || access
+                .devices
+                .iter()
+                .any(|device| device.token_credential_ref.as_ref() == Some(credential_ref))
+    }) {
+        return Err(AppError::BadRequest(
+            "access-control credentials must be changed through the revisioned access APIs"
                 .to_string(),
         ));
     }
@@ -506,6 +527,55 @@ mod tests {
                 .map(|auth| auth.username.as_str()),
             Some("active")
         );
+    }
+
+    #[actix_web::test]
+    async fn generic_mutations_reject_active_connect_and_access_references() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        let connect = CredentialRef::parse("connect.platform-one.token").unwrap();
+        let access_password =
+            bamboo_config::config_crypto::access_password_credential_ref().unwrap();
+        let access_device =
+            bamboo_config::config_crypto::access_device_credential_ref("device-one").unwrap();
+        {
+            let mut config = state.config.write().await;
+            config.connect.platforms.push(
+                serde_json::from_value(serde_json::json!({
+                    "id": "platform-one",
+                    "type": "telegram",
+                    "token_credential_ref": connect.clone(),
+                    "token_configured": true
+                }))
+                .unwrap(),
+            );
+            config.access_control = Some(bamboo_config::AccessControlConfig {
+                password_enabled: true,
+                password_credential_ref: Some(access_password.clone()),
+                password_configured: true,
+                devices: vec![bamboo_config::DeviceCredential {
+                    device_id: "device-one".to_string(),
+                    label: "Device".to_string(),
+                    token_hash: String::new(),
+                    token_salt: String::new(),
+                    token_credential_ref: Some(access_device.clone()),
+                    token_configured: true,
+                    created_at: "2026-07-27T00:00:00Z".to_string(),
+                    last_used_at: None,
+                    revoked: false,
+                }],
+                ..Default::default()
+            });
+        }
+
+        for reference in [&connect, &access_password, &access_device] {
+            assert!(
+                reject_managed_credential_ref(&state, reference)
+                    .await
+                    .is_err(),
+                "{reference:?}"
+            );
+        }
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/mod.rs
@@ -1,5 +1,6 @@
 mod codex;
 mod config_endpoints;
+mod connect;
 mod credentials;
 mod notifications;
 mod proxy_auth;
@@ -16,11 +17,12 @@ pub use config_endpoints::{
     confirm_config_recovery, get_bamboo_config, get_config_recovery_status,
     get_model_limit_defaults, reset_bamboo_config, set_bamboo_config,
 };
+pub use connect::{get_connect_config, put_connect_config};
 pub use credentials::{
     clear_credential, get_credential_status, get_live_config_health, list_credentials,
     replace_credential, reset_credentials,
 };
-pub use notifications::get_notification_config;
+pub use notifications::{get_notification_config, put_notification_config};
 pub use proxy_auth::{get_proxy_auth_status, set_proxy_auth};
 pub use sections::{
     get_mcp_section, get_provider_section, get_provider_settings_section, get_typed_section,

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/notifications.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/notifications.rs
@@ -116,30 +116,14 @@ fn notification_response(
 pub async fn get_notification_config(
     app_state: web::Data<AppState>,
 ) -> Result<HttpResponse, AppError> {
-    let _io = app_state.config_io_lock.lock().await;
-    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
-        AppError::BadRequest(
-            "notification settings require the modular configuration facade".to_string(),
-        )
-    })?;
-    let section = facade
-        .registry()
-        .envelope_value(bamboo_config::SectionId::Notifications)
-        .map_err(|error| {
-            AppError::InternalError(anyhow::anyhow!(
-                "notification section envelope unavailable: {error}"
-            ))
-        })?;
-    let config = app_state.config.read().await.clone();
-    let (statuses, credential_health) = app_state
-        .credential_store
-        .statuses_with_health()
-        .map_err(super::credentials::map_store_read_error)?;
+    let exact = app_state
+        .read_exact_credential_section(bamboo_config::SectionId::Notifications)
+        .await?;
     Ok(HttpResponse::Ok().json(notification_response(
-        section,
-        &config,
-        statuses,
-        credential_health,
+        exact.section,
+        &exact.config,
+        exact.metadata.credential_statuses,
+        exact.metadata.credential_health,
     )))
 }
 

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/notifications.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/notifications.rs
@@ -1,60 +1,99 @@
 use actix_web::{web, HttpResponse};
+use serde::Deserialize;
 use std::collections::BTreeMap;
 
+use crate::handlers::settings::credential_action::{
+    credential_status_view, CredentialAction, CredentialStatusView,
+};
 use crate::{app_state::AppState, error::AppError};
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NotificationMutationRequest {
+    expected_revision: u64,
+    data: NotificationMutationData,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NotificationMutationData {
+    desktop: DesktopMutationData,
+    ntfy: NtfyMutationData,
+    bark: BarkMutationData,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DesktopMutationData {
+    enabled: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NtfyMutationData {
+    enabled: bool,
+    base_url: String,
+    topic: String,
+    #[serde(default)]
+    credential_change: Option<CredentialAction>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BarkMutationData {
+    enabled: bool,
+    base_url: String,
+    #[serde(default)]
+    credential_change: Option<CredentialAction>,
+}
 
 fn channel_status_from_snapshot(
     reference: Option<bamboo_config::CredentialRef>,
+    expected_configured: bool,
     statuses: &BTreeMap<bamboo_config::CredentialRef, bamboo_config::CredentialStatus>,
-) -> serde_json::Value {
-    let Some(reference) = reference else {
-        return serde_json::json!({
-            "credential_ref": serde_json::Value::Null,
-            "configured": false,
-            "source": serde_json::Value::Null,
-            "updated_at": serde_json::Value::Null,
-        });
-    };
-    match statuses.get(&reference) {
-        Some(status) => serde_json::json!({
-            "credential_ref": status.credential_ref,
-            "configured": status.configured,
-            "source": status.source,
-            "updated_at": status.updated_at,
-        }),
-        None => serde_json::json!({
-            "credential_ref": reference,
-            "configured": false,
-            "source": bamboo_config::CredentialSource::User,
-            "updated_at": serde_json::Value::Null,
-        }),
-    }
+    health: &bamboo_config::CredentialStoreHealth,
+) -> CredentialStatusView {
+    let status = reference
+        .as_ref()
+        .and_then(|reference| statuses.get(reference));
+    credential_status_view(reference.as_ref(), expected_configured, status, health)
 }
 
-/// Metadata-only notification configuration and credential status. Secret
-/// values, ciphertext and masks are never returned.
-pub async fn get_notification_config(
-    app_state: web::Data<AppState>,
-) -> Result<HttpResponse, AppError> {
-    let _io = app_state.config_io_lock.lock().await;
-    let config = app_state.config.read().await.clone();
-    let (statuses, health) = app_state
-        .credential_store
-        .statuses_with_health()
-        .map_err(super::credentials::map_store_read_error)?;
+fn notification_response(
+    section: bamboo_config::SectionEnvelope<serde_json::Value>,
+    config: &bamboo_config::Config,
+    statuses: Vec<bamboo_config::CredentialStatus>,
+    credential_health: bamboo_config::CredentialStoreHealth,
+) -> serde_json::Value {
     let statuses = statuses
         .into_iter()
         .map(|status| (status.credential_ref.clone(), status))
         .collect::<BTreeMap<_, _>>();
-    let ntfy =
-        channel_status_from_snapshot(config.notifications.ntfy.credential_ref.clone(), &statuses);
-    let bark =
-        channel_status_from_snapshot(config.notifications.bark.credential_ref.clone(), &statuses);
-    Ok(HttpResponse::Ok().json(serde_json::json!({
-        "revision": health.revision,
-        "status": health.status,
-        "source": health.source,
-        "last_error": health.last_error,
+    let ntfy = channel_status_from_snapshot(
+        config.notifications.ntfy.credential_ref.clone(),
+        config.notifications.ntfy.configured,
+        &statuses,
+        &credential_health,
+    );
+    let bark = channel_status_from_snapshot(
+        config.notifications.bark.credential_ref.clone(),
+        config.notifications.bark.configured,
+        &statuses,
+        &credential_health,
+    );
+    serde_json::json!({
+        "revision": section.revision,
+        "status": section.status,
+        "source": section.source_kind,
+        "source_path": section.source_path,
+        "loaded_at": section.loaded_at,
+        "last_error": section.last_error,
+        "section": section.clone(),
+        "credential_revision": credential_health.revision,
+        "credential_status": credential_health.status,
+        "credential_source": credential_health.source,
+        "credential_last_error": credential_health.last_error,
+        "credential_health": credential_health,
         "data": {
             "desktop": { "enabled": config.notifications.desktop.enabled },
             "ntfy": {
@@ -69,15 +108,159 @@ pub async fn get_notification_config(
                 "credential": bark,
             }
         }
-    })))
+    })
+}
+
+/// Metadata-only notification configuration and credential status. Secret
+/// values, ciphertext and masks are never returned.
+pub async fn get_notification_config(
+    app_state: web::Data<AppState>,
+) -> Result<HttpResponse, AppError> {
+    let _io = app_state.config_io_lock.lock().await;
+    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
+        AppError::BadRequest(
+            "notification settings require the modular configuration facade".to_string(),
+        )
+    })?;
+    let section = facade
+        .registry()
+        .envelope_value(bamboo_config::SectionId::Notifications)
+        .map_err(|error| {
+            AppError::InternalError(anyhow::anyhow!(
+                "notification section envelope unavailable: {error}"
+            ))
+        })?;
+    let config = app_state.config.read().await.clone();
+    let (statuses, credential_health) = app_state
+        .credential_store
+        .statuses_with_health()
+        .map_err(super::credentials::map_store_read_error)?;
+    Ok(HttpResponse::Ok().json(notification_response(
+        section,
+        &config,
+        statuses,
+        credential_health,
+    )))
+}
+
+/// Replace notification metadata and explicitly keep, replace, or clear each
+/// channel credential using the Notifications section revision as the only
+/// public precondition.
+pub async fn put_notification_config(
+    app_state: web::Data<AppState>,
+    payload: web::Json<NotificationMutationRequest>,
+) -> Result<HttpResponse, AppError> {
+    let payload = payload.into_inner();
+    for (label, action) in [
+        (
+            "ntfy credential",
+            payload.data.ntfy.credential_change.as_ref(),
+        ),
+        (
+            "Bark credential",
+            payload.data.bark.credential_change.as_ref(),
+        ),
+    ] {
+        if let Some(action) = action {
+            action.validate(label)?;
+        }
+    }
+
+    let mut intents = std::collections::BTreeSet::new();
+    if payload
+        .data
+        .ntfy
+        .credential_change
+        .as_ref()
+        .is_some_and(|action| !action.is_keep())
+    {
+        intents.insert("ntfy".to_string());
+    }
+    if payload
+        .data
+        .bark
+        .credential_change
+        .as_ref()
+        .is_some_and(|action| !action.is_keep())
+    {
+        intents.insert("bark".to_string());
+    }
+
+    let expected_revision = payload.expected_revision;
+    let data = payload.data;
+    let (config, _, metadata, section) = app_state
+        .update_notification_credentials(expected_revision, intents, false, move |config| {
+            let current = config.notifications.clone();
+            let mut candidate = bamboo_config::NotificationsConfig {
+                desktop: bamboo_config::DesktopChannelConfig {
+                    enabled: data.desktop.enabled,
+                },
+                ntfy: bamboo_config::NtfyChannelConfig {
+                    enabled: data.ntfy.enabled,
+                    base_url: data.ntfy.base_url,
+                    topic: data.ntfy.topic,
+                    ..Default::default()
+                },
+                bark: bamboo_config::BarkChannelConfig {
+                    enabled: data.bark.enabled,
+                    base_url: data.bark.base_url,
+                    ..Default::default()
+                },
+            };
+            match data.ntfy.credential_change.as_ref() {
+                None | Some(CredentialAction::Keep) => {
+                    candidate.ntfy.token = current.ntfy.token;
+                    candidate.ntfy.credential_ref = current.ntfy.credential_ref;
+                    candidate.ntfy.configured = current.ntfy.configured;
+                }
+                Some(CredentialAction::Replace { value }) => {
+                    candidate.ntfy.token = Some(value.clone());
+                    candidate.ntfy.credential_ref = current.ntfy.credential_ref;
+                    candidate.ntfy.configured = true;
+                }
+                Some(CredentialAction::Clear) => {
+                    candidate.ntfy.credential_ref = current.ntfy.credential_ref;
+                }
+            }
+            match data.bark.credential_change.as_ref() {
+                None | Some(CredentialAction::Keep) => {
+                    candidate.bark.device_key = current.bark.device_key;
+                    candidate.bark.credential_ref = current.bark.credential_ref;
+                    candidate.bark.configured = current.bark.configured;
+                }
+                Some(CredentialAction::Replace { value }) => {
+                    candidate.bark.device_key = Some(value.clone());
+                    candidate.bark.credential_ref = current.bark.credential_ref;
+                    candidate.bark.configured = true;
+                }
+                Some(CredentialAction::Clear) => {
+                    candidate.bark.credential_ref = current.bark.credential_ref;
+                }
+            }
+            config.notifications = candidate;
+            Ok(())
+        })
+        .await?;
+    let section = section.ok_or_else(|| {
+        AppError::InternalError(anyhow::anyhow!(
+            "notification mutation completed without a typed section envelope"
+        ))
+    })?;
+    Ok(HttpResponse::Ok().json(notification_response(
+        section,
+        &config,
+        metadata.credential_statuses,
+        metadata.credential_health,
+    )))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use actix_web::{http::StatusCode, test, App};
 
-    #[test]
-    fn channel_status_uses_only_the_supplied_snapshot() {
+    #[actix_web::test]
+    async fn channel_status_uses_only_the_supplied_snapshot() {
         let reference = bamboo_config::CredentialRef::parse("notification.ntfy.token").unwrap();
         let status = bamboo_config::CredentialStatus {
             credential_ref: reference.clone(),
@@ -86,12 +269,234 @@ mod tests {
             updated_at: None,
         };
         let snapshot = BTreeMap::from([(reference.clone(), status)]);
-        let configured = channel_status_from_snapshot(Some(reference.clone()), &snapshot);
+        let health = bamboo_config::CredentialStoreHealth::committed(1);
+        let configured = serde_json::to_value(channel_status_from_snapshot(
+            Some(reference.clone()),
+            true,
+            &snapshot,
+            &health,
+        ))
+        .unwrap();
         assert_eq!(configured["configured"], true);
+        assert_eq!(configured["state"], "configured");
         assert_eq!(configured["source"], "migrated");
 
-        let missing = channel_status_from_snapshot(Some(reference), &BTreeMap::new());
-        assert_eq!(missing["configured"], false);
-        assert_eq!(missing["source"], "user");
+        let incoherent = serde_json::to_value(channel_status_from_snapshot(
+            Some(reference),
+            true,
+            &BTreeMap::new(),
+            &health,
+        ))
+        .unwrap();
+        assert_eq!(incoherent["configured"], false);
+        assert_eq!(incoherent["state"], "error");
+        assert!(incoherent.get("source").is_none());
+    }
+
+    #[actix_web::test]
+    async fn dedicated_mutation_returns_exact_section_and_explicit_secret_status() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0xc4; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let mut events = state.account_sink.subscribe();
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .route("/notifications", web::put().to(put_notification_config)),
+        )
+        .await;
+
+        let replace = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/notifications")
+                .set_json(serde_json::json!({
+                    "expected_revision": 0,
+                    "data": {
+                        "desktop": {"enabled": null},
+                        "ntfy": {
+                            "enabled": true,
+                            "base_url": "https://ntfy.sh",
+                            "topic": "alerts",
+                            "credential_change": {
+                                "action": "replace",
+                                "value": "notification-secret"
+                            }
+                        },
+                        "bark": {
+                            "enabled": false,
+                            "base_url": "https://api.day.app"
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(replace.status(), StatusCode::OK);
+        let replace: serde_json::Value = test::read_body_json(replace).await;
+        assert_eq!(replace["revision"], 1);
+        assert_eq!(replace["section"]["revision"], 1);
+        assert_eq!(replace["data"]["ntfy"]["credential"]["configured"], true);
+        assert_eq!(replace["data"]["ntfy"]["credential"]["state"], "configured");
+        assert!(!replace.to_string().contains("notification-secret"));
+        assert!(!replace.to_string().contains("********"));
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let event = events.recv().await.unwrap();
+                if matches!(
+                    &event.event,
+                    bamboo_agent_core::AgentEvent::ConfigChanged { section, revision: 1 }
+                        if section == "notifications"
+                ) {
+                    break event;
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert!(matches!(
+            event.event,
+            bamboo_agent_core::AgentEvent::ConfigChanged { ref section, revision: 1 }
+                if section == "notifications"
+        ));
+
+        let stale = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/notifications")
+                .set_json(serde_json::json!({
+                    "expected_revision": 0,
+                    "data": {
+                        "desktop": {"enabled": true},
+                        "ntfy": {
+                            "enabled": true,
+                            "base_url": "https://ntfy.sh",
+                            "topic": "stale",
+                            "credential_change": {
+                                "action": "replace",
+                                "value": "stale-notification-secret"
+                            }
+                        },
+                        "bark": {
+                            "enabled": false,
+                            "base_url": "https://api.day.app"
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(stale.status(), StatusCode::CONFLICT);
+        assert!(!String::from_utf8(test::read_body(stale).await.to_vec())
+            .unwrap()
+            .contains("stale-notification-secret"));
+
+        let keep = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/notifications")
+                .set_json(serde_json::json!({
+                    "expected_revision": 1,
+                    "data": {
+                        "desktop": {"enabled": true},
+                        "ntfy": {
+                            "enabled": true,
+                            "base_url": "https://ntfy.sh",
+                            "topic": "renamed",
+                            "credential_change": {"action": "keep"}
+                        },
+                        "bark": {
+                            "enabled": false,
+                            "base_url": "https://api.day.app"
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(keep.status(), StatusCode::OK);
+        let keep: serde_json::Value = test::read_body_json(keep).await;
+        assert_eq!(keep["section"]["revision"], 2);
+        assert_eq!(keep["data"]["ntfy"]["topic"], "renamed");
+        assert_eq!(
+            state
+                .config
+                .read()
+                .await
+                .notifications
+                .ntfy
+                .token
+                .as_deref(),
+            Some("notification-secret")
+        );
+
+        let clear = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/notifications")
+                .set_json(serde_json::json!({
+                    "expected_revision": 2,
+                    "data": {
+                        "desktop": {"enabled": true},
+                        "ntfy": {
+                            "enabled": false,
+                            "base_url": "https://ntfy.sh",
+                            "topic": "renamed",
+                            "credential_change": {"action": "clear"}
+                        },
+                        "bark": {
+                            "enabled": false,
+                            "base_url": "https://api.day.app"
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(clear.status(), StatusCode::OK);
+        let clear: serde_json::Value = test::read_body_json(clear).await;
+        assert_eq!(clear["section"]["revision"], 3);
+        assert_eq!(clear["data"]["ntfy"]["credential"]["configured"], false);
+        assert_eq!(clear["data"]["ntfy"]["credential"]["state"], "missing");
+
+        let masked = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/notifications")
+                .set_json(serde_json::json!({
+                    "expected_revision": 3,
+                    "data": {
+                        "desktop": {"enabled": true},
+                        "ntfy": {
+                            "enabled": false,
+                            "base_url": "https://ntfy.sh",
+                            "topic": "renamed",
+                            "credential_change": {
+                                "action": "replace",
+                                "value": "********"
+                            }
+                        },
+                        "bark": {
+                            "enabled": false,
+                            "base_url": "https://api.day.app"
+                        }
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(masked.status(), StatusCode::BAD_REQUEST);
+
+        let notification_file =
+            std::fs::read_to_string(dir.path().join("notifications.json")).unwrap();
+        let credential_file = std::fs::read_to_string(dir.path().join("credentials.json")).unwrap();
+        for secret in [
+            "notification-secret",
+            "stale-notification-secret",
+            "********",
+        ] {
+            assert!(!notification_file.contains(secret));
+            assert!(!credential_file.contains(secret));
+        }
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/proxy_auth.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/proxy_auth.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use actix_web::{web, HttpResponse};
 
-use super::types::ProxyAuthPayload;
+use super::{super::credential_action::credential_status_view, types::ProxyAuthPayload};
 
 /// Sets proxy authentication credentials
 ///
@@ -15,6 +15,7 @@ use super::types::ProxyAuthPayload;
 /// ```json
 /// {
 ///   "expected_revision": 0,
+///   "action": "replace",
 ///   "username": "user",
 ///   "password": "pass"
 /// }
@@ -23,7 +24,10 @@ use super::types::ProxyAuthPayload;
 /// # Response Format
 /// ```json
 /// {
-///   "success": true
+///   "success": true,
+///   "revision": 1,
+///   "section": { "revision": 1, "data": {} },
+///   "configured": true
 /// }
 /// ```
 ///
@@ -39,7 +43,7 @@ use super::types::ProxyAuthPayload;
 /// ```bash
 /// curl -X POST http://localhost:3000/bamboo/proxy-auth \
 ///   -H "Content-Type: application/json" \
-///   -d '{"expected_revision": 0, "username": "user", "password": "pass"}'
+///   -d '{"expected_revision":0,"action":"replace","username":"user","password":"pass"}'
 /// ```
 pub async fn set_proxy_auth(
     app_state: web::Data<AppState>,
@@ -47,9 +51,9 @@ pub async fn set_proxy_auth(
 ) -> Result<HttpResponse, AppError> {
     let payload = payload.into_inner();
     let expected_revision = payload.expected_revision();
-    let auth = payload.into_proxy_auth();
+    let auth = payload.into_proxy_auth().map_err(AppError::BadRequest)?;
 
-    let (_, status, health) = app_state
+    let (config, revision, status, credential_health, section) = app_state
         .update_proxy_auth_credential(
             auth,
             expected_revision,
@@ -62,17 +66,32 @@ pub async fn set_proxy_auth(
             },
         )
         .await?;
+    let section = section.ok_or_else(|| {
+        AppError::InternalError(anyhow::anyhow!(
+            "proxy mutation completed without a typed Core section envelope"
+        ))
+    })?;
+    let credential = credential_status_view(
+        config.proxy_auth_credential_ref.as_ref(),
+        config.proxy_auth_credential_ref.is_some(),
+        Some(&status),
+        &credential_health,
+    );
 
     Ok(HttpResponse::Ok().json(serde_json::json!({
         "success": true,
-        "credential_ref": status.credential_ref,
-        "configured": status.configured,
-        "source": status.source,
-        "updated_at": status.updated_at,
-        "revision": health.revision,
-        "status": health.status,
-        "source_kind": health.source,
-        "last_error": health.last_error,
+        "section": section,
+        "credential_ref": credential.credential_ref,
+        "state": credential.state,
+        "configured": credential.configured,
+        "source": credential.source,
+        "updated_at": credential.updated_at,
+        "revision": revision,
+        "credential_health": credential_health.clone(),
+        "credential_revision": credential_health.revision,
+        "credential_status": credential_health.status,
+        "credential_source_kind": credential_health.source,
+        "credential_last_error": credential_health.last_error,
     })))
 }
 
@@ -105,6 +124,17 @@ pub async fn get_proxy_auth_status(
     app_state: web::Data<AppState>,
 ) -> Result<HttpResponse, AppError> {
     let _io = app_state.config_io_lock.lock().await;
+    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
+        AppError::BadRequest("proxy settings require the modular configuration facade".to_string())
+    })?;
+    let section = facade
+        .registry()
+        .envelope_value(bamboo_config::SectionId::Core)
+        .map_err(|error| {
+            AppError::InternalError(anyhow::anyhow!(
+                "Core section envelope unavailable: {error}"
+            ))
+        })?;
     let reference = app_state
         .config
         .read()
@@ -116,30 +146,50 @@ pub async fn get_proxy_auth_status(
             .credential_store
             .statuses_with_health()
             .map_err(super::credentials::map_store_read_error)?;
+        let credential = credential_status_view(None, false, None, &health);
         return Ok(HttpResponse::Ok().json(serde_json::json!({
-            "credential_ref": serde_json::Value::Null,
-            "configured": false,
-            "source": serde_json::Value::Null,
-            "updated_at": serde_json::Value::Null,
-            "revision": health.revision,
-            "status": health.status,
-            "source_kind": health.source,
-            "last_error": health.last_error,
+            "section": section.clone(),
+            "credential_ref": credential.credential_ref,
+            "state": credential.state,
+            "configured": credential.configured,
+            "source": credential.source,
+            "updated_at": credential.updated_at,
+            "revision": section.revision,
+            "status": section.status,
+            "source_kind": section.source_kind,
+            "source_path": section.source_path,
+            "loaded_at": section.loaded_at,
+            "last_error": section.last_error,
+            "credential_health": health.clone(),
+            "credential_revision": health.revision,
+            "credential_status": health.status,
+            "credential_source_kind": health.source,
+            "credential_last_error": health.last_error,
         })));
     };
     let (status, health) = app_state
         .credential_store
         .status_with_health(&reference)
         .map_err(super::credentials::map_store_read_error)?;
+    let credential = credential_status_view(Some(&reference), true, Some(&status), &health);
     Ok(HttpResponse::Ok().json(serde_json::json!({
-        "credential_ref": status.credential_ref,
-        "configured": status.configured,
-        "source": status.source,
-        "updated_at": status.updated_at,
-        "revision": health.revision,
-        "status": health.status,
-        "source_kind": health.source,
-        "last_error": health.last_error,
+        "section": section.clone(),
+        "credential_ref": credential.credential_ref,
+        "state": credential.state,
+        "configured": credential.configured,
+        "source": credential.source,
+        "updated_at": credential.updated_at,
+        "revision": section.revision,
+        "status": section.status,
+        "source_kind": section.source_kind,
+        "source_path": section.source_path,
+        "loaded_at": section.loaded_at,
+        "last_error": section.last_error,
+        "credential_health": health.clone(),
+        "credential_revision": health.revision,
+        "credential_status": health.status,
+        "credential_source_kind": health.source,
+        "credential_last_error": health.last_error,
     })))
 }
 
@@ -176,13 +226,16 @@ mod tests {
         let response: serde_json::Value = test::call_and_read_body_json(&app, request).await;
         assert_eq!(response["credential_ref"], serde_json::Value::Null);
         assert_eq!(response["configured"], false);
-        assert_eq!(response["revision"], 1);
+        assert_eq!(response["state"], "missing");
+        assert_eq!(response["revision"], 0);
+        assert_eq!(response["credential_revision"], 1);
     }
 
     #[actix_web::test]
     async fn proxy_auth_update_requires_revision_and_stale_write_is_conflict() {
         let dir = tempfile::tempdir().unwrap();
         let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let mut events = state.account_sink.subscribe();
         let app = test::init_service(
             App::new()
                 .app_data(state.clone())
@@ -194,6 +247,7 @@ mod tests {
             .uri("/proxy-auth")
             .set_json(serde_json::json!({
                 "expected_revision": 0,
+                "action": "replace",
                 "username": "proxy-user",
                 "password": "proxy-secret"
             }))
@@ -203,8 +257,29 @@ mod tests {
         let body: serde_json::Value = test::read_body_json(response).await;
         assert_eq!(body["revision"], 1);
         assert_eq!(body["configured"], true);
+        assert_eq!(body["state"], "configured");
         assert_eq!(body["credential_ref"], "proxy.default.auth");
         assert!(!body.to_string().contains("proxy-secret"));
+        assert_eq!(body["section"]["revision"], 1);
+        let event = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let event = events.recv().await.unwrap();
+                if matches!(
+                    &event.event,
+                    bamboo_agent_core::AgentEvent::ConfigChanged { section, revision: 1 }
+                        if section == "core"
+                ) {
+                    break event;
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert!(matches!(
+            event.event,
+            bamboo_agent_core::AgentEvent::ConfigChanged { ref section, revision: 1 }
+                if section == "core"
+        ));
         let (committed_ref, committed_auth) = {
             let config = state.config.read().await;
             (
@@ -253,13 +328,17 @@ mod tests {
 
         let clear = test::TestRequest::post()
             .uri("/proxy-auth")
-            .set_json(serde_json::json!({"expected_revision": 1}))
+            .set_json(serde_json::json!({
+                "expected_revision": 1,
+                "action": "clear"
+            }))
             .to_request();
         let clear = test::call_service(&app, clear).await;
         assert!(clear.status().is_success());
         let body: serde_json::Value = test::read_body_json(clear).await;
         assert_eq!(body["revision"], 2);
         assert_eq!(body["configured"], false);
+        assert_eq!(body["state"], "missing");
         assert!(state.config.read().await.proxy_auth.is_none());
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/proxy_auth.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/proxy_auth.rs
@@ -123,29 +123,13 @@ pub async fn set_proxy_auth(
 pub async fn get_proxy_auth_status(
     app_state: web::Data<AppState>,
 ) -> Result<HttpResponse, AppError> {
-    let _io = app_state.config_io_lock.lock().await;
-    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
-        AppError::BadRequest("proxy settings require the modular configuration facade".to_string())
-    })?;
-    let section = facade
-        .registry()
-        .envelope_value(bamboo_config::SectionId::Core)
-        .map_err(|error| {
-            AppError::InternalError(anyhow::anyhow!(
-                "Core section envelope unavailable: {error}"
-            ))
-        })?;
-    let reference = app_state
-        .config
-        .read()
-        .await
-        .proxy_auth_credential_ref
-        .clone();
+    let exact = app_state
+        .read_exact_credential_section(bamboo_config::SectionId::Core)
+        .await?;
+    let section = exact.section;
+    let reference = exact.config.proxy_auth_credential_ref.clone();
     let Some(reference) = reference else {
-        let (_, health) = app_state
-            .credential_store
-            .statuses_with_health()
-            .map_err(super::credentials::map_store_read_error)?;
+        let health = exact.metadata.credential_health;
         let credential = credential_status_view(None, false, None, &health);
         return Ok(HttpResponse::Ok().json(serde_json::json!({
             "section": section.clone(),
@@ -167,11 +151,13 @@ pub async fn get_proxy_auth_status(
             "credential_last_error": health.last_error,
         })));
     };
-    let (status, health) = app_state
-        .credential_store
-        .status_with_health(&reference)
-        .map_err(super::credentials::map_store_read_error)?;
-    let credential = credential_status_view(Some(&reference), true, Some(&status), &health);
+    let health = exact.metadata.credential_health;
+    let status = exact
+        .metadata
+        .credential_statuses
+        .iter()
+        .find(|status| status.credential_ref == reference);
+    let credential = credential_status_view(Some(&reference), true, status, &health);
     Ok(HttpResponse::Ok().json(serde_json::json!({
         "section": section.clone(),
         "credential_ref": credential.credential_ref,
@@ -229,6 +215,107 @@ mod tests {
         assert_eq!(response["state"], "missing");
         assert_eq!(response["revision"], 0);
         assert_eq!(response["credential_revision"], 1);
+    }
+
+    #[actix_web::test]
+    async fn status_reports_valid_ciphertext_with_invalid_proxy_payload_as_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        state
+            .update_proxy_auth_credential(
+                Some(bamboo_config::ProxyAuth {
+                    username: "proxy-user".to_string(),
+                    password: "proxy-secret".to_string(),
+                }),
+                0,
+                Default::default(),
+            )
+            .await
+            .unwrap();
+        let reference = credential_ref("proxy", "default", "auth").unwrap();
+        state
+            .credential_store
+            .replace(
+                reference.clone(),
+                r#"{"username":"","password":"still-encrypted"}"#,
+                CredentialSource::User,
+                1,
+            )
+            .unwrap();
+
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .route("/proxy-auth/status", web::get().to(get_proxy_auth_status)),
+        )
+        .await;
+        let response: serde_json::Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get()
+                .uri("/proxy-auth/status")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response["revision"], 1);
+        assert_eq!(response["credential_revision"], 2);
+        assert_eq!(response["configured"], false);
+        assert_eq!(response["state"], "error");
+
+        state
+            .credential_store
+            .replace(
+                reference,
+                r#"{"username":"****...****","password":"still-encrypted"}"#,
+                CredentialSource::User,
+                2,
+            )
+            .unwrap();
+        let masked: serde_json::Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get()
+                .uri("/proxy-auth/status")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(masked["credential_revision"], 3);
+        assert_eq!(masked["configured"], false);
+        assert_eq!(masked["state"], "error");
+    }
+
+    #[actix_web::test]
+    async fn exact_status_reports_wrong_encryption_key_as_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        state
+            .update_proxy_auth_credential(
+                Some(bamboo_config::ProxyAuth {
+                    username: "proxy-user".to_string(),
+                    password: "proxy-secret".to_string(),
+                }),
+                0,
+                Default::default(),
+            )
+            .await
+            .unwrap();
+        let data_dir = dir.path().to_path_buf();
+        let exact = tokio::task::spawn_blocking(move || {
+            let _wrong_key = bamboo_config::encryption::set_test_encryption_key([0xa7; 32]);
+            bamboo_config::read_exact_credential_section_snapshot(
+                data_dir,
+                bamboo_config::SectionId::Core,
+                None,
+            )
+        })
+        .await;
+        let exact = exact.unwrap().unwrap();
+        assert_eq!(exact.section.revision, 1);
+        let reference = credential_ref("proxy", "default", "auth").unwrap();
+        let status = exact
+            .credential_statuses
+            .iter()
+            .find(|status| status.credential_ref == reference)
+            .unwrap();
+        assert!(!status.configured);
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -517,6 +517,14 @@ pub async fn get_typed_section(
         bamboo_config::SectionId::ClusterFabric => {
             super::super::cluster_fabric::get_cluster_section(app_state).await
         }
+        bamboo_config::SectionId::Core
+        | bamboo_config::SectionId::Env
+        | bamboo_config::SectionId::Notifications
+        | bamboo_config::SectionId::Connect
+        | bamboo_config::SectionId::AccessControl => {
+            let exact = app_state.read_exact_credential_section(id).await?;
+            Ok(HttpResponse::Ok().json(exact.section))
+        }
         _ => {
             let _io = app_state.config_io_lock.lock().await;
             let facade = app_state.config_facade.as_ref().ok_or_else(|| {
@@ -558,20 +566,11 @@ pub async fn put_typed_section(
         ));
     }
     let payload = payload.into_inner();
-    app_state
+    let committed = app_state
         .put_ordinary_section(id, payload.expected_revision, payload.data)
         .await
         .map_err(map_mutation_error)?;
-
-    let _io = app_state.config_io_lock.lock().await;
-    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
-        AppError::BadRequest("typed sections require the modular configuration facade".to_string())
-    })?;
-    let envelope = facade
-        .registry()
-        .envelope_value(id)
-        .map_err(|error| map_mutation_error(ConfigSectionMutationError::Store(error)))?;
-    Ok(HttpResponse::Ok().json(envelope))
+    Ok(HttpResponse::Ok().json(committed))
 }
 
 /// Reset exactly one section to its backend-owned default using the typed
@@ -597,8 +596,13 @@ pub async fn reset_typed_section(
                 .reset_credential_backed_section(id, expected_revision)
                 .await
                 .map_err(map_mutation_error)?;
-            if let CredentialBackedResetCommit::Cluster(snapshot) = commit {
-                return cluster_reset_response(*snapshot);
+            match commit {
+                CredentialBackedResetCommit::Cluster(snapshot) => {
+                    return cluster_reset_response(*snapshot);
+                }
+                CredentialBackedResetCommit::Section(section) => {
+                    return Ok(HttpResponse::Ok().json(section));
+                }
             }
         }
         SectionId::Providers => {
@@ -622,10 +626,11 @@ pub async fn reset_typed_section(
         }
         ordinary => {
             let candidate = default_section_value(ordinary)?;
-            app_state
+            let committed = app_state
                 .put_ordinary_section(ordinary, expected_revision, candidate)
                 .await
                 .map_err(map_mutation_error)?;
+            return Ok(HttpResponse::Ok().json(committed));
         }
     }
 
@@ -3669,6 +3674,415 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn exact_core_get_can_commit_over_a_stopped_watchers_durable_base() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut stale = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stale.stop_config_watcher_for_test();
+        assert_eq!(
+            stale
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .envelope_value(SectionId::Core)
+                .unwrap()
+                .revision,
+            0
+        );
+
+        let writer = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        writer
+            .update_proxy_auth_credential(
+                Some(bamboo_config::ProxyAuth {
+                    username: "external-user".to_string(),
+                    password: "external-secret".to_string(),
+                }),
+                0,
+                Default::default(),
+            )
+            .await
+            .unwrap();
+
+        let reference = bamboo_config::credential_ref("proxy", "default", "auth").unwrap();
+        let stale = web::Data::new(stale);
+        let app = test::init_service(
+            App::new().app_data(stale.clone()).service(
+                web::resource("/sections/{section}")
+                    .route(web::get().to(get_typed_section))
+                    .route(web::put().to(put_typed_section)),
+            ),
+        )
+        .await;
+        let exact: Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get().uri("/sections/core").to_request(),
+        )
+        .await;
+        assert_eq!(exact["revision"], 1);
+        assert_eq!(
+            exact["data"]["proxy_auth_credential_ref"],
+            reference.as_str()
+        );
+        let mut feed = stale.account_sink.subscribe();
+
+        let mut candidate = exact["data"].clone();
+        candidate["headless_auth"] = json!(true);
+        let response = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/sections/core")
+                .set_json(json!({"expected_revision": 1, "data": candidate}))
+                .to_request(),
+        )
+        .await;
+        assert!(response.status().is_success());
+        let committed: Value = test::read_body_json(response).await;
+        assert_eq!(committed["revision"], 2);
+        assert_eq!(committed["data"]["headless_auth"], true);
+        assert_eq!(
+            committed["data"]["proxy_auth_credential_ref"],
+            reference.as_str()
+        );
+        assert!(
+            writer
+                .credential_store
+                .status(&reference)
+                .unwrap()
+                .configured
+        );
+        let live = stale.config.read().await;
+        assert!(live.headless_auth);
+        assert_eq!(
+            live.proxy_auth.as_ref().map(|auth| auth.username.as_str()),
+            Some("external-user")
+        );
+        drop(live);
+        let committed_event = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let event = feed.recv().await.unwrap();
+                if matches!(
+                    &event.event,
+                    bamboo_agent_core::AgentEvent::ConfigChanged { section, .. }
+                        | bamboo_agent_core::AgentEvent::ConfigRecovered { section, .. }
+                        | bamboo_agent_core::AgentEvent::ConfigInvalid { section, .. }
+                        if section == "core"
+                ) {
+                    return event;
+                }
+            }
+        })
+        .await
+        .expect("committed Core event");
+        assert!(matches!(
+            committed_event.event,
+            bamboo_agent_core::AgentEvent::ConfigChanged {
+                ref section,
+                revision: 2
+            } if section == "core"
+        ));
+        let duplicate = tokio::time::timeout(Duration::from_millis(300), async {
+            loop {
+                let event = feed.recv().await.unwrap();
+                if matches!(
+                    &event.event,
+                    bamboo_agent_core::AgentEvent::ConfigChanged { section, .. }
+                        | bamboo_agent_core::AgentEvent::ConfigRecovered { section, .. }
+                        | bamboo_agent_core::AgentEvent::ConfigInvalid { section, .. }
+                        if section == "core"
+                ) {
+                    return event;
+                }
+            }
+        })
+        .await;
+        assert!(
+            duplicate.is_err(),
+            "stale-local success must publish only committed r2"
+        );
+    }
+
+    #[actix_web::test]
+    async fn failed_stale_core_put_emits_nothing_until_normal_reload_installs_r1() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut stale = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stale.stop_config_watcher_for_test();
+
+        let writer = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        writer
+            .update_proxy_auth_credential(
+                Some(bamboo_config::ProxyAuth {
+                    username: "external-user".to_string(),
+                    password: "external-secret".to_string(),
+                }),
+                0,
+                Default::default(),
+            )
+            .await
+            .unwrap();
+
+        let stale = web::Data::new(stale);
+        let mut feed = stale.account_sink.subscribe();
+        let app = test::init_service(
+            App::new().app_data(stale.clone()).service(
+                web::resource("/sections/{section}")
+                    .route(web::get().to(get_typed_section))
+                    .route(web::put().to(put_typed_section)),
+            ),
+        )
+        .await;
+        let exact: Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get().uri("/sections/core").to_request(),
+        )
+        .await;
+        assert_eq!(exact["revision"], 1);
+        let mut invalid = exact["data"].clone();
+        invalid["http_proxy"] = json!("http://user:secret@proxy.example");
+        let response = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/sections/core")
+                .set_json(json!({"expected_revision": 1, "data": invalid}))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), actix_web::http::StatusCode::BAD_REQUEST);
+        assert_eq!(
+            stale
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .envelope_value(SectionId::Core)
+                .unwrap()
+                .revision,
+            0
+        );
+        {
+            let live = stale.config.read().await;
+            assert!(live.proxy_auth.is_none());
+            assert!(live.proxy_auth_credential_ref.is_none());
+        }
+        let premature = tokio::time::timeout(Duration::from_millis(300), async {
+            loop {
+                let event = feed.recv().await.unwrap();
+                if matches!(
+                    &event.event,
+                    bamboo_agent_core::AgentEvent::ConfigChanged { section, .. }
+                        | bamboo_agent_core::AgentEvent::ConfigRecovered { section, .. }
+                        | bamboo_agent_core::AgentEvent::ConfigInvalid { section, .. }
+                        if section == "core"
+                ) {
+                    return event;
+                }
+            }
+        })
+        .await;
+        assert!(
+            premature.is_err(),
+            "failed stale-local PUT must not publish durable r1"
+        );
+
+        stale
+            .reload_ordinary_section_for_test(SectionId::Core)
+            .await;
+        assert_eq!(
+            stale
+                .config_facade
+                .as_ref()
+                .unwrap()
+                .registry()
+                .envelope_value(SectionId::Core)
+                .unwrap()
+                .revision,
+            1
+        );
+        {
+            let live = stale.config.read().await;
+            assert_eq!(
+                live.proxy_auth.as_ref().map(|auth| auth.username.as_str()),
+                Some("external-user")
+            );
+            assert!(live.proxy_auth_credential_ref.is_some());
+        }
+        let reloaded = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let event = feed.recv().await.unwrap();
+                if matches!(
+                    &event.event,
+                    bamboo_agent_core::AgentEvent::ConfigChanged { section, revision }
+                        | bamboo_agent_core::AgentEvent::ConfigRecovered { section, revision }
+                        if section == "core" && *revision == 1
+                ) {
+                    return event;
+                }
+            }
+        })
+        .await;
+        assert!(
+            reloaded.is_ok(),
+            "normal reload publishes r1 only after runtime adoption"
+        );
+    }
+
+    #[actix_web::test]
+    async fn core_metadata_rejects_invalid_proxy_keep_while_replace_repairs_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        state
+            .update_proxy_auth_credential(
+                Some(bamboo_config::ProxyAuth {
+                    username: "initial-user".to_string(),
+                    password: "initial-secret".to_string(),
+                }),
+                0,
+                Default::default(),
+            )
+            .await
+            .unwrap();
+        let reference = bamboo_config::credential_ref("proxy", "default", "auth").unwrap();
+        state
+            .credential_store
+            .replace(
+                reference.clone(),
+                "not-json",
+                bamboo_config::CredentialSource::User,
+                1,
+            )
+            .unwrap();
+
+        let exact = state
+            .read_exact_credential_section(SectionId::Core)
+            .await
+            .unwrap();
+        assert_eq!(exact.section.revision, 1);
+        assert!(!exact.metadata.status(&reference).configured);
+        let mut candidate = exact.section.data;
+        candidate["headless_auth"] = json!(true);
+        let core_path = dir.path().join("core.json");
+        let credential_path = dir.path().join("credentials.json");
+        let core_before = std::fs::read(&core_path).unwrap();
+        let credentials_before = std::fs::read(&credential_path).unwrap();
+        let app = test::init_service(
+            App::new()
+                .app_data(state.clone())
+                .route("/sections/{section}", web::put().to(put_typed_section)),
+        )
+        .await;
+        let keep = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/sections/core")
+                .set_json(json!({"expected_revision": 1, "data": candidate}))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(keep.status(), actix_web::http::StatusCode::BAD_REQUEST);
+        assert_eq!(std::fs::read(&core_path).unwrap(), core_before);
+        assert_eq!(std::fs::read(&credential_path).unwrap(), credentials_before);
+
+        let (_, revision, status, _, section) = state
+            .update_proxy_auth_credential(
+                Some(bamboo_config::ProxyAuth {
+                    username: "replacement-user".to_string(),
+                    password: "replacement-secret".to_string(),
+                }),
+                1,
+                Default::default(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(revision, 2);
+        assert!(status.configured);
+        assert_eq!(section.unwrap().revision, 2);
+        let repaired = state.credential_store.resolve(&reference).unwrap().unwrap();
+        let repaired: bamboo_config::ProxyAuth = serde_json::from_str(repaired.expose()).unwrap();
+        assert_eq!(repaired.username, "replacement-user");
+        assert_eq!(repaired.password, "replacement-secret");
+    }
+
+    #[actix_web::test]
+    async fn stale_generic_core_put_cannot_rebind_proxy_ref_cleared_by_exact_api() {
+        let dir = tempfile::tempdir().unwrap();
+        let writer = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        writer
+            .update_proxy_auth_credential(
+                Some(bamboo_config::ProxyAuth {
+                    username: "proxy-user".to_string(),
+                    password: "proxy-secret".to_string(),
+                }),
+                0,
+                Default::default(),
+            )
+            .await
+            .unwrap();
+
+        let mut stale = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stale.stop_config_watcher_for_test();
+        let mut stale_core = stale
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .envelope_value(bamboo_config::SectionId::Core)
+            .unwrap()
+            .data;
+        assert_eq!(
+            stale_core["proxy_auth_credential_ref"],
+            "proxy.default.auth"
+        );
+        stale_core["headless_auth"] = json!(true);
+
+        writer
+            .update_proxy_auth_credential(None, 1, Default::default())
+            .await
+            .unwrap();
+        let reference = bamboo_config::credential_ref("proxy", "default", "auth").unwrap();
+        assert!(
+            !writer
+                .credential_store
+                .status(&reference)
+                .unwrap()
+                .configured
+        );
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(stale))
+                .route("/sections/{section}", web::put().to(put_typed_section)),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::put()
+                .uri("/sections/core")
+                .set_json(json!({
+                    "expected_revision": 2,
+                    "data": stale_core
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), actix_web::http::StatusCode::BAD_REQUEST);
+
+        let exact = bamboo_config::read_exact_credential_section_snapshot(
+            dir.path(),
+            bamboo_config::SectionId::Core,
+            Some(2),
+        )
+        .unwrap();
+        assert!(exact.section.data["proxy_auth_credential_ref"].is_null());
+        assert_eq!(exact.section.data["headless_auth"], false);
+        assert!(
+            !writer
+                .credential_store
+                .status(&reference)
+                .unwrap()
+                .configured
+        );
+    }
+
+    #[actix_web::test]
     async fn generic_cluster_section_put_cannot_bypass_dedicated_transaction() {
         let dir = tempfile::tempdir().unwrap();
         let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
@@ -3834,6 +4248,60 @@ mod tests {
                 .label,
             "queued-second-commit"
         );
+    }
+
+    #[actix_web::test]
+    async fn delayed_non_cluster_reset_response_stays_bound_to_its_exact_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        state
+            .update_notification_credentials(
+                0,
+                BTreeSet::from(["ntfy".to_string()]),
+                false,
+                |config| {
+                    config.notifications.ntfy.enabled = true;
+                    config.notifications.ntfy.topic = "before-reset".to_string();
+                    config.notifications.ntfy.token = Some("reset-secret".to_string());
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+
+        let reset = state
+            .reset_credential_backed_section(SectionId::Notifications, 1)
+            .await
+            .unwrap();
+        let CredentialBackedResetCommit::Section(reset_section) = reset else {
+            panic!("non-cluster reset must return its exact committed envelope");
+        };
+        let (_, _, _, later_section) = state
+            .update_notification_credentials(2, BTreeSet::new(), false, |config| {
+                config.notifications.desktop.enabled = Some(true);
+                Ok(())
+            })
+            .await
+            .unwrap();
+        let later_section = later_section.unwrap();
+
+        assert_eq!(reset_section.revision, 2);
+        assert_eq!(
+            reset_section.data,
+            json!({
+                "notifications":
+                    serde_json::to_value(bamboo_config::NotificationsConfig::default()).unwrap()
+            })
+        );
+        assert_eq!(later_section.revision, 3);
+        assert_eq!(
+            later_section.data["notifications"]["desktop"]["enabled"],
+            true
+        );
+        assert!(reset_section.data["notifications"]["desktop"]["enabled"].is_null());
+        assert!(!serde_json::to_string(&reset_section)
+            .unwrap()
+            .contains("reset-secret"));
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -548,6 +548,10 @@ pub async fn put_typed_section(
             | bamboo_config::SectionId::Mcp
             | bamboo_config::SectionId::Credentials
             | bamboo_config::SectionId::ClusterFabric
+            | bamboo_config::SectionId::Env
+            | bamboo_config::SectionId::Notifications
+            | bamboo_config::SectionId::Connect
+            | bamboo_config::SectionId::AccessControl
     ) {
         return Err(AppError::BadRequest(
             "this section requires its dedicated endpoint".to_string(),
@@ -3830,6 +3834,36 @@ mod tests {
                 .label,
             "queued-second-commit"
         );
+    }
+
+    #[actix_web::test]
+    async fn generic_typed_put_rejects_credential_backed_domain_bypasses() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/sections/{section}", web::put().to(put_typed_section)),
+        )
+        .await;
+
+        for section in ["env", "notifications", "connect", "access-control"] {
+            let response = test::call_service(
+                &app,
+                test::TestRequest::put()
+                    .uri(&format!("/sections/{section}"))
+                    .set_json(json!({"expected_revision": 0, "data": {}}))
+                    .to_request(),
+            )
+            .await;
+            assert_eq!(
+                response.status(),
+                actix_web::http::StatusCode::BAD_REQUEST,
+                "{section}"
+            );
+            let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+            assert!(body.contains("dedicated endpoint"), "{section}: {body}");
+        }
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/tests.rs
@@ -59,14 +59,14 @@ fn provider_validation_issue_returns_provider_path_when_openai_key_present() {
 }
 
 #[test]
-fn proxy_auth_payload_without_username_disables_proxy_auth() {
+fn proxy_auth_payload_without_username_rejects_ambiguous_password() {
     let payload: ProxyAuthPayload = serde_json::from_value(serde_json::json!({
         "expected_revision": 0,
         "password": "secret"
     }))
     .unwrap();
 
-    assert!(payload.into_proxy_auth().is_none());
+    assert!(payload.into_proxy_auth().is_err());
 }
 
 #[test]
@@ -78,7 +78,10 @@ fn proxy_auth_payload_with_username_creates_proxy_auth() {
     }))
     .unwrap();
 
-    let auth = payload.into_proxy_auth().expect("proxy auth should exist");
+    let auth = payload
+        .into_proxy_auth()
+        .expect("proxy auth payload should be valid")
+        .expect("proxy auth should exist");
     assert_eq!(auth.username, "alice");
     assert_eq!(auth.password, "secret");
 }

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/types.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/types.rs
@@ -19,12 +19,24 @@ pub(super) struct ValidateConfigResponse {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ProxyAuthPayload {
-    /// Credential-store revision required for replace or clear.
+    /// Core section revision required for replace or clear.
     expected_revision: u64,
+    /// Explicit mutation intent. Omission retains the legacy behavior where a
+    /// nonempty username replaces and an empty username clears.
+    #[serde(default)]
+    action: Option<ProxyCredentialAction>,
     /// Proxy username.
     username: Option<String>,
     /// Proxy password.
     password: Option<String>,
+}
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ProxyCredentialAction {
+    Keep,
+    Replace,
+    Clear,
 }
 
 impl std::fmt::Debug for ProxyAuthPayload {
@@ -32,6 +44,14 @@ impl std::fmt::Debug for ProxyAuthPayload {
         formatter
             .debug_struct("ProxyAuthPayload")
             .field("expected_revision", &self.expected_revision)
+            .field(
+                "action",
+                &self.action.map(|action| match action {
+                    ProxyCredentialAction::Keep => "keep",
+                    ProxyCredentialAction::Replace => "replace",
+                    ProxyCredentialAction::Clear => "clear",
+                }),
+            )
             .field("username", &self.username.as_ref().map(|_| "[REDACTED]"))
             .field("password", &self.password.as_ref().map(|_| "[REDACTED]"))
             .finish()
@@ -43,16 +63,41 @@ impl ProxyAuthPayload {
         self.expected_revision
     }
 
-    pub(super) fn into_proxy_auth(self) -> Option<ProxyAuth> {
+    pub(super) fn into_proxy_auth(self) -> Result<Option<ProxyAuth>, String> {
         let username = self.username.unwrap_or_default();
-        if username.trim().is_empty() {
-            return None;
+        let password = self.password.unwrap_or_default();
+        let action = self.action.unwrap_or_else(|| {
+            if username.trim().is_empty() {
+                ProxyCredentialAction::Clear
+            } else {
+                ProxyCredentialAction::Replace
+            }
+        });
+        match action {
+            ProxyCredentialAction::Keep => {
+                if !username.is_empty() || !password.is_empty() {
+                    return Err("proxy keep must not include credential values".to_string());
+                }
+                Err("proxy keep is not a mutation; omit the request".to_string())
+            }
+            ProxyCredentialAction::Clear => {
+                if !username.is_empty() || !password.is_empty() {
+                    return Err("proxy clear must not include credential values".to_string());
+                }
+                Ok(None)
+            }
+            ProxyCredentialAction::Replace => {
+                if username.trim().is_empty() {
+                    return Err("proxy replace requires a username".to_string());
+                }
+                if bamboo_config::patch::is_masked_api_key(&username)
+                    || bamboo_config::patch::is_masked_api_key(&password)
+                {
+                    return Err("proxy credential value must not be a mask".to_string());
+                }
+                Ok(Some(ProxyAuth { username, password }))
+            }
         }
-
-        Some(ProxyAuth {
-            username,
-            password: self.password.unwrap_or_default(),
-        })
     }
 }
 
@@ -144,14 +189,12 @@ mod tests {
     fn test_proxy_auth_payload_into_proxy_auth_valid() {
         let payload = ProxyAuthPayload {
             expected_revision: 0,
+            action: None,
             username: Some("user".to_string()),
             password: Some("pass".to_string()),
         };
 
-        let auth = payload.into_proxy_auth();
-        assert!(auth.is_some());
-
-        let auth = auth.unwrap();
+        let auth = payload.into_proxy_auth().unwrap().unwrap();
         assert_eq!(auth.username, "user");
         assert_eq!(auth.password, "pass");
     }
@@ -160,47 +203,48 @@ mod tests {
     fn test_proxy_auth_payload_into_proxy_auth_empty_username() {
         let payload = ProxyAuthPayload {
             expected_revision: 0,
+            action: None,
             username: Some("".to_string()),
             password: Some("pass".to_string()),
         };
 
-        let auth = payload.into_proxy_auth();
-        assert!(auth.is_none());
+        assert!(payload.into_proxy_auth().is_err());
     }
 
     #[test]
     fn test_proxy_auth_payload_into_proxy_auth_whitespace_username() {
         let payload = ProxyAuthPayload {
             expected_revision: 0,
+            action: None,
             username: Some("   ".to_string()),
             password: Some("pass".to_string()),
         };
 
-        let auth = payload.into_proxy_auth();
-        assert!(auth.is_none());
+        assert!(payload.into_proxy_auth().is_err());
     }
 
     #[test]
     fn test_proxy_auth_payload_into_proxy_auth_none_username() {
         let payload = ProxyAuthPayload {
             expected_revision: 0,
+            action: None,
             username: None,
             password: Some("pass".to_string()),
         };
 
-        let auth = payload.into_proxy_auth();
-        assert!(auth.is_none());
+        assert!(payload.into_proxy_auth().is_err());
     }
 
     #[test]
     fn test_proxy_auth_payload_into_proxy_auth_no_password() {
         let payload = ProxyAuthPayload {
             expected_revision: 0,
+            action: None,
             username: Some("user".to_string()),
             password: None,
         };
 
-        let auth = payload.into_proxy_auth().unwrap();
+        let auth = payload.into_proxy_auth().unwrap().unwrap();
         assert_eq!(auth.username, "user");
         assert_eq!(auth.password, "");
     }
@@ -209,6 +253,7 @@ mod tests {
     fn test_proxy_auth_payload_debug() {
         let payload = ProxyAuthPayload {
             expected_revision: 0,
+            action: None,
             username: Some("user".to_string()),
             password: Some("pass".to_string()),
         };

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/validation.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/validation.rs
@@ -38,6 +38,8 @@ pub async fn validate_bamboo_config_patch(
                 .to_string(),
         ));
     }
+    let current = app_state.config.read().await.clone();
+    config_manager::remove_unchanged_core_proxy_echo(&current, &mut patch_obj)?;
     config_manager::sanitize_root_patch(&mut patch_obj);
 
     let lifecycle_schema_issues = patch_obj
@@ -66,7 +68,6 @@ pub async fn validate_bamboo_config_patch(
         }));
     }
 
-    let current = app_state.config.read().await.clone();
     let merged = config_manager::build_merged_config(&current, patch_obj.clone())?;
     let domains = config_manager::domains_for_root_patch(&patch_obj);
 

--- a/crates/app/bamboo-server/src/handlers/settings/credential_action.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/credential_action.rs
@@ -1,0 +1,242 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::AppError;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CredentialState {
+    Configured,
+    FromEnv,
+    Missing,
+    Error,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct CredentialStatusView {
+    pub(crate) credential_ref: Option<String>,
+    pub(crate) state: CredentialState,
+    pub(crate) configured: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) source: Option<bamboo_config::CredentialSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) updated_at: Option<DateTime<Utc>>,
+}
+
+pub(crate) fn credential_status_view(
+    reference: Option<&bamboo_config::CredentialRef>,
+    expected_configured: bool,
+    status: Option<&bamboo_config::CredentialStatus>,
+    health: &bamboo_config::CredentialStoreHealth,
+) -> CredentialStatusView {
+    let state = if !expected_configured {
+        CredentialState::Missing
+    } else if health.status != bamboo_config::SectionStatus::Healthy {
+        CredentialState::Error
+    } else {
+        match status.filter(|status| status.configured) {
+            Some(status) if status.source == bamboo_config::CredentialSource::Environment => {
+                CredentialState::FromEnv
+            }
+            Some(_) => CredentialState::Configured,
+            None => CredentialState::Error,
+        }
+    };
+    let configured = matches!(
+        state,
+        CredentialState::Configured | CredentialState::FromEnv
+    );
+    let status = status.filter(|status| configured && status.configured);
+    CredentialStatusView {
+        credential_ref: reference.map(|reference| reference.as_str().to_string()),
+        state,
+        configured,
+        source: status.map(|status| status.source),
+        updated_at: status.and_then(|status| status.updated_at),
+    }
+}
+
+/// Explicit mutation intent for one secret value.
+///
+/// The value is carried only by `replace`; `keep` and `clear` cannot
+/// accidentally deserialize plaintext. Custom `Debug` keeps request logging
+/// secret-free.
+#[derive(Clone)]
+pub(crate) enum CredentialAction {
+    Keep,
+    Replace { value: String },
+    Clear,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum CredentialActionKind {
+    Keep,
+    Replace,
+    Clear,
+}
+
+#[derive(Default)]
+struct ActionValue {
+    present: bool,
+    value: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for ActionValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self {
+            present: true,
+            value: Option::<String>::deserialize(deserializer)?,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CredentialActionWire {
+    action: CredentialActionKind,
+    #[serde(default)]
+    value: ActionValue,
+}
+
+impl<'de> Deserialize<'de> for CredentialAction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = CredentialActionWire::deserialize(deserializer)?;
+        match (wire.action, wire.value.present, wire.value.value) {
+            (CredentialActionKind::Keep, false, None) => Ok(Self::Keep),
+            (CredentialActionKind::Clear, false, None) => Ok(Self::Clear),
+            (CredentialActionKind::Replace, true, Some(value)) => Ok(Self::Replace { value }),
+            (CredentialActionKind::Replace, _, _) => Err(serde::de::Error::custom(
+                "replace action requires a string value",
+            )),
+            (CredentialActionKind::Keep | CredentialActionKind::Clear, true, _) => Err(
+                serde::de::Error::custom("keep and clear actions must not include a value"),
+            ),
+            (CredentialActionKind::Keep | CredentialActionKind::Clear, false, Some(_)) => {
+                unreachable!("an absent action value cannot contain data")
+            }
+        }
+    }
+}
+
+impl CredentialAction {
+    pub(crate) fn validate(&self, label: &str) -> Result<(), AppError> {
+        let Self::Replace { value } = self else {
+            return Ok(());
+        };
+        if value.trim().is_empty() {
+            return Err(AppError::BadRequest(format!(
+                "{label} replace requires a nonempty value"
+            )));
+        }
+        if bamboo_config::patch::is_masked_api_key(value) {
+            return Err(AppError::BadRequest(format!(
+                "{label} value must not be a mask"
+            )));
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn replacement(&self) -> Option<&str> {
+        match self {
+            Self::Replace { value } => Some(value),
+            Self::Keep | Self::Clear => None,
+        }
+    }
+
+    pub(crate) fn is_keep(&self) -> bool {
+        matches!(self, Self::Keep)
+    }
+}
+
+impl std::fmt::Debug for CredentialAction {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Keep => formatter.write_str("CredentialAction::Keep"),
+            Self::Replace { .. } => formatter.write_str("CredentialAction::Replace([REDACTED])"),
+            Self::Clear => formatter.write_str("CredentialAction::Clear"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn action_shape_is_explicit_and_debug_is_redacted() {
+        let replace: CredentialAction =
+            serde_json::from_str(r#"{"action":"replace","value":"secret-value"}"#).unwrap();
+        assert_eq!(replace.replacement(), Some("secret-value"));
+        assert!(!format!("{replace:?}").contains("secret-value"));
+
+        assert!(serde_json::from_str::<CredentialAction>(
+            r#"{"action":"clear","value":"must-not-be-accepted"}"#
+        )
+        .is_err());
+        assert!(
+            serde_json::from_str::<CredentialAction>(r#"{"action":"keep","value":null}"#).is_err()
+        );
+        assert!(serde_json::from_str::<CredentialAction>(r#"{"action":"replace"}"#).is_err());
+        assert!(serde_json::from_str::<CredentialAction>(
+            r#"{"action":"replace","value":"secret","future":"field"}"#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn replace_rejects_empty_and_mask_values() {
+        let empty = CredentialAction::Replace {
+            value: " ".to_string(),
+        };
+        assert!(empty.validate("test credential").is_err());
+        let masked = CredentialAction::Replace {
+            value: "********".to_string(),
+        };
+        assert!(masked.validate("test credential").is_err());
+    }
+
+    #[test]
+    fn status_view_distinguishes_configured_environment_missing_and_error() {
+        let reference = bamboo_config::credential_ref("notification", "ntfy", "token").unwrap();
+        let mut status = bamboo_config::CredentialStatus {
+            credential_ref: reference.clone(),
+            configured: true,
+            source: bamboo_config::CredentialSource::User,
+            updated_at: None,
+        };
+        let healthy = bamboo_config::CredentialStoreHealth::committed(3);
+        assert_eq!(
+            credential_status_view(Some(&reference), true, Some(&status), &healthy).state,
+            CredentialState::Configured
+        );
+        status.source = bamboo_config::CredentialSource::Environment;
+        assert_eq!(
+            credential_status_view(Some(&reference), true, Some(&status), &healthy).state,
+            CredentialState::FromEnv
+        );
+        assert_eq!(
+            credential_status_view(Some(&reference), true, None, &healthy).state,
+            CredentialState::Error
+        );
+        assert_eq!(
+            credential_status_view(Some(&reference), false, Some(&status), &healthy).state,
+            CredentialState::Missing
+        );
+        let degraded = bamboo_config::CredentialStoreHealth {
+            status: bamboo_config::SectionStatus::Degraded,
+            ..healthy
+        };
+        assert_eq!(
+            credential_status_view(Some(&reference), true, Some(&status), &degraded).state,
+            CredentialState::Error
+        );
+    }
+}

--- a/crates/app/bamboo-server/src/handlers/settings/env_vars/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/env_vars/handlers.rs
@@ -1,4 +1,5 @@
 use actix_web::{web, HttpResponse};
+use std::collections::BTreeMap;
 
 use crate::{app_state::AppState, error::AppError};
 use bamboo_config::EnvVarEntry;
@@ -10,22 +11,113 @@ use super::{
     },
     validation::{check_duplicate_names, validate_env_var_name, validate_env_var_value},
 };
+use crate::handlers::settings::credential_action::CredentialAction;
 
-/// `GET /bamboo/env-vars` – list all env vars (secrets masked).
-pub async fn list_env_vars(app_state: web::Data<AppState>) -> Result<HttpResponse, AppError> {
-    let _io = app_state.config_io_lock.lock().await;
-    let revision = app_state.credential_store.revision().map_err(|error| {
-        AppError::InternalError(anyhow::anyhow!(
-            "env credential status unavailable: {error}"
-        ))
-    })?;
-    let config = app_state.config.read().await;
-    let entries: Vec<EnvVarResponse> = config
+#[derive(Clone)]
+enum EnvSecretChange {
+    Keep,
+    Replace(String),
+    Clear,
+}
+
+fn resolve_env_secret_change(
+    entry: &super::types::EnvVarInput,
+) -> Result<Option<EnvSecretChange>, AppError> {
+    if !entry.secret {
+        if entry.credential_change.is_some() {
+            return Err(AppError::BadRequest(
+                "credential_change is valid only for secret environment variables".to_string(),
+            ));
+        }
+        return Ok(None);
+    }
+    if entry.credential_change.is_some() && entry.value.is_some() {
+        return Err(AppError::BadRequest(
+            "secret environment variables must use either credential_change or the legacy value field, not both"
+                .to_string(),
+        ));
+    }
+    let change = match entry.credential_change.as_ref() {
+        Some(action) => {
+            action.validate("environment credential")?;
+            match action {
+                CredentialAction::Keep => EnvSecretChange::Keep,
+                CredentialAction::Replace { value } => EnvSecretChange::Replace(value.clone()),
+                CredentialAction::Clear => EnvSecretChange::Clear,
+            }
+        }
+        None => match entry.value.as_ref() {
+            Some(value) if value.is_empty() => EnvSecretChange::Clear,
+            Some(value) => EnvSecretChange::Replace(value.clone()),
+            None => EnvSecretChange::Keep,
+        },
+    };
+    Ok(Some(change))
+}
+
+fn env_response(
+    config: &bamboo_config::Config,
+    revision: u64,
+    statuses: &[bamboo_config::CredentialStatus],
+    section: bamboo_config::SectionEnvelope<serde_json::Value>,
+    credential_health: bamboo_config::CredentialStoreHealth,
+) -> EnvVarsListResponse {
+    let statuses = statuses
+        .iter()
+        .map(|status| (status.credential_ref.clone(), status))
+        .collect::<BTreeMap<_, _>>();
+    let entries = config
         .env_vars
         .iter()
-        .map(EnvVarResponse::from_entry)
+        .map(|entry| {
+            EnvVarResponse::from_entry(
+                entry,
+                entry
+                    .credential_ref
+                    .as_ref()
+                    .and_then(|reference| statuses.get(reference).copied()),
+                &credential_health,
+            )
+        })
         .collect();
-    Ok(HttpResponse::Ok().json(EnvVarsListResponse { revision, entries }))
+    EnvVarsListResponse {
+        revision,
+        entries,
+        section,
+        credential_health,
+    }
+}
+
+/// `GET /bamboo/env-vars` – list all env vars without secret values or masks.
+pub async fn list_env_vars(app_state: web::Data<AppState>) -> Result<HttpResponse, AppError> {
+    let _io = app_state.config_io_lock.lock().await;
+    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
+        AppError::BadRequest("env settings require the modular configuration facade".to_string())
+    })?;
+    let section = facade
+        .registry()
+        .envelope_value(bamboo_config::SectionId::Env)
+        .map_err(|error| {
+            AppError::InternalError(anyhow::anyhow!("env section envelope unavailable: {error}"))
+        })?;
+    let revision = section.revision;
+    let (statuses, credential_health) =
+        app_state
+            .credential_store
+            .statuses_with_health()
+            .map_err(|error| {
+                AppError::InternalError(anyhow::anyhow!(
+                    "env credential status unavailable: {error}"
+                ))
+            })?;
+    let config = app_state.config.read().await;
+    Ok(HttpResponse::Ok().json(env_response(
+        &config,
+        revision,
+        &statuses,
+        section,
+        credential_health,
+    )))
 }
 
 /// `POST /bamboo/env-vars` – create or update a single env var.
@@ -45,9 +137,10 @@ pub async fn upsert_env_var(
             ));
         }
     }
+    let secret_change = resolve_env_secret_change(&req)?;
     let name = req.name.clone();
 
-    let (updated, revision) = app_state
+    let (updated, revision, metadata, section) = app_state
         .update_env_var_credentials(
             expected_revision,
             std::collections::BTreeSet::from([name]),
@@ -55,26 +148,63 @@ pub async fn upsert_env_var(
                 // Replace existing or push new.
                 if let Some(existing) = cfg.env_vars.iter_mut().find(|e| e.name == req.name) {
                     let was_secret = existing.secret;
-                    if let Some(value) = req.value.as_ref() {
-                        // Empty is an explicit clear. Missing is the only keep
-                        // operation, and masks are rejected above.
-                        existing.value = value.clone();
-                        existing.configured = !value.is_empty();
-                    } else if was_secret && req.secret {
-                        // Preserve is represented to the transaction by
-                        // configured metadata without re-supplying plaintext.
-                        existing.value.clear();
+                    if req.secret {
+                        match secret_change
+                            .as_ref()
+                            .expect("secret input has a resolved credential action")
+                        {
+                            EnvSecretChange::Keep => {
+                                if !was_secret {
+                                    return Err(AppError::BadRequest(
+                                        "converting a plain environment variable to secret requires replace"
+                                            .to_string(),
+                                    ));
+                                }
+                                // Preserve is represented to the transaction by
+                                // configured metadata without re-supplying plaintext.
+                                existing.value.clear();
+                            }
+                            EnvSecretChange::Replace(value) => {
+                                existing.value = value.clone();
+                                existing.configured = true;
+                            }
+                            EnvSecretChange::Clear => {
+                                existing.value.clear();
+                                existing.configured = false;
+                            }
+                        }
+                    } else {
+                        if was_secret && req.value.is_none() {
+                            return Err(AppError::BadRequest(
+                                "converting a secret environment variable to plain requires an explicit value"
+                                    .to_string(),
+                            ));
+                        }
+                        if let Some(value) = req.value.as_ref() {
+                            existing.value = value.clone();
+                            existing.configured = !value.is_empty();
+                        }
                     }
                     existing.secret = req.secret;
                     existing.value_encrypted = None;
                     existing.description = req.description.clone();
                 } else {
-                    if req.secret && req.value.is_none() {
-                        return Err(AppError::BadRequest(
-                            "a new secret environment variable requires a value".to_string(),
-                        ));
-                    }
-                    let value = req.value.clone().unwrap_or_default();
+                    let value = if req.secret {
+                        match secret_change
+                            .as_ref()
+                            .expect("secret input has a resolved credential action")
+                        {
+                            EnvSecretChange::Replace(value) => value.clone(),
+                            EnvSecretChange::Keep | EnvSecretChange::Clear => {
+                                return Err(AppError::BadRequest(
+                                    "a new secret environment variable requires replace"
+                                        .to_string(),
+                                ));
+                            }
+                        }
+                    } else {
+                        req.value.clone().unwrap_or_default()
+                    };
                     cfg.env_vars.push(EnvVarEntry {
                         name: req.name.clone(),
                         value: value.clone(),
@@ -90,12 +220,18 @@ pub async fn upsert_env_var(
         )
         .await?;
 
-    let entries: Vec<EnvVarResponse> = updated
-        .env_vars
-        .iter()
-        .map(EnvVarResponse::from_entry)
-        .collect();
-    Ok(HttpResponse::Ok().json(EnvVarsListResponse { revision, entries }))
+    let section = section.ok_or_else(|| {
+        AppError::InternalError(anyhow::anyhow!(
+            "env mutation completed without a typed section envelope"
+        ))
+    })?;
+    Ok(HttpResponse::Ok().json(env_response(
+        &updated,
+        revision,
+        &metadata.credential_statuses,
+        section,
+        metadata.credential_health,
+    )))
 }
 
 /// `PUT /bamboo/env-vars` – replace the entire env vars list.
@@ -120,7 +256,14 @@ pub async fn replace_env_vars(
             }
         }
     }
-    let requested_entries = req.entries;
+    let requested_entries = req
+        .entries
+        .into_iter()
+        .map(|entry| {
+            let secret_change = resolve_env_secret_change(&entry)?;
+            Ok::<_, AppError>((entry, secret_change))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     let mut intents = {
         let cfg = app_state.config.read().await;
@@ -129,29 +272,58 @@ pub async fn replace_env_vars(
             .map(|entry| entry.name.clone())
             .collect::<std::collections::BTreeSet<_>>()
     };
-    intents.extend(requested_entries.iter().map(|entry| entry.name.clone()));
-    let (updated, revision) = app_state
+    intents.extend(
+        requested_entries
+            .iter()
+            .map(|(entry, _)| entry.name.clone()),
+    );
+    let (updated, revision, metadata, section) = app_state
         .update_env_var_credentials(expected_revision, intents, move |cfg| {
             let mut new_entries = Vec::with_capacity(requested_entries.len());
-            for entry in &requested_entries {
+            for (entry, secret_change) in &requested_entries {
                 let existing = cfg
                     .env_vars
                     .iter()
                     .find(|current| current.name == entry.name);
-                if entry.secret && entry.value.is_none() && existing.is_none() {
-                    return Err(AppError::BadRequest(
-                        "a new secret environment variable requires a value".to_string(),
-                    ));
-                }
-                let value = entry
-                    .value
-                    .clone()
-                    .or_else(|| {
-                        existing.and_then(|current| {
-                            (!(current.secret && entry.secret)).then(|| current.value.clone())
-                        })
-                    })
-                    .unwrap_or_default();
+                let value = if entry.secret {
+                    match secret_change
+                        .as_ref()
+                        .expect("secret input has a resolved credential action")
+                    {
+                        EnvSecretChange::Keep => {
+                            let Some(existing) = existing.filter(|current| current.secret) else {
+                                return Err(AppError::BadRequest(
+                                    "a new or newly-secret environment variable requires replace"
+                                        .to_string(),
+                                ));
+                            };
+                            let _ = existing;
+                            String::new()
+                        }
+                        EnvSecretChange::Replace(value) => value.clone(),
+                        EnvSecretChange::Clear => {
+                            if existing.is_none() {
+                                return Err(AppError::BadRequest(
+                                    "a new secret environment variable requires replace"
+                                        .to_string(),
+                                ));
+                            }
+                            String::new()
+                        }
+                    }
+                } else {
+                    if existing.is_some_and(|current| current.secret) && entry.value.is_none() {
+                        return Err(AppError::BadRequest(
+                            "converting a secret environment variable to plain requires an explicit value"
+                                .to_string(),
+                        ));
+                    }
+                    entry
+                        .value
+                        .clone()
+                        .or_else(|| existing.map(|current| current.value.clone()))
+                        .unwrap_or_default()
+                };
                 new_entries.push(EnvVarEntry {
                     name: entry.name.clone(),
                     value: value.clone(),
@@ -159,10 +331,15 @@ pub async fn replace_env_vars(
                     value_encrypted: None,
                     credential_ref: existing.and_then(|current| current.credential_ref.clone()),
                     configured: if entry.secret {
-                        if entry.value.is_some() {
-                            !value.is_empty()
-                        } else {
-                            existing.is_some_and(|current| current.configured) || !value.is_empty()
+                        match secret_change
+                            .as_ref()
+                            .expect("secret input has a resolved credential action")
+                        {
+                            EnvSecretChange::Keep => {
+                                existing.is_some_and(|current| current.configured)
+                            }
+                            EnvSecretChange::Replace(_) => true,
+                            EnvSecretChange::Clear => false,
                         }
                     } else {
                         !value.is_empty()
@@ -175,12 +352,18 @@ pub async fn replace_env_vars(
         })
         .await?;
 
-    let entries: Vec<EnvVarResponse> = updated
-        .env_vars
-        .iter()
-        .map(EnvVarResponse::from_entry)
-        .collect();
-    Ok(HttpResponse::Ok().json(EnvVarsListResponse { revision, entries }))
+    let section = section.ok_or_else(|| {
+        AppError::InternalError(anyhow::anyhow!(
+            "env mutation completed without a typed section envelope"
+        ))
+    })?;
+    Ok(HttpResponse::Ok().json(env_response(
+        &updated,
+        revision,
+        &metadata.credential_statuses,
+        section,
+        metadata.credential_health,
+    )))
 }
 
 /// `DELETE /bamboo/env-vars/{name}` – delete a single env var.
@@ -193,7 +376,7 @@ pub async fn delete_env_var(
     let expected_revision = query.expected_revision;
     let intent = name.clone();
 
-    let (updated, revision) = app_state
+    let (updated, revision, metadata, section) = app_state
         .update_env_var_credentials(
             expected_revision,
             std::collections::BTreeSet::from([intent]),
@@ -211,12 +394,18 @@ pub async fn delete_env_var(
         )
         .await?;
 
-    let entries: Vec<EnvVarResponse> = updated
-        .env_vars
-        .iter()
-        .map(EnvVarResponse::from_entry)
-        .collect();
-    Ok(HttpResponse::Ok().json(EnvVarsListResponse { revision, entries }))
+    let section = section.ok_or_else(|| {
+        AppError::InternalError(anyhow::anyhow!(
+            "env mutation completed without a typed section envelope"
+        ))
+    })?;
+    Ok(HttpResponse::Ok().json(env_response(
+        &updated,
+        revision,
+        &metadata.credential_statuses,
+        section,
+        metadata.credential_health,
+    )))
 }
 
 #[cfg(test)]
@@ -250,7 +439,10 @@ mod tests {
                 .set_json(serde_json::json!({
                     "expected_revision": 0,
                     "name": "TOKEN",
-                    "value": "super-secret-value",
+                    "credential_change": {
+                        "action": "replace",
+                        "value": "super-secret-value"
+                    },
                     "secret": true
                 }))
                 .to_request(),
@@ -259,11 +451,16 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body: serde_json::Value = test::read_body_json(response).await;
         assert_eq!(body["revision"], 1);
-        assert_eq!(body["entries"][0]["value"], "****...****");
+        assert_eq!(body["section"]["revision"], 1);
+        assert_eq!(body["credential_health"]["revision"], 1);
+        assert!(body["entries"][0].get("value").is_none());
         assert_eq!(body["entries"][0]["configured"], true);
+        assert_eq!(body["entries"][0]["credential_state"], "configured");
+        assert_eq!(body["entries"][0]["credential_ref"], "env.TOKEN.value");
+        assert_eq!(body["entries"][0]["source"], "user");
         let rendered = body.to_string();
         assert!(!rendered.contains("super-secret-value"));
-        assert!(!rendered.contains("credential_ref"));
+        assert!(!rendered.contains("****"));
 
         let mut metadata_feed = state.account_sink.subscribe();
         let metadata = test::call_service(
@@ -445,7 +642,7 @@ mod tests {
                 .set_json(serde_json::json!({
                     "expected_revision": 3,
                     "name": "TOKEN",
-                    "value": "",
+                    "credential_change": {"action": "clear"},
                     "secret": true
                 }))
                 .to_request(),
@@ -495,8 +692,84 @@ mod tests {
         let non_secret_update: serde_json::Value = test::read_body_json(non_secret_update).await;
         assert_eq!(non_secret_update["revision"], 6);
 
+        let invalid_plain_to_secret_keep = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/env-vars")
+                .set_json(serde_json::json!({
+                    "expected_revision": 6,
+                    "name": "PUBLIC_VALUE",
+                    "secret": true,
+                    "credential_change": {"action": "keep"}
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            invalid_plain_to_secret_keep.status(),
+            StatusCode::BAD_REQUEST
+        );
+
+        let convert_to_secret = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/env-vars")
+                .set_json(serde_json::json!({
+                    "expected_revision": 6,
+                    "name": "PUBLIC_VALUE",
+                    "secret": true,
+                    "credential_change": {
+                        "action": "replace",
+                        "value": "converted-secret"
+                    }
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(convert_to_secret.status(), StatusCode::OK);
+        let convert_to_secret: serde_json::Value = test::read_body_json(convert_to_secret).await;
+        assert_eq!(convert_to_secret["revision"], 7);
+        assert!(convert_to_secret["entries"][1].get("value").is_none());
+        assert!(!convert_to_secret.to_string().contains("converted-secret"));
+
+        let unsafe_secret_to_plain = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/env-vars")
+                .set_json(serde_json::json!({
+                    "expected_revision": 7,
+                    "name": "PUBLIC_VALUE",
+                    "secret": false
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(unsafe_secret_to_plain.status(), StatusCode::BAD_REQUEST);
+
+        let convert_to_plain = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/env-vars")
+                .set_json(serde_json::json!({
+                    "expected_revision": 7,
+                    "name": "PUBLIC_VALUE",
+                    "secret": false,
+                    "value": "public-after-secret"
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(convert_to_plain.status(), StatusCode::OK);
+        let convert_to_plain: serde_json::Value = test::read_body_json(convert_to_plain).await;
+        assert_eq!(convert_to_plain["revision"], 8);
+        assert_eq!(
+            convert_to_plain["entries"][1]["value"],
+            "public-after-secret"
+        );
+
         let root = std::fs::read_to_string(dir.path().join("env.json")).unwrap();
         assert!(!root.contains("super-secret-value"));
+        assert!(!root.contains("converted-secret"));
         assert!(!root.contains("value_encrypted"));
         assert!(!root.contains("****...****"));
     }
@@ -604,7 +877,7 @@ mod tests {
             );
             std::fs::write(&path, serde_json::to_vec_pretty(&root).unwrap()).unwrap();
         });
-        let (committed, revision) = state
+        let (committed, revision, _, _) = state
             .update_env_var_credentials(
                 0,
                 std::collections::BTreeSet::from(["TOKEN".to_string()]),

--- a/crates/app/bamboo-server/src/handlers/settings/env_vars/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/env_vars/handlers.rs
@@ -90,33 +90,17 @@ fn env_response(
 
 /// `GET /bamboo/env-vars` – list all env vars without secret values or masks.
 pub async fn list_env_vars(app_state: web::Data<AppState>) -> Result<HttpResponse, AppError> {
-    let _io = app_state.config_io_lock.lock().await;
-    let facade = app_state.config_facade.as_ref().ok_or_else(|| {
-        AppError::BadRequest("env settings require the modular configuration facade".to_string())
-    })?;
-    let section = facade
-        .registry()
-        .envelope_value(bamboo_config::SectionId::Env)
-        .map_err(|error| {
-            AppError::InternalError(anyhow::anyhow!("env section envelope unavailable: {error}"))
-        })?;
+    let exact = app_state
+        .read_exact_credential_section(bamboo_config::SectionId::Env)
+        .await?;
+    let section = exact.section;
     let revision = section.revision;
-    let (statuses, credential_health) =
-        app_state
-            .credential_store
-            .statuses_with_health()
-            .map_err(|error| {
-                AppError::InternalError(anyhow::anyhow!(
-                    "env credential status unavailable: {error}"
-                ))
-            })?;
-    let config = app_state.config.read().await;
     Ok(HttpResponse::Ok().json(env_response(
-        &config,
+        &exact.config,
         revision,
-        &statuses,
+        &exact.metadata.credential_statuses,
         section,
-        credential_health,
+        exact.metadata.credential_health,
     )))
 }
 
@@ -144,6 +128,7 @@ pub async fn upsert_env_var(
         .update_env_var_credentials(
             expected_revision,
             std::collections::BTreeSet::from([name]),
+            false,
             move |cfg| {
                 // Replace existing or push new.
                 if let Some(existing) = cfg.env_vars.iter_mut().find(|e| e.name == req.name) {
@@ -265,20 +250,12 @@ pub async fn replace_env_vars(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    let mut intents = {
-        let cfg = app_state.config.read().await;
-        cfg.env_vars
-            .iter()
-            .map(|entry| entry.name.clone())
-            .collect::<std::collections::BTreeSet<_>>()
-    };
-    intents.extend(
-        requested_entries
-            .iter()
-            .map(|(entry, _)| entry.name.clone()),
-    );
+    let intents = requested_entries
+        .iter()
+        .map(|(entry, _)| entry.name.clone())
+        .collect::<std::collections::BTreeSet<_>>();
     let (updated, revision, metadata, section) = app_state
-        .update_env_var_credentials(expected_revision, intents, move |cfg| {
+        .update_env_var_credentials(expected_revision, intents, true, move |cfg| {
             let mut new_entries = Vec::with_capacity(requested_entries.len());
             for (entry, secret_change) in &requested_entries {
                 let existing = cfg
@@ -380,6 +357,7 @@ pub async fn delete_env_var(
         .update_env_var_credentials(
             expected_revision,
             std::collections::BTreeSet::from([intent]),
+            false,
             move |cfg| {
                 let before = cfg.env_vars.len();
                 cfg.env_vars.retain(|e| e.name != name);
@@ -775,6 +753,138 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn stale_full_replace_clears_omitted_durable_secret_and_credential_record() {
+        let _serial = encryption_test_lock().lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let mut stale = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stale.stop_config_watcher_for_test();
+        let writer = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        writer
+            .update_env_var_credentials(
+                0,
+                std::collections::BTreeSet::from(["EXTERNAL_SECRET".to_string()]),
+                false,
+                |config| {
+                    config.env_vars.push(EnvVarEntry {
+                        name: "EXTERNAL_SECRET".to_string(),
+                        value: "external-secret-value".to_string(),
+                        secret: true,
+                        value_encrypted: None,
+                        credential_ref: None,
+                        configured: true,
+                        description: None,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        assert!(stale.config.read().await.env_vars.is_empty());
+
+        let stale_store = stale.credential_store.clone();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(stale))
+                .route("/env-vars/replace", web::post().to(replace_env_vars)),
+        )
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/env-vars/replace")
+                .set_json(serde_json::json!({
+                    "expected_revision": 1,
+                    "entries": [{
+                        "name": "PUBLIC_VALUE",
+                        "value": "public",
+                        "secret": false
+                    }]
+                }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = test::read_body_json(response).await;
+        assert_eq!(body["revision"], 2);
+        assert_eq!(body["entries"].as_array().unwrap().len(), 1);
+        assert_eq!(body["entries"][0]["name"], "PUBLIC_VALUE");
+
+        let reference = bamboo_config::credential_ref("env", "EXTERNAL_SECRET", "value").unwrap();
+        assert!(!stale_store.status(&reference).unwrap().configured);
+        assert!(stale_store.resolve(&reference).unwrap().is_none());
+        let durable: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(dir.path().join("env.json")).unwrap()).unwrap();
+        assert_eq!(durable["revision"], 2);
+        assert_eq!(durable["data"].as_array().unwrap().len(), 1);
+        assert!(
+            !std::fs::read_to_string(dir.path().join("credentials.json"))
+                .unwrap()
+                .contains("EXTERNAL_SECRET")
+        );
+    }
+
+    #[actix_web::test]
+    async fn stale_process_get_pairs_latest_env_section_with_same_credential_generation() {
+        let _serial = encryption_test_lock().lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let writer = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        writer
+            .update_env_var_credentials(
+                0,
+                std::collections::BTreeSet::from(["TOKEN".to_string()]),
+                false,
+                |config| {
+                    config.env_vars.push(EnvVarEntry {
+                        name: "TOKEN".to_string(),
+                        value: "first-generation-secret".to_string(),
+                        secret: true,
+                        value_encrypted: None,
+                        credential_ref: None,
+                        configured: true,
+                        description: None,
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        let mut stale = AppState::new(dir.path().to_path_buf()).await.unwrap();
+        stale.stop_config_watcher_for_test();
+        assert_eq!(stale.config.read().await.env_vars.len(), 1);
+
+        writer
+            .update_env_var_credentials(
+                1,
+                std::collections::BTreeSet::from(["TOKEN".to_string()]),
+                false,
+                |config| {
+                    config.env_vars.clear();
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(stale.config.read().await.env_vars.len(), 1);
+
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(stale))
+                .route("/env-vars", web::get().to(list_env_vars)),
+        )
+        .await;
+        let body: serde_json::Value = test::call_and_read_body_json(
+            &app,
+            test::TestRequest::get().uri("/env-vars").to_request(),
+        )
+        .await;
+        assert_eq!(body["revision"], 2);
+        assert_eq!(body["section"]["revision"], 2);
+        assert_eq!(body["credential_health"]["revision"], 2);
+        assert!(body["entries"].as_array().unwrap().is_empty());
+        assert!(!body.to_string().contains("env.TOKEN.value"));
+    }
+
+    #[actix_web::test]
     async fn cancelled_caller_finishes_once_and_old_revision_retry_cannot_replay() {
         let _serial = encryption_test_lock().lock().await;
         let dir = tempfile::tempdir().unwrap();
@@ -786,6 +896,7 @@ mod tests {
                 .update_env_var_credentials(
                     0,
                     std::collections::BTreeSet::from(["TOKEN".to_string()]),
+                    false,
                     |config| {
                         config.env_vars.push(EnvVarEntry {
                             name: "TOKEN".to_string(),
@@ -844,6 +955,7 @@ mod tests {
             .update_env_var_credentials(
                 0,
                 std::collections::BTreeSet::from(["TOKEN".to_string()]),
+                false,
                 |_| Ok(()),
             )
             .await;
@@ -881,6 +993,7 @@ mod tests {
             .update_env_var_credentials(
                 0,
                 std::collections::BTreeSet::from(["TOKEN".to_string()]),
+                false,
                 |config| {
                     config.env_vars.push(EnvVarEntry {
                         name: "TOKEN".to_string(),
@@ -927,5 +1040,113 @@ mod tests {
             &event.event,
             bamboo_agent_core::AgentEvent::ConfigChanged { section, .. } if section == "core"
         )));
+    }
+
+    #[actix_web::test]
+    async fn post_manifest_section_rebase_returns_and_publishes_actual_revision() {
+        let _serial = encryption_test_lock().lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let baseline_seq = state.account_sink.latest_seq();
+        bamboo_config::set_env_transaction_test_hook(|data_dir| {
+            let path = data_dir.join("env.json");
+            let mut envelope: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+            assert_eq!(envelope["revision"], 0);
+            envelope["revision"] = serde_json::Value::from(1);
+            envelope["data"]
+                .as_array_mut()
+                .unwrap()
+                .push(serde_json::json!({
+                    "name": "EXTERNAL",
+                    "value": "external-winner",
+                    "secret": false,
+                    "configured": true,
+                    "description": "post-manifest generation"
+                }));
+            std::fs::write(path, serde_json::to_vec_pretty(&envelope).unwrap()).unwrap();
+        });
+
+        let (committed, revision, _, section) = state
+            .update_env_var_credentials(
+                0,
+                std::collections::BTreeSet::from(["TOKEN".to_string()]),
+                false,
+                |config| {
+                    config.env_vars.push(EnvVarEntry {
+                        name: "TOKEN".to_string(),
+                        value: "transaction-secret".to_string(),
+                        secret: true,
+                        value_encrypted: None,
+                        credential_ref: None,
+                        configured: true,
+                        description: Some("transaction generation".to_string()),
+                    });
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(revision, 2);
+        let section = section.expect("exact committed envelope");
+        assert_eq!(section.revision, revision);
+        let returned_names = section
+            .data
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|entry| entry["name"].as_str())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            returned_names,
+            std::collections::BTreeSet::from(["EXTERNAL", "TOKEN"])
+        );
+        let live = state.config.read().await.clone();
+        for config in [&committed, &live] {
+            assert!(config.env_vars.iter().any(|entry| {
+                entry.name == "EXTERNAL" && entry.value == "external-winner" && !entry.secret
+            }));
+            assert!(config
+                .env_vars
+                .iter()
+                .any(|entry| entry.name == "TOKEN" && entry.value == "transaction-secret"));
+        }
+
+        let facade = state.config_facade.as_ref().unwrap();
+        assert_eq!(facade.registry().env.snapshot().revision, revision);
+        let durable: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(dir.path().join("env.json")).unwrap()).unwrap();
+        assert_eq!(durable["revision"], revision);
+        assert_eq!(
+            durable["data"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|entry| entry["name"].as_str())
+                .collect::<std::collections::BTreeSet<_>>(),
+            std::collections::BTreeSet::from(["EXTERNAL", "TOKEN"])
+        );
+        let credentials = std::fs::read_to_string(dir.path().join("credentials.json")).unwrap();
+        assert!(!credentials.contains("transaction-secret"));
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        let events = bamboo_engine::events::journal::read_since(
+            state.account_sink.events_dir(),
+            baseline_seq,
+        )
+        .unwrap();
+        let env_revisions = events
+            .iter()
+            .filter_map(|event| match &event.event {
+                bamboo_agent_core::AgentEvent::ConfigChanged { section, revision }
+                    if section == "env" =>
+                {
+                    Some(*revision)
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(env_revisions, vec![revision]);
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/env_vars/types.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/env_vars/types.rs
@@ -1,5 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+use crate::handlers::settings::credential_action::{
+    credential_status_view, CredentialAction, CredentialState,
+};
+
 /// Request payload for creating or updating an environment variable.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -9,17 +13,34 @@ pub struct UpsertEnvVarRequest {
     pub entry: EnvVarInput,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EnvVarInput {
     pub name: String,
     /// Missing keeps an existing value; `""` explicitly clears it.
     #[serde(default)]
     pub value: Option<String>,
+    /// Explicit secret mutation. Omission retains the compatibility form:
+    /// missing `value` keeps, nonempty `value` replaces, and `""` clears.
+    #[serde(default)]
+    pub(crate) credential_change: Option<CredentialAction>,
     #[serde(default)]
     pub secret: bool,
     #[serde(default)]
     pub description: Option<String>,
+}
+
+impl std::fmt::Debug for EnvVarInput {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("EnvVarInput")
+            .field("name", &self.name)
+            .field("value", &self.value.as_ref().map(|_| "[REDACTED]"))
+            .field("credential_change", &self.credential_change)
+            .field("secret", &self.secret)
+            .field("description", &self.description)
+            .finish()
+    }
 }
 
 /// Request payload for bulk-replacing the entire env vars list.
@@ -37,18 +58,29 @@ pub struct DeleteEnvVarQuery {
     pub expected_revision: u64,
 }
 
-/// Single env var in API response (secrets are masked).
+/// Single env var in API response. Secret values are never serialized.
 #[derive(Debug, Clone, Serialize)]
 pub struct EnvVarResponse {
     pub name: String,
-    /// Masked for secrets (`****...****`); plaintext for non-secrets.
-    pub value: String,
+    /// Plaintext is returned only for non-secret entries. A secret entry omits
+    /// this field entirely; masks are not part of the wire contract.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
     pub secret: bool,
-    /// Whether a real value is configured (useful for secret entries where value is masked).
+    /// Whether a real value is configured (useful for secret entries whose
+    /// value is omitted).
     pub has_value: bool,
     /// Truthful configured status (kept alongside `has_value` for API
     /// compatibility).
     pub configured: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential_state: Option<CredentialState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credential_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<bamboo_config::CredentialSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }
@@ -56,31 +88,49 @@ pub struct EnvVarResponse {
 /// Full list response.
 #[derive(Debug, Clone, Serialize)]
 pub struct EnvVarsListResponse {
-    /// Credential document revision to bind to the next write.
+    /// Env section revision to bind to the next write.
     pub revision: u64,
     pub entries: Vec<EnvVarResponse>,
+    /// Exact typed Env section generation paired with this projection.
+    pub section: bamboo_config::SectionEnvelope<serde_json::Value>,
+    /// Internal credential-document health is diagnostic only; clients must
+    /// never use its revision as the Env mutation precondition.
+    pub credential_health: bamboo_config::CredentialStoreHealth,
 }
 
-const SECRET_MASK: &str = "****...****";
-
 impl EnvVarResponse {
-    pub fn from_entry(entry: &bamboo_config::EnvVarEntry) -> Self {
-        let has_value = if entry.secret {
-            entry.configured
-        } else {
-            !entry.value.is_empty()
-        };
-        let display_value = if entry.secret {
-            SECRET_MASK.to_string()
-        } else {
-            entry.value.clone()
-        };
+    pub fn from_entry(
+        entry: &bamboo_config::EnvVarEntry,
+        status: Option<&bamboo_config::CredentialStatus>,
+        health: &bamboo_config::CredentialStoreHealth,
+    ) -> Self {
+        let credential = entry.secret.then(|| {
+            credential_status_view(
+                entry.credential_ref.as_ref(),
+                entry.configured,
+                status,
+                health,
+            )
+        });
+        let has_value = credential
+            .as_ref()
+            .map(|credential| credential.configured)
+            .unwrap_or_else(|| !entry.value.is_empty());
         Self {
             name: entry.name.clone(),
-            value: display_value,
+            value: (!entry.secret).then(|| entry.value.clone()),
             secret: entry.secret,
             has_value,
             configured: has_value,
+            credential_state: credential.as_ref().map(|credential| credential.state),
+            credential_ref: entry
+                .credential_ref
+                .as_ref()
+                .map(|reference| reference.as_str().to_string()),
+            source: credential.as_ref().and_then(|credential| credential.source),
+            updated_at: credential
+                .and_then(|credential| credential.updated_at)
+                .map(|updated_at| updated_at.to_rfc3339()),
             description: entry.description.clone(),
         }
     }
@@ -131,37 +181,63 @@ mod tests {
 
     #[test]
     fn from_entry_plain_shows_value() {
-        let resp = EnvVarResponse::from_entry(&plain_entry());
+        let resp = EnvVarResponse::from_entry(
+            &plain_entry(),
+            None,
+            &bamboo_config::CredentialStoreHealth::committed(0),
+        );
         assert_eq!(resp.name, "NODE_ENV");
-        assert_eq!(resp.value, "production");
+        assert_eq!(resp.value.as_deref(), Some("production"));
         assert!(!resp.secret);
         assert!(resp.has_value);
         assert_eq!(resp.description.as_deref(), Some("Node environment"));
     }
 
     #[test]
-    fn from_entry_secret_masks_value() {
-        let resp = EnvVarResponse::from_entry(&secret_entry_with_value());
+    fn from_entry_secret_omits_value() {
+        let entry = secret_entry_with_value();
+        let status = bamboo_config::CredentialStatus {
+            credential_ref: entry.credential_ref.clone().unwrap(),
+            configured: true,
+            source: bamboo_config::CredentialSource::User,
+            updated_at: None,
+        };
+        let resp = EnvVarResponse::from_entry(
+            &entry,
+            Some(&status),
+            &bamboo_config::CredentialStoreHealth::committed(1),
+        );
         assert_eq!(resp.name, "API_KEY");
-        assert_eq!(resp.value, "****...****");
+        assert_eq!(resp.value, None);
         assert!(resp.secret);
         assert!(resp.has_value);
+        assert_eq!(resp.credential_state, Some(CredentialState::Configured));
+        assert_eq!(resp.source, Some(bamboo_config::CredentialSource::User));
     }
 
     #[test]
     fn from_entry_secret_without_value_shows_not_set() {
-        let resp = EnvVarResponse::from_entry(&secret_entry_without_value());
-        assert_eq!(resp.value, "****...****");
+        let resp = EnvVarResponse::from_entry(
+            &secret_entry_without_value(),
+            None,
+            &bamboo_config::CredentialStoreHealth::committed(0),
+        );
+        assert_eq!(resp.value, None);
         assert!(resp.secret);
         assert!(!resp.has_value);
+        assert_eq!(resp.credential_state, Some(CredentialState::Missing));
     }
 
     #[test]
     fn from_entry_plain_empty_value() {
         let mut entry = plain_entry();
         entry.value = "".to_string();
-        let resp = EnvVarResponse::from_entry(&entry);
-        assert_eq!(resp.value, "");
+        let resp = EnvVarResponse::from_entry(
+            &entry,
+            None,
+            &bamboo_config::CredentialStoreHealth::committed(0),
+        );
+        assert_eq!(resp.value.as_deref(), Some(""));
         assert!(!resp.has_value);
     }
 }

--- a/crates/app/bamboo-server/src/handlers/settings/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/mod.rs
@@ -6,6 +6,7 @@
 mod access_control;
 mod bamboo_config;
 mod cluster_fabric;
+mod credential_action;
 mod env_vars;
 mod keyword_masking;
 mod lifecycle_hooks;
@@ -26,12 +27,13 @@ pub use access_control::{
 pub(crate) use access_control::{request_is_authorized, verify_device_token};
 pub use bamboo_config::{
     clear_credential, confirm_config_recovery, detect_codex_cli, get_bamboo_config,
-    get_bamboo_tools, get_config_recovery_status, get_credential_status, get_live_config_health,
-    get_mcp_section, get_model_limit_defaults, get_notification_config, get_provider_section,
-    get_provider_settings_section, get_proxy_auth_status, get_typed_section, list_credentials,
-    put_mcp_section, put_provider_section, put_provider_settings_section, put_typed_section,
-    replace_credential, reset_bamboo_config, reset_credentials, reset_typed_section,
-    set_bamboo_config, set_proxy_auth, validate_bamboo_config_patch, ProxyAuthPayload,
+    get_bamboo_tools, get_config_recovery_status, get_connect_config, get_credential_status,
+    get_live_config_health, get_mcp_section, get_model_limit_defaults, get_notification_config,
+    get_provider_section, get_provider_settings_section, get_proxy_auth_status, get_typed_section,
+    list_credentials, put_connect_config, put_mcp_section, put_notification_config,
+    put_provider_section, put_provider_settings_section, put_typed_section, replace_credential,
+    reset_bamboo_config, reset_credentials, reset_typed_section, set_bamboo_config, set_proxy_auth,
+    validate_bamboo_config_patch, ProxyAuthPayload,
 };
 pub use cluster_fabric::{
     create_cluster, create_node, delete_cluster, delete_node, get_node, list_nodes, node_deploy,

--- a/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/provider_instances/mod.rs
@@ -623,8 +623,7 @@ mod tests {
         assert_eq!(create_resp.status(), actix_web::http::StatusCode::CREATED);
 
         // A settings save that does not mention `provider_instances` at all.
-        let save_payload: Value =
-            serde_json::json!({ "http_proxy": "http://example.invalid:8080" });
+        let save_payload: Value = serde_json::json!({ "headless_auth": true });
         crate::handlers::settings::set_bamboo_config(app_state.clone(), web::Json(save_payload))
             .await
             .expect("unrelated settings save should succeed");
@@ -697,8 +696,7 @@ mod tests {
         .await
         .expect("update should succeed");
 
-        let save_payload: Value =
-            serde_json::json!({ "http_proxy": "http://example.invalid:9090" });
+        let save_payload: Value = serde_json::json!({ "headless_auth": true });
         crate::handlers::settings::set_bamboo_config(app_state.clone(), web::Json(save_payload))
             .await
             .expect("unrelated settings save should succeed");

--- a/crates/app/bamboo-server/src/routes/bamboo_v1.rs
+++ b/crates/app/bamboo-server/src/routes/bamboo_v1.rs
@@ -194,6 +194,18 @@ pub(crate) fn bamboo_relative_routes() -> impl HttpServiceFactory {
             web::get().to(settings::get_notification_config),
         )
         .route(
+            "/bamboo/config/notifications",
+            web::put().to(settings::put_notification_config),
+        )
+        .route(
+            "/bamboo/config/connect",
+            web::get().to(settings::get_connect_config),
+        )
+        .route(
+            "/bamboo/config/connect",
+            web::put().to(settings::put_connect_config),
+        )
+        .route(
             "/bamboo/proxy-auth",
             web::post().to(settings::set_proxy_auth),
         )

--- a/crates/app/bamboo-server/src/routes/tests.rs
+++ b/crates/app/bamboo-server/src/routes/tests.rs
@@ -21,6 +21,8 @@ async fn configure_routes_registers_expected_api_prefixes() {
         ("DELETE", "/api/v1/sessions/example/discoverable-tools"),
         ("GET", "/v1/bamboo/workflows"),
         ("GET", "/v1/bamboo/access/status"),
+        ("PUT", "/v1/bamboo/config/notifications"),
+        ("PUT", "/v1/bamboo/config/connect"),
         ("GET", "/api/v1/plugins"),
         ("GET", "/openai/v1/models"),
         ("GET", "/anthropic/v1/models"),
@@ -30,6 +32,7 @@ async fn configure_routes_registers_expected_api_prefixes() {
     for (method, uri) in requests {
         let req = match method {
             "POST" => test::TestRequest::post().uri(uri).to_request(),
+            "PUT" => test::TestRequest::put().uri(uri).to_request(),
             "DELETE" => test::TestRequest::delete().uri(uri).to_request(),
             _ => test::TestRequest::get().uri(uri).to_request(),
         };
@@ -57,6 +60,8 @@ async fn configure_routes_with_rate_limiting_registers_expected_api_prefixes() {
         ("DELETE", "/api/v1/sessions/example/discoverable-tools"),
         ("GET", "/v1/bamboo/workflows"),
         ("GET", "/v1/bamboo/access/status"),
+        ("PUT", "/v1/bamboo/config/notifications"),
+        ("PUT", "/v1/bamboo/config/connect"),
         ("GET", "/api/v1/plugins"),
         ("GET", "/openai/v1/models"),
         ("GET", "/anthropic/v1/models"),
@@ -66,6 +71,7 @@ async fn configure_routes_with_rate_limiting_registers_expected_api_prefixes() {
     for (method, uri) in requests {
         let req = match method {
             "POST" => test::TestRequest::post().uri(uri).to_request(),
+            "PUT" => test::TestRequest::put().uri(uri).to_request(),
             "DELETE" => test::TestRequest::delete().uri(uri).to_request(),
             _ => test::TestRequest::get().uri(uri).to_request(),
         };
@@ -97,6 +103,8 @@ async fn bamboo_v1_routes_resolve_under_both_canonical_and_legacy_prefix() {
         "/sessions/session/workflow-runs/example",
         "/bamboo/setup/status",
         "/bamboo/config",
+        "/bamboo/config/notifications",
+        "/bamboo/config/connect",
         "/bamboo/access/status",
         "/bamboo/model-limits/defaults",
         "/bamboo/tools",
@@ -757,10 +765,22 @@ async fn password_change_preserves_paired_devices() {
     assert_eq!(device_count_before, 1);
 
     // Change the root password (local bypass → current_password not required).
+    let expected_revision = app_state
+        .config_facade
+        .as_ref()
+        .expect("modular config facade")
+        .registry()
+        .access_control
+        .snapshot()
+        .revision;
     let change_req = test::TestRequest::post()
         .uri("/v1/bamboo/access/password")
         .insert_header((header::HOST, "localhost:9562"))
-        .set_json(serde_json::json!({ "new_password": "newsecret" }))
+        .set_json(serde_json::json!({
+            "expected_revision": expected_revision,
+            "action": "replace",
+            "value": "newsecret"
+        }))
         .to_request();
     let change_resp = test::call_service(&app, change_req).await;
     assert_eq!(change_resp.status(), StatusCode::OK);

--- a/crates/app/bamboo-server/src/routes/tests.rs
+++ b/crates/app/bamboo-server/src/routes/tests.rs
@@ -1035,10 +1035,13 @@ async fn v2_devices_list_excludes_secret_material() {
 async fn v2_devices_delete_revokes_and_404s_unknown() {
     let data_dir = tempdir().unwrap();
     let app_state = web::Data::new(AppState::new(data_dir.path().to_path_buf()).await.unwrap());
-    {
-        let mut config = app_state.config.write().await;
-        config.access_control = Some(password_access_control());
-    }
+    app_state
+        .update_access_control_credentials(0, true, Default::default(), |config| {
+            config.access_control = Some(password_access_control());
+            Ok(())
+        })
+        .await
+        .unwrap();
     inject_code(&app_state, "333333", Duration::from_secs(120));
     let app = test::init_service(
         App::new()

--- a/crates/infra/bamboo-config/src/config_crypto.rs
+++ b/crates/infra/bamboo-config/src/config_crypto.rs
@@ -74,7 +74,9 @@ fn validate_access_verifier(hash: &str, salt: &str) -> crate::ConfigStoreResult<
     Ok(())
 }
 
-fn decode_access_verifier(secret: &str) -> crate::ConfigStoreResult<AccessVerifierRecord> {
+pub(crate) fn decode_access_verifier(
+    secret: &str,
+) -> crate::ConfigStoreResult<AccessVerifierRecord> {
     let record: AccessVerifierRecord = serde_json::from_str(secret).map_err(|_| {
         crate::ConfigStoreError::Validation(
             "access-control verifier credential is invalid".to_string(),

--- a/crates/infra/bamboo-config/src/config_store.rs
+++ b/crates/infra/bamboo-config/src/config_store.rs
@@ -1406,6 +1406,68 @@ where
         self.commit_inner(expected_revision, candidate, || {})
     }
 
+    /// Commit and return the immutable envelope published by this exact
+    /// operation while the section operation lock still excludes reloads.
+    pub fn commit_with_envelope(
+        &self,
+        expected_revision: u64,
+        candidate: T,
+    ) -> ConfigStoreResult<(ConfigSectionEvent, SectionEnvelope<T>)> {
+        self.commit_inner_with_envelope(expected_revision, candidate, || {})
+    }
+
+    /// Commit against an exact healthy durable base while permitting this
+    /// process's immutable snapshot to lag behind that base.
+    ///
+    /// The caller must hold any wider transaction lock needed by the section
+    /// and supply the exact durable value loaded for `expected_revision`.
+    /// Keeping the section operation lock across the content-aware file CAS
+    /// and publication means a successful stale-local write can jump directly
+    /// from rN to rN+K, while a failed write neither consumes nor publishes an
+    /// intermediate durable generation.
+    pub(crate) fn commit_from_durable_base_with_envelope(
+        &self,
+        expected_revision: u64,
+        expected_data: &T,
+        candidate: T,
+    ) -> ConfigStoreResult<(ConfigSectionEvent, SectionEnvelope<T>)> {
+        let _operation = self
+            .operation_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let current = self.snapshot();
+        if current.revision > expected_revision {
+            return Err(ConfigStoreError::Validation(format!(
+                "process-local {} revision {} is ahead of durable mutation base {expected_revision}",
+                self.name, current.revision
+            )));
+        }
+        let revision = self.store.commit_from_live_snapshot(
+            expected_revision,
+            expected_data,
+            candidate.clone(),
+            |value| (self.validate)(value),
+        )?;
+        let committed = SectionSnapshot {
+            data: Arc::new(candidate),
+            revision,
+            loaded_at: Utc::now(),
+            source_path: self.store.path().to_path_buf(),
+            source_kind: SectionSourceKind::File,
+            status: SectionStatus::Healthy,
+            last_error: None,
+        };
+        let envelope = committed.envelope();
+        self.publish(committed, LiveRepairAuthority::None);
+        Ok((
+            ConfigSectionEvent::Changed {
+                section: self.name.clone(),
+                revision,
+            },
+            envelope,
+        ))
+    }
+
     /// Adopt a snapshot that was durably installed by a compound transaction
     /// while that transaction still owns its cross-process commit lock.
     ///
@@ -1521,6 +1583,19 @@ where
     where
         F: FnOnce(),
     {
+        self.commit_inner_with_envelope(expected_revision, candidate, before_publish)
+            .map(|(event, _)| event)
+    }
+
+    fn commit_inner_with_envelope<F>(
+        &self,
+        expected_revision: u64,
+        candidate: T,
+        before_publish: F,
+    ) -> ConfigStoreResult<(ConfigSectionEvent, SectionEnvelope<T>)>
+    where
+        F: FnOnce(),
+    {
         let _operation = self
             .operation_lock
             .lock()
@@ -1558,22 +1633,24 @@ where
             }
         };
         before_publish();
-        self.publish(
-            SectionSnapshot {
-                data: Arc::new(candidate),
-                revision,
-                loaded_at: Utc::now(),
-                source_path: self.store.path().to_path_buf(),
-                source_kind: SectionSourceKind::File,
-                status: SectionStatus::Healthy,
-                last_error: None,
-            },
-            LiveRepairAuthority::None,
-        );
-        Ok(ConfigSectionEvent::Changed {
-            section: self.name.clone(),
+        let committed = SectionSnapshot {
+            data: Arc::new(candidate),
             revision,
-        })
+            loaded_at: Utc::now(),
+            source_path: self.store.path().to_path_buf(),
+            source_kind: SectionSourceKind::File,
+            status: SectionStatus::Healthy,
+            last_error: None,
+        };
+        let envelope = committed.envelope();
+        self.publish(committed, LiveRepairAuthority::None);
+        Ok((
+            ConfigSectionEvent::Changed {
+                section: self.name.clone(),
+                revision,
+            },
+            envelope,
+        ))
     }
 
     pub fn reload(&self) -> ConfigSectionEvent {
@@ -3536,6 +3613,87 @@ mod tests {
         ));
         assert_eq!(section.snapshot().data.value, "durable-r2");
         assert_eq!(std::fs::read(path).unwrap(), durable);
+    }
+
+    #[test]
+    fn failed_durable_base_commit_leaves_intermediate_revision_for_reload() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("example.json");
+        std::fs::write(
+            &path,
+            serde_json::to_vec_pretty(&RevisionedDocument {
+                schema_version: 1,
+                revision: 0,
+                data: Example {
+                    value: "local-r0".into(),
+                },
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        let section = LiveSection::open(
+            "example",
+            AtomicJsonStore::new(&path, 1),
+            Example {
+                value: "local-r0".into(),
+            },
+            |_| Ok(()),
+        )
+        .unwrap();
+        let external = AtomicJsonStore::new(&path, 1);
+        external
+            .commit(
+                0,
+                Example {
+                    value: "durable-r1".into(),
+                },
+                |_| Ok(()),
+            )
+            .unwrap();
+        let captured_base = Example {
+            value: "durable-r1".into(),
+        };
+
+        // An out-of-contract editor reuses r1 with different content after
+        // the exact base was captured. The content-aware durable CAS must
+        // reject it without advancing or publishing the stale local snapshot.
+        std::fs::write(
+            &path,
+            serde_json::to_vec_pretty(&RevisionedDocument {
+                schema_version: 1,
+                revision: 1,
+                data: Example {
+                    value: "rewritten-r1".into(),
+                },
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(matches!(
+            section.commit_from_durable_base_with_envelope(
+                1,
+                &captured_base,
+                Example {
+                    value: "candidate-r2".into(),
+                },
+            ),
+            Err(ConfigStoreError::Conflict {
+                expected: 1,
+                actual: 1
+            })
+        ));
+        assert_eq!(section.snapshot().revision, 0);
+        assert_eq!(section.snapshot().data.value, "local-r0");
+
+        assert_eq!(
+            section.reload(),
+            ConfigSectionEvent::Changed {
+                section: "example".to_string(),
+                revision: 1,
+            }
+        );
+        assert_eq!(section.snapshot().revision, 1);
+        assert_eq!(section.snapshot().data.value, "rewritten-r1");
     }
 
     #[test]

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -1745,9 +1745,10 @@ fn persist_proxy_auth_credential_transaction(
     persist_proxy_auth_credential_transaction_at_revision(data_dir, config, expected_revision)
 }
 
-/// Persist proxy authentication with an explicit credential-store revision
-/// precondition. The returned revision is the durable credential revision
-/// committed by the exact transaction.
+/// Persist proxy authentication with an explicit revision precondition. In the
+/// modular layout the core section is the public CAS authority and the returned
+/// revision is its exact committed revision. The legacy layout retains the
+/// credential-document revision contract for bounded compatibility.
 pub fn persist_proxy_auth_credential_transaction_at_revision(
     data_dir: impl AsRef<Path>,
     config: &mut crate::Config,
@@ -1784,8 +1785,9 @@ pub fn persist_proxy_auth_credential_transaction_at_revision(
     )
 }
 
-/// Persist secret env values and their root metadata as one recoverable exact
-/// transaction guarded by the credential document revision.
+/// Persist secret env values and their metadata as one recoverable exact
+/// transaction. In the modular layout the env section is the sole public CAS
+/// authority; the credential revision remains an internal transaction member.
 pub fn persist_env_var_credential_transaction_at_revision(
     data_dir: impl AsRef<Path>,
     config: &mut crate::Config,
@@ -2035,6 +2037,7 @@ pub struct CredentialSectionTransactionCommit {
     pub revision: u64,
     pub section_adoption: Option<ConfigStoreResult<crate::ConfigSectionEvent>>,
     pub credential_adoption: Option<ConfigStoreResult<Option<crate::ConfigSectionEvent>>>,
+    pub section: ConfigStoreResult<crate::SectionEnvelope<Value>>,
     pub runtime: ConfigStoreResult<CredentialSectionRuntimeSnapshot>,
 }
 
@@ -2143,6 +2146,7 @@ where
     F: FnOnce(SectionPostCommit<'_>) -> ConfigStoreResult<u64>,
 {
     let mut section_adoption = None;
+    let mut exact_section = None;
     let mut exact_runtime = None;
     let mut callback =
         |scope: ExactTransactionScope,
@@ -2174,6 +2178,19 @@ where
                         .catch_up_committed_section(scope.section_id())
                         .map(Ok)
                 };
+                exact_section = Some(
+                    if section_adoption
+                        .as_ref()
+                        .is_none_or(|adoption| adoption.is_ok())
+                    {
+                        facade.registry().envelope_value(scope.section_id())
+                    } else {
+                        Err(ConfigStoreError::Validation(
+                            "committed section could not be adopted for exact response capture"
+                                .to_string(),
+                        ))
+                    },
+                );
             }
             exact_runtime = Some(runtime);
         };
@@ -2181,6 +2198,11 @@ where
     let exact_runtime = exact_runtime.unwrap_or_else(|| {
         Err(ConfigStoreError::Validation(
             "exact section transaction omitted runtime materialization".to_string(),
+        ))
+    });
+    let section = exact_section.unwrap_or_else(|| {
+        Err(ConfigStoreError::Validation(
+            "exact section transaction omitted its committed envelope".to_string(),
         ))
     });
     let (runtime, credential_adoption) = match exact_runtime {
@@ -2200,6 +2222,7 @@ where
         revision,
         section_adoption,
         credential_adoption,
+        section,
         runtime,
     })
 }
@@ -3610,46 +3633,38 @@ fn persist_exact_credential_transaction_inner(
     } else {
         None
     };
-    if let (Some(expected), Some(section), Some(ExactTransactionScope::Providers)) = (
-        provider_expected_revision,
-        active_section.as_ref(),
-        exact_scope,
-    ) {
-        if section.expected_revision != expected {
-            return Err(ConfigStoreError::Conflict {
-                expected,
-                actual: section.expected_revision,
-            });
+    let client_section_revision = match exact_scope {
+        Some(ExactTransactionScope::Providers) => provider_expected_revision,
+        Some(ExactTransactionScope::Mcp) => {
+            mcp_transaction.map(|(_, expected_revision)| expected_revision)
         }
-    }
-    if let (Some(expected), Some(section), Some(ExactTransactionScope::Mcp)) = (
-        mcp_transaction.map(|(_, revision)| revision),
-        active_section.as_ref(),
-        exact_scope,
-    ) {
-        if section.expected_revision != expected {
-            return Err(ConfigStoreError::Conflict {
-                expected,
-                actual: section.expected_revision,
-            });
+        Some(ExactTransactionScope::ProxyAuth) => proxy_expected_revision,
+        Some(ExactTransactionScope::EnvVars) => env_expected_revision,
+        Some(ExactTransactionScope::Notifications) => notification_expected_revision,
+        Some(ExactTransactionScope::Connect) => {
+            connect_transaction.map(|(_, expected_revision)| expected_revision)
         }
-    }
-    if let (Some((_, expected)), Some(section), Some(ExactTransactionScope::ClusterFabric)) =
-        (cluster_transaction, active_section.as_ref(), exact_scope)
-    {
-        if section.expected_revision != expected {
-            return Err(ConfigStoreError::Conflict {
-                expected,
-                actual: section.expected_revision,
-            });
+        Some(ExactTransactionScope::AccessControl) => {
+            access_transaction.map(|(_, _, expected_revision)| expected_revision)
         }
+        Some(ExactTransactionScope::ClusterFabric) => {
+            cluster_transaction.map(|(_, expected_revision)| expected_revision)
+        }
+        None => None,
     }
-    if let (Some((_, expected)), Some(section)) = (reset_scope, active_section.as_ref()) {
-        if section.expected_revision != expected {
-            return Err(ConfigStoreError::Conflict {
-                expected,
-                actual: section.expected_revision,
-            });
+    .or_else(|| reset_scope.map(|(_, expected_revision)| expected_revision));
+    if let Some(section) = active_section.as_ref() {
+        if let Some(expected) = client_section_revision {
+            if section.expected_revision != expected {
+                return Err(ConfigStoreError::Conflict {
+                    expected,
+                    actual: section.expected_revision,
+                });
+            }
+        } else if !matches!(exact_scope, Some(ExactTransactionScope::Providers)) {
+            return Err(ConfigStoreError::Validation(
+                "owned section revision precondition is required".to_string(),
+            ));
         }
     }
 
@@ -3855,17 +3870,6 @@ fn persist_exact_credential_transaction_inner(
             store.prepare_provider_metadata_update()?
         }
         None if section_post_commit.is_some() && active_section.is_some() => {
-            let expected_credential_revision = proxy_expected_revision
-                .or(env_expected_revision)
-                .or(notification_expected_revision)
-                .or_else(|| connect_transaction.map(|(_, revision)| revision))
-                .or_else(|| access_transaction.map(|(_, _, revision)| revision));
-            if let Some(expected) = expected_credential_revision {
-                let actual = store.revision_unchecked()?;
-                if actual != expected {
-                    return Err(ConfigStoreError::Conflict { expected, actual });
-                }
-            }
             let scope = exact_scope.expect("active exact section has a scope");
             let section = active_section
                 .as_ref()
@@ -3881,11 +3885,11 @@ fn persist_exact_credential_transaction_inner(
                     .as_mut()
                     .expect("guarded by post-commit callback presence"),
             );
-            return store.revision_unchecked();
+            return Ok(section.expected_revision);
         }
         None => return store.revision_unchecked(),
     };
-    if proxy_only && reset_scope.is_none() {
+    if active_section.is_none() && proxy_only && reset_scope.is_none() {
         let expected = proxy_expected_revision.ok_or_else(|| {
             ConfigStoreError::Validation(
                 "proxy auth credential revision precondition is required".to_string(),
@@ -3898,7 +3902,7 @@ fn persist_exact_credential_transaction_inner(
             });
         }
     }
-    if env_only && reset_scope.is_none() {
+    if active_section.is_none() && env_only && reset_scope.is_none() {
         let expected = env_expected_revision.ok_or_else(|| {
             ConfigStoreError::Validation(
                 "env credential revision precondition is required".to_string(),
@@ -3911,7 +3915,7 @@ fn persist_exact_credential_transaction_inner(
             });
         }
     }
-    if notification_only && reset_scope.is_none() {
+    if active_section.is_none() && notification_only && reset_scope.is_none() {
         let expected = notification_expected_revision.ok_or_else(|| {
             ConfigStoreError::Validation(
                 "notification credential revision precondition is required".to_string(),
@@ -3924,20 +3928,22 @@ fn persist_exact_credential_transaction_inner(
             });
         }
     }
-    if let Some((_, expected)) = connect_transaction {
-        if prepared.expected_revision != expected {
-            return Err(ConfigStoreError::Conflict {
-                expected,
-                actual: prepared.expected_revision,
-            });
+    if active_section.is_none() {
+        if let Some((_, expected)) = connect_transaction {
+            if prepared.expected_revision != expected {
+                return Err(ConfigStoreError::Conflict {
+                    expected,
+                    actual: prepared.expected_revision,
+                });
+            }
         }
-    }
-    if let Some((_, _, expected)) = access_transaction {
-        if prepared.expected_revision != expected {
-            return Err(ConfigStoreError::Conflict {
-                expected,
-                actual: prepared.expected_revision,
-            });
+        if let Some((_, _, expected)) = access_transaction {
+            if prepared.expected_revision != expected {
+                return Err(ConfigStoreError::Conflict {
+                    expected,
+                    actual: prepared.expected_revision,
+                });
+            }
         }
     }
     if proxy_only && active_section.is_some() && prepared.required_refs.is_empty() {
@@ -4021,8 +4027,10 @@ fn persist_exact_credential_transaction_inner(
             original_data != candidate_data,
         )
     } else if let (Some(section), Some(scope)) = (active_section.as_ref(), exact_scope) {
-        let credential_changed =
-            (mcp_only || cluster_only) && prepared.revision != prepared.expected_revision;
+        // A secret-only replacement/clear is still an owned-section mutation:
+        // clients observing only the typed section revision must be able to
+        // detect it even when the persisted metadata is otherwise unchanged.
+        let credential_changed = prepared.revision != prepared.expected_revision;
         let (bytes, changed) = prepare_active_exact_section_document(
             section,
             scope,
@@ -4078,7 +4086,21 @@ fn persist_exact_credential_transaction_inner(
         )?;
     }
     let current_credential_revision = store.revision_unchecked()?;
-    if current_credential_revision != prepared.expected_revision && !cluster_only {
+    let owned_section_is_public_authority = active_section.is_some()
+        && matches!(
+            exact_scope,
+            Some(
+                ExactTransactionScope::ProxyAuth
+                    | ExactTransactionScope::EnvVars
+                    | ExactTransactionScope::Notifications
+                    | ExactTransactionScope::Connect
+                    | ExactTransactionScope::AccessControl
+                    | ExactTransactionScope::ClusterFabric
+            )
+        );
+    if current_credential_revision != prepared.expected_revision
+        && !owned_section_is_public_authority
+    {
         return Err(ConfigStoreError::Conflict {
             expected: prepared.expected_revision,
             actual: current_credential_revision,
@@ -4126,7 +4148,7 @@ fn persist_exact_credential_transaction_inner(
                 callback,
             );
         }
-        return if cluster_only && active_section.is_some() {
+        return if active_section.is_some() {
             Ok(committed_authority_revision)
         } else {
             store.revision_unchecked()
@@ -4250,8 +4272,8 @@ fn persist_exact_credential_transaction_inner(
         let current_sha256 = sha256(&current);
         if file.original_sha256.as_deref() != Some(current_sha256.as_str()) {
             if file.name == CREDENTIALS_FILE {
-                if exact_scope == Some(ExactTransactionScope::ClusterFabric) {
-                    // The cluster section is the external CAS authority. Commit
+                if owned_section_is_public_authority {
+                    // The owned section is the external CAS authority. Commit
                     // the manifest against its still-current revision and let
                     // `install_exact_credential_member` three-way rebase this
                     // internal member over unrelated credential winners.
@@ -4627,9 +4649,13 @@ fn persist_exact_credential_transaction_inner(
             callback,
         );
         // Credential-member rebases can advance beyond the initially staged
-        // revision. Keep the public credential revision distinct from the
-        // exact owned-section envelope revision passed to adoption above.
-        store.revision_unchecked()
+        // revision. The owned section remains the sole public CAS authority.
+        Ok(committed_authority_revision)
+    } else if active_section.is_some() {
+        // Non-adopting callers use the same public contract: the returned
+        // revision is the owned section generation, never the internal
+        // credential-document generation.
+        Ok(committed_authority_revision)
     } else {
         // Credential-member rebases can advance beyond the initially staged
         // revision. Preserve the existing exact-transaction return contract
@@ -11720,9 +11746,17 @@ fn install_exact_credential_member(
             continue;
         }
         if file.touched_credential_refs.is_empty()
-            && manifest.exact_scope != Some(ExactTransactionScope::Notifications)
-            && manifest.exact_scope != Some(ExactTransactionScope::Connect)
-            && manifest.exact_scope != Some(ExactTransactionScope::ClusterFabric)
+            && !matches!(
+                manifest.exact_scope,
+                Some(
+                    ExactTransactionScope::ProxyAuth
+                        | ExactTransactionScope::EnvVars
+                        | ExactTransactionScope::Notifications
+                        | ExactTransactionScope::Connect
+                        | ExactTransactionScope::AccessControl
+                        | ExactTransactionScope::ClusterFabric
+                )
+            )
         {
             return Err(ConfigStoreError::Validation(
                 "committed credential transaction cannot be safely rebased".to_string(),
@@ -16020,6 +16054,251 @@ mod tests {
         (facade.effective_config(), revision)
     }
 
+    fn active_facade_config_and_section_revision(
+        data_dir: &Path,
+        section: crate::SectionId,
+    ) -> (crate::Config, u64) {
+        let facade = crate::ConfigFacade::open(data_dir).unwrap();
+        let revision = facade.registry().envelope_value(section).unwrap().revision;
+        (facade.effective_config(), revision)
+    }
+
+    fn install_unrelated_credential(data_dir: &Path, value: &str) -> CredentialRef {
+        let reference = credential_ref("provider", "unrelated", "api_key").unwrap();
+        CredentialStore::open(data_dir)
+            .replace(reference.clone(), value, crate::CredentialSource::User, 0)
+            .unwrap();
+        reference
+    }
+
+    fn assert_unrelated_credential(data_dir: &Path, reference: &CredentialRef, value: &str) {
+        assert_eq!(
+            CredentialStore::open(data_dir)
+                .resolve(reference)
+                .unwrap()
+                .unwrap()
+                .expose(),
+            value
+        );
+    }
+
+    fn persist_owned_domain_with_fault(
+        data_dir: &Path,
+        config: &mut crate::Config,
+        scope: ExactTransactionScope,
+        expected_revision: u64,
+        fault: MigrationFault,
+    ) -> ConfigStoreResult<u64> {
+        let empty = BTreeSet::new();
+        match scope {
+            ExactTransactionScope::ProxyAuth => {
+                let providers = BTreeSet::from(["__proxy_auth".to_string()]);
+                persist_exact_credential_transaction_inner(
+                    data_dir,
+                    config,
+                    &providers,
+                    &empty,
+                    Some(expected_revision),
+                    &empty,
+                    None,
+                    false,
+                    &empty,
+                    false,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(fault),
+                )
+            }
+            ExactTransactionScope::EnvVars => {
+                let intents = config
+                    .env_vars
+                    .iter()
+                    .map(|entry| entry.name.clone())
+                    .collect::<BTreeSet<_>>();
+                persist_exact_credential_transaction_inner(
+                    data_dir,
+                    config,
+                    &empty,
+                    &empty,
+                    None,
+                    &intents,
+                    Some(expected_revision),
+                    false,
+                    &empty,
+                    false,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(fault),
+                )
+            }
+            ExactTransactionScope::Notifications => {
+                let intents = BTreeSet::from(["ntfy".to_string()]);
+                persist_exact_credential_transaction_inner(
+                    data_dir,
+                    config,
+                    &empty,
+                    &empty,
+                    None,
+                    &empty,
+                    None,
+                    true,
+                    &intents,
+                    false,
+                    Some(expected_revision),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(fault),
+                )
+            }
+            ExactTransactionScope::Connect => {
+                let mut intents = crate::patch::ConnectSecretIntents::default();
+                intents.token.insert(0);
+                persist_exact_credential_transaction_inner(
+                    data_dir,
+                    config,
+                    &empty,
+                    &empty,
+                    None,
+                    &empty,
+                    None,
+                    false,
+                    &empty,
+                    false,
+                    None,
+                    None,
+                    Some((&intents, expected_revision)),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some(fault),
+                )
+            }
+            ExactTransactionScope::AccessControl => persist_exact_credential_transaction_inner(
+                data_dir,
+                config,
+                &empty,
+                &empty,
+                None,
+                &empty,
+                None,
+                false,
+                &empty,
+                false,
+                None,
+                None,
+                None,
+                Some((true, &empty, expected_revision)),
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(fault),
+            ),
+            ExactTransactionScope::Providers
+            | ExactTransactionScope::Mcp
+            | ExactTransactionScope::ClusterFabric => unreachable!("test helper scope"),
+        }
+    }
+
+    fn populate_owned_domain_candidate(
+        config: &mut crate::Config,
+        scope: ExactTransactionScope,
+        suffix: usize,
+    ) -> (CredentialRef, String) {
+        match scope {
+            ExactTransactionScope::ProxyAuth => {
+                let secret = format!("fault-proxy-secret-{suffix}");
+                config.proxy_auth = Some(crate::ProxyAuth {
+                    username: "fault-user".to_string(),
+                    password: secret.clone(),
+                });
+                (credential_ref("proxy", "default", "auth").unwrap(), secret)
+            }
+            ExactTransactionScope::EnvVars => {
+                let name = format!("FAULT_TOKEN_{suffix}");
+                let secret = format!("fault-env-secret-{suffix}");
+                config.env_vars.push(crate::EnvVarEntry {
+                    name: name.clone(),
+                    value: secret.clone(),
+                    secret: true,
+                    value_encrypted: None,
+                    credential_ref: None,
+                    configured: true,
+                    description: None,
+                });
+                (credential_ref("env", &name, "value").unwrap(), secret)
+            }
+            ExactTransactionScope::Notifications => {
+                let secret = format!("fault-notification-secret-{suffix}");
+                config.notifications.ntfy.enabled = true;
+                config.notifications.ntfy.topic = format!("fault-topic-{suffix}");
+                config.notifications.ntfy.token = Some(secret.clone());
+                config.notifications.ntfy.configured = true;
+                (
+                    credential_ref("notification", "ntfy", "token").unwrap(),
+                    secret,
+                )
+            }
+            ExactTransactionScope::Connect => {
+                let id = format!("fault-connect-{suffix}");
+                let secret = format!("fault-connect-secret-{suffix}");
+                config.connect.platforms.push(
+                    serde_json::from_value(serde_json::json!({
+                        "id": id.clone(),
+                        "type": "telegram",
+                        "token": secret.clone(),
+                        "allow_from": ["owner"]
+                    }))
+                    .unwrap(),
+                );
+                (credential_ref("connect", &id, "token").unwrap(), secret)
+            }
+            ExactTransactionScope::AccessControl => {
+                let marker = format!("{:064x}", suffix + 1);
+                config.access_control = Some(crate::AccessControlConfig {
+                    password_enabled: true,
+                    password_hash: Some(marker.clone()),
+                    password_salt: Some("03".repeat(16)),
+                    password_credential_ref: None,
+                    password_configured: false,
+                    updated_at: None,
+                    devices: Vec::new(),
+                });
+                (
+                    crate::config_crypto::access_password_credential_ref().unwrap(),
+                    marker,
+                )
+            }
+            ExactTransactionScope::Providers
+            | ExactTransactionScope::Mcp
+            | ExactTransactionScope::ClusterFabric => unreachable!("test helper scope"),
+        }
+    }
+
     fn active_facade_config_and_cluster_revision(data_dir: &Path) -> (crate::Config, u64) {
         let facade = crate::ConfigFacade::open(data_dir).unwrap();
         let revision = facade.registry().cluster_fabric.snapshot().revision;
@@ -16261,6 +16540,415 @@ mod tests {
     }
 
     #[test]
+    fn active_credential_domains_use_owned_section_cas_and_rebase_unrelated_credentials() {
+        {
+            let _key = crate::encryption::set_test_encryption_key([0xc1; 32]);
+            let dir = tempfile::tempdir().unwrap();
+            crate::migrate_config_facade_layout(dir.path()).unwrap();
+            let (mut candidate, revision) =
+                active_facade_config_and_section_revision(dir.path(), crate::SectionId::Core);
+            let unrelated = install_unrelated_credential(dir.path(), "proxy-unrelated-winner");
+            candidate.proxy_auth = Some(crate::ProxyAuth {
+                username: "proxy-user".to_string(),
+                password: "proxy-secret".to_string(),
+            });
+
+            let committed = persist_proxy_auth_credential_transaction_at_revision(
+                dir.path(),
+                &mut candidate,
+                revision,
+            )
+            .unwrap();
+
+            assert_eq!(committed, revision + 1);
+            assert_eq!(
+                crate::ConfigFacade::open(dir.path())
+                    .unwrap()
+                    .registry()
+                    .core
+                    .snapshot()
+                    .revision,
+                revision + 1
+            );
+            assert_unrelated_credential(dir.path(), &unrelated, "proxy-unrelated-winner");
+        }
+
+        {
+            let _key = crate::encryption::set_test_encryption_key([0xc2; 32]);
+            let dir = tempfile::tempdir().unwrap();
+            crate::migrate_config_facade_layout(dir.path()).unwrap();
+            let (mut candidate, revision) =
+                active_facade_config_and_section_revision(dir.path(), crate::SectionId::Env);
+            let unrelated = install_unrelated_credential(dir.path(), "env-unrelated-winner");
+            candidate.env_vars.push(crate::EnvVarEntry {
+                name: "OWNED_TOKEN".to_string(),
+                value: "owned-env-secret".to_string(),
+                secret: true,
+                value_encrypted: None,
+                credential_ref: None,
+                configured: true,
+                description: Some("owned metadata".to_string()),
+            });
+
+            let committed = persist_env_var_credential_transaction_at_revision(
+                dir.path(),
+                &mut candidate,
+                &BTreeSet::from(["OWNED_TOKEN".to_string()]),
+                revision,
+            )
+            .unwrap();
+
+            assert_eq!(committed, revision + 1);
+            assert_eq!(
+                crate::ConfigFacade::open(dir.path())
+                    .unwrap()
+                    .registry()
+                    .env
+                    .snapshot()
+                    .revision,
+                revision + 1
+            );
+            assert_unrelated_credential(dir.path(), &unrelated, "env-unrelated-winner");
+        }
+
+        {
+            let _key = crate::encryption::set_test_encryption_key([0xc3; 32]);
+            let dir = tempfile::tempdir().unwrap();
+            crate::migrate_config_facade_layout(dir.path()).unwrap();
+            let (mut candidate, revision) = active_facade_config_and_section_revision(
+                dir.path(),
+                crate::SectionId::Notifications,
+            );
+            let unrelated =
+                install_unrelated_credential(dir.path(), "notification-unrelated-winner");
+            candidate.notifications.ntfy.enabled = true;
+            candidate.notifications.ntfy.topic = "owned-topic".to_string();
+            candidate.notifications.ntfy.token = Some("owned-notification-secret".to_string());
+            candidate.notifications.ntfy.configured = true;
+
+            let committed = persist_notification_credential_transaction_at_revision(
+                dir.path(),
+                &mut candidate,
+                &BTreeSet::from(["ntfy".to_string()]),
+                revision,
+            )
+            .unwrap();
+
+            assert_eq!(committed, revision + 1);
+            assert_eq!(
+                crate::ConfigFacade::open(dir.path())
+                    .unwrap()
+                    .registry()
+                    .notifications
+                    .snapshot()
+                    .revision,
+                revision + 1
+            );
+            assert_unrelated_credential(dir.path(), &unrelated, "notification-unrelated-winner");
+        }
+
+        {
+            let _key = crate::encryption::set_test_encryption_key([0xc4; 32]);
+            let dir = tempfile::tempdir().unwrap();
+            crate::migrate_config_facade_layout(dir.path()).unwrap();
+            let (mut candidate, revision) =
+                active_facade_config_and_section_revision(dir.path(), crate::SectionId::Connect);
+            let unrelated = install_unrelated_credential(dir.path(), "connect-unrelated-winner");
+            candidate.connect.platforms.push(
+                serde_json::from_value(serde_json::json!({
+                    "id": "telegram-owned",
+                    "type": "telegram",
+                    "token": "owned-connect-secret",
+                    "allow_from": ["owner"]
+                }))
+                .unwrap(),
+            );
+            let mut intents = crate::patch::ConnectSecretIntents::default();
+            intents.token.insert(0);
+
+            let committed = persist_connect_credential_transaction_at_revision(
+                dir.path(),
+                &mut candidate,
+                &intents,
+                revision,
+            )
+            .unwrap();
+
+            assert_eq!(committed, revision + 1);
+            assert_eq!(
+                crate::ConfigFacade::open(dir.path())
+                    .unwrap()
+                    .registry()
+                    .connect
+                    .snapshot()
+                    .revision,
+                revision + 1
+            );
+            assert_unrelated_credential(dir.path(), &unrelated, "connect-unrelated-winner");
+        }
+
+        {
+            let _key = crate::encryption::set_test_encryption_key([0xc5; 32]);
+            let dir = tempfile::tempdir().unwrap();
+            crate::migrate_config_facade_layout(dir.path()).unwrap();
+            let (mut candidate, revision) = active_facade_config_and_section_revision(
+                dir.path(),
+                crate::SectionId::AccessControl,
+            );
+            let unrelated = install_unrelated_credential(dir.path(), "access-unrelated-winner");
+            candidate.access_control = Some(crate::AccessControlConfig {
+                password_enabled: true,
+                password_hash: Some("a".repeat(64)),
+                password_salt: Some("01".repeat(16)),
+                password_credential_ref: None,
+                password_configured: false,
+                updated_at: None,
+                devices: Vec::new(),
+            });
+
+            let committed = persist_access_control_credential_transaction_at_revision(
+                dir.path(),
+                &mut candidate,
+                true,
+                &BTreeSet::new(),
+                revision,
+            )
+            .unwrap();
+
+            assert_eq!(committed, revision + 1);
+            assert_eq!(
+                crate::ConfigFacade::open(dir.path())
+                    .unwrap()
+                    .registry()
+                    .access_control
+                    .snapshot()
+                    .revision,
+                revision + 1
+            );
+            assert_unrelated_credential(dir.path(), &unrelated, "access-unrelated-winner");
+        }
+    }
+
+    #[test]
+    fn owned_section_transactions_rebase_unrelated_credentials_changed_after_preparation() {
+        for (scope, key) in [
+            (ExactTransactionScope::ProxyAuth, 0xd0),
+            (ExactTransactionScope::EnvVars, 0xd1),
+            (ExactTransactionScope::Notifications, 0xd2),
+            (ExactTransactionScope::Connect, 0xd3),
+            (ExactTransactionScope::AccessControl, 0xd4),
+        ] {
+            let _key = crate::encryption::set_test_encryption_key([key; 32]);
+            let dir = tempfile::tempdir().unwrap();
+            crate::migrate_config_facade_layout(dir.path()).unwrap();
+            let (mut candidate, revision) =
+                active_facade_config_and_section_revision(dir.path(), scope.section_id());
+            match scope {
+                ExactTransactionScope::ProxyAuth => {
+                    candidate.proxy_auth = Some(crate::ProxyAuth {
+                        username: "race-proxy-user".to_string(),
+                        password: "race-proxy-secret".to_string(),
+                    });
+                }
+                ExactTransactionScope::EnvVars => {
+                    candidate.env_vars.push(crate::EnvVarEntry {
+                        name: "RACE_TOKEN".to_string(),
+                        value: "race-env-secret".to_string(),
+                        secret: true,
+                        value_encrypted: None,
+                        credential_ref: None,
+                        configured: true,
+                        description: None,
+                    });
+                }
+                ExactTransactionScope::Notifications => {
+                    candidate.notifications.ntfy.enabled = true;
+                    candidate.notifications.ntfy.topic = "race-topic".to_string();
+                    candidate.notifications.ntfy.token =
+                        Some("race-notification-secret".to_string());
+                    candidate.notifications.ntfy.configured = true;
+                }
+                ExactTransactionScope::Connect => {
+                    candidate.connect.platforms.push(
+                        serde_json::from_value(serde_json::json!({
+                            "id": "race-telegram",
+                            "type": "telegram",
+                            "token": "race-connect-secret",
+                            "allow_from": ["owner"]
+                        }))
+                        .unwrap(),
+                    );
+                }
+                ExactTransactionScope::AccessControl => {
+                    candidate.access_control = Some(crate::AccessControlConfig {
+                        password_enabled: true,
+                        password_hash: Some("b".repeat(64)),
+                        password_salt: Some("02".repeat(16)),
+                        password_credential_ref: None,
+                        password_configured: false,
+                        updated_at: None,
+                        devices: Vec::new(),
+                    });
+                }
+                ExactTransactionScope::Providers
+                | ExactTransactionScope::Mcp
+                | ExactTransactionScope::ClusterFabric => unreachable!(),
+            }
+
+            let committed = persist_owned_domain_with_fault(
+                dir.path(),
+                &mut candidate,
+                scope,
+                revision,
+                MigrationFault::BeforeExactStagingUnrelatedCredentialRace,
+            )
+            .unwrap();
+
+            assert_eq!(committed, revision + 1, "{scope:?}");
+            assert_eq!(
+                crate::ConfigFacade::open(dir.path())
+                    .unwrap()
+                    .registry()
+                    .envelope_value(scope.section_id())
+                    .unwrap()
+                    .revision,
+                committed,
+                "{scope:?}"
+            );
+            let unrelated = credential_ref("provider", "anthropic", "api_key").unwrap();
+            assert_eq!(
+                CredentialStore::open(dir.path())
+                    .resolve(&unrelated)
+                    .unwrap()
+                    .unwrap()
+                    .expose(),
+                "concurrent-pre-staging-winner",
+                "{scope:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn owned_credential_sections_recover_every_durable_boundary_atomically() {
+        let scopes = [
+            ExactTransactionScope::ProxyAuth,
+            ExactTransactionScope::EnvVars,
+            ExactTransactionScope::Notifications,
+            ExactTransactionScope::Connect,
+            ExactTransactionScope::AccessControl,
+        ];
+        let faults = [
+            MigrationFault::AfterManifest,
+            MigrationFault::AfterCredentials,
+            MigrationFault::AfterAuthoritativeSection,
+        ];
+        for (scope_index, scope) in scopes.into_iter().enumerate() {
+            for (fault_index, fault) in faults.into_iter().enumerate() {
+                let case = scope_index * faults.len() + fault_index;
+                let _key = crate::encryption::set_test_encryption_key([0xe0 + case as u8; 32]);
+                let dir = tempfile::tempdir().unwrap();
+                crate::migrate_config_facade_layout(dir.path()).unwrap();
+                let (mut candidate, revision) =
+                    active_facade_config_and_section_revision(dir.path(), scope.section_id());
+                let (reference, secret_marker) =
+                    populate_owned_domain_candidate(&mut candidate, scope, case);
+
+                let error = persist_owned_domain_with_fault(
+                    dir.path(),
+                    &mut candidate,
+                    scope,
+                    revision,
+                    fault,
+                )
+                .unwrap_err();
+                assert!(
+                    matches!(error, ConfigStoreError::Io(_)),
+                    "{scope:?} {fault:?}"
+                );
+                assert!(
+                    crate::ConfigFacade::open(dir.path()).is_err(),
+                    "{scope:?} {fault:?} must not expose a partial generation"
+                );
+                assert!(
+                    recover_pending_config_transaction(dir.path()).unwrap(),
+                    "{scope:?} {fault:?}"
+                );
+                let fresh = crate::ConfigFacade::open(dir.path()).unwrap();
+                assert_eq!(
+                    fresh
+                        .registry()
+                        .envelope_value(scope.section_id())
+                        .unwrap()
+                        .revision,
+                    revision + 1,
+                    "{scope:?} {fault:?}"
+                );
+                assert!(
+                    CredentialStore::open(dir.path())
+                        .status(&reference)
+                        .unwrap()
+                        .configured,
+                    "{scope:?} {fault:?}"
+                );
+                for file in [scope.section_id().descriptor().file_name, CREDENTIALS_FILE] {
+                    let bytes = std::fs::read_to_string(dir.path().join(file)).unwrap();
+                    assert!(
+                        !bytes.contains(&secret_marker),
+                        "{scope:?} {fault:?} leaked into {file}"
+                    );
+                }
+                assert_active_exact_manifest(dir.path(), scope);
+            }
+        }
+    }
+
+    #[test]
+    fn stale_env_section_revision_conflicts_without_touching_credentials() {
+        let _key = crate::encryption::set_test_encryption_key([0xc6; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut candidate, stale_revision) =
+            active_facade_config_and_section_revision(dir.path(), crate::SectionId::Env);
+        candidate.env_vars.push(crate::EnvVarEntry {
+            name: "STALE_TOKEN".to_string(),
+            value: "must-not-commit".to_string(),
+            secret: true,
+            value_encrypted: None,
+            credential_ref: None,
+            configured: true,
+            description: None,
+        });
+        let path = dir.path().join(ENV_FILE);
+        let mut envelope: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        envelope["revision"] = Value::from(stale_revision + 1);
+        let bytes = serde_json::to_vec_pretty(&envelope).unwrap();
+        crate::section_facade::validate_section_envelope(ENV_FILE, &bytes, stale_revision + 1)
+            .unwrap();
+        std::fs::write(&path, bytes).unwrap();
+        let credentials_before = std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap();
+
+        let error = persist_env_var_credential_transaction_at_revision(
+            dir.path(),
+            &mut candidate,
+            &BTreeSet::from(["STALE_TOKEN".to_string()]),
+            stale_revision,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ConfigStoreError::Conflict {
+                expected,
+                actual
+            } if expected == stale_revision && actual == stale_revision + 1
+        ));
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+    }
+
+    #[test]
     fn adopted_env_semantic_noop_catches_up_only_the_stale_owned_generation() {
         let _key = crate::encryption::set_test_encryption_key([0x5a; 32]);
         let dir = tempfile::tempdir().unwrap();
@@ -16311,9 +16999,11 @@ mod tests {
             revision: committed_revision,
             section_adoption,
             credential_adoption,
+            section,
             runtime,
         } = commit;
         assert_eq!(committed_revision, revision);
+        assert_eq!(section.unwrap().revision, committed_revision);
         assert!(matches!(
             section_adoption.unwrap().unwrap(),
             crate::ConfigSectionEvent::Changed {

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -162,6 +162,156 @@ impl ExactTransactionScope {
     }
 }
 
+fn non_cluster_credential_scope(
+    section: crate::SectionId,
+) -> ConfigStoreResult<ExactTransactionScope> {
+    match section {
+        crate::SectionId::Core => Ok(ExactTransactionScope::ProxyAuth),
+        crate::SectionId::Env => Ok(ExactTransactionScope::EnvVars),
+        crate::SectionId::Notifications => Ok(ExactTransactionScope::Notifications),
+        crate::SectionId::Connect => Ok(ExactTransactionScope::Connect),
+        crate::SectionId::AccessControl => Ok(ExactTransactionScope::AccessControl),
+        _ => Err(ConfigStoreError::Validation(
+            "section is not a non-cluster credential-backed domain".to_string(),
+        )),
+    }
+}
+
+fn credential_refs_for_scope(
+    config: &crate::Config,
+    scope: ExactTransactionScope,
+) -> BTreeSet<crate::CredentialRef> {
+    match scope {
+        ExactTransactionScope::ProxyAuth => {
+            config.proxy_auth_credential_ref.iter().cloned().collect()
+        }
+        ExactTransactionScope::EnvVars => config
+            .env_vars
+            .iter()
+            .filter(|entry| entry.secret && entry.configured)
+            .filter_map(|entry| entry.credential_ref.clone())
+            .collect(),
+        ExactTransactionScope::Notifications => [
+            config
+                .notifications
+                .ntfy
+                .configured
+                .then(|| config.notifications.ntfy.credential_ref.clone())
+                .flatten(),
+            config
+                .notifications
+                .bark
+                .configured
+                .then(|| config.notifications.bark.credential_ref.clone())
+                .flatten(),
+        ]
+        .into_iter()
+        .flatten()
+        .collect(),
+        ExactTransactionScope::Connect => config
+            .connect
+            .platforms
+            .iter()
+            .flat_map(|platform| {
+                [
+                    platform
+                        .token_configured
+                        .then(|| platform.token_credential_ref.clone())
+                        .flatten(),
+                    platform
+                        .app_secret_configured
+                        .then(|| platform.app_secret_credential_ref.clone())
+                        .flatten(),
+                ]
+                .into_iter()
+                .flatten()
+            })
+            .collect(),
+        ExactTransactionScope::AccessControl => config
+            .access_control
+            .iter()
+            .flat_map(|access| {
+                access
+                    .password_configured
+                    .then(|| access.password_credential_ref.clone())
+                    .flatten()
+                    .into_iter()
+                    .chain(access.devices.iter().filter_map(|device| {
+                        device
+                            .token_configured
+                            .then(|| device.token_credential_ref.clone())
+                            .flatten()
+                    }))
+            })
+            .collect(),
+        ExactTransactionScope::Providers
+        | ExactTransactionScope::Mcp
+        | ExactTransactionScope::ClusterFabric => BTreeSet::new(),
+    }
+}
+
+fn credential_value_is_valid_for_scope(scope: ExactTransactionScope, value: &str) -> bool {
+    match scope {
+        ExactTransactionScope::ProxyAuth => serde_json::from_str::<crate::ProxyAuth>(value)
+            .is_ok_and(|auth| {
+                !auth.username.trim().is_empty()
+                    && !crate::patch::is_masked_api_key(&auth.username)
+                    && !crate::patch::is_masked_api_key(&auth.password)
+            }),
+        ExactTransactionScope::AccessControl => {
+            crate::config_crypto::decode_access_verifier(value).is_ok()
+        }
+        ExactTransactionScope::EnvVars
+        | ExactTransactionScope::Notifications
+        | ExactTransactionScope::Connect => {
+            !value.trim().is_empty() && !crate::patch::is_masked_api_key(value)
+        }
+        ExactTransactionScope::Providers
+        | ExactTransactionScope::Mcp
+        | ExactTransactionScope::ClusterFabric => true,
+    }
+}
+
+fn semantic_credential_statuses_for_scope(
+    config: &crate::Config,
+    scope: ExactTransactionScope,
+    credential_lkg: &crate::credential_store::CredentialDocumentLkg,
+) -> (BTreeSet<crate::CredentialRef>, Vec<crate::CredentialStatus>) {
+    let active_refs = credential_refs_for_scope(config, scope);
+    let statuses = credential_lkg.statuses_with_validation(&active_refs, |_, value| {
+        credential_value_is_valid_for_scope(scope, value)
+    });
+    (active_refs, statuses)
+}
+
+fn ensure_active_credential_statuses(
+    active_refs: &BTreeSet<crate::CredentialRef>,
+    statuses: &[crate::CredentialStatus],
+) -> ConfigStoreResult<()> {
+    if let Some(reference) = active_refs.iter().find(|reference| {
+        !statuses
+            .iter()
+            .any(|status| &status.credential_ref == *reference && status.configured)
+    }) {
+        return Err(ConfigStoreError::Validation(format!(
+            "active credential '{}' is invalid; explicitly replace or clear it",
+            reference.as_str()
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_active_section_credential_values(
+    config: &crate::Config,
+    section: crate::SectionId,
+    credential_lkg: &crate::credential_store::CredentialDocumentLkg,
+) -> ConfigStoreResult<()> {
+    let scope = non_cluster_credential_scope(section)?;
+    let (active_refs, statuses) =
+        semantic_credential_statuses_for_scope(config, scope, credential_lkg);
+    ensure_active_credential_statuses(&active_refs, &statuses)
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 enum MigrationScope {
@@ -2009,6 +2159,34 @@ impl CredentialSectionRuntimeMetadata {
     }
 }
 
+/// One coherent durable generation of a non-cluster credential-backed
+/// section and the credential document observed under the same migration
+/// lock.
+///
+/// With an expected revision this contains a hydrated, mutation-safe runtime
+/// section and requires healthy primary authorities. Without one it contains
+/// the secret-free durable projection, including degraded last-known-good
+/// metadata suitable for GET/status responses.
+pub struct ExactCredentialSectionReadSnapshot {
+    pub section: crate::SectionEnvelope<Value>,
+    pub credential_statuses: Vec<crate::CredentialStatus>,
+    pub credential_health: crate::CredentialStoreHealth,
+    section_id: crate::SectionId,
+    runtime: crate::Config,
+}
+
+impl ExactCredentialSectionReadSnapshot {
+    /// Install only this snapshot's owned section into an existing runtime.
+    /// Unrelated process-local sections are preserved.
+    pub fn install_into(self, target: &mut crate::Config) -> CredentialSectionRuntimeMetadata {
+        crate::section_facade::apply_runtime_section(self.section_id, &self.runtime, target);
+        CredentialSectionRuntimeMetadata {
+            credential_statuses: self.credential_statuses,
+            credential_health: self.credential_health,
+        }
+    }
+}
+
 /// Exact runtime projection for one non-cluster credential-backed section.
 ///
 /// Callers can install only the owned section into an existing process
@@ -2046,6 +2224,83 @@ struct ExactSectionRuntimeSnapshot {
     credential_lkg: crate::credential_store::CredentialDocumentLkg,
 }
 
+/// Recover readiness and read one durable credential-backed section together
+/// with one immutable credential generation while the shared migration lock
+/// excludes compound writers.
+///
+/// Revision-bound reads are mutation preflights: the section itself is the
+/// CAS authority and both primary documents must be healthy. Unbound reads
+/// are secret-free response snapshots and may report degraded LKG health.
+pub fn read_exact_credential_section_snapshot(
+    data_dir: impl AsRef<Path>,
+    section: crate::SectionId,
+    expected_revision: Option<u64>,
+) -> ConfigStoreResult<ExactCredentialSectionReadSnapshot> {
+    let data_dir = data_dir.as_ref();
+    let scope = non_cluster_credential_scope(section)?;
+    with_migration_lock(data_dir, || {
+        recover_committed(
+            data_dir,
+            #[cfg(test)]
+            None,
+        )?;
+        ensure_provider_mcp_migration_ready(data_dir)?;
+
+        let (config, envelope) = if expected_revision.is_some() {
+            crate::section_facade::load_durable_effective_section_under_migration_lock(
+                data_dir, section,
+            )?
+        } else {
+            crate::section_facade::load_durable_effective_section_snapshot_under_migration_lock(
+                data_dir, section,
+            )?
+        };
+        if let Some(expected) = expected_revision {
+            if expected != envelope.revision {
+                return Err(ConfigStoreError::Conflict {
+                    expected,
+                    actual: envelope.revision,
+                });
+            }
+        }
+
+        let store = CredentialStore::open(data_dir);
+        let (runtime, credential_statuses, credential_health) = if expected_revision.is_some() {
+            let exact =
+                materialize_section_runtime_under_migration_lock(config, scope, &store, false)?;
+            if exact.runtime.credential_health.status == crate::SectionStatus::Degraded {
+                return Err(ConfigStoreError::Validation(format!(
+                    "revision-bound {} mutations require a healthy primary credential section",
+                    section.descriptor().name
+                )));
+            }
+            let credential_statuses = exact.runtime.credential_statuses.clone();
+            let credential_health = exact.runtime.credential_health.clone();
+            (
+                exact.runtime.runtime,
+                credential_statuses,
+                credential_health,
+            )
+        } else {
+            let (credential_lkg, _, credential_health) = store.snapshot_with_health_unchecked()?;
+            let active_refs = credential_refs_for_scope(&config, scope);
+            let credential_statuses = credential_lkg
+                .statuses_with_validation(&active_refs, |_, value| {
+                    credential_value_is_valid_for_scope(scope, value)
+                });
+            (config, credential_statuses, credential_health)
+        };
+
+        Ok(ExactCredentialSectionReadSnapshot {
+            section: envelope,
+            credential_statuses,
+            credential_health,
+            section_id: section,
+            runtime,
+        })
+    })
+}
+
 type SectionPostCommit<'a> = &'a mut dyn FnMut(
     ExactTransactionScope,
     u64,
@@ -2059,35 +2314,48 @@ fn materialize_section_runtime_under_migration_lock(
     mut runtime: crate::Config,
     scope: ExactTransactionScope,
     store: &CredentialStore,
+    reject_invalid_active: bool,
 ) -> ConfigStoreResult<ExactSectionRuntimeSnapshot> {
-    let (credential_lkg, credential_statuses, credential_health) =
-        store.snapshot_with_health_unchecked()?;
-    match scope {
-        ExactTransactionScope::Providers => {
-            runtime.hydrate_provider_credentials_from_snapshot(&credential_lkg)?;
-        }
-        ExactTransactionScope::Mcp => {
-            runtime.hydrate_mcp_credentials_from_snapshot(&credential_lkg)?;
-        }
-        ExactTransactionScope::ProxyAuth => {
-            runtime.hydrate_proxy_auth_from_snapshot(&credential_lkg)?;
-        }
-        ExactTransactionScope::EnvVars => {
-            runtime.hydrate_env_var_credentials_from_snapshot(&credential_lkg)?;
-        }
-        ExactTransactionScope::Notifications => {
-            runtime.hydrate_notification_credentials_from_snapshot(&credential_lkg)?;
-        }
-        ExactTransactionScope::Connect => {
-            runtime.hydrate_connect_credentials_from_snapshot(&credential_lkg)?;
-        }
-        ExactTransactionScope::AccessControl => {
-            runtime.hydrate_access_control_credentials_from_snapshot(&credential_lkg)?;
-        }
-        ExactTransactionScope::ClusterFabric => {
-            return Err(ConfigStoreError::Validation(
-                "cluster runtime uses its dedicated transaction snapshot".to_string(),
-            ));
+    let (credential_lkg, _, credential_health) = store.snapshot_with_health_unchecked()?;
+    let (active_refs, credential_statuses) =
+        semantic_credential_statuses_for_scope(&runtime, scope, &credential_lkg);
+    let active_values_valid =
+        ensure_active_credential_statuses(&active_refs, &credential_statuses).is_ok();
+    if reject_invalid_active {
+        ensure_active_credential_statuses(&active_refs, &credential_statuses)?;
+    }
+    // A mutation base must remain repairable. If an active value decrypts but
+    // fails its domain semantics, retain only the secret-free durable
+    // metadata. Explicit replace/clear can repair it; keep/metadata is rejected
+    // against the prepared credential candidate before staging.
+    if active_values_valid {
+        match scope {
+            ExactTransactionScope::Providers => {
+                runtime.hydrate_provider_credentials_from_snapshot(&credential_lkg)?;
+            }
+            ExactTransactionScope::Mcp => {
+                runtime.hydrate_mcp_credentials_from_snapshot(&credential_lkg)?;
+            }
+            ExactTransactionScope::ProxyAuth => {
+                runtime.hydrate_proxy_auth_from_snapshot(&credential_lkg)?;
+            }
+            ExactTransactionScope::EnvVars => {
+                runtime.hydrate_env_var_credentials_from_snapshot(&credential_lkg)?;
+            }
+            ExactTransactionScope::Notifications => {
+                runtime.hydrate_notification_credentials_from_snapshot(&credential_lkg)?;
+            }
+            ExactTransactionScope::Connect => {
+                runtime.hydrate_connect_credentials_from_snapshot(&credential_lkg)?;
+            }
+            ExactTransactionScope::AccessControl => {
+                runtime.hydrate_access_control_credentials_from_snapshot(&credential_lkg)?;
+            }
+            ExactTransactionScope::ClusterFabric => {
+                return Err(ConfigStoreError::Validation(
+                    "cluster runtime uses its dedicated transaction snapshot".to_string(),
+                ));
+            }
         }
     }
     runtime.apply_runtime_env_overrides();
@@ -2105,36 +2373,58 @@ fn materialize_section_runtime_under_migration_lock(
 fn capture_section_post_commit(
     data_dir: &Path,
     scope: ExactTransactionScope,
-    expected_revision: u64,
-    committed_revision: u64,
+    request_expected_revision: u64,
+    staged_committed_revision: u64,
     changed: bool,
     store: &CredentialStore,
     callback: &mut SectionPostCommit<'_>,
-) {
+) -> u64 {
     match crate::section_facade::load_durable_effective_section_under_migration_lock(
         data_dir,
         scope.section_id(),
     ) {
-        Ok(candidate) => {
-            let runtime =
-                materialize_section_runtime_under_migration_lock(candidate.clone(), scope, store);
+        Ok((candidate, envelope)) => {
+            let actual_revision = envelope.revision;
+            let adoption_expected_revision = if changed {
+                actual_revision.saturating_sub(1)
+            } else {
+                request_expected_revision
+            };
+            let runtime = if changed && actual_revision < staged_committed_revision {
+                Err(ConfigStoreError::Validation(format!(
+                    "committed {} section revision {actual_revision} precedes staged revision \
+                     {staged_committed_revision}",
+                    scope.section_id().descriptor().name
+                )))
+            } else {
+                materialize_section_runtime_under_migration_lock(
+                    candidate.clone(),
+                    scope,
+                    store,
+                    true,
+                )
+            };
             callback(
                 scope,
-                expected_revision,
-                committed_revision,
+                adoption_expected_revision,
+                actual_revision,
                 changed,
                 Some(&candidate),
                 runtime,
             );
+            actual_revision
         }
-        Err(error) => callback(
-            scope,
-            expected_revision,
-            committed_revision,
-            changed,
-            None,
-            Err(error),
-        ),
+        Err(error) => {
+            callback(
+                scope,
+                request_expected_revision,
+                staged_committed_revision,
+                changed,
+                None,
+                Err(error),
+            );
+            staged_committed_revision
+        }
     }
 }
 
@@ -2532,8 +2822,7 @@ pub fn read_exact_cluster_fabric_snapshot(
                     .values()
                     .flat_map(|metadata| metadata.references().cloned())
                     .collect::<BTreeSet<_>>();
-                credential_statuses =
-                    credential_lkg.statuses_with_cluster_crypto_validation(&active_refs);
+                credential_statuses = credential_lkg.statuses_with_crypto_validation(&active_refs);
             }
         }
         let credential_degraded = credential_health.status == crate::SectionStatus::Degraded;
@@ -3874,7 +4163,7 @@ fn persist_exact_credential_transaction_inner(
             let section = active_section
                 .as_ref()
                 .expect("guarded by active-section presence");
-            capture_section_post_commit(
+            let actual_revision = capture_section_post_commit(
                 data_dir,
                 scope,
                 section.expected_revision,
@@ -3885,7 +4174,7 @@ fn persist_exact_credential_transaction_inner(
                     .as_mut()
                     .expect("guarded by post-commit callback presence"),
             );
-            return Ok(section.expected_revision);
+            return Ok(actual_revision);
         }
         None => return store.revision_unchecked(),
     };
@@ -3948,6 +4237,24 @@ fn persist_exact_credential_transaction_inner(
     }
     if proxy_only && active_section.is_some() && prepared.required_refs.is_empty() {
         config.proxy_auth_credential_ref = None;
+    }
+    if active_section.is_some()
+        && matches!(
+            exact_scope,
+            Some(
+                ExactTransactionScope::ProxyAuth
+                    | ExactTransactionScope::EnvVars
+                    | ExactTransactionScope::Notifications
+                    | ExactTransactionScope::Connect
+                    | ExactTransactionScope::AccessControl
+            )
+        )
+    {
+        let scope = exact_scope.expect("matched an active non-cluster credential scope");
+        let active_refs = credential_refs_for_scope(config, scope);
+        prepared.validate_active_values(&active_refs, |_, value| {
+            credential_value_is_valid_for_scope(scope, value)
+        })?;
     }
     let (config_bytes, provider_bytes) = if proxy_only {
         (
@@ -4138,7 +4445,7 @@ fn persist_exact_credential_transaction_inner(
             active_section.as_ref(),
             section_post_commit.as_mut(),
         ) {
-            capture_section_post_commit(
+            let actual_revision = capture_section_post_commit(
                 data_dir,
                 scope,
                 section.expected_revision,
@@ -4147,6 +4454,7 @@ fn persist_exact_credential_transaction_inner(
                 &store,
                 callback,
             );
+            return Ok(actual_revision);
         }
         return if active_section.is_some() {
             Ok(committed_authority_revision)
@@ -4639,7 +4947,7 @@ fn persist_exact_credential_transaction_inner(
         active_section.as_ref(),
         section_post_commit.as_mut(),
     ) {
-        capture_section_post_commit(
+        let actual_revision = capture_section_post_commit(
             data_dir,
             scope,
             section.expected_revision,
@@ -4650,12 +4958,16 @@ fn persist_exact_credential_transaction_inner(
         );
         // Credential-member rebases can advance beyond the initially staged
         // revision. The owned section remains the sole public CAS authority.
-        Ok(committed_authority_revision)
-    } else if active_section.is_some() {
+        Ok(actual_revision)
+    } else if let (Some(scope), Some(_)) = (exact_scope, active_section.as_ref()) {
         // Non-adopting callers use the same public contract: the returned
         // revision is the owned section generation, never the internal
         // credential-document generation.
-        Ok(committed_authority_revision)
+        crate::section_facade::load_durable_effective_section_under_migration_lock(
+            data_dir,
+            scope.section_id(),
+        )
+        .map(|(_, envelope)| envelope.revision)
     } else {
         // Credential-member rebases can advance beyond the initially staged
         // revision. Preserve the existing exact-transaction return contract
@@ -16945,6 +17257,137 @@ mod tests {
         assert_eq!(
             std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
             credentials_before
+        );
+    }
+
+    #[test]
+    fn env_keep_rejects_a_semantically_invalid_active_credential_without_writes() {
+        let _key = crate::encryption::set_test_encryption_key([0x4d; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        crate::migrate_config_facade_layout(dir.path()).unwrap();
+        let (mut seed, initial_revision) =
+            active_facade_config_and_section_revision(dir.path(), crate::SectionId::Env);
+        seed.env_vars.push(crate::EnvVarEntry {
+            name: "MASKED_TOKEN".to_string(),
+            value: "initial-secret".to_string(),
+            secret: true,
+            value_encrypted: None,
+            credential_ref: None,
+            configured: true,
+            description: None,
+        });
+        let intents = BTreeSet::from(["MASKED_TOKEN".to_string()]);
+        let section_revision = persist_env_var_credential_transaction_at_revision(
+            dir.path(),
+            &mut seed,
+            &intents,
+            initial_revision,
+        )
+        .unwrap();
+        let reference = seed.env_vars[0].credential_ref.clone().unwrap();
+        let credential_path = dir.path().join(CREDENTIALS_FILE);
+        let mut credential_document: Value =
+            serde_json::from_slice(&std::fs::read(&credential_path).unwrap()).unwrap();
+        credential_document["data"]["entries"][reference.as_str()]["ciphertext"] =
+            Value::String(crate::encryption::encrypt("********").unwrap());
+        std::fs::write(
+            &credential_path,
+            serde_json::to_vec_pretty(&credential_document).unwrap(),
+        )
+        .unwrap();
+        let process_facade = crate::ConfigFacade::open(dir.path()).unwrap();
+
+        let exact = read_exact_credential_section_snapshot(
+            dir.path(),
+            crate::SectionId::Env,
+            Some(section_revision),
+        )
+        .unwrap();
+        let mut keep = crate::Config::default();
+        let metadata = exact.install_into(&mut keep);
+        assert!(!metadata.status(&reference).configured);
+        let entry = keep
+            .env_vars
+            .iter_mut()
+            .find(|entry| entry.name == "MASKED_TOKEN")
+            .unwrap();
+        entry.value.clear();
+        entry.description = Some("metadata-only edit".to_string());
+
+        let env_before = std::fs::read(dir.path().join(ENV_FILE)).unwrap();
+        let credentials_before = std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap();
+        let directory_before = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<BTreeSet<_>>();
+        let error = persist_env_var_credential_transaction_at_revision_with_adoption(
+            dir.path(),
+            &mut keep,
+            &intents,
+            section_revision,
+            &process_facade,
+        )
+        .err()
+        .expect("retaining a semantic mask must fail");
+        assert!(matches!(
+            error,
+            ConfigStoreError::Validation(message)
+                if message.contains("explicitly replace or clear")
+        ));
+        assert_eq!(
+            std::fs::read(dir.path().join(ENV_FILE)).unwrap(),
+            env_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join(CREDENTIALS_FILE)).unwrap(),
+            credentials_before
+        );
+        assert_eq!(
+            std::fs::read_dir(dir.path())
+                .unwrap()
+                .map(|entry| entry.unwrap().file_name())
+                .collect::<BTreeSet<_>>(),
+            directory_before
+        );
+        assert!(!dir.path().join(JOURNAL_FILE).exists());
+        assert_active_exact_manifest(dir.path(), ExactTransactionScope::EnvVars);
+
+        let get = read_exact_credential_section_snapshot(dir.path(), crate::SectionId::Env, None)
+            .unwrap();
+        assert!(
+            !get.credential_statuses
+                .iter()
+                .find(|status| status.credential_ref == reference)
+                .unwrap()
+                .configured,
+            "GET/status must report the invalid active record truthfully"
+        );
+
+        let entry = keep
+            .env_vars
+            .iter_mut()
+            .find(|entry| entry.name == "MASKED_TOKEN")
+            .unwrap();
+        entry.value = "replacement-secret".to_string();
+        entry.configured = true;
+        let repaired = persist_env_var_credential_transaction_at_revision_with_adoption(
+            dir.path(),
+            &mut keep,
+            &intents,
+            section_revision,
+            &process_facade,
+        )
+        .unwrap();
+        assert_eq!(repaired.revision, section_revision + 1);
+        assert!(
+            repaired
+                .runtime
+                .unwrap()
+                .credential_statuses
+                .iter()
+                .find(|status| status.credential_ref == reference)
+                .unwrap()
+                .configured
         );
     }
 

--- a/crates/infra/bamboo-config/src/credential_store.rs
+++ b/crates/infra/bamboo-config/src/credential_store.rs
@@ -161,6 +161,41 @@ impl PreparedProviderCredentialUpdate {
         self.bytes = serde_json::to_vec_pretty(&envelope)?;
         Ok(())
     }
+
+    /// Validate the active owned references against the exact credential
+    /// candidate that would be staged. This keeps metadata/keep mutations
+    /// from retaining a decryptable-but-semantic mask or empty value, while
+    /// still allowing an explicit replace or clear to repair that record.
+    pub(crate) fn validate_active_values(
+        &self,
+        active_refs: &BTreeSet<CredentialRef>,
+        validate: impl Fn(&CredentialRef, &str) -> bool,
+    ) -> ConfigStoreResult<()> {
+        let envelope: PreparedCredentialEnvelope = serde_json::from_slice(&self.bytes)?;
+        if envelope.schema_version != CREDENTIAL_SCHEMA_VERSION
+            || envelope.revision != self.revision
+        {
+            return Err(ConfigStoreError::Validation(
+                "prepared credential envelope metadata is invalid".to_string(),
+            ));
+        }
+        let lkg = CredentialDocumentLkg {
+            revision: envelope.revision,
+            document: envelope.data,
+        };
+        let statuses = lkg.statuses_with_validation(active_refs, validate);
+        if let Some(reference) = active_refs.iter().find(|reference| {
+            !statuses
+                .iter()
+                .any(|status| &status.credential_ref == *reference && status.configured)
+        }) {
+            return Err(ConfigStoreError::Validation(format!(
+                "active credential '{}' is invalid; explicitly replace or clear it",
+                reference.as_str()
+            )));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -208,15 +243,25 @@ impl CredentialDocumentLkg {
     }
 
     /// Project secret-free status metadata while cryptographically validating
-    /// only the references owned by the active cluster generation.
+    /// only the references owned by the requested active section generation.
     ///
     /// Decrypted values are dropped inside this authority and never returned
     /// to GET/status callers. A present but undecryptable entry is represented
     /// as `configured = false`, which the cluster projection renders as
     /// `error` when durable metadata still says the field is configured.
-    pub(crate) fn statuses_with_cluster_crypto_validation(
+    pub(crate) fn statuses_with_crypto_validation(
         &self,
         active_refs: &BTreeSet<CredentialRef>,
+    ) -> Vec<CredentialStatus> {
+        self.statuses_with_validation(active_refs, |_, _| true)
+    }
+
+    /// Project statuses while decrypting and semantically validating only the
+    /// references owned by one active section generation.
+    pub(crate) fn statuses_with_validation(
+        &self,
+        active_refs: &BTreeSet<CredentialRef>,
+        validate: impl Fn(&CredentialRef, &str) -> bool,
     ) -> Vec<CredentialStatus> {
         self.document
             .entries
@@ -224,8 +269,8 @@ impl CredentialDocumentLkg {
             .map(|(credential_ref, entry)| {
                 let configured = if active_refs.contains(credential_ref) {
                     crate::encryption::decrypt(&entry.ciphertext)
-                        .map(drop)
-                        .is_ok()
+                        .map(|value| validate(credential_ref, &value))
+                        .unwrap_or(false)
                 } else {
                     true
                 };
@@ -431,6 +476,25 @@ impl CredentialStore {
         })
     }
 
+    /// Replace an orphan credential through the standalone credential API.
+    ///
+    /// The durable config ownership check and credential CAS execute under the
+    /// same cross-process migration lock. A stale process-local config snapshot
+    /// can therefore never mutate a reference that a newer owned section has
+    /// already claimed.
+    pub fn replace_unreferenced(
+        &self,
+        credential_ref: CredentialRef,
+        secret: &str,
+        source: CredentialSource,
+        expected_revision: u64,
+    ) -> ConfigStoreResult<(u64, CredentialStatus)> {
+        self.with_transaction_lock(|| {
+            self.ensure_unreferenced_under_lock(&credential_ref)?;
+            self.replace_unchecked(credential_ref, secret, source, expected_revision)
+        })
+    }
+
     /// Replace an internally managed rotating credential at the latest durable
     /// revision. This is not an HTTP/client mutation primitive: external
     /// callers must continue to use [`Self::replace`] with explicit CAS. The
@@ -570,6 +634,38 @@ impl CredentialStore {
         expected_revision: u64,
     ) -> ConfigStoreResult<(u64, CredentialStatus)> {
         self.with_transaction_lock(|| self.clear_unchecked(credential_ref, expected_revision))
+    }
+
+    /// Clear an orphan credential through the standalone credential API.
+    ///
+    /// See [`Self::replace_unreferenced`]: durable ownership and the credential
+    /// CAS share one cross-process critical section.
+    pub fn clear_unreferenced(
+        &self,
+        credential_ref: &CredentialRef,
+        expected_revision: u64,
+    ) -> ConfigStoreResult<(u64, CredentialStatus)> {
+        self.with_transaction_lock(|| {
+            self.ensure_unreferenced_under_lock(credential_ref)?;
+            self.clear_unchecked(credential_ref, expected_revision)
+        })
+    }
+
+    fn ensure_unreferenced_under_lock(
+        &self,
+        credential_ref: &CredentialRef,
+    ) -> ConfigStoreResult<()> {
+        let durable = crate::section_facade::load_durable_effective_config_under_migration_lock(
+            self.data_dir(),
+        )?;
+        if config_credential_ref_counts(&durable)?.contains_key(credential_ref) {
+            return Err(ConfigStoreError::Validation(
+                "credential reference is managed by configuration and must be changed through its \
+                 owning section"
+                    .to_string(),
+            ));
+        }
+        Ok(())
     }
 
     /// Clear the standalone credential document in one CAS commit, but only
@@ -3172,6 +3268,90 @@ mod tests {
         assert_eq!(
             store.resolve(&password_ref).unwrap().unwrap().expose(),
             durable_secret.as_str()
+        );
+    }
+
+    #[test]
+    fn standalone_mutations_use_durable_owner_not_stale_facade() {
+        let _key = crate::encryption::set_test_encryption_key([0x35; 32]);
+        let dir = TempDir::new().unwrap();
+        let stale_facade = crate::ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let store = CredentialStore::open(dir.path());
+        let reference = CredentialRef::parse("custom.managed.token").unwrap();
+        let original_secret = uuid::Uuid::new_v4().to_string();
+        assert_eq!(
+            store
+                .replace(
+                    reference.clone(),
+                    &original_secret,
+                    CredentialSource::User,
+                    0,
+                )
+                .unwrap()
+                .0,
+            1
+        );
+
+        let external_facade = crate::ConfigFacade::open(dir.path()).unwrap();
+        external_facade
+            .registry()
+            .env
+            .commit(
+                0,
+                crate::EnvSection(vec![crate::EnvVarEntry {
+                    name: "CUSTOM_TOKEN".to_string(),
+                    value: String::new(),
+                    secret: true,
+                    value_encrypted: None,
+                    credential_ref: Some(reference.clone()),
+                    configured: true,
+                    description: Some("claimed by a newer process".to_string()),
+                }]),
+            )
+            .unwrap();
+        assert_eq!(
+            stale_facade.registry().env.snapshot().revision,
+            0,
+            "the first process must remain stale for this regression"
+        );
+        assert_eq!(
+            crate::ConfigFacade::open(dir.path())
+                .unwrap()
+                .registry()
+                .env
+                .snapshot()
+                .revision,
+            1
+        );
+        let before = std::fs::read(store.path()).unwrap();
+
+        for error in [
+            store
+                .replace_unreferenced(
+                    reference.clone(),
+                    "stale-process-replacement",
+                    CredentialSource::User,
+                    1,
+                )
+                .unwrap_err(),
+            store.clear_unreferenced(&reference, 1).unwrap_err(),
+        ] {
+            assert!(
+                matches!(
+                    error,
+                    ConfigStoreError::Validation(ref message)
+                        if message.starts_with(
+                            "credential reference is managed by configuration"
+                        )
+                ),
+                "{error}"
+            );
+        }
+        assert_eq!(std::fs::read(store.path()).unwrap(), before);
+        assert_eq!(store.revision().unwrap(), 1);
+        assert_eq!(
+            store.resolve(&reference).unwrap().unwrap().expose(),
+            original_secret
         );
     }
 

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -4144,11 +4144,37 @@ impl SectionRegistry {
         expected_revision: u64,
         candidate: Value,
     ) -> ConfigStoreResult<ConfigSectionEvent> {
+        self.commit_value_with_envelope(id, expected_revision, candidate)
+            .map(|(event, _)| event)
+    }
+
+    /// Commit one ordinary section and return the immutable public envelope
+    /// captured by that exact commit before a later reload can advance the
+    /// process snapshot.
+    pub fn commit_value_with_envelope(
+        &self,
+        id: SectionId,
+        expected_revision: u64,
+        candidate: Value,
+    ) -> ConfigStoreResult<(ConfigSectionEvent, SectionEnvelope<Value>)> {
         validate_ordinary_section_json(&candidate)?;
         macro_rules! commit {
             ($field:ident, $ty:ty) => {{
                 let typed: $ty = serde_json::from_value(candidate)?;
-                self.$field.commit(expected_revision, typed)
+                let (event, envelope) =
+                    self.$field.commit_with_envelope(expected_revision, typed)?;
+                Ok((
+                    event,
+                    SectionEnvelope {
+                        data: serde_json::to_value(envelope.data)?,
+                        revision: envelope.revision,
+                        loaded_at: envelope.loaded_at,
+                        source_path: envelope.source_path,
+                        source_kind: envelope.source_kind,
+                        status: envelope.status,
+                        last_error: envelope.last_error,
+                    },
+                ))
             }};
         }
         match id {
@@ -4376,9 +4402,9 @@ pub(crate) fn load_durable_effective_config_under_migration_lock(
 pub(crate) fn load_durable_effective_section_under_migration_lock(
     data_dir: &Path,
     id: SectionId,
-) -> ConfigStoreResult<Config> {
-    let registry = SectionRegistry::open_configured(data_dir, true)?;
-    let envelope = registry.envelope_value(id)?;
+) -> ConfigStoreResult<(Config, SectionEnvelope<Value>)> {
+    let (config, envelope) =
+        load_durable_effective_section_snapshot_under_migration_lock(data_dir, id)?;
     if envelope.status != SectionStatus::Healthy || envelope.source_kind != SectionSourceKind::File
     {
         return Err(crate::ConfigStoreError::Validation(format!(
@@ -4386,7 +4412,23 @@ pub(crate) fn load_durable_effective_section_under_migration_lock(
             id.descriptor().name
         )));
     }
-    Ok(registry.projection().into_config())
+    Ok((config, envelope))
+}
+
+/// Reconstruct one durable section and its exact envelope while the caller
+/// owns the shared migration lock, including degraded last-known-good reads.
+///
+/// Mutation preflights must use
+/// [`load_durable_effective_section_under_migration_lock`] so a backup can
+/// never authorize a write. Secret-free GET projections use this variant to
+/// pair the same immutable section generation with one credential snapshot.
+pub(crate) fn load_durable_effective_section_snapshot_under_migration_lock(
+    data_dir: &Path,
+    id: SectionId,
+) -> ConfigStoreResult<(Config, SectionEnvelope<Value>)> {
+    let registry = SectionRegistry::open_configured(data_dir, true)?;
+    let envelope = registry.envelope_value(id)?;
+    Ok((registry.projection().into_config(), envelope))
 }
 
 /// Effective compatibility facade assembled from immutable section snapshots.
@@ -4535,6 +4577,78 @@ impl ConfigFacade {
             .credentials
             .adopt_captured_with_event(document_lkg, statuses, health)
     }
+}
+
+/// Commit secret-free Core metadata against the exact durable Core generation
+/// even when `process_facade` has not observed that generation yet.
+///
+/// The shared migration lock remains held from durable Core/credential
+/// validation through the content-aware Core file CAS. A successful stale
+/// process jumps directly to the committed revision; a failed attempt leaves
+/// its facade untouched so the ordinary watcher can still adopt the durable
+/// base later.
+pub fn commit_core_metadata_from_durable_base(
+    data_dir: impl AsRef<Path>,
+    process_facade: &ConfigFacade,
+    expected_revision: u64,
+    candidate: Value,
+) -> ConfigStoreResult<(ConfigSectionEvent, SectionEnvelope<Value>)> {
+    validate_ordinary_section_json(&candidate)?;
+    let candidate: CoreSection = serde_json::from_value(candidate)?;
+    let data_dir = data_dir.as_ref();
+
+    crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
+        crate::ensure_provider_mcp_migration_ready(data_dir)?;
+        if !section_layout_is_active(data_dir)? {
+            return Err(layout_not_committed());
+        }
+
+        let (mut durable_config, durable_envelope) =
+            load_durable_effective_section_under_migration_lock(data_dir, SectionId::Core)?;
+        if durable_envelope.revision != expected_revision {
+            return Err(crate::ConfigStoreError::Conflict {
+                expected: expected_revision,
+                actual: durable_envelope.revision,
+            });
+        }
+        let durable: CoreSection = serde_json::from_value(durable_envelope.data)?;
+        if durable.proxy_auth_credential_ref != candidate.proxy_auth_credential_ref {
+            return Err(crate::ConfigStoreError::Validation(
+                "Core credential bindings are server-managed; use the proxy-auth API".to_string(),
+            ));
+        }
+
+        let store = CredentialStore::open(data_dir);
+        let (credential_lkg, _, credential_health) = store.snapshot_with_health_unchecked()?;
+        if credential_health.status == SectionStatus::Degraded {
+            return Err(crate::ConfigStoreError::Validation(
+                "Core metadata mutation base is unavailable".to_string(),
+            ));
+        }
+        durable_config.proxy_auth_credential_ref = candidate.proxy_auth_credential_ref.clone();
+        crate::credential_migration::validate_active_section_credential_values(
+            &durable_config,
+            SectionId::Core,
+            &credential_lkg,
+        )?;
+
+        let (event, envelope) = process_facade
+            .registry
+            .core
+            .commit_from_durable_base_with_envelope(expected_revision, &durable, candidate)?;
+        Ok((
+            event,
+            SectionEnvelope {
+                data: serde_json::to_value(envelope.data)?,
+                revision: envelope.revision,
+                loaded_at: envelope.loaded_at,
+                source_path: envelope.source_path,
+                source_kind: envelope.source_kind,
+                status: envelope.status,
+                last_error: envelope.last_error,
+            },
+        ))
+    })
 }
 
 /// Adopt the two historical plaintext Copilot OAuth caches into the encrypted
@@ -4741,6 +4855,88 @@ fn materialize_facade_commit_runtime_under_lock(
     Ok(FacadeSectionRuntimeSnapshot { section, runtime })
 }
 
+fn exact_section_credential_bindings(
+    projection: &SectionProjection,
+    section: SectionId,
+) -> Vec<(String, Option<String>)> {
+    let reference = |reference: &Option<crate::CredentialRef>| {
+        reference
+            .as_ref()
+            .map(|reference| reference.as_str().to_string())
+    };
+    let mut bindings = match section {
+        SectionId::Core => vec![(
+            "proxy.default.auth".to_string(),
+            reference(&projection.core.proxy_auth_credential_ref),
+        )],
+        SectionId::Env => projection
+            .env
+            .0
+            .iter()
+            .map(|entry| {
+                (
+                    format!("env.{}", entry.name),
+                    reference(&entry.credential_ref),
+                )
+            })
+            .collect(),
+        SectionId::Notifications => vec![
+            (
+                "notifications.ntfy".to_string(),
+                reference(&projection.notifications.notifications.ntfy.credential_ref),
+            ),
+            (
+                "notifications.bark".to_string(),
+                reference(&projection.notifications.notifications.bark.credential_ref),
+            ),
+        ],
+        SectionId::Connect => projection
+            .connect
+            .0
+            .platforms
+            .iter()
+            .enumerate()
+            .flat_map(|(index, platform)| {
+                let owner = platform
+                    .id
+                    .clone()
+                    .unwrap_or_else(|| format!("index-{index}:{}", platform.platform_type));
+                [
+                    (
+                        format!("connect.{owner}.token"),
+                        reference(&platform.token_credential_ref),
+                    ),
+                    (
+                        format!("connect.{owner}.app_secret"),
+                        reference(&platform.app_secret_credential_ref),
+                    ),
+                ]
+            })
+            .collect(),
+        SectionId::AccessControl => projection
+            .access_control
+            .0
+            .as_ref()
+            .map(|access| {
+                std::iter::once((
+                    "access.root.password".to_string(),
+                    reference(&access.password_credential_ref),
+                ))
+                .chain(access.devices.iter().map(|device| {
+                    (
+                        format!("access.device.{}", device.device_id),
+                        reference(&device.token_credential_ref),
+                    )
+                }))
+                .collect()
+            })
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+    bindings.sort();
+    bindings
+}
+
 fn persist_facade_effective_config_inner(
     data_dir: impl AsRef<Path>,
     config: &Config,
@@ -4748,89 +4944,209 @@ fn persist_facade_effective_config_inner(
 ) -> ConfigStoreResult<(Vec<ConfigSectionEvent>, Option<FacadeConfigCommit>)> {
     let data_dir = data_dir.as_ref();
     let facade = ConfigFacade::open(data_dir)?;
-    let current = facade.registry.projection();
-    let mut candidate = SectionProjection::from_config(config, current.model_limits.clone())?;
+    let durable = facade.registry.projection();
+    // A process-owned facade is the immutable source generation from which
+    // AppState built this compatibility candidate. Comparing against that
+    // source, rather than the freshly opened durable facade, distinguishes the
+    // caller's one intended section change from unrelated external winners.
+    let source = process_facade
+        .map(|facade| facade.registry.projection())
+        .unwrap_or_else(|| durable.clone());
+    let mut candidate = SectionProjection::from_config(config, source.model_limits.clone())?;
     // The external broker is owned by broker.json / the migration planner and
     // is not part of the compatibility Config wire shape. Preserve its current
-    // durable projection across unrelated root writes.
-    candidate.subagents.external_broker = current.subagents.external_broker.clone();
-    // Compatibility/root writers never own cluster CAS. Rebase this field on
-    // the freshly opened durable facade, not the caller's possibly stale
-    // process projection, before validation and change detection.
-    candidate.cluster_fabric = current.cluster_fabric.clone();
+    // source projection across unrelated root writes.
+    candidate.subagents.external_broker = source.subagents.external_broker.clone();
+    // Compatibility/root writers never own cluster CAS. It is excluded from
+    // the caller's intended changes; the dedicated cluster transaction remains
+    // its sole write authority.
+    candidate.cluster_fabric = source.cluster_fabric.clone();
     validate_projection(&candidate)?;
 
     crate::credential_migration::with_provider_mcp_migration_lock(data_dir, || {
         if !section_layout_is_active(data_dir)? {
             return Err(layout_not_committed());
         }
-        let mut changed = Vec::new();
+        let mut changed = Vec::<SectionId>::new();
         macro_rules! record_change {
-            ($field:ident, $name:literal) => {
-                if serde_json::to_value(facade.registry.$field.snapshot().data.as_ref())?
-                    != serde_json::to_value(&candidate.$field)?
+            ($id:ident, $field:ident) => {
+                if serde_json::to_value(&source.$field)? != serde_json::to_value(&candidate.$field)?
                 {
-                    changed.push($name);
+                    changed.push(SectionId::$id);
                 }
             };
         }
-        record_change!(core, "core");
-        record_change!(providers, "providers");
-        record_change!(mcp, "mcp");
-        record_change!(tools_skills, "tools-skills");
-        record_change!(memory, "memory");
-        record_change!(subagents, "subagents");
-        record_change!(notifications, "notifications");
-        record_change!(connect, "connect");
-        record_change!(cluster_fabric, "cluster-fabric");
-        record_change!(env, "env");
-        record_change!(access_control, "access-control");
-        record_change!(hooks, "hooks");
-        record_change!(model_policy, "model-policy");
+        record_change!(Core, core);
+        record_change!(Providers, providers);
+        record_change!(Mcp, mcp);
+        record_change!(ToolsSkills, tools_skills);
+        record_change!(Memory, memory);
+        record_change!(Subagents, subagents);
+        record_change!(Notifications, notifications);
+        record_change!(Connect, connect);
+        record_change!(Env, env);
+        record_change!(AccessControl, access_control);
+        record_change!(Hooks, hooks);
+        record_change!(ModelPolicy, model_policy);
         if changed.len() > 1 {
             return Err(crate::ConfigStoreError::Validation(format!(
                 "a compatibility write changed multiple sections ({}); split the request",
-                changed.join(", ")
+                changed
+                    .iter()
+                    .map(|section| section.descriptor().name)
+                    .collect::<Vec<_>>()
+                    .join(", ")
             )));
         }
-        let mut events = Vec::new();
-        let mut committed = None;
-        macro_rules! commit_if_changed {
-            ($id:ident, $field:ident, $candidate:expr) => {{
-                let candidate = $candidate;
-                let snapshot = facade.registry.$field.snapshot();
-                if serde_json::to_value(snapshot.data.as_ref())?
-                    != serde_json::to_value(&candidate)?
-                {
-                    let expected_revision = snapshot.revision;
-                    let event = facade
-                        .registry
-                        .$field
-                        .commit(expected_revision, candidate)?;
-                    let committed_revision = match &event {
-                        ConfigSectionEvent::Changed { revision, .. }
-                        | ConfigSectionEvent::Recovered { revision, .. }
-                        | ConfigSectionEvent::Invalid { revision, .. } => *revision,
-                    };
-                    events.push(event);
-                    committed = Some((SectionId::$id, expected_revision, committed_revision));
-                }
-            }};
+        let Some(section) = changed.into_iter().next() else {
+            let process_commit = process_facade.map(|_| FacadeConfigCommit {
+                section_adoption: None,
+                runtime: Ok(None),
+            });
+            return Ok((Vec::new(), process_commit));
+        };
+        let exact_credential_section = matches!(
+            section,
+            SectionId::Core
+                | SectionId::Env
+                | SectionId::Notifications
+                | SectionId::Connect
+                | SectionId::AccessControl
+        );
+        if process_facade.is_none() && exact_credential_section {
+            return Err(crate::ConfigStoreError::Validation(format!(
+                "{} must be changed through its dedicated revisioned API",
+                section.descriptor().name
+            )));
+        }
+        if exact_credential_section
+            && exact_section_credential_bindings(&source, section)
+                != exact_section_credential_bindings(&candidate, section)
+        {
+            return Err(crate::ConfigStoreError::Validation(format!(
+                "{} credential bindings are server-managed; use its dedicated revisioned API",
+                section.descriptor().name
+            )));
         }
 
-        commit_if_changed!(Core, core, candidate.core);
-        commit_if_changed!(Providers, providers, candidate.providers);
-        commit_if_changed!(Mcp, mcp, candidate.mcp);
-        commit_if_changed!(ToolsSkills, tools_skills, candidate.tools_skills);
-        commit_if_changed!(Memory, memory, candidate.memory);
-        commit_if_changed!(Subagents, subagents, candidate.subagents);
-        commit_if_changed!(Notifications, notifications, candidate.notifications);
-        commit_if_changed!(Connect, connect, candidate.connect);
-        commit_if_changed!(ClusterFabric, cluster_fabric, candidate.cluster_fabric);
-        commit_if_changed!(Env, env, candidate.env);
-        commit_if_changed!(AccessControl, access_control, candidate.access_control);
-        commit_if_changed!(Hooks, hooks, candidate.hooks);
-        commit_if_changed!(ModelPolicy, model_policy, candidate.model_policy);
+        let source_registry = process_facade
+            .map(|facade| facade.registry.as_ref())
+            .unwrap_or(facade.registry.as_ref());
+        let (expected_revision, source_status, source_kind, _, source_value) =
+            source_registry.observation(section);
+        let (actual_revision, durable_status, durable_kind, _, durable_value) =
+            facade.registry.observation(section);
+        if expected_revision != actual_revision {
+            return Err(crate::ConfigStoreError::Conflict {
+                expected: expected_revision,
+                actual: actual_revision,
+            });
+        }
+        if source_value != durable_value {
+            return Err(crate::ConfigStoreError::Validation(format!(
+                "{} changed without advancing revision {expected_revision}",
+                section.descriptor().name
+            )));
+        }
+        if exact_credential_section
+            && (source_status != SectionStatus::Healthy
+                || source_kind != SectionSourceKind::File
+                || durable_status != SectionStatus::Healthy
+                || durable_kind != SectionSourceKind::File)
+        {
+            return Err(crate::ConfigStoreError::Validation(format!(
+                "{} compatibility mutation base is unavailable",
+                section.descriptor().name
+            )));
+        }
+        if exact_credential_section {
+            let store = CredentialStore::open(data_dir);
+            let (credential_lkg, _, credential_health) = store.snapshot_with_health_unchecked()?;
+            if credential_health.status == SectionStatus::Degraded {
+                return Err(crate::ConfigStoreError::Validation(format!(
+                    "{} compatibility mutation base is unavailable",
+                    section.descriptor().name
+                )));
+            }
+            crate::credential_migration::validate_active_section_credential_values(
+                &candidate.clone().into_config(),
+                section,
+                &credential_lkg,
+            )?;
+        }
+
+        let event = match section {
+            SectionId::Core => facade
+                .registry
+                .core
+                .commit(expected_revision, candidate.core)?,
+            SectionId::Providers => facade
+                .registry
+                .providers
+                .commit(expected_revision, candidate.providers)?,
+            SectionId::Mcp => facade
+                .registry
+                .mcp
+                .commit(expected_revision, candidate.mcp)?,
+            SectionId::ToolsSkills => facade
+                .registry
+                .tools_skills
+                .commit(expected_revision, candidate.tools_skills)?,
+            SectionId::Memory => facade
+                .registry
+                .memory
+                .commit(expected_revision, candidate.memory)?,
+            SectionId::Subagents => facade
+                .registry
+                .subagents
+                .commit(expected_revision, candidate.subagents)?,
+            SectionId::Notifications => facade
+                .registry
+                .notifications
+                .commit(expected_revision, candidate.notifications)?,
+            SectionId::Connect => facade
+                .registry
+                .connect
+                .commit(expected_revision, candidate.connect)?,
+            SectionId::ClusterFabric => {
+                return Err(crate::ConfigStoreError::Validation(
+                    "cluster-fabric requires the dedicated revisioned API".to_string(),
+                ))
+            }
+            SectionId::Env => facade
+                .registry
+                .env
+                .commit(expected_revision, candidate.env)?,
+            SectionId::AccessControl => facade
+                .registry
+                .access_control
+                .commit(expected_revision, candidate.access_control)?,
+            SectionId::Hooks => facade
+                .registry
+                .hooks
+                .commit(expected_revision, candidate.hooks)?,
+            SectionId::ModelPolicy => facade
+                .registry
+                .model_policy
+                .commit(expected_revision, candidate.model_policy)?,
+            SectionId::ModelLimits => {
+                return Err(crate::ConfigStoreError::Validation(
+                    "model limits require their dedicated persistence path".to_string(),
+                ))
+            }
+            SectionId::Credentials => {
+                return Err(crate::ConfigStoreError::Validation(
+                    "compatibility config cannot own the credential section".to_string(),
+                ))
+            }
+        };
+        let committed_revision = match &event {
+            ConfigSectionEvent::Changed { revision, .. }
+            | ConfigSectionEvent::Recovered { revision, .. }
+            | ConfigSectionEvent::Invalid { revision, .. } => *revision,
+        };
+        let events = vec![event];
+        let committed = Some((section, expected_revision, committed_revision));
 
         let process_commit = process_facade.map(|process_facade| {
             let Some((section, expected_revision, committed_revision)) = committed else {
@@ -8810,7 +9126,8 @@ mod tests {
             1
         );
 
-        let stale_caller = ConfigFacade::open(dir.path()).unwrap().effective_config();
+        let stale_process = ConfigFacade::open(dir.path()).unwrap();
+        let stale_caller = stale_process.effective_config();
         let mut external = stale_caller.clone();
         external
             .cluster_fabric
@@ -8840,10 +9157,11 @@ mod tests {
 
         let mut unrelated = stale_caller;
         unrelated.server.port = 22_222;
-        let events = persist_facade_effective_config(dir.path(), &unrelated).unwrap();
-        assert_eq!(events.len(), 1);
+        let commit =
+            persist_facade_effective_config_with_adoption(dir.path(), &unrelated, &stale_process)
+                .unwrap();
         assert!(matches!(
-            &events[0],
+            commit.section_adoption.unwrap().unwrap(),
             ConfigSectionEvent::Changed { section, .. } if section == "core"
         ));
         assert_eq!(std::fs::read(&cluster_path).unwrap(), cluster_r2);
@@ -8863,35 +9181,147 @@ mod tests {
     }
 
     #[test]
-    fn failed_compatibility_runtime_materialization_leaves_process_facade_reloadable() {
+    fn compatibility_core_write_conflicts_with_newer_exact_proxy_generation() {
+        let _key = crate::encryption::set_test_encryption_key([0x5c; 32]);
+        let dir = TempDir::new().unwrap();
+        let stale_process = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let mut stale_candidate = stale_process.effective_config();
+        stale_candidate.server.port = 22_224;
+
+        let external_facade = ConfigFacade::open(dir.path()).unwrap();
+        let mut external_core = external_facade
+            .registry()
+            .envelope_value(SectionId::Core)
+            .unwrap()
+            .data;
+        external_core["http_proxy"] = json!("http://external-proxy.test:8080");
+        external_facade
+            .registry()
+            .commit_value(SectionId::Core, 0, external_core)
+            .unwrap();
+        let mut external = ConfigFacade::open(dir.path()).unwrap().effective_config();
+        external.proxy_auth = Some(crate::ProxyAuth {
+            username: "external-user".to_string(),
+            password: "external-password".to_string(),
+        });
+        assert_eq!(
+            crate::persist_proxy_auth_credential_transaction_at_revision(
+                dir.path(),
+                &mut external,
+                1,
+            )
+            .unwrap(),
+            2
+        );
+        let core_before = std::fs::read(dir.path().join("core.json")).unwrap();
+        let credentials_before = std::fs::read(dir.path().join("credentials.json")).unwrap();
+
+        let error = match persist_facade_effective_config_with_adoption(
+            dir.path(),
+            &stale_candidate,
+            &stale_process,
+        ) {
+            Ok(_) => panic!("stale Core compatibility writer must conflict"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            crate::ConfigStoreError::Conflict {
+                expected: 0,
+                actual: 2
+            }
+        ));
+        assert_eq!(
+            std::fs::read(dir.path().join("core.json")).unwrap(),
+            core_before
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join("credentials.json")).unwrap(),
+            credentials_before
+        );
+        let exact =
+            crate::read_exact_credential_section_snapshot(dir.path(), SectionId::Core, Some(2))
+                .unwrap();
+        let mut committed = Config::default();
+        exact.install_into(&mut committed);
+        assert_eq!(committed.http_proxy, "http://external-proxy.test:8080");
+        assert_eq!(
+            committed.proxy_auth.as_ref().unwrap().username,
+            "external-user"
+        );
+        assert_ne!(committed.server.port, 22_224);
+    }
+
+    #[test]
+    fn processless_compatibility_write_rejects_exact_credential_sections() {
+        let dir = TempDir::new().unwrap();
+        let facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let mut candidate = facade.effective_config();
+        candidate.server.port = 22_225;
+
+        let error = persist_facade_effective_config(dir.path(), &candidate).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("core must be changed through its dedicated revisioned API"));
+        assert_ne!(
+            ConfigFacade::open(dir.path())
+                .unwrap()
+                .effective_config()
+                .server
+                .port,
+            22_225
+        );
+    }
+
+    #[test]
+    fn invalid_compatibility_credential_base_is_zero_write_and_process_facade_stays_reloadable() {
         let _key = crate::encryption::set_test_encryption_key([91; 32]);
         let dir = TempDir::new().unwrap();
         let process_facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
         let reference = CredentialRef::parse("proxy.default.auth").unwrap();
-        CredentialStore::open(dir.path())
-            .replace(reference.clone(), "not-json", CredentialSource::User, 0)
+        let mut proxy = process_facade.effective_config();
+        proxy.proxy_auth = Some(crate::ProxyAuth {
+            username: "initial-user".to_string(),
+            password: "initial-secret".to_string(),
+        });
+        crate::persist_proxy_auth_credential_transaction_at_revision_with_adoption(
+            dir.path(),
+            &mut proxy,
+            0,
+            &process_facade,
+        )
+        .unwrap();
+        let store = CredentialStore::open(dir.path());
+        store
+            .replace(
+                reference,
+                "not-json",
+                CredentialSource::User,
+                store.revision().unwrap(),
+            )
             .unwrap();
 
         let mut candidate = process_facade.effective_config();
         candidate.server.port = 22_223;
-        candidate.proxy_auth_credential_ref = Some(reference);
         let core_before = process_facade.registry().core.snapshot().revision;
+        let core_bytes_before = std::fs::read(dir.path().join("core.json")).unwrap();
 
-        let commit =
+        let error =
             persist_facade_effective_config_with_adoption(dir.path(), &candidate, &process_facade)
-                .unwrap();
-        assert!(commit.runtime.is_err());
-        assert!(
-            commit.section_adoption.is_none(),
-            "an unmaterialized runtime must not advance the process facade"
-        );
+                .err()
+                .expect("invalid active credential must fail before the Core commit");
+        assert!(error.to_string().contains("explicitly replace or clear"));
         assert_eq!(
             process_facade.registry().core.snapshot().revision,
             core_before
         );
+        assert_eq!(
+            std::fs::read(dir.path().join("core.json")).unwrap(),
+            core_bytes_before
+        );
 
         let durable = ConfigFacade::open(dir.path()).unwrap();
-        assert_eq!(durable.registry().core.snapshot().revision, core_before + 1);
-        assert_eq!(durable.effective_config().server.port, 22_223);
+        assert_eq!(durable.registry().core.snapshot().revision, core_before);
+        assert_ne!(durable.effective_config().server.port, 22_223);
     }
 }

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -1780,20 +1780,16 @@ fn validate_external_broker_endpoint(raw: &str) -> Result<(), String> {
 
 fn validate_notifications(value: &NotificationsSection) -> Result<(), String> {
     let ntfy = &value.notifications.ntfy;
-    if ntfy
-        .token
-        .as_ref()
-        .is_some_and(|value| !value.trim().is_empty())
+    validate_secret_free_http_url("ntfy base", &ntfy.base_url, false)?;
+    if ntfy.token.is_some()
         || ntfy.token_encrypted.is_some()
         || ntfy.configured != ntfy.credential_ref.is_some()
     {
         return Err("ntfy credential metadata is not isolated".to_string());
     }
     let bark = &value.notifications.bark;
-    if bark
-        .device_key
-        .as_ref()
-        .is_some_and(|value| !value.trim().is_empty())
+    validate_secret_free_http_url("Bark base", &bark.base_url, false)?;
+    if bark.device_key.is_some()
         || bark.device_key_encrypted.is_some()
         || bark.configured != bark.credential_ref.is_some()
     {
@@ -1809,27 +1805,22 @@ fn validate_connect(value: &ConnectSection) -> Result<(), String> {
 
 pub(crate) fn validate_connect_isolated(value: &ConnectConfig) -> Result<(), String> {
     for platform in &value.platforms {
-        let has_secret = platform
-            .token
-            .as_ref()
-            .is_some_and(|value| !value.trim().is_empty())
-            || platform
-                .token_encrypted
-                .as_ref()
-                .is_some_and(|value| !value.trim().is_empty())
-            || platform
-                .app_secret
-                .as_ref()
-                .is_some_and(|value| !value.trim().is_empty())
-            || platform
-                .app_secret_encrypted
-                .as_ref()
-                .is_some_and(|value| !value.trim().is_empty());
+        let has_secret = platform.token.is_some()
+            || platform.token_encrypted.is_some()
+            || platform.app_secret.is_some()
+            || platform.app_secret_encrypted.is_some();
         if has_secret {
             return Err("connect credentials must use credential references".to_string());
         }
         if platform.platform_type.trim().is_empty() {
             return Err("connect platform type must not be empty".to_string());
+        }
+        if let Some(domain) = platform
+            .domain
+            .as_deref()
+            .filter(|domain| domain.contains("://"))
+        {
+            validate_secret_free_http_url("connect platform domain", domain, false)?;
         }
         if platform.token_configured != platform.token_credential_ref.is_some()
             || platform.app_secret_configured != platform.app_secret_credential_ref.is_some()
@@ -7555,7 +7546,7 @@ mod tests {
     }
 
     #[test]
-    fn core_provider_and_mcp_validators_reject_noncanonical_secret_channels() {
+    fn section_validators_reject_noncanonical_secret_channels() {
         for url in [
             "http://user:password@example.test/path",
             "https://example.test/path?token=secret",
@@ -7822,6 +7813,58 @@ mod tests {
                     "servers": [{
                         "id": "zero-connect",
                         "transport": {"type": "sse", "url": "https://mcp.test/sse", "connect_timeout_ms": 0}
+                    }]
+                }),
+            ),
+            (
+                "notifications.json",
+                json!({
+                    "notifications": {
+                        "ntfy": {
+                            "base_url": "https://user:literal-secret@ntfy.test",
+                            "topic": "alerts"
+                        }
+                    }
+                }),
+            ),
+            (
+                "notifications.json",
+                json!({
+                    "notifications": {
+                        "bark": {
+                            "base_url": "https://bark.test?device_key=literal-secret"
+                        }
+                    }
+                }),
+            ),
+            (
+                "notifications.json",
+                json!({
+                    "notifications": {
+                        "ntfy": {
+                            "base_url": "https://ntfy.test",
+                            "token": ""
+                        }
+                    }
+                }),
+            ),
+            (
+                "connect.json",
+                json!({
+                    "platforms": [{
+                        "type": "feishu",
+                        "domain": "https://user:literal-secret@feishu.test",
+                        "allow_from": ["owner"]
+                    }]
+                }),
+            ),
+            (
+                "connect.json",
+                json!({
+                    "platforms": [{
+                        "type": "telegram",
+                        "token_encrypted": "",
+                        "allow_from": ["owner"]
                     }]
                 }),
             ),

--- a/docs/design/config-facade-and-credential-store.md
+++ b/docs/design/config-facade-and-credential-store.md
@@ -100,6 +100,18 @@ into independent user-visible commits; any future operation requiring all-or-non
 semantics must use a staged manifest/journal transaction rather than sequential
 file rewrites.
 
+For a credential-backed modular section, the owned section envelope is the sole
+public CAS authority. This applies to `core` proxy authentication, `env`,
+`notifications`, `connect`, `access-control`, and `cluster-fabric`. The
+`credentials.json` revision is an internal transaction member and diagnostic
+health value, never the precondition for one of those domain forms. An exact
+transaction compares the client section revision, stages metadata and explicit
+credential actions together, and three-way-merges an unrelated credential-store
+winner under the migration lock. A competing edit to the owned section returns
+`409`; an unrelated credential edit does not create a false domain conflict.
+The committed section envelope and matching `config.changed` event use the same
+revision, even for a secret-only replace or clear.
+
 On a corrupt primary, the bytes are copied to a uniquely named quarantine and the
 newest valid backup is loaded as degraded last-known-good. No default is written
 over the corrupt file. Repairing the primary transitions to healthy. Errors exposed
@@ -123,7 +135,7 @@ content-derived value in the quarantine filename.
 | cluster password/private key/passphrase | `cluster.<node-id>.<field>`; ordinary config stores these refs and configured metadata in `cluster_fabric.credential_refs` |
 | connect platform token/app secret | `connect.<stable-platform-id>.<field>` |
 | external broker bearer token | `broker.external.bearer_token` |
-| access password/device token | `access_control.<stable-rule-id>.<field>`; ordinary config stores refs/configured metadata only |
+| access password/device token | `access.root.password_verifier` / `access.<device-id>.device_token_verifier`; ordinary config stores refs/configured metadata only |
 | Copilot GitHub OAuth access token | `copilot.oauth.github_access_token` |
 | Copilot chat token cache | `copilot.oauth.chat_config` |
 
@@ -191,16 +203,19 @@ writes share the same exact credentials/providers/root transaction. Client-owned
 precedes live publication, and generic saves fail closed if an unreferenced
 instance secret would re-enter `config.json`.
 
-Notification ntfy/Bark updates use their own exact credentials/root transaction
-scope. The complete notification subtree is hash-CAS/revision protected; a
-committed transaction rebases unrelated root edits, rejects a competing
-notification-domain edit, and rolls back both members on an unsafe consumer
-conflict. Parseable root backup generations are scrubbed only after their secret
-is durably represented in the credential store. Runtime hydration fails closed
-when configured refs are missing or corrupt. Root PATCH requires an expected
-credential revision, uses omission/clear/replace semantics, and rejects masks or
-client-owned ref/configured metadata; the metadata GET never exposes secret
-material.
+Notification ntfy/Bark updates use their own exact Notifications-section and
+credentials transaction scope. The complete notification subtree is
+revision-protected; a committed transaction rebases unrelated credential-store
+edits, rejects a competing Notifications-section edit, and rolls back both
+members on an unsafe consumer conflict. Parseable root backup generations are
+scrubbed only after their secret is durably represented in the credential store.
+Runtime hydration fails closed when configured refs are missing or corrupt.
+`PUT /bamboo/config/notifications`
+requires the Notifications section revision and accepts explicit
+`keep | replace | clear` actions. The bounded root-PATCH compatibility path also
+requires that section revision. Both reject masks and client-owned
+ref/configured metadata; GET and mutation responses pair the exact typed section
+envelope with secret-free credential status.
 
 The external broker loader completes/rechecks migration before reading
 `broker.json`, then resolves `broker.external.bearer_token` through the credential
@@ -228,10 +243,13 @@ intact, keeps the last-known-good revision, marks health degraded and publishes
 `config.invalid`; repair publishes `config.recovered`. Directory debouncing and
 missing-file retries cover editor temp-write/rename bursts.
 
-Credential metadata/status/replace/clear HTTP adapters now use the encrypted store
-with expected-revision CAS. Responses contain only status metadata and health;
-conflicts return HTTP 409. Successful mutations publish `config.changed` through
-the durable account feed, which also supplies the v2 WebSocket `feed` channel.
+Generic credential metadata/status/replace/clear HTTP adapters use the encrypted
+store with credential-document CAS only for unowned references. Active proxy,
+Env, Notifications, Connect, Access Control, and Cluster references reject that
+generic mutation path and point to their domain transaction. Responses contain
+only status metadata and health; conflicts return HTTP 409. Successful mutations
+publish `config.changed` through the durable account feed, which also supplies
+the v2 WebSocket `feed` channel.
 
 Read-only typed provider and MCP section endpoints expose the same independent
 revision/health/source envelopes used by the watcher. Their DTOs are intentionally
@@ -245,14 +263,42 @@ metadata-only sidecars. Runtime construction hydrates references from
 candidate with a redacted degraded/invalid transition and retains the
 last-known-good runtime.
 
-The typed section API exposes GET envelopes and revisioned PUT mutations for all
-ordinary sections; provider, MCP and credentials retain their dedicated validated
-transactions. Server-owned credential-reference fields are preserved and cannot
-be replaced through an ordinary DTO. Compatibility writes are preflighted against
-the facade projection and rejected before the first durable write if they change
-more than one section. `model_limits` cannot be combined with another section.
-The legacy full-reset endpoint is likewise rejected for an active modular layout
-until it has a recoverable multi-file manifest; callers reset sections separately.
+The typed section API exposes GET envelopes and revisioned PUT mutations for
+ordinary non-credential sections. Provider, MCP, Env, Notifications, Connect,
+Access Control, Cluster Fabric, and credentials use dedicated validated
+transactions; generic `PUT /config/sections/{id}` rejects those domains so it
+cannot become a second write authority. Server-owned credential-reference fields
+are preserved and cannot be replaced through an ordinary DTO. Compatibility
+writes are preflighted against the facade projection and rejected before the
+first durable write if they change more than one section. `model_limits` cannot
+be combined with another section. The legacy full-reset endpoint is likewise
+rejected for an active modular layout until it has a recoverable multi-file
+manifest; callers reset sections separately.
+
+The domain mutation adapters use explicit secret intent without masks:
+
+- Env accepts `credential_change: {action: keep|replace|clear}` per secret
+  entry; omission retains the documented missing/nonempty/empty compatibility
+  form. A secret-to-plain conversion requires an explicit new plain value.
+- Notifications and Connect expose dedicated PUT/GET adapters whose mutation
+  payloads separate metadata from `credential_change`, `token_change`, and
+  `app_secret_change`.
+- `POST /bamboo/access/password` requires the Access Control section revision
+  and supports revisioned password `replace` and `clear`, preserving paired
+  devices. The public pre-auth Access status exposes the authoritative
+  revision, health and source projection but omits section data and local
+  source paths; the gated password mutation returns its exact committed
+  envelope.
+- `POST /bamboo/proxy-auth` requires the Core section revision and returns the
+  exact committed Core envelope.
+
+Every mutation response is built from the runtime/credential snapshot captured
+under the exact transaction and contains no plaintext, ciphertext, or UI mask.
+Each credential field reports one explicit state: `configured` when the owned
+record is usable, `from_env` when an environment source is active, `missing`
+when no usable value is bound, or `error` when configured metadata cannot be
+resolved safely. Credential-store revision and health remain nested diagnostics
+and never become the domain mutation precondition.
 
 Omitted or empty reference metadata preserves an existing binding (clearing is a
 separate credential operation); an explicit replacement reference must parse and
@@ -267,6 +313,7 @@ Proxy authentication now follows the same isolated-store boundary. Legacy
 credential/config manifest. Ordinary root config and rotated backups retain
 only `proxy_auth_credential_ref`; runtime construction resolves and parses the
 credential after migration readiness. The dedicated set/clear endpoint uses an
-exact transaction, and its status endpoint returns credential/section metadata
-without username, password, ciphertext, or mask values. Generic root saves
-refuse an unisolated proxy secret rather than recreating legacy ciphertext.
+exact Core-section transaction, and its status and mutation responses return the
+typed Core envelope plus credential status without username, password,
+ciphertext, or mask values. Generic root saves refuse an unisolated proxy secret
+rather than recreating legacy ciphertext.

--- a/src/setup_cli.rs
+++ b/src/setup_cli.rs
@@ -317,6 +317,9 @@ pub fn run_config_set(
             if v.is_empty() {
                 bail!("token must not be empty");
             }
+            if bamboo_config::patch::is_masked_api_key(v) {
+                bail!("token must not be a mask");
+            }
             config.notifications.ntfy.token = Some(v.to_string());
             config.notifications.ntfy.configured = true;
             notification_credential_intents.insert("ntfy".to_string());
@@ -326,6 +329,9 @@ pub fn run_config_set(
             let v = value.trim();
             if v.is_empty() {
                 bail!("device_key must not be empty");
+            }
+            if bamboo_config::patch::is_masked_api_key(v) {
+                bail!("device_key must not be a mask");
             }
             config.notifications.bark.device_key = Some(v.to_string());
             config.notifications.bark.configured = true;
@@ -351,6 +357,27 @@ pub fn run_config_set(
         value.to_string()
     };
 
+    if let Some(outcome) = outcome.as_ref() {
+        if bamboo_config::section_layout_is_active(&data_dir)? {
+            let changed = bamboo_config::changed_facade_sections(&config, &outcome.config)?;
+            if changed.iter().any(|section| {
+                matches!(
+                    section,
+                    bamboo_config::SectionId::Core
+                        | bamboo_config::SectionId::Env
+                        | bamboo_config::SectionId::Notifications
+                        | bamboo_config::SectionId::Connect
+                        | bamboo_config::SectionId::AccessControl
+                )
+            }) {
+                bail!(
+                    "{key} belongs to a revisioned credential-backed section in the modular layout; \
+                     use its dedicated API"
+                );
+            }
+        }
+    }
+
     if dry_run {
         match &outcome {
             Some(out) => print_dry_run_diff(&config, &out.config),
@@ -367,7 +394,40 @@ pub fn run_config_set(
         None => config,
     };
     if !notification_credential_intents.is_empty() {
-        let revision = bamboo_config::CredentialStore::open(&data_dir).revision()?;
+        let revision = if bamboo_config::section_layout_is_active(&data_dir)? {
+            // The Notifications section is the sole CAS authority in the
+            // modular layout. Read it and its credential document coherently,
+            // then bind a second strict read to that observed generation so a
+            // cross-process winner between reads becomes a conflict.
+            let observed = bamboo_config::read_exact_credential_section_snapshot(
+                &data_dir,
+                bamboo_config::SectionId::Notifications,
+                None,
+            )
+            .context("failed to inspect the Notifications section")?;
+            let revision = observed.section.revision;
+            let exact = bamboo_config::read_exact_credential_section_snapshot(
+                &data_dir,
+                bamboo_config::SectionId::Notifications,
+                Some(revision),
+            )
+            .context("failed to establish an exact Notifications mutation base")?;
+            exact.install_into(&mut to_save);
+            match parts.as_slice() {
+                ["notifications", "ntfy", "token"] => {
+                    to_save.notifications.ntfy.token = Some(value.trim().to_string());
+                    to_save.notifications.ntfy.configured = true;
+                }
+                ["notifications", "bark", "device_key"] => {
+                    to_save.notifications.bark.device_key = Some(value.trim().to_string());
+                    to_save.notifications.bark.configured = true;
+                }
+                _ => unreachable!("notification intent is created only by dedicated CLI keys"),
+            }
+            revision
+        } else {
+            bamboo_config::CredentialStore::open(&data_dir).revision()?
+        };
         bamboo_config::persist_notification_credential_transaction_at_revision(
             &data_dir,
             &mut to_save,
@@ -692,6 +752,7 @@ fn info(msg: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     /// A default in-memory config that never touches a real data dir: loading
     /// from a non-existent directory returns defaults without reading or writing
@@ -890,6 +951,175 @@ mod tests {
     }
 
     #[test]
+    fn modular_notification_secret_uses_section_cas_and_preserves_external_metadata() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = dir.path().to_path_buf();
+        let facade = bamboo_config::ConfigFacade::open_or_migrate(&data_dir).unwrap();
+        let mut external = facade.effective_config();
+        external.notifications.ntfy.enabled = true;
+        external.notifications.ntfy.topic = "external-winner".to_string();
+        external.notifications.bark.enabled = true;
+        external.notifications.bark.device_key = Some("external-bark-secret".to_string());
+        external.notifications.bark.configured = true;
+        assert_eq!(
+            bamboo_config::persist_notification_credential_transaction_at_revision(
+                &data_dir,
+                &mut external,
+                &BTreeSet::from(["bark".to_string()]),
+                0,
+            )
+            .unwrap(),
+            1
+        );
+
+        let store = bamboo_config::CredentialStore::open(&data_dir);
+        store
+            .replace(
+                bamboo_config::CredentialRef::parse("custom.cli.first").unwrap(),
+                "unrelated-one",
+                bamboo_config::CredentialSource::User,
+                1,
+            )
+            .unwrap();
+        store
+            .replace(
+                bamboo_config::CredentialRef::parse("custom.cli.second").unwrap(),
+                "unrelated-two",
+                bamboo_config::CredentialSource::User,
+                2,
+            )
+            .unwrap();
+        assert_eq!(store.revision().unwrap(), 3);
+
+        run_config_set(
+            "notifications.ntfy.token",
+            "cli-section-cas-secret",
+            Some(data_dir.clone()),
+            false,
+        )
+        .unwrap();
+
+        let exact = bamboo_config::read_exact_credential_section_snapshot(
+            &data_dir,
+            bamboo_config::SectionId::Notifications,
+            Some(2),
+        )
+        .unwrap();
+        assert_eq!(exact.credential_health.revision, 4);
+        let committed_section = exact.section.clone();
+        let mut committed = Config::default();
+        exact.install_into(&mut committed);
+        assert_eq!(committed.notifications.ntfy.topic, "external-winner");
+        assert_eq!(
+            committed.notifications.ntfy.token.as_deref(),
+            Some("cli-section-cas-secret")
+        );
+        assert_eq!(
+            committed.notifications.bark.device_key.as_deref(),
+            Some("external-bark-secret")
+        );
+        for (reference, secret) in [
+            ("custom.cli.first", "unrelated-one"),
+            ("custom.cli.second", "unrelated-two"),
+        ] {
+            assert_eq!(
+                store
+                    .resolve(&bamboo_config::CredentialRef::parse(reference).unwrap())
+                    .unwrap()
+                    .unwrap()
+                    .expose(),
+                secret
+            );
+        }
+        for path in [
+            data_dir.join("notifications.json"),
+            data_dir.join("credentials.json"),
+            data_dir.join("config.json"),
+        ] {
+            if path.exists() {
+                let raw = std::fs::read_to_string(path).unwrap();
+                assert!(!raw.contains("cli-section-cas-secret"));
+                assert!(!raw.contains("external-bark-secret"));
+            }
+        }
+
+        let rejected = run_config_set(
+            "notifications.ntfy.topic",
+            "stale-cli-overwrite",
+            Some(data_dir.clone()),
+            false,
+        );
+        assert!(rejected.is_err());
+        assert!(rejected.unwrap_err().to_string().contains("dedicated API"));
+        let after = bamboo_config::read_exact_credential_section_snapshot(
+            &data_dir,
+            bamboo_config::SectionId::Notifications,
+            None,
+        )
+        .unwrap();
+        assert_eq!(after.section.revision, committed_section.revision);
+        assert_eq!(after.section.data, committed_section.data);
+    }
+
+    #[test]
+    fn modular_generic_cli_rejects_every_exact_credential_section_and_flattened_core_key() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let data_dir = dir.path().to_path_buf();
+        let mut seed = Config::default();
+        seed.extra
+            .insert("setup".to_string(), serde_json::json!({"completed": false}));
+        seed.save_to_dir(data_dir.clone()).unwrap();
+        bamboo_config::ConfigFacade::open_or_migrate(&data_dir).unwrap();
+        let paths = [
+            "core.json",
+            "env.json",
+            "notifications.json",
+            "connect.json",
+            "access-control.json",
+            "credentials.json",
+        ];
+        let before = paths
+            .iter()
+            .map(|name| {
+                (
+                    *name,
+                    std::fs::read(data_dir.join(name)).expect("section exists"),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        for (key, value) in [
+            ("setup.completed", "true"),
+            ("http_proxy", "http://cli-bypass.test:8080"),
+            ("env_vars", "[]"),
+            ("notifications.ntfy.topic", "cli-bypass"),
+            (
+                "connect",
+                r#"{"platforms":[{"id":"cli-platform","type":"telegram","token_credential_ref":"connect.cli-platform.token","token_configured":true,"app_secret_configured":false,"allow_from":[],"admin_from":[]}]}"#,
+            ),
+            (
+                "access_control",
+                r#"{"password_enabled":true,"password_credential_ref":"access.root.password_verifier","password_configured":true}"#,
+            ),
+        ] {
+            let error = run_config_set(key, value, Some(data_dir.clone()), false).unwrap_err();
+            let message = error.to_string();
+            assert!(
+                message.contains("dedicated") || message.contains("revisioned env API"),
+                "{key}: {message}"
+            );
+        }
+        assert!(run_config_set("setup.completed", "true", Some(data_dir.clone()), true,).is_err());
+        for (name, expected) in before {
+            assert_eq!(
+                std::fs::read(data_dir.join(name)).unwrap(),
+                expected,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
     fn config_set_rejects_secret_paths_it_cannot_protect() {
         let dir = tempfile::tempdir().expect("tempdir");
         let data_dir = dir.path().to_path_buf();
@@ -908,5 +1138,12 @@ mod tests {
             );
         }
         assert!(!data_dir.join("config.json").exists());
+
+        for key in ["notifications.ntfy.token", "notifications.bark.device_key"] {
+            assert!(
+                run_config_set(key, "****...****", Some(data_dir.clone()), false).is_err(),
+                "{key} must reject masks"
+            );
+        }
     }
 }

--- a/tests/e2e/config_flow/flows.rs
+++ b/tests/e2e/config_flow/flows.rs
@@ -25,20 +25,38 @@ async fn test_full_setup_and_provider_flow_does_not_conflict() {
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert!(resp.status().is_success());
-    let req = test::TestRequest::post()
-        .uri("/v1/bamboo/config")
+    let req = test::TestRequest::get()
+        .uri("/v1/bamboo/config/sections/core")
+        .to_request();
+    let mut core: serde_json::Value = test::call_and_read_body_json(&app, req).await;
+    core["data"]["http_proxy"] = json!("http://proxy:8080");
+    let req = test::TestRequest::put()
+        .uri("/v1/bamboo/config/sections/core")
         .set_json(json!({
-            "http_proxy": "http://proxy:8080"
+            "expected_revision": core["revision"],
+            "data": core["data"]
         }))
         .to_request();
     let resp = test::call_service(&app, req).await;
     assert!(resp.status().is_success());
 
-    // 2) Persist proxy auth (optional) and mark setup complete.
+    // 2) Persist proxy auth against the Core section revision exposed by the
+    // secret-free status endpoint, then mark setup complete.
+    let req = test::TestRequest::get()
+        .uri("/v1/bamboo/proxy-auth/status")
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+    let body = test::read_body(resp).await;
+    let proxy_status: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(proxy_status["configured"], false);
+    let core_revision = proxy_status["revision"].as_u64().unwrap();
+
     let req = test::TestRequest::post()
         .uri("/v1/bamboo/proxy-auth")
         .set_json(json!({
-            "expected_revision": 0,
+            "expected_revision": core_revision,
+            "action": "replace",
             "username": "proxy-user-name",
             "password": "proxy-pass-value"
         }))
@@ -67,7 +85,8 @@ async fn test_full_setup_and_provider_flow_does_not_conflict() {
     assert!(!credentials.contains("proxy-user-name"));
     assert!(!credentials.contains("proxy-pass-value"));
 
-    // Attempt to inject proxy_auth_encrypted via permissive endpoint - must be ignored.
+    // Attempt to inject proxy_auth_encrypted via permissive endpoint - it must
+    // fail closed in favor of the revisioned Core/proxy-auth APIs.
     let req = test::TestRequest::post()
         .uri("/v1/bamboo/config")
         .set_json(json!({
@@ -75,7 +94,7 @@ async fn test_full_setup_and_provider_flow_does_not_conflict() {
         }))
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
 
     // Proxy auth should remain configured (sanitize must prevent overwriting credentials).
     let req = test::TestRequest::get()
@@ -190,10 +209,16 @@ async fn test_full_setup_and_provider_flow_does_not_conflict() {
     assert!(providers["openai"].get("api_key_encrypted").is_none());
 
     // Ensure the permissive endpoint merges without clobbering prior provider/setup state.
-    let req = test::TestRequest::post()
-        .uri("/v1/bamboo/config")
+    let req = test::TestRequest::get()
+        .uri("/v1/bamboo/config/sections/core")
+        .to_request();
+    let mut core: serde_json::Value = test::call_and_read_body_json(&app, req).await;
+    core["data"]["https_proxy"] = json!("http://proxy:8080");
+    let req = test::TestRequest::put()
+        .uri("/v1/bamboo/config/sections/core")
         .set_json(json!({
-            "https_proxy": "http://proxy:8080"
+            "expected_revision": core["revision"],
+            "data": core["data"]
         }))
         .to_request();
     let resp = test::call_service(&app, req).await;

--- a/tests/e2e/config_flow/validation.rs
+++ b/tests/e2e/config_flow/validation.rs
@@ -5,7 +5,7 @@ async fn test_validate_config_patch_reports_domain_errors() {
     let state = crate::e2e::common::create_test_app().await;
     let app = test::init_service(App::new().app_data(state).configure(configure_routes)).await;
 
-    // Invalid proxy URL should be reported under proxy domain.
+    // Root proxy edits fail closed in favor of the revisioned Core API.
     let req = test::TestRequest::post()
         .uri("/v1/bamboo/config/validate")
         .set_json(json!({
@@ -13,11 +13,10 @@ async fn test_validate_config_patch_reports_domain_errors() {
         }))
         .to_request();
     let resp = test::call_service(&app, req).await;
-    assert!(resp.status().is_success());
+    assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
     let body = test::read_body(resp).await;
-    let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(result["valid"], false);
-    assert!(!result["errors"]["proxy"].as_array().unwrap().is_empty());
+    let body = String::from_utf8(body.to_vec()).unwrap();
+    assert!(body.contains("revisioned Core"), "{body}");
 
     // Invalid setup shape should be reported under setup domain.
     let req = test::TestRequest::post()

--- a/tests/e2e/settings/config.rs
+++ b/tests/e2e/settings/config.rs
@@ -62,6 +62,14 @@ async fn test_set_bamboo_config() {
             .route(
                 "/v1/bamboo/config",
                 web::get().to(settings::get_bamboo_config),
+            )
+            .route(
+                "/v1/bamboo/config/sections/{section}",
+                web::get().to(settings::get_typed_section),
+            )
+            .route(
+                "/v1/bamboo/config/sections/{section}",
+                web::put().to(settings::put_typed_section),
             ),
     )
     .await;
@@ -80,10 +88,16 @@ async fn test_set_bamboo_config() {
 
     let set_resp = test::call_service(&app, set_req).await;
     assert!(set_resp.status().is_success());
-    let proxy_req = test::TestRequest::post()
-        .uri("/v1/bamboo/config")
+    let core_req = test::TestRequest::get()
+        .uri("/v1/bamboo/config/sections/core")
+        .to_request();
+    let mut core: serde_json::Value = test::call_and_read_body_json(&app, core_req).await;
+    core["data"]["http_proxy"] = json!("http://proxy:8080");
+    let proxy_req = test::TestRequest::put()
+        .uri("/v1/bamboo/config/sections/core")
         .set_json(json!({
-            "http_proxy": "http://proxy:8080"
+            "expected_revision": core["revision"],
+            "data": core["data"]
         }))
         .to_request();
     let proxy_resp = test::call_service(&app, proxy_req).await;
@@ -195,6 +209,14 @@ async fn test_set_bamboo_config_allows_incomplete_provider_config() {
             .route(
                 "/v1/bamboo/config",
                 web::get().to(settings::get_bamboo_config),
+            )
+            .route(
+                "/v1/bamboo/config/sections/{section}",
+                web::get().to(settings::get_typed_section),
+            )
+            .route(
+                "/v1/bamboo/config/sections/{section}",
+                web::put().to(settings::put_typed_section),
             ),
     )
     .await;
@@ -202,13 +224,26 @@ async fn test_set_bamboo_config_allows_incomplete_provider_config() {
     let set_req = test::TestRequest::post()
         .uri("/v1/bamboo/config")
         .set_json(json!({
-            "provider": "anthropic",
-            "http_proxy": "http://proxy:8080"
+            "provider": "anthropic"
         }))
         .to_request();
 
     let set_resp = test::call_service(&app, set_req).await;
     assert!(set_resp.status().is_success());
+    let core_req = test::TestRequest::get()
+        .uri("/v1/bamboo/config/sections/core")
+        .to_request();
+    let mut core: serde_json::Value = test::call_and_read_body_json(&app, core_req).await;
+    core["data"]["http_proxy"] = json!("http://proxy:8080");
+    let proxy_req = test::TestRequest::put()
+        .uri("/v1/bamboo/config/sections/core")
+        .set_json(json!({
+            "expected_revision": core["revision"],
+            "data": core["data"]
+        }))
+        .to_request();
+    let proxy_resp = test::call_service(&app, proxy_req).await;
+    assert!(proxy_resp.status().is_success());
 
     let get_req = test::TestRequest::get()
         .uri("/v1/bamboo/config")


### PR DESCRIPTION
## Summary

- make `env`, `notifications`, `connect`, `access-control`, and Core proxy-auth section revisions the sole public CAS authority while rebasing unrelated credential-store winners under the exact transaction lock
- add explicit secret-safe `keep | replace | clear` mutation contracts, exact section/event responses, and configured/from-env/missing/error status projections; keep the public Access status free of section data and local paths
- reject generic typed-section and active generic-credential bypasses, fail closed on legacy masks, and cover stale writers, unrelated races, recovery boundaries, response races, and secret leakage
- make stopped-watcher Core commits validate against the exact durable base, publish only after process adoption, and leave failed durable commits available for the normal reload path

Closes #738

## Test Plan

- `cargo fmt --all -- --check`
- `git diff --check`
- repository CI clippy command: passed
- `cargo clippy -p bamboo-config -p bamboo-server --all-targets -- -D warnings`
- `cargo clippy -p bamboo-agent --lib -- -D warnings`
- `cargo check -p bamboo-config -p bamboo-server`
- `cargo test -p bamboo-config` — 616 passed
- `cargo test -p bamboo-server --lib` — 1,656 passed, 1 ignored
- `cargo test -p bamboo-agent --lib` — 163 passed
- `cargo test -p bamboo-agent --test e2e_tests` — 208 passed

## Screenshots

N/A — backend/config API and transaction changes only.