### PR TITLE
fix: restore typed settings and separate workflow identity

### DIFF
--- a/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
+++ b/crates/app/bamboo-server-tools/src/skill_runtime/tests.rs
@@ -1318,7 +1318,7 @@ Use this demo skill."#,
 }
 
 #[tokio::test]
-async fn session_workspace_catalog_selection_and_runtime_roots_are_isolated() {
+async fn session_workspace_skill_catalog_selection_and_runtime_roots_are_isolated() {
     let temp_dir = tempfile::tempdir().expect("tempdir");
     let global_skills = temp_dir.path().join("data/skills");
     let workspace_one = temp_dir.path().join("workspace-one");
@@ -1372,15 +1372,17 @@ async fn session_workspace_catalog_selection_and_runtime_roots_are_isolated() {
         .expect("initialize manager");
 
     let catalog_one = skill_manager
-        .store()
-        .workflow_catalog_for_workspace(&workspace_one)
+        .store_for_workspace(Some(&workspace_one))
         .await
-        .expect("workspace one catalog");
+        .expect("workspace one store")
+        .skill_catalog_snapshot()
+        .await;
     let catalog_two = skill_manager
-        .store()
-        .workflow_catalog_for_workspace(&workspace_two)
+        .store_for_workspace(Some(&workspace_two))
         .await
-        .expect("workspace two catalog");
+        .expect("workspace two store")
+        .skill_catalog_snapshot()
+        .await;
     assert_eq!(
         catalog_one
             .entries

--- a/crates/app/bamboo-server/src/app_state/builder.rs
+++ b/crates/app/bamboo-server/src/app_state/builder.rs
@@ -441,6 +441,9 @@ impl AppState {
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                     };
+                    if !event.public_workflow {
+                        continue;
+                    }
                     let event = match event.kind {
                         bamboo_skills::WorkflowCatalogEventKind::Changed => {
                             AgentEvent::WorkflowChanged {

--- a/crates/app/bamboo-server/src/app_state/config_runtime.rs
+++ b/crates/app/bamboo-server/src/app_state/config_runtime.rs
@@ -228,6 +228,13 @@ fn materialize_facade_effective_config(
         config.clear_access_control_runtime_verifiers();
         failures.insert(SectionId::AccessControl);
     }
+    if config
+        .access_control
+        .as_ref()
+        .is_some_and(|access| access.repair_required)
+    {
+        failures.insert(SectionId::AccessControl);
+    }
     if let Some(broker) = config.subagents_mut().broker.as_mut() {
         if let Err(error) = broker.hydrate_credential_from_store(data_dir) {
             tracing::warn!(error = %error, "external broker credential hydration unavailable");
@@ -243,7 +250,14 @@ pub(super) fn load_facade_effective_config(
     facade: &bamboo_config::ConfigFacade,
     data_dir: &Path,
 ) -> Config {
-    materialize_facade_effective_config(facade, data_dir).config
+    let materialized = materialize_facade_effective_config(facade, data_dir);
+    for section in &materialized.failures {
+        facade.registry().mark_runtime_degraded(
+            *section,
+            "configuration runtime credential repair is required",
+        );
+    }
+    materialized.config
 }
 
 fn load_committed_effective_config(data_dir: &Path) -> Result<Config, ConfigStoreError> {

--- a/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
+++ b/crates/app/bamboo-server/src/handlers/agent/ws_v2/mod.rs
@@ -957,6 +957,7 @@ mod tests {
             let mut config = state.config.write().await;
             config.access_control = Some(AccessControlConfig {
                 password_enabled: false,
+                repair_required: false,
                 password_hash: None,
                 password_salt: None,
                 password_credential_ref: None,

--- a/crates/app/bamboo-server/src/handlers/command/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/command/handlers.rs
@@ -7,8 +7,8 @@ use crate::error::AppError;
 use crate::handlers::settings::is_safe_workflow_name;
 
 use super::sources::{
-    catalog_entry_to_command, list_markdown_commands, list_mcp_tools_as_commands,
-    list_prompt_presets_as_commands, safe_project_commands_dir,
+    legacy_workflow_catalog_entry_to_command, list_markdown_commands, list_mcp_tools_as_commands,
+    list_prompt_presets_as_commands, safe_project_commands_dir, skill_catalog_entry_to_command,
 };
 use super::types::{CommandItem, CommandListResponse, GetCommandQuery, ListCommandsQuery};
 
@@ -20,11 +20,11 @@ struct SessionResourceContext {
 
 pub(super) fn append_unique(
     commands: &mut Vec<CommandItem>,
-    seen: &mut HashSet<String>,
+    seen: &mut HashSet<(String, String)>,
     items: Vec<CommandItem>,
 ) {
     for item in items {
-        if seen.insert(item.name.clone()) {
+        if seen.insert((item.command_type.clone(), item.name.clone())) {
             commands.push(item);
         }
     }
@@ -107,6 +107,26 @@ async fn session_resource_context(
     })
 }
 
+async fn scoped_skill_store(
+    app_state: &AppState,
+    context: &SessionResourceContext,
+) -> Result<std::sync::Arc<bamboo_skills::SkillStore>, AppError> {
+    if let (Some(project_id), Some(project_home)) =
+        (context.project_id.as_ref(), context.project_home.as_ref())
+    {
+        app_state
+            .skill_manager
+            .store_for_project_workspace(project_id, project_home, context.workspace.as_deref())
+            .await
+    } else {
+        app_state
+            .skill_manager
+            .store_for_workspace(context.workspace.as_deref())
+            .await
+    }
+    .map_err(|error| AppError::BadRequest(format!("Invalid session resource scope: {error}")))
+}
+
 /// Lists all available commands from workflows, skills, and MCP tools.
 pub async fn list_commands(
     app_state: web::Data<AppState>,
@@ -160,38 +180,20 @@ pub async fn list_commands(
         list_prompt_presets_as_commands(&app_state.app_data_dir).await,
     );
 
-    let catalog = if let (Some(project_id), Some(project_home)) =
-        (context.project_id.as_ref(), context.project_home.as_ref())
-    {
-        app_state
-            .skill_manager
-            .workflow_catalog_for_project_workspace(
-                project_id,
-                project_home,
-                context.workspace.as_deref(),
-            )
-            .await
-            .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?
-    } else if let Some(workspace) = context.workspace.as_ref() {
-        app_state
-            .skill_manager
-            .store()
-            .workflow_catalog_for_workspace(workspace)
-            .await
-            .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?
-    } else {
-        app_state
-            .skill_manager
-            .store()
-            .workflow_catalog_snapshot()
-            .await
-    };
-    let skill_commands = catalog
+    let store = scoped_skill_store(app_state.get_ref(), &context).await?;
+    let (skill_catalog, workflow_catalog) = store.command_catalog_snapshots().await;
+    let skill_commands = skill_catalog
         .entries
         .into_iter()
-        .map(|entry| catalog_entry_to_command(&entry))
+        .filter_map(|entry| skill_catalog_entry_to_command(&entry))
         .collect();
     append_unique(&mut commands, &mut seen, skill_commands);
+    let workflow_commands = workflow_catalog
+        .entries
+        .into_iter()
+        .filter_map(|entry| legacy_workflow_catalog_entry_to_command(&entry))
+        .collect();
+    append_unique(&mut commands, &mut seen, workflow_commands);
 
     match list_mcp_tools_as_commands(app_state.get_ref()).await {
         Ok(mcp_tools) => append_unique(&mut commands, &mut seen, mcp_tools),
@@ -200,7 +202,11 @@ pub async fn list_commands(
         }
     }
 
-    commands.sort_by(|left, right| left.name.cmp(&right.name));
+    commands.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| left.command_type.cmp(&right.command_type))
+    });
     Ok(HttpResponse::Ok().json(CommandListResponse {
         total: commands.len(),
         commands,
@@ -281,19 +287,14 @@ pub async fn get_command(
                 return Err(AppError::BadRequest("Invalid workflow name".to_string()));
             }
 
-            let workflows_dir = app_state.app_data_dir.join("workflows");
-            let filename = format!("{id}.md");
-            let filepath = workflows_dir.join(&filename);
-
-            if !filepath.exists() {
-                return Err(AppError::NotFound(format!("Workflow {id} not found")));
-            }
-
-            let content = tokio::fs::read_to_string(&filepath)
+            let store = scoped_skill_store(app_state.get_ref(), &context).await?;
+            let filepath = store
+                .get_legacy_workflow_source(&id)
                 .await
-                .map_err(|error| {
-                    AppError::InternalError(anyhow::anyhow!("Failed to read workflow: {error}"))
-                })?;
+                .map_err(|_| AppError::NotFound(format!("Workflow {id} not found")))?;
+            let content = bamboo_skills::legacy::read_legacy_markdown_workflow(&filepath)
+                .await
+                .map_err(|_| AppError::NotFound(format!("Workflow {id} not found")))?;
 
             Ok(HttpResponse::Ok().json(serde_json::json!({
                 "id": format!("workflow-{id}"),
@@ -303,26 +304,7 @@ pub async fn get_command(
             })))
         }
         "skill" => {
-            let store = if let (Some(project_id), Some(project_home)) =
-                (context.project_id.as_ref(), context.project_home.as_ref())
-            {
-                app_state
-                    .skill_manager
-                    .store_for_project_workspace(
-                        project_id,
-                        project_home,
-                        context.workspace.as_deref(),
-                    )
-                    .await
-            } else {
-                app_state
-                    .skill_manager
-                    .store_for_workspace(context.workspace.as_deref())
-                    .await
-            }
-            .map_err(|error| {
-                AppError::BadRequest(format!("Invalid session resource scope: {error}"))
-            })?;
+            let store = scoped_skill_store(app_state.get_ref(), &context).await?;
             match store.get_skill(&id).await {
                 Ok(skill) => Ok(HttpResponse::Ok().json(skill)),
                 Err(error) => Err(AppError::NotFound(format!("Skill {id} not found: {error}"))),

--- a/crates/app/bamboo-server/src/handlers/command/sources.rs
+++ b/crates/app/bamboo-server/src/handlers/command/sources.rs
@@ -2,7 +2,9 @@ use std::path::{Component, Path, PathBuf};
 
 use crate::app_state::AppState;
 use crate::error::AppError;
-use bamboo_skills::WorkflowCatalogEntry;
+use bamboo_skills::{
+    LegacyWorkflowMigrationStatus, WorkflowCatalogEntry, WorkflowKind, WorkflowStatus,
+};
 use serde::Deserialize;
 
 use super::types::CommandItem;
@@ -217,15 +219,8 @@ pub(super) async fn list_prompt_presets_as_commands(data_dir: &Path) -> Vec<Comm
     }
 }
 
-pub(super) fn catalog_entry_to_command(entry: &WorkflowCatalogEntry) -> CommandItem {
-    // Until the WorkflowRun engine owns orchestration activation (#578), every catalog bundle is
-    // selected through its canonical SKILL.md instruction entrypoint. Advertising an
-    // orchestration bundle as a legacy `workflow` makes Lotus fetch
-    // `/commands/workflow/{id}`, whose compatibility handler only serves
-    // `${BAMBOO_DATA_DIR}/workflows/{id}.md`; a bundle-local workflow.yaml therefore becomes a
-    // visible command that always fails on selection. Keep the future execution semantic in
-    // metadata.kind without pretending the legacy prompt-workflow adapter can execute it.
-    CommandItem {
+pub(super) fn skill_catalog_entry_to_command(entry: &WorkflowCatalogEntry) -> Option<CommandItem> {
+    (entry.winner && entry.status == WorkflowStatus::Valid).then(|| CommandItem {
         id: format!("skill-{}", entry.id),
         name: entry.id.clone(),
         display_name: entry.name.clone(),
@@ -242,7 +237,35 @@ pub(super) fn catalog_entry_to_command(entry: &WorkflowCatalogEntry) -> CommandI
             "argumentSchema": entry.argument_schema,
             "status": entry.status,
         }),
-    }
+    })
+}
+
+pub(super) fn legacy_workflow_catalog_entry_to_command(
+    entry: &WorkflowCatalogEntry,
+) -> Option<CommandItem> {
+    (entry.winner
+        && entry.kind == WorkflowKind::Instruction
+        && entry.status == WorkflowStatus::Valid
+        && entry.migration_status == Some(LegacyWorkflowMigrationStatus::Available))
+    .then(|| CommandItem {
+        id: format!("workflow-{}", entry.id),
+        name: entry.id.clone(),
+        display_name: entry.name.clone(),
+        description: entry.description.clone(),
+        command_type: "workflow".to_string(),
+        category: None,
+        tags: None,
+        metadata: serde_json::json!({
+            "kind": entry.kind,
+            "source": entry.source,
+            "revision": entry.revision,
+            "version": entry.version,
+            "invocationPolicy": entry.invocation_policy,
+            "argumentSchema": entry.argument_schema,
+            "status": entry.status,
+            "migrationStatus": entry.migration_status,
+        }),
+    })
 }
 
 pub(super) async fn list_mcp_tools_as_commands(

--- a/crates/app/bamboo-server/src/handlers/command/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/command/tests.rs
@@ -1,14 +1,20 @@
 use actix_web::{http::StatusCode, web};
-use bamboo_skills::{WorkflowCatalogEntry, WorkflowKind, WorkflowSource, WorkflowStatus};
+use bamboo_skills::{
+    LegacyWorkflowMigrationStatus, WorkflowCatalogEntry, WorkflowKind, WorkflowSource,
+    WorkflowStatus,
+};
 
 use std::collections::HashSet;
 
 use super::handlers::{append_unique, expand_arguments};
-use super::sources::{catalog_entry_to_command, list_markdown_commands};
+use super::sources::{
+    legacy_workflow_catalog_entry_to_command, list_markdown_commands,
+    skill_catalog_entry_to_command,
+};
 use super::types::CommandItem;
 
 #[test]
-fn catalog_entry_to_command_maps_metadata_without_prompt() {
+fn skill_catalog_entry_to_command_maps_metadata_without_prompt() {
     let entry = WorkflowCatalogEntry {
         id: "sample".into(),
         name: "Sample".into(),
@@ -26,7 +32,7 @@ fn catalog_entry_to_command_maps_metadata_without_prompt() {
         winner: true,
         shadowed_candidates: vec![],
     };
-    let command = catalog_entry_to_command(&entry);
+    let command = skill_catalog_entry_to_command(&entry).unwrap();
 
     assert_eq!(command.id, "skill-sample");
     assert_eq!(command.name, "sample");
@@ -36,7 +42,7 @@ fn catalog_entry_to_command_maps_metadata_without_prompt() {
 }
 
 #[test]
-fn orchestration_catalog_entry_stays_selectable_as_skill_until_workflow_run_exists() {
+fn orchestration_catalog_entry_is_omitted_from_legacy_workflow_commands() {
     let entry = WorkflowCatalogEntry {
         id: "review-run".into(),
         name: "Review run".into(),
@@ -55,11 +61,32 @@ fn orchestration_catalog_entry_stays_selectable_as_skill_until_workflow_run_exis
         shadowed_candidates: vec![],
     };
 
-    let command = catalog_entry_to_command(&entry);
+    assert!(legacy_workflow_catalog_entry_to_command(&entry).is_none());
+}
 
-    assert_eq!(command.id, "skill-review-run");
-    assert_eq!(command.command_type, "skill");
-    assert_eq!(command.metadata["kind"], "orchestration");
+#[test]
+fn source_backed_legacy_catalog_entry_maps_to_workflow_command() {
+    let entry = WorkflowCatalogEntry {
+        id: "review".into(),
+        name: "Review".into(),
+        description: "Legacy review workflow".into(),
+        kind: WorkflowKind::Instruction,
+        source: WorkflowSource::User,
+        revision: 3,
+        version: "1".into(),
+        invocation_policy: serde_json::json!({"explicit": true}),
+        argument_schema: serde_json::json!({"type": "object"}),
+        status: WorkflowStatus::Valid,
+        legacy: true,
+        migration_status: Some(LegacyWorkflowMigrationStatus::Available),
+        last_error: None,
+        winner: true,
+        shadowed_candidates: vec![],
+    };
+
+    let command = legacy_workflow_catalog_entry_to_command(&entry).unwrap();
+    assert_eq!(command.id, "workflow-review");
+    assert_eq!(command.command_type, "workflow");
 }
 
 #[tokio::test]
@@ -114,6 +141,83 @@ async fn prompt_preset_list_item_can_be_resolved_and_expanded() {
         .to_request();
     let body: serde_json::Value = actix_web::test::call_and_read_body_json(&app, request).await;
     assert_eq!(body["content"], "Review code");
+}
+
+#[actix_web::test]
+async fn command_palette_keeps_skill_and_workflow_sources_separate() {
+    let data = tempfile::tempdir().expect("data dir");
+    let skill = data.path().join("skills/review");
+    std::fs::create_dir_all(&skill).expect("skill root");
+    std::fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: review\ndescription: Review Skill\n---\nSKILL BODY MUST NOT SERVE AS WORKFLOW\n",
+    )
+    .expect("skill");
+    let workflows = data.path().join("workflows");
+    std::fs::create_dir_all(&workflows).expect("workflow root");
+    let workflow_body = "---\ndescription: Review Workflow\n---\nSOURCE WORKFLOW BODY\n";
+    std::fs::write(workflows.join("review.md"), workflow_body).expect("legacy workflow");
+    let orchestration = data.path().join("skills/orchestrate");
+    std::fs::create_dir_all(&orchestration).expect("orchestration root");
+    std::fs::write(
+        orchestration.join("SKILL.md"),
+        "---\nname: orchestrate\ndescription: True orchestration\n---\nSupport text\n",
+    )
+    .expect("orchestration instructions");
+    std::fs::write(
+        orchestration.join("workflow.yaml"),
+        "id: orchestrate\nname: Orchestrate\ndescription: Runs tools\nversion: '1'\ncomposition:\n  type: call\n  tool: read_file\n  args: {}\n",
+    )
+    .expect("orchestration metadata");
+
+    let app_state = web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let app = actix_web::test::init_service(
+        actix_web::App::new()
+            .app_data(app_state)
+            .configure(super::config),
+    )
+    .await;
+
+    let list: serde_json::Value = actix_web::test::call_and_read_body_json(
+        &app,
+        actix_web::test::TestRequest::get()
+            .uri("/commands")
+            .to_request(),
+    )
+    .await;
+    let commands = list["commands"].as_array().expect("commands");
+    let review = commands
+        .iter()
+        .filter(|command| command["name"] == "review")
+        .collect::<Vec<_>>();
+    assert!(review.iter().any(|command| command["type"] == "skill"));
+    assert!(review.iter().any(|command| command["type"] == "workflow"));
+    assert!(commands
+        .iter()
+        .all(|command| command["name"] != "orchestrate"));
+
+    let workflow: serde_json::Value = actix_web::test::call_and_read_body_json(
+        &app,
+        actix_web::test::TestRequest::get()
+            .uri("/commands/workflow/review")
+            .to_request(),
+    )
+    .await;
+    assert_eq!(workflow["content"], workflow_body);
+    assert!(!workflow["content"].as_str().unwrap().contains("SKILL BODY"));
+
+    let orchestration = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::get()
+            .uri("/commands/workflow/orchestrate")
+            .to_request(),
+    )
+    .await;
+    assert_eq!(orchestration.status(), StatusCode::NOT_FOUND);
 }
 
 #[cfg(unix)]
@@ -189,6 +293,22 @@ fn command_conflicts_keep_first_source_by_documented_precedence() {
 
     assert_eq!(merged.len(), 1);
     assert_eq!(merged[0].metadata["source"], "project");
+}
+
+#[test]
+fn same_name_skill_and_workflow_commands_both_survive() {
+    let mut merged = Vec::new();
+    let mut seen = HashSet::new();
+    let mut skill = command("review", "skill");
+    skill.command_type = "skill".to_string();
+    let mut workflow = command("review", "workflow");
+    workflow.command_type = "workflow".to_string();
+
+    append_unique(&mut merged, &mut seen, vec![skill, workflow]);
+
+    assert_eq!(merged.len(), 2);
+    assert!(merged.iter().any(|item| item.command_type == "skill"));
+    assert!(merged.iter().any(|item| item.command_type == "workflow"));
 }
 
 #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/access_control.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/access_control.rs
@@ -315,7 +315,7 @@ fn verify_password(config: &Config, password: &str) -> bool {
     let Some(access) = config.access_control.as_ref() else {
         return false;
     };
-    if !access.password_enabled {
+    if access.repair_required || !access.password_enabled {
         return false;
     }
 
@@ -408,6 +408,9 @@ pub(crate) fn verify_device_token(config: &Config, device_id: &str, token: &str)
     let Some(access) = config.access_control.as_ref() else {
         return false;
     };
+    if access.repair_required {
+        return false;
+    }
     // device_id is a public, non-secret companion id; a plain `==` lookup here is
     // intentional. Only the token hash compare below must be constant-time.
     let Some(device) = access.devices.iter().find(|d| d.device_id == device_id) else {
@@ -431,6 +434,13 @@ fn has_active_devices(config: &Config) -> bool {
         .as_ref()
         .map(|access| access.devices.iter().any(|d| !d.revoked))
         .unwrap_or(false)
+}
+
+fn access_repair_required(config: &Config) -> bool {
+    config
+        .access_control
+        .as_ref()
+        .is_some_and(|access| access.repair_required)
 }
 
 /// Extract a presented device token from a request.
@@ -477,7 +487,7 @@ fn request_has_valid_device_token(req: &HttpRequest, config: &Config) -> bool {
 
 fn access_verification_cookie_value(config: &Config) -> Option<String> {
     let access = config.access_control.as_ref()?;
-    if !access.password_enabled {
+    if access.repair_required || !access.password_enabled {
         return None;
     }
 
@@ -575,6 +585,14 @@ fn is_public_access_route(path: &str) -> bool {
 /// This MUST stay a pure extraction of the middleware's prior allow expression:
 /// changing it changes the gate for every route at once.
 pub(crate) fn request_is_authorized(req: &HttpRequest, config: &Config) -> bool {
+    if access_repair_required(config) {
+        // A quarantined access document may still contain a verifier that was
+        // structurally recoverable. Do not let that partial recovery reopen
+        // remote access. The existing loopback/localhost bypass remains the
+        // only allow path until an explicit repair/reset transaction clears
+        // the server-owned flag.
+        return is_local_request(req);
+    }
     !build_access_status(config, req).requires_password
         || request_has_verified_access_cookie(req, config)
         || request_has_valid_device_token(req, config)
@@ -651,25 +669,14 @@ fn build_access_status(config: &Config, req: &HttpRequest) -> AccessStatusRespon
     let password_enabled = config
         .access_control
         .as_ref()
-        .map(|access| {
-            access.password_enabled
-                && access
-                    .password_hash
-                    .as_deref()
-                    .map(|value| !value.trim().is_empty())
-                    .unwrap_or(false)
-                && access
-                    .password_salt
-                    .as_deref()
-                    .map(|value| !value.trim().is_empty())
-                    .unwrap_or(false)
-        })
+        .map(|access| access.password_enabled)
         .unwrap_or(false);
     let local_bypass = is_local_request(req);
     // v2-P2 (#181): once any device is paired, public access requires a
     // credential even if the root password itself is unset — the device tokens
     // become the gating mechanism. No devices + no password ⇒ unchanged behavior.
-    let credential_required = password_enabled || has_active_devices(config);
+    let credential_required =
+        password_enabled || has_active_devices(config) || access_repair_required(config);
 
     AccessStatusResponse {
         password_enabled,
@@ -680,42 +687,27 @@ fn build_access_status(config: &Config, req: &HttpRequest) -> AccessStatusRespon
 
 fn build_exact_access_status(
     config: &Config,
-    statuses: &[bamboo_config::CredentialStatus],
-    health: &bamboo_config::CredentialStoreHealth,
+    _statuses: &[bamboo_config::CredentialStatus],
+    _health: &bamboo_config::CredentialStoreHealth,
     req: &HttpRequest,
 ) -> AccessStatusResponse {
-    let status_for = |reference: &bamboo_config::CredentialRef| {
-        statuses
-            .iter()
-            .find(|status| &status.credential_ref == reference)
-    };
-    let password_enabled = config.access_control.as_ref().is_some_and(|access| {
-        access.password_enabled
-            && credential_status_view(
-                access.password_credential_ref.as_ref(),
-                access.password_configured,
-                access.password_credential_ref.as_ref().and_then(status_for),
-                health,
-            )
-            .configured
-    });
-    let has_device = config.access_control.as_ref().is_some_and(|access| {
-        access.devices.iter().any(|device| {
-            !device.revoked
-                && credential_status_view(
-                    device.token_credential_ref.as_ref(),
-                    device.token_configured,
-                    device.token_credential_ref.as_ref().and_then(status_for),
-                    health,
-                )
-                .configured
-        })
-    });
+    // Durable `password_enabled` is the authentication intent. Missing or
+    // unreadable verifier material is a degraded repair state, not permission
+    // to silently reopen remote access; verification will simply fail closed.
+    let password_enabled = config
+        .access_control
+        .as_ref()
+        .is_some_and(|access| access.password_enabled);
+    let has_device = config
+        .access_control
+        .as_ref()
+        .is_some_and(|access| access.devices.iter().any(|device| !device.revoked));
+    let repair_required = access_repair_required(config);
     let local_bypass = is_local_request(req);
     AccessStatusResponse {
         password_enabled,
         local_bypass,
-        requires_password: (password_enabled || has_device) && !local_bypass,
+        requires_password: (password_enabled || has_device || repair_required) && !local_bypass,
     }
 }
 
@@ -1643,6 +1635,82 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn quarantined_access_is_fail_closed_and_recovery_credentials_stay_private() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0xb7; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        let secret_fragment = "server-api-private-access-fragment";
+        let mut root = serde_json::to_value(Config::default()).unwrap();
+        root["access_control"] = serde_json::json!({
+            "password_enabled": "yes",
+            "password_hash": secret_fragment
+        });
+        std::fs::write(
+            dir.path().join("config.json"),
+            serde_json::to_vec_pretty(&root).unwrap(),
+        )
+        .unwrap();
+
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        assert!(state
+            .config
+            .read()
+            .await
+            .access_control
+            .as_ref()
+            .is_some_and(|access| access.repair_required));
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/access/status", web::get().to(get_access_status))
+                .route(
+                    "/credentials",
+                    web::get().to(crate::handlers::settings::list_credentials),
+                )
+                .route(
+                    "/credentials/{credential_ref}",
+                    web::get().to(crate::handlers::settings::get_credential_status),
+                ),
+        )
+        .await;
+
+        let status = test::call_service(
+            &app,
+            TestRequest::get()
+                .uri("/access/status")
+                .peer_addr("203.0.113.8:5700".parse().unwrap())
+                .insert_header((header::HOST, "bamboo.example.com"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(status.status(), StatusCode::OK);
+        let status: serde_json::Value = test::read_body_json(status).await;
+        assert_eq!(status["requires_password"], true);
+        assert_eq!(status["status"], "degraded");
+        let serialized_status = status.to_string();
+        assert!(!serialized_status.contains("access_repair."));
+        assert!(!serialized_status.contains(secret_fragment));
+
+        let list =
+            test::call_service(&app, TestRequest::get().uri("/credentials").to_request()).await;
+        assert_eq!(list.status(), StatusCode::OK);
+        let serialized_list = String::from_utf8(test::read_body(list).await.to_vec()).unwrap();
+        assert!(!serialized_list.contains("access_repair."));
+        assert!(!serialized_list.contains(secret_fragment));
+
+        let direct = test::call_service(
+            &app,
+            TestRequest::get()
+                .uri("/credentials/access_repair.root.payload")
+                .to_request(),
+        )
+        .await;
+        assert_eq!(direct.status(), StatusCode::BAD_REQUEST);
+        let direct = String::from_utf8(test::read_body(direct).await.to_vec()).unwrap();
+        assert!(!direct.contains(secret_fragment));
+        assert!(!direct.contains("access_repair.root.payload"));
+    }
+
+    #[actix_web::test]
     async fn access_status_reports_valid_ciphertext_with_invalid_verifier_as_error() {
         let dir = tempfile::tempdir().unwrap();
         let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
@@ -1702,9 +1770,15 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body: serde_json::Value = test::read_body_json(response).await;
         assert_eq!(body["revision"], 1);
-        assert_eq!(body["password_enabled"], false);
+        assert_eq!(body["password_enabled"], true);
+        assert_eq!(body["requires_password"], true);
         assert_eq!(body["password_configured"], false);
         assert_eq!(body["credential_state"], "error");
+        assert_eq!(body["status"], "degraded");
+        assert_eq!(
+            body["last_error"],
+            "access-control credential repair is required"
+        );
 
         let (_, revision, metadata, section) = state
             .update_access_control_credentials(1, true, BTreeSet::new(), |config| {
@@ -2140,6 +2214,7 @@ mod tests {
         let config = test_config! {
             access_control: Some(AccessControlConfig {
                 password_enabled: true,
+                repair_required: false,
                 password_hash: Some(hash),
                 password_salt: Some(salt_hex),
                 password_credential_ref: None,
@@ -2161,6 +2236,7 @@ mod tests {
         test_config! {
             access_control: Some(AccessControlConfig {
                 password_enabled: true,
+                repair_required: false,
                 password_hash: Some(hash),
                 password_salt: Some(salt_hex),
                 password_credential_ref: None,
@@ -2259,12 +2335,36 @@ mod tests {
     }
 
     #[test]
+    fn enabled_password_with_missing_verifier_fails_closed_for_remote_requests() {
+        let config = test_config! {
+            access_control: Some(AccessControlConfig {
+                password_enabled: true,
+                repair_required: false,
+                password_hash: None,
+                password_salt: None,
+                password_credential_ref: None,
+                password_configured: false,
+                updated_at: None,
+                devices: Vec::new(),
+            }),
+        };
+        let remote = remote_req();
+        let local = local_req();
+        assert!(build_access_status(&config, &remote).password_enabled);
+        assert!(build_access_status(&config, &remote).requires_password);
+        assert!(!verify_password(&config, "any-password"));
+        assert!(!request_is_authorized(&remote, &config));
+        assert!(request_is_authorized(&local, &config));
+    }
+
+    #[test]
     fn device_presence_requires_credential_even_without_password() {
         // A device paired but no root password still gates remote access.
         let (cred, _t) = issue_device_token("d");
         let config = test_config! {
             access_control: Some(AccessControlConfig {
                 password_enabled: false,
+                repair_required: false,
                 password_hash: None,
                 password_salt: None,
                 password_credential_ref: None,
@@ -2326,6 +2426,7 @@ mod tests {
         let config = test_config! {
             access_control: Some(AccessControlConfig {
                 password_enabled: false,
+                repair_required: false,
                 password_hash: None,
                 password_salt: None,
                 password_credential_ref: None,
@@ -2368,6 +2469,39 @@ mod tests {
             .insert_header((DEVICE_ID_HEADER, device_id))
             .to_http_request();
         assert!(request_is_authorized(&req, &config));
+    }
+
+    #[test]
+    fn repair_required_rejects_valid_remote_credentials_but_keeps_local_bypass() {
+        let (cred, token) = issue_device_token("repair-device");
+        let device_id = cred.device_id.clone();
+        let mut config = config_with_password();
+        config.access_control.as_mut().unwrap().devices.push(cred);
+        let previously_valid_cookie = access_verification_cookie_value(&config)
+            .expect("healthy password verifier produces a cookie");
+        config.access_control.as_mut().unwrap().repair_required = true;
+
+        let remote_cookie = TestRequest::default()
+            .insert_header((header::HOST, "bamboo.example.com"))
+            .cookie(Cookie::new(
+                ACCESS_VERIFIED_COOKIE_NAME,
+                previously_valid_cookie,
+            ))
+            .to_http_request();
+        let remote_device = TestRequest::default()
+            .insert_header((header::HOST, "bamboo.example.com"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .insert_header((DEVICE_ID_HEADER, device_id.clone()))
+            .to_http_request();
+
+        assert!(build_access_status(&config, &remote_cookie).requires_password);
+        assert!(!build_access_status(&config, &local_req()).requires_password);
+        assert!(!verify_password(&config, "secret"));
+        assert!(!verify_device_token(&config, &device_id, &token));
+        assert!(access_verification_cookie_value(&config).is_none());
+        assert!(!request_is_authorized(&remote_cookie, &config));
+        assert!(!request_is_authorized(&remote_device, &config));
+        assert!(request_is_authorized(&local_req(), &config));
     }
 
     #[test]

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/tests.rs
@@ -14,6 +14,7 @@ use super::reset::remove_config_file_if_exists;
 fn access_control_fixture() -> bamboo_config::AccessControlConfig {
     bamboo_config::AccessControlConfig {
         password_enabled: true,
+        repair_required: false,
         password_hash: Some("a".repeat(64)),
         password_salt: Some("00112233445566778899aabbccddeeff".to_string()),
         password_credential_ref: None,

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/credentials.rs
@@ -49,7 +49,7 @@ pub async fn get_credential_status(
     path: web::Path<String>,
 ) -> Result<HttpResponse, AppError> {
     let credential_ref = parse_credential_ref(path.into_inner())?;
-    reject_cluster_credential_ref(&credential_ref)?;
+    reject_reserved_credential_ref(&credential_ref)?;
     let (status, health) = app_state
         .credential_store
         .status_with_health(&credential_ref)
@@ -162,7 +162,7 @@ async fn reject_managed_credential_ref(
     app_state: &AppState,
     credential_ref: &CredentialRef,
 ) -> Result<(), AppError> {
-    reject_cluster_credential_ref(credential_ref)?;
+    reject_reserved_credential_ref(credential_ref)?;
     let config = app_state.config.read().await;
     if config.proxy_auth_credential_ref.as_ref() == Some(credential_ref) {
         return Err(AppError::BadRequest(
@@ -230,11 +230,20 @@ fn is_cluster_credential_ref(credential_ref: &CredentialRef) -> bool {
     credential_ref.as_str().starts_with("cluster.")
 }
 
-fn reject_cluster_credential_ref(credential_ref: &CredentialRef) -> Result<(), AppError> {
+fn is_access_recovery_credential_ref(credential_ref: &CredentialRef) -> bool {
+    credential_ref.as_str().starts_with("access_repair.")
+}
+
+fn reject_reserved_credential_ref(credential_ref: &CredentialRef) -> Result<(), AppError> {
     if is_cluster_credential_ref(credential_ref) {
         return Err(AppError::BadRequest(
             "cluster credential references are reserved for the dedicated revisioned cluster-fabric API"
                 .to_string(),
+        ));
+    }
+    if is_access_recovery_credential_ref(credential_ref) {
+        return Err(AppError::BadRequest(
+            "credential reference is reserved for server-owned access recovery".to_string(),
         ));
     }
     Ok(())

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/sections.rs
@@ -1881,6 +1881,77 @@ mod tests {
     }
 
     #[actix_web::test]
+    async fn partial_access_control_does_not_disable_other_typed_sections() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            serde_json::to_vec_pretty(&json!({
+                "access_control": {
+                    "password_enabled": true,
+                    "password_hash": "orphaned-legacy-hash"
+                },
+                "tools": {
+                    "disabled": ["bash"]
+                },
+                "mcp": {}
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        assert!(
+            state.config_facade.is_some(),
+            "repairable AccessControl metadata must not disable the modular facade"
+        );
+        let app = test::init_service(
+            App::new()
+                .app_data(state)
+                .route("/sections/{section}", web::get().to(get_typed_section)),
+        )
+        .await;
+
+        for section in ["tools-skills", "mcp"] {
+            let response = test::call_service(
+                &app,
+                test::TestRequest::get()
+                    .uri(&format!("/sections/{section}"))
+                    .to_request(),
+            )
+            .await;
+            assert!(
+                response.status().is_success(),
+                "{section} must remain independently available"
+            );
+        }
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/sections/access-control")
+                .to_request(),
+        )
+        .await;
+        assert!(response.status().is_success());
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["status"], "degraded");
+        assert_eq!(
+            body["last_error"],
+            "access-control credential repair is required"
+        );
+        assert_eq!(body["data"]["password_enabled"], true);
+        assert_eq!(body["data"]["password_configured"], false);
+        assert!(body["data"].get("password_hash").is_none());
+        assert!(body["data"].get("password_salt").is_none());
+        for name in ["config.json", "access-control.json", "credentials.json"] {
+            assert!(
+                !std::fs::read_to_string(dir.path().join(name))
+                    .unwrap()
+                    .contains("orphaned-legacy-hash"),
+                "{name} must not retain unusable verifier material"
+            );
+        }
+    }
+
+    #[actix_web::test]
     async fn typed_sections_expose_health_and_diagnostics_without_secret_material() {
         let _key = bamboo_config::encryption::set_test_encryption_key([0x49; 32]);
         let dir = tempfile::tempdir().unwrap();
@@ -4588,6 +4659,55 @@ mod tests {
                 .unwrap()
                 .configured
         );
+    }
+
+    #[actix_web::test]
+    async fn access_control_reset_clears_server_owned_recovery_payload() {
+        let _key = bamboo_config::encryption::set_test_encryption_key([0x66; 32]);
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            serde_json::to_vec_pretty(&json!({
+                "access_control": {
+                    "password_enabled": "yes",
+                    "password_hash": "reset-recovery-private-fragment"
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let state = web::Data::new(AppState::new(dir.path().to_path_buf()).await.unwrap());
+        let recovery = bamboo_config::CredentialRef::parse("access_repair.root.payload").unwrap();
+        assert!(state.credential_store.resolve(&recovery).unwrap().is_some());
+        let revision = state
+            .config_facade
+            .as_ref()
+            .unwrap()
+            .registry()
+            .access_control
+            .snapshot()
+            .revision;
+
+        let app = test::init_service(App::new().app_data(state.clone()).route(
+            "/sections/{section}/reset",
+            web::post().to(reset_typed_section),
+        ))
+        .await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/sections/access-control/reset")
+                .set_json(json!({"expected_revision": revision}))
+                .to_request(),
+        )
+        .await;
+        let status = response.status();
+        let body = String::from_utf8(test::read_body(response).await.to_vec()).unwrap();
+        assert!(status.is_success(), "unexpected response {status}: {body}");
+        assert!(state.config.read().await.access_control.is_none());
+        assert!(state.credential_store.resolve(&recovery).unwrap().is_none());
+        assert!(!body.contains("reset-recovery-private-fragment"));
+        assert!(!body.contains("access_repair."));
     }
 
     #[actix_web::test]

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/handlers.rs
@@ -1,6 +1,5 @@
 use actix_web::{http::StatusCode, web, HttpResponse};
-use bamboo_skills::legacy::{LegacySyncOutcome, LegacyWorkflowMigrationOutcome};
-use bamboo_skills::types::SkillDefinition;
+use bamboo_skills::legacy::LegacyWorkflowMigrationOutcome;
 use bamboo_skills::LegacyWorkflowMigrationStatus;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
@@ -142,10 +141,10 @@ pub async fn list_workflow_catalog(
     };
     Ok(HttpResponse::Ok()
         .insert_header(("Cache-Control", "no-store"))
-        .json(snapshot))
+        .json(snapshot.public_workflows()))
 }
 
-/// Clone one read-only workspace/plugin legacy workflow into the trusted
+/// Clone one read-only global/workspace/plugin legacy workflow into the trusted
 /// session workspace's canonical `.bamboo/skills/<id>/SKILL.md` bundle.
 ///
 /// The legacy source is never changed or removed, and an existing target is
@@ -257,9 +256,12 @@ pub async fn migrate_workflow(
         )));
     }
 
-    let source = store.get_skill_root(&workflow_id).await.map_err(|error| {
-        AppError::BadRequest(format!("Legacy workflow is unavailable: {error}"))
-    })?;
+    let source = store
+        .get_legacy_workflow_source(&workflow_id)
+        .await
+        .map_err(|error| {
+            AppError::BadRequest(format!("Legacy workflow is unavailable: {error}"))
+        })?;
     let source = tokio::fs::canonicalize(&source).await.map_err(|error| {
         AppError::BadRequest(format!("Legacy workflow source is unavailable: {error}"))
     })?;
@@ -295,11 +297,31 @@ pub async fn migrate_workflow(
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
             Err(error) => return Err(AppError::StorageError(error)),
         };
+    let global_workflows = app_state.app_data_dir.join("workflows");
+    let global_source_identity = match tokio::fs::symlink_metadata(&global_workflows).await {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
+            let canonical_app_data = tokio::fs::canonicalize(&app_state.app_data_dir).await?;
+            let root = tokio::fs::canonicalize(&global_workflows).await?;
+            if root.starts_with(&canonical_app_data) && source.parent() == Some(root.as_path()) {
+                source
+                    .file_name()
+                    .and_then(|filename| filename.to_str())
+                    .map(|filename| format!("workflows/{filename}"))
+            } else {
+                None
+            }
+        }
+        Ok(_) => None,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(AppError::StorageError(error)),
+    };
     let source_identity = workspace_source_identity
+        .or(global_source_identity)
         .or(plugin_source_identity)
         .ok_or_else(|| {
             AppError::Forbidden(
-                "Legacy workflow source is outside a migratable workspace/plugin scope".to_string(),
+                "Legacy workflow source is outside a migratable global/workspace/plugin scope"
+                    .to_string(),
             )
         })?;
 
@@ -358,20 +380,35 @@ pub async fn migrate_workflow(
 /// - `200 OK`: Successfully retrieved workflow list
 pub async fn list_workflows(app_state: web::Data<AppState>) -> Result<HttpResponse, AppError> {
     let workflows_dir = app_state.app_data_dir.join("workflows");
-    let mut workflows: Vec<WorkflowListItem> = app_state
-        .skill_manager
-        .store()
-        .list_skills(None, false)
-        .await
-        .into_iter()
-        .filter(|skill| legacy_source(skill, &workflows_dir).is_some())
-        .map(|skill| WorkflowListItem {
-            name: legacy_name(&skill).to_string(),
-            filename: format!("{}.md", legacy_name(&skill)),
-            size: skill.prompt.len() as u64,
+    let mut workflows = Vec::new();
+    let mut entries = match fs::read_dir(&workflows_dir).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(legacy_response().json(workflows));
+        }
+        Err(error) => return Err(AppError::StorageError(error)),
+    };
+    while let Some(entry) = entries.next_entry().await? {
+        let Some(filename) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let Some(name) = filename.strip_suffix(".md") else {
+            continue;
+        };
+        if !is_safe_workflow_name(name) {
+            continue;
+        }
+        let file_type = entry.file_type().await?;
+        if !file_type.is_file() || file_type.is_symlink() {
+            continue;
+        }
+        workflows.push(WorkflowListItem {
+            name: name.to_string(),
+            filename,
+            size: entry.metadata().await?.len(),
             modified_at: None,
-        })
-        .collect();
+        });
+    }
 
     workflows.sort_by(|left, right| left.name.cmp(&right.name));
 
@@ -395,17 +432,20 @@ pub async fn get_workflow(
 
     let dir = app_state.app_data_dir.join("workflows");
     let filename = format!("{name}.md");
-    let skill_id = bamboo_skills::legacy::legacy_workflow_skill_id(&name);
-    let skill = app_state
-        .skill_manager
-        .store()
-        .get_skill(&skill_id)
-        .await
-        .map_err(|_| AppError::NotFound(format!("Workflow '{name}'")))?;
-    if legacy_source(&skill, &dir).is_none() || legacy_name(&skill) != name {
+    let file_path = dir.join(&filename);
+    let metadata = match fs::symlink_metadata(&file_path).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(AppError::NotFound(format!("Workflow '{name}'")));
+        }
+        Err(error) => return Err(AppError::StorageError(error)),
+    };
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
         return Err(AppError::NotFound(format!("Workflow '{name}'")));
     }
-    let content = skill.prompt;
+    let content = bamboo_skills::legacy::read_legacy_markdown_workflow(&file_path)
+        .await
+        .map_err(|error| AppError::BadRequest(format!("Workflow '{name}' is invalid: {error}")))?;
     let size = content.len() as u64;
 
     Ok(legacy_response().json(WorkflowGetResponse {
@@ -435,24 +475,6 @@ pub async fn save_workflow(
     fs::create_dir_all(&dir).await?;
 
     let file_path = dir.join(format!("{}.md", name));
-    let skill_id = bamboo_skills::legacy::legacy_workflow_skill_id(name);
-    let preflight = bamboo_skills::legacy::legacy_bundle_preflight(
-        &file_path,
-        &app_state.app_data_dir.join("skills"),
-        &skill_id,
-    )
-    .await;
-    match preflight {
-        Ok(true) => {}
-        Ok(false) => {
-            return Err(AppError::BadRequest(format!(
-                "Workflow '{name}' conflicts with a non-legacy skill bundle"
-            )))
-        }
-        Err(error) => {
-            return Err(AppError::InternalError(anyhow::anyhow!(error)));
-        }
-    }
 
     let temporary = dir.join(format!(".{name}.{}.tmp", uuid::Uuid::new_v4()));
     let mut staging = fs::OpenOptions::new()
@@ -473,25 +495,12 @@ pub async fn save_workflow(
         return Err(error.into());
     }
 
-    // Source is authoritative and durable first. If bundle sync fails, the watcher/import pass
-    // retries from this committed source instead of leaving an unrecoverable split-brain write.
-    let outcome = bamboo_skills::legacy::sync_legacy_markdown_bundle(
-        &file_path,
-        &app_state.app_data_dir.join("skills"),
-        &skill_id,
-        &payload.content,
-    )
-    .await
-    .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
-    if outcome == LegacySyncOutcome::Conflict {
-        return Err(AppError::BadRequest(format!(
-            "Workflow '{name}' ownership changed during update; source was committed and will not overwrite the bundle"
-        )));
-    }
+    // The legacy source remains a Workflow. Reload discovers it through the
+    // read-only adapter; saving must never materialize or overwrite a Skill.
     app_state
         .skill_manager
         .store()
-        .reload()
+        .reload_global_workflow_views()
         .await
         .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
 
@@ -518,48 +527,34 @@ pub async fn delete_workflow(
 
     let dir = app_state.app_data_dir.join("workflows");
     let file_path = dir.join(format!("{}.md", name));
-    let skill_id = bamboo_skills::legacy::legacy_workflow_skill_id(&name);
-
-    if !file_path.exists() {
-        return Err(AppError::NotFound(format!("Workflow '{}'", name)));
+    let metadata = match fs::symlink_metadata(&file_path).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(AppError::NotFound(format!("Workflow '{name}'")));
+        }
+        Err(error) => return Err(AppError::StorageError(error)),
+    };
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return Err(AppError::NotFound(format!("Workflow '{name}'")));
     }
-
-    let removed_bundle = app_state
+    let skill_id = bamboo_skills::legacy::legacy_workflow_skill_id(&name);
+    let removed = app_state
         .skill_manager
         .store()
         .remove_legacy_workflow(&file_path, &skill_id)
         .await
         .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
-    if !removed_bundle {
-        return Err(AppError::BadRequest(format!(
-            "Workflow '{name}' is not owned by the legacy adapter"
-        )));
+    if !removed {
+        return Err(AppError::NotFound(format!("Workflow '{name}'")));
     }
+    app_state
+        .skill_manager
+        .store()
+        .reload_global_workflow_views()
+        .await
+        .map_err(|error| AppError::InternalError(anyhow::anyhow!(error)))?;
 
     Ok(legacy_response().json(serde_json::json!({ "success": true })))
-}
-
-fn legacy_source(skill: &SkillDefinition, workflows_dir: &std::path::Path) -> Option<String> {
-    let metadata = skill.metadata.as_ref()?;
-    if metadata
-        .get("legacy_import")
-        .and_then(|value| value.as_bool())
-        != Some(true)
-    {
-        return None;
-    }
-    let source = metadata.get("original_source")?.as_str()?;
-    let expected = workflows_dir.join(format!("{}.md", legacy_name(skill)));
-    (std::path::Path::new(source) == expected).then(|| source.to_string())
-}
-
-fn legacy_name(skill: &SkillDefinition) -> &str {
-    skill
-        .metadata
-        .as_ref()
-        .and_then(|metadata| metadata.get("legacy_name"))
-        .and_then(|value| value.as_str())
-        .unwrap_or(&skill.id)
 }
 
 fn legacy_response() -> actix_web::HttpResponseBuilder {

--- a/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/workflows/tests.rs
@@ -1,7 +1,7 @@
 use super::validation::is_safe_workflow_name;
 
 #[actix_web::test]
-async fn workflow_catalog_api_returns_metadata_without_skill_body() {
+async fn workflow_catalog_excludes_instruction_skills_and_returns_orchestration_metadata() {
     let data = tempfile::tempdir().expect("data dir");
     let skill = data.path().join("skills/review");
     tokio::fs::create_dir_all(&skill).await.expect("skill dir");
@@ -11,6 +11,22 @@ async fn workflow_catalog_api_returns_metadata_without_skill_body() {
     )
     .await
     .expect("skill");
+    let workflow = data.path().join("skills/deploy");
+    tokio::fs::create_dir_all(&workflow)
+        .await
+        .expect("workflow dir");
+    tokio::fs::write(
+        workflow.join("SKILL.md"),
+        "---\nname: deploy\ndescription: Deploys changes\n---\nWORKFLOW SECRET BODY\n",
+    )
+    .await
+    .expect("workflow skill");
+    tokio::fs::write(
+        workflow.join("workflow.yaml"),
+        "id: deploy\nname: Deploy\ndescription: Deploys changes\nversion: '1'\ncomposition:\n  type: call\n  tool: read_file\n  args: {}\n",
+    )
+    .await
+    .expect("workflow metadata");
     let state = actix_web::web::Data::new(
         crate::app_state::AppState::new(data.path().to_path_buf())
             .await
@@ -26,9 +42,11 @@ async fn workflow_catalog_api_returns_metadata_without_skill_body() {
         .to_request();
     let body = actix_web::test::call_and_read_body(&app, request).await;
     let text = std::str::from_utf8(&body).expect("utf8 response");
-    assert!(text.contains("Reviews changes"));
+    assert!(!text.contains("Reviews changes"));
+    assert!(text.contains("Deploys changes"));
     assert!(text.contains("\"revision\""));
     assert!(!text.contains("TOP SECRET INSTRUCTIONS"));
+    assert!(!text.contains("WORKFLOW SECRET BODY"));
     assert!(!text.contains("SKILL.md"));
 }
 
@@ -43,6 +61,12 @@ async fn workflow_catalog_session_without_workspace_uses_global_snapshot() {
     )
     .await
     .expect("skill");
+    tokio::fs::write(
+        skill.join("workflow.yaml"),
+        "id: global-review\nname: Global review\ndescription: Global review workflow\nversion: '1'\ncomposition:\n  type: call\n  tool: read_file\n  args: {}\n",
+    )
+    .await
+    .expect("workflow metadata");
     let state = actix_web::web::Data::new(
         crate::app_state::AppState::new(data.path().to_path_buf())
             .await
@@ -94,6 +118,13 @@ async fn assigned_project_workflow_catalog_reports_workspace_then_project_source
             format!("---\nname: {id}\ndescription: {description}\n---\nPROJECT BODY\n"),
         )
         .expect("write Project skill");
+        std::fs::write(
+            skill.join("workflow.yaml"),
+            format!(
+                "id: {id}\nname: {id}\ndescription: {description}\nversion: '1'\ncomposition:\n  type: call\n  tool: read_file\n  args: {{}}\n"
+            ),
+        )
+        .expect("write Project workflow metadata");
     }
     let workspace_skill = workspace.path().join(".bamboo/skills/shared-workflow");
     std::fs::create_dir_all(&workspace_skill).expect("workspace skill");
@@ -102,6 +133,11 @@ async fn assigned_project_workflow_catalog_reports_workspace_then_project_source
         "---\nname: shared-workflow\ndescription: Workspace overlay workflow\n---\nWORKSPACE BODY\n",
     )
     .expect("write workspace skill");
+    std::fs::write(
+        workspace_skill.join("workflow.yaml"),
+        "id: shared-workflow\nname: shared-workflow\ndescription: Workspace overlay workflow\nversion: '1'\ncomposition:\n  type: call\n  tool: read_file\n  args: {}\n",
+    )
+    .expect("write workspace workflow metadata");
 
     let state = actix_web::web::Data::new(
         crate::app_state::AppState::new(data.path().to_path_buf())
@@ -258,7 +294,7 @@ async fn workspace_legacy_workflow_migration_is_explicit_non_destructive_and_ide
     );
     let app = actix_web::test::init_service(
         actix_web::App::new()
-            .app_data(state)
+            .app_data(state.clone())
             .route(
                 "/catalog",
                 actix_web::web::get().to(super::list_workflow_catalog),
@@ -333,6 +369,22 @@ async fn workspace_legacy_workflow_migration_is_explicit_non_destructive_and_ide
     assert_eq!(second["outcome"], "already_migrated");
     assert_eq!(std::fs::read_to_string(&source).unwrap(), original);
 
+    let store = state
+        .skill_manager
+        .store_for_workspace(Some(workspace.path()))
+        .await
+        .expect("workspace SkillStore");
+    let skill_catalog = store.skill_catalog_snapshot().await;
+    let migrated_skill = skill_catalog
+        .entries
+        .iter()
+        .find(|entry| entry.id == "daily-report")
+        .expect("migrated Skill entry");
+    assert_eq!(
+        migrated_skill.migration_status,
+        Some(bamboo_skills::LegacyWorkflowMigrationStatus::Migrated)
+    );
+
     let after: serde_json::Value = actix_web::test::call_and_read_body_json(
         &app,
         actix_web::test::TestRequest::get()
@@ -340,21 +392,117 @@ async fn workspace_legacy_workflow_migration_is_explicit_non_destructive_and_ide
             .to_request(),
     )
     .await;
-    let migrated = after["entries"]
+    let source_workflow = after["entries"]
         .as_array()
         .expect("catalog entries")
         .iter()
         .find(|entry| entry["id"] == "daily-report")
-        .expect("migrated workflow entry");
-    assert_eq!(migrated["migration_status"], "migrated");
+        .expect("source Workflow entry");
+    assert_eq!(source_workflow["migration_status"], "available");
+    assert!(source_workflow.get("shadowed_candidates").is_none());
+}
+
+#[actix_web::test]
+async fn global_legacy_workflow_advertised_as_available_migrates_into_session_workspace() {
+    let data = tempfile::tempdir().expect("data dir");
+    let workspace = tempfile::tempdir().expect("workspace");
+    let global_workflows = data.path().join("workflows");
+    std::fs::create_dir_all(&global_workflows).expect("global workflows");
+    let source = global_workflows.join("global-review.md");
+    let original =
+        "---\ndescription: Review changes from the global Workflow.\n---\nReview the diff.\n";
+    std::fs::write(&source, original).expect("global legacy workflow");
+
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let mut session = bamboo_agent_core::Session::new("global-migration-session", "test-model");
+    session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
+    state.sessions.insert(
+        session.id.clone(),
+        std::sync::Arc::new(parking_lot::RwLock::new(session)),
+    );
+    let app = actix_web::test::init_service(
+        actix_web::App::new()
+            .app_data(state.clone())
+            .route(
+                "/catalog",
+                actix_web::web::get().to(super::list_workflow_catalog),
+            )
+            .route(
+                "/catalog/{workflow_id}/migrate",
+                actix_web::web::post().to(super::migrate_workflow),
+            ),
+    )
+    .await;
+
+    let before: serde_json::Value = actix_web::test::call_and_read_body_json(
+        &app,
+        actix_web::test::TestRequest::get()
+            .uri("/catalog?session_id=global-migration-session")
+            .to_request(),
+    )
+    .await;
+    let advertised = before["entries"]
+        .as_array()
+        .expect("catalog entries")
+        .iter()
+        .find(|entry| entry["id"] == "global-review")
+        .expect("global Workflow");
+    assert_eq!(advertised["source"], "user");
+    assert_eq!(advertised["migration_status"], "available");
+
+    let response = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::post()
+            .uri("/catalog/global-review/migrate")
+            .set_json(serde_json::json!({
+                "session_id": "global-migration-session"
+            }))
+            .to_request(),
+    )
+    .await;
+    assert!(response.status().is_success());
+    let body: serde_json::Value = actix_web::test::read_body_json(response).await;
+    assert_eq!(body["outcome"], "migrated");
+    assert_eq!(body["source_preserved"], true);
+    assert_eq!(std::fs::read_to_string(&source).unwrap(), original);
+
+    let target = workspace
+        .path()
+        .join(".bamboo/skills/global-review/SKILL.md");
+    let migrated = std::fs::read_to_string(&target).expect("migrated Skill");
+    assert!(migrated.contains("workflows/global-review.md"));
+    assert!(!migrated.contains(data.path().to_string_lossy().as_ref()));
+    let scoped = state
+        .skill_manager
+        .store_for_workspace(Some(workspace.path()))
+        .await
+        .expect("workspace store");
     assert_eq!(
-        migrated["shadowed_candidates"][0]["migration_status"],
-        "available"
+        scoped
+            .get_skill("global-review")
+            .await
+            .expect("real migrated Skill")
+            .prompt,
+        "Review the diff."
+    );
+    assert_eq!(
+        std::fs::canonicalize(
+            scoped
+                .get_legacy_workflow_source("global-review")
+                .await
+                .expect("preserved source Workflow")
+        )
+        .unwrap(),
+        std::fs::canonicalize(&source).unwrap()
     );
 }
 
 #[actix_web::test]
-async fn legacy_api_writes_through_bundle_and_bridges_catalog_event() {
+async fn legacy_api_keeps_workflow_source_only_and_bridges_catalog_event() {
     let data = tempfile::tempdir().expect("data dir");
     let state = actix_web::web::Data::new(
         crate::app_state::AppState::new(data.path().to_path_buf())
@@ -372,6 +520,10 @@ async fn legacy_api_writes_through_bundle_and_bridges_catalog_event() {
             .route(
                 "/workflows/{name}",
                 actix_web::web::get().to(super::get_workflow),
+            )
+            .route(
+                "/workflows/{name}",
+                actix_web::web::delete().to(super::delete_workflow),
             ),
     )
     .await;
@@ -389,10 +541,8 @@ async fn legacy_api_writes_through_bundle_and_bridges_catalog_event() {
     let body: serde_json::Value = actix_web::test::call_and_read_body_json(&app, request).await;
     assert_eq!(body["content"], "Second body");
     assert!(
-        tokio::fs::read_to_string(data.path().join("skills/legacy/SKILL.md"))
-            .await
-            .expect("adapter bundle")
-            .contains("Second body")
+        !data.path().join("skills/legacy/SKILL.md").exists(),
+        "legacy Workflow writes must not materialize a Skill"
     );
 
     let bridged = tokio::time::timeout(std::time::Duration::from_secs(2), async {
@@ -415,7 +565,285 @@ async fn legacy_api_writes_through_bundle_and_bridges_catalog_event() {
 }
 
 #[actix_web::test]
-async fn concurrent_legacy_updates_leave_source_and_bundle_consistent() {
+async fn global_workflow_create_update_delete_is_immediate_in_cached_session_views() {
+    let data = tempfile::tempdir().expect("data dir");
+    let workspace = tempfile::tempdir().expect("workspace");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let project = state
+        .project_store
+        .create("Workflow cache Project", None)
+        .expect("Project");
+    let mut workspace_session =
+        bamboo_agent_core::Session::new("workspace-cache-session", "test-model");
+    workspace_session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
+    state.sessions.insert(
+        workspace_session.id.clone(),
+        std::sync::Arc::new(parking_lot::RwLock::new(workspace_session)),
+    );
+    let mut project_session =
+        bamboo_agent_core::Session::new("project-cache-session", "test-model");
+    project_session.set_project_id_meta(project.id.to_string());
+    project_session.set_workspace_path_meta(workspace.path().to_string_lossy().into_owned());
+    state.sessions.insert(
+        project_session.id.clone(),
+        std::sync::Arc::new(parking_lot::RwLock::new(project_session)),
+    );
+    let app = actix_web::test::init_service(
+        actix_web::App::new()
+            .app_data(state)
+            .route(
+                "/catalog",
+                actix_web::web::get().to(super::list_workflow_catalog),
+            )
+            .route(
+                "/workflows",
+                actix_web::web::post().to(super::save_workflow),
+            )
+            .route(
+                "/workflows/{name}",
+                actix_web::web::delete().to(super::delete_workflow),
+            ),
+    )
+    .await;
+
+    let session_ids = ["workspace-cache-session", "project-cache-session"];
+    let mut initial_revisions = Vec::new();
+    for session_id in session_ids {
+        let catalog: serde_json::Value = actix_web::test::call_and_read_body_json(
+            &app,
+            actix_web::test::TestRequest::get()
+                .uri(&format!("/catalog?session_id={session_id}"))
+                .to_request(),
+        )
+        .await;
+        initial_revisions.push(catalog["revision"].as_u64().expect("catalog revision"));
+        assert!(!catalog["entries"]
+            .as_array()
+            .expect("entries")
+            .iter()
+            .any(|entry| entry["id"] == "live-global"));
+    }
+
+    for (description, body) in [
+        ("First global Workflow.", "First body"),
+        ("Second global Workflow.", "Second body"),
+    ] {
+        let response = actix_web::test::call_service(
+            &app,
+            actix_web::test::TestRequest::post()
+                .uri("/workflows")
+                .set_json(serde_json::json!({
+                    "name": "live-global",
+                    "content": format!(
+                        "---\ndescription: {description}\n---\n{body}\n"
+                    )
+                }))
+                .to_request(),
+        )
+        .await;
+        assert!(response.status().is_success());
+
+        for (index, session_id) in session_ids.iter().enumerate() {
+            let catalog: serde_json::Value = actix_web::test::call_and_read_body_json(
+                &app,
+                actix_web::test::TestRequest::get()
+                    .uri(&format!("/catalog?session_id={session_id}"))
+                    .to_request(),
+            )
+            .await;
+            assert!(catalog["revision"].as_u64().unwrap() > initial_revisions[index]);
+            let entry = catalog["entries"]
+                .as_array()
+                .expect("entries")
+                .iter()
+                .find(|entry| entry["id"] == "live-global")
+                .expect("same-request publication");
+            assert_eq!(entry["description"], description);
+            assert_eq!(entry["migration_status"], "available");
+            initial_revisions[index] = catalog["revision"].as_u64().unwrap();
+        }
+    }
+
+    let deleted = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::delete()
+            .uri("/workflows/live-global")
+            .to_request(),
+    )
+    .await;
+    assert!(deleted.status().is_success());
+    for (index, session_id) in session_ids.iter().enumerate() {
+        let catalog: serde_json::Value = actix_web::test::call_and_read_body_json(
+            &app,
+            actix_web::test::TestRequest::get()
+                .uri(&format!("/catalog?session_id={session_id}"))
+                .to_request(),
+        )
+        .await;
+        assert!(catalog["revision"].as_u64().unwrap() > initial_revisions[index]);
+        assert!(!catalog["entries"]
+            .as_array()
+            .expect("entries")
+            .iter()
+            .any(|entry| entry["id"] == "live-global"));
+    }
+}
+
+#[actix_web::test]
+async fn historical_legacy_import_remains_a_workflow_without_rewriting_its_bundle() {
+    let data = tempfile::tempdir().expect("data dir");
+    let source = data.path().join("workflows/legacy.md");
+    tokio::fs::create_dir_all(source.parent().expect("workflow parent"))
+        .await
+        .expect("workflow dir");
+    tokio::fs::write(&source, "Current Workflow source\n")
+        .await
+        .expect("workflow source");
+    let bundle = data.path().join("skills/legacy/SKILL.md");
+    tokio::fs::create_dir_all(bundle.parent().expect("bundle parent"))
+        .await
+        .expect("bundle dir");
+    let old_bundle = format!(
+        "---\nname: legacy\ndescription: Imported legacy workflow\nmetadata:\n  legacy_import: true\n  legacy_name: legacy\n  original_source: '{}'\n---\nHistorical copied body\n",
+        source.display()
+    );
+    tokio::fs::write(&bundle, &old_bundle)
+        .await
+        .expect("legacy bundle");
+
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let app = actix_web::test::init_service(
+        actix_web::App::new()
+            .app_data(state)
+            .route(
+                "/catalog",
+                actix_web::web::get().to(super::list_workflow_catalog),
+            )
+            .route(
+                "/workflows/{name}",
+                actix_web::web::get().to(super::get_workflow),
+            )
+            .route(
+                "/workflows/{name}",
+                actix_web::web::delete().to(super::delete_workflow),
+            ),
+    )
+    .await;
+
+    let catalog: serde_json::Value = actix_web::test::call_and_read_body_json(
+        &app,
+        actix_web::test::TestRequest::get()
+            .uri("/catalog")
+            .to_request(),
+    )
+    .await;
+    let entry = catalog["entries"]
+        .as_array()
+        .expect("catalog entries")
+        .iter()
+        .find(|entry| entry["id"] == "legacy")
+        .expect("legacy Workflow");
+    assert_eq!(entry["legacy"], true);
+    assert_eq!(entry["migration_status"], "available");
+
+    let workflow: serde_json::Value = actix_web::test::call_and_read_body_json(
+        &app,
+        actix_web::test::TestRequest::get()
+            .uri("/workflows/legacy")
+            .to_request(),
+    )
+    .await;
+    assert_eq!(workflow["content"], "Current Workflow source\n");
+    assert_eq!(
+        tokio::fs::read_to_string(&bundle)
+            .await
+            .expect("bundle preserved"),
+        old_bundle
+    );
+
+    let deleted = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::delete()
+            .uri("/workflows/legacy")
+            .to_request(),
+    )
+    .await;
+    assert!(deleted.status().is_success());
+    assert!(!source.exists());
+    assert!(
+        !bundle.exists(),
+        "explicit deletion may clean only the adapter owned by this source"
+    );
+    let after: serde_json::Value = actix_web::test::call_and_read_body_json(
+        &app,
+        actix_web::test::TestRequest::get()
+            .uri("/catalog")
+            .to_request(),
+    )
+    .await;
+    assert!(!after["entries"]
+        .as_array()
+        .expect("catalog entries")
+        .iter()
+        .any(|entry| entry["id"] == "legacy"));
+}
+
+#[actix_web::test]
+async fn deleting_legacy_source_never_deletes_a_same_id_ordinary_skill() {
+    let data = tempfile::tempdir().expect("data dir");
+    let source = data.path().join("workflows/shared.md");
+    tokio::fs::create_dir_all(source.parent().expect("workflow parent"))
+        .await
+        .expect("workflow dir");
+    tokio::fs::write(&source, "Workflow source\n")
+        .await
+        .expect("workflow source");
+    let skill = data.path().join("skills/shared/SKILL.md");
+    tokio::fs::create_dir_all(skill.parent().expect("skill parent"))
+        .await
+        .expect("skill dir");
+    let ordinary = "---\nname: shared\ndescription: Ordinary Skill\n---\nOrdinary Skill body\n";
+    tokio::fs::write(&skill, ordinary)
+        .await
+        .expect("ordinary skill");
+    let state = actix_web::web::Data::new(
+        crate::app_state::AppState::new(data.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let app = actix_web::test::init_service(actix_web::App::new().app_data(state).route(
+        "/workflows/{name}",
+        actix_web::web::delete().to(super::delete_workflow),
+    ))
+    .await;
+
+    let deleted = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::delete()
+            .uri("/workflows/shared")
+            .to_request(),
+    )
+    .await;
+    assert!(deleted.status().is_success());
+    assert!(!source.exists());
+    assert_eq!(
+        tokio::fs::read_to_string(&skill)
+            .await
+            .expect("ordinary Skill preserved"),
+        ordinary
+    );
+}
+
+#[actix_web::test]
+async fn concurrent_legacy_updates_leave_one_source_and_no_skill_bundle() {
     let data = tempfile::tempdir().expect("data dir");
     let state = actix_web::web::Data::new(
         crate::app_state::AppState::new(data.path().to_path_buf())
@@ -444,10 +872,11 @@ async fn concurrent_legacy_updates_leave_source_and_bundle_consistent() {
     let source = tokio::fs::read_to_string(data.path().join("workflows/race.md"))
         .await
         .expect("source");
-    let bundle = tokio::fs::read_to_string(data.path().join("skills/race/SKILL.md"))
-        .await
-        .expect("bundle");
-    assert!(bundle.contains(&source));
+    assert!(source == "body one" || source == "body two");
+    assert!(
+        !data.path().join("skills/race/SKILL.md").exists(),
+        "concurrent Workflow writes must not create a Skill"
+    );
     let mut entries = tokio::fs::read_dir(data.path().join("workflows"))
         .await
         .expect("workflow dir");

--- a/crates/app/bamboo-server/src/handlers/skill/listing.rs
+++ b/crates/app/bamboo-server/src/handlers/skill/listing.rs
@@ -22,12 +22,11 @@ pub async fn list_skills(
         let config = state.config.read().await;
         config.disabled_skill_ids()
     };
-    let skills = state
-        .skill_manager
-        .as_ref()
-        .store()
-        .list_skills(Some(filter), refresh)
-        .await
+    let store = state.skill_manager.as_ref().store();
+    let (skills, _skill_catalog) = store
+        .skills_and_catalog_snapshot(Some(filter), refresh)
+        .await;
+    let skills = skills
         .into_iter()
         .filter(|skill| include_disabled || !disabled_skill_ids.contains(&skill.id))
         .collect::<Vec<_>>();
@@ -44,10 +43,8 @@ pub async fn get_skill(
     path: web::Path<String>,
 ) -> Result<HttpResponse, AppError> {
     let id = path.into_inner();
-    let skill = state
-        .skill_manager
-        .as_ref()
-        .store()
+    let store = state.skill_manager.as_ref().store();
+    let skill = store
         .get_skill(&id)
         .await
         .map_err(|_| AppError::NotFound(format!("Skill {} not found", id)))?;

--- a/crates/app/bamboo-server/src/handlers/skill/tests.rs
+++ b/crates/app/bamboo-server/src/handlers/skill/tests.rs
@@ -156,6 +156,156 @@ async fn get_available_workflows_maps_listing_failures_to_internal_error() {
     }
 }
 
+#[actix_web::test]
+async fn historical_legacy_import_bundle_is_not_a_public_skill() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let source = temp_dir.path().join("workflows/legacy.md");
+    tokio::fs::create_dir_all(source.parent().expect("workflow parent"))
+        .await
+        .expect("workflow dir");
+    tokio::fs::write(&source, "Legacy Workflow body\n")
+        .await
+        .expect("workflow source");
+    let bundle = temp_dir.path().join("skills/legacy/SKILL.md");
+    tokio::fs::create_dir_all(bundle.parent().expect("bundle parent"))
+        .await
+        .expect("bundle dir");
+    let bundle_body = format!(
+        "---\nname: legacy\ndescription: Imported legacy workflow\nmetadata:\n  legacy_import: true\n  legacy_name: legacy\n  original_source: '{}'\n---\nLegacy Workflow body\n",
+        source.display()
+    );
+    tokio::fs::write(&bundle, &bundle_body)
+        .await
+        .expect("legacy bundle");
+
+    let state = web::Data::new(
+        AppState::new(temp_dir.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let app = actix_web::test::init_service(
+        actix_web::App::new()
+            .app_data(state)
+            .route("/skills", web::get().to(super::list_skills))
+            .route("/skills/{id}", web::get().to(super::get_skill)),
+    )
+    .await;
+
+    let response = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::get()
+            .uri("/skills?include_disabled=true")
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let listed: serde_json::Value = actix_web::test::read_body_json(response).await;
+    assert!(!listed["skills"]
+        .as_array()
+        .expect("skills")
+        .iter()
+        .any(|skill| skill["id"] == "legacy"));
+
+    let detail = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::get()
+            .uri("/skills/legacy")
+            .to_request(),
+    )
+    .await;
+    assert_eq!(detail.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        tokio::fs::read_to_string(&bundle)
+            .await
+            .expect("bundle preserved"),
+        bundle_body
+    );
+    assert_eq!(
+        tokio::fs::read_to_string(&source)
+            .await
+            .expect("source preserved"),
+        "Legacy Workflow body\n"
+    );
+}
+
+#[actix_web::test]
+async fn orchestration_workflow_is_not_a_public_skill_but_explicit_migration_is() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let skills = temp_dir.path().join("skills");
+    let orchestration = skills.join("deploy");
+    tokio::fs::create_dir_all(&orchestration)
+        .await
+        .expect("orchestration bundle");
+    tokio::fs::write(
+        orchestration.join("SKILL.md"),
+        "---\nname: deploy\ndescription: Deploy workflow\n---\nDeploy instructions\n",
+    )
+    .await
+    .expect("orchestration instructions");
+    tokio::fs::write(
+        orchestration.join("workflow.yaml"),
+        "id: deploy\nname: Deploy\ndescription: Deploy workflow\nversion: '1'\ncomposition:\n  type: call\n  tool: read_file\n  args: {}\n",
+    )
+    .await
+    .expect("workflow definition");
+
+    let migration = skills.join("migrated");
+    tokio::fs::create_dir_all(&migration)
+        .await
+        .expect("migration bundle");
+    tokio::fs::write(
+        migration.join("SKILL.md"),
+        "---\nname: migrated\ndescription: Explicitly migrated workflow\nmetadata:\n  legacy_migration: true\n  legacy_name: migrated\n  original_source: workflows/migrated.md\n---\nMigrated instructions\n",
+    )
+    .await
+    .expect("migrated skill");
+
+    let state = web::Data::new(
+        AppState::new(temp_dir.path().to_path_buf())
+            .await
+            .expect("app state"),
+    );
+    let app = actix_web::test::init_service(
+        actix_web::App::new()
+            .app_data(state)
+            .route("/skills", web::get().to(super::list_skills))
+            .route("/skills/{id}", web::get().to(super::get_skill)),
+    )
+    .await;
+
+    let response = actix_web::test::call_service(
+        &app,
+        actix_web::test::TestRequest::get()
+            .uri("/skills?include_disabled=true")
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let listed: serde_json::Value = actix_web::test::read_body_json(response).await;
+    let listed_ids = listed["skills"]
+        .as_array()
+        .expect("skills")
+        .iter()
+        .filter_map(|skill| skill["id"].as_str())
+        .collect::<Vec<_>>();
+    assert!(!listed_ids.contains(&"deploy"));
+    assert!(listed_ids.contains(&"migrated"));
+
+    for (id, expected) in [
+        ("deploy", StatusCode::NOT_FOUND),
+        ("migrated", StatusCode::OK),
+    ] {
+        let detail = actix_web::test::call_service(
+            &app,
+            actix_web::test::TestRequest::get()
+                .uri(&format!("/skills/{id}"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(detail.status(), expected, "{id}");
+    }
+}
+
 #[tokio::test]
 async fn filtered_tools_rejects_runner_marker_when_pinned_snapshot_is_missing() {
     let temp_dir = tempfile::tempdir().expect("temp dir");

--- a/crates/app/bamboo-server/src/routes/tests.rs
+++ b/crates/app/bamboo-server/src/routes/tests.rs
@@ -200,6 +200,7 @@ async fn remote_unverified_request_is_blocked_by_access_middleware() {
         let mut config = app_state.config.write().await;
         config.access_control = Some(AccessControlConfig {
             password_enabled: true,
+            repair_required: false,
             password_hash: Some(
                 "a65192f8d645bc4d19765b8ea61bfbb896dc999cb88a4be419518c5493f92c9d".to_string(),
             ),
@@ -228,6 +229,7 @@ async fn lifecycle_hook_dry_run_is_blocked_by_access_middleware() {
         let mut config = app_state.config.write().await;
         config.access_control = Some(AccessControlConfig {
             password_enabled: true,
+            repair_required: false,
             password_hash: Some(
                 "a65192f8d645bc4d19765b8ea61bfbb896dc999cb88a4be419518c5493f92c9d".to_string(),
             ),
@@ -265,6 +267,7 @@ async fn workflow_run_routes_are_blocked_by_the_same_access_middleware() {
         let mut config = app_state.config.write().await;
         config.access_control = Some(AccessControlConfig {
             password_enabled: true,
+            repair_required: false,
             password_hash: Some(
                 "a65192f8d645bc4d19765b8ea61bfbb896dc999cb88a4be419518c5493f92c9d".to_string(),
             ),
@@ -309,6 +312,7 @@ async fn plugin_routes_are_blocked_by_the_same_access_middleware() {
         let mut config = app_state.config.write().await;
         config.access_control = Some(AccessControlConfig {
             password_enabled: true,
+            repair_required: false,
             password_hash: Some(
                 "a65192f8d645bc4d19765b8ea61bfbb896dc999cb88a4be419518c5493f92c9d".to_string(),
             ),
@@ -337,6 +341,7 @@ async fn access_bootstrap_endpoints_remain_public() {
         let mut config = app_state.config.write().await;
         config.access_control = Some(AccessControlConfig {
             password_enabled: true,
+            repair_required: false,
             password_hash: Some(
                 "a65192f8d645bc4d19765b8ea61bfbb896dc999cb88a4be419518c5493f92c9d".to_string(),
             ),
@@ -372,6 +377,7 @@ async fn verified_cookie_allows_remote_request_through_middleware() {
         let mut config = app_state.config.write().await;
         config.access_control = Some(AccessControlConfig {
             password_enabled: true,
+            repair_required: false,
             password_hash: Some(
                 "a65192f8d645bc4d19765b8ea61bfbb896dc999cb88a4be419518c5493f92c9d".to_string(),
             ),
@@ -469,6 +475,7 @@ async fn local_request_bypasses_access_middleware() {
         let mut config = app_state.config.write().await;
         config.access_control = Some(AccessControlConfig {
             password_enabled: true,
+            repair_required: false,
             password_hash: Some(
                 "a65192f8d645bc4d19765b8ea61bfbb896dc999cb88a4be419518c5493f92c9d".to_string(),
             ),
@@ -554,6 +561,7 @@ async fn v2_stream_upgrade_is_open_but_siblings_stay_gated() {
         let mut config = app_state.config.write().await;
         config.access_control = Some(AccessControlConfig {
             password_enabled: true,
+            repair_required: false,
             password_hash: Some(
                 "a65192f8d645bc4d19765b8ea61bfbb896dc999cb88a4be419518c5493f92c9d".to_string(),
             ),
@@ -619,6 +627,7 @@ const SECRET_SALT: &str = "01010101010101010101010101010101";
 fn password_access_control() -> AccessControlConfig {
     AccessControlConfig {
         password_enabled: true,
+        repair_required: false,
         password_hash: Some(SECRET_HASH.to_string()),
         password_salt: Some(SECRET_SALT.to_string()),
         password_credential_ref: None,

--- a/crates/app/bamboo-server/tests/ws_v2_live.rs
+++ b/crates/app/bamboo-server/tests/ws_v2_live.rs
@@ -371,6 +371,7 @@ fn with_device(config: &mut bamboo_config::Config) -> (DeviceCredential, String)
     };
     config.access_control = Some(AccessControlConfig {
         password_enabled: false,
+        repair_required: false,
         password_hash: None,
         password_salt: None,
         password_credential_ref: None,

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -224,6 +224,12 @@ pub struct AccessControlConfig {
     /// Whether password protection is enabled.
     #[serde(default)]
     pub password_enabled: bool,
+    /// A malformed legacy verifier or device record was isolated into the
+    /// encrypted recovery store and needs an explicit user repair. Runtime
+    /// authorization treats this as fail-closed even when no usable verifier
+    /// can be hydrated.
+    #[serde(default)]
+    pub repair_required: bool,
     /// Runtime-only password verifier hash. Legacy documents may still
     /// deserialize it for migration, but ordinary section serialization never
     /// writes verifier material.
@@ -5402,6 +5408,7 @@ mod tests {
         // identical for instances that never paired a device.
         let access = AccessControlConfig {
             password_enabled: true,
+            repair_required: false,
             password_hash: Some("deadbeef".to_string()),
             password_salt: Some("01020304".to_string()),
             password_credential_ref: None,
@@ -5432,6 +5439,7 @@ mod tests {
         };
         let access = AccessControlConfig {
             password_enabled: true,
+            repair_required: false,
             password_hash: Some("deadbeef".to_string()),
             password_salt: Some("01020304".to_string()),
             password_credential_ref: None,

--- a/crates/infra/bamboo-config/src/credential_migration.rs
+++ b/crates/infra/bamboo-config/src/credential_migration.rs
@@ -16,6 +16,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex, Weak};
 
+use base64::Engine as _;
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -715,14 +716,16 @@ pub(crate) fn plan_facade_compound_credentials(
         .map(ToOwned::to_owned)
     {
         primary_authority.access_control = true;
-        if let Some(section) = plan_access_control_document(original, &mut primary_extracted, 1)? {
+        if let Some(section) =
+            plan_access_control_document(original, &mut primary_extracted, 1, "section")?
+        {
             source_overrides.insert(ACCESS_CONTROL_FILE.to_string(), section.bytes);
         }
     }
 
     if let Some(original) = source_snapshot.bytes(CONFIG_FILE)?.map(ToOwned::to_owned) {
         let mut root_extracted = Vec::new();
-        let planned = plan_facade_root_document(original.clone(), &mut root_extracted, 1)?;
+        let planned = plan_facade_root_document(original.clone(), &mut root_extracted, 1, "root")?;
         let mut candidate = planned
             .as_ref()
             .map(|section| section.bytes.clone())
@@ -859,8 +862,12 @@ pub(crate) fn plan_facade_compound_credentials(
         if let Some(original) = source_snapshot.bytes(&access_name)?.map(ToOwned::to_owned) {
             if serde_json::from_slice::<Value>(&original).is_ok() {
                 let mut access_extracted = Vec::new();
-                let planned =
-                    plan_access_control_document(original.clone(), &mut access_extracted, 1)?;
+                let planned = plan_access_control_document(
+                    original.clone(),
+                    &mut access_extracted,
+                    1,
+                    &format!("section.{suffix}"),
+                )?;
                 discard_shadowed_sidecar_backup_secrets(&mut access_extracted, &primary_authority);
                 if let Some(section) = planned {
                     generation_extracted.extend(access_extracted);
@@ -878,7 +885,12 @@ pub(crate) fn plan_facade_compound_credentials(
         if let Some(original) = source_snapshot.bytes(&config_name)?.map(ToOwned::to_owned) {
             if serde_json::from_slice::<Value>(&original).is_ok() {
                 let mut root_extracted = Vec::new();
-                let planned = plan_facade_root_document(original.clone(), &mut root_extracted, 1)?;
+                let planned = plan_facade_root_document(
+                    original.clone(),
+                    &mut root_extracted,
+                    1,
+                    &format!("root.{suffix}"),
+                )?;
                 let mut candidate = planned
                     .as_ref()
                     .map(|section| section.bytes.clone())
@@ -975,6 +987,9 @@ enum ExtractedSecretKind {
     ExternalBroker,
     Connect,
     AccessControl,
+    /// Server-owned encrypted recovery payload for malformed legacy access
+    /// data. It is never referenced by the public runtime projection.
+    AccessControlRepair,
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -1252,6 +1267,22 @@ pub(crate) fn migrate_cluster_credentials_locked(
     migrate_cluster_locked(data_dir, None)
 }
 
+pub(crate) fn migrate_access_control_credentials_for_facade_locked(
+    data_dir: &Path,
+) -> ConfigStoreResult<CredentialMigrationOutcome> {
+    migrate_access_control_locked(data_dir, None)
+}
+
+pub(crate) fn access_control_requires_opaque_repair(data_dir: &Path) -> ConfigStoreResult<bool> {
+    let Some(bytes) = read_optional_target(&data_dir.join(ACCESS_CONTROL_FILE))? else {
+        return Ok(false);
+    };
+    let Ok(mut document) = serde_json::from_slice::<Value>(&bytes) else {
+        return Ok(true);
+    };
+    Ok(section_data_mut(&mut document).is_err())
+}
+
 /// Run the provider/MCP/root planner and every ownership/decryption check
 /// without creating the migration lock or staging any bytes. This is the
 /// facade's zero-write gate before independently-scoped migrations begin.
@@ -1279,7 +1310,7 @@ pub(crate) fn preflight_provider_mcp_credential_migration(
     };
     let mut root_extracted = Vec::new();
     let root = match read_optional_target(&data_dir.join(CONFIG_FILE))? {
-        Some(original) => plan_facade_root_document(original, &mut root_extracted, 1)?,
+        Some(original) => plan_facade_root_document(original, &mut root_extracted, 1, "root")?,
         None => None,
     };
     discard_shadowed_root_secrets(&mut root_extracted, &authority);
@@ -2246,7 +2277,7 @@ pub fn read_exact_credential_section_snapshot(
         )?;
         ensure_provider_mcp_migration_ready(data_dir)?;
 
-        let (config, envelope) = if expected_revision.is_some() {
+        let (config, mut envelope) = if expected_revision.is_some() {
             crate::section_facade::load_durable_effective_section_under_migration_lock(
                 data_dir, section,
             )?
@@ -2290,6 +2321,38 @@ pub fn read_exact_credential_section_snapshot(
                 });
             (config, credential_statuses, credential_health)
         };
+        if section == crate::SectionId::AccessControl
+            && runtime.access_control.as_ref().is_some_and(|access| {
+                let password_invalid = access.password_enabled
+                    && (!access.password_configured
+                        || access
+                            .password_credential_ref
+                            .as_ref()
+                            .is_none_or(|reference| {
+                                !credential_statuses.iter().any(|status| {
+                                    &status.credential_ref == reference && status.configured
+                                })
+                            }));
+                let device_invalid = access.devices.iter().any(|device| {
+                    !device.token_configured
+                        || device
+                            .token_credential_ref
+                            .as_ref()
+                            .is_none_or(|reference| {
+                                !credential_statuses.iter().any(|status| {
+                                    &status.credential_ref == reference && status.configured
+                                })
+                            })
+                });
+                access.repair_required
+                    || password_invalid
+                    || device_invalid
+                    || credential_health.status == crate::SectionStatus::Degraded
+            })
+        {
+            envelope.status = crate::SectionStatus::Degraded;
+            envelope.last_error = Some("access-control credential repair is required".to_string());
+        }
 
         Ok(ExactCredentialSectionReadSnapshot {
             section: envelope,
@@ -3964,6 +4027,19 @@ fn persist_exact_credential_transaction_inner(
         .as_ref()
         .map(|section| section.legacy_root.as_slice())
         .unwrap_or(config_original.as_slice());
+    if access_only
+        && !reset_is(ExactTransactionScope::AccessControl)
+        && access_repair_required_from_document(domain_original)?
+        && !config
+            .access_control
+            .as_ref()
+            .is_some_and(|access| access.repair_required)
+    {
+        return Err(ConfigStoreError::Validation(
+            "access-control repair state is server-owned and requires an explicit reset"
+                .to_string(),
+        ));
+    }
     let persisted_instance_refs = provider_instance_refs_from_document(
         if exact_scope == Some(ExactTransactionScope::Providers) {
             domain_original
@@ -4026,6 +4102,7 @@ fn persist_exact_credential_transaction_inner(
             ExactTransactionScope::AccessControl => {
                 references.extend(persisted_access_refs.password.iter().cloned());
                 references.extend(persisted_access_refs.devices.values().cloned());
+                references.extend(access_repair_credential_refs()?);
             }
             ExactTransactionScope::ClusterFabric => {
                 for metadata in persisted_cluster_refs.values() {
@@ -4287,7 +4364,11 @@ fn persist_exact_credential_transaction_inner(
         )
     } else if access_only {
         (
-            prepare_access_control_config_document(domain_original, config)?,
+            prepare_access_control_config_document(
+                domain_original,
+                config,
+                reset_is(ExactTransactionScope::AccessControl),
+            )?,
             providers_original.clone(),
         )
     } else if mcp_only {
@@ -5107,6 +5188,97 @@ fn migrate_broker_locked(
     })
 }
 
+fn migrate_access_control_locked(
+    data_dir: &Path,
+    #[cfg_attr(not(test), allow(unused_variables))] fault: Option<MigrationFault>,
+) -> ConfigStoreResult<CredentialMigrationOutcome> {
+    cleanup_orphan_transaction_dirs(data_dir)?;
+    if let Some(outcome) = recover_committed(
+        data_dir,
+        #[cfg(test)]
+        fault,
+    )? {
+        return Ok(outcome);
+    }
+    discard_uncommitted(data_dir)?;
+
+    let mut extracted = Vec::new();
+    let Some(section) = plan_access_control_section(data_dir, &mut extracted, 1)? else {
+        return Ok(CredentialMigrationOutcome {
+            migrated_credentials: 0,
+            resumed: false,
+        });
+    };
+    let credential_original = read_optional_target(&data_dir.join(CREDENTIALS_FILE))?;
+    let store = CredentialStore::open(data_dir);
+    let resolved = resolve_extracted_secrets(&store, extracted)?;
+    let prepared_credentials = store.prepare_migration(resolved)?;
+
+    let transaction_id = Uuid::new_v4().to_string();
+    let stage_dir_name = format!("{STAGE_PREFIX}{transaction_id}");
+    let stage_dir = data_dir.join(&stage_dir_name);
+    let backup_dir = data_dir.join(format!("{BACKUP_PREFIX}{transaction_id}"));
+    create_private_dir(&stage_dir)?;
+    create_private_dir(&backup_dir)?;
+    sync_dir(data_dir)?;
+
+    let mut staged = Vec::new();
+    stage_file(
+        &stage_dir,
+        &backup_dir,
+        CREDENTIALS_FILE,
+        &prepared_credentials.bytes,
+        credential_original.as_deref(),
+        true,
+        None,
+        InstallMode::Migration,
+        None,
+        &mut staged,
+    )?;
+    stage_file(
+        &stage_dir,
+        &backup_dir,
+        ACCESS_CONTROL_FILE,
+        &section.bytes,
+        Some(&section.original),
+        false,
+        Some(section.migration_generation),
+        InstallMode::Migration,
+        None,
+        &mut staged,
+    )?;
+    restrict_directory_files_to_owner(&stage_dir)?;
+    restrict_directory_files_to_owner(&backup_dir)?;
+    sync_dir(&stage_dir)?;
+    sync_dir(&backup_dir)?;
+
+    let manifest = MigrationManifest {
+        version: MIGRATION_VERSION,
+        transaction_id,
+        stage_dir: stage_dir_name,
+        state: MigrationState::Pending,
+        exact_scope: None,
+        migration_scope: None,
+        source_attestation: BTreeMap::new(),
+        files: staged,
+    };
+    write_manifest(data_dir.join(JOURNAL_FILE), &manifest)?;
+    write_manifest(data_dir.join(MANIFEST_FILE), &manifest)?;
+    let mut manifest = manifest;
+    install_pending(
+        data_dir,
+        &mut manifest,
+        None,
+        #[cfg(test)]
+        fault,
+    )?;
+    finish_transaction(data_dir, manifest)?;
+    Ok(CredentialMigrationOutcome {
+        migrated_credentials: prepared_credentials.added,
+        resumed: false,
+    })
+}
+
 #[cfg(test)]
 fn migrate_cluster_with_fault(
     data_dir: &Path,
@@ -5501,10 +5673,18 @@ fn resolve_extracted_secrets(
         // also makes a fresh plan after an uncommitted crash idempotent.
         let status = store.status_unchecked(&secret.credential_ref)?;
         if status.configured && status.source != crate::CredentialSource::Migrated {
-            if secret.kind == ExtractedSecretKind::EnvVar {
-                return Err(ConfigStoreError::Validation(
-                    "legacy env credential target is already user-managed".to_string(),
-                ));
+            match secret.kind {
+                ExtractedSecretKind::EnvVar => {
+                    return Err(ConfigStoreError::Validation(
+                        "legacy env credential target is already user-managed".to_string(),
+                    ));
+                }
+                ExtractedSecretKind::AccessControlRepair => {
+                    return Err(ConfigStoreError::Validation(
+                        "access recovery target credential is already user-managed".to_string(),
+                    ));
+                }
+                _ => {}
             }
             continue;
         }
@@ -5533,10 +5713,18 @@ fn resolve_extracted_secrets_from_sources(
             .get(&secret.credential_ref)
             .is_some_and(|source| *source != crate::CredentialSource::Migrated)
         {
-            if secret.kind == ExtractedSecretKind::EnvVar {
-                return Err(ConfigStoreError::Validation(
-                    "legacy env credential target is already user-managed".to_string(),
-                ));
+            match secret.kind {
+                ExtractedSecretKind::EnvVar => {
+                    return Err(ConfigStoreError::Validation(
+                        "legacy env credential target is already user-managed".to_string(),
+                    ));
+                }
+                ExtractedSecretKind::AccessControlRepair => {
+                    return Err(ConfigStoreError::Validation(
+                        "access recovery target credential is already user-managed".to_string(),
+                    ));
+                }
+                _ => {}
             }
             continue;
         }
@@ -5568,10 +5756,18 @@ fn resolve_compound_extracted_secrets_from_sources(
     for secret in primary {
         if let Some(source) = sources.get(&secret.credential_ref) {
             if *source != crate::CredentialSource::Migrated {
-                if secret.kind == ExtractedSecretKind::EnvVar {
-                    return Err(ConfigStoreError::Validation(
-                        "legacy env credential target is already user-managed".to_string(),
-                    ));
+                match secret.kind {
+                    ExtractedSecretKind::EnvVar => {
+                        return Err(ConfigStoreError::Validation(
+                            "legacy env credential target is already user-managed".to_string(),
+                        ));
+                    }
+                    ExtractedSecretKind::AccessControlRepair => {
+                        return Err(ConfigStoreError::Validation(
+                            "access recovery target credential is already user-managed".to_string(),
+                        ));
+                    }
+                    _ => {}
                 }
                 continue;
             }
@@ -5588,12 +5784,21 @@ fn resolve_compound_extracted_secrets_from_sources(
         let mut generation_selected = BTreeMap::<CredentialRef, (String, u64)>::new();
         for secret in generation {
             if let Some(source) = sources.get(&secret.credential_ref) {
-                if secret.kind == ExtractedSecretKind::EnvVar
-                    && *source != crate::CredentialSource::Migrated
-                {
-                    return Err(ConfigStoreError::Validation(
-                        "legacy env credential target is already user-managed".to_string(),
-                    ));
+                if *source != crate::CredentialSource::Migrated {
+                    match secret.kind {
+                        ExtractedSecretKind::EnvVar => {
+                            return Err(ConfigStoreError::Validation(
+                                "legacy env credential target is already user-managed".to_string(),
+                            ));
+                        }
+                        ExtractedSecretKind::AccessControlRepair => {
+                            return Err(ConfigStoreError::Validation(
+                                "access recovery target credential is already user-managed"
+                                    .to_string(),
+                            ));
+                        }
+                        _ => {}
+                    }
                 }
                 continue;
             }
@@ -7268,6 +7473,7 @@ fn plan_facade_root_document(
     original: Vec<u8>,
     extracted: &mut Vec<ExtractedSecret>,
     migration_generation: u64,
+    access_repair_slot: &str,
 ) -> ConfigStoreResult<Option<PlannedSection>> {
     let provider =
         plan_provider_instance_document(original.clone(), extracted, migration_generation, true)?;
@@ -7314,7 +7520,14 @@ fn plan_facade_root_document(
     let access_changed = root_after_cluster
         .as_object_mut()
         .and_then(|root| root.get_mut("access_control"))
-        .map(|access| migrate_access_control_credentials(access, extracted, migration_generation))
+        .map(|access| {
+            migrate_access_control_credentials(
+                access,
+                extracted,
+                migration_generation,
+                access_repair_slot,
+            )
+        })
         .transpose()?
         .unwrap_or(false);
     if !provider_changed && !root_mcp && !cluster_changed && !connect_changed && !access_changed {
@@ -7332,24 +7545,44 @@ fn plan_facade_root_document(
     }))
 }
 
+fn plan_access_control_section(
+    data_dir: &Path,
+    extracted: &mut Vec<ExtractedSecret>,
+    minimum_generation: u64,
+) -> ConfigStoreResult<Option<PlannedSection>> {
+    let path = data_dir.join(ACCESS_CONTROL_FILE);
+    let original = match read_file_reject_symlink(&path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    let structurally_parseable = serde_json::from_slice::<Value>(&original)
+        .ok()
+        .is_some_and(|mut document| section_data_mut(&mut document).is_ok());
+    if structurally_parseable {
+        plan_access_control_document(original, extracted, minimum_generation, "section")
+    } else {
+        let migration_generation =
+            opaque_access_control_repair_generation(data_dir, minimum_generation)?;
+        plan_opaque_access_control_document(original, extracted, migration_generation, "section")
+            .map(Some)
+    }
+}
+
 fn plan_access_control_document(
     original: Vec<u8>,
     extracted: &mut Vec<ExtractedSecret>,
     minimum_generation: u64,
+    repair_slot: &str,
 ) -> ConfigStoreResult<Option<PlannedSection>> {
     let mut root: Value = serde_json::from_slice(&original)?;
     let (data, revision) = section_data_mut(&mut root)?;
     let migration_generation = next_revision(revision.unwrap_or(0))?.max(minimum_generation);
-    if !migrate_access_control_credentials(data, extracted, migration_generation)? {
+    if !migrate_access_control_credentials(data, extracted, migration_generation, repair_slot)? {
         return Ok(None);
     }
     let access: Option<crate::AccessControlConfig> = serde_json::from_value(data.clone())?;
     if let Some(access) = access.as_ref() {
-        if access.password_enabled && !access.password_configured {
-            return Err(ConfigStoreError::Validation(
-                "enabled access-control password has no verifier".to_string(),
-            ));
-        }
         if access.devices.iter().any(|device| !device.token_configured) {
             return Err(ConfigStoreError::Validation(
                 "access-control device has no token verifier".to_string(),
@@ -7365,85 +7598,328 @@ fn plan_access_control_document(
     }))
 }
 
+fn opaque_access_control_repair_generation(
+    data_dir: &Path,
+    minimum_generation: u64,
+) -> ConfigStoreResult<u64> {
+    let mut revision_floor = minimum_generation.saturating_sub(1);
+    if let Some(marker) = read_optional_target(&data_dir.join(crate::SECTION_LAYOUT_FILE))? {
+        if let Ok(completion) =
+            crate::section_facade::validate_completed_section_layout_marker(&marker)
+        {
+            if let Some(access) = completion.members.get(ACCESS_CONTROL_FILE) {
+                revision_floor = revision_floor.max(access.revision);
+            }
+        }
+    }
+    for suffix in ["", ".bak", ".bak.1", ".bak.2"] {
+        let Some(bytes) =
+            read_optional_target(&data_dir.join(format!("{ACCESS_CONTROL_FILE}{suffix}")))?
+        else {
+            continue;
+        };
+        let Ok(document) = serde_json::from_slice::<Value>(&bytes) else {
+            continue;
+        };
+        let Some(object) = document.as_object() else {
+            continue;
+        };
+        if object.get("schema_version").and_then(Value::as_u64) == Some(1)
+            && object.contains_key("data")
+        {
+            if let Some(revision) = object.get("revision").and_then(Value::as_u64) {
+                revision_floor = revision_floor.max(revision);
+            }
+        }
+    }
+    next_revision(revision_floor)
+}
+
+fn plan_opaque_access_control_document(
+    original: Vec<u8>,
+    extracted: &mut Vec<ExtractedSecret>,
+    migration_generation: u64,
+    repair_slot: &str,
+) -> ConfigStoreResult<PlannedSection> {
+    let reference = CredentialRef::parse(format!("access_repair.{repair_slot}.payload"))?;
+    let payload = serde_json::to_string(&serde_json::json!({
+        "schema_version": 1,
+        "source_slot": repair_slot,
+        "encoding": "base64",
+        "access_control_bytes": base64::engine::general_purpose::STANDARD.encode(&original),
+    }))?;
+    extracted.push(ExtractedSecret {
+        credential_ref: reference,
+        value: LegacySecret::Plaintext(payload),
+        migration_generation,
+        kind: ExtractedSecretKind::AccessControlRepair,
+        env_owner: None,
+        provider_owner: None,
+        mcp_owner: None,
+        connect_owner: None,
+    });
+    let repaired = serde_json::json!({
+        "schema_version": 1,
+        "revision": migration_generation,
+        "data": {
+            "password_enabled": true,
+            "repair_required": true,
+            "password_configured": false
+        }
+    });
+    let bytes = serde_json::to_vec_pretty(&repaired)?;
+    crate::section_facade::validate_section_envelope(
+        ACCESS_CONTROL_FILE,
+        &bytes,
+        migration_generation,
+    )?;
+    Ok(PlannedSection {
+        name: ACCESS_CONTROL_FILE,
+        bytes,
+        original,
+        migration_generation,
+    })
+}
+
+/// Apply the migration projection without publishing any extracted values.
+/// Section-facade preflight uses this exact code path so malformed legacy
+/// AccessControl data cannot pass one parser and fail a later planner.
+pub(crate) fn sanitize_access_control_for_preflight(value: &mut Value) -> ConfigStoreResult<()> {
+    let mut extracted = Vec::new();
+    migrate_access_control_credentials(value, &mut extracted, 1, "preflight")?;
+    Ok(())
+}
+
 fn migrate_access_control_credentials(
     value: &mut Value,
     extracted: &mut Vec<ExtractedSecret>,
     migration_generation: u64,
+    repair_slot: &str,
 ) -> ConfigStoreResult<bool> {
     if value.is_null() {
         return Ok(false);
     }
-    let access = value.as_object_mut().ok_or_else(|| {
-        ConfigStoreError::Validation("access_control must be an object or null".to_string())
-    })?;
-    let mut changed = false;
-    let password_hash = take_nonempty_string(access, "password_hash")?;
-    let password_salt = take_nonempty_string(access, "password_salt")?;
-    match (password_hash, password_salt) {
-        (Some(hash), Some(salt)) => {
-            let reference = existing_or_generated_ref(
-                access.get("password_credential_ref"),
-                "access",
-                "root",
-                "password_verifier",
-            )?;
-            let value = crate::config_crypto::encode_access_verifier(&hash, &salt)?;
-            access.insert(
-                "password_credential_ref".to_string(),
-                Value::String(reference.as_str().to_string()),
-            );
-            access.insert("password_configured".to_string(), Value::Bool(true));
-            extracted.push(ExtractedSecret {
-                credential_ref: reference,
-                value: LegacySecret::Plaintext(value),
-                migration_generation,
-                kind: ExtractedSecretKind::AccessControl,
-                env_owner: None,
-                provider_owner: None,
-                mcp_owner: None,
-                connect_owner: None,
-            });
-            changed = true;
+    let original = value.clone();
+    let mut repair_required = false;
+    let mut access = match value.as_object() {
+        Some(access) => access.clone(),
+        None => {
+            repair_required = true;
+            Map::from_iter([
+                ("password_enabled".to_string(), Value::Bool(true)),
+                ("password_configured".to_string(), Value::Bool(false)),
+            ])
         }
-        (None, None) => {}
-        _ => {
-            return Err(ConfigStoreError::Validation(
-                "legacy access-control password verifier is incomplete".to_string(),
-            ));
+    };
+    let known_access_fields = [
+        "password_enabled",
+        "password_hash",
+        "password_salt",
+        "password_credential_ref",
+        "password_configured",
+        "updated_at",
+        "devices",
+        "repair_required",
+    ];
+    if access
+        .keys()
+        .any(|key| !known_access_fields.contains(&key.as_str()))
+    {
+        repair_required = true;
+        access.retain(|key, _| known_access_fields.contains(&key.as_str()));
+    }
+
+    match access.get("password_enabled") {
+        Some(Value::Bool(_)) | None => {}
+        Some(_) => {
+            // A malformed enablement value must not turn remote authentication
+            // off. Preserve the conservative intent until an explicit repair.
+            access.insert("password_enabled".to_string(), Value::Bool(true));
+            repair_required = true;
         }
     }
-    if let Some(devices) = access.get_mut("devices").and_then(Value::as_array_mut) {
-        for device in devices {
-            let device = device.as_object_mut().ok_or_else(|| {
-                ConfigStoreError::Validation("access-control device must be an object".to_string())
-            })?;
-            let device_id = device
-                .get("device_id")
-                .and_then(Value::as_str)
-                .filter(|id| !id.trim().is_empty())
-                .ok_or_else(|| {
-                    ConfigStoreError::Validation("access-control device id is missing".to_string())
-                })?
-                .to_string();
-            let token_hash = take_nonempty_string(device, "token_hash")?;
-            let token_salt = take_nonempty_string(device, "token_salt")?;
-            match (token_hash, token_salt) {
-                (Some(hash), Some(salt)) => {
-                    let reference = existing_or_generated_ref(
-                        device.get("token_credential_ref"),
-                        "access",
-                        &device_id,
-                        "device_token_verifier",
-                    )?;
-                    let value = crate::config_crypto::encode_access_verifier(&hash, &salt)?;
+    let durable_repair = match access.get("repair_required") {
+        Some(Value::Bool(value)) => *value,
+        None => false,
+        Some(_) => {
+            repair_required = true;
+            true
+        }
+    };
+    if access
+        .get("updated_at")
+        .is_some_and(|updated| !updated.is_null() && !updated.is_string())
+    {
+        access.remove("updated_at");
+        repair_required = true;
+    }
+
+    let password_hash = access.remove("password_hash");
+    let password_salt = access.remove("password_salt");
+    let previous_password_ref = access.remove("password_credential_ref");
+    let previous_password_configured = access.remove("password_configured");
+    let canonical_password = crate::config_crypto::access_password_credential_ref()?;
+    let raw_password_present = password_hash.is_some() || password_salt.is_some();
+    let migrated_password = match (password_hash.as_ref(), password_salt.as_ref()) {
+        (Some(Value::String(hash)), Some(Value::String(salt)))
+            if !hash.is_empty() && !salt.is_empty() =>
+        {
+            match crate::config_crypto::encode_access_verifier(hash, salt) {
+                Ok(verifier) => Some(verifier),
+                Err(_) => {
+                    repair_required = true;
+                    None
+                }
+            }
+        }
+        (None, None) => None,
+        _ => {
+            repair_required = true;
+            None
+        }
+    };
+    if let Some(verifier) = migrated_password {
+        let metadata_valid = previous_password_configured
+            .as_ref()
+            .is_none_or(|value| value.as_bool() == Some(true))
+            && previous_password_ref
+                .as_ref()
+                .is_none_or(|value| value.as_str() == Some(canonical_password.as_str()));
+        repair_required |= !metadata_valid;
+        access.insert(
+            "password_credential_ref".to_string(),
+            Value::String(canonical_password.as_str().to_string()),
+        );
+        access.insert("password_configured".to_string(), Value::Bool(true));
+        extracted.push(ExtractedSecret {
+            credential_ref: canonical_password,
+            value: LegacySecret::Plaintext(verifier),
+            migration_generation,
+            kind: ExtractedSecretKind::AccessControl,
+            env_owner: None,
+            provider_owner: None,
+            mcp_owner: None,
+            connect_owner: None,
+        });
+    } else if !raw_password_present {
+        let configured = previous_password_configured
+            .as_ref()
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let reference = previous_password_ref.as_ref().and_then(Value::as_str);
+        let binding_valid = (configured && reference == Some(canonical_password.as_str()))
+            || (!configured && reference.is_none());
+        let metadata_typed = previous_password_configured
+            .as_ref()
+            .is_none_or(Value::is_boolean)
+            && previous_password_ref.as_ref().is_none_or(Value::is_string);
+        if binding_valid && metadata_typed {
+            if configured {
+                access.insert(
+                    "password_credential_ref".to_string(),
+                    Value::String(canonical_password.as_str().to_string()),
+                );
+                access.insert("password_configured".to_string(), Value::Bool(true));
+            } else if previous_password_configured.is_some() {
+                access.insert("password_configured".to_string(), Value::Bool(false));
+            }
+        } else {
+            repair_required = true;
+            access.insert("password_configured".to_string(), Value::Bool(false));
+        }
+    } else {
+        access.insert("password_configured".to_string(), Value::Bool(false));
+    }
+
+    let original_had_devices = access.contains_key("devices");
+    let original_devices = access.remove("devices");
+    let mut sanitized_devices = Vec::new();
+    let mut seen_device_ids = BTreeSet::new();
+    match original_devices {
+        None => {}
+        Some(Value::Array(devices)) => {
+            for raw_device in devices {
+                let Some(mut device) = raw_device.as_object().cloned() else {
+                    repair_required = true;
+                    continue;
+                };
+                let known_device_fields = [
+                    "device_id",
+                    "label",
+                    "token_hash",
+                    "token_salt",
+                    "token_credential_ref",
+                    "token_configured",
+                    "created_at",
+                    "last_used_at",
+                    "revoked",
+                ];
+                if device
+                    .keys()
+                    .any(|key| !known_device_fields.contains(&key.as_str()))
+                {
+                    repair_required = true;
+                    device.retain(|key, _| known_device_fields.contains(&key.as_str()));
+                }
+                let Some(device_id) = device
+                    .get("device_id")
+                    .and_then(Value::as_str)
+                    .filter(|id| !id.trim().is_empty())
+                    .map(str::to_string)
+                else {
+                    repair_required = true;
+                    continue;
+                };
+                if !seen_device_ids.insert(device_id.clone())
+                    || !device.get("label").is_some_and(Value::is_string)
+                    || !device.get("created_at").is_some_and(Value::is_string)
+                    || device
+                        .get("last_used_at")
+                        .is_some_and(|item| !item.is_null() && !item.is_string())
+                    || device.get("revoked").is_some_and(|item| !item.is_boolean())
+                {
+                    repair_required = true;
+                    continue;
+                }
+
+                let token_hash = device.remove("token_hash");
+                let token_salt = device.remove("token_salt");
+                let previous_ref = device.remove("token_credential_ref");
+                let previous_configured = device.remove("token_configured");
+                let Ok(canonical) = crate::config_crypto::access_device_credential_ref(&device_id)
+                else {
+                    repair_required = true;
+                    continue;
+                };
+                let raw_token_present = token_hash.is_some() || token_salt.is_some();
+                let migrated_token = match (token_hash.as_ref(), token_salt.as_ref()) {
+                    (Some(Value::String(hash)), Some(Value::String(salt)))
+                        if !hash.is_empty() && !salt.is_empty() =>
+                    {
+                        crate::config_crypto::encode_access_verifier(hash, salt).ok()
+                    }
+                    _ => None,
+                };
+                if raw_token_present && migrated_token.is_none() {
+                    repair_required = true;
+                    continue;
+                }
+                if let Some(verifier) = migrated_token {
+                    let metadata_valid = previous_configured
+                        .as_ref()
+                        .is_none_or(|item| item.as_bool() == Some(true))
+                        && previous_ref
+                            .as_ref()
+                            .is_none_or(|item| item.as_str() == Some(canonical.as_str()));
+                    repair_required |= !metadata_valid;
                     device.insert(
                         "token_credential_ref".to_string(),
-                        Value::String(reference.as_str().to_string()),
+                        Value::String(canonical.as_str().to_string()),
                     );
                     device.insert("token_configured".to_string(), Value::Bool(true));
                     extracted.push(ExtractedSecret {
-                        credential_ref: reference,
-                        value: LegacySecret::Plaintext(value),
+                        credential_ref: canonical,
+                        value: LegacySecret::Plaintext(verifier),
                         migration_generation,
                         kind: ExtractedSecretKind::AccessControl,
                         env_owner: None,
@@ -7451,16 +7927,66 @@ fn migrate_access_control_credentials(
                         mcp_owner: None,
                         connect_owner: None,
                     });
-                    changed = true;
+                } else {
+                    let configured = previous_configured
+                        .as_ref()
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false);
+                    let metadata_valid = configured
+                        && previous_ref.as_ref().and_then(Value::as_str)
+                            == Some(canonical.as_str())
+                        && previous_configured.as_ref().is_some_and(Value::is_boolean)
+                        && previous_ref.as_ref().is_some_and(Value::is_string);
+                    if !metadata_valid {
+                        repair_required = true;
+                        continue;
+                    }
+                    device.insert(
+                        "token_credential_ref".to_string(),
+                        Value::String(canonical.as_str().to_string()),
+                    );
+                    device.insert("token_configured".to_string(), Value::Bool(true));
                 }
-                (None, None) => {}
-                _ => {
-                    return Err(ConfigStoreError::Validation(format!(
-                        "legacy access-control device '{device_id}' verifier is incomplete"
-                    )));
+                if serde_json::from_value::<crate::DeviceCredential>(Value::Object(device.clone()))
+                    .is_err()
+                {
+                    repair_required = true;
+                    continue;
                 }
+                sanitized_devices.push(Value::Object(device));
             }
         }
+        Some(_) => {
+            repair_required = true;
+        }
+    }
+    if original_had_devices || !sanitized_devices.is_empty() {
+        access.insert("devices".to_string(), Value::Array(sanitized_devices));
+    }
+
+    access.insert(
+        "repair_required".to_string(),
+        Value::Bool(durable_repair || repair_required),
+    );
+    *value = Value::Object(access);
+    let changed = *value != original;
+    if repair_required {
+        let reference = CredentialRef::parse(format!("access_repair.{repair_slot}.payload"))?;
+        let payload = serde_json::to_string(&serde_json::json!({
+            "schema_version": 1,
+            "source_slot": repair_slot,
+            "access_control": original.clone(),
+        }))?;
+        extracted.push(ExtractedSecret {
+            credential_ref: reference,
+            value: LegacySecret::Plaintext(payload),
+            migration_generation,
+            kind: ExtractedSecretKind::AccessControlRepair,
+            env_owner: None,
+            provider_owner: None,
+            mcp_owner: None,
+            connect_owner: None,
+        });
     }
     Ok(changed)
 }
@@ -8906,6 +9432,35 @@ fn connect_domain_changed(current: &[u8], candidate: &[u8]) -> ConfigStoreResult
     Ok(current.get("connect") != candidate.get("connect"))
 }
 
+fn access_repair_required_from_document(bytes: &[u8]) -> ConfigStoreResult<bool> {
+    let root = parse_config_root_object(
+        bytes,
+        "config.json is invalid during access-control credential transaction",
+    )?;
+    Ok(root
+        .get("access_control")
+        .and_then(Value::as_object)
+        .and_then(|access| access.get("repair_required"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false))
+}
+
+fn access_repair_credential_refs() -> ConfigStoreResult<Vec<CredentialRef>> {
+    [
+        "section",
+        "section.bak",
+        "section.bak.1",
+        "section.bak.2",
+        "root",
+        "root.bak",
+        "root.bak.1",
+        "root.bak.2",
+    ]
+    .into_iter()
+    .map(|slot| CredentialRef::parse(format!("access_repair.{slot}.payload")))
+    .collect()
+}
+
 fn access_refs_from_document(
     bytes: &[u8],
 ) -> ConfigStoreResult<crate::credential_store::PersistedAccessCredentialRefs> {
@@ -8968,7 +9523,20 @@ fn access_refs_from_document(
 fn prepare_access_control_config_document(
     current: &[u8],
     candidate: &crate::Config,
+    allow_repair_clear: bool,
 ) -> ConfigStoreResult<Vec<u8>> {
+    if !allow_repair_clear
+        && access_repair_required_from_document(current)?
+        && !candidate
+            .access_control
+            .as_ref()
+            .is_some_and(|access| access.repair_required)
+    {
+        return Err(ConfigStoreError::Validation(
+            "access-control repair state is server-owned and requires an explicit reset"
+                .to_string(),
+        ));
+    }
     let mut root = parse_config_root_object(
         current,
         "config.json is invalid during access-control credential transaction",
@@ -10353,6 +10921,11 @@ fn ensure_access_consumers_or_abort(
     let staged_refs = access_refs_from_document(&staged)?;
     let original_refs = access_refs_from_document(&original)?;
     for raw in &credential_file.touched_credential_refs {
+        if raw.starts_with("access_repair.") {
+            // Internal quarantine records intentionally have no public config
+            // consumer. An explicit AccessControl reset owns and clears them.
+            continue;
+        }
         let owner = if staged_refs
             .password
             .as_ref()
@@ -12350,6 +12923,9 @@ fn rebase_changed_section(
         PROVIDERS_FILE => plan_provider_section(data_dir, &mut extracted, minimum_generation)?,
         MCP_FILE => plan_mcp_section(data_dir, &mut extracted, minimum_generation)?,
         BROKER_FILE => plan_broker_section(data_dir, &mut extracted, minimum_generation)?,
+        ACCESS_CONTROL_FILE => {
+            plan_access_control_section(data_dir, &mut extracted, minimum_generation)?
+        }
         CONFIG_FILE if manifest.migration_scope == Some(MigrationScope::ClusterFabric) => {
             plan_cluster_section(data_dir, &mut extracted, minimum_generation, false)?
         }
@@ -16593,6 +17169,7 @@ mod tests {
                 let marker = format!("{:064x}", suffix + 1);
                 config.access_control = Some(crate::AccessControlConfig {
                     password_enabled: true,
+                    repair_required: false,
                     password_hash: Some(marker.clone()),
                     password_salt: Some("03".repeat(16)),
                     password_credential_ref: None,
@@ -17010,6 +17587,7 @@ mod tests {
             let unrelated = install_unrelated_credential(dir.path(), "access-unrelated-winner");
             candidate.access_control = Some(crate::AccessControlConfig {
                 password_enabled: true,
+                repair_required: false,
                 password_hash: Some("a".repeat(64)),
                 password_salt: Some("01".repeat(16)),
                 password_credential_ref: None,
@@ -17094,6 +17672,7 @@ mod tests {
                 ExactTransactionScope::AccessControl => {
                     candidate.access_control = Some(crate::AccessControlConfig {
                         password_enabled: true,
+                        repair_required: false,
                         password_hash: Some("b".repeat(64)),
                         password_salt: Some("02".repeat(16)),
                         password_credential_ref: None,
@@ -17629,6 +18208,7 @@ mod tests {
         let (mut candidate, revision) = active_facade_config_and_credential_revision(dir.path());
         candidate.access_control = Some(crate::AccessControlConfig {
             password_enabled: true,
+            repair_required: false,
             password_hash: Some("a".repeat(64)),
             password_salt: Some("01".repeat(16)),
             password_credential_ref: None,

--- a/crates/infra/bamboo-config/src/credential_store.rs
+++ b/crates/infra/bamboo-config/src/credential_store.rs
@@ -266,6 +266,10 @@ impl CredentialDocumentLkg {
         self.document
             .entries
             .iter()
+            // Recovery payloads are server-owned quarantine records, not
+            // runtime credentials. Do not disclose their fixed slots through
+            // status/list APIs; AccessControl exposes only repair_required.
+            .filter(|(credential_ref, _)| !credential_ref.as_str().starts_with("access_repair."))
             .map(|(credential_ref, entry)| {
                 let configured = if active_refs.contains(credential_ref) {
                     crate::encryption::decrypt(&entry.ciphertext)
@@ -382,6 +386,7 @@ impl CredentialStore {
         &self,
         credential_ref: &CredentialRef,
     ) -> ConfigStoreResult<(CredentialStatus, CredentialStoreHealth)> {
+        reject_internal_recovery_ref(credential_ref)?;
         self.with_transaction_lock(|| self.status_with_health_unchecked(credential_ref))
     }
 
@@ -571,6 +576,7 @@ impl CredentialStore {
         expected_revision: u64,
         authority: CredentialCommitAuthority<'_>,
     ) -> ConfigStoreResult<CredentialMutation> {
+        reject_internal_recovery_ref(&credential_ref)?;
         if secret.trim().is_empty() || crate::patch::is_masked_api_key(secret) {
             return Err(ConfigStoreError::Validation(
                 "credential value must not be empty or a mask; use clear instead".to_string(),
@@ -693,9 +699,13 @@ impl CredentialStore {
                         .to_string(),
                 ));
             }
+            let (mut document, _) = self.load_document_with_health()?;
+            document
+                .entries
+                .retain(|reference, _| is_internal_recovery_ref(reference));
             let revision = self.store.commit(
                 expected_revision,
-                CredentialDocument::default(),
+                document,
                 validate_document,
             )?;
             Ok((revision, Vec::new()))
@@ -802,6 +812,7 @@ impl CredentialStore {
         expected_revision: u64,
         authority: CredentialCommitAuthority<'_>,
     ) -> ConfigStoreResult<CredentialMutation> {
+        reject_internal_recovery_ref(credential_ref)?;
         let mut document = match authority.document(expected_revision)? {
             Some(document) => document,
             None => self.load_document()?,
@@ -2915,10 +2926,24 @@ impl CredentialStore {
     }
 }
 
+fn is_internal_recovery_ref(credential_ref: &CredentialRef) -> bool {
+    credential_ref.as_str().starts_with("access_repair.")
+}
+
+fn reject_internal_recovery_ref(credential_ref: &CredentialRef) -> ConfigStoreResult<()> {
+    if is_internal_recovery_ref(credential_ref) {
+        return Err(ConfigStoreError::Validation(
+            "credential reference is reserved for internal recovery".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn credential_statuses(document: &CredentialDocument) -> Vec<CredentialStatus> {
     document
         .entries
         .iter()
+        .filter(|(credential_ref, _)| !is_internal_recovery_ref(credential_ref))
         .map(|(credential_ref, entry)| CredentialStatus {
             credential_ref: credential_ref.clone(),
             configured: true,

--- a/crates/infra/bamboo-config/src/section_facade.rs
+++ b/crates/infra/bamboo-config/src/section_facade.rs
@@ -1953,7 +1953,6 @@ fn validate_access_control(value: &AccessControlSection) -> Result<(), String> {
         if access.password_hash.is_some()
             || access.password_salt.is_some()
             || access.password_configured != access.password_credential_ref.is_some()
-            || (access.password_enabled && !access.password_configured)
         {
             return Err("access-control password verifier metadata is not isolated".to_string());
         }
@@ -2238,6 +2237,12 @@ fn load_strict_root(
     }
     if read_planning_source(data_dir, "connect.json", overrides)?.is_some() {
         effective_root.remove("connect");
+    }
+    if let Some(access) = effective_root.get_mut("access_control") {
+        // Strict root decoding must use the same secret-free repair projection
+        // as the later compound planner. Otherwise one malformed verifier
+        // disables every typed section before AccessControl can be isolated.
+        scrub_preflight_access_control_secrets(access)?;
     }
     let config = serde_json::from_value::<Config>(effective).map_err(|error| {
         crate::ConfigStoreError::Validation(format!(
@@ -2527,6 +2532,14 @@ fn scrub_preflight_connect_secrets(raw: &mut Value) {
     }
 }
 
+/// Mirror the credential planner's AccessControl extraction in the zero-write
+/// facade preflight by invoking the same pure sanitizer against a clone. The
+/// returned extraction plan is intentionally discarded: durable writes remain
+/// owned by the migration transaction after every preflight succeeds.
+fn scrub_preflight_access_control_secrets(raw: &mut Value) -> ConfigStoreResult<()> {
+    crate::credential_migration::sanitize_access_control_for_preflight(raw)
+}
+
 fn preflight_legacy_root_sections(
     data_dir: &Path,
     input: &StrictPlanningInput,
@@ -2592,6 +2605,7 @@ fn preflight_legacy_root_sections(
             SectionId::Env => scrub_preflight_env_secrets(&mut data),
             SectionId::ClusterFabric => scrub_preflight_cluster_secrets(&mut data),
             SectionId::Connect => scrub_preflight_connect_secrets(&mut data),
+            SectionId::AccessControl => scrub_preflight_access_control_secrets(&mut data)?,
             SectionId::Credentials => unreachable!("credentials were skipped above"),
             _ => {}
         }
@@ -3008,6 +3022,16 @@ pub fn migrate_config_facade_layout(
     let mut recovered = false;
     for _ in 0..4 {
         recovered |= crate::recover_pending_config_transaction(data_dir)?;
+        if section_layout_is_active(data_dir)?
+            && crate::credential_migration::access_control_requires_opaque_repair(data_dir)?
+        {
+            let access = crate::credential_migration::with_migration_lock(data_dir, || {
+                crate::credential_migration::migrate_access_control_credentials_for_facade_locked(
+                    data_dir,
+                )
+            })?;
+            recovered |= access.resumed;
+        }
         let source_before = preflight_source_hashes(data_dir)?;
         let preflight = (|| {
             let broker_ready = preflight_broker_document(data_dir)?;
@@ -3049,6 +3073,8 @@ pub fn migrate_config_facade_layout(
                     migrate_provider_mcp_credentials_for_facade_locked(data_dir)?;
                 let cluster =
                     crate::credential_migration::migrate_cluster_credentials_locked(data_dir)?;
+                let access = crate::credential_migration::
+                    migrate_access_control_credentials_for_facade_locked(data_dir)?;
                 let mut broker_resumed = false;
                 if broker_ready {
                     match crate::credential_migration::migrate_external_broker_credentials_locked(
@@ -3067,7 +3093,11 @@ pub fn migrate_config_facade_layout(
                 }
                 return Ok(Some(crate::SectionMigrationOutcome {
                     activated: false,
-                    resumed: recovered || provider.resumed || cluster.resumed || broker_resumed,
+                    resumed: recovered
+                        || provider.resumed
+                        || cluster.resumed
+                        || access.resumed
+                        || broker_resumed,
                 }));
             }
 
@@ -3344,6 +3374,37 @@ pub(crate) fn current_members_satisfy_completion(
         } else {
             match validate_section_envelope(descriptor.file_name, &bytes, 0) {
                 Ok(revision) => revision,
+                Err(_) if descriptor.id == SectionId::AccessControl => {
+                    // Access is the sole section whose damaged bytes can be
+                    // projected into an encrypted, fail-closed repair record.
+                    // Keep validating every structurally recoverable revision
+                    // below, but let opaque Access damage through recovery so
+                    // it cannot revoke the already-attested unrelated layout.
+                    let Ok(mut envelope) = serde_json::from_slice::<Value>(&bytes) else {
+                        continue;
+                    };
+                    let Some(object) = envelope.as_object_mut() else {
+                        continue;
+                    };
+                    if object.get("schema_version").and_then(Value::as_u64)
+                        != Some(u64::from(SECTION_SCHEMA_VERSION))
+                    {
+                        continue;
+                    }
+                    let Some(revision) = object.get("revision").and_then(Value::as_u64) else {
+                        continue;
+                    };
+                    let Some(data) = object.get_mut("data") else {
+                        continue;
+                    };
+                    if crate::credential_migration::sanitize_access_control_for_preflight(data)
+                        .is_err()
+                        || validate_section_data(descriptor.file_name, data).is_err()
+                    {
+                        continue;
+                    }
+                    revision
+                }
                 Err(_) => return Ok(false),
             }
         };
@@ -5290,6 +5351,7 @@ fn layout_not_committed() -> crate::ConfigStoreError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::Engine as _;
     use serde_json::json;
     use std::collections::BTreeSet;
     use tempfile::TempDir;
@@ -5412,6 +5474,33 @@ mod tests {
         let mut snapshot = BTreeMap::new();
         visit(root, root, &mut snapshot);
         snapshot
+    }
+
+    fn assert_no_plaintext_in_persistent_files(root: &Path, forbidden: &[&str]) {
+        fn visit(root: &Path, current: &Path, forbidden: &[&str]) {
+            for entry in std::fs::read_dir(current).unwrap().map(Result::unwrap) {
+                let path = entry.path();
+                if entry.file_type().unwrap().is_dir() {
+                    visit(root, &path, forbidden);
+                    continue;
+                }
+                if path.extension().and_then(|extension| extension.to_str()) == Some("lock") {
+                    continue;
+                }
+                let bytes = std::fs::read(&path).unwrap();
+                for sentinel in forbidden {
+                    assert!(
+                        !bytes
+                            .windows(sentinel.len())
+                            .any(|window| window == sentinel.as_bytes()),
+                        "{} leaked plaintext sentinel {sentinel}",
+                        path.strip_prefix(root).unwrap().display()
+                    );
+                }
+            }
+        }
+
+        visit(root, root, forbidden);
     }
 
     fn section_document(revision: u64, data: Value) -> Value {
@@ -5807,6 +5896,510 @@ mod tests {
                 bytes
             );
         }
+    }
+
+    #[test]
+    fn incomplete_enabled_access_control_keeps_facade_available_and_reports_repair_state() {
+        let _key = crate::encryption::set_test_encryption_key([0xa1; 32]);
+        let dir = TempDir::new().unwrap();
+        write_json(
+            &dir.path().join("config.json"),
+            &json!({
+                "access_control": {
+                    "password_enabled": true
+                },
+                "tools": {"disabled": ["bash"]},
+                "mcp": {}
+            }),
+        );
+
+        let facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let access = facade.registry().access_control.snapshot();
+        let access = access.data.0.as_ref().unwrap();
+        assert!(access.password_enabled);
+        assert!(!access.password_configured);
+        assert!(access.password_credential_ref.is_none());
+        assert!(facade.registry().tools_skills.snapshot().status == SectionStatus::Healthy);
+        assert!(facade.registry().mcp.snapshot().status == SectionStatus::Healthy);
+        assert!(facade.registry().credentials.statuses().is_empty());
+
+        let exact = crate::read_exact_credential_section_snapshot(
+            dir.path(),
+            SectionId::AccessControl,
+            None,
+        )
+        .unwrap();
+        assert_eq!(exact.section.status, SectionStatus::Degraded);
+        assert_eq!(
+            exact.section.last_error.as_deref(),
+            Some("access-control credential repair is required")
+        );
+
+        let before = directory_snapshot(dir.path());
+        let outcome = migrate_config_facade_layout(dir.path()).unwrap();
+        assert!(!outcome.activated);
+        assert_eq!(directory_snapshot(dir.path()), before);
+    }
+
+    #[test]
+    fn corrupted_access_password_metadata_isolated_to_degraded_access_section() {
+        let _key = crate::encryption::set_test_encryption_key([0xa4; 32]);
+        for (label, access, forbidden) in [
+            (
+                "hash-only",
+                json!({
+                    "password_enabled": true,
+                    "password_hash": "orphan-hash"
+                }),
+                "orphan-hash",
+            ),
+            (
+                "salt-only",
+                json!({
+                    "password_enabled": true,
+                    "password_salt": "orphan-salt"
+                }),
+                "orphan-salt",
+            ),
+            (
+                "configured-without-ref",
+                json!({
+                    "password_enabled": true,
+                    "password_configured": true
+                }),
+                "configured-without-ref",
+            ),
+            (
+                "noncanonical-ref",
+                json!({
+                    "password_enabled": true,
+                    "password_configured": true,
+                    "password_credential_ref": "access.other.password_verifier"
+                }),
+                "access.other.password_verifier",
+            ),
+        ] {
+            let dir = TempDir::new().unwrap();
+            write_json(
+                &dir.path().join("config.json"),
+                &json!({
+                    "access_control": access,
+                    "tools": {"disabled": ["bash"]},
+                    "mcp": {}
+                }),
+            );
+
+            let facade = ConfigFacade::open_or_migrate(dir.path())
+                .unwrap_or_else(|error| panic!("{label} must not disable the facade: {error}"));
+            assert_eq!(
+                facade.registry().tools_skills.snapshot().status,
+                SectionStatus::Healthy,
+                "{label}"
+            );
+            assert_eq!(
+                facade.registry().mcp.snapshot().status,
+                SectionStatus::Healthy,
+                "{label}"
+            );
+            let exact = crate::read_exact_credential_section_snapshot(
+                dir.path(),
+                SectionId::AccessControl,
+                None,
+            )
+            .unwrap();
+            assert_eq!(exact.section.status, SectionStatus::Degraded, "{label}");
+            assert_eq!(
+                exact.section.last_error.as_deref(),
+                Some("access-control credential repair is required"),
+                "{label}"
+            );
+            let access: AccessControlSection = serde_json::from_value(exact.section.data).unwrap();
+            let access = access.0.unwrap();
+            assert!(access.password_enabled, "{label}");
+            assert!(!access.password_configured, "{label}");
+            assert!(access.password_credential_ref.is_none(), "{label}");
+            assert!(access.password_hash.is_none(), "{label}");
+            assert!(access.password_salt.is_none(), "{label}");
+            if label != "configured-without-ref" {
+                for name in ["config.json", "access-control.json", "credentials.json"] {
+                    assert!(
+                        !std::fs::read_to_string(dir.path().join(name))
+                            .unwrap()
+                            .contains(forbidden),
+                        "{label} leaked repair material in {name}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn malformed_access_fragments_are_encrypted_in_one_stable_recovery_slot() {
+        let _key = crate::encryption::set_test_encryption_key([0xa5; 32]);
+        let dir = TempDir::new().unwrap();
+        let original_access = json!({
+            "password_enabled": true,
+            "password_hash": "root-hash-fragment",
+            "password_salt": "root-salt-fragment",
+            "devices": [{
+                "device_id": "bamboo_0123456789ab",
+                "label": "Damaged phone",
+                "token_hash": "device-hash-fragment",
+                "token_salt": "device-salt-fragment",
+                "created_at": "2026-07-29T00:00:00Z"
+            }],
+            "future_private_fragment": "payload-private-fragment"
+        });
+        write_json(
+            &dir.path().join("config.json"),
+            &json!({
+                "access_control": original_access,
+                "tools": {"disabled": ["bash"]},
+                "mcp": {}
+            }),
+        );
+
+        let facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        assert_eq!(
+            facade.registry().tools_skills.snapshot().status,
+            SectionStatus::Healthy
+        );
+        assert_eq!(
+            facade.registry().mcp.snapshot().status,
+            SectionStatus::Healthy
+        );
+        let access = facade.registry().access_control.snapshot();
+        let access = access.data.0.as_ref().unwrap();
+        assert!(access.password_enabled);
+        assert!(access.repair_required);
+        assert!(!access.password_configured);
+        assert!(access.devices.is_empty());
+
+        let recovery_ref = CredentialRef::parse("access_repair.root.payload".to_string()).unwrap();
+        let store = CredentialStore::open(dir.path());
+        let recovery = store.resolve(&recovery_ref).unwrap().unwrap();
+        let payload: Value = serde_json::from_str(recovery.expose()).unwrap();
+        assert_eq!(payload["schema_version"], 1);
+        assert_eq!(payload["source_slot"], "root");
+        assert_eq!(payload["access_control"], original_access);
+        assert!(store.statuses().unwrap().is_empty());
+        assert!(store.status_with_health(&recovery_ref).is_err());
+
+        assert_no_plaintext_in_persistent_files(
+            dir.path(),
+            &[
+                "root-hash-fragment",
+                "root-salt-fragment",
+                "device-hash-fragment",
+                "device-salt-fragment",
+                "payload-private-fragment",
+            ],
+        );
+
+        let before = directory_snapshot(dir.path());
+        let second = migrate_config_facade_layout(dir.path()).unwrap();
+        assert!(!second.activated);
+        assert_eq!(directory_snapshot(dir.path()), before);
+        assert!(ConfigFacade::open(dir.path())
+            .unwrap()
+            .registry()
+            .access_control
+            .snapshot()
+            .data
+            .0
+            .as_ref()
+            .is_some_and(|access| access.repair_required));
+    }
+
+    #[test]
+    fn active_layout_quarantines_access_damage_without_accepting_flag_clear() {
+        let _key = crate::encryption::set_test_encryption_key([0xa6; 32]);
+        let dir = TempDir::new().unwrap();
+        let facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let revision = facade.registry().access_control.snapshot().revision;
+        let damaged = json!({
+            "schema_version": SECTION_SCHEMA_VERSION,
+            "revision": revision + 1,
+            "data": {
+                "password_enabled": "yes",
+                "password_hash": "active-layout-secret"
+            }
+        });
+        write_json(&dir.path().join("access-control.json"), &damaged);
+
+        migrate_config_facade_layout(dir.path()).unwrap();
+        let exact = crate::read_exact_credential_section_snapshot(
+            dir.path(),
+            SectionId::AccessControl,
+            None,
+        )
+        .unwrap();
+        assert_eq!(exact.section.status, SectionStatus::Degraded);
+        let exact_revision = exact.section.revision;
+        let mut candidate = Config::default();
+        exact.install_into(&mut candidate);
+        let access = candidate.access_control.as_mut().unwrap();
+        assert!(access.password_enabled);
+        assert!(access.repair_required);
+        access.repair_required = false;
+
+        let before_access = std::fs::read(dir.path().join("access-control.json")).unwrap();
+        let before_credentials = std::fs::read(dir.path().join("credentials.json")).unwrap();
+        let error = crate::persist_access_control_credential_transaction_at_revision(
+            dir.path(),
+            &mut candidate,
+            false,
+            &BTreeSet::new(),
+            exact_revision,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("server-owned"));
+        assert_eq!(
+            std::fs::read(dir.path().join("access-control.json")).unwrap(),
+            before_access
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join("credentials.json")).unwrap(),
+            before_credentials
+        );
+
+        let recovery_ref =
+            CredentialRef::parse("access_repair.section.payload".to_string()).unwrap();
+        let recovery = CredentialStore::open(dir.path())
+            .resolve(&recovery_ref)
+            .unwrap()
+            .unwrap();
+        let payload: Value = serde_json::from_str(recovery.expose()).unwrap();
+        assert_eq!(payload["access_control"], damaged["data"]);
+        assert_no_plaintext_in_persistent_files(dir.path(), &["active-layout-secret"]);
+    }
+
+    #[test]
+    fn active_layout_repairs_syntax_invalid_access_without_disabling_other_sections() {
+        let _key = crate::encryption::set_test_encryption_key([0xa8; 32]);
+        let dir = TempDir::new().unwrap();
+        let initial = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let initial_access_revision = initial.registry().access_control.snapshot().revision;
+        drop(initial);
+
+        let damaged = br#"{ "password_hash": "opaque-access-secret""#;
+        std::fs::write(dir.path().join("access-control.json"), damaged).unwrap();
+
+        let facade = ConfigFacade::open_or_migrate(dir.path())
+            .expect("AccessControl damage must remain section-local");
+        assert_eq!(
+            facade.registry().tools_skills.snapshot().status,
+            SectionStatus::Healthy
+        );
+        assert_eq!(
+            facade.registry().mcp.snapshot().status,
+            SectionStatus::Healthy
+        );
+        let access = facade.registry().access_control.snapshot();
+        let access = access.data.0.as_ref().unwrap();
+        assert!(access.password_enabled);
+        assert!(access.repair_required);
+        assert!(!access.password_configured);
+
+        let tools = facade.registry().tools_skills.snapshot();
+        let mut tools_candidate = serde_json::to_value(tools.data.as_ref()).unwrap();
+        tools_candidate["tools"]["disabled"] = json!(["bash"]);
+        let event = facade
+            .registry()
+            .commit_value(SectionId::ToolsSkills, tools.revision, tools_candidate)
+            .unwrap();
+        assert_eq!(
+            event,
+            ConfigSectionEvent::Changed {
+                section: "tools-skills".to_string(),
+                revision: tools.revision + 1,
+            }
+        );
+
+        let exact = crate::read_exact_credential_section_snapshot(
+            dir.path(),
+            SectionId::AccessControl,
+            None,
+        )
+        .unwrap();
+        assert_eq!(exact.section.status, SectionStatus::Degraded);
+        assert_eq!(
+            exact.section.last_error.as_deref(),
+            Some("access-control credential repair is required")
+        );
+        assert!(validate_section_envelope(
+            "access-control.json",
+            &std::fs::read(dir.path().join("access-control.json")).unwrap(),
+            initial_access_revision + 1,
+        )
+        .is_ok());
+
+        let recovery_ref =
+            CredentialRef::parse("access_repair.section.payload".to_string()).unwrap();
+        let recovery = CredentialStore::open(dir.path())
+            .resolve(&recovery_ref)
+            .unwrap()
+            .unwrap();
+        let payload: Value = serde_json::from_str(recovery.expose()).unwrap();
+        assert_eq!(payload["encoding"], "base64");
+        let encoded = payload["access_control_bytes"].as_str().unwrap();
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .unwrap(),
+            damaged
+        );
+        assert_no_plaintext_in_persistent_files(dir.path(), &["opaque-access-secret"]);
+    }
+
+    #[test]
+    fn access_recovery_slot_collision_aborts_without_mutating_any_source() {
+        let _key = crate::encryption::set_test_encryption_key([0xa7; 32]);
+        let dir = TempDir::new().unwrap();
+        let store = CredentialStore::open(dir.path());
+        let ordinary = CredentialRef::parse("custom.collision.payload").unwrap();
+        store
+            .replace(
+                ordinary,
+                "preexisting-user-value",
+                crate::CredentialSource::User,
+                0,
+            )
+            .unwrap();
+        let credentials_path = dir.path().join("credentials.json");
+        let credentials = std::fs::read_to_string(&credentials_path)
+            .unwrap()
+            .replace("custom.collision.payload", "access_repair.root.payload");
+        std::fs::write(&credentials_path, credentials).unwrap();
+        write_json(
+            &dir.path().join("config.json"),
+            &json!({
+                "access_control": {
+                    "password_enabled": "yes",
+                    "password_hash": "collision-private-fragment"
+                },
+                "tools": {"disabled": ["bash"]},
+                "mcp": {}
+            }),
+        );
+        let before = directory_snapshot(dir.path());
+
+        let error = migrate_config_facade_layout(dir.path()).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("access recovery target credential is already user-managed"));
+        assert_eq!(directory_snapshot(dir.path()), before);
+        assert!(std::fs::read_to_string(dir.path().join("config.json"))
+            .unwrap()
+            .contains("collision-private-fragment"));
+    }
+
+    #[test]
+    fn complete_legacy_access_verifier_migrates_atomically_and_idempotently() {
+        let _key = crate::encryption::set_test_encryption_key([0xa2; 32]);
+        let dir = TempDir::new().unwrap();
+        let hash = "a".repeat(64);
+        let salt = "01".repeat(16);
+        write_json(
+            &dir.path().join("config.json"),
+            &json!({
+                "access_control": {
+                    "password_enabled": true,
+                    "password_hash": hash,
+                    "password_salt": salt
+                }
+            }),
+        );
+
+        let facade = ConfigFacade::open_or_migrate(dir.path()).unwrap();
+        let access = facade.registry().access_control.snapshot();
+        let access = access.data.0.as_ref().unwrap();
+        assert!(access.password_enabled);
+        assert!(access.password_configured);
+        assert_eq!(
+            access
+                .password_credential_ref
+                .as_ref()
+                .map(CredentialRef::as_str),
+            Some("access.root.password_verifier")
+        );
+        assert!(access.password_hash.is_none());
+        assert!(access.password_salt.is_none());
+
+        let mut runtime = facade.effective_config();
+        runtime
+            .hydrate_access_control_credentials_from_store(dir.path())
+            .unwrap();
+        let hydrated = runtime.access_control.as_ref().unwrap();
+        assert_eq!(hydrated.password_hash.as_deref(), Some(hash.as_str()));
+        assert_eq!(hydrated.password_salt.as_deref(), Some(salt.as_str()));
+        for name in ["config.json", "access-control.json", "credentials.json"] {
+            let persisted = std::fs::read_to_string(dir.path().join(name)).unwrap();
+            assert!(!persisted.contains(&hash), "{name} leaked the legacy hash");
+            assert!(!persisted.contains(&salt), "{name} leaked the legacy salt");
+        }
+
+        let before = directory_snapshot(dir.path());
+        let outcome = migrate_config_facade_layout(dir.path()).unwrap();
+        assert!(!outcome.activated);
+        assert_eq!(directory_snapshot(dir.path()), before);
+    }
+
+    #[test]
+    fn legacy_access_verifier_recovers_after_compound_manifest_interruption() {
+        use crate::credential_migration::{
+            install_section_split_migration_with_fault, plan_facade_compound_credentials,
+            FacadeSourceSnapshot, SectionSplitTestFault,
+        };
+
+        let _key = crate::encryption::set_test_encryption_key([0xa3; 32]);
+        let dir = TempDir::new().unwrap();
+        let hash = "b".repeat(64);
+        let salt = "02".repeat(16);
+        write_json(
+            &dir.path().join("config.json"),
+            &json!({
+                "access_control": {
+                    "password_enabled": true,
+                    "password_hash": hash,
+                    "password_salt": salt
+                }
+            }),
+        );
+
+        let source_snapshot = FacadeSourceSnapshot::capture(dir.path()).unwrap();
+        let credentials =
+            plan_facade_compound_credentials(dir.path(), source_snapshot, false).unwrap();
+        let plan = plan_config_facade_compound_layout(dir.path(), false, credentials).unwrap();
+        assert!(install_section_split_migration_with_fault(
+            dir.path(),
+            plan,
+            SectionSplitTestFault::Manifest,
+        )
+        .is_err());
+        assert!(!section_layout_is_active(dir.path()).unwrap());
+
+        let recovered = migrate_config_facade_layout(dir.path()).unwrap();
+        assert!(recovered.resumed);
+        let facade = ConfigFacade::open(dir.path()).unwrap();
+        let mut runtime = facade.effective_config();
+        runtime
+            .hydrate_access_control_credentials_from_store(dir.path())
+            .unwrap();
+        let access = runtime.access_control.as_ref().unwrap();
+        assert_eq!(access.password_hash.as_deref(), Some(hash.as_str()));
+        assert_eq!(access.password_salt.as_deref(), Some(salt.as_str()));
+        assert_eq!(
+            facade.registry().credentials.statuses().len(),
+            1,
+            "recovery must not duplicate the migrated verifier"
+        );
+
+        let before = directory_snapshot(dir.path());
+        let second = migrate_config_facade_layout(dir.path()).unwrap();
+        assert!(!second.activated);
+        assert_eq!(directory_snapshot(dir.path()), before);
     }
 
     #[test]

--- a/crates/infra/bamboo-skills/src/catalog.rs
+++ b/crates/infra/bamboo-skills/src/catalog.rs
@@ -92,10 +92,27 @@ pub struct WorkflowCatalogEntry {
     pub shadowed_candidates: Vec<ShadowedWorkflowCandidate>,
 }
 
+impl WorkflowCatalogEntry {
+    /// Only orchestration bundles and explicit legacy workflow adapters belong
+    /// to the public Workflow identity. Plain instruction Skills stay in the
+    /// Skill catalog even though the runtime shares discovery internals.
+    pub fn is_public_workflow(&self) -> bool {
+        self.kind == WorkflowKind::Orchestration || self.legacy
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct WorkflowCatalogSnapshot {
     pub revision: u64,
     pub entries: Vec<WorkflowCatalogEntry>,
+}
+
+impl WorkflowCatalogSnapshot {
+    pub fn public_workflows(mut self) -> Self {
+        self.entries
+            .retain(WorkflowCatalogEntry::is_public_workflow);
+        self
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -111,6 +128,10 @@ pub struct WorkflowCatalogEvent {
     pub workflow_id: String,
     pub revision: u64,
     pub kind: WorkflowCatalogEventKind,
+    /// Whether this transition belongs to the public Workflow identity rather
+    /// than to an instruction-only Skill sharing the internal catalog.
+    #[serde(default)]
+    pub public_workflow: bool,
     /// `global`, `project:<id>`, or an opaque `workspace:<hash>`; never an
     /// absolute filesystem path.
     pub scope: String,
@@ -326,6 +347,22 @@ mod tests {
         assert!(!json.contains("prompt"));
         assert!(!json.contains("SKILL.md"));
         assert!(!json.contains("references"));
+    }
+
+    #[test]
+    fn workflow_event_decodes_legacy_payload_without_namespace_marker() {
+        let event: WorkflowCatalogEvent = serde_json::from_value(serde_json::json!({
+            "workflow_id": "legacy-review",
+            "revision": 7,
+            "kind": "changed",
+            "scope": "global"
+        }))
+        .expect("older event DTO remains readable");
+
+        assert_eq!(event.workflow_id, "legacy-review");
+        assert_eq!(event.revision, 7);
+        assert_eq!(event.kind, WorkflowCatalogEventKind::Changed);
+        assert!(!event.public_workflow);
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-skills/src/legacy.rs
+++ b/crates/infra/bamboo-skills/src/legacy.rs
@@ -126,6 +126,14 @@ async fn read_bounded_file(path: &Path, max_bytes: usize) -> SkillResult<Vec<u8>
     Ok(bytes)
 }
 
+/// Read one legacy Workflow source without following symlinks and with the
+/// same size bound used by catalog discovery.
+pub async fn read_legacy_markdown_workflow(path: &Path) -> SkillResult<String> {
+    let bytes = read_bounded_file(path, MAX_LEGACY_WORKFLOW_FILE_BYTES).await?;
+    String::from_utf8(bytes)
+        .map_err(|_| SkillError::Validation("legacy workflow is not valid UTF-8".to_string()))
+}
+
 fn validate_legacy_description(description: &str) -> SkillResult<()> {
     if description.contains('<') || description.contains('>') {
         return Err(SkillError::Validation(
@@ -199,8 +207,9 @@ fn parse_legacy_markdown_adapter(
 
 /// Discover legacy markdown workflows without modifying their source directory.
 ///
-/// Each source file becomes a virtual instruction Skill whose root identity is
-/// the source file itself. Virtual legacy skills expose no sibling resources.
+/// Each source file becomes a virtual instruction Workflow whose root identity
+/// is the source file itself. Virtual legacy workflows expose no sibling
+/// resources and never enter Skill activation.
 pub async fn load_legacy_markdown_workflow_records(
     discovery_dirs: &[SkillDiscoveryDir],
     max_file_bytes: usize,

--- a/crates/infra/bamboo-skills/src/lib.rs
+++ b/crates/infra/bamboo-skills/src/lib.rs
@@ -583,7 +583,7 @@ impl SkillManager {
             let original_len = skills.len();
             skills = budget_skills_for_context(
                 skills,
-                &self.store.workflow_catalog_snapshot().await,
+                &self.store.skill_catalog_snapshot().await,
                 request_hint,
                 DEFAULT_WORKFLOW_CATALOG_CONTEXT_TOKENS,
             )
@@ -668,7 +668,7 @@ impl SkillManager {
         .await;
 
         if selected_skill_ids.is_none() {
-            let catalog = store.workflow_catalog_snapshot().await;
+            let catalog = store.skill_catalog_snapshot().await;
             skills = budget_skills_for_context(
                 skills,
                 &catalog,
@@ -1215,6 +1215,146 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn workflows_never_enter_automatic_or_explicit_skill_activation() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let data = directory.path().join("data");
+        let orchestration = data.join("skills/orchestrate");
+        fs::create_dir_all(&orchestration)
+            .await
+            .expect("orchestration root");
+        fs::write(
+            orchestration.join("SKILL.md"),
+            "---\nname: orchestrate\ndescription: Runs a workflow.\n---\nWorkflow support text.\n",
+        )
+        .await
+        .expect("workflow instructions");
+        fs::write(
+            orchestration.join("workflow.yaml"),
+            "id: orchestrate\nname: Orchestrate\ndescription: Runs tools\nversion: '1'\ncomposition:\n  type: call\n  tool: read_file\n  args: {}\n",
+        )
+        .await
+        .expect("workflow metadata");
+        let workflows = data.join("workflows");
+        fs::create_dir_all(&workflows)
+            .await
+            .expect("legacy workflows");
+        fs::write(
+            workflows.join("legacy-review.md"),
+            "---\ndescription: Reviews a legacy change.\n---\nReview it.\n",
+        )
+        .await
+        .expect("legacy workflow");
+
+        let manager = SkillManager::with_config(SkillStoreConfig {
+            skills_dir: data.join("skills"),
+            ..Default::default()
+        });
+        manager.initialize().await.expect("initialize manager");
+
+        let automatic = manager
+            .resolve_skills_for_request_with_mode(
+                &BTreeSet::new(),
+                None,
+                None,
+                Some("orchestrate and review"),
+            )
+            .await;
+        for id in ["orchestrate", "legacy-review"] {
+            assert!(automatic.iter().all(|skill| skill.id != id));
+            let explicit_ids = vec![id.to_string()];
+            let explicit = manager
+                .resolve_skills_for_request_with_mode(
+                    &BTreeSet::new(),
+                    Some(&explicit_ids),
+                    None,
+                    Some("run it"),
+                )
+                .await;
+            assert!(explicit.iter().all(|skill| skill.id != id));
+        }
+        let skill_catalog = manager.store().skill_catalog_snapshot().await;
+        assert!(skill_catalog
+            .entries
+            .iter()
+            .all(|entry| !matches!(entry.id.as_str(), "orchestrate" | "legacy-review")));
+        let workflow_catalog = manager.store().workflow_catalog_snapshot().await;
+        assert!(workflow_catalog
+            .entries
+            .iter()
+            .any(|entry| entry.id == "orchestrate"));
+        assert!(workflow_catalog
+            .entries
+            .iter()
+            .any(|entry| entry.id == "legacy-review"));
+    }
+
+    #[tokio::test]
+    async fn explicit_legacy_migration_is_a_selectable_skill_not_a_workflow_replacement() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let data = directory.path().join("data");
+        let source = data.join("workflows/migrated-review.md");
+        fs::create_dir_all(source.parent().unwrap())
+            .await
+            .expect("workflow root");
+        fs::write(&source, "Review the migrated change.\n")
+            .await
+            .expect("legacy source");
+        crate::legacy::migrate_legacy_markdown_workflow(
+            &source,
+            "workflows/migrated-review.md",
+            &data.join("skills"),
+            "migrated-review",
+            Some("Use when reviewing a migrated change."),
+        )
+        .await
+        .expect("explicit migration");
+        let manager = SkillManager::with_config(SkillStoreConfig {
+            skills_dir: data.join("skills"),
+            ..Default::default()
+        });
+        manager.initialize().await.expect("initialize manager");
+
+        let ids = vec!["migrated-review".to_string()];
+        let explicit = manager
+            .resolve_skills_for_request_with_mode(
+                &BTreeSet::new(),
+                Some(&ids),
+                None,
+                Some("review"),
+            )
+            .await;
+        assert_eq!(
+            explicit
+                .iter()
+                .map(|skill| skill.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["migrated-review"]
+        );
+        assert!(manager
+            .store()
+            .skill_catalog_snapshot()
+            .await
+            .entries
+            .iter()
+            .any(|entry| {
+                entry.id == "migrated-review"
+                    && entry.migration_status
+                        == Some(crate::LegacyWorkflowMigrationStatus::Migrated)
+            }));
+        assert!(manager
+            .store()
+            .workflow_catalog_snapshot()
+            .await
+            .entries
+            .iter()
+            .any(|entry| {
+                entry.id == "migrated-review"
+                    && entry.migration_status
+                        == Some(crate::LegacyWorkflowMigrationStatus::Available)
+            }));
+    }
+
+    #[tokio::test]
     async fn automatic_selection_keeps_lkg_policy_until_recovery() {
         let directory = tempfile::tempdir().expect("tempdir");
         let skills_dir = directory.path().join("skills");
@@ -1261,7 +1401,7 @@ mod tests {
         assert!(resolve().await.iter().any(|skill| skill.id == "steady"));
         let invalid = manager
             .store()
-            .workflow_catalog_snapshot()
+            .skill_catalog_snapshot()
             .await
             .entries
             .into_iter()
@@ -1278,7 +1418,7 @@ mod tests {
         assert!(!resolve().await.iter().any(|skill| skill.id == "steady"));
         let recovered = manager
             .store()
-            .workflow_catalog_snapshot()
+            .skill_catalog_snapshot()
             .await
             .entries
             .into_iter()
@@ -1408,9 +1548,11 @@ mod tests {
         manager.initialize().await.expect("initialize");
         let project_id = bamboo_domain::ProjectId::parse("project-1").expect("project id");
         let project_only = manager
-            .workflow_catalog_for_project_workspace(&project_id, &project_home, None)
+            .store_for_project_workspace(&project_id, &project_home, None)
             .await
-            .expect("project catalog");
+            .expect("project store")
+            .skill_catalog_snapshot()
+            .await;
         assert_eq!(
             project_only
                 .entries
@@ -1422,9 +1564,11 @@ mod tests {
         );
 
         let overlaid = manager
-            .workflow_catalog_for_project_workspace(&project_id, &project_home, Some(&workspace))
+            .store_for_project_workspace(&project_id, &project_home, Some(&workspace))
             .await
-            .expect("overlay catalog");
+            .expect("overlay store")
+            .skill_catalog_snapshot()
+            .await;
         let winner = overlaid
             .entries
             .iter()

--- a/crates/infra/bamboo-skills/src/store/mod.rs
+++ b/crates/infra/bamboo-skills/src/store/mod.rs
@@ -556,6 +556,80 @@ async fn snapshot_skill_resources(
     Ok(snapshots)
 }
 
+fn skill_metadata_flag(skill: &SkillDefinition, name: &str) -> bool {
+    skill.metadata.as_ref().is_some_and(|metadata| {
+        metadata.get(name).and_then(serde_json::Value::as_bool) == Some(true)
+    })
+}
+
+async fn loaded_record_is_workflow(
+    record: &LoadedSkillRecord,
+    previous_workflow_roots: &HashMap<SkillId, PathBuf>,
+) -> bool {
+    // Explicit user-requested migration materializes a real Skill. The
+    // read-only source adapter remains a separate Workflow with the same ID.
+    if skill_metadata_flag(&record.skill, "legacy_migration") {
+        return false;
+    }
+    if skill_metadata_flag(&record.skill, "legacy_adapter")
+        || skill_metadata_flag(&record.skill, "legacy_import")
+    {
+        return true;
+    }
+    if tokio::fs::try_exists(record.skill_root.join("workflow.yaml"))
+        .await
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    match load_bundle_metadata(&record.skill_root).await {
+        Ok(metadata) => metadata.kind == WorkflowKind::Orchestration,
+        Err(_) => previous_workflow_roots.get(&record.skill.id) == Some(&record.skill_root),
+    }
+}
+
+async fn failed_record_is_workflow(
+    record: &FailedSkillRecord,
+    previous_workflow_roots: &HashMap<SkillId, PathBuf>,
+) -> bool {
+    if record
+        .skill_root
+        .extension()
+        .and_then(|value| value.to_str())
+        == Some("md")
+        || tokio::fs::try_exists(record.skill_root.join("workflow.yaml"))
+            .await
+            .unwrap_or(false)
+    {
+        return true;
+    }
+    record
+        .skill_id
+        .as_ref()
+        .is_some_and(|id| previous_workflow_roots.get(id) == Some(&record.skill_root))
+}
+
+fn preserve_catalog_entry_revisions(
+    entries: &mut [WorkflowCatalogEntry],
+    previous_catalog: &WorkflowCatalogSnapshot,
+    definition_changed: &HashSet<String>,
+) {
+    for entry in entries {
+        let Some(previous) = previous_catalog
+            .entries
+            .iter()
+            .find(|previous| previous.id == entry.id)
+        else {
+            continue;
+        };
+        let mut comparable = entry.clone();
+        comparable.revision = previous.revision;
+        if !definition_changed.contains(&entry.id) && comparable == *previous {
+            entry.revision = previous.revision;
+        }
+    }
+}
+
 /// Persistent storage for skills with in-memory caching.
 ///
 /// Manages a collection of skills loaded from Markdown files on disk.
@@ -590,6 +664,14 @@ pub struct SkillStore {
     /// Immutable bytes for every resource in the currently published generation.
     /// Activations retain these snapshots after a watcher publishes a newer bundle.
     skill_resources: RwLock<HashMap<SkillId, SkillResourceSnapshot>>,
+    /// Policy metadata for prompt/explicit Skill activation only.
+    skill_catalog: RwLock<WorkflowCatalogSnapshot>,
+    /// Workflow definitions are published independently from Skills so equal
+    /// IDs can coexist without either identity shadowing the other.
+    workflow_definitions: RwLock<HashMap<SkillId, SkillDefinition>>,
+    workflow_roots: RwLock<HashMap<SkillId, PathBuf>>,
+    workflow_resources: RwLock<HashMap<SkillId, SkillResourceSnapshot>>,
+    /// Public Workflow catalog (legacy adapters and orchestration bundles).
     catalog: RwLock<WorkflowCatalogSnapshot>,
     /// Session/activation-scoped immutable workflow generations. The cache is bounded,
     /// and normal runtime finalization explicitly removes completed activations.
@@ -843,6 +925,10 @@ impl SkillStore {
             skills: RwLock::new(HashMap::new()),
             skill_roots: RwLock::new(HashMap::new()),
             skill_resources: RwLock::new(HashMap::new()),
+            skill_catalog: RwLock::new(WorkflowCatalogSnapshot::default()),
+            workflow_definitions: RwLock::new(HashMap::new()),
+            workflow_roots: RwLock::new(HashMap::new()),
+            workflow_resources: RwLock::new(HashMap::new()),
             catalog: RwLock::new(WorkflowCatalogSnapshot::default()),
             pinned_activations: RwLock::new(PinnedSkillActivations::default()),
             next_revision: AtomicU64::new(1),
@@ -905,17 +991,6 @@ impl SkillStore {
             .parent()
             .map(|parent| parent.join("workflows"))
             .unwrap_or_else(|| PathBuf::from("workflows"));
-        let report = crate::legacy::import_legacy_markdown_workflows(
-            &workflows_dir,
-            &self.config.skills_dir,
-        )
-        .await?;
-        if !report.imported.is_empty() {
-            info!("Imported legacy workflows as skills: {:?}", report.imported);
-        }
-        for diagnostic in report.diagnostics {
-            tracing::warn!("Legacy workflow import: {diagnostic}");
-        }
         self.create_builtin_skills().await?;
         for diagnostic in
             crate::legacy::migrate_legacy_yaml_workflows(&workflows_dir, &self.config.skills_dir)
@@ -961,6 +1036,13 @@ impl SkillStore {
         .await?;
         let mut legacy_dirs =
             crate::legacy::discover_plugin_legacy_workflow_dirs(&plugins_root).await;
+        if let Some(data_dir) = self.config.skills_dir.parent() {
+            legacy_dirs.push(SkillDiscoveryDir {
+                dir: data_dir.join("workflows"),
+                source: SkillDirectorySource::Global,
+                mode: None,
+            });
+        }
         if let Some(workspace) = self.workspace_overlay_dir.as_ref() {
             legacy_dirs.push(SkillDiscoveryDir {
                 dir: workspace.join(".bamboo").join("workflows"),
@@ -979,36 +1061,96 @@ impl SkillStore {
         report.loaded.extend(legacy_report.loaded);
         report.failed.extend(legacy_report.failed);
 
-        let (previous_skills, previous_roots, previous_resources, previous_catalog) = {
+        let (
+            previous_skills,
+            previous_roots,
+            previous_resources,
+            previous_skill_catalog,
+            previous_workflows,
+            previous_workflow_roots,
+            previous_workflow_resources,
+            previous_catalog,
+        ) = {
             let _snapshot_guard = self.snapshot_publish_lock.read().await;
             (
                 self.skills.read().await.clone(),
                 self.skill_roots.read().await.clone(),
                 self.skill_resources.read().await.clone(),
+                self.skill_catalog.read().await.clone(),
+                self.workflow_definitions.read().await.clone(),
+                self.workflow_roots.read().await.clone(),
+                self.workflow_resources.read().await.clone(),
                 self.catalog.read().await.clone(),
             )
         };
+        let mut skill_loaded = Vec::new();
+        let mut workflow_loaded = Vec::new();
+        for record in report.loaded {
+            if loaded_record_is_workflow(&record, &previous_workflow_roots).await {
+                workflow_loaded.push(record);
+            } else {
+                skill_loaded.push(record);
+            }
+        }
+        let mut skill_failed = Vec::new();
+        let mut workflow_failed = Vec::new();
+        for record in report.failed {
+            if failed_record_is_workflow(&record, &previous_workflow_roots).await {
+                workflow_failed.push(record);
+            } else {
+                skill_failed.push(record);
+            }
+        }
+
         let revision = self.next_revision.load(Ordering::SeqCst);
-        let (resolved_skills, resolved_roots, mut entries) = self
+        let (resolved_skills, resolved_roots, mut skill_entries) = self
             .resolve_catalog(
-                report.loaded,
-                report.failed,
+                skill_loaded,
+                skill_failed,
                 &previous_skills,
                 &previous_roots,
+                &previous_skill_catalog,
+                revision,
+            )
+            .await;
+        let (resolved_workflows, resolved_workflow_roots, mut workflow_entries) = self
+            .resolve_catalog(
+                workflow_loaded,
+                workflow_failed,
+                &previous_workflows,
+                &previous_workflow_roots,
                 &previous_catalog,
                 revision,
             )
             .await;
-        let count = resolved_skills.len();
+        for entry in &mut workflow_entries {
+            if !entry.legacy && entry.kind != WorkflowKind::Orchestration {
+                // This partition contains only Workflow identities. A brand
+                // new invalid workflow.yaml has no parsed metadata yet, but it
+                // must remain catalog-visible as a degraded orchestration.
+                entry.kind = WorkflowKind::Orchestration;
+            }
+        }
+        let count = resolved_skills
+            .len()
+            .saturating_add(resolved_workflows.len());
         let resolved_resources = snapshot_skill_resources(
             &resolved_roots,
             &resolved_skills,
-            &entries,
+            &skill_entries,
             &previous_resources,
             self.snapshot_limits,
         )
         .await?;
-        let definition_changed: HashSet<String> = resolved_skills
+        let resolved_workflow_resources = snapshot_skill_resources(
+            &resolved_workflow_roots,
+            &resolved_workflows,
+            &workflow_entries,
+            &previous_workflow_resources,
+            self.snapshot_limits,
+        )
+        .await?;
+        let skill_definition_changed: HashSet<String> = resolved_skills
             .iter()
             .filter(|(id, skill)| {
                 previous_skills.get(*id) != Some(*skill)
@@ -1017,37 +1159,54 @@ impl SkillStore {
             })
             .map(|(id, _)| id.clone())
             .collect();
-        // `WorkflowCatalogEntry::revision` identifies the revision of that workflow,
-        // not merely the revision of the containing snapshot. Preserve it across
-        // unrelated catalog updates so an activation can pin a meaningful definition
-        // revision. Prompt-only changes are covered by `definition_changed` even though
-        // the metadata-only public entry would otherwise compare equal.
-        for entry in &mut entries {
-            let Some(previous) = previous_catalog
-                .entries
-                .iter()
-                .find(|previous| previous.id == entry.id)
-            else {
-                continue;
-            };
-            let mut comparable = entry.clone();
-            comparable.revision = previous.revision;
-            if !definition_changed.contains(&entry.id) && comparable == *previous {
-                entry.revision = previous.revision;
-            }
-        }
-        let next_catalog = WorkflowCatalogSnapshot { revision, entries };
+        let workflow_definition_changed: HashSet<String> = resolved_workflows
+            .iter()
+            .filter(|(id, workflow)| {
+                previous_workflows.get(*id) != Some(*workflow)
+                    || previous_workflow_roots.get(*id) != resolved_workflow_roots.get(*id)
+                    || previous_workflow_resources.get(*id) != resolved_workflow_resources.get(*id)
+            })
+            .map(|(id, _)| id.clone())
+            .collect();
+        // Entry revisions identify each definition generation rather than the
+        // containing publication. Preserve them independently in both
+        // namespaces across unrelated updates.
+        preserve_catalog_entry_revisions(
+            &mut skill_entries,
+            &previous_skill_catalog,
+            &skill_definition_changed,
+        );
+        preserve_catalog_entry_revisions(
+            &mut workflow_entries,
+            &previous_catalog,
+            &workflow_definition_changed,
+        );
+        let next_skill_catalog = WorkflowCatalogSnapshot {
+            revision,
+            entries: skill_entries,
+        };
+        let next_catalog = WorkflowCatalogSnapshot {
+            revision,
+            entries: workflow_entries,
+        };
+        let mut comparable_previous_skill_catalog = previous_skill_catalog.clone();
+        comparable_previous_skill_catalog.revision = revision;
         let mut comparable_previous = previous_catalog.clone();
         comparable_previous.revision = revision;
         if resolved_skills == previous_skills
             && resolved_roots == previous_roots
             && resolved_resources == previous_resources
+            && next_skill_catalog == comparable_previous_skill_catalog
+            && resolved_workflows == previous_workflows
+            && resolved_workflow_roots == previous_workflow_roots
+            && resolved_workflow_resources == previous_workflow_resources
             && next_catalog == comparable_previous
         {
             return Ok(count);
         }
         let publication_definition_bytes = resolved_skills
             .values()
+            .chain(resolved_workflows.values())
             .map(|skill| {
                 serde_json::to_vec(skill)
                     .map(|bytes| bytes.len())
@@ -1055,7 +1214,10 @@ impl SkillStore {
             })
             .sum::<usize>();
         let mut publication_resources = HashMap::<usize, usize>::new();
-        for snapshot in resolved_resources.values() {
+        for snapshot in resolved_resources
+            .values()
+            .chain(resolved_workflow_resources.values())
+        {
             for bytes in snapshot.values() {
                 publication_resources
                     .entry(Arc::as_ptr(bytes) as usize)
@@ -1069,6 +1231,10 @@ impl SkillStore {
         let mut skills_guard = self.skills.write().await;
         let mut roots_guard = self.skill_roots.write().await;
         let mut resources_guard = self.skill_resources.write().await;
+        let mut skill_catalog_guard = self.skill_catalog.write().await;
+        let mut workflows_guard = self.workflow_definitions.write().await;
+        let mut workflow_roots_guard = self.workflow_roots.write().await;
+        let mut workflow_resources_guard = self.workflow_resources.write().await;
         let mut catalog_guard = self.catalog.write().await;
         self.retained_budget.replace_publication(
             self.store_token,
@@ -1080,13 +1246,25 @@ impl SkillStore {
         *skills_guard = resolved_skills;
         *roots_guard = resolved_roots;
         *resources_guard = resolved_resources;
+        *skill_catalog_guard = next_skill_catalog;
+        *workflows_guard = resolved_workflows;
+        *workflow_roots_guard = resolved_workflow_roots;
+        *workflow_resources_guard = resolved_workflow_resources;
         *catalog_guard = next_catalog.clone();
         drop(catalog_guard);
+        drop(workflow_resources_guard);
+        drop(workflow_roots_guard);
+        drop(workflows_guard);
+        drop(skill_catalog_guard);
         drop(resources_guard);
         drop(roots_guard);
         drop(skills_guard);
         drop(_snapshot_guard);
-        self.publish_catalog_events(&previous_catalog, &next_catalog, &definition_changed);
+        self.publish_catalog_events(
+            &previous_catalog,
+            &next_catalog,
+            &workflow_definition_changed,
+        );
 
         Ok(count)
     }
@@ -1155,6 +1333,42 @@ impl SkillStore {
                     Self::Invalid(_) => None,
                 }
             }
+            fn identity_rank(&self) -> u8 {
+                match self {
+                    Self::Valid(record)
+                        if record.skill.metadata.as_ref().is_some_and(|metadata| {
+                            metadata
+                                .get("legacy_import")
+                                .and_then(serde_json::Value::as_bool)
+                                == Some(true)
+                        }) =>
+                    {
+                        1
+                    }
+                    Self::Valid(record)
+                        if record.skill.metadata.as_ref().is_some_and(|metadata| {
+                            metadata
+                                .get("legacy_adapter")
+                                .and_then(serde_json::Value::as_bool)
+                                == Some(true)
+                        }) =>
+                    {
+                        2
+                    }
+                    Self::Invalid(record)
+                        if record
+                            .skill_root
+                            .extension()
+                            .and_then(|value| value.to_str())
+                            == Some("md") =>
+                    {
+                        2
+                    }
+                    // A normal Skill or an explicitly migrated legacy bundle
+                    // keeps existing precedence over a read-only adapter.
+                    _ => 3,
+                }
+            }
         }
 
         let mut grouped: HashMap<String, Vec<Candidate>> = HashMap::new();
@@ -1185,6 +1399,7 @@ impl SkillStore {
                 Self::source_rank(right.source())
                     .cmp(&Self::source_rank(left.source()))
                     .then_with(|| right.mode().is_some().cmp(&left.mode().is_some()))
+                    .then_with(|| right.identity_rank().cmp(&left.identity_rank()))
                     .then_with(|| left.root().cmp(right.root()))
             });
             let Some(winner) = candidates.first() else {
@@ -1283,6 +1498,24 @@ impl SkillStore {
         self.catalog.read().await.clone()
     }
 
+    /// Return Skill activation metadata from the same publication machinery as
+    /// the public Workflow catalog, but from its independent namespace.
+    pub async fn skill_catalog_snapshot(&self) -> WorkflowCatalogSnapshot {
+        let _snapshot_guard = self.snapshot_publish_lock.read().await;
+        self.skill_catalog.read().await.clone()
+    }
+
+    /// Return both command-facing namespaces from one publication generation.
+    pub async fn command_catalog_snapshots(
+        &self,
+    ) -> (WorkflowCatalogSnapshot, WorkflowCatalogSnapshot) {
+        let _snapshot_guard = self.snapshot_publish_lock.read().await;
+        (
+            self.skill_catalog.read().await.clone(),
+            self.catalog.read().await.clone(),
+        )
+    }
+
     /// Pin every new-format orchestration definition from one validated store
     /// publication. `workflow.yaml` bytes come from the immutable resource
     /// snapshot (including LKG recovery), never from a second filesystem read.
@@ -1298,7 +1531,7 @@ impl SkillStore {
         }
         let _snapshot_guard = self.snapshot_publish_lock.read().await;
         let catalog = self.catalog.read().await;
-        let resources = self.skill_resources.read().await;
+        let resources = self.workflow_resources.read().await;
         let mut definitions = BTreeMap::new();
         for entry in catalog
             .entries
@@ -1412,7 +1645,7 @@ impl SkillStore {
         skills.sort_by_key(|skill| skill.name.clone());
         let roots = store.skill_roots.read().await.clone();
         let resources = store.skill_resources.read().await.clone();
-        let catalog = store.catalog.read().await.clone();
+        let catalog = store.skill_catalog.read().await.clone();
         Ok((skills, roots, resources, catalog))
     }
 
@@ -2086,6 +2319,8 @@ impl SkillStore {
                 workflow_id: entry.id.clone(),
                 revision: next.revision,
                 kind,
+                public_workflow: entry.is_public_workflow()
+                    || old.is_some_and(WorkflowCatalogEntry::is_public_workflow),
                 scope: "global".to_string(),
             });
         }
@@ -2099,6 +2334,7 @@ impl SkillStore {
                 workflow_id: removed.id.clone(),
                 revision: next.revision,
                 kind: WorkflowCatalogEventKind::Changed,
+                public_workflow: removed.is_public_workflow(),
                 scope: "global".to_string(),
             });
         }
@@ -2297,6 +2533,45 @@ impl SkillStore {
             }
         }
         unique
+    }
+
+    async fn cached_dependent_stores(&self) -> Vec<std::sync::Arc<SkillStore>> {
+        let mut unique = HashMap::<u64, std::sync::Arc<SkillStore>>::new();
+        for store in self.mode_stores.read().await.values() {
+            unique
+                .entry(store.store_token)
+                .or_insert_with(|| store.clone());
+        }
+        for store in self.workspace_stores.read().await.values() {
+            unique
+                .entry(store.store_token)
+                .or_insert_with(|| store.clone());
+        }
+        for store in self.project_workspace_stores.read().await.values() {
+            unique
+                .entry(store.store_token)
+                .or_insert_with(|| store.clone());
+        }
+        unique.into_values().collect()
+    }
+
+    /// Publish a global Workflow source mutation synchronously to every cached
+    /// catalog view. Workspace, Project/workspace, and mode stores own
+    /// independent immutable snapshots; relying on their filesystem watchers
+    /// would leave the mutating request with a stale same-session read and has
+    /// a registration window in which the event can be lost entirely.
+    pub async fn reload_global_workflow_views(&self) -> SkillResult<()> {
+        self.reload().await?;
+        let mut pending = self.cached_dependent_stores().await;
+        let mut visited = HashSet::new();
+        while let Some(store) = pending.pop() {
+            if !visited.insert(store.store_token) {
+                continue;
+            }
+            store.reload().await?;
+            pending.extend(store.cached_dependent_stores().await);
+        }
+        Ok(())
     }
 
     /// Resolve an isolated catalog view for a specific session workspace without changing the
@@ -2526,14 +2801,6 @@ impl SkillStore {
             .parent()
             .map(|parent| parent.join("workflows"))
             .unwrap_or_else(|| PathBuf::from("workflows"));
-        let report = crate::legacy::import_legacy_markdown_workflows(
-            &workflows_dir,
-            &self.config.skills_dir,
-        )
-        .await?;
-        for diagnostic in report.diagnostics {
-            tracing::warn!("Legacy workflow import: {diagnostic}");
-        }
         for diagnostic in
             crate::legacy::migrate_legacy_yaml_workflows(&workflows_dir, &self.config.skills_dir)
                 .await
@@ -2545,29 +2812,27 @@ impl SkillStore {
         self.load_locked().await
     }
 
-    /// Remove a legacy workflow source and its generated skill bundle while
-    /// excluding watcher reloads. Without one lock across both files, a watcher
-    /// can observe the still-present source after the bundle is removed and
-    /// immediately re-import the workflow being deleted.
+    /// Remove a legacy workflow source and, when present, only the historical
+    /// adapter bundle whose metadata confirms ownership by that source.
+    /// Same-id ordinary or explicitly migrated Skills are never removed.
     pub async fn remove_legacy_workflow(&self, source: &Path, id: &str) -> SkillResult<bool> {
         let _reload_guard = self.reload_lock.lock().await;
-        let removed =
+        let removed_bundle =
             crate::legacy::remove_legacy_markdown_bundle(source, &self.config.skills_dir, id)
                 .await?;
-        if !removed {
-            return Ok(false);
-        }
         if let Err(error) = tokio::fs::remove_file(source).await {
             // Restore the owned bundle when the authoritative source could not
             // be removed, so callers never observe a silent partial deletion.
-            if let Ok(body) = tokio::fs::read_to_string(source).await {
-                let _ = crate::legacy::sync_legacy_markdown_bundle(
-                    source,
-                    &self.config.skills_dir,
-                    id,
-                    &body,
-                )
-                .await;
+            if removed_bundle {
+                if let Ok(body) = tokio::fs::read_to_string(source).await {
+                    let _ = crate::legacy::sync_legacy_markdown_bundle(
+                        source,
+                        &self.config.skills_dir,
+                        id,
+                        &body,
+                    )
+                    .await;
+                }
             }
             return Err(error.into());
         }
@@ -2601,6 +2866,17 @@ impl SkillStore {
         filter: Option<SkillFilter>,
         refresh: bool,
     ) -> Vec<SkillDefinition> {
+        self.skills_and_catalog_snapshot(filter, refresh).await.0
+    }
+
+    /// Clone the visible Skills and their activation policy catalog while
+    /// holding one publication read lock. API callers can therefore never
+    /// combine generation N definitions with generation N+1 identity data.
+    pub async fn skills_and_catalog_snapshot(
+        &self,
+        filter: Option<SkillFilter>,
+        refresh: bool,
+    ) -> (Vec<SkillDefinition>, WorkflowCatalogSnapshot) {
         // Optionally reload from disk to pick up new/updated skills
         if refresh {
             if let Err(e) = self.reload().await {
@@ -2610,6 +2886,7 @@ impl SkillStore {
 
         let _snapshot_guard = self.snapshot_publish_lock.read().await;
         let skills = self.skills.read().await;
+        let catalog = self.skill_catalog.read().await.clone();
 
         let mut result: Vec<SkillDefinition> = skills
             .values()
@@ -2621,7 +2898,7 @@ impl SkillStore {
             .collect();
 
         result.sort_by_key(|s| s.name.clone());
-        result
+        (result, catalog)
     }
 
     /// List skills with an optional mode override (without mutating in-memory cache).
@@ -2744,6 +3021,42 @@ impl SkillStore {
         let _snapshot_guard = self.snapshot_publish_lock.read().await;
         let roots = self.skill_roots.read().await;
         roots
+            .get(id)
+            .cloned()
+            .ok_or_else(|| SkillError::NotFound(id.to_string()))
+    }
+
+    /// Get the immutable publication root for a Workflow identity. Legacy
+    /// markdown adapters use the source file itself as this root.
+    pub async fn get_workflow_root(&self, id: &str) -> SkillResult<PathBuf> {
+        let _snapshot_guard = self.snapshot_publish_lock.read().await;
+        self.workflow_roots
+            .read()
+            .await
+            .get(id)
+            .cloned()
+            .ok_or_else(|| SkillError::NotFound(id.to_string()))
+    }
+
+    /// Resolve only a source-backed legacy Workflow command. Historical
+    /// auto-imports and orchestration definitions intentionally have no
+    /// command-palette content endpoint.
+    pub async fn get_legacy_workflow_source(&self, id: &str) -> SkillResult<PathBuf> {
+        let _snapshot_guard = self.snapshot_publish_lock.read().await;
+        let catalog = self.catalog.read().await;
+        let selectable = catalog.entries.iter().any(|entry| {
+            entry.id == id
+                && entry.winner
+                && entry.kind == WorkflowKind::Instruction
+                && entry.status == WorkflowStatus::Valid
+                && entry.migration_status == Some(LegacyWorkflowMigrationStatus::Available)
+        });
+        if !selectable {
+            return Err(SkillError::NotFound(id.to_string()));
+        }
+        self.workflow_roots
+            .read()
+            .await
             .get(id)
             .cloned()
             .ok_or_else(|| SkillError::NotFound(id.to_string()))
@@ -3093,7 +3406,7 @@ mod tests {
     use crate::store::storage::write_skill_file;
     use crate::store::storage::SkillDirectorySource;
     use crate::types::SkillStoreConfig;
-    use crate::{SkillManager, WorkflowCatalogEventKind, WorkflowSource, WorkflowStatus};
+    use crate::{SkillManager, WorkflowSource, WorkflowStatus};
 
     #[test]
     fn agents_skill_precedence_is_below_bamboo_global_and_above_plugin() {
@@ -3194,7 +3507,7 @@ Use this skill for testing.
     }
 
     #[tokio::test]
-    async fn workflow_builtins_are_versioned_instruction_catalog_entries() {
+    async fn skill_builtins_are_versioned_instruction_catalog_entries() {
         let directory = tempfile::tempdir().expect("tempdir");
         let store = SkillStore::new(SkillStoreConfig {
             skills_dir: directory.path().join("skills"),
@@ -3202,7 +3515,7 @@ Use this skill for testing.
         });
         store.initialize().await.expect("initialize");
 
-        let catalog = store.workflow_catalog_snapshot().await;
+        let catalog = store.skill_catalog_snapshot().await;
         for (id, automatic) in WORKFLOW_BUILTINS {
             let entry = catalog
                 .entries
@@ -3286,7 +3599,7 @@ Use this skill for testing.
         );
         assert_eq!(
             store
-                .workflow_catalog_snapshot()
+                .skill_catalog_snapshot()
                 .await
                 .entries
                 .into_iter()
@@ -3338,7 +3651,7 @@ Use this skill for testing.
             .contains("User customization must survive"));
         assert_eq!(
             store
-                .workflow_catalog_snapshot()
+                .skill_catalog_snapshot()
                 .await
                 .entries
                 .into_iter()
@@ -3413,7 +3726,7 @@ Use this skill for testing.
             .await
             .expect("canonical expected root");
         assert_eq!(resolved_root, expected_root);
-        let catalog = store.workflow_catalog_snapshot().await;
+        let catalog = store.skill_catalog_snapshot().await;
         let entry = catalog
             .entries
             .iter()
@@ -3650,7 +3963,7 @@ Use this skill for testing.
             skill.description, "alpha version",
             "lowest-sorting plugin id must deterministically win a same-id collision"
         );
-        let catalog = store.workflow_catalog_snapshot().await;
+        let catalog = store.skill_catalog_snapshot().await;
         let entry = catalog
             .entries
             .iter()
@@ -3756,7 +4069,7 @@ Use this skill for testing.
     }
 
     #[tokio::test]
-    async fn mode_override_uses_catalog_validation_and_retains_lkg() {
+    async fn mode_orchestration_stays_out_of_skills_and_retains_workflow_lkg() {
         let directory = tempfile::tempdir().expect("tempdir");
         let data_dir = directory.path().join("data");
         let global_skills_dir = data_dir.join("skills");
@@ -3784,11 +4097,28 @@ Use this skill for testing.
             active_mode: None,
         });
         store.initialize().await.expect("initialize");
+        assert!(store
+            .get_skill_for_mode("mode-catalog", Some("code"))
+            .await
+            .is_err());
+        let mode_store = store
+            .skill_store_for_mode(Some("code"))
+            .await
+            .expect("mode store")
+            .expect("non-default mode");
+        assert!(mode_store
+            .skill_catalog_snapshot()
+            .await
+            .entries
+            .iter()
+            .all(|entry| entry.id != "mode-catalog"));
         assert_eq!(
-            store
-                .get_skill_for_mode("mode-catalog", Some("code"))
+            mode_store
+                .workflow_definitions
+                .read()
                 .await
-                .expect("initial mode skill")
+                .get("mode-catalog")
+                .expect("initial workflow")
                 .prompt,
             "Mode prompt v1"
         );
@@ -3802,14 +4132,20 @@ Use this skill for testing.
         fs::write(mode_root.join("workflow.yaml"), "version: 2\n")
             .await
             .expect("invalid workflow metadata");
+        mode_store
+            .reload()
+            .await
+            .expect("invalid reload is isolated");
         assert_eq!(
-            store
-                .get_skill_for_mode("mode-catalog", Some("code"))
+            mode_store
+                .workflow_definitions
+                .read()
                 .await
-                .expect("mode LKG")
+                .get("mode-catalog")
+                .expect("workflow LKG")
                 .prompt,
             "Mode prompt v1",
-            "invalid mode metadata must not activate new instructions"
+            "invalid mode metadata must not activate new workflow instructions"
         );
 
         fs::write(
@@ -3818,18 +4154,21 @@ Use this skill for testing.
         )
         .await
         .expect("recovered metadata");
+        mode_store.reload().await.expect("recovered workflow");
         assert_eq!(
-            store
-                .get_skill_for_mode("mode-catalog", Some("code"))
+            mode_store
+                .workflow_definitions
+                .read()
                 .await
-                .expect("recovered mode skill")
+                .get("mode-catalog")
+                .expect("recovered workflow")
                 .prompt,
             "Mode prompt v2"
         );
     }
 
     #[tokio::test]
-    async fn invalid_reload_retains_lkg_and_emits_invalid_then_recovered() {
+    async fn invalid_skill_reload_retains_lkg_without_workflow_events() {
         const PRIVATE_FIELD: &str = "private-lkg-frontmatter-field";
         const PRIVATE_INSTRUCTIONS: &str = "Private LKG replacement instructions";
         let directory = tempfile::tempdir().expect("tempdir");
@@ -3856,7 +4195,7 @@ Use this skill for testing.
         let skill = store.get_skill("steady").await.expect("LKG retained");
         assert_eq!(skill.description, "original");
         let invalid = store
-            .workflow_catalog_snapshot()
+            .skill_catalog_snapshot()
             .await
             .entries
             .into_iter()
@@ -3868,10 +4207,10 @@ Use this skill for testing.
         assert!(!public_error.contains(PRIVATE_FIELD));
         assert!(!public_error.contains(PRIVATE_INSTRUCTIONS));
         assert!(!public_error.contains(root.to_string_lossy().as_ref()));
-        assert_eq!(
-            events.recv().await.expect("invalid event").kind,
-            WorkflowCatalogEventKind::Invalid
-        );
+        assert!(matches!(
+            events.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
 
         write_skill(
             root.parent().expect("skills root"),
@@ -3890,10 +4229,10 @@ Use this skill for testing.
                 .description,
             "recovered"
         );
-        assert_eq!(
-            events.recv().await.expect("recovered event").kind,
-            WorkflowCatalogEventKind::Recovered
-        );
+        assert!(matches!(
+            events.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
     }
 
     #[tokio::test]
@@ -3953,7 +4292,14 @@ Use this skill for testing.
         assert_eq!(invalid.status, WorkflowStatus::Invalid);
         assert_eq!(invalid.kind, crate::WorkflowKind::Orchestration);
         assert_eq!(invalid.version, "2");
-        let active = store.get_skill("orchestrate").await.expect("LKG active");
+        assert!(store.get_skill("orchestrate").await.is_err());
+        let active = store
+            .workflow_definitions
+            .read()
+            .await
+            .get("orchestrate")
+            .cloned()
+            .expect("workflow LKG active");
         assert_eq!(active.description, "orchestrates");
         assert_eq!(active.prompt, "Instructions");
         let public_error = invalid.last_error.as_deref().expect("public error");
@@ -4131,7 +4477,7 @@ Use this skill for testing.
         });
 
         store.initialize().await.expect("isolate invalid skill");
-        let serialized = serde_json::to_string(&store.workflow_catalog_snapshot().await)
+        let serialized = serde_json::to_string(&store.skill_catalog_snapshot().await)
             .expect("serialize catalog");
 
         assert!(
@@ -4170,7 +4516,7 @@ Use this skill for testing.
         });
 
         store.initialize().await.expect("initialize");
-        let snapshot = store.workflow_catalog_snapshot().await;
+        let snapshot = store.skill_catalog_snapshot().await;
         let serialized = serde_json::to_string(&snapshot).expect("serialize catalog");
         let entry = snapshot
             .entries
@@ -4204,7 +4550,7 @@ Use this skill for testing.
             ..Default::default()
         });
         store.initialize().await.expect("initialize");
-        let before = store.workflow_catalog_snapshot().await;
+        let before = store.skill_catalog_snapshot().await;
         let alpha_before = before
             .entries
             .iter()
@@ -4226,7 +4572,7 @@ Use this skill for testing.
         .expect("update alpha");
         store.reload().await.expect("reload");
 
-        let after = store.workflow_catalog_snapshot().await;
+        let after = store.skill_catalog_snapshot().await;
         assert!(after.revision > before.revision);
         assert!(
             after
@@ -4259,7 +4605,7 @@ Use this skill for testing.
             ..Default::default()
         });
         manager.initialize().await.expect("initialize manager");
-        let initial_revision = manager.store().workflow_catalog_snapshot().await.revision;
+        let initial_revision = manager.store().skill_catalog_snapshot().await.revision;
         let plugin_skills = directory.path().join("data/plugins/late/skills");
         write_skill(&plugin_skills, "hot-plugin", "hot discovered", "Prompt")
             .await
@@ -4267,7 +4613,7 @@ Use this skill for testing.
 
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
             loop {
-                let snapshot = manager.store().workflow_catalog_snapshot().await;
+                let snapshot = manager.store().skill_catalog_snapshot().await;
                 if snapshot.revision > initial_revision
                     && snapshot
                         .entries
@@ -4283,7 +4629,7 @@ Use this skill for testing.
         .expect("watcher should publish plugin without explicit refresh");
 
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-        let stable_revision = manager.store().workflow_catalog_snapshot().await.revision;
+        let stable_revision = manager.store().skill_catalog_snapshot().await.revision;
         fs::create_dir_all(directory.path().join("data/sessions"))
             .await
             .expect("sessions dir");
@@ -4292,7 +4638,7 @@ Use this skill for testing.
             .expect("unrelated write");
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
         assert_eq!(
-            manager.store().workflow_catalog_snapshot().await.revision,
+            manager.store().skill_catalog_snapshot().await.revision,
             stable_revision,
             "unrelated data-dir writes must not publish a catalog revision"
         );
@@ -4368,23 +4714,22 @@ Use this skill for testing.
         });
         store.initialize().await.expect("initialize");
         let mut events = store.subscribe_workflow_catalog();
-        let first = store
-            .workflow_catalog_for_workspace(&one)
+        let first_store = store
+            .skill_store_for_workspace(&one)
             .await
-            .expect("first view");
-        let second = store
-            .workflow_catalog_for_workspace(&two)
+            .expect("first store");
+        let second_store = store
+            .skill_store_for_workspace(&two)
             .await
-            .expect("second view");
+            .expect("second store");
+        let first = first_store.skill_catalog_snapshot().await;
+        let second = second_store.skill_catalog_snapshot().await;
         assert!(first.entries.iter().any(|entry| entry.id == "only-one"));
         assert!(!first.entries.iter().any(|entry| entry.id == "only-two"));
         assert!(second.entries.iter().any(|entry| entry.id == "only-two"));
         assert!(!second.entries.iter().any(|entry| entry.id == "only-one"));
 
-        let repeated = store
-            .workflow_catalog_for_workspace(&one)
-            .await
-            .expect("cached first view");
+        let repeated = first_store.skill_catalog_snapshot().await;
         assert_eq!(repeated.revision, first.revision, "read must not bump");
 
         let skill_file = one.join(".bamboo/skills/only-one/SKILL.md");
@@ -4398,25 +4743,27 @@ Use this skill for testing.
         fs::rename(&staging, &skill_file)
             .await
             .expect("atomic rename");
-        let event = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let updated = tokio::time::timeout(std::time::Duration::from_secs(5), async {
             loop {
-                let event = events.recv().await.expect("workspace event");
-                if event.workflow_id == "only-one" {
-                    break event;
+                let snapshot = first_store.skill_catalog_snapshot().await;
+                if snapshot.revision > first.revision
+                    && snapshot
+                        .entries
+                        .iter()
+                        .any(|entry| entry.id == "only-one" && entry.description == "one changed")
+                {
+                    break snapshot;
                 }
+                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
             }
         })
         .await
-        .expect("workspace watcher event");
-        assert!(event.scope.starts_with("workspace:"));
-        let updated = store
-            .workflow_catalog_for_workspace(&one)
-            .await
-            .expect("updated first view");
-        let untouched = store
-            .workflow_catalog_for_workspace(&two)
-            .await
-            .expect("untouched second view");
+        .expect("workspace watcher publication");
+        assert!(matches!(
+            events.try_recv(),
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+        ));
+        let untouched = second_store.skill_catalog_snapshot().await;
         assert!(updated.revision > first.revision);
         assert_eq!(untouched.revision, second.revision);
         assert_eq!(
@@ -4898,7 +5245,7 @@ Use this skill for testing.
             },
         );
         store.reload().await.expect("publish N");
-        let catalog_n = store.workflow_catalog_snapshot().await;
+        let catalog_n = store.skill_catalog_snapshot().await;
         let ids = vec!["bounded-bytes".to_string()];
         store
             .pin_current_activation("bounded-active", &ids, None)
@@ -4909,7 +5256,7 @@ Use this skill for testing.
             .expect("oversize resource");
         let error = store.reload().await.expect_err("oversize reload rejected");
         assert!(error.to_string().contains("per-file limit"));
-        assert_eq!(store.workflow_catalog_snapshot().await, catalog_n);
+        assert_eq!(store.skill_catalog_snapshot().await, catalog_n);
         assert_eq!(
             store
                 .get_pinned_skill_with_root("bounded-active", "bounded-bytes")
@@ -5006,13 +5353,13 @@ Use this skill for testing.
             .await
             .expect("resource N+1");
         store.reload().await.expect("publish N+1");
-        let catalog_n1 = store.workflow_catalog_snapshot().await;
+        let catalog_n1 = store.skill_catalog_snapshot().await;
         let error = store
             .pin_current_activation("new-n1", &ids, None)
             .await
             .expect_err("N and current N+1 fit, but pinning retained N+1 must exceed budget");
         assert!(error.to_string().contains("budget"));
-        assert_eq!(store.workflow_catalog_snapshot().await, catalog_n1);
+        assert_eq!(store.skill_catalog_snapshot().await, catalog_n1);
         assert_eq!(
             store
                 .read_pinned_skill_resource(
@@ -5116,6 +5463,174 @@ Use this skill for testing.
     }
 
     #[tokio::test]
+    async fn global_legacy_workflow_is_discovered_without_materializing_a_skill() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let data = directory.path().join("data");
+        let workflows = data.join("workflows");
+        fs::create_dir_all(&workflows).await.expect("workflows");
+        let source = workflows.join("daily-report.md");
+        fs::write(
+            &source,
+            "---\ndescription: Use for the daily report.\n---\nReport instructions.\n",
+        )
+        .await
+        .expect("legacy workflow");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir: data.join("skills"),
+            ..Default::default()
+        });
+
+        store.initialize().await.expect("initialize");
+        let catalog = store.workflow_catalog_snapshot().await;
+        let entry = catalog
+            .public_workflows()
+            .entries
+            .into_iter()
+            .find(|entry| entry.id == "daily-report")
+            .expect("legacy workflow");
+        assert!(entry.legacy);
+        assert_eq!(
+            entry.migration_status,
+            Some(crate::LegacyWorkflowMigrationStatus::Available)
+        );
+        assert!(source.exists());
+        assert!(
+            !data.join("skills/daily-report/SKILL.md").exists(),
+            "discovery must not turn a Workflow into a Skill"
+        );
+
+        store.reload().await.expect("reload");
+        assert!(
+            !data.join("skills/daily-report/SKILL.md").exists(),
+            "reload must remain read-only for legacy Workflow sources"
+        );
+    }
+
+    #[tokio::test]
+    async fn same_id_skill_and_legacy_workflow_publish_independent_winners() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let data = directory.path().join("data");
+        let skill_root = write_skill(
+            &data.join("skills"),
+            "shared",
+            "Independent Skill",
+            "Skill instructions.",
+        )
+        .await
+        .expect("skill");
+        let workflow_source = data.join("workflows/shared.md");
+        fs::create_dir_all(workflow_source.parent().unwrap())
+            .await
+            .expect("workflows");
+        fs::write(
+            &workflow_source,
+            "---\ndescription: Independent Workflow\n---\nWorkflow instructions.\n",
+        )
+        .await
+        .expect("workflow");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir: data.join("skills"),
+            ..Default::default()
+        });
+        store.initialize().await.expect("initialize");
+
+        let skills = store.list_skills(None, false).await;
+        let shared = skills
+            .iter()
+            .filter(|skill| skill.id == "shared")
+            .collect::<Vec<_>>();
+        assert_eq!(shared.len(), 1);
+        assert_eq!(shared[0].description, "Independent Skill");
+        let (skill_catalog, workflow_catalog) = store.command_catalog_snapshots().await;
+        assert_eq!(
+            skill_catalog.revision, workflow_catalog.revision,
+            "cross-namespace readers must observe one publication generation"
+        );
+        let skill_entry = skill_catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "shared")
+            .expect("skill winner");
+        assert!(skill_entry.winner);
+        assert!(!skill_entry.legacy);
+        assert_eq!(skill_entry.description, "Independent Skill");
+        let workflow_entry = workflow_catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "shared")
+            .expect("workflow winner");
+        assert!(workflow_entry.winner);
+        assert_eq!(
+            workflow_entry.migration_status,
+            Some(crate::LegacyWorkflowMigrationStatus::Available)
+        );
+        assert_eq!(workflow_entry.description, "Independent Workflow");
+        assert_eq!(store.get_skill_root("shared").await.unwrap(), skill_root);
+        assert_eq!(
+            store.get_workflow_root("shared").await.unwrap(),
+            workflow_source
+        );
+    }
+
+    #[tokio::test]
+    async fn authoritative_legacy_source_wins_over_stale_automatic_import_bundle() {
+        let directory = tempfile::tempdir().expect("tempdir");
+        let data = directory.path().join("data");
+        let source = data.join("workflows/legacy.md");
+        fs::create_dir_all(source.parent().unwrap())
+            .await
+            .expect("workflows");
+        fs::write(
+            &source,
+            "---\ndescription: Current Workflow description.\n---\nCurrent Workflow body.\n",
+        )
+        .await
+        .expect("source");
+        let bundle = data.join("skills/legacy/SKILL.md");
+        fs::create_dir_all(bundle.parent().unwrap())
+            .await
+            .expect("skills");
+        let stale = format!(
+            "---\nname: legacy\ndescription: Stale imported description\nmetadata:\n  legacy_import: true\n  legacy_name: legacy\n  original_source: '{}'\n---\nStale copied body.\n",
+            source.display()
+        );
+        fs::write(&bundle, &stale).await.expect("stale bundle");
+        let store = SkillStore::new(SkillStoreConfig {
+            skills_dir: data.join("skills"),
+            ..Default::default()
+        });
+
+        store.initialize().await.expect("initialize");
+        assert!(store.get_skill("legacy").await.is_err());
+        assert!(store
+            .skill_catalog_snapshot()
+            .await
+            .entries
+            .iter()
+            .all(|entry| entry.id != "legacy"));
+        let entry = store
+            .workflow_catalog_snapshot()
+            .await
+            .public_workflows()
+            .entries
+            .into_iter()
+            .find(|entry| entry.id == "legacy")
+            .expect("workflow catalog entry");
+        assert_eq!(entry.description, "Current Workflow description.");
+        assert_eq!(
+            entry.migration_status,
+            Some(crate::LegacyWorkflowMigrationStatus::Available)
+        );
+        assert!(entry.shadowed_candidates.iter().any(|candidate| {
+            candidate.migration_status == Some(crate::LegacyWorkflowMigrationStatus::Migrated)
+        }));
+        assert_eq!(
+            fs::read_to_string(&bundle).await.expect("bundle preserved"),
+            stale
+        );
+    }
+
+    #[tokio::test]
     async fn workspace_legacy_workflow_is_read_only_catalog_input_with_lkg() {
         let directory = tempfile::tempdir().expect("tempdir");
         let workspace = directory.path().join("workspace");
@@ -5150,13 +5665,19 @@ Use this skill for testing.
         );
         assert_eq!(entry.status, WorkflowStatus::Valid);
         assert_eq!(entry.invocation_policy["automatic"], true);
+        assert!(workspace_store.get_skill("review").await.is_err());
         assert_eq!(
-            workspace_store
-                .get_skill("review")
+            fs::canonicalize(
+                workspace_store
+                    .get_legacy_workflow_source("review")
+                    .await
+                    .expect("legacy source")
+            )
+            .await
+            .expect("canonical resolved source"),
+            fs::canonicalize(&source)
                 .await
-                .expect("legacy skill")
-                .prompt,
-            "Stable review instructions."
+                .expect("canonical expected source")
         );
         assert!(source.exists());
         assert!(!workspace.join(".bamboo/skills/review/SKILL.md").exists());
@@ -5187,18 +5708,15 @@ Use this skill for testing.
         assert!(!public.contains("private-broken-value"));
         assert!(!public.contains("PRIVATE BROKEN BODY"));
         assert!(!public.contains(workspace.to_string_lossy().as_ref()));
-        assert_eq!(
-            workspace_store
-                .get_skill("review")
-                .await
-                .expect("retained LKG skill")
-                .prompt,
-            "Stable review instructions."
-        );
+        assert!(workspace_store.get_skill("review").await.is_err());
+        assert!(workspace_store
+            .get_legacy_workflow_source("review")
+            .await
+            .is_err());
     }
 
     #[tokio::test]
-    async fn migrated_workspace_bundle_wins_and_reports_legacy_shadow() {
+    async fn explicit_migrated_skill_coexists_with_legacy_workflow_source() {
         let directory = tempfile::tempdir().expect("tempdir");
         let workspace = directory.path().join("workspace");
         let workflows = workspace.join(".bamboo/workflows");
@@ -5226,23 +5744,48 @@ Use this skill for testing.
         .await
         .expect("migration");
         workspace_store.reload().await.expect("reload migration");
-        let catalog = workspace_store.workflow_catalog_snapshot().await;
-        let entry = catalog
+        let (skill_catalog, workflow_catalog) = workspace_store.command_catalog_snapshots().await;
+        assert_eq!(skill_catalog.revision, workflow_catalog.revision);
+        let skill_entry = skill_catalog
             .entries
             .iter()
             .find(|entry| entry.id == "review")
-            .expect("migrated winner");
-        assert!(entry.legacy);
+            .expect("migrated Skill");
+        assert!(skill_entry.legacy);
         assert_eq!(
-            entry.migration_status,
+            skill_entry.migration_status,
             Some(crate::LegacyWorkflowMigrationStatus::Migrated)
         );
-        assert_eq!(entry.source, crate::WorkflowSource::Workspace);
-        assert_eq!(entry.shadowed_candidates.len(), 1);
-        assert!(entry.shadowed_candidates[0].legacy);
+        assert_eq!(skill_entry.source, crate::WorkflowSource::Workspace);
+        let workflow_entry = workflow_catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "review")
+            .expect("source Workflow");
         assert_eq!(
-            entry.shadowed_candidates[0].migration_status,
+            workflow_entry.migration_status,
             Some(crate::LegacyWorkflowMigrationStatus::Available)
+        );
+        assert_eq!(
+            workspace_store
+                .get_skill("review")
+                .await
+                .expect("migrated Skill")
+                .prompt,
+            "Review the diff."
+        );
+        assert_eq!(
+            fs::canonicalize(
+                workspace_store
+                    .get_workflow_root("review")
+                    .await
+                    .expect("source Workflow")
+            )
+            .await
+            .expect("canonical resolved source"),
+            fs::canonicalize(&source)
+                .await
+                .expect("canonical expected source")
         );
     }
 

--- a/src/setup_cli.rs
+++ b/src/setup_cli.rs
@@ -1099,7 +1099,7 @@ mod tests {
             ),
             (
                 "access_control",
-                r#"{"password_enabled":true,"password_credential_ref":"access.root.password_verifier","password_configured":true}"#,
+                r#"{"password_enabled":true,"repair_required":false,"password_credential_ref":"access.root.password_verifier","password_configured":true}"#,
             ),
         ] {
             let error = run_config_set(key, value, Some(data_dir.clone()), false).unwrap_err();

--- a/tests/e2e/commands/get.rs
+++ b/tests/e2e/commands/get.rs
@@ -22,20 +22,28 @@ async fn test_get_command_by_id_workflow() {
     ))
     .await;
 
-    let req = test::TestRequest::get()
-        .uri("/v1/commands/workflow/test-workflow")
-        .to_request();
-
-    let resp = test::call_service(&app, req).await;
-
-    assert!(resp.status().is_success());
+    let resp = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let req = test::TestRequest::get()
+                .uri("/v1/commands/workflow/test-workflow")
+                .to_request();
+            let resp = test::call_service(&app, req).await;
+            if resp.status().is_success() {
+                break resp;
+            }
+            assert_eq!(resp.status(), actix_web::http::StatusCode::NOT_FOUND);
+            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+        }
+    })
+    .await
+    .expect("watcher should publish the legacy Workflow source");
 
     let body = test::read_body(resp).await;
     let result: Value = serde_json::from_slice(&body).expect("Response should be valid JSON");
 
     assert_eq!(result["type"], "workflow");
     assert_eq!(result["name"], "test-workflow");
-    assert!(result.get("content").is_some());
+    assert_eq!(result["content"], workflow_content);
 }
 
 #[actix_web::test]

--- a/tests/e2e/commands/list.rs
+++ b/tests/e2e/commands/list.rs
@@ -88,10 +88,9 @@ async fn test_list_commands_includes_workflows_and_skills() {
     .await
     .expect("watcher should publish the imported workflow command");
 
-    assert_eq!(command["id"], "skill-example");
-    assert_eq!(command["type"], "skill");
-    assert_eq!(
-        command["description"],
-        "Imported legacy workflow 'example'."
-    );
+    assert_eq!(command["id"], "workflow-example");
+    assert_eq!(command["type"], "workflow");
+    assert!(command["description"]
+        .as_str()
+        .is_some_and(|description| description.contains("Legacy workflow 'example'")));
 }


### PR DESCRIPTION
## Summary

- keep the modular configuration facade available when Access password verifier metadata is missing, incomplete, or syntactically corrupt
- recover a corrupt active Access section locally and fail closed with repair_required, while encrypting the original bytes in the credential store and keeping unrelated typed sections healthy
- separate public Workflow and Skill identity: ordinary SKILL.md bundles leave the Workflow catalog, orchestration definitions leave /skills, and explicit legacy Workflows remain source-backed until migration
- support safe explicit migration for both workspace/plugin and global legacy Workflow sources without deleting or rewriting the source Workflow
- synchronously refresh root, mode, workspace, and Project catalog views after global Workflow mutation, closing cached-view and lost-event races

## Test Plan

- cargo test -p bamboo-config: 624 passed
- cargo test -p bamboo-skills: 126 passed
- cargo test -p bamboo-server: 1699 passed, 1 ignored; integration and doc tests passed
- cargo test -p bamboo-server-tools --all-features --lib: 134 passed
- workflow handler suite: 28 passed
- commands E2E: 6 passed
- cargo clippy -p bamboo-config -p bamboo-skills -p bamboo-server --all-targets: passed with one pre-existing too_many_arguments warning
- cargo build --bin bamboo: passed
- cargo fmt --all -- --check and git diff --check: passed
- final independent review passed at exact head `4fb9459e705769b22f748947fe7f05c11a5f786f`
- live final-binary startup with an intentionally corrupt active Access JSON: Access alone became degraded/repair-required; tools-skills and MCP stayed healthy; corrupt plaintext was absent from disk

Refs bigduu/Zenith#36
