### PR TITLE
fix: make workflow_run tool schema provider-safe (#734)

### DIFF
--- a/crates/app/bamboo-server/src/app_state/provider_api.rs
+++ b/crates/app/bamboo-server/src/app_state/provider_api.rs
@@ -228,6 +228,46 @@ mod tests {
         assert!(!names(ToolSurface::Child).contains("workflow_run"));
     }
 
+    #[tokio::test]
+    async fn workflow_run_root_overlay_advertises_provider_safe_parameters() {
+        let (_temp, state) = make_state().await;
+        let workflow_run = state
+            .tools_for(ToolSurface::Root)
+            .list_tools()
+            .into_iter()
+            .find(|schema| schema.function.name == "workflow_run")
+            .expect("root workflow_run overlay");
+        let parameters = &workflow_run.function.parameters;
+
+        for combinator in ["oneOf", "anyOf", "allOf"] {
+            assert!(
+                parameters.get(combinator).is_none(),
+                "root workflow_run overlay must not advertise {combinator}"
+            );
+        }
+        let properties = parameters["properties"]
+            .as_object()
+            .expect("root workflow_run properties");
+        assert!(
+            !properties.is_empty(),
+            "root workflow_run overlay must not advertise empty properties"
+        );
+        for field in [
+            "action",
+            "workflow_id",
+            "revision",
+            "args",
+            "budget",
+            "run_id",
+            "since",
+        ] {
+            assert!(
+                properties.contains_key(field),
+                "root workflow_run overlay is missing {field}"
+            );
+        }
+    }
+
     // ---- get_all_tool_schemas ----
 
     #[tokio::test]

--- a/crates/app/bamboo-server/src/workflow/run.rs
+++ b/crates/app/bamboo-server/src/workflow/run.rs
@@ -678,7 +678,7 @@ enum WorkflowToolInput {
         #[serde(default)]
         budget: Option<WorkflowBudgets>,
     },
-    List,
+    List {},
     Get {
         run_id: String,
     },
@@ -722,14 +722,41 @@ impl Tool for WorkflowRunTool {
     fn parameters_schema(&self) -> Value {
         json!({
             "type": "object",
-            "oneOf": [
-                {"properties": {"action": {"const": "start"}, "workflow_id": {"type": "string", "minLength": 1}, "revision": {"type": "integer", "minimum": 1}, "args": {"type": "object", "default": {}}, "budget": {"type": "object", "properties": {"max_concurrency": {"type":"integer","minimum":1}, "max_agents": {"type":"integer","minimum":0}, "max_steps": {"type":"integer","minimum":1}, "max_retries": {"type":"integer","minimum":0}, "max_nesting_depth": {"type":"integer","minimum":1}, "wall_time_ms": {"type":"integer","minimum":1}, "max_tokens": {"type":"integer","minimum":0}, "max_cost_micros": {"type":"integer","minimum":0}}, "required": ["max_concurrency","max_agents","max_steps","max_retries","max_nesting_depth","wall_time_ms"], "additionalProperties": false}}, "required": ["action", "workflow_id", "revision"], "additionalProperties": false},
-                {"properties": {"action": {"const": "list"}}, "required": ["action"], "additionalProperties": false},
-                {"properties": {"action": {"const": "get"}, "run_id": {"type": "string"}}, "required": ["action", "run_id"], "additionalProperties": false},
-                {"properties": {"action": {"const": "events"}, "run_id": {"type": "string"}, "since": {"type": "integer", "minimum": 0}}, "required": ["action", "run_id"], "additionalProperties": false},
-                {"properties": {"action": {"const": "cancel"}, "run_id": {"type": "string"}}, "required": ["action", "run_id"], "additionalProperties": false},
-                {"properties": {"action": {"const": "restart"}, "run_id": {"type": "string"}}, "required": ["action", "run_id"], "additionalProperties": false}
-            ]
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["start", "list", "get", "events", "cancel", "restart"]
+                },
+                "workflow_id": {"type": "string", "minLength": 1},
+                "revision": {"type": "integer", "minimum": 1},
+                "args": {"type": "object", "default": {}},
+                "budget": {
+                    "type": "object",
+                    "properties": {
+                        "max_concurrency": {"type": "integer", "minimum": 1},
+                        "max_agents": {"type": "integer", "minimum": 0},
+                        "max_steps": {"type": "integer", "minimum": 1},
+                        "max_retries": {"type": "integer", "minimum": 0},
+                        "max_nesting_depth": {"type": "integer", "minimum": 1},
+                        "wall_time_ms": {"type": "integer", "minimum": 1},
+                        "max_tokens": {"type": "integer", "minimum": 0},
+                        "max_cost_micros": {"type": "integer", "minimum": 0}
+                    },
+                    "required": [
+                        "max_concurrency",
+                        "max_agents",
+                        "max_steps",
+                        "max_retries",
+                        "max_nesting_depth",
+                        "wall_time_ms"
+                    ],
+                    "additionalProperties": false
+                },
+                "run_id": {"type": "string"},
+                "since": {"type": "integer", "minimum": 0}
+            },
+            "required": ["action"],
+            "additionalProperties": false
         })
     }
 
@@ -758,7 +785,7 @@ impl Tool for WorkflowRunTool {
                     .await
                     .map_err(workflow_tool_error)?,
             )),
-            WorkflowToolInput::List => serde_json::to_value(
+            WorkflowToolInput::List {} => serde_json::to_value(
                 self.access
                     .list_for_session(session_id)
                     .await
@@ -823,6 +850,7 @@ mod tests {
         FunctionSchema, ToolCall, ToolExecutor, ToolResult, ToolSchema,
     };
     use bamboo_agent_core::Session;
+    use bamboo_llm::protocol::{gemini::GeminiTool, ToProvider};
     use std::collections::HashMap;
     use tokio::sync::RwLock;
 
@@ -910,6 +938,96 @@ mod tests {
         .await
         .expect("workflow access");
         (access, repo, directory)
+    }
+
+    fn canonical_workflow_run_schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["start", "list", "get", "events", "cancel", "restart"]
+                },
+                "workflow_id": {"type": "string", "minLength": 1},
+                "revision": {"type": "integer", "minimum": 1},
+                "args": {"type": "object", "default": {}},
+                "budget": {
+                    "type": "object",
+                    "properties": {
+                        "max_concurrency": {"type": "integer", "minimum": 1},
+                        "max_agents": {"type": "integer", "minimum": 0},
+                        "max_steps": {"type": "integer", "minimum": 1},
+                        "max_retries": {"type": "integer", "minimum": 0},
+                        "max_nesting_depth": {"type": "integer", "minimum": 1},
+                        "wall_time_ms": {"type": "integer", "minimum": 1},
+                        "max_tokens": {"type": "integer", "minimum": 0},
+                        "max_cost_micros": {"type": "integer", "minimum": 0}
+                    },
+                    "required": [
+                        "max_concurrency",
+                        "max_agents",
+                        "max_steps",
+                        "max_retries",
+                        "max_nesting_depth",
+                        "wall_time_ms"
+                    ],
+                    "additionalProperties": false
+                },
+                "run_id": {"type": "string"},
+                "since": {"type": "integer", "minimum": 0}
+            },
+            "required": ["action"],
+            "additionalProperties": false
+        })
+    }
+
+    #[tokio::test]
+    async fn workflow_run_schema_is_flat_complete_and_canonical() {
+        let (access, _, _) = workflow_test_access().await;
+        let schema = WorkflowRunTool::new(access).parameters_schema();
+
+        for combinator in ["oneOf", "anyOf", "allOf"] {
+            assert!(
+                schema.get(combinator).is_none(),
+                "workflow_run must not advertise root {combinator}"
+            );
+        }
+        assert_eq!(schema, canonical_workflow_run_schema());
+    }
+
+    #[tokio::test]
+    async fn workflow_run_schema_survives_openai_sanitization_with_all_properties() {
+        let (access, _, _) = workflow_test_access().await;
+        let schema = WorkflowRunTool::new(access).parameters_schema();
+        let sanitized =
+            bamboo_llm::providers::common::tool_schema::sanitize_openai_function_parameters_schema(
+                &schema,
+            );
+
+        let properties = sanitized["properties"]
+            .as_object()
+            .expect("sanitized workflow_run properties");
+        assert!(!properties.is_empty());
+        assert_eq!(properties.len(), 7);
+        assert_eq!(sanitized, canonical_workflow_run_schema());
+    }
+
+    #[tokio::test]
+    async fn workflow_run_schema_reaches_gemini_unchanged() {
+        let (access, _, _) = workflow_test_access().await;
+        let direct = WorkflowRunTool::new(access).to_schema();
+        let gemini: GeminiTool = direct.to_provider().expect("Gemini tool conversion");
+        let declaration = gemini
+            .function_declarations
+            .first()
+            .expect("workflow_run declaration");
+
+        assert_eq!(declaration.name, "workflow_run");
+        assert_eq!(
+            declaration.parameters_json_schema.as_ref(),
+            Some(&canonical_workflow_run_schema())
+        );
+        assert!(declaration.parameters.is_none());
     }
 
     #[tokio::test]
@@ -1095,6 +1213,38 @@ mod tests {
         assert!(error.to_string().contains("unknown field"));
     }
 
+    #[test]
+    fn tool_input_rejects_fields_from_other_actions() {
+        let invalid = [
+            json!({"action": "list", "run_id": "run-1"}),
+            json!({"action": "get", "run_id": "run-1", "since": 1}),
+            json!({"action": "events", "run_id": "run-1", "workflow_id": "flow"}),
+            json!({"action": "cancel", "run_id": "run-1", "revision": 1}),
+            json!({"action": "restart", "run_id": "run-1", "budget": {}}),
+            json!({
+                "action": "start",
+                "workflow_id": "flow",
+                "revision": 1,
+                "run_id": "run-1"
+            }),
+        ];
+
+        for input in invalid {
+            let error = serde_json::from_value::<WorkflowToolInput>(input.clone())
+                .expect_err("action-specific fields must remain authoritative at runtime");
+            assert!(
+                error.to_string().contains("unknown field"),
+                "unexpected error for {input}: {error}"
+            );
+        }
+
+        assert!(matches!(
+            serde_json::from_value::<WorkflowToolInput>(json!({"action": "list"}))
+                .expect("fieldless list action"),
+            WorkflowToolInput::List {}
+        ));
+    }
+
     #[tokio::test]
     async fn omitted_start_args_and_zero_budgets_match_schema() {
         let WorkflowToolInput::Start { args, .. } =
@@ -1115,22 +1265,22 @@ mod tests {
 
         let (access, _, _) = workflow_test_access().await;
         let schema = WorkflowRunTool { access }.parameters_schema();
-        let start = &schema["oneOf"][0];
-        assert_eq!(start["properties"]["args"]["default"], json!({}));
+        let properties = &schema["properties"];
+        assert_eq!(properties["args"]["default"], json!({}));
         assert_eq!(
-            start["properties"]["budget"]["properties"]["max_agents"]["minimum"],
+            properties["budget"]["properties"]["max_agents"]["minimum"],
             0
         );
         assert_eq!(
-            start["properties"]["budget"]["properties"]["max_retries"]["minimum"],
+            properties["budget"]["properties"]["max_retries"]["minimum"],
             0
         );
         assert_eq!(
-            start["properties"]["budget"]["properties"]["max_tokens"]["minimum"],
+            properties["budget"]["properties"]["max_tokens"]["minimum"],
             0
         );
         assert_eq!(
-            start["properties"]["budget"]["properties"]["max_cost_micros"]["minimum"],
+            properties["budget"]["properties"]["max_cost_micros"]["minimum"],
             0
         );
     }


### PR DESCRIPTION
## Summary

- replace `workflow_run`'s provider-hostile top-level `oneOf` with a complete flat canonical object schema
- keep tagged Serde input authoritative and reject fields from the wrong action, including `list + run_id`
- verify the schema remains complete through OpenAI sanitization and Gemini conversion
- guard the composed root `workflow_run` overlay against forbidden root combinators and empty properties

This fixes Anthropic-compatible HTTP 400 failures and prevents OpenAI-compatible paths from degrading `workflow_run` to an empty parameters object. No provider-specific production heuristic was added.

## Test Plan

- [x] `cargo fmt --all --check`
- [x] `cargo test -p bamboo-server workflow::run` — 12 passed
- [x] `cargo test -p bamboo-server workflow` — 76 passed
- [x] `cargo test -p bamboo-server workflow_run_root_overlay_advertises_provider_safe_parameters` — 1 passed
- [x] `cargo test -p bamboo-llm` — 507 unit tests passed
- [x] CI-equivalent Clippy for `bamboo-server` and `bamboo-llm` with `-D warnings`
- [x] independent adversarial review at head `a2d1ce488c3b97650fa88819c0aaddb5952120c1` — no actionable findings

The existing macOS oversized `__eh_frame` linker warning appeared while linking server tests; all affected tests passed.

## Screenshots

N/A — backend schema fix.

Fixes #734