### PR TITLE
fix: stop retrying empty assistant responses (#740)

### DIFF
--- a/crates/core/bamboo-agent-core/src/agent/error.rs
+++ b/crates/core/bamboo-agent-core/src/agent/error.rs
@@ -83,3 +83,31 @@ impl AgentError {
         matches!(self, AgentError::HookSuspended(_))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::AgentError;
+
+    #[test]
+    fn empty_assistant_response_is_typed_and_has_secret_free_diagnostics() {
+        let with_id = AgentError::EmptyAssistantResponse {
+            response_id: Some("resp_740".to_string()),
+        };
+        assert!(matches!(
+            &with_id,
+            AgentError::EmptyAssistantResponse {
+                response_id: Some(response_id)
+            } if response_id == "resp_740"
+        ));
+        assert_eq!(
+            with_id.to_string(),
+            "Empty assistant response from LLM (response_id=Some(\"resp_740\"))"
+        );
+
+        let without_id = AgentError::EmptyAssistantResponse { response_id: None };
+        assert_eq!(
+            without_id.to_string(),
+            "Empty assistant response from LLM (response_id=None)"
+        );
+    }
+}

--- a/crates/core/bamboo-agent-core/src/agent/error.rs
+++ b/crates/core/bamboo-agent-core/src/agent/error.rs
@@ -15,6 +15,17 @@ pub enum AgentError {
     #[error("LLM error: {0}")]
     LLM(String),
 
+    /// The provider completed an assistant response without visible content or
+    /// tool calls. Kept distinct from transient provider failures so turn-level
+    /// retry logic cannot replay the same billable empty response.
+    #[error("Empty assistant response from LLM (response_id={response_id:?})")]
+    EmptyAssistantResponse {
+        /// Provider response identifier when one was emitted. Response IDs are
+        /// diagnostic correlation handles; no request content or credentials
+        /// are retained here.
+        response_id: Option<String>,
+    },
+
     /// LLM request exceeded provider context/input limits and requires
     /// host-side overflow recovery before retry.
     #[error("LLM overflow: {0}")]

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -4569,6 +4569,19 @@ mod tests {
         assert!(should_retry_turn_error(&AgentError::LLM(
             "API error: HTTP 503: Service Unavailable".to_string(),
         )));
+    }
+
+    #[test]
+    fn empty_assistant_response_is_terminal_by_variant_not_message_text() {
+        assert!(!should_retry_turn_error(
+            &AgentError::EmptyAssistantResponse {
+                response_id: Some("resp_740".to_string()),
+            }
+        ));
+
+        // Unknown provider failures retain the existing allow-by-default
+        // behavior. The empty-response decision is made by the typed variant,
+        // not by matching this legacy message text.
         assert!(should_retry_turn_error(&AgentError::LLM(
             "empty assistant response".to_string(),
         )));
@@ -4708,6 +4721,7 @@ mod tests {
     fn test_map_turn_error_only_cancelled_gets_cancelled_status() {
         let errors = vec![
             AgentError::LLM("error".to_string()),
+            AgentError::EmptyAssistantResponse { response_id: None },
             AgentError::Tool("error".to_string()),
             AgentError::SessionNotFound("id".to_string()),
             AgentError::Budget("error".to_string()),

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle.rs
@@ -81,9 +81,9 @@ pub(crate) async fn execute_llm_round(
     .await?;
 
     if stream_output.tool_calls.is_empty() && stream_output.content.trim().is_empty() {
-        return Err(AgentError::LLM(
-            "empty assistant response from LLM (retryable)".to_string(),
-        ));
+        return Err(AgentError::EmptyAssistantResponse {
+            response_id: stream_output.response_id.clone(),
+        });
     }
 
     let prompt_tokens = estimate_prompt_tokens(&prepared.prepared_context.messages);

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution.rs
@@ -58,6 +58,7 @@ fn interruption_kind(error: &AgentError) -> &'static str {
         AgentError::Cancelled => "cancelled",
         AgentError::StreamTimeout(_) => "stream_timeout",
         AgentError::LLMOverflow(_) => "llm_overflow",
+        AgentError::EmptyAssistantResponse { .. } => "empty_assistant_response",
         AgentError::LLM(_) => "llm_error",
         _ => "execution_error",
     }

--- a/crates/engine/bamboo-engine/src/runtime/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/tests.rs
@@ -345,6 +345,49 @@ struct RetryBeforeStreamThenSuccessProvider {
     calls: AtomicUsize,
 }
 
+struct EmptyAssistantResponseProvider {
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl LLMProvider for EmptyAssistantResponseProvider {
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSchema],
+        _max_output_tokens: Option<u32>,
+        _model: &str,
+    ) -> Result<LLMStream, LLMError> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        assert_eq!(call, 0, "an empty assistant response must not be retried");
+        Ok(Box::pin(stream::iter(vec![
+            Ok(LLMChunk::ResponseId("resp_empty_740".to_string())),
+            Ok(LLMChunk::Token(" \n ".to_string())),
+            Ok(LLMChunk::Done),
+        ])))
+    }
+}
+
+struct AlwaysTransientProvider {
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl LLMProvider for AlwaysTransientProvider {
+    async fn chat_stream(
+        &self,
+        _messages: &[Message],
+        _tools: &[ToolSchema],
+        _max_output_tokens: Option<u32>,
+        _model: &str,
+    ) -> Result<LLMStream, LLMError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Err(LLMError::Api(
+            "temporary provider dispatch failure".to_string(),
+        ))
+    }
+}
+
 #[async_trait]
 impl LLMProvider for RetryBeforeStreamThenSuccessProvider {
     async fn chat_stream(
@@ -566,6 +609,98 @@ async fn retryable_pre_stream_error_does_not_delete_existing_interrupted_tail() 
         .messages
         .iter()
         .any(|message| message.content == "retry recovered"));
+}
+
+#[tokio::test]
+async fn direct_execute_surfaces_and_checkpoints_empty_response_without_retry() {
+    let provider = Arc::new(EmptyAssistantResponseProvider {
+        calls: AtomicUsize::new(0),
+    });
+    let (_temp, agent, storage) = build_direct_execute_agent(provider.clone(), None, None).await;
+    let mut session = Session::new("direct-empty-response", "test-model");
+    session.add_message(Message::user("durable base"));
+    storage.save_session(&session).await.unwrap();
+    session.add_message(Message::user("checkpoint this turn"));
+
+    let (event_tx, mut event_rx) = mpsc::channel(64);
+    let result = agent
+        .execute(
+            &mut session,
+            direct_request(event_tx, CancellationToken::new()),
+        )
+        .await;
+
+    assert!(matches!(
+        &result,
+        Err(bamboo_agent_core::AgentError::EmptyAssistantResponse {
+            response_id: Some(response_id)
+        }) if response_id == "resp_empty_740"
+    ));
+    assert_eq!(
+        provider.calls.load(Ordering::SeqCst),
+        1,
+        "the real provider pipeline must make exactly one billable call"
+    );
+
+    let terminal_event =
+        crate::runtime::execution::agent_spawn::terminal_error_event_for_result(&result)
+            .expect("terminal empty response must remain visible to event consumers");
+    match terminal_event {
+        AgentEvent::Error { message } => {
+            assert!(message.contains("Empty assistant response from LLM"));
+            assert!(message.contains("resp_empty_740"));
+        }
+        other => panic!("unexpected terminal event: {other:?}"),
+    }
+
+    let saved = storage
+        .load_session(&session.id)
+        .await
+        .unwrap()
+        .expect("saved session");
+    assert!(
+        saved
+            .messages
+            .iter()
+            .any(|message| message.content == "checkpoint this turn"),
+        "the shared execute boundary must checkpoint the terminal turn"
+    );
+    assert!(!saved.agent_runtime_state.as_ref().is_some_and(|state| {
+        matches!(state.status, bamboo_domain::AgentStatusState::Completed)
+    }));
+    while let Ok(event) = event_rx.try_recv() {
+        assert!(!matches!(event, AgentEvent::Complete { .. }));
+    }
+}
+
+#[tokio::test]
+async fn direct_execute_retries_transient_llm_errors_to_existing_limit() {
+    let provider = Arc::new(AlwaysTransientProvider {
+        calls: AtomicUsize::new(0),
+    });
+    let (_temp, agent, _storage) = build_direct_execute_agent(provider.clone(), None, None).await;
+    let mut session = Session::new("direct-transient-retry-limit", "test-model");
+    session.add_message(Message::user("retry transient failures"));
+    let (event_tx, _event_rx) = mpsc::channel(64);
+
+    let error = agent
+        .execute(
+            &mut session,
+            direct_request(event_tx, CancellationToken::new()),
+        )
+        .await
+        .expect_err("an always-transient provider must exhaust the retry limit");
+
+    assert!(matches!(
+        error,
+        bamboo_agent_core::AgentError::LLM(message)
+            if message.contains("temporary provider dispatch failure")
+    ));
+    assert_eq!(
+        provider.calls.load(Ordering::SeqCst),
+        3,
+        "genuine transient LLM failures keep the existing three-attempt limit"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Add a dedicated `AgentError::EmptyAssistantResponse` carrying only an optional provider `response_id` for secret-free correlation.
- Treat a successful but content/tool-free assistant stream as terminal in both turn retry paths, preventing repeated identical billable calls.
- Preserve existing transient LLM retry behavior, terminal error events, and shared execution checkpoint semantics.

Closes #740.

## Scope

This PR intentionally does not redesign the global fail-open LLM classifier or make retry budgets/backoff configurable. Those broader policy changes are outside #740.

## Test Plan

- `cargo fmt --all -- --check`
- `cargo test -p bamboo-agent-core` — 141 passed
- `cargo test -p bamboo-engine` — 1213 passed; 1 doc test passed
- Repository CI Clippy command with `-D warnings` — passed
- Focused real-pipeline coverage verifies empty response provider call-count is exactly 1, terminal Error is visible, the failed turn is checkpointed, and no Complete event is emitted.
- Focused regression verifies transient LLM failures retain the existing 3-attempt limit.
- Two independent adversarial reviews approved exact head `99c663f43fc5b8a4835e25f0c0c9bbdce967532b` with no actionable findings.

## Screenshots

N/A — backend-only behavior.