### PR TITLE
fix: preserve OpenAI streaming token usage (#687)

### DIFF
--- a/crates/app/bamboo-server/src/handlers/anthropic/complete/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/anthropic/complete/non_stream.rs
@@ -93,6 +93,7 @@ pub(super) async fn handle_non_streaming_complete(
             Ok(bamboo_llm::types::LLMChunk::Done) => break,
             Ok(bamboo_llm::types::LLMChunk::TransportActivity)
             | Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. })
+            | Ok(bamboo_llm::types::LLMChunk::ProviderUsage { .. })
             | Ok(bamboo_llm::types::LLMChunk::UsageSummary { .. })
             | Ok(bamboo_llm::types::LLMChunk::ReasoningSignature(_)) => {}
             Err(error) => {

--- a/crates/app/bamboo-server/src/handlers/anthropic/conversion.rs
+++ b/crates/app/bamboo-server/src/handlers/anthropic/conversion.rs
@@ -157,6 +157,7 @@ pub(super) fn convert_llm_chunk_to_openai(
         }),
         bamboo_llm::types::LLMChunk::TransportActivity
         | bamboo_llm::types::LLMChunk::CacheUsage { .. }
+        | bamboo_llm::types::LLMChunk::ProviderUsage { .. }
         | bamboo_llm::types::LLMChunk::UsageSummary { .. }
         | bamboo_llm::types::LLMChunk::ReasoningSignature(_) => None,
     }

--- a/crates/app/bamboo-server/src/handlers/anthropic/messages/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/anthropic/messages/non_stream.rs
@@ -91,6 +91,7 @@ pub(super) async fn handle_non_streaming_messages(
             Ok(bamboo_llm::types::LLMChunk::Done) => break,
             Ok(bamboo_llm::types::LLMChunk::TransportActivity)
             | Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. })
+            | Ok(bamboo_llm::types::LLMChunk::ProviderUsage { .. })
             | Ok(bamboo_llm::types::LLMChunk::UsageSummary { .. })
             | Ok(bamboo_llm::types::LLMChunk::ReasoningSignature(_)) => {}
             Err(error) => {

--- a/crates/app/bamboo-server/src/handlers/gemini/generate/collect.rs
+++ b/crates/app/bamboo-server/src/handlers/gemini/generate/collect.rs
@@ -29,6 +29,7 @@ where
             }
             LLMChunk::TransportActivity
             | LLMChunk::CacheUsage { .. }
+            | LLMChunk::ProviderUsage { .. }
             | LLMChunk::UsageSummary { .. }
             | LLMChunk::ReasoningSignature(_) => {}
         }

--- a/crates/app/bamboo-server/src/handlers/gemini/stream/runtime.rs
+++ b/crates/app/bamboo-server/src/handlers/gemini/stream/runtime.rs
@@ -66,6 +66,7 @@ pub(super) fn build_gemini_event_stream(
                 }
                 Ok(LLMChunk::TransportActivity)
                 | Ok(LLMChunk::CacheUsage { .. })
+                | Ok(LLMChunk::ProviderUsage { .. })
                 | Ok(LLMChunk::UsageSummary { .. })
                 | Ok(LLMChunk::ReasoningSignature(_)) => {}
                 Err(error) => {

--- a/crates/app/bamboo-server/src/handlers/openai/chat/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/chat/non_stream.rs
@@ -88,6 +88,7 @@ pub(super) async fn handle_non_streaming_chat(
             }
             Ok(bamboo_llm::types::LLMChunk::TransportActivity) => {}
             Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. }) => {}
+            Ok(bamboo_llm::types::LLMChunk::ProviderUsage { .. }) => {}
             Ok(bamboo_llm::types::LLMChunk::ReasoningSignature(_)) => {}
             Ok(bamboo_llm::types::LLMChunk::UsageSummary { .. }) => {}
             Ok(bamboo_llm::types::LLMChunk::Done) => break,

--- a/crates/app/bamboo-server/src/handlers/openai/chat/stream/worker.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/chat/stream/worker.rs
@@ -68,6 +68,7 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
             }
             Ok(LLMChunk::TransportActivity)
             | Ok(LLMChunk::CacheUsage { .. })
+            | Ok(LLMChunk::ProviderUsage { .. })
             | Ok(LLMChunk::UsageSummary { .. })
             | Ok(LLMChunk::ReasoningSignature(_)) => {}
             Err(error) => {

--- a/crates/app/bamboo-server/src/handlers/openai/helpers/stream_utils.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/helpers/stream_utils.rs
@@ -111,6 +111,7 @@ pub(super) fn convert_chunk_to_openai(
         }),
         bamboo_llm::types::LLMChunk::TransportActivity
         | bamboo_llm::types::LLMChunk::CacheUsage { .. }
+        | bamboo_llm::types::LLMChunk::ProviderUsage { .. }
         | bamboo_llm::types::LLMChunk::UsageSummary { .. }
         | bamboo_llm::types::LLMChunk::ReasoningSignature(_) => None,
     }

--- a/crates/app/bamboo-server/src/handlers/openai/responses/non_stream.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/non_stream.rs
@@ -78,6 +78,7 @@ pub(super) async fn handle_non_streaming_response(
             Ok(bamboo_llm::types::LLMChunk::Done) => break,
             Ok(bamboo_llm::types::LLMChunk::TransportActivity)
             | Ok(bamboo_llm::types::LLMChunk::CacheUsage { .. })
+            | Ok(bamboo_llm::types::LLMChunk::ProviderUsage { .. })
             | Ok(bamboo_llm::types::LLMChunk::UsageSummary { .. })
             | Ok(bamboo_llm::types::LLMChunk::ReasoningSignature(_)) => {}
             Err(error) => {

--- a/crates/app/bamboo-server/src/handlers/openai/responses/stream/worker.rs
+++ b/crates/app/bamboo-server/src/handlers/openai/responses/stream/worker.rs
@@ -132,6 +132,7 @@ async fn run_stream_worker(mut args: StreamWorkerArgs) {
             Ok(LLMChunk::Done) => break,
             Ok(LLMChunk::TransportActivity)
             | Ok(LLMChunk::CacheUsage { .. })
+            | Ok(LLMChunk::ProviderUsage { .. })
             | Ok(LLMChunk::UsageSummary { .. })
             | Ok(LLMChunk::ReasoningSignature(_)) => {}
             Err(error) => {

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -153,7 +153,7 @@ impl RoundActivity {
             .saturating_add(stream_output.prompt_tokens_for_runtime_budget());
         self.completion_tokens = self
             .completion_tokens
-            .saturating_add(stream_output.output_tokens);
+            .saturating_add(stream_output.completion_tokens_for_runtime_budget());
         self.tool_call_count = self
             .tool_call_count
             .saturating_add(stream_output.tool_calls.len() as u32);
@@ -4292,15 +4292,17 @@ mod tests {
     fn round_activity_prefers_provider_prompt_total_without_adding_reasoning_twice() {
         use crate::runtime::stream::handler::{ProviderUsageSnapshot, StreamHandlingOutput};
 
-        let output = StreamHandlingOutput {
+        let mut output = StreamHandlingOutput {
             response_id: None,
             content: "answer".to_string(),
             reasoning_content: "thought".to_string(),
             reasoning_signature: None,
             token_count: 6,
             tool_calls: Vec::new(),
-            output_tokens: 120,
-            thinking_tokens: 20,
+            // Deliberately conflicting legacy flat values prove runtime
+            // guardrails consult the authoritative provider snapshot.
+            output_tokens: 56,
+            thinking_tokens: 78,
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 768,
             provider_usage: Some(ProviderUsageSnapshot {
@@ -4320,6 +4322,18 @@ mod tests {
         assert_eq!(
             activity.completion_tokens, 120,
             "reasoning is a subset of provider output, not additional output"
+        );
+
+        output
+            .provider_usage
+            .as_mut()
+            .expect("provider usage")
+            .output_tokens = Some(0);
+        let mut zero_activity = super::RoundActivity::default();
+        zero_activity.absorb_attempt(&output);
+        assert_eq!(
+            zero_activity.completion_tokens, 0,
+            "explicit provider zero must beat a nonzero legacy flat value"
         );
     }
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -150,7 +150,7 @@ impl RoundActivity {
     fn absorb_attempt(&mut self, stream_output: &StreamHandlingOutput) {
         self.prompt_tokens = self
             .prompt_tokens
-            .saturating_add(stream_output.input_tokens);
+            .saturating_add(stream_output.prompt_tokens_for_runtime_budget());
         self.completion_tokens = self
             .completion_tokens
             .saturating_add(stream_output.output_tokens);
@@ -4286,6 +4286,41 @@ mod tests {
         activity.absorb_attempt(&attempt(u64::MAX, u64::MAX, vec![]));
         assert_eq!(activity.prompt_tokens, u64::MAX);
         assert_eq!(activity.completion_tokens, u64::MAX);
+    }
+
+    #[test]
+    fn round_activity_prefers_provider_prompt_total_without_adding_reasoning_twice() {
+        use crate::runtime::stream::handler::{ProviderUsageSnapshot, StreamHandlingOutput};
+
+        let output = StreamHandlingOutput {
+            response_id: None,
+            content: "answer".to_string(),
+            reasoning_content: "thought".to_string(),
+            reasoning_signature: None,
+            token_count: 6,
+            tool_calls: Vec::new(),
+            output_tokens: 120,
+            thinking_tokens: 20,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 768,
+            provider_usage: Some(ProviderUsageSnapshot {
+                input_tokens: Some(1000),
+                output_tokens: Some(120),
+                reasoning_tokens: Some(20),
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: Some(768),
+            }),
+            input_tokens: 232,
+        };
+
+        let mut activity = super::RoundActivity::default();
+        activity.absorb_attempt(&output);
+
+        assert_eq!(activity.prompt_tokens, 1000);
+        assert_eq!(
+            activity.completion_tokens, 120,
+            "reasoning is a subset of provider output, not additional output"
+        );
     }
 
     /// PR #539 review #2: `runtime.budget_exceeded_kind` must be cleared at

--- a/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/loop_execution/pipeline.rs
@@ -4257,6 +4257,7 @@ mod tests {
                 thinking_tokens: 0,
                 cache_creation_input_tokens: 0,
                 cache_read_input_tokens: 0,
+                provider_usage: None,
                 input_tokens: input,
             }
         }
@@ -5384,6 +5385,7 @@ mod tests {
             thinking_tokens: 0,
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            provider_usage: None,
             input_tokens: 0,
         }
     }
@@ -5731,6 +5733,7 @@ mod tests {
             thinking_tokens: 0,
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            provider_usage: None,
             input_tokens: 0,
         };
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
@@ -508,10 +508,16 @@ async fn execute_llm_stream_emits_final_budget_event_with_provider_usage() {
         other => panic!("unexpected second event: {other:?}"),
     }
 
-    assert_eq!(stream_output.input_tokens, 100);
+    assert_eq!(stream_output.input_tokens, 66);
     assert_eq!(stream_output.output_tokens, 80);
     assert_eq!(stream_output.thinking_tokens, 24);
     assert_eq!(stream_output.cache_read_input_tokens, 34);
+    assert_eq!(
+        stream_output
+            .provider_usage
+            .and_then(|usage| usage.input_tokens),
+        Some(100)
+    );
     assert_eq!(
         session
             .token_usage

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
@@ -439,7 +439,7 @@ async fn explicit_activation_pending_suppresses_answer_tokens() {
 }
 
 #[tokio::test]
-async fn execute_llm_stream_emits_final_budget_event_with_stream_usage() {
+async fn execute_llm_stream_emits_final_budget_event_with_provider_usage() {
     let _env_lock = isolate_prompt_safe_env_cache();
     let mut session = Session::new("session-stream-final-budget", "test-model");
     let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(16);
@@ -456,14 +456,12 @@ async fn execute_llm_stream_emits_final_budget_event_with_stream_usage() {
     };
 
     let llm = mock_llm(vec![
-        LLMChunk::CacheUsage {
-            cache_creation_input_tokens: 21,
-            cache_read_input_tokens: 34,
-            input_tokens: 12,
-        },
-        LLMChunk::UsageSummary {
-            output_tokens: 56,
-            thinking_tokens: 78,
+        LLMChunk::ProviderUsage {
+            input_tokens: Some(100),
+            output_tokens: Some(80),
+            reasoning_tokens: Some(24),
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: Some(34),
         },
         LLMChunk::Done,
     ]);
@@ -504,21 +502,22 @@ async fn execute_llm_stream_emits_final_budget_event_with_stream_usage() {
 
     match event_rx.recv().await.expect("final budget event expected") {
         AgentEvent::TokenBudgetUpdated { usage } => {
-            assert_eq!(usage.thinking_tokens, 78);
+            assert_eq!(usage.thinking_tokens, 24);
             assert_eq!(usage.cache_read_input_tokens, 34);
         }
         other => panic!("unexpected second event: {other:?}"),
     }
 
-    assert_eq!(stream_output.output_tokens, 56);
-    assert_eq!(stream_output.thinking_tokens, 78);
+    assert_eq!(stream_output.input_tokens, 100);
+    assert_eq!(stream_output.output_tokens, 80);
+    assert_eq!(stream_output.thinking_tokens, 24);
     assert_eq!(stream_output.cache_read_input_tokens, 34);
     assert_eq!(
         session
             .token_usage
             .as_ref()
             .map(|usage| (usage.thinking_tokens, usage.cache_read_input_tokens)),
-        Some((78, 34))
+        Some((24, 34))
     );
 }
 

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/stream_execution/tests.rs
@@ -463,6 +463,17 @@ async fn execute_llm_stream_emits_final_budget_event_with_provider_usage() {
             cache_creation_input_tokens: None,
             cache_read_input_tokens: Some(34),
         },
+        // Later legacy summaries/cache frames must not overwrite authoritative
+        // provider fields or double the cache badge.
+        LLMChunk::UsageSummary {
+            output_tokens: 56,
+            thinking_tokens: 78,
+        },
+        LLMChunk::CacheUsage {
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 34,
+            input_tokens: 66,
+        },
         LLMChunk::Done,
     ]);
     let llm_dyn: Arc<dyn LLMProvider> = llm.clone();

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
@@ -94,11 +94,23 @@ pub struct StreamHandlingOutput {
     /// chunk was observed. Repeated cumulative snapshots are idempotent, absent
     /// fields do not erase known values, and explicit zeros remain `Some(0)`.
     pub provider_usage: Option<ProviderUsageSnapshot>,
-    /// Provider-reported total input when a [`bamboo_llm::LLMChunk::ProviderUsage`]
-    /// snapshot is available. Legacy cache-only chunks retain their historical
-    /// fresh-input semantics; callers can distinguish cached input through the
-    /// adjacent cache counters.
+    /// Normalized non-cached ("fresh") input, disjoint from the adjacent cache
+    /// counters. When a provider total is available this is derived from that
+    /// total with a saturating, cache-subset policy; the raw total remains in
+    /// [`Self::provider_usage`].
     pub input_tokens: u64,
+}
+
+impl StreamHandlingOutput {
+    /// Prompt usage for runtime budget enforcement.
+    ///
+    /// Provider-reported totals are authoritative when present. Legacy streams
+    /// retain their historical fallback to the flat fresh-input counter.
+    pub(crate) fn prompt_tokens_for_runtime_budget(&self) -> u64 {
+        self.provider_usage
+            .and_then(|usage| usage.input_tokens)
+            .unwrap_or(self.input_tokens)
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
@@ -111,6 +111,16 @@ impl StreamHandlingOutput {
             .and_then(|usage| usage.input_tokens)
             .unwrap_or(self.input_tokens)
     }
+
+    /// Completion usage for runtime budget enforcement.
+    ///
+    /// A provider-reported output total (including explicit zero) wins over
+    /// legacy summaries. Reasoning is a subset breakdown and is never added.
+    pub(crate) fn completion_tokens_for_runtime_budget(&self) -> u64 {
+        self.provider_usage
+            .and_then(|usage| usage.output_tokens)
+            .unwrap_or(self.output_tokens)
+    }
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
@@ -76,6 +76,10 @@ pub struct StreamHandlingOutput {
     pub thinking_tokens: u64,
     pub cache_creation_input_tokens: u64,
     pub cache_read_input_tokens: u64,
+    /// Provider-reported total input when a [`bamboo_llm::LLMChunk::ProviderUsage`]
+    /// snapshot is available. Legacy cache-only chunks retain their historical
+    /// fresh-input semantics; callers can distinguish cached input through the
+    /// adjacent cache counters.
     pub input_tokens: u64,
 }
 

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler.rs
@@ -62,6 +62,20 @@ fn sanitize_identifier(value: &str) -> Option<String> {
     (!sanitized.is_empty()).then_some(sanitized)
 }
 
+/// Raw authoritative usage fields preserved from provider terminal events.
+///
+/// Each field remains optional so callers can distinguish an explicit
+/// provider-reported zero from an omitted value. Flat counters on
+/// [`StreamHandlingOutput`] remain the normalized compatibility view.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ProviderUsageSnapshot {
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub reasoning_tokens: Option<u64>,
+    pub cache_creation_input_tokens: Option<u64>,
+    pub cache_read_input_tokens: Option<u64>,
+}
+
 pub struct StreamHandlingOutput {
     pub response_id: Option<String>,
     pub content: String,
@@ -76,6 +90,10 @@ pub struct StreamHandlingOutput {
     pub thinking_tokens: u64,
     pub cache_creation_input_tokens: u64,
     pub cache_read_input_tokens: u64,
+    /// Merged authoritative provider snapshot, when at least one provider-usage
+    /// chunk was observed. Repeated cumulative snapshots are idempotent, absent
+    /// fields do not erase known values, and explicit zeros remain `Some(0)`.
+    pub provider_usage: Option<ProviderUsageSnapshot>,
     /// Provider-reported total input when a [`bamboo_llm::LLMChunk::ProviderUsage`]
     /// snapshot is available. Legacy cache-only chunks retain their historical
     /// fresh-input semantics; callers can distinguish cached input through the

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/chunk_handling.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/chunk_handling.rs
@@ -116,6 +116,32 @@ pub(super) async fn handle_chunk_result(
             );
             Ok(())
         }
+        Ok(LLMChunk::ProviderUsage {
+            input_tokens,
+            output_tokens,
+            reasoning_tokens,
+            cache_creation_input_tokens,
+            cache_read_input_tokens,
+        }) => {
+            tracing::debug!(
+                "[{}] Provider usage: input={:?}, output={:?}, reasoning={:?}, \
+                 cache_creation={:?}, cache_read={:?}",
+                session_id,
+                input_tokens,
+                output_tokens,
+                reasoning_tokens,
+                cache_creation_input_tokens,
+                cache_read_input_tokens
+            );
+            state.record_provider_usage(
+                input_tokens,
+                output_tokens,
+                reasoning_tokens,
+                cache_creation_input_tokens,
+                cache_read_input_tokens,
+            );
+            Ok(())
+        }
         Ok(LLMChunk::UsageSummary {
             output_tokens,
             thinking_tokens,

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/stream_state.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/stream_state.rs
@@ -85,8 +85,13 @@ impl StreamAccumulationState {
     }
 
     pub(super) fn record_usage(&mut self, output_tokens: u64, thinking_tokens: u64) {
-        self.output_tokens = output_tokens;
-        self.thinking_tokens = thinking_tokens;
+        let provider_usage = self.provider_usage.unwrap_or_default();
+        if provider_usage.output_tokens.is_none() {
+            self.output_tokens = output_tokens;
+        }
+        if provider_usage.reasoning_tokens.is_none() {
+            self.thinking_tokens = thinking_tokens;
+        }
     }
 
     pub(super) fn record_cache(&mut self, creation: u64, read: u64, input: u64) {
@@ -163,6 +168,18 @@ impl StreamAccumulationState {
         let Some(snapshot) = self.provider_usage else {
             return;
         };
+
+        // Provider cache fields are independently authoritative even when the
+        // provider omitted its input total. Restore them before considering
+        // legacy cache deltas so arrival order cannot turn one cumulative
+        // provider value into an accidental sum.
+        if let Some(cache_read_input_tokens) = snapshot.cache_read_input_tokens {
+            self.cache_read_input_tokens = cache_read_input_tokens;
+        }
+        if let Some(cache_creation_input_tokens) = snapshot.cache_creation_input_tokens {
+            self.cache_creation_input_tokens = cache_creation_input_tokens;
+        }
+
         let Some(total_input_tokens) = snapshot.input_tokens else {
             return;
         };

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/stream_state.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/stream_state.rs
@@ -1,6 +1,8 @@
 use bamboo_agent_core::tools::ToolCallAccumulator;
 
-use super::{InterruptedStreamOutput, PartialToolCallSnapshot, StreamHandlingOutput};
+use super::{
+    InterruptedStreamOutput, PartialToolCallSnapshot, ProviderUsageSnapshot, StreamHandlingOutput,
+};
 
 pub(super) struct StreamAccumulationState {
     response_id: Option<String>,
@@ -17,6 +19,7 @@ pub(super) struct StreamAccumulationState {
     thinking_tokens: u64,
     cache_creation_input_tokens: u64,
     cache_read_input_tokens: u64,
+    provider_usage: Option<ProviderUsageSnapshot>,
     input_tokens: u64,
 }
 
@@ -34,6 +37,7 @@ impl StreamAccumulationState {
             thinking_tokens: 0,
             cache_creation_input_tokens: 0,
             cache_read_input_tokens: 0,
+            provider_usage: None,
             input_tokens: 0,
         }
     }
@@ -110,19 +114,25 @@ impl StreamAccumulationState {
         cache_creation_input_tokens: Option<u64>,
         cache_read_input_tokens: Option<u64>,
     ) {
+        let snapshot = self.provider_usage.get_or_insert_default();
         if let Some(input_tokens) = input_tokens {
+            snapshot.input_tokens = Some(input_tokens);
             self.input_tokens = input_tokens;
         }
         if let Some(output_tokens) = output_tokens {
+            snapshot.output_tokens = Some(output_tokens);
             self.output_tokens = output_tokens;
         }
         if let Some(reasoning_tokens) = reasoning_tokens {
+            snapshot.reasoning_tokens = Some(reasoning_tokens);
             self.thinking_tokens = reasoning_tokens;
         }
         if let Some(cache_creation_input_tokens) = cache_creation_input_tokens {
+            snapshot.cache_creation_input_tokens = Some(cache_creation_input_tokens);
             self.cache_creation_input_tokens = cache_creation_input_tokens;
         }
         if let Some(cache_read_input_tokens) = cache_read_input_tokens {
+            snapshot.cache_read_input_tokens = Some(cache_read_input_tokens);
             self.cache_read_input_tokens = cache_read_input_tokens;
         }
     }
@@ -139,6 +149,7 @@ impl StreamAccumulationState {
             thinking_tokens: self.thinking_tokens,
             cache_creation_input_tokens: self.cache_creation_input_tokens,
             cache_read_input_tokens: self.cache_read_input_tokens,
+            provider_usage: self.provider_usage,
             input_tokens: self.input_tokens,
         }
     }

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/stream_state.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/stream_state.rs
@@ -97,6 +97,7 @@ impl StreamAccumulationState {
         // message_start. Take the max rather than accumulating so a delta that
         // echoes it does not double-count.
         self.input_tokens = self.input_tokens.max(input);
+        self.normalize_provider_input_compatibility_view();
     }
 
     /// Record an authoritative provider usage snapshot.
@@ -114,27 +115,72 @@ impl StreamAccumulationState {
         cache_creation_input_tokens: Option<u64>,
         cache_read_input_tokens: Option<u64>,
     ) {
-        let snapshot = self.provider_usage.get_or_insert_default();
-        if let Some(input_tokens) = input_tokens {
-            snapshot.input_tokens = Some(input_tokens);
-            self.input_tokens = input_tokens;
+        {
+            let snapshot = self.provider_usage.get_or_insert_default();
+            if let Some(input_tokens) = input_tokens {
+                snapshot.input_tokens = Some(input_tokens);
+            }
+            if let Some(output_tokens) = output_tokens {
+                snapshot.output_tokens = Some(output_tokens);
+            }
+            if let Some(reasoning_tokens) = reasoning_tokens {
+                snapshot.reasoning_tokens = Some(reasoning_tokens);
+            }
+            if let Some(cache_creation_input_tokens) = cache_creation_input_tokens {
+                snapshot.cache_creation_input_tokens = Some(cache_creation_input_tokens);
+            }
+            if let Some(cache_read_input_tokens) = cache_read_input_tokens {
+                snapshot.cache_read_input_tokens = Some(cache_read_input_tokens);
+            }
         }
+
         if let Some(output_tokens) = output_tokens {
-            snapshot.output_tokens = Some(output_tokens);
             self.output_tokens = output_tokens;
         }
         if let Some(reasoning_tokens) = reasoning_tokens {
-            snapshot.reasoning_tokens = Some(reasoning_tokens);
             self.thinking_tokens = reasoning_tokens;
         }
         if let Some(cache_creation_input_tokens) = cache_creation_input_tokens {
-            snapshot.cache_creation_input_tokens = Some(cache_creation_input_tokens);
             self.cache_creation_input_tokens = cache_creation_input_tokens;
         }
         if let Some(cache_read_input_tokens) = cache_read_input_tokens {
-            snapshot.cache_read_input_tokens = Some(cache_read_input_tokens);
             self.cache_read_input_tokens = cache_read_input_tokens;
         }
+        self.normalize_provider_input_compatibility_view();
+    }
+
+    /// Normalize the historical flat counters without mutating the raw provider
+    /// snapshot.
+    ///
+    /// Cache counts must form a subset of the authoritative prompt total so
+    /// legacy analytics can continue using
+    /// `fresh + cache_read + cache_creation`. Cache-read is retained first
+    /// because it carries the cache-hit/badge semantics; cache-creation is
+    /// clamped to the remaining total, and fresh input receives the remainder.
+    /// This also handles malformed `cache > input` reports without inflating
+    /// the normalized prompt beyond the provider total.
+    fn normalize_provider_input_compatibility_view(&mut self) {
+        let Some(snapshot) = self.provider_usage else {
+            return;
+        };
+        let Some(total_input_tokens) = snapshot.input_tokens else {
+            return;
+        };
+
+        let raw_cache_read = snapshot
+            .cache_read_input_tokens
+            .unwrap_or(self.cache_read_input_tokens);
+        let normalized_cache_read = raw_cache_read.min(total_input_tokens);
+        let after_cache_read = total_input_tokens.saturating_sub(normalized_cache_read);
+
+        let raw_cache_creation = snapshot
+            .cache_creation_input_tokens
+            .unwrap_or(self.cache_creation_input_tokens);
+        let normalized_cache_creation = raw_cache_creation.min(after_cache_read);
+
+        self.cache_read_input_tokens = normalized_cache_read;
+        self.cache_creation_input_tokens = normalized_cache_creation;
+        self.input_tokens = after_cache_read.saturating_sub(normalized_cache_creation);
     }
 
     pub(super) fn into_output(self) -> StreamHandlingOutput {

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/stream_state.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/stream_state.rs
@@ -95,6 +95,38 @@ impl StreamAccumulationState {
         self.input_tokens = self.input_tokens.max(input);
     }
 
+    /// Record an authoritative provider usage snapshot.
+    ///
+    /// Snapshot values replace previously observed values rather than being
+    /// summed. OpenAI-compatible terminal usage objects are cumulative for the
+    /// request, so addition would double-count if an upstream repeats a final
+    /// frame. Omitted fields leave existing state untouched; an explicit zero
+    /// remains authoritative.
+    pub(super) fn record_provider_usage(
+        &mut self,
+        input_tokens: Option<u64>,
+        output_tokens: Option<u64>,
+        reasoning_tokens: Option<u64>,
+        cache_creation_input_tokens: Option<u64>,
+        cache_read_input_tokens: Option<u64>,
+    ) {
+        if let Some(input_tokens) = input_tokens {
+            self.input_tokens = input_tokens;
+        }
+        if let Some(output_tokens) = output_tokens {
+            self.output_tokens = output_tokens;
+        }
+        if let Some(reasoning_tokens) = reasoning_tokens {
+            self.thinking_tokens = reasoning_tokens;
+        }
+        if let Some(cache_creation_input_tokens) = cache_creation_input_tokens {
+            self.cache_creation_input_tokens = cache_creation_input_tokens;
+        }
+        if let Some(cache_read_input_tokens) = cache_read_input_tokens {
+            self.cache_read_input_tokens = cache_read_input_tokens;
+        }
+    }
+
     pub(super) fn into_output(self) -> StreamHandlingOutput {
         StreamHandlingOutput {
             response_id: self.response_id,

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
@@ -9,6 +9,8 @@ use bamboo_agent_core::tools::{FunctionCall, ToolCall};
 use bamboo_agent_core::{AgentError, AgentEvent};
 use bamboo_config::StreamTimeoutConfig;
 use bamboo_llm::provider::LLMError;
+use bamboo_llm::providers::common::openai_compat::parse_openai_compat_sse_data_strict;
+use bamboo_llm::providers::common::openai_responses::ResponsesSseParser;
 use bamboo_llm::{LLMChunk, LLMStream};
 
 use super::consume::consume_llm_stream_internal;
@@ -178,6 +180,79 @@ async fn consume_llm_stream_records_provider_usage_snapshots_without_double_coun
     assert_eq!(output.thinking_tokens, 11);
     assert_eq!(output.cache_creation_input_tokens, 0);
     assert_eq!(output.cache_read_input_tokens, 29);
+}
+
+#[tokio::test]
+async fn openai_chat_usage_parser_reaches_stream_output_once() {
+    let usage = parse_openai_compat_sse_data_strict(
+        r#"{"id":"chatcmpl_1","choices":[],"usage":{"prompt_tokens":1000,"completion_tokens":120,"prompt_tokens_details":{"cached_tokens":768},"completion_tokens_details":{"reasoning_tokens":20}}}"#,
+    )
+    .expect("chat usage chunk");
+    assert!(matches!(usage, LLMChunk::ProviderUsage { .. }));
+
+    let stream = build_stream(vec![Ok(usage), Ok(LLMChunk::Done)]);
+    let output = consume_llm_stream_silent(
+        stream,
+        &CancellationToken::new(),
+        "session-openai-chat-usage",
+    )
+    .await
+    .expect("stream should succeed");
+
+    assert_eq!(output.input_tokens, 1000);
+    assert_eq!(output.output_tokens, 120);
+    assert_eq!(output.thinking_tokens, 20);
+    assert_eq!(output.cache_creation_input_tokens, 0);
+    assert_eq!(output.cache_read_input_tokens, 768);
+    assert_eq!(
+        output.input_tokens - output.cache_read_input_tokens,
+        232,
+        "fresh input remains derivable from the authoritative total"
+    );
+}
+
+#[tokio::test]
+async fn openai_responses_completed_usage_reaches_stream_output_once() {
+    let mut parser = ResponsesSseParser::new();
+    let chunks = parser
+        .handle_event_multi(
+            "response.completed",
+            r#"{"type":"response.completed","response":{"id":"resp_usage","output":[{"id":"msg_usage","type":"message","content":[{"type":"output_text","text":"answer"}]}],"usage":{"input_tokens":55,"output_tokens":21,"input_tokens_details":{"cached_tokens":13},"output_tokens_details":{"reasoning_tokens":8}}}}"#,
+        )
+        .expect("responses completed event");
+
+    assert_eq!(
+        chunks
+            .iter()
+            .filter(|chunk| matches!(chunk, LLMChunk::ProviderUsage { .. }))
+            .count(),
+        1
+    );
+    assert!(chunks
+        .iter()
+        .all(|chunk| !matches!(chunk, LLMChunk::CacheUsage { .. })));
+
+    let stream = build_stream(chunks.into_iter().map(Ok).collect());
+    let output = consume_llm_stream_silent(
+        stream,
+        &CancellationToken::new(),
+        "session-openai-responses-usage",
+    )
+    .await
+    .expect("stream should succeed");
+
+    assert_eq!(output.response_id.as_deref(), Some("resp_usage"));
+    assert_eq!(output.content, "answer");
+    assert_eq!(output.input_tokens, 55);
+    assert_eq!(output.output_tokens, 21);
+    assert_eq!(output.thinking_tokens, 8);
+    assert_eq!(output.cache_creation_input_tokens, 0);
+    assert_eq!(output.cache_read_input_tokens, 13);
+    assert_eq!(
+        output.input_tokens - output.cache_read_input_tokens,
+        42,
+        "fresh input remains derivable without emitting a second cache chunk"
+    );
 }
 
 #[tokio::test]

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
@@ -253,6 +253,151 @@ async fn provider_usage_snapshot_distinguishes_omitted_from_zero_for_every_field
 }
 
 #[tokio::test]
+async fn provider_output_and_reasoning_reconcile_independently_in_both_orders() {
+    let cases = [
+        (Some(120), Some(20), 120, 20),
+        (Some(0), Some(0), 0, 0),
+        (None, Some(20), 56, 20),
+        (Some(120), None, 120, 78),
+    ];
+
+    for (case_index, (provider_output, provider_reasoning, expected_output, expected_reasoning)) in
+        cases.into_iter().enumerate()
+    {
+        for provider_first in [true, false] {
+            let provider = LLMChunk::ProviderUsage {
+                input_tokens: None,
+                output_tokens: provider_output,
+                reasoning_tokens: provider_reasoning,
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: None,
+            };
+            let legacy = LLMChunk::UsageSummary {
+                output_tokens: 56,
+                thinking_tokens: 78,
+            };
+            let chunks = if provider_first {
+                vec![provider, legacy, LLMChunk::Done]
+            } else {
+                vec![legacy, provider, LLMChunk::Done]
+            };
+            let output = consume_llm_stream_silent(
+                build_stream(chunks.into_iter().map(Ok).collect()),
+                &CancellationToken::new(),
+                &format!("session-provider-output-{case_index}-{provider_first}"),
+            )
+            .await
+            .expect("mixed provider and legacy usage");
+
+            assert_eq!(output.output_tokens, expected_output);
+            assert_eq!(output.thinking_tokens, expected_reasoning);
+            assert_eq!(
+                output.provider_usage,
+                Some(ProviderUsageSnapshot {
+                    input_tokens: None,
+                    output_tokens: provider_output,
+                    reasoning_tokens: provider_reasoning,
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: None,
+                })
+            );
+
+            let log_record = crate::token_usage_log::TokenUsageRecord::new(
+                "2026-07-29T00:00:00Z".to_string(),
+                "session-provider-output",
+                "test-model",
+                "openai",
+                1,
+                None,
+                output.cache_creation_input_tokens,
+                output.cache_read_input_tokens,
+                output.input_tokens,
+                output.output_tokens,
+                output.thinking_tokens,
+            );
+            assert_eq!(log_record.output_tokens, expected_output);
+            assert_eq!(log_record.thinking_tokens, expected_reasoning);
+        }
+    }
+}
+
+#[tokio::test]
+async fn provider_cache_reconciles_without_input_total_in_both_orders() {
+    let cases = [
+        (None, Some(50), 11, 50),
+        (Some(0), Some(0), 0, 0),
+        (Some(7), None, 7, 50),
+    ];
+
+    for (case_index, (provider_creation, provider_read, expected_creation, expected_read)) in
+        cases.into_iter().enumerate()
+    {
+        for provider_first in [true, false] {
+            let provider = LLMChunk::ProviderUsage {
+                input_tokens: None,
+                output_tokens: None,
+                reasoning_tokens: None,
+                cache_creation_input_tokens: provider_creation,
+                cache_read_input_tokens: provider_read,
+            };
+            let legacy = LLMChunk::CacheUsage {
+                cache_creation_input_tokens: 11,
+                cache_read_input_tokens: 50,
+                input_tokens: 80,
+            };
+            let chunks = if provider_first {
+                vec![provider, legacy, LLMChunk::Done]
+            } else {
+                vec![legacy, provider, LLMChunk::Done]
+            };
+            let output = consume_llm_stream_silent(
+                build_stream(chunks.into_iter().map(Ok).collect()),
+                &CancellationToken::new(),
+                &format!("session-provider-cache-{case_index}-{provider_first}"),
+            )
+            .await
+            .expect("mixed provider and legacy cache usage");
+
+            assert_eq!(output.input_tokens, 80);
+            assert_eq!(
+                output.cache_creation_input_tokens, expected_creation,
+                "provider creation availability must be order-independent"
+            );
+            assert_eq!(
+                output.cache_read_input_tokens, expected_read,
+                "provider read availability must be order-independent"
+            );
+            assert_eq!(
+                output.provider_usage,
+                Some(ProviderUsageSnapshot {
+                    input_tokens: None,
+                    output_tokens: None,
+                    reasoning_tokens: None,
+                    cache_creation_input_tokens: provider_creation,
+                    cache_read_input_tokens: provider_read,
+                })
+            );
+
+            let log_record = crate::token_usage_log::TokenUsageRecord::new(
+                "2026-07-29T00:00:00Z".to_string(),
+                "session-provider-cache",
+                "test-model",
+                "openai",
+                1,
+                None,
+                output.cache_creation_input_tokens,
+                output.cache_read_input_tokens,
+                output.input_tokens,
+                output.output_tokens,
+                output.thinking_tokens,
+            );
+            assert_eq!(log_record.cache_creation_input_tokens, expected_creation);
+            assert_eq!(log_record.cache_read_input_tokens, expected_read);
+        }
+    }
+}
+
+#[tokio::test]
 async fn openai_chat_usage_parser_reaches_stream_output_once() {
     let usage = parse_openai_compat_sse_data_strict(
         r#"{"id":"chatcmpl_1","choices":[],"usage":{"prompt_tokens":1000,"completion_tokens":120,"prompt_tokens_details":{"cached_tokens":768},"completion_tokens_details":{"reasoning_tokens":20}}}"#,

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
@@ -177,7 +177,7 @@ async fn consume_llm_stream_records_provider_usage_snapshots_without_double_coun
             .await
             .expect("stream should succeed");
 
-    assert_eq!(output.input_tokens, 101);
+    assert_eq!(output.input_tokens, 72);
     assert_eq!(output.output_tokens, 37);
     assert_eq!(output.thinking_tokens, 11);
     assert_eq!(output.cache_creation_input_tokens, 0);
@@ -269,15 +269,14 @@ async fn openai_chat_usage_parser_reaches_stream_output_once() {
     .await
     .expect("stream should succeed");
 
-    assert_eq!(output.input_tokens, 1000);
+    assert_eq!(output.input_tokens, 232);
     assert_eq!(output.output_tokens, 120);
     assert_eq!(output.thinking_tokens, 20);
     assert_eq!(output.cache_creation_input_tokens, 0);
     assert_eq!(output.cache_read_input_tokens, 768);
     assert_eq!(
-        output.input_tokens - output.cache_read_input_tokens,
-        232,
-        "fresh input remains derivable from the authoritative total"
+        output.provider_usage.and_then(|usage| usage.input_tokens),
+        Some(1000)
     );
 }
 
@@ -313,15 +312,83 @@ async fn openai_responses_completed_usage_reaches_stream_output_once() {
 
     assert_eq!(output.response_id.as_deref(), Some("resp_usage"));
     assert_eq!(output.content, "answer");
-    assert_eq!(output.input_tokens, 55);
+    assert_eq!(output.input_tokens, 42);
     assert_eq!(output.output_tokens, 21);
     assert_eq!(output.thinking_tokens, 8);
     assert_eq!(output.cache_creation_input_tokens, 0);
     assert_eq!(output.cache_read_input_tokens, 13);
     assert_eq!(
-        output.input_tokens - output.cache_read_input_tokens,
-        42,
-        "fresh input remains derivable without emitting a second cache chunk"
+        output.provider_usage.and_then(|usage| usage.input_tokens),
+        Some(55)
+    );
+}
+
+#[tokio::test]
+async fn provider_total_clamps_flat_cache_subset_without_mutating_raw_snapshot() {
+    let aggregate_overflow = consume_llm_stream_silent(
+        build_stream(vec![
+            Ok(LLMChunk::ProviderUsage {
+                input_tokens: Some(100),
+                output_tokens: None,
+                reasoning_tokens: None,
+                cache_creation_input_tokens: Some(50),
+                cache_read_input_tokens: Some(80),
+            }),
+            Ok(LLMChunk::Done),
+        ]),
+        &CancellationToken::new(),
+        "session-provider-cache-overflow",
+    )
+    .await
+    .expect("aggregate cache overflow");
+
+    assert_eq!(aggregate_overflow.input_tokens, 0);
+    assert_eq!(aggregate_overflow.cache_read_input_tokens, 80);
+    assert_eq!(aggregate_overflow.cache_creation_input_tokens, 20);
+    assert_eq!(
+        aggregate_overflow.input_tokens
+            + aggregate_overflow.cache_read_input_tokens
+            + aggregate_overflow.cache_creation_input_tokens,
+        100
+    );
+    assert_eq!(
+        aggregate_overflow.provider_usage,
+        Some(ProviderUsageSnapshot {
+            input_tokens: Some(100),
+            output_tokens: None,
+            reasoning_tokens: None,
+            cache_creation_input_tokens: Some(50),
+            cache_read_input_tokens: Some(80),
+        }),
+        "raw anomalous provider values remain available for diagnostics"
+    );
+
+    let cache_exceeds_input = consume_llm_stream_silent(
+        build_stream(vec![
+            Ok(LLMChunk::ProviderUsage {
+                input_tokens: Some(100),
+                output_tokens: None,
+                reasoning_tokens: None,
+                cache_creation_input_tokens: Some(30),
+                cache_read_input_tokens: Some(120),
+            }),
+            Ok(LLMChunk::Done),
+        ]),
+        &CancellationToken::new(),
+        "session-provider-cache-exceeds-input",
+    )
+    .await
+    .expect("cache exceeds input");
+
+    assert_eq!(cache_exceeds_input.input_tokens, 0);
+    assert_eq!(cache_exceeds_input.cache_read_input_tokens, 100);
+    assert_eq!(cache_exceeds_input.cache_creation_input_tokens, 0);
+    assert_eq!(
+        cache_exceeds_input.input_tokens
+            + cache_exceeds_input.cache_read_input_tokens
+            + cache_exceeds_input.cache_creation_input_tokens,
+        100,
+        "normalized compatibility fields never exceed authoritative input"
     );
 }
 

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
@@ -145,6 +145,42 @@ async fn consume_llm_stream_silent_does_not_emit_events() {
 }
 
 #[tokio::test]
+async fn consume_llm_stream_records_provider_usage_snapshots_without_double_counting() {
+    let usage = LLMChunk::ProviderUsage {
+        input_tokens: Some(101),
+        output_tokens: Some(37),
+        reasoning_tokens: Some(11),
+        cache_creation_input_tokens: Some(0),
+        cache_read_input_tokens: Some(29),
+    };
+    let stream = build_stream(vec![
+        Ok(usage.clone()),
+        // Repeated cumulative snapshots are idempotent, not additive.
+        Ok(usage),
+        // Omitted fields must not invent or erase authoritative totals.
+        Ok(LLMChunk::ProviderUsage {
+            input_tokens: None,
+            output_tokens: None,
+            reasoning_tokens: None,
+            cache_creation_input_tokens: None,
+            cache_read_input_tokens: None,
+        }),
+        Ok(LLMChunk::Done),
+    ]);
+
+    let output =
+        consume_llm_stream_silent(stream, &CancellationToken::new(), "session-provider-usage")
+            .await
+            .expect("stream should succeed");
+
+    assert_eq!(output.input_tokens, 101);
+    assert_eq!(output.output_tokens, 37);
+    assert_eq!(output.thinking_tokens, 11);
+    assert_eq!(output.cache_creation_input_tokens, 0);
+    assert_eq!(output.cache_read_input_tokens, 29);
+}
+
+#[tokio::test]
 async fn consume_llm_stream_returns_single_prefix_stream_error_message() {
     let stream = build_stream(vec![Err(LLMError::Stream(
         "Transport error: error decoding response body".to_string(),

--- a/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/stream/handler/tests.rs
@@ -14,7 +14,9 @@ use bamboo_llm::providers::common::openai_responses::ResponsesSseParser;
 use bamboo_llm::{LLMChunk, LLMStream};
 
 use super::consume::consume_llm_stream_internal;
-use super::{consume_llm_stream, consume_llm_stream_silent, StreamTimeoutContext};
+use super::{
+    consume_llm_stream, consume_llm_stream_silent, ProviderUsageSnapshot, StreamTimeoutContext,
+};
 
 fn build_stream(items: Vec<bamboo_llm::provider::Result<LLMChunk>>) -> LLMStream {
     Box::pin(stream::iter(items))
@@ -180,6 +182,74 @@ async fn consume_llm_stream_records_provider_usage_snapshots_without_double_coun
     assert_eq!(output.thinking_tokens, 11);
     assert_eq!(output.cache_creation_input_tokens, 0);
     assert_eq!(output.cache_read_input_tokens, 29);
+    assert_eq!(
+        output.provider_usage,
+        Some(ProviderUsageSnapshot {
+            input_tokens: Some(101),
+            output_tokens: Some(37),
+            reasoning_tokens: Some(11),
+            cache_creation_input_tokens: Some(0),
+            cache_read_input_tokens: Some(29),
+        })
+    );
+}
+
+#[tokio::test]
+async fn provider_usage_snapshot_distinguishes_omitted_from_zero_for_every_field() {
+    let omitted = consume_llm_stream_silent(
+        build_stream(vec![
+            Ok(LLMChunk::ProviderUsage {
+                input_tokens: None,
+                output_tokens: None,
+                reasoning_tokens: None,
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: None,
+            }),
+            Ok(LLMChunk::Done),
+        ]),
+        &CancellationToken::new(),
+        "session-provider-usage-omitted",
+    )
+    .await
+    .expect("omitted snapshot");
+    assert_eq!(
+        omitted.provider_usage,
+        Some(ProviderUsageSnapshot::default())
+    );
+
+    let explicit_zero = consume_llm_stream_silent(
+        build_stream(vec![
+            Ok(LLMChunk::ProviderUsage {
+                input_tokens: Some(9),
+                output_tokens: Some(9),
+                reasoning_tokens: Some(9),
+                cache_creation_input_tokens: Some(9),
+                cache_read_input_tokens: Some(9),
+            }),
+            Ok(LLMChunk::ProviderUsage {
+                input_tokens: Some(0),
+                output_tokens: Some(0),
+                reasoning_tokens: Some(0),
+                cache_creation_input_tokens: Some(0),
+                cache_read_input_tokens: Some(0),
+            }),
+            Ok(LLMChunk::Done),
+        ]),
+        &CancellationToken::new(),
+        "session-provider-usage-zero",
+    )
+    .await
+    .expect("zero snapshot");
+    assert_eq!(
+        explicit_zero.provider_usage,
+        Some(ProviderUsageSnapshot {
+            input_tokens: Some(0),
+            output_tokens: Some(0),
+            reasoning_tokens: Some(0),
+            cache_creation_input_tokens: Some(0),
+            cache_read_input_tokens: Some(0),
+        })
+    );
 }
 
 #[tokio::test]

--- a/crates/engine/bamboo-engine/src/token_usage_log.rs
+++ b/crates/engine/bamboo-engine/src/token_usage_log.rs
@@ -37,6 +37,9 @@ pub struct TokenUsageRecord {
     /// `input_tokens + cache_read + cache_creation`, and the exact cache-hit
     /// ratio is `cache_read / that_sum`.
     pub input_tokens: u64,
+    /// Total provider output. For reasoning-capable OpenAI-compatible models,
+    /// `thinking_tokens` is a subset breakdown of this value, not an additional
+    /// quantity.
     pub output_tokens: u64,
     pub thinking_tokens: u64,
 
@@ -144,5 +147,34 @@ mod tests {
         assert!(line.contains("\"cache_read_input_tokens\":12000"));
         assert!(line.contains("\"input_tokens\":800"));
         assert!(line.contains("\"session_id\":\"sess-1\""));
+    }
+
+    #[test]
+    fn openai_flat_log_contract_keeps_fresh_cache_and_total_disjoint() {
+        let record = TokenUsageRecord::new(
+            "2026-07-29T00:00:00Z".to_string(),
+            "sess-openai",
+            "gpt-5",
+            "openai",
+            4,
+            None,
+            0,
+            768,
+            232,
+            120,
+            20,
+        );
+
+        let prompt_total = record
+            .input_tokens
+            .saturating_add(record.cache_read_input_tokens)
+            .saturating_add(record.cache_creation_input_tokens);
+        let cache_hit_ratio = record.cache_read_input_tokens as f64 / prompt_total as f64;
+
+        assert_eq!(record.input_tokens, 232);
+        assert_eq!(prompt_total, 1000);
+        assert!((cache_hit_ratio - 0.768).abs() < f64::EPSILON);
+        assert_eq!(record.output_tokens, 120);
+        assert_eq!(record.thinking_tokens, 20);
     }
 }

--- a/crates/infra/bamboo-llm/src/cache.rs
+++ b/crates/infra/bamboo-llm/src/cache.rs
@@ -16,9 +16,10 @@
 //!    `cache_read_input_tokens`; OpenAI-compatible APIs report
 //!    `prompt_tokens_details.cached_tokens` (or `input_tokens_details.cached_tokens`
 //!    on the Responses API); Gemini reports `cachedContentTokenCount`. The
-//!    `cache_usage_from_*` helpers normalize these into [`LLMChunk::CacheUsage`]
-//!    so the same downstream accounting (and the frontend cache badge) works for
-//!    every provider.
+//!    OpenAI terminal usage is normalized into a combined
+//!    [`LLMChunk::ProviderUsage`] snapshot, while the remaining
+//!    `cache_usage_from_*` helpers use [`LLMChunk::CacheUsage`]. Both feed the
+//!    same downstream cache fields (and frontend cache badge).
 //!
 //! [`PromptCachePlan`] is the provider-agnostic description of (1): the engine
 //! builds it once from the prompt envelope and each provider renders it in its
@@ -93,12 +94,15 @@ impl PromptCachePlan {
     }
 }
 
-/// Normalize an OpenAI-style `usage` object into a [`LLMChunk::CacheUsage`], if
-/// it reports cached prompt tokens.
+/// Normalize an OpenAI-style `usage` object into a cache-only chunk, if it
+/// reports cached prompt tokens.
 ///
 /// OpenAI exposes cached input tokens under `prompt_tokens_details.cached_tokens`
 /// (Chat Completions) or `input_tokens_details.cached_tokens` (Responses API).
 /// Returns `None` when no cache hit is reported, so callers can skip emitting.
+///
+/// Streaming parsers use [`provider_usage_from_openai_usage`] instead so input,
+/// output, reasoning, and cache fields from one terminal event remain atomic.
 pub fn cache_usage_from_openai_usage(usage: &Value) -> Option<LLMChunk> {
     let cached = usage
         .get("prompt_tokens_details")

--- a/crates/infra/bamboo-llm/src/cache.rs
+++ b/crates/infra/bamboo-llm/src/cache.rs
@@ -119,6 +119,52 @@ pub fn cache_usage_from_openai_usage(usage: &Value) -> Option<LLMChunk> {
     })
 }
 
+/// Preserve every authoritative token field reported by an OpenAI-compatible
+/// terminal usage object in one [`LLMChunk::ProviderUsage`] snapshot.
+///
+/// Chat Completions and Responses use different field names, so both spellings
+/// are accepted. Each value remains optional: an explicit zero is retained,
+/// while an absent or non-numeric field is not synthesized. OpenAI reports
+/// reasoning tokens as a subset of output/completion tokens.
+pub fn provider_usage_from_openai_usage(usage: &Value) -> Option<LLMChunk> {
+    fn direct_u64(value: &Value, key: &str) -> Option<u64> {
+        value.get(key).and_then(Value::as_u64)
+    }
+
+    fn nested_u64(value: &Value, parent: &str, key: &str) -> Option<u64> {
+        value
+            .get(parent)
+            .and_then(|details| details.get(key))
+            .and_then(Value::as_u64)
+    }
+
+    let input_tokens =
+        direct_u64(usage, "prompt_tokens").or_else(|| direct_u64(usage, "input_tokens"));
+    let output_tokens =
+        direct_u64(usage, "completion_tokens").or_else(|| direct_u64(usage, "output_tokens"));
+    let reasoning_tokens = nested_u64(usage, "completion_tokens_details", "reasoning_tokens")
+        .or_else(|| nested_u64(usage, "output_tokens_details", "reasoning_tokens"))
+        .or_else(|| direct_u64(usage, "reasoning_tokens"));
+    let cache_read_input_tokens = nested_u64(usage, "prompt_tokens_details", "cached_tokens")
+        .or_else(|| nested_u64(usage, "input_tokens_details", "cached_tokens"));
+
+    if input_tokens.is_none()
+        && output_tokens.is_none()
+        && reasoning_tokens.is_none()
+        && cache_read_input_tokens.is_none()
+    {
+        return None;
+    }
+
+    Some(LLMChunk::ProviderUsage {
+        input_tokens,
+        output_tokens,
+        reasoning_tokens,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens,
+    })
+}
+
 /// Normalize a Gemini `usageMetadata` object into a [`LLMChunk::CacheUsage`], if
 /// it reports cached content tokens (`cachedContentTokenCount`).
 pub fn cache_usage_from_gemini_usage(usage_metadata: &Value) -> Option<LLMChunk> {
@@ -203,6 +249,54 @@ mod tests {
         let usage = serde_json::json!({"prompt_tokens_details": {"cached_tokens": 0}});
         assert!(cache_usage_from_openai_usage(&usage).is_none());
         assert!(cache_usage_from_openai_usage(&serde_json::json!({})).is_none());
+    }
+
+    #[test]
+    fn openai_provider_usage_preserves_chat_and_responses_fields() {
+        let chat = serde_json::json!({
+            "prompt_tokens": 100,
+            "completion_tokens": 30,
+            "prompt_tokens_details": {"cached_tokens": 0},
+            "completion_tokens_details": {"reasoning_tokens": 7}
+        });
+        assert!(matches!(
+            provider_usage_from_openai_usage(&chat),
+            Some(LLMChunk::ProviderUsage {
+                input_tokens: Some(100),
+                output_tokens: Some(30),
+                reasoning_tokens: Some(7),
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: Some(0),
+            })
+        ));
+
+        let responses = serde_json::json!({
+            "input_tokens": 80,
+            "output_tokens": 20,
+            "input_tokens_details": {"cached_tokens": 24},
+            "output_tokens_details": {"reasoning_tokens": 5}
+        });
+        assert!(matches!(
+            provider_usage_from_openai_usage(&responses),
+            Some(LLMChunk::ProviderUsage {
+                input_tokens: Some(80),
+                output_tokens: Some(20),
+                reasoning_tokens: Some(5),
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: Some(24),
+            })
+        ));
+    }
+
+    #[test]
+    fn openai_provider_usage_does_not_invent_missing_fields() {
+        assert!(provider_usage_from_openai_usage(&serde_json::json!({})).is_none());
+        assert!(provider_usage_from_openai_usage(&serde_json::json!({
+            "total_tokens": 42,
+            "prompt_tokens": null,
+            "output_tokens_details": {}
+        }))
+        .is_none());
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/bodhi/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/bodhi/mod.rs
@@ -14,9 +14,9 @@ use serde_json::json;
 use crate::provider::{LLMError, LLMProvider, LLMRequestOptions, LLMStream, Result};
 use crate::providers::common::model_fetcher;
 use crate::providers::common::openai_compat::{
-    build_openai_compat_body, parse_openai_compat_sse_data_strict,
+    build_openai_compat_body, parse_openai_compat_sse_data_strict_multi,
 };
-use crate::providers::common::sse::llm_stream_from_sse;
+use crate::providers::common::sse::{llm_stream_from_sse, llm_stream_from_sse_multi};
 use crate::types::LLMChunk;
 use bamboo_config::KeywordMaskingConfig;
 use bamboo_domain::{Message, ReasoningEffort, ToolSchema};
@@ -237,15 +237,11 @@ impl BodhiProvider {
             )));
         }
 
-        let stream = llm_stream_from_sse(response, |_event, data| {
+        let stream = llm_stream_from_sse_multi(response, |_event, data| {
             if data.trim().is_empty() {
-                return Ok(None);
+                return Ok(Vec::new());
             }
-            let chunk = parse_openai_compat_sse_data_strict(data)?;
-            match chunk {
-                LLMChunk::Done => Ok(Some(LLMChunk::Done)),
-                other => Ok(Some(other)),
-            }
+            parse_openai_compat_sse_data_strict_multi(data)
         });
 
         Ok(stream)
@@ -442,6 +438,7 @@ impl BodhiProvider {
 mod tests {
     use super::*;
     use bamboo_domain::FunctionSchema;
+    use futures::StreamExt;
     use serde_json::Value;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
@@ -472,6 +469,51 @@ mod tests {
                 parameters: serde_json::json!({"type": "object"}),
             },
         }
+    }
+
+    #[tokio::test]
+    async fn openai_proxy_stream_preserves_same_frame_text_and_usage() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/proxy/openai/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(
+                        concat!(
+                            "data: {\"choices\":[{\"delta\":{\"content\":\"answer\"}}],\"usage\":{\"prompt_tokens\":1000,\"completion_tokens\":120,\"prompt_tokens_details\":{\"cached_tokens\":768}}}\n",
+                            "\n",
+                            "data: [DONE]\n",
+                            "\n",
+                        ),
+                    ),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let provider = BodhiProvider::new("test-key").with_base_url(server.uri());
+
+        let mut stream = provider
+            .chat_stream(&[Message::user("hello")], &[], None, "gpt-4o")
+            .await
+            .expect("Bodhi OpenAI proxy stream");
+        let mut chunks = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            chunks.push(chunk.expect("stream chunk"));
+        }
+
+        assert_eq!(chunks.len(), 3);
+        assert!(matches!(&chunks[0], LLMChunk::Token(text) if text == "answer"));
+        assert!(matches!(
+            chunks[1],
+            LLMChunk::ProviderUsage {
+                input_tokens: Some(1000),
+                output_tokens: Some(120),
+                cache_read_input_tokens: Some(768),
+                ..
+            }
+        ));
+        assert!(matches!(chunks[2], LLMChunk::Done));
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-llm/src/providers/bodhi/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/bodhi/mod.rs
@@ -17,7 +17,6 @@ use crate::providers::common::openai_compat::{
     build_openai_compat_body, parse_openai_compat_sse_data_strict_multi,
 };
 use crate::providers::common::sse::{llm_stream_from_sse, llm_stream_from_sse_multi};
-use crate::types::LLMChunk;
 use bamboo_config::KeywordMaskingConfig;
 use bamboo_domain::{Message, ReasoningEffort, ToolSchema};
 
@@ -437,6 +436,7 @@ impl BodhiProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::LLMChunk;
     use bamboo_domain::FunctionSchema;
     use futures::StreamExt;
     use serde_json::Value;

--- a/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
@@ -207,73 +207,95 @@ struct OpenAICompatFunctionDelta {
     arguments: Option<String>,
 }
 
-/// Convert a single OpenAI-compatible stream chunk into an [`LLMChunk`].
-pub fn parse_openai_compat_chunk(chunk: OpenAICompatStreamChunk) -> LLMChunk {
-    // Final usage chunk (normally empty choices): preserve provider-reported
-    // input/output/reasoning totals and cache data together. Returning one
-    // combined snapshot is required because this parser emits one chunk per
-    // Chat Completions SSE event.
+/// Convert one OpenAI-compatible stream frame into every logical chunk it
+/// carries.
+///
+/// Some compatible gateways attach `usage` to the same frame as content, tool
+/// deltas, or `finish_reason`. Business output is emitted first, the cumulative
+/// provider snapshot follows it, and [`LLMChunk::Done`] is always last so no
+/// semantic chunk is stranded behind a terminal marker.
+pub fn parse_openai_compat_chunk_multi(chunk: OpenAICompatStreamChunk) -> Vec<LLMChunk> {
+    let mut chunks = Vec::new();
+    let mut is_terminal = false;
+
+    if let Some(choice) = chunk.choices.first() {
+        if let Some(tool_calls) = &choice.delta.tool_calls {
+            // Carry each delta's `index` so the engine accumulator can route
+            // argument-only continuation fragments (which arrive with empty id/name)
+            // to the matching call. A positional heuristic corrupts arguments when an
+            // aggregator interleaves fragments across indices. #236.
+            let calls: Vec<(u32, bamboo_domain::ToolCall)> = tool_calls
+                .iter()
+                .map(|tc| {
+                    (
+                        tc.index,
+                        bamboo_domain::ToolCall {
+                            id: tc.id.clone().unwrap_or_default(),
+                            tool_type: tc
+                                .tool_type
+                                .clone()
+                                .unwrap_or_else(|| "function".to_string()),
+                            function: bamboo_domain::FunctionCall {
+                                name: tc
+                                    .function
+                                    .as_ref()
+                                    .and_then(|f| f.name.clone())
+                                    .unwrap_or_default(),
+                                arguments: tc
+                                    .function
+                                    .as_ref()
+                                    .and_then(|f| f.arguments.clone())
+                                    .unwrap_or_default(),
+                            },
+                        },
+                    )
+                })
+                .collect();
+
+            if !calls.is_empty() {
+                chunks.push(LLMChunk::ToolCallsIndexed(calls));
+            }
+        }
+
+        if let Some(content) = &choice.delta.content {
+            chunks.push(LLMChunk::Token(content.clone()));
+        }
+
+        is_terminal = choice.finish_reason.is_some();
+    }
+
     if let Some(usage) = &chunk.usage {
         if let Some(usage_chunk) = crate::cache::provider_usage_from_openai_usage(usage) {
-            return usage_chunk;
+            chunks.push(usage_chunk);
         }
     }
 
-    let Some(choice) = chunk.choices.first() else {
-        return LLMChunk::Token(String::new());
-    };
-
-    if let Some(tool_calls) = &choice.delta.tool_calls {
-        // Carry each delta's `index` so the engine accumulator can route
-        // argument-only continuation fragments (which arrive with empty id/name)
-        // to the matching call. A positional heuristic corrupts arguments when an
-        // aggregator interleaves fragments across indices. #236.
-        let calls: Vec<(u32, bamboo_domain::ToolCall)> = tool_calls
-            .iter()
-            .map(|tc| {
-                (
-                    tc.index,
-                    bamboo_domain::ToolCall {
-                        id: tc.id.clone().unwrap_or_default(),
-                        tool_type: tc
-                            .tool_type
-                            .clone()
-                            .unwrap_or_else(|| "function".to_string()),
-                        function: bamboo_domain::FunctionCall {
-                            name: tc
-                                .function
-                                .as_ref()
-                                .and_then(|f| f.name.clone())
-                                .unwrap_or_default(),
-                            arguments: tc
-                                .function
-                                .as_ref()
-                                .and_then(|f| f.arguments.clone())
-                                .unwrap_or_default(),
-                        },
-                    },
-                )
-            })
-            .collect();
-
-        if !calls.is_empty() {
-            return LLMChunk::ToolCallsIndexed(calls);
-        }
-
-        return LLMChunk::Token(String::new());
+    if is_terminal {
+        chunks.push(LLMChunk::Done);
+    } else if chunks.is_empty() {
+        chunks.push(LLMChunk::Token(String::new()));
     }
 
-    if let Some(content) = &choice.delta.content {
-        return LLMChunk::Token(content.clone());
-    }
+    chunks
+}
 
-    // Some OpenAI-compatible providers terminate with an empty delta plus
-    // finish_reason (without emitting a separate [DONE] marker).
-    if choice.finish_reason.is_some() {
-        return LLMChunk::Done;
+fn require_single_openai_compat_chunk(mut chunks: Vec<LLMChunk>) -> Result<LLMChunk> {
+    if chunks.len() != 1 {
+        return Err(LLMError::Stream(format!(
+            "OpenAI-compatible SSE frame produced {} logical chunks; use the multi-output parser",
+            chunks.len()
+        )));
     }
+    Ok(chunks.remove(0))
+}
 
-    LLMChunk::Token(String::new())
+/// Legacy single-output conversion.
+///
+/// Valid multi-semantic frames fail explicitly instead of silently discarding
+/// content or usage. Production Chat adapters use
+/// [`parse_openai_compat_chunk_multi`].
+pub fn parse_openai_compat_chunk(chunk: OpenAICompatStreamChunk) -> Result<LLMChunk> {
+    require_single_openai_compat_chunk(parse_openai_compat_chunk_multi(chunk))
 }
 
 /// Surface a mid-stream OpenAI-compatible `"error"` event as an [`LLMError::Api`].
@@ -305,8 +327,14 @@ fn openai_compat_error_to_llm_error(error: &Value) -> LLMError {
 ///   token). See issue #26.
 /// - Invalid JSON -> error
 pub fn parse_openai_compat_sse_data_strict(data: &str) -> Result<LLMChunk> {
+    require_single_openai_compat_chunk(parse_openai_compat_sse_data_strict_multi(data)?)
+}
+
+/// Strict OpenAI-compatible SSE parsing that preserves every logical chunk in
+/// one frame.
+pub fn parse_openai_compat_sse_data_strict_multi(data: &str) -> Result<Vec<LLMChunk>> {
     if data.trim() == "[DONE]" {
-        return Ok(LLMChunk::Done);
+        return Ok(vec![LLMChunk::Done]);
     }
 
     // Parse into a generic JSON value first so we can detect mid-stream error
@@ -318,7 +346,7 @@ pub fn parse_openai_compat_sse_data_strict(data: &str) -> Result<LLMChunk> {
         return Err(openai_compat_error_to_llm_error(error));
     }
     let chunk: OpenAICompatStreamChunk = serde_json::from_value(value)?;
-    Ok(parse_openai_compat_chunk(chunk))
+    Ok(parse_openai_compat_chunk_multi(chunk))
 }
 
 /// Parse an SSE `data:` payload in lenient mode (Copilot behavior).
@@ -329,8 +357,15 @@ pub fn parse_openai_compat_sse_data_strict(data: &str) -> Result<LLMChunk> {
 ///   swallowed as empty tokens). See issue #26.
 /// - Invalid JSON -> `LLMChunk::Token("")`
 pub fn parse_openai_compat_sse_data_lenient(data: &str) -> Result<LLMChunk> {
+    require_single_openai_compat_chunk(parse_openai_compat_sse_data_lenient_multi(data)?)
+}
+
+/// Lenient Copilot-compatible SSE parsing that preserves every logical chunk
+/// in one valid frame while retaining the historical empty-token fallback for
+/// malformed payloads.
+pub fn parse_openai_compat_sse_data_lenient_multi(data: &str) -> Result<Vec<LLMChunk>> {
     if data.trim() == "[DONE]" {
-        return Ok(LLMChunk::Done);
+        return Ok(vec![LLMChunk::Done]);
     }
 
     match serde_json::from_str::<Value>(data) {
@@ -342,11 +377,11 @@ pub fn parse_openai_compat_sse_data_lenient(data: &str) -> Result<LLMChunk> {
                 return Err(openai_compat_error_to_llm_error(error));
             }
             match serde_json::from_value::<OpenAICompatStreamChunk>(value) {
-                Ok(chunk) => Ok(parse_openai_compat_chunk(chunk)),
-                Err(_) => Ok(LLMChunk::Token(String::new())),
+                Ok(chunk) => Ok(parse_openai_compat_chunk_multi(chunk)),
+                Err(_) => Ok(vec![LLMChunk::Token(String::new())]),
             }
         }
-        Err(_) => Ok(LLMChunk::Token(String::new())),
+        Err(_) => Ok(vec![LLMChunk::Token(String::new())]),
     }
 }
 
@@ -767,6 +802,79 @@ mod tests {
         let chunk = super::parse_openai_compat_sse_data_strict(data).unwrap();
 
         assert!(matches!(chunk, LLMChunk::Token(token) if token.is_empty()));
+    }
+
+    #[test]
+    fn multi_parsers_preserve_text_tool_and_finish_frames_with_usage() {
+        type MultiParser = fn(&str) -> crate::provider::Result<Vec<LLMChunk>>;
+        let parsers: [MultiParser; 2] = [
+            super::parse_openai_compat_sse_data_strict_multi,
+            super::parse_openai_compat_sse_data_lenient_multi,
+        ];
+        let usage = r#""usage":{"prompt_tokens":10,"completion_tokens":4,"prompt_tokens_details":{"cached_tokens":3},"completion_tokens_details":{"reasoning_tokens":2}}"#;
+
+        for parse in parsers {
+            let text = format!(r#"{{"choices":[{{"delta":{{"content":"answer"}}}}],{usage}}}"#);
+            let chunks = parse(&text).expect("text plus usage");
+            assert_eq!(chunks.len(), 2);
+            assert!(matches!(&chunks[0], LLMChunk::Token(token) if token == "answer"));
+            assert!(matches!(chunks[1], LLMChunk::ProviderUsage { .. }));
+
+            let tool = format!(
+                r#"{{"choices":[{{"delta":{{"tool_calls":[{{"index":0,"id":"call_1","type":"function","function":{{"name":"search","arguments":"{{}}"}}}}]}}}}],{usage}}}"#
+            );
+            let chunks = parse(&tool).expect("tool plus usage");
+            assert_eq!(chunks.len(), 2);
+            assert!(matches!(
+                &chunks[0],
+                LLMChunk::ToolCallsIndexed(calls)
+                    if calls.len() == 1 && calls[0].1.function.name == "search"
+            ));
+            assert!(matches!(chunks[1], LLMChunk::ProviderUsage { .. }));
+
+            let finish =
+                format!(r#"{{"choices":[{{"delta":{{}},"finish_reason":"stop"}}],{usage}}}"#);
+            let chunks = parse(&finish).expect("finish plus usage");
+            assert_eq!(chunks.len(), 2);
+            assert!(matches!(chunks[0], LLMChunk::ProviderUsage { .. }));
+            assert!(
+                matches!(chunks[1], LLMChunk::Done),
+                "Done must remain the final logical chunk"
+            );
+        }
+    }
+
+    #[test]
+    fn multi_parsers_preserve_independent_empty_choices_usage_frame() {
+        let data = r#"{"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":4,"prompt_tokens_details":{"cached_tokens":0}}}"#;
+
+        for chunks in [
+            super::parse_openai_compat_sse_data_strict_multi(data).unwrap(),
+            super::parse_openai_compat_sse_data_lenient_multi(data).unwrap(),
+        ] {
+            assert_eq!(chunks.len(), 1);
+            assert!(matches!(
+                chunks[0],
+                LLMChunk::ProviderUsage {
+                    input_tokens: Some(10),
+                    output_tokens: Some(4),
+                    cache_read_input_tokens: Some(0),
+                    ..
+                }
+            ));
+        }
+    }
+
+    #[test]
+    fn legacy_single_parsers_reject_multi_semantic_frames_explicitly() {
+        let data = r#"{"choices":[{"delta":{"content":"answer"}}],"usage":{"prompt_tokens":10,"completion_tokens":4}}"#;
+
+        for error in [
+            super::parse_openai_compat_sse_data_strict(data).unwrap_err(),
+            super::parse_openai_compat_sse_data_lenient(data).unwrap_err(),
+        ] {
+            assert!(error.to_string().contains("use the multi-output parser"));
+        }
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_compat.rs
@@ -209,11 +209,13 @@ struct OpenAICompatFunctionDelta {
 
 /// Convert a single OpenAI-compatible stream chunk into an [`LLMChunk`].
 pub fn parse_openai_compat_chunk(chunk: OpenAICompatStreamChunk) -> LLMChunk {
-    // Final usage chunk (empty choices): surface provider-side prompt cache hits
-    // so the cache badge works for OpenAI-compatible providers too.
+    // Final usage chunk (normally empty choices): preserve provider-reported
+    // input/output/reasoning totals and cache data together. Returning one
+    // combined snapshot is required because this parser emits one chunk per
+    // Chat Completions SSE event.
     if let Some(usage) = &chunk.usage {
-        if let Some(cache_chunk) = crate::cache::cache_usage_from_openai_usage(usage) {
-            return cache_chunk;
+        if let Some(usage_chunk) = crate::cache::provider_usage_from_openai_usage(usage) {
+            return usage_chunk;
         }
     }
 
@@ -723,31 +725,48 @@ mod tests {
     }
 
     #[test]
-    fn parse_openai_compat_usage_chunk_yields_cache_usage() {
-        // Final usage chunk with empty choices and cached prompt tokens.
-        let data = r#"{"id":"chatcmpl_1","choices":[],"usage":{"prompt_tokens":1000,"prompt_tokens_details":{"cached_tokens":768}}}"#;
+    fn parse_openai_compat_usage_chunk_preserves_totals_reasoning_and_cache() {
+        let data = r#"{"id":"chatcmpl_1","choices":[],"usage":{"prompt_tokens":1000,"completion_tokens":120,"prompt_tokens_details":{"cached_tokens":768},"completion_tokens_details":{"reasoning_tokens":20}}}"#;
 
         let chunk = super::parse_openai_compat_sse_data_strict(data).unwrap();
 
-        match chunk {
-            LLMChunk::CacheUsage {
-                cache_read_input_tokens,
-                ..
-            } => assert_eq!(cache_read_input_tokens, 768),
-            other => panic!("expected LLMChunk::CacheUsage, got {other:?}"),
-        }
+        assert!(matches!(
+            chunk,
+            LLMChunk::ProviderUsage {
+                input_tokens: Some(1000),
+                output_tokens: Some(120),
+                reasoning_tokens: Some(20),
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: Some(768),
+            }
+        ));
     }
 
     #[test]
-    fn parse_openai_compat_usage_chunk_without_cache_yields_empty_token() {
-        let data = r#"{"id":"chatcmpl_1","choices":[],"usage":{"prompt_tokens":1000,"prompt_tokens_details":{"cached_tokens":0}}}"#;
+    fn parse_openai_compat_usage_chunk_preserves_totals_with_zero_cache() {
+        let data = r#"{"id":"chatcmpl_1","choices":[],"usage":{"prompt_tokens":1000,"completion_tokens":120,"prompt_tokens_details":{"cached_tokens":0}}}"#;
 
         let chunk = super::parse_openai_compat_sse_data_strict(data).unwrap();
 
-        match chunk {
-            LLMChunk::Token(token) => assert!(token.is_empty()),
-            other => panic!("expected empty LLMChunk::Token, got {other:?}"),
-        }
+        assert!(matches!(
+            chunk,
+            LLMChunk::ProviderUsage {
+                input_tokens: Some(1000),
+                output_tokens: Some(120),
+                reasoning_tokens: None,
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: Some(0),
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_openai_compat_usage_chunk_does_not_invent_missing_totals() {
+        let data = r#"{"id":"chatcmpl_1","choices":[],"usage":{"total_tokens":1120}}"#;
+
+        let chunk = super::parse_openai_compat_sse_data_strict(data).unwrap();
+
+        assert!(matches!(chunk, LLMChunk::Token(token) if token.is_empty()));
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/openai_responses.rs
@@ -436,7 +436,7 @@ struct AccFnCall {
 /// - `response.content_part.added/done` (output_text parts) -> `LLMChunk::Token(...)`
 /// - `response.output_item.added/done` message output_text -> `LLMChunk::Token(...)`
 /// - `response.output_item.*` + `response.function_call_arguments.delta` -> `LLMChunk::ToolCalls`
-/// - `response.completed` -> terminal output fallbacks, cache usage, then `LLMChunk::Done`
+/// - `response.completed` -> terminal output fallbacks, provider usage, then `LLMChunk::Done`
 pub struct ResponsesSseParser {
     // item_id -> accumulated function call
     fn_calls: HashMap<String, AccFnCall>,
@@ -1514,9 +1514,9 @@ impl ResponsesSseParser {
     /// Parse one Responses SSE event into every logical downstream chunk it carries.
     ///
     /// Most events produce zero or one chunk. `response.completed` can carry a
-    /// response ID, several output items, cache usage, and terminal completion in
-    /// the same frame; returning a vector keeps all of them without deferring state
-    /// to a later event that may never arrive.
+    /// response ID, several output items, provider usage, and terminal completion
+    /// in the same frame; returning a vector keeps all of them without deferring
+    /// state to a later event that may never arrive.
     pub fn handle_event_multi(&mut self, event: &str, data: &str) -> Result<Vec<LLMChunk>> {
         let Ok(v) = serde_json::from_str::<Value>(data) else {
             // Be lenient: some upstreams occasionally send non-JSON keepalives.
@@ -1536,8 +1536,10 @@ impl ResponsesSseParser {
                 .and_then(|response| response.get("usage"))
                 .or_else(|| v.get("usage"));
             self.log_reasoning_summary_if_needed(usage);
-            if let Some(cache_chunk) = usage.and_then(crate::cache::cache_usage_from_openai_usage) {
-                chunks.push(cache_chunk);
+            if let Some(usage_chunk) =
+                usage.and_then(crate::cache::provider_usage_from_openai_usage)
+            {
+                chunks.push(usage_chunk);
             }
             chunks.push(LLMChunk::Done);
             return Ok(chunks);
@@ -2436,12 +2438,12 @@ mod tests {
     }
 
     #[test]
-    fn parser_completed_only_response_id_coexists_with_output_cache_and_done() {
+    fn parser_completed_only_response_id_coexists_with_output_usage_and_done() {
         let mut parser = ResponsesSseParser::new();
         let chunks = parser
             .handle_event_multi(
                 "response.completed",
-                r#"{"type":"response.completed","response":{"id":"resp_terminal","output":[{"id":"msg_terminal","type":"message","content":[{"type":"output_text","text":"terminal answer"}]}],"usage":{"input_tokens":21,"input_tokens_details":{"cached_tokens":8}}}}"#,
+                r#"{"type":"response.completed","response":{"id":"resp_terminal","output":[{"id":"msg_terminal","type":"message","content":[{"type":"output_text","text":"terminal answer"}]}],"usage":{"input_tokens":21,"output_tokens":13,"input_tokens_details":{"cached_tokens":8},"output_tokens_details":{"reasoning_tokens":5}}}}"#,
             )
             .expect("completed event");
 
@@ -2450,13 +2452,67 @@ mod tests {
         assert!(matches!(&chunks[1], LLMChunk::Token(text) if text == "terminal answer"));
         assert!(matches!(
             chunks[2],
-            LLMChunk::CacheUsage {
-                cache_creation_input_tokens: 0,
-                cache_read_input_tokens: 8,
-                input_tokens: 13,
+            LLMChunk::ProviderUsage {
+                input_tokens: Some(21),
+                output_tokens: Some(13),
+                reasoning_tokens: Some(5),
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: Some(8),
             }
         ));
         assert!(matches!(chunks[3], LLMChunk::Done));
+        assert_eq!(
+            chunks
+                .iter()
+                .filter(|chunk| matches!(chunk, LLMChunk::ProviderUsage { .. }))
+                .count(),
+            1,
+            "one terminal provider event must emit usage exactly once"
+        );
+        assert!(
+            chunks
+                .iter()
+                .all(|chunk| !matches!(chunk, LLMChunk::CacheUsage { .. })),
+            "combined provider usage must not also emit legacy cache usage"
+        );
+    }
+
+    #[test]
+    fn parser_completed_usage_preserves_totals_with_zero_cache() {
+        let mut parser = ResponsesSseParser::new();
+        let chunks = parser
+            .handle_event_multi(
+                "response.completed",
+                r#"{"type":"response.completed","response":{"usage":{"input_tokens":34,"output_tokens":12,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":3}}}}"#,
+            )
+            .expect("completed event");
+
+        assert_eq!(chunks.len(), 2);
+        assert!(matches!(
+            chunks[0],
+            LLMChunk::ProviderUsage {
+                input_tokens: Some(34),
+                output_tokens: Some(12),
+                reasoning_tokens: Some(3),
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: Some(0),
+            }
+        ));
+        assert!(matches!(chunks[1], LLMChunk::Done));
+    }
+
+    #[test]
+    fn parser_completed_usage_does_not_invent_missing_totals() {
+        let mut parser = ResponsesSseParser::new();
+        let chunks = parser
+            .handle_event_multi(
+                "response.completed",
+                r#"{"type":"response.completed","response":{"usage":{"total_tokens":46,"input_tokens":null,"output_tokens_details":{}}}}"#,
+            )
+            .expect("completed event");
+
+        assert_eq!(chunks.len(), 1);
+        assert!(matches!(chunks[0], LLMChunk::Done));
     }
 
     #[test]

--- a/crates/infra/bamboo-llm/src/providers/common/sse.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/sse.rs
@@ -94,6 +94,7 @@ where
 mod tests {
     use super::*;
     use crate::providers::anthropic::{parse_anthropic_sse_event, AnthropicStreamState};
+    use crate::providers::common::openai_compat::parse_openai_compat_sse_data_strict_multi;
     use crate::providers::common::openai_responses::ResponsesSseParser;
     use futures::StreamExt;
     use serde_json::json;
@@ -243,6 +244,46 @@ mod tests {
             }
         ));
         assert!(matches!(chunks[3], LLMChunk::Done));
+    }
+
+    #[tokio::test]
+    async fn openai_chat_frame_flattens_business_output_and_usage_before_done() {
+        let response = reqwest::Response::from(
+            http::Response::builder()
+                .status(200)
+                .header("content-type", "text/event-stream")
+                .body(
+                    concat!(
+                        "data: {\"choices\":[{\"delta\":{\"content\":\"answer\"}}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":4,\"prompt_tokens_details\":{\"cached_tokens\":3}}}\n",
+                        "\n",
+                        "data: [DONE]\n",
+                        "\n",
+                    )
+                    .to_string(),
+                )
+                .expect("http response"),
+        );
+        let mut stream = llm_stream_from_sse_multi(response, |_event, data| {
+            parse_openai_compat_sse_data_strict_multi(data)
+        });
+
+        let mut chunks = Vec::new();
+        while let Some(item) = stream.next().await {
+            chunks.push(item.expect("stream chunk"));
+        }
+
+        assert_eq!(chunks.len(), 3);
+        assert!(matches!(&chunks[0], LLMChunk::Token(text) if text == "answer"));
+        assert!(matches!(
+            chunks[1],
+            LLMChunk::ProviderUsage {
+                input_tokens: Some(10),
+                output_tokens: Some(4),
+                cache_read_input_tokens: Some(3),
+                ..
+            }
+        ));
+        assert!(matches!(chunks[2], LLMChunk::Done));
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-llm/src/providers/common/sse.rs
+++ b/crates/infra/bamboo-llm/src/providers/common/sse.rs
@@ -212,7 +212,7 @@ mod tests {
                 .body(
                     concat!(
                         "event: response.completed\n",
-                        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_terminal\",\"output\":[{\"id\":\"msg_terminal\",\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"terminal answer\"}]}],\"usage\":{\"input_tokens\":21,\"input_tokens_details\":{\"cached_tokens\":8}}}}\n",
+                        "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_terminal\",\"output\":[{\"id\":\"msg_terminal\",\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"terminal answer\"}]}],\"usage\":{\"input_tokens\":21,\"output_tokens\":13,\"input_tokens_details\":{\"cached_tokens\":8},\"output_tokens_details\":{\"reasoning_tokens\":5}}}}\n",
                         "\n",
                     )
                     .to_string(),
@@ -234,10 +234,12 @@ mod tests {
         assert!(matches!(&chunks[1], LLMChunk::Token(text) if text == "terminal answer"));
         assert!(matches!(
             chunks[2],
-            LLMChunk::CacheUsage {
-                cache_creation_input_tokens: 0,
-                cache_read_input_tokens: 8,
-                input_tokens: 13,
+            LLMChunk::ProviderUsage {
+                input_tokens: Some(21),
+                output_tokens: Some(13),
+                reasoning_tokens: Some(5),
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: Some(8),
             }
         ));
         assert!(matches!(chunks[3], LLMChunk::Done));

--- a/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
@@ -19,7 +19,7 @@ use bamboo_domain::ReasoningEffort;
 use bamboo_domain::ToolSchema;
 
 use super::common::openai_compat::{
-    messages_to_openai_compat_json, parse_openai_compat_sse_data_lenient,
+    messages_to_openai_compat_json, parse_openai_compat_sse_data_lenient_multi,
     tools_to_openai_compat_json,
 };
 use super::common::openai_responses::{
@@ -27,7 +27,7 @@ use super::common::openai_responses::{
 };
 use super::common::request_overrides;
 use super::common::responses_debug::append_responses_sse_record;
-use super::common::sse::{llm_stream_from_sse, llm_stream_from_sse_multi};
+use super::common::sse::llm_stream_from_sse_multi;
 
 const COPILOT_TRANSPORT_MAX_ATTEMPTS: usize = 2;
 const COPILOT_TRANSPORT_RETRY_BASE_DELAY_MS: u64 = 250;
@@ -1398,12 +1398,8 @@ impl LLMProvider for CopilotProvider {
                     }
 
                     if retry.status().is_success() {
-                        let stream = llm_stream_from_sse(retry, |_event, data| {
-                            let chunk = parse_openai_compat_sse_data_lenient(data)?;
-                            match chunk {
-                                LLMChunk::Done => Ok(Some(LLMChunk::Done)),
-                                other => Ok(Some(other)),
-                            }
+                        let stream = llm_stream_from_sse_multi(retry, |_event, data| {
+                            parse_openai_compat_sse_data_lenient_multi(data)
                         });
                         return Ok(stream);
                     }
@@ -1466,7 +1462,7 @@ impl LLMProvider for CopilotProvider {
         let mut observed_reasoning_signal = false;
         let mut reasoning_chars = 0usize;
         let mut logged_summary = false;
-        let stream = llm_stream_from_sse(response, move |_event, data| {
+        let stream = llm_stream_from_sse_multi(response, move |_event, data| {
             let mut reasoning_chunk_to_emit: Option<String> = None;
             if let Ok(v) = serde_json::from_str::<serde_json::Value>(data) {
                 if let Some(delta) = v
@@ -1493,32 +1489,29 @@ impl LLMProvider for CopilotProvider {
                 }
             }
 
+            let mut chunks = parse_openai_compat_sse_data_lenient_multi(data)?;
             if let Some(reasoning_chunk) = reasoning_chunk_to_emit {
-                return Ok(Some(LLMChunk::ReasoningToken(reasoning_chunk)));
+                chunks.retain(|chunk| !matches!(chunk, LLMChunk::Token(token) if token.is_empty()));
+                chunks.insert(0, LLMChunk::ReasoningToken(reasoning_chunk));
             }
 
-            let chunk = parse_openai_compat_sse_data_lenient(data)?;
-            match chunk {
-                LLMChunk::Done => {
-                    if !logged_summary
-                        && (requested_reasoning.is_some() || observed_reasoning_signal)
-                    {
-                        tracing::info!(
-                            "[{}] Copilot chat_completions reasoning summary: model='{}' requested_effort={} observed_reasoning_signal={} reasoning_text_chars={}",
-                            session_for_log,
-                            model_for_log,
-                            requested_reasoning
-                                .map(ReasoningEffort::as_str)
-                                .unwrap_or("none"),
-                            observed_reasoning_signal,
-                            reasoning_chars
-                        );
-                        logged_summary = true;
-                    }
-                    Ok(Some(LLMChunk::Done))
-                }
-                other => Ok(Some(other)),
+            if chunks.iter().any(|chunk| matches!(chunk, LLMChunk::Done))
+                && !logged_summary
+                && (requested_reasoning.is_some() || observed_reasoning_signal)
+            {
+                tracing::info!(
+                    "[{}] Copilot chat_completions reasoning summary: model='{}' requested_effort={} observed_reasoning_signal={} reasoning_text_chars={}",
+                    session_for_log,
+                    model_for_log,
+                    requested_reasoning
+                        .map(ReasoningEffort::as_str)
+                        .unwrap_or("none"),
+                    observed_reasoning_signal,
+                    reasoning_chars
+                );
+                logged_summary = true;
             }
+            Ok(chunks)
         });
 
         Ok(stream)

--- a/crates/infra/bamboo-llm/src/providers/openai/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/openai/mod.rs
@@ -21,13 +21,16 @@ use bamboo_domain::ReasoningEffort;
 use bamboo_domain::ToolSchema;
 
 use super::common::model_fetcher;
-use super::common::openai_compat::{build_openai_compat_body, parse_openai_compat_sse_data_strict};
+use super::common::openai_compat::{
+    build_openai_compat_body, parse_openai_compat_sse_data_strict,
+    parse_openai_compat_sse_data_strict_multi,
+};
 use super::common::openai_responses::{
     build_responses_body, select_responses_input_messages, ResponsesInputSource, ResponsesSseParser,
 };
 use super::common::request_overrides;
 use super::common::responses_debug::append_responses_sse_record;
-use super::common::sse::{llm_stream_from_sse, llm_stream_from_sse_multi};
+use super::common::sse::llm_stream_from_sse_multi;
 
 /// OpenAI API provider for chat completions.
 pub struct OpenAIProvider {
@@ -527,16 +530,12 @@ impl LLMProvider for OpenAIProvider {
                     .await?;
 
                 if fallback.status().is_success() {
-                    let stream = llm_stream_from_sse(fallback, |_event, data| {
+                    let stream = llm_stream_from_sse_multi(fallback, |_event, data| {
                         if data.trim().is_empty() {
-                            return Ok(None);
+                            return Ok(Vec::new());
                         }
 
-                        let chunk = parse_openai_compat_sse_data_strict(data)?;
-                        match chunk {
-                            LLMChunk::Done => Ok(Some(LLMChunk::Done)),
-                            other => Ok(Some(other)),
-                        }
+                        parse_openai_compat_sse_data_strict_multi(data)
                     });
 
                     return Ok(stream);
@@ -582,9 +581,9 @@ impl LLMProvider for OpenAIProvider {
         let mut observed_reasoning_signal = false;
         let mut reasoning_chars = 0usize;
         let mut logged_summary = false;
-        let stream = llm_stream_from_sse(response, move |_event, data| {
+        let stream = llm_stream_from_sse_multi(response, move |_event, data| {
             if data.trim().is_empty() {
-                return Ok(None);
+                return Ok(Vec::new());
             }
 
             let mut reasoning_chunk_to_emit: Option<String> = None;
@@ -613,31 +612,28 @@ impl LLMProvider for OpenAIProvider {
                 }
             }
 
+            let mut chunks = parse_openai_compat_sse_data_strict_multi(data)?;
             if let Some(reasoning_chunk) = reasoning_chunk_to_emit {
-                return Ok(Some(LLMChunk::ReasoningToken(reasoning_chunk)));
+                chunks.retain(|chunk| !matches!(chunk, LLMChunk::Token(token) if token.is_empty()));
+                chunks.insert(0, LLMChunk::ReasoningToken(reasoning_chunk));
             }
 
-            let chunk = parse_openai_compat_sse_data_strict(data)?;
-            match chunk {
-                LLMChunk::Done => {
-                    if !logged_summary
-                        && (requested_reasoning.is_some() || observed_reasoning_signal)
-                    {
-                        tracing::info!(
-                            "OpenAI chat_completions reasoning summary: model='{}' requested_effort={} observed_reasoning_signal={} reasoning_text_chars={}",
-                            model_for_log,
-                            requested_reasoning
-                                .map(ReasoningEffort::as_str)
-                                .unwrap_or("none"),
-                            observed_reasoning_signal,
-                            reasoning_chars
-                        );
-                        logged_summary = true;
-                    }
-                    Ok(Some(LLMChunk::Done))
-                }
-                other => Ok(Some(other)),
+            if chunks.iter().any(|chunk| matches!(chunk, LLMChunk::Done))
+                && !logged_summary
+                && (requested_reasoning.is_some() || observed_reasoning_signal)
+            {
+                tracing::info!(
+                    "OpenAI chat_completions reasoning summary: model='{}' requested_effort={} observed_reasoning_signal={} reasoning_text_chars={}",
+                    model_for_log,
+                    requested_reasoning
+                        .map(ReasoningEffort::as_str)
+                        .unwrap_or("none"),
+                    observed_reasoning_signal,
+                    reasoning_chars
+                );
+                logged_summary = true;
             }
+            Ok(chunks)
         });
 
         Ok(stream)
@@ -1062,6 +1058,52 @@ mod tests {
         );
         assert_eq!(body["parallel_tool_calls"], false);
         assert_eq!(body["reasoning_effort"], "high");
+    }
+
+    #[tokio::test]
+    async fn chat_completions_production_stream_preserves_same_frame_text_and_usage() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(
+                        concat!(
+                            "data: {\"choices\":[{\"delta\":{\"content\":\"answer\"}}],\"usage\":{\"prompt_tokens\":1000,\"completion_tokens\":120,\"prompt_tokens_details\":{\"cached_tokens\":768},\"completion_tokens_details\":{\"reasoning_tokens\":20}}}\n",
+                            "\n",
+                            "data: [DONE]\n",
+                            "\n",
+                        ),
+                    ),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let provider = OpenAIProvider::new("test-key").with_base_url(server.uri());
+
+        let mut stream = provider
+            .chat_stream(&[Message::user("hello")], &[], None, "gpt-4o")
+            .await
+            .expect("chat stream");
+        let mut chunks = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            chunks.push(chunk.expect("stream chunk"));
+        }
+
+        assert_eq!(chunks.len(), 3);
+        assert!(matches!(&chunks[0], LLMChunk::Token(text) if text == "answer"));
+        assert!(matches!(
+            chunks[1],
+            LLMChunk::ProviderUsage {
+                input_tokens: Some(1000),
+                output_tokens: Some(120),
+                reasoning_tokens: Some(20),
+                cache_read_input_tokens: Some(768),
+                ..
+            }
+        ));
+        assert!(matches!(chunks[2], LLMChunk::Done));
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-llm/src/providers/openai/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/openai/mod.rs
@@ -22,8 +22,7 @@ use bamboo_domain::ToolSchema;
 
 use super::common::model_fetcher;
 use super::common::openai_compat::{
-    build_openai_compat_body, parse_openai_compat_sse_data_strict,
-    parse_openai_compat_sse_data_strict_multi,
+    build_openai_compat_body, parse_openai_compat_sse_data_strict_multi,
 };
 use super::common::openai_responses::{
     build_responses_body, select_responses_input_messages, ResponsesInputSource, ResponsesSseParser,
@@ -649,6 +648,7 @@ impl LLMProvider for OpenAIProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::providers::common::openai_compat::parse_openai_compat_sse_data_strict;
     use bamboo_domain::Message;
     use bamboo_domain::{FunctionSchema, ToolSchema};
 

--- a/crates/infra/bamboo-llm/src/types.rs
+++ b/crates/infra/bamboo-llm/src/types.rs
@@ -43,6 +43,24 @@ pub enum LLMChunk {
         /// does not report it on this event.
         input_tokens: u64,
     },
+    /// Authoritative token-usage snapshot reported by one provider event.
+    ///
+    /// Every field is optional so parsers preserve the distinction between a
+    /// provider reporting `0` and omitting a field entirely. Cache counts are
+    /// carried alongside the input/output totals because OpenAI-compatible
+    /// terminal events report all of them in one object and the single-chunk
+    /// Chat Completions parser must not discard either half.
+    ///
+    /// `reasoning_tokens` is a subset of `output_tokens` for OpenAI Responses
+    /// and reasoning Chat Completions. Consumers must not add it to the output
+    /// total.
+    ProviderUsage {
+        input_tokens: Option<u64>,
+        output_tokens: Option<u64>,
+        reasoning_tokens: Option<u64>,
+        cache_creation_input_tokens: Option<u64>,
+        cache_read_input_tokens: Option<u64>,
+    },
     /// Token usage summary at the end of an Anthropic response.
     UsageSummary {
         output_tokens: u64,
@@ -64,6 +82,7 @@ impl LLMChunk {
             | Self::ResponseId(_)
             | Self::ReasoningSignature(_)
             | Self::CacheUsage { .. }
+            | Self::ProviderUsage { .. }
             | Self::UsageSummary { .. }
             | Self::Done => false,
         }


### PR DESCRIPTION
## Summary

- Preserve provider-reported OpenAI Chat and Responses input/output/reasoning/cache usage as one optional-field `ProviderUsage` snapshot.
- Deliver co-located Chat business output and usage losslessly through multi-output SSE parsing across OpenAI, Copilot, and Bodhi production paths.
- Keep #651 Responses terminal recovery ordering: response ID, terminal content/tools, provider usage, then Done.
- Retain raw authoritative totals while preserving the existing fresh-input/cache log contract, runtime budgets, cache badge, and legacy usage fallback.

Closes #687.

## Implementation details

- Missing provider fields remain distinguishable from explicit zero through `StreamHandlingOutput.provider_usage`.
- Repeated cumulative snapshots are idempotent; provider `Some` fields win independently over legacy usage regardless of arrival order, while `None` fields fall back.
- Cache compatibility counters use a read-first subset clamp; `1000 total / 768 cached` remains `232 fresh + 768 cached`, and malformed cache totals cannot inflate normalized prompt usage.
- Provider output already includes reasoning, so runtime budgets do not double-count reasoning tokens.

## Scope

- Durable round/session metrics and cross-retry failure aggregation remain in #688.
- The pre-existing global Chat Done/usage-trailer terminal contract is tracked separately in #760.

## Test Plan

- `cargo fmt --all -- --check`
- Repository CI-style workspace Clippy with `-D warnings`
- `cargo test -p bamboo-llm --all-features --lib --tests` — 529 passed
- `cargo test -p bamboo-engine --all-features --lib --tests` — 1222 passed
- `cargo test -p bamboo-server --all-features --lib --tests` — 1705 passed, 1 expected ignored; 19 integration tests passed
- Parser/adapter regressions cover strict and lenient Chat text/tool/finish plus usage, official empty-choices usage, SSE flattening, and OpenAI/Bodhi production streams.
- Handler regressions cover Responses ordering, missing vs explicit zero, both provider/legacy arrival orders, raw vs normalized usage, cache clamping, runtime budgets, final events, and token logs.
- Two independent adversarial reviewers approved exact head `63775f2363e435c872a5f35db04d07996f9efa66` after three review rounds with no remaining actionable findings.

## Screenshots

N/A — backend-only behavior.