### PR TITLE
fix: make context compression budget-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Long conversations don't grow without bound. Bamboo uses a **hybrid strategy**: 
 
 - `counter` — counts tokens via tiktoken BPE or heuristic estimation (`TiktokenTokenCounter` / `HeuristicTokenCounter`).
 - `segmenter` — preserves the atomicity of tool calls when segmenting (it won't split a single tool call apart).
-- `limits` — **deliberately ships no per-model table**. Real context/output limits come from (1) provider runtime metadata, (2) user overrides in `model_limits.json`; with neither, it falls back to a global default of **200K context / 64K output**. This way the table never goes stale as models are updated.
+- `limits` — **deliberately ships no per-model table**. Explicit user overrides in `model_limits.json` take precedence over provider runtime metadata; with neither, Bamboo falls back to **1M total input+output context / 128K output**. Prompt fitting reserves the output allowance and tokenizer safety margin from that total window, and root sessions re-read the instance-local override file each round.
 - `summarizer` / `preparation` — builds the compression plan, generates the summary message, prepares context against the budget (`prepare_hybrid_context`), and can estimate prompt-cache savings.
 - **Oversized output** — oversized output produced by tools is trimmed/managed at `bamboo-tools/output_manager.rs`, avoiding stuffing the context all at once.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,7 +99,7 @@ graph TD
 
 - `counter` — 通过 tiktoken BPE 或启发式估算计 token（`TiktokenTokenCounter` / `HeuristicTokenCounter`）。
 - `segmenter` — 分段时保持工具调用的原子性（不会把一次 tool call 拆散）。
-- `limits` — **刻意不内置 per-model 表**。真实上下文/输出上限来自 (1) provider 运行时元数据，(2) 用户在 `model_limits.json` 的覆盖；都没有则回落到全局默认 **200K 上下文 / 64K 输出**。这样模型更新换代也不会让表过时。
+- `limits` — **刻意不内置 per-model 表**。`model_limits.json` 中的显式用户覆盖优先于 provider 运行时元数据；两者都没有时回落到全局默认 **1M 输入+输出总上下文 / 128K 输出**。构建 prompt 时会从总窗口预留输出额度和 tokenizer 安全余量，root session 每轮都会重新读取当前实例目录下的覆盖文件。
 - `summarizer` / `preparation` — 构建压缩计划、生成摘要消息、按预算准备上下文（`prepare_hybrid_context`），并能估算 prompt cache 节省。
 - **超大输出处理** — 工具产生的超大输出在 `bamboo-tools/output_manager.rs` 处会被裁剪/管理，避免一次性塞爆上下文。
 

--- a/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/model_limit_defaults.rs
+++ b/crates/app/bamboo-server/src/handlers/settings/bamboo_config/config_endpoints/model_limit_defaults.rs
@@ -23,7 +23,7 @@ struct ModelLimitDefaultsResponse {
 }
 
 /// Returns the single global model-limit default from the backend
-/// source-of-truth (`1M` context / `128K` output).
+/// source-of-truth (`1M` total input+output context / `128K` output).
 pub async fn get_model_limit_defaults() -> Result<HttpResponse, AppError> {
     let limit = default_model_limit();
     let default = ModelLimitDefault {

--- a/crates/core/bamboo-domain/src/session/budget_types.rs
+++ b/crates/core/bamboo-domain/src/session/budget_types.rs
@@ -22,11 +22,12 @@ pub struct TokenBudget {
     /// Compression target threshold as a percentage of context window tokens.
     #[serde(default = "default_compression_target_percent")]
     pub compression_target_percent: u8,
-    /// Fixed number of tokens reserved for model reasoning and output.
+    /// Fixed number of input tokens kept free before the request hard limit.
     ///
     /// Compression triggers when `(max_context_tokens - working_reserve_tokens)` is
-    /// exceeded. This provides consistent reasoning space regardless of model context
-    /// window size (Claude Code uses ~50K).
+    /// exceeded, but never later than the request input limit after reserving
+    /// `max_output_tokens` and `safety_margin`. This provides consistent working
+    /// space regardless of model context window size (Claude Code uses ~50K).
     ///
     /// When `working_reserve_tokens == 0`, falls back to percentage-based triggering
     /// via `compression_trigger_percent` for backward compatibility.
@@ -141,30 +142,49 @@ impl TokenBudget {
         }
     }
 
+    /// Maximum estimated input tokens that may be sent in one model request.
+    ///
+    /// `max_context_tokens` is the provider's total input + output window, so
+    /// prompt preparation must reserve both the configured output allowance and
+    /// the tokenizer-estimation safety margin before selecting input messages.
+    pub fn max_request_input_tokens(&self) -> u32 {
+        self.max_context_tokens
+            .saturating_sub(self.max_output_tokens)
+            .saturating_sub(self.safety_margin)
+    }
+
     pub fn compression_trigger_context_tokens(&self) -> u32 {
         let context_window = self.max_context_tokens;
-        if context_window == 0 {
+        let request_input_limit = self.max_request_input_tokens();
+        if context_window == 0 || request_input_limit == 0 {
             return 0;
         }
 
         // Primary: fixed reserve mode — trigger when (context - reserve) is exceeded.
-        if self.working_reserve_tokens > 0 && context_window >= self.working_reserve_tokens * 2 {
-            return context_window.saturating_sub(self.working_reserve_tokens);
-        }
-
-        // Fallback 1: small context window — use fallback_trigger_percent.
-        if self.working_reserve_tokens > 0 {
+        let trigger = if self.working_reserve_tokens > 0
+            && context_window >= self.working_reserve_tokens.saturating_mul(2)
+        {
+            context_window.saturating_sub(self.working_reserve_tokens)
+        } else if self.working_reserve_tokens > 0 {
+            // Fallback 1: small context window — use fallback_trigger_percent.
             let percent = normalize_trigger_percent(self.fallback_trigger_percent);
-            return context_window
+            context_window
                 .saturating_mul(percent)
                 .saturating_div(100)
-                .clamp(1, context_window);
-        }
+                .clamp(1, context_window)
+        } else {
+            // Fallback 2: working_reserve_tokens == 0 — legacy percentage mode.
+            let percent = normalize_trigger_percent(self.compression_trigger_percent);
+            context_window
+                .saturating_mul(percent)
+                .saturating_div(100)
+                .clamp(1, context_window)
+        };
 
-        // Fallback 2: working_reserve_tokens == 0 — legacy percentage mode.
-        let percent = normalize_trigger_percent(self.compression_trigger_percent);
-        let trigger = context_window.saturating_mul(percent).saturating_div(100);
-        trigger.clamp(1, context_window)
+        // A configured reserve can be smaller than the provider's maximum
+        // output allowance. Never wait until the prompt itself has consumed
+        // tokens that are required for output or the safety margin.
+        trigger.min(request_input_limit)
     }
 
     pub fn compression_target_context_tokens(&self) -> u32 {
@@ -174,6 +194,9 @@ impl TokenBudget {
         }
 
         let trigger = self.compression_trigger_context_tokens();
+        if trigger == 0 {
+            return 0;
+        }
         let percent = normalize_target_percent(self.compression_target_percent);
         let mut target = context_window
             .saturating_mul(percent)
@@ -366,6 +389,34 @@ mod tests {
             target < trigger,
             "target ({target}) must be < trigger ({trigger})"
         );
+    }
+
+    #[test]
+    fn request_input_limit_reserves_output_and_safety_margin() {
+        let budget =
+            TokenBudget::with_safety_margin(100_000, 30_000, BudgetStrategy::default(), 2_000);
+
+        assert_eq!(budget.max_request_input_tokens(), 68_000);
+    }
+
+    #[test]
+    fn request_input_limit_saturates_when_reserves_exceed_context() {
+        let budget =
+            TokenBudget::with_safety_margin(10_000, 9_500, BudgetStrategy::default(), 1_000);
+
+        assert_eq!(budget.max_request_input_tokens(), 0);
+        assert_eq!(budget.compression_trigger_context_tokens(), 0);
+        assert_eq!(budget.compression_target_context_tokens(), 0);
+    }
+
+    #[test]
+    fn compression_trigger_never_consumes_reserved_output_capacity() {
+        let mut budget =
+            TokenBudget::with_safety_margin(200_000, 80_000, BudgetStrategy::default(), 5_000);
+        budget.working_reserve_tokens = 50_000;
+
+        assert_eq!(budget.max_request_input_tokens(), 115_000);
+        assert_eq!(budget.compression_trigger_context_tokens(), 115_000);
     }
 
     #[test]

--- a/crates/core/bamboo-domain/src/session/types.rs
+++ b/crates/core/bamboo-domain/src/session/types.rs
@@ -635,11 +635,12 @@ pub struct Session {
     pub metadata: std::collections::HashMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token_budget: Option<TokenBudget>,
-    /// Per-process cache of the model-limit-derived budget, keyed by the model it
-    /// was resolved for. Never persisted (`#[serde(skip)]`), so a reloaded session
-    /// re-resolves from the current `model_limits.json`, and a mid-session model
-    /// switch invalidates it (the key no longer matches). `token_budget` above
-    /// stays the persisted genuine/child override that takes priority. (#180)
+    /// Runtime snapshot of the model-limit-derived budget for downstream readers
+    /// in the current round, keyed by model. It is never persisted and never
+    /// short-circuits the next round's resolution, so live `model_limits.json`
+    /// edits and provider-metadata refreshes take effect without reloading the
+    /// session. `token_budget` above remains the persisted genuine/child override
+    /// that takes priority. (#180, #763)
     #[serde(skip)]
     pub resolved_token_budget: Option<(String, TokenBudget)>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -700,11 +701,11 @@ impl Session {
     }
 
     /// The effective token budget: a genuine/child override (`token_budget`) if
-    /// set, otherwise the per-process resolved-budget cache
+    /// set, otherwise the current round's resolved-budget snapshot
     /// (`resolved_token_budget`). Both are `None` until the first resolution.
     /// Downstream readers should use this rather than `token_budget` directly so
     /// they observe the engine-resolved budget without persisting it. Note the
-    /// cache is returned regardless of which model it was resolved for; that is
+    /// snapshot is returned regardless of which model it was resolved for; that is
     /// safe because `resolve_token_budget` runs at round start (re-keying to the
     /// current model) before any reader — don't call this expecting model-freshness
     /// without a preceding same-round resolve. (#180)

--- a/crates/core/bamboo-domain/src/session/types.rs
+++ b/crates/core/bamboo-domain/src/session/types.rs
@@ -344,6 +344,24 @@ pub struct ConversationSummary {
     pub content: String,
     pub message_count: usize,
     pub token_count: u32,
+    /// Number of raw source tokens represented by this summary across all
+    /// compression passes. Legacy summaries deserialize as `0`, which signals
+    /// that callers must use the conservative existing-summary fallback.
+    #[serde(default)]
+    pub represented_source_tokens: u32,
+    /// Desired summary size for the logical compression pass that produced this
+    /// value. `token_count` remains the actual rendered summary token count.
+    #[serde(default)]
+    pub target_token_count: u32,
+    /// Source-to-summary target ratio used by the logical compression pass.
+    #[serde(default)]
+    pub target_ratio: f64,
+    /// Whether model/context capacity or an underfilled model response left the
+    /// summary materially below its desired source-derived token budget.
+    #[serde(default)]
+    pub budget_clamped: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_clamp_reason: Option<String>,
 }
 
 impl ConversationSummary {
@@ -355,7 +373,29 @@ impl ConversationSummary {
             content: content.into(),
             message_count,
             token_count,
+            represented_source_tokens: 0,
+            target_token_count: 0,
+            target_ratio: 0.0,
+            budget_clamped: false,
+            budget_clamp_reason: None,
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_compression_metrics(
+        mut self,
+        represented_source_tokens: u32,
+        target_token_count: u32,
+        target_ratio: f64,
+        budget_clamped: bool,
+        budget_clamp_reason: Option<String>,
+    ) -> Self {
+        self.represented_source_tokens = represented_source_tokens;
+        self.target_token_count = target_token_count;
+        self.target_ratio = target_ratio;
+        self.budget_clamped = budget_clamped;
+        self.budget_clamp_reason = budget_clamp_reason;
+        self
     }
 
     pub fn update(&mut self, content: impl Into<String>, message_count: usize, token_count: u32) {
@@ -389,6 +429,10 @@ pub struct CompressionEvent {
     pub usage_after_percent: f64,
     #[serde(default)]
     pub summary_tokens: u32,
+    /// Actual token count of the summary body, excluding the system-envelope
+    /// wrapper tracked by the legacy `summary_tokens` field.
+    #[serde(default)]
+    pub actual_summary_tokens: u32,
     #[serde(default)]
     pub trigger_type: CompressionTriggerType,
     #[serde(default)]
@@ -397,6 +441,34 @@ pub struct CompressionEvent {
     pub model_used: Option<String>,
     #[serde(default)]
     pub latency_ms: u64,
+    /// Raw source tokens newly archived by this event.
+    #[serde(default)]
+    pub source_tokens: u32,
+    /// Active prompt tokens outside `Session.messages` that were included in
+    /// the post-compression target calculation.
+    #[serde(default)]
+    pub fixed_prompt_tokens: u32,
+    /// Source-derived summary budget for the completed logical pass.
+    #[serde(default)]
+    pub target_summary_tokens: u32,
+    /// Configured source-to-summary target ratio.
+    #[serde(default)]
+    pub summary_target_ratio: f64,
+    /// Actual summary/source ratio after the pass.
+    #[serde(default)]
+    pub actual_summary_ratio: f64,
+    /// Whether capacity or output quality left the persisted summary below its
+    /// source-derived target.
+    #[serde(default)]
+    pub summary_budget_clamped: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary_budget_clamp_reason: Option<String>,
+    #[serde(default)]
+    pub summarization_map_calls: u32,
+    #[serde(default)]
+    pub summarization_reduce_calls: u32,
+    #[serde(default)]
+    pub summarization_fallback_used: bool,
 }
 
 impl CompressionEvent {
@@ -420,10 +492,21 @@ impl CompressionEvent {
             usage_before_percent,
             usage_after_percent,
             summary_tokens,
+            actual_summary_tokens: 0,
             trigger_type,
             compression_ratio,
             model_used,
             latency_ms,
+            source_tokens: 0,
+            fixed_prompt_tokens: 0,
+            target_summary_tokens: 0,
+            summary_target_ratio: 0.0,
+            actual_summary_ratio: 0.0,
+            summary_budget_clamped: false,
+            summary_budget_clamp_reason: None,
+            summarization_map_calls: 0,
+            summarization_reduce_calls: 0,
+            summarization_fallback_used: false,
         }
     }
 }
@@ -1252,13 +1335,7 @@ mod tests {
             thinking_tokens: 0,
             cache_read_input_tokens: 0,
         });
-        session.conversation_summary = Some(ConversationSummary {
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            content: "summary".to_string(),
-            message_count: 5,
-            token_count: 100,
-        });
+        session.conversation_summary = Some(ConversationSummary::new("summary", 5, 100));
         session.compression_events = vec![CompressionEvent::new(
             1,
             2,
@@ -1378,7 +1455,7 @@ mod tests {
 
     #[test]
     fn compression_event_extended_fields_roundtrip() {
-        let event = CompressionEvent::new(
+        let mut event = CompressionEvent::new(
             42,   // messages_compressed
             10,   // segments_removed
             92.5, // usage_before_percent
@@ -1389,6 +1466,18 @@ mod tests {
             Some("gpt-5.4-mini".to_string()),
             1500, // latency_ms
         );
+        event.source_tokens = 2_500;
+        event.fixed_prompt_tokens = 300;
+        event.actual_summary_tokens = 480;
+        event.target_summary_tokens = 500;
+        event.summary_target_ratio = 0.20;
+        event.actual_summary_ratio = 0.192;
+        event.summary_budget_clamped = true;
+        event.summary_budget_clamp_reason =
+            Some("model_returned_below_80_percent_of_target".to_string());
+        event.summarization_map_calls = 4;
+        event.summarization_reduce_calls = 2;
+        event.summarization_fallback_used = false;
 
         let json = serde_json::to_string(&event).unwrap();
         let back: CompressionEvent = serde_json::from_str(&json).unwrap();
@@ -1402,6 +1491,37 @@ mod tests {
         assert!((back.compression_ratio - 2.63).abs() < 0.01);
         assert_eq!(back.model_used.as_deref(), Some("gpt-5.4-mini"));
         assert_eq!(back.latency_ms, 1500);
+        assert_eq!(back.source_tokens, 2_500);
+        assert_eq!(back.fixed_prompt_tokens, 300);
+        assert_eq!(back.actual_summary_tokens, 480);
+        assert_eq!(back.target_summary_tokens, 500);
+        assert_eq!(back.summary_target_ratio, 0.20);
+        assert_eq!(back.actual_summary_ratio, 0.192);
+        assert!(back.summary_budget_clamped);
+        assert_eq!(
+            back.summary_budget_clamp_reason.as_deref(),
+            Some("model_returned_below_80_percent_of_target")
+        );
+        assert_eq!(back.summarization_map_calls, 4);
+        assert_eq!(back.summarization_reduce_calls, 2);
+        assert!(!back.summarization_fallback_used);
+    }
+
+    #[test]
+    fn conversation_summary_backward_compat_defaults_compression_metrics() {
+        let json = r#"{
+            "created_at": "2025-01-01T00:00:00Z",
+            "updated_at": "2025-01-01T00:00:00Z",
+            "content": "legacy summary",
+            "message_count": 10,
+            "token_count": 200
+        }"#;
+        let summary: ConversationSummary = serde_json::from_str(json).unwrap();
+        assert_eq!(summary.represented_source_tokens, 0);
+        assert_eq!(summary.target_token_count, 0);
+        assert_eq!(summary.target_ratio, 0.0);
+        assert!(!summary.budget_clamped);
+        assert!(summary.budget_clamp_reason.is_none());
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/llm_summarizer.rs
+++ b/crates/engine/bamboo-engine/src/llm_summarizer.rs
@@ -2,9 +2,11 @@
 //!
 //! `LlmSummarizer` is the infrastructure-coupled implementation of
 //! `bamboo_compression::Summarizer`: it calls the session model to produce a
-//! rich summary of compressed/removed messages. Legacy, unbudgeted callers may
-//! fall back to the pure `HeuristicSummarizer`; the bounded map/reduce pipeline
-//! surfaces every failed stage so callers can preserve session state atomically.
+//! rich summary of compressed/removed messages. Callers without an explicit
+//! model budget use a conservative compatibility budget, so every LLM-backed
+//! path still runs through bounded map/reduce. Compatibility callers may fall
+//! back to the pure `HeuristicSummarizer`; explicitly budgeted production passes
+//! surface every failed stage so callers can preserve session state atomically.
 //! It lives in the engine (not in bamboo-compression) so that the compression
 //! crate stays free of any LLM-provider dependency.
 
@@ -23,6 +25,11 @@ use bamboo_domain::{
 };
 use bamboo_llm::LLMChunk;
 use bamboo_llm::{LLMProvider, LLMRequestOptions};
+
+const COMPATIBILITY_CONTEXT_WINDOW_TOKENS: u32 = 32_000;
+const COMPATIBILITY_MAX_OUTPUT_TOKENS: u32 = 8_000;
+const COMPATIBILITY_SAFETY_MARGIN_TOKENS: u32 = 1_000;
+const COMPATIBILITY_SAFE_WINDOW_PERCENT: u8 = 80;
 
 /// Mode controlling how the LLM summarizer handles existing summaries.
 #[derive(Debug, Clone, Default)]
@@ -120,8 +127,8 @@ struct SummaryPart {
 /// LLM-based summarizer that calls the current session's model to generate
 /// a rich summary of compressed/removed messages.
 ///
-/// Legacy unbudgeted calls fall back to [`HeuristicSummarizer`] if the LLM call
-/// fails, UNLESS
+/// Calls without an explicit request budget fall back to
+/// [`HeuristicSummarizer`] if the bounded LLM pipeline fails, UNLESS
 /// [`with_heuristic_fallback_on_error(false)`](Self::with_heuristic_fallback_on_error)
 /// is set. Budgeted calls always surface failed map/reduce stages so the archive
 /// transaction cannot commit a heuristic summary that represents a failed pass.
@@ -136,10 +143,11 @@ pub struct LlmSummarizer {
     custom_instructions: Option<String>,
     /// Controls how the summarizer handles existing summaries.
     summary_mode: SummaryMode,
-    /// When true (default), a transient legacy/unbudgeted LLM call failure is
-    /// recovered by falling back to the [`HeuristicSummarizer`]. Budgeted calls
-    /// always return stage failures so a multi-request pass remains atomic. The
-    /// empty-response fallback is unaffected either way. (issues #238, #763)
+    /// When true (default), a transient compatibility-path LLM failure is
+    /// recovered by falling back to the [`HeuristicSummarizer`]. Explicitly
+    /// budgeted calls always return stage failures so a multi-request pass
+    /// remains atomic. The empty-response fallback is unaffected either way.
+    /// (issues #238, #763)
     heuristic_fallback_on_error: bool,
     /// Exact selected summarization-model limits and source-derived output goal.
     request_budget: Option<SummaryRequestBudget>,
@@ -187,10 +195,10 @@ impl LlmSummarizer {
         }
     }
 
-    /// Control whether a transient legacy/unbudgeted LLM *error* recovers via
+    /// Control whether a transient compatibility-path LLM *error* recovers via
     /// the heuristic summarizer (default `true`) or surfaces to the caller
-    /// (`false`). Budgeted map/reduce failures always surface. (issues #238,
-    /// #763)
+    /// (`false`). Explicitly budgeted map/reduce failures always surface.
+    /// (issues #238, #763)
     pub fn with_heuristic_fallback_on_error(mut self, enabled: bool) -> Self {
         self.heuristic_fallback_on_error = enabled;
         self
@@ -262,6 +270,12 @@ impl LlmSummarizer {
         }
     }
 
+    fn render_shared_context(&self) -> String {
+        let mut content = String::new();
+        self.append_shared_context(&mut content);
+        content
+    }
+
     fn render_message_block(message: &Message) -> Option<String> {
         let role_label = match message.role {
             Role::User => "User",
@@ -307,75 +321,6 @@ impl LlmSummarizer {
             .iter()
             .filter_map(Self::render_message_block)
             .collect::<String>()
-    }
-
-    /// Build the summarization prompt for the LLM.
-    fn build_summarization_messages(&self, messages: &[Message]) -> Vec<Message> {
-        let mut prompt_messages = Vec::new();
-
-        let system_prompt = match self.summary_mode {
-            SummaryMode::FullRewrite => {
-                r#"You are a conversation summarizer. Your task is to create a concise but reliable working-memory summary for a conversation that was removed due to context window limits.
-
-Guidelines:
-- First capture the in-flight work right before compression (what was being done, where, and with which tool/file)
-- Distinguish clearly between CURRENT ACTIVE work, COMPLETED work, and OBSOLETE or superseded work
-- Do not restate old tasks as active unless they are still unresolved
-- The provided current task list is the source of truth for active work
-- Preserve key decisions, constraints, file paths, code changes, tool findings, blockers, and important outcomes
-- Preserve error messages, test results (pass/fail counts), and function/variable names that are relevant to active work
-- If earlier plans conflict with newer messages or the current task list, mark them as obsolete or completed
-- Explicitly evaluate each clear user requirement (e.g. requirement 1, requirement 2) with a status and evidence
-- Keep the next step specific and aligned with the active work only
-- Use structured sections
-- Write in the same language as the original conversation"#
-            }
-            SummaryMode::IncrementalMerge => {
-                r#"You are updating an existing conversation summary with new information from recent messages.
-
-Guidelines:
-- Incorporate new information into the existing summary structure
-- Mark previously active work as completed if the new messages confirm completion
-- Remove or condense information that is no longer relevant
-- Preserve all key decisions, file paths, and constraints that remain active
-- If new messages conflict with the existing summary, the new messages take precedence
-- Keep the summary focused on what is currently active and relevant
-- The provided current task list is the source of truth for active work
-- Maintain the same structured sections as the existing summary
-- Write in the same language as the original conversation
-- Be concise: avoid repeating information already well-captured in the existing summary"#
-            }
-        };
-
-        prompt_messages.push(Message::system(system_prompt));
-
-        let mut user_content = String::new();
-
-        self.append_shared_context(&mut user_content);
-
-        if let Some(budget) = self.request_budget.as_ref() {
-            user_content.push_str(&format!(
-                "## Summary Size Budget\nTarget approximately {} tokens (about {:.0}% of the represented raw source). Preserve coverage and useful detail up to this budget; do not collapse the result to a tiny synopsis.\n\n",
-                budget.target_summary_tokens,
-                budget.target_ratio * 100.0,
-            ));
-        }
-
-        user_content.push_str(
-            "## Required Output Sections\n1. Pre-compression in-flight work (what was being done immediately before compression)\n2. Current active objective\n3. Requirement checklist (Requirement | Status: completed/in_progress/pending/blocked/obsolete | Evidence)\n4. Active tasks\n5. Completed tasks\n6. Obsolete or superseded tasks\n7. Important context and constraints\n8. Files, code, and tool findings\n9. Open issues and next step\n\n",
-        );
-
-        user_content.push_str("## Messages to Summarize\n\n");
-
-        user_content.push_str(&Self::render_messages(messages));
-
-        user_content.push_str(
-            "\n---\n\nReturn only the summary text. Be explicit about what is active now versus what is already completed or no longer relevant.",
-        );
-
-        prompt_messages.push(Message::user(user_content));
-
-        prompt_messages
     }
 
     fn build_map_messages(&self, units: &[SourceUnit], target_tokens: u32) -> Vec<Message> {
@@ -446,14 +391,85 @@ Guidelines:
         user_content.push_str(
             "Return only the merged summary. Preserve source chronology and remove only genuine duplication.",
         );
-        vec![
-            Message::system(if include_shared_context {
-                "You are the final reduce stage of a bounded conversation-compression pipeline. \
-                 Merge all ordered partials and the supplied prior/runtime context into one reliable \
-                 working-memory summary."
+        let system_prompt = if include_shared_context {
+            match self.summary_mode {
+                SummaryMode::FullRewrite => {
+                    "You are the final reduce stage of a bounded conversation-compression \
+                     pipeline. Merge all ordered partials and the supplied prior/runtime context \
+                     into one reliable working-memory summary."
+                }
+                SummaryMode::IncrementalMerge => {
+                    "You are the incremental final reduce stage of a bounded \
+                     conversation-compression pipeline. Update the supplied prior summary with the \
+                     ordered new partials and current runtime context. Newer facts supersede stale \
+                     prior state."
+                }
+            }
+        } else {
+            "You are an intermediate reduce stage of a bounded conversation-compression pipeline. \
+             Merge ordered partials without compounding the source-to-summary ratio."
+        };
+        vec![Message::system(system_prompt), Message::user(user_content)]
+    }
+
+    fn build_multipart_finalize_messages(
+        &self,
+        parts: &[SummaryPart],
+        target_tokens: u32,
+        shared_context_capsule: &str,
+        retain_shared_context_capsule: bool,
+    ) -> Vec<Message> {
+        let represented_source_tokens = parts.iter().fold(0u32, |total, part| {
+            total.saturating_add(part.represented_source_tokens)
+        });
+        let has_shared_context = !shared_context_capsule.trim().is_empty();
+        let mut user_content = String::new();
+        if has_shared_context {
+            let retention_instruction = if retain_shared_context_capsule {
+                "The shared-context capsule is retained once before the multipart updates, so do \
+                 not repeat unchanged capsule text; emit corrections, superseding facts, and \
+                 current runtime state when relevant."
             } else {
-                "You are an intermediate reduce stage of a bounded conversation-compression \
-                 pipeline. Merge ordered partials without compounding the source-to-summary ratio."
+                "The shared-context capsule is reference material and is not stored separately. \
+                 Incorporate its durable prior state and current runtime facts wherever needed, \
+                 while applying its custom and hook-injected instructions as binding directives."
+            };
+            user_content.push_str(&format!(
+                "## Shared Context Capsule\n\n{shared_context_capsule}\n\n\
+                 Apply all custom and hook-injected instructions carried by the capsule. \
+                 {retention_instruction}\n\n"
+            ));
+        }
+        user_content.push_str(&format!(
+            "## Multipart Section Budget\n\n\
+             Target approximately {target_tokens} tokens for the source ranges in this section. \
+             They represent approximately {represented_source_tokens} raw source tokens. Preserve \
+             that source-derived allocation instead of applying the compression ratio again.\n\n\
+             ## Ordered Partial Summaries\n\n"
+        ));
+        for (index, part) in parts.iter().enumerate() {
+            user_content.push_str(&format!(
+                "### Partial {} — source {}..{} ({} represented raw tokens)\n\n{}\n\n",
+                index + 1,
+                part.first_message_id,
+                part.last_message_id,
+                part.represented_source_tokens,
+                part.content.trim(),
+            ));
+        }
+        user_content.push_str(
+            "Return only this finalized chronological multipart section. Preserve detailed evidence \
+             up to the allocated budget and make any newer correction explicit.",
+        );
+        vec![
+            Message::system(if has_shared_context {
+                "You are the instruction-aware multipart final stage of a bounded \
+                 conversation-compression pipeline. Finalize one ordered section under the supplied \
+                 shared context without compounding the source-to-summary ratio."
+            } else {
+                "You are the multipart final stage of a bounded conversation-compression pipeline. \
+                 Reduce one ordered section into its final form without compounding the \
+                 source-to-summary ratio."
             }),
             Message::user(user_content),
         ]
@@ -466,6 +482,26 @@ Guidelines:
             .map(|budget| budget.target_ratio)
             .unwrap_or(0.20);
         ((represented_source_tokens as f64) * ratio).ceil().max(1.0) as u32
+    }
+
+    fn compatibility_request_budget(&self, messages: &[Message]) -> SummaryRequestBudget {
+        let counter = TiktokenTokenCounter::default();
+        let represented_source_tokens = counter.count_messages(messages);
+        let previous_summary_tokens = self
+            .existing_summary
+            .as_deref()
+            .map(|summary| counter.count_text(summary))
+            .unwrap_or(0);
+        SummaryRequestBudget {
+            context_window_tokens: COMPATIBILITY_CONTEXT_WINDOW_TOKENS,
+            max_output_tokens: COMPATIBILITY_MAX_OUTPUT_TOKENS,
+            safety_margin_tokens: COMPATIBILITY_SAFETY_MARGIN_TOKENS,
+            safe_window_percent: COMPATIBILITY_SAFE_WINDOW_PERCENT,
+            target_summary_tokens: previous_summary_tokens
+                .saturating_add(((represented_source_tokens as f64) * 0.20).ceil().max(1.0) as u32)
+                .max(1),
+            target_ratio: 0.20,
+        }
     }
 
     fn request_fits(
@@ -697,6 +733,150 @@ Guidelines:
         groups
     }
 
+    fn pack_multipart_final_groups(
+        &self,
+        parts: &[SummaryPart],
+        shared_context_capsule: &str,
+        retain_shared_context_capsule: bool,
+        budget: &SummaryRequestBudget,
+    ) -> Result<Vec<Vec<SummaryPart>>, bamboo_compression::types::BudgetError> {
+        let mut bounded_parts = Vec::new();
+        for part in parts {
+            let requested_output = self.target_for_source(part.represented_source_tokens);
+            if self.request_fits(
+                &self.build_multipart_finalize_messages(
+                    std::slice::from_ref(part),
+                    requested_output,
+                    shared_context_capsule,
+                    retain_shared_context_capsule,
+                ),
+                requested_output,
+                budget,
+            ) {
+                bounded_parts.push(part.clone());
+            } else {
+                bounded_parts.extend(self.split_oversized_multipart_part(
+                    part.clone(),
+                    shared_context_capsule,
+                    retain_shared_context_capsule,
+                    budget,
+                )?);
+            }
+        }
+
+        let mut groups = Vec::new();
+        let mut current = Vec::<SummaryPart>::new();
+        for part in &bounded_parts {
+            let mut candidate = current.clone();
+            candidate.push(part.clone());
+            let represented = candidate.iter().fold(0u32, |total, item| {
+                total.saturating_add(item.represented_source_tokens)
+            });
+            let requested_output = self.target_for_source(represented);
+            if self.request_fits(
+                &self.build_multipart_finalize_messages(
+                    &candidate,
+                    requested_output,
+                    shared_context_capsule,
+                    retain_shared_context_capsule,
+                ),
+                requested_output,
+                budget,
+            ) {
+                current = candidate;
+                continue;
+            }
+
+            if !current.is_empty() {
+                groups.push(std::mem::take(&mut current));
+            }
+            current.push(part.clone());
+        }
+        if !current.is_empty() {
+            groups.push(current);
+        }
+        Ok(groups)
+    }
+
+    fn split_oversized_multipart_part(
+        &self,
+        part: SummaryPart,
+        shared_context_capsule: &str,
+        retain_shared_context_capsule: bool,
+        budget: &SummaryRequestBudget,
+    ) -> Result<Vec<SummaryPart>, bamboo_compression::types::BudgetError> {
+        let counter = TiktokenTokenCounter::default();
+        let mut remaining = part.content;
+        let mut remaining_represented = part.represented_source_tokens;
+        let mut split_parts = Vec::new();
+        while !remaining.is_empty() {
+            let remaining_text_tokens = counter.count_text(&remaining).max(1);
+            let mut piece_token_budget = remaining_text_tokens;
+            let (piece_text, piece_represented) = loop {
+                let mut prefix = counter.truncate_to_token_prefix(&remaining, piece_token_budget);
+                if prefix.is_empty() {
+                    prefix = remaining
+                        .chars()
+                        .next()
+                        .map(|character| character.to_string())
+                        .unwrap_or_default();
+                }
+                let is_last = prefix.len() == remaining.len();
+                let prefix_tokens = counter.count_text(&prefix).max(1);
+                let represented = if is_last {
+                    remaining_represented
+                } else if remaining_represented <= 1 {
+                    0
+                } else {
+                    (((remaining_represented as u64) * (prefix_tokens as u64)
+                        / (remaining_text_tokens as u64))
+                        .max(1)
+                        .min(remaining_represented.saturating_sub(1) as u64))
+                        as u32
+                };
+                let candidate = SummaryPart {
+                    content: prefix.clone(),
+                    represented_source_tokens: represented,
+                    first_message_id: part.first_message_id.clone(),
+                    last_message_id: part.last_message_id.clone(),
+                };
+                let requested_output = self.target_for_source(represented);
+                if self.request_fits(
+                    &self.build_multipart_finalize_messages(
+                        std::slice::from_ref(&candidate),
+                        requested_output,
+                        shared_context_capsule,
+                        retain_shared_context_capsule,
+                    ),
+                    requested_output,
+                    budget,
+                ) {
+                    break (prefix, represented);
+                }
+                if piece_token_budget <= 1 {
+                    return Err(bamboo_compression::types::BudgetError::TokenCountError(
+                        format!(
+                            "shared-context capsule and multipart source range {}..{} cannot fit the summarization request ceiling",
+                            part.first_message_id, part.last_message_id
+                        ),
+                    ));
+                }
+                piece_token_budget = (piece_token_budget * 3 / 4).max(1);
+            };
+
+            let consumed_bytes = piece_text.len();
+            split_parts.push(SummaryPart {
+                content: piece_text,
+                represented_source_tokens: piece_represented,
+                first_message_id: part.first_message_id.clone(),
+                last_message_id: part.last_message_id.clone(),
+            });
+            remaining = remaining[consumed_bytes..].to_string();
+            remaining_represented = remaining_represented.saturating_sub(piece_represented);
+        }
+        Ok(split_parts)
+    }
+
     async fn execute_bounded_request(
         &self,
         stage: &str,
@@ -760,15 +940,66 @@ Guidelines:
         Ok(content)
     }
 
-    fn compose_multipart_summary(&self, parts: &[SummaryPart]) -> String {
-        let mut sections = Vec::new();
-        if let Some(existing) = self
-            .existing_summary
-            .as_deref()
-            .map(str::trim)
-            .filter(|summary| !summary.is_empty())
+    async fn build_bounded_shared_context_capsule(
+        &self,
+        shared_context: &str,
+        target_tokens: u32,
+        budget: &SummaryRequestBudget,
+    ) -> Result<(String, u32, u32), bamboo_compression::types::BudgetError> {
+        let counter = TiktokenTokenCounter::default();
+        let shared_tokens = counter.count_text(shared_context).max(1);
+        let capsule_target = target_tokens.max(1).min(shared_tokens);
+        // A shared-context capsule is still a compression pass, so it follows
+        // the same map-then-reduce contract even when its fully rendered source
+        // would fit one provider request. The child has no shared context of its
+        // own, so multipart finalization cannot recurse back into this lane.
+        let capsule_messages = [Message::user(format!(
+            "Preserve this shared context capsule, including every binding compression \
+             instruction and hook-injected directive:\n\n{shared_context}"
+        ))];
+        let capsule_source_tokens = counter.count_messages(&capsule_messages).max(1);
+        let mut capsule_budget = budget.clone();
+        capsule_budget.target_summary_tokens = capsule_target;
+        // A prior durable summary has already paid the global compression
+        // ratio. Allow a 1:1 capsule map when its retained allocation calls for
+        // it; clamping this child to the normal 50% ceiling would silently apply
+        // a second compression ratio before the outer multipart reduce.
+        capsule_budget.target_ratio =
+            (capsule_target as f64 / capsule_source_tokens as f64).min(1.0);
+        let mut capsule_summarizer =
+            LlmSummarizer::new(Arc::clone(&self.llm), self.model.clone(), None, None)
+                .with_summary_mode(SummaryMode::FullRewrite)
+                .with_request_budget(capsule_budget)
+                .with_heuristic_fallback_on_error(false);
+        if let (Some(pass_id), Some(phase)) =
+            (self.logical_pass_id.as_ref(), self.logical_phase.as_ref())
         {
-            sections.push(existing.to_string());
+            capsule_summarizer =
+                capsule_summarizer.with_logical_pass_context(pass_id.clone(), phase.clone());
+        }
+        if let Some(callback) = self.progress_callback.as_ref() {
+            capsule_summarizer = capsule_summarizer.with_progress_callback(Arc::clone(callback));
+        }
+        let report = Box::pin(capsule_summarizer.summarize_with_report(&capsule_messages)).await?;
+        let content = counter.truncate_to_token_prefix(report.content.trim(), capsule_target);
+        if content.trim().is_empty() {
+            return Err(bamboo_compression::types::BudgetError::TokenCountError(
+                "bounded shared-context capsule is empty".to_string(),
+            ));
+        }
+        Ok((content, report.map_calls, report.reduce_calls))
+    }
+
+    fn compose_multipart_summary(
+        parts: &[SummaryPart],
+        shared_context_capsule: Option<&str>,
+    ) -> String {
+        let mut sections = Vec::new();
+        if let Some(capsule) = shared_context_capsule
+            .map(str::trim)
+            .filter(|capsule| !capsule.is_empty())
+        {
+            sections.push(capsule.to_string());
         }
         sections.extend(
             parts
@@ -780,6 +1011,93 @@ Guidelines:
         sections.join("\n\n")
     }
 
+    async fn finalize_multipart_summary(
+        &self,
+        parts: &[SummaryPart],
+        budget: &SummaryRequestBudget,
+    ) -> Result<(String, u32, u32), bamboo_compression::types::BudgetError> {
+        let shared_context = self.render_shared_context();
+        let represented_new_source = parts.iter().fold(0u32, |total, part| {
+            total.saturating_add(part.represented_source_tokens)
+        });
+        let new_source_target = self.target_for_source(represented_new_source);
+        let retained_capsule_target = budget
+            .target_summary_tokens
+            .saturating_sub(new_source_target);
+        let retain_shared_context_capsule = retained_capsule_target > 0;
+        let (shared_context_capsule, capsule_map_calls, capsule_reduce_calls) =
+            if shared_context.trim().is_empty() {
+                (String::new(), 0, 0)
+            } else {
+                let counter = TiktokenTokenCounter::default();
+                let reference_only_target =
+                    self.target_for_source(counter.count_text(&shared_context));
+                self.build_bounded_shared_context_capsule(
+                    &shared_context,
+                    if retain_shared_context_capsule {
+                        retained_capsule_target
+                    } else {
+                        reference_only_target
+                    },
+                    budget,
+                )
+                .await?
+            };
+        let mut multipart_reduce_calls = 0u32;
+        let groups = self.pack_multipart_final_groups(
+            parts,
+            &shared_context_capsule,
+            retain_shared_context_capsule,
+            budget,
+        )?;
+        let group_count = groups.len();
+        let mut finalized = Vec::with_capacity(group_count);
+        for (group_index, group) in groups.into_iter().enumerate() {
+            let represented = group.iter().fold(0u32, |total, part| {
+                total.saturating_add(part.represented_source_tokens)
+            });
+            let requested_output = self.target_for_source(represented);
+            let prompt = self.build_multipart_finalize_messages(
+                &group,
+                requested_output,
+                &shared_context_capsule,
+                retain_shared_context_capsule,
+            );
+            let content = self
+                .execute_bounded_request(
+                    "multipart_final_reduce",
+                    group_index + 1,
+                    group_count,
+                    &prompt,
+                    requested_output,
+                    budget,
+                )
+                .await?;
+            multipart_reduce_calls = multipart_reduce_calls.saturating_add(1);
+            finalized.push(SummaryPart {
+                content,
+                represented_source_tokens: represented,
+                first_message_id: group
+                    .first()
+                    .map(|part| part.first_message_id.clone())
+                    .unwrap_or_default(),
+                last_message_id: group
+                    .last()
+                    .map(|part| part.last_message_id.clone())
+                    .unwrap_or_default(),
+            });
+        }
+        Ok((
+            Self::compose_multipart_summary(
+                &finalized,
+                (retain_shared_context_capsule && !shared_context_capsule.trim().is_empty())
+                    .then_some(shared_context_capsule.as_str()),
+            ),
+            capsule_map_calls,
+            capsule_reduce_calls.saturating_add(multipart_reduce_calls),
+        ))
+    }
+
     async fn summarize_bounded(
         &self,
         messages: &[Message],
@@ -788,28 +1106,12 @@ Guidelines:
         let counter = TiktokenTokenCounter::default();
         let represented_source_tokens = counter.count_messages(messages);
         let final_target = budget.target_summary_tokens.max(1);
-        let one_shot_prompt = self.build_summarization_messages(messages);
-        if self.request_fits(&one_shot_prompt, final_target, budget) {
-            let content = self
-                .execute_bounded_request("one_shot", 1, 1, &one_shot_prompt, final_target, budget)
-                .await?;
-            let actual_summary_tokens = counter.count_text(&content);
-            let underfilled =
-                actual_summary_tokens.saturating_mul(5) < final_target.saturating_mul(4);
-            return Ok(SummarizationReport {
-                content,
-                represented_source_tokens,
-                target_summary_tokens: final_target,
-                actual_summary_tokens,
-                map_calls: 0,
-                reduce_calls: 0,
-                fallback_used: false,
-                budget_clamped: underfilled,
-                budget_clamp_reason: underfilled
-                    .then(|| "model_returned_below_80_percent_of_target".to_string()),
-            });
-        }
 
+        // Every bounded compression pass deliberately goes through map then
+        // reduce, even when the source would fit a single provider request.
+        // Keeping one pipeline for all source sizes avoids a size-dependent
+        // semantic split and guarantees that no raw source is ever sent
+        // directly to the terminal summarizer.
         let chunks = self.pack_source_chunks(messages, budget)?;
         let mut map_calls = 0u32;
         let mut parts = Vec::with_capacity(chunks.len());
@@ -928,18 +1230,24 @@ Guidelines:
 
         // A single final model response cannot represent an arbitrarily large
         // 20%-of-source target when the selected model has a smaller output
-        // limit. Preserve the bounded partials as one multipart stored summary
-        // instead of applying another 20% pass (which would collapse to ~4%).
-        let content = self.compose_multipart_summary(&parts);
+        // limit. Finalize bounded sections under one shared-context capsule,
+        // then compose them instead of applying another global 20% pass (which
+        // would collapse to ~4%).
+        let (content, multipart_map_calls, multipart_reduce_calls) =
+            self.finalize_multipart_summary(&parts, budget).await?;
+        map_calls = map_calls.saturating_add(multipart_map_calls);
+        reduce_calls = reduce_calls.saturating_add(multipart_reduce_calls);
         let actual_summary_tokens = counter.count_text(&content);
         let underfilled = actual_summary_tokens.saturating_mul(5) < final_target.saturating_mul(4);
         tracing::info!(
             logical_pass_id = self.logical_pass_id.as_deref().unwrap_or("untracked"),
             logical_phase = self.logical_phase.as_deref().unwrap_or("unspecified"),
             part_count = parts.len(),
+            multipart_map_calls,
+            multipart_reduce_calls,
             actual_summary_tokens,
             target_summary_tokens = final_target,
-            "Final single-response reduce did not fit; composing bounded multipart summary"
+            "Final single-response reduce did not fit; composed instruction-aware bounded multipart summary"
         );
         Ok(SummarizationReport {
             content,
@@ -995,32 +1303,15 @@ Guidelines:
             });
         }
 
-        let target_summary_tokens = self
-            .request_budget
-            .as_ref()
-            .map(|budget| budget.target_summary_tokens)
-            .unwrap_or_else(|| self.estimate_summary_tokens(messages.len()).max(1));
-        let result = if let Some(budget) = self.request_budget.as_ref() {
-            self.summarize_bounded(messages, budget).await
+        let compatibility_budget;
+        let budget = if let Some(budget) = self.request_budget.as_ref() {
+            budget
         } else {
-            let prompt = self.build_summarization_messages(messages);
-            self.collect_stream_response(&prompt, 8192)
-                .await
-                .map(|content| {
-                    let counter = TiktokenTokenCounter::default();
-                    SummarizationReport {
-                        represented_source_tokens: counter.count_messages(messages),
-                        actual_summary_tokens: counter.count_text(&content),
-                        target_summary_tokens,
-                        content,
-                        map_calls: 0,
-                        reduce_calls: 0,
-                        fallback_used: false,
-                        budget_clamped: false,
-                        budget_clamp_reason: None,
-                    }
-                })
+            compatibility_budget = self.compatibility_request_budget(messages);
+            &compatibility_budget
         };
+        let target_summary_tokens = budget.target_summary_tokens;
+        let result = self.summarize_bounded(messages, budget).await;
 
         match result {
             Ok(report) if !report.content.trim().is_empty() => Ok(report),
@@ -1033,7 +1324,7 @@ Guidelines:
             }
             Err(error) if self.heuristic_fallback_on_error && self.request_budget.is_none() => {
                 tracing::warn!(
-                    "LlmSummarizer: legacy LLM call failed ({}), falling back to heuristic",
+                    "LlmSummarizer: compatibility map/reduce pipeline failed ({}), falling back to heuristic",
                     error
                 );
                 self.heuristic_report(
@@ -1183,6 +1474,16 @@ mod tests {
             ])))
         }
     }
+
+    fn test_summary_part() -> SummaryPart {
+        SummaryPart {
+            content: "New chronological partial summary".to_string(),
+            represented_source_tokens: 100,
+            first_message_id: "first".to_string(),
+            last_message_id: "last".to_string(),
+        }
+    }
+
     #[test]
     fn llm_summarizer_prompt_includes_context_blocks_and_state_sections() {
         let summarizer = LlmSummarizer::new(
@@ -1210,12 +1511,7 @@ mod tests {
                 "Session note body",
             ),
         ]);
-        let messages = vec![
-            Message::user("继续做压缩修复"),
-            Message::assistant("我先检查 trigger 与 target", None),
-        ];
-
-        let prompt_messages = summarizer.build_summarization_messages(&messages);
+        let prompt_messages = summarizer.build_reduce_messages(&[test_summary_part()], 20, true);
         assert_eq!(prompt_messages.len(), 2);
         assert_eq!(prompt_messages[0].role, Role::System);
         assert!(prompt_messages[1]
@@ -1298,7 +1594,11 @@ mod tests {
             .captured_reasoning
             .lock()
             .expect("captured reasoning lock should not be poisoned");
-        assert_eq!(captured.as_slice(), [Some(ReasoningEffort::Low)]);
+        assert_eq!(
+            captured.as_slice(),
+            [Some(ReasoningEffort::Low), Some(ReasoningEffort::Low)],
+            "compatibility callers must use one map request followed by one reduce request"
+        );
     }
 
     /// Provider that captures both `reasoning_effort` and `max_output_tokens`.
@@ -1345,7 +1645,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn llm_summarizer_uses_explicit_output_budget_with_low_reasoning() {
+    async fn compatibility_summarizer_uses_source_derived_output_budget_with_low_reasoning() {
         let provider = Arc::new(RequestOptionsCaptureProvider::default());
         let summarizer = LlmSummarizer::new(
             provider.clone(),
@@ -1372,31 +1672,62 @@ mod tests {
             .captured_max_tokens
             .lock()
             .expect("lock should not be poisoned");
-        assert_eq!(captured_reasoning.as_slice(), [Some(ReasoningEffort::Low)]);
-        let max_tokens = captured_max_tokens[0].expect("max_output_tokens should be set");
-        assert_eq!(max_tokens, 8192);
+        assert_eq!(
+            captured_reasoning.as_slice(),
+            [Some(ReasoningEffort::Low), Some(ReasoningEffort::Low)]
+        );
+        let expected_target = ((TiktokenTokenCounter::default().count_messages(&messages) as f64)
+            * 0.20)
+            .ceil()
+            .max(1.0) as u32;
+        assert_eq!(
+            captured_max_tokens.as_slice(),
+            [Some(expected_target), Some(expected_target)],
+            "both compatibility map and reduce requests use the source-derived 20% target"
+        );
     }
 
     #[test]
-    fn full_rewrite_mode_uses_default_system_prompt() {
+    fn compatibility_budget_retains_previous_summary_before_adding_twenty_percent() {
+        let previous_summary = "durable prior summary evidence ".repeat(20);
+        let summarizer = LlmSummarizer::new(
+            Arc::new(DummyProvider),
+            "summary-model".to_string(),
+            Some(previous_summary.clone()),
+            None,
+        );
+        let messages = summary_messages();
+        let counter = TiktokenTokenCounter::default();
+
+        let budget = summarizer.compatibility_request_budget(&messages);
+
+        let expected = counter.count_text(&previous_summary).saturating_add(
+            ((counter.count_messages(&messages) as f64) * 0.20)
+                .ceil()
+                .max(1.0) as u32,
+        );
+        assert_eq!(budget.target_summary_tokens, expected);
+    }
+
+    #[test]
+    fn full_rewrite_mode_uses_default_final_reduce_prompt() {
         let summarizer =
             LlmSummarizer::new(Arc::new(DummyProvider), "model".to_string(), None, None)
                 .with_summary_mode(SummaryMode::FullRewrite);
-        let messages = vec![Message::user("hello"), Message::assistant("hi", None)];
-        let prompts = summarizer.build_summarization_messages(&messages);
+        let prompts = summarizer.build_reduce_messages(&[test_summary_part()], 20, true);
         let system = &prompts[0].content;
         assert!(
-            system.contains("conversation summarizer"),
-            "FullRewrite prompt should contain 'conversation summarizer'"
+            system.contains("final reduce stage"),
+            "FullRewrite prompt should identify the final reduce stage"
         );
         assert!(
-            !system.contains("updating an existing"),
+            !system.contains("incremental final reduce"),
             "FullRewrite prompt should not contain incremental language"
         );
     }
 
     #[test]
-    fn incremental_merge_mode_uses_update_system_prompt() {
+    fn incremental_merge_mode_uses_update_final_reduce_prompt() {
         let summarizer = LlmSummarizer::new(
             Arc::new(DummyProvider),
             "model".to_string(),
@@ -1404,16 +1735,15 @@ mod tests {
             None,
         )
         .with_summary_mode(SummaryMode::IncrementalMerge);
-        let messages = vec![Message::user("hello"), Message::assistant("hi", None)];
-        let prompts = summarizer.build_summarization_messages(&messages);
+        let prompts = summarizer.build_reduce_messages(&[test_summary_part()], 20, true);
         let system = &prompts[0].content;
         assert!(
-            system.contains("updating an existing conversation summary"),
-            "IncrementalMerge prompt should contain 'updating an existing conversation summary'"
+            system.contains("incremental final reduce stage"),
+            "IncrementalMerge prompt should identify the incremental final reduce stage"
         );
         assert!(
-            system.contains("Incorporate new information"),
-            "IncrementalMerge prompt should mention incorporating new information"
+            system.contains("Update the supplied prior summary"),
+            "IncrementalMerge prompt should direct the reducer to update the prior summary"
         );
     }
 
@@ -1431,11 +1761,7 @@ mod tests {
             None,
         )
         .with_summary_mode(SummaryMode::IncrementalMerge);
-        let messages = vec![
-            Message::user("new work"),
-            Message::assistant("doing it", None),
-        ];
-        let prompts = summarizer.build_summarization_messages(&messages);
+        let prompts = summarizer.build_reduce_messages(&[test_summary_part()], 20, true);
         let user_content = &prompts[1].content;
         assert!(
             user_content.contains("Previous Summary"),
@@ -1473,9 +1799,9 @@ mod tests {
 
     #[tokio::test]
     async fn summarize_falls_back_to_heuristic_on_llm_error_by_default() {
-        // Default: a transient LLM failure is recovered by the heuristic
-        // summarizer, so summarize() succeeds. This is what makes pre-turn /
-        // overflow compression resilient (and, historically, masked #238).
+        // Compatibility callers that do not provide exact model limits retain
+        // the historical heuristic recovery behavior. Production compression
+        // always supplies an explicit budget and surfaces stage failures.
         let summarizer =
             LlmSummarizer::new(Arc::new(FailingProvider), "model".to_string(), None, None);
         let out = summarizer.summarize(&summary_messages()).await;
@@ -1487,10 +1813,7 @@ mod tests {
 
     #[tokio::test]
     async fn summarize_surfaces_llm_error_when_heuristic_fallback_disabled() {
-        // Best-effort caller (mid-turn compression) opts out of the heuristic
-        // fallback: the transient error must SURFACE so the caller can skip
-        // compression rather than substitute a low-quality heuristic summary.
-        // (issue #238)
+        // Compatibility callers can still opt out of heuristic recovery.
         let summarizer =
             LlmSummarizer::new(Arc::new(FailingProvider), "model".to_string(), None, None)
                 .with_heuristic_fallback_on_error(false);
@@ -1529,6 +1852,75 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct MultipartSharedContextProvider {
+        requests: Mutex<Vec<(Vec<Message>, u32)>>,
+    }
+
+    impl MultipartSharedContextProvider {
+        fn echoed_shared_context(rendered: &str) -> String {
+            let mut retained = vec!["SHARED_CAPSULE_763"];
+            for sentinel in [
+                "PREVIOUS_SENTINEL_763",
+                "RUNTIME_CONTEXT_SENTINEL_763",
+                "CUSTOM_INSTRUCTION_SENTINEL_763",
+                "PRECOMPACT_SENTINEL_763",
+            ] {
+                if rendered.contains(sentinel) {
+                    retained.push(sentinel);
+                }
+            }
+            retained.join(" ")
+        }
+    }
+
+    #[async_trait]
+    impl LLMProvider for MultipartSharedContextProvider {
+        async fn chat_stream(
+            &self,
+            messages: &[Message],
+            _tools: &[bamboo_domain::ToolSchema],
+            max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<LLMStream, LLMError> {
+            self.requests
+                .lock()
+                .expect("multipart request capture lock")
+                .push((messages.to_vec(), max_output_tokens.unwrap_or_default()));
+            let rendered = messages
+                .iter()
+                .map(|message| message.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+            let response = if rendered.contains("shared-context capsule stage") {
+                "SHARED_CAPSULE_763 PREVIOUS_SENTINEL_763 RUNTIME_CONTEXT_SENTINEL_763 \
+                 CUSTOM_INSTRUCTION_SENTINEL_763 PRECOMPACT_SENTINEL_763"
+                    .to_string()
+            } else if rendered.contains("multipart final stage") {
+                format!(
+                    "FINAL_MULTIPART_SECTION_763 {}",
+                    Self::echoed_shared_context(&rendered)
+                )
+            } else if rendered.contains("Preserve this shared context capsule")
+                || rendered.contains("SHARED_CAPSULE_763")
+                || rendered.contains("PREVIOUS_SENTINEL_763")
+                || rendered.contains("RUNTIME_CONTEXT_SENTINEL_763")
+                || rendered.contains("CUSTOM_INSTRUCTION_SENTINEL_763")
+                || rendered.contains("PRECOMPACT_SENTINEL_763")
+            {
+                Self::echoed_shared_context(&rendered)
+            } else if rendered.contains("intermediate reduce stage") {
+                "INTERMEDIATE_PART_763 with detailed chronological evidence. ".repeat(12)
+            } else {
+                "MAP_PART_763 with detailed chronological evidence. ".repeat(12)
+            };
+            Ok(Box::pin(stream::iter(vec![
+                Ok::<LLMChunk, LLMError>(LLMChunk::Token(response)),
+                Ok::<LLMChunk, LLMError>(LLMChunk::Done),
+            ])))
+        }
+    }
+
     fn bounded_budget(
         context_window_tokens: u32,
         max_output_tokens: u32,
@@ -1545,7 +1937,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bounded_one_shot_uses_one_dynamic_request_when_fully_rendered_prompt_fits() {
+    async fn bounded_small_source_still_uses_map_then_reduce() {
         let provider = Arc::new(BoundedRequestCaptureProvider::default());
         let budget = bounded_budget(10_000, 2_000, 100, 400);
         let summarizer =
@@ -1556,20 +1948,67 @@ mod tests {
         let report = summarizer
             .summarize_with_report(&summary_messages())
             .await
-            .expect("bounded one-shot summary");
-        assert_eq!(report.map_calls, 0);
-        assert_eq!(report.reduce_calls, 0);
+            .expect("bounded chunked summary");
+        assert_eq!(report.map_calls, 1);
+        assert_eq!(report.reduce_calls, 1);
 
         let requests = provider.requests.lock().expect("capture lock");
-        assert_eq!(requests.len(), 1);
-        assert_eq!(requests[0].1, 400);
+        assert_eq!(requests.len(), 2);
+        let map_request = requests
+            .iter()
+            .find(|(messages, _)| {
+                messages
+                    .iter()
+                    .any(|message| message.content.contains("map stage"))
+            })
+            .expect("small input must still use a map request");
+        let reduce_request = requests
+            .iter()
+            .find(|(messages, _)| {
+                messages
+                    .iter()
+                    .any(|message| message.content.contains("final reduce stage"))
+            })
+            .expect("small input must still use a final reduce request");
+        assert_eq!(reduce_request.1, 400);
         let counter = TiktokenTokenCounter::default();
+        for (request, output) in [map_request, reduce_request] {
+            assert!(
+                counter
+                    .count_messages(request)
+                    .saturating_add(*output)
+                    .saturating_add(budget.safety_margin_tokens)
+                    <= budget.safe_request_tokens()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn retained_shared_context_is_mapped_and_reduced_without_a_second_ratio() {
+        let provider = Arc::new(BoundedRequestCaptureProvider::default());
+        let budget = bounded_budget(10_000, 2_000, 100, 1_000);
+        let summarizer =
+            LlmSummarizer::new(provider.clone(), "summary-model".to_string(), None, None)
+                .with_request_budget(budget.clone())
+                .with_heuristic_fallback_on_error(false);
+        let shared_context =
+            "durable prior summary requirement decision exact path test evidence ".repeat(24);
+        let shared_tokens = TiktokenTokenCounter::default().count_text(&shared_context);
+
+        let (_capsule, map_calls, reduce_calls) = summarizer
+            .build_bounded_shared_context_capsule(&shared_context, shared_tokens, &budget)
+            .await
+            .expect("retained shared context should use bounded map/reduce");
+
+        assert_eq!(map_calls, 1);
+        assert_eq!(reduce_calls, 1);
+        let requests = provider.requests.lock().expect("capture lock");
+        assert_eq!(requests.len(), 2);
         assert!(
-            counter
-                .count_messages(&requests[0].0)
-                .saturating_add(requests[0].1)
-                .saturating_add(budget.safety_margin_tokens)
-                <= budget.safe_request_tokens()
+            requests
+                .iter()
+                .all(|(_, output)| *output >= shared_tokens.saturating_sub(1)),
+            "the child map/reduce must preserve its allocated prior-summary size instead of applying 20% again"
         );
     }
 
@@ -1658,6 +2097,259 @@ mod tests {
         assert!(final_rendered.contains("Previous durable summary evidence"));
         assert!(final_rendered.contains("Current Task List"));
         assert!(final_rendered.contains("Keep exact paths"));
+    }
+
+    #[tokio::test]
+    async fn multipart_terminal_path_preserves_shared_context_and_instructions_boundedly() {
+        let provider = Arc::new(MultipartSharedContextProvider::default());
+        let budget = bounded_budget(3_000, 240, 100, 700);
+        let summarizer = LlmSummarizer::new(
+            provider.clone(),
+            "small-summary-model".to_string(),
+            Some(format!(
+                "PREVIOUS_SENTINEL_763 durable prior state. {}",
+                "large previous summary evidence ".repeat(2_000)
+            )),
+            None,
+        )
+        .with_context_blocks(vec![ContextBlock::new(
+            ContextBlockType::TaskSnapshot,
+            ContextBlockPriority::High,
+            ContextBlockStability::RoundDynamic,
+            "Current Runtime State",
+            "RUNTIME_CONTEXT_SENTINEL_763 active objective and exact evidence.",
+        )])
+        .with_custom_instructions(Some(
+            "CUSTOM_INSTRUCTION_SENTINEL_763 keep exact paths and failures.\n\n\
+             ## PreCompact Hook Instructions\n\n\
+             PRECOMPACT_SENTINEL_763 preserve the hook-injected next step."
+                .to_string(),
+        ))
+        .with_request_budget(budget.clone())
+        .with_heuristic_fallback_on_error(false);
+        let messages = (0..100)
+            .map(|index| {
+                if index % 2 == 0 {
+                    Message::user(format!(
+                        "user-{index} {}",
+                        "requirement decision path error evidence ".repeat(24)
+                    ))
+                } else {
+                    Message::assistant(
+                        format!(
+                            "assistant-{index} {}",
+                            "implementation command output test result next step ".repeat(24)
+                        ),
+                        None,
+                    )
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let report = summarizer
+            .summarize_with_report(&messages)
+            .await
+            .expect("multipart finalization should preserve shared context");
+        assert!(report.map_calls > 1);
+        assert!(
+            report.reduce_calls >= 2,
+            "the shared capsule and multipart final sections must be observable as reduce calls"
+        );
+        assert!(report.content.contains("PREVIOUS_SENTINEL_763"));
+        assert!(report.content.contains("RUNTIME_CONTEXT_SENTINEL_763"));
+        assert!(report.content.contains("CUSTOM_INSTRUCTION_SENTINEL_763"));
+        assert!(report.content.contains("PRECOMPACT_SENTINEL_763"));
+
+        let requests = provider.requests.lock().expect("capture lock");
+        let counter = TiktokenTokenCounter::default();
+        for (request, output_tokens) in requests.iter() {
+            assert!(
+                counter
+                    .count_messages(request)
+                    .saturating_add(*output_tokens)
+                    .saturating_add(budget.safety_margin_tokens)
+                    <= budget.safe_request_tokens(),
+                "every shared-capsule and multipart request must remain under the safe ceiling"
+            );
+        }
+
+        assert!(
+            requests.iter().all(|(request, _)| !request
+                .iter()
+                .any(|message| message.content.contains("shared-context capsule stage"))),
+            "large shared context must use the bounded hierarchical capsule path"
+        );
+        let capsule_inputs = requests
+            .iter()
+            .filter(|(request, _)| {
+                request
+                    .iter()
+                    .any(|message| message.content.contains("You are the map stage"))
+                    && request.iter().any(|message| {
+                        message
+                            .content
+                            .contains("Preserve this shared context capsule")
+                            || message.content.contains("PREVIOUS_SENTINEL_763")
+                            || message.content.contains("RUNTIME_CONTEXT_SENTINEL_763")
+                            || message.content.contains("CUSTOM_INSTRUCTION_SENTINEL_763")
+                            || message.content.contains("PRECOMPACT_SENTINEL_763")
+                    })
+            })
+            .flat_map(|(request, _)| request.iter())
+            .map(|message| message.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(capsule_inputs.contains("PREVIOUS_SENTINEL_763"));
+        assert!(capsule_inputs.contains("RUNTIME_CONTEXT_SENTINEL_763"));
+        assert!(capsule_inputs.contains("CUSTOM_INSTRUCTION_SENTINEL_763"));
+        assert!(capsule_inputs.contains("PRECOMPACT_SENTINEL_763"));
+
+        let multipart_requests = requests
+            .iter()
+            .filter(|(request, _)| {
+                request.iter().any(|message| {
+                    message
+                        .content
+                        .contains("instruction-aware multipart final stage")
+                })
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            !multipart_requests.is_empty(),
+            "global target above model output capacity must use multipart final sections"
+        );
+        for (request, _) in multipart_requests {
+            let rendered = request
+                .iter()
+                .map(|message| message.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert!(rendered.contains("SHARED_CAPSULE_763"));
+            assert!(rendered.contains("PREVIOUS_SENTINEL_763"));
+            assert!(rendered.contains("RUNTIME_CONTEXT_SENTINEL_763"));
+            assert!(rendered.contains("CUSTOM_INSTRUCTION_SENTINEL_763"));
+            assert!(rendered.contains("PRECOMPACT_SENTINEL_763"));
+        }
+    }
+
+    #[tokio::test]
+    async fn multipart_terminal_path_without_shared_context_still_reduces_every_section() {
+        let provider = Arc::new(BoundedRequestCaptureProvider::default());
+        let budget = bounded_budget(3_000, 240, 100, 700);
+        let summarizer = LlmSummarizer::new(
+            provider.clone(),
+            "small-summary-model".to_string(),
+            None,
+            None,
+        )
+        .with_request_budget(budget.clone())
+        .with_heuristic_fallback_on_error(false);
+        let messages = (0..100)
+            .map(|index| {
+                if index % 2 == 0 {
+                    Message::user(format!(
+                        "user-{index} {}",
+                        "requirement decision path error evidence ".repeat(24)
+                    ))
+                } else {
+                    Message::assistant(
+                        format!(
+                            "assistant-{index} {}",
+                            "implementation command output test result next step ".repeat(24)
+                        ),
+                        None,
+                    )
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let report = summarizer
+            .summarize_with_report(&messages)
+            .await
+            .expect("multipart finalization should reduce every section");
+        assert!(report.map_calls > 1);
+        assert!(
+            report.reduce_calls >= 1,
+            "the terminal path must never persist unreduced map/intermediate partials"
+        );
+
+        let requests = provider.requests.lock().expect("capture lock");
+        assert!(requests.iter().any(|(request, _)| request
+            .iter()
+            .any(|message| message.content.contains("multipart final stage"))));
+        let counter = TiktokenTokenCounter::default();
+        for (request, output_tokens) in requests.iter() {
+            assert!(
+                counter
+                    .count_messages(request)
+                    .saturating_add(*output_tokens)
+                    .saturating_add(budget.safety_margin_tokens)
+                    <= budget.safe_request_tokens(),
+                "every terminal reduce request must remain under the safe ceiling"
+            );
+        }
+    }
+
+    #[test]
+    fn oversized_terminal_partial_is_split_into_bounded_reduce_sections() {
+        let budget = bounded_budget(3_000, 800, 100, 1_600);
+        let summarizer = LlmSummarizer::new(
+            Arc::new(DummyProvider),
+            "small-summary-model".to_string(),
+            None,
+            None,
+        )
+        .with_request_budget(budget.clone());
+        let counter = TiktokenTokenCounter::default();
+        let capsule =
+            counter.truncate_to_token_prefix(&"shared capsule evidence ".repeat(1_000), 575);
+        let part = SummaryPart {
+            content: counter
+                .truncate_to_token_prefix(&"ordered partial evidence ".repeat(1_000), 800),
+            represented_source_tokens: 4_000,
+            first_message_id: "first".to_string(),
+            last_message_id: "last".to_string(),
+        };
+        let requested_output = summarizer.target_for_source(part.represented_source_tokens);
+        assert!(!summarizer.request_fits(
+            &summarizer.build_multipart_finalize_messages(
+                std::slice::from_ref(&part),
+                requested_output,
+                &capsule,
+                true,
+            ),
+            requested_output,
+            &budget,
+        ));
+
+        let groups = summarizer
+            .pack_multipart_final_groups(std::slice::from_ref(&part), &capsule, true, &budget)
+            .expect("every finite terminal partial should split into bounded reduce sections");
+        assert!(groups.len() > 1);
+        assert_eq!(
+            groups
+                .iter()
+                .flatten()
+                .map(|part| part.represented_source_tokens)
+                .sum::<u32>(),
+            part.represented_source_tokens
+        );
+        for group in groups {
+            let represented = group.iter().fold(0u32, |total, part| {
+                total.saturating_add(part.represented_source_tokens)
+            });
+            let requested_output = summarizer.target_for_source(represented);
+            assert!(summarizer.request_fits(
+                &summarizer.build_multipart_finalize_messages(
+                    &group,
+                    requested_output,
+                    &capsule,
+                    true,
+                ),
+                requested_output,
+                &budget,
+            ));
+        }
     }
 
     #[test]

--- a/crates/engine/bamboo-engine/src/llm_summarizer.rs
+++ b/crates/engine/bamboo-engine/src/llm_summarizer.rs
@@ -2,17 +2,21 @@
 //!
 //! `LlmSummarizer` is the infrastructure-coupled implementation of
 //! `bamboo_compression::Summarizer`: it calls the session model to produce a
-//! rich summary of compressed/removed messages, falling back to the pure
-//! `HeuristicSummarizer` on failure. It lives in the engine (not in
-//! bamboo-compression) so that the compression crate stays free of any
-//! LLM-provider dependency.
+//! rich summary of compressed/removed messages. Legacy, unbudgeted callers may
+//! fall back to the pure `HeuristicSummarizer`; the bounded map/reduce pipeline
+//! surfaces every failed stage so callers can preserve session state atomically.
+//! It lives in the engine (not in bamboo-compression) so that the compression
+//! crate stays free of any LLM-provider dependency.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::StreamExt;
 
-use bamboo_compression::{HeuristicSummarizer, Summarizer};
+use bamboo_compression::{
+    HeuristicSummarizer, MessageSegmenter, Summarizer, TiktokenTokenCounter, TokenBudget,
+    TokenCounter,
+};
 use bamboo_domain::ReasoningEffort;
 use bamboo_domain::{
     ContextBlock, ContextBlockPriority, ContextBlockStability, ContextBlockType, Message, Role,
@@ -30,14 +34,97 @@ pub enum SummaryMode {
     IncrementalMerge,
 }
 
+/// Hard request limits for a logical compression pass.
+#[derive(Debug, Clone)]
+pub struct SummaryRequestBudget {
+    pub context_window_tokens: u32,
+    pub max_output_tokens: u32,
+    pub safety_margin_tokens: u32,
+    pub safe_window_percent: u8,
+    pub target_summary_tokens: u32,
+    pub target_ratio: f64,
+}
+
+impl SummaryRequestBudget {
+    pub fn from_token_budget(
+        budget: &TokenBudget,
+        safe_window_percent: u8,
+        target_summary_tokens: u32,
+        target_ratio: f64,
+    ) -> Self {
+        Self {
+            context_window_tokens: budget.max_context_tokens.max(1),
+            max_output_tokens: budget.max_output_tokens.max(1),
+            safety_margin_tokens: budget.safety_margin,
+            safe_window_percent: safe_window_percent.clamp(10, 95),
+            target_summary_tokens: target_summary_tokens.max(1),
+            target_ratio: if target_ratio.is_finite() && target_ratio > 0.0 {
+                target_ratio.clamp(0.01, 0.50)
+            } else {
+                0.20
+            },
+        }
+    }
+
+    fn safe_request_tokens(&self) -> u32 {
+        self.context_window_tokens
+            .saturating_mul(self.safe_window_percent as u32)
+            .saturating_div(100)
+            .max(1)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SummarizationReport {
+    pub content: String,
+    pub represented_source_tokens: u32,
+    pub target_summary_tokens: u32,
+    pub actual_summary_tokens: u32,
+    pub map_calls: u32,
+    pub reduce_calls: u32,
+    pub fallback_used: bool,
+    pub budget_clamped: bool,
+    pub budget_clamp_reason: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SummarizationProgress {
+    pub stage: String,
+    pub stage_index: usize,
+    pub stage_count: usize,
+    pub estimated_input_tokens: u32,
+    pub requested_output_tokens: u32,
+    pub safe_request_tokens: u32,
+    pub model_context_tokens: u32,
+}
+
+type SummarizationProgressCallback = dyn Fn(&SummarizationProgress) + Send + Sync;
+
+#[derive(Debug, Clone)]
+struct SourceUnit {
+    text: String,
+    represented_source_tokens: u32,
+    first_message_id: String,
+    last_message_id: String,
+    continuation_part: usize,
+}
+
+#[derive(Debug, Clone)]
+struct SummaryPart {
+    content: String,
+    represented_source_tokens: u32,
+    first_message_id: String,
+    last_message_id: String,
+}
+
 /// LLM-based summarizer that calls the current session's model to generate
 /// a rich summary of compressed/removed messages.
 ///
-/// Falls back to [`HeuristicSummarizer`] if the LLM call fails, UNLESS
+/// Legacy unbudgeted calls fall back to [`HeuristicSummarizer`] if the LLM call
+/// fails, UNLESS
 /// [`with_heuristic_fallback_on_error(false)`](Self::with_heuristic_fallback_on_error)
-/// is set — in which case a transient LLM *error* surfaces to the caller so a
-/// best-effort caller (mid-turn context compression) can skip and degrade
-/// gracefully instead of silently substituting a low-quality heuristic summary.
+/// is set. Budgeted calls always surface failed map/reduce stages so the archive
+/// transaction cannot commit a heuristic summary that represents a failed pass.
 pub struct LlmSummarizer {
     llm: Arc<dyn LLMProvider>,
     model: String,
@@ -49,12 +136,18 @@ pub struct LlmSummarizer {
     custom_instructions: Option<String>,
     /// Controls how the summarizer handles existing summaries.
     summary_mode: SummaryMode,
-    /// When true (default), a transient LLM call/stream failure is recovered by
-    /// falling back to the [`HeuristicSummarizer`]. When false, that error is
-    /// returned to the caller instead — used by best-effort callers that would
-    /// rather SKIP compression than emit a degraded heuristic summary. The
-    /// empty-response fallback is unaffected either way. (issue #238)
+    /// When true (default), a transient legacy/unbudgeted LLM call failure is
+    /// recovered by falling back to the [`HeuristicSummarizer`]. Budgeted calls
+    /// always return stage failures so a multi-request pass remains atomic. The
+    /// empty-response fallback is unaffected either way. (issues #238, #763)
     heuristic_fallback_on_error: bool,
+    /// Exact selected summarization-model limits and source-derived output goal.
+    request_budget: Option<SummaryRequestBudget>,
+    /// Correlates every map/reduce request with the eventual persisted
+    /// compression event (or with a failed logical pass).
+    logical_pass_id: Option<String>,
+    logical_phase: Option<String>,
+    progress_callback: Option<Arc<SummarizationProgressCallback>>,
 }
 
 impl LlmSummarizer {
@@ -87,13 +180,17 @@ impl LlmSummarizer {
             custom_instructions: None,
             summary_mode: SummaryMode::default(),
             heuristic_fallback_on_error: true,
+            request_budget: None,
+            logical_pass_id: None,
+            logical_phase: None,
+            progress_callback: None,
         }
     }
 
-    /// Control whether a transient LLM *error* recovers via the heuristic
-    /// summarizer (default `true`) or surfaces to the caller (`false`). Set
-    /// `false` for best-effort compression (mid-turn) that should skip rather
-    /// than substitute a heuristic summary. (issue #238)
+    /// Control whether a transient legacy/unbudgeted LLM *error* recovers via
+    /// the heuristic summarizer (default `true`) or surfaces to the caller
+    /// (`false`). Budgeted map/reduce failures always surface. (issues #238,
+    /// #763)
     pub fn with_heuristic_fallback_on_error(mut self, enabled: bool) -> Self {
         self.heuristic_fallback_on_error = enabled;
         self
@@ -112,6 +209,104 @@ impl LlmSummarizer {
     pub fn with_summary_mode(mut self, mode: SummaryMode) -> Self {
         self.summary_mode = mode;
         self
+    }
+
+    pub fn with_request_budget(mut self, budget: SummaryRequestBudget) -> Self {
+        self.request_budget = Some(budget);
+        self
+    }
+
+    pub fn with_logical_pass_context(
+        mut self,
+        logical_pass_id: impl Into<String>,
+        logical_phase: impl Into<String>,
+    ) -> Self {
+        self.logical_pass_id = Some(logical_pass_id.into());
+        self.logical_phase = Some(logical_phase.into());
+        self
+    }
+
+    pub fn with_progress_callback(mut self, callback: Arc<SummarizationProgressCallback>) -> Self {
+        self.progress_callback = Some(callback);
+        self
+    }
+
+    fn append_shared_context(&self, user_content: &mut String) {
+        if let Some(ref existing) = self.existing_summary {
+            user_content.push_str("## Previous Summary\n\n");
+            user_content.push_str(existing);
+            user_content.push_str("\n\n---\n\n");
+        }
+
+        if !self.context_blocks.is_empty() {
+            user_content.push_str("## Compression Context Blocks\n\n");
+            for block in &self.context_blocks {
+                user_content.push_str(&format!(
+                    "### {}\n- type: {}\n- priority: {}\n- stability: {}\n\n{}\n\n",
+                    block.title.trim(),
+                    block.block_type.as_str(),
+                    block.priority.as_str(),
+                    block.stability.as_str(),
+                    block.content.trim(),
+                ));
+            }
+            user_content.push_str("---\n\n");
+        }
+
+        if let Some(ref instructions) = self.custom_instructions {
+            if !instructions.trim().is_empty() {
+                user_content.push_str("## Custom Compression Instructions\n\n");
+                user_content.push_str(instructions.trim());
+                user_content.push_str("\n\n---\n\n");
+            }
+        }
+    }
+
+    fn render_message_block(message: &Message) -> Option<String> {
+        let role_label = match message.role {
+            Role::User => "User",
+            Role::Assistant => "Assistant",
+            Role::Tool => "Tool Result",
+            Role::System => return None,
+        };
+        let mut block = String::new();
+        if let Some(ref tool_calls) = message.tool_calls {
+            if !tool_calls.is_empty() {
+                let tool_names = tool_calls
+                    .iter()
+                    .map(|call| call.function.name.as_str())
+                    .collect::<Vec<_>>();
+                block.push_str(&format!(
+                    "**{}** [message_id: {}; called tools: {}]:\n",
+                    role_label,
+                    message.id,
+                    tool_names.join(", ")
+                ));
+            } else {
+                block.push_str(&format!(
+                    "**{}** [message_id: {}]:\n",
+                    role_label, message.id
+                ));
+            }
+        } else {
+            block.push_str(&format!(
+                "**{}** [message_id: {}]:\n",
+                role_label, message.id
+            ));
+        }
+        if let Some(ref tool_call_id) = message.tool_call_id {
+            block.push_str(&format!("(tool_call_id: {})\n", tool_call_id));
+        }
+        block.push_str(&message.content);
+        block.push_str("\n\n");
+        Some(block)
+    }
+
+    fn render_messages(messages: &[Message]) -> String {
+        messages
+            .iter()
+            .filter_map(Self::render_message_block)
+            .collect::<String>()
     }
 
     /// Build the summarization prompt for the LLM.
@@ -156,33 +351,14 @@ Guidelines:
 
         let mut user_content = String::new();
 
-        if let Some(ref existing) = self.existing_summary {
-            user_content.push_str("## Previous Summary\n\n");
-            user_content.push_str(existing);
-            user_content.push_str("\n\n---\n\n");
-        }
+        self.append_shared_context(&mut user_content);
 
-        if !self.context_blocks.is_empty() {
-            user_content.push_str("## Compression Context Blocks\n\n");
-            for block in &self.context_blocks {
-                user_content.push_str(&format!(
-                    "### {}\n- type: {}\n- priority: {}\n- stability: {}\n\n{}\n\n",
-                    block.title.trim(),
-                    block.block_type.as_str(),
-                    block.priority.as_str(),
-                    block.stability.as_str(),
-                    block.content.trim(),
-                ));
-            }
-            user_content.push_str("---\n\n");
-        }
-
-        if let Some(ref instructions) = self.custom_instructions {
-            if !instructions.trim().is_empty() {
-                user_content.push_str("## Custom Compression Instructions\n\n");
-                user_content.push_str(instructions.trim());
-                user_content.push_str("\n\n---\n\n");
-            }
+        if let Some(budget) = self.request_budget.as_ref() {
+            user_content.push_str(&format!(
+                "## Summary Size Budget\nTarget approximately {} tokens (about {:.0}% of the represented raw source). Preserve coverage and useful detail up to this budget; do not collapse the result to a tiny synopsis.\n\n",
+                budget.target_summary_tokens,
+                budget.target_ratio * 100.0,
+            ));
         }
 
         user_content.push_str(
@@ -191,47 +367,7 @@ Guidelines:
 
         user_content.push_str("## Messages to Summarize\n\n");
 
-        for message in messages {
-            let role_label = match message.role {
-                Role::User => "User",
-                Role::Assistant => "Assistant",
-                Role::Tool => "Tool Result",
-                Role::System => continue,
-            };
-
-            if let Some(ref tool_calls) = message.tool_calls {
-                if !tool_calls.is_empty() {
-                    let tool_names: Vec<&str> = tool_calls
-                        .iter()
-                        .map(|tc| tc.function.name.as_str())
-                        .collect();
-                    user_content.push_str(&format!(
-                        "**{}** [called tools: {}]:\n",
-                        role_label,
-                        tool_names.join(", ")
-                    ));
-                } else {
-                    user_content.push_str(&format!("**{}**:\n", role_label));
-                }
-            } else {
-                user_content.push_str(&format!("**{}**:\n", role_label));
-            }
-
-            if let Some(ref tool_call_id) = message.tool_call_id {
-                user_content.push_str(&format!("(tool_call_id: {})\n", tool_call_id));
-            }
-
-            let content = &message.content;
-            const MAX_CONTENT_CHARS: usize = 2000;
-            if content.chars().count() > MAX_CONTENT_CHARS {
-                let truncated: String = content.chars().take(MAX_CONTENT_CHARS).collect();
-                user_content.push_str(&truncated);
-                user_content.push_str("... [truncated]\n\n");
-            } else {
-                user_content.push_str(content);
-                user_content.push_str("\n\n");
-            }
-        }
+        user_content.push_str(&Self::render_messages(messages));
 
         user_content.push_str(
             "\n---\n\nReturn only the summary text. Be explicit about what is active now versus what is already completed or no longer relevant.",
@@ -242,16 +378,687 @@ Guidelines:
         prompt_messages
     }
 
+    fn build_map_messages(&self, units: &[SourceUnit], target_tokens: u32) -> Vec<Message> {
+        let represented_source_tokens = units.iter().fold(0u32, |total, unit| {
+            total.saturating_add(unit.represented_source_tokens)
+        });
+        let mut user_content = format!(
+            "Summarize this chronological source slice as loss-aware working memory.\n\
+             It represents approximately {represented_source_tokens} raw source tokens.\n\
+             Target approximately {target_tokens} output tokens. Preserve concrete requirements, \
+             decisions, paths, commands, errors, test results, tool outcomes, active work, and next \
+             steps. Do not turn it into a tiny high-level synopsis.\n\n## Source Slice\n\n"
+        );
+        for unit in units {
+            user_content.push_str(&format!(
+                "### Source range {}..{} (continuation part {})\n\n",
+                unit.first_message_id, unit.last_message_id, unit.continuation_part
+            ));
+            user_content.push_str(&unit.text);
+            user_content.push('\n');
+        }
+        user_content.push_str(
+            "\nReturn only the chronological partial summary. Do not claim this is the final conversation summary.",
+        );
+        vec![
+            Message::system(
+                "You are the map stage of a bounded conversation-compression pipeline. \
+                 Preserve detailed facts and ordering for a later reducer.",
+            ),
+            Message::user(user_content),
+        ]
+    }
+
+    fn build_reduce_messages(
+        &self,
+        parts: &[SummaryPart],
+        target_tokens: u32,
+        include_shared_context: bool,
+    ) -> Vec<Message> {
+        let represented_source_tokens = parts.iter().fold(0u32, |total, part| {
+            total.saturating_add(part.represented_source_tokens)
+        });
+        let mut user_content = String::new();
+        if include_shared_context {
+            self.append_shared_context(&mut user_content);
+        }
+        user_content.push_str(&format!(
+            "## Summary Size Budget\nTarget approximately {target_tokens} tokens. The partials \
+             below represent approximately {represented_source_tokens} raw source tokens. Derive \
+             detail from represented source size, not from the already-compressed partial length; \
+             do not apply the target ratio again.\n\n## Ordered Partial Summaries\n\n"
+        ));
+        for (index, part) in parts.iter().enumerate() {
+            user_content.push_str(&format!(
+                "### Partial {} — source {}..{} ({} represented raw tokens)\n\n{}\n\n",
+                index + 1,
+                part.first_message_id,
+                part.last_message_id,
+                part.represented_source_tokens,
+                part.content.trim(),
+            ));
+        }
+        if include_shared_context {
+            user_content.push_str(
+                "## Required Final Sections\n1. Pre-compression in-flight work\n2. Current active objective\n3. Requirement checklist with status and evidence\n4. Active tasks\n5. Completed tasks\n6. Obsolete or superseded tasks\n7. Important context and constraints\n8. Files, code, and tool findings\n9. Open issues and next step\n\n",
+            );
+        }
+        user_content.push_str(
+            "Return only the merged summary. Preserve source chronology and remove only genuine duplication.",
+        );
+        vec![
+            Message::system(if include_shared_context {
+                "You are the final reduce stage of a bounded conversation-compression pipeline. \
+                 Merge all ordered partials and the supplied prior/runtime context into one reliable \
+                 working-memory summary."
+            } else {
+                "You are an intermediate reduce stage of a bounded conversation-compression \
+                 pipeline. Merge ordered partials without compounding the source-to-summary ratio."
+            }),
+            Message::user(user_content),
+        ]
+    }
+
+    fn target_for_source(&self, represented_source_tokens: u32) -> u32 {
+        let ratio = self
+            .request_budget
+            .as_ref()
+            .map(|budget| budget.target_ratio)
+            .unwrap_or(0.20);
+        ((represented_source_tokens as f64) * ratio).ceil().max(1.0) as u32
+    }
+
+    fn request_fits(
+        &self,
+        messages: &[Message],
+        requested_output_tokens: u32,
+        budget: &SummaryRequestBudget,
+    ) -> bool {
+        if requested_output_tokens == 0 || requested_output_tokens > budget.max_output_tokens {
+            return false;
+        }
+        let counter = TiktokenTokenCounter::default();
+        let input_tokens = counter.count_messages(messages);
+        input_tokens
+            .saturating_add(requested_output_tokens)
+            .saturating_add(budget.safety_margin_tokens)
+            <= budget.safe_request_tokens()
+    }
+
+    fn source_units(&self, messages: &[Message]) -> Vec<SourceUnit> {
+        let counter = TiktokenTokenCounter::default();
+        MessageSegmenter::new()
+            .segment(messages.to_vec())
+            .into_iter()
+            .filter(|segment| !segment.messages.is_empty())
+            .map(|segment| {
+                let first_message_id = segment
+                    .messages
+                    .first()
+                    .map(|message| message.id.clone())
+                    .unwrap_or_default();
+                let last_message_id = segment
+                    .messages
+                    .last()
+                    .map(|message| message.id.clone())
+                    .unwrap_or_else(|| first_message_id.clone());
+                SourceUnit {
+                    text: Self::render_messages(&segment.messages),
+                    represented_source_tokens: counter.count_messages(&segment.messages),
+                    first_message_id,
+                    last_message_id,
+                    continuation_part: 1,
+                }
+            })
+            .collect()
+    }
+
+    fn split_oversized_source_unit(
+        &self,
+        unit: SourceUnit,
+        budget: &SummaryRequestBudget,
+    ) -> Result<Vec<SourceUnit>, bamboo_compression::types::BudgetError> {
+        let counter = TiktokenTokenCounter::default();
+        let empty_prompt_tokens = counter.count_messages(&self.build_map_messages(&[], 1));
+        let available = budget
+            .safe_request_tokens()
+            .saturating_sub(budget.safety_margin_tokens)
+            .saturating_sub(empty_prompt_tokens);
+        if available < 2 {
+            return Err(bamboo_compression::types::BudgetError::TokenCountError(
+                "summarization model context is too small for map prompt overhead".to_string(),
+            ));
+        }
+
+        let ratio = budget.target_ratio.max(0.01);
+        let max_by_window = ((available as f64) / (1.0 + ratio)).floor() as u32;
+        let max_by_output = ((budget.max_output_tokens as f64) / ratio).floor() as u32;
+        let initial_piece_tokens = max_by_window.min(max_by_output).max(1);
+
+        let mut remaining = unit.text;
+        let mut remaining_represented = unit.represented_source_tokens;
+        let mut continuation_part = unit.continuation_part;
+        let mut parts = Vec::new();
+        while !remaining.is_empty() {
+            let remaining_text_tokens = counter.count_text(&remaining).max(1);
+            let mut piece_token_budget = initial_piece_tokens.min(remaining_text_tokens).max(1);
+            let (piece_text, piece_represented) = loop {
+                let mut prefix = counter.truncate_to_token_prefix(&remaining, piece_token_budget);
+                if prefix.is_empty() {
+                    prefix = remaining
+                        .chars()
+                        .next()
+                        .map(|character| character.to_string())
+                        .unwrap_or_default();
+                }
+                let is_last = prefix.len() == remaining.len();
+                let prefix_tokens = counter.count_text(&prefix).max(1);
+                let represented = if is_last {
+                    remaining_represented
+                } else if remaining_represented <= 1 {
+                    0
+                } else {
+                    (((remaining_represented as u64) * (prefix_tokens as u64)
+                        / (remaining_text_tokens as u64))
+                        .max(1)
+                        .min(remaining_represented.saturating_sub(1) as u64))
+                        as u32
+                };
+                let candidate = SourceUnit {
+                    text: prefix.clone(),
+                    represented_source_tokens: represented,
+                    first_message_id: unit.first_message_id.clone(),
+                    last_message_id: unit.last_message_id.clone(),
+                    continuation_part,
+                };
+                let requested_output = self.target_for_source(represented);
+                if self.request_fits(
+                    &self.build_map_messages(std::slice::from_ref(&candidate), requested_output),
+                    requested_output,
+                    budget,
+                ) {
+                    break (prefix, represented);
+                }
+                if piece_token_budget <= 1 {
+                    return Err(bamboo_compression::types::BudgetError::TokenCountError(
+                        format!(
+                            "single source continuation cannot fit summarization model window (range {}..{})",
+                            unit.first_message_id, unit.last_message_id
+                        ),
+                    ));
+                }
+                piece_token_budget = (piece_token_budget * 3 / 4).max(1);
+            };
+
+            let consumed_bytes = piece_text.len();
+            parts.push(SourceUnit {
+                text: piece_text,
+                represented_source_tokens: piece_represented,
+                first_message_id: unit.first_message_id.clone(),
+                last_message_id: unit.last_message_id.clone(),
+                continuation_part,
+            });
+            remaining = remaining[consumed_bytes..].to_string();
+            remaining_represented = remaining_represented.saturating_sub(piece_represented);
+            continuation_part += 1;
+        }
+        Ok(parts)
+    }
+
+    fn pack_source_chunks(
+        &self,
+        messages: &[Message],
+        budget: &SummaryRequestBudget,
+    ) -> Result<Vec<Vec<SourceUnit>>, bamboo_compression::types::BudgetError> {
+        let mut bounded_units = Vec::new();
+        for unit in self.source_units(messages) {
+            let requested_output = self.target_for_source(unit.represented_source_tokens);
+            let prompt = self.build_map_messages(std::slice::from_ref(&unit), requested_output);
+            if self.request_fits(&prompt, requested_output, budget) {
+                bounded_units.push(unit);
+            } else {
+                bounded_units.extend(self.split_oversized_source_unit(unit, budget)?);
+            }
+        }
+
+        let mut chunks = Vec::new();
+        let mut current = Vec::<SourceUnit>::new();
+        for unit in bounded_units {
+            let mut candidate = current.clone();
+            candidate.push(unit.clone());
+            let represented = candidate.iter().fold(0u32, |total, item| {
+                total.saturating_add(item.represented_source_tokens)
+            });
+            let requested_output = self.target_for_source(represented);
+            if self.request_fits(
+                &self.build_map_messages(&candidate, requested_output),
+                requested_output,
+                budget,
+            ) {
+                current = candidate;
+                continue;
+            }
+            if !current.is_empty() {
+                chunks.push(std::mem::take(&mut current));
+            }
+            let requested_output = self.target_for_source(unit.represented_source_tokens);
+            if !self.request_fits(
+                &self.build_map_messages(std::slice::from_ref(&unit), requested_output),
+                requested_output,
+                budget,
+            ) {
+                return Err(bamboo_compression::types::BudgetError::TokenCountError(
+                    "split source unit still exceeds summarization request ceiling".to_string(),
+                ));
+            }
+            current.push(unit);
+        }
+        if !current.is_empty() {
+            chunks.push(current);
+        }
+        if chunks.is_empty() {
+            return Err(bamboo_compression::types::BudgetError::TokenCountError(
+                "no bounded summarization chunks were produced".to_string(),
+            ));
+        }
+        Ok(chunks)
+    }
+
+    fn pack_reduction_groups(
+        &self,
+        parts: &[SummaryPart],
+        budget: &SummaryRequestBudget,
+    ) -> Vec<Vec<SummaryPart>> {
+        let mut groups = Vec::new();
+        let mut current = Vec::<SummaryPart>::new();
+        for part in parts {
+            let mut candidate = current.clone();
+            candidate.push(part.clone());
+            let represented = candidate.iter().fold(0u32, |total, item| {
+                total.saturating_add(item.represented_source_tokens)
+            });
+            let requested_output = self.target_for_source(represented);
+            if self.request_fits(
+                &self.build_reduce_messages(&candidate, requested_output, false),
+                requested_output,
+                budget,
+            ) {
+                current = candidate;
+            } else {
+                if !current.is_empty() {
+                    groups.push(std::mem::take(&mut current));
+                }
+                current.push(part.clone());
+            }
+        }
+        if !current.is_empty() {
+            groups.push(current);
+        }
+        groups
+    }
+
+    async fn execute_bounded_request(
+        &self,
+        stage: &str,
+        stage_index: usize,
+        stage_count: usize,
+        messages: &[Message],
+        requested_output_tokens: u32,
+        budget: &SummaryRequestBudget,
+    ) -> Result<String, bamboo_compression::types::BudgetError> {
+        let counter = TiktokenTokenCounter::default();
+        let input_tokens = counter.count_messages(messages);
+        let safe_request_tokens = budget.safe_request_tokens();
+        if !self.request_fits(messages, requested_output_tokens, budget) {
+            return Err(bamboo_compression::types::BudgetError::TokenCountError(
+                format!(
+                    "bounded summarization invariant failed for {stage}: input={input_tokens}, output={requested_output_tokens}, safety={}, safe_limit={safe_request_tokens}",
+                    budget.safety_margin_tokens,
+                ),
+            ));
+        }
+        let progress = SummarizationProgress {
+            stage: stage.to_string(),
+            stage_index,
+            stage_count,
+            estimated_input_tokens: input_tokens,
+            requested_output_tokens,
+            safe_request_tokens,
+            model_context_tokens: budget.context_window_tokens,
+        };
+        if let Some(callback) = self.progress_callback.as_ref() {
+            callback(&progress);
+        }
+        tracing::info!(
+            logical_pass_id = self.logical_pass_id.as_deref().unwrap_or("untracked"),
+            logical_phase = self.logical_phase.as_deref().unwrap_or("unspecified"),
+            stage,
+            stage_index,
+            stage_count,
+            input_tokens,
+            requested_output_tokens,
+            safe_request_tokens,
+            model_context_tokens = budget.context_window_tokens,
+            model = %self.model,
+            "Executing bounded summarization request"
+        );
+        let content = self
+            .collect_stream_response(messages, requested_output_tokens)
+            .await
+            .map_err(|error| {
+                bamboo_compression::types::BudgetError::TokenCountError(format!(
+                    "{stage} stage {stage_index}/{stage_count} failed: {error}"
+                ))
+            })?;
+        if content.trim().is_empty() {
+            return Err(bamboo_compression::types::BudgetError::TokenCountError(
+                format!(
+                    "{stage} stage {stage_index}/{stage_count} returned an empty completed response"
+                ),
+            ));
+        }
+        Ok(content)
+    }
+
+    fn compose_multipart_summary(&self, parts: &[SummaryPart]) -> String {
+        let mut sections = Vec::new();
+        if let Some(existing) = self
+            .existing_summary
+            .as_deref()
+            .map(str::trim)
+            .filter(|summary| !summary.is_empty())
+        {
+            sections.push(existing.to_string());
+        }
+        sections.extend(
+            parts
+                .iter()
+                .map(|part| part.content.trim())
+                .filter(|content| !content.is_empty())
+                .map(String::from),
+        );
+        sections.join("\n\n")
+    }
+
+    async fn summarize_bounded(
+        &self,
+        messages: &[Message],
+        budget: &SummaryRequestBudget,
+    ) -> Result<SummarizationReport, bamboo_compression::types::BudgetError> {
+        let counter = TiktokenTokenCounter::default();
+        let represented_source_tokens = counter.count_messages(messages);
+        let final_target = budget.target_summary_tokens.max(1);
+        let one_shot_prompt = self.build_summarization_messages(messages);
+        if self.request_fits(&one_shot_prompt, final_target, budget) {
+            let content = self
+                .execute_bounded_request("one_shot", 1, 1, &one_shot_prompt, final_target, budget)
+                .await?;
+            let actual_summary_tokens = counter.count_text(&content);
+            let underfilled =
+                actual_summary_tokens.saturating_mul(5) < final_target.saturating_mul(4);
+            return Ok(SummarizationReport {
+                content,
+                represented_source_tokens,
+                target_summary_tokens: final_target,
+                actual_summary_tokens,
+                map_calls: 0,
+                reduce_calls: 0,
+                fallback_used: false,
+                budget_clamped: underfilled,
+                budget_clamp_reason: underfilled
+                    .then(|| "model_returned_below_80_percent_of_target".to_string()),
+            });
+        }
+
+        let chunks = self.pack_source_chunks(messages, budget)?;
+        let mut map_calls = 0u32;
+        let mut parts = Vec::with_capacity(chunks.len());
+        for (index, chunk) in chunks.iter().enumerate() {
+            let represented = chunk.iter().fold(0u32, |total, unit| {
+                total.saturating_add(unit.represented_source_tokens)
+            });
+            let requested_output = self.target_for_source(represented);
+            let prompt = self.build_map_messages(chunk, requested_output);
+            let content = self
+                .execute_bounded_request(
+                    "map",
+                    index + 1,
+                    chunks.len(),
+                    &prompt,
+                    requested_output,
+                    budget,
+                )
+                .await?;
+            map_calls = map_calls.saturating_add(1);
+            let first_message_id = chunk
+                .first()
+                .map(|unit| unit.first_message_id.clone())
+                .unwrap_or_else(|| format!("chunk-{index}"));
+            let last_message_id = chunk
+                .last()
+                .map(|unit| unit.last_message_id.clone())
+                .unwrap_or_else(|| first_message_id.clone());
+            parts.push(SummaryPart {
+                content,
+                represented_source_tokens: represented,
+                first_message_id,
+                last_message_id,
+            });
+        }
+
+        let mut reduce_calls = 0u32;
+        let mut depth = 0usize;
+        loop {
+            let final_prompt = self.build_reduce_messages(&parts, final_target, true);
+            if self.request_fits(&final_prompt, final_target, budget) {
+                let content = self
+                    .execute_bounded_request(
+                        "final_reduce",
+                        1,
+                        1,
+                        &final_prompt,
+                        final_target,
+                        budget,
+                    )
+                    .await?;
+                reduce_calls = reduce_calls.saturating_add(1);
+                let actual_summary_tokens = counter.count_text(&content);
+                let underfilled =
+                    actual_summary_tokens.saturating_mul(5) < final_target.saturating_mul(4);
+                return Ok(SummarizationReport {
+                    content,
+                    represented_source_tokens,
+                    target_summary_tokens: final_target,
+                    actual_summary_tokens,
+                    map_calls,
+                    reduce_calls,
+                    fallback_used: false,
+                    budget_clamped: underfilled,
+                    budget_clamp_reason: underfilled
+                        .then(|| "model_returned_below_80_percent_of_target".to_string()),
+                });
+            }
+
+            if parts.len() <= 1 || depth >= 8 {
+                break;
+            }
+            let groups = self.pack_reduction_groups(&parts, budget);
+            if groups.len() >= parts.len() {
+                break;
+            }
+            let mut reduced = Vec::with_capacity(groups.len());
+            let group_count = groups.len();
+            for (group_index, group) in groups.into_iter().enumerate() {
+                if group.len() == 1 {
+                    reduced.push(group.into_iter().next().expect("single reduction part"));
+                    continue;
+                }
+                let represented = group.iter().fold(0u32, |total, part| {
+                    total.saturating_add(part.represented_source_tokens)
+                });
+                let requested_output = self.target_for_source(represented);
+                let prompt = self.build_reduce_messages(&group, requested_output, false);
+                let content = self
+                    .execute_bounded_request(
+                        "intermediate_reduce",
+                        group_index + 1,
+                        group_count,
+                        &prompt,
+                        requested_output,
+                        budget,
+                    )
+                    .await?;
+                reduce_calls = reduce_calls.saturating_add(1);
+                reduced.push(SummaryPart {
+                    content,
+                    represented_source_tokens: represented,
+                    first_message_id: group
+                        .first()
+                        .map(|part| part.first_message_id.clone())
+                        .unwrap_or_default(),
+                    last_message_id: group
+                        .last()
+                        .map(|part| part.last_message_id.clone())
+                        .unwrap_or_default(),
+                });
+            }
+            parts = reduced;
+            depth += 1;
+        }
+
+        // A single final model response cannot represent an arbitrarily large
+        // 20%-of-source target when the selected model has a smaller output
+        // limit. Preserve the bounded partials as one multipart stored summary
+        // instead of applying another 20% pass (which would collapse to ~4%).
+        let content = self.compose_multipart_summary(&parts);
+        let actual_summary_tokens = counter.count_text(&content);
+        let underfilled = actual_summary_tokens.saturating_mul(5) < final_target.saturating_mul(4);
+        tracing::info!(
+            logical_pass_id = self.logical_pass_id.as_deref().unwrap_or("untracked"),
+            logical_phase = self.logical_phase.as_deref().unwrap_or("unspecified"),
+            part_count = parts.len(),
+            actual_summary_tokens,
+            target_summary_tokens = final_target,
+            "Final single-response reduce did not fit; composing bounded multipart summary"
+        );
+        Ok(SummarizationReport {
+            content,
+            represented_source_tokens,
+            target_summary_tokens: final_target,
+            actual_summary_tokens,
+            map_calls,
+            reduce_calls,
+            fallback_used: false,
+            budget_clamped: underfilled,
+            budget_clamp_reason: underfilled
+                .then(|| "multipart_summary_below_80_percent_of_target".to_string()),
+        })
+    }
+
+    async fn heuristic_report(
+        &self,
+        messages: &[Message],
+        target_summary_tokens: u32,
+        reason: &str,
+    ) -> Result<SummarizationReport, bamboo_compression::types::BudgetError> {
+        let counter = TiktokenTokenCounter::default();
+        let heuristic = HeuristicSummarizer::new().summarize(messages).await?;
+        let content = counter.truncate_to_token_prefix(&heuristic, target_summary_tokens.max(1));
+        Ok(SummarizationReport {
+            represented_source_tokens: counter.count_messages(messages),
+            actual_summary_tokens: counter.count_text(&content),
+            target_summary_tokens,
+            content,
+            map_calls: 0,
+            reduce_calls: 0,
+            fallback_used: true,
+            budget_clamped: true,
+            budget_clamp_reason: Some(reason.to_string()),
+        })
+    }
+
+    pub async fn summarize_with_report(
+        &self,
+        messages: &[Message],
+    ) -> Result<SummarizationReport, bamboo_compression::types::BudgetError> {
+        if messages.is_empty() {
+            return Ok(SummarizationReport {
+                content: "No conversation history to summarize.".to_string(),
+                represented_source_tokens: 0,
+                target_summary_tokens: 0,
+                actual_summary_tokens: 0,
+                map_calls: 0,
+                reduce_calls: 0,
+                fallback_used: false,
+                budget_clamped: false,
+                budget_clamp_reason: None,
+            });
+        }
+
+        let target_summary_tokens = self
+            .request_budget
+            .as_ref()
+            .map(|budget| budget.target_summary_tokens)
+            .unwrap_or_else(|| self.estimate_summary_tokens(messages.len()).max(1));
+        let result = if let Some(budget) = self.request_budget.as_ref() {
+            self.summarize_bounded(messages, budget).await
+        } else {
+            let prompt = self.build_summarization_messages(messages);
+            self.collect_stream_response(&prompt, 8192)
+                .await
+                .map(|content| {
+                    let counter = TiktokenTokenCounter::default();
+                    SummarizationReport {
+                        represented_source_tokens: counter.count_messages(messages),
+                        actual_summary_tokens: counter.count_text(&content),
+                        target_summary_tokens,
+                        content,
+                        map_calls: 0,
+                        reduce_calls: 0,
+                        fallback_used: false,
+                        budget_clamped: false,
+                        budget_clamp_reason: None,
+                    }
+                })
+        };
+
+        match result {
+            Ok(report) if !report.content.trim().is_empty() => Ok(report),
+            Ok(_) => {
+                tracing::warn!(
+                    "LlmSummarizer: LLM returned empty summary, falling back to heuristic"
+                );
+                self.heuristic_report(messages, target_summary_tokens, "empty_llm_response")
+                    .await
+            }
+            Err(error) if self.heuristic_fallback_on_error && self.request_budget.is_none() => {
+                tracing::warn!(
+                    "LlmSummarizer: legacy LLM call failed ({}), falling back to heuristic",
+                    error
+                );
+                self.heuristic_report(
+                    messages,
+                    target_summary_tokens,
+                    "llm_error_heuristic_fallback",
+                )
+                .await
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     /// Consume an LLM stream and collect the full text response.
     async fn collect_stream_response(
         &self,
         messages: &[Message],
+        max_output_tokens: u32,
     ) -> Result<String, bamboo_compression::types::BudgetError> {
-        // Summarization is a lightweight auxiliary request; cap reasoning effort at `high`
-        // to stay compatible with fast models (e.g. gpt-5-mini).
+        // Compression calls need most of their output allowance for the summary
+        // itself. Low reasoning keeps dynamic, potentially small output budgets
+        // useful across both reasoning and non-reasoning models.
         let options = LLMRequestOptions {
             session_id: None,
-            reasoning_effort: Some(ReasoningEffort::High),
+            reasoning_effort: Some(ReasoningEffort::Low),
             parallel_tool_calls: None,
             required_tool: None,
             responses: None,
@@ -260,7 +1067,13 @@ Guidelines:
         };
         let stream = self
             .llm
-            .chat_stream_with_options(messages, &[], Some(8192), &self.model, Some(&options))
+            .chat_stream_with_options(
+                messages,
+                &[],
+                Some(max_output_tokens.max(1)),
+                &self.model,
+                Some(&options),
+            )
             .await
             .map_err(|e| {
                 bamboo_compression::types::BudgetError::TokenCountError(format!(
@@ -271,17 +1084,18 @@ Guidelines:
 
         let mut content = String::new();
         let mut stream = stream;
+        let mut terminal_done = false;
 
         while let Some(chunk_result) = stream.next().await {
             match chunk_result {
                 Ok(LLMChunk::Token(text)) => content.push_str(&text),
-                Ok(LLMChunk::Done) => break,
+                Ok(LLMChunk::Done) => {
+                    terminal_done = true;
+                    break;
+                }
                 Ok(_) => {} // Ignore reasoning tokens, tool calls, etc.
                 Err(e) => {
                     tracing::warn!("LLM summarization stream error: {}", e);
-                    if !content.is_empty() {
-                        break;
-                    }
                     return Err(bamboo_compression::types::BudgetError::TokenCountError(
                         format!("LLM summarization stream failed: {}", e),
                     ));
@@ -289,6 +1103,11 @@ Guidelines:
             }
         }
 
+        if !terminal_done && !content.is_empty() {
+            return Err(bamboo_compression::types::BudgetError::TokenCountError(
+                "LLM summarization stream ended without terminal completion".to_string(),
+            ));
+        }
         Ok(content)
     }
 }
@@ -299,6 +1118,9 @@ impl std::fmt::Debug for LlmSummarizer {
             .field("model", &self.model)
             .field("has_existing_summary", &self.existing_summary.is_some())
             .field("context_block_count", &self.context_blocks.len())
+            .field("logical_pass_id", &self.logical_pass_id)
+            .field("logical_phase", &self.logical_phase)
+            .field("has_progress_callback", &self.progress_callback.is_some())
             .finish()
     }
 }
@@ -309,60 +1131,37 @@ impl Summarizer for LlmSummarizer {
         &self,
         messages: &[Message],
     ) -> Result<String, bamboo_compression::types::BudgetError> {
-        if messages.is_empty() {
-            return Ok("No conversation history to summarize.".to_string());
-        }
-
-        let prompt_messages = self.build_summarization_messages(messages);
-
         tracing::info!(
             "LlmSummarizer: summarizing {} messages using model '{}' (existing_summary={})",
             messages.len(),
             self.model,
             self.existing_summary.is_some()
         );
-
-        match self.collect_stream_response(&prompt_messages).await {
-            Ok(summary) if !summary.trim().is_empty() => {
-                tracing::info!("LlmSummarizer: generated summary ({} chars)", summary.len());
-                Ok(summary)
-            }
-            Ok(_) => {
-                tracing::warn!(
-                    "LlmSummarizer: LLM returned empty summary, falling back to heuristic"
-                );
-                HeuristicSummarizer::new().summarize(messages).await
-            }
-            Err(e) if self.heuristic_fallback_on_error => {
-                tracing::warn!(
-                    "LlmSummarizer: LLM call failed ({}), falling back to heuristic",
-                    e
-                );
-                HeuristicSummarizer::new().summarize(messages).await
-            }
-            // Best-effort caller opted out of the heuristic fallback: surface the
-            // transient error so the caller can skip compression entirely rather
-            // than substitute a low-quality heuristic summary. (issue #238)
-            Err(e) => {
-                tracing::warn!(
-                    "LlmSummarizer: LLM call failed ({}); surfacing error (heuristic fallback disabled)",
-                    e
-                );
-                Err(e)
-            }
-        }
+        let report = self.summarize_with_report(messages).await?;
+        tracing::info!(
+            chars = report.content.len(),
+            actual_summary_tokens = report.actual_summary_tokens,
+            target_summary_tokens = report.target_summary_tokens,
+            map_calls = report.map_calls,
+            reduce_calls = report.reduce_calls,
+            fallback_used = report.fallback_used,
+            "LlmSummarizer: generated summary"
+        );
+        Ok(report.content)
     }
 
     fn estimate_summary_tokens(&self, message_count: usize) -> u32 {
-        // LLM summaries tend to be more detailed; estimate higher than heuristic
-        (message_count * 80).min(2000) as u32
+        self.request_budget
+            .as_ref()
+            .map(|budget| budget.target_summary_tokens)
+            .unwrap_or_else(|| (message_count * 80).min(2000) as u32)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bamboo_domain::ReasoningEffort;
+    use bamboo_domain::{FunctionCall, ReasoningEffort, ToolCall};
     use bamboo_llm::{LLMChunk, LLMError, LLMRequestOptions, LLMStream};
     use futures::stream;
     use std::sync::Mutex;
@@ -476,7 +1275,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn llm_summarizer_requests_high_reasoning_effort_for_summary_calls() {
+    async fn llm_summarizer_requests_low_reasoning_effort_for_summary_calls() {
         let provider = Arc::new(ReasoningCaptureProvider::default());
         let summarizer = LlmSummarizer::new(
             provider.clone(),
@@ -499,7 +1298,7 @@ mod tests {
             .captured_reasoning
             .lock()
             .expect("captured reasoning lock should not be poisoned");
-        assert_eq!(captured.as_slice(), [Some(ReasoningEffort::High)]);
+        assert_eq!(captured.as_slice(), [Some(ReasoningEffort::Low)]);
     }
 
     /// Provider that captures both `reasoning_effort` and `max_output_tokens`.
@@ -546,7 +1345,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn llm_summarizer_sufficient_max_tokens_for_high_reasoning() {
+    async fn llm_summarizer_uses_explicit_output_budget_with_low_reasoning() {
         let provider = Arc::new(RequestOptionsCaptureProvider::default());
         let summarizer = LlmSummarizer::new(
             provider.clone(),
@@ -573,14 +1372,9 @@ mod tests {
             .captured_max_tokens
             .lock()
             .expect("lock should not be poisoned");
-        assert_eq!(captured_reasoning.as_slice(), [Some(ReasoningEffort::High)]);
+        assert_eq!(captured_reasoning.as_slice(), [Some(ReasoningEffort::Low)]);
         let max_tokens = captured_max_tokens[0].expect("max_output_tokens should be set");
-        // ReasoningEffort::High targets 4096 thinking budget; max_tokens must leave room for output.
-        assert!(
-            max_tokens > 4096,
-            "max_output_tokens ({}) must exceed thinking budget (4096) to avoid truncation",
-            max_tokens
-        );
+        assert_eq!(max_tokens, 8192);
     }
 
     #[test]
@@ -705,5 +1499,397 @@ mod tests {
             out.is_err(),
             "with the heuristic fallback disabled, a transient LLM error must surface"
         );
+    }
+
+    #[derive(Default)]
+    struct BoundedRequestCaptureProvider {
+        requests: Mutex<Vec<(Vec<Message>, u32)>>,
+    }
+
+    #[async_trait]
+    impl LLMProvider for BoundedRequestCaptureProvider {
+        async fn chat_stream(
+            &self,
+            messages: &[Message],
+            _tools: &[bamboo_domain::ToolSchema],
+            max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<LLMStream, LLMError> {
+            self.requests
+                .lock()
+                .expect("bounded request capture lock")
+                .push((messages.to_vec(), max_output_tokens.unwrap_or_default()));
+            Ok(Box::pin(stream::iter(vec![
+                Ok::<LLMChunk, LLMError>(LLMChunk::Token(
+                    "Detailed bounded summary with requirements, decisions, files, tests, and next steps. "
+                        .repeat(16),
+                )),
+                Ok::<LLMChunk, LLMError>(LLMChunk::Done),
+            ])))
+        }
+    }
+
+    fn bounded_budget(
+        context_window_tokens: u32,
+        max_output_tokens: u32,
+        safety_margin_tokens: u32,
+        target_summary_tokens: u32,
+    ) -> SummaryRequestBudget {
+        let token_budget = TokenBudget::with_safety_margin(
+            context_window_tokens,
+            max_output_tokens,
+            bamboo_compression::BudgetStrategy::default(),
+            safety_margin_tokens,
+        );
+        SummaryRequestBudget::from_token_budget(&token_budget, 80, target_summary_tokens, 0.20)
+    }
+
+    #[tokio::test]
+    async fn bounded_one_shot_uses_one_dynamic_request_when_fully_rendered_prompt_fits() {
+        let provider = Arc::new(BoundedRequestCaptureProvider::default());
+        let budget = bounded_budget(10_000, 2_000, 100, 400);
+        let summarizer =
+            LlmSummarizer::new(provider.clone(), "summary-model".to_string(), None, None)
+                .with_request_budget(budget.clone())
+                .with_heuristic_fallback_on_error(false);
+
+        let report = summarizer
+            .summarize_with_report(&summary_messages())
+            .await
+            .expect("bounded one-shot summary");
+        assert_eq!(report.map_calls, 0);
+        assert_eq!(report.reduce_calls, 0);
+
+        let requests = provider.requests.lock().expect("capture lock");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].1, 400);
+        let counter = TiktokenTokenCounter::default();
+        assert!(
+            counter
+                .count_messages(&requests[0].0)
+                .saturating_add(requests[0].1)
+                .saturating_add(budget.safety_margin_tokens)
+                <= budget.safe_request_tokens()
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_pipeline_chunks_large_source_and_never_compounds_twenty_percent_target() {
+        let provider = Arc::new(BoundedRequestCaptureProvider::default());
+        let budget = bounded_budget(3_000, 800, 100, 600);
+        let summarizer = LlmSummarizer::new(
+            provider.clone(),
+            "small-summary-model".to_string(),
+            Some("Previous durable summary evidence. ".repeat(12)),
+            None,
+        )
+        .with_context_blocks(vec![ContextBlock::new(
+            ContextBlockType::TaskSnapshot,
+            ContextBlockPriority::High,
+            ContextBlockStability::RoundDynamic,
+            "Current Task List",
+            "Active compression task with exact acceptance evidence. ".repeat(8),
+        )])
+        .with_custom_instructions(Some(
+            "Keep exact paths, failures, and remaining work.".to_string(),
+        ))
+        .with_request_budget(budget.clone())
+        .with_heuristic_fallback_on_error(false);
+        let messages = (0..80)
+            .map(|index| {
+                if index % 2 == 0 {
+                    Message::user(format!(
+                        "user-{index} {}",
+                        "requirement decision path error evidence ".repeat(24)
+                    ))
+                } else {
+                    Message::assistant(
+                        format!(
+                            "assistant-{index} {}",
+                            "implementation command output test result next step ".repeat(24)
+                        ),
+                        None,
+                    )
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let report = summarizer
+            .summarize_with_report(&messages)
+            .await
+            .expect("chunked summary");
+        assert!(report.map_calls > 1, "large source must use multiple maps");
+        assert!(
+            report.reduce_calls >= 1,
+            "bounded partials should receive a final reduce when it fits"
+        );
+
+        let requests = provider.requests.lock().expect("capture lock");
+        let counter = TiktokenTokenCounter::default();
+        for (request, output_tokens) in requests.iter() {
+            assert!(
+                counter
+                    .count_messages(request)
+                    .saturating_add(*output_tokens)
+                    .saturating_add(budget.safety_margin_tokens)
+                    <= budget.safe_request_tokens(),
+                "every map/reduce request must satisfy the 80% invariant"
+            );
+            assert!(*output_tokens <= budget.max_output_tokens);
+        }
+        assert_eq!(
+            requests.last().map(|(_, output)| *output),
+            Some(600),
+            "the final reduce keeps the global source-derived target instead of taking 20% of map summaries"
+        );
+        assert!(
+            requests.iter().any(|(request, _)| request
+                .iter()
+                .any(|message| { message.content.contains("intermediate reduce stage") })),
+            "large ordered partials should be recursively reduced before the final merge"
+        );
+        let final_request = requests.last().expect("final reduce request");
+        let final_rendered = final_request
+            .0
+            .iter()
+            .map(|message| message.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(final_rendered.contains("Previous durable summary evidence"));
+        assert!(final_rendered.contains("Current Task List"));
+        assert!(final_rendered.contains("Keep exact paths"));
+    }
+
+    #[test]
+    fn one_hundred_thousand_raw_tokens_receive_twenty_thousand_token_target() {
+        let summarizer = LlmSummarizer::new(
+            Arc::new(DummyProvider),
+            "summary-model".to_string(),
+            None,
+            None,
+        )
+        .with_request_budget(bounded_budget(128_000, 32_000, 1_000, 20_000));
+
+        assert_eq!(summarizer.target_for_source(100_000), 20_000);
+    }
+
+    #[tokio::test]
+    async fn bounded_stage_errors_never_fall_back_to_heuristic_by_default() {
+        let summarizer = LlmSummarizer::new(
+            Arc::new(FailingProvider),
+            "summary-model".to_string(),
+            None,
+            None,
+        )
+        .with_request_budget(bounded_budget(10_000, 2_000, 100, 400));
+
+        let error = summarizer
+            .summarize_with_report(&summary_messages())
+            .await
+            .expect_err("a failed bounded stage must surface atomically");
+        assert!(error.to_string().contains("http 500 transient"));
+    }
+
+    #[tokio::test]
+    async fn hundreds_of_individually_small_messages_never_use_one_unbounded_request() {
+        let provider = Arc::new(BoundedRequestCaptureProvider::default());
+        let messages = (0..400)
+            .map(|index| {
+                if index % 2 == 0 {
+                    Message::user(format!(
+                        "small-user-{index} {}",
+                        "requirement evidence detail ".repeat(4)
+                    ))
+                } else {
+                    Message::assistant(
+                        format!(
+                            "small-assistant-{index} {}",
+                            "result test next-step ".repeat(4)
+                        ),
+                        None,
+                    )
+                }
+            })
+            .collect::<Vec<_>>();
+        let counter = TiktokenTokenCounter::default();
+        let represented = counter.count_messages(&messages);
+        let target = ((represented as f64) * 0.20).ceil() as u32;
+        let budget = bounded_budget(3_000, 800, 100, target);
+        let summarizer = LlmSummarizer::new(
+            provider.clone(),
+            "small-summary-model".to_string(),
+            None,
+            None,
+        )
+        .with_request_budget(budget.clone())
+        .with_heuristic_fallback_on_error(false);
+
+        let report = summarizer
+            .summarize_with_report(&messages)
+            .await
+            .expect("hundreds of small messages should chunk");
+        assert!(report.map_calls > 1);
+        assert_eq!(report.target_summary_tokens, target);
+        let requests = provider.requests.lock().expect("capture lock");
+        for (request, output) in requests.iter() {
+            assert!(
+                counter
+                    .count_messages(request)
+                    .saturating_add(*output)
+                    .saturating_add(budget.safety_margin_tokens)
+                    <= budget.safe_request_tokens()
+            );
+        }
+        let raw_map_prompts = requests
+            .iter()
+            .filter(|(request, _)| {
+                request
+                    .iter()
+                    .any(|message| message.content.contains("map stage"))
+            })
+            .flat_map(|(request, _)| request.iter())
+            .map(|message| message.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(raw_map_prompts.contains("small-user-0"));
+        assert!(raw_map_prompts.contains("small-assistant-399"));
+    }
+
+    #[tokio::test]
+    async fn map_chunk_boundaries_do_not_split_generic_multi_tool_chains() {
+        let provider = Arc::new(BoundedRequestCaptureProvider::default());
+        let budget = bounded_budget(2_000, 300, 100, 300);
+        let summarizer = LlmSummarizer::new(
+            provider.clone(),
+            "tiny-summary-model".to_string(),
+            None,
+            None,
+        )
+        .with_request_budget(budget)
+        .with_heuristic_fallback_on_error(false);
+        let mut messages = (0..8)
+            .map(|index| {
+                Message::user(format!(
+                    "prefix-{index} {}",
+                    "filler requirement evidence ".repeat(14)
+                ))
+            })
+            .collect::<Vec<_>>();
+        let mut chain = Message::assistant("CHAIN_ASSISTANT_763", None);
+        chain.tool_calls = Some(vec![
+            ToolCall {
+                id: "chain-call-a-763".to_string(),
+                tool_type: "function".to_string(),
+                function: FunctionCall {
+                    name: "search".to_string(),
+                    arguments: r#"{"query":"a"}"#.to_string(),
+                },
+            },
+            ToolCall {
+                id: "chain-call-b-763".to_string(),
+                tool_type: "function".to_string(),
+                function: FunctionCall {
+                    name: "read".to_string(),
+                    arguments: r#"{"path":"b"}"#.to_string(),
+                },
+            },
+        ]);
+        messages.push(chain);
+        messages.push(Message::tool_result(
+            "chain-call-a-763",
+            "CHAIN_RESULT_A_763",
+        ));
+        messages.push(Message::tool_result(
+            "chain-call-b-763",
+            "CHAIN_RESULT_B_763",
+        ));
+        messages.extend((0..8).map(|index| {
+            Message::assistant(
+                format!(
+                    "suffix-{index} {}",
+                    "implementation result evidence ".repeat(14)
+                ),
+                None,
+            )
+        }));
+
+        let report = summarizer
+            .summarize_with_report(&messages)
+            .await
+            .expect("tool-chain source should chunk");
+        assert!(report.map_calls > 1);
+        let requests = provider.requests.lock().expect("capture lock");
+        let chain_map = requests
+            .iter()
+            .flat_map(|(request, _)| request.iter())
+            .find(|message| message.content.contains("CHAIN_RESULT_A_763"))
+            .expect("map request containing tool chain");
+        assert!(chain_map.content.contains("CHAIN_ASSISTANT_763"));
+        assert!(chain_map.content.contains("CHAIN_RESULT_B_763"));
+    }
+
+    #[tokio::test]
+    async fn oversized_single_message_is_split_without_dropping_its_tail() {
+        let provider = Arc::new(BoundedRequestCaptureProvider::default());
+        let budget = bounded_budget(2_000, 300, 100, 300);
+        let summarizer = LlmSummarizer::new(
+            provider.clone(),
+            "tiny-summary-model".to_string(),
+            None,
+            None,
+        )
+        .with_request_budget(budget)
+        .with_heuristic_fallback_on_error(false);
+        let messages = vec![Message::user(format!(
+            "{} TAIL_SENTINEL_763",
+            "very large source message with concrete content ".repeat(2_000)
+        ))];
+
+        let report = summarizer
+            .summarize_with_report(&messages)
+            .await
+            .expect("oversized source should split");
+        assert!(report.map_calls > 1);
+        let requests = provider.requests.lock().expect("capture lock");
+        assert!(
+            requests.iter().any(|(request, _)| request
+                .iter()
+                .any(|message| message.content.contains("TAIL_SENTINEL_763"))),
+            "the deterministic continuation chunks must include the original tail"
+        );
+    }
+
+    struct PartialWithoutDoneProvider;
+
+    #[async_trait]
+    impl LLMProvider for PartialWithoutDoneProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[bamboo_domain::ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<LLMStream, LLMError> {
+            Ok(Box::pin(stream::iter(vec![Ok::<LLMChunk, LLMError>(
+                LLMChunk::Token("partial but incomplete summary".to_string()),
+            )])))
+        }
+    }
+
+    #[tokio::test]
+    async fn partial_stream_without_done_is_never_accepted_as_summary() {
+        let summarizer = LlmSummarizer::new(
+            Arc::new(PartialWithoutDoneProvider),
+            "model".to_string(),
+            None,
+            None,
+        )
+        .with_request_budget(bounded_budget(10_000, 2_000, 100, 400))
+        .with_heuristic_fallback_on_error(false);
+        let error = summarizer
+            .summarize_with_report(&summary_messages())
+            .await
+            .expect_err("partial stream must fail");
+        assert!(error.to_string().contains("without terminal completion"));
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -398,6 +398,12 @@ pub struct AgentLoopConfig {
     ///
     /// Resolution order: session-level > config-level > built-in defaults.
     pub(crate) compression_instructions: Option<String>,
+    /// Desired final summary size relative to the raw source tokens represented
+    /// by it. Values are normalized at the compression boundary.
+    pub(crate) summary_target_ratio: f64,
+    /// Safe request ceiling as a percentage of the selected summarization
+    /// model's context window.
+    pub(crate) summary_safe_window_percent: u8,
     /// Dedicated model for summarization. Falls back to `background_model_name`.
     pub(crate) summarization_model_name: Option<String>,
     /// Optional provider override for memory/background model LLM calls.
@@ -548,6 +554,8 @@ impl Default for AgentLoopConfig {
             planning_model_name: None,
             search_model_name: None,
             compression_instructions: None,
+            summary_target_ratio: 0.20,
+            summary_safe_window_percent: 80,
             summarization_model_name: None,
             background_model_provider: None,
             summarization_model_provider: None,

--- a/crates/engine/bamboo-engine/src/runtime/config.rs
+++ b/crates/engine/bamboo-engine/src/runtime/config.rs
@@ -437,10 +437,10 @@ pub struct AgentLoopConfig {
     /// Token budget for context management (optional, defaults to model's limits)
     pub(crate) token_budget: Option<TokenBudget>,
     /// Legacy `config.json` `model_limits` value, snapshotted from the live
-    /// in-memory Config when this loop config is built. Consulted only by
-    /// `resolve_token_budget` as a last-resort fallback when `model_limits.json`
-    /// fails to load — so the engine never does a fresh disk-reading
-    /// `Config::new()` (which would also clobber the global env-var cache). #38.
+    /// in-memory Config when this loop config is built. Consulted per model when
+    /// the instance-local `model_limits.json` has no matching entry or cannot be
+    /// loaded, so the engine never does a fresh disk-reading `Config::new()`
+    /// (which would also clobber the global env-var cache). #38.
     pub(crate) legacy_model_limits: Option<serde_json::Value>,
     /// Optional image fallback behavior applied to *LLM requests only* (never persisted).
     ///

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation.rs
@@ -1,4 +1,4 @@
-use crate::llm_summarizer::LlmSummarizer;
+use crate::llm_summarizer::{LlmSummarizer, SummaryRequestBudget};
 use crate::runtime::config::AgentLoopConfig;
 use crate::runtime::runner::session_setup::prompt_envelope::{
     build_active_workflow_context_block, build_external_memory_context_block,
@@ -10,9 +10,9 @@ use bamboo_agent_core::{
     AgentError, AgentEvent, CompressionTriggerType, ContextBlock, Role, Session,
 };
 use bamboo_compression::{
-    apply_compression_plan, build_forced_compression_plan_with_summary,
-    estimate_context_compression_exposure, prepare_hybrid_context, summary_source_messages,
-    PreparedContext, Summarizer, TiktokenTokenCounter, TokenBudget, TokenCounter,
+    apply_compression_plan, build_forced_compression_candidate_plan_with_fixed_tokens,
+    estimate_context_compression_exposure, finalize_compression_candidate_plan,
+    prepare_hybrid_context, PreparedContext, TiktokenTokenCounter, TokenBudget, TokenCounter,
 };
 use bamboo_domain::{AgentHookPoint, AgentRuntimeState, HookPayload};
 use bamboo_llm::LLMProvider;
@@ -308,9 +308,15 @@ async fn maybe_apply_host_context_compression_with_budget(
     };
 
     let trigger_type_clone = trigger_type.clone();
+    let logical_pass_id = uuid::Uuid::new_v4().to_string();
 
-    let messages = summary_source_messages(session);
-    if messages.len() < 3 {
+    let active_non_system_count = session
+        .messages
+        .iter()
+        .filter(|message| !message.compressed)
+        .filter(|message| !matches!(message.role, Role::System))
+        .count();
+    if active_non_system_count < 3 {
         tracing::warn!(
             "[{}] {} context compression skipped: usage={:.1}%, auto_threshold={:.1}%, critical_threshold={}%, not enough active messages ({})",
             session_id,
@@ -318,7 +324,7 @@ async fn maybe_apply_host_context_compression_with_budget(
             usage_percent,
             auto_threshold,
             FORCE_CONTEXT_COMPRESSION_PERCENT,
-            messages.len()
+            active_non_system_count
         );
         return Ok(false);
     }
@@ -338,6 +344,38 @@ async fn maybe_apply_host_context_compression_with_budget(
         emit_context_compression_status(event_tx, phase_label, "skipped_no_background_model").await;
         return Ok(false);
     };
+
+    let compression_context_blocks =
+        build_compression_context_blocks(session, config.app_data_dir.as_deref());
+    let counter = TiktokenTokenCounter::default();
+    let additional_fixed_tokens = compression_context_blocks
+        .iter()
+        .fold(0u32, |total, block| {
+            total.saturating_add(counter.count_message(&block.render_runtime_context_message()))
+        });
+    let candidate = match build_forced_compression_candidate_plan_with_fixed_tokens(
+        session,
+        model_name,
+        Some(budget),
+        config.summary_target_ratio,
+        trigger_type_clone,
+        additional_fixed_tokens,
+    ) {
+        Ok(candidate) => candidate,
+        Err(reason) => {
+            tracing::warn!(
+                "[{}] {} context compression pass {} candidate planning failed before summarization: {}",
+                session_id,
+                phase_label,
+                logical_pass_id,
+                reason
+            );
+            let status = format!("failed_candidate_plan:{reason}");
+            emit_context_compression_status(event_tx, phase_label, &status).await;
+            return Ok(false);
+        }
+    };
+    let messages = candidate.messages_to_summarize.clone();
 
     let mut hook_compression_instructions = Vec::new();
     if config
@@ -381,9 +419,6 @@ async fn maybe_apply_host_context_compression_with_budget(
         .conversation_summary
         .as_ref()
         .map(|summary| summary.content.clone());
-    let compression_context_blocks =
-        build_compression_context_blocks(session, config.app_data_dir.as_deref());
-
     let base_instructions = session
         .compression_instructions
         .as_deref()
@@ -407,58 +442,101 @@ async fn maybe_apply_host_context_compression_with_budget(
         .as_ref()
         .or(config.background_model_provider.as_ref())
         .unwrap_or(llm);
-    // Mid-turn compression is BEST-EFFORT (it runs between a turn's tool calls,
-    // after the assistant message is already committed). A transient
-    // summarization failure there must NOT be papered over with a low-quality
-    // heuristic summary that mutates in-flight context; it should SURFACE so the
-    // mid-turn call site can skip compression and continue with the uncompressed
-    // context (see `maybe_apply_mid_turn_context_compression_after_tool`). Every
-    // other phase (pre-turn, overflow-recovery) keeps the heuristic fallback so a
-    // round that genuinely needs the context reduced stays resilient. (issue #238)
-    let heuristic_fallback_on_error = phase_label != "mid-turn";
+    let summary_model_budget = super::token_budget::resolve_auxiliary_token_budget(
+        config,
+        summary_model,
+        summary_provider.as_ref(),
+    )
+    .await;
+    let summary_request_budget = SummaryRequestBudget::from_token_budget(
+        &summary_model_budget,
+        config.summary_safe_window_percent,
+        candidate.target_summary_tokens,
+        candidate.summary_target_ratio,
+    );
+    // A bounded pass is a single archive transaction even when it uses several
+    // provider requests. Any failed map/reduce stage must surface without
+    // substituting a heuristic summary, otherwise the caller could archive a
+    // candidate set after only part of the source was successfully processed.
+    // The mid-turn caller still swallows this error as best-effort (#238);
+    // pre-turn/overflow callers retain the unchanged session and can retry.
     let summarizer = LlmSummarizer::new(
         Arc::clone(summary_provider),
         summary_model.to_string(),
         existing_summary.clone(),
         None,
     )
-    .with_heuristic_fallback_on_error(heuristic_fallback_on_error)
+    .with_heuristic_fallback_on_error(false)
     .with_context_blocks(compression_context_blocks)
     .with_custom_instructions(compression_instructions)
     .with_summary_mode(if existing_summary.is_some() {
         crate::llm_summarizer::SummaryMode::IncrementalMerge
     } else {
         crate::llm_summarizer::SummaryMode::FullRewrite
-    });
+    })
+    .with_request_budget(summary_request_budget);
+    let mut summarizer =
+        summarizer.with_logical_pass_context(logical_pass_id.clone(), phase_label.to_string());
+    if let Some(tx) = event_tx {
+        let progress_tx = tx.clone();
+        let progress_phase = phase_label.to_string();
+        summarizer = summarizer.with_progress_callback(Arc::new(
+            move |progress: &crate::llm_summarizer::SummarizationProgress| {
+                let status = format!(
+                    "{}:{}/{} input={} output={} safe={} model_limit={}",
+                    progress.stage,
+                    progress.stage_index,
+                    progress.stage_count,
+                    progress.estimated_input_tokens,
+                    progress.requested_output_tokens,
+                    progress.safe_request_tokens,
+                    progress.model_context_tokens,
+                );
+                let _ = progress_tx.try_send(AgentEvent::ContextCompressionStatus {
+                    phase: progress_phase.clone(),
+                    status,
+                });
+            },
+        ));
+    }
     emit_context_compression_status(event_tx, phase_label, "started").await;
-    let summary = match summarizer.summarize(&messages).await {
-        Ok(summary) => summary,
+    let summary_report = match summarizer.summarize_with_report(&messages).await {
+        Ok(report) => report,
         Err(error) => {
-            emit_context_compression_status(event_tx, phase_label, "failed").await;
+            tracing::warn!(
+                logical_pass_id = %logical_pass_id,
+                phase = phase_label,
+                error = %error,
+                "Bounded context compression failed before commit"
+            );
+            let status = format!("failed:{error}");
+            emit_context_compression_status(event_tx, phase_label, &status).await;
             return Err(AgentError::Budget(error.to_string()));
         }
     };
 
-    let mut plan = match build_forced_compression_plan_with_summary(
-        session,
-        model_name,
-        Some(budget),
-        summary,
-        trigger_type_clone,
-    ) {
-        Ok(plan) => plan,
-        Err(reason) => {
-            tracing::warn!(
+    let mut plan =
+        match finalize_compression_candidate_plan(session, candidate, summary_report.content) {
+            Ok(plan) => plan,
+            Err(reason) => {
+                tracing::warn!(
                 "[{}] {} context compression attempted (usage={:.1}%) but plan build failed: {}",
                 session_id,
                 phase_label,
                 usage_percent,
                 reason
             );
-            emit_context_compression_status(event_tx, phase_label, "failed").await;
-            return Ok(false);
-        }
-    };
+                let status = format!("failed_postcondition:{reason}");
+                emit_context_compression_status(event_tx, phase_label, &status).await;
+                return Ok(false);
+            }
+        };
+    plan.summary_budget_clamped = summary_report.budget_clamped;
+    plan.summary_budget_clamp_reason = summary_report.budget_clamp_reason;
+    plan.summarization_map_calls = summary_report.map_calls;
+    plan.summarization_reduce_calls = summary_report.reduce_calls;
+    plan.summarization_fallback_used = summary_report.fallback_used;
+    plan.logical_pass_id = Some(logical_pass_id);
 
     let elapsed = start.elapsed();
     let latency_ms = elapsed.as_millis() as u64;

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation/tests.rs
@@ -9,10 +9,10 @@ use bamboo_agent_core::tools::{FunctionCall, ToolCall};
 use bamboo_agent_core::{
     AgentEvent, AgentHook, CompressionTriggerType, Message, Role, Session, TokenBudgetUsage,
 };
-use bamboo_compression::{BudgetStrategy, TokenBudget};
+use bamboo_compression::{BudgetStrategy, TiktokenTokenCounter, TokenBudget, TokenCounter};
 use bamboo_domain::{AgentHookPoint, HookPayload, HookResult, TaskItem, TaskItemStatus, TaskList};
 use bamboo_llm::models::{ContentPart, ImageUrl};
-use bamboo_llm::provider::{LLMProvider, LLMRequestOptions, LLMStream};
+use bamboo_llm::provider::{LLMProvider, LLMRequestOptions, LLMStream, ProviderModelInfo};
 use bamboo_llm::{LLMChunk, LLMError};
 use futures::stream;
 use tokio::sync::mpsc;
@@ -141,6 +141,470 @@ fn prompt_capture_llm() -> (Arc<dyn LLMProvider>, Arc<Mutex<Vec<Vec<Message>>>>)
     (llm, requests)
 }
 
+#[derive(Debug, Clone)]
+struct CapturedBoundedRequest {
+    messages: Vec<Message>,
+    max_output_tokens: u32,
+    model: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BoundedFailureMode {
+    None,
+    Call(usize),
+    PartialWithoutDone(usize),
+    Reduce,
+}
+
+struct BoundedCompressionProvider {
+    model_info: ProviderModelInfo,
+    requests: Arc<Mutex<Vec<CapturedBoundedRequest>>>,
+    failure_mode: BoundedFailureMode,
+}
+
+#[async_trait::async_trait]
+impl LLMProvider for BoundedCompressionProvider {
+    async fn chat_stream(
+        &self,
+        messages: &[Message],
+        _tools: &[bamboo_agent_core::tools::ToolSchema],
+        max_output_tokens: Option<u32>,
+        model: &str,
+    ) -> bamboo_llm::provider::Result<LLMStream> {
+        let request = CapturedBoundedRequest {
+            messages: messages.to_vec(),
+            max_output_tokens: max_output_tokens.unwrap_or_default(),
+            model: model.to_string(),
+        };
+        let call_number = {
+            let mut requests = self
+                .requests
+                .lock()
+                .expect("bounded compression request lock");
+            requests.push(request);
+            requests.len()
+        };
+        let is_reduce = messages.iter().any(|message| {
+            message.content.contains("final reduce stage")
+                || message.content.contains("intermediate reduce stage")
+        });
+
+        match self.failure_mode {
+            BoundedFailureMode::Call(failed_call) if call_number == failed_call => {
+                Err(LLMError::Api(format!(
+                    "injected map failure on call {call_number}"
+                )))
+            }
+            BoundedFailureMode::Reduce if is_reduce => {
+                Err(LLMError::Api("injected reduce failure".to_string()))
+            }
+            BoundedFailureMode::PartialWithoutDone(failed_call)
+                if call_number == failed_call =>
+            {
+                Ok(Box::pin(stream::iter(vec![Ok::<LLMChunk, LLMError>(
+                    LLMChunk::Token("partial summary that must not commit".to_string()),
+                )])))
+            }
+            _ => Ok(Box::pin(stream::iter(vec![
+                Ok::<LLMChunk, LLMError>(LLMChunk::Token(format!(
+                    "bounded summary part {call_number} with requirements, decisions, and test evidence"
+                ))),
+                Ok::<LLMChunk, LLMError>(LLMChunk::Done),
+            ]))),
+        }
+    }
+
+    async fn list_model_info(&self) -> bamboo_llm::provider::Result<Vec<ProviderModelInfo>> {
+        Ok(vec![self.model_info.clone()])
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn bounded_compression_llm(
+    failure_mode: BoundedFailureMode,
+) -> (
+    Arc<dyn LLMProvider>,
+    Arc<Mutex<Vec<CapturedBoundedRequest>>>,
+) {
+    bounded_compression_llm_with_limits(failure_mode, 5_000, 2_000)
+}
+
+#[allow(clippy::type_complexity)]
+fn bounded_compression_llm_with_limits(
+    failure_mode: BoundedFailureMode,
+    max_context_tokens: u32,
+    max_output_tokens: u32,
+) -> (
+    Arc<dyn LLMProvider>,
+    Arc<Mutex<Vec<CapturedBoundedRequest>>>,
+) {
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let llm: Arc<dyn LLMProvider> = Arc::new(BoundedCompressionProvider {
+        model_info: ProviderModelInfo {
+            id: "summary-model-763".to_string(),
+            max_context_tokens: Some(max_context_tokens),
+            max_output_tokens: Some(max_output_tokens),
+        },
+        requests: Arc::clone(&requests),
+        failure_mode,
+    });
+    (llm, requests)
+}
+
+fn bounded_compression_session(id: &str) -> Session {
+    let mut session = Session::new(id, "main-model-763");
+    session.token_budget = Some(TokenBudget {
+        max_context_tokens: 24_000,
+        max_output_tokens: 4_000,
+        strategy: BudgetStrategy::Hybrid {
+            window_size: 20,
+            enable_summarization: true,
+        },
+        safety_margin: 0,
+        compression_trigger_percent: 80,
+        compression_target_percent: 50,
+        working_reserve_tokens: 0,
+        fallback_trigger_percent: 75,
+        prompt_cache_min_tool_output_chars: 1_200,
+        prompt_cache_head_chars: 280,
+        prompt_cache_tail_chars: 180,
+        prompt_cache_recent_user_turns: 2,
+        prompt_cache_recent_tool_chains: 2,
+        max_tool_output_tokens: 0,
+    });
+    session.messages.push(Message::system("System prompt"));
+    for index in 0..40 {
+        let user_marker = if index >= 37 {
+            format!("LATEST_PROTECTED_763_{index}")
+        } else {
+            format!("ARCHIVE_SOURCE_763_{index}")
+        };
+        session.messages.push(Message::user(format!(
+            "{user_marker} {}",
+            "requirement detail evidence alpha beta gamma ".repeat(40)
+        )));
+        session.messages.push(Message::assistant(
+            format!(
+                "assistant-{index} {}",
+                "implementation result test output followup delta ".repeat(40)
+            ),
+            None,
+        ));
+    }
+    let mut never_compress = Message::assistant(
+        format!(
+            "NEVER_COMPRESS_763 {}",
+            "durable protected runtime state ".repeat(40)
+        ),
+        None,
+    );
+    never_compress.never_compress = true;
+    session.messages.insert(5, never_compress);
+    session.token_usage = Some(TokenBudgetUsage {
+        system_tokens: 100,
+        summary_tokens: 0,
+        window_tokens: 20_000,
+        total_tokens: 20_100,
+        max_context_tokens: 24_000,
+        budget_limit: 24_000,
+        truncation_occurred: true,
+        segments_removed: 0,
+        prompt_cached_tool_outputs: 0,
+        prompt_cached_tool_tokens_saved: 0,
+        thinking_tokens: 0,
+        cache_read_input_tokens: 0,
+    });
+    session.force_manual_compression = Some("Preserve concrete evidence".to_string());
+    session
+}
+
+fn bounded_compression_config(summary_provider: Arc<dyn LLMProvider>) -> AgentLoopConfig {
+    AgentLoopConfig {
+        model_name: Some("main-model-763".to_string()),
+        summarization_model_name: Some("summary-model-763".to_string()),
+        summarization_model_provider: Some(summary_provider),
+        summary_target_ratio: 0.20,
+        summary_safe_window_percent: 80,
+        ..Default::default()
+    }
+}
+
+fn archive_state(session: &Session) -> Vec<(String, bool, Option<String>)> {
+    session
+        .messages
+        .iter()
+        .map(|message| {
+            (
+                message.id.clone(),
+                message.compressed,
+                message.compressed_by_event_id.clone(),
+            )
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn bounded_host_compression_uses_auxiliary_model_budget_and_exact_candidates() {
+    let mut session = bounded_compression_session("bounded-success-763");
+    let never_compress_id = session
+        .messages
+        .iter()
+        .find(|message| message.content.contains("NEVER_COMPRESS_763"))
+        .map(|message| message.id.clone())
+        .expect("never-compress fixture");
+    let latest_user_ids = session
+        .messages
+        .iter()
+        .filter(|message| {
+            matches!(message.role, Role::User) && message.content.contains("LATEST_PROTECTED_763")
+        })
+        .map(|message| message.id.clone())
+        .collect::<Vec<_>>();
+    let (summary_llm, captured) = bounded_compression_llm(BoundedFailureMode::None);
+    let config = bounded_compression_config(summary_llm);
+    let main_llm = noop_llm();
+    let (event_tx, mut event_rx) = mpsc::channel(128);
+
+    let applied = maybe_apply_host_context_compression(
+        &mut session,
+        &config,
+        "main-model-763",
+        "bounded-success-763",
+        &[],
+        &main_llm,
+        Some(&event_tx),
+        "pre-turn",
+    )
+    .await
+    .expect("bounded host compression should succeed");
+    assert!(applied);
+    drop(event_tx);
+    let progress_statuses = std::iter::from_fn(|| event_rx.try_recv().ok())
+        .filter_map(|event| match event {
+            AgentEvent::ContextCompressionStatus { status, .. } => Some(status),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert!(progress_statuses.iter().any(|status| status == "started"));
+    assert!(progress_statuses
+        .iter()
+        .any(|status| status.starts_with("map:")));
+    assert!(progress_statuses
+        .iter()
+        .any(|status| status.starts_with("final_reduce:")
+            || status.starts_with("intermediate_reduce:")));
+    assert!(progress_statuses.iter().any(|status| status == "completed"));
+
+    let requests = captured.lock().expect("bounded capture lock").clone();
+    assert!(
+        requests.len() >= 3,
+        "the much smaller summary model should force multiple bounded map/reduce stages"
+    );
+    let counter = TiktokenTokenCounter::default();
+    for request in &requests {
+        assert_eq!(request.model, "summary-model-763");
+        let input_tokens = counter.count_messages(&request.messages);
+        assert!(
+            input_tokens
+                .saturating_add(request.max_output_tokens)
+                .saturating_add(1_000)
+                <= 4_000,
+            "request exceeded auxiliary model 80% ceiling: input={input_tokens}, output={}",
+            request.max_output_tokens
+        );
+        assert!(request.max_output_tokens <= 2_000);
+    }
+
+    let rendered_requests = requests
+        .iter()
+        .flat_map(|request| request.messages.iter())
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered_requests.contains("ARCHIVE_SOURCE_763_0"));
+    assert!(!rendered_requests.contains("NEVER_COMPRESS_763"));
+    assert!(!rendered_requests.contains("LATEST_PROTECTED_763"));
+
+    let compressed_messages = session
+        .messages
+        .iter()
+        .filter(|message| message.compressed)
+        .collect::<Vec<_>>();
+    assert!(!compressed_messages.is_empty());
+    for message in compressed_messages {
+        assert!(
+            rendered_requests.contains(&message.id),
+            "archived message {} was not represented in a raw map request",
+            message.id
+        );
+    }
+    assert!(session
+        .messages
+        .iter()
+        .find(|message| message.id == never_compress_id)
+        .is_some_and(|message| !message.compressed));
+    for id in latest_user_ids {
+        assert!(
+            session
+                .messages
+                .iter()
+                .find(|message| message.id == id)
+                .is_some_and(|message| !message.compressed),
+            "newest protected user message must remain active"
+        );
+    }
+
+    let event = session
+        .compression_events
+        .last()
+        .expect("successful pass should persist an event");
+    assert!(event.summarization_map_calls > 1);
+    assert!(event.summarization_reduce_calls >= 1);
+    assert_eq!(event.model_used.as_deref(), Some("summary-model-763"));
+    assert_eq!(event.summary_target_ratio, 0.20);
+    assert!(event.target_summary_tokens > 0);
+    assert!(event.actual_summary_tokens > 0);
+    assert!(
+        session
+            .messages
+            .iter()
+            .filter(|message| message.compressed)
+            .all(|message| message.compressed_by_event_id.as_deref() == Some(event.id.as_str())),
+        "logical pass id should correlate requests, archive markers, and event"
+    );
+}
+
+#[tokio::test]
+async fn same_size_chat_and_summary_windows_still_split_near_critical_pressure() {
+    let mut session = bounded_compression_session("same-window-763");
+    let budget = session
+        .token_budget
+        .as_mut()
+        .expect("main token budget fixture");
+    budget.compression_target_percent = 25;
+    session.token_usage = Some(TokenBudgetUsage {
+        system_tokens: 100,
+        summary_tokens: 0,
+        window_tokens: 23_500,
+        total_tokens: 23_600,
+        max_context_tokens: 24_000,
+        budget_limit: 24_000,
+        truncation_occurred: true,
+        segments_removed: 0,
+        prompt_cached_tool_outputs: 0,
+        prompt_cached_tool_tokens_saved: 0,
+        thinking_tokens: 0,
+        cache_read_input_tokens: 0,
+    });
+    let (summary_llm, captured) =
+        bounded_compression_llm_with_limits(BoundedFailureMode::None, 24_000, 6_000);
+    let config = bounded_compression_config(summary_llm);
+    let main_llm = noop_llm();
+
+    let applied = maybe_apply_host_context_compression(
+        &mut session,
+        &config,
+        "main-model-763",
+        "same-window-763",
+        &[],
+        &main_llm,
+        None,
+        "pre-turn",
+    )
+    .await
+    .expect("same-window bounded compression");
+    assert!(applied);
+    let event = session
+        .compression_events
+        .last()
+        .expect("compression event");
+    assert!(
+        event.summarization_map_calls > 1,
+        "near-critical source must split even when both models advertise the same context size"
+    );
+
+    let requests = captured.lock().expect("capture lock");
+    let counter = TiktokenTokenCounter::default();
+    for request in requests.iter() {
+        assert!(
+            counter
+                .count_messages(&request.messages)
+                .saturating_add(request.max_output_tokens)
+                .saturating_add(1_000)
+                <= 19_200,
+            "same-window request exceeded the 80% ceiling"
+        );
+    }
+}
+
+async fn assert_failed_bounded_pass_is_atomic(
+    failure_mode: BoundedFailureMode,
+    expected_error: &str,
+) {
+    let mut session = bounded_compression_session("bounded-failure-763");
+    let before_archive = archive_state(&session);
+    let before_summary =
+        serde_json::to_value(&session.conversation_summary).expect("serialize summary");
+    let before_events =
+        serde_json::to_value(&session.compression_events).expect("serialize events");
+    let before_manual = session.force_manual_compression.clone();
+    let (summary_llm, captured) = bounded_compression_llm(failure_mode);
+    let config = bounded_compression_config(summary_llm);
+    let main_llm = noop_llm();
+
+    let error = maybe_apply_host_context_compression(
+        &mut session,
+        &config,
+        "main-model-763",
+        "bounded-failure-763",
+        &[],
+        &main_llm,
+        None,
+        "pre-turn",
+    )
+    .await
+    .expect_err("injected bounded stage failure must surface");
+    assert!(
+        error.to_string().contains(expected_error),
+        "unexpected error: {error}"
+    );
+    assert_eq!(archive_state(&session), before_archive);
+    assert_eq!(
+        serde_json::to_value(&session.conversation_summary).expect("serialize summary"),
+        before_summary
+    );
+    assert_eq!(
+        serde_json::to_value(&session.compression_events).expect("serialize events"),
+        before_events
+    );
+    assert_eq!(session.force_manual_compression, before_manual);
+    assert!(!captured.lock().expect("bounded capture lock").is_empty());
+}
+
+#[tokio::test]
+async fn failed_map_chunk_leaves_archive_summary_and_events_unchanged() {
+    assert_failed_bounded_pass_is_atomic(
+        BoundedFailureMode::Call(2),
+        "injected map failure on call 2",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn failed_reduce_leaves_archive_summary_and_events_unchanged() {
+    assert_failed_bounded_pass_is_atomic(BoundedFailureMode::Reduce, "injected reduce failure")
+        .await;
+}
+
+#[tokio::test]
+async fn partial_stream_leaves_archive_summary_and_events_unchanged() {
+    assert_failed_bounded_pass_is_atomic(
+        BoundedFailureMode::PartialWithoutDone(1),
+        "without terminal completion",
+    )
+    .await;
+}
+
 struct CompressionInstructionHook;
 
 #[async_trait::async_trait]
@@ -160,8 +624,8 @@ impl AgentHook for CompressionInstructionHook {
             HookPayload::Compression {
                 estimated_tokens,
                 usage_percent,
-                max_context_tokens: 1_200,
-                trigger_context_tokens: 960,
+                max_context_tokens: 5_000,
+                trigger_context_tokens: 4_000,
                 trigger,
                 phase,
             } if *estimated_tokens > 0
@@ -424,7 +888,7 @@ async fn prepare_round_context_applies_placeholder_fallback_only_to_prepared_con
 async fn prepare_round_context_auto_compresses_when_hard_limit_truncation_pressure_is_high() {
     let mut session = Session::new("session-cp-2", "test-model");
     session.token_budget = Some(TokenBudget::new(
-        360,
+        600,
         80,
         BudgetStrategy::Window { size: 50 },
     ));
@@ -445,7 +909,7 @@ async fn prepare_round_context_auto_compresses_when_hard_limit_truncation_pressu
         ..Default::default()
     };
 
-    let llm = noop_llm();
+    let (llm, _) = recording_llm();
     let prepared = prepare_round_context(
         &mut session,
         &config,
@@ -663,7 +1127,7 @@ async fn prepare_round_context_forces_compression_when_usage_crosses_ninety_eigh
         ..Default::default()
     };
 
-    let llm = noop_llm();
+    let (llm, _) = recording_llm();
     let prepared = prepare_round_context(
         &mut session,
         &config,
@@ -748,7 +1212,7 @@ async fn maybe_apply_host_context_compression_supports_mid_turn_phase() {
         background_model_name: Some("test-model".to_string()),
         ..Default::default()
     };
-    let llm = noop_llm();
+    let (llm, _) = recording_llm();
 
     let applied = maybe_apply_host_context_compression(
         &mut session,
@@ -794,7 +1258,7 @@ async fn mid_turn_host_context_compression_includes_unified_context_blocks_in_su
         "## External Memory (Persistent)\n\nSession memory note".to_string(),
     );
     session.token_budget = Some(TokenBudget {
-        max_context_tokens: 1200,
+        max_context_tokens: 5000,
         max_output_tokens: 200,
         strategy: BudgetStrategy::Hybrid {
             window_size: 20,
@@ -836,10 +1300,10 @@ async fn mid_turn_host_context_compression_includes_unified_context_blocks_in_su
     session.token_usage = Some(TokenBudgetUsage {
         system_tokens: 100,
         summary_tokens: 0,
-        window_tokens: 850,
-        total_tokens: 950,
-        max_context_tokens: 1200,
-        budget_limit: 1000,
+        window_tokens: 4_100,
+        total_tokens: 4_200,
+        max_context_tokens: 5000,
+        budget_limit: 5000,
         truncation_occurred: true,
         segments_removed: 8,
         prompt_cached_tool_outputs: 0,
@@ -904,7 +1368,7 @@ async fn pre_turn_host_context_compression_includes_available_context_blocks_in_
     let mut session = Session::new("session-cp-pre-turn-context-blocks", "test-model");
     activate_plan_mode(&mut session);
     session.token_budget = Some(TokenBudget {
-        max_context_tokens: 1200,
+        max_context_tokens: 5000,
         max_output_tokens: 200,
         strategy: BudgetStrategy::Hybrid {
             window_size: 20,
@@ -945,10 +1409,10 @@ async fn pre_turn_host_context_compression_includes_available_context_blocks_in_
     session.token_usage = Some(TokenBudgetUsage {
         system_tokens: 100,
         summary_tokens: 0,
-        window_tokens: 900,
-        total_tokens: 1000,
-        max_context_tokens: 1200,
-        budget_limit: 1200,
+        window_tokens: 4_100,
+        total_tokens: 4_200,
+        max_context_tokens: 5000,
+        budget_limit: 5000,
         truncation_occurred: true,
         segments_removed: 8,
         prompt_cached_tool_outputs: 0,
@@ -1061,7 +1525,7 @@ async fn prepare_round_context_auto_compresses_when_context_window_usage_crosses
         ..Default::default()
     };
 
-    let llm = noop_llm();
+    let (llm, _) = recording_llm();
     let _prepared = prepare_round_context(
         &mut session,
         &config,
@@ -1219,7 +1683,7 @@ async fn force_overflow_context_recovery_can_bypass_regular_trigger_gate() {
         background_model_name: Some("test-model".to_string()),
         ..Default::default()
     };
-    let llm = noop_llm();
+    let (llm, _) = recording_llm();
 
     let applied = super::force_overflow_context_recovery(
         &mut session,

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/context_preparation/tests.rs
@@ -644,7 +644,7 @@ impl AgentHook for CompressionInstructionHook {
 }
 
 #[tokio::test]
-async fn maybe_apply_host_context_compression_uses_fast_model_for_summary_request() {
+async fn maybe_apply_host_context_compression_uses_fast_model_for_every_summary_stage() {
     let mut session = Session::new("session-cp-fast-model", "main-model");
     session.token_budget = Some(TokenBudget {
         max_context_tokens: 1200,
@@ -721,7 +721,11 @@ async fn maybe_apply_host_context_compression_uses_fast_model_for_summary_reques
     let models = models
         .lock()
         .expect("recorded model list lock should not be poisoned");
-    assert_eq!(models.as_slice(), ["fast-model"]);
+    assert_eq!(
+        models.as_slice(),
+        ["fast-model", "fast-model"],
+        "even a small compression candidate must route both map and reduce through the selected background model"
+    );
 }
 
 #[tokio::test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/token_budget.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/token_budget.rs
@@ -3,10 +3,19 @@ use bamboo_agent_core::Session;
 use bamboo_compression::limits::{load_model_limits_from_unified_config, ModelLimit};
 use bamboo_compression::{ModelLimitsRegistry, TokenBudget};
 use bamboo_llm::provider::LLMProvider;
+use std::path::{Path, PathBuf};
 
 const CONSERVATIVE_SUMMARIZER_CONTEXT_TOKENS: u32 = 32_000;
 const CONSERVATIVE_SUMMARIZER_OUTPUT_TOKENS: u32 = 8_000;
 const CONSERVATIVE_SUMMARIZER_SAFETY_MARGIN: u32 = 1_000;
+
+fn model_limits_path(config: &AgentLoopConfig) -> PathBuf {
+    let data_dir = config
+        .app_data_dir
+        .clone()
+        .unwrap_or_else(bamboo_config::paths::bamboo_dir);
+    bamboo_compression::limits::get_default_config_path(&data_dir)
+}
 
 /// Resolve the budget for an auxiliary model/provider pair without touching the
 /// chat model's session cache. Compression can route to a completely different
@@ -16,52 +25,41 @@ pub(super) async fn resolve_auxiliary_token_budget(
     model_name: &str,
     llm: &dyn LLMProvider,
 ) -> TokenBudget {
-    let mut registry = ModelLimitsRegistry::with_config_path(
-        bamboo_compression::limits::get_default_config_path(&bamboo_config::paths::bamboo_dir()),
-    );
+    let model_limits_path = model_limits_path(config);
 
-    let provider_limit = match llm.list_model_info().await {
-        Ok(models) => models
-            .into_iter()
-            .find(|entry| entry.id == model_name)
-            .and_then(|model_info| {
-                model_info.max_context_tokens.map(|max_context_tokens| {
-                    let mut limit = ModelLimit::new(model_name.to_string(), max_context_tokens);
-                    limit.max_output_tokens = model_info.max_output_tokens;
-                    limit
-                })
-            }),
-        Err(error) => {
-            tracing::warn!(
-                model = model_name,
-                error = %error,
-                "Failed to resolve summarization-model runtime limits; checking configured overrides"
-            );
-            None
+    let configured_limit =
+        resolve_configured_model_limit(config, model_name, &model_limits_path, "summarization")
+            .await;
+    let provider_limit = if configured_limit.is_some() {
+        None
+    } else {
+        match llm.list_model_info().await {
+            Ok(models) => models
+                .into_iter()
+                .find(|entry| entry.id == model_name)
+                .and_then(|model_info| {
+                    model_info.max_context_tokens.map(|max_context_tokens| {
+                        let mut limit = ModelLimit::new(model_name.to_string(), max_context_tokens);
+                        limit.max_output_tokens = model_info.max_output_tokens;
+                        limit
+                    })
+                }),
+            Err(error) => {
+                tracing::warn!(
+                    model = model_name,
+                    error = %error,
+                    "Failed to resolve summarization-model runtime limits"
+                );
+                None
+            }
         }
     };
 
-    // Legacy config is lower priority than the dedicated model_limits.json
-    // file, but still needs to participate when that file is absent. Apply it
-    // before loading the dedicated file so the latter can overwrite exact
-    // patterns deterministically.
-    apply_legacy_model_limits(&mut registry, config.legacy_model_limits.as_ref());
-
-    match registry.load_user_config().await {
-        Ok(()) => {}
-        Err(error) => {
-            tracing::warn!(
-                model = model_name,
-                error = %error,
-                "Failed to load model_limits.json for summarization; using provider/legacy limits"
-            );
-        }
-    }
-
     // Explicit user overrides (including partial patterns) outrank exact
-    // provider metadata. Keeping provider metadata out of the override registry
-    // avoids an exact provider entry accidentally shadowing a user pattern.
-    let model_limit = match registry.get(model_name).or(provider_limit) {
+    // provider metadata. Keeping every source in its own registry avoids an
+    // exact provider or legacy entry accidentally shadowing a higher-priority
+    // user pattern.
+    let model_limit = match configured_limit.or(provider_limit) {
         Some(limit) => limit,
         None => {
             tracing::warn!(
@@ -94,8 +92,26 @@ pub(super) async fn resolve_token_budget(
     model_name: &str,
     llm: &dyn LLMProvider,
 ) -> TokenBudget {
-    // Priority: session/child override > config override > per-process cache >
-    // freshly-resolved model defaults.
+    let model_limits_path = model_limits_path(config);
+    resolve_token_budget_with_model_limits_path(
+        session,
+        config,
+        model_name,
+        llm,
+        &model_limits_path,
+    )
+    .await
+}
+
+async fn resolve_token_budget_with_model_limits_path(
+    session: &mut Session,
+    config: &AgentLoopConfig,
+    model_name: &str,
+    llm: &dyn LLMProvider,
+    model_limits_path: &Path,
+) -> TokenBudget {
+    // Priority: session/child override > config override > freshly-resolved
+    // model defaults.
     if let Some(ref budget) = session.token_budget {
         tracing::debug!("Using session-specific token budget");
         return budget.clone();
@@ -106,56 +122,19 @@ pub(super) async fn resolve_token_budget(
         return budget.clone();
     }
 
-    // Per-process cache of a previous resolution, reused only when it was
-    // resolved for the SAME model. It is never persisted (`#[serde(skip)]`), so a
-    // reloaded session falls through and re-resolves from the current
-    // `model_limits.json`; a mid-session model switch also falls through because
-    // the cached model key no longer matches. (#180)
-    if let Some((cached_model, budget)) = session.resolved_token_budget.as_ref() {
-        if cached_model.as_str() == model_name {
-            tracing::debug!("Using cached resolved token budget for '{model_name}'");
-            return budget.clone();
-        }
-    }
-
-    // Default to model limits:
-    // 1. built-in defaults
-    // 2. provider runtime metadata (copilot only)
-    // 3. dedicated config file: model_limits.json
-    // 4. legacy fallback: config.json -> model_limits
-    let mut registry = ModelLimitsRegistry::with_config_path(
-        bamboo_compression::limits::get_default_config_path(&bamboo_config::paths::bamboo_dir()),
-    );
-
-    if let Some(provider_limit) = resolve_provider_runtime_limit(config, llm, model_name).await {
-        registry.add_limit(provider_limit);
-    }
-
-    let loaded_from_file = match registry.load_user_config().await {
-        Ok(()) => true,
-        Err(error) => {
-            tracing::warn!(
-                "Failed to load model limits from {:?}: {}. Falling back to legacy config.json key.",
-                bamboo_compression::limits::get_default_config_path(&bamboo_config::paths::bamboo_dir()),
-                error
-            );
-            false
-        }
-    };
-
-    if !loaded_from_file {
-        // Legacy fallback: parse the config.json `model_limits` key. The value is
-        // snapshotted from the live in-memory config at loop-config build time
-        // (config.legacy_model_limits) — NOT re-read from disk via Config::new(),
-        // which would diverge from the server's live config and clobber the global
-        // env-var cache (#38). Pure JSON parse, so no spawn_blocking needed.
-        apply_legacy_model_limits(&mut registry, config.legacy_model_limits.as_ref());
-    }
-
-    let matched_limit = registry.get(model_name);
+    // Resolve each source independently so an exact lower-priority provider
+    // record cannot shadow a higher-priority partial user pattern:
+    // 1. dedicated model_limits.json
+    // 2. legacy config.json -> model_limits
+    // 3. provider runtime metadata (Copilot)
+    // 4. global fallback
+    let configured_limit =
+        resolve_configured_model_limit(config, model_name, model_limits_path, "chat").await;
+    let provider_limit = resolve_provider_runtime_limit(config, llm, model_name).await;
+    let matched_limit = configured_limit.or(provider_limit);
     let model_limit = matched_limit
         .clone()
-        .unwrap_or_else(|| registry.get_or_default(model_name));
+        .unwrap_or_else(|| ModelLimitsRegistry::new().get_or_default(model_name));
 
     if matched_limit.is_some() {
         tracing::debug!(
@@ -171,7 +150,7 @@ pub(super) async fn resolve_token_budget(
             model_name,
             model_limit.model_pattern,
             model_limit.max_context_tokens,
-            bamboo_compression::limits::get_default_config_path(&bamboo_config::paths::bamboo_dir())
+            model_limits_path
         );
     }
 
@@ -182,17 +161,51 @@ pub(super) async fn resolve_token_budget(
         model_limit.get_safety_margin(),
     );
 
-    // Cache the resolved budget on the session (keyed by model) so every
-    // downstream reader — `build_context_pressure` (tool-output truncation), the
-    // server context bar, `estimate_context_compression_exposure` — sees the
-    // real, model-limit-derived budget via `Session::effective_token_budget`
-    // instead of `None` (issue #20 bug 1). Unlike the persisted `token_budget`
-    // override, this cache is `#[serde(skip)]`: a reloaded session re-resolves
-    // (picking up a `model_limits.json` edit) and a mid-session model switch
-    // invalidates it. (#180)
+    // Publish the freshly resolved budget on the session so every downstream
+    // reader in this round — `build_context_pressure` (tool-output truncation),
+    // the server context bar, `estimate_context_compression_exposure` — sees the
+    // same limits via `Session::effective_token_budget` instead of `None`
+    // (issue #20 bug 1). This runtime snapshot is never used to skip resolution:
+    // every new round re-reads `model_limits.json` and refreshes provider
+    // metadata, so an edit takes effect in an already-running session.
     session.resolved_token_budget = Some((model_name.to_string(), resolved.clone()));
 
     resolved
+}
+
+/// Resolve user-configured limits without mixing source precedence into a
+/// single registry.
+///
+/// The dedicated revisioned sidecar is the authoritative first layer. A
+/// legacy flattened config entry is still checked per model when the sidecar
+/// has no matching pattern, which supports gradual migration without allowing
+/// an exact provider metadata record to shadow a user family pattern.
+async fn resolve_configured_model_limit(
+    config: &AgentLoopConfig,
+    model_name: &str,
+    model_limits_path: &Path,
+    purpose: &str,
+) -> Option<ModelLimit> {
+    let mut dedicated_registry = ModelLimitsRegistry::with_config_path(model_limits_path);
+    if let Err(error) = dedicated_registry.load_user_config().await {
+        tracing::warn!(
+            model = model_name,
+            purpose,
+            error = %error,
+            path = ?model_limits_path,
+            "Failed to load model_limits.json; checking legacy configured limits"
+        );
+    } else if let Some(limit) = dedicated_registry.get(model_name) {
+        return Some(limit);
+    }
+
+    // The legacy value is snapshotted from the live in-memory config at
+    // loop-config build time. Do not re-read Config::new() here: that would
+    // diverge from the server's live config and clobber the global env cache
+    // (#38).
+    let mut legacy_registry = ModelLimitsRegistry::new();
+    apply_legacy_model_limits(&mut legacy_registry, config.legacy_model_limits.as_ref());
+    legacy_registry.get(model_name)
 }
 
 /// Apply the legacy `config.json` `model_limits` value (snapshotted from the
@@ -259,6 +272,7 @@ async fn resolve_provider_runtime_limit(
 #[cfg(test)]
 mod tests {
     use std::pin::Pin;
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     use async_trait::async_trait;
     use futures::{stream, Stream};
@@ -295,14 +309,14 @@ mod tests {
         assert!(registry.get("legacy-model").is_none());
     }
 
-    // Issue #20 bug 1: `resolve_token_budget` must cache the resolved budget so
+    // Issue #20 bug 1: `resolve_token_budget` must publish the resolved budget so
     // every downstream reader (build_context_pressure, the server context bar,
     // estimate_context_compression_exposure) observes it via
-    // `effective_token_budget` instead of `None`. Per #180 the cache lives in the
+    // `effective_token_budget` instead of `None`. Per #180 the snapshot lives in the
     // non-persisted `resolved_token_budget` slot (keyed by model), NOT the
     // persisted `token_budget` override slot.
     #[tokio::test]
-    async fn resolve_token_budget_caches_resolved_budget_on_session() {
+    async fn resolve_token_budget_publishes_resolved_budget_on_session() {
         let mut session = bamboo_agent_core::Session::new("budget-cache", "some-model");
         assert!(
             session.effective_token_budget().is_none(),
@@ -314,16 +328,16 @@ mod tests {
 
         let resolved = resolve_token_budget(&mut session, &config, "some-model", &provider).await;
 
-        // The persisted override slot stays empty; the cache holds the resolved
+        // The persisted override slot stays empty; the snapshot holds the resolved
         // budget keyed by model, and effective_token_budget surfaces it.
         assert!(
             session.token_budget.is_none(),
-            "the resolved cache must NOT populate the persisted override slot (#180)"
+            "the resolved snapshot must NOT populate the persisted override slot (#180)"
         );
         let (cached_model, cached) = session
             .resolved_token_budget
             .clone()
-            .expect("resolved budget must be cached on the session (#20 bug 1)");
+            .expect("resolved budget must be published on the session (#20 bug 1)");
         assert_eq!(cached_model, "some-model");
         assert_eq!(cached.max_context_tokens, resolved.max_context_tokens);
         assert_eq!(cached.max_output_tokens, resolved.max_output_tokens);
@@ -334,8 +348,8 @@ mod tests {
         );
     }
 
-    // #180: the resolved cache is `#[serde(skip)]`, so it never persists. A
-    // reloaded long-lived session therefore starts with no cache and re-resolves
+    // #180: the resolved snapshot is `#[serde(skip)]`, so it never persists. A
+    // reloaded long-lived session therefore starts with no snapshot and re-resolves
     // from the current `model_limits.json` — the exact staleness #180 fixes.
     #[tokio::test]
     async fn resolved_token_budget_is_not_persisted() {
@@ -343,24 +357,25 @@ mod tests {
         let config = AgentLoopConfig::default();
         let provider = MetadataProvider::default();
         let _ = resolve_token_budget(&mut session, &config, "some-model", &provider).await;
-        assert!(session.resolved_token_budget.is_some(), "cache populated");
+        assert!(
+            session.resolved_token_budget.is_some(),
+            "runtime snapshot populated"
+        );
 
         let json = serde_json::to_string(&session).expect("serialize");
         assert!(
             !json.contains("resolved_token_budget"),
-            "the resolved cache must not be serialized (#180)"
+            "the resolved snapshot must not be serialized (#180)"
         );
         let reloaded: bamboo_agent_core::Session =
             serde_json::from_str(&json).expect("deserialize");
         assert!(
             reloaded.resolved_token_budget.is_none(),
-            "a reloaded session must have no cached budget, so it re-resolves (#180)"
+            "a reloaded session must have no resolved snapshot, so it re-resolves (#180)"
         );
     }
 
-    // #180: a mid-session model switch invalidates the cache (keyed by model), so
-    // the budget is re-resolved for the new model instead of reusing the first
-    // model's cached budget.
+    // #180: a mid-session model switch updates the keyed runtime snapshot.
     #[tokio::test]
     async fn resolve_token_budget_reresolves_on_model_switch() {
         let mut session = bamboo_agent_core::Session::new("budget-switch", "model-a");
@@ -370,8 +385,7 @@ mod tests {
         let _ = resolve_token_budget(&mut session, &config, "model-a", &provider).await;
         assert_eq!(session.resolved_token_budget.as_ref().unwrap().0, "model-a");
 
-        // Switch the model: the cache key no longer matches, so it re-resolves and
-        // re-keys instead of short-circuiting on "model-a".
+        // Switch the model: resolution refreshes and re-keys the snapshot.
         let _ = resolve_token_budget(&mut session, &config, "model-b", &provider).await;
         assert_eq!(
             session.resolved_token_budget.as_ref().unwrap().0,
@@ -427,6 +441,254 @@ mod tests {
         async fn list_model_info(&self) -> Result<Vec<ProviderModelInfo>> {
             Ok(self.models.clone())
         }
+    }
+
+    struct MutableMetadataProvider {
+        max_context_tokens: AtomicU32,
+        max_output_tokens: AtomicU32,
+    }
+
+    #[async_trait]
+    impl LLMProvider for MutableMetadataProvider {
+        async fn chat_stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _max_output_tokens: Option<u32>,
+            _model: &str,
+        ) -> Result<Pin<Box<dyn Stream<Item = Result<LLMChunk>> + Send>>> {
+            Ok(Box::pin(stream::empty()))
+        }
+
+        async fn list_model_info(&self) -> Result<Vec<ProviderModelInfo>> {
+            Ok(vec![ProviderModelInfo {
+                id: "dynamic-model-limit-763".to_string(),
+                max_context_tokens: Some(self.max_context_tokens.load(Ordering::SeqCst)),
+                max_output_tokens: Some(self.max_output_tokens.load(Ordering::SeqCst)),
+            }])
+        }
+    }
+
+    #[tokio::test]
+    async fn same_model_limit_is_refreshed_each_round_without_session_reload() {
+        let mut session =
+            bamboo_agent_core::Session::new("dynamic-limit", "dynamic-model-limit-763");
+        let config = AgentLoopConfig {
+            provider_type: Some("copilot".to_string()),
+            ..Default::default()
+        };
+        let provider = MutableMetadataProvider {
+            max_context_tokens: AtomicU32::new(64_000),
+            max_output_tokens: AtomicU32::new(8_000),
+        };
+
+        let first =
+            resolve_token_budget(&mut session, &config, "dynamic-model-limit-763", &provider).await;
+        assert_eq!(first.max_context_tokens, 64_000);
+        assert_eq!(first.max_output_tokens, 8_000);
+
+        provider.max_context_tokens.store(96_000, Ordering::SeqCst);
+        provider.max_output_tokens.store(12_000, Ordering::SeqCst);
+        let refreshed =
+            resolve_token_budget(&mut session, &config, "dynamic-model-limit-763", &provider).await;
+
+        assert_eq!(refreshed.max_context_tokens, 96_000);
+        assert_eq!(refreshed.max_output_tokens, 12_000);
+        assert_eq!(
+            session
+                .resolved_token_budget
+                .as_ref()
+                .expect("latest runtime snapshot")
+                .1
+                .max_context_tokens,
+            96_000
+        );
+    }
+
+    #[tokio::test]
+    async fn revisioned_model_limit_edit_refreshes_same_running_session() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("model_limits.json");
+        let write_limit = |revision: u64, context: u32, output: u32| {
+            let path = path.clone();
+            async move {
+                tokio::fs::write(
+                    path,
+                    serde_json::to_vec_pretty(&serde_json::json!({
+                        "schema_version": 1,
+                        "revision": revision,
+                        "data": [{
+                            "model_pattern": "live-sidecar-model-763",
+                            "max_context_tokens": context,
+                            "max_output_tokens": output,
+                            "safety_margin": 500
+                        }]
+                    }))
+                    .expect("serialize model-limit envelope"),
+                )
+                .await
+                .expect("write model-limit envelope");
+            }
+        };
+        write_limit(1, 64_000, 8_000).await;
+
+        let mut session = bamboo_agent_core::Session::new("live-sidecar", "live-sidecar-model-763");
+        let config = AgentLoopConfig::default();
+        let provider = MetadataProvider::default();
+        let first = resolve_token_budget_with_model_limits_path(
+            &mut session,
+            &config,
+            "live-sidecar-model-763",
+            &provider,
+            &path,
+        )
+        .await;
+        assert_eq!(first.max_context_tokens, 64_000);
+        assert_eq!(first.max_output_tokens, 8_000);
+
+        write_limit(2, 96_000, 12_000).await;
+        let refreshed = resolve_token_budget_with_model_limits_path(
+            &mut session,
+            &config,
+            "live-sidecar-model-763",
+            &provider,
+            &path,
+        )
+        .await;
+
+        assert_eq!(refreshed.max_context_tokens, 96_000);
+        assert_eq!(refreshed.max_output_tokens, 12_000);
+        assert_eq!(
+            session
+                .resolved_token_budget
+                .as_ref()
+                .expect("latest runtime snapshot")
+                .1
+                .max_context_tokens,
+            96_000
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_reads_model_limits_from_the_instance_app_data_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("model_limits.json");
+        tokio::fs::write(
+            &path,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "schema_version": 1,
+                "revision": 1,
+                "data": [{
+                    "model_pattern": "instance-data-dir-model-763",
+                    "max_context_tokens": 72_000,
+                    "max_output_tokens": 9_000,
+                    "safety_margin": 600
+                }]
+            }))
+            .expect("serialize instance model limits"),
+        )
+        .await
+        .expect("write instance model limits");
+
+        let config = AgentLoopConfig {
+            app_data_dir: Some(dir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let provider = MetadataProvider::default();
+        let mut session =
+            bamboo_agent_core::Session::new("instance-data-dir", "instance-data-dir-model-763");
+
+        let budget = resolve_token_budget(
+            &mut session,
+            &config,
+            "instance-data-dir-model-763",
+            &provider,
+        )
+        .await;
+
+        assert_eq!(budget.max_context_tokens, 72_000);
+        assert_eq!(budget.max_output_tokens, 9_000);
+        assert_eq!(budget.safety_margin, 600);
+    }
+
+    #[tokio::test]
+    async fn dedicated_partial_pattern_outranks_exact_provider_metadata() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("model_limits.json");
+        tokio::fs::write(
+            &path,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "schema_version": 1,
+                "revision": 7,
+                "data": [{
+                    "model_pattern": "configured-family-763",
+                    "max_context_tokens": 48_000,
+                    "max_output_tokens": 6_000,
+                    "safety_margin": 500
+                }]
+            }))
+            .expect("serialize model-limit envelope"),
+        )
+        .await
+        .expect("write model-limit envelope");
+
+        let mut session =
+            bamboo_agent_core::Session::new("configured-over-provider", "configured-family-763-v2");
+        let config = AgentLoopConfig {
+            provider_type: Some("copilot".to_string()),
+            ..Default::default()
+        };
+        let provider = MetadataProvider {
+            models: vec![ProviderModelInfo {
+                id: "configured-family-763-v2".to_string(),
+                max_context_tokens: Some(128_000),
+                max_output_tokens: Some(16_000),
+            }],
+        };
+
+        let budget = resolve_token_budget_with_model_limits_path(
+            &mut session,
+            &config,
+            "configured-family-763-v2",
+            &provider,
+            &path,
+        )
+        .await;
+
+        assert_eq!(budget.max_context_tokens, 48_000);
+        assert_eq!(budget.max_output_tokens, 6_000);
+        assert_eq!(budget.safety_margin, 500);
+    }
+
+    #[tokio::test]
+    async fn legacy_limit_is_used_when_dedicated_sidecar_has_no_match() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing_path = dir.path().join("model_limits.json");
+        let model = "legacy-chat-model-763";
+        let config = AgentLoopConfig {
+            legacy_model_limits: Some(serde_json::json!([{
+                "model_pattern": model,
+                "max_context_tokens": 24_000,
+                "max_output_tokens": 4_000,
+                "safety_margin": 400
+            }])),
+            ..Default::default()
+        };
+        let provider = MetadataProvider::default();
+        let mut session = bamboo_agent_core::Session::new("legacy-chat-limit", model);
+
+        let budget = resolve_token_budget_with_model_limits_path(
+            &mut session,
+            &config,
+            model,
+            &provider,
+            &missing_path,
+        )
+        .await;
+
+        assert_eq!(budget.max_context_tokens, 24_000);
+        assert_eq!(budget.max_output_tokens, 4_000);
+        assert_eq!(budget.safety_margin, 400);
     }
 
     #[tokio::test]

--- a/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/token_budget.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/round_lifecycle/token_budget.rs
@@ -4,6 +4,90 @@ use bamboo_compression::limits::{load_model_limits_from_unified_config, ModelLim
 use bamboo_compression::{ModelLimitsRegistry, TokenBudget};
 use bamboo_llm::provider::LLMProvider;
 
+const CONSERVATIVE_SUMMARIZER_CONTEXT_TOKENS: u32 = 32_000;
+const CONSERVATIVE_SUMMARIZER_OUTPUT_TOKENS: u32 = 8_000;
+const CONSERVATIVE_SUMMARIZER_SAFETY_MARGIN: u32 = 1_000;
+
+/// Resolve the budget for an auxiliary model/provider pair without touching the
+/// chat model's session cache. Compression can route to a completely different
+/// provider and must therefore never inherit the triggering model's limits.
+pub(super) async fn resolve_auxiliary_token_budget(
+    config: &AgentLoopConfig,
+    model_name: &str,
+    llm: &dyn LLMProvider,
+) -> TokenBudget {
+    let mut registry = ModelLimitsRegistry::with_config_path(
+        bamboo_compression::limits::get_default_config_path(&bamboo_config::paths::bamboo_dir()),
+    );
+
+    let provider_limit = match llm.list_model_info().await {
+        Ok(models) => models
+            .into_iter()
+            .find(|entry| entry.id == model_name)
+            .and_then(|model_info| {
+                model_info.max_context_tokens.map(|max_context_tokens| {
+                    let mut limit = ModelLimit::new(model_name.to_string(), max_context_tokens);
+                    limit.max_output_tokens = model_info.max_output_tokens;
+                    limit
+                })
+            }),
+        Err(error) => {
+            tracing::warn!(
+                model = model_name,
+                error = %error,
+                "Failed to resolve summarization-model runtime limits; checking configured overrides"
+            );
+            None
+        }
+    };
+
+    // Legacy config is lower priority than the dedicated model_limits.json
+    // file, but still needs to participate when that file is absent. Apply it
+    // before loading the dedicated file so the latter can overwrite exact
+    // patterns deterministically.
+    apply_legacy_model_limits(&mut registry, config.legacy_model_limits.as_ref());
+
+    match registry.load_user_config().await {
+        Ok(()) => {}
+        Err(error) => {
+            tracing::warn!(
+                model = model_name,
+                error = %error,
+                "Failed to load model_limits.json for summarization; using provider/legacy limits"
+            );
+        }
+    }
+
+    // Explicit user overrides (including partial patterns) outrank exact
+    // provider metadata. Keeping provider metadata out of the override registry
+    // avoids an exact provider entry accidentally shadowing a user pattern.
+    let model_limit = match registry.get(model_name).or(provider_limit) {
+        Some(limit) => limit,
+        None => {
+            tracing::warn!(
+                model = model_name,
+                context_tokens = CONSERVATIVE_SUMMARIZER_CONTEXT_TOKENS,
+                output_tokens = CONSERVATIVE_SUMMARIZER_OUTPUT_TOKENS,
+                "No summarization-model limit is known; using conservative bounded fallback"
+            );
+            let mut fallback = ModelLimit::new(
+                model_name.to_string(),
+                CONSERVATIVE_SUMMARIZER_CONTEXT_TOKENS,
+            );
+            fallback.max_output_tokens = Some(CONSERVATIVE_SUMMARIZER_OUTPUT_TOKENS);
+            fallback.safety_margin = Some(CONSERVATIVE_SUMMARIZER_SAFETY_MARGIN);
+            fallback
+        }
+    };
+
+    TokenBudget::with_safety_margin(
+        model_limit.max_context_tokens,
+        model_limit.get_max_output_tokens(),
+        bamboo_compression::BudgetStrategy::default(),
+        model_limit.get_safety_margin(),
+    )
+}
+
 pub(super) async fn resolve_token_budget(
     session: &mut Session,
     config: &AgentLoopConfig,
@@ -434,5 +518,97 @@ mod tests {
         let limit =
             resolve_provider_runtime_limit(&config, &FailingProvider, "gpt-5.3-codex").await;
         assert!(limit.is_none());
+    }
+
+    #[tokio::test]
+    async fn auxiliary_budget_uses_exact_selected_provider_model_metadata() {
+        let config = AgentLoopConfig {
+            provider_type: Some("openai".to_string()),
+            ..Default::default()
+        };
+        let provider = MetadataProvider {
+            models: vec![ProviderModelInfo {
+                id: "summary-model-763".to_string(),
+                max_context_tokens: Some(32_000),
+                max_output_tokens: Some(6_000),
+            }],
+        };
+
+        let budget = resolve_auxiliary_token_budget(&config, "summary-model-763", &provider).await;
+        assert_eq!(budget.max_context_tokens, 32_000);
+        assert_eq!(budget.max_output_tokens, 6_000);
+        assert_eq!(budget.safety_margin, 1_000);
+    }
+
+    #[tokio::test]
+    async fn auxiliary_budget_honors_legacy_model_limit_when_dedicated_file_is_absent() {
+        let model = "legacy-summary-model-763-no-user-file-collision";
+        let config = AgentLoopConfig {
+            legacy_model_limits: Some(serde_json::json!([
+                {
+                    "model_pattern": model,
+                    "max_context_tokens": 12_345,
+                    "max_output_tokens": 2_345,
+                    "safety_margin": 345
+                }
+            ])),
+            ..Default::default()
+        };
+        let provider = MetadataProvider::default();
+
+        let budget = resolve_auxiliary_token_budget(&config, model, &provider).await;
+        assert_eq!(budget.max_context_tokens, 12_345);
+        assert_eq!(budget.max_output_tokens, 2_345);
+        assert_eq!(budget.safety_margin, 345);
+    }
+
+    #[tokio::test]
+    async fn auxiliary_user_pattern_override_outranks_exact_provider_metadata() {
+        let config = AgentLoopConfig {
+            legacy_model_limits: Some(serde_json::json!([
+                {
+                    "model_pattern": "summary-family-763",
+                    "max_context_tokens": 16_000,
+                    "max_output_tokens": 3_000,
+                    "safety_margin": 500
+                }
+            ])),
+            ..Default::default()
+        };
+        let provider = MetadataProvider {
+            models: vec![ProviderModelInfo {
+                id: "summary-family-763-latest".to_string(),
+                max_context_tokens: Some(64_000),
+                max_output_tokens: Some(8_000),
+            }],
+        };
+
+        let budget =
+            resolve_auxiliary_token_budget(&config, "summary-family-763-latest", &provider).await;
+        assert_eq!(budget.max_context_tokens, 16_000);
+        assert_eq!(budget.max_output_tokens, 3_000);
+        assert_eq!(budget.safety_margin, 500);
+    }
+
+    #[tokio::test]
+    async fn auxiliary_budget_uses_conservative_fallback_when_limit_is_unknown() {
+        let config = AgentLoopConfig::default();
+        let provider = MetadataProvider::default();
+
+        let budget = resolve_auxiliary_token_budget(
+            &config,
+            "definitely-unknown-summary-model-763",
+            &provider,
+        )
+        .await;
+        assert_eq!(
+            budget.max_context_tokens,
+            CONSERVATIVE_SUMMARIZER_CONTEXT_TOKENS
+        );
+        assert_eq!(
+            budget.max_output_tokens,
+            CONSERVATIVE_SUMMARIZER_OUTPUT_TOKENS
+        );
+        assert_eq!(budget.safety_margin, CONSERVATIVE_SUMMARIZER_SAFETY_MARGIN);
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runtime.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runtime.rs
@@ -751,6 +751,16 @@ impl AgentRuntime {
                 .and_then(|d| d.search.as_ref().or(d.fast.as_ref()))
                 .map(|r| r.model.clone()),
             compression_instructions: None,
+            summary_target_ratio: config
+                .memory()
+                .as_ref()
+                .map(|memory| memory.summary_target_ratio)
+                .unwrap_or(0.20),
+            summary_safe_window_percent: config
+                .memory()
+                .as_ref()
+                .map(|memory| memory.summary_safe_window_percent)
+                .unwrap_or(80),
             summarization_model_name: summarization_model
                 .or_else(|| config.get_task_summary_model()),
             background_model_provider,

--- a/crates/infra/bamboo-compression/src/compression_tooling.rs
+++ b/crates/infra/bamboo-compression/src/compression_tooling.rs
@@ -564,7 +564,8 @@ pub fn estimate_context_compression_exposure(
     configured_budget: Option<&TokenBudget>,
 ) -> ContextCompressionExposure {
     // When a budget was already resolved upstream (the production path — see
-    // `resolve_token_budget`, which caches it in `session.resolved_token_budget` (#180),
+    // `resolve_token_budget`, which publishes the current-round snapshot in
+    // `session.resolved_token_budget` (#180),
     // issue #20 bug 1), use it directly. Only when none is available do we fall
     // back to a model-derived budget. No `model_limits.json` registry is in
     // scope synchronously here, so this fallback resolves to the global default
@@ -1183,8 +1184,9 @@ pub fn apply_compression_plan(session: &mut Session, plan: CompressionPlan) -> u
     // Instead of clearing token_usage entirely (which forces the next round
     // to rely on heuristic estimates that don't account for tool schema
     // tokens), recompute an approximate post-compression snapshot.  We
-    // preserve the context-window denominator from the previous usage snapshot
-    // so percentages stay consistent across rounds.
+    // preserve both the total context-window denominator and the request input
+    // limit from the previous usage snapshot so their meanings stay distinct
+    // across rounds.
     let counter = TiktokenTokenCounter::default();
     let remaining_active: Vec<_> = session
         .messages
@@ -1214,10 +1216,12 @@ pub fn apply_compression_plan(session: &mut Session, plan: CompressionPlan) -> u
     let budget_limit = previous_usage
         .as_ref()
         .map(|u| {
-            if u.max_context_tokens > 0 {
-                u.max_context_tokens
-            } else {
+            if u.budget_limit > 0 {
                 u.budget_limit
+            } else {
+                // Legacy snapshots used the total context window as the only
+                // denominator.
+                u.max_context_tokens
             }
         })
         .unwrap_or(0);

--- a/crates/infra/bamboo-compression/src/compression_tooling.rs
+++ b/crates/infra/bamboo-compression/src/compression_tooling.rs
@@ -81,6 +81,20 @@ pub enum CompressionPlanError {
         anchor_index: usize,
         non_system_count: usize,
     },
+    /// Eligible history was exhausted while protected/recent content still kept
+    /// the active prompt above the configured post-compression target.
+    ProtectedContentExceedsTarget {
+        projected_tokens: u32,
+        target_tokens: u32,
+    },
+    /// The session changed after candidate selection and before finalization.
+    CandidateSetChanged,
+    /// The real generated summary was larger than the source-derived reserve,
+    /// so applying the candidate set would miss the post-compression target.
+    SummaryExceedsTarget {
+        projected_tokens: u32,
+        target_tokens: u32,
+    },
 }
 
 impl std::fmt::Display for CompressionPlanError {
@@ -108,6 +122,25 @@ impl std::fmt::Display for CompressionPlanError {
                 "nothing to compress after anchor/keep splitting (anchor_index={}, non_system={})",
                 anchor_index, non_system_count
             ),
+            Self::ProtectedContentExceedsTarget {
+                projected_tokens,
+                target_tokens,
+            } => write!(
+                f,
+                "protected active content prevents compression target (projected={}, target={})",
+                projected_tokens, target_tokens
+            ),
+            Self::CandidateSetChanged => {
+                write!(f, "compression candidate set changed before finalization")
+            }
+            Self::SummaryExceedsTarget {
+                projected_tokens,
+                target_tokens,
+            } => write!(
+                f,
+                "actual summary misses compression target (projected={}, target={})",
+                projected_tokens, target_tokens
+            ),
         }
     }
 }
@@ -127,6 +160,11 @@ pub struct ContextCompressionExposure {
 /// archived and summarized.
 #[derive(Debug, Clone)]
 pub struct CompressionPlan {
+    /// Stable identifier for all requests and the persisted event belonging to
+    /// one logical compression pass.
+    pub logical_pass_id: Option<String>,
+    /// Tokens from active prompt blocks rendered outside `Session.messages`.
+    pub fixed_prompt_tokens: u32,
     pub compressed_message_ids: Vec<String>,
     pub messages_to_summarize: Vec<Message>,
     pub summary_tokens: u32,
@@ -140,6 +178,367 @@ pub struct CompressionPlan {
     pub compression_ratio: f64,
     pub model_used: Option<String>,
     pub latency_ms: u64,
+    pub source_tokens: u32,
+    pub represented_source_tokens: u32,
+    pub target_summary_tokens: u32,
+    pub actual_summary_content_tokens: u32,
+    pub summary_target_ratio: f64,
+    pub summary_budget_clamped: bool,
+    pub summary_budget_clamp_reason: Option<String>,
+    pub summarization_map_calls: u32,
+    pub summarization_reduce_calls: u32,
+    pub summarization_fallback_used: bool,
+}
+
+/// Immutable archive selection produced before any summarization request is
+/// sent. The final summary must represent exactly this set.
+#[derive(Debug, Clone)]
+pub struct CompressionCandidatePlan {
+    pub compressed_message_ids: Vec<String>,
+    pub messages_to_summarize: Vec<Message>,
+    pub source_tokens: u32,
+    pub previous_represented_source_tokens: u32,
+    pub represented_source_tokens: u32,
+    pub target_summary_tokens: u32,
+    pub summary_target_ratio: f64,
+    pub active_usage_before_percent: f64,
+    pub projected_usage_after_percent: f64,
+    pub trigger_percent: u8,
+    pub target_percent: u8,
+    pub segments_removed: usize,
+    pub trigger_type: CompressionTriggerType,
+    additional_fixed_tokens: u32,
+    context_window: u32,
+    target_limit: u32,
+}
+
+pub const DEFAULT_SUMMARY_TARGET_RATIO: f64 = 0.20;
+
+pub fn normalized_summary_target_ratio(value: f64) -> f64 {
+    if value.is_finite() && value > 0.0 {
+        value.clamp(0.01, 0.50)
+    } else {
+        DEFAULT_SUMMARY_TARGET_RATIO
+    }
+}
+
+fn target_summary_content_tokens(
+    session: &Session,
+    counter: &impl TokenCounter,
+    newly_represented_tokens: u32,
+    target_ratio: f64,
+) -> (u32, u32) {
+    let target_ratio = normalized_summary_target_ratio(target_ratio);
+    match session.conversation_summary.as_ref() {
+        Some(summary) if summary.represented_source_tokens > 0 => {
+            let represented = summary
+                .represented_source_tokens
+                .saturating_add(newly_represented_tokens);
+            (
+                ((represented as f64) * target_ratio).ceil() as u32,
+                summary.represented_source_tokens,
+            )
+        }
+        Some(summary) => {
+            let existing_tokens = counter.count_text(&summary.content);
+            let inferred_previous_source = ((existing_tokens as f64) / target_ratio).ceil() as u32;
+            (
+                existing_tokens.saturating_add(
+                    ((newly_represented_tokens as f64) * target_ratio).ceil() as u32,
+                ),
+                inferred_previous_source,
+            )
+        }
+        None => (
+            ((newly_represented_tokens as f64) * target_ratio).ceil() as u32,
+            0,
+        ),
+    }
+}
+
+fn protected_compression_message_ids(non_system: &[Message]) -> HashSet<String> {
+    let user_indexes = non_system
+        .iter()
+        .enumerate()
+        .filter_map(|(index, message)| {
+            matches!(message.role, bamboo_domain::Role::User).then_some(index)
+        })
+        .collect::<Vec<_>>();
+    let keep_user_count = user_indexes.len().min(3);
+    let mut protected = user_indexes[user_indexes.len().saturating_sub(keep_user_count)..]
+        .iter()
+        .filter_map(|index| non_system.get(*index))
+        .map(|message| message.id.clone())
+        .collect::<HashSet<_>>();
+
+    let skill_call_ids = non_system
+        .iter()
+        .filter(|message| is_skill_tool_chain_message(message))
+        .flat_map(|message| {
+            message
+                .tool_calls
+                .iter()
+                .flatten()
+                .map(|call| call.id.clone())
+        })
+        .collect::<HashSet<_>>();
+
+    for message in non_system {
+        if message.never_compress
+            || is_skill_tool_chain_message(message)
+            || message
+                .tool_call_id
+                .as_ref()
+                .is_some_and(|id| skill_call_ids.contains(id))
+        {
+            protected.insert(message.id.clone());
+        }
+    }
+    protected
+}
+
+fn post_compaction_recovery_tokens(
+    compressed_messages: &[Message],
+    session: &Session,
+    counter: &impl TokenCounter,
+) -> u32 {
+    build_post_compaction_recovery_message(compressed_messages, session)
+        .as_ref()
+        .map(|message| counter.count_message(message))
+        .unwrap_or(0)
+}
+
+/// Select the exact archive candidates before invoking the summarization model.
+///
+/// Candidate segments are considered oldest-first. Generic tool chains remain
+/// atomic because selection operates on [`crate::MessageSegmenter`] output;
+/// newest user turns, `never_compress`, and skill chains remain active.
+pub fn build_forced_compression_candidate_plan(
+    session: &Session,
+    model_name: &str,
+    configured_budget: Option<&TokenBudget>,
+    summary_target_ratio: f64,
+    trigger_type: CompressionTriggerType,
+) -> Result<CompressionCandidatePlan, CompressionPlanError> {
+    build_forced_compression_candidate_plan_with_fixed_tokens(
+        session,
+        model_name,
+        configured_budget,
+        summary_target_ratio,
+        trigger_type,
+        0,
+    )
+}
+
+/// Variant of [`build_forced_compression_candidate_plan`] that accounts for
+/// fixed prompt blocks rendered outside `Session.messages` (for example task,
+/// plan, workflow, project-resource, and external-memory context blocks).
+pub fn build_forced_compression_candidate_plan_with_fixed_tokens(
+    session: &Session,
+    model_name: &str,
+    configured_budget: Option<&TokenBudget>,
+    summary_target_ratio: f64,
+    trigger_type: CompressionTriggerType,
+    additional_fixed_tokens: u32,
+) -> Result<CompressionCandidatePlan, CompressionPlanError> {
+    let exposure = estimate_context_compression_exposure(session, model_name, configured_budget);
+    let budget = &exposure.budget;
+    let counter = TiktokenTokenCounter::default();
+    let active_messages = active_messages_for_budget(session);
+    if active_messages.is_empty() {
+        return Err(CompressionPlanError::NoActiveMessages);
+    }
+
+    let system_messages = active_messages
+        .iter()
+        .filter(|message| matches!(message.role, bamboo_domain::Role::System))
+        .cloned()
+        .collect::<Vec<_>>();
+    let non_system = active_messages
+        .into_iter()
+        .filter(|message| !matches!(message.role, bamboo_domain::Role::System))
+        .collect::<Vec<_>>();
+    if non_system.len() < 3 {
+        return Err(CompressionPlanError::NotEnoughMessages {
+            non_system_count: non_system.len(),
+        });
+    }
+
+    let context_window = budget.max_context_tokens;
+    let target_limit = budget.compression_target_context_tokens();
+    let system_tokens = counter.count_messages(&system_messages);
+    let protected_ids = protected_compression_message_ids(&non_system);
+    let segments = crate::segmenter::MessageSegmenter::new().segment(non_system.clone());
+    let mut remaining_tokens = counter.count_messages(&non_system);
+    let mut source_tokens = 0u32;
+    let mut selected_messages = Vec::new();
+    let mut selected_segment_count = 0usize;
+    let ratio = normalized_summary_target_ratio(summary_target_ratio);
+    let summary_envelope_tokens = counter.count_messages(&[compression_summary_message("")]);
+    let mut projected_tokens = system_tokens
+        .saturating_add(remaining_tokens)
+        .saturating_add(additional_fixed_tokens);
+    let mut target_summary_tokens = 0u32;
+    let mut previous_represented_source_tokens = session
+        .conversation_summary
+        .as_ref()
+        .map(|summary| summary.represented_source_tokens)
+        .unwrap_or(0);
+
+    for segment in segments {
+        if segment
+            .messages
+            .iter()
+            .any(|message| protected_ids.contains(&message.id))
+        {
+            continue;
+        }
+
+        let segment_tokens = counter.count_messages(&segment.messages);
+        source_tokens = source_tokens.saturating_add(segment_tokens);
+        remaining_tokens = remaining_tokens.saturating_sub(segment_tokens);
+        selected_messages.extend(segment.messages);
+        selected_segment_count += 1;
+
+        let (desired, previous_represented) =
+            target_summary_content_tokens(session, &counter, source_tokens, ratio);
+        target_summary_tokens = desired;
+        previous_represented_source_tokens = previous_represented;
+        let recovery_tokens =
+            post_compaction_recovery_tokens(&selected_messages, session, &counter);
+        projected_tokens = system_tokens
+            .saturating_add(remaining_tokens)
+            .saturating_add(additional_fixed_tokens)
+            .saturating_add(summary_envelope_tokens)
+            .saturating_add(target_summary_tokens)
+            .saturating_add(recovery_tokens);
+        if projected_tokens <= target_limit {
+            break;
+        }
+    }
+
+    if selected_messages.is_empty() {
+        return Err(CompressionPlanError::NothingToCompress {
+            anchor_index: 0,
+            non_system_count: non_system.len(),
+        });
+    }
+    if projected_tokens > target_limit {
+        return Err(CompressionPlanError::ProtectedContentExceedsTarget {
+            projected_tokens,
+            target_tokens: target_limit,
+        });
+    }
+
+    let represented_source_tokens =
+        previous_represented_source_tokens.saturating_add(source_tokens);
+    let projected_usage_after_percent =
+        context_window_usage_percent(projected_tokens, context_window);
+    let compressed_message_ids = selected_messages
+        .iter()
+        .map(|message| message.id.clone())
+        .collect();
+
+    Ok(CompressionCandidatePlan {
+        compressed_message_ids,
+        messages_to_summarize: selected_messages,
+        source_tokens,
+        previous_represented_source_tokens,
+        represented_source_tokens,
+        target_summary_tokens,
+        summary_target_ratio: ratio,
+        active_usage_before_percent: exposure.active_usage_percent,
+        projected_usage_after_percent,
+        trigger_percent: budget.compression_trigger_percent,
+        target_percent: budget.compression_target_percent,
+        segments_removed: selected_segment_count,
+        trigger_type,
+        additional_fixed_tokens,
+        context_window,
+        target_limit,
+    })
+}
+
+/// Bind a completed summary to a previously selected candidate set and verify
+/// the real post-compression prompt before any session mutation occurs.
+pub fn finalize_compression_candidate_plan(
+    session: &Session,
+    candidate: CompressionCandidatePlan,
+    summary_content: String,
+) -> Result<CompressionPlan, CompressionPlanError> {
+    let active_ids = session
+        .messages
+        .iter()
+        .filter(|message| !message.compressed)
+        .map(|message| message.id.as_str())
+        .collect::<HashSet<_>>();
+    if candidate
+        .compressed_message_ids
+        .iter()
+        .any(|id| !active_ids.contains(id.as_str()))
+    {
+        return Err(CompressionPlanError::CandidateSetChanged);
+    }
+
+    let candidate_ids = candidate
+        .compressed_message_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    let counter = TiktokenTokenCounter::default();
+    let summary_tokens = counter.count_messages(&[compression_summary_message(&summary_content)]);
+    let actual_summary_content_tokens = counter.count_text(&summary_content);
+    let recovery_tokens =
+        post_compaction_recovery_tokens(&candidate.messages_to_summarize, session, &counter);
+    let remaining_tokens = session
+        .messages
+        .iter()
+        .filter(|message| !message.compressed)
+        .filter(|message| !candidate_ids.contains(message.id.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let projected_tokens = counter
+        .count_messages(&remaining_tokens)
+        .saturating_add(candidate.additional_fixed_tokens)
+        .saturating_add(summary_tokens)
+        .saturating_add(recovery_tokens);
+    if projected_tokens > candidate.target_limit {
+        return Err(CompressionPlanError::SummaryExceedsTarget {
+            projected_tokens,
+            target_tokens: candidate.target_limit,
+        });
+    }
+
+    Ok(CompressionPlan {
+        logical_pass_id: None,
+        fixed_prompt_tokens: candidate.additional_fixed_tokens,
+        compressed_message_ids: candidate.compressed_message_ids,
+        messages_to_summarize: candidate.messages_to_summarize,
+        summary_tokens,
+        summary_content,
+        active_usage_before_percent: candidate.active_usage_before_percent,
+        active_usage_after_percent: context_window_usage_percent(
+            projected_tokens,
+            candidate.context_window,
+        ),
+        trigger_percent: candidate.trigger_percent,
+        target_percent: candidate.target_percent,
+        segments_removed: candidate.segments_removed,
+        trigger_type: candidate.trigger_type,
+        compression_ratio: 0.0,
+        model_used: None,
+        latency_ms: 0,
+        source_tokens: candidate.source_tokens,
+        represented_source_tokens: candidate.represented_source_tokens,
+        target_summary_tokens: candidate.target_summary_tokens,
+        actual_summary_content_tokens,
+        summary_target_ratio: candidate.summary_target_ratio,
+        summary_budget_clamped: false,
+        summary_budget_clamp_reason: None,
+        summarization_map_calls: 0,
+        summarization_reduce_calls: 0,
+        summarization_fallback_used: false,
+    })
 }
 
 pub fn context_window_usage_percent(total_tokens: u32, context_window_tokens: u32) -> f64 {
@@ -472,8 +871,17 @@ fn build_compression_plan_with_summary_internal(
     // prepare_hybrid_context uses, so the segment count is accurate.
     let segmenter = crate::segmenter::MessageSegmenter::new();
     let segments_removed = segmenter.segment(messages_to_summarize.clone()).len();
+    let source_tokens = counter.count_messages(&messages_to_summarize);
+    let actual_summary_content_tokens = counter.count_text(&summary_content);
+    let previous_represented_source_tokens = session
+        .conversation_summary
+        .as_ref()
+        .map(|summary| summary.represented_source_tokens)
+        .unwrap_or(0);
 
     Ok(CompressionPlan {
+        logical_pass_id: None,
+        fixed_prompt_tokens: 0,
         compressed_message_ids,
         messages_to_summarize,
         summary_tokens,
@@ -487,6 +895,16 @@ fn build_compression_plan_with_summary_internal(
         compression_ratio: 0.0,
         model_used: None,
         latency_ms: 0,
+        source_tokens,
+        represented_source_tokens: previous_represented_source_tokens.saturating_add(source_tokens),
+        target_summary_tokens: actual_summary_content_tokens,
+        actual_summary_content_tokens,
+        summary_target_ratio: 0.0,
+        summary_budget_clamped: false,
+        summary_budget_clamp_reason: None,
+        summarization_map_calls: 0,
+        summarization_reduce_calls: 0,
+        summarization_fallback_used: false,
     })
 }
 
@@ -684,7 +1102,7 @@ pub fn apply_compression_plan(session: &mut Session, plan: CompressionPlan) -> u
         return 0;
     }
 
-    let event = CompressionEvent::new(
+    let mut event = CompressionEvent::new(
         changed_indexes.len(),
         plan.segments_removed,
         plan.active_usage_before_percent,
@@ -695,16 +1113,43 @@ pub fn apply_compression_plan(session: &mut Session, plan: CompressionPlan) -> u
         plan.model_used.clone(),
         plan.latency_ms,
     );
+    if let Some(logical_pass_id) = plan.logical_pass_id.as_ref() {
+        event.id.clone_from(logical_pass_id);
+    }
+    event.source_tokens = plan.source_tokens;
+    event.fixed_prompt_tokens = plan.fixed_prompt_tokens;
+    event.actual_summary_tokens = plan.actual_summary_content_tokens;
+    event.target_summary_tokens = plan.target_summary_tokens;
+    event.summary_target_ratio = plan.summary_target_ratio;
+    event.actual_summary_ratio = if plan.represented_source_tokens == 0 {
+        0.0
+    } else {
+        plan.actual_summary_content_tokens as f64 / plan.represented_source_tokens as f64
+    };
+    event.summary_budget_clamped = plan.summary_budget_clamped;
+    event.summary_budget_clamp_reason = plan.summary_budget_clamp_reason.clone();
+    event.summarization_map_calls = plan.summarization_map_calls;
+    event.summarization_reduce_calls = plan.summarization_reduce_calls;
+    event.summarization_fallback_used = plan.summarization_fallback_used;
     let event_id = event.id.clone();
     for index in changed_indexes {
         session.messages[index].compressed_by_event_id = Some(event_id.clone());
     }
     session.compression_events.push(event);
-    session.conversation_summary = Some(ConversationSummary::new(
-        &plan.summary_content,
-        plan.compressed_message_ids.len(),
-        plan.summary_tokens,
-    ));
+    session.conversation_summary = Some(
+        ConversationSummary::new(
+            &plan.summary_content,
+            plan.compressed_message_ids.len(),
+            plan.summary_tokens,
+        )
+        .with_compression_metrics(
+            plan.represented_source_tokens,
+            plan.target_summary_tokens,
+            plan.summary_target_ratio,
+            plan.summary_budget_clamped,
+            plan.summary_budget_clamp_reason.clone(),
+        ),
+    );
 
     // Inject a post-compaction recovery message to preserve critical context
     // from the compressed messages (files, tasks, decisions).
@@ -757,7 +1202,9 @@ pub fn apply_compression_plan(session: &mut Session, plan: CompressionPlan) -> u
         .filter(|m| !matches!(m.role, bamboo_domain::Role::System))
         .cloned()
         .collect();
-    let system_tokens = counter.count_messages(&system_msgs);
+    let system_tokens = counter
+        .count_messages(&system_msgs)
+        .saturating_add(plan.fixed_prompt_tokens);
     let new_summary_tokens = plan.summary_tokens;
     let window_tokens = counter.count_messages(&window_msgs);
     let total_tokens = system_tokens
@@ -891,8 +1338,10 @@ pub fn build_summary_prompt(
             content.push_str(tool_call_id);
             content.push('\n');
         }
-        let snippet = truncate_chars(&message.content, 2000);
-        content.push_str(&snippet);
+        // Keep this compatibility renderer lossless. Production callers bound
+        // the fully rendered request through the hierarchical summarizer;
+        // clipping each message would discard tails without bounding the total.
+        content.push_str(&message.content);
         content.push_str("\n\n");
     }
 
@@ -900,13 +1349,6 @@ pub fn build_summary_prompt(
         "Return only the summary text. Be explicit about what is active now versus what is already done or no longer relevant.",
     );
     content
-}
-
-fn truncate_chars(value: &str, max_chars: usize) -> String {
-    if value.chars().count() <= max_chars {
-        return value.to_string();
-    }
-    value.chars().take(max_chars).collect::<String>() + "..."
 }
 
 #[cfg(test)]
@@ -1732,5 +2174,353 @@ mod tests {
         let quality = validate_summary_quality("some summary", &[]);
         assert_eq!(quality.file_coverage, 1.0);
         assert_eq!(quality.decision_coverage, 1.0);
+    }
+
+    fn candidate_budget(max_context_tokens: u32, target_percent: u8) -> TokenBudget {
+        TokenBudget {
+            max_context_tokens,
+            max_output_tokens: max_context_tokens / 4,
+            strategy: BudgetStrategy::Hybrid {
+                window_size: 20,
+                enable_summarization: true,
+            },
+            safety_margin: 0,
+            compression_trigger_percent: 80,
+            compression_target_percent: target_percent,
+            working_reserve_tokens: 0,
+            fallback_trigger_percent: 75,
+            prompt_cache_min_tool_output_chars: 1_200,
+            prompt_cache_head_chars: 280,
+            prompt_cache_tail_chars: 180,
+            prompt_cache_recent_user_turns: 2,
+            prompt_cache_recent_tool_chains: 2,
+            max_tool_output_tokens: 0,
+        }
+    }
+
+    #[test]
+    fn candidate_plan_is_selected_before_summary_and_reserves_twenty_percent_of_source() {
+        let budget = candidate_budget(6_000, 40);
+        let mut session = Session::new("candidate-first", "main-model");
+        session.add_message(Message::system("system"));
+
+        let mut tool_call = Message::assistant("searching", None);
+        tool_call.tool_calls = Some(vec![ToolCall {
+            id: "candidate-chain".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: "search".to_string(),
+                arguments: r#"{"q":"compression"}"#.to_string(),
+            },
+        }]);
+        let tool_call_id = tool_call.id.clone();
+        session.add_message(tool_call);
+        let tool_result = Message::tool_result(
+            "candidate-chain",
+            "result payload with decisions and paths ".repeat(80),
+        );
+        let tool_result_id = tool_result.id.clone();
+        session.add_message(tool_result);
+
+        let mut never = Message::assistant("protected runtime state ".repeat(80), None);
+        never.never_compress = true;
+        let never_id = never.id.clone();
+        session.add_message(never);
+
+        for index in 0..12 {
+            session.add_message(Message::user(format!(
+                "U{index}: {}",
+                "requirement context decision ".repeat(40)
+            )));
+            session.add_message(Message::assistant(
+                format!("A{index}: {}", "implementation evidence result ".repeat(40)),
+                None,
+            ));
+        }
+        let newest_user_ids = session
+            .messages
+            .iter()
+            .filter(|message| matches!(message.role, bamboo_domain::Role::User))
+            .rev()
+            .take(3)
+            .map(|message| message.id.clone())
+            .collect::<HashSet<_>>();
+
+        let candidate = build_forced_compression_candidate_plan(
+            &session,
+            "main-model",
+            Some(&budget),
+            0.20,
+            CompressionTriggerType::Auto,
+        )
+        .expect("candidate plan should reach target");
+        let selected = candidate
+            .compressed_message_ids
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>();
+
+        assert_eq!(
+            selected,
+            candidate
+                .messages_to_summarize
+                .iter()
+                .map(|message| message.id.clone())
+                .collect()
+        );
+        assert_eq!(
+            candidate.target_summary_tokens,
+            ((candidate.source_tokens as f64) * 0.20).ceil() as u32
+        );
+        assert!(!selected.contains(&never_id));
+        assert!(newest_user_ids.is_disjoint(&selected));
+        assert_eq!(
+            selected.contains(&tool_call_id),
+            selected.contains(&tool_result_id),
+            "generic tool chain must be selected atomically"
+        );
+        assert!(
+            candidate.projected_usage_after_percent <= budget.compression_target_percent as f64
+        );
+    }
+
+    #[test]
+    fn cumulative_twenty_percent_uses_represented_raw_tokens_not_previous_summary_length() {
+        let budget = candidate_budget(30_000, 50);
+        let mut session = Session::new("cumulative-ratio", "main-model");
+        session.add_message(Message::system("system"));
+        session.conversation_summary = Some(
+            ConversationSummary::new("existing detailed summary ".repeat(200), 40, 2_000)
+                .with_compression_metrics(10_000, 2_000, 0.20, false, None),
+        );
+        for index in 0..80 {
+            session.add_message(Message::user(format!(
+                "U{index}: {}",
+                "raw source requirement and evidence ".repeat(30)
+            )));
+            session.add_message(Message::assistant(
+                format!(
+                    "A{index}: {}",
+                    "implementation result and next step ".repeat(30)
+                ),
+                None,
+            ));
+        }
+
+        let candidate = build_forced_compression_candidate_plan(
+            &session,
+            "main-model",
+            Some(&budget),
+            0.20,
+            CompressionTriggerType::Auto,
+        )
+        .expect("cumulative candidate plan");
+        assert_eq!(
+            candidate.target_summary_tokens,
+            ((10_000u32.saturating_add(candidate.source_tokens) as f64) * 0.20).ceil() as u32
+        );
+        assert_eq!(
+            candidate.represented_source_tokens,
+            10_000u32.saturating_add(candidate.source_tokens)
+        );
+    }
+
+    #[test]
+    fn legacy_summary_uses_conservative_growth_and_migrates_represented_source_metadata() {
+        let budget = candidate_budget(20_000, 50);
+        let counter = TiktokenTokenCounter::default();
+        let existing_content = "legacy summary fact and decision ".repeat(180);
+        let existing_tokens = counter.count_text(&existing_content);
+        let mut session = Session::new("legacy-summary-ratio", "main-model");
+        session.add_message(Message::system("system"));
+        session.conversation_summary = Some(ConversationSummary::new(
+            existing_content,
+            40,
+            existing_tokens,
+        ));
+        for index in 0..40 {
+            session.add_message(Message::user(format!(
+                "U{index}: {}",
+                "raw requirement evidence ".repeat(40)
+            )));
+            session.add_message(Message::assistant(
+                format!("A{index}: {}", "result next step ".repeat(40)),
+                None,
+            ));
+        }
+
+        let candidate = build_forced_compression_candidate_plan(
+            &session,
+            "main-model",
+            Some(&budget),
+            0.20,
+            CompressionTriggerType::Auto,
+        )
+        .expect("legacy candidate plan");
+        assert_eq!(
+            candidate.target_summary_tokens,
+            existing_tokens.saturating_add(((candidate.source_tokens as f64) * 0.20).ceil() as u32)
+        );
+        assert_eq!(
+            candidate.previous_represented_source_tokens,
+            ((existing_tokens as f64) / 0.20).ceil() as u32
+        );
+        let expected_represented = candidate.represented_source_tokens;
+        let expected_target = candidate.target_summary_tokens;
+        let plan = finalize_compression_candidate_plan(
+            &session,
+            candidate,
+            "migrated legacy summary with new evidence".to_string(),
+        )
+        .expect("short real summary should satisfy target");
+        assert!(apply_compression_plan(&mut session, plan) > 0);
+        let migrated = session
+            .conversation_summary
+            .as_ref()
+            .expect("migrated summary");
+        assert_eq!(migrated.represented_source_tokens, expected_represented);
+        assert_eq!(migrated.target_token_count, expected_target);
+        assert_eq!(migrated.target_ratio, 0.20);
+    }
+
+    #[test]
+    fn final_postcondition_counts_the_recovery_message_inserted_during_apply() {
+        let budget = candidate_budget(8_000, 40);
+        let mut session = Session::new("recovery-postcondition", "main-model");
+        session.add_message(Message::system("system"));
+        for index in 0..20 {
+            session.add_message(Message::user(format!(
+                "U{index}: {}",
+                "requirement source content ".repeat(45)
+            )));
+            let mut assistant = Message::assistant(
+                format!("A{index}: {}", "implementation evidence ".repeat(45)),
+                None,
+            );
+            if index == 0 {
+                assistant.tool_calls = Some(vec![ToolCall {
+                    id: "write-recovery-763".to_string(),
+                    tool_type: "function".to_string(),
+                    function: FunctionCall {
+                        name: "Write".to_string(),
+                        arguments:
+                            r#"{"file_path":"/workspace/src/recovery_763.rs","content":"fixed"}"#
+                                .to_string(),
+                    },
+                }]);
+            }
+            session.add_message(assistant);
+            if index == 0 {
+                session.add_message(Message::tool_result(
+                    "write-recovery-763",
+                    "write completed",
+                ));
+            }
+        }
+
+        let candidate = build_forced_compression_candidate_plan(
+            &session,
+            "main-model",
+            Some(&budget),
+            0.20,
+            CompressionTriggerType::CriticalOverflow,
+        )
+        .expect("candidate should reserve recovery-message tokens");
+        let plan = finalize_compression_candidate_plan(
+            &session,
+            candidate,
+            "summary with /workspace/src/recovery_763.rs".to_string(),
+        )
+        .expect("final plan");
+        assert!(apply_compression_plan(&mut session, plan) > 0);
+        assert!(session
+            .messages
+            .iter()
+            .any(|message| message.content.contains("[post-compaction-recovery]")));
+        assert!(
+            session.token_usage.as_ref().is_some_and(
+                |usage| usage.total_tokens <= budget.compression_target_context_tokens()
+            ),
+            "the real active context, including recovery, must remain at or below target"
+        );
+    }
+
+    #[test]
+    fn finalization_revalidates_actual_summary_without_mutating_session() {
+        let budget = candidate_budget(6_000, 40);
+        let mut session = Session::new("atomic-finalize", "main-model");
+        session.add_message(Message::system("system"));
+        for index in 0..20 {
+            session.add_message(Message::user(format!(
+                "U{index}: {}",
+                "source content ".repeat(50)
+            )));
+            session.add_message(Message::assistant(
+                format!("A{index}: {}", "response content ".repeat(50)),
+                None,
+            ));
+        }
+        let candidate = build_forced_compression_candidate_plan(
+            &session,
+            "main-model",
+            Some(&budget),
+            0.20,
+            CompressionTriggerType::CriticalOverflow,
+        )
+        .expect("candidate plan");
+        let before_flags = session
+            .messages
+            .iter()
+            .map(|message| (message.id.clone(), message.compressed))
+            .collect::<Vec<_>>();
+
+        let result = finalize_compression_candidate_plan(
+            &session,
+            candidate,
+            "oversized summary ".repeat(20_000),
+        );
+        assert!(matches!(
+            result,
+            Err(CompressionPlanError::SummaryExceedsTarget { .. })
+        ));
+        assert_eq!(
+            before_flags,
+            session
+                .messages
+                .iter()
+                .map(|message| (message.id.clone(), message.compressed))
+                .collect::<Vec<_>>()
+        );
+        assert!(session.conversation_summary.is_none());
+        assert!(session.compression_events.is_empty());
+    }
+
+    #[test]
+    fn candidate_plan_reports_when_protected_content_makes_target_impossible() {
+        let budget = candidate_budget(2_000, 20);
+        let mut session = Session::new("protected-capacity", "main-model");
+        session.add_message(Message::system("system"));
+        session.add_message(Message::assistant(
+            "one eligible old message ".repeat(200),
+            None,
+        ));
+        for index in 0..3 {
+            session.add_message(Message::user(format!(
+                "protected recent user {index} {}",
+                "large active content ".repeat(300)
+            )));
+        }
+
+        let result = build_forced_compression_candidate_plan(
+            &session,
+            "main-model",
+            Some(&budget),
+            0.20,
+            CompressionTriggerType::CriticalOverflow,
+        );
+        assert!(matches!(
+            result,
+            Err(CompressionPlanError::ProtectedContentExceedsTarget { .. })
+        ));
     }
 }

--- a/crates/infra/bamboo-compression/src/lib.rs
+++ b/crates/infra/bamboo-compression/src/lib.rs
@@ -23,10 +23,13 @@ pub mod types;
 
 pub use compression_tooling::{
     active_messages_for_budget, apply_compression_plan, build_compression_plan_with_summary,
+    build_forced_compression_candidate_plan,
+    build_forced_compression_candidate_plan_with_fixed_tokens,
     build_forced_compression_plan_with_summary, build_summary_prompt, compression_summary_message,
     context_window_usage_percent, estimate_context_compression_exposure,
-    normalized_trigger_percent, summary_source_messages, CompressionPlan, CompressionPlanError,
-    ContextCompressionExposure,
+    finalize_compression_candidate_plan, normalized_summary_target_ratio,
+    normalized_trigger_percent, summary_source_messages, CompressionCandidatePlan, CompressionPlan,
+    CompressionPlanError, ContextCompressionExposure, DEFAULT_SUMMARY_TARGET_RATIO,
 };
 pub use counter::{HeuristicTokenCounter, TiktokenTokenCounter, TokenCounter};
 pub use limits::{create_budget_for_model, ModelLimitsRegistry};

--- a/crates/infra/bamboo-compression/src/limits.rs
+++ b/crates/infra/bamboo-compression/src/limits.rs
@@ -1,9 +1,10 @@
 //! Model context window limits registry.
 //!
 //! There is intentionally **no** built-in per-model table. Real per-model
-//! values come from two sources, in priority order:
-//!   1. provider runtime metadata (e.g. Copilot reports real context/output),
-//!   2. user overrides persisted in `model_limits.json`.
+//! values come from provider runtime metadata (e.g. Copilot reports real
+//! context/output) and user overrides persisted in `model_limits.json`.
+//! Runtime resolution gives explicit user configuration precedence over
+//! provider metadata.
 //!
 //! Anything without a match falls back to a single global default
 //! (`DEFAULT_MAX_CONTEXT_TOKENS` / `DEFAULT_MAX_OUTPUT_TOKENS`). This keeps the
@@ -55,7 +56,7 @@ pub fn is_default_limit(limit: &ModelLimit) -> bool {
 pub struct ModelLimit {
     /// Model identifier (partial match supported, e.g., "gpt-4" matches "gpt-4o")
     pub model_pattern: String,
-    /// Maximum context window size in tokens
+    /// Maximum total context window size (input + output) in tokens
     pub max_context_tokens: u32,
     /// Maximum output tokens (defaults to min(max_context / 4,
     /// DEFAULT_MAX_OUTPUT_TOKENS) when unset — see [`Self::get_max_output_tokens`])
@@ -131,6 +132,9 @@ impl ModelLimitsRegistry {
 
     /// Load user overrides from the registry's configured path.
     ///
+    /// Accepts both the legacy raw array and the revisioned section envelope
+    /// written by Bamboo's modular configuration store.
+    ///
     /// No-op when the registry was created without a `config_path` (use
     /// [`Self::with_config_path`] — e.g. with [`get_default_config_path`] — to
     /// point it at `{bamboo_data_dir}/model_limits.json`).
@@ -140,16 +144,33 @@ impl ModelLimitsRegistry {
         };
 
         if !path.exists() {
+            // A previously loaded file may have been deleted between reloads.
+            // Treat absence as an empty override set instead of retaining stale
+            // in-memory patterns.
+            self.user_limits.clear();
             return Ok(());
         }
 
         let content = tokio::fs::read_to_string(&path).await?;
-        let limits: Vec<ModelLimit> = serde_json::from_str(&content)
+        let value: Value = serde_json::from_str(&content)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        let data = value
+            .as_object()
+            .filter(|object| {
+                object.contains_key("schema_version")
+                    && object.contains_key("revision")
+                    && object.contains_key("data")
+            })
+            .and_then(|object| object.get("data"))
+            .cloned()
+            .unwrap_or(value);
+        let limits: Vec<ModelLimit> = serde_json::from_value(data)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
 
-        for limit in limits {
-            self.user_limits.insert(limit.model_pattern.clone(), limit);
-        }
+        self.user_limits = limits
+            .into_iter()
+            .map(|limit| (limit.model_pattern.clone(), limit))
+            .collect();
 
         tracing::info!(
             "Loaded {} user model limits from {:?}",
@@ -516,6 +537,115 @@ mod tests {
         assert_eq!(unknown.model_pattern, DEFAULT_MODEL_PATTERN);
         assert_eq!(unknown.max_context_tokens, 1_000_000);
         assert_eq!(unknown.get_max_output_tokens(), 128_000);
+    }
+
+    #[tokio::test]
+    async fn revisioned_model_limits_sidecar_drives_runtime_resolution() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("model_limits.json");
+        tokio::fs::write(
+            &path,
+            r#"{
+                "schema_version": 1,
+                "revision": 7,
+                "data": [{
+                    "model_pattern": "dynamic-summary-model",
+                    "max_context_tokens": 96000,
+                    "max_output_tokens": 12000,
+                    "safety_margin": 800
+                }]
+            }"#,
+        )
+        .await
+        .expect("seed revisioned overrides");
+
+        let mut registry = ModelLimitsRegistry::with_config_path(path);
+        registry
+            .load_user_config()
+            .await
+            .expect("load revisioned model-limit sidecar");
+
+        let limit = registry
+            .get("dynamic-summary-model")
+            .expect("revisioned override present");
+        assert_eq!(limit.max_context_tokens, 96_000);
+        assert_eq!(limit.get_max_output_tokens(), 12_000);
+        assert_eq!(limit.get_safety_margin(), 800);
+    }
+
+    #[tokio::test]
+    async fn reloading_user_config_replaces_removed_patterns() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("model_limits.json");
+        tokio::fs::write(
+            &path,
+            r#"[{
+                "model_pattern": "removed-model",
+                "max_context_tokens": 64000,
+                "max_output_tokens": 8000
+            }]"#,
+        )
+        .await
+        .expect("seed legacy sidecar");
+
+        let mut registry = ModelLimitsRegistry::with_config_path(&path);
+        registry.load_user_config().await.expect("first load");
+        assert!(registry.get("removed-model").is_some());
+
+        tokio::fs::write(
+            &path,
+            r#"{
+                "schema_version": 1,
+                "revision": 2,
+                "data": [{
+                    "model_pattern": "replacement-model",
+                    "max_context_tokens": 96000,
+                    "max_output_tokens": 12000
+                }]
+            }"#,
+        )
+        .await
+        .expect("replace sidecar");
+        registry.load_user_config().await.expect("reload");
+
+        assert!(registry.get("removed-model").is_none());
+        assert_eq!(
+            registry
+                .get("replacement-model")
+                .expect("replacement pattern")
+                .max_context_tokens,
+            96_000
+        );
+    }
+
+    #[tokio::test]
+    async fn reloading_after_sidecar_deletion_clears_stale_patterns() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("model_limits.json");
+        tokio::fs::write(
+            &path,
+            r#"[{
+                "model_pattern": "deleted-model",
+                "max_context_tokens": 64000,
+                "max_output_tokens": 8000
+            }]"#,
+        )
+        .await
+        .expect("seed model-limit sidecar");
+
+        let mut registry = ModelLimitsRegistry::with_config_path(&path);
+        registry.load_user_config().await.expect("first load");
+        assert!(registry.get("deleted-model").is_some());
+
+        tokio::fs::remove_file(&path)
+            .await
+            .expect("remove model-limit sidecar");
+        registry.load_user_config().await.expect("reload deletion");
+
+        assert!(
+            registry.get("deleted-model").is_none(),
+            "deleting the sidecar must not leave its patterns active in memory"
+        );
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-compression/src/preparation.rs
+++ b/crates/infra/bamboo-compression/src/preparation.rs
@@ -100,11 +100,15 @@ pub fn prepare_hybrid_context(
     // 2. Count system tokens
     let system_tokens = counter.count_messages(&system_messages);
 
-    // 3. Check if system prompt alone exceeds context window
-    let hard_limit = budget.max_context_tokens;
-    if system_tokens > hard_limit {
+    // 3. Check if the system prompt alone exceeds the request input limit.
+    // The provider's context window covers input + output, so reserve the
+    // configured output allowance and tokenizer safety margin before fitting
+    // prompt messages.
+    let hard_limit = budget.max_request_input_tokens();
+    let required_prompt_tokens = system_tokens.saturating_add(summary_tokens);
+    if required_prompt_tokens > hard_limit {
         return Err(BudgetError::SystemPromptTooLarge {
-            system_tokens,
+            system_tokens: required_prompt_tokens,
             available_tokens: hard_limit,
         });
     }
@@ -1188,7 +1192,7 @@ mod tests {
         session.conversation_summary = Some(ConversationSummary::new(summary_text, 2, 30));
 
         let prepared = prepare_hybrid_context(&session, &budget, &counter).unwrap();
-        let hard_limit = budget.max_context_tokens;
+        let hard_limit = budget.max_request_input_tokens();
 
         assert!(
             prepared.truncation_occurred,
@@ -1212,6 +1216,36 @@ mod tests {
                 .any(|message| message.content.contains(summary_text)),
             "prepared context should include the conversation summary"
         );
+    }
+
+    #[test]
+    fn required_summary_and_system_prompt_must_fit_reserved_input_limit() {
+        let summary_text = "oversized-required-summary";
+        let summary_message = compression_summary_message(summary_text);
+        let counter = DeterministicCounter::new(1)
+            .with_message_token("System", 10)
+            .with_message_token(summary_message.content, 55);
+        let budget = TokenBudget::with_safety_margin(
+            100,
+            40,
+            BudgetStrategy::Hybrid {
+                window_size: 20,
+                enable_summarization: true,
+            },
+            0,
+        );
+        let mut session = make_session_with_messages(vec![Message::system("System")]);
+        session.conversation_summary = Some(ConversationSummary::new(summary_text, 1, 55));
+
+        let result = prepare_hybrid_context(&session, &budget, &counter);
+
+        assert!(matches!(
+            result,
+            Err(BudgetError::SystemPromptTooLarge {
+                system_tokens: 65,
+                available_tokens: 60
+            })
+        ));
     }
 
     #[test]
@@ -1268,6 +1302,19 @@ mod tests {
             prepared.token_usage.total_tokens,
             prepared.token_usage.budget_limit
         );
+        assert_eq!(
+            prepared.token_usage.budget_limit,
+            budget.max_request_input_tokens()
+        );
+        assert!(
+            prepared
+                .token_usage
+                .total_tokens
+                .saturating_add(budget.max_output_tokens)
+                .saturating_add(budget.safety_margin)
+                <= budget.max_context_tokens,
+            "Prepared input + output reserve + safety margin must fit the total context window"
+        );
     }
 
     #[test]
@@ -1275,7 +1322,8 @@ mod tests {
         // Test that segments exceeding remaining budget are skipped
         let counter = TiktokenTokenCounter::default();
         // Tight budget: large message should not fit, but small message should.
-        let budget = TokenBudget::new(100, 50, BudgetStrategy::Window { size: 50 });
+        let budget =
+            TokenBudget::with_safety_margin(100, 50, BudgetStrategy::Window { size: 50 }, 0);
 
         // Use diverse text — BPE tokenizers compress repeated chars (e.g. "xxx...")
         // into very few tokens, so varied words produce a reliably large token count.

--- a/crates/infra/bamboo-compression/src/types.rs
+++ b/crates/infra/bamboo-compression/src/types.rs
@@ -114,14 +114,14 @@ mod tests {
     }
 
     #[test]
-    fn trigger_percent_zero_means_disabled() {
+    fn trigger_percent_zero_disables_proactive_trigger_but_respects_request_limit() {
         let mut budget =
             TokenBudget::with_safety_margin(1000, 200, BudgetStrategy::Window { size: 20 }, 100);
         budget.working_reserve_tokens = 0; // use legacy percentage mode
         budget.compression_trigger_percent = 0;
         assert_eq!(
             budget.compression_trigger_context_tokens(),
-            budget.max_context_tokens
+            budget.max_request_input_tokens()
         );
     }
 

--- a/crates/infra/bamboo-config/src/config.rs
+++ b/crates/infra/bamboo-config/src/config.rs
@@ -297,6 +297,16 @@ pub struct MemoryConfig {
     /// Falls back to the provider fast model when unset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub background_model: Option<String>,
+    /// Desired conversation-summary size as a fraction of the raw source tokens
+    /// represented by that summary. The default keeps roughly 20% of source
+    /// content as durable working memory.
+    #[serde(default = "default_summary_target_ratio")]
+    pub summary_target_ratio: f64,
+    /// Maximum fraction of the summarization model context window consumed by a
+    /// fully rendered map/reduce request, including reserved output and safety
+    /// margin.
+    #[serde(default = "default_summary_safe_window_percent")]
+    pub summary_safe_window_percent: u8,
     /// Whether lightweight automatic Dream-style consolidation should run in the
     /// background. Default ON (memory redesign L4): each tick no-ops when there is
     /// no background model configured or no new candidate sessions, so it is free
@@ -429,6 +439,8 @@ impl Default for MemoryConfig {
     fn default() -> Self {
         Self {
             background_model: None,
+            summary_target_ratio: default_summary_target_ratio(),
+            summary_safe_window_percent: default_summary_safe_window_percent(),
             auto_dream_enabled: default_true_auto_dream_enabled(),
             auto_dream_interval_secs: default_auto_dream_interval_secs(),
             project_prompt_injection: default_true_memory_project_prompt_injection(),
@@ -454,6 +466,14 @@ impl Default for MemoryConfig {
                 default_true_granularity_freshness_gardener_enabled(),
         }
     }
+}
+
+fn default_summary_target_ratio() -> f64 {
+    0.20
+}
+
+fn default_summary_safe_window_percent() -> u8 {
+    80
 }
 
 fn default_true_granularity_freshness_gardener_enabled() -> bool {
@@ -7475,6 +7495,8 @@ mod tests {
         let legacy = serde_json::json!({
             "memory": MemoryConfig {
                 background_model: Some("dream-fast".to_string()),
+                summary_target_ratio: 0.20,
+                summary_safe_window_percent: 80,
                 auto_dream_enabled: true,
                 auto_dream_interval_secs: 900,
                 project_prompt_injection: false,
@@ -7540,6 +7562,18 @@ mod tests {
             memory.capacity_max_archivals_per_run, 50,
             "omitted field takes the serde default fn"
         );
+    }
+
+    #[test]
+    fn compression_summary_budget_defaults_to_twenty_percent_and_eighty_percent_window() {
+        let defaults = MemoryConfig::default();
+        assert_eq!(defaults.summary_target_ratio, 0.20);
+        assert_eq!(defaults.summary_safe_window_percent, 80);
+
+        let parsed: Config = serde_json::from_str(r#"{"memory":{}}"#).expect("parse");
+        let memory = parsed.memory.as_ref().expect("memory present");
+        assert_eq!(memory.summary_target_ratio, 0.20);
+        assert_eq!(memory.summary_safe_window_percent, 80);
     }
 
     /// L4: the maintenance integrators are ON by default — both via

--- a/crates/infra/bamboo-llm/src/model_catalog.rs
+++ b/crates/infra/bamboo-llm/src/model_catalog.rs
@@ -40,7 +40,11 @@ impl ModelCatalogService {
                                 reference: ProviderModelRef::new(&meta.id, &info.id),
                                 display_name: info.id.clone(),
                                 provider_display_name: meta.display_name.clone(),
-                                capabilities: ModelCapabilities::default(),
+                                capabilities: ModelCapabilities {
+                                    max_context_tokens: info.max_context_tokens,
+                                    max_output_tokens: info.max_output_tokens,
+                                    ..ModelCapabilities::default()
+                                },
                                 source: Some(ModelSource::Upstream),
                                 discovered_at: None,
                             });
@@ -86,7 +90,11 @@ impl ModelCatalogService {
                 reference: ProviderModelRef::new(provider_name, &info.id),
                 display_name: info.id.clone(),
                 provider_display_name: provider_display_name.clone(),
-                capabilities: ModelCapabilities::default(),
+                capabilities: ModelCapabilities {
+                    max_context_tokens: info.max_context_tokens,
+                    max_output_tokens: info.max_output_tokens,
+                    ..ModelCapabilities::default()
+                },
                 source: Some(ModelSource::Upstream),
                 discovered_at: None,
             })
@@ -291,6 +299,33 @@ mod tests {
         assert_eq!(model.reference.provider, "openai");
         assert_eq!(model.reference.model, "gpt-4o");
         assert_eq!(model.provider_display_name, "OpenAI");
+    }
+
+    #[tokio::test]
+    async fn catalog_preserves_dynamic_model_token_limits() {
+        let registry = make_registry(
+            vec![(
+                "copilot",
+                vec![ProviderModelInfo {
+                    id: "dynamic-model".to_string(),
+                    max_context_tokens: Some(264_000),
+                    max_output_tokens: Some(64_000),
+                }],
+            )],
+            "copilot",
+        );
+        let service = ModelCatalogService::new(registry);
+        let catalog = service.get_catalog().await;
+
+        assert_eq!(catalog.models.len(), 1);
+        assert_eq!(
+            catalog.models[0].capabilities.max_context_tokens,
+            Some(264_000)
+        );
+        assert_eq!(
+            catalog.models[0].capabilities.max_output_tokens,
+            Some(64_000)
+        );
     }
 
     #[tokio::test]

--- a/crates/infra/bamboo-llm/src/provider.rs
+++ b/crates/infra/bamboo-llm/src/provider.rs
@@ -52,7 +52,9 @@ pub type LLMStream = Pin<Box<dyn Stream<Item = Result<LLMChunk>> + Send>>;
 pub struct ProviderModelInfo {
     /// Model identifier.
     pub id: String,
-    /// Maximum context window (input + output) in tokens when known.
+    /// Maximum total context window (input + output) in tokens when known.
+    /// Provider adapters that receive an input-only limit must add the model's
+    /// output capacity before populating this field.
     pub max_context_tokens: Option<u32>,
     /// Maximum output/completion tokens when known.
     pub max_output_tokens: Option<u32>,

--- a/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
+++ b/crates/infra/bamboo-llm/src/providers/copilot/mod.rs
@@ -918,15 +918,17 @@ impl CopilotProvider {
     }
 
     fn parse_model_info(payload: serde_json::Value) -> Result<Vec<ProviderModelInfo>> {
-        const CONTEXT_KEYS: &[&str] = &[
+        const TOTAL_CONTEXT_KEYS: &[&str] = &[
             "max_context_tokens",
-            "max_input_tokens",
-            "max_prompt_tokens",
             "context_window",
             "context_window_tokens",
+            "context_length",
+        ];
+        const INPUT_KEYS: &[&str] = &[
+            "max_input_tokens",
+            "max_prompt_tokens",
             "input_token_limit",
             "prompt_token_limit",
-            "context_length",
         ];
         const OUTPUT_KEYS: &[&str] = &[
             "max_output_tokens",
@@ -954,8 +956,13 @@ impl CopilotProvider {
                 continue;
             };
 
-            let context_tokens = Self::find_max_token_limit_by_keys(model, CONTEXT_KEYS);
             let output_tokens = Self::find_max_token_limit_by_keys(model, OUTPUT_KEYS);
+            let context_tokens = Self::find_max_token_limit_by_keys(model, TOTAL_CONTEXT_KEYS)
+                .or_else(|| {
+                    Self::find_max_token_limit_by_keys(model, INPUT_KEYS).map(|input_tokens| {
+                        input_tokens.saturating_add(output_tokens.unwrap_or_default())
+                    })
+                });
 
             dedup
                 .entry(id.to_string())
@@ -1554,6 +1561,42 @@ mod tests {
 
         let provider = CopilotProvider::new();
         assert!(!provider.is_authenticated());
+    }
+
+    #[test]
+    fn model_info_adds_output_capacity_to_input_only_limit() {
+        let models = CopilotProvider::parse_model_info(serde_json::json!({
+            "data": [{
+                "id": "dynamic-model",
+                "capabilities": {
+                    "limits": {
+                        "max_input_tokens": 200_000,
+                        "max_output_tokens": 64_000
+                    }
+                }
+            }]
+        }))
+        .expect("parse model metadata");
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].max_context_tokens, Some(264_000));
+        assert_eq!(models[0].max_output_tokens, Some(64_000));
+    }
+
+    #[test]
+    fn model_info_does_not_add_output_to_explicit_total_context_window() {
+        let models = CopilotProvider::parse_model_info(serde_json::json!({
+            "data": [{
+                "id": "dynamic-model",
+                "context_window": 200_000,
+                "max_output_tokens": 64_000
+            }]
+        }))
+        .expect("parse model metadata");
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].max_context_tokens, Some(200_000));
+        assert_eq!(models[0].max_output_tokens, Some(64_000));
     }
 
     #[tokio::test]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -211,6 +211,8 @@ the shipped defaults, so an empty `{}` is already reasonable:
 | Field | Default | What it does |
 |---|---|---|
 | `background_model` | `None` | Model used for memory extraction/consolidation background work; falls back to the primary model. |
+| `summary_target_ratio` | `0.20` | Desired durable conversation-summary size relative to the raw source tokens represented by it. Hierarchical reducers retain this global ratio instead of applying it again at every level. |
+| `summary_safe_window_percent` | `80` | Maximum share of the summarization model's total context window used by each fully rendered map/reduce request, including requested output and the tokenizer safety margin. |
 | `auto_dream_enabled` | `true` | Distill conversation stretches into candidate memories + notebook entries as the session runs. |
 | `auto_dream_interval_secs` | `1800` | How often the dream pass runs. |
 | `project_prompt_injection` | `true` | Inject relevant project-scoped memory into the system prompt. |
@@ -229,6 +231,11 @@ the shipped defaults, so an empty `{}` is already reasonable:
 | `memory_active_capacity` | `0` (unbounded/off) | Cap on "active" memory count before older ones archive. |
 | `capacity_max_archivals_per_run` | `50` | Cap per capacity-enforcement pass. |
 | `granularity_freshness_gardener_enabled` | `true` | Background staleness/granularity pass. |
+
+Automatic conversation compression always maps bounded source chunks and then
+reduces their summaries, even when the selected source would fit in one model
+request. Large terminal results are reduced into bounded multipart sections;
+the persisted summary keeps the single overall `summary_target_ratio` budget.
 
 `project_prompt_injection` / `relevant_recall` / `relevant_recall_rerank` /
 `project_first_dream` can also be flipped via env vars — see
@@ -478,22 +485,46 @@ always prompt regardless of mode.
 ## Model limits (`model_limits.json`)
 
 A separate file, `${data_dir}/model_limits.json` — user-supplied
-context/output token limit overrides, consulted only when provider runtime
-metadata doesn't already know a model's limits:
+context/output token limit overrides. Explicit user matches take precedence
+over provider runtime metadata. The legacy standalone representation is a raw
+array:
 
 ```json
 [
-  { "model_pattern": "my-custom-model-*", "max_context_tokens": 128000, "max_output_tokens": 8192 }
+  { "model_pattern": "my-custom-model", "max_context_tokens": 136192, "max_output_tokens": 8192 }
 ]
 ```
 
-`model_pattern` matches against the model id (glob-style), `safety_margin` is
-an optional token buffer subtracted from the limit. With no match anywhere
-(provider metadata nor this file), Bamboo falls back to a global default of
-200K context / 64K output — deliberately with **no built-in per-model table**,
-so the fallback never goes stale as models are updated upstream. Manage this
-via `PUT`/`DELETE` on the model-limits HTTP routes rather than hand-editing,
-if you're running the server.
+`model_pattern` is either an exact model id or a literal substring of the
+runtime model id; `*` and other glob characters have no special meaning.
+Among substring matches, the longest pattern wins.
+
+`max_context_tokens` is the provider's **total input + output context
+window**, not its input allowance alone. Bamboo derives the per-request input
+limit as:
+
+```text
+max_request_input_tokens =
+    max_context_tokens - max_output_tokens - safety_margin
+```
+
+`safety_margin` is optional. When `max_output_tokens` is omitted, Bamboo
+derives it from the context window. Provider metadata that exposes separate
+`max_input_tokens` and `max_output_tokens` is normalized to the same total
+context-window contract before runtime budgeting.
+
+The modular configuration store persists this section in a revisioned
+`{schema_version, revision, data}` envelope. Runtime loading accepts both that
+envelope and the legacy raw array, and root sessions re-read the sidecar at
+the start of every agent round; an explicit session/child or engine-level
+`TokenBudget` remains an intentional higher-priority override. Manage the
+section through Bamboo's settings API instead of hand-editing it while the
+server is running.
+
+With no matching user or provider value, Bamboo falls back to a global default
+of 1M total context / 128K output. There is deliberately **no built-in
+per-model table**, so stale hard-coded model names cannot override live
+provider metadata.
 
 ## Schedules (`schedules.json`)
 


### PR DESCRIPTION
## Summary

- plan the exact archive candidate set before invoking the summarizer, preserving newest user turns, `never_compress`, skill chains, and generic tool-call chains
- use one bounded pipeline for every non-empty compression source: chronological map chunks followed by bounded reduce, even when the source fits one request
- deterministically split oversized source/terminal partials, carry ordering/range metadata, and use an instruction-aware shared-context capsule plus bounded multipart final reducers when one final response cannot fit
- size the durable result from represented raw content using configurable `summary_target_ratio` (20% by default), retaining prior-summary allocation once and never compounding 20% at each hierarchy level
- dynamically re-read the instance-local `model_limits.json` on every root round, accepting both revisioned section envelopes and legacy arrays; explicit user patterns outrank legacy/provider/fallback limits and removed/deleted patterns do not remain stale
- define `max_context_tokens` as total input + output capacity, reserve `max_output_tokens` and tokenizer safety before prompt selection, and normalize provider input-only metadata without double-counting explicit total context
- revalidate the actual summary against the main prompt target before atomically applying archive flags, summary metadata, events, and recovery context; partial streams and failed stages leave session state unchanged
- expose pass/chunk/call/token/ratio/clamp/failure observability and preserve backward-compatible persisted session data

## Root Cause

The old path aggregated all active non-system messages into one request before selecting archive candidates. It used a fixed output allowance and could read the wrong `model_limits.json` path/shape: the modular settings store writes an instance-local revisioned envelope, while runtime expected a global raw array and cached same-model results. It also treated provider context metadata inconsistently with output capacity. Together these defects made compression overflow a similar/smaller model and made live limit edits ineffective.

## Test Plan

- `cargo test --workspace`
- `cargo test -p bamboo-engine llm_summarizer::tests -- --nocapture`
- `cargo test -p bamboo-engine runtime::runner::round_lifecycle::token_budget::tests -- --nocapture`
- `cargo test -p bamboo-compression limits::tests::reloading_after_sidecar_deletion_clears_stale_patterns -- --exact`
- `cargo fmt --all -- --check`
- `cargo clippy -p bamboo-domain -p bamboo-config -p bamboo-compression -p bamboo-engine -- -D warnings`
- `git diff --check origin/dev...HEAD`

Regression coverage includes small-input map→reduce, same/smaller summarizer windows, hundreds of small messages, oversized source and terminal partials, global 20% sizing, shared-context/instruction preservation, protected/tool-chain boundaries, exact archive candidates, atomic map/reduce/incomplete-stream failures, same-session revisioned sidecar edits and deletion, instance-local path resolution, source precedence, output reservation, and provider input-only versus total-context metadata.

No UI changes; screenshots are not applicable.

Closes #763