### PR TITLE
fix: persist Task updates through control plane

### DIFF
--- a/crates/core/bamboo-domain/src/session/persistence.rs
+++ b/crates/core/bamboo-domain/src/session/persistence.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::sync::Arc;
 
+use crate::session::task::TaskList;
 use crate::session::types::Session;
 
 /// Merge messages from a live runner snapshot into an already-durable
@@ -117,6 +118,57 @@ pub trait RuntimeSessionPersistence: Send + Sync {
     /// Persist the session, merging any newer authoritative metadata from disk.
     async fn save_runtime_session(&self, session: &mut Session) -> io::Result<()>;
 
+    /// Persist only the runtime control-plane for a session.
+    ///
+    /// Task lists and other runtime metadata belong to the control-plane and do
+    /// not require rewriting the potentially large message transcript. Built-in
+    /// persistence implementations with a runtime sidecar should override this
+    /// operation with their sidecar-only path. Custom/legacy implementations
+    /// remain source-compatible and safely fall back to the full runtime save.
+    ///
+    /// Callers must not rely on this operation to persist message changes.
+    async fn save_runtime_control_plane(&self, session: &mut Session) -> io::Result<()> {
+        self.save_runtime_session(session).await
+    }
+
+    /// Load the representation paired with
+    /// [`save_runtime_control_plane`](Self::save_runtime_control_plane).
+    ///
+    /// Sidecar-capable implementations should return their message-free
+    /// control-plane snapshot. The default deliberately returns the full
+    /// runtime session: when the paired save also falls back to a full save,
+    /// retaining the transcript makes that fallback safe rather than replacing
+    /// durable messages with an empty sidecar-shaped snapshot.
+    async fn load_runtime_control_plane(&self, session_id: &str) -> io::Result<Option<Session>> {
+        self.load_runtime_session(session_id).await
+    }
+
+    /// Atomically update only the shared Task list and its version.
+    ///
+    /// The default is safe for custom/legacy persistence: it loads the full
+    /// runtime session, changes only Task-owned fields, then uses the paired
+    /// control-plane save (which itself defaults to a full save). Returning
+    /// `false` means the implementation could not load the target; callers that
+    /// also hold a [`Storage`](crate::storage::Storage) may retain legacy
+    /// behavior with an explicit full-load/full-save fallback.
+    ///
+    /// Implementations with per-session transactions should override this so
+    /// the load, narrow mutation and save share one critical section.
+    async fn update_task_list_control_plane(
+        &self,
+        session_id: &str,
+        task_list: &TaskList,
+        version: &str,
+    ) -> io::Result<bool> {
+        let Some(mut session) = self.load_runtime_session(session_id).await? else {
+            return Ok(false);
+        };
+        session.set_task_list(task_list.clone());
+        session.set_task_list_version_meta(version.to_string());
+        self.save_runtime_control_plane(&mut session).await?;
+        Ok(true)
+    }
+
     /// Append-safe checkpoint used at the shared engine execute boundary.
     ///
     /// Unlike [`save_runtime_session`](Self::save_runtime_session), this must
@@ -176,6 +228,25 @@ pub trait RuntimeSessionPersistence: Send + Sync {
 impl<T: RuntimeSessionPersistence + ?Sized> RuntimeSessionPersistence for Arc<T> {
     async fn save_runtime_session(&self, session: &mut Session) -> io::Result<()> {
         (**self).save_runtime_session(session).await
+    }
+
+    async fn save_runtime_control_plane(&self, session: &mut Session) -> io::Result<()> {
+        (**self).save_runtime_control_plane(session).await
+    }
+
+    async fn load_runtime_control_plane(&self, session_id: &str) -> io::Result<Option<Session>> {
+        (**self).load_runtime_control_plane(session_id).await
+    }
+
+    async fn update_task_list_control_plane(
+        &self,
+        session_id: &str,
+        task_list: &TaskList,
+        version: &str,
+    ) -> io::Result<bool> {
+        (**self)
+            .update_task_list_control_plane(session_id, task_list, version)
+            .await
     }
 
     async fn checkpoint_runtime_session(&self, session: &mut Session) -> io::Result<()> {

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/taskwrite.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/taskwrite.rs
@@ -82,59 +82,105 @@ pub(in crate::runtime::runner) async fn persist_shared_task_list(
     session_id: &str,
     task_list: &bamboo_domain::TaskList,
 ) {
-    if let Some(ref storage) = config.storage {
-        if let Some(ref persistence) = config.persistence {
-            if let Err(error) = persistence.save_runtime_session(session).await {
+    let Some(ref persistence) = config.persistence else {
+        return;
+    };
+
+    if let Err(error) = persistence.save_runtime_control_plane(session).await {
+        tracing::warn!(
+            "[{}] Failed to save session control-plane after Task update: {}",
+            session_id,
+            error
+        );
+    } else {
+        tracing::debug!(
+            "[{}] Session control-plane saved after Task update",
+            session_id
+        );
+    }
+
+    if shared_session_id == session.id {
+        return;
+    }
+
+    let Some(version) = session.task_list_version_meta() else {
+        tracing::warn!(
+            "[{}] Shared root Task update on {} has no task-list version",
+            session_id,
+            shared_session_id
+        );
+        return;
+    };
+
+    match persistence
+        .update_task_list_control_plane(shared_session_id, task_list, &version)
+        .await
+    {
+        Ok(true) => {
+            tracing::debug!(
+                "[{}] Shared root Task control-plane patched on {}",
+                session_id,
+                shared_session_id
+            );
+        }
+        Ok(false) => {
+            // Save-only legacy/custom persisters leave the default load hook at
+            // `None`, so the default atomic patch cannot find the root. Retain
+            // source-compatible behavior with an explicitly full snapshot and
+            // full save; this path must never feed a message-free sidecar
+            // snapshot into a full-save fallback.
+            let Some(ref storage) = config.storage else {
                 tracing::warn!(
-                    "[{}] Failed to save session after Task update: {}",
+                    "[{}] Root session {} unavailable through persistence and no storage fallback is configured",
                     session_id,
+                    shared_session_id
+                );
+                return;
+            };
+            let mut root_session = match storage.load_session(shared_session_id).await {
+                Ok(Some(root_session)) => root_session,
+                Ok(None) => {
+                    tracing::warn!(
+                        "[{}] Root session {} not found while syncing shared task list",
+                        session_id,
+                        shared_session_id
+                    );
+                    return;
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        "[{}] Failed to load root session {} through storage fallback: {}",
+                        session_id,
+                        shared_session_id,
+                        error
+                    );
+                    return;
+                }
+            };
+            root_session.set_task_list(task_list.clone());
+            root_session.set_task_list_version_meta(version);
+            if let Err(error) = persistence.save_runtime_session(&mut root_session).await {
+                tracing::warn!(
+                    "[{}] Failed to full-save shared root Task fallback on {}: {}",
+                    session_id,
+                    shared_session_id,
                     error
                 );
             } else {
-                tracing::debug!("[{}] Session saved after Task update", session_id);
+                tracing::debug!(
+                    "[{}] Shared root Task full-save fallback completed on {}",
+                    session_id,
+                    shared_session_id
+                );
             }
-
-            if shared_session_id != session.id {
-                match storage.load_session(shared_session_id).await {
-                    Ok(Some(mut root_session)) => {
-                        root_session.set_task_list(task_list.clone());
-                        if let Some(version) = session.task_list_version_meta() {
-                            root_session.set_task_list_version_meta(version);
-                        }
-                        if let Err(error) =
-                            persistence.save_runtime_session(&mut root_session).await
-                        {
-                            tracing::warn!(
-                                "[{}] Failed to save shared root task list on {}: {}",
-                                session_id,
-                                shared_session_id,
-                                error
-                            );
-                        } else {
-                            tracing::debug!(
-                                "[{}] Shared root task list saved on {}",
-                                session_id,
-                                shared_session_id
-                            );
-                        }
-                    }
-                    Ok(None) => {
-                        tracing::warn!(
-                            "[{}] Root session {} not found while syncing shared task list",
-                            session_id,
-                            shared_session_id
-                        );
-                    }
-                    Err(error) => {
-                        tracing::warn!(
-                            "[{}] Failed to load root session {} while syncing shared task list: {}",
-                            session_id,
-                            shared_session_id,
-                            error
-                        );
-                    }
-                }
-            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                "[{}] Failed to patch shared root Task control-plane on {}: {}",
+                session_id,
+                shared_session_id,
+                error
+            );
         }
     }
 }

--- a/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/tests.rs
+++ b/crates/engine/bamboo-engine/src/runtime/runner/tool_execution/task/tests.rs
@@ -1,40 +1,187 @@
+use std::collections::HashMap;
+use std::io;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
 use tokio::sync::mpsc;
 
 use super::maybe_handle_taskwrite;
 use crate::runtime::config::AgentLoopConfig;
 use crate::runtime::task_context::TaskLoopContext;
+use bamboo_agent_core::storage::Storage;
 use bamboo_agent_core::tools::{FunctionCall, ToolCall, ToolResult};
-use bamboo_agent_core::AgentEvent;
-use bamboo_agent_core::Session;
-use bamboo_domain::TaskItemStatus;
+use bamboo_agent_core::{AgentEvent, Message, Session};
+use bamboo_domain::{AgentRuntimeState, RuntimeSessionPersistence, TaskItemStatus};
+
+#[derive(Default)]
+struct RecordingPersistence {
+    full_saves: AtomicUsize,
+    control_plane_saves: AtomicUsize,
+    task_patches: AtomicUsize,
+    control_planes: Mutex<Vec<Session>>,
+    patched_task_sessions: Mutex<Vec<Session>>,
+    sessions: Mutex<HashMap<String, Session>>,
+}
+
+impl RecordingPersistence {
+    fn seed(&self, session: Session) {
+        self.sessions
+            .lock()
+            .expect("recording persistence lock")
+            .insert(session.id.clone(), session);
+    }
+}
+
+#[async_trait]
+impl RuntimeSessionPersistence for RecordingPersistence {
+    async fn save_runtime_session(&self, _session: &mut Session) -> io::Result<()> {
+        self.full_saves.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn save_runtime_control_plane(&self, session: &mut Session) -> io::Result<()> {
+        self.control_plane_saves.fetch_add(1, Ordering::SeqCst);
+        self.control_planes
+            .lock()
+            .expect("recording persistence lock")
+            .push(session.clone());
+        Ok(())
+    }
+
+    async fn update_task_list_control_plane(
+        &self,
+        session_id: &str,
+        task_list: &bamboo_domain::TaskList,
+        version: &str,
+    ) -> io::Result<bool> {
+        self.task_patches.fetch_add(1, Ordering::SeqCst);
+        let patched = {
+            let mut sessions = self.sessions.lock().expect("recording persistence lock");
+            let Some(session) = sessions.get_mut(session_id) else {
+                return Ok(false);
+            };
+            session.set_task_list(task_list.clone());
+            session.set_task_list_version_meta(version.to_string());
+            session.clone()
+        };
+        self.patched_task_sessions
+            .lock()
+            .expect("recorded Task patches lock")
+            .push(patched);
+        Ok(true)
+    }
+}
+
+struct SaveOnlyPersistence {
+    full_saves: AtomicUsize,
+    storage: Arc<dyn Storage>,
+}
+
+#[derive(Default)]
+struct FullSessionPersistence {
+    full_saves: AtomicUsize,
+    full_loads: AtomicUsize,
+    sessions: Mutex<HashMap<String, Session>>,
+}
+
+impl FullSessionPersistence {
+    fn seed(&self, session: Session) {
+        self.sessions
+            .lock()
+            .expect("full-session persistence lock")
+            .insert(session.id.clone(), session);
+    }
+
+    fn get(&self, session_id: &str) -> Session {
+        self.sessions
+            .lock()
+            .expect("full-session persistence lock")
+            .get(session_id)
+            .cloned()
+            .expect("persisted session")
+    }
+}
+
+#[async_trait]
+impl RuntimeSessionPersistence for FullSessionPersistence {
+    async fn save_runtime_session(&self, session: &mut Session) -> io::Result<()> {
+        self.full_saves.fetch_add(1, Ordering::SeqCst);
+        self.sessions
+            .lock()
+            .expect("full-session persistence lock")
+            .insert(session.id.clone(), session.clone());
+        Ok(())
+    }
+
+    async fn load_runtime_session(&self, session_id: &str) -> io::Result<Option<Session>> {
+        self.full_loads.fetch_add(1, Ordering::SeqCst);
+        Ok(self
+            .sessions
+            .lock()
+            .expect("full-session persistence lock")
+            .get(session_id)
+            .cloned())
+    }
+}
+
+impl SaveOnlyPersistence {
+    fn new(storage: Arc<dyn Storage>) -> Self {
+        Self {
+            full_saves: AtomicUsize::new(0),
+            storage,
+        }
+    }
+}
+
+#[async_trait]
+impl RuntimeSessionPersistence for SaveOnlyPersistence {
+    async fn save_runtime_session(&self, session: &mut Session) -> io::Result<()> {
+        self.full_saves.fetch_add(1, Ordering::SeqCst);
+        self.storage.save_session(session).await
+    }
+}
+
+fn task_call_and_result() -> (ToolCall, ToolResult) {
+    (
+        ToolCall {
+            id: "task-call-1".to_string(),
+            tool_type: "function".to_string(),
+            function: FunctionCall {
+                name: "Task".to_string(),
+                arguments: serde_json::json!({
+                    "tasks": [{
+                        "content": "Refactor module",
+                        "status": "in_progress",
+                        "activeForm": "Refactoring module"
+                    }]
+                })
+                .to_string(),
+            },
+        },
+        ToolResult {
+            success: true,
+            result: "ok".to_string(),
+            display_preference: None,
+            images: Vec::new(),
+        },
+    )
+}
+
+fn task_list_value(session: &Session) -> serde_json::Value {
+    serde_json::to_value(&session.task_list).expect("serialize task list")
+}
 
 #[tokio::test]
-async fn maybe_handle_taskwrite_handles_task_tool_updates_session_and_context() {
-    let tool_call = ToolCall {
-        id: "task-call-1".to_string(),
-        tool_type: "function".to_string(),
-        function: FunctionCall {
-            name: "Task".to_string(),
-            arguments: serde_json::json!({
-                "tasks": [{
-                    "content": "Refactor module",
-                    "status": "in_progress",
-                    "activeForm": "Refactoring module"
-                }]
-            })
-            .to_string(),
-        },
-    };
-    let result = ToolResult {
-        success: true,
-        result: "ok".to_string(),
-        display_preference: None,
-        images: Vec::new(),
-    };
+async fn root_taskwrite_uses_control_plane_save_and_preserves_event_and_context_behavior() {
+    let (tool_call, result) = task_call_and_result();
 
     let mut session = Session::new("session-1", "model");
     let mut task_context: Option<TaskLoopContext> = None;
     let (tx, mut rx) = mpsc::channel(4);
+    let persistence = Arc::new(RecordingPersistence::default());
+    let mut config = AgentLoopConfig::default();
+    config.persistence = Some(persistence.clone());
 
     maybe_handle_taskwrite(
         &tool_call,
@@ -42,7 +189,7 @@ async fn maybe_handle_taskwrite_handles_task_tool_updates_session_and_context() 
         &mut session,
         "session-1",
         &tx,
-        &AgentLoopConfig::default(),
+        &config,
         &mut task_context,
     )
     .await;
@@ -50,7 +197,25 @@ async fn maybe_handle_taskwrite_handles_task_tool_updates_session_and_context() 
     let task_list = session.task_list.as_ref().expect("task list should be set");
     assert_eq!(task_list.items.len(), 1);
     assert_eq!(task_list.items[0].status, TaskItemStatus::InProgress);
-    assert!(task_context.is_some());
+    assert_eq!(session.task_list_version_meta().as_deref(), Some("1"));
+    assert!(
+        task_context
+            .as_ref()
+            .is_some_and(|context| context.task_list_dirty),
+        "Task context must still be reinitialized and marked dirty"
+    );
+    assert_eq!(persistence.full_saves.load(Ordering::SeqCst), 0);
+    assert_eq!(persistence.control_plane_saves.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        persistence
+            .control_planes
+            .lock()
+            .expect("recorded control planes")
+            .as_slice()
+            .first()
+            .map(|saved| saved.id.as_str()),
+        Some("session-1")
+    );
 
     let event = rx.recv().await.expect("task update event");
     match event {
@@ -59,6 +224,343 @@ async fn maybe_handle_taskwrite_handles_task_tool_updates_session_and_context() 
         }
         other => panic!("unexpected event: {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn child_taskwrite_saves_child_and_shared_root_control_planes_without_full_history() {
+    let (tool_call, result) = task_call_and_result();
+    let mut root = Session::new("root-1", "model");
+    root.add_message(Message::user("durable root history"));
+
+    let persistence = Arc::new(RecordingPersistence::default());
+    persistence.seed(root);
+    let mut config = AgentLoopConfig::default();
+    config.persistence = Some(persistence.clone());
+
+    let mut child = Session::new_child("child-1", "root-1", "model", "Child");
+    child.add_message(Message::user("live child history"));
+    let mut task_context: Option<TaskLoopContext> = None;
+    let (tx, mut rx) = mpsc::channel(4);
+
+    maybe_handle_taskwrite(
+        &tool_call,
+        &result,
+        &mut child,
+        "child-1",
+        &tx,
+        &config,
+        &mut task_context,
+    )
+    .await;
+
+    assert_eq!(persistence.full_saves.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        persistence.control_plane_saves.load(Ordering::SeqCst),
+        1,
+        "the executing child must use a control-plane save"
+    );
+    assert_eq!(
+        persistence.task_patches.load(Ordering::SeqCst),
+        1,
+        "the shared root must use one atomic Task patch"
+    );
+
+    let saves = persistence
+        .control_planes
+        .lock()
+        .expect("recorded control planes");
+    let child_save = saves
+        .iter()
+        .find(|saved| saved.id == "child-1")
+        .expect("child control-plane save");
+    let patches = persistence
+        .patched_task_sessions
+        .lock()
+        .expect("recorded Task patches");
+    let root_save = patches
+        .iter()
+        .find(|saved| saved.id == "root-1")
+        .expect("root atomic Task patch");
+    assert_eq!(child_save.task_list_version_meta().as_deref(), Some("1"));
+    assert_eq!(root_save.task_list_version_meta().as_deref(), Some("1"));
+    assert_eq!(task_list_value(child_save), task_list_value(root_save));
+    assert_eq!(
+        root_save.messages.len(),
+        1,
+        "atomic patch must preserve unrelated root fields"
+    );
+
+    assert!(
+        task_context
+            .as_ref()
+            .is_some_and(|context| context.task_list_dirty),
+        "Task context must still be reinitialized and marked dirty"
+    );
+    assert!(matches!(
+        rx.recv().await,
+        Some(AgentEvent::TaskListUpdated { .. })
+    ));
+}
+
+#[tokio::test]
+async fn child_taskwrite_custom_fallback_full_load_and_save_preserve_message_histories() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let store = Arc::new(
+        bamboo_storage::SessionStoreV2::new(directory.path().to_path_buf())
+            .await
+            .expect("SessionStoreV2"),
+    );
+    let mut root = Session::new("fallback-root", "model");
+    root.add_message(Message::user("root history must survive"));
+    store.save_session(&root).await.expect("seed root");
+
+    let storage: Arc<dyn Storage> = store.clone();
+    let persistence = Arc::new(SaveOnlyPersistence::new(storage.clone()));
+    let mut child = Session::new_child("fallback-child", "fallback-root", "model", "Child");
+    child.add_message(Message::user("child history must survive"));
+    let mut config = AgentLoopConfig::default();
+    config.storage = Some(storage);
+    config.persistence = Some(persistence.clone());
+    let mut task_context = None;
+    let (tx, _rx) = mpsc::channel(4);
+    let (tool_call, result) = task_call_and_result();
+
+    maybe_handle_taskwrite(
+        &tool_call,
+        &result,
+        &mut child,
+        "fallback-child",
+        &tx,
+        &config,
+        &mut task_context,
+    )
+    .await;
+
+    assert_eq!(
+        persistence.full_saves.load(Ordering::SeqCst),
+        2,
+        "default control-plane fallback must full-save child and root"
+    );
+    let saved_child = store
+        .load_session("fallback-child")
+        .await
+        .expect("load child")
+        .expect("saved child");
+    let saved_root = store
+        .load_session("fallback-root")
+        .await
+        .expect("load root")
+        .expect("saved root");
+    assert_eq!(saved_child.messages.len(), 1);
+    assert_eq!(
+        saved_child.messages[0].content,
+        "child history must survive"
+    );
+    assert_eq!(saved_root.messages.len(), 1);
+    assert_eq!(saved_root.messages[0].content, "root history must survive");
+    assert_eq!(task_list_value(&saved_child), task_list_value(&saved_root));
+    assert_eq!(
+        saved_root.task_list_version_meta(),
+        saved_child.task_list_version_meta()
+    );
+}
+
+#[tokio::test]
+async fn child_taskwrite_default_atomic_port_preserves_custom_full_session_state() {
+    let persistence = Arc::new(FullSessionPersistence::default());
+    let mut root = Session::new("default-port-root", "model");
+    root.add_message(Message::user("root history"));
+    root.agent_runtime_state = Some(AgentRuntimeState::new("root-runtime"));
+    persistence.seed(root);
+
+    let mut child = Session::new_child("default-port-child", "default-port-root", "model", "Child");
+    child.add_message(Message::user("child history"));
+    let mut config = AgentLoopConfig::default();
+    config.persistence = Some(persistence.clone());
+    let mut task_context = None;
+    let (tx, _rx) = mpsc::channel(4);
+    let (tool_call, result) = task_call_and_result();
+
+    maybe_handle_taskwrite(
+        &tool_call,
+        &result,
+        &mut child,
+        "default-port-child",
+        &tx,
+        &config,
+        &mut task_context,
+    )
+    .await;
+
+    assert_eq!(persistence.full_loads.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        persistence.full_saves.load(Ordering::SeqCst),
+        2,
+        "executing child and shared root use safe full-save defaults"
+    );
+    let saved_root = persistence.get("default-port-root");
+    assert_eq!(saved_root.messages.len(), 1);
+    assert_eq!(
+        saved_root
+            .agent_runtime_state
+            .as_ref()
+            .map(|state| state.run_id.as_str()),
+        Some("root-runtime")
+    );
+    assert_eq!(saved_root.task_list_version_meta().as_deref(), Some("1"));
+    assert_eq!(task_list_value(&saved_root), task_list_value(&child));
+}
+
+#[tokio::test]
+async fn child_task_control_planes_reload_without_rewriting_history_or_unrelated_root_state() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let store = Arc::new(
+        bamboo_storage::SessionStoreV2::new(directory.path().to_path_buf())
+            .await
+            .expect("SessionStoreV2"),
+    );
+    let mut durable_root = Session::new("reload-root", "model");
+    durable_root.add_message(Message::user("durable root transcript"));
+    durable_root.agent_runtime_state = Some(AgentRuntimeState::new("latest-root-run"));
+    durable_root
+        .metadata
+        .insert("durable.unrelated".to_string(), "keep".to_string());
+    store.save_session(&durable_root).await.expect("seed root");
+
+    let mut durable_child = Session::new_child("reload-child", "reload-root", "model", "Child");
+    durable_child.add_message(Message::user("durable child transcript"));
+    store
+        .save_session(&durable_child)
+        .await
+        .expect("seed child");
+
+    let locked = Arc::new(bamboo_storage::LockedSessionStore::new(store.clone()));
+    let repository =
+        crate::SessionRepository::new(Default::default(), store.clone(), locked.clone());
+    repository
+        .load("reload-root")
+        .await
+        .expect("backfill root cache");
+    repository
+        .load("reload-child")
+        .await
+        .expect("backfill child cache");
+    {
+        let cached_root = repository.cache().get("reload-root").expect("cached root");
+        cached_root
+            .write()
+            .metadata
+            .insert("cache.concurrent".to_string(), "preserve".to_string());
+    }
+
+    let mut live_child = durable_child.clone();
+    live_child.add_message(Message::assistant(
+        "uncheckpointed child message must not be rewritten by Task",
+        None,
+    ));
+    let mut config = AgentLoopConfig::default();
+    config.storage = Some(store.clone());
+    config.persistence = Some(Arc::new(repository.clone()));
+    let mut task_context = None;
+    let (tx, mut rx) = mpsc::channel(4);
+    let (tool_call, result) = task_call_and_result();
+
+    maybe_handle_taskwrite(
+        &tool_call,
+        &result,
+        &mut live_child,
+        "reload-child",
+        &tx,
+        &config,
+        &mut task_context,
+    )
+    .await;
+
+    let reloaded_root = store
+        .load_session("reload-root")
+        .await
+        .expect("normal root reload")
+        .expect("root exists");
+    let reloaded_child = store
+        .load_session("reload-child")
+        .await
+        .expect("normal child reload")
+        .expect("child exists");
+    assert_eq!(
+        task_list_value(&reloaded_root),
+        task_list_value(&live_child)
+    );
+    assert_eq!(
+        task_list_value(&reloaded_child),
+        task_list_value(&live_child)
+    );
+    assert_eq!(reloaded_root.task_list_version_meta().as_deref(), Some("1"));
+    assert_eq!(
+        reloaded_child.task_list_version_meta().as_deref(),
+        Some("1")
+    );
+    assert_eq!(
+        reloaded_root.messages.len(),
+        1,
+        "root Task patch must not rewrite session.json messages"
+    );
+    assert_eq!(reloaded_root.messages[0].content, "durable root transcript");
+    assert_eq!(
+        reloaded_child.messages.len(),
+        1,
+        "child control-plane save must not write its uncheckpointed message"
+    );
+    assert_eq!(
+        reloaded_child.messages[0].content,
+        "durable child transcript"
+    );
+    assert_eq!(
+        reloaded_root
+            .agent_runtime_state
+            .as_ref()
+            .map(|state| state.run_id.as_str()),
+        Some("latest-root-run")
+    );
+    assert_eq!(
+        reloaded_root
+            .metadata
+            .get("durable.unrelated")
+            .map(String::as_str),
+        Some("keep")
+    );
+
+    let cached_root = repository
+        .load("reload-root")
+        .await
+        .expect("cache-visible root");
+    assert_eq!(task_list_value(&cached_root), task_list_value(&live_child));
+    assert_eq!(
+        cached_root.messages.len(),
+        1,
+        "atomic Task cache patch must preserve the cached transcript"
+    );
+    assert_eq!(
+        cached_root
+            .metadata
+            .get("cache.concurrent")
+            .map(String::as_str),
+        Some("preserve"),
+        "atomic Task cache patch must preserve concurrent unrelated fields"
+    );
+    assert_eq!(
+        cached_root
+            .agent_runtime_state
+            .as_ref()
+            .map(|state| state.run_id.as_str()),
+        Some("latest-root-run")
+    );
+    assert!(task_context
+        .as_ref()
+        .is_some_and(|context: &TaskLoopContext| context.task_list_dirty));
+    assert!(matches!(
+        rx.recv().await,
+        Some(AgentEvent::TaskListUpdated { .. })
+    ));
 }
 
 #[tokio::test]

--- a/crates/engine/bamboo-engine/src/session_repository.rs
+++ b/crates/engine/bamboo-engine/src/session_repository.rs
@@ -81,7 +81,10 @@ impl SessionRepository {
             return Some(session);
         }
 
-        match self.storage.load_session(session_id).await {
+        let loaded = self.storage.load_session(session_id).await;
+        #[cfg(test)]
+        self.run_post_durable_hook("load", session_id);
+        match loaded {
             Ok(Some(session)) => {
                 self.cache.insert(
                     session_id.to_string(),
@@ -101,6 +104,8 @@ impl SessionRepository {
             return Ok(Some(session));
         }
         let loaded = self.storage.load_session(session_id).await?;
+        #[cfg(test)]
+        self.run_post_durable_hook("try_load", session_id);
         if let Some(ref session) = loaded {
             self.cache.insert(
                 session_id.to_string(),
@@ -115,6 +120,8 @@ impl SessionRepository {
     /// fire-and-forget variant that logs and continues on failure.
     pub async fn save(&self, session: &mut Session) -> std::io::Result<()> {
         self.persistence.merge_save_runtime(session).await?;
+        #[cfg(test)]
+        self.run_post_durable_hook("save_full", &session.id);
         self.cache.insert(
             session.id.clone(),
             Arc::new(parking_lot::RwLock::new(session.clone())),
@@ -174,6 +181,8 @@ impl SessionRepository {
             .load_session(session_id)
             .await
             .unwrap_or_default();
+        #[cfg(test)]
+        self.run_post_durable_hook("load_merged", session_id);
 
         match (memory_session, storage_session) {
             (Some(memory), Some(storage)) => {
@@ -235,7 +244,10 @@ impl SessionRepository {
     /// Persist the session (merge-on-write, preserving concurrent UI edits to
     /// the authoritative metadata group) and refresh the in-memory cache.
     pub async fn save_and_cache(&self, session: &mut Session) {
-        if let Err(error) = self.persistence.merge_save_runtime(session).await {
+        let result = self.persistence.merge_save_runtime(session).await;
+        #[cfg(test)]
+        self.run_post_durable_hook("save_and_cache", &session.id);
+        if let Err(error) = result {
             tracing::warn!("[{}] Failed to save session: {}", session.id, error);
         }
         self.cache.insert(
@@ -271,6 +283,8 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
         // a previous run's skill allowlist. The error is still returned to the
         // caller and durable state remains unchanged.
         let result = self.persistence.merge_save_runtime(session).await;
+        #[cfg(test)]
+        self.run_post_durable_hook("save_runtime_session", &session.id);
         self.cache.insert(
             session.id.clone(),
             Arc::new(parking_lot::RwLock::new(session.clone())),
@@ -358,6 +372,8 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
         // replacing a fresher cache entry with the stale runner snapshot would
         // set up a later SHRINK write.
         let result = self.persistence.checkpoint_runtime_session(session).await;
+        #[cfg(test)]
+        self.run_post_durable_hook("checkpoint", &session.id);
         if result.is_ok() {
             self.cache.insert(
                 session.id.clone(),
@@ -402,6 +418,8 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
                     format!("session disappeared after clearing legacy inbox: {session_id}"),
                 )
             })?;
+        #[cfg(test)]
+        self.run_post_durable_hook("clear_legacy", session_id);
         self.cache.insert(
             session_id.to_string(),
             Arc::new(parking_lot::RwLock::new(latest)),
@@ -495,13 +513,15 @@ mod tests {
     }
 
     fn durable_cache_fence(
-        operation: &'static str,
-        marker: &'static str,
+        operation: impl Into<String>,
+        marker: impl Into<String>,
     ) -> (
         PostDurableHook,
         tokio::sync::oneshot::Receiver<()>,
         Arc<(Mutex<bool>, Condvar)>,
     ) {
+        let operation = operation.into();
+        let marker = marker.into();
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
         let started_tx = Arc::new(Mutex::new(Some(started_tx)));
         let release = Arc::new((Mutex::new(false), Condvar::new()));
@@ -556,6 +576,455 @@ mod tests {
             "the second write must remain behind the first write's durable-to-cache fence"
         );
         (first, second)
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum FullSaveRoute {
+        InherentSave,
+        SaveAndCache,
+        RuntimePersistence,
+    }
+
+    impl FullSaveRoute {
+        fn operation(self) -> &'static str {
+            match self {
+                Self::InherentSave => "save_full",
+                Self::SaveAndCache => "save_and_cache",
+                Self::RuntimePersistence => "save_runtime_session",
+            }
+        }
+
+        fn name(self) -> &'static str {
+            match self {
+                Self::InherentSave => "inherent",
+                Self::SaveAndCache => "save-and-cache",
+                Self::RuntimePersistence => "runtime-persistence",
+            }
+        }
+    }
+
+    async fn assert_full_save_route_serializes_cache_publish(route: FullSaveRoute) {
+        let temp = tempfile::tempdir().unwrap();
+        let concrete_storage = Arc::new(
+            bamboo_storage::SessionStoreV2::new(temp.path().to_path_buf())
+                .await
+                .expect("SessionStoreV2"),
+        );
+        let storage: Arc<dyn Storage> = concrete_storage;
+        let id = format!("root-full-cache-order-{}", route.name());
+        let (hook, first_durable, release) = durable_cache_fence(route.operation(), id.clone());
+        let repo = Arc::new(test_repo(storage.clone()).with_post_durable_hook(hook));
+
+        let mut initial = Session::new(&id, "model");
+        initial.add_message(bamboo_agent_core::Message::user("durable transcript"));
+        initial.set_task_list(task_list(&id, "initial"));
+        initial.set_task_list_version_meta("0");
+        initial
+            .metadata
+            .insert("unrelated.runtime".to_string(), "keep".to_string());
+        storage.save_session(&initial).await.unwrap();
+        cache_put(&repo, &initial);
+
+        let first_repo = repo.clone();
+        let mut root_snapshot = initial.clone();
+        root_snapshot.add_message(bamboo_agent_core::Message::assistant(
+            "full-save transcript suffix",
+            None,
+        ));
+        root_snapshot.set_task_list(task_list(&id, "root"));
+        root_snapshot.set_task_list_version_meta("1");
+        let first = tokio::spawn(async move {
+            match route {
+                FullSaveRoute::InherentSave => first_repo.save(&mut root_snapshot).await,
+                FullSaveRoute::SaveAndCache => {
+                    first_repo.save_and_cache(&mut root_snapshot).await;
+                    Ok(())
+                }
+                FullSaveRoute::RuntimePersistence => {
+                    bamboo_domain::RuntimeSessionPersistence::save_runtime_session(
+                        first_repo.as_ref(),
+                        &mut root_snapshot,
+                    )
+                    .await
+                }
+            }
+        });
+        first_durable
+            .await
+            .expect("root full durable write reached");
+
+        let second_repo = repo.clone();
+        let second_id = id.clone();
+        let child_task_list = task_list(&id, "child");
+        let second = tokio::spawn(async move {
+            bamboo_domain::RuntimeSessionPersistence::update_task_list_control_plane(
+                second_repo.as_ref(),
+                &second_id,
+                &child_task_list,
+                "2",
+            )
+            .await
+            .map(|updated| assert!(updated, "root must exist"))
+        });
+        assert_second_write_waits_for_cache_publish(first, second, release).await;
+
+        let durable = storage.load_session(&id).await.unwrap().unwrap();
+        let cached = read_cached_session(repo.cache(), &id).expect("cached root");
+        for (tier, session) in [("durable", durable), ("cache", cached)] {
+            assert_eq!(
+                session.task_list_version_meta().as_deref(),
+                Some("2"),
+                "{route:?} {tier} must retain the child transaction"
+            );
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some("child"),
+                "{route:?} {tier} must retain the child transaction"
+            );
+            assert_eq!(
+                session
+                    .metadata
+                    .get("unrelated.runtime")
+                    .map(String::as_str),
+                Some("keep"),
+                "{route:?} {tier} must preserve unrelated runtime state"
+            );
+            assert_eq!(
+                session.messages.len(),
+                2,
+                "{route:?} {tier} must preserve the full-save transcript"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn root_full_saves_and_child_task_patch_share_publish_order() {
+        for route in [
+            FullSaveRoute::InherentSave,
+            FullSaveRoute::SaveAndCache,
+            FullSaveRoute::RuntimePersistence,
+        ] {
+            assert_full_save_route_serializes_cache_publish(route).await;
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn checkpoint_and_child_task_patch_share_publish_order() {
+        let temp = tempfile::tempdir().unwrap();
+        let concrete_storage = Arc::new(
+            bamboo_storage::SessionStoreV2::new(temp.path().to_path_buf())
+                .await
+                .expect("SessionStoreV2"),
+        );
+        let storage: Arc<dyn Storage> = concrete_storage;
+        let id = "checkpoint-cache-order";
+        let (hook, checkpoint_durable, release) = durable_cache_fence("checkpoint", id);
+        let repo = Arc::new(test_repo(storage.clone()).with_post_durable_hook(hook));
+
+        let mut initial = Session::new(id, "model");
+        initial.add_message(bamboo_agent_core::Message::user("durable transcript"));
+        initial.set_task_list(task_list(id, "initial"));
+        initial.set_task_list_version_meta("0");
+        initial
+            .metadata
+            .insert("unrelated.runtime".to_string(), "keep".to_string());
+        storage.save_session(&initial).await.unwrap();
+        cache_put(&repo, &initial);
+
+        let checkpoint_repo = repo.clone();
+        let mut checkpoint_snapshot = initial.clone();
+        checkpoint_snapshot.add_message(bamboo_agent_core::Message::assistant(
+            "checkpoint transcript suffix",
+            None,
+        ));
+        checkpoint_snapshot.set_task_list(task_list(id, "checkpoint"));
+        checkpoint_snapshot.set_task_list_version_meta("1");
+        let checkpoint = tokio::spawn(async move {
+            bamboo_domain::RuntimeSessionPersistence::checkpoint_runtime_session(
+                checkpoint_repo.as_ref(),
+                &mut checkpoint_snapshot,
+            )
+            .await
+        });
+        checkpoint_durable
+            .await
+            .expect("checkpoint durable write reached");
+
+        let child_repo = repo.clone();
+        let child_task_list = task_list(id, "child");
+        let child_patch = tokio::spawn(async move {
+            bamboo_domain::RuntimeSessionPersistence::update_task_list_control_plane(
+                child_repo.as_ref(),
+                id,
+                &child_task_list,
+                "2",
+            )
+            .await
+            .map(|updated| assert!(updated, "root must exist"))
+        });
+        assert_second_write_waits_for_cache_publish(checkpoint, child_patch, release).await;
+
+        let durable = storage.load_session(id).await.unwrap().unwrap();
+        let cached = read_cached_session(repo.cache(), id).expect("cached root");
+        for (tier, session) in [("durable", durable), ("cache", cached)] {
+            assert_eq!(
+                session.task_list_version_meta().as_deref(),
+                Some("2"),
+                "{tier} must retain the child transaction"
+            );
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some("child"),
+                "{tier} must retain the child transaction"
+            );
+            assert_eq!(
+                session
+                    .metadata
+                    .get("unrelated.runtime")
+                    .map(String::as_str),
+                Some("keep"),
+                "{tier} must preserve unrelated runtime state"
+            );
+            assert_eq!(
+                session.messages.len(),
+                2,
+                "{tier} must preserve the checkpoint transcript"
+            );
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum CacheBackfillRoute {
+        Load,
+        TryLoad,
+    }
+
+    impl CacheBackfillRoute {
+        fn operation(self) -> &'static str {
+            match self {
+                Self::Load => "load",
+                Self::TryLoad => "try_load",
+            }
+        }
+
+        fn name(self) -> &'static str {
+            match self {
+                Self::Load => "load",
+                Self::TryLoad => "try-load",
+            }
+        }
+    }
+
+    async fn assert_cache_backfill_serializes_with_task_patch(route: CacheBackfillRoute) {
+        let temp = tempfile::tempdir().unwrap();
+        let concrete_storage = Arc::new(
+            bamboo_storage::SessionStoreV2::new(temp.path().to_path_buf())
+                .await
+                .expect("SessionStoreV2"),
+        );
+        let storage: Arc<dyn Storage> = concrete_storage;
+        let id = format!("cache-backfill-order-{}", route.name());
+        let (hook, loaded_old_durable, release) =
+            durable_cache_fence(route.operation(), id.clone());
+        let repo = Arc::new(test_repo(storage.clone()).with_post_durable_hook(hook));
+
+        let mut initial = Session::new(&id, "model");
+        initial.set_task_list(task_list(&id, "initial"));
+        initial.set_task_list_version_meta("0");
+        storage.save_session(&initial).await.unwrap();
+        assert!(
+            read_cached_session(repo.cache(), &id).is_none(),
+            "the race requires a genuine cache miss"
+        );
+
+        let load_repo = repo.clone();
+        let load_id = id.clone();
+        let load = tokio::spawn(async move {
+            let loaded = match route {
+                CacheBackfillRoute::Load => load_repo.load(&load_id).await,
+                CacheBackfillRoute::TryLoad => {
+                    load_repo.try_load(&load_id).await.expect("storage load")
+                }
+            };
+            assert!(loaded.is_some(), "seeded session must load");
+            Ok(())
+        });
+        loaded_old_durable
+            .await
+            .expect("old durable snapshot loaded");
+
+        let patch_repo = repo.clone();
+        let patch_id = id.clone();
+        let child_task_list = task_list(&id, "child");
+        let patch = tokio::spawn(async move {
+            bamboo_domain::RuntimeSessionPersistence::update_task_list_control_plane(
+                patch_repo.as_ref(),
+                &patch_id,
+                &child_task_list,
+                "1",
+            )
+            .await
+            .map(|updated| assert!(updated, "root must exist"))
+        });
+        assert_second_write_waits_for_cache_publish(load, patch, release).await;
+
+        let durable = storage.load_session(&id).await.unwrap().unwrap();
+        let cached = read_cached_session(repo.cache(), &id).expect("backfilled cache");
+        for (tier, session) in [("durable", durable), ("cache", cached)] {
+            assert_eq!(
+                session.task_list_version_meta().as_deref(),
+                Some("1"),
+                "{route:?} {tier} must retain the child transaction"
+            );
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some("child"),
+                "{route:?} {tier} must retain the child transaction"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn cache_miss_backfills_and_child_task_patch_share_publish_order() {
+        for route in [CacheBackfillRoute::Load, CacheBackfillRoute::TryLoad] {
+            assert_cache_backfill_serializes_with_task_patch(route).await;
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn load_merged_storage_refresh_and_child_task_patch_share_publish_order() {
+        let temp = tempfile::tempdir().unwrap();
+        let concrete_storage = Arc::new(
+            bamboo_storage::SessionStoreV2::new(temp.path().to_path_buf())
+                .await
+                .expect("SessionStoreV2"),
+        );
+        let storage: Arc<dyn Storage> = concrete_storage;
+        let id = "load-merged-cache-order";
+        let (hook, loaded_old_durable, release) = durable_cache_fence("load_merged", id);
+        let repo = Arc::new(test_repo(storage.clone()).with_post_durable_hook(hook));
+
+        let mut durable = Session::new(id, "model");
+        durable.updated_at = Utc::now();
+        durable.set_task_list(task_list(id, "initial"));
+        durable.set_task_list_version_meta("0");
+        storage.save_session(&durable).await.unwrap();
+
+        let mut memory = durable.clone();
+        memory.updated_at = durable.updated_at - chrono::Duration::seconds(1);
+        memory.set_task_list(task_list(id, "memory"));
+        cache_put(&repo, &memory);
+
+        let load_repo = repo.clone();
+        let load = tokio::spawn(async move {
+            assert!(
+                load_repo.load_merged(id).await.is_some(),
+                "seeded session must load"
+            );
+            Ok(())
+        });
+        loaded_old_durable
+            .await
+            .expect("old durable snapshot loaded");
+
+        let patch_repo = repo.clone();
+        let child_task_list = task_list(id, "child");
+        let patch = tokio::spawn(async move {
+            bamboo_domain::RuntimeSessionPersistence::update_task_list_control_plane(
+                patch_repo.as_ref(),
+                id,
+                &child_task_list,
+                "1",
+            )
+            .await
+            .map(|updated| assert!(updated, "root must exist"))
+        });
+        assert_second_write_waits_for_cache_publish(load, patch, release).await;
+
+        let durable = storage.load_session(id).await.unwrap().unwrap();
+        let cached = read_cached_session(repo.cache(), id).expect("refreshed cache");
+        for (tier, session) in [("durable", durable), ("cache", cached)] {
+            assert_eq!(
+                session.task_list_version_meta().as_deref(),
+                Some("1"),
+                "{tier} must retain the child transaction"
+            );
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some("child"),
+                "{tier} must retain the child transaction"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn legacy_clear_refresh_and_child_task_patch_share_publish_order() {
+        let temp = tempfile::tempdir().unwrap();
+        let concrete_storage = Arc::new(
+            bamboo_storage::SessionStoreV2::new(temp.path().to_path_buf())
+                .await
+                .expect("SessionStoreV2"),
+        );
+        let storage: Arc<dyn Storage> = concrete_storage;
+        let id = "legacy-clear-cache-order";
+        let expected = vec![serde_json::json!({"content": "legacy"})];
+        let (hook, loaded_post_cas_snapshot, release) = durable_cache_fence("clear_legacy", id);
+        let repo = Arc::new(test_repo(storage.clone()).with_post_durable_hook(hook));
+
+        let mut initial = Session::new(id, "model");
+        initial.set_pending_injected_messages(expected.clone());
+        initial.set_task_list(task_list(id, "initial"));
+        initial.set_task_list_version_meta("0");
+        storage.save_session(&initial).await.unwrap();
+        cache_put(&repo, &initial);
+
+        let clear_repo = repo.clone();
+        let clear_expected = expected.clone();
+        let clear = tokio::spawn(async move {
+            bamboo_domain::RuntimeSessionPersistence::clear_legacy_pending_messages(
+                clear_repo.as_ref(),
+                id,
+                &clear_expected,
+            )
+            .await
+            .map(|cleared| assert!(cleared, "legacy queue must match"))
+        });
+        loaded_post_cas_snapshot
+            .await
+            .expect("post-CAS snapshot loaded");
+
+        let patch_repo = repo.clone();
+        let child_task_list = task_list(id, "child");
+        let patch = tokio::spawn(async move {
+            bamboo_domain::RuntimeSessionPersistence::update_task_list_control_plane(
+                patch_repo.as_ref(),
+                id,
+                &child_task_list,
+                "1",
+            )
+            .await
+            .map(|updated| assert!(updated, "root must exist"))
+        });
+        assert_second_write_waits_for_cache_publish(clear, patch, release).await;
+
+        let durable = storage.load_session(id).await.unwrap().unwrap();
+        let cached = read_cached_session(repo.cache(), id).expect("refreshed cache");
+        for (tier, session) in [("durable", durable), ("cache", cached)] {
+            assert_eq!(
+                session.task_list_version_meta().as_deref(),
+                Some("1"),
+                "{tier} must retain the child transaction"
+            );
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some("child"),
+                "{tier} must retain the child transaction"
+            );
+            assert!(
+                !session.has_pending_injected_messages(),
+                "{tier} must retain the successful legacy clear"
+            );
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -875,6 +1344,77 @@ mod tests {
                 .get("skill_runtime_selected_skill_ids")
                 .map(String::as_str),
             Some("[\"plan\"]")
+        );
+    }
+
+    #[tokio::test]
+    async fn inherent_save_leaves_existing_cache_untouched_when_storage_fails() {
+        let id = "inherent-save-failure";
+        let previous = Session::new(id, "previous");
+        let storage: Arc<dyn Storage> = Arc::new(FailingSaveStorage {
+            persisted: Mutex::new(Some(previous.clone())),
+        });
+        let repo = test_repo(storage);
+        cache_put(&repo, &previous);
+
+        let mut current = previous.clone();
+        current.model = "current".to_string();
+        assert!(repo.save(&mut current).await.is_err());
+        assert_eq!(
+            read_cached_session(repo.cache(), id)
+                .expect("existing cache")
+                .model,
+            "previous",
+            "fallible inherent save must publish only after a durable commit"
+        );
+    }
+
+    #[tokio::test]
+    async fn save_and_cache_still_refreshes_cache_when_storage_fails() {
+        let id = "save-and-cache-failure";
+        let previous = Session::new(id, "previous");
+        let storage: Arc<dyn Storage> = Arc::new(FailingSaveStorage {
+            persisted: Mutex::new(Some(previous.clone())),
+        });
+        let repo = test_repo(storage);
+        cache_put(&repo, &previous);
+
+        let mut current = previous;
+        current.model = "current".to_string();
+        repo.save_and_cache(&mut current).await;
+        assert_eq!(
+            read_cached_session(repo.cache(), id)
+                .expect("refreshed cache")
+                .model,
+            "current",
+            "fire-and-forget save must retain its existing cache-on-failure behavior"
+        );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_leaves_existing_cache_untouched_when_storage_fails() {
+        let id = "checkpoint-failure";
+        let previous = Session::new(id, "previous");
+        let storage: Arc<dyn Storage> = Arc::new(FailingSaveStorage {
+            persisted: Mutex::new(Some(previous.clone())),
+        });
+        let repo = test_repo(storage);
+        cache_put(&repo, &previous);
+
+        let mut current = previous.clone();
+        current.model = "current".to_string();
+        let result = bamboo_domain::RuntimeSessionPersistence::checkpoint_runtime_session(
+            &repo,
+            &mut current,
+        )
+        .await;
+        assert!(result.is_err());
+        assert_eq!(
+            read_cached_session(repo.cache(), id)
+                .expect("existing cache")
+                .model,
+            "previous",
+            "checkpoint must publish only after a durable commit"
         );
     }
 

--- a/crates/engine/bamboo-engine/src/session_repository.rs
+++ b/crates/engine/bamboo-engine/src/session_repository.rs
@@ -77,6 +77,7 @@ impl SessionRepository {
     /// Load a session from the memory cache, falling back to durable storage
     /// (and back-filling the cache on a storage hit). `None` if absent in both.
     pub async fn load(&self, session_id: &str) -> Option<Session> {
+        let _guard = self.persistence.acquire_lock(session_id).await;
         if let Some(session) = read_cached_session(&self.cache, session_id) {
             return Some(session);
         }
@@ -100,6 +101,7 @@ impl SessionRepository {
     /// swallowing them to `None`. Cache hit short-circuits; a storage hit
     /// back-fills the cache.
     pub async fn try_load(&self, session_id: &str) -> std::io::Result<Option<Session>> {
+        let _guard = self.persistence.acquire_lock(session_id).await;
         if let Some(session) = read_cached_session(&self.cache, session_id) {
             return Ok(Some(session));
         }
@@ -119,14 +121,18 @@ impl SessionRepository {
     /// storage errors. Use [`save_and_cache`](Self::save_and_cache) for the
     /// fire-and-forget variant that logs and continues on failure.
     pub async fn save(&self, session: &mut Session) -> std::io::Result<()> {
-        self.persistence.merge_save_runtime(session).await?;
-        #[cfg(test)]
-        self.run_post_durable_hook("save_full", &session.id);
-        self.cache.insert(
-            session.id.clone(),
-            Arc::new(parking_lot::RwLock::new(session.clone())),
-        );
-        Ok(())
+        self.persistence
+            .merge_save_runtime_and_publish(session, |saved, committed| {
+                if committed {
+                    #[cfg(test)]
+                    self.run_post_durable_hook("save_full", &saved.id);
+                    self.cache.insert(
+                        saved.id.clone(),
+                        Arc::new(parking_lot::RwLock::new(saved.clone())),
+                    );
+                }
+            })
+            .await
     }
 
     /// Atomically mutate the latest durable runtime session and refresh the
@@ -141,21 +147,20 @@ impl SessionRepository {
     where
         F: FnOnce(&mut Session),
     {
-        let saved = self
-            .persistence
-            .update_runtime_config(session_id, mutate)
-            .await?;
-        if let (Some(saved), Some(cached)) = (saved.as_ref(), self.cache.get(session_id)) {
-            let mut cached = cached.write();
-            for key in metadata_keys {
-                if let Some(value) = saved.metadata.get(*key) {
-                    cached.metadata.insert((*key).to_string(), value.clone());
-                } else {
-                    cached.metadata.remove(*key);
+        self.persistence
+            .update_runtime_config_and_publish(session_id, mutate, |saved| {
+                if let Some(cached) = self.cache.get(session_id) {
+                    let mut cached = cached.write();
+                    for key in metadata_keys {
+                        if let Some(value) = saved.metadata.get(*key) {
+                            cached.metadata.insert((*key).to_string(), value.clone());
+                        } else {
+                            cached.metadata.remove(*key);
+                        }
+                    }
                 }
-            }
-        }
-        Ok(saved)
+            })
+            .await
     }
 
     /// Load a session, creating a fresh `Session::new(id, model)` if absent.
@@ -175,6 +180,7 @@ impl SessionRepository {
     /// `load_merged` never overwrites a newer cached session with an older
     /// storage copy, so it is safe to call from hot read paths.
     pub async fn load_merged(&self, session_id: &str) -> Option<Session> {
+        let _guard = self.persistence.acquire_lock(session_id).await;
         let memory_session = read_cached_session(&self.cache, session_id);
         let storage_session = self
             .storage
@@ -244,16 +250,20 @@ impl SessionRepository {
     /// Persist the session (merge-on-write, preserving concurrent UI edits to
     /// the authoritative metadata group) and refresh the in-memory cache.
     pub async fn save_and_cache(&self, session: &mut Session) {
-        let result = self.persistence.merge_save_runtime(session).await;
-        #[cfg(test)]
-        self.run_post_durable_hook("save_and_cache", &session.id);
+        let result = self
+            .persistence
+            .merge_save_runtime_and_publish(session, |saved, _| {
+                #[cfg(test)]
+                self.run_post_durable_hook("save_and_cache", &saved.id);
+                self.cache.insert(
+                    saved.id.clone(),
+                    Arc::new(parking_lot::RwLock::new(saved.clone())),
+                );
+            })
+            .await;
         if let Err(error) = result {
             tracing::warn!("[{}] Failed to save session: {}", session.id, error);
         }
-        self.cache.insert(
-            session.id.clone(),
-            Arc::new(parking_lot::RwLock::new(session.clone())),
-        );
     }
 }
 
@@ -282,14 +292,16 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
         // when durable storage fails so a current activation can never observe
         // a previous run's skill allowlist. The error is still returned to the
         // caller and durable state remains unchanged.
-        let result = self.persistence.merge_save_runtime(session).await;
-        #[cfg(test)]
-        self.run_post_durable_hook("save_runtime_session", &session.id);
-        self.cache.insert(
-            session.id.clone(),
-            Arc::new(parking_lot::RwLock::new(session.clone())),
-        );
-        result
+        self.persistence
+            .merge_save_runtime_and_publish(session, |saved, _| {
+                #[cfg(test)]
+                self.run_post_durable_hook("save_runtime_session", &saved.id);
+                self.cache.insert(
+                    saved.id.clone(),
+                    Arc::new(parking_lot::RwLock::new(saved.clone())),
+                );
+            })
+            .await
     }
 
     async fn save_runtime_control_plane(&self, session: &mut Session) -> std::io::Result<()> {
@@ -371,16 +383,18 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
         // checkpoint may have failed to load the latest durable transcript, and
         // replacing a fresher cache entry with the stale runner snapshot would
         // set up a later SHRINK write.
-        let result = self.persistence.checkpoint_runtime_session(session).await;
-        #[cfg(test)]
-        self.run_post_durable_hook("checkpoint", &session.id);
-        if result.is_ok() {
-            self.cache.insert(
-                session.id.clone(),
-                Arc::new(parking_lot::RwLock::new(session.clone())),
-            );
-        }
-        result
+        self.persistence
+            .checkpoint_runtime_session_and_publish(session, |saved, committed| {
+                #[cfg(test)]
+                self.run_post_durable_hook("checkpoint", &saved.id);
+                if committed {
+                    self.cache.insert(
+                        saved.id.clone(),
+                        Arc::new(parking_lot::RwLock::new(saved.clone())),
+                    );
+                }
+            })
+            .await
     }
 
     async fn load_runtime_session(&self, session_id: &str) -> std::io::Result<Option<Session>> {
@@ -396,35 +410,16 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
         // cache-first, so a stale cache could erase a message concurrently
         // appended to the durable legacy queue. Delegate the compare-and-clear
         // to LockedSessionStore's single per-session critical section.
-        let cleared = bamboo_domain::RuntimeSessionPersistence::clear_legacy_pending_messages(
-            self.persistence.as_ref(),
-            session_id,
-            expected,
-        )
-        .await?;
-        if !cleared {
-            return Ok(false);
-        }
-
-        // Refresh only after the durable CAS succeeds. A failed comparison or
-        // persistence error leaves the live cache untouched.
-        let latest = self
-            .storage
-            .load_session(session_id)
-            .await?
-            .ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    format!("session disappeared after clearing legacy inbox: {session_id}"),
-                )
-            })?;
-        #[cfg(test)]
-        self.run_post_durable_hook("clear_legacy", session_id);
-        self.cache.insert(
-            session_id.to_string(),
-            Arc::new(parking_lot::RwLock::new(latest)),
-        );
-        Ok(true)
+        self.persistence
+            .clear_legacy_pending_messages_and_publish(session_id, expected, |latest| {
+                #[cfg(test)]
+                self.run_post_durable_hook("clear_legacy", session_id);
+                self.cache.insert(
+                    session_id.to_string(),
+                    Arc::new(parking_lot::RwLock::new(latest.clone())),
+                );
+            })
+            .await
     }
 
     async fn append_token_usage_record(

--- a/crates/engine/bamboo-engine/src/session_repository.rs
+++ b/crates/engine/bamboo-engine/src/session_repository.rs
@@ -886,6 +886,36 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn cache_hits_do_not_wait_for_the_persistence_lock() {
+        let storage: Arc<dyn Storage> = Arc::new(MapStorage::default());
+        let repo = test_repo(storage);
+        let id = "cache-hit-lock-free";
+        let cached = Session::new(id, "cached-model");
+        cache_put(&repo, &cached);
+        let persistence_guard = repo.persistence().acquire_lock(id).await;
+
+        let loaded = tokio::time::timeout(Duration::from_millis(100), repo.load(id)).await;
+        let try_loaded = tokio::time::timeout(Duration::from_millis(100), repo.try_load(id)).await;
+        drop(persistence_guard);
+
+        assert_eq!(
+            loaded
+                .expect("cache hit must not wait for the persistence lock")
+                .expect("cached session")
+                .model,
+            "cached-model"
+        );
+        assert_eq!(
+            try_loaded
+                .expect("fallible cache hit must not wait for the persistence lock")
+                .expect("cache read succeeds")
+                .expect("cached session")
+                .model,
+            "cached-model"
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn load_merged_storage_refresh_and_child_task_patch_share_publish_order() {
         let temp = tempfile::tempdir().unwrap();

--- a/crates/engine/bamboo-engine/src/session_repository.rs
+++ b/crates/engine/bamboo-engine/src/session_repository.rs
@@ -279,39 +279,39 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
     }
 
     async fn save_runtime_control_plane(&self, session: &mut Session) -> std::io::Result<()> {
-        let result = self.persistence.save_runtime_only(session).await;
+        self.persistence
+            .save_runtime_only_and_publish(session, |saved| {
+                #[cfg(test)]
+                self.run_post_durable_hook("save", &saved.id);
 
-        #[cfg(test)]
-        self.run_post_durable_hook("save", &session.id);
-
-        // A control-plane snapshot may intentionally carry no messages (for
-        // example, child Task synchronization loads the root's runtime
-        // sidecar). Publish its fresh runtime fields without replacing a
-        // cache-resident transcript with that empty snapshot. SessionInbox
-        // admission is coupled to transcript persistence and is therefore
-        // preserved alongside the cached messages, matching the V2 sidecar
-        // overlay contract.
-        if let Some(cached) = self.cache.get(&session.id) {
-            let mut cached = cached.write();
-            let messages = cached.messages.clone();
-            let admission = cached
-                .runtime_metadata
-                .as_ref()
-                .and_then(|metadata| metadata.session_inbox_admission.clone());
-            let mut refreshed = session.clone();
-            refreshed.messages = messages;
-            if let Some(admission) = admission {
-                refreshed
-                    .runtime_metadata
-                    .get_or_insert_with(Default::default)
-                    .session_inbox_admission = Some(admission);
-            } else if let Some(metadata) = refreshed.runtime_metadata.as_mut() {
-                metadata.session_inbox_admission = None;
-            }
-            *cached = refreshed;
-        }
-
-        result
+                // A control-plane snapshot may intentionally carry no messages
+                // (for example, child Task synchronization loads the root's
+                // runtime sidecar). Publish its fresh runtime fields without
+                // replacing a cache-resident transcript with that empty
+                // snapshot. SessionInbox admission is coupled to transcript
+                // persistence and is therefore preserved alongside the cached
+                // messages, matching the V2 sidecar overlay contract.
+                if let Some(cached) = self.cache.get(&saved.id) {
+                    let mut cached = cached.write();
+                    let messages = cached.messages.clone();
+                    let admission = cached
+                        .runtime_metadata
+                        .as_ref()
+                        .and_then(|metadata| metadata.session_inbox_admission.clone());
+                    let mut refreshed = saved.clone();
+                    refreshed.messages = messages;
+                    if let Some(admission) = admission {
+                        refreshed
+                            .runtime_metadata
+                            .get_or_insert_with(Default::default)
+                            .session_inbox_admission = Some(admission);
+                    } else if let Some(metadata) = refreshed.runtime_metadata.as_mut() {
+                        metadata.session_inbox_admission = None;
+                    }
+                    *cached = refreshed;
+                }
+            })
+            .await
     }
 
     async fn load_runtime_control_plane(
@@ -331,30 +331,23 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
         task_list: &bamboo_domain::TaskList,
         version: &str,
     ) -> std::io::Result<bool> {
-        let updated = bamboo_domain::RuntimeSessionPersistence::update_task_list_control_plane(
-            self.persistence.as_ref(),
-            session_id,
-            task_list,
-            version,
-        )
-        .await?;
-        if !updated {
-            return Ok(false);
-        }
+        self.persistence
+            .update_task_list_control_plane_and_publish(session_id, task_list, version, |_| {
+                #[cfg(test)]
+                self.run_post_durable_hook("task", version);
 
-        #[cfg(test)]
-        self.run_post_durable_hook("task", version);
-
-        // The durable transaction changed only Task-owned fields. Mirror that
-        // same narrow patch into the cache so a concurrent round/status/child
-        // transition already present in memory cannot be replaced by a stale
-        // whole-control-plane snapshot.
-        if let Some(cached) = self.cache.get(session_id) {
-            let mut cached = cached.write();
-            cached.set_task_list(task_list.clone());
-            cached.set_task_list_version_meta(version.to_string());
-        }
-        Ok(true)
+                // The durable transaction changed only Task-owned fields.
+                // Mirror that same narrow patch into the cache so a
+                // concurrent round/status/child transition already present
+                // in memory cannot be replaced by a stale whole-control-
+                // plane snapshot.
+                if let Some(cached) = self.cache.get(session_id) {
+                    let mut cached = cached.write();
+                    cached.set_task_list(task_list.clone());
+                    cached.set_task_list_version_meta(version.to_string());
+                }
+            })
+            .await
     }
 
     async fn checkpoint_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {

--- a/crates/engine/bamboo-engine/src/session_repository.rs
+++ b/crates/engine/bamboo-engine/src/session_repository.rs
@@ -20,6 +20,9 @@ use bamboo_storage::LockedSessionStore;
 
 use crate::{read_cached_session, SessionCache};
 
+#[cfg(test)]
+type PostDurableHook = Arc<dyn Fn(&str, &str) + Send + Sync>;
+
 /// Framework-owned coordinator over a session's cache / storage / persistence
 /// tiers. Cheap to clone (all fields are `Arc`).
 #[derive(Clone)]
@@ -27,6 +30,8 @@ pub struct SessionRepository {
     cache: SessionCache,
     storage: Arc<dyn Storage>,
     persistence: Arc<LockedSessionStore>,
+    #[cfg(test)]
+    post_durable_hook: Option<PostDurableHook>,
 }
 
 impl SessionRepository {
@@ -39,6 +44,21 @@ impl SessionRepository {
             cache,
             storage,
             persistence,
+            #[cfg(test)]
+            post_durable_hook: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_post_durable_hook(mut self, hook: PostDurableHook) -> Self {
+        self.post_durable_hook = Some(hook);
+        self
+    }
+
+    #[cfg(test)]
+    fn run_post_durable_hook(&self, operation: &str, marker: &str) {
+        if let Some(hook) = self.post_durable_hook.as_ref() {
+            hook(operation, marker);
         }
     }
 
@@ -261,6 +281,9 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
     async fn save_runtime_control_plane(&self, session: &mut Session) -> std::io::Result<()> {
         let result = self.persistence.save_runtime_only(session).await;
 
+        #[cfg(test)]
+        self.run_post_durable_hook("save", &session.id);
+
         // A control-plane snapshot may intentionally carry no messages (for
         // example, child Task synchronization loads the root's runtime
         // sidecar). Publish its fresh runtime fields without replacing a
@@ -318,6 +341,9 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
         if !updated {
             return Ok(false);
         }
+
+        #[cfg(test)]
+        self.run_post_durable_hook("task", version);
 
         // The durable transaction changed only Task-owned fields. Mirror that
         // same narrow patch into the cache so a concurrent round/status/child
@@ -407,7 +433,8 @@ mod tests {
     use bamboo_agent_core::storage::Storage;
     use chrono::Utc;
     use std::collections::HashMap;
-    use std::sync::Mutex;
+    use std::sync::{Condvar, Mutex};
+    use std::time::Duration;
 
     #[derive(Default)]
     struct MapStorage {
@@ -461,6 +488,212 @@ mod tests {
             session.id.clone(),
             Arc::new(parking_lot::RwLock::new(session.clone())),
         );
+    }
+
+    fn task_list(session_id: &str, title: &str) -> bamboo_domain::TaskList {
+        let now = Utc::now();
+        bamboo_domain::TaskList {
+            session_id: session_id.to_string(),
+            title: title.to_string(),
+            items: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn durable_cache_fence(
+        operation: &'static str,
+        marker: &'static str,
+    ) -> (
+        PostDurableHook,
+        tokio::sync::oneshot::Receiver<()>,
+        Arc<(Mutex<bool>, Condvar)>,
+    ) {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let started_tx = Arc::new(Mutex::new(Some(started_tx)));
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let hook_release = release.clone();
+        let hook: PostDurableHook = Arc::new(move |actual_operation, actual_marker| {
+            if actual_operation != operation || actual_marker != marker {
+                return;
+            }
+            if let Some(started_tx) = started_tx.lock().unwrap().take() {
+                started_tx.send(()).expect("fence observer still present");
+            }
+            let (released, wake) = &*hook_release;
+            let mut released = released.lock().unwrap();
+            while !*released {
+                released = wake.wait(released).unwrap();
+            }
+        });
+        (hook, started_rx, release)
+    }
+
+    fn release_fence(release: &Arc<(Mutex<bool>, Condvar)>) {
+        let (released, wake) = &**release;
+        *released.lock().unwrap() = true;
+        wake.notify_all();
+    }
+
+    async fn assert_second_write_waits_for_cache_publish<T>(
+        first: tokio::task::JoinHandle<std::io::Result<T>>,
+        mut second: tokio::task::JoinHandle<std::io::Result<T>>,
+        release: Arc<(Mutex<bool>, Condvar)>,
+    ) -> (T, T) {
+        let second_before_release =
+            tokio::time::timeout(Duration::from_millis(100), &mut second).await;
+        let completed_before_release = second_before_release.is_ok();
+        release_fence(&release);
+
+        let first = first
+            .await
+            .expect("first writer joins")
+            .expect("first writer succeeds");
+        let second = match second_before_release {
+            Ok(joined) => joined
+                .expect("second writer joins")
+                .expect("second writer succeeds"),
+            Err(_) => second
+                .await
+                .expect("second writer joins")
+                .expect("second writer succeeds"),
+        };
+        assert!(
+            !completed_before_release,
+            "the second write must remain behind the first write's durable-to-cache fence"
+        );
+        (first, second)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_task_patches_publish_cache_in_durable_order() {
+        let storage: Arc<dyn Storage> = Arc::new(MapStorage::default());
+        let (hook, first_durable, release) = durable_cache_fence("task", "1");
+        let repo = Arc::new(test_repo(storage.clone()).with_post_durable_hook(hook));
+        let id = "concurrent-task-cache-order";
+        let mut initial = Session::new(id, "model");
+        initial.set_task_list(task_list(id, "initial"));
+        initial.set_task_list_version_meta("0");
+        storage.save_session(&initial).await.unwrap();
+        cache_put(&repo, &initial);
+
+        let first_repo = repo.clone();
+        let first_task_list = task_list(id, "first");
+        let first = tokio::spawn(async move {
+            bamboo_domain::RuntimeSessionPersistence::update_task_list_control_plane(
+                first_repo.as_ref(),
+                id,
+                &first_task_list,
+                "1",
+            )
+            .await
+        });
+        first_durable.await.expect("first durable write reached");
+
+        let second_repo = repo.clone();
+        let second_task_list = task_list(id, "second");
+        let second = tokio::spawn(async move {
+            bamboo_domain::RuntimeSessionPersistence::update_task_list_control_plane(
+                second_repo.as_ref(),
+                id,
+                &second_task_list,
+                "2",
+            )
+            .await
+        });
+        let (first_updated, second_updated) =
+            assert_second_write_waits_for_cache_publish(first, second, release).await;
+        assert!(first_updated && second_updated);
+
+        let durable = storage.load_session(id).await.unwrap().unwrap();
+        let cached = read_cached_session(repo.cache(), id).expect("cached root");
+        for (tier, session) in [("durable", durable), ("cache", cached)] {
+            assert_eq!(
+                session.task_list_version_meta().as_deref(),
+                Some("2"),
+                "{tier} must retain the second transaction"
+            );
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some("second"),
+                "{tier} must retain the second transaction"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn root_control_plane_save_and_child_task_patch_share_publish_order() {
+        let storage: Arc<dyn Storage> = Arc::new(MapStorage::default());
+        let (hook, root_durable, release) = durable_cache_fence("save", "root-control-plane-order");
+        let repo = Arc::new(test_repo(storage.clone()).with_post_durable_hook(hook));
+        let id = "root-control-plane-order";
+
+        let mut initial = Session::new(id, "model");
+        initial.add_message(bamboo_agent_core::Message::user("durable transcript"));
+        initial.set_task_list(task_list(id, "initial"));
+        initial.set_task_list_version_meta("0");
+        initial
+            .metadata
+            .insert("unrelated.runtime".to_string(), "keep".to_string());
+        storage.save_session(&initial).await.unwrap();
+        cache_put(&repo, &initial);
+
+        let root_repo = repo.clone();
+        let mut root_snapshot = initial.clone();
+        root_snapshot.set_task_list(task_list(id, "root"));
+        root_snapshot.set_task_list_version_meta("1");
+        let root_save = tokio::spawn(async move {
+            bamboo_domain::RuntimeSessionPersistence::save_runtime_control_plane(
+                root_repo.as_ref(),
+                &mut root_snapshot,
+            )
+            .await
+        });
+        root_durable.await.expect("root durable write reached");
+
+        let child_repo = repo.clone();
+        let child_task_list = task_list(id, "child");
+        let child_patch = tokio::spawn(async move {
+            bamboo_domain::RuntimeSessionPersistence::update_task_list_control_plane(
+                child_repo.as_ref(),
+                id,
+                &child_task_list,
+                "2",
+            )
+            .await
+            .map(|updated| {
+                assert!(updated, "root must exist");
+            })
+        });
+        assert_second_write_waits_for_cache_publish(root_save, child_patch, release).await;
+
+        let durable = storage.load_session(id).await.unwrap().unwrap();
+        let cached = read_cached_session(repo.cache(), id).expect("cached root");
+        for (tier, session) in [("durable", durable), ("cache", cached)] {
+            assert_eq!(
+                session.task_list_version_meta().as_deref(),
+                Some("2"),
+                "{tier} must retain the child transaction"
+            );
+            assert_eq!(
+                session.task_list.as_ref().map(|list| list.title.as_str()),
+                Some("child"),
+                "{tier} must retain the child transaction"
+            );
+            assert_eq!(
+                session
+                    .metadata
+                    .get("unrelated.runtime")
+                    .map(String::as_str),
+                Some("keep"),
+                "{tier} must preserve unrelated runtime state"
+            );
+            assert_eq!(
+                session.messages.len(),
+                1,
+                "{tier} must preserve the transcript"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/engine/bamboo-engine/src/session_repository.rs
+++ b/crates/engine/bamboo-engine/src/session_repository.rs
@@ -77,6 +77,10 @@ impl SessionRepository {
     /// Load a session from the memory cache, falling back to durable storage
     /// (and back-filling the cache on a storage hit). `None` if absent in both.
     pub async fn load(&self, session_id: &str) -> Option<Session> {
+        if let Some(session) = read_cached_session(&self.cache, session_id) {
+            return Some(session);
+        }
+
         let _guard = self.persistence.acquire_lock(session_id).await;
         if let Some(session) = read_cached_session(&self.cache, session_id) {
             return Some(session);
@@ -101,10 +105,15 @@ impl SessionRepository {
     /// swallowing them to `None`. Cache hit short-circuits; a storage hit
     /// back-fills the cache.
     pub async fn try_load(&self, session_id: &str) -> std::io::Result<Option<Session>> {
+        if let Some(session) = read_cached_session(&self.cache, session_id) {
+            return Ok(Some(session));
+        }
+
         let _guard = self.persistence.acquire_lock(session_id).await;
         if let Some(session) = read_cached_session(&self.cache, session_id) {
             return Ok(Some(session));
         }
+
         let loaded = self.storage.load_session(session_id).await?;
         #[cfg(test)]
         self.run_post_durable_hook("try_load", session_id);

--- a/crates/engine/bamboo-engine/src/session_repository.rs
+++ b/crates/engine/bamboo-engine/src/session_repository.rs
@@ -258,6 +258,79 @@ impl bamboo_domain::RuntimeSessionPersistence for SessionRepository {
         result
     }
 
+    async fn save_runtime_control_plane(&self, session: &mut Session) -> std::io::Result<()> {
+        let result = self.persistence.save_runtime_only(session).await;
+
+        // A control-plane snapshot may intentionally carry no messages (for
+        // example, child Task synchronization loads the root's runtime
+        // sidecar). Publish its fresh runtime fields without replacing a
+        // cache-resident transcript with that empty snapshot. SessionInbox
+        // admission is coupled to transcript persistence and is therefore
+        // preserved alongside the cached messages, matching the V2 sidecar
+        // overlay contract.
+        if let Some(cached) = self.cache.get(&session.id) {
+            let mut cached = cached.write();
+            let messages = cached.messages.clone();
+            let admission = cached
+                .runtime_metadata
+                .as_ref()
+                .and_then(|metadata| metadata.session_inbox_admission.clone());
+            let mut refreshed = session.clone();
+            refreshed.messages = messages;
+            if let Some(admission) = admission {
+                refreshed
+                    .runtime_metadata
+                    .get_or_insert_with(Default::default)
+                    .session_inbox_admission = Some(admission);
+            } else if let Some(metadata) = refreshed.runtime_metadata.as_mut() {
+                metadata.session_inbox_admission = None;
+            }
+            *cached = refreshed;
+        }
+
+        result
+    }
+
+    async fn load_runtime_control_plane(
+        &self,
+        session_id: &str,
+    ) -> std::io::Result<Option<Session>> {
+        bamboo_domain::RuntimeSessionPersistence::load_runtime_control_plane(
+            self.persistence.as_ref(),
+            session_id,
+        )
+        .await
+    }
+
+    async fn update_task_list_control_plane(
+        &self,
+        session_id: &str,
+        task_list: &bamboo_domain::TaskList,
+        version: &str,
+    ) -> std::io::Result<bool> {
+        let updated = bamboo_domain::RuntimeSessionPersistence::update_task_list_control_plane(
+            self.persistence.as_ref(),
+            session_id,
+            task_list,
+            version,
+        )
+        .await?;
+        if !updated {
+            return Ok(false);
+        }
+
+        // The durable transaction changed only Task-owned fields. Mirror that
+        // same narrow patch into the cache so a concurrent round/status/child
+        // transition already present in memory cannot be replaced by a stale
+        // whole-control-plane snapshot.
+        if let Some(cached) = self.cache.get(session_id) {
+            let mut cached = cached.write();
+            cached.set_task_list(task_list.clone());
+            cached.set_task_list_version_meta(version.to_string());
+        }
+        Ok(true)
+    }
+
     async fn checkpoint_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {
         // The execute-boundary checkpoint uses LockedSessionStore's atomic
         // append-safe transcript merge, then publishes that reconciled snapshot

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -342,6 +342,33 @@ impl RuntimeSessionPersistence for LockedSessionStore {
         self.merge_save_runtime(session).await
     }
 
+    async fn save_runtime_control_plane(&self, session: &mut Session) -> std::io::Result<()> {
+        self.save_runtime_only(session).await
+    }
+
+    async fn load_runtime_control_plane(
+        &self,
+        session_id: &str,
+    ) -> std::io::Result<Option<Session>> {
+        self.storage.load_runtime_control_plane(session_id).await
+    }
+
+    async fn update_task_list_control_plane(
+        &self,
+        session_id: &str,
+        task_list: &bamboo_domain::TaskList,
+        version: &str,
+    ) -> std::io::Result<bool> {
+        let _guard = self.acquire_lock(session_id).await;
+        let Some(mut latest) = self.storage.load_runtime_control_plane(session_id).await? else {
+            return Ok(false);
+        };
+        latest.set_task_list(task_list.clone());
+        latest.set_task_list_version_meta(version.to_string());
+        self.storage.save_runtime_state(&latest).await?;
+        Ok(true)
+    }
+
     async fn checkpoint_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {
         LockedSessionStore::checkpoint_runtime_session(self, session).await
     }
@@ -471,6 +498,39 @@ mod tests {
     use super::*;
     use crate::v2::SessionStoreV2;
     use bamboo_domain::session::types::Session;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingControlPlaneStorage {
+        inner: Arc<SessionStoreV2>,
+        control_plane_loads: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl Storage for CountingControlPlaneStorage {
+        async fn save_session(&self, session: &Session) -> std::io::Result<()> {
+            self.inner.save_session(session).await
+        }
+
+        async fn load_session(&self, session_id: &str) -> std::io::Result<Option<Session>> {
+            self.inner.load_session(session_id).await
+        }
+
+        async fn delete_session(&self, session_id: &str) -> std::io::Result<bool> {
+            self.inner.delete_session(session_id).await
+        }
+
+        async fn save_runtime_state(&self, session: &Session) -> std::io::Result<()> {
+            self.inner.save_runtime_state(session).await
+        }
+
+        async fn load_runtime_control_plane(
+            &self,
+            session_id: &str,
+        ) -> std::io::Result<Option<Session>> {
+            self.control_plane_loads.fetch_add(1, Ordering::SeqCst);
+            self.inner.load_runtime_control_plane(session_id).await
+        }
+    }
 
     async fn make_storage() -> (tempfile::TempDir, Arc<dyn Storage>) {
         let temp = tempfile::tempdir().unwrap();
@@ -1169,6 +1229,148 @@ mod tests {
         assert_eq!(after.metadata_version, 5);
         assert_eq!(after.messages.len(), 1);
         assert_eq!(after.messages[0].content, "keep me");
+    }
+
+    #[tokio::test]
+    async fn runtime_control_plane_port_uses_sidecar_without_rewriting_messages() {
+        use bamboo_domain::session::types::Message;
+
+        let (_temp, storage) = make_storage().await;
+        let store = LockedSessionStore::new(storage.clone());
+        let session_id = "runtime-control-plane";
+
+        let mut durable = fresh(session_id);
+        durable.add_message(Message::user("durable transcript"));
+        storage.save_session(&durable).await.unwrap();
+
+        let mut runtime = durable.clone();
+        runtime.model = "updated-control-plane-model".to_string();
+        runtime.add_message(Message::assistant("uncheckpointed runtime message", None));
+        RuntimeSessionPersistence::save_runtime_control_plane(&store, &mut runtime)
+            .await
+            .unwrap();
+
+        let control_plane =
+            RuntimeSessionPersistence::load_runtime_control_plane(&store, session_id)
+                .await
+                .unwrap()
+                .expect("control-plane exists");
+        assert!(
+            control_plane.messages.is_empty(),
+            "LockedSessionStore must expose its message-free sidecar"
+        );
+        assert_eq!(control_plane.model, "updated-control-plane-model");
+
+        let reloaded = storage
+            .load_session(session_id)
+            .await
+            .unwrap()
+            .expect("session exists");
+        assert_eq!(reloaded.model, "updated-control-plane-model");
+        assert_eq!(
+            reloaded.messages.len(),
+            1,
+            "control-plane save must not write the uncheckpointed message"
+        );
+        assert_eq!(reloaded.messages[0].content, "durable transcript");
+    }
+
+    #[tokio::test]
+    async fn atomic_task_patch_loads_inside_lock_and_preserves_interleaved_runtime_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let inner = Arc::new(
+            SessionStoreV2::new(temp.path().to_path_buf())
+                .await
+                .expect("storage init"),
+        );
+        let session_id = "atomic-task-patch";
+        inner
+            .save_session(&fresh(session_id))
+            .await
+            .expect("seed session");
+
+        let counted = Arc::new(CountingControlPlaneStorage {
+            inner: inner.clone(),
+            control_plane_loads: AtomicUsize::new(0),
+        });
+        let storage: Arc<dyn Storage> = counted.clone();
+        let store = Arc::new(LockedSessionStore::new(storage));
+        let guard = store.acquire_lock(session_id).await;
+        let now = chrono::Utc::now();
+        let task_list = bamboo_domain::TaskList {
+            session_id: session_id.to_string(),
+            title: "Atomic Task patch".to_string(),
+            items: Vec::new(),
+            created_at: now,
+            updated_at: now,
+        };
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let patch_store = store.clone();
+        let patch = tokio::spawn(async move {
+            let _ = started_tx.send(());
+            RuntimeSessionPersistence::update_task_list_control_plane(
+                patch_store.as_ref(),
+                session_id,
+                &task_list,
+                "9",
+            )
+            .await
+        });
+        started_rx.await.expect("patch task started");
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert_eq!(
+            counted.control_plane_loads.load(Ordering::SeqCst),
+            0,
+            "Task patch must acquire the session lock before loading its snapshot"
+        );
+
+        // Publish a newer unrelated runtime transition while the Task patch is
+        // queued on the same session lock. Once the guard releases, the patch
+        // must load this latest snapshot and change only Task-owned fields.
+        let mut latest = inner
+            .load_runtime_control_plane(session_id)
+            .await
+            .expect("load latest control-plane")
+            .expect("control-plane exists");
+        latest.agent_runtime_state = Some(bamboo_domain::AgentRuntimeState::new("latest-run"));
+        latest
+            .metadata
+            .insert("concurrent.runtime".to_string(), "preserve".to_string());
+        inner
+            .save_runtime_state(&latest)
+            .await
+            .expect("publish concurrent runtime transition");
+        drop(guard);
+
+        assert!(
+            patch.await.expect("patch join").expect("patch succeeds"),
+            "existing root must be patched"
+        );
+        assert_eq!(counted.control_plane_loads.load(Ordering::SeqCst), 1);
+        let reloaded = inner
+            .load_session(session_id)
+            .await
+            .expect("reload")
+            .expect("session exists");
+        assert_eq!(
+            reloaded
+                .agent_runtime_state
+                .as_ref()
+                .map(|state| state.run_id.as_str()),
+            Some("latest-run")
+        );
+        assert_eq!(
+            reloaded
+                .metadata
+                .get("concurrent.runtime")
+                .map(String::as_str),
+            Some("preserve")
+        );
+        assert_eq!(reloaded.task_list_version_meta().as_deref(), Some("9"));
+        assert_eq!(
+            reloaded.task_list.as_ref().map(|list| list.title.as_str()),
+            Some("Atomic Task patch")
+        );
     }
 
     // ── LockedSessionStore tests ────────────────────────────────────

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -151,6 +151,26 @@ impl LockedSessionStore {
     /// Callers MUST NOT use this when they have appended messages: the in-memory
     /// `messages` are ignored by the sidecar and would not be persisted.
     pub async fn save_runtime_only(&self, session: &mut Session) -> std::io::Result<()> {
+        self.save_runtime_only_and_publish(session, |_| {}).await
+    }
+
+    /// Save the runtime control-plane and synchronously publish the committed
+    /// snapshot before releasing this session's serialization lock.
+    ///
+    /// `publish` must remain a short, non-blocking operation. Its synchronous
+    /// shape intentionally prevents callers from holding an in-memory cache
+    /// guard across an await. The callback also runs when the durable save
+    /// fails, preserving [`RuntimeSessionPersistence::save_runtime_control_plane`]
+    /// implementations that publish current runtime authorization state while
+    /// still returning the storage error.
+    pub async fn save_runtime_only_and_publish<F>(
+        &self,
+        session: &mut Session,
+        publish: F,
+    ) -> std::io::Result<()>
+    where
+        F: FnOnce(&Session) + Send,
+    {
         let _guard = self.acquire_lock(&session.id).await;
         if let Ok(Some(latest)) = self.storage.load_runtime_control_plane(&session.id).await {
             apply_authoritative_metadata(session, &latest);
@@ -158,7 +178,36 @@ impl LockedSessionStore {
             // concurrent mid-run bypass flip is here too — don't revert it. #540.
             adopt_disk_bypass_permissions(session, &latest);
         }
-        self.storage.save_runtime_state(session).await
+        let result = self.storage.save_runtime_state(session).await;
+        publish(session);
+        result
+    }
+
+    /// Atomically patch Task-owned control-plane fields and publish the saved
+    /// value before releasing this session's serialization lock.
+    ///
+    /// This couples durable commit order to cache publication order for
+    /// repository callers. The synchronous callback may take a cache guard but
+    /// cannot hold one across an await.
+    pub async fn update_task_list_control_plane_and_publish<F>(
+        &self,
+        session_id: &str,
+        task_list: &bamboo_domain::TaskList,
+        version: &str,
+        publish: F,
+    ) -> std::io::Result<bool>
+    where
+        F: FnOnce(&Session) + Send,
+    {
+        let _guard = self.acquire_lock(session_id).await;
+        let Some(mut latest) = self.storage.load_runtime_control_plane(session_id).await? else {
+            return Ok(false);
+        };
+        latest.set_task_list(task_list.clone());
+        latest.set_task_list_version_meta(version.to_string());
+        self.storage.save_runtime_state(&latest).await?;
+        publish(&latest);
+        Ok(true)
     }
 
     /// Authoritative metadata commit.
@@ -359,14 +408,8 @@ impl RuntimeSessionPersistence for LockedSessionStore {
         task_list: &bamboo_domain::TaskList,
         version: &str,
     ) -> std::io::Result<bool> {
-        let _guard = self.acquire_lock(session_id).await;
-        let Some(mut latest) = self.storage.load_runtime_control_plane(session_id).await? else {
-            return Ok(false);
-        };
-        latest.set_task_list(task_list.clone());
-        latest.set_task_list_version_meta(version.to_string());
-        self.storage.save_runtime_state(&latest).await?;
-        Ok(true)
+        self.update_task_list_control_plane_and_publish(session_id, task_list, version, |_| {})
+            .await
     }
 
     async fn checkpoint_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {

--- a/crates/infra/bamboo-storage/src/session_merge.rs
+++ b/crates/infra/bamboo-storage/src/session_merge.rs
@@ -241,7 +241,26 @@ impl LockedSessionStore {
     /// [`Self::save_runtime_authoritative_flags`] instead, which persists the
     /// in-memory flag as-is.
     pub async fn merge_save_runtime(&self, session: &mut Session) -> std::io::Result<()> {
-        self.merge_save_runtime_inner(session, true).await
+        self.merge_save_runtime_and_publish(session, |_, _| {})
+            .await
+    }
+
+    /// Merge-save a runtime session and synchronously publish the resulting
+    /// snapshot before releasing its per-session serialization lock.
+    ///
+    /// The callback receives whether the durable save committed. It always runs
+    /// after the save attempt so repository callers can preserve their existing
+    /// cache-on-failure policy without reopening a durable-to-cache race.
+    pub async fn merge_save_runtime_and_publish<F>(
+        &self,
+        session: &mut Session,
+        publish: F,
+    ) -> std::io::Result<()>
+    where
+        F: FnOnce(&Session, bool) + Send,
+    {
+        self.merge_save_runtime_inner_and_publish(session, true, publish)
+            .await
     }
 
     /// Persist an execute-boundary transcript checkpoint without allowing a
@@ -253,6 +272,24 @@ impl LockedSessionStore {
     /// latest transcript cannot be read would reintroduce the SHRINK hazard
     /// this checkpoint exists to prevent.
     pub async fn checkpoint_runtime_session(&self, session: &mut Session) -> std::io::Result<()> {
+        self.checkpoint_runtime_session_and_publish(session, |_, _| {})
+            .await
+    }
+
+    /// Checkpoint a runtime session and publish its reconciled snapshot before
+    /// releasing the same per-session serialization lock.
+    ///
+    /// The callback runs after the durable save attempt and receives its commit
+    /// status. A load failure returns before publication, matching the
+    /// checkpoint's fail-closed behavior.
+    pub async fn checkpoint_runtime_session_and_publish<F>(
+        &self,
+        session: &mut Session,
+        publish: F,
+    ) -> std::io::Result<()>
+    where
+        F: FnOnce(&Session, bool) + Send,
+    {
         let _guard = self.acquire_lock(&session.id).await;
         let latest = self.storage.load_session(&session.id).await?;
 
@@ -273,7 +310,9 @@ impl LockedSessionStore {
             adopt_disk_bypass_permissions(session, latest);
         }
 
-        self.storage.save_session(session).await
+        let result = self.storage.save_session(session).await;
+        publish(session, result.is_ok());
+        result
     }
 
     /// Like [`Self::merge_save_runtime`] but does NOT adopt the on-disk
@@ -288,14 +327,19 @@ impl LockedSessionStore {
         &self,
         session: &mut Session,
     ) -> std::io::Result<()> {
-        self.merge_save_runtime_inner(session, false).await
+        self.merge_save_runtime_inner_and_publish(session, false, |_, _| {})
+            .await
     }
 
-    async fn merge_save_runtime_inner(
+    async fn merge_save_runtime_inner_and_publish<F>(
         &self,
         session: &mut Session,
         adopt_bypass: bool,
-    ) -> std::io::Result<()> {
+        publish: F,
+    ) -> std::io::Result<()>
+    where
+        F: FnOnce(&Session, bool) + Send,
+    {
         let _guard = self.acquire_lock(&session.id).await;
 
         // Single disk read serves BOTH the SHRINK diagnostic and the
@@ -350,7 +394,9 @@ impl LockedSessionStore {
                 adopt_disk_bypass_permissions(session, latest);
             }
         }
-        self.storage.save_session(session).await
+        let result = self.storage.save_session(session).await;
+        publish(session, result.is_ok());
+        result
     }
 
     /// Apply a config-only mutation to a session without ever clobbering its
@@ -372,13 +418,54 @@ impl LockedSessionStore {
     where
         F: FnOnce(&mut Session),
     {
+        self.update_runtime_config_and_publish(session_id, mutate, |_| {})
+            .await
+    }
+
+    /// Apply a config-only mutation and synchronously publish the saved
+    /// snapshot before releasing the session lock.
+    pub async fn update_runtime_config_and_publish<M, P>(
+        &self,
+        session_id: &str,
+        mutate: M,
+        publish: P,
+    ) -> std::io::Result<Option<Session>>
+    where
+        M: FnOnce(&mut Session),
+        P: FnOnce(&Session),
+    {
         let _guard = self.acquire_lock(session_id).await;
         let Some(mut session) = self.storage.load_session(session_id).await? else {
             return Ok(None);
         };
         mutate(&mut session);
         self.storage.save_session(&session).await?;
+        publish(&session);
         Ok(Some(session))
+    }
+
+    /// Clear the legacy compatibility queue using durable CAS and publish the
+    /// saved full snapshot before releasing the same session lock.
+    pub async fn clear_legacy_pending_messages_and_publish<F>(
+        &self,
+        session_id: &str,
+        expected: &[serde_json::Value],
+        publish: F,
+    ) -> std::io::Result<bool>
+    where
+        F: FnOnce(&Session) + Send,
+    {
+        let _guard = self.acquire_lock(session_id).await;
+        let Some(mut latest) = self.storage.load_session(session_id).await? else {
+            return Ok(false);
+        };
+        if latest.pending_injected_messages().as_deref() != Some(expected) {
+            return Ok(false);
+        }
+        latest.clear_pending_injected_messages();
+        self.storage.save_runtime_state(&latest).await?;
+        publish(&latest);
+        Ok(true)
     }
 }
 
@@ -425,16 +512,8 @@ impl RuntimeSessionPersistence for LockedSessionStore {
         session_id: &str,
         expected: &[serde_json::Value],
     ) -> std::io::Result<bool> {
-        let _guard = self.acquire_lock(session_id).await;
-        let Some(mut latest) = self.storage.load_session(session_id).await? else {
-            return Ok(false);
-        };
-        if latest.pending_injected_messages().as_deref() != Some(expected) {
-            return Ok(false);
-        }
-        latest.clear_pending_injected_messages();
-        self.storage.save_runtime_state(&latest).await?;
-        Ok(true)
+        self.clear_legacy_pending_messages_and_publish(session_id, expected, |_| {})
+            .await
     }
 }
 


### PR DESCRIPTION
## Summary

- add an explicit runtime control-plane persistence port with source-compatible full-session defaults for custom/non-V2 implementations
- route direct root/child Task updates through the runtime sidecar and atomically patch only the shared root Task list/version under its per-session lock
- linearize every canonical SessionRepository durable write/backfill with cache publication under the same per-session ordering fence
- retain lock-free cache hot hits while double-checking cache misses inside the persistence lock
- preserve messages, SessionInbox admission, unrelated runtime state, existing failure-cache semantics, `TaskListUpdated`, and Task context reinitialization

## Root Cause

Successful `Task` post-processing called `save_runtime_session` before `ToolComplete`, forcing the full transcript through the storage commit path. The former child-to-root load/save flow could also commit a stale whole control-plane snapshot after another root transition. During adversarial review, the same durable-write-then-cache-publish window was found in sibling repository save, checkpoint, load/backfill, metadata, and legacy-CAS paths; those paths now share the same ordering invariant.

## Test Plan

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo metadata --locked --all-features --format-version 1`
- `cargo clippy -p bamboo-domain -p bamboo-storage -p bamboo-engine --lib -- -D warnings`
- `cargo test -p bamboo-domain --lib` — 179 passed
- `cargo test -p bamboo-storage --lib` — 100 passed
- `cargo test -p bamboo-engine --lib` — 1264 passed
- focused `SessionRepository` regressions — 17 passed
- focused Task regressions — 6 passed
- test-only race heads: five durable/cache fence tests and the lock-free-hit test each failed deterministically across six runs
- final head: corresponding regression groups passed across ten consecutive runs
- exact-head independent agent review: APPROVE, Critical/High/Medium/Low = 0
- GitHub CI: Test, E2E, Lint, MSRV, TLS fixtures on Linux/macOS/Windows, Documentation, Security Audit, cargo-deny, and CodeQL all passed

## Screenshots

N/A — backend persistence change.

Closes #754