### PR TITLE
chore: remove stale root base64 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,6 @@ dependencies = [
  "bamboo-subagent",
  "bamboo-tools",
  "bamboo-tui",
- "base64 0.22.1",
  "bytes",
  "chrono",
  "chrono-tz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,6 @@ reqwest-retry = "0.9"
 
 # Encryption
 aes-gcm = "0.11"
-base64 = "0.22"
 sha2 = "0.11"
 hex = "0.4"
 rand = "0.10"


### PR DESCRIPTION
## Summary

Remove the stale root `bamboo-agent` direct dependency on `base64 0.22`. A target-level audit found no direct crate usage in the root library, binary, build script, examples, or integration tests; the remaining matches are data strings and variable names.

## Changes

- Remove `base64 = "0.22"` from the root `Cargo.toml`.
- Remove only the root package's `"base64 0.22.1"` dependency edge from `Cargo.lock`.
- Keep the `base64 0.22.1` package for third-party transitive consumers.
- Keep all seven workspace direct consumers on `base64 0.23` unchanged.

## Validation

- [x] `cargo metadata --locked --all-features --format-version 1`
- [x] Root direct `base64` dependency count is zero
- [x] Workspace direct dependency graph still contains exactly seven `^0.23` consumers
- [x] `cargo check --locked -p bamboo-agent --all-features`
- [x] Focused root encryption, server callback encoding, config recovery, and storage URL-safe digest tests
- [x] `cargo fmt --check`
- [x] `python3 scripts/check-msrv.py`
- [x] `git diff --check`

## Risk

This is dependency-graph cleanup only: two deleted manifest/lockfile lines and no source changes. CI must still complete successfully on the exact head before merge.

Closes #764
